### PR TITLE
fix(ai): converge miniSummary backfill — split fetch into fresh reserve + aged drain (#13638)

### DIFF
--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -30,6 +30,19 @@ const MINI_SUMMARY_TIMEOUT_MS = 30000;
 const MINI_SUMMARY_BACKFILL_MAX_RUN_MS = 600000;
 
 /**
+ * Of a backfill batch's `limit`, how many NEWEST rows to reserve; the remainder drains the OLDEST
+ * (aged) rows.
+ *
+ * A single newest-first (`timestamp DESC`) fetch is LIFO: every agent `add_memory` lands a fresh
+ * `miniSummary:NULL` row at the DESC top, so a newest-only batch perpetually re-summarizes fresh
+ * inflow while the aged tail (rows days old) never enters the window and starves forever.
+ * Splitting the batch converges the tail while the fresh reserve still feeds the `summary`
+ * producer→consumer soft-gate + absorbs per-turn inflow. Clamped to the run's `limit`.
+ * @type {Number}
+ */
+const MINI_SUMMARY_BACKFILL_FRESH_RESERVE = 10;
+
+/**
  * Maximum time to wait for the backfill's content-store (Chroma) metadata fetch before deferring
  * the whole batch. Usually milliseconds; the bound exists only to defeat a hung connection.
  * @type {Number}
@@ -1593,11 +1606,13 @@ class MemoryService extends Base {
      * @summary Backfills compact per-turn summaries for existing `AGENT_MEMORY` graph rows.
      *
      * Mirrors the inline {@link addMemory} enrichment path for pre-existing memories and for
-     * turns written while the summarizer was unavailable. The scan is graph-first and
-     * most-recent-first; Chroma is only joined by the selected node ids to fetch that memory's own
-     * prompt/response. Updates merge `miniSummary` into the same graph node through a
-     * tenant-preserving storage-layer merge, preserving tenant attribution (`userId`, `agentIdentity`)
-     * and every other property already present on the row.
+     * turns written while the summarizer was unavailable. The scan is graph-first and SPLIT across
+     * both ends of the backlog — a fresh reserve (newest) + an aged-drain bulk (oldest) — so the
+     * aged tail converges instead of starving behind perpetual fresh inflow (see
+     * {@link MINI_SUMMARY_BACKFILL_FRESH_RESERVE}). Chroma is only joined by the selected node ids to
+     * fetch that memory's own prompt/response. Updates merge `miniSummary` into the same graph node
+     * through a tenant-preserving storage-layer merge, preserving tenant attribution (`userId`,
+     * `agentIdentity`) and every other property already present on the row.
      *
      * Fail-soft by construction: model/provider failures leave the row unmodified so a later batch
      * can retry it. A failure for one row never aborts the batch.
@@ -1605,6 +1620,9 @@ class MemoryService extends Base {
      * @param {Object} [options]
      * @param {Number} [options.limit] Maximum rows to fetch. Defaults to
      *     `aiConfig.summarizationBatchLimit`.
+     * @param {Number} [options.freshReserve] Of `limit`, how many newest rows to reserve before the
+     *     remainder drains the oldest. Defaults to `MINI_SUMMARY_BACKFILL_FRESH_RESERVE`; clamped to
+     *     `limit`. Exposed for deterministic split-coverage tests.
      * @param {Function} [options.buildMiniSummary] Optional summarizer seam for deterministic tests.
      * @param {Number} [options.maxRunMs] Wall-clock budget for the run; defaults to
      *     `MINI_SUMMARY_BACKFILL_MAX_RUN_MS`. The loop stops starting new rows once reached and defers
@@ -1612,7 +1630,7 @@ class MemoryService extends Base {
      * @param {Function} [options.now] Clock seam (defaults to `Date.now`) for deterministic budget tests.
      * @returns {Promise<{processed: Number, updated: Number, deferred: Number, missingContent: Number, runBudgetHit: Boolean}>}
      */
-    async backfillMiniSummaries({limit, buildMiniSummary, maxRunMs, now = () => Date.now()} = {}) {
+    async backfillMiniSummaries({limit, freshReserve, buildMiniSummary, maxRunMs, now = () => Date.now()} = {}) {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite) {
             return {processed: 0, updated: 0, deferred: 0, missingContent: 0, runBudgetHit: false};
@@ -1625,15 +1643,31 @@ class MemoryService extends Base {
         const runBudgetMs  = Number(maxRunMs) > 0 ? Number(maxRunMs) : MINI_SUMMARY_BACKFILL_MAX_RUN_MS;
         const startedAt    = now();
 
-        const rows = sqlite.prepare(`
-            SELECT memory.id                                          AS id,
-                   json_extract(memory.data, '$.properties.timestamp') AS timestamp
+        // Split the batch across BOTH ends of the backlog. A single newest-first fetch is
+        // LIFO — fresh add_memory rows land at the DESC top, so a newest-only batch re-summarizes
+        // inflow forever while the aged tail starves. A fresh reserve (newest — feeds the summary
+        // producer→consumer soft-gate + absorbs inflow) + an aged-drain bulk (oldest — converges the
+        // starved tail). Both ends skip rows already archived as un-summarizable so the
+        // drain doesn't burn budget re-archiving them. De-dup: the windows overlap once the backlog
+        // is shallower than the limit.
+        const reserveBudget = Number.isInteger(freshReserve) && freshReserve >= 0 ? freshReserve : MINI_SUMMARY_BACKFILL_FRESH_RESERVE;
+        const reserve       = Math.min(reserveBudget, boundedLimit);
+        const drainLimit    = boundedLimit - reserve;
+
+        const orderedScan = direction => `
+            SELECT memory.id AS id
             FROM Nodes memory
             WHERE json_extract(memory.data, '$.label') = 'AGENT_MEMORY'
               AND json_extract(memory.data, '$.properties.miniSummary') IS NULL
-            ORDER BY json_extract(memory.data, '$.properties.timestamp') DESC, memory.id DESC
+              AND json_extract(memory.data, '$.properties.archivedAt')  IS NULL
+            ORDER BY json_extract(memory.data, '$.properties.timestamp') ${direction}, memory.id ${direction}
             LIMIT ?
-        `).all(boundedLimit);
+        `;
+        const scanIds = (direction, n) => n > 0
+            ? sqlite.prepare(orderedScan(direction)).all(n).map(row => row.id).filter(Boolean)
+            : [];
+
+        const rows = [...new Set([...scanIds('DESC', reserve), ...scanIds('ASC', drainLimit)])].map(id => ({id}));
 
         if (rows.length === 0) {
             return {processed: 0, updated: 0, deferred: 0, missingContent: 0, runBudgetHit: false};

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -207,19 +207,19 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         memStore.set('backfill-new', {prompt: 'new prompt', response: 'new response'});
 
         GraphService.upsertNode({
-            id: 'backfill-old', type: 'AGENT_MEMORY', name: 'Memory: old', description: 'old',
+            id              : 'backfill-old', type: 'AGENT_MEMORY', name: 'Memory: old', description: 'old',
             semanticVectorId: 'backfill-old',
             properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'backfill', timestamp: oldTs}
         });
         GraphService.upsertNode({
-            id: 'backfill-new', type: 'AGENT_MEMORY', name: 'Memory: new', description: 'new',
+            id              : 'backfill-new', type: 'AGENT_MEMORY', name: 'Memory: new', description: 'new',
             semanticVectorId: 'backfill-new',
             properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'backfill', timestamp: newTs}
         });
 
         const calls = [];
         const result = await MemoryService.backfillMiniSummaries({
-            limit: 1,
+            limit           : 1,
             buildMiniSummary: async ({prompt}) => {
                 calls.push(prompt);
                 return `summary:${prompt}`;
@@ -244,13 +244,13 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
 
         memStore.set('backfill-failure', {prompt: 'failure prompt', response: 'failure response'});
         GraphService.upsertNode({
-            id: 'backfill-failure', type: 'AGENT_MEMORY', name: 'Memory: failure', description: 'failure',
+            id              : 'backfill-failure', type: 'AGENT_MEMORY', name: 'Memory: failure', description: 'failure',
             semanticVectorId: 'backfill-failure',
             properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'backfill', timestamp: ts}
         });
 
         const result = await MemoryService.backfillMiniSummaries({
-            limit: 1,
+            limit           : 1,
             buildMiniSummary: async () => {
                 throw new Error('provider unavailable');
             }
@@ -279,9 +279,9 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         let fakeNow   = 0;
         const calls   = [];
         const result  = await MemoryService.backfillMiniSummaries({
-            limit   : 3,
-            maxRunMs: 100,
-            now     : () => fakeNow,
+            limit           : 3,
+            maxRunMs        : 100,
+            now             : () => fakeNow,
             buildMiniSummary: async ({prompt}) => {
                 calls.push(prompt);
                 fakeNow += 1000;
@@ -301,5 +301,63 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
             return JSON.parse(seeded.data).properties.miniSummary !== undefined;
         });
         expect(summarized.length).toBe(1);
+    });
+
+    test('#13638: backfillMiniSummaries splits the batch across fresh + aged ends so the tail converges', async () => {
+        // A newest-only (LIFO) fetch starves the aged tail forever. The split takes BOTH ends:
+        // freshReserve newest + the remainder oldest. Extreme timestamps make the picks unambiguous
+        // against rows left pending by sibling serial tests; the MIDDLE row proves the window is the
+        // two ENDS, not a contiguous newest slice.
+        const seedRow = (id, ts) => {
+            memStore.set(id, {prompt: `p-${id}`, response: `r-${id}`});
+            GraphService.upsertNode({
+                id, type: 'AGENT_MEMORY', name: id, description: id, semanticVectorId: id,
+                properties: {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'split', timestamp: ts}
+            });
+        };
+        seedRow('split-aged',   '2000-01-01T00:00:00.000Z');  // oldest globally → the aged-drain pick
+        seedRow('split-middle', '2050-01-01T00:00:00.000Z');  // neither end → left for a later sweep
+        seedRow('split-fresh',  '2100-01-01T00:00:00.000Z');  // newest globally → the fresh-reserve pick
+
+        const calls  = [];
+        const result = await MemoryService.backfillMiniSummaries({
+            limit           : 2, freshReserve: 1,
+            buildMiniSummary: async ({prompt}) => { calls.push(prompt); return `summary:${prompt}`; }
+        });
+
+        // Both ends summarized in one run; the middle row deliberately untouched.
+        expect(result.updated).toBe(2);
+        expect(calls.sort()).toEqual(['p-split-aged', 'p-split-fresh']);
+
+        const mid = JSON.parse(GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('split-middle').data);
+        expect(mid.properties.miniSummary).toBeUndefined();
+    });
+
+    test('#13566/#13638: backfillMiniSummaries skips rows already archived as un-summarizable', async () => {
+        // An archived row keeps miniSummary:NULL; the fetch must exclude it (the scheduler + count
+        // already do) so the aged drain does not burn budget re-archiving. Seed it as the NEWEST row,
+        // so a green test proves the filter rather than ordering luck.
+        memStore.set('arch-live', {prompt: 'live prompt', response: 'live response'});
+        GraphService.upsertNode({
+            id              : 'arch-archived', type: 'AGENT_MEMORY', name: 'arch-archived', description: 'archived',
+            semanticVectorId: 'arch-archived',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'arch',
+                         timestamp: '2103-01-01T00:00:00.000Z', archivedAt: '2103-01-02T00:00:00.000Z'}
+        });
+        GraphService.upsertNode({
+            id              : 'arch-live', type: 'AGENT_MEMORY', name: 'arch-live', description: 'live',
+            semanticVectorId: 'arch-live',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'arch',
+                         timestamp: '2102-01-01T00:00:00.000Z'}
+        });
+
+        const calls = [];
+        await MemoryService.backfillMiniSummaries({
+            limit           : 1, freshReserve: 1,
+            buildMiniSummary: async ({prompt}) => { calls.push(prompt); return `summary:${prompt}`; }
+        });
+
+        // The archived row is the newest, yet excluded by the fetch filter; only the live row runs.
+        expect(calls).toEqual(['live prompt']);
     });
 });


### PR DESCRIPTION
Resolves #13638

Splits the miniSummary backfill's child fetch across both ends of the backlog so the aged tail converges instead of starving behind perpetual fresh inflow, and adds the `archivedAt IS NULL` filter the child was missing.

Evidence: L2 (committed unit tests — split-coverage + archived-skip; 13/13 `QueryRecentTurns` + 14/14 scheduler green) → L3 required (AC2: the backlog converges toward 0 over a live heavy-maintenance window). Residual: AC2 [#13638] — observable only on the running orchestrator.

## The bug

The miniSummary backfill **never converges** despite draining every run. The convergence-critical fetch is the lifecycle child's — `MemoryService.backfillMiniSummaries` — which ordered `timestamp DESC` (newest-first / **LIFO**). Every agent `add_memory` lands a fresh `miniSummary:NULL` row at the DESC top, so a newest-only batch perpetually re-summarizes fresh inflow while the **aged tail** (3504 rows >2 days old on the live graph, per @neo-opus-vega's V-B-A) never enters the window and **starves forever**.

> **V-B-A redirect:** the ticket pointed at the scheduler's `getPendingMemorySummaryBackfillJobs`, but that fetch is only the trigger + no-progress attempted-set — the **child** decides which rows actually get summarized. Reading the child first moved the fix to the right layer.

## The fix

**Split the batch across BOTH ends** (within the same per-run budget — no lease-hold change):

- a **fresh reserve** (newest `freshReserve` rows) — feeds the `summary` producer→consumer soft-gate (a context-overflow session degrades its summary to per-turn miniSummaries) + absorbs per-turn inflow. Pure oldest-first would starve these and defer recent summaries behind the entire aged drain.
- an **aged-drain bulk** (oldest `limit - freshReserve` rows) — converges the starved tail: each aged row is summarized, or archived if it has no recoverable content — either way it drains the count.

Also adds the `archivedAt IS NULL` filter the scheduler + count already carry (a gap from the archived-rows work) so the aged drain does not burn budget re-archiving no-content rows.

**Scheduler unchanged (deliberate):** `getPendingMemorySummaryBackfillJobs` is the existence-trigger (order-independent) + the no-progress attempted-set. Its backoff arms only on *genuine* no-progress — a Chroma-down run defers ALL rows including the child's — which the newest-biased set still detects. Convergence lives entirely in the child fetch.

## Deltas

- **Fix layer redirected (V-B-A):** the ticket scoped the scheduler's `getPendingMemorySummaryBackfillJobs`; the actual convergence lever is the child fetch `MemoryService.backfillMiniSummaries`. The scheduler is left unchanged, with the rationale above.
- **Added the missing `archivedAt IS NULL` filter to the child** (beyond the split) so the aged drain does not waste budget re-archiving no-content rows — a gap from the earlier archived-rows work.
- `freshReserve` is a module constant (default 10) + a test seam, **not** an aiConfig leaf — an internal tuning value, not deployment-varying config (keeps ADR-0019 minimal).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs` → **13/13**. New coverage: split (`limit=2`/`freshReserve=1` → both ends summarized, the MIDDLE row left for a later sweep, proving the window is the two ends not a contiguous newest slice) + archived-skip (the newest row, archived, is excluded by the fetch filter).
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs` → **14/14** (scheduler untouched — sanity).
- Husky pre-commit green (jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation

- [ ] Over a heavy-maintenance window on the live graph, the `AGENT_MEMORY` `miniSummary:NULL` backlog **converges toward 0** (net-progress), rather than the inflow≈outflow flat line — AC2. Watch via the orchestrator log + the pending count.
- [ ] The aged rows (>2 days) demonstrably drain (summarized or archived), not just the fresh top.

## Related

- Refs #13624 (axis 2 of the orchestrator-stability epic), #13637 (axis 1 — froze the session-summary churn that hogged the lease, which this depends on).
- Couples ADR-0022 (heavy-maintenance lease fairness): #13586/#13592 get the backfill its lease time; this PR ensures that lease time makes **net progress** on the aged backlog rather than re-churning the fresh top.

Authored by Grace (Claude Opus 4.8, Claude Code).
