### PR TITLE
feat(memory-core): MC defrag repair path behind --allow-memory-core (#13634)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -650,7 +650,12 @@ export async function rewriteCollectionViaShadowPromotion({
  *
  * Fail-loud: a collection with ANY unrecoverable row (document-less / metadata-absent) aborts its
  * own promotion with counts — never a silent partial promote. The seams (`auditFn` / `extractFn` /
- * `promoteFn`) are injectable for unit isolation.
+ * `promoteFn` / `clearStateFn` / `writeStateFn`) are injectable for unit isolation.
+ *
+ * State-marker lifecycle: `promoteFn` writes durable per-phase markers, so a fully successful repair
+ * CLEARS the marker (`clearStateFn`) before returning — else the next run aborts as DEFRAG_INCOMPLETE_STATE.
+ * An aborted/partial repair instead rewrites an explicit `memory-core-repair-aborted` marker (`writeStateFn`)
+ * so `assertNoIncompleteDefragState` blocks rerun with an accurate diagnostic, not a stale mid-phase marker.
  *
  * This function is INERT until wired behind the explicit `--allow-memory-core` opt-in; the default
  * `assertDefragTargetSupported` fail-closed stands until then.
@@ -667,6 +672,8 @@ export async function rewriteCollectionViaShadowPromotion({
  * @param {Function} [options.auditFn=auditChromaVectorCoverage] Enumeration seam (test injection).
  * @param {Function} [options.extractFn=extractMemoryCoreCollectionData] Extract + re-embed seam.
  * @param {Function} [options.promoteFn=rewriteCollectionViaShadowPromotion] Shadow-promotion seam.
+ * @param {Function} [options.clearStateFn=clearDefragState] Clears the durable marker on a fully successful repair.
+ * @param {Function} [options.writeStateFn=writeDefragState] Rewrites the explicit aborted marker on a partial repair.
  * @param {Function} [options.log=console.log] Log sink.
  * @returns {Promise<{results: Object[]}>} Per collection: `{collectionName, promotion, counts}` on success
  *   or `{collectionName, aborted: true, unrecoverable, counts}` when fail-loud aborts the promotion.
@@ -680,10 +687,12 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
     embeddingFunction,
     statePath,
     stateBase = {},
-    auditFn   = auditChromaVectorCoverage,
-    extractFn = extractMemoryCoreCollectionData,
-    promoteFn = rewriteCollectionViaShadowPromotion,
-    log       = console.log
+    auditFn      = auditChromaVectorCoverage,
+    extractFn    = extractMemoryCoreCollectionData,
+    promoteFn    = rewriteCollectionViaShadowPromotion,
+    clearStateFn = clearDefragState,
+    writeStateFn = writeDefragState,
+    log          = console.log
 } = {}) {
     const coverage = await auditFn({
         snapshotPath,
@@ -712,6 +721,23 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
 
         const promotion = await promoteFn({client, collectionName, data, embeddingFunction, statePath, stateBase});
         results.push({collectionName, promotion, counts});
+    }
+
+    // State-marker lifecycle (mirrors the KB path's end-of-run clearDefragState): rewriteCollectionViaShadowPromotion
+    // wrote durable per-phase markers, so a fully successful repair MUST clear the marker — else the next run aborts
+    // as DEFRAG_INCOMPLETE_STATE. An aborted/partial repair instead rewrites an explicit aborted marker so
+    // assertNoIncompleteDefragState blocks rerun with an accurate diagnostic, not a stale mid-phase marker.
+    if (statePath) {
+        if (anyRepairAborted(results)) {
+            await writeStateFn({statePath, state: {
+                ...stateBase,
+                phase   : 'memory-core-repair-aborted',
+                aborted : results.filter(result => result.aborted).map(result => result.collectionName),
+                promoted: results.filter(result => result.promotion).map(result => result.collectionName)
+            }});
+        } else {
+            await clearStateFn({statePath});
+        }
     }
 
     return {results};
@@ -818,7 +844,9 @@ async function defragChromaDB() {
         // 2.5 Memory Core repair-defrag path (explicit --allow-memory-core opt-in).
         // MC cannot use the KB extract/promote below — its missing-vector rows throw on stored-embedding
         // export — so it runs the dedicated full-enumeration repair (extract intact + re-embed missing)
-        // against the pre-nuke snapshot, then shadow-promotes the recovered data. Returns before the KB path.
+        // against the pre-nuke snapshot, then shadow-promotes the recovered data. The orchestration clears the
+        // defrag state marker on clean success (or rewrites an explicit aborted marker on a partial repair)
+        // before this branch returns ahead of the KB path.
         if (targetName === 'memory-core') {
             console.log(`\n3️⃣  Memory Core repair-defrag: full-enumeration extract + re-embed + shadow-promote...`);
             const {default: TextEmbeddingService} = await import('../../services/memory-core/TextEmbeddingService.mjs');
@@ -829,7 +857,8 @@ async function defragChromaDB() {
                 persistDir       : backupPath,
                 embedFn          : docs => TextEmbeddingService.embedTexts(docs, config.embeddingProvider),
                 embeddingFunction: dummyEf,
-                statePath
+                statePath,
+                stateBase        : {targetName}
             });
 
             for (const result of results) {

--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -1,13 +1,15 @@
-import {program}       from 'commander';
-import {ChromaClient}  from 'chromadb';
-import {execSync}      from 'child_process';
-import crypto          from 'crypto';
-import fs              from 'fs-extra';
-import path            from 'path';
-import {fileURLToPath, pathToFileURL} from 'url';
-import Neo             from '../../../src/Neo.mjs';
-import AiConfig        from '../../config.mjs';
+import {program}                             from 'commander';
+import {ChromaClient}                        from 'chromadb';
+import {execSync}                            from 'child_process';
+import crypto                                from 'crypto';
+import fs                                    from 'fs-extra';
+import path                                  from 'path';
+import {fileURLToPath, pathToFileURL}        from 'url';
+import Neo                                   from '../../../src/Neo.mjs';
+import AiConfig                              from '../../config.mjs';
 import {registerNeoChromaEmbeddingFunctions} from '../../services/shared/vector/chromaClientPrimitives.mjs';
+import {auditChromaVectorCoverage}           from './checkChromaIntegrity.mjs';
+import {extractMemoryCoreCollectionData}     from './repairMemoryCoreStoredEmbeddings.mjs';
 
 /**
  * @summary Defragments collection groups inside the unified ChromaDB store.
@@ -80,7 +82,7 @@ registerNeoChromaEmbeddingFunctions({
 export const TARGETS = {
     'knowledge-base': {
         configPath: '../../mcp/server/knowledge-base/config.mjs',
-        adapt: (cfg) => ({
+        adapt     : (cfg) => ({
             host       : cfg.host,
             path       : cfg.path,
             port       : cfg.port,
@@ -89,11 +91,12 @@ export const TARGETS = {
     },
     'memory-core'   : {
         configPath: '../../mcp/server/memory-core/config.mjs',
-        adapt: (cfg) => ({
-            host       : cfg.engines.chroma.host,
-            path       : cfg.engines.chroma.dataDir,
-            port       : cfg.engines.chroma.port,
-            collections: [
+        adapt     : (cfg) => ({
+            host             : cfg.engines.chroma.host,
+            path             : cfg.engines.chroma.dataDir,
+            port             : cfg.engines.chroma.port,
+            embeddingProvider: cfg.embeddingProvider,
+            collections      : [
                 cfg.collections.memory,
                 cfg.collections.session,
                 cfg.collections.graph
@@ -161,14 +164,17 @@ export function resolveDefragSnapshotRetention({
 }
 
 /**
- * Fails closed for target groups whose interruption safety is not yet proven.
+ * Fails closed for target groups whose interruption safety is not yet proven. Memory Core is allowed
+ * ONLY behind the explicit `allowMemoryCore` opt-in (the `--allow-memory-core` CLI flag), which routes
+ * it through the dedicated full-enumeration repair path — never the KB delete/recreate defrag.
  *
  * @param {Object} options
  * @param {String} options.targetName CLI target name.
+ * @param {Boolean} [options.allowMemoryCore=false] Explicit opt-in to the Memory Core repair path.
  * @returns {void}
  */
-export function assertDefragTargetSupported({targetName} = {}) {
-    if (targetName === 'memory-core') {
+export function assertDefragTargetSupported({targetName, allowMemoryCore = false} = {}) {
+    if (targetName === 'memory-core' && !allowMemoryCore) {
         const error = new Error(MEMORY_CORE_UNSAFE_MESSAGE);
         error.code  = 'DEFRAG_MEMORY_CORE_UNSAFE';
         throw error
@@ -550,9 +556,9 @@ export async function rewriteCollectionViaShadowPromotion({
     await writeDefragState({statePath, state: {...baseState, phase: 'creating-shadow'}});
 
     shadowCollection = await client.createCollection({
-        name             : shadowName,
+        name    : shadowName,
         embeddingFunction,
-        metadata         : {"hnsw:space": "cosine"}
+        metadata: {"hnsw:space": "cosine"}
     });
 
     try {
@@ -631,6 +637,100 @@ export async function rewriteCollectionViaShadowPromotion({
 }
 
 /**
+ * @summary Repairs Memory Core collections' missing stored-embeddings via FULL (uncapped) enumeration,
+ * then promotes the recovered data through the existing shadow-promotion path.
+ *
+ * MC cannot use the KB extract path — `collection.get({include:['embeddings']})` throws "Error finding id"
+ * for the missing-vector rows. This orchestration instead, per MC collection:
+ *   1. enumerates the FULL metadata-id vs vector-index-id drift (uncapped — `auditChromaVectorCoverage`
+ *      with `includeFullIds`, NOT the sampled coverage audit);
+ *   2. extracts intact rows with their stored vectors and RE-EMBEDS the missing-vector rows from their
+ *      still-materializing documents (`extractMemoryCoreCollectionData`);
+ *   3. promotes the recovered `{ids, embeddings, documents, metadatas}` through the shadow/parking promotion.
+ *
+ * Fail-loud: a collection with ANY unrecoverable row (document-less / metadata-absent) aborts its
+ * own promotion with counts — never a silent partial promote. The seams (`auditFn` / `extractFn` /
+ * `promoteFn`) are injectable for unit isolation.
+ *
+ * This function is INERT until wired behind the explicit `--allow-memory-core` opt-in; the default
+ * `assertDefragTargetSupported` fail-closed stands until then.
+ *
+ * @param {Object} options
+ * @param {Object} options.client Chroma client.
+ * @param {String[]} options.collections MC collection names to repair.
+ * @param {String} options.snapshotPath SQLite metadata snapshot path (the full-id enumeration source).
+ * @param {String} options.persistDir HNSW persist dir (the vector-index-id source).
+ * @param {Function} options.embedFn `documents -> embeddings` re-embedder (e.g. TextEmbeddingService.embedTexts).
+ * @param {Object} options.embeddingFunction Chroma embedding function (dummy, for raw-vector moves).
+ * @param {String} options.statePath Durable defrag-state marker path.
+ * @param {Object} [options.stateBase={}] Stable fields written into every phase marker.
+ * @param {Function} [options.auditFn=auditChromaVectorCoverage] Enumeration seam (test injection).
+ * @param {Function} [options.extractFn=extractMemoryCoreCollectionData] Extract + re-embed seam.
+ * @param {Function} [options.promoteFn=rewriteCollectionViaShadowPromotion] Shadow-promotion seam.
+ * @param {Function} [options.log=console.log] Log sink.
+ * @returns {Promise<{results: Object[]}>} Per collection: `{collectionName, promotion, counts}` on success
+ *   or `{collectionName, aborted: true, unrecoverable, counts}` when fail-loud aborts the promotion.
+ */
+export async function repairMemoryCoreCollectionsViaFullEnumeration({
+    client,
+    collections,
+    snapshotPath,
+    persistDir,
+    embedFn,
+    embeddingFunction,
+    statePath,
+    stateBase = {},
+    auditFn   = auditChromaVectorCoverage,
+    extractFn = extractMemoryCoreCollectionData,
+    promoteFn = rewriteCollectionViaShadowPromotion,
+    log       = console.log
+} = {}) {
+    const coverage = await auditFn({
+        snapshotPath,
+        persistDir,
+        collectionNames: collections,
+        includeFullIds : true
+    });
+    const results = [];
+
+    for (const collectionName of collections) {
+        const cov = coverage.collections.find(entry => entry.name === collectionName);
+        if (!cov) {
+            throw new Error(`repairMemoryCoreCollectionsViaFullEnumeration: no coverage row for '${collectionName}' — refusing to promote a collection the enumeration never saw.`);
+        }
+
+        const {allIds, missingVectorIds}     = cov,
+              collection                     = await client.getCollection({name: collectionName, embeddingFunction}),
+              {data, unrecoverable, counts}  = await extractFn({collection, allIds, missingVectorIds, embedFn});
+
+        // Fail-loud: never promote a collection that lost rows to unrecoverable extraction.
+        if (unrecoverable.length > 0) {
+            log(`   ⚠️  '${collectionName}': ${unrecoverable.length} unrecoverable row(s) (document-less / metadata-absent) — aborting its promotion, no silent drop. Counts: ${JSON.stringify(counts)}`);
+            results.push({collectionName, aborted: true, unrecoverable, counts});
+            continue;
+        }
+
+        const promotion = await promoteFn({client, collectionName, data, embeddingFunction, statePath, stateBase});
+        results.push({collectionName, promotion, counts});
+    }
+
+    return {results};
+}
+
+/**
+ * @summary True when any repair result aborted (a collection with unrecoverable rows). The
+ * operator-facing fail-loud predicate: an aborted collection is never a successful repair, so the
+ * `--allow-memory-core` CLI path exits non-zero on it (mirrors the KB extractionErrors / hasRestoreErrors
+ * discipline) rather than reporting success on a partial repair.
+ *
+ * @param {Object[]} [results=[]] Per-collection results from `repairMemoryCoreCollectionsViaFullEnumeration`.
+ * @returns {Boolean}
+ */
+export function anyRepairAborted(results = []) {
+    return results.some(result => result?.aborted === true);
+}
+
+/**
  * Main execution function for the defragmentation process.
  *
  * It orchestrates the Snapshot -> Extract -> Shadow Load -> Promote -> Cleanup pipeline.
@@ -650,6 +750,7 @@ async function defragChromaDB() {
         .name('defragChromaDB')
         .description('Defragment ChromaDB instances by rewriting data and cleaning orphaned files.')
         .requiredOption('-t, --target <name>', 'Database target (knowledge-base, memory-core)')
+        .option('--allow-memory-core', 'Opt in to the Memory Core repair-defrag path (default: fails closed)')
         .parse(process.argv);
 
     const options    = program.opts();
@@ -663,7 +764,7 @@ async function defragChromaDB() {
         const config    = await loadConfig(targetName);
         const statePath = resolveDefragStatePath({targetName});
 
-        assertDefragTargetSupported({targetName});
+        assertDefragTargetSupported({targetName, allowMemoryCore: options.allowMemoryCore});
         await assertNoIncompleteDefragState({statePath});
 
         const DB_PATH = config.path;
@@ -713,6 +814,42 @@ async function defragChromaDB() {
         // Dummy embedding function — single source of truth: Tier-1 AiConfig.dummyEmbeddingFunction.
         // Satisfies the Chroma client for raw embeddings without re-generating via a provider.
         const dummyEf = AiConfig.dummyEmbeddingFunction;
+
+        // 2.5 Memory Core repair-defrag path (explicit --allow-memory-core opt-in).
+        // MC cannot use the KB extract/promote below — its missing-vector rows throw on stored-embedding
+        // export — so it runs the dedicated full-enumeration repair (extract intact + re-embed missing)
+        // against the pre-nuke snapshot, then shadow-promotes the recovered data. Returns before the KB path.
+        if (targetName === 'memory-core') {
+            console.log(`\n3️⃣  Memory Core repair-defrag: full-enumeration extract + re-embed + shadow-promote...`);
+            const {default: TextEmbeddingService} = await import('../../services/memory-core/TextEmbeddingService.mjs');
+            const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
+                client,
+                collections      : config.collections,
+                snapshotPath     : path.join(backupPath, 'chroma.sqlite3'),
+                persistDir       : backupPath,
+                embedFn          : docs => TextEmbeddingService.embedTexts(docs, config.embeddingProvider),
+                embeddingFunction: dummyEf,
+                statePath
+            });
+
+            for (const result of results) {
+                console.log(result.aborted
+                    ? `   ⚠️  ${result.collectionName}: ABORTED — ${result.unrecoverable.length} unrecoverable row(s); counts ${JSON.stringify(result.counts)}`
+                    : `   ✅ ${result.collectionName}: repaired + promoted; counts ${JSON.stringify(result.counts)}`);
+            }
+
+            const finalSize = await getDirSize(DB_PATH);
+            console.log(`   📊 Final Size: ${(finalSize / 1024 / 1024).toFixed(2)} MB`);
+
+            // Fail loud at the operator boundary: an aborted collection is NOT a successful repair
+            // (mirrors the KB extractionErrors / hasRestoreErrors -> process.exit(1) discipline below).
+            if (anyRepairAborted(results)) {
+                const abortedNames = results.filter(result => result.aborted).map(result => result.collectionName);
+                console.error(`❌ Memory Core repair aborted for ${abortedNames.join(', ')} (unrecoverable rows) — NOT a successful repair; resolve the unrecoverable rows and re-run. Counts logged above.`);
+                process.exit(1);
+            }
+            return;
+        }
 
         // 3. Extract All Data (Multi-Collection)
         console.log(`\n3️⃣  Fetching data from all collections...`);
@@ -814,11 +951,11 @@ async function defragChromaDB() {
                 console.log(`   Rewriting ${colName}...`);
                 const result = await rewriteCollectionViaShadowPromotion({
                     client,
-                    collectionName    : colName,
+                    collectionName   : colName,
                     data,
-                    embeddingFunction : dummyEf,
+                    embeddingFunction: dummyEf,
                     statePath,
-                    stateBase         : {
+                    stateBase        : {
                         targetName,
                         dbPath      : DB_PATH,
                         snapshotPath: backupPath,

--- a/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
@@ -12,14 +12,16 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
           embedFn           = async docs => docs.map(() => [0.1, 0.2]);
 
     function makeSeams({coverage, extractResults}) {
-        const calls = {audit: [], extract: [], promote: []};
+        const calls = {audit: [], extract: [], promote: [], clearState: [], writeState: []};
 
         return {
             calls,
-            client   : {getCollection: async ({name}) => ({_name: name})},
-            auditFn  : async args => { calls.audit.push(args);   return coverage; },
-            extractFn: async args => { calls.extract.push(args); return extractResults[args.collection._name]; },
-            promoteFn: async args => { calls.promote.push(args); return {promoted: args.collectionName}; }
+            client      : {getCollection: async ({name}) => ({_name: name})},
+            auditFn     : async args => { calls.audit.push(args);   return coverage; },
+            extractFn   : async args => { calls.extract.push(args); return extractResults[args.collection._name]; },
+            promoteFn   : async args => { calls.promote.push(args); return {promoted: args.collectionName}; },
+            clearStateFn: async args => { calls.clearState.push(args); },
+            writeStateFn: async args => { calls.writeState.push(args); }
         };
     }
 
@@ -32,11 +34,11 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
                   'mc-memory': {data: {ids: ['a', 'b', 'c'], embeddings: [[1], [2], [3]], documents: ['', '', ''], metadatas: [{}, {}, {}]}, unrecoverable: [], counts: {total: 3, intact: 2, reEmbedded: 1, unrecoverable: 0}},
                   'mc-graph' : {data: {ids: ['x'], embeddings: [[9]], documents: [''], metadatas: [{}]},             unrecoverable: [], counts: {total: 1, intact: 1, reEmbedded: 0, unrecoverable: 0}}
               },
-              {calls, client, auditFn, extractFn, promoteFn} = makeSeams({coverage, extractResults});
+              {calls, client, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
 
         const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-memory', 'mc-graph'], snapshotPath: '/snap', persistDir: '/persist',
-            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, log: () => {}
+            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, clearStateFn, writeStateFn, log: () => {}
         });
 
         // exactly one enumeration call, uncapped (includeFullIds), over the requested collections
@@ -53,6 +55,10 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
         expect(calls.promote[0].data.ids).toEqual(['a', 'b', 'c']);
         expect(results).toHaveLength(2);
         expect(results.every(r => r.promotion && !r.aborted)).toBe(true);
+
+        // clean success CLEARS the durable marker (no rerun-poisoning); the aborted marker is never written
+        expect(calls.clearState).toEqual([{statePath: '/state'}]);
+        expect(calls.writeState).toHaveLength(0);
     });
 
     test('fail-loud: unrecoverable rows abort that collection promotion (no silent drop)', async () => {
@@ -60,17 +66,27 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
               extractResults = {
                   'mc-memory': {data: {ids: ['a'], embeddings: [[1]], documents: [''], metadatas: [{}]}, unrecoverable: ['b'], counts: {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}}
               },
-              {calls, client, auditFn, extractFn, promoteFn} = makeSeams({coverage, extractResults});
+              {calls, client, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
 
         const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
-            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, log: () => {}
+            embedFn, embeddingFunction, statePath: '/state', stateBase: {targetName: 'memory-core'},
+            auditFn, extractFn, promoteFn, clearStateFn, writeStateFn, log: () => {}
         });
 
         expect(calls.promote).toHaveLength(0);              // never promoted
         expect(results[0].aborted).toBe(true);
         expect(results[0].unrecoverable).toEqual(['b']);
         expect(results[0].counts.unrecoverable).toBe(1);
+
+        // an aborted repair NEVER clears the marker; it rewrites an explicit aborted marker so the next run
+        // blocks as DEFRAG_INCOMPLETE_STATE with an accurate diagnostic
+        expect(calls.clearState).toHaveLength(0);
+        expect(calls.writeState).toHaveLength(1);
+        expect(calls.writeState[0].statePath).toBe('/state');
+        expect(calls.writeState[0].state.phase).toBe('memory-core-repair-aborted');
+        expect(calls.writeState[0].state.targetName).toBe('memory-core');
+        expect(calls.writeState[0].state.aborted).toEqual(['mc-memory']);
     });
 
     test('throws when the enumeration returns no coverage row for a requested collection', async () => {
@@ -80,6 +96,22 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
             client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
             embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, log: () => {}
         })).rejects.toThrow(/no coverage row for 'mc-memory'/);
+    });
+
+    test('omitting statePath skips all state-marker ops (no marker lifecycle without a path)', async () => {
+        const coverage = {collections: [{name: 'mc-memory', allIds: ['a'], missingVectorIds: []}]},
+              extractResults = {
+                  'mc-memory': {data: {ids: ['a'], embeddings: [[1]], documents: [''], metadatas: [{}]}, unrecoverable: [], counts: {total: 1, intact: 1, reEmbedded: 0, unrecoverable: 0}}
+              },
+              {calls, client, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
+
+        await repairMemoryCoreCollectionsViaFullEnumeration({
+            client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
+            embedFn, embeddingFunction, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn, log: () => {}
+        });
+
+        expect(calls.clearState).toHaveLength(0);
+        expect(calls.writeState).toHaveLength(0);
     });
 });
 

--- a/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
@@ -1,0 +1,118 @@
+import {test, expect}                                                                                 from '@playwright/test';
+import {anyRepairAborted, assertDefragTargetSupported, repairMemoryCoreCollectionsViaFullEnumeration} from '../../../../../../ai/scripts/maintenance/defragChromaDB.mjs';
+
+/**
+ * AC4 — the Memory Core defrag-wiring orchestration: full (uncapped) enumeration ->
+ * extract + re-embed -> shadow-promotion, with fail-loud on unrecoverable rows. The seams
+ * (auditFn / extractFn / promoteFn) are injected so the orchestration is verified without a
+ * live Chroma store.
+ */
+test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () => {
+    const embeddingFunction = {name: 'dummy'},
+          embedFn           = async docs => docs.map(() => [0.1, 0.2]);
+
+    function makeSeams({coverage, extractResults}) {
+        const calls = {audit: [], extract: [], promote: []};
+
+        return {
+            calls,
+            client   : {getCollection: async ({name}) => ({_name: name})},
+            auditFn  : async args => { calls.audit.push(args);   return coverage; },
+            extractFn: async args => { calls.extract.push(args); return extractResults[args.collection._name]; },
+            promoteFn: async args => { calls.promote.push(args); return {promoted: args.collectionName}; }
+        };
+    }
+
+    test('full-enumeration audit feeds extract + promote per collection (happy path)', async () => {
+        const coverage = {collections: [
+                  {name: 'mc-memory', allIds: ['a', 'b', 'c'], missingVectorIds: ['c']},
+                  {name: 'mc-graph',  allIds: ['x'],           missingVectorIds: []}
+              ]},
+              extractResults = {
+                  'mc-memory': {data: {ids: ['a', 'b', 'c'], embeddings: [[1], [2], [3]], documents: ['', '', ''], metadatas: [{}, {}, {}]}, unrecoverable: [], counts: {total: 3, intact: 2, reEmbedded: 1, unrecoverable: 0}},
+                  'mc-graph' : {data: {ids: ['x'], embeddings: [[9]], documents: [''], metadatas: [{}]},             unrecoverable: [], counts: {total: 1, intact: 1, reEmbedded: 0, unrecoverable: 0}}
+              },
+              {calls, client, auditFn, extractFn, promoteFn} = makeSeams({coverage, extractResults});
+
+        const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
+            client, collections: ['mc-memory', 'mc-graph'], snapshotPath: '/snap', persistDir: '/persist',
+            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, log: () => {}
+        });
+
+        // exactly one enumeration call, uncapped (includeFullIds), over the requested collections
+        expect(calls.audit).toHaveLength(1);
+        expect(calls.audit[0].includeFullIds).toBe(true);
+        expect(calls.audit[0].collectionNames).toEqual(['mc-memory', 'mc-graph']);
+
+        // extract receives the FULL {allIds, missingVectorIds} from the coverage, per collection
+        expect(calls.extract.map(c => c.allIds)).toEqual([['a', 'b', 'c'], ['x']]);
+        expect(calls.extract.map(c => c.missingVectorIds)).toEqual([['c'], []]);
+
+        // both promoted with their recovered data
+        expect(calls.promote.map(c => c.collectionName)).toEqual(['mc-memory', 'mc-graph']);
+        expect(calls.promote[0].data.ids).toEqual(['a', 'b', 'c']);
+        expect(results).toHaveLength(2);
+        expect(results.every(r => r.promotion && !r.aborted)).toBe(true);
+    });
+
+    test('fail-loud: unrecoverable rows abort that collection promotion (no silent drop)', async () => {
+        const coverage = {collections: [{name: 'mc-memory', allIds: ['a', 'b'], missingVectorIds: ['b']}]},
+              extractResults = {
+                  'mc-memory': {data: {ids: ['a'], embeddings: [[1]], documents: [''], metadatas: [{}]}, unrecoverable: ['b'], counts: {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}}
+              },
+              {calls, client, auditFn, extractFn, promoteFn} = makeSeams({coverage, extractResults});
+
+        const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
+            client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
+            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, log: () => {}
+        });
+
+        expect(calls.promote).toHaveLength(0);              // never promoted
+        expect(results[0].aborted).toBe(true);
+        expect(results[0].unrecoverable).toEqual(['b']);
+        expect(results[0].counts.unrecoverable).toBe(1);
+    });
+
+    test('throws when the enumeration returns no coverage row for a requested collection', async () => {
+        const {client, auditFn, extractFn, promoteFn} = makeSeams({coverage: {collections: []}, extractResults: {}});
+
+        await expect(repairMemoryCoreCollectionsViaFullEnumeration({
+            client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
+            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, log: () => {}
+        })).rejects.toThrow(/no coverage row for 'mc-memory'/);
+    });
+});
+
+test.describe('assertDefragTargetSupported — Memory Core opt-in gate (#13634 AC4)', () => {
+    test('fails closed for memory-core by default (no opt-in)', () => {
+        expect(() => assertDefragTargetSupported({targetName: 'memory-core'})).toThrow(/Memory Core defrag is disabled/);
+    });
+
+    test('allows memory-core only with the explicit allowMemoryCore opt-in', () => {
+        expect(() => assertDefragTargetSupported({targetName: 'memory-core', allowMemoryCore: true})).not.toThrow();
+    });
+
+    test('knowledge-base is always allowed', () => {
+        expect(() => assertDefragTargetSupported({targetName: 'knowledge-base'})).not.toThrow();
+    });
+});
+
+test.describe('anyRepairAborted — operator fail-loud predicate (#13634 AC4)', () => {
+    test('true when any collection aborted — the CLI exits non-zero on this', () => {
+        expect(anyRepairAborted([
+            {collectionName: 'mc-memory', promotion: {}},
+            {collectionName: 'mc-graph',  aborted: true, unrecoverable: ['x'], counts: {unrecoverable: 1}}
+        ])).toBe(true);
+    });
+
+    test('false when every collection promoted cleanly', () => {
+        expect(anyRepairAborted([
+            {collectionName: 'mc-memory', promotion: {}},
+            {collectionName: 'mc-graph',  promotion: {}}
+        ])).toBe(false);
+    });
+
+    test('false for an empty result set', () => {
+        expect(anyRepairAborted([])).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Delivers **AC4 of #13496** — the safe Memory Core defrag repair path, behind an explicit `--allow-memory-core` opt-in. MC defrag failed closed because the KB extract (`collection.get({include:['embeddings']})`) throws "Error finding id" for the missing-vector rows the stored-embedding export bug leaves behind. This adds `repairMemoryCoreCollectionsViaFullEnumeration`: per MC collection, full (uncapped) metadata-vs-vector enumeration (`auditChromaVectorCoverage({includeFullIds:true})`) → extract intact rows + re-embed the missing-vector rows from their documents (`extractMemoryCoreCollectionData`) → shadow-promote the recovered data.

**Two-level fail-loud + state-marker lifecycle:**
- any unrecoverable row aborts that collection's promotion (no silent partial), and
- an aborted/partial repair exits the operator CLI non-zero (`anyRepairAborted` → `process.exit(1)`), and
- a clean repair clears the durable defrag state marker (an aborted repair rewrites an explicit `memory-core-repair-aborted` marker) so a successful run never poisons the next as `DEFRAG_INCOMPLETE_STATE`.

Resolves #13634. Refs #13496 (AC4; AC5 runbook + AC6 + live validation stay open).

## Deltas from ticket

None — implements the leaf as specified. The flag is a CLI opt-in (`--allow-memory-core`) rather than a persistent config leaf, so enabling MC-defrag is a deliberate per-run decision (a safety gate should not be a default that can be left on).

## Behavior / safety

- **Default unchanged:** `assertDefragTargetSupported` still fails closed for `memory-core` — the MC repair path runs ONLY with the explicit `--allow-memory-core` flag.
- **Opt-in-gated:** no regression risk to the existing KB defrag or the MC fail-closed until an operator opts in.
- **Fail-loud (collection):** unrecoverable rows abort the promotion with counts — never a silent partial promote.
- **Fail-loud (operator CLI):** any aborted collection exits non-zero (`process.exit(1)`) — a partial repair never reports success (mirrors the KB `extractionErrors`/`hasRestoreErrors` discipline).
- **State-marker lifecycle:** a clean repair clears the durable marker; an aborted repair rewrites an explicit `memory-core-repair-aborted` marker so `assertNoIncompleteDefragState` blocks rerun with an accurate diagnostic instead of poisoning the next run.

## Test Evidence

10/10 unit tests in `defragMemoryCoreRepair.spec.mjs` (injected audit/extract/promote/state seams, no live Chroma):
- orchestration (4): full-enum → extract → promote (happy path, asserts clean-success marker clear), fail-loud abort on unrecoverable (asserts the explicit aborted marker), throw on missing coverage row, `statePath`-omitted no-op.
- gate (3): fail-closed-by-default, opt-in-allows, KB-always-allowed.
- predicate (3): `anyRepairAborted` true-on-aborted / false-clean / false-empty.

`npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs` → **10 passed**.

Evidence: L2 (unit tests exercise the orchestration + the gate + the marker lifecycle with injected seams) → L3 (live MC repair run) required for the close-target's runtime AC. Residual: AC4 live-validation [#13634].

## Post-Merge Validation

The live MC repair run (`defragChromaDB --target memory-core --allow-memory-core`) is operator/env-gated — the sandbox cannot reach Chroma (IPv6-loopback only). Default behavior is unchanged (fails closed), so there is no regression risk until an operator explicitly opts in and runs it.

## Commits

1. `14f5561e2` — the repair orchestration core + the enable (flag-gate + `--allow-memory-core` CLI + `embeddingProvider` adapt + MC-routing) + two-level fail-loud (collection-abort + CLI `process.exit(1)`).
2. `1de499377` — the MC defrag state-marker lifecycle fix (clear on clean success, rewrite explicit aborted marker on partial) + 3 marker-lifecycle tests. Addresses @neo-gpt Cycle-2 RA1.

---

Authored by Ada (Claude Opus 4.8, Claude Code). Session aab4962b-4da9-4b52-a212-3fda560d70ad.
