### PR TITLE
docs(agentos): MC stored-embedding-export repair runbook (#13496)

### DIFF
--- a/learn/agentos/tooling/RestorationRunbook.md
+++ b/learn/agentos/tooling/RestorationRunbook.md
@@ -130,13 +130,14 @@ A distinct failure from §3 (FTS5) and from a full restore (§2): `npm run ai:ch
    node ai/scripts/maintenance/probeCollectionQueryHealth.mjs
    npm run ai:check-chroma-integrity -- --exportability-sample-size 2 --json
    ```
-2. Stop every writer that can reach the unified Chroma store (as in §3 step 3): Orchestrator, Memory Core, Knowledge Base, wake daemons, harness MCP server instances, and the Chroma daemon.
-3. Capture a canonical backup **and** a physical copy of the store before any mutation:
+2. Quiesce every **competing writer** — but **leave the Chroma server running** (both the backup and the repair use its API; unlike §3's file-level FTS5 repair, this does **not** stop Chroma). Stop the Orchestrator, Memory Core, Knowledge Base, wake daemons, and harness MCP server instances (the `npm run ai:server` processes) so nothing else mutates the collections during the repair.
+3. With the writers stopped (store quiescent, Chroma still up), capture the canonical SDK backup and a coarse physical rollback copy:
    ```bash
    npm run ai:backup
    cp -R .neo-ai-data/chroma/unified .neo-ai-data/chroma/unified.pre-mc-repair-<timestamp>
    ```
-4. Run the repair (opt-in; it shadow-extracts intact vectors, re-embeds the missing ids, validates the shadow collection, then promotes copy-first):
+   (`ai:backup` reads through Chroma's API, so Chroma must be up; the physical copy is a coarse rollback taken while no writers are active. `defragChromaDB` additionally takes its own private pre-promote snapshot.)
+4. Run the repair with Chroma running and no competing writers (the repair is the exclusive collection writer; opt-in — it shadow-extracts intact vectors, re-embeds the missing ids, validates the shadow collection, then promotes copy-first):
    ```bash
    node ai/scripts/maintenance/defragChromaDB.mjs --target memory-core --allow-memory-core
    ```

--- a/learn/agentos/tooling/RestorationRunbook.md
+++ b/learn/agentos/tooling/RestorationRunbook.md
@@ -84,7 +84,7 @@ as a substitute for SQLite FTS5 repair.
 - MC backup import restores collection rows, but it is not required when the
   copied FTS5 rebuild validates cleanly.
 - API embedding-export failures such as `Error finding id` are a separate
-  Chroma read-path issue; do not conflate them with FTS5 index repair.
+  Chroma read-path issue (see §7 for its repair); do not conflate them with FTS5 index repair.
 
 ### 4. Memory Core - Native Edge Graph
 The Memory Core Edge Graph is persisted in SQLite.
@@ -120,6 +120,37 @@ The RLAIF trajectories capture interaction feedback and metadata for offline RL 
    ```bash
    cp .neo-ai-data/backups/backup-<timestamp>/trajectories/trajectories.jsonl .neo-ai-data/datasets/rlaif/trajectories.jsonl
    ```
+
+### 7. Memory Core Stored-Embedding Export Repair
+A distinct failure from §3 (FTS5) and from a full restore (§2): `npm run ai:check-chroma-integrity` reports `get embedding by id: Error finding id` (stored-embedding export fails) for `neo-agent-memory` / `neo-agent-sessions` / `neo-native-graph` **while the query canary stays healthy** — Chroma metadata rows are present but many ids are missing from the persisted HNSW vector index (#13496 / #13467). Backup/export silently skips the missing-vector ids, so it is **not** a safe substitute. The repair re-embeds the missing vectors into a shadow collection and promotes copy-first (`defragChromaDB.mjs` `repairMemoryCoreCollectionsViaFullEnumeration`, #13635), behind the `--allow-memory-core` opt-in (default fails closed).
+
+**Procedure:**
+1. Confirm the diagnosis (read-only — a healthy query canary plus a failing exportability sample is the signature):
+   ```bash
+   node ai/scripts/maintenance/probeCollectionQueryHealth.mjs
+   npm run ai:check-chroma-integrity -- --exportability-sample-size 2 --json
+   ```
+2. Stop every writer that can reach the unified Chroma store (as in §3 step 3): Orchestrator, Memory Core, Knowledge Base, wake daemons, harness MCP server instances, and the Chroma daemon.
+3. Capture a canonical backup **and** a physical copy of the store before any mutation:
+   ```bash
+   npm run ai:backup
+   cp -R .neo-ai-data/chroma/unified .neo-ai-data/chroma/unified.pre-mc-repair-<timestamp>
+   ```
+4. Run the repair (opt-in; it shadow-extracts intact vectors, re-embeds the missing ids, validates the shadow collection, then promotes copy-first):
+   ```bash
+   node ai/scripts/maintenance/defragChromaDB.mjs --target memory-core --allow-memory-core
+   ```
+   A clean run clears its repair state-marker; a partial run rewrites an explicit `memory-core-repair-aborted` marker and exits non-zero — investigate before re-running.
+5. Verify export and query health are both green, then restart the AI services (see Verification below):
+   ```bash
+   npm run ai:check-chroma-integrity -- --json
+   node ai/scripts/maintenance/probeCollectionQueryHealth.mjs
+   ```
+
+**Boundaries:**
+- This repairs stored-embedding export (re-embed missing vectors); it is **not** the §3 FTS5 SQLite repair and **not** the §2 backup-restore — use those for their respective failures.
+- The repair is gated behind `--allow-memory-core` (default fails closed) and promotes copy-first; it never deletes/recreates the live collection in place.
+- The heavier exportability probe (`get embedding by id`) stays **on-demand** (the maintenance scripts above); the routine bounded healthcheck remains query-path only.
 
 ## Verification
 After restoration, restart the subsystem and verify health.


### PR DESCRIPTION
## Summary

Adds **RestorationRunbook §7** — the safe pre-repair sequence for the Memory Core stored-embedding-export failure (#13496 / #13467): confirm diagnosis (read-only) → stop writers → canonical backup + physical copy → run the #13635 repair (`defragChromaDB --target memory-core --allow-memory-core`; shadow-extract intact + re-embed missing + promote copy-first) → verify export & query health. This is AC5; with it, all #13496 ACs are delivered.

Resolves #13496
Related: #13635 (the repair path, merged), #13467 (FTS5 sibling), ADR 0017

## AC closure map

- **AC1–3** (bounded exportability diagnostic; query-vs-export split): shipped (#13501 / PR #13502 + `checkChromaIntegrity --exportability`).
- **AC4** (safe repair validated on shadow/copy before live mutation): merged via **#13635** (`repairMemoryCoreCollectionsViaFullEnumeration`, 10/10 tests, shadow-promote copy-first).
- **AC5** (pre-repair backup / stop-daemon / operator sequence documented): **this PR** (RestorationRunbook §7).
- **AC6** (normal healthchecks stay bounded; heavier exportability probe on-demand): satisfied **by construction** — the probe lives only in the on-demand maintenance scripts (`checkChromaIntegrity.mjs` / `defragChromaDB.mjs`), not in any bounded healthcheck.

## Deltas from ticket

- Home is the existing `RestorationRunbook.md` (sibling to §1–§6) — on-demand operational docs, **not** a new always-loaded substrate file. Cross-links §3's existing "separate read-path issue" note to the new §7.
- AC4-live (the operator running the live `--allow-memory-core` repair on a real corrupted store) is inherently post-merge + operator-gated (sandbox cannot reach Chroma) → listed in Post-Merge Validation, not a code AC.

Evidence: L1 (docs — every command V-B-A'd against the merged #13635 path + the existing runbook conventions) → no runtime AC (docs-only). Residual: AC4-live operator run (post-merge).

## Test Evidence

Docs-only change (a runbook section) — no unit tests.
- Commands cross-checked against source: `defragChromaDB.mjs` `--allow-memory-core` gate + `repairMemoryCoreCollectionsViaFullEnumeration`; `ai:backup` / `ai:check-chroma-integrity` / `ai:defrag-memory` (package.json); `probeCollectionQueryHealth.mjs`.
- AC6 verified: the exportability probe (`get embedding by id`) appears only in the on-demand maintenance scripts, not in any bounded healthcheck surface.
- Pre-commit whitespace hook: green.

## Post-Merge Validation

- [ ] AC4-live (operator-gated): on a host that can reach Chroma, run the §7 sequence end-to-end against a real corrupted MC store and confirm the exportability sample flips to passing.

## Commits
- `383e41586` — docs(agentos): MC stored-embedding-export repair runbook (#13496)

Authored by Ada (Claude Opus 4.8, Claude Code). Session 95241bfa-5c15-4a48-846b-fe21c869696b.
