### PR TITLE
fix(ai): bound summary lease-hold — cap sessions-per-sweep so the picker interleaves (#13592)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -122,6 +122,15 @@ class Config extends ConfigProvider {
              */
             summarizationBatchLimit: leaf(2000),
             /**
+             * Maximum sessions one summary sweep drains before the child exits + releases the
+             * heavy-maintenance lease, so the fair picker interleaves dream / golden-path / backfill
+             * frequently instead of waiting out a whole drift batch. The drift sweep self-continues
+             * (the next sweep re-derives the remainder), so this chunks the work, never drops it. A
+             * small default keeps holds short.
+             * @type {number}
+             */
+            maxSessionsPerSummarySweep: leaf(5, 'NEO_MC_MAX_SESSIONS_PER_SUMMARY_SWEEP', 'number'),
+            /**
              * Maximum number of undigested sessions the REM pipeline processes per cycle.
              * Keeps each sleep pass bounded even when the query batch is larger.
              * @type {number}

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -6,6 +6,7 @@ import {withTimeout}                                 from './helpers/withTimeout
 import {appendWalEmbedMarker, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
 import crypto                                        from 'crypto';
 import GraphService                                  from './GraphService.mjs';
+import {capSessionsForSweep}                         from './capSessionsForSweep.mjs';
 import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER}   from '../../graph/identityRoots.mjs';
 
 import StorageRouter from './managers/StorageRouter.mjs';
@@ -1393,7 +1394,13 @@ ${sessionContent}
                     logger.info(`[SessionService] Skipping session ${sessionId} - active lease held by another instance or already completed.`);
                 }
             } else {
-                const sessionsToSummarize = await this.findSessionsToSummarize();
+                // Cap the per-sweep drain so the child releases the heavy-maintenance lease after a
+                // small batch — the fair picker then interleaves dream / golden-path / backfill rather
+                // than waiting out the whole drift list. The next sweep re-derives the remainder.
+                const sessionsToSummarize = capSessionsForSweep(
+                    await this.findSessionsToSummarize(),
+                    aiConfig.maxSessionsPerSummarySweep
+                );
 
                 // Hardware concurrency scaling
                 let batchSize;

--- a/ai/services/memory-core/capSessionsForSweep.mjs
+++ b/ai/services/memory-core/capSessionsForSweep.mjs
@@ -1,0 +1,28 @@
+/**
+ * @module ai/services/memory-core/capSessionsForSweep
+ * @summary Bounds how many sessions a single summary sweep drains before the child exits and
+ * releases the heavy-maintenance lease.
+ *
+ * `SessionService.summarizeSessions` otherwise drains the entire drift list in one child run, holding
+ * the exclusive heavy-maintenance lease for the whole batch — starving `dream` / `backup` /
+ * `memory-summary-backfill`, which only win the lease at a release boundary (the fair picker, see
+ * `learn/agentos/decisions/0022-heavy-maintenance-scheduling-fairness.md`). Capping the per-sweep
+ * count yields release boundaries frequently, so the picker interleaves the rest of the REM chain.
+ *
+ * The drift sweep is self-continuing — the next sweep re-derives the remaining sessions — so capping
+ * CHUNKS the backlog, it never drops work.
+ */
+
+/**
+ * @summary Caps a session list to its first `maxPerSweep` entries when that is a positive integer;
+ * otherwise returns the list unchanged (an unset / zero / non-integer cap means "no bound").
+ * Pure — no I/O, no `aiConfig` mutation — so it is unit-testable in isolation.
+ * @param {Array} sessions The full drift list from `findSessionsToSummarize`.
+ * @param {Number} maxPerSweep The per-sweep cap (read at the use site as `aiConfig.maxSessionsPerSummarySweep`).
+ * @returns {Array} The capped (or unchanged) list.
+ */
+export function capSessionsForSweep(sessions, maxPerSweep) {
+    return Number.isInteger(maxPerSweep) && maxPerSweep > 0
+        ? sessions.slice(0, maxPerSweep)
+        : sessions;
+}

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -1,8 +1,8 @@
-import { test, expect } from '@playwright/test';
-import path from 'path';
-import Neo from '../../../../../../../src/Neo.mjs';
+import { test, expect }                    from '@playwright/test';
+import path                                from 'path';
+import Neo                                 from '../../../../../../../src/Neo.mjs';
 import ConfigProvider, {createConfigProxy} from '../../../../../../../ai/ConfigProvider.mjs';
-import {TIER1_DEFAULTS} from '../../../../../fixtures/aiConfigDefaults.mjs';
+import {TIER1_DEFAULTS}                    from '../../../../../fixtures/aiConfigDefaults.mjs';
 
 test.describe('Memory Core Config (#10010)', () => {
     let originalEnv;
@@ -249,6 +249,22 @@ test.describe('Memory Core Config (#10010)', () => {
 
         try {
             expect(freshCfg.remRunRetentionLimit).toBe(50);
+        } finally {
+            freshCfg.destroy();
+        }
+    });
+
+    test('maxSessionsPerSummarySweep defaults to 5 and parses NEO_MC_MAX_SESSIONS_PER_SUMMARY_SWEEP as a number (#13592)', () => {
+        expect(config.maxSessionsPerSummarySweep).toBe(5);
+
+        process.env.NEO_MC_MAX_SESSIONS_PER_SUMMARY_SWEEP = '3';
+
+        // Fresh isolated instance picks up the env via #applyEnvLayer at construction —
+        // never mutate the shared singleton.
+        const freshCfg = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(freshCfg.maxSessionsPerSummarySweep).toBe(3);
         } finally {
             freshCfg.destroy();
         }

--- a/test/playwright/unit/ai/services/memory-core/capSessionsForSweep.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/capSessionsForSweep.spec.mjs
@@ -1,0 +1,39 @@
+import {test, expect}        from '@playwright/test';
+import {capSessionsForSweep} from '../../../../../../ai/services/memory-core/capSessionsForSweep.mjs';
+
+/**
+ * Direct coverage for the pure per-sweep cap that bounds how many sessions one summary child drains
+ * before releasing the heavy-maintenance lease. Pure — no I/O, no aiConfig — so it tests in isolation.
+ */
+test.describe('ai/services/memory-core/capSessionsForSweep', () => {
+    const sessions = ['s1', 's2', 's3', 's4', 's5', 's6', 's7'];
+
+    test('caps to the first N when maxPerSweep is a positive integer', () => {
+        expect(capSessionsForSweep(sessions, 3)).toEqual(['s1', 's2', 's3']);
+        expect(capSessionsForSweep(sessions, 1)).toEqual(['s1']);
+    });
+
+    test('passes through unchanged when the cap exceeds the list length', () => {
+        expect(capSessionsForSweep(sessions, 100)).toEqual(sessions);
+    });
+
+    test('passes through (no bound) when the cap is unset / zero / negative / non-integer', () => {
+        // The same passthrough ref is returned — confirms there is no defensive copy on the no-bound path.
+        expect(capSessionsForSweep(sessions, undefined)).toBe(sessions);
+        expect(capSessionsForSweep(sessions, null)).toBe(sessions);
+        expect(capSessionsForSweep(sessions, 0)).toBe(sessions);
+        expect(capSessionsForSweep(sessions, -1)).toBe(sessions);
+        expect(capSessionsForSweep(sessions, 2.5)).toBe(sessions);
+        expect(capSessionsForSweep(sessions, '3')).toBe(sessions);
+    });
+
+    test('does not mutate the input list when capping', () => {
+        const input = ['a', 'b', 'c'];
+        capSessionsForSweep(input, 1);
+        expect(input).toEqual(['a', 'b', 'c']);
+    });
+
+    test('handles an empty list', () => {
+        expect(capSessionsForSweep([], 5)).toEqual([]);
+    });
+});


### PR DESCRIPTION
Resolves #13592

Bounds how many sessions a single summary sweep drains before the child releases the heavy-maintenance lease, so the fair picker gets release boundaries frequently and interleaves `dream` / `golden-path` / `memory-summary-backfill` instead of waiting out a whole drift batch. Part 2 of #13586 (the staleness picker is Part 1).

Evidence: L2 (committed unit tests — pure helper 5/5 + config-leaf resolution + the bulk-path `ResumeValidation` spec green) → L3 required (AC4: the live orchestrator shows `dream`/`backup` interleaving within a cap-window + `undigested` drains). Residual: AC4 [#13592] — observable only on the running orchestrator.

## Deltas

- The pure helper `capSessionsForSweep` lives in its own sibling module (`ai/services/memory-core/capSessionsForSweep.mjs`, the `heartbeatPulseEvaluator.mjs` precedent) so it unit-tests in isolation without bootstrapping the full `SessionService` Neo class.
- Cap default = 5 (per the ticket's "small default"); the optimal value is the empirical follow-up (out of scope). No existing bulk-path test summarizes >5 sessions, so the cap is behavior-neutral for the current suite.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/capSessionsForSweep.spec.mjs` → **5/5** (cap-to-N, passthrough on unset/zero/negative/non-integer, no input mutation, empty list).
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs` → **13/13** (new: `maxSessionsPerSummarySweep` default 5 + `NEO_MC_MAX_SESSIONS_PER_SUMMARY_SWEEP` env override).
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs` → **9 passed** (the `#13462` bulk-path test green under cap=5; 2 gemma4-gated skips).
- Husky pre-commit green (ticket-archaeology, block-alignment, jsdoc-types).

## MCP config-template clone-sync

`maxSessionsPerSummarySweep` is added to `ai/mcp/server/memory-core/config.template.mjs` (the tracked SSOT). Each clone's gitignored `config.mjs` re-materializes via `npm run prepare -- --migrate-config`; the Memory-Core server processes must **restart** to pick up the new leaf. CI materializes `config.mjs` fresh, so there is no committed-config drift.

## Post-Merge Validation

- [ ] **AC4 `[L3-deferred — operator handoff needed]`** — on the live orchestrator: `summary` no longer holds the lease for a whole batch; the deferral log shows `dream`/`backup` interleaving within one cap-window; `undigested` (REM) drains. Observable only on the running orchestrator, not in CI.

Refs #13586, #13624, #12065. Complements the heavy-maintenance fair picker (ADR 0022).

Authored by Grace (Claude Opus 4.8, Claude Code).
