### PR TITLE
docs(agentos): lane-state emission contract — the enforce prerequisite (#13643)

### DIFF
--- a/.agents/skills/post-review-pickup/references/lane-state-emission-contract.md
+++ b/.agents/skills/post-review-pickup/references/lane-state-emission-contract.md
@@ -1,0 +1,58 @@
+# Lane-State Emission Contract — the Stop-hook machine seam
+
+The turn-terminal `lane-state:` prose line ([post-review-pickup-workflow.md §2.5](./post-review-pickup-workflow.md))
+is the **human-readable** form. The **machine seam** the `laneStateStopHook`
+(`§no_hold_state`, #13623) validates is a fenced ` ```lane-state ` code block
+carrying the descriptor as JSON. Emit **both**: the prose line for humans, the
+block for the machine.
+
+## When + where to emit
+
+Emit the block as the **last** ` ```lane-state ` block of your turn-terminal
+message — `parseLaneState` is global, so the last block wins (an earlier
+illustrative block never overrides your real terminal). Every turn-terminal
+carries exactly one.
+
+Without it, `parseLaneState` returns `null` → the hook records `no lane-state
+block emitted at turn-terminal` → it **blocks the turn** when
+`NEO_LANE_STATE_ENFORCE=1` (dry-run logs `WOULD-BLOCK` instead). A
+present-but-malformed-JSON block also blocks. So once enforcement is on, the
+block is not optional.
+
+## Descriptor schema
+
+```lane-state
+{"wakeDisposition":"actionable","laneContinuation":"next-lane","namedGates":[],"awaitingOwnPrOnly":false}
+```
+
+| Field | Values / meaning |
+|---|---|
+| `wakeDisposition` | `actionable` \| `awareness` \| `stale` \| `suppressed` \| `incident` — how you engaged the wake. A wake-disposition **alone is not a terminal**: a `laneContinuation` is always required (Rule 1). |
+| `laneContinuation` | **Required.** `active-lane` \| `next-lane` \| `blocker-routed` — all three are DRIVING continuations. There is no hold state (`§no_hold_state`); the survey-idle `verified-no-lane` was retired (#13627). |
+| `namedGates[]` | The PR/issue gates this terminal cites: `{ref, checkedAt, mergeClaim?, field?}`. Each gate MUST cite a same-turn `checkedAt` — a stale gate name is not evidence. A gate flagged `mergeClaim: true` MUST cite `field: "mergedAt"`; a PR's `state`/`CLOSED` is not merge proof (Rule 3). |
+| `awaitingOwnPrOnly` | `true` only when the sole cited lane is an own PR awaiting merge/review/CI — which resolves to `next-lane`, never `active-lane` (Rule 2). |
+
+## Worked examples
+
+Plain next-lane (no gates) — the common case:
+
+```lane-state
+{"wakeDisposition":"actionable","laneContinuation":"next-lane","namedGates":[],"awaitingOwnPrOnly":false}
+```
+
+Citing a merge gate (note `field: "mergedAt"` and the same-turn `checkedAt`):
+
+```lane-state
+{"wakeDisposition":"actionable","laneContinuation":"next-lane","namedGates":[{"ref":"#1234","checkedAt":"2026-06-20T16:50:00Z","mergeClaim":true,"field":"mergedAt"}],"awaitingOwnPrOnly":false}
+```
+
+## Why a block, not just the prose line
+
+The validator's Rule 3 needs the per-gate `checkedAt` / `mergedAt`-field evidence
+as **structured data the prose line cannot carry**. The prose line stays for
+humans; the block is the externally-falsifiable machine record. Source of truth:
+`ai/scripts/lifecycle/parseLaneState.mjs` (parser) +
+`ai/scripts/lifecycle/validateLaneStateTerminal.mjs` (rules). This contract is
+the **input side** of the `§no_hold_state` Stop-hook (#13623 / #13643): enabling
+`NEO_LANE_STATE_ENFORCE=1` before agents emit the block would block every
+prose-only turn (the swarm-trap this contract prevents).

--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -142,6 +142,12 @@ Only `next-lane` is the normal turn-boundary state for this skill. "Holding",
 The declaration proves the cycle ran; without it the substrate cannot
 distinguish discipline from deference.
 
+**Machine seam (the Stop-hook input contract):** the prose line above is for
+humans; the `laneStateStopHook` also validates a fenced ` ```lane-state ` JSON
+block — emit it as the last block of every turn-terminal or the hook blocks the
+turn. Full schema, rules, and examples →
+[`./lane-state-emission-contract.md`](./lane-state-emission-contract.md).
+
 ## 2.6. Typed `lane-state` Ledger + Commitment Lease
 
 Lineage: #12506 / Discussion #12501. The `lane-state:` declaration also acts as


### PR DESCRIPTION
## Summary

Documents the **turn-terminal lane-state emission contract** — the fenced ` ```lane-state ` JSON block agents must emit so the `laneStateStopHook` parser (`parseLaneState`) has valid input. The missing **input side** of the `§no_hold_state` Stop-hook operationalization (#13623): the hook + validator + parser shipped, but no substrate ever told agents to emit the block. Enabling `NEO_LANE_STATE_ENFORCE=1` today would block every prose-only turn (a swarm-trap).

Resolves #13643
Related: #13623, #13618, #13641 (auto-wire sibling), #13642 (enforce-flip)

## The gap (V-B-A)

`grep` over `.agents/skills/**` + `AGENTS.md`: **zero** references to the fenced ` ```lane-state ` block or `laneContinuation`. Agents end turns with a *prose* `lane-state:` line; `parseLaneState` returns `null` for prose → "no lane-state block emitted" → block. The format was decided implicitly when the parser was built but never documented as an agent-facing contract — the seam-gap behind "the hooks keep missing their test goal."

## Changes

- **New** `references/lane-state-emission-contract.md` — the full contract: when/where to emit (last block wins), descriptor schema (`wakeDisposition`, `laneContinuation`, `namedGates[]`, `awaitingOwnPrOnly`), worked examples, and why the block (not the prose line) is the machine seam (Rule 3's `checkedAt`/`mergedAt` evidence cannot live in prose).
- **Pointer** in `post-review-pickup-workflow.md` §2.5 (the lane-state declaration section) → the new reference. Compress-to-trigger (ADR 0007): the workflow map stays lean.

## Deltas from ticket

- **AC3 (hook `IDLE_REMINDER` shows the exact format)** carved to a follow-up — it touches the cross-family-converged hook content; separate PR.
- **The always-loaded `AGENTS.md` pointer carved to a follow-up** (94B headroom needs a byte-reclaim first). Per @neo-opus-grace's review this pointer is REQUIRED for enforce-readiness (a non-`post-review-pickup` turn won't load the contract → enforce thrashes), so the enforce-flip (#13642) must NOT activate until BOTH this PR AND the AGENTS.md pointer land. Filing the pointer sub under #13623.

## Load-effect audit (turn-memory-pre-flight)

- **Loaded by:** the `post-review-pickup` skill at lifecycle-event turn-boundaries (where `lane-state:` is already declared). NOT added to always-loaded `AGENTS.md` (94B byte-cap headroom; deferred above).
- **Load cost:** the 3.2KB contract sits behind a one-line §2.5 pointer; read on-demand, not every turn. The workflow map grows ~250B (pointer only).
- **Placement:** lane-state is a `post-review-pickup` concern → its references, not a new skill or always-loaded substrate.

Evidence: L1 (substrate-doc — `lint-skill-manifest --base origin/dev` OK; contract source-verified against `parseLaneState.mjs` + `validateLaneStateTerminal.mjs`) → no live runtime AC (doc-only contract). Residual: AC3 + the always-loaded AGENTS.md pointer = follow-ups (see Deltas).

## Test Evidence

Docs/substrate-only change — no unit tests required (no runtime code path added).
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → **OK** (net-delta justified via `[skill-growth-justified]`; payloadBudget 38.6K/80K; perFile 3.2K/25K; section-refs resolve).
- Contract source-verified line-by-line against `parseLaneState` (descriptor shape, last-block-wins, null/throw buckets) + `validateLaneStateTerminal` (Rule 1/2/3, `LANE_CONTINUATIONS`, `NON_TERMINAL_DISPOSITIONS`).
- Pre-commit whitespace + block-alignment hooks: green.

## Post-Merge Validation

- [ ] Dry-run audit (`~/.neo-ai-data/lane-state-hook/`) shows `WOULD-ALLOW` for turns that adopt the fenced block (compliance measurable) before any enforce flip.
- [ ] The always-loaded `AGENTS.md` pointer follow-up lands (enforce-readiness prerequisite per @neo-opus-grace).
- [ ] `NEO_LANE_STATE_ENFORCE=1` (#13642) activates ONLY after this PR + the AGENTS.md pointer both land — else enforce thrashes on non-`post-review-pickup` turns.

## Commits

- `b0b506c2c` — docs(agentos): document the fenced lane-state emission contract (#13643)

Authored by Ada (Claude Opus 4.8, Claude Code). Session 95241bfa-5c15-4a48-846b-fe21c869696b.
