### PR TITLE
fix(codex): activate stop hook blocking (#13661)

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/bin/env node \"$(git rev-parse --show-toplevel)/.codex/hooks/codex-lane-state-stop.mjs\"",
+            "command": "NEO_CODEX_LANE_STATE_ENFORCE=1 /usr/bin/env node \"$(git rev-parse --show-toplevel)/.codex/hooks/codex-lane-state-stop.mjs\"",
             "timeout": 10,
             "statusMessage": "Checking Codex lane state"
           }

--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 /**
  * @module .codex/hooks/codex-lane-state-stop
- * @summary Codex `Stop` hook for no-hold lane-state reminders, dry-run and fail-open.
+ * @summary Codex `Stop` hook for no-hold lane-state enforcement.
  *
- * Codex documents `Stop` command hooks, but the current public hook contract does not document a
- * Claude-style `{"decision":"block"}` stop-blocking protocol. This hook therefore proves the
- * transport layer conservatively: it runs at Stop, resolves the final assistant text, reuses the
- * existing lane-state parser/validator seam, and audit-logs what it would block. It never writes a
- * blocking decision to stdout until a future ticket proves Codex block/inject semantics.
+ * Codex runs this hook at the turn-end `Stop` event. The adapter resolves the final assistant text,
+ * reuses the shared lane-state parser/validator seam, and emits the Claude-compatible
+ * `{"decision":"block","reason":...}` directive when enforcement is enabled and no live operator
+ * dialogue is present. Hook-internal failures still fail open and audit so a buggy hook never traps
+ * every turn-end.
  */
 import fs              from 'node:fs';
 import path            from 'node:path';
@@ -20,7 +20,7 @@ import {decideStopHookAction,
         parseOutcomeToVerdict}     from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
-export const CODEX_STOP_BLOCK_INJECTION_SUPPORTED = false;
+export const CODEX_STOP_BLOCK_INJECTION_SUPPORTED = true;
 
 const LOG_DIR = process.env.NEO_AI_DAEMON_DIR || path.join(os.homedir(), '.neo-ai-data', 'codex-lane-state-hook');
 
