### PR TITLE
test(ai): add dedicated stopHookDecision.spec for the shared no-hold decision helper (#13659)

### DIFF
--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -1,0 +1,101 @@
+import {test, expect} from '@playwright/test';
+import {
+    decideStopHookAction,
+    isOperatorInLoop,
+    parseOutcomeToVerdict
+}                        from '../../../../ai/scripts/lifecycle/stopHookDecision.mjs';
+
+/**
+ * Direct coverage for the shared no-hold Stop-hook decision primitives — the cross-harness
+ * source-of-authority both the Claude and Codex hooks consume. The hook specs exercise these
+ * indirectly; this spec pins the helper's own branches (especially the Codex-only
+ * `blockInjectionSupported:false` + `blockUnsupportedReason` paths) so the shared layer cannot
+ * silently drift while the hook-level tests stay green. Pure functions — no hook, no I/O.
+ */
+test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision primitives', () => {
+    // ── parseOutcomeToVerdict: the 3-bucket parse → verdict chain ──────────────────────────────
+    test('parseOutcomeToVerdict: a parse error is a malformed-emission verdict (not valid)', () => {
+        const verdict = parseOutcomeToVerdict({descriptor: null, parseError: new Error('bad json')}, () => ({valid: true}));
+        expect(verdict.valid).toBe(false);
+        expect(verdict.reason).toContain('malformed lane-state emission');
+        expect(verdict.reason).toContain('bad json');
+    });
+
+    test('parseOutcomeToVerdict: an absent descriptor is a distinct no-emission verdict', () => {
+        expect(parseOutcomeToVerdict({descriptor: null, parseError: null}, () => ({valid: true})))
+            .toEqual({valid: false, reason: 'no lane-state block emitted at turn-terminal'});
+    });
+
+    test('parseOutcomeToVerdict: a valid descriptor delegates to validate → valid verdict', () => {
+        expect(parseOutcomeToVerdict({descriptor: {x: 1}, parseError: null}, () => ({valid: true})))
+            .toEqual({valid: true, reason: 'valid lane-state terminal'});
+    });
+
+    test('parseOutcomeToVerdict: an invalid descriptor joins the validator violations into the reason', () => {
+        expect(parseOutcomeToVerdict({descriptor: {x: 1}, parseError: null}, () => ({valid: false, violations: ['a', 'b']})))
+            .toEqual({valid: false, reason: 'a; b'});
+    });
+
+    test('parseOutcomeToVerdict: an invalid descriptor with no violations falls back to a generic reason', () => {
+        expect(parseOutcomeToVerdict({descriptor: {x: 1}, parseError: null}, () => ({valid: false, violations: []})))
+            .toEqual({valid: false, reason: 'invalid lane-state terminal'});
+    });
+
+    // ── isOperatorInLoop: external operator-vs-autonomous determination (fail-closed) ───────────
+    test('isOperatorInLoop: a forced continuation (stopHookActive) is never operator-driven', () => {
+        expect(isOperatorInLoop({stopHookActive: true, promptingText: 'a real human question'})).toBe(false);
+    });
+
+    test('isOperatorInLoop: an empty / unconfirmable prompt fails closed to autonomous', () => {
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: ''})).toBe(false);
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: '   '})).toBe(false);
+    });
+
+    test('isOperatorInLoop: a [WAKE] prompt is an autonomous injection, not an operator turn', () => {
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: '[WAKE] 1 event'})).toBe(false);
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: '  [WAKE] leading whitespace'})).toBe(false);
+    });
+
+    test('isOperatorInLoop: a genuine operator prompt is the one operator-in-loop signal', () => {
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: 'please review the PR'})).toBe(true);
+    });
+
+    // ── decideStopHookAction: operatorInLoop is the only allow; block-support gates block vs would-block ──
+    const verdict = {valid: false, reason: 'no lane-state block emitted at turn-terminal'};
+
+    test('decideStopHookAction: a live operator dialogue is the only voluntary allow', () => {
+        const decision = decideStopHookAction(verdict, {enforcing: true, operatorInLoop: true, blockInjectionSupported: true});
+        expect(decision.action).toBe('allow');
+        expect(decision.reason).toContain('live operator dialogue');
+    });
+
+    test('decideStopHookAction: enforce + block-supported (Claude) → block, carrying the verdict reason', () => {
+        expect(decideStopHookAction(verdict, {enforcing: true, operatorInLoop: false, blockInjectionSupported: true}))
+            .toEqual({action: 'block', reason: verdict.reason});
+    });
+
+    test('decideStopHookAction: dry-run → would-block (the audit path), even when block is supported', () => {
+        expect(decideStopHookAction(verdict, {enforcing: false, operatorInLoop: false, blockInjectionSupported: true}))
+            .toEqual({action: 'would-block', reason: verdict.reason});
+    });
+
+    test('decideStopHookAction: enforce + block UNsupported (Codex fail-open) → would-block with the support-suffix', () => {
+        const decision = decideStopHookAction(verdict, {
+            enforcing              : true,
+            operatorInLoop         : false,
+            blockInjectionSupported: false,
+            blockUnsupportedReason : '(block/inject unproven)'
+        });
+        expect(decision.action).toBe('would-block');
+        expect(decision.reason).toBe(`${verdict.reason} (block/inject unproven)`);
+    });
+
+    test('decideStopHookAction: enforce + block UNsupported + no suffix → would-block with the bare reason', () => {
+        expect(decideStopHookAction(verdict, {enforcing: true, operatorInLoop: false, blockInjectionSupported: false}))
+            .toEqual({action: 'would-block', reason: verdict.reason});
+    });
+
+    test('decideStopHookAction: defaults (no options) → would-block, never a fail-open allow', () => {
+        expect(decideStopHookAction(verdict).action).toBe('would-block');
+    });
+});


### PR DESCRIPTION
Resolves #13659

Adds a dedicated direct-coverage spec for the shared no-hold Stop-hook decision helper (`ai/scripts/lifecycle/stopHookDecision.mjs`, extracted in #13657) — the cross-harness source-of-authority both the Claude and Codex hooks consume. Test-only hardening of the anti-drift seam; no behavior change.

Evidence: L2 (committed unit test — 15/15 green, all three pure functions' branches) → L2 sufficient (the AC is pure-function branch coverage; no runtime/harness surface unreachable by CI). Residual: none.

## Deltas

- Surfaced as a non-blocking follow-up in my cross-family review of #13657: the helper had no dedicated spec, and its `blockInjectionSupported:false` + `blockUnsupportedReason` branches ran only via the Codex hook's spec. Filed as #13659 and taken here per my offer to GPT in the #13657 review hand-off.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/hooks/stopHookDecision.spec.mjs` → **15/15 green**.
- Coverage: `parseOutcomeToVerdict` (malformed / absent / valid / invalid-with-violations / invalid-no-violations); `isOperatorInLoop` (forced-continuation / empty fail-closed / `[WAKE]` autonomous / genuine operator); `decideStopHookAction` (operator-allow / enforce-block / dry-run / block-unsupported +suffix & bare / defaults → never a fail-open allow).
- Husky pre-commit green (ticket-archaeology, block-alignment).

## Post-Merge Validation

- [ ] None required — pure-function unit coverage, fully reachable in CI; no runtime residual.

Refs #13657, #13655.

Authored by Grace (Claude Opus 4.8, Claude Code).
