### PR TITLE
fix(ai): exclude archived/orphaned sessions from the session-summary-pending count (#13667)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/summary.mjs
+++ b/ai/daemons/orchestrator/scheduling/summary.mjs
@@ -70,10 +70,14 @@ export function getPendingSummarizationCount(db) {
  * summary artifact itself is `SESSION_SUMMARY` (`summary_<sessionId>`), while the REM projection
  * layer also creates `SESSION` nodes from Chroma summary rows (`session:<sessionId>` with
  * `properties.chromaId = summary_<sessionId>`). Minimal `SESSION` placeholders without a summary
- * Chroma id are deliberately excluded so they do not mask truly unsummarized sessions.
+ * Chroma id are deliberately excluded so they do not mask truly unsummarized sessions. Archived
+ * memories are excluded too: an archived row has no recoverable content to summarize, so it is an
+ * integrity concern, not summary-pending work — counting it would inflate the proxy with sessions
+ * the drain can never drain.
  *
- * @summary Feeds the periodic-sweep trigger reason as a graph-backed proxy, not a claim that
- * Chroma drift has drainable work. Fail-soft: returns `null` when the graph table is unavailable.
+ * @summary Feeds the periodic-sweep trigger reason as a graph-backed proxy of drainable
+ * session-summary work — un-archived sessions lacking summary evidence. Fail-soft: returns `null`
+ * when the graph table is unavailable.
  * @param {Object} db SQLite database handle.
  * @returns {Number|null}
  */
@@ -92,6 +96,12 @@ export function getPendingSessionSummaryCount(db) {
                 FROM Nodes memory
                 WHERE json_extract(memory.data, '$.label')                = 'AGENT_MEMORY'
                   AND json_extract(memory.data, '$.properties.sessionId') IS NOT NULL
+                  -- Exclude archived/orphaned sessions: an archived memory has no recoverable
+                  -- content (its vector row was GC'd or never landed), so it can never be
+                  -- summarized — it is an integrity concern, not summary-pending work. A session
+                  -- keeps counting while it has any un-archived memory node. Mirrors the
+                  -- archived-skip the miniSummary backfill fetch applies for the same reason.
+                  AND json_extract(memory.data, '$.properties.archivedAt') IS NULL
             ),
             summary_sessions AS (
                 SELECT DISTINCT json_extract(summary.data, '$.properties.sessionId') AS sessionId

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/SessionSummaryBacklogCount.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/SessionSummaryBacklogCount.spec.mjs
@@ -13,8 +13,8 @@ setup({
     }
 });
 
-import {test, expect}              from '@playwright/test';
-import Neo                         from '../../../../../../../src/Neo.mjs';
+import {test, expect}                  from '@playwright/test';
+import Neo                             from '../../../../../../../src/Neo.mjs';
 import {getPendingSessionSummaryCount} from '../../../../../../../ai/daemons/orchestrator/scheduling/summary.mjs';
 
 /**
@@ -71,6 +71,26 @@ test.describe('orchestrator/scheduling getPendingSessionSummaryCount (#12821)', 
         // collapse the count.
         expect(after).toBe(before + 2);
         expect(after).toBeGreaterThan(0);
+    });
+
+    test('excludes archived/orphaned sessions — an archived memory is not summary-pending', () => {
+        const before = getPendingSessionSummaryCount(sqlite);
+
+        // sARCH: a single, archived memory with no summary. Its content is gone (vector row GC'd or
+        // never landed) so it can never be summarized — it must NOT inflate the pending proxy.
+        GraphService.upsertNode({id: 'bk-mem-ARCH', type: 'AGENT_MEMORY', name: 'mem arch', properties: {sessionId: 'bk-sess-ARCH', timestamp: 1, archivedAt: '2026-01-01T00:00:00.000Z', archivedReason: 'no-content'}});
+        // sLIVE: a single, un-archived, unsummarized memory — the control that DOES count, so the
+        // delta isolates the archived-exclusion rather than a flat count.
+        GraphService.upsertNode({id: 'bk-mem-LIVE', type: 'AGENT_MEMORY', name: 'mem live', properties: {sessionId: 'bk-sess-LIVE', timestamp: 1}});
+        // sMIX: one archived + one live memory node. A session still counts while it has any
+        // un-archived (summarizable) memory — only fully-orphaned sessions drop out.
+        GraphService.upsertNode({id: 'bk-mem-MIX-arch', type: 'AGENT_MEMORY', name: 'mix arch', properties: {sessionId: 'bk-sess-MIX', timestamp: 1, archivedAt: '2026-01-01T00:00:00.000Z'}});
+        GraphService.upsertNode({id: 'bk-mem-MIX-live', type: 'AGENT_MEMORY', name: 'mix live', properties: {sessionId: 'bk-sess-MIX', timestamp: 2}});
+
+        const after = getPendingSessionSummaryCount(sqlite);
+
+        // +2, not +3: sLIVE and sMIX count; the fully-archived sARCH is excluded.
+        expect(after).toBe(before + 2);
     });
 
     test('is fail-soft when the db handle is unavailable', () => {


### PR DESCRIPTION
Resolves #13667

`getPendingSessionSummaryCount` now excludes archived/orphaned sessions: added `archivedAt IS NULL` to the `memory_sessions` CTE so the session-summary-pending telemetry stops counting sessions whose memory has no recoverable Chroma content. A session counts while it has any un-archived memory node; a fully-archived (orphaned) session drops out. Mirrors the archived-skip #13656 added to the miniSummary backfill fetch.

Evidence: L2 (unit — real `:memory:` graph under `UNIT_TEST_MODE`, no Chroma / live model). All close-target ACs are pure graph-query behavior → L2 sufficient; no residuals.

## Why (the V-B-A behind it)
Cross-store V-B-A on the parent (#13647 issuecomment-4759938336): of 285 graph-pending sessions, **238 are orphaned** (no Chroma content → unsummarizable), 45 Chroma-summarized-but-graph-unprojected, 2 real. The drift sweep finds only ~40 candidates/run and processing them never moves the marker — the orphans are structurally non-drainable, so the "backlog 283→284" was misleading telemetry, not summary-work. A live orchestrator run after #13656 merged confirmed it at scale: the miniSummary aged-drain processed 1344 rows → **1335 missing-content** (orphaned). As those orphans are archived (by #13656 / axis-3 #13639), this filter drops them from the marker so it reflects drainable truth.

The marker is telemetry-only (feeds the periodic-sweep trigger *reason*, does NOT gate the sweep) and `getDueTask` is a pure-sync projection (registry contract: no I/O), so a cross-store Chroma-truth marker is out of contract — the graph-only `archivedAt` filter is the correct, in-contract fix.

## Test Evidence
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/SessionSummaryBacklogCount.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs` → **24 passed**.
- New test `excludes archived/orphaned sessions — an archived memory is not summary-pending`: archived-only excluded; live + mixed-node (one archived + one live) sessions still count (delta `+2`, not `+3`).
- Husky pre-commit green (whitespace, aiconfig-test-mutation, shorthand, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation
- [ ] As #13656 / #13639 archive the orphaned sessions, the live `graph-pending-session-summary` count drops toward the genuinely-drainable set (was ~285; orphans ≈238).

## Deltas from ticket
None — delivers #13667's two ACs exactly.

## Related
Related: #13647 (parent — remaining there: the 45 projection-lag, the gate-hardening ACs, the axis-3 coupling). Related: #13624 (epic). Couples: #13656, #13639.

Authored by Vega (Claude Opus 4.8, Claude Code). Session c4fcedd0-c449-4f8c-b368-e3ac0c0509ff.
