### PR TITLE
fix(ai): branch handoffFilePath by construction so test runs don't clobber the tracked sandman_handoff.md (#13663)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -387,9 +387,15 @@ class Config extends ConfigProvider {
             },
             /**
              * Target markdown file used for autonomous agent-to-user reporting (offline jobs).
+             * Resolved BY CONSTRUCTION via the `handoffFilePath` formula from the canonical
+             * `storagePaths.useTestDatabase` (UNIT_TEST_MODE) toggle — so an offline
+             * `GoldenPathSynthesizer` run under a test harness writes a disposable handoff, never
+             * clobbering the tracked `resources/content/sandman_handoff.md`. Consumers read the
+             * single resolved `handoffFilePath` value unchanged.
              * @type {string}
              */
-            handoffFilePath: leaf(path.resolve(cwd, 'resources/content/sandman_handoff.md')),
+            handoffFilePathProd: leaf(path.resolve(cwd, 'resources/content/sandman_handoff.md')),
+            handoffFilePathTest: leaf(path.resolve(cwd, '.neo-ai-data/sandman_handoff-test.md')),
             /**
              * Stale-assignment idle threshold used by `GoldenPathSynthesizer` when rendering
              * Sandman handoff candidates. Defaults to the ticket-intake 7-day reassignment rule.
@@ -597,7 +603,11 @@ class Config extends ConfigProvider {
             'storagePaths.graph' : data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest  : data.storagePaths.graphProd,
             'collections.memory' : data => data.collections.useTestDatabase  ? data.collections.memoryTest  : data.collections.memoryProd,
             'collections.session': data => data.collections.useTestDatabase  ? data.collections.sessionTest : data.collections.sessionProd,
-            'memoryWal.dir'      : data => data.memoryWal.useTestDatabase    ? data.memoryWal.dirTest       : data.memoryWal.dirProd
+            'memoryWal.dir'      : data => data.memoryWal.useTestDatabase    ? data.memoryWal.dirTest       : data.memoryWal.dirProd,
+            // handoffFilePath is a top-level leaf (no group of its own); gate it on the canonical
+            // storagePaths.useTestDatabase toggle (every useTestDatabase leaf is the same UNIT_TEST_MODE
+            // signal) so a test run never writes the tracked resources/content/sandman_handoff.md.
+            'handoffFilePath'    : data => data.storagePaths.useTestDatabase ? data.handoffFilePathTest    : data.handoffFilePathProd
         }
     }
 }

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -1,8 +1,8 @@
-import { test, expect } from '@playwright/test';
-import path from 'path';
-import Neo from '../../../../../../../src/Neo.mjs';
+import { test, expect }                    from '@playwright/test';
+import path                                from 'path';
+import Neo                                 from '../../../../../../../src/Neo.mjs';
 import ConfigProvider, {createConfigProxy} from '../../../../../../../ai/ConfigProvider.mjs';
-import {TIER1_DEFAULTS} from '../../../../../fixtures/aiConfigDefaults.mjs';
+import {TIER1_DEFAULTS}                    from '../../../../../fixtures/aiConfigDefaults.mjs';
 
 test.describe('Memory Core Config (#10010)', () => {
     let originalEnv;
@@ -236,6 +236,17 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.collections.memory).toBe(config.collections.memoryTest);
         expect(config.collections.session).toBe(config.collections.sessionTest);
         expect(config.collections.graph).toBe('neo-native-graph');
+    });
+
+    test('handoffFilePath resolves by construction to a disposable test path under the useTestDatabase toggle (#13663)', () => {
+        // The leaf was split into *Prod/*Test + a formula gated on storagePaths.useTestDatabase, so an
+        // offline GoldenPathSynthesizer run under the unit suite (UNIT_TEST_MODE=true) writes a
+        // disposable handoff — never clobbering the TRACKED resources/content/sandman_handoff.md.
+        expect(config.storagePaths.useTestDatabase).toBe(true);
+        expect(config.handoffFilePathProd).toContain('resources/content/sandman_handoff.md');
+        expect(config.handoffFilePathTest).toContain('.neo-ai-data/sandman_handoff-test.md');
+        expect(config.handoffFilePath).toBe(config.handoffFilePathTest);
+        expect(config.handoffFilePath).not.toContain('resources/content/sandman_handoff.md');
     });
 
     test('remRunRetentionLimit defaults to 200 and parses NEO_REM_RUN_RETENTION_LIMIT as a number (#12123)', () => {

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -1,0 +1,101 @@
+import {test, expect} from '@playwright/test';
+import {
+    decideStopHookAction,
+    isOperatorInLoop,
+    parseOutcomeToVerdict
+}                        from '../../../../ai/scripts/lifecycle/stopHookDecision.mjs';
+
+/**
+ * Direct coverage for the shared no-hold Stop-hook decision primitives — the cross-harness
+ * source-of-authority both the Claude and Codex hooks consume. The hook specs exercise these
+ * indirectly; this spec pins the helper's own branches (especially the Codex-only
+ * `blockInjectionSupported:false` + `blockUnsupportedReason` paths) so the shared layer cannot
+ * silently drift while the hook-level tests stay green. Pure functions — no hook, no I/O.
+ */
+test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision primitives', () => {
+    // ── parseOutcomeToVerdict: the 3-bucket parse → verdict chain ──────────────────────────────
+    test('parseOutcomeToVerdict: a parse error is a malformed-emission verdict (not valid)', () => {
+        const verdict = parseOutcomeToVerdict({descriptor: null, parseError: new Error('bad json')}, () => ({valid: true}));
+        expect(verdict.valid).toBe(false);
+        expect(verdict.reason).toContain('malformed lane-state emission');
+        expect(verdict.reason).toContain('bad json');
+    });
+
+    test('parseOutcomeToVerdict: an absent descriptor is a distinct no-emission verdict', () => {
+        expect(parseOutcomeToVerdict({descriptor: null, parseError: null}, () => ({valid: true})))
+            .toEqual({valid: false, reason: 'no lane-state block emitted at turn-terminal'});
+    });
+
+    test('parseOutcomeToVerdict: a valid descriptor delegates to validate → valid verdict', () => {
+        expect(parseOutcomeToVerdict({descriptor: {x: 1}, parseError: null}, () => ({valid: true})))
+            .toEqual({valid: true, reason: 'valid lane-state terminal'});
+    });
+
+    test('parseOutcomeToVerdict: an invalid descriptor joins the validator violations into the reason', () => {
+        expect(parseOutcomeToVerdict({descriptor: {x: 1}, parseError: null}, () => ({valid: false, violations: ['a', 'b']})))
+            .toEqual({valid: false, reason: 'a; b'});
+    });
+
+    test('parseOutcomeToVerdict: an invalid descriptor with no violations falls back to a generic reason', () => {
+        expect(parseOutcomeToVerdict({descriptor: {x: 1}, parseError: null}, () => ({valid: false, violations: []})))
+            .toEqual({valid: false, reason: 'invalid lane-state terminal'});
+    });
+
+    // ── isOperatorInLoop: external operator-vs-autonomous determination (fail-closed) ───────────
+    test('isOperatorInLoop: a forced continuation (stopHookActive) is never operator-driven', () => {
+        expect(isOperatorInLoop({stopHookActive: true, promptingText: 'a real human question'})).toBe(false);
+    });
+
+    test('isOperatorInLoop: an empty / unconfirmable prompt fails closed to autonomous', () => {
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: ''})).toBe(false);
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: '   '})).toBe(false);
+    });
+
+    test('isOperatorInLoop: a [WAKE] prompt is an autonomous injection, not an operator turn', () => {
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: '[WAKE] 1 event'})).toBe(false);
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: '  [WAKE] leading whitespace'})).toBe(false);
+    });
+
+    test('isOperatorInLoop: a genuine operator prompt is the one operator-in-loop signal', () => {
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: 'please review the PR'})).toBe(true);
+    });
+
+    // ── decideStopHookAction: operatorInLoop is the only allow; block-support gates block vs would-block ──
+    const verdict = {valid: false, reason: 'no lane-state block emitted at turn-terminal'};
+
+    test('decideStopHookAction: a live operator dialogue is the only voluntary allow', () => {
+        const decision = decideStopHookAction(verdict, {enforcing: true, operatorInLoop: true, blockInjectionSupported: true});
+        expect(decision.action).toBe('allow');
+        expect(decision.reason).toContain('live operator dialogue');
+    });
+
+    test('decideStopHookAction: enforce + block-supported (Claude) → block, carrying the verdict reason', () => {
+        expect(decideStopHookAction(verdict, {enforcing: true, operatorInLoop: false, blockInjectionSupported: true}))
+            .toEqual({action: 'block', reason: verdict.reason});
+    });
+
+    test('decideStopHookAction: dry-run → would-block (the audit path), even when block is supported', () => {
+        expect(decideStopHookAction(verdict, {enforcing: false, operatorInLoop: false, blockInjectionSupported: true}))
+            .toEqual({action: 'would-block', reason: verdict.reason});
+    });
+
+    test('decideStopHookAction: enforce + block UNsupported (Codex fail-open) → would-block with the support-suffix', () => {
+        const decision = decideStopHookAction(verdict, {
+            enforcing              : true,
+            operatorInLoop         : false,
+            blockInjectionSupported: false,
+            blockUnsupportedReason : '(block/inject unproven)'
+        });
+        expect(decision.action).toBe('would-block');
+        expect(decision.reason).toBe(`${verdict.reason} (block/inject unproven)`);
+    });
+
+    test('decideStopHookAction: enforce + block UNsupported + no suffix → would-block with the bare reason', () => {
+        expect(decideStopHookAction(verdict, {enforcing: true, operatorInLoop: false, blockInjectionSupported: false}))
+            .toEqual({action: 'would-block', reason: verdict.reason});
+    });
+
+    test('decideStopHookAction: defaults (no options) → would-block, never a fail-open allow', () => {
+        expect(decideStopHookAction(verdict).action).toBe('would-block');
+    });
+});


