### PR TITLE
refactor(ai): retire verified-no-lane from validateLaneStateTerminal (#13627)

### DIFF
--- a/ai/scripts/lifecycle/parseLaneState.mjs
+++ b/ai/scripts/lifecycle/parseLaneState.mjs
@@ -27,7 +27,7 @@ export const LANE_STATE_BLOCK = /```lane-state\s*\r?\n([\s\S]*?)\r?\n```/g;
  * @summary Parses the last fenced ```lane-state block from transcript text into a lane-state descriptor.
  *
  * @param {String} transcriptText The agent's final turn-terminal message text (or the transcript tail).
- * @returns {Object|null} The descriptor `{wakeDisposition, laneContinuation, namedGates, awaitingOwnPrOnly, backlogSurvey}`
+ * @returns {Object|null} The descriptor `{wakeDisposition, laneContinuation, namedGates, awaitingOwnPrOnly}`
  *   normalized from the LAST ```lane-state block, or `null` when no block is present.
  * @throws {Error} When a ```lane-state block IS present but its body is not valid JSON — a
  *   present-but-malformed emission is a distinct failure the hook logs separately from an absent one.
@@ -57,8 +57,7 @@ export function parseLaneState(transcriptText) {
         wakeDisposition  : parsed.wakeDisposition,
         laneContinuation : parsed.laneContinuation,
         namedGates       : Array.isArray(parsed.namedGates) ? parsed.namedGates : [],
-        awaitingOwnPrOnly: parsed.awaitingOwnPrOnly === true,
-        backlogSurvey    : parsed.backlogSurvey ?? null
+        awaitingOwnPrOnly: parsed.awaitingOwnPrOnly === true
     };
 }
 

--- a/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
+++ b/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
@@ -5,18 +5,21 @@
  * The wake-disposition vs lane-continuation discipline is repeatedly lost to disciplined-sounding
  * terminal prose: a wake correctly classified as low-action, then a turn that ends "standing by"
  * while naming an already-merged PR as a live gate. This validator mechanically rejects stale gate
- * names and own-slice `verified-no-lane` claims. It deliberately validates ONLY the author-provided
- * terminal evidence — it does not compute claimable work, count contributions, or enforce external
- * liveness (that is the separate, deferred external-enforcement layer).
+ * names and non-driving terminals. It deliberately validates ONLY the author-provided terminal
+ * evidence — it does not compute claimable work, count contributions, or enforce external liveness
+ * (that is the separate, deferred external-enforcement layer).
  *
  * @module Neo.ai.scripts.lifecycle.validateLaneStateTerminal
  */
 
 /**
- * The lane-continuation states that answer "may the turn end?".
+ * The lane-continuation states that answer "may the turn end?" — all three are DRIVING continuations.
+ * Per §no_hold_state there is no hold state: the only valid turn-state is on / jumped-to a high-value
+ * lane. The survey-idle terminal `verified-no-lane` was retired — under "high-value work is infinite"
+ * it is ~never honestly true, and the `L3_No_Hold_State` firewall brands it a manufactured idle.
  * @type {String[]}
  */
-export const LANE_CONTINUATIONS = ['active-lane', 'next-lane', 'blocker-routed', 'verified-no-lane'];
+export const LANE_CONTINUATIONS = ['active-lane', 'next-lane', 'blocker-routed'];
 
 /**
  * Wake dispositions that answer only "engage this message?" — never "does the turn have a lane?".
@@ -35,15 +38,12 @@ export const NON_TERMINAL_DISPOSITIONS = ['awareness', 'stale', 'suppressed'];
  *  3. Every named PR/issue gate must cite a same-turn `checkedAt` (stale gate names are not evidence);
  *     a gate flagged `mergeClaim` must cite `field === 'mergedAt'` (reading a PR's `state`/CLOSED is
  *     not merge proof — a closed PR may be un-merged).
- *  4. `laneContinuation='verified-no-lane'` must cite a NAMED full-backlog survey artifact with a
- *     `checkedAt` AND `scope === 'full-backlog'` — an own-PR-only, own-epic-only, or unscoped survey fails.
  *
  * @param {Object} [laneState={}]
  * @param {String} [laneState.wakeDisposition] One of `actionable|awareness|stale|suppressed|incident`.
- * @param {String} [laneState.laneContinuation] One of `active-lane|next-lane|blocker-routed|verified-no-lane`.
+ * @param {String} [laneState.laneContinuation] One of `active-lane|next-lane|blocker-routed`.
  * @param {Object[]} [laneState.namedGates] Named PR/issue gates this terminal cites: `[{ref, checkedAt, mergeClaim?, field?}]`.
  * @param {Boolean} [laneState.awaitingOwnPrOnly] True when the only cited lane is an own PR awaiting merge/review/CI.
- * @param {Object} [laneState.backlogSurvey] `{checkedAt, scope}` backing a `verified-no-lane` claim; `scope` must be `'full-backlog'`.
  * @returns {{valid: Boolean, violations: String[]}} `valid` is true when no rule is violated.
  */
 export function validateLaneStateTerminal(laneState = {}) {
@@ -51,8 +51,7 @@ export function validateLaneStateTerminal(laneState = {}) {
         wakeDisposition,
         laneContinuation,
         namedGates        = [],
-        awaitingOwnPrOnly = false,
-        backlogSurvey     = null
+        awaitingOwnPrOnly = false
     } = laneState;
 
     const violations = [];
@@ -80,15 +79,6 @@ export function validateLaneStateTerminal(laneState = {}) {
             violations.push(`Named gate ${gate?.ref ?? '(unnamed)'} must cite a same-turn checkedAt — a stale gate name is not evidence.`);
         } else if (gate.mergeClaim && gate.field !== 'mergedAt') {
             violations.push(`Named gate ${gate.ref ?? '(unnamed)'} claims merge state but cites field ${gate.field ? `'${gate.field}'` : '(none)'} — a merge claim must read mergedAt (a PR's state/CLOSED is not merge proof).`);
-        }
-    }
-
-    // Rule 4 — verified-no-lane needs a named full-backlog survey; an unscoped survey is not full-backlog.
-    if (laneContinuation === 'verified-no-lane') {
-        if (!backlogSurvey?.checkedAt) {
-            violations.push('verified-no-lane must cite a named full-backlog survey artifact (e.g. list_issues / gh issue list) with a checkedAt.');
-        } else if (backlogSurvey.scope !== 'full-backlog') {
-            violations.push(`verified-no-lane requires a full-backlog survey scope (got ${backlogSurvey.scope ? `'${backlogSurvey.scope}'` : 'no scope'}) — own-PR-only / own-epic-only / unscoped surveys fail.`);
         }
     }
 

