### PR TITLE
feat(codex): add wake submit nonce causality (#13636)

### DIFF
--- a/.codex/hooks/codex-context.mjs
+++ b/.codex/hooks/codex-context.mjs
@@ -1,16 +1,76 @@
-import {readFileSync} from 'node:fs';
-import {randomUUID} from 'node:crypto';
+import {readFileSync}                 from 'node:fs';
+import {randomUUID}                   from 'node:crypto';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import {
     resolveMemoryCoreGraphPath,
     resolveTurnPresenceRuntimeConfig
 } from '../../ai/mcp/server/memory-core/helpers/TurnPresenceConfig.mjs';
 
+const WAKE_SUBMIT_NONCE_PATTERN = /NEO_WAKE_SUBMIT_NONCE:([0-9a-fA-F-]{36})/;
+
 function normalizeAgentIdentity(value) {
     if (!value || typeof value !== 'string') return null;
     const trimmed = value.trim();
     if (!trimmed) return null;
     return trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
+}
+
+function normalizeWakeSubmitNonce(value) {
+    if (!value || typeof value !== 'string') return null;
+
+    const trimmed = value.trim();
+    return /^[0-9a-fA-F-]{36}$/.test(trimmed) ? trimmed.toLowerCase() : null;
+}
+
+/**
+ * @summary Extracts a wake-submit nonce from a Codex hook payload or raw prompt text.
+ * @param {*} value Hook payload value.
+ * @param {Number} [depth=0] Recursion guard for nested payloads.
+ * @returns {String|null}
+ */
+export function extractWakeSubmitNonce(value, depth = 0) {
+    if (depth > 8 || value == null) return null;
+
+    if (typeof value === 'string') {
+        const match = value.match(WAKE_SUBMIT_NONCE_PATTERN);
+        return normalizeWakeSubmitNonce(match?.[1]);
+    }
+
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            const nonce = extractWakeSubmitNonce(item, depth + 1);
+            if (nonce) return nonce;
+        }
+        return null;
+    }
+
+    if (typeof value === 'object') {
+        for (const item of Object.values(value)) {
+            const nonce = extractWakeSubmitNonce(item, depth + 1);
+            if (nonce) return nonce;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * @summary Reads the Codex hook event payload from stdin when Codex provides one.
+ * @param {Object} [options]
+ * @param {NodeJS.ReadStream} [options.stdin=process.stdin]
+ * @returns {Promise<String>}
+ */
+export function readHookPayload({stdin = process.stdin} = {}) {
+    if (stdin.isTTY) return Promise.resolve('');
+
+    return new Promise((resolve, reject) => {
+        let data = '';
+
+        stdin.setEncoding('utf8');
+        stdin.on('data',  chunk => data += chunk);
+        stdin.on('end',   ()    => resolve(data));
+        stdin.on('error', reject);
+    });
 }
 
 async function withTimeout(promise, timeoutMs) {
@@ -33,11 +93,13 @@ async function withTimeout(promise, timeoutMs) {
  * @param {Object} options
  * @param {Object} [options.env=process.env] Environment source.
  * @param {String} [options.rootDir] Repository root.
+ * @param {*} [options.hookPayload] Codex hook payload used to extract a wake-submit nonce.
  * @returns {Promise<void>|undefined}
  */
 export async function recordTurnStarted({
     env = process.env,
-    rootDir = fileURLToPath(new URL('../../', import.meta.url))
+    rootDir = fileURLToPath(new URL('../../', import.meta.url)),
+    hookPayload
 } = {}) {
     const agentIdentity = normalizeAgentIdentity(env.NEO_AGENT_IDENTITY);
     if (!agentIdentity) return;
@@ -47,14 +109,15 @@ export async function recordTurnStarted({
 
     return withTimeout(writeTurnStarted({
         agentIdentity,
-        dbPath: resolveMemoryCoreGraphPath({env, rootDir}),
+        dbPath         : resolveMemoryCoreGraphPath({env, rootDir}),
         freshMs,
         noteMaxChars,
-        ttlMs
+        ttlMs,
+        wakeSubmitNonce: extractWakeSubmitNonce(hookPayload)
     }), timeoutMs);
 }
 
-async function writeTurnStarted({agentIdentity, dbPath, freshMs, noteMaxChars, ttlMs}) {
+async function writeTurnStarted({agentIdentity, dbPath, freshMs, noteMaxChars, ttlMs, wakeSubmitNonce}) {
     const {default: Database} = await import('better-sqlite3');
     const db = new Database(dbPath, {fileMustExist: true});
 
@@ -87,7 +150,8 @@ async function writeTurnStarted({agentIdentity, dbPath, freshMs, noteMaxChars, t
                       note,
                       updatedAt     : nowIso,
                       userId        : agentIdentity,
-                      sharedEntity  : false
+                      sharedEntity  : false,
+                      ...(wakeSubmitNonce ? {wakeSubmitNonce} : {})
                   }
               };
 
@@ -111,7 +175,21 @@ export function readCodexContext() {
 }
 
 async function main() {
-    await recordTurnStarted().catch(() => {});
+    let hookPayload = '';
+    try {
+        const rawPayload = await readHookPayload();
+        if (rawPayload) {
+            try {
+                hookPayload = JSON.parse(rawPayload);
+            } catch {
+                hookPayload = rawPayload;
+            }
+        }
+    } catch {
+        // Fail-soft hook: absence of parseable stdin only drops nonce correlation, not context loading.
+    }
+
+    await recordTurnStarted({hookPayload}).catch(() => {});
 
     const context = readCodexContext();
 

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -87,6 +87,7 @@ const CODEX_APP_SERVER_ADAPTER   = 'codex-app-server';
 const DEFAULT_CODEX_DESKTOP_CLI_PATH = '/Applications/Codex.app/Contents/Resources/codex';
 const CODEX_TURN_START_PROOF_TIMEOUT_MS = Number(process.env.WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS) || 45000;
 const CODEX_TURN_START_PROOF_POLL_MS    = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
+const CODEX_WAKE_SUBMIT_NONCE_PREFIX    = 'NEO_WAKE_SUBMIT_NONCE:';
 const WAKE_PRIORITY_RANKS      = {
     low   : 0,
     normal: 1,
@@ -950,11 +951,12 @@ function formatWakeDeliveryEvidence(evidence, {adapter, adapterSource, appName})
     const scenario       = evidence.scenario || 'unknown',
           submitBoundary = adapter === 'osascript' && appName === 'Codex'
               ? '; submitProof=attempted; turnStartProof=live-required'
-              : '';
+              : '',
+          nonceBoundary  = evidence.wakeSubmitNonce ? `; wakeSubmitNonce=${evidence.wakeSubmitNonce}` : '';
 
     return ` (scenario=${scenario}; route=${adapter}; adapterSource=${adapterSource}; app=${appName || ''}; ` +
         `counts=messages:${counts.messages || 0},tasks:${counts.tasks || 0},` +
-        `permissions:${counts.permissions || 0},heartbeats:${counts.heartbeats || 0}${submitBoundary})`;
+        `permissions:${counts.permissions || 0},heartbeats:${counts.heartbeats || 0}${submitBoundary}${nonceBoundary})`;
 }
 
 /**
@@ -978,8 +980,34 @@ function formatWakeCorrelationEvidence(evidence = {}) {
     if (correlation.heartbeatIds?.length) {
         parts.push(`heartbeatLogIds=${correlation.heartbeatIds.slice(-3).join(',')}`);
     }
+    if (evidence.wakeSubmitNonce) {
+        parts.push(`wakeSubmitNonce=${evidence.wakeSubmitNonce}`);
+    }
 
     return parts.length ? `; ${parts.join('; ')}` : '';
+}
+
+/**
+ * @summary Whether a delivery adapter attempts to submit a Codex prompt and therefore needs
+ * nonce-backed turn-start causality evidence.
+ * @param {Object} options
+ * @param {String} options.adapter Resolved wake adapter.
+ * @param {String} [options.appName] Target app name.
+ * @returns {Boolean}
+ */
+function isCodexSubmitProofAdapter({adapter, appName}) {
+    return appName === 'Codex' && (adapter === 'osascript' || adapter === 'test-codex-submit');
+}
+
+/**
+ * @summary Appends a hook-visible nonce to a Codex wake digest without changing wake semantics.
+ * @param {String} digest Wake digest body.
+ * @param {String} wakeSubmitNonce Per-submit correlation id.
+ * @returns {String}
+ */
+function appendCodexWakeSubmitNonce(digest, wakeSubmitNonce) {
+    if (!wakeSubmitNonce) return digest;
+    return `${digest}\n\n<!-- ${CODEX_WAKE_SUBMIT_NONCE_PREFIX}${wakeSubmitNonce} -->`;
 }
 
 /**
@@ -994,9 +1022,19 @@ function formatWakeCorrelationEvidence(evidence = {}) {
  * @param {Object} sqlite better-sqlite3 handle.
  * @param {String} agentIdentity Recipient AgentIdentity node id.
  * @param {String} sinceIso Submit-attempt timestamp.
+ * @param {Object} [options]
+ * @param {String} [options.wakeSubmitNonce] Required wake-submit nonce for causal matches.
  * @returns {Object|null}
  */
-function findTurnPresenceAfter(sqlite, agentIdentity, sinceIso) {
+function findTurnPresenceAfter(sqlite, agentIdentity, sinceIso, {wakeSubmitNonce} = {}) {
+    const params = [agentIdentity, sinceIso];
+    let nonceFilter = '';
+
+    if (wakeSubmitNonce) {
+        nonceFilter = `AND json_extract(data, '$.properties.wakeSubmitNonce') = ?`;
+        params.push(wakeSubmitNonce);
+    }
+
     const row = sqlite.prepare(`
         SELECT data FROM Nodes
         WHERE (
@@ -1005,9 +1043,10 @@ function findTurnPresenceAfter(sqlite, agentIdentity, sinceIso) {
         )
           AND json_extract(data, '$.properties.agentIdentity') = ?
           AND json_extract(data, '$.properties.startedAt') >= ?
+          ${nonceFilter}
         ORDER BY json_extract(data, '$.properties.startedAt') ASC
         LIMIT 1
-    `).get(agentIdentity, sinceIso);
+    `).get(...params);
 
     if (!row?.data) return null;
 
@@ -1024,8 +1063,8 @@ function findTurnPresenceAfter(sqlite, agentIdentity, sinceIso) {
  * This is evidence-only: it does not retry, alter the submit primitive, or gate delivery. It converts
  * `turnStartProof=live-required` into one of three durable log outcomes when the graph oracle is
  * available: `wake-submit-started`, `wake-submit-not-started`, or `wake-submit-unknown`. The started
- * outcome means turn presence appeared in the observation window; without a nonce it must not be
- * over-read as human-free submit proof.
+ * outcome is reserved for a nonce-correlated turn-presence row; timestamp-window-only matches are
+ * ambiguous because a later human Enter can create the same active-turn evidence.
  *
  * @param {Object} subscription WAKE_SUBSCRIPTION node.
  * @param {Date} submitAttemptedAt Timestamp immediately before the submit adapter ran.
@@ -1041,7 +1080,8 @@ function scheduleCodexTurnStartProof(subscription, submitAttemptedAt, deliveryEv
     const agentIdentity = subscription.properties?.agentIdentity,
           submitIso     = submitAttemptedAt.toISOString(),
           deadlineAt    = Date.now() + timeoutMs,
-          correlation   = formatWakeCorrelationEvidence(deliveryEvidence);
+          correlation   = formatWakeCorrelationEvidence(deliveryEvidence),
+          wakeSubmitNonce = deliveryEvidence.wakeSubmitNonce;
 
     if (!agentIdentity) {
         writeLog('WARN',
@@ -1050,17 +1090,36 @@ function scheduleCodexTurnStartProof(subscription, submitAttemptedAt, deliveryEv
         );
         return;
     }
+    if (!wakeSubmitNonce) {
+        writeLog('WARN',
+            `[Wake Daemon] Turn-start proof wake-submit-unknown ${subscription.id} ` +
+            `for ${agentIdentity}: missing wakeSubmitNonce${correlation}`
+        );
+        return;
+    }
 
     const poll = () => {
         try {
-            const turn = findTurnPresenceAfter(db, agentIdentity, submitIso);
+            const turn = findTurnPresenceAfter(db, agentIdentity, submitIso, {wakeSubmitNonce});
             if (turn) {
                 const latencyMs = Math.max(0, new Date(turn.startedAt).getTime() - submitAttemptedAt.getTime());
                 writeLog('INFO',
                     `[Wake Daemon] Turn-start proof wake-submit-started ${subscription.id} ` +
                     `for ${agentIdentity} after ${latencyMs}ms ` +
-                    `(correlation=timestamp-window; turnId=${turn.turnId || 'unknown'}; startedAt=${turn.startedAt}; ` +
+                    `(correlation=nonce; turnId=${turn.turnId || 'unknown'}; startedAt=${turn.startedAt}; ` +
                     `source=${turn.source || 'unknown'}${correlation})`
+                );
+                return;
+            }
+
+            const ambiguousTurn = findTurnPresenceAfter(db, agentIdentity, submitIso);
+            if (ambiguousTurn) {
+                const latencyMs = Math.max(0, new Date(ambiguousTurn.startedAt).getTime() - submitAttemptedAt.getTime());
+                writeLog('WARN',
+                    `[Wake Daemon] Turn-start proof wake-submit-unknown ${subscription.id} ` +
+                    `for ${agentIdentity} after ${latencyMs}ms ` +
+                    `(correlation=timestamp-window-without-nonce; turnId=${ambiguousTurn.turnId || 'unknown'}; ` +
+                    `startedAt=${ambiguousTurn.startedAt}; source=${ambiguousTurn.source || 'unknown'}${correlation})`
                 );
                 return;
             }
@@ -1076,7 +1135,7 @@ function scheduleCodexTurnStartProof(subscription, submitAttemptedAt, deliveryEv
             writeLog('WARN',
                 `[Wake Daemon] Turn-start proof wake-submit-not-started ${subscription.id} ` +
                 `for ${agentIdentity} after ${timeoutMs}ms since ${submitIso} ` +
-                `(correlation=timestamp-window${correlation})`
+                `(correlation=nonce${correlation})`
             );
             return;
         }
@@ -1127,7 +1186,10 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
     const defaultAdapter = process.platform === 'darwin' ? 'osascript' : 'tmux';
     const adapter       = meta.adapter || defaultAdapter;
     const adapterSource = meta.adapter ? 'metadata' : 'platform-default';
-    const evidenceLabel = formatWakeDeliveryEvidence(deliveryEvidence, {adapter, adapterSource, appName: meta.appName});
+    const wakeSubmitNonce = isCodexSubmitProofAdapter({adapter, appName: meta.appName}) ? crypto.randomUUID() : null;
+    const dispatchDigest  = wakeSubmitNonce ? appendCodexWakeSubmitNonce(digest, wakeSubmitNonce) : digest;
+    const proofEvidence   = wakeSubmitNonce ? {...deliveryEvidence, wakeSubmitNonce} : deliveryEvidence;
+    const evidenceLabel   = formatWakeDeliveryEvidence(proofEvidence, {adapter, adapterSource, appName: meta.appName});
 
     // Serialize execution to prevent focus collisions (Electron-Paradox defense)
     deliveryPromise = deliveryPromise.then(async () => {
@@ -1146,12 +1208,12 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
         }
 
         if (addressType === 'webhookUrl') {
-            await deliverViaWebhookUrl(subscription, digest, instanceAddress);
+            await deliverViaWebhookUrl(subscription, dispatchDigest, instanceAddress);
             return;
         }
 
         if (adapter === CODEX_APP_SERVER_ADAPTER) {
-            await deliverViaCodexAppServer(subscription, digest, evidenceLabel);
+            await deliverViaCodexAppServer(subscription, dispatchDigest, evidenceLabel);
             return;
         }
 
@@ -1159,7 +1221,7 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
             const tmuxSession = addressType === 'tmuxSession' && instanceAddress
                 ? instanceAddress
                 : meta.tmuxSession || process.env.TMUX_SESSION || 'neo-agent';
-            await spawnAsync('tmux', ['send-keys', '-t', tmuxSession, digest, 'C-m']);
+            await spawnAsync('tmux', ['send-keys', '-t', tmuxSession, dispatchDigest, 'C-m']);
             writeLog('INFO', `[Wake Daemon] Delivered ${subscription.id} via tmux to session ${tmuxSession}${evidenceLabel}`);
         } else if (adapter === 'osascript') {
             const appName = meta.appName;
@@ -1408,24 +1470,24 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
                 '-e', '    error errMsg',
                 '-e', '  end try',
                 '-e', 'end run',
-                digest
+                dispatchDigest
             );
 
             const submitAttemptedAt = new Date();
             await deliverViaOsascriptWithRetry(osascriptArgs, subscription.id, appName, evidenceLabel);
             if (appName === 'Codex') {
-                scheduleCodexTurnStartProof(subscription, submitAttemptedAt, deliveryEvidence);
+                scheduleCodexTurnStartProof(subscription, submitAttemptedAt, proofEvidence);
             }
         } else if (adapter === 'test') {
-            writeLog('INFO', `[Wake Daemon Test Adapter] Delivered ${subscription.id}: ${digest}`);
+            writeLog('INFO', `[Wake Daemon Test Adapter] Delivered ${subscription.id}: ${dispatchDigest}`);
         } else if (adapter === 'test-codex-submit') {
             const submitAttemptedAt = new Date();
             writeLog('INFO', `[Wake Daemon] Submit attempted ${subscription.id} via test-codex-submit to Codex${evidenceLabel}`);
-            scheduleCodexTurnStartProof(subscription, submitAttemptedAt, deliveryEvidence);
+            scheduleCodexTurnStartProof(subscription, submitAttemptedAt, proofEvidence);
         } else if (adapter === 'test-fail') {
             // Deterministic delivery-failure hook for retry-path testing (no live target needed).
             // Log the attempted digest first so the coalesced retry content is observable, then throw.
-            writeLog('INFO', `[Wake Daemon Test-Fail Adapter] Attempted ${subscription.id}: ${digest}`);
+            writeLog('INFO', `[Wake Daemon Test-Fail Adapter] Attempted ${subscription.id}: ${dispatchDigest}`);
             throw new Error('test-fail adapter: simulated delivery failure');
         } else {
             writeLog('ERROR', `[Wake Daemon] Unknown adapter '${adapter}' for subscription ${subscription.id}`);

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -108,7 +108,8 @@ function insertTurnPresence(db, {
     agentId,
     turnId = 'turn_' + crypto.randomUUID(),
     startedAt = new Date().toISOString(),
-    source = 'codex-user-prompt-submit'
+    source = 'codex-user-prompt-submit',
+    wakeSubmitNonce
 }) {
     const nodeId = `AGENT_TURN_PRESENCE:${agentId}:${turnId}`;
 
@@ -122,11 +123,16 @@ function insertTurnPresence(db, {
             lastProgressAt: startedAt,
             status        : 'active',
             terminalState : null,
-            source
+            source,
+            ...(wakeSubmitNonce ? {wakeSubmitNonce} : {})
         }
     }));
 
     return {nodeId, turnId};
+}
+
+function extractWakeSubmitNonce(output) {
+    return output.match(/wakeSubmitNonce=([0-9a-f-]{36})/)?.[1] || null;
 }
 
 test.describe('Wake Daemon', () => {
@@ -319,12 +325,14 @@ test.describe('Wake Daemon', () => {
             const onData = data => {
                 output += data.toString();
 
-                if (!insertedPresence && output.includes(`Submit attempted ${subId}`)) {
+                const wakeSubmitNonce = extractWakeSubmitNonce(output);
+                if (!insertedPresence && wakeSubmitNonce && output.includes(`Submit attempted ${subId}`)) {
                     insertedPresence = true;
                     insertTurnPresence(db, {
                         agentId,
                         turnId   : 'started-proof',
-                        startedAt: new Date().toISOString()
+                        startedAt: new Date().toISOString(),
+                        wakeSubmitNonce
                     });
                 }
 
@@ -347,8 +355,75 @@ test.describe('Wake Daemon', () => {
         const logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
         expect(logContents).toContain(`Submit attempted ${subId} via test-codex-submit to Codex`);
         expect(logContents).toContain(`Turn-start proof wake-submit-started ${subId}`);
+        expect(logContents).toContain('correlation=nonce');
         expect(logContents).toContain('turnId=started-proof');
         expect(logContents).toContain(`messageIds=${msgId}`);
+        expect(logContents).toMatch(/wakeSubmitNonce=[0-9a-f-]{36}/);
+    });
+
+    test('#13636: Codex timestamp-only turn presence is ambiguous, not causal started proof', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-codex-ambiguous';
+
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'test-codex-submit',
+                appName       : 'Codex',
+                coalesceWindow: 1
+            }
+        });
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {
+                ...process.env,
+                NEO_MEMORY_DB_PATH                    : DB_PATH,
+                NEO_AI_DAEMON_DIR                     : DAEMON_DIR,
+                WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS: '3000',
+                WAKE_CODEX_TURN_START_PROOF_POLL_MS   : '50'
+            }
+        });
+
+        let output = '';
+        let insertedPresence = false;
+
+        const proofPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon did not log Codex ambiguous turn-start proof')), 10000);
+            const onData = data => {
+                output += data.toString();
+
+                if (!insertedPresence && output.includes(`Submit attempted ${subId}`)) {
+                    insertedPresence = true;
+                    insertTurnPresence(db, {
+                        agentId,
+                        turnId   : 'timestamp-only-proof',
+                        startedAt: new Date().toISOString()
+                    });
+                }
+
+                if (output.includes('wake-submit-unknown') && output.includes('timestamp-window-without-nonce')) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+
+            daemonProcess.stdout.on('data', onData);
+            daemonProcess.stderr.on('data', onData);
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {agentId, subject: 'Codex Ambiguous Turn Presence'});
+
+        await proofPromise;
+
+        const logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
+        expect(logContents).toContain(`Turn-start proof wake-submit-unknown ${subId}`);
+        expect(logContents).toContain('correlation=timestamp-window-without-nonce');
+        expect(logContents).toContain('turnId=timestamp-only-proof');
+        expect(logContents).not.toContain(`Turn-start proof wake-submit-started ${subId}`);
     });
 
     test('#13480: Codex submit attempts log not-started when turn presence does not appear', async () => {
@@ -402,7 +477,9 @@ test.describe('Wake Daemon', () => {
         const logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
         expect(logContents).toContain(`Submit attempted ${subId} via test-codex-submit to Codex`);
         expect(logContents).toContain(`Turn-start proof wake-submit-not-started ${subId}`);
+        expect(logContents).toContain('correlation=nonce');
         expect(logContents).toContain(`messageIds=${msgId}`);
+        expect(logContents).toMatch(/wakeSubmitNonce=[0-9a-f-]{36}/);
     });
 
     test('#13077: a failed wake delivery is retried, then capped with a terminal error', async () => {

--- a/test/playwright/unit/hooks/codexContextHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexContextHook.spec.mjs
@@ -1,0 +1,62 @@
+import {test, expect} from '@playwright/test';
+import Database       from 'better-sqlite3';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+import {
+    extractWakeSubmitNonce,
+    recordTurnStarted
+} from '../../../../.codex/hooks/codex-context.mjs';
+
+test.describe('codex-context hook - wake submit nonce', () => {
+    test('extracts a wake-submit nonce from nested hook payload text', () => {
+        const nonce = '123e4567-e89b-12d3-a456-426614174000';
+
+        expect(extractWakeSubmitNonce({
+            transcript: [
+                {role: 'user', content: `[WAKE]\n<!-- NEO_WAKE_SUBMIT_NONCE:${nonce} -->`}
+            ]
+        })).toBe(nonce);
+    });
+
+    test('records wakeSubmitNonce on the turn-presence row when present', async () => {
+        const dir    = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-context-hook-')),
+              dbPath = path.join(dir, 'graph.sqlite'),
+              db     = new Database(dbPath),
+              nonce  = '123e4567-e89b-12d3-a456-426614174001';
+
+        db.exec(`
+            CREATE TABLE Nodes (
+                id TEXT PRIMARY KEY,
+                user_id TEXT,
+                data TEXT
+            )
+        `);
+
+        try {
+            await recordTurnStarted({
+                env: {
+                    NEO_AGENT_IDENTITY: '@test-codex',
+                    NEO_MEMORY_DB_PATH: dbPath,
+                    NEO_AI_DAEMON_DIR : dir
+                },
+                hookPayload: {
+                    prompt: `[WAKE]\n<!-- NEO_WAKE_SUBMIT_NONCE:${nonce} -->`
+                },
+                rootDir: path.resolve(new URL('../../../..', import.meta.url).pathname)
+            });
+
+            const row = db.prepare('SELECT data FROM Nodes WHERE id LIKE ?').get('AGENT_TURN_PRESENCE:%');
+            expect(row).toBeTruthy();
+
+            const node = JSON.parse(row.data);
+            expect(node.properties.agentIdentity).toBe('@test-codex');
+            expect(node.properties.source).toBe('codex-user-prompt-submit');
+            expect(node.properties.wakeSubmitNonce).toBe(nonce);
+        } finally {
+            db.close();
+            fs.rmSync(dir, {recursive: true, force: true});
+        }
+    });
+});


### PR DESCRIPTION
Resolves #13636
Related: #13624

Adds nonce-backed Codex wake-submit causality so the wake daemon no longer treats timestamp-window turn presence as proof that scripted Enter started the turn. Codex submit adapters append a bounded nonce to the submitted wake payload; the Codex `UserPromptSubmit` hook records that nonce on `AGENT_TURN_PRESENCE`; the daemon now reserves `wake-submit-started` for nonce-matched rows and downgrades timestamp-only matches to `wake-submit-unknown`.

Evidence: L2 (focused unit coverage with daemon subprocess + SQLite turn-presence oracle + hook persistence test) -> L4 required (live Codex Desktop wake against the active subscription). Residual: AC6 [#13636].

## Deltas from ticket

The implementation keeps the existing `osascript` route unchanged. It adds a hook-visible HTML-comment nonce to Codex submit payloads only for Codex submit-proof adapters, so non-Codex wake routes and non-submit transports are not reclassified.

Timestamp-window matches are now explicitly ambiguous instead of successful. That is stricter than the previous `wake-submit-started` vocabulary and prevents a later human Enter from masquerading as scripted-submit causality.

Ada's concurrent hook finding is respected: this PR does not attempt to make Codex Stop blocking. Codex Stop remains audit/fail-open; this PR only repairs wake-submit causality evidence.

## Test Evidence

- `node --check ai/daemons/wake/daemon.mjs`
- `node --check .codex/hooks/codex-context.mjs`
- `node --check test/playwright/unit/ai/daemons/wake/daemon.spec.mjs`
- `node --check test/playwright/unit/hooks/codexContextHook.spec.mjs`
- `npm run test-unit -- test/playwright/unit/hooks/codexContextHook.spec.mjs` -> 2 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` -> 39 passed
- `git diff --check`
- `node buildScripts/util/check-block-alignment.mjs .codex/hooks/codex-context.mjs test/playwright/unit/ai/daemons/wake/daemon.spec.mjs test/playwright/unit/hooks/codexContextHook.spec.mjs`

## Post-Merge Validation

- [ ] Trigger a live Codex A2A wake against `WAKE_SUB:7648b86c-2f1e-43a8-95a6-cc399f66a938` and confirm the daemon logs nonce-correlated `wake-submit-started` only when the `UserPromptSubmit` hook writes a matching `wakeSubmitNonce`.
- [ ] Confirm a live operator/manual Enter without a matching nonce is logged as `wake-submit-unknown`, not `wake-submit-started`.

## Commits

- `2766e2217` - `feat(codex): add wake submit nonce causality (#13636)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee5c2-82ba-7b73-8812-df59106ff61a.