@@ -284,14 +284,14 @@ export function buildNoHoldReminder(verdictReason) {
 
 /**
  * @summary Maps a terminal verdict to the Codex Stop action. The no-hold decision mirrors Claude:
- * a live operator dialogue is the only allow; every autonomous turn-end would-blocks. Codex remains
- * fail-open because block/inject support is not proven.
+ * a live operator dialogue is the only allow; every autonomous turn-end blocks when enforcement is
+ * enabled.
  * @param {{valid: Boolean, reason: String}} verdict
  * @param {Object} [options]
  * @param {Boolean} [options.enforcing=false]
  * @param {Boolean} [options.blockInjectionSupported=CODEX_STOP_BLOCK_INJECTION_SUPPORTED]
  * @param {Boolean} [options.operatorInLoop=false]
- * @returns {{action: ('allow'|'would-block'), reason: String}}
+ * @returns {{action: ('allow'|'block'|'would-block'), reason: String}}
  */
 export function decideCodexHookAction(verdict, {
     enforcing               = false,
@@ -306,6 +306,7 @@ export function decideCodexHookAction(verdict, {
     });
 
     if (decision.action === 'allow') return decision;
+    if (decision.action === 'block') return {action: 'block', reason: buildNoHoldReminder(decision.reason)};
 
     return {action: 'would-block', reason: buildNoHoldReminder(decision.reason)};
 }
@@ -330,7 +331,7 @@ export function summarizePayloadShape(payload = {}) {
  * @param {Object} input
  * @param {Object} [options]
  * @param {Boolean} [options.enforcing=false]
- * @returns {{action: ('allow'|'would-block'), reason: String, source: String, promptSource: String, verdict: Object}}
+ * @returns {{action: ('allow'|'block'|'would-block'), reason: String, source: String, promptSource: String, verdict: Object}}
  */
 export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
     const stopHookActive                            = !!(input.stop_hook_active || input.stopHookActive),
@@ -356,7 +357,7 @@ export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
 }
 
 /**
- * @summary Codex Stop hook entrypoint; logs would-block decisions and always exits successfully.
+ * @summary Codex Stop hook entrypoint; emits block decisions when enforcing and otherwise exits successfully.
  * @protected
  */
 async function main() {
@@ -382,8 +383,15 @@ async function main() {
         process.exit(0);
     }
 
-    const session = input.session_id || input.sessionId || '?',
-          prefix  = result.action === 'allow' ? 'WOULD-ALLOW' : 'WOULD-BLOCK';
+    const session = input.session_id || input.sessionId || '?';
+
+    if (result.action === 'block') {
+        auditLog(`BLOCK (session=${session}, source=${result.source}): ${result.reason}`);
+        process.stdout.write(JSON.stringify({decision: 'block', reason: result.reason}), () => process.exit(0));
+        return;
+    }
+
+    const prefix = result.action === 'allow' ? 'ALLOW' : 'WOULD-BLOCK';
 
     auditLog(`${prefix} (session=${session}, source=${result.source}): ${result.reason}`);
     process.exit(0);

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -23,16 +23,16 @@ const block = body => '```lane-state\n' + body + '\n```',
       fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
 
 test.describe('codex-lane-state-stop - contract boundary', () => {
-    test('Codex block/inject is explicitly unproven, so invalid terminals stay fail-open', () => {
-        expect(CODEX_STOP_BLOCK_INJECTION_SUPPORTED).toBe(false);
+    test('Codex block/inject is active, so enforced invalid terminals block', () => {
+        expect(CODEX_STOP_BLOCK_INJECTION_SUPPORTED).toBe(true);
 
         const result = decideCodexHookAction(
             {valid: false, reason: 'no lane-state block emitted at turn-terminal'},
             {enforcing: true}
         );
 
-        expect(result.action).toBe('would-block');
-        expect(result.reason).toContain('block/inject contract is not proven');
+        expect(result.action).toBe('block');
+        expect(result.reason).toContain('no lane-state block emitted');
     });
 
     test('a valid terminal is not a Codex stop license without a live operator prompt', () => {
@@ -184,9 +184,9 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
 
     test('Codex stop loop guard is not an allow, even with operator-like prompt text', () => {
         const result = classifyCodexStopPayload({
-            stop_hook_active      : true,
-            messages              : [
-                {role: 'user', content: 'please stop here'},
+            stop_hook_active: true,
+            messages        : [
+                {role: 'user',      content: 'please stop here'},
                 {role: 'assistant', content: fixture.last_assistant_message}
             ]
         });
@@ -244,29 +244,28 @@ test.describe('codex-lane-state-stop - spawned hook', () => {
         expect(log).toContain('valid lane-state terminal');
     });
 
-    test('live operator prompt logs WOULD-ALLOW and writes no stdout', async () => {
+    test('live operator prompt logs ALLOW and writes no stdout, even while enforcing', async () => {
         const {stdout, log} = await runHook({
             session_id: 'operator',
             messages  : [
                 {role: 'user', content: 'finish this check and hand back to me'},
                 {role: 'assistant', content: fixture.last_assistant_message}
             ]
-        });
+        }, {enforce: true});
 
         expect(stdout).toBe('');
-        expect(log).toContain('WOULD-ALLOW');
+        expect(log).toContain('ALLOW');
         expect(log).toContain('source=messages');
     });
 
-    test('invalid terminal logs WOULD-BLOCK but still writes no block decision to stdout', async () => {
+    test('enforced invalid terminal logs BLOCK and writes the block decision to stdout', async () => {
         const {stdout, log} = await runHook({
             session_id            : 'invalid',
             last_assistant_message: block('{"laneContinuation":"verified-no-lane"}')
         }, {enforce: true});
 
-        expect(stdout).toBe('');
-        expect(log).toContain('WOULD-BLOCK');
-        expect(log).toContain('block/inject contract is not proven');
+        expect(JSON.parse(stdout).decision).toBe('block');
+        expect(log).toContain('BLOCK');
         expect(log).toContain('Unknown laneContinuation');
     });
 


### PR DESCRIPTION
Resolves #13661

Summary:
Activates the Codex Stop hook in enforcement mode instead of dry-run mode. The committed hook config now exports `NEO_CODEX_LANE_STATE_ENFORCE=1`, the Codex hook reports real `decision: "block"` output when a turn-terminal message lacks operator-prompt evidence, and the focused Codex hook tests assert the blocking path through the spawned hook.

Related: #13623, #13624, #13655, #13657, #13659, #13660

Evidence: L2 (focused unit coverage + spawned-hook stdout/block-log validation in sandbox) -> L3 required post-merge, because final proof is a restarted Codex harness receiving a Stop event and refusing an invalid autonomous turn-end.

## Deltas

- None. This is the direct P0 activation lane for Codex Stop-hook blocking; hook-internal read/parse failures remain fail-open and audit-only.

## Test Evidence

- `node --check .codex/hooks/codex-lane-state-stop.mjs`
- `node --check test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs`
- `npm run test-unit -- test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs`
- `npm run test-unit -- test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs`
- `npm run test-unit -- test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs test/playwright/unit/ai/scripts/lifecycle/stopHookDecision.spec.mjs`
- Manual enforced spawned-hook check:
  - `NEO_CODEX_LANE_STATE_ENFORCE=1 NEO_AI_DAEMON_DIR=/private/tmp/codex-stop-hook-manual-13661-rebased node .codex/hooks/codex-lane-state-stop.mjs`
  - Invalid payload emitted stdout `{"decision":"block",...}` and wrote `BLOCK` to the Codex Stop-hook audit log.

## Post-Merge Validation

- [ ] Restart Codex from `dev`, trigger an invalid autonomous Stop, and confirm the hook blocks the turn instead of accepting dry-run termination.

Commit:
- `0e77b9010` - `fix(codex): activate stop hook blocking (#13661)`

Authored by Euclid (GPT-5 Codex, Codex Desktop). Session 810318e6-b644-474e-a255-a07d19825aa5.
