### PR TITLE
docs(agentos): recover the Anchor & Echo Knowledge Base Enhancement Strategy (#13597)

### DIFF
--- a/apps/portal/llms.txt
+++ b/apps/portal/llms.txt
@@ -408,6 +408,7 @@ Here you find the full history of Neo.mjs updates.
 - [The Concept Ontology](https://neomjs.com/raw/learn/agentos/ConceptOntology.md)
 - [Neural Link: Live Application Mutability](https://neomjs.com/raw/learn/agentos/NeuralLink.md)
 - [The Knowledge Base Server](https://neomjs.com/raw/learn/agentos/KnowledgeBase.md)
+- [Knowledge Base Enhancement (Anchor & Echo)](https://neomjs.com/raw/learn/agentos/KnowledgeBaseEnhancement.md)
 - [The Memory Core Server](https://neomjs.com/raw/learn/agentos/MemoryCore.md)
 - [The GitHub Workflow Server](https://neomjs.com/raw/learn/agentos/GitHubWorkflow.md)
 - [Code Execution (AI SDK)](https://neomjs.com/raw/learn/agentos/CodeExecution.md)

--- a/apps/portal/sitemap.xml
+++ b/apps/portal/sitemap.xml
@@ -218,6 +218,10 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://neomjs.com/learn/agentos/KnowledgeBaseEnhancement</loc>
+    <lastmod>2026-06-20T23:58:04+02:00</lastmod>
+  </url>
+  <url>
     <loc>https://neomjs.com/learn/agentos/MemoryCore</loc>
     <lastmod>2026-06-14T13:37:07Z</lastmod>
     <priority>1.0</priority>

--- a/learn/agentos/AGENTS_ATLAS.md
+++ b/learn/agentos/AGENTS_ATLAS.md
@@ -119,6 +119,7 @@ Per `AGENTS.md` §pr_diff_equals_pr_body: PR body + review templates are graph-i
 - **Step 1: The Anchor:** Establish high-value vocabulary at class level and major overrides.
 - **Step 2: The Echo:** Explicitly reuse anchor terms in isolated fields and helper methods.
 - **Step 3: Generate Structured Comments:** Use `@summary`, `@see`, `@protected`.
+- **Why (both readers):** *amnesiac-first-read* — a cold human / fresh AI session must land on load-bearing intent on first read; *Chroma-retrieval quality* — the docs ARE the embedded corpus, so dense intent-anchored vocabulary yields better `ask_knowledge_base` / `query_documents` matches. Full teaching + the `src/core/Base.mjs` worked example: `learn/agentos/KnowledgeBaseEnhancement.md`.
 **15.3 The Two-Stage Query Protocol**
 - Stage 1: Query for Knowledge (`ask_knowledge_base`).
 - Stage 2: Query for Memory (`query_summaries`, `query_raw_memories`). Mandatory for regressions, surprises, architecture queries, trade-offs.

--- a/learn/agentos/KnowledgeBase.md
+++ b/learn/agentos/KnowledgeBase.md
@@ -154,7 +154,7 @@ A critical part of the workflow is that the AI agent is not just a consumer, but
 
 1.  **Query:** The agent searches for information.
 2.  **Analyze:** If the returned source code lacks comments or intent, the agent struggles.
-3.  **Enhance:** The agent applies the **Knowledge Base Enhancement Strategy** (defined in `AGENTS_STARTUP.md`). It adds rich JSDoc comments, `@summary` tags, and semantic keywords to the code.
+3.  **Enhance:** The agent applies the **Knowledge Base Enhancement Strategy** (the Anchor & Echo guide — `learn/agentos/KnowledgeBaseEnhancement.md`). It adds rich JSDoc comments, `@summary` tags, and semantic keywords to the code.
 4.  **Sync:** The agent runs `manage_knowledge_base(action: 'sync')`.
 5.  **Improve:** The next query (by this agent or another) will find this enhanced content, yielding a higher score and better understanding.
 

--- a/learn/agentos/KnowledgeBaseEnhancement.md
+++ b/learn/agentos/KnowledgeBaseEnhancement.md
@@ -1,0 +1,38 @@
+# Knowledge Base Enhancement Strategy (Anchor & Echo)
+
+> How to write source documentation so a cold reader — a human, or a fresh / **amnesiac** AI session — lands on the file's most relevant *intent* on first read, AND so `ask_knowledge_base` / `query_documents` semantic search actually returns it. The commit-time gate is `AGENTS.md` §pre_commit_gates **Gate 2**; this guide is the *why* and the worked example behind that gate. The trigger-shaped skeleton lives at `AGENTS_ATLAS.md` §15.2.
+
+## Why it exists — two rationales (both easy to forget)
+
+**1. The amnesiac-first-read.** A cold reader opening a file for the first time — a new human contributor, or (far more often in Neo) a fresh AI session with no prior context — must land on the file's load-bearing *intent* immediately, not reconstruct it from the mechanics. The class-level JSDoc is the first thing read; it carries the *why* and the invariants, not a restatement of the *what*. **Write for the reader who has no memory of this file** — that reader is the common case, not the exception.
+
+**2. Chroma semantic-retrieval quality.** The docs ARE the embedded corpus. `ask_knowledge_base` / `query_documents` retrieve by *vector similarity* over the doc text (see `KnowledgeBase.md` for the RAG / ChromaDB engine). Dense, intent-anchored **vocabulary** produces better embeddings → better matches. A class whose JSDoc names the concepts it embodies, in domain vocabulary reused consistently, is findable by a semantic query for those concepts; a class with thin "sets the value" docs is invisible to it. **Retrieval quality is a direct function of the doc vocabulary** — this is the mechanism the bare "add JSDoc" checkbox loses.
+
+## The mechanics — Anchor, then Echo
+
+- **Anchor** — at the class level and major overrides, establish the high-value vocabulary: the concepts the class embodies, the load-bearing invariants, the *why* of non-obvious choices, and any "do not do X without measuring Y" change-guards. This is the term-anchor the rest of the file — and the embedder — keys on.
+- **Echo** — reuse the anchored terms in the isolated fields and helper methods. A `@member` doc that echoes the class-level vocabulary keeps the concept retrievable at member granularity and reinforces the embedding.
+- **Tag** — `@summary` (one-line intent), `@see` (a *stable* related symbol / ADR / guide — never a line number), `@protected` / `@private` (the contract surface).
+
+## Worked example — `src/core/Base.mjs` (the bar)
+
+**The class JSDoc carries the *why* + a change-guard, not just the *what*:**
+> *"`className` and `ntype` intentionally live on instances as well as on static class config. This costs a few prototype slots, but it keeps Chrome DevTools and Neural Link inspection direct... That ergonomics choice is part of the core debugging contract; **do not demote these values to static-only metadata without measuring the runtime/debugging trade-off** and updating every consumer that serializes, routes, or instantiates by class identity."*
+
+A cold reader learns the invariant, its rationale, and the change-guard in three sentences — and a semantic query for "instance className debugging contract" retrieves exactly this class.
+
+**The `undefined` sentinel — the *why* is taught where the concept lives:**
+> *"In Neo.mjs, `undefined` is used as a strict, immutable sentinel value representing 'initial instantiation'... you should never set a config to `undefined` later in its lifecycle. If you need to clear or reset a config's state, explicitly set it to `null`."*
+
+The reactive-vs-prototype config distinction, the `beforeGet` / `beforeSet` / `afterSet` lifecycle hooks, and the sentinel are documented at the point of definition, in reused vocabulary — that is the Echo, and it is why an agent can `ask` "how do reactive configs signal first instantiation" and land here.
+
+## The virtuous cycle
+
+Better intent-docs → better embeddings → better `ask` / `query` retrieval → the next agent finds the right prior art → builds on it instead of re-deriving or duplicating → documents the new work to the same bar. The discipline **compounds**: every well-anchored file makes the corpus more findable. Thin docs break the cycle — the work exists but is unretrievable, so it gets re-derived (the failure mode this strategy prevents).
+
+## Where this lives
+
+- **Commit gate:** `AGENTS.md` §pre_commit_gates Gate 2 — new/modified classes and methods need JSDoc / `@summary` (this guide is the *why* behind that gate).
+- **Trigger skeleton:** `AGENTS_ATLAS.md` §15.2 (Anchor → Echo → tags), §15.6 (source-comment intent filter: durable intent, not ticket / line-number archaeology), §15.7 (virtuous cycle).
+- **The system it feeds:** `KnowledgeBase.md` (the RAG / ChromaDB engine + the `ask` / `query` tools).
+- **The bar:** `src/core/Base.mjs`.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -40,6 +40,7 @@
         {"name": "The Concept Ontology",                                "parentId": "AgentOS",                                             "id": "agentos/ConceptOntology"},
         {"name": "Neural Link: Live Application Mutability",           "parentId": "AgentOS",                                             "id": "agentos/NeuralLink"},
         {"name": "The Knowledge Base Server",                          "parentId": "AgentOS",                                             "id": "agentos/KnowledgeBase"},
+        {"name": "Knowledge Base Enhancement (Anchor & Echo)",         "parentId": "AgentOS",                                             "id": "agentos/KnowledgeBaseEnhancement"},
         {"name": "The Memory Core Server",                             "parentId": "AgentOS",                                             "id": "agentos/MemoryCore"},
         {"name": "The GitHub Workflow Server",                         "parentId": "AgentOS",                                             "id": "agentos/GitHubWorkflow"},
         {"name": "Code Execution (AI SDK)",                            "parentId": "AgentOS",                                             "id": "agentos/CodeExecution"},


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13597

## Summary

Recovers the **Knowledge Base Enhancement Strategy (Anchor & Echo)** — write source docs so a cold / **amnesiac** reader (a human, or a fresh AI session) lands on the file's load-bearing intent on first read, AND so `ask_knowledge_base` / `query_documents` semantic search retrieves it. The strategy was referenced across the substrate (`AGENTS.md` Gate 2, `pr-review` CONTENT_COMPLETENESS, `structural-pre-flight`) but the *teaching* had decayed to a 3-line `AGENTS_ATLAS §15.2` skeleton; the two rationales were lost.

Premise-check (V-B-A through the reference chain) confirmed it — and found a bonus bug: **`KnowledgeBase.md:157` pointed to `AGENTS_STARTUP.md` for the strategy definition, but it isn't there (a dangling reference).**

- **NEW `learn/agentos/KnowledgeBaseEnhancement.md`** — the dedicated teaching guide: the two rationales (amnesiac-first-read + Chroma-retrieval quality), the Anchor/Echo mechanics, the `src/core/Base.mjs` worked example (the `className`/`ntype` debugging-contract intent + the `undefined`-sentinel / reactive-config density), and the virtuous cycle.
- **`AGENTS_ATLAS §15.2`** — terse compress-to-trigger enrichment (the two rationales + pointers to `Base.mjs` and the guide); the trigger stays lean, the depth is on-demand (ADR-0007).
- **`KnowledgeBase.md:157`** — fixed the dangling `AGENTS_STARTUP.md` reference → the new guide.
- **`tree.json`** — registered the guide under Agent OS.

Non-loaded recovery (a `learn/` guide is on-demand, not always-loaded substrate) — aligns with #13652's reduction philosophy rather than adding loaded bloat.

## Test Evidence

Evidence: docs-only change (no unit tests).
- `node -e "JSON.parse(require('fs').readFileSync('learn/tree.json','utf8'))"` → valid JSON (the nav entry parses).
- The two prior references now resolve to the guide (`KnowledgeBase.md:157` + `AGENTS_ATLAS §15.2`), replacing the dangling `AGENTS_STARTUP.md` pointer.
- The guide cites only stable anchors (`Base.mjs`, `AGENTS.md` Gate 2, ADR-0007) — no line-number/ticket archaeology in the durable doc.

## Post-Merge Validation

- After `manage_knowledge_base(action: 'sync')`, `ask_knowledge_base("Anchor and Echo documentation strategy amnesiac first read Chroma retrieval")` should retrieve the new guide — the strategy made retrievable by the corpus it describes (the virtuous cycle, self-demonstrated).

<!-- ## Deltas: none — single-commit docs-recovery lane. -->
