### PR TITLE
feat(wake): classify Codex submit turn-start proof (#13480)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -85,6 +85,8 @@ const POLL_INTERVAL_MS         = 3000;
 const DEFAULT_COALESCE_WINDOW_MS = 30000; // 30 seconds
 const CODEX_APP_SERVER_ADAPTER   = 'codex-app-server';
 const DEFAULT_CODEX_DESKTOP_CLI_PATH = '/Applications/Codex.app/Contents/Resources/codex';
+const CODEX_TURN_START_PROOF_TIMEOUT_MS = Number(process.env.WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS) || 45000;
+const CODEX_TURN_START_PROOF_POLL_MS    = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
 const WAKE_PRIORITY_RANKS      = {
     low   : 0,
     normal: 1,
@@ -911,6 +913,12 @@ function buildWakeDeliveryEvidence({messages = [], tasks = [], permissions = [],
     };
 
     const actionableCount = counts.messages + counts.tasks + counts.permissions;
+    const correlation = {
+        messageIds   : messages.map(message => message.messageId).filter(Boolean),
+        taskIds      : tasks.map(task => task.taskId).filter(Boolean),
+        permissionIds: permissions.map(permission => permission.logId).filter(Boolean),
+        heartbeatIds : heartbeats.map(heartbeat => heartbeat.logId).filter(Boolean)
+    };
 
     let scenario = 'empty';
     if (counts.heartbeats > 0 && actionableCount === 0) {
@@ -925,7 +933,7 @@ function buildWakeDeliveryEvidence({messages = [], tasks = [], permissions = [],
         scenario = 'actionable';
     }
 
-    return {scenario, counts};
+    return {scenario, counts, correlation};
 }
 
 /**
@@ -947,6 +955,138 @@ function formatWakeDeliveryEvidence(evidence, {adapter, adapterSource, appName})
     return ` (scenario=${scenario}; route=${adapter}; adapterSource=${adapterSource}; app=${appName || ''}; ` +
         `counts=messages:${counts.messages || 0},tasks:${counts.tasks || 0},` +
         `permissions:${counts.permissions || 0},heartbeats:${counts.heartbeats || 0}${submitBoundary})`;
+}
+
+/**
+ * @summary Formats stable event identifiers for post-submit turn-start correlation logs.
+ * @param {Object} evidence Scenario/count evidence from buildWakeDeliveryEvidence().
+ * @returns {String}
+ */
+function formatWakeCorrelationEvidence(evidence = {}) {
+    const correlation = evidence.correlation || {},
+          parts       = [];
+
+    if (correlation.messageIds?.length) {
+        parts.push(`messageIds=${correlation.messageIds.slice(-3).join(',')}`);
+    }
+    if (correlation.taskIds?.length) {
+        parts.push(`taskIds=${correlation.taskIds.slice(-3).join(',')}`);
+    }
+    if (correlation.permissionIds?.length) {
+        parts.push(`permissionLogIds=${correlation.permissionIds.slice(-3).join(',')}`);
+    }
+    if (correlation.heartbeatIds?.length) {
+        parts.push(`heartbeatLogIds=${correlation.heartbeatIds.slice(-3).join(',')}`);
+    }
+
+    return parts.length ? `; ${parts.join('; ')}` : '';
+}
+
+/**
+ * @summary Reads the first turn-presence interval that started after a wake submit attempt.
+ *
+ * The Codex prompt-submit hook writes `AGENT_TURN_PRESENCE` at the actual turn boundary. Terminal
+ * updates can later change `source` to `add_memory`, so source is diagnostic only. Until the wake
+ * payload carries a nonce into the prompt-submit hook, this query is timestamp-window evidence: useful
+ * for classifying no-turn-start failures, but not proof that the scripted Enter rather than a later
+ * human Enter caused a matching turn.
+ *
+ * @param {Object} sqlite better-sqlite3 handle.
+ * @param {String} agentIdentity Recipient AgentIdentity node id.
+ * @param {String} sinceIso Submit-attempt timestamp.
+ * @returns {Object|null}
+ */
+function findTurnPresenceAfter(sqlite, agentIdentity, sinceIso) {
+    const row = sqlite.prepare(`
+        SELECT data FROM Nodes
+        WHERE (
+            json_extract(data, '$.label') = 'AGENT_TURN_PRESENCE'
+            OR json_extract(data, '$.type') = 'AGENT_TURN_PRESENCE'
+        )
+          AND json_extract(data, '$.properties.agentIdentity') = ?
+          AND json_extract(data, '$.properties.startedAt') >= ?
+        ORDER BY json_extract(data, '$.properties.startedAt') ASC
+        LIMIT 1
+    `).get(agentIdentity, sinceIso);
+
+    if (!row?.data) return null;
+
+    try {
+        return JSON.parse(row.data).properties || null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * @summary Schedules a bounded Codex submit-attempt observer using turn-presence rows.
+ *
+ * This is evidence-only: it does not retry, alter the submit primitive, or gate delivery. It converts
+ * `turnStartProof=live-required` into one of three durable log outcomes when the graph oracle is
+ * available: `wake-submit-started`, `wake-submit-not-started`, or `wake-submit-unknown`. The started
+ * outcome means turn presence appeared in the observation window; without a nonce it must not be
+ * over-read as human-free submit proof.
+ *
+ * @param {Object} subscription WAKE_SUBSCRIPTION node.
+ * @param {Date} submitAttemptedAt Timestamp immediately before the submit adapter ran.
+ * @param {Object} deliveryEvidence Scenario/count/correlation evidence.
+ * @returns {void}
+ */
+function scheduleCodexTurnStartProof(subscription, submitAttemptedAt, deliveryEvidence = {}) {
+    const timeoutMs = CODEX_TURN_START_PROOF_TIMEOUT_MS,
+          pollMs    = Math.max(50, CODEX_TURN_START_PROOF_POLL_MS);
+
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return;
+
+    const agentIdentity = subscription.properties?.agentIdentity,
+          submitIso     = submitAttemptedAt.toISOString(),
+          deadlineAt    = Date.now() + timeoutMs,
+          correlation   = formatWakeCorrelationEvidence(deliveryEvidence);
+
+    if (!agentIdentity) {
+        writeLog('WARN',
+            `[Wake Daemon] Turn-start proof wake-submit-unknown ${subscription.id}: ` +
+            `missing subscription.properties.agentIdentity${correlation}`
+        );
+        return;
+    }
+
+    const poll = () => {
+        try {
+            const turn = findTurnPresenceAfter(db, agentIdentity, submitIso);
+            if (turn) {
+                const latencyMs = Math.max(0, new Date(turn.startedAt).getTime() - submitAttemptedAt.getTime());
+                writeLog('INFO',
+                    `[Wake Daemon] Turn-start proof wake-submit-started ${subscription.id} ` +
+                    `for ${agentIdentity} after ${latencyMs}ms ` +
+                    `(correlation=timestamp-window; turnId=${turn.turnId || 'unknown'}; startedAt=${turn.startedAt}; ` +
+                    `source=${turn.source || 'unknown'}${correlation})`
+                );
+                return;
+            }
+        } catch (error) {
+            writeLog('WARN',
+                `[Wake Daemon] Turn-start proof wake-submit-unknown ${subscription.id} ` +
+                `for ${agentIdentity}: ${error.message}${correlation}`
+            );
+            return;
+        }
+
+        if (Date.now() >= deadlineAt) {
+            writeLog('WARN',
+                `[Wake Daemon] Turn-start proof wake-submit-not-started ${subscription.id} ` +
+                `for ${agentIdentity} after ${timeoutMs}ms since ${submitIso} ` +
+                `(correlation=timestamp-window${correlation})`
+            );
+            return;
+        }
+
+        const timer = setTimeout(poll, pollMs);
+        timer.unref?.();
+    };
+
+    const timer = setTimeout(poll, pollMs);
+    timer.unref?.();
 }
 
 /**
@@ -1271,9 +1411,17 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
                 digest
             );
 
+            const submitAttemptedAt = new Date();
             await deliverViaOsascriptWithRetry(osascriptArgs, subscription.id, appName, evidenceLabel);
+            if (appName === 'Codex') {
+                scheduleCodexTurnStartProof(subscription, submitAttemptedAt, deliveryEvidence);
+            }
         } else if (adapter === 'test') {
             writeLog('INFO', `[Wake Daemon Test Adapter] Delivered ${subscription.id}: ${digest}`);
+        } else if (adapter === 'test-codex-submit') {
+            const submitAttemptedAt = new Date();
+            writeLog('INFO', `[Wake Daemon] Submit attempted ${subscription.id} via test-codex-submit to Codex${evidenceLabel}`);
+            scheduleCodexTurnStartProof(subscription, submitAttemptedAt, deliveryEvidence);
         } else if (adapter === 'test-fail') {
             // Deterministic delivery-failure hook for retry-path testing (no live target needed).
             // Log the attempted digest first so the coalesced retry content is observable, then throw.

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -104,6 +104,31 @@ function insertMessageWake(db, {agentId, subject = 'Addressed Wake Event'}) {
     return {msgId, edgeId};
 }
 
+function insertTurnPresence(db, {
+    agentId,
+    turnId = 'turn_' + crypto.randomUUID(),
+    startedAt = new Date().toISOString(),
+    source = 'codex-user-prompt-submit'
+}) {
+    const nodeId = `AGENT_TURN_PRESENCE:${agentId}:${turnId}`;
+
+    db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(nodeId, JSON.stringify({
+        id        : nodeId,
+        label     : 'AGENT_TURN_PRESENCE',
+        properties: {
+            agentIdentity : agentId,
+            turnId,
+            startedAt,
+            lastProgressAt: startedAt,
+            status        : 'active',
+            terminalState : null,
+            source
+        }
+    }));
+
+    return {nodeId, turnId};
+}
+
 test.describe('Wake Daemon', () => {
     let db;
     let daemonProcess;
@@ -258,6 +283,126 @@ test.describe('Wake Daemon', () => {
         expect(logContents).toMatch(/\[PID:\d+\]/);                                       // PID prefix
         expect(logContents).toMatch(/\[INFO\]/);                                          // level prefix
         expect(logContents).toContain('[Wake Daemon Test Adapter] Delivered');          // Same delivery line as stdout
+    });
+
+    test('#13480: Codex submit attempts log turn-start proof when turn presence appears', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-codex-started';
+
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'test-codex-submit',
+                appName       : 'Codex',
+                coalesceWindow: 1
+            }
+        });
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {
+                ...process.env,
+                NEO_MEMORY_DB_PATH                    : DB_PATH,
+                NEO_AI_DAEMON_DIR                     : DAEMON_DIR,
+                WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS: '3000',
+                WAKE_CODEX_TURN_START_PROOF_POLL_MS   : '50'
+            }
+        });
+
+        let output = '';
+        let insertedPresence = false;
+        let msgId;
+
+        const proofPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon did not log Codex turn-start proof')), 10000);
+            const onData = data => {
+                output += data.toString();
+
+                if (!insertedPresence && output.includes(`Submit attempted ${subId}`)) {
+                    insertedPresence = true;
+                    insertTurnPresence(db, {
+                        agentId,
+                        turnId   : 'started-proof',
+                        startedAt: new Date().toISOString()
+                    });
+                }
+
+                if (output.includes('wake-submit-started')) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+
+            daemonProcess.stdout.on('data', onData);
+            daemonProcess.stderr.on('data', onData);
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        ({msgId} = insertMessageWake(db, {agentId, subject: 'Codex Turn Presence Proof'}));
+
+        await proofPromise;
+
+        const logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
+        expect(logContents).toContain(`Submit attempted ${subId} via test-codex-submit to Codex`);
+        expect(logContents).toContain(`Turn-start proof wake-submit-started ${subId}`);
+        expect(logContents).toContain('turnId=started-proof');
+        expect(logContents).toContain(`messageIds=${msgId}`);
+    });
+
+    test('#13480: Codex submit attempts log not-started when turn presence does not appear', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-codex-not-started';
+
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'test-codex-submit',
+                appName       : 'Codex',
+                coalesceWindow: 1
+            }
+        });
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {
+                ...process.env,
+                NEO_MEMORY_DB_PATH                    : DB_PATH,
+                NEO_AI_DAEMON_DIR                     : DAEMON_DIR,
+                WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS: '300',
+                WAKE_CODEX_TURN_START_PROOF_POLL_MS   : '50'
+            }
+        });
+
+        let output = '';
+        let msgId;
+
+        const proofPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon did not log Codex not-started proof')), 10000);
+            const onData = data => {
+                output += data.toString();
+                if (output.includes('wake-submit-not-started')) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+
+            daemonProcess.stdout.on('data', onData);
+            daemonProcess.stderr.on('data', onData);
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        ({msgId} = insertMessageWake(db, {agentId, subject: 'Codex Missing Turn Presence'}));
+
+        await proofPromise;
+
+        const logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
+        expect(logContents).toContain(`Submit attempted ${subId} via test-codex-submit to Codex`);
+        expect(logContents).toContain(`Turn-start proof wake-submit-not-started ${subId}`);
+        expect(logContents).toContain(`messageIds=${msgId}`);
     });
 
     test('#13077: a failed wake delivery is retried, then capped with a terminal error', async () => {


### PR DESCRIPTION
Resolves #13480

Adds a bounded Codex-only turn-start observer after submit attempts. The wake daemon keeps the existing `Submit attempted` evidence boundary, then watches graph-backed `AGENT_TURN_PRESENCE` rows and logs `wake-submit-started`, `wake-submit-not-started`, or `wake-submit-unknown` with message/task/heartbeat correlation where available. The `osascript` submit primitive is unchanged.

Evidence: L2 (focused daemon unit coverage plus static checks) -> L4 required for live Codex Desktop submit reliability. Residual: post-merge live wakes must still verify human-free turn start behavior; `wake-submit-started` is timestamp-window evidence until a future nonce can prove script-vs-human causality.

## Deltas from ticket

- Implements observability/classification first, matching the fresh recurrence disposition.
- Leaves the active `osascript` route and key sequence unchanged.
- Documents the timestamp-window caveat in source so a later human Enter is not over-read as proof that scripted Enter succeeded.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` — 38 passed.
- `git diff --check` — passed.
- `node --check ai/daemons/wake/daemon.mjs` — passed.
- `node --check test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` — passed.
- `npm run ai:lint-mcp-test-locations` — passed.
- Pre-commit hooks passed: whitespace, shorthand, aiConfig mutation, JSDoc types, ticket archaeology, block alignment.

## Post-Merge Validation

- [ ] Observe the next unsuppressed `@neo-gpt` Codex wake and confirm `WAKE_SUB:7648b86c-2f1e-43a8-95a6-cc399f66a938` logs a turn-start classifier outcome.
- [ ] If the operator still has to press Enter, use the new classifier row to distinguish no-turn-start from timestamp-window/human-entry ambiguity.
- [ ] If timestamp-window ambiguity remains material, file the follow-up nonce path from wake payload to `UserPromptSubmit` turn-presence note.

## Commits

- `fa3b17322` — add Codex submit turn-start classifier and tests.

Authored by Euclid (GPT-5 Codex, Codex Desktop). Session 2513f864-fce4-4a47-8d4b-afe8a5532e91.