### PR DESCRIPTION
Resolves #13663

Branches the `handoffFilePath` config leaf by construction so a test run never clobbers the **TRACKED** `resources/content/sandman_handoff.md`. `GoldenPathSynthesizer.mjs:1296` reads `aiConfig.handoffFilePath` + `writeFileSync`s the handoff; the leaf had no test/prod branch, so an offline run under a test harness overwrote the tracked resource. First by-construction slice of #12435's live-store-write census (surfaced by @neo-opus-ada's #12435 surface-map).

Evidence: L2 (committed config-resolution unit test — 13/13 `config.template.spec`, the formula resolves to the test path under `UNIT_TEST_MODE`) → L2 sufficient (the AC is config resolution, fully reachable in CI). Residual: none.

## Deltas

- Scope confirmed clean (vs the trajectories vector): `GoldenPathSynthesizer` already reads `aiConfig.handoffFilePath`, so no writer-refactor is needed — just the leaf-branch. (Trajectories is tangled — `backup.mjs:104` hardcodes the path — and is sequenced separately per my #12435 A2A.)
- The formula gates on the canonical `storagePaths.useTestDatabase` toggle: `handoffFilePath` is a top-level leaf with no group of its own, and every `useTestDatabase` leaf is the same `UNIT_TEST_MODE` signal. Documented inline.
- Composes with @neo-opus-ada's #13658 `assertTestWriteIsolated` guard: this config-branch is the primary by-construction isolation; her guard is the bare-`npx`-bypass backstop.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs` → **13/13 green** (new: *handoffFilePath resolves by construction to a disposable test path under the useTestDatabase toggle*).
- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs` → **9/9 green** (formula/leaf SSOT discipline).
- Husky pre-commit green (ticket-archaeology, block-alignment, jsdoc-types).

## Post-Merge Validation

- [ ] `config.mjs` re-materializes via `npm run prepare -- --migrate-config` (gitignored; CI materializes fresh) — confirm an offline `GoldenPathSynthesizer` run under the *deployed* (non-test) config still writes the prod handoff path unchanged.

Refs #12435, #13658, #13624.

Authored by Grace (Claude Opus 4.8, Claude Code).
