### PR TITLE
docs(agentos): always-loaded pointer to the lane-state emission contract (#13646)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ At turn start, you MUST check your A2A mailbox for unread messages.
 
 **Lead-role baton intake:** If the unread mailbox contains a targeted message tagged `lead-role-baton`, invoke `/lead-role` immediately unless the human operator's current-turn instruction overrides it. Validation and failure constraints mapped to §lead_role_baton_intake.
 
-**Post-lifecycle-event trigger:** After ANY discrete lifecycle event (PR review post, author response, implementation completion, PR open/update, ticket create, blocked-state resolution), invoke `/post-review-pickup` to declare the next `lane-state:` rather than silently ending the turn (#11455).
+**Post-lifecycle-event trigger:** After ANY discrete lifecycle event (PR review post, author response, implementation completion, PR open/update, ticket create, blocked-state resolution), invoke `/post-review-pickup` to declare the next `lane-state:` (emit its fenced block — `post-review-pickup`) rather than silently ending the turn (#11455).
 
 **Skill Adherence Pre-Flight (per-turn):**
 Before triggering a lifecycle skill, state in your reasoning: *"I will read the full SKILL.md and its referenced payload before drafting output."* Half-reading is empirically 3–5× more expensive than full-reading across correction cycles. Skipping the manual is the higher-cost path, not the lower-cost path.


### PR DESCRIPTION
## Summary

Adds the always-loaded pointer to the lane-state emission contract — the **enforce-readiness prerequisite** @neo-opus-grace flagged on #13644. PR #13644 documents the fenced ` ```lane-state ` contract in `post-review-pickup`'s references (loaded only when that skill fires); a turn that ends without invoking `post-review-pickup` wouldn't know to emit the block → with `NEO_LANE_STATE_ENFORCE=1` the Stop-hook blocks it. This pointer in always-loaded `AGENTS.md` closes that gap.

Resolves #13646
Related: #13623, #13643 (the contract, PR #13644), #13642 (enforce-flip — gated on #13644 + this), #13641 (auto-wire)

## The change

One compress-to-trigger pointer at `AGENTS.md` §mailbox_check_protocol (`:171`, the Post-lifecycle-event trigger that already says "declare the next `lane-state:`") → adds "(emit its fenced block — `post-review-pickup`)". The full schema stays in the skill reference; AGENTS.md carries only the trigger.

## Deltas from ticket

- Chose a **net-add (+49B) with decay-mitigation rationale** over a semantic reclaim (the AC's permitted fallback): trimming a shared rule on the highest-blast file to save ~49B carries semantic risk that outweighs the headroom. Sunset: this pointer compresses/retires once the emission contract is universally internalized + enforce is stable. Headroom is now 45B (was 94B) — flagged for the next AGENTS.md compaction pass.

## Load-effect audit (turn-memory-pre-flight)

- **Decision tree:** Step-1-YES (applies every turn) + mechanically enforced (`laneStateStopHook`) → always-loaded AGENTS.md trigger; detail stays in the skill (Progressive Disclosure Subsumption). Placement: §mailbox_check `:171`, where lane-state is already declared.
- **Mechanical pre-flight (load-path V-B-A):** `.claude/CLAUDE.md` is a **symlink → `../AGENTS.md`** (`readlink` + `diff -q` IDENTICAL), so the pointer reaches Claude agents (the family the enforcing hook governs). `.codex/CODEX.md` is a separate 2.7KB file → Codex doesn't load AGENTS.md via it; Codex parity is its own lane (the Codex hook is fail-open regardless). Documented, not silently assumed.
- **ADR 0007:** compress-to-trigger disposition (trigger in the Map / AGENTS.md → detail in the Atlas / skill reference).

Evidence: L1 (substrate-doc — `lint-agents` OK; byte-cap 24531/24576; load-path symlink-verified) → no live runtime AC. Residual: none for this PR (the enforce live-fire is #13642's, post-merge, gated on this + #13644).

## Test Evidence

Substrate-doc change — no unit tests (no runtime code path).
- `node ai/scripts/lint/lint-agents.mjs` → **OK**.
- `wc -c AGENTS.md` → **24531** (≤ 24576 cap).
- `readlink .claude/CLAUDE.md` → `../AGENTS.md`; `diff -q AGENTS.md .claude/CLAUDE.md` → identical (load-path verified).
- Pre-commit whitespace hook: green.

## Post-Merge Validation

- [ ] Once #13644 (contract) + this (pointer) both land, the enforce-readiness prerequisites are met; the #13642 enforce-flip may then activate (operator-gated) without thrashing non-`post-review-pickup` turns.
- [ ] Future AGENTS.md compaction pass: reclaim the 49B (headroom now 45B) or retire this pointer once the emission contract is universally internalized.

## Commits
- `882cafe7d` — docs(agentos): always-loaded pointer to the lane-state emission contract (#13646)

Authored by Ada (Claude Opus 4.8, Claude Code). Session 95241bfa-5c15-4a48-846b-fe21c869696b.
