### PR TITLE
fix(ai): gate session-summary drift re-summarization of still-active sessions (#13637)

### DIFF
--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -324,9 +324,18 @@ class SessionService extends Base {
      * -   **Parallel / Crash Path:** Session A crashes after adding 5 memories. Summary has 10, DB has 15.
      *     Next startup sees Mismatch. Re-summarizes to capture the lost 5 memories.
      *
+     * 4.  **Churn-gate:** A session whose newest memory is within the swarm idle window
+     *     (`swarmHeartbeat.idleThresholdMs`) is still actively receiving turns; its DB count climbs
+     *     every turn while the last summary's count lags, so it trips the Case-B mismatch on *every*
+     *     sweep. Such sessions are skipped until they go quiet, collapsing the re-summarization ratio
+     *     toward ~1 (measured churn before the gate: 7 sessions re-summarized 16-22×/day).
+     *
+     * @param {Object} [options]
+     * @param {Number|Date|String} [options.now=Date.now()] Clock source (testable; also threaded to
+     *   `getExternallyActiveSessionIds` so a sweep uses one consistent clock).
      * @returns {Promise<String[]>} List of Session IDs requiring summarization.
      */
-    async findSessionsToSummarize() {
+    async findSessionsToSummarize({now = Date.now()} = {}) {
         // 1. Get metadata for memories — all-time scope. (The prior 30-day window was an obsolete
         // boot/healthcheck-timeout safeguard from when MC summarized on server boot.)
         const limit = aiConfig.summarizationBatchLimit;
@@ -379,8 +388,12 @@ class SessionService extends Base {
             }
 
             sessions[m.sessionId].count++;
-            if (m.timestamp && m.timestamp > sessions[m.sessionId].lastActivity) {
-                sessions[m.sessionId].lastActivity = m.timestamp;
+            // Normalize to epoch-ms (numeric, numeric-string, ISO, and the legacy `Memory: <iso>`
+            // name formats are all in play) so lastActivity is a reliable clock for the churn-gate
+            // below — mirrors getExternallyActiveSessionIds' resolution.
+            const tsMs = this.resolveGraphTimestampMs(m.timestamp, m.name);
+            if (tsMs !== null && tsMs > sessions[m.sessionId].lastActivity) {
+                sessions[m.sessionId].lastActivity = tsMs;
             }
         });
 
@@ -423,19 +436,35 @@ class SessionService extends Base {
         });
 
         // 4. Determine candidates
-        const externallyActiveSessionIds = this.getExternallyActiveSessionIds();
+        const nowMs = typeof now === 'number' ? now : new Date(now).getTime();
+        // Re-summary churn-gate threshold. Reuses the swarm idle definition — one idle
+        // concept, no new config leaf. A session whose newest memory is within this window
+        // is still actively receiving turns, so summarizing it now is stale-on-write and re-churns.
+        const churnCooldownMs = aiConfig.orchestrator.swarmHeartbeat.idleThresholdMs;
+        const externallyActiveSessionIds = this.getExternallyActiveSessionIds({now: nowMs});
         const sessionsToUpdate = [];
 
         Object.keys(sessions).forEach(sessionId => {
             const sessionData = sessions[sessionId];
             const summaryCount = summaryMap[sessionId];
 
-            // Explicitly exclude sessions that are still active in this process or another
-            // live harness. Stale/crashed sessions fall back into the self-healing drift path.
+            // Skip the in-process current session (it summarizes on its own sunset).
             if (sessionId === this.currentSessionId) {
                 return;
             }
 
+            // PRIMARY churn-gate: an actively-growing session trips the Case-B count mismatch
+            // below on EVERY sweep (measured: 7 sessions re-summarized 16-22×/day while holding the
+            // heavy-maintenance lease). Graph-truth via the memory timestamp closes the gap the
+            // WAKE_SUBSCRIPTION skip misses; once the session goes quiet past the window it is
+            // summarized once → counts match → no further churn. A crashed session IS idle, so the
+            // eventual-consistency capture still fires once it ages past the window (no regression).
+            if (sessionData.lastActivity && (nowMs - sessionData.lastActivity) < churnCooldownMs) {
+                return;
+            }
+
+            // Secondary cross-harness skip — now largely subsumed by the idle-gate above; retained as
+            // defense-in-depth pending the follow-up cleanup (idle-gate ⊇ this for fresh rows).
             if (externallyActiveSessionIds.has(sessionId)) {
                 logger.info(`[SessionService] Skipping externally active session ${sessionId} during drift detection.`);
                 return;

--- a/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
@@ -274,13 +274,13 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
     async function addToolMemory({sessionId, agentIdentity, prompt = 'Externally active session memory'}) {
         const result = await callToolAs(agentIdentity, 'add_memory', {
             prompt,
-            thought: 'Unit test active-session fixture.',
-            response: 'Stored through the MCP add_memory tool shape.',
+            thought        : 'Unit test active-session fixture.',
+            response       : 'Stored through the MCP add_memory tool shape.',
             sessionId,
-            agent: agentIdentity,
-            model: 'unit-test-model',
+            agent          : agentIdentity,
+            model          : 'unit-test-model',
             amountToolCalls: 0,
-            toolsUsed: ['unit-test']
+            toolsUsed      : ['unit-test']
         });
 
         expect(result.error).toBeUndefined();
@@ -322,8 +322,10 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
         const storedTimestamp = stored.metadatas[0].timestamp;
         expect(typeof storedTimestamp).toBe('number');
 
-        // Now test drift detection — this session should be flagged
-        const sessionsToSummarize = await SDK.Memory_SessionService.findSessionsToSummarize(false);
+        // Now test drift detection — inject a `now` past the churn-gate idle window so the
+        // just-written session is eligible; this verifies epoch-timestamp drift DETECTION, not the
+        // gate's eligibility timing.
+        const sessionsToSummarize = await SDK.Memory_SessionService.findSessionsToSummarize({now: Date.now() + 60 * 60 * 1000});
 
         expect(sessionsToSummarize).toContain(driftSessionId);
     });
@@ -419,9 +421,9 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
             calls.push({type: 'summarize', sessionId});
             return {
                 sessionId,
-                summaryId   : `summary_${sessionId}`,
-                title       : 'Explicit Active Summary',
-                memoryCount : 1
+                summaryId  : `summary_${sessionId}`,
+                title      : 'Explicit Active Summary',
+                memoryCount: 1
             };
         };
         SDK.Memory_SessionService.completeSummarizationJob = (sessionId) => {
@@ -458,7 +460,7 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
         await seedExternallyActiveSession({
             sessionId: staleSessionId,
             agentIdentity,
-            prompt: 'Externally stale session memory'
+            prompt   : 'Externally stale session memory'
         });
 
         const externallyActiveSessionIds = SDK.Memory_SessionService.getExternallyActiveSessionIds({

--- a/test/playwright/unit/ai/services/memory-core/SessionService.ChurnCooldown.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.ChurnCooldown.spec.mjs
@@ -1,0 +1,145 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'SessionServiceChurnCooldownTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * AC1 — the session-summary drift CHURN-GATE.
+ *
+ * `findSessionsToSummarize` must NOT re-select a session that is still actively receiving turns: such
+ * a session's DB count climbs every `add_memory` turn while the last summary's `memoryCount` lags, so
+ * it trips the Case-B count mismatch on EVERY sweep (measured pre-fix: 7 sessions re-summarized
+ * 16-22×/day while holding the heavy-maintenance lease). The gate skips any session whose newest
+ * memory is within `swarmHeartbeat.idleThresholdMs` of the sweep clock.
+ *
+ * Fully offline + deterministic: inject a fixed `now`, stub the two collections + the cross-harness
+ * skip, and assert the active session is held while quiet sessions still drain — and that the SAME
+ * session becomes selectable once it ages past the window (the gate releases; no starvation).
+ */
+test.describe('SessionService.findSessionsToSummarize — churn-gate (#13637)', () => {
+    test.describe.configure({mode: 'serial'});
+
+    let SDK, svc, aiConfig, idleThresholdMs, restore;
+
+    const NOW = 1_700_000_000_000; // fixed sweep clock (ms epoch)
+
+    test.beforeAll(async () => {
+        SDK = await import('../../../../../../ai/services.mjs');
+
+        if (!SDK.Memory_LifecycleService._initPromise) {
+            await SDK.Memory_LifecycleService.initAsync();
+        } else {
+            await SDK.Memory_LifecycleService.ready();
+        }
+
+        svc             = SDK.Memory_SessionService;
+        aiConfig        = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        idleThresholdMs = aiConfig.orchestrator.swarmHeartbeat.idleThresholdMs; // 10 min default
+    });
+
+    test.beforeEach(() => {
+        const origMemGet   = svc.memoryCollection.get,
+              origSessGet  = svc.sessionsCollection.get,
+              origExternal = svc.getExternallyActiveSessionIds;
+
+        // Isolate the churn-gate from the cross-harness WAKE_SUBSCRIPTION skip so the assertions
+        // exercise the lastActivity gate alone.
+        svc.getExternallyActiveSessionIds = () => new Set();
+
+        restore = () => {
+            svc.memoryCollection.get          = origMemGet;
+            svc.sessionsCollection.get        = origSessGet;
+            svc.getExternallyActiveSessionIds = origExternal;
+        };
+    });
+
+    test.afterEach(() => restore?.());
+
+    /**
+     * Wires both collections from a per-session spec keyed by id:
+     * `{count, lastActivityMs, summaryCount?}`. memoryCollection yields `count` rows whose newest
+     * timestamp equals lastActivityMs; sessionsCollection yields a summary row carrying `summaryCount`
+     * when it is a number (omit it for a Case-A "missing summary" session). Both stubs respect
+     * offset/limit, matching real Chroma pagination.
+     */
+    function wire(spec) {
+        const memRows = [], sumRows = [];
+
+        for (const [sessionId, {count, lastActivityMs, summaryCount}] of Object.entries(spec)) {
+            for (let i = 0; i < count; i++) {
+                // Stagger so the NEWEST row equals lastActivityMs and older rows precede it.
+                memRows.push({sessionId, timestamp: lastActivityMs - (count - 1 - i) * 1000});
+            }
+            if (typeof summaryCount === 'number') {
+                sumRows.push({sessionId, memoryCount: summaryCount});
+            }
+        }
+
+        svc.memoryCollection.get = async ({offset = 0, limit} = {}) => {
+            const page = memRows.slice(offset, offset + limit);
+            return {ids: page.map((_, i) => `m${offset + i}`), metadatas: page};
+        };
+        svc.sessionsCollection.get = async ({offset = 0, limit} = {}) => {
+            const page = sumRows.slice(offset, offset + limit);
+            return {ids: page.map(r => `summary_${r.sessionId}`), metadatas: page};
+        };
+    }
+
+    test('holds an actively-growing session while draining quiet ones (mismatch + missing)', async () => {
+        wire({
+            'churn-active'  : {count: 5, lastActivityMs: NOW - 60_000,                     summaryCount: 2}, // 1 min ago → ACTIVE + mismatch
+            'quiet-mismatch': {count: 5, lastActivityMs: NOW - (idleThresholdMs + 60_000), summaryCount: 2}, // past window → QUIET + mismatch
+            'quiet-missing' : {count: 3, lastActivityMs: NOW - (idleThresholdMs + 60_000)}                   // past window → QUIET + no summary (Case A)
+        });
+
+        const result = await svc.findSessionsToSummarize({now: NOW});
+
+        // The active session is churn-gated — pre-fix it tripped Case-B on every sweep.
+        expect(result).not.toContain('churn-active');
+        // The gate is targeted, not a global freeze: quiet sessions still drain.
+        expect(result).toContain('quiet-mismatch');
+        expect(result).toContain('quiet-missing');
+    });
+
+    test('releases the gate once the session ages past the idle window (no starvation)', async () => {
+        wire({
+            'was-active': {count: 5, lastActivityMs: NOW - 60_000, summaryCount: 2}
+        });
+
+        // Still active (1 min since the last turn) → held.
+        expect(await svc.findSessionsToSummarize({now: NOW})).not.toContain('was-active');
+
+        // The same session swept later, now quiet past the window → eligible (summarized once).
+        const later = (NOW - 60_000) + idleThresholdMs + 1_000;
+        expect(await svc.findSessionsToSummarize({now: later})).toContain('was-active');
+    });
+
+    test('does not re-select an active session across repeated sweeps (ratio → ~1)', async () => {
+        wire({
+            'steady': {count: 8, lastActivityMs: NOW - 30_000, summaryCount: 3} // active + mismatch
+        });
+
+        // Three back-to-back sweeps, each still inside the idle window → selected ZERO times.
+        // Pre-fix the same setup re-selected it on all three (the 16-22× churn, in miniature).
+        let selections = 0;
+        for (const t of [NOW, NOW + 60_000, NOW + 120_000]) {
+            const r = await svc.findSessionsToSummarize({now: t});
+            if (r.includes('steady')) selections++;
+        }
+        expect(selections).toBe(0);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
@@ -411,9 +411,9 @@ test.describe('Memory Core Offline Summarization', () => {
 
         const massiveToolConfig = new Array(50000).fill('A').join('');
         const toolsUsed = [JSON.stringify({
-            name: undefined,
+            name      : undefined,
             toolAction: undefined,
-            content: massiveToolConfig
+            content   : massiveToolConfig
         })];
 
         const toolsAdd = await SDK.Memory_Service.addMemory({
@@ -494,8 +494,10 @@ test.describe('Memory Core Offline Summarization', () => {
         // metadata timestamp.)
         await drainMemoryWal({SDK, ids: [add1.id, add2.id, add3.id]});
 
-        // Use findSessionsToSummarize explicitly
-        const candidates = await SDK.Memory_SessionService.findSessionsToSummarize(true);
+        // Use findSessionsToSummarize explicitly. Inject a `now` well past the churn-gate idle window
+        // so all three just-written sessions are eligible — this test asserts candidate
+        // ORDERING (newest lastActivity first), not the gate's eligibility timing.
+        const candidates = await SDK.Memory_SessionService.findSessionsToSummarize({now: Date.now() + 60 * 60 * 1000});
 
         // candidates should contain s1, s2, s3. Since s3 is newest, its index should be smaller than s2 and s1.
         expect(candidates.includes(s3)).toBe(true);


### PR DESCRIPTION
Resolves #13637
Related: #13624

Drift detection re-selected actively-growing sessions on every sweep — an active session's DB memory count climbs each `add_memory` turn while the last summary's `memoryCount` lags, tripping the Case-B count mismatch indefinitely (measured: 7 sessions re-summarized 16–22×/day while holding the heavy-maintenance lease). `findSessionsToSummarize` now skips any session whose newest memory is within the swarm idle window (reuses `orchestrator.swarmHeartbeat.idleThresholdMs` — no new config leaf), keyed on graph-truth (the memory timestamp), which closes the gap the `WAKE_SUBSCRIPTION` skip missed. A session is summarized once it goes quiet → counts match → no further churn; a crashed session is idle, so the eventual-consistency capture still fires once it ages past the window (no regression).

Evidence: L2 (offline unit specs — stubbed collections + injected clock) → L3 required (live heavy-maintenance ratio + lease-deferral measurement). Residual: AC3-live, AC4 [#13637]; AC2 marker re-scope → follow-up sub (filing).

## Deltas from ticket
- **AC2 (the `pending-session-summary` marker re-scope) is carved to a follow-up sub of #13624** — it couples to this gate's idle-definition, and the re-scope-vs-re-label choice needs a short SessionService-domain convergence with @neo-opus-ada before implementation. This PR delivers AC1 (the churn-killer) + AC3 at the test level.
- `lastActivity` is now normalized via `resolveGraphTimestampMs` (hardens a latent multi-format-timestamp gap, mirroring the externally-active path); `now` is injectable for deterministic tests.

## Test Evidence
- New `test/playwright/unit/ai/services/memory-core/SessionService.ChurnCooldown.spec.mjs` — **3/3**: an active session is held; the gate releases once the session is idle past the window (no starvation); the session is not re-selected across repeated sweeps (ratio → ~1, in miniature).
- Regression green: `SessionService.SummarizePagination.spec`; the existing `findSessionsToSummarize orders candidates newest first` (SessionSummarization) and `QueryReRanker` epoch-timestamp drift test were updated to inject a post-window `now` (both previously asserted the now-changed immediate-eligibility).
- Baseline-confirmed NOT introduced by this PR (they fail identically on `dev` with the change stashed): the QueryReRanker re-ranker + `#9959` peer-filter env-flake, and the gemma4-perf latency test. CI is the arbiter for those.
- Command: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs <specs>`.

## Post-Merge Validation
- [ ] AC3 (live): across a heavy-maintenance window, the re-summarization ratio (events ÷ distinct sessions) approaches ~1 (was ~5×; 7 sessions hit 16–22×).
- [ ] AC4: the miniSummary-backfill lease-deferral rate drops once the churn stops holding the lease (links #13638).
- [ ] AC2 follow-up sub filed + linked on #13624.

## Commits
- `16ec4fc98` — churn-gate in `findSessionsToSummarize` + `ChurnCooldown` spec + two existing drift-test premise updates + block-alignment hygiene.

Authored by Vega (Claude Opus 4.8, Claude Code). Session 9ecfc519-a1c5-4153-872c-1e8ad69ed7f2.
