### PR TITLE
fix(ai): wire the Claude Stop hook into worktrees via bootstrapWorktree (#13681)

### DIFF
--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -5,6 +5,11 @@
  * Memory Core, knowledge-base, and bridge-daemon state is unified across worktree
  * MCP server processes — while leaving the git-tracked `concepts/` subdir untouched.
  *
+ * It also materializes the worktree's `.claude/settings.json` (the no-hold Stop hook) from the
+ * tracked `.claude/settings.template.json` via `initClaudeSettings` — the Claude analog of the
+ * config-overlay hydration, so the hook is wired in worktrees deterministically rather than
+ * relying on the `npm prepare` that `installDependencies` skips when `node_modules` already exists.
+ *
  * **Background (config copy):** `ai/config.mjs` is the Tier-1 operator overlay.
  * `ai/mcp/server/{github-workflow,knowledge-base,memory-core,neural-link}/config.mjs`
  * are gitignored per-server overlays. Fresh git worktrees under
@@ -109,13 +114,13 @@
  * @see .gitignore
  * @see {@link materializeServerConfigTemplate}
  */
-import {execFile}       from 'child_process';
-import fs               from 'fs/promises';
-import path             from 'path';
-import {fileURLToPath}  from 'url';
-import {promisify}      from 'util';
+import {execFile}      from 'child_process';
+import fs              from 'fs/promises';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import {promisify}     from 'util';
 
-import {listServersWithTemplates, materializeServerConfigTemplate} from '../setup/initServerConfigs.mjs';
+import {initClaudeSettings, listServersWithTemplates, materializeServerConfigTemplate} from '../setup/initServerConfigs.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -745,10 +750,10 @@ export async function classifyWorktree({
         current,
         mainCheckout: primaryMainCheckout,
         remove      : classification.remove,
-        removeArgs: ['worktree', 'remove', '--force', worktree.path],
-        status    : classification.status,
-        reason    : classification.reason,
-        dirtyStatus: classification.dirtyStatus || null
+        removeArgs  : ['worktree', 'remove', '--force', worktree.path],
+        status      : classification.status,
+        reason      : classification.reason,
+        dirtyStatus : classification.dirtyStatus || null
     };
 }
 
