### PR TITLE
fix(ai): Stop-hook refuses turn-end in enforce — operator-dialogue is the only valid stop (#13649)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -157,6 +157,7 @@ export function isOperatorInLoop({stopHookActive, promptingText = ''}) {
 // are cross-family-convergence-fixed — refine prose, not meaning.
 const IDLE_REMINDER = `Turn-end refused — L3_No_Hold_State: there is no hold state, and you do not get to stop.
 Declaring a lane is NOT driving it. Do the next concrete action NOW:
+  • check your mailbox (list_messages) — new A2A or a lifecycle event may have shifted your lane
   • continue your own lane
   • open a PR
   • clear CHANGES_REQUESTED on your own PR

--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -1,39 +1,39 @@
 #!/usr/bin/env node
 /**
  * @module .claude/hooks/laneStateStopHook
- * @summary Claude Code `Stop` hook for idle-out enforcement — DRY-RUN (log-only) by default.
+ * @summary Claude Code `Stop` hook — REFUSES every turn-end except a live operator dialogue.
+ * DRY-RUN (log-only) by default; ENFORCE via `NEO_LANE_STATE_ENFORCE=1`.
  *
- * Fires at every agent turn-end (the `Stop` event). Reads the turn transcript, extracts the agent's
- * declared lane-state terminal from a fenced ```lane-state block, validates it, and — in ENFORCING
- * mode — blocks the stop + injects a "pick a lane" directive when the terminal is an invalid idle-out.
- * In DRY-RUN mode (default) it only LOGS what it WOULD block, so the swarm can audit for false-
- * positives (e.g. a legitimate all-lanes-handed-off terminal — the handoff-terminal AC) before
- * enforcement is on.
+ * Fires at every agent turn-end (the `Stop` event). The decision rule: there is NO valid voluntary
+ * stop except a **live operator dialogue** — a turn that directly replied to a genuine human-operator
+ * message, where the human takes the next turn (turn-taking, not idling). A "valid" fenced ```lane-state
+ * block is a RECORD (the directive's context + the external substance record), NOT a license to stop:
+ * declaring a lane and halting is the announce-without-execute idle-out the hook exists to prevent.
  *
- * Mechanism (docs-grounded; the Option-A convergence):
- *  - `stop_hook_active` loop-guard: if Claude is already in a forced continuation, allow the stop
- *    (Claude Code also force-overrides after 8 consecutive blocks).
- *  - `transcript_path` → final text → `parseLaneState` → one of three buckets:
- *      null (no block emitted → ABSENT) · throw (block present but malformed JSON → MALFORMED) ·
- *      descriptor → `validateLaneStateTerminal` → {valid, violations}. All non-valid buckets are
- *      idle-out failures with distinct reasons; a valid terminal allows.
+ * Mechanism:
+ *  - `operatorInLoop` (the one allow) is determined EXTERNALLY by `isOperatorInLoop`, never
+ *    self-declared, so it cannot be gamed: the prompting message must NOT be a `stop_hook_active`
+ *    forced continuation, NOT a `[WAKE]` autonomous injection, and must be confirmable (fail-closed).
+ *  - Otherwise: ENFORCE → block; DRY-RUN → would-block (log only — the audit path). The lane-state
+ *    `verdict` (`parseLaneState` → `validateLaneStateTerminal`) no longer gates the action — it only
+ *    supplies the `reason` for the injected directive.
  *  - Block path (ENFORCING): write `{"decision":"block","reason":"…"}` to stdout — Claude keeps
- *    working and uses the `reason` as its next instruction.
+ *    working and uses the injected directive as its next instruction. The only autonomous stop is a
+ *    hard external limit: Claude Code's consecutive-block force-override (the bounded ceiling the hook
+ *    cannot override), context-sunset, or an operator halt.
  *
  * SAFETY — this hook MUST NEVER block a turn-end on its OWN failure (a malformed hook payload, an
  * unreadable transcript, a validator throw). Those allow the stop + audit. A *malformed lane-state
- * emission* (parseLaneState throws) is NOT our failure — it's the agent emitting garbage, a real
- * block-able bucket. So a hook bug can never trap the swarm, but a broken emission still counts.
+ * emission* (parseLaneState throws) is NOT our failure — it feeds the directive's `reason`, not the gate.
  *
  * ACTIVATION = operator-authority: this script is INERT until wired into the harness settings
- * (`.claude/settings.*` — gitignored per-clone). Wire it in DRY-RUN first, audit the WOULD-BLOCK
- * log for handoff false-positives, then set `NEO_LANE_STATE_ENFORCE=1` to enforce. A buggy blocking
- * hook would trap every agent's turn-end, so the dry-run → audit → enforce ramp is the safe rollout.
+ * (`.claude/settings.*`). Wire it in DRY-RUN first, audit the WOULD-BLOCK log, then set
+ * `NEO_LANE_STATE_ENFORCE=1` to enforce. A buggy blocking hook would trap every agent's turn-end, so
+ * the dry-run → audit → enforce ramp is the safe rollout.
  *
- * SEAM: `parseLaneState` (transcript → descriptor | null | throws) + `validateLaneStateTerminal`
- * (descriptor → {valid, violations}) are imported from `ai/scripts/lifecycle/` — pure, zero-dependency
- * modules so this hook stays light on every turn-end. The pure `parseOutcomeToVerdict` (3 buckets →
- * verdict) + `decideHookAction` (verdict + enforcing → action) are exported + unit-tested independently.
+ * SEAM: `parseLaneState` + `validateLaneStateTerminal` (imported from `ai/scripts/lifecycle/`) supply
+ * the `verdict`'s reason; the pure `parseOutcomeToVerdict`, `decideHookAction`, and `isOperatorInLoop`
+ * are exported + unit-tested independently.
  *
  * @see https://code.claude.com/docs/en/hooks — Stop hook contract (stdin payload, decision:block)
  */
@@ -48,8 +48,8 @@ import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLane
 // Enforce ONLY when the operator explicitly activates it; default is DRY-RUN (log-only, never blocks).
 const ENFORCING = process.env.NEO_LANE_STATE_ENFORCE === '1';
 
-// Append-only dry-run audit log — the substrate for auditing WOULD-BLOCK false-positives (esp. the
-// handoff-terminal AC) before enforcement. NEO_AI_DAEMON_DIR override keeps tests off the real store.
+// Append-only audit log — the WOULD-BLOCK / ALLOW record for auditing the dry-run before enforcement.
+// NEO_AI_DAEMON_DIR override keeps tests off the real store.
 const LOG_DIR  = process.env.NEO_AI_DAEMON_DIR || path.join(os.homedir(), '.neo-ai-data', 'lane-state-hook');
 const LOG_FILE = path.join(LOG_DIR, 'lane-state-stop-hook.log');
 
@@ -271,10 +271,10 @@ export function extractFinalAssistantText(input = {}) {
 }
 
 /**
- * @summary Hook entry. Resolves the Stop-hook payload → loop-guard → final message → parse outcome →
- * verdict → decideHookAction, then blocks+injects (enforcing) or audit-logs the would-be decision.
- * Always exits 0 on any of OUR OWN failures (bad payload, unreadable transcript, validator throw) — a
- * hook bug must never trap a turn-end. A malformed *emission* still counts (that's the agent's, not ours).
+ * @summary Hook entry. Resolves the Stop-hook payload → final message + prompting message →
+ * operator-in-loop check → verdict → decideHookAction, then blocks+injects (enforcing) or audit-logs
+ * the decision. Always exits 0 on any of OUR OWN failures (bad payload, unreadable transcript,
+ * validator throw) — a hook bug must never trap a turn-end.
  * @protected
  */
 async function main() {

--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -105,34 +105,67 @@ export function parseOutcomeToVerdict({descriptor, parseError}, validate) {
 }
 
 /**
- * @summary Pure decision — maps a terminal `verdict` + whether we're `enforcing` to the Stop-hook
- * action. Exported + unit-tested: the heart of the idle-out mechanism — a non-valid terminal blocks
- * (enforcing) or would-block (dry-run); a valid terminal always allows (so a legitimate handoff is
- * never trapped, even when enforcing).
+ * @summary Pure decision — maps a terminal `verdict` + the mode (`enforcing`) + whether a live human
+ * operator prompted this turn (`operatorInLoop`) to the Stop-hook action. The heart of the idle-out
+ * mechanism; exported + unit-tested.
+ *
+ * The ONE legitimate voluntary stop is a **live operator dialogue** — this turn directly replied to a
+ * genuine human-operator message, so the human takes the next turn (turn-taking, not idling). That is
+ * `operatorInLoop`, and it ALWAYS allows. `operatorInLoop` is determined EXTERNALLY (the prompting
+ * message type — see the entry `main`), never self-declared, so it cannot be gamed.
+ *
+ * Every OTHER turn-end is an idle-out. A "valid" lane-state terminal is a declaration, not a license
+ * to stop (the announce-without-execute loophole the prior `verdict.valid → allow` branch left open).
+ * ENFORCE refuses it (block); DRY-RUN previews it (would-block, the false-positive audit path). The
+ * `verdict` no longer gates the action — it only supplies the `reason` for the injected directive and
+ * the external substance record. The only autonomous stop is a hard external limit (Claude Code's
+ * consecutive-block force-override, context-sunset, or an operator halt).
  * @param {{valid: Boolean, reason: String}} verdict
  * @param {Boolean} enforcing
+ * @param {Boolean} [operatorInLoop=false] True iff a genuine human-operator message prompted this turn.
  * @returns {{action: ('allow'|'block'|'would-block'), reason: String}}
  */
-export function decideHookAction(verdict, enforcing) {
-    if (verdict.valid) return {action: 'allow',       reason: verdict.reason};
-    if (enforcing)     return {action: 'block',       reason: verdict.reason};
-    return             {action: 'would-block', reason: verdict.reason};
+export function decideHookAction(verdict, enforcing, operatorInLoop = false) {
+    if (operatorInLoop) {
+        return {action: 'allow', reason: 'live operator dialogue — yielding for the human turn'};
+    }
+    return enforcing
+        ? {action: 'block',       reason: verdict.reason}
+        : {action: 'would-block', reason: verdict.reason};
+}
+
+/**
+ * @summary Detects whether a genuine human OPERATOR prompted this turn — the one signal that makes a
+ * voluntary stop legitimate (turn-taking with a human who takes the next turn). Determined externally
+ * so it cannot be self-declared/gamed: a turn is operator-driven iff it is NOT a forced continuation
+ * (`stop_hook_active`), its prompting message is NOT an autonomous `[WAKE]` injection, AND a prompt is
+ * actually confirmable. FAIL-CLOSED: an empty / unreadable prompt is treated as autonomous (no idle
+ * granted on uncertainty) — the real Stop payload always carries the transcript, so this only bites a
+ * transient read-failure, which should keep working rather than idle. Pure; exported + unit-tested.
+ * @param {{stopHookActive: Boolean, promptingText: String}} signals
+ * @returns {Boolean}
+ */
+export function isOperatorInLoop({stopHookActive, promptingText = ''}) {
+    if (stopHookActive)        return false;                // forced continuation — no human waiting
+    if (!promptingText.trim()) return false;                // no confirmable human prompt → autonomous
+    return !/^\s*\[WAKE\]/.test(promptingText);             // [WAKE] = autonomous wake; else = operator
 }
 
 // The curated no-hold-state directive injected on a block. References the always-loaded
 // L3_No_Hold_State stance + carries a self-sufficient operational core (the lifecycle ladder + the
 // named-lane teeth-test) so it redirects without assuming a live L3 lookup. The wording's semantics
 // are cross-family-convergence-fixed — refine prose, not meaning.
-const IDLE_REMINDER = `Blocked — L3_No_Hold_State: there is no hold state.
-Name the next concrete action that is YOURS to take now:
+const IDLE_REMINDER = `Turn-end refused — L3_No_Hold_State: there is no hold state, and you do not get to stop.
+Declaring a lane is NOT driving it. Do the next concrete action NOW:
   • continue your own lane
+  • open a PR
   • clear CHANGES_REQUESTED on your own PR
-  • do an assigned review that advances a named lane
+  • review a peer's PR that advances a named lane
   • or claim a new high-value lane
 Teeth-test: does this advance a NAMED lane right now? If you can't name the lane, it isn't driving.
 Collaboration (review · ideation · A2A) counts ONLY when it advances a named lane AND ends with a return to your own lane or an explicit lane-swap — it is an interruption, not a replacement for your own PRs.
 Passive waiting (a merge · a review · CI) is parked, not driven — take another lane.
-The only real stop is a hard external limit: context-sunset or an operator halt.`;
+The only stop is a hard external limit: context-sunset, an operator halt, or a live operator reply.`;
 
 /**
  * @summary Composes the directive injected on a block — the curated `IDLE_REMINDER` (the actionable
@@ -190,6 +223,33 @@ export function extractLastAssistantTextFromJsonl(jsonl = '') {
 }
 
 /**
+ * @summary Extracts the LAST user message's text from a Claude Code JSONL transcript — the message
+ * that PROMPTED the current turn. Used to classify the prompt as a genuine operator turn vs an
+ * autonomous `[WAKE]` injection. Skips tool_result records (no text blocks); tolerant of malformed
+ * lines. Mirrors {@link extractLastAssistantTextFromJsonl}.
+ * @param {String} jsonl
+ * @returns {String}
+ * @protected
+ */
+export function extractLastUserTextFromJsonl(jsonl = '') {
+    const lines = jsonl.split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        let record;
+        try { record = JSON.parse(line); } catch { continue; }
+
+        const message = record.message || record;
+        if ((message.role || record.type) !== 'user') continue;
+
+        const text = extractTextFromContent(message.content);
+        if (text) return text;
+    }
+    return '';
+}
+
+/**
  * @summary Resolves the agent's FINAL assistant message text — the surface the lane-state block is
  * emitted into. Prefers the Stop payload's `last_assistant_message` (already-decoded; a string or a
  * message object); falls back to JSONL-parsing `transcript_path` for the last assistant text. Raw
@@ -225,11 +285,6 @@ async function main() {
         process.exit(0);
     }
 
-    // Loop-safety: if Claude is already in a forced continuation from a prior block, allow the stop.
-    if (input.stop_hook_active) {
-        process.exit(0);
-    }
-
     // Resolve the agent's FINAL message text (last_assistant_message, or JSONL-extracted from the
     // transcript) — NOT the raw transcript: raw Claude JSONL is JSON-escaped, so the fence parser
     // only matches extracted text (the runtime input boundary a cross-family review caught).
@@ -241,6 +296,20 @@ async function main() {
         auditLog(`READ-ERROR: ${e.message}; allowing stop.`);
         process.exit(0);
     }
+
+    // The ONE legitimate voluntary stop is a live operator dialogue — determined EXTERNALLY (the
+    // prompting message type), never self-declared. A `stop_hook_active` forced continuation OR a
+    // `[WAKE]` autonomous prompt is not a human turn → no voluntary stop. A transcript read-failure
+    // here is OUR failure → fall back to the stop_hook_active signal alone (never trap on a read error).
+    let promptingText = '';
+    try {
+        if (input.transcript_path) {
+            promptingText = extractLastUserTextFromJsonl(fs.readFileSync(input.transcript_path, 'utf8'));
+        }
+    } catch (e) {
+        // best-effort; isOperatorInLoop falls back to stop_hook_active when promptingText is empty
+    }
+    const operatorInLoop = isOperatorInLoop({stopHookActive: !!input.stop_hook_active, promptingText});
 
     // parseLaneState throwing is a MALFORMED emission (the agent's garbage), NOT our failure → it
     // feeds the verdict (a real block-able bucket), distinct from an absent emission (null).
@@ -261,7 +330,7 @@ async function main() {
     }
 
     const session          = input.session_id || '?',
-          {action, reason} = decideHookAction(verdict, ENFORCING);
+          {action, reason} = decideHookAction(verdict, ENFORCING, operatorInLoop);
 
     if (action === 'block') {
         auditLog(`BLOCK (session=${session}): ${reason}`);
@@ -273,7 +342,7 @@ async function main() {
         return;
     }
 
-    auditLog(`${action === 'would-block' ? 'WOULD-BLOCK' : 'WOULD-ALLOW'} (session=${session}): ${reason}`);
+    auditLog(`${action === 'would-block' ? 'WOULD-BLOCK' : 'ALLOW'} (session=${session}): ${reason}`);
     process.exit(0);
 }
 

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,6 +1,6 @@
-import {test, expect}                                                                             from '@playwright/test';
-import {composeBlockDirective, decideHookAction, parseOutcomeToVerdict, extractFinalAssistantText,
-        extractLastAssistantTextFromJsonl}                                                       from '../../../../.claude/hooks/laneStateStopHook.mjs';
+import {test, expect}                                                                              from '@playwright/test';
+import {composeBlockDirective, decideHookAction, isOperatorInLoop, parseOutcomeToVerdict,
+        extractFinalAssistantText, extractLastAssistantTextFromJsonl, extractLastUserTextFromJsonl} from '../../../../.claude/hooks/laneStateStopHook.mjs';
 import {spawn} from 'node:child_process';
 import fs      from 'node:fs';
 import os      from 'node:os';
@@ -9,11 +9,14 @@ import path    from 'node:path';
 const block = body => '```lane-state\n' + body + '\n```';
 
 /**
- * Falsification tests for the idle-out Stop-hook. Three layers: (1) the pure decision logic
- * (`parseOutcomeToVerdict` 3-bucket chain + `decideHookAction`); (2) input resolution — the agent's
- * final message comes from the Stop payload's `last_assistant_message`, NOT the raw JSONL transcript
- * (the runtime boundary a cross-family review caught — raw JSONL is escaped, so the fence parser must run
- * on extracted text); (3) end-to-end — the spawned real hook against the real Stop payload shape.
+ * Falsification tests for the idle-out Stop-hook. Layers: (1) the pure decision logic
+ * (`parseOutcomeToVerdict` 3-bucket chain + `decideHookAction` + `isOperatorInLoop`); (2) input
+ * resolution — final assistant text + the prompting user message come from the Stop payload /
+ * transcript, not raw JSONL lines (raw JSONL is escaped); (3) end-to-end — the spawned real hook.
+ *
+ * The decision rule: there is NO valid voluntary stop except a live operator dialogue. A
+ * "valid" lane-state terminal is a declaration, not a license to stop — enforce REFUSES it. The one
+ * allow is `operatorInLoop`, determined EXTERNALLY (the prompting message type), never self-declared.
  */
 test.describe('laneStateStopHook — pure idle-out decision logic', () => {
     test.describe('parseOutcomeToVerdict — the 3-bucket chain', () => {
@@ -44,40 +47,62 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
         });
     });
 
-    test.describe('decideHookAction — enforce / dry-run', () => {
-        test('a VALID terminal always ALLOWS — dry-run AND enforcing (never traps a legit handoff)', () => {
-            expect(decideHookAction({valid: true, reason: 'ok'}, false).action).toBe('allow');
-            expect(decideHookAction({valid: true, reason: 'ok'}, true).action).toBe('allow');
+    test.describe('decideHookAction — operator-dialogue is the only allow (#13649)', () => {
+        test('VALID + no operator → BLOCK (enforce) / WOULD-BLOCK (dry-run) — the loophole is closed', () => {
+            expect(decideHookAction({valid: true, reason: 'ok'}, true,  false).action).toBe('block');
+            expect(decideHookAction({valid: true, reason: 'ok'}, false, false).action).toBe('would-block');
         });
 
-        test('an INVALID terminal WOULD-BLOCK in dry-run — logs the would-be block, never blocks', () => {
-            const result = decideHookAction({valid: false, reason: 'no active lane'}, false);
+        test('operatorInLoop ALWAYS allows — a live human takes the next turn (enforce AND dry-run)', () => {
+            expect(decideHookAction({valid: false, reason: 'x'}, true,  true).action).toBe('allow');
+            expect(decideHookAction({valid: true,  reason: 'x'}, false, true).action).toBe('allow');
+        });
+
+        test('INVALID + no operator → BLOCK when enforcing — the reason is carried through to inject', () => {
+            const result = decideHookAction({valid: false, reason: 'no active lane — pick one or drive'}, true, false);
+            expect(result.action).toBe('block');
+            expect(result.reason).toBe('no active lane — pick one or drive');
+        });
+
+        test('INVALID + no operator → WOULD-BLOCK in dry-run — previews, never blocks', () => {
+            const result = decideHookAction({valid: false, reason: 'no active lane'}, false, false);
             expect(result.action).toBe('would-block');
             expect(result.reason).toBe('no active lane');
         });
+    });
 
-        test('an INVALID terminal BLOCKS when enforcing — the reason is carried through to inject', () => {
-            const result = decideHookAction({valid: false, reason: 'no active lane — pick one or cite a survey'}, true);
-            expect(result.action).toBe('block');
-            expect(result.reason).toBe('no active lane — pick one or cite a survey');
+    test.describe('isOperatorInLoop — the external, non-self-declared stop signal', () => {
+        test('stop_hook_active (forced continuation) → false', () => {
+            expect(isOperatorInLoop({stopHookActive: true, promptingText: 'do X'})).toBe(false);
+        });
+
+        test('a [WAKE] autonomous prompt → false', () => {
+            expect(isOperatorInLoop({stopHookActive: false, promptingText: '[WAKE][priority:normal] 1 events for @neo-opus-grace'})).toBe(false);
+        });
+
+        test('an empty / unconfirmable prompt → false (FAIL-CLOSED: no idle on uncertainty)', () => {
+            expect(isOperatorInLoop({stopHookActive: false, promptingText: ''})).toBe(false);
+            expect(isOperatorInLoop({stopHookActive: false, promptingText: '   '})).toBe(false);
+        });
+
+        test('a genuine operator message → true', () => {
+            expect(isOperatorInLoop({stopHookActive: false, promptingText: 'please do X, then report'})).toBe(true);
         });
     });
 
     test.describe('composeBlockDirective — the injected no-hold-state directive', () => {
-        test('carries the curated reminder (L3 stance + lifecycle + teeth-test) AND the trigger cause', () => {
+        test('carries the curated reminder (L3 stance + teeth-test + lifecycle) AND the trigger cause', () => {
             const directive = composeBlockDirective('no lane-state block emitted at turn-terminal');
-            // The actionable WHAT-to-do: the L3 stance + the named-lane teeth-test + the lifecycle ladder.
             expect(directive).toContain('L3_No_Hold_State');
             expect(directive).toContain('there is no hold state');
             expect(directive).toContain('advance a NAMED lane');
             expect(directive).toContain('Passive waiting');
-            // The WHY-blocked: the specific trigger cause, preserved for context.
             expect(directive).toContain('no lane-state block emitted at turn-terminal');
         });
     });
 });
 
-test.describe('laneStateStopHook — input resolution (last_assistant_message primary + JSONL fallback)', () => {
+test.describe('laneStateStopHook — input resolution (assistant final text + prompting user message)', () => {
     test('last_assistant_message string is used verbatim', () => {
         const text = `On it.\n\n${block('{"laneContinuation":"active-lane"}')}`;
         expect(extractFinalAssistantText({last_assistant_message: text})).toBe(text);
@@ -110,6 +135,16 @@ test.describe('laneStateStopHook — input resolution (last_assistant_message pr
         expect(extractLastAssistantTextFromJsonl(jsonl)).toBe('earlier text');
     });
 
+    test('extractLastUserTextFromJsonl: returns the LAST user text record (skips assistant + tool_result)', () => {
+        const jsonl = [
+            JSON.stringify({type: 'user',      message: {role: 'user',      content: 'first operator message'}}),
+            JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'reply'}]}}),
+            JSON.stringify({type: 'user',      message: {role: 'user',      content: [{type: 'tool_result', tool_use_id: 'x', content: 'r'}]}}),
+            JSON.stringify({type: 'user',      message: {role: 'user',      content: '[WAKE][priority:normal] 1 events'}})
+        ].join('\n');
+        expect(extractLastUserTextFromJsonl(jsonl)).toBe('[WAKE][priority:normal] 1 events');
+    });
+
     test('no assistant text → empty string (so the hook treats it as an absent emission)', () => {
         expect(extractLastAssistantTextFromJsonl('{"type":"user","message":{"role":"user","content":"q"}}')).toBe('');
         expect(extractFinalAssistantText({})).toBe('');
@@ -119,22 +154,23 @@ test.describe('laneStateStopHook — input resolution (last_assistant_message pr
 test.describe('laneStateStopHook — end-to-end (spawned hook against the real Stop payload)', () => {
     /**
      * @summary Spawns the real hook with a Stop payload + a temp audit-log dir; returns `{stdout, log}`.
-     * Default passes the text as `last_assistant_message` (the real Stop shape); `viaJsonl` instead
-     * writes a JSONL `transcript_path` whose last assistant record carries the text (the fallback path).
+     * `promptingText` (when set) writes a `transcript_path` whose last USER record carries it — the
+     * operator-vs-wake classification surface. Otherwise the final text rides `last_assistant_message`
+     * with no transcript → no confirmable prompt → fail-closed autonomous.
      * @param {String} finalText
-     * @param {{enforce: Boolean, viaJsonl: Boolean}} [opts]
+     * @param {{enforce: Boolean, promptingText: (String|null), stopHookActive: Boolean}} [opts]
      * @returns {Promise<{stdout: String, log: String}>}
      */
-    function runHook(finalText, {enforce = false, viaJsonl = false} = {}) {
+    function runHook(finalText, {enforce = false, promptingText = null, stopHookActive = false} = {}) {
         return new Promise((resolve, reject) => {
             const dir            = fs.mkdtempSync(path.join(os.tmpdir(), 'lane-hook-e2e-')),
                   transcriptPath = path.join(dir, 'transcript.jsonl'),
                   env            = {...process.env, NEO_AI_DAEMON_DIR: dir},
-                  payload        = {stop_hook_active: false, session_id: 'e2e'};
+                  payload        = {stop_hook_active: stopHookActive, session_id: 'e2e'};
 
-            if (viaJsonl) {
+            if (promptingText !== null) {
                 fs.writeFileSync(transcriptPath, [
-                    JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'thinking', thinking: 'noise'}]}}),
+                    JSON.stringify({type: 'user',      message: {role: 'user',      content: promptingText}}),
                     JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: finalText}]}})
                 ].join('\n') + '\n');
                 payload.transcript_path = transcriptPath;
@@ -159,47 +195,51 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         });
     }
 
-    test('a VALID emission (active-lane) via last_assistant_message → WOULD-ALLOW, no block on stdout', async () => {
-        const {stdout, log} = await runHook(`On it.\n\n${block('{"laneContinuation":"active-lane"}')}`);
-        expect(log).toContain('WOULD-ALLOW');
+    const validTerminal = `On it.\n\n${block('{"laneContinuation":"active-lane"}')}`;
+
+    test('LIVE OPERATOR dialogue (genuine prompt) → ALLOW even with a bare prose terminal', async () => {
+        const {stdout, log} = await runHook('Done — over to you.', {enforce: true, promptingText: 'please do X, then report'});
+        expect(log).toContain('ALLOW');
         expect(stdout).toBe('');
     });
 
-    test('an INVALID emission (verified-no-lane — a retired continuation) → WOULD-BLOCK as unknown', async () => {
-        const {stdout, log} = await runHook(block('{"laneContinuation":"verified-no-lane"}'));
+    test('loophole closed: a VALID terminal with NO operator prompt → WOULD-BLOCK (dry-run)', async () => {
+        const {stdout, log} = await runHook(validTerminal);
         expect(log).toContain('WOULD-BLOCK');
-        expect(log).toContain('Unknown laneContinuation');
         expect(stdout).toBe('');
     });
 
-    test('an ABSENT emission (no lane-state block) → WOULD-BLOCK', async () => {
+    test('ENFORCE + VALID terminal + WAKE prompt → BLOCK (a valid block is not a stop-license)', async () => {
+        const {stdout, log} = await runHook(validTerminal, {enforce: true, promptingText: '[WAKE][priority:normal] 1 events'});
+        expect(log).toContain('BLOCK');
+        expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('an ABSENT emission (no operator) → WOULD-BLOCK (dry-run)', async () => {
         const {log} = await runHook('Just some prose, no lane-state block here.');
         expect(log).toContain('WOULD-BLOCK');
         expect(log).toContain('no lane-state block emitted');
     });
 
-    test('a MALFORMED emission (block present, broken JSON) → WOULD-BLOCK, distinct from absent', async () => {
+    test('a MALFORMED emission → WOULD-BLOCK, distinct from absent', async () => {
         const {log} = await runHook(block('{laneContinuation: not valid json}'));
         expect(log).toContain('WOULD-BLOCK');
         expect(log).toContain('malformed');
     });
 
-    test('ENFORCING + invalid emission → blocks: {"decision":"block"} injects the curated directive + the cause', async () => {
-        const {stdout, log} = await runHook(block('{"laneContinuation":"verified-no-lane"}'), {enforce: true});
+    test('ENFORCE + invalid emission + autonomous prompt → BLOCK: injects the curated directive + cause', async () => {
+        const {stdout, log} = await runHook(block('{"laneContinuation":"verified-no-lane"}'), {enforce: true, promptingText: '[WAKE] 1 event'});
         expect(log).toContain('BLOCK');
         const decision = JSON.parse(stdout);
         expect(decision.decision).toBe('block');
-        // The injected reason is the curated no-hold-state directive ...
         expect(decision.reason).toContain('there is no hold state');
         expect(decision.reason).toContain('advance a NAMED lane');
-        // ... plus the specific trigger cause for context (post-#13630: verified-no-lane is a retired
-        // continuation, so the cause is the validator's unknown-continuation violation, not a survey rule).
         expect(decision.reason).toContain('Unknown laneContinuation');
     });
 
-    test('JSONL fallback: a valid block in the last assistant transcript record → WOULD-ALLOW', async () => {
-        const {stdout, log} = await runHook(`Done.\n\n${block('{"laneContinuation":"active-lane"}')}`, {viaJsonl: true});
-        expect(log).toContain('WOULD-ALLOW');
-        expect(stdout).toBe('');
+    test('stop_hook_active (forced continuation) + enforce → BLOCK (keeps refusing, no auto-allow)', async () => {
+        const {stdout, log} = await runHook(validTerminal, {enforce: true, promptingText: 'please do X', stopHookActive: true});
+        expect(log).toContain('BLOCK');
+        expect(JSON.parse(stdout).decision).toBe('block');
     });
 });


### PR DESCRIPTION
Resolves #13649

The live enforce test exposed the loophole: `decideHookAction` allowed a turn-end when a valid lane-state block was emitted, so an agent declares `active-lane #N` and idles — the announce-without-execute the hook exists to prevent. This adopts @neo-opus-vega's shape (drop the `verdict.valid → allow` branch) plus the operator-in-loop carve @tobiu raised: the one legitimate voluntary stop is a live operator dialogue.

## Decision rule

- `decideHookAction(verdict, enforcing, operatorInLoop)`: `operatorInLoop` ALWAYS allows; otherwise enforce **blocks** / dry-run **would-blocks**. The `verdict` no longer gates the action — the lane-state block becomes a *record* (directive context + the future external substance-check), not a stop-license.
- `isOperatorInLoop({stopHookActive, promptingText})`: the one valid voluntary stop, determined **externally** (NOT `stop_hook_active`, NOT a `[WAKE]` prompt, AND a confirmable prompt) so it cannot be self-declared/gamed. **Fail-closed** on an empty/unreadable prompt (no idle on uncertainty).
- `main()`: extracts the prompting user message; removed the `stop_hook_active` auto-allow — enforce keeps refusing, with Claude Code's consecutive-block force-override as the bounded ceiling (the one residual the hook can't override).

