### PR TITLE
feat(ai): auto-wire the Claude Stop-hook into every clone via initServerConfigs (#13641)

### DIFF
--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -28,5 +28,18 @@
       "Never push or commit directly to the `main` or `dev` branches. Always branch and open a pull request targeting `dev` (AGENTS.md critical gates #3 and #8). The release pipeline is the only sanctioned exception.",
       "Never write a client, customer, or partner name — or private business strategy — into any public-facing artifact: public-repo issues, pull requests, discussions, docs, or comments (AGENTS.md critical gate #9)."
     ]
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "NEO_LANE_STATE_ENFORCE=1 /usr/bin/env node \"$(git rev-parse --show-toplevel)/.claude/hooks/laneStateStopHook.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
   }
 }

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -699,7 +699,11 @@ export function mergeClaudeHooks(activeSettings = {}, templateSettings = {}) {
  * enforcement) without per-repo manual management — the Claude analog of {@link initConfigs} /
  * {@link initTier1Config}. A missing active file is cloned whole from the template; an existing one
  * gets only its `hooks` block ensured ({@link mergeClaudeHooks}), preserving operator-local keys.
- * Idempotent: an already-wired settings file is a silent no-op. Runs at `npm prepare`.
+ * Idempotent: an already-wired settings file is a silent no-op. Runs at `npm prepare`. The tracked
+ * template carries `NEO_LANE_STATE_ENFORCE=1` in the Stop-hook command — the operator-directed enforce
+ * default (the forcing-function rollout: the hook blocks + injects the no-hold directive at an
+ * invalid idle-out turn-terminal, rather than only audit-logging it). Enforce is opted OUT locally by
+ * dropping that env prefix in the gitignored `.claude/settings.json`, not by changing the default.
  *
  * Distinct from the server/Tier-1 config path: Claude settings are JSON (not `.mjs`), so the regex
  * shape-drift detector does not apply — a structural `hooks`-key merge is the right primitive.

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -666,10 +666,83 @@ export async function assertConfigFresh({serverPath, aiRoot = aiDir, logger = co
     }
 }
 
