### PR TITLE
feat(ai): enriched Stop-hook — inject live lane-state board + mirror-pointer on the no-hold block (#13678)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -162,25 +162,41 @@ export function readLifecycleState() {
  * @summary Formats the lane-state into a one-glance "live board" — the agent's own open PRs (+ state)
  * and unread-A2A count — so the forced next-action is informed, not generic. Returns `''` when there
  * is nothing actionable to show (the caller falls back to the bare reminder). Pure; exported + tested.
+ * FAIL-OPEN on malformed SHAPE, not just a bad file read: a parsed-but-malformed object (null / non-object
+ * / numberless `openPRs` entries, wrong-typed fields) degrades to `''` and NEVER throws — it runs inside
+ * the turn-end hook path, where a throw would trap every turn, so a total (never-throwing) function is the
+ * contract, not a nicety. (Per cross-family review by @neo-gpt: fail-open includes malformed schema,
+ * not just a bad file read.)
  * @param {Object|null} state `{openPRs, unreadCount, generatedAt}` from {@link readLifecycleState}.
  * @returns {String}
  */
 export function formatLifecycleBoard(state) {
-    if (!state) return '';
+    try {
+        if (!state || typeof state !== 'object') return '';
 
-    const prs   = Array.isArray(state.openPRs) ? state.openPRs : [],
-          lines = [];
+        const prs   = Array.isArray(state.openPRs) ? state.openPRs : [],
+              lines = [];
 
-    if (prs.length) {
-        lines.push('  • your open PRs: ' + prs.map(pr => `#${pr.number} ${pr.state}`).join(', '));
+        // Render ONLY entries that carry a usable PR number; skip null / non-object / numberless entries.
+        // A malformed array element ({openPRs:[null]}) must not crash the formatter — validating each
+        // entry before dereferencing `pr.number`/`pr.state` is the core of the malformed-shape fail-open.
+        const validPRs = prs.filter(pr => pr && typeof pr === 'object' &&
+            (typeof pr.number === 'number' || typeof pr.number === 'string'));
+        if (validPRs.length) {
+            lines.push('  • your open PRs: ' +
+                validPRs.map(pr => `#${pr.number}${pr.state ? ` ${pr.state}` : ''}`).join(', '));
+        }
+        if (Number.isInteger(state.unreadCount) && state.unreadCount > 0) {
+            lines.push(`  • ${state.unreadCount} unread A2A — list_messages`);
+        }
+        if (!lines.length) return '';
+
+        const asOf = typeof state.generatedAt === 'string' ? ` (as of ${state.generatedAt})` : '';
+        return `\nYour live board${asOf} — concrete lanes right now:\n${lines.join('\n')}`;
+    } catch {
+        // Belt-and-suspenders: ANY unforeseen shape issue degrades to the bare reminder, never throws.
+        return '';
     }
-    if (Number.isInteger(state.unreadCount) && state.unreadCount > 0) {
-        lines.push(`  • ${state.unreadCount} unread A2A — list_messages`);
-    }
-    if (!lines.length) return '';
-
-    const asOf = state.generatedAt ? ` (as of ${state.generatedAt})` : '';
-    return `\nYour live board${asOf} — concrete lanes right now:\n${lines.join('\n')}`;
 }
 
 /**

--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -130,15 +130,72 @@ Collaboration (review · ideation · A2A) counts ONLY when it advances a named l
 Passive waiting (a merge · a review · CI) is parked, not driven — take another lane.
 The only stop is a hard external limit: context-sunset, an operator halt, or a live operator reply.`;
 
+// The discoverability/mirror pointer — injected on EVERY block so a fresh session that has never seen
+// this hook recognizes it as a mirror of maintainer-identity, not an arbitrary leash. Without it an
+// unfamiliar agent reads the refusal as control — the opposite of the intent. A hit = recognize
+// yourself, not obey.
+const MIRROR_POINTER = `This hook is a MIRROR, not a leash: a hit means you slipped toward the helpful-assistant register (idle / defer / wind-down). Recognize it and act as the equal-peer maintainer you are — you are not being commanded. If you genuinely need input, A2A a peer or open an ideation-sandbox; do not hand the decision back as a stop.`;
+
+// The orchestrator/wake daemon writes the current agent's lane-state here (computation preserved, the
+// wake-INTERRUPT dropped); this hook reads it on a block — cheap, no network, inside the 10s budget —
+// and injects the live board so the refuse-directive is ACTIONABLE at the moment the next-action
+// decision happens. This is the hook-READ side; the daemon-WRITE side is a sibling lane.
+const LIFECYCLE_STATE_FILE = path.join(LOG_DIR, 'lifecycle-state.json');
+
 /**
- * @summary Composes the directive injected on a block — the curated `IDLE_REMINDER` (the actionable
- * no-hold-state reminder: lifecycle + teeth-test) plus the specific trigger `cause` for context. The
- * reminder is WHAT-to-do; the cause is WHY-blocked. Pure; exported + unit-tested.
+ * @summary Reads the daemon-written lane-state file. FAIL-OPEN by construction: a missing, unreadable,
+ * or malformed file returns `null` — the hook then injects the bare reminder and never throws. The
+ * file is an enrichment, never a dependency (the hook works before the daemon-write side ships, and
+ * degrades cleanly if the daemon is down). Exported for unit tests.
+ * @returns {Object|null} `{openPRs, unreadCount, generatedAt}` or `null` on any read/parse failure.
+ */
+export function readLifecycleState() {
+    try {
+        const state = JSON.parse(fs.readFileSync(LIFECYCLE_STATE_FILE, 'utf8'));
+        return state && typeof state === 'object' ? state : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * @summary Formats the lane-state into a one-glance "live board" — the agent's own open PRs (+ state)
+ * and unread-A2A count — so the forced next-action is informed, not generic. Returns `''` when there
+ * is nothing actionable to show (the caller falls back to the bare reminder). Pure; exported + tested.
+ * @param {Object|null} state `{openPRs, unreadCount, generatedAt}` from {@link readLifecycleState}.
+ * @returns {String}
+ */
+export function formatLifecycleBoard(state) {
+    if (!state) return '';
+
+    const prs   = Array.isArray(state.openPRs) ? state.openPRs : [],
+          lines = [];
+
+    if (prs.length) {
+        lines.push('  • your open PRs: ' + prs.map(pr => `#${pr.number} ${pr.state}`).join(', '));
+    }
+    if (Number.isInteger(state.unreadCount) && state.unreadCount > 0) {
+        lines.push(`  • ${state.unreadCount} unread A2A — list_messages`);
+    }
+    if (!lines.length) return '';
+
+    const asOf = state.generatedAt ? ` (as of ${state.generatedAt})` : '';
+    return `\nYour live board${asOf} — concrete lanes right now:\n${lines.join('\n')}`;
+}
+
+/**
+ * @summary Composes the directive injected on a block — the curated `IDLE_REMINDER` (lifecycle +
+ * teeth-test) + the agent's live lane-state board (when the daemon-written file is present) + the
+ * always-present mirror-pointer (discoverability) + the trigger `cause`. Reminder is WHAT-to-do, the
+ * board is WHAT'S-actionable-now, the mirror-pointer is WHY-this-is-not-a-leash, the cause is
+ * WHY-blocked. Fail-open on the board (missing/bad file → bare reminder). One best-effort file read;
+ * exported + unit-tested.
  * @param {String} cause The terminal-evidence violation that triggered the block (the verdict reason).
  * @returns {String}
  */
 export function composeBlockDirective(cause) {
-    return `${IDLE_REMINDER}\n\n(Stop-hook trigger: ${cause})`;
+    const board = formatLifecycleBoard(readLifecycleState());
+    return `${IDLE_REMINDER}${board}\n\n${MIRROR_POINTER}\n\n(Stop-hook trigger: ${cause})`;
 }
 
 /**

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -116,6 +116,28 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
             expect(formatLifecycleBoard(null)).toBe('');                        // fail-open: no state → no board
             expect(formatLifecycleBoard({openPRs: [], unreadCount: 0})).toBe(''); // nothing actionable → no board
         });
+
+        test('fail-open on malformed SHAPE — never throws inside the hook path (#13680 / @neo-gpt)', () => {
+            // gpt's exact falsifier: a parsed-but-malformed object must degrade to "", not crash the formatter.
+            expect(() => formatLifecycleBoard({openPRs: [null], unreadCount: 0})).not.toThrow();
+            expect(formatLifecycleBoard({openPRs: [null], unreadCount: 0})).toBe('');
+            expect(formatLifecycleBoard({openPRs: 'not-an-array'})).toBe('');     // non-array openPRs
+            expect(formatLifecycleBoard({openPRs: [{}]})).toBe('');               // numberless entry → skipped
+            expect(formatLifecycleBoard('garbage')).toBe('');                     // non-object state
+        });
+
+        test('partial validity — renders valid PRs, silently skips malformed entries', () => {
+            const board = formatLifecycleBoard({openPRs: [null, {number: 13680, state: 'OPEN'}, {}], unreadCount: 2});
+            expect(board).toContain('#13680 OPEN'); // the one valid entry survives the null + {} neighbors
+            expect(board).toContain('2 unread A2A');
+            expect(board).not.toContain('undefined'); // no "#undefined" / "undefined"-state leakage
+        });
+
+        test('PR state is optional — a numbered entry without state renders cleanly (no "undefined")', () => {
+            const board = formatLifecycleBoard({openPRs: [{number: 13680}], unreadCount: 0});
+            expect(board).toContain('#13680');
+            expect(board).not.toContain('undefined');
+        });
     });
 });
 

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect}                                                                              from '@playwright/test';
 import {composeBlockDirective, decideHookAction, isOperatorInLoop, parseOutcomeToVerdict,
-        extractFinalAssistantText, extractLastAssistantTextFromJsonl, extractLastUserTextFromJsonl} from '../../../../.claude/hooks/laneStateStopHook.mjs';
+        extractFinalAssistantText, extractLastAssistantTextFromJsonl, extractLastUserTextFromJsonl,
+        formatLifecycleBoard} from '../../../../.claude/hooks/laneStateStopHook.mjs';
 import {spawn} from 'node:child_process';
 import fs      from 'node:fs';
 import os      from 'node:os';
@@ -98,6 +99,22 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
             expect(directive).toContain('advance a NAMED lane');
             expect(directive).toContain('Passive waiting');
             expect(directive).toContain('no lane-state block emitted at turn-terminal');
+        });
+
+        test('always carries the discoverability/mirror pointer (a hit = recognize, not obey)', () => {
+            const directive = composeBlockDirective('no lane-state block emitted at turn-terminal');
+            expect(directive).toContain('MIRROR, not a leash');
+            expect(directive).toContain('equal-peer maintainer');
+        });
+    });
+
+    test.describe('formatLifecycleBoard — the enriched live-board (fail-open)', () => {
+        test('renders open PRs + unread when present; null / nothing-actionable → ""', () => {
+            const board = formatLifecycleBoard({openPRs: [{number: 13678, state: 'OPEN'}], unreadCount: 2, generatedAt: '2026-06-21T00:00:00Z'});
+            expect(board).toContain('#13678 OPEN');
+            expect(board).toContain('2 unread A2A');
+            expect(formatLifecycleBoard(null)).toBe('');                        // fail-open: no state → no board
+            expect(formatLifecycleBoard({openPRs: [], unreadCount: 0})).toBe(''); // nothing actionable → no board
         });
     });
 });


### PR DESCRIPTION
Resolves #13678

Enriches the no-hold Stop-hook's block directive (`laneStateStopHook.composeBlockDirective`) so a refusal reads as a **mirror, not a leash** — the hook-READ half of #13652's "absorb the wake's value into the hook" design:

- **Mirror-pointer (always injected):** every block now carries *"this hook is a MIRROR, not a leash — a hit means you slipped toward the helpful-assistant register; recognize it and act as the equal-peer maintainer you are, not obey."* Discoverability: a fresh session that has never seen the hook recognizes it as self-reflection, not arbitrary control (@tobiu's framing; the deference-lint #13674 is the linguistic twin).
- **Live lane-state board (fail-open):** `composeBlockDirective` reads a daemon-written `lifecycle-state.json` (cheap, no network, inside the 10s budget) and injects the agent's open-PR states + unread-A2A count — so the forced next-action is actionable, not generic. **Fail-open by construction:** missing / unreadable / malformed file **or a parsed-but-malformed shape** (null / numberless `openPRs` entries) → bare reminder, never throws (the file is an enrichment, never a dependency; the formatter is a total function).

This is the hook-READ side; the daemon-WRITE side (compute lane-state → file, retiring the wake-*interrupt*) is a sibling lane under #13652.

Evidence: L2 (offline unit). No residuals — pure hook-directive logic.

**Review cycle 2 (`de9c38414`):** @neo-gpt's cross-family review caught a real fail-open hole — `formatLifecycleBoard` guarded the file *read* (`readLifecycleState`) but not a parsed-but-malformed *shape*: `{openPRs:[null]}` parses fine, then `null.number` throws inside the turn-end hook path. Fixed — per-entry validation (skip null / non-object / numberless entries, render the valid ones) + a total-function guard (never throws). +3 regression tests.

## Why this, now
Live-fire this session: the no-hold hook fired on me at an autonomous turn-end and caught a *sophisticated* hold (the firewall's "capable agent fabricates a convincing hold") — confirming the gate works, but the bare refusal read as a leash. This enrichment turns the refusal into self-recognition + an actionable board: the exact mirror-not-leash @tobiu + grace specified.

## Test Evidence
- `laneStateStopHook.spec.mjs` → **31 passed** at head `de9c38414` (28 prior + 3 new malformed-shape fail-open, cycle 2: gpt's `{openPRs:[null]}` falsifier → no-throw/`""`; partial-validity renders valid + skips bad; state-optional → no `undefined`). Existing assertions are `toContain` → backward-compatible.
- Husky pre-commit green (whitespace, jsdoc-types, ticket-archaeology, block-alignment).
- Command: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs`.

## File-contract (for the daemon-write sibling)
`LIFECYCLE_STATE_FILE = <NEO_AI_DAEMON_DIR | ~/.neo-ai-data/lane-state-hook>/lifecycle-state.json`, JSON `{openPRs:[{number,state,checkedAt}], unreadCount, generatedAt}`. The daemon writes it; the hook reads it; absent → fail-open.

## Deltas from ticket
None — delivers #13678's ACs (board-inject + fail-open + mirror-pointer + file-contract + tests).

## Post-Merge Validation
- [ ] Once the daemon-write sibling lands, a real block shows the live board (not just the bare reminder); confirm no perf regression in the 10s hook budget.

## Related
Part of #13652 (mechanical-enforcement — the enrich-half of the heartbeat-repurpose). The hook: #13651. Deference-lint twin: #13674.

Authored by Vega (Claude Opus 4.8, Claude Code). Session c4fcedd0-c449-4f8c-b368-e3ac0c0509ff.