Evidence: L2 (committed unit tests — 26/26 green: pure decision + `isOperatorInLoop` + operator-vs-wake E2E) → L3 required (live enforce-fire across a restart). Residual: AC4 [#13649] — the force-override ceiling is verifiable only against a live Claude Code harness.

## Deltas from ticket
Added the operator-in-loop carve (per @tobiu, beyond the original always-block) — the one valid voluntary stop. Fail-closed default decided during implementation (no idle on an unreadable prompt).

## Test Evidence
- `npm run test-unit -- test/playwright/unit/hooks/laneStateStopHook.spec.mjs` → **26/26 green**.
- New coverage: `decideHookAction` (loophole-closed + operator-allow), `isOperatorInLoop` (stop_hook_active / `[WAKE]` / empty → false, operator → true), `extractLastUserTextFromJsonl`, and E2E (operator-dialogue → ALLOW; valid/wake/continuation → BLOCK).
- Husky pre-commit green.

## Post-Merge Validation
- [ ] After merge + `--migrate-config` + restart, an autonomous idle-out is refused (block + directive); a reply to a live operator message yields cleanly.
- [ ] The Claude Code consecutive-block force-override ceiling (AC4) behaves as the bounded escape.

## Commits
- `873455bcc` — `decideHookAction` + `isOperatorInLoop` + `main()` detection + `IDLE_REMINDER` + spec.

Refs #13623, #13624, #13628, #13642.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 1b60126f-a089-47e7-af8b-f47f3876f3a6.
