### PR TITLE
feat(ai): shared store-write guard util + SQLite adoption (#13665)

### DIFF
--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -1,5 +1,6 @@
-import Base                            from './Base.mjs';
-import { SQLITE_IN_CLAUSE_BATCH_SIZE } from './constants.mjs';
+import Base                                           from './Base.mjs';
+import { SQLITE_IN_CLAUSE_BATCH_SIZE }                from './constants.mjs';
+import { isDisposableStorePath, isTestRunnerContext } from '../../services/shared/storeWriteGuard.mjs';
 
 const GRAPH_SCHEMA_VERSION = 1;
 const GRAPH_SCHEMA_VERSION_ID = 'graph';
@@ -285,15 +286,16 @@ class SQLite extends Base {
     /**
      * @summary Classifies a SQLite path as disposable (test-isolated) versus a live production database.
      *
-     * Disposable = SQLite `:memory:`, an OS-temp / repo-`tmp/` path, or any `*test*` path. This is the single
-     * definition of "safe to mutate from a test", shared by `clear()`'s production-wipe guard and
-     * `assertTestWriteIsolated()` so the destructive and the write-isolation guards never drift apart.
+     * Delegates to the Agent-OS-wide `storeWriteGuard.isDisposableStorePath` classifier — one definition of
+     * "safe to mutate from a test" (`:memory:`, an OS-temp / repo-`tmp/`, or any `*test*` path) shared across
+     * the graph store and the file-stores so no per-store classifier drifts. Used here by both `clear()`'s
+     * production-wipe guard and `assertTestWriteIsolated()`.
      * @param {String|null} [dbPath=this.dbPath]
      * @returns {Boolean}
      * @protected
      */
     isDisposableDbPath(dbPath=this.dbPath) {
-        return !dbPath || dbPath === ':memory:' || dbPath.includes('tmp') || dbPath.includes('test');
+        return isDisposableStorePath(dbPath);
     }
 
     /**
@@ -318,9 +320,7 @@ class SQLite extends Base {
      * @protected
      */
     assertTestWriteIsolated({dbPath=this.dbPath, env=process.env}={}) {
-        const inTestRunner = env.TEST_WORKER_INDEX !== undefined || env.UNIT_TEST_MODE === 'true';
-
-        if (!inTestRunner || this.isDisposableDbPath(dbPath)) return;
+        if (!isTestRunnerContext(env) || this.isDisposableDbPath(dbPath)) return;
 
         throw new Error(
             `GRAPH_WRITE_GUARD: refusing a graph write to the production database "${dbPath}" from a test ` +

--- a/ai/services/shared/storeWriteGuard.mjs
+++ b/ai/services/shared/storeWriteGuard.mjs
@@ -1,0 +1,63 @@
+/**
+ * @module ai/services/shared/storeWriteGuard
+ * @summary Shared test-write isolation primitives: a test context MUST NOT write to a production store.
+ *
+ * The single classifier behind every Agent-OS persistent-store write guard — the SQLite graph store
+ * (`Neo.ai.graph.storage.SQLite`), the concept ontology, and (pending) trajectories/handoff. Centralizing
+ * it here means one definition of "disposable (test-isolated) vs production", rather than a classifier
+ * drifting per store (the review note on the first guard).
+ *
+ * The danger it closes: a bare `npx playwright test` never sets `UNIT_TEST_MODE`, so a store path that
+ * resolves test/prod by construction falls back to the **production** path — and the test silently writes
+ * into the live store (the orphan-bleed / backlog-corruption class). By-construction config isolation can't
+ * reach that bypass; this guard is the config-INDEPENDENT defense-in-depth that fires regardless of harness.
+ */
+
+/**
+ * @summary Classifies a store path as disposable (test-isolated) versus a live production store.
+ *
+ * Disposable = SQLite `:memory:`, an OS-temp / repo-`tmp/` path, or any `*test*` path. The broad substring
+ * match deliberately mirrors the graph store's `clear()` production-wipe guard so the destructive- and
+ * write-isolation guards classify production paths identically.
+ * @param {String|null} storePath
+ * @returns {Boolean}
+ */
+export function isDisposableStorePath(storePath) {
+    return !storePath || storePath === ':memory:' || storePath.includes('tmp') || storePath.includes('test');
+}
+
+/**
+ * @summary True when a test runner is executing (so a production-store write would be test pollution).
+ *
+ * Playwright sets `TEST_WORKER_INDEX` in every worker process; `UNIT_TEST_MODE` covers the unit harness.
+ * The live runtime (MCP server / orchestrator / daemons) sets neither, so callers early-return — zero
+ * production blast.
+ * @param {Object} [env=process.env] Injectable for tests.
+ * @returns {Boolean}
+ */
+export function isTestRunnerContext(env=process.env) {
+    return env.TEST_WORKER_INDEX !== undefined || env.UNIT_TEST_MODE === 'true';
+}
+
+/**
+ * @summary Fail-closed guard: throws when a test runner is about to write a production-store path.
+ *
+ * Fires only at the intersection (test runner AND production-like path); a disposable target or the live
+ * runtime passes through. Each caller passes its `subsystem` for the diagnostic.
+ * @param {Object}  options
+ * @param {String}  options.storePath           The resolved store path about to be written.
+ * @param {String}  options.subsystem           Owning subsystem identifier for the diagnostic.
+ * @param {Object} [options.env=process.env]    Injectable for tests.
+ * @throws {Error} `STORE_WRITE_GUARD` when a test context targets a production store path.
+ */
+export function assertTestWriteIsolated({storePath, subsystem='store', env=process.env}={}) {
+    if (!isTestRunnerContext(env) || isDisposableStorePath(storePath)) {
+        return;
+    }
+
+    throw new Error(
+        `STORE_WRITE_GUARD: refusing a ${subsystem} write to the production store "${storePath}" from a test ` +
+        `context (TEST_WORKER_INDEX/UNIT_TEST_MODE detected). Tests MUST resolve a test/tmp store path — a bare ` +
+        `\`npx playwright test\` would otherwise pollute the live store.`
+    );
+}

--- a/test/playwright/unit/ai/services/shared/storeWriteGuard.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/storeWriteGuard.spec.mjs
@@ -1,0 +1,39 @@
+import {test, expect}                                                        from '@playwright/test';
+import {isDisposableStorePath, isTestRunnerContext, assertTestWriteIsolated} from '../../../../../../ai/services/shared/storeWriteGuard.mjs';
+
+// A production-like absolute path: not :memory:, no tmp/test segment.
+const PROD_PATH = '/srv/neo/.neo-ai-data/datasets/rlaif/trajectories.jsonl';
+
+test.describe('ai/services/shared/storeWriteGuard', () => {
+    test('isDisposableStorePath: :memory:/tmp/*test*/empty are disposable; production paths are not', () => {
+        expect(isDisposableStorePath(':memory:')).toBe(true);
+        expect(isDisposableStorePath('/var/folders/q/tmp/neo.jsonl')).toBe(true);
+        expect(isDisposableStorePath('/x/concepts-test/nodes.jsonl')).toBe(true);
+        expect(isDisposableStorePath(null)).toBe(true);
+        expect(isDisposableStorePath('')).toBe(true);
+        expect(isDisposableStorePath(PROD_PATH)).toBe(false);
+    });
+
+    test('isTestRunnerContext: TEST_WORKER_INDEX or UNIT_TEST_MODE → true; neither → false', () => {
+        expect(isTestRunnerContext({TEST_WORKER_INDEX: '0'})).toBe(true);
+        expect(isTestRunnerContext({TEST_WORKER_INDEX: '3'})).toBe(true);
+        expect(isTestRunnerContext({UNIT_TEST_MODE: 'true'})).toBe(true);
+        expect(isTestRunnerContext({})).toBe(false);
+        expect(isTestRunnerContext({UNIT_TEST_MODE: 'false'})).toBe(false);
+    });
+
+    test('assertTestWriteIsolated: throws for a test runner targeting a production store path', () => {
+        expect(() => assertTestWriteIsolated({storePath: PROD_PATH, subsystem: 'rlaif',   env: {TEST_WORKER_INDEX: '0'}})).toThrow(/STORE_WRITE_GUARD/);
+        expect(() => assertTestWriteIsolated({storePath: PROD_PATH, subsystem: 'concept', env: {UNIT_TEST_MODE: 'true'}})).toThrow(/STORE_WRITE_GUARD/);
+    });
+
+    test('assertTestWriteIsolated: allows disposable targets from a test context', () => {
+        expect(() => assertTestWriteIsolated({storePath: ':memory:',        env: {TEST_WORKER_INDEX: '0'}})).not.toThrow();
+        expect(() => assertTestWriteIsolated({storePath: '/tmp/neo.jsonl',  env: {TEST_WORKER_INDEX: '0'}})).not.toThrow();
+        expect(() => assertTestWriteIsolated({storePath: '/x/foo-test.db',  env: {UNIT_TEST_MODE: 'true'}})).not.toThrow();
+    });
+
+    test('zero production blast: the live runtime (no test signal) writing to a production path is never guarded', () => {
+        expect(() => assertTestWriteIsolated({storePath: PROD_PATH, env: {}})).not.toThrow();
+    });
+});


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13665

## Summary

Establishes the canonical test-write-isolation primitive for the Agent OS — the shared foundation for the store-write guard layer that #13658 began for the graph store.

- **New `ai/services/shared/storeWriteGuard.mjs`** — one Agent-OS-wide classifier: `isDisposableStorePath` + `isTestRunnerContext` + `assertTestWriteIsolated`. Keys on the test **caller** (`TEST_WORKER_INDEX` / `UNIT_TEST_MODE`) × a production-like path — config-independent, **zero production blast** (live runtime sets neither signal → early-return).
- **`SQLite.mjs` delegates** its `isDisposableDbPath` + runner-check to the util — **behavior-preserving** (keeps its `GRAPH_WRITE_GUARD` message; the merged #13658 spec is the regression guard). Centralizing the classifier addresses @neo-gpt's #13658 review note ("don't drift a second classifier").

The file-store guard **applications** (the #12435 division with @neo-opus-grace) are follow-ups, deliberately not in this PR:
- **Concept-ontology guard** — design-ready but **blocked by #13670** (the `check-block-alignment` lint corrupts the adjacent prompt-template JSON when `ConceptDiscoveryService.mjs` is staged). Lands once #13670 is fixed.
- **Trajectories + handoff guards** — after Grace's #12435 config branches (handoff after #13664).

## Test Evidence

- Evidence: `npm run test-unit -- test/playwright/unit/ai/services/shared/storeWriteGuard.spec.mjs` → **5 passed** (full branch coverage of all 3 primitives via injected `env`).
- Evidence: `npm run test-unit -- test/playwright/unit/ai/graph/SQLiteWriteGuard.spec.mjs` → **6 passed** — the SQLite delegation is behavior-preserving (the merged #13658 graph-guard spec is unchanged and green).

## Post-Merge Validation

- The util is the shared foundation the file-store guards reuse; once #13670 unblocks `ConceptDiscoveryService`, the concept guard adopts `assertTestWriteIsolated` directly (no second classifier).
- CI confirms the full memory-core + graph suites stay green with SQLite delegating to the shared classifier.

<!-- ## Deltas: none — single-commit lane (foundation; guard applications are follow-ups). -->
