### PR TITLE
fix(ai): harden session-summary churn-gate timestamp edges — future-skew + unparseable-ts (#13672)

### DIFF
--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -459,7 +459,18 @@ class SessionService extends Base {
             // WAKE_SUBSCRIPTION skip misses; once the session goes quiet past the window it is
             // summarized once → counts match → no further churn. A crashed session IS idle, so the
             // eventual-consistency capture still fires once it ages past the window (no regression).
-            if (sessionData.lastActivity && (nowMs - sessionData.lastActivity) < churnCooldownMs) {
+            //
+            // Timestamp-edge hardening:
+            //   • Future-skew: a clock-drifted memory (plausible across multi-machine / multi-tenant
+            //     deployments) gives lastActivity > nowMs, so a bare `nowMs - lastActivity` is
+            //     negative — perpetually below the cooldown — which would gate the session FOREVER.
+            //     The `idleMs >= 0` guard treats a future timestamp as eligible (summarize once)
+            //     rather than permanently stuck.
+            //   • Unparseable/missing timestamp: resolveGraphTimestampMs returns null, so lastActivity
+            //     stays 0 (falsy) and bypasses this gate — fail-open, since a session we cannot time
+            //     is better summarized than stranded.
+            const idleMs = nowMs - sessionData.lastActivity;
+            if (sessionData.lastActivity && idleMs >= 0 && idleMs < churnCooldownMs) {
                 return;
             }
 

--- a/test/playwright/unit/ai/services/memory-core/SessionService.ChurnCooldown.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.ChurnCooldown.spec.mjs
@@ -142,4 +142,32 @@ test.describe('SessionService.findSessionsToSummarize — churn-gate (#13637)', 
         }
         expect(selections).toBe(0);
     });
+
+    test('a future-skewed session stays eligible — never perpetually gated (timestamp-edge hardening)', async () => {
+        wire({
+            // lastActivity is in the FUTURE (clock drift): `nowMs - lastActivity` is negative, so a
+            // bare `< cooldown` check is ALWAYS true → pre-fix the session was gated forever. The
+            // `idleMs >= 0` guard makes a future timestamp eligible (summarize once) instead.
+            'future-skew': {count: 5, lastActivityMs: NOW + 60_000, summaryCount: 2} // 1 min in the FUTURE + mismatch
+        });
+
+        expect(await svc.findSessionsToSummarize({now: NOW})).toContain('future-skew');
+    });
+
+    test('a session with an unparseable timestamp fails open (eligible), not stranded', async () => {
+        // resolveGraphTimestampMs cannot parse the timestamp → lastActivity stays 0 (falsy), so the
+        // gate's `sessionData.lastActivity && ...` short-circuits and the session stays eligible.
+        svc.memoryCollection.get = async ({offset = 0, limit} = {}) => {
+            const rows = [{sessionId: 'bad-ts', timestamp: 'not-a-timestamp'}, {sessionId: 'bad-ts', timestamp: 'also-bad'}];
+            const page = rows.slice(offset, offset + limit);
+            return {ids: page.map((_, i) => `m${offset + i}`), metadatas: page};
+        };
+        svc.sessionsCollection.get = async ({offset = 0, limit} = {}) => {
+            const rows = [{sessionId: 'bad-ts', memoryCount: 99}]; // count mismatch (2 != 99) → Case B
+            const page = rows.slice(offset, offset + limit);
+            return {ids: page.map(r => `summary_${r.sessionId}`), metadatas: page};
+        };
+
+        expect(await svc.findSessionsToSummarize({now: NOW})).toContain('bad-ts');
+    });
 });


### PR DESCRIPTION
Resolves #13672

Hardens the session-summary churn-gate (`findSessionsToSummarize`, `ai/services/memory-core/SessionService.mjs`) against two timestamp edge-cases flagged in the #13645 review:
- **Future-skew:** adds an `idleMs >= 0` guard so a clock-drifted `lastActivity > now` (plausible across multi-machine / multi-tenant deployments) is treated as eligible (summarize once) instead of perpetually gated — pre-fix the negative idle was always `< cooldown`, gating the session **forever** (lost summarization).
- **Unparseable-ts:** documents the existing fail-open (`resolveGraphTimestampMs` → null → `lastActivity = 0` falsy → bypasses the gate, stays eligible).

Evidence: L2 (offline unit — stubbed collections + injected clock). All ACs are pure gate-logic; no residuals.

## Test Evidence
- `SessionService.ChurnCooldown.spec.mjs` → **5 passed** (3 existing churn-gate + 2 new: future-skew eligible; unparseable-ts fails open).
- Regression `SessionSummarization.spec.mjs`: the `findSessionsToSummarize orders candidates newest first` test (the relevant regression for this change) is **green** (4 passed). The 2 failures in that file — `:115` gemma4 live-model routing + `:515` gemma4 perf latency — are live-model tests with no gemma4 provider in the local sandbox, structurally unrelated to the churn-gate candidate logic, and baseline-confirmed pre-existing in prior sessions. CI (with the suite environment) is the arbiter for those.
- Husky pre-commit green (whitespace, aiconfig-test-mutation, shorthand, jsdoc-types, ticket-archaeology, block-alignment).
- Command: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs <specs>`.

## Deltas from ticket
None — delivers #13672's three ACs exactly.

## Post-Merge Validation
- [ ] No clock-skewed session is observed perpetually unsummarized across a heavy-maintenance window.

## Related
Related: #13647 (parent — sibling to #13667 / PR #13668, the marker archived-filter; remaining there: the 45 projection-lag). Related: #13624 (epic), #13637 (the churn-gate this hardens).

Authored by Vega (Claude Opus 4.8, Claude Code). Session c4fcedd0-c449-4f8c-b368-e3ac0c0509ff.
