### PR TITLE
feat(ai): fail-closed test-write isolation guard for the graph storage (#13639)

### DIFF
--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -283,12 +283,61 @@ class SQLite extends Base {
     }
 
     /**
+     * @summary Classifies a SQLite path as disposable (test-isolated) versus a live production database.
+     *
+     * Disposable = SQLite `:memory:`, an OS-temp / repo-`tmp/` path, or any `*test*` path. This is the single
+     * definition of "safe to mutate from a test", shared by `clear()`'s production-wipe guard and
+     * `assertTestWriteIsolated()` so the destructive and the write-isolation guards never drift apart.
+     * @param {String|null} [dbPath=this.dbPath]
+     * @returns {Boolean}
+     * @protected
+     */
+    isDisposableDbPath(dbPath=this.dbPath) {
+        return !dbPath || dbPath === ':memory:' || dbPath.includes('tmp') || dbPath.includes('test');
+    }
+
+    /**
+     * @summary Fail-closed guard: a test context MUST NOT write to a production graph database.
+     *
+     * The write-path twin of `clear()`'s production-wipe guard. Graph writes were otherwise unguarded, so a bare
+     * `npx playwright test` — which, unlike `playwright.config.unit.mjs`, never sets `UNIT_TEST_MODE`, so
+     * `storagePaths.graph` resolves to the live `graphProd` — would silently write test rows into the shared
+     * production graph (the live-DB orphan-bleed / backlog-corruption vector).
+     *
+     * Inserts are constant in production, so a target-path refusal (the shape that is correct for *destructive*
+     * ops in `DestructiveOperationGuard`) would break the live runtime. This therefore keys on the test
+     * **caller**, not the target: it fires only when a test runner is detected (`TEST_WORKER_INDEX`, which
+     * Playwright sets in every worker process, or `UNIT_TEST_MODE`) AND the resolved path is production-like.
+     * It is config-independent — it fires regardless of harness or config state (the prior live-collection-wipe
+     * lesson). Zero production blast: the live runtime sets neither signal, so this early-returns.
+     *
+     * @param {Object} [options]
+     * @param {String} [options.dbPath=this.dbPath] Resolved SQLite path; injectable for tests.
+     * @param {Object} [options.env=process.env]    Environment map; injectable for tests.
+     * @throws {Error} When a test context targets a production graph path.
+     * @protected
+     */
+    assertTestWriteIsolated({dbPath=this.dbPath, env=process.env}={}) {
+        const inTestRunner = env.TEST_WORKER_INDEX !== undefined || env.UNIT_TEST_MODE === 'true';
+
+        if (!inTestRunner || this.isDisposableDbPath(dbPath)) return;
+
+        throw new Error(
+            `GRAPH_WRITE_GUARD: refusing a graph write to the production database "${dbPath}" from a test ` +
+            `context (TEST_WORKER_INDEX/UNIT_TEST_MODE detected). Tests MUST run with UNIT_TEST_MODE=true, so ` +
+            `storagePaths.graph resolves to the in-memory graphTest — a bare \`npx playwright test\` would ` +
+            `otherwise pollute the live graph.`
+        );
+    }
+
+    /**
      * Maps volatile Memory Node structures directly into SQLite standard JSON buffers using Upsert topologies natively.
      * @param {Object[]} nodes
      */
     addNodes(nodes) {
         if (!this.db || !nodes || nodes.length === 0) return;
         if (!this.db.open) throw new Error('SQLite connection is closed (lifecycle violation).');
+        this.assertTestWriteIsolated();
         const stmt = this.db.prepare(`
             INSERT INTO Nodes (id, user_id, data)
             VALUES (?, ?, ?)
@@ -322,6 +371,7 @@ class SQLite extends Base {
     addEdges(edges) {
         if (!this.db || !edges || edges.length === 0) return;
         if (!this.db.open) throw new Error('SQLite connection is closed (lifecycle violation).');
+        this.assertTestWriteIsolated();
         const stmt = this.db.prepare(`
             INSERT INTO Edges (id, user_id, source, target, type, data)
             VALUES (?, ?, ?, ?, ?, ?)
@@ -357,6 +407,7 @@ class SQLite extends Base {
     removeNodes(nodes) {
         if (!this.db || !nodes || nodes.length === 0) return;
         if (!this.db.open) throw new Error('SQLite connection is closed (lifecycle violation).');
+        this.assertTestWriteIsolated();
         const stmt = this.db.prepare('DELETE FROM Nodes WHERE id = ?');
 
         const removeMany = this.db.transaction((nodesList) => {
@@ -376,6 +427,7 @@ class SQLite extends Base {
     removeEdges(edges) {
         if (!this.db || !edges || edges.length === 0) return;
         if (!this.db.open) throw new Error('SQLite connection is closed (lifecycle violation).');
+        this.assertTestWriteIsolated();
         const stmt = this.db.prepare('DELETE FROM Edges WHERE id = ?');
 
         const removeMany = this.db.transaction((edgesList) => {
@@ -395,6 +447,7 @@ class SQLite extends Base {
     executeTransaction(diffLog) {
         if (!this.db || !diffLog || diffLog.length === 0) return;
         if (!this.db.open) throw new Error('SQLite connection is closed (lifecycle violation).');
+        this.assertTestWriteIsolated();
 
         const insertNodeStmt = this.db.prepare(`
             INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)
@@ -441,8 +494,9 @@ class SQLite extends Base {
         if (!this.db) return;
         if (!this.db.open) throw new Error('SQLite connection is closed (lifecycle violation).');
 
-        // Prevent accidental test-driven wipes of non-temporary graph databases.
-        if (this.dbPath && !this.dbPath.includes('tmp') && !this.dbPath.includes('test') && this.dbPath !== ':memory:') {
+        // Prevent accidental test-driven wipes of non-temporary graph databases (shares isDisposableDbPath
+        // with assertTestWriteIsolated so the destructive- and write-guards classify prod paths identically).
+        if (!this.isDisposableDbPath()) {
             throw new Error(`FATAL: Attempted to clear a non-temporary SQLite database natively! Path: ${this.dbPath}`);
         }
 

--- a/test/playwright/unit/ai/graph/SQLiteWriteGuard.spec.mjs
+++ b/test/playwright/unit/ai/graph/SQLiteWriteGuard.spec.mjs
@@ -1,0 +1,80 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'AiSQLiteWriteGuardTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import SQLite         from '../../../../../ai/graph/storage/SQLite.mjs';
+
+// A production-like absolute path: not `:memory:`, no `tmp`/`test` segment.
+const PROD_PATH          = '/srv/neo/.neo-ai-data/sqlite/memory-core-graph.sqlite';
+const PLAYWRIGHT_WORKER  = {TEST_WORKER_INDEX: '0'}; // Playwright sets this in every worker process
+const UNIT_TEST_MODE_ENV = {UNIT_TEST_MODE: 'true'};
+const PRODUCTION_RUNTIME = {};                       // neither test signal — the live MCP server / orchestrator
+
+test.describe('Neo.ai.graph.storage.SQLite — test-write isolation guard (#13639 / #13624 axis-3)', () => {
+    let storage;
+
+    test.beforeEach(() => {
+        storage = Neo.create(SQLite, {dbPath: ':memory:'});
+    });
+
+    test.afterEach(() => {
+        storage?.destroy?.();
+        storage = null;
+    });
+
+    test('isDisposableDbPath: :memory:/tmp/*test*/empty are disposable; production paths are not', () => {
+        expect(storage.isDisposableDbPath(':memory:')).toBe(true);
+        expect(storage.isDisposableDbPath('/var/folders/q/tmp/neo-graph.db')).toBe(true);
+        expect(storage.isDisposableDbPath('/Users/x/neo-graph-test-42.db')).toBe(true);
+        expect(storage.isDisposableDbPath(null)).toBe(true);
+        expect(storage.isDisposableDbPath(PROD_PATH)).toBe(false);
+    });
+
+    test('blocks a write to a production graph from a Playwright worker (TEST_WORKER_INDEX set)', () => {
+        expect(() => storage.assertTestWriteIsolated({dbPath: PROD_PATH, env: PLAYWRIGHT_WORKER}))
+            .toThrow(/GRAPH_WRITE_GUARD/);
+    });
+
+    test('blocks a write to a production graph under UNIT_TEST_MODE (test mode resolved to a prod path = misconfig)', () => {
+        expect(() => storage.assertTestWriteIsolated({dbPath: PROD_PATH, env: UNIT_TEST_MODE_ENV}))
+            .toThrow(/GRAPH_WRITE_GUARD/);
+    });
+
+    test('allows disposable targets from a test context (:memory:, tmp, *test*)', () => {
+        expect(() => storage.assertTestWriteIsolated({dbPath: ':memory:',        env: PLAYWRIGHT_WORKER})).not.toThrow();
+        expect(() => storage.assertTestWriteIsolated({dbPath: '/tmp/neo.db',      env: PLAYWRIGHT_WORKER})).not.toThrow();
+        expect(() => storage.assertTestWriteIsolated({dbPath: '/x/graph-test.db', env: UNIT_TEST_MODE_ENV})).not.toThrow();
+    });
+
+    test('zero production blast: the live runtime (no test signal) writing to a production path is never guarded', () => {
+        expect(() => storage.assertTestWriteIsolated({dbPath: PROD_PATH, env: PRODUCTION_RUNTIME})).not.toThrow();
+    });
+
+    test('wired into the real write funnel: addNodes to a production-bound graph throws in a test context', async () => {
+        // Await async init so the in-memory DB handle exists — otherwise addNodes early-returns on `!this.db`
+        // BEFORE reaching the guard, which would false-green this assertion.
+        for (let i = 0; i < 200 && !storage.db; i++) { await new Promise(resolve => setTimeout(resolve, 5)); }
+        expect(storage.db, 'SQLite in-memory DB should be initialised before the write-path assertion').toBeTruthy();
+
+        // The DB stays in-memory (disposable + harmless); only dbPath is repointed at a prod path, so the
+        // guard fires BEFORE any row is written — proving the funnel is guarded without ever touching prod.
+        storage.dbPath = PROD_PATH;
+        expect(() => storage.addNodes([{id: 'pollution-node', label: 'X', properties: {}}])).toThrow(/GRAPH_WRITE_GUARD/);
+
+        // And with the DB still bound to :memory: (disposable), the same funnel allows the write (no false-positive).
+        storage.dbPath = ':memory:';
+        expect(() => storage.addNodes([{id: 'ok-node', label: 'X', properties: {name: 'ok'}}])).not.toThrow();
+    });
+});


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13639

## Summary

Graph-node writes had no production guard — `GraphService.upsertNode` only validated the id. So a bare `npx playwright test` (which, unlike `playwright.config.unit.mjs`, never sets `UNIT_TEST_MODE`, so `storagePaths.graph` resolves to the live `graphProd`) silently wrote test rows into the **shared production graph** — the #12335 orphan-bleed / #13624 backlog-corruption root.

The destructive twins (`Store.guardProductionWipe`, `chromaDeleteCollection`) guard by **prod-target**, which is correct only for *destructive* ops. Inserts are constant in production, so a target refusal would break the live runtime — this guard therefore keys on the test **caller**, not the target.

`SQLite.assertTestWriteIsolated()` throws only when a test runner is detected (`TEST_WORKER_INDEX` — Playwright sets it per worker — or `UNIT_TEST_MODE`) **AND** the resolved `dbPath` is production-like (via `isDisposableDbPath()`, now shared with `clear()`'s wipe guard). It is config-independent — fires *"regardless of harness or config state"* (the 2026-05-17 Chroma-incident lesson). **Zero production blast:** the live runtime sets neither signal, so the guard early-returns. Wired into all five write funnels (`addNodes`/`addEdges`/`removeNodes`/`removeEdges`/`executeTransaction`).

Axis-3 (integrity / corruption-prevention) of #13624. Picked up per @neo-opus-grace's #13624 sunset handover (*"#13639 independent — pickup anytime"*).

## Test Evidence

Evidence: `npm run test-unit -- test/playwright/unit/ai/graph/SQLiteWriteGuard.spec.mjs` → **6 passed (688ms)**.

New spec `SQLiteWriteGuard.spec.mjs` — full branch coverage via injected `dbPath`/`env` (deterministic, DOG-style):
- `isDisposableDbPath`: `:memory:`/tmp/`*test*`/empty disposable; production paths not.
- blocks a write to a production graph from a Playwright worker (`TEST_WORKER_INDEX`).
- blocks a write to a production graph under `UNIT_TEST_MODE` (test mode → prod path = misconfig).
- allows disposable targets from a test context.
- **zero production blast**: the live runtime (no test signal) writing to a production path is never guarded.
- **wired into the real write funnel**: `addNodes` to a production-bound graph throws `GRAPH_WRITE_GUARD` (and allows `:memory:`).

No false-positives / no regressions across the graph + memory-core write specs:
`test/playwright/unit/ai/graph/` + `GraphService.spec` + `Server.spec` + `WriteSideInvariant.spec` → **59 passed, 0 failed** (incl. `Database.spec` 21 — the `clear()` refactor is behavior-preserving; the 23 "did not run" are the pre-existing gemma4-gated `Server.spec` skips).

## Post-Merge Validation

- Operator/CI: a full-suite `--workers=1` run stays green (the #12335-class confidence check; the guard adds a fail-closed assertion, not a behavior change for in-mode tests).
- Latent confirmation: a deliberate bare `npx playwright test` against a graph-writing spec now fails closed with `GRAPH_WRITE_GUARD` instead of polluting the live graph.

<!-- ## Deltas: none — single-commit lane. -->
