### PR TITLE
fix(codex): align stop hook no-hold gate (#13655)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -43,7 +43,12 @@ import os              from 'node:os';
 import {pathToFileURL} from 'node:url';
 
 import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneState.mjs';
+import {decideStopHookAction,
+        isOperatorInLoop,
+        parseOutcomeToVerdict}     from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+
+export {isOperatorInLoop, parseOutcomeToVerdict};
 
 // Enforce ONLY when the operator explicitly activates it; default is DRY-RUN (log-only, never blocks).
 const ENFORCING = process.env.NEO_LANE_STATE_ENFORCE === '1';
@@ -84,27 +89,6 @@ function auditLog(line) {
 }
 
 /**
- * @summary Pure mapping of a parse OUTCOME to a terminal verdict — the 3-bucket chain. A malformed
- * emission (parseLaneState threw) and an absent emission (null) are distinct idle-out failures from an
- * invalid descriptor, each with its own reason; a parsed descriptor is delegated to `validate` (the
- * real validator), whose `{valid, violations}` is mapped to the `{valid, reason}` verdict
- * `decideHookAction` consumes. Exported + unit-tested with injected outcomes (no I/O, no real parser).
- * @param {{descriptor: (Object|null), parseError: (Error|null)}} outcome
- * @param {Function} validate descriptor → {valid: Boolean, violations: String[]}
- * @returns {{valid: Boolean, reason: String}}
- */
-export function parseOutcomeToVerdict({descriptor, parseError}, validate) {
-    if (parseError)          return {valid: false, reason: `malformed lane-state emission: ${parseError.message}`};
-    if (descriptor === null) return {valid: false, reason: 'no lane-state block emitted at turn-terminal'};
-
-    const result = validate(descriptor);
-
-    return result.valid
-        ? {valid: true,  reason: 'valid lane-state terminal'}
-        : {valid: false, reason: (result.violations || []).join('; ') || 'invalid lane-state terminal'};
-}
-
-/**
  * @summary Pure decision — maps a terminal `verdict` + the mode (`enforcing`) + whether a live human
  * operator prompted this turn (`operatorInLoop`) to the Stop-hook action. The heart of the idle-out
  * mechanism; exported + unit-tested.
@@ -126,29 +110,7 @@ export function parseOutcomeToVerdict({descriptor, parseError}, validate) {
  * @returns {{action: ('allow'|'block'|'would-block'), reason: String}}
  */
 export function decideHookAction(verdict, enforcing, operatorInLoop = false) {
-    if (operatorInLoop) {
-        return {action: 'allow', reason: 'live operator dialogue — yielding for the human turn'};
-    }
-    return enforcing
-        ? {action: 'block',       reason: verdict.reason}
-        : {action: 'would-block', reason: verdict.reason};
-}
-
-/**
- * @summary Detects whether a genuine human OPERATOR prompted this turn — the one signal that makes a
- * voluntary stop legitimate (turn-taking with a human who takes the next turn). Determined externally
- * so it cannot be self-declared/gamed: a turn is operator-driven iff it is NOT a forced continuation
- * (`stop_hook_active`), its prompting message is NOT an autonomous `[WAKE]` injection, AND a prompt is
- * actually confirmable. FAIL-CLOSED: an empty / unreadable prompt is treated as autonomous (no idle
- * granted on uncertainty) — the real Stop payload always carries the transcript, so this only bites a
- * transient read-failure, which should keep working rather than idle. Pure; exported + unit-tested.
- * @param {{stopHookActive: Boolean, promptingText: String}} signals
- * @returns {Boolean}
- */
-export function isOperatorInLoop({stopHookActive, promptingText = ''}) {
-    if (stopHookActive)        return false;                // forced continuation — no human waiting
-    if (!promptingText.trim()) return false;                // no confirmable human prompt → autonomous
-    return !/^\s*\[WAKE\]/.test(promptingText);             // [WAKE] = autonomous wake; else = operator
+    return decideStopHookAction(verdict, {enforcing, operatorInLoop, blockInjectionSupported: true});
 }
 
 // The curated no-hold-state directive injected on a block. References the always-loaded

--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -15,6 +15,9 @@ import os              from 'node:os';
 import {pathToFileURL} from 'node:url';
 
 import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneState.mjs';
+import {decideStopHookAction,
+        isOperatorInLoop,
+        parseOutcomeToVerdict}     from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
 export const CODEX_STOP_BLOCK_INJECTION_SUPPORTED = false;
@@ -113,6 +116,21 @@ function isAssistantMessage(message) {
 }
 
 /**
+ * @summary Returns whether a message-like object represents user/operator input.
+ * @param {Object} message
+ * @returns {Boolean}
+ * @protected
+ */
+function isUserMessage(message) {
+    if (!message || typeof message !== 'object') return false;
+
+    return message.role === 'user' ||
+        message.type === 'user' ||
+        message.message?.role === 'user' ||
+        message.item?.role === 'user';
+}
+
+/**
  * @summary Extracts the last assistant text from an array of message-like records.
  * @param {Object[]} messages
  * @returns {String}
@@ -126,6 +144,28 @@ export function extractLastAssistantTextFromMessages(messages = []) {
               message = record?.message || record?.item || record;
 
         if (!isAssistantMessage(record) && !isAssistantMessage(message)) continue;
+
+        const text = extractTextFromMessage(message);
+        if (text) return text;
+    }
+
+    return '';
+}
+
+/**
+ * @summary Extracts the last user text from an array of message-like records.
+ * @param {Object[]} messages
+ * @returns {String}
+ * @protected
+ */
+export function extractLastUserTextFromMessages(messages = []) {
+    if (!Array.isArray(messages)) return '';
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const record  = messages[i],
+              message = record?.message || record?.item || record;
+
+        if (!isUserMessage(record) && !isUserMessage(message)) continue;
 
         const text = extractTextFromMessage(message);
         if (text) return text;
@@ -151,6 +191,29 @@ export function extractLastAssistantTextFromJsonl(jsonl = '') {
         try { record = JSON.parse(line); } catch { continue; }
 
         const text = extractLastAssistantTextFromMessages([record]);
+        if (text) return text;
+    }
+
+    return '';
+}
+
+/**
+ * @summary Extracts the last user text from JSONL transcript records, tolerating malformed lines.
+ * @param {String} jsonl
+ * @returns {String}
+ * @protected
+ */
+export function extractLastUserTextFromJsonl(jsonl = '') {
+    const lines = jsonl.split('\n');
+
+    for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        let record;
+        try { record = JSON.parse(line); } catch { continue; }
+
+        const text = extractLastUserTextFromMessages([record]);
         if (text) return text;
     }
 
@@ -187,20 +250,27 @@ export function extractFinalAssistantText(input = {}) {
 }
 
 /**
- * @summary Converts a parse result into the lane-state terminal verdict consumed by the hook.
- * @param {{descriptor: (Object|null), parseError: (Error|null)}} outcome
- * @param {Function} validate
- * @returns {{valid: Boolean, reason: String}}
+ * @summary Resolves the best available text that prompted this Codex turn. This is the external
+ * operator-vs-wake signal; missing text fails closed to autonomous in `isOperatorInLoop`.
+ * @param {Object} [input={}]
+ * @returns {{text: String, source: String}}
  */
-export function parseOutcomeToVerdict({descriptor, parseError}, validate = validateLaneStateTerminal) {
-    if (parseError)          return {valid: false, reason: `malformed lane-state emission: ${parseError.message}`};
-    if (descriptor === null) return {valid: false, reason: 'no lane-state block emitted at turn-terminal'};
+export function extractPromptingText(input = {}) {
+    const messages = input.messages ?? input.conversation ?? input.transcript;
+    if (Array.isArray(messages)) {
+        const text = extractLastUserTextFromMessages(messages);
+        if (text.trim()) return {text, source: 'messages'};
+    }
 
-    const result = validate(descriptor);
+    const transcriptPath = input.transcript_path ?? input.transcriptPath;
+    if (transcriptPath) {
+        return {
+            text  : extractLastUserTextFromJsonl(fs.readFileSync(transcriptPath, 'utf8')),
+            source: 'transcript_path'
+        };
+    }
 
-    return result.valid
-        ? {valid: true,  reason: 'valid lane-state terminal'}
-        : {valid: false, reason: (result.violations || []).join('; ') || 'invalid lane-state terminal'};
+    return {text: '', source: 'none'};
 }
 
 /**
@@ -213,29 +283,31 @@ export function buildNoHoldReminder(verdictReason) {
 }
 
 /**
- * @summary Maps a terminal verdict to the Codex Stop action; invalid terminals are dry-run only.
+ * @summary Maps a terminal verdict to the Codex Stop action. The no-hold decision mirrors Claude:
+ * a live operator dialogue is the only allow; every autonomous turn-end would-blocks. Codex remains
+ * fail-open because block/inject support is not proven.
  * @param {{valid: Boolean, reason: String}} verdict
  * @param {Object} [options]
  * @param {Boolean} [options.enforcing=false]
  * @param {Boolean} [options.blockInjectionSupported=CODEX_STOP_BLOCK_INJECTION_SUPPORTED]
+ * @param {Boolean} [options.operatorInLoop=false]
  * @returns {{action: ('allow'|'would-block'), reason: String}}
  */
 export function decideCodexHookAction(verdict, {
     enforcing               = false,
-    blockInjectionSupported = CODEX_STOP_BLOCK_INJECTION_SUPPORTED
+    blockInjectionSupported = CODEX_STOP_BLOCK_INJECTION_SUPPORTED,
+    operatorInLoop          = false
 } = {}) {
-    if (verdict.valid) return {action: 'allow', reason: verdict.reason};
+    const decision = decideStopHookAction(verdict, {
+        enforcing,
+        operatorInLoop,
+        blockInjectionSupported,
+        blockUnsupportedReason: 'Codex Stop block/inject contract is not proven, so this hook remains fail-open.'
+    });
 
-    const reason = buildNoHoldReminder(verdict.reason);
+    if (decision.action === 'allow') return decision;
 
-    if (enforcing && !blockInjectionSupported) {
-        return {
-            action: 'would-block',
-            reason: `${reason} Codex Stop block/inject contract is not proven, so this hook remains fail-open.`
-        };
-    }
-
-    return {action: 'would-block', reason};
+    return {action: 'would-block', reason: buildNoHoldReminder(decision.reason)};
 }
 
 /**
@@ -258,15 +330,13 @@ export function summarizePayloadShape(payload = {}) {
  * @param {Object} input
  * @param {Object} [options]
  * @param {Boolean} [options.enforcing=false]
- * @returns {{action: ('allow'|'would-block'), reason: String, source: String, verdict: Object}}
+ * @returns {{action: ('allow'|'would-block'), reason: String, source: String, promptSource: String, verdict: Object}}
  */
 export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
-    if (input.stop_hook_active || input.stopHookActive) {
-        const verdict = {valid: true, reason: 'Codex Stop loop guard active'};
-        return {action: 'allow', reason: verdict.reason, source: 'loop-guard', verdict};
-    }
-
-    const {text, source} = extractFinalAssistantText(input);
+    const stopHookActive                            = !!(input.stop_hook_active || input.stopHookActive),
+          {text, source}                            = extractFinalAssistantText(input),
+          {text: promptingText, source: promptSource} = extractPromptingText(input),
+          operatorInLoop                            = isOperatorInLoop({stopHookActive, promptingText});
 
     let descriptor = null, parseError = null;
     try {
@@ -275,11 +345,12 @@ export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
         parseError = e;
     }
 
-    const verdict = parseOutcomeToVerdict({descriptor, parseError});
+    const verdict = parseOutcomeToVerdict({descriptor, parseError}, validateLaneStateTerminal);
 
     return {
-        ...decideCodexHookAction(verdict, {enforcing}),
+        ...decideCodexHookAction(verdict, {enforcing, operatorInLoop}),
         source,
+        promptSource,
         verdict
     };
 }

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -1,0 +1,74 @@
+/**
+ * Shared pure decision primitives for lane-state Stop hooks.
+ *
+ * Harness adapters own payload extraction and transport behavior; this module owns the no-hold
+ * decision semantics so Claude and Codex cannot drift on the valid-terminal / loop-guard gate.
+ *
+ * @module Neo.ai.scripts.lifecycle.stopHookDecision
+ */
+
+/**
+ * @summary Pure mapping of a parse OUTCOME to a terminal verdict — the 3-bucket chain. A malformed
+ * emission (parseLaneState threw) and an absent emission (null) are distinct idle-out failures from an
+ * invalid descriptor, each with its own reason; a parsed descriptor is delegated to `validate`.
+ * @param {{descriptor: (Object|null), parseError: (Error|null)}} outcome
+ * @param {Function} validate descriptor → {valid: Boolean, violations: String[]}
+ * @returns {{valid: Boolean, reason: String}}
+ */
+export function parseOutcomeToVerdict({descriptor, parseError}, validate) {
+    if (parseError)          return {valid: false, reason: `malformed lane-state emission: ${parseError.message}`};
+    if (descriptor === null) return {valid: false, reason: 'no lane-state block emitted at turn-terminal'};
+
+    const result = validate(descriptor);
+
+    return result.valid
+        ? {valid: true,  reason: 'valid lane-state terminal'}
+        : {valid: false, reason: (result.violations || []).join('; ') || 'invalid lane-state terminal'};
+}
+
+/**
+ * @summary Detects whether a genuine human OPERATOR prompted this turn — the one signal that makes a
+ * voluntary stop legitimate. Determined externally so it cannot be self-declared: a turn is operator
+ * driven iff it is not a forced continuation, its prompting message is not an autonomous `[WAKE]`
+ * injection, and a prompt is actually confirmable.
+ * @param {{stopHookActive: Boolean, promptingText: String}} signals
+ * @returns {Boolean}
+ */
+export function isOperatorInLoop({stopHookActive, promptingText = ''}) {
+    if (stopHookActive)        return false;
+    if (!promptingText.trim()) return false;
+    return !/^\s*\[WAKE\]/.test(promptingText);
+}
+
+/**
+ * @summary Shared no-hold Stop-hook decision. The one voluntary allow is live operator dialogue;
+ * every other turn-end is blocked when the harness has a proven block/inject contract, or would-block
+ * when dry-run / fail-open transport semantics apply. The `verdict` reason is evidence, not a gate.
+ * @param {{valid: Boolean, reason: String}} verdict
+ * @param {Object} [options]
+ * @param {Boolean} [options.enforcing=false]
+ * @param {Boolean} [options.operatorInLoop=false]
+ * @param {Boolean} [options.blockInjectionSupported=true]
+ * @param {String} [options.blockUnsupportedReason='']
+ * @returns {{action: ('allow'|'block'|'would-block'), reason: String}}
+ */
+export function decideStopHookAction(verdict, {
+    enforcing               = false,
+    operatorInLoop          = false,
+    blockInjectionSupported = true,
+    blockUnsupportedReason  = ''
+} = {}) {
+    if (operatorInLoop) {
+        return {action: 'allow', reason: 'live operator dialogue — yielding for the human turn'};
+    }
+
+    if (enforcing && blockInjectionSupported) {
+        return {action: 'block', reason: verdict.reason};
+    }
+
+    const reason = enforcing && !blockInjectionSupported && blockUnsupportedReason
+        ? `${verdict.reason} ${blockUnsupportedReason}`
+        : verdict.reason;
+
+    return {action: 'would-block', reason};
+}

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -12,6 +12,9 @@ import {
     extractFinalAssistantText,
     extractLastAssistantTextFromJsonl,
     extractLastAssistantTextFromMessages,
+    extractLastUserTextFromJsonl,
+    extractLastUserTextFromMessages,
+    extractPromptingText,
     summarizePayloadShape
 } from '../../../../.codex/hooks/codex-lane-state-stop.mjs';
 
@@ -30,6 +33,14 @@ test.describe('codex-lane-state-stop - contract boundary', () => {
 
         expect(result.action).toBe('would-block');
         expect(result.reason).toContain('block/inject contract is not proven');
+    });
+
+    test('a valid terminal is not a Codex stop license without a live operator prompt', () => {
+        const result = decideCodexHookAction({valid: true, reason: 'valid lane-state terminal'});
+
+        expect(result.action).toBe('would-block');
+        expect(result.reason).toContain('valid lane-state terminal');
+        expect(result.reason).toContain('No-hold reminder');
     });
 
     test('the no-hold reminder names concrete non-hold exits', () => {
@@ -77,6 +88,20 @@ test.describe('codex-lane-state-stop - input resolution', () => {
         });
     });
 
+    test('message arrays use the last user text-bearing record for operator detection', () => {
+        const text = extractLastUserTextFromMessages([
+            {role: 'user', content: 'earlier prompt'},
+            {role: 'assistant', content: 'ignore'},
+            {type: 'user', message: {role: 'user', content: [{type: 'text', text: 'latest prompt'}]}}
+        ]);
+
+        expect(text).toBe('latest prompt');
+        expect(extractPromptingText({messages: [{role: 'user', content: 'from messages'}]})).toEqual({
+            text  : 'from messages',
+            source: 'messages'
+        });
+    });
+
     test('JSONL fallback tolerates malformed lines and skips user records', () => {
         const jsonl = [
             '{ not json }',
@@ -86,15 +111,54 @@ test.describe('codex-lane-state-stop - input resolution', () => {
 
         expect(extractLastAssistantTextFromJsonl(jsonl)).toBe('answer');
     });
+
+    test('JSONL prompt fallback tolerates malformed lines and skips assistant records', () => {
+        const jsonl = [
+            '{ not json }',
+            JSON.stringify({type: 'assistant', message: {role: 'assistant', content: 'answer'}}),
+            JSON.stringify({type: 'user', message: {role: 'user', content: [{type: 'text', text: '[WAKE][priority:normal] 1 events'}]}})
+        ].join('\n');
+
+        expect(extractLastUserTextFromJsonl(jsonl)).toBe('[WAKE][priority:normal] 1 events');
+    });
 });
 
 test.describe('codex-lane-state-stop - lane-state classification', () => {
-    test('valid representative payload allows', () => {
+    test('valid representative payload without an operator prompt would-blocks', () => {
         const result = classifyCodexStopPayload(fixture);
 
-        expect(result.action).toBe('allow');
-        expect(result.reason).toBe('valid lane-state terminal');
+        expect(result.action).toBe('would-block');
+        expect(result.reason).toContain('valid lane-state terminal');
+        expect(result.reason).toContain('No-hold reminder');
         expect(result.source).toBe('last_assistant_message');
+        expect(result.promptSource).toBe('none');
+    });
+
+    test('live operator prompt is the only valid voluntary allow', () => {
+        const result = classifyCodexStopPayload({
+            messages: [
+                {role: 'user', content: 'please finish this one check and report back'},
+                {role: 'assistant', content: fixture.last_assistant_message}
+            ]
+        });
+
+        expect(result.action).toBe('allow');
+        expect(result.reason).toContain('live operator dialogue');
+        expect(result.source).toBe('messages');
+        expect(result.promptSource).toBe('messages');
+    });
+
+    test('[WAKE] prompt is autonomous, so a valid terminal still would-blocks', () => {
+        const result = classifyCodexStopPayload({
+            messages: [
+                {role: 'user', content: '[WAKE][priority:normal] 1 events for @neo-gpt'},
+                {role: 'assistant', content: fixture.last_assistant_message}
+            ]
+        });
+
+        expect(result.action).toBe('would-block');
+        expect(result.reason).toContain('valid lane-state terminal');
+        expect(result.promptSource).toBe('messages');
     });
 
     test('absent lane-state would-block with no-hold reminder', () => {
@@ -118,14 +182,19 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
         expect(result.verdict.reason).toContain('malformed lane-state emission');
     });
 
-    test('Codex stop loop guard allows', () => {
+    test('Codex stop loop guard is not an allow, even with operator-like prompt text', () => {
         const result = classifyCodexStopPayload({
             stop_hook_active      : true,
-            last_assistant_message: 'no lane-state'
+            messages              : [
+                {role: 'user', content: 'please stop here'},
+                {role: 'assistant', content: fixture.last_assistant_message}
+            ]
         });
 
-        expect(result.action).toBe('allow');
-        expect(result.source).toBe('loop-guard');
+        expect(result.action).toBe('would-block');
+        expect(result.reason).toContain('valid lane-state terminal');
+        expect(result.source).toBe('messages');
+        expect(result.promptSource).toBe('messages');
     });
 });
 
@@ -166,12 +235,27 @@ test.describe('codex-lane-state-stop - spawned hook', () => {
         });
     }
 
-    test('valid fixture logs WOULD-ALLOW and writes no stdout', async () => {
+    test('valid fixture logs WOULD-BLOCK and writes no stdout', async () => {
         const {stdout, log} = await runHook(fixture);
 
         expect(stdout).toBe('');
-        expect(log).toContain('WOULD-ALLOW');
+        expect(log).toContain('WOULD-BLOCK');
         expect(log).toContain('source=last_assistant_message');
+        expect(log).toContain('valid lane-state terminal');
+    });
+
+    test('live operator prompt logs WOULD-ALLOW and writes no stdout', async () => {
+        const {stdout, log} = await runHook({
+            session_id: 'operator',
+            messages  : [
+                {role: 'user', content: 'finish this check and hand back to me'},
+                {role: 'assistant', content: fixture.last_assistant_message}
+            ]
+        });
+
+        expect(stdout).toBe('');
+        expect(log).toContain('WOULD-ALLOW');
+        expect(log).toContain('source=messages');
     });
 
     test('invalid terminal logs WOULD-BLOCK but still writes no block decision to stdout', async () => {


### PR DESCRIPTION
Resolves #13655

Codex Stop-hook no-hold semantics now share the same pure decision helper Claude uses: live operator dialogue is the only allow, valid lane-state terminals without operator prompts would-block, and `stop_hook_active` stays autonomous. Codex remains audit/fail-open while block/inject support is unproven.

Evidence: L2 (focused unit/static hook coverage for shared decision, Codex payload classification, spawned fail-open logging, and Claude adapter parity) -> L2 required (all close-target ACs are pure hook decision/payload behavior; Codex live block/inject proof is explicitly out of scope). No residuals.

## Deltas from ticket

- Added `ai/scripts/lifecycle/stopHookDecision.mjs` for shared `parseOutcomeToVerdict`, `isOperatorInLoop`, and no-hold Stop-hook action selection.
- Updated Claude to consume the shared helper while preserving the merged `#13651` behavior and existing test import surface.
- Updated Codex to resolve prompting user text from `messages` / `transcript_path`, treat `[WAKE]`, empty prompts, and `stop_hook_active` as autonomous, and keep fail-open logging while block/inject support is false.

## Test Evidence

- `node --check ai/scripts/lifecycle/stopHookDecision.mjs`
- `node --check .claude/hooks/laneStateStopHook.mjs`
- `node --check .codex/hooks/codex-lane-state-stop.mjs`
- `npm run test-unit -- test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs` — 20 passed
- `npm run test-unit -- test/playwright/unit/hooks/laneStateStopHook.spec.mjs` — 26 passed
- `git diff --cached --check`

## Post-Merge Validation

- [ ] Observe the Codex Stop hook audit log in a live harness with `NEO_CODEX_LANE_STATE_CAPTURE=1` when an operator prompt is present, to confirm the real payload carries a prompting-text surface.
- [ ] Leave Codex block/inject enforcement disabled until a separate ticket proves Codex blocking semantics.

## Commits

- `9b800f331` — `fix(codex): align stop hook no-hold gate (#13655)`

Related: #13623
Related: #13624
Related: #13651

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee5c2-82ba-7b73-8812-df59106ff61a.