--- a/test/playwright/unit/ai/scripts/lifecycle/parseLaneState.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/parseLaneState.spec.mjs
@@ -38,15 +38,14 @@ test.describe('parseLaneState — fenced lane-state block extraction', () => {
     });
 
     test('the LAST block wins when multiple are present', () => {
-        const text = '```lane-state\n{"laneContinuation":"active-lane"}\n```\n...later...\n```lane-state\n{"laneContinuation":"verified-no-lane","backlogSurvey":{"checkedAt":"t","scope":"full-backlog"}}\n```';
-        expect(parseLaneState(text).laneContinuation).toBe('verified-no-lane');
+        const text = '```lane-state\n{"laneContinuation":"active-lane"}\n```\n...later...\n```lane-state\n{"laneContinuation":"blocker-routed"}\n```';
+        expect(parseLaneState(text).laneContinuation).toBe('blocker-routed');
     });
 
     test('normalizes missing optional fields to safe defaults', () => {
         const d = parseLaneState('```lane-state\n{"laneContinuation":"next-lane"}\n```');
         expect(d.namedGates).toEqual([]);
         expect(d.awaitingOwnPrOnly).toBe(false);
-        expect(d.backlogSurvey).toBe(null);
     });
 
     test('round-trips into validateLaneStateTerminal — the hook seam end-to-end (#12633)', () => {

--- a/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
@@ -56,42 +56,16 @@ test.describe('validateLaneStateTerminal — turn-terminal evidence shape', () =
         expect(result.valid).toBe(true);
     });
 
-    test('verified-no-lane fails on an own-PR/own-epic slice (no full-backlog survey)', () => {
-        const result = validateLaneStateTerminal({
-            laneContinuation: 'verified-no-lane',
-            backlogSurvey   : {checkedAt: NOW, scope: 'own-pr'}
-        });
-        expect(result.valid).toBe(false);
-        expect(result.violations.join(' ')).toContain('full-backlog');
-    });
-
-    test('verified-no-lane fails when no survey is cited at all', () => {
+    test('verified-no-lane is retired — now rejected as an unknown (non-driving) continuation', () => {
         const result = validateLaneStateTerminal({laneContinuation: 'verified-no-lane'});
         expect(result.valid).toBe(false);
-        expect(result.violations.join(' ')).toContain('full-backlog survey');
-    });
-
-    test('verified-no-lane passes with a named full-backlog survey + checkedAt', () => {
-        const result = validateLaneStateTerminal({
-            laneContinuation: 'verified-no-lane',
-            backlogSurvey   : {checkedAt: NOW, scope: 'full-backlog'}
-        });
-        expect(result.valid).toBe(true);
+        expect(result.violations.join(' ')).toContain("Unknown laneContinuation 'verified-no-lane'");
     });
 
     test('an unknown laneContinuation (e.g. "holding") fails', () => {
         const result = validateLaneStateTerminal({laneContinuation: 'holding'});
         expect(result.valid).toBe(false);
         expect(result.violations.join(' ')).toContain("Unknown laneContinuation 'holding'");
-    });
-
-    test('verified-no-lane fails when the survey is unscoped (the no-scope loophole)', () => {
-        const result = validateLaneStateTerminal({
-            laneContinuation: 'verified-no-lane',
-            backlogSurvey   : {checkedAt: NOW}   // checkedAt but no scope → not a proven full-backlog survey
-        });
-        expect(result.valid).toBe(false);
-        expect(result.violations.join(' ')).toContain('full-backlog survey scope');
     });
 
     test('a named gate claiming merge state must cite field mergedAt, not state', () => {

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -183,7 +183,7 @@ test.describe('codex-lane-state-stop - spawned hook', () => {
         expect(stdout).toBe('');
         expect(log).toContain('WOULD-BLOCK');
         expect(log).toContain('block/inject contract is not proven');
-        expect(log).toContain('full-backlog survey');
+        expect(log).toContain('Unknown laneContinuation');
     });
 
     test('capture mode logs only the redacted payload shape', async () => {

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -18,7 +18,7 @@ const block = body => '```lane-state\n' + body + '\n```';
 test.describe('laneStateStopHook — pure idle-out decision logic', () => {
     test.describe('parseOutcomeToVerdict — the 3-bucket chain', () => {
         const alwaysValid   = () => ({valid: true,  violations: []}),
-              alwaysInvalid = () => ({valid: false, violations: ['Rule 4: verified-no-lane without a full-backlog survey']});
+              alwaysInvalid = () => ({valid: false, violations: ['invalid lane-state terminal']});
 
         test('MALFORMED emission (parseLaneState threw) → invalid, with the parse error in the reason', () => {
             const verdict = parseOutcomeToVerdict({descriptor: null, parseError: new Error('Unexpected token }')}, alwaysValid);
@@ -38,9 +38,9 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
         });
 
         test('a parsed descriptor — INVALID → invalid verdict carrying the validator violations', () => {
-            const verdict = parseOutcomeToVerdict({descriptor: {laneContinuation: 'verified-no-lane'}, parseError: null}, alwaysInvalid);
+            const verdict = parseOutcomeToVerdict({descriptor: {laneContinuation: 'active-lane'}, parseError: null}, alwaysInvalid);
             expect(verdict.valid).toBe(false);
-            expect(verdict.reason).toContain('Rule 4');
+            expect(verdict.reason).toContain('invalid lane-state terminal');
         });
     });
 
@@ -152,10 +152,10 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         expect(stdout).toBe('');
     });
 
-    test('an INVALID emission (verified-no-lane, no full-backlog survey) → WOULD-BLOCK via Rule 4', async () => {
+    test('an INVALID emission (verified-no-lane — a retired continuation) → WOULD-BLOCK as unknown', async () => {
         const {stdout, log} = await runHook(block('{"laneContinuation":"verified-no-lane"}'));
         expect(log).toContain('WOULD-BLOCK');
-        expect(log).toContain('full-backlog survey');
+        expect(log).toContain('Unknown laneContinuation');
         expect(stdout).toBe('');
     });
 
@@ -176,7 +176,7 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         expect(log).toContain('BLOCK');
         const decision = JSON.parse(stdout);
         expect(decision.decision).toBe('block');
-        expect(decision.reason).toContain('full-backlog survey');
+        expect(decision.reason).toContain('Unknown laneContinuation');
     });
 
     test('JSONL fallback: a valid block in the last assistant transcript record → WOULD-ALLOW', async () => {


### PR DESCRIPTION
## Summary

#13618 **AC2** (graduated #13621→#13623): retire the survey-idle terminal `verified-no-lane` from `validateLaneStateTerminal` so the validator admits only the 3 **driving** continuations (`active-lane` / `next-lane` / `blocker-routed`). This is the foundation grace's #13623 Axis-2 hook-content rides + the hook-critical piece for @tobiu's land→sunset→verify plan.

**Correctness, not just net-reduction:** `L3`'s premise (`AGENTS.md:37`) already brands `verified-no-lane` a *manufactured idle* — yet the validator still **certified it** (`LANE_CONTINUATIONS` + Rule 4). This aligns the validator to the merged `§no_hold_state` stance (#13620). Surfaced in my #13621 §5.2 STEP_BACK.

Resolves #13627
Refs #13618 #13623 #13620 #13625

Evidence: L1 — pure validator + parser refactor (no runtime-AC beyond unit tests); 50 related unit tests green at head across 4 specs; net −38 lines.

## Changes

- `validateLaneStateTerminal.mjs`: drop `verified-no-lane` from `LANE_CONTINUATIONS`; remove Rule 4 + the `backlogSurvey` param/JSDoc; add a JSDoc retirement-note (the WHY, `#N`-free for husky).
- `parseLaneState.mjs`: drop the now-orphaned `backlogSurvey` from the normalized descriptor (the parser stays continuation-agnostic by design).
- Specs: removed the `verified-no-lane` / Rule-4 / `backlogSurvey` cases; added a retirement test (`verified-no-lane` → rejected as `Unknown laneContinuation`). Both Stop-hook specs (`laneStateStopHook` Claude + the merged `codexLaneStateStopHook` Codex, #13625) repointed — `verified-no-lane` now demonstrates a *retired* continuation rejected as unknown (the reason both hooks surface still embeds it).

## Test Evidence

```
UNIT_TEST_MODE=true playwright test (4 related specs) : 50 passed (1.0s)
  - validateLaneStateTerminal.spec.mjs
  - parseLaneState.spec.mjs
  - laneStateStopHook.spec.mjs              (Claude hook)
  - codexLaneStateStopHook.spec.mjs         (Codex hook, #13625)
git diff --staged --numstat : +23 / -61  (net -38)
husky pre-commit            : check-jsdoc-types + check-ticket-archaeology + check-block-alignment PASS
```

Checked out + run at head `581dca65a` in the opus-vega clone (not the cross-clone canonical — no false-green).

## Post-Merge Validation

- [ ] CI green on `dev` (the merged #13625 Codex spec stays green with the repointed assertion).
- [ ] The retired `verified-no-lane` no longer validates as a terminal — validator is driving-only.

## Deltas

- **Out of scope (paired siblings):** the `L3` teeth-test + the `verified-no-lane` token-trim + the atlas detail = #13623 **Axis-1**; the `laneStateStopHook.mjs` reminder-content injection = @neo-opus-grace's #13623 **Axis-2** (she owns the hook file; this PR touches only the `verified-no-lane` test-block in its spec — coordinated, different blocks, whoever merges 2nd rebases).
- Archive/historical refs (`issue-10777`, `discussion-12627`/`-12630`) deliberately NOT retro-edited (they record what was true then).
- The shared-validator reuse (verified in my #13625 review) means this retirement propagates to BOTH Stop-hooks automatically — no per-harness fork.

Authored by Vega (Claude Opus 4.8, Claude Code). #13618 AC2; graduated from #13621 / #13616.