@@ -822,7 +827,7 @@ export async function pruneStaleWorktrees({
     }
 
     return {
-        worktrees      : classified,
+        worktrees     : classified,
         removed,
         skipped,
         totalBytes,
@@ -833,20 +838,29 @@ export async function pruneStaleWorktrees({
 }
 
 /**
- * @summary Reuses the existing bootstrap + `--link-data` hydration path for one checkout.
+ * @summary Reuses the existing bootstrap + `--link-data` hydration path for one checkout, and
+ * wires the Claude no-hold Stop hook into the worktree's `.claude/settings.json`.
+ *
+ * The Claude-settings wiring (`initClaudeSettings`) materializes the gitignored
+ * `.claude/settings.json` from the worktree's own tracked `.claude/settings.template.json` — the
+ * Claude analog of the `ai/config.mjs` / per-server overlay hydration `bootstrapWorktree` performs.
+ * Without it the Stop hook is only wired by the `npm prepare` that `installDependencies` skips when
+ * `node_modules` already exists, leaving the no-hold enforcement silently inert in worktrees.
  *
  * @param {object}   options
  * @param {string}   options.mainCheckout Canonical checkout path.
  * @param {string}   options.projectRoot Current checkout path to hydrate.
  * @param {Function} [options.log] Logger fn.
- * @returns {Promise<object>} Hydration sub-results.
+ * @param {Function} [options.wireClaudeSettings=initClaudeSettings] Claude-settings materializer; injectable for tests.
+ * @returns {Promise<object>} Hydration sub-results (`bootstrap`, `data`, `files`, `claudeSettings`).
  */
-export async function hydrateCurrentWorktree({mainCheckout, projectRoot, log = console.log}) {
-    const bootstrap = await bootstrapWorktree({mainCheckout, projectRoot, log});
-    const data      = await symlinkDataDir({mainCheckout, projectRoot, log});
-    const files     = await symlinkGitignoredFiles({mainCheckout, projectRoot, log});
+export async function hydrateCurrentWorktree({mainCheckout, projectRoot, log = console.log, wireClaudeSettings = initClaudeSettings}) {
+    const bootstrap      = await bootstrapWorktree({mainCheckout, projectRoot, log});
+    const data           = await symlinkDataDir({mainCheckout, projectRoot, log});
+    const files          = await symlinkGitignoredFiles({mainCheckout, projectRoot, log});
+    const claudeSettings = await wireClaudeSettings({claudeDir: path.join(projectRoot, '.claude'), logger: {log, warn: log}});
 
-    return {bootstrap, data, files};
+    return {bootstrap, data, files, claudeSettings};
 }
 
 /**
@@ -933,7 +947,7 @@ async function getWorktreeDirtyState({worktreePath, exec = execFileAsync}) {
         };
     } catch (error) {
         return {
-            dirty: true,
+            dirty : true,
             stdout: '',
             error
         };
@@ -1033,6 +1047,13 @@ if (isMain) {
         const result = await bootstrapWorktree({mainCheckout, projectRoot});
         const total  = result.copied.length + result.skipped.length + result.missing.length;
         console.log(`\n✓ Bootstrap complete: ${result.copied.length} copied, ${result.skipped.length} skipped, ${result.missing.length} missing (${total} total)`);
+
+        // Materialize the worktree's .claude/settings.json (the no-hold Stop hook) from its tracked
+        // settings.template.json — the Claude-settings parallel to the config hydration above, wired
+        // deterministically rather than via the npm prepare that runBuildAll's installDependencies
+        // skips when node_modules already exists.
+        const claudeSettings = await initClaudeSettings({claudeDir: path.join(projectRoot, '.claude')});
+        console.log(`✓ Claude settings: ${claudeSettings.action}`);
 
         if (linkData) {
             const symlinkResult = await symlinkDataDir({mainCheckout, projectRoot, force});

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -30,6 +30,7 @@ import path            from 'path';
  */
 test.describe('ai/scripts/bootstrapWorktree', () => {
     let bootstrapWorktree;
+    let hydrateCurrentWorktree;
     let symlinkDataDir;
     let symlinkGitignoredFiles;
     let installDependencies;
@@ -55,6 +56,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     test.beforeAll(async () => {
         const mod               = await import('../../../../../../ai/scripts/migrations/bootstrapWorktree.mjs');
         bootstrapWorktree        = mod.bootstrapWorktree;
+        hydrateCurrentWorktree   = mod.hydrateCurrentWorktree;
         symlinkDataDir           = mod.symlinkDataDir;
         symlinkGitignoredFiles   = mod.symlinkGitignoredFiles;
         installDependencies      = mod.installDependencies;
@@ -984,9 +986,9 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             const result = await pruneStaleWorktrees({
                 projectRoot: fakeMainCheckout,
                 currentPath: paths.current,
-                dryRun    : true,
+                dryRun     : true,
                 exec,
-                getSize: async p => ({
+                getSize    : async p => ({
                     [paths.current] : 1024,
                     [paths.stale]   : 2048,
                     [paths.unmerged]: 3072,
@@ -1020,7 +1022,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 projectRoot: fakeMainCheckout,
                 currentPath: paths.current,
                 exec,
-                getSize: async p => ({
+                getSize    : async p => ({
                     [paths.current] : 1024,
                     [paths.stale]   : 2048,
                     [paths.unmerged]: 3072,
@@ -1060,7 +1062,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 currentPath : paths.current,
                 includeDirty: true,
                 exec,
-                getSize: async p => ({
+                getSize     : async p => ({
                     [paths.current] : 1024,
                     [paths.stale]   : 2048,
                     [paths.unmerged]: 3072,
@@ -1096,9 +1098,9 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 projectRoot: fakeMainCheckout,
                 currentPath: paths.current,
                 exec,
-                getSize: async () => 1,
-                hydrate: async () => ({ok: true}),
-                log: () => {}
+                getSize    : async () => 1,
+                hydrate    : async () => ({ok: true}),
+                log        : () => {}
             });
 
             const byPath = Object.fromEntries(result.worktrees.map(item => [item.path, item]));
@@ -1121,9 +1123,9 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 currentPath  : paths.current,
                 worktreesRoot: fakeMainCheckout,
                 exec,
-                getSize: async () => 1,
-                hydrate: async () => ({ok: true}),
-                log: () => {}
+                getSize      : async () => 1,
+                hydrate      : async () => ({ok: true}),
+                log          : () => {}
             });
 
             const byPath = Object.fromEntries(result.worktrees.map(item => [item.path, item]));
@@ -1146,8 +1148,8 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             await pruneStaleWorktrees({
                 projectRoot: fakeMainCheckout,
                 exec,
-                getSize: async () => 1,
-                hydrate: async args => {
+                getSize    : async () => 1,
+                hydrate    : async args => {
                     hydrated.push(args);
                     return {ok: true};
                 },
@@ -1160,6 +1162,55 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 ['worktree', 'remove', '--force', paths.unmerged]
             ]);
             expect(hydrated[0].projectRoot).toBe(fakeMainCheckout);
+        });
+    });
+
+    // --------------------------------------------------------------------------------
+    // hydrateCurrentWorktree — wires the Claude no-hold Stop hook into the worktree's
+    // .claude/settings.json via initClaudeSettings (the Claude analog of the config-overlay
+    // hydration). Without it the Stop hook is only wired by the npm prepare that
+    // installDependencies skips when node_modules exists — leaving the no-hold enforcement
+    // silently inert in worktrees.
+    // --------------------------------------------------------------------------------
+    test.describe('#13681 hydrateCurrentWorktree wires the Claude Stop hook', () => {
+        test('calls the Claude-settings materializer with the worktree .claude dir', async () => {
+            const calls = [];
+            const spy   = async (opts) => { calls.push(opts); return {action: 'wired'}; };
+
+            const result = await hydrateCurrentWorktree({
+                mainCheckout      : fakeMainCheckout,
+                projectRoot       : fakeWorktree,
+                log               : () => {},
+                wireClaudeSettings: spy
+            });
+
+            expect(calls).toHaveLength(1);
+            expect(calls[0].claudeDir).toBe(path.join(fakeWorktree, '.claude'));
+            expect(result.claudeSettings).toEqual({action: 'wired'});
+        });
+
+        test('real initClaudeSettings materializes the Stop hook from the tracked template', async () => {
+            // Seed the worktree's tracked .claude/settings.template.json (the canonical Stop-hook
+            // wiring); the default (real) initClaudeSettings must clone it into .claude/settings.json.
+            const template = {
+                hooks: {Stop: [{hooks: [{type: 'command', command: 'node .claude/hooks/laneStateStopHook.mjs', timeout: 10}]}]}
+            };
+            await fs.ensureDir(path.join(fakeWorktree, '.claude'));
+            await fs.writeFile(
+                path.join(fakeWorktree, '.claude', 'settings.template.json'),
+                JSON.stringify(template, null, 2) + '\n', 'utf-8'
+            );
+
+            const result = await hydrateCurrentWorktree({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                log         : () => {}
+            });
+
+            expect(result.claudeSettings.action).toBe('clone');
+
+            const settings = JSON.parse(await fs.readFile(path.join(fakeWorktree, '.claude', 'settings.json'), 'utf-8'));
+            expect(settings.hooks.Stop[0].hooks[0].command).toContain('laneStateStopHook.mjs');
         });
     });
 });


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13681

## Summary

`initServerConfigs.mjs` gained **`initClaudeSettings()`** — it materializes the gitignored `.claude/settings.json` from the tracked `.claude/settings.template.json`, wiring the no-hold **Stop hook** (`NEO_LANE_STATE_ENFORCE=1 … laneStateStopHook.mjs`) at `npm prepare`. But `bootstrapWorktree.mjs` (the worktree-hydration script) never called it — so a worktree's `.claude/settings.json` was only wired by the `npm prepare` that `installDependencies` **skips when `node_modules` already exists**. The Stop hook was silently unwired in worktrees (caught when `@neo-opus-ada`'s worktree was "the last that hadn't tried the hook").

- **`bootstrapWorktree` imports + calls `initClaudeSettings`** in the CLI hydration flow **and** in `hydrateCurrentWorktree` (the `--prune-stale` rehydrate path) — the Claude analog of the `BOOTSTRAP_CONFIGS` overlay hydration. Deterministic, not dependent on the conditional `npm prepare`.
- **`hydrateCurrentWorktree`** gains an injectable `wireClaudeSettings` param + returns `claudeSettings`.
- **Materialize-from-the-worktree-template, not copy-`main`'s-`settings.json`** (Tier-2, decide-and-document): matches the `initServerConfigs` parallel + the ENFORCE-rollout intent (worktrees get the hook **on** by default); the per-checkout opt-out (drop the `NEO_LANE_STATE_ENFORCE=1` prefix in the gitignored `settings.json`) stays a deliberate operator choice, not silently inherited. In the common case the two are identical (`main`'s `settings.json` is itself materialized from the same template).

The pre-commit block-alignment lint (`lint-staged`, full-file check) required aligning **pre-existing** drift in the touched files (`classifyWorktree` / `pruneStaleWorktrees` returns, `getWorktreeDirtyState`, the import block, the `pruneStaleWorktrees` `getSize` test blocks) — mechanical whitespace, no logic change. The alignment lint post-dated that code, so it had slipped.

## Test Evidence

Evidence: `npx playwright test test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs` → **44 passed** (incl. the 2 new tests).
- `hydrateCurrentWorktree` calls the Claude-settings materializer with the worktree `.claude` dir (spy) + returns `claudeSettings`.
- Real `initClaudeSettings` materializes the Stop hook from a tracked `settings.template.json` (clone → `settings.json` carries the `laneStateStopHook.mjs` command).
- V-B-A before the PR: a manual `initClaudeSettings({claudeDir})` run on this worktree wired the ENFORCE hook (`{"action":"wired"}`) — the fix shape verified end-to-end.
- Block-alignment re-check after `--fix`: CLEAN; the full `lint-staged` suite passed at commit.

## Post-Merge Validation

- A fresh worktree bootstrapped via `node ai/scripts/migrations/bootstrapWorktree.mjs` (or a `--prune-stale` rehydrate) has `.claude/settings.json` with the Stop hook wired, regardless of whether `npm install` ran — confirm via `grep NEO_LANE_STATE_ENFORCE .claude/settings.json` in a newly-bootstrapped worktree.

<!-- ## Deltas: none — single-commit worktree-hook-wiring lane. -->