+/**
+ * @summary Pure merge that ensures the template's `hooks` block is present in the active Claude
+ * settings object, preserving every other key (permissions, autoMode, operator-local edits) and any
+ * non-`Stop` hook events. Template hook events overwrite same-named active events (the template owns
+ * the canonical hook wiring); other active events are kept. Returns the merged settings plus a
+ * `changed` flag so an idempotent re-run is a no-op write.
+ *
+ * @param {Object} [activeSettings={}]   Parsed `.claude/settings.json` (or `{}` when absent).
+ * @param {Object} [templateSettings={}] Parsed `.claude/settings.template.json`.
+ * @returns {{settings: Object, changed: Boolean}}
+ */
+export function mergeClaudeHooks(activeSettings = {}, templateSettings = {}) {
+    const templateHooks = templateSettings.hooks;
+
+    if (!templateHooks || Object.keys(templateHooks).length === 0) {
+        return {settings: activeSettings, changed: false};
+    }
+
+    const mergedHooks = {...(activeSettings.hooks || {}), ...templateHooks};
+
+    if (JSON.stringify(activeSettings.hooks || {}) === JSON.stringify(mergedHooks)) {
+        return {settings: activeSettings, changed: false};
+    }
+
+    return {settings: {...activeSettings, hooks: mergedHooks}, changed: true};
+}
+
+/**
+ * @summary Materializes the tracked `.claude/settings.template.json` into the gitignored
+ * `.claude/settings.json` so every clone self-wires the Claude Stop hook (no-hold lane-state
+ * enforcement) without per-repo manual management — the Claude analog of {@link initConfigs} /
+ * {@link initTier1Config}. A missing active file is cloned whole from the template; an existing one
+ * gets only its `hooks` block ensured ({@link mergeClaudeHooks}), preserving operator-local keys.
+ * Idempotent: an already-wired settings file is a silent no-op. Runs at `npm prepare`.
+ *
+ * Distinct from the server/Tier-1 config path: Claude settings are JSON (not `.mjs`), so the regex
+ * shape-drift detector does not apply — a structural `hooks`-key merge is the right primitive.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.claudeDir] `.claude/` dir; defaults to `<repo>/.claude`. Override for tests.
+ * @param {Object} [options.logger=console] Log sink; injectable for tests.
+ * @returns {Promise<{action: String}>} `action` is one of `clone` / `wired` / `silent` / `skip-no-template`.
+ */
+export async function initClaudeSettings({claudeDir = path.join(cwd, '.claude'), logger = console} = {}) {
+    const templatePath = path.join(claudeDir, 'settings.template.json');
+    const activePath   = path.join(claudeDir, 'settings.json');
+
+    if (!fs.existsSync(templatePath)) {
+        logger.warn('[Neo AI] .claude/settings.template.json not found; skipping Claude settings initialization.');
+        return {action: 'skip-no-template'};
+    }
+
+    const templateSettings = JSON.parse(await fs.readFile(templatePath, 'utf-8'));
+
+    if (!fs.existsSync(activePath)) {
+        await fs.writeFile(activePath, JSON.stringify(templateSettings, null, 2) + '\n', 'utf-8');
+        logger.log('[Neo AI] .claude/settings.json missing. Materialized from template (Stop hook wired).');
+        return {action: 'clone'};
+    }
+
+    const activeSettings      = JSON.parse(await fs.readFile(activePath, 'utf-8'));
+    const {settings, changed} = mergeClaudeHooks(activeSettings, templateSettings);
+
+    if (!changed) {
+        return {action: 'silent'};
+    }
+
+    await fs.writeFile(activePath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+    logger.log('[Neo AI] Wired the Claude Stop hook into .claude/settings.json (auto-materialized from template).');
+    return {action: 'wired'};
+}
+
 if (import.meta.url === `file://${process.argv[1]}`) {
     (async () => {
         await initTier1Config();
         await initConfigs();
+        await initClaudeSettings();
     })().catch(err => {
         console.error('[Neo AI] Failed to initialize configs:', err);
         process.exit(1);

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -34,9 +34,9 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
         const warn = [];
         const error = [];
         return {
-            log:   (...args) => log.push(args.join(' ')),
-            warn:  (...args) => warn.push(args.join(' ')),
-            error: (...args) => error.push(args.join(' ')),
+            log    : (...args) => log.push(args.join(' ')),
+            warn   : (...args) => warn.push(args.join(' ')),
+            error  : (...args) => error.push(args.join(' ')),
             entries: {log, warn, error}
         }
     }
@@ -807,5 +807,105 @@ test.describe('assertConfigFresh — boot freshness guard (#13560)', () => {
 
         expect(error).toBeNull();
         expect(logger.entries.warn.some(w => w.includes('benign config drift'))).toBe(true);
+    });
+});
+
+test.describe('initClaudeSettings — Claude Stop-hook auto-wire (#13641)', () => {
+    let initClaudeSettings, mergeClaudeHooks;
+    let claudeRoot;
+
+    const recordingLogger = () => {
+        const log = [], warn = [];
+        return {log: (...a) => log.push(a.join(' ')), warn: (...a) => warn.push(a.join(' ')), entries: {log, warn}};
+    };
+
+    // The tracked template the materializer reads — the Stop hook with the operator-directed
+    // enforce=1 default (the forcing-function rollout; NOT dry-run).
+    const TEMPLATE = {
+        permissions: {allow: ['mcp__neo-mjs-memory-core__healthcheck']},
+        hooks      : {
+            Stop: [{hooks: [{
+                type   : 'command',
+                command: 'NEO_LANE_STATE_ENFORCE=1 /usr/bin/env node "$(git rev-parse --show-toplevel)/.claude/hooks/laneStateStopHook.mjs"',
+                timeout: 10
+            }]}]
+        }
+    };
+
+    const buildClaudeDir = (name, {template, settings} = {}) => {
+        const dir = path.join(claudeRoot, name);
+        fs.mkdirSync(dir, {recursive: true});
+        if (template !== undefined) fs.writeFileSync(path.join(dir, 'settings.template.json'), JSON.stringify(template, null, 2));
+        if (settings !== undefined) fs.writeFileSync(path.join(dir, 'settings.json'), JSON.stringify(settings, null, 2));
+        return dir;
+    };
+
+    test.beforeAll(async () => {
+        ({initClaudeSettings, mergeClaudeHooks} = await import('../../../../../../ai/scripts/setup/initServerConfigs.mjs'));
+        claudeRoot = path.resolve(process.cwd(), 'tmp', `init-claude-settings-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(claudeRoot, {recursive: true});
+    });
+
+    test.afterAll(() => {
+        if (claudeRoot && fs.existsSync(claudeRoot)) fs.rmSync(claudeRoot, {recursive: true, force: true});
+    });
+
+    test('mergeClaudeHooks: ensures the template Stop hook, preserves other keys + non-Stop events', () => {
+        const active = {permissions: {allow: ['local-perm']}, hooks: {PreToolUse: [{hooks: []}]}};
+        const {settings, changed} = mergeClaudeHooks(active, TEMPLATE);
+
+        expect(changed).toBe(true);
+        expect(settings.permissions.allow).toEqual(['local-perm']);     // operator-local key preserved
+        expect(settings.hooks.PreToolUse).toEqual([{hooks: []}]);       // non-Stop hook event preserved
+        expect(settings.hooks.Stop).toEqual(TEMPLATE.hooks.Stop);       // Stop wired from template
+    });
+
+    test('mergeClaudeHooks: idempotent — already-wired hooks report changed=false', () => {
+        const {changed} = mergeClaudeHooks({hooks: {Stop: TEMPLATE.hooks.Stop}}, TEMPLATE);
+        expect(changed).toBe(false);
+    });
+
+    test('mergeClaudeHooks: a template without hooks is a no-op', () => {
+        const active = {permissions: {allow: ['x']}};
+        const {settings, changed} = mergeClaudeHooks(active, {permissions: {}});
+        expect(changed).toBe(false);
+        expect(settings).toBe(active);
+    });
+
+    test('initClaudeSettings: missing settings.json → clone (full template, enforce=1 command wired)', async () => {
+        const dir = buildClaudeDir('clone', {template: TEMPLATE});
+        const r   = await initClaudeSettings({claudeDir: dir, logger: recordingLogger()});
+        expect(r.action).toBe('clone');
+
+        const written = JSON.parse(fs.readFileSync(path.join(dir, 'settings.json'), 'utf-8'));
+        const command = written.hooks.Stop[0].hooks[0].command;
+        // Operator-directed default: the tracked default DOES force enforce — the forcing-function
+        // rollout. A future drift to dry-run fails this assertion.
+        expect(command).toContain('NEO_LANE_STATE_ENFORCE=1');
+        expect(command).toContain('laneStateStopHook.mjs');
+    });
+
+    test('initClaudeSettings: re-run is idempotent → silent', async () => {
+        const dir = buildClaudeDir('silent', {template: TEMPLATE});
+        await initClaudeSettings({claudeDir: dir, logger: recordingLogger()});
+        const r2 = await initClaudeSettings({claudeDir: dir, logger: recordingLogger()});
+        expect(r2.action).toBe('silent');
+    });
+
+    test('initClaudeSettings: existing settings.json (perms only) → wired, local keys preserved', async () => {
+        const dir = buildClaudeDir('wired', {template: TEMPLATE, settings: {permissions: {allow: ['my-local-perm']}}});
+        const r   = await initClaudeSettings({claudeDir: dir, logger: recordingLogger()});
+        expect(r.action).toBe('wired');
+
+        const written = JSON.parse(fs.readFileSync(path.join(dir, 'settings.json'), 'utf-8'));
+        expect(written.permissions.allow).toEqual(['my-local-perm']);                      // preserved
+        expect(written.hooks.Stop[0].hooks[0].command).toContain('NEO_LANE_STATE_ENFORCE=1');
+    });
+
+    test('initClaudeSettings: no template → skip-no-template (no settings.json written)', async () => {
+        const dir = buildClaudeDir('no-template', {});
+        const r   = await initClaudeSettings({claudeDir: dir, logger: recordingLogger()});
+        expect(r.action).toBe('skip-no-template');
+        expect(fs.existsSync(path.join(dir, 'settings.json'))).toBe(false);
     });
 });


### PR DESCRIPTION
Resolves #13641

The Claude Stop-hook (`laneStateStopHook.mjs`, #13589/#13629) was built and merged but never active in any clone: unlike Codex's tracked `.codex/hooks.json`, Claude's `settings.json`/`settings.local.json` are gitignored and `settings.template.json` carried no hooks block, so activation was an uncompleted per-repo manual step. This adds the Stop-hook block to the tracked template plus an `initClaudeSettings()` materializer wired into `npm prepare`, so every clone self-wires on pull (`--migrate-config`) — Codex-parity, no manual per-repo management.

**Rollout mode — enforce, by operator directive (@tobiu).** The tracked template ships `NEO_LANE_STATE_ENFORCE=1` (the forcing-function rollout): an invalid idle-out turn-terminal is **blocked + the no-hold directive injected immediately**, not merely audit-logged. Dry-run is a local opt-out (drop the env prefix in the gitignored `.claude/settings.json`), not the default. This is the **operator override** of the dry-run-default Required Action (pull-request §6.1 explicit-operator-override exception); GPT's other review actions are addressed below.

Evidence: L2 (committed unit tests for the materializer — 36/36 green) → L3 required (live per-clone materialization + restart-into-enforce across the fleet, AC3). Residual: AC3 [#13641] — fleet self-wire + the live enforce-fire are verifiable only post-merge.

## Deltas from ticket
Rollout mode is enforce per operator directive (vs the hook's documented dry-run-first ramp). The transition cost — prose-only turns block to the 8-block override until the #13644 emission contract + its always-loaded AGENTS.md pointer land — is the accepted forcing-function tradeoff.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs` → **36/36 green**.
- New committed coverage (`initClaudeSettings` / `mergeClaudeHooks`): clone / silent / wired-preserve-local-keys / skip-no-template / merge-preserve-non-`Stop`-events / idempotent — including an assertion that the tracked default **forces** `NEO_LANE_STATE_ENFORCE=1` (locks the operator-directed default; a drift to dry-run fails the test). Addresses review RA#3.
- Husky pre-commit green (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment).
- Contract Ledger backfilled on #13641 (review RA#4).

## Post-Merge Validation
- [ ] On a peer clone, `git pull && npm run prepare -- --migrate-config` writes the enforce Stop hook into `.claude/settings.json` (AC3 self-wire-on-pull).
- [ ] After a harness restart, the Stop hook fires at a real turn-end (`decision:block` + injected directive on an idle-out).
- [ ] Transition: until #13644 (emission contract) + its AGENTS.md pointer land, prose-only turns block to the 8-block override — the accepted forcing-function cost.

## Commits
- `74369cd41` — template Stop-hook block + `initClaudeSettings()`/`mergeClaudeHooks()` + `npm prepare` CLI wire.
- `e9545b995` — committed unit coverage + enforce-default JSDoc.

Refs #13623, #13624, #13628.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 4ae2bfaa-178d-4883-bf33-9e140c6cebe3.
