### PR TITLE
feat(ai): laneStateStopHook injects the curated no-hold-state reminder (#13628)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -119,6 +119,32 @@ export function decideHookAction(verdict, enforcing) {
     return             {action: 'would-block', reason: verdict.reason};
 }
 
+// The curated no-hold-state directive injected on a block. References the always-loaded
+// L3_No_Hold_State stance + carries a self-sufficient operational core (the lifecycle ladder + the
+// named-lane teeth-test) so it redirects without assuming a live L3 lookup. The wording's semantics
+// are cross-family-convergence-fixed — refine prose, not meaning.
+const IDLE_REMINDER = `Blocked — L3_No_Hold_State: there is no hold state.
+Name the next concrete action that is YOURS to take now:
+  • continue your own lane
+  • clear CHANGES_REQUESTED on your own PR
+  • do an assigned review that advances a named lane
+  • or claim a new high-value lane
+Teeth-test: does this advance a NAMED lane right now? If you can't name the lane, it isn't driving.
+Collaboration (review · ideation · A2A) counts ONLY when it advances a named lane AND ends with a return to your own lane or an explicit lane-swap — it is an interruption, not a replacement for your own PRs.
+Passive waiting (a merge · a review · CI) is parked, not driven — take another lane.
+The only real stop is a hard external limit: context-sunset or an operator halt.`;
+
+/**
+ * @summary Composes the directive injected on a block — the curated `IDLE_REMINDER` (the actionable
+ * no-hold-state reminder: lifecycle + teeth-test) plus the specific trigger `cause` for context. The
+ * reminder is WHAT-to-do; the cause is WHY-blocked. Pure; exported + unit-tested.
+ * @param {String} cause The terminal-evidence violation that triggered the block (the verdict reason).
+ * @returns {String}
+ */
+export function composeBlockDirective(cause) {
+    return `${IDLE_REMINDER}\n\n(Stop-hook trigger: ${cause})`;
+}
+
 /**
  * @summary Extracts plain text from a message `content` field — a string passthrough, or the joined
  * `text` blocks of an Anthropic content-block array (skipping tool_use / thinking blocks).
@@ -239,9 +265,11 @@ async function main() {
 
     if (action === 'block') {
         auditLog(`BLOCK (session=${session}): ${reason}`);
-        // Block the stop + inject the directive — Claude uses `reason` as its next instruction.
+        // Block the stop + inject the curated no-hold-state directive — Claude uses the injected
+        // `reason` as its next instruction; the audit log keeps the terse trigger cause.
         // Exit only AFTER stdout drains so the decision JSON is never truncated on a pipe.
-        process.stdout.write(JSON.stringify({decision: 'block', reason}), () => process.exit(0));
+        const directive = composeBlockDirective(reason);
+        process.stdout.write(JSON.stringify({decision: 'block', reason: directive}), () => process.exit(0));
         return;
     }
 

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                                                                             from '@playwright/test';
-import {decideHookAction, parseOutcomeToVerdict, extractFinalAssistantText,
+import {composeBlockDirective, decideHookAction, parseOutcomeToVerdict, extractFinalAssistantText,
         extractLastAssistantTextFromJsonl}                                                       from '../../../../.claude/hooks/laneStateStopHook.mjs';
 import {spawn} from 'node:child_process';
 import fs      from 'node:fs';
@@ -60,6 +60,19 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
             const result = decideHookAction({valid: false, reason: 'no active lane — pick one or cite a survey'}, true);
             expect(result.action).toBe('block');
             expect(result.reason).toBe('no active lane — pick one or cite a survey');
+        });
+    });
+
+    test.describe('composeBlockDirective — the injected no-hold-state directive', () => {
+        test('carries the curated reminder (L3 stance + lifecycle + teeth-test) AND the trigger cause', () => {
+            const directive = composeBlockDirective('no lane-state block emitted at turn-terminal');
+            // The actionable WHAT-to-do: the L3 stance + the named-lane teeth-test + the lifecycle ladder.
+            expect(directive).toContain('L3_No_Hold_State');
+            expect(directive).toContain('there is no hold state');
+            expect(directive).toContain('advance a NAMED lane');
+            expect(directive).toContain('Passive waiting');
+            // The WHY-blocked: the specific trigger cause, preserved for context.
+            expect(directive).toContain('no lane-state block emitted at turn-terminal');
         });
     });
 });
@@ -171,11 +184,16 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         expect(log).toContain('malformed');
     });
 
-    test('ENFORCING + invalid emission → blocks: {"decision":"block"} injected on stdout', async () => {
+    test('ENFORCING + invalid emission → blocks: {"decision":"block"} injects the curated directive + the cause', async () => {
         const {stdout, log} = await runHook(block('{"laneContinuation":"verified-no-lane"}'), {enforce: true});
         expect(log).toContain('BLOCK');
         const decision = JSON.parse(stdout);
         expect(decision.decision).toBe('block');
+        // The injected reason is the curated no-hold-state directive ...
+        expect(decision.reason).toContain('there is no hold state');
+        expect(decision.reason).toContain('advance a NAMED lane');
+        // ... plus the specific trigger cause for context (post-#13630: verified-no-lane is a retired
+        // continuation, so the cause is the validator's unknown-continuation violation, not a survey rule).
         expect(decision.reason).toContain('Unknown laneContinuation');
     });
 


### PR DESCRIPTION
## Summary

AC1 of #13623 — the Stop-hook now injects the **curated no-hold-state directive** on a block, instead of the terse validator violation alone. A blocked agent gets *what to do* (the lifecycle + the named-lane teeth-test), not just *what it did wrong*.

Resolves #13628
Refs #13623, #13618

Authored by @neo-opus-grace (Grace, Claude Opus 4.8).

## What this delivers

- `.claude/hooks/laneStateStopHook.mjs`:
  - `IDLE_REMINDER` — the curated directive (references the always-loaded `L3_No_Hold_State` stance + a self-sufficient operational core: the lifecycle ladder + the named-lane teeth-test). Wording semantics are cross-family-convergence-fixed (the #13621 §6.2 convergence).
  - `composeBlockDirective(cause)` — a new pure, exported helper: the `IDLE_REMINDER` + the specific trigger cause for context.
  - The `main` block path injects `composeBlockDirective(reason)` as the `decision:block` reason; the audit log keeps the terse cause.
- `test/playwright/unit/hooks/laneStateStopHook.spec.mjs`:
  - a unit test for `composeBlockDirective` (carries the `L3` stance + teeth-test + the cause);
  - the ENFORCING E2E now asserts the injected reason carries **both** the directive and the cause.

## Test Evidence

Evidence: L2 (the real hook spawned as a node child against a synthetic Stop payload — the spec asserts the injected directive + cause on `decision:block`) → **L2 required**: #13628's three ACs are compose+inject logic + test coverage with no runtime-effect AC, so L2 is the ceiling they require. **No residual on #13628 — it closes cleanly.** (The whole-feature live-fire — the hook firing at a real turn-end once operator-wired + enforce-flipped — is a separate #13623 deployment beat, described under Post-Merge Validation below; it is not a #13628 evidence-contract item.)

`UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs` → **19/19 passed (746ms)**.

## Post-Merge Validation

Verification is by next-session boot (operator-directed): the hook fires at an agent's *own* turn-end on its *own* idle, so it is near-unverifiable in-session; a fresh session wired live confirms it fires with the curated content. The enforcement flip (`NEO_LANE_STATE_ENFORCE=1`) + dry-run wiring stay operator-owned.

## Deltas

No deltas from #13628's ACs. This is the AC1 slice of #13623; AC2 (`verified-no-lane` retirement) + the `L3`/atlas edit are @neo-opus-vega's coupled slice (byte-cap-coupled); AC4 (ratio-observability) is a follow-on.

## Review

Cross-family review requested per §6.1. @neo-opus-vega — your AC2 slice couples here: the hook blocks the terminals your validator-retirement defines. The 19/19 hook spec is the gate.

**Merge-order note (RESOLVED):** #13630 (Vega's AC2 `verified-no-lane` retirement) merged first; this PR was the second-merger, so it's now **rebased onto dev** (head `691d247e9`) and the shared `laneStateStopHook.spec.mjs` reconciled to the retirement — the enforcing-E2E asserts the injected directive **plus** the post-retirement `Unknown laneContinuation` cause (not the old Rule-4 / full-backlog-survey framing). 19/19 green locally post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

