### PR TITLE
feat(ai): wire syncGithubWorkflow as a local-only orchestrator task (#13626)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -364,6 +364,7 @@ class Config extends ConfigProvider {
                     pollMs              : leaf(3000, 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS', 'number'),
                     summarySweepMs      : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'number'),
                     kbSyncMs            : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS', 'number'),
+                    githubWorkflowSyncMs: leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_INTERVAL_MS', 'number'),
                     backupMs            : leaf(DAY_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS', 'number'),
                     graphLogCompactionMs: leaf(DAY_MS, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_INTERVAL_MS', 'number'),
                     primaryDevSyncMs    : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS', 'number'),
@@ -514,8 +515,9 @@ class Config extends ConfigProvider {
                  * @type {Object}
                  */
                 localOnly: {
-                    primaryDevSyncEnabled: leaf(null, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED', 'boolean'),
-                    kbSyncEnabled        : leaf(null, 'NEO_ORCHESTRATOR_KB_SYNC_ENABLED', 'boolean'),
+                    primaryDevSyncEnabled    : leaf(null, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED', 'boolean'),
+                    kbSyncEnabled            : leaf(null, 'NEO_ORCHESTRATOR_KB_SYNC_ENABLED', 'boolean'),
+                    githubWorkflowSyncEnabled: leaf(null, 'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_ENABLED', 'boolean'),
                     // Local profile may supervise a child Chroma process; cloud profile
                     // reaches the compose-owned `chroma` peer container instead.
                     chromaDaemonEnabled    : leaf(null, 'NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED', 'boolean'),

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -265,6 +265,7 @@ export class Orchestrator extends Base {
     }
 
     get kbSyncEnabled()                  { return resolveDeploymentEnabled('kbSyncEnabled');                  }
+    get githubWorkflowSyncEnabled()      { return resolveDeploymentEnabled('githubWorkflowSyncEnabled');      }
     get primaryDevSyncEnabled()          { return resolveDeploymentEnabled('primaryDevSyncEnabled');          }
     get tenantRepoSyncEnabled()          { return resolveCloudOnlyEnabled('tenantRepoSyncEnabled');           }
     get chromaDaemonEnabled()            { return resolveDeploymentEnabled('chromaDaemonEnabled');            }

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -26,6 +26,7 @@ export const TASK_STALENESS_CADENCE_KEY = Object.freeze({
     summary                  : 'summarySweep',
     'memory-summary-backfill': 'summarySweep',
     kbSync                   : 'kbSync',
+    githubWorkflowSync       : 'githubWorkflowSync',
     backup                   : 'backup',
     'graphlog-compaction'    : 'graphLogCompaction',
     'primary-dev-sync'       : 'primaryDevSync',
@@ -86,6 +87,7 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
             intervals: {
                 summarySweep                   : config.orchestrator.intervals.summarySweepMs,
                 kbSync                         : config.orchestrator.intervals.kbSyncMs,
+                githubWorkflowSync             : config.orchestrator.intervals.githubWorkflowSyncMs,
                 backup                         : config.orchestrator.intervals.backupMs,
                 graphLogCompaction             : config.orchestrator.intervals.graphLogCompactionMs,
                 primaryDevSync                 : config.orchestrator.intervals.primaryDevSyncMs,
@@ -98,6 +100,7 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
             },
             enables: {
                 kbSync            : orchestrator.kbSyncEnabled,
+                githubWorkflowSync: orchestrator.githubWorkflowSyncEnabled,
                 graphLogCompaction: orchestrator.graphLogCompactionEnabled,
                 primaryDevSync    : orchestrator.primaryDevSyncEnabled,
                 tenantRepoSync    : orchestrator.tenantRepoSyncEnabled,

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -82,6 +82,26 @@ export const TASK_REGISTRY = Object.freeze([
         }
     },
     {
+        taskName        : 'githubWorkflowSync',
+        executionKind   : 'supervised-child-process',
+        maintenanceClass: 'heavy',
+        backpressure    : 'exclusive-heavy',
+        dependencies    : [],
+        getDueTask({state, now, intervals, enables}) {
+            if (!enables.githubWorkflowSync) return null;
+            const lastRunAt  = state.githubWorkflowSync?.lastRunAt ?? 0;
+            const intervalMs = intervals.githubWorkflowSync;
+            if (intervalMs > 0 && now - lastRunAt >= intervalMs) {
+                return {
+                    taskName: 'githubWorkflowSync',
+                    source  : 'periodic-sync',
+                    reason  : `periodic-sync:${intervalMs}`
+                };
+            }
+            return null;
+        }
+    },
+    {
         taskName        : 'backup',
         executionKind   : 'supervised-child-process',
         maintenanceClass: 'heavy',

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -19,6 +19,7 @@ export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
     'summary',
     'memory-summary-backfill',
     'kbSync',
+    'githubWorkflowSync',
     'backup',
     'graphlog-compaction',
     'primary-dev-sync',
@@ -116,7 +117,7 @@ export function getActiveHeavyMaintenanceTask({
     for (const taskName of heavyMaintenanceTaskNames) {
         if (taskName === excludeTaskName) continue;
         if (areHeavyMaintenanceTasksCompatible({
-            taskName: candidateTaskName,
+            taskName     : candidateTaskName,
             otherTaskName: taskName,
             compatibleHeavyMaintenanceTaskPairs
         })) continue;
@@ -401,8 +402,8 @@ export class MaintenanceBackpressureService extends Base {
      */
     getActiveHeavyMaintenanceTask({excludeTaskName = null, candidateTaskName = null} = {}) {
         return getActiveHeavyMaintenanceTask({
-            heavyMaintenanceTaskNames: this.heavyMaintenanceTaskNames,
-            taskStateService         : this.taskStateService,
+            heavyMaintenanceTaskNames          : this.heavyMaintenanceTaskNames,
+            taskStateService                   : this.taskStateService,
             excludeTaskName,
             candidateTaskName,
             compatibleHeavyMaintenanceTaskPairs: this.compatibleHeavyMaintenanceTaskPairs
@@ -505,7 +506,7 @@ export class MaintenanceBackpressureService extends Base {
 
         if (!blockingTaskName) {
             blockingTaskName = this.getActiveHeavyMaintenanceTask({
-                excludeTaskName : taskName,
+                excludeTaskName  : taskName,
                 candidateTaskName: taskName
             });
         }

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -196,6 +196,13 @@ export function buildTaskDefinitions({
             pidFileName    : 'kb-sync.pid',
             expectedCommand: 'syncKnowledgeBase.mjs'
         },
+        githubWorkflowSync: {
+            label          : 'github workflow sync',
+            command        : nodeBin,
+            args           : [path.join(scriptDir, 'maintenance', 'syncGithubWorkflow.mjs')],
+            pidFileName    : 'github-workflow-sync.pid',
+            expectedCommand: 'syncGithubWorkflow.mjs'
+        },
         backup: {
             label          : 'agent OS backup',
             command        : nodeBin,

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -132,6 +132,7 @@ test.describe('Tier 1 Config Immutability', () => {
             pollMs                           : 3000,
             summarySweepMs                   : 10 * 60 * 1000,
             kbSyncMs                         : 30 * 60 * 1000,
+            githubWorkflowSyncMs             : 30 * 60 * 1000,
             backupMs                         : 24 * 60 * 60 * 1000,
             graphLogCompactionMs             : 24 * 60 * 60 * 1000,
             primaryDevSyncMs                 : 10 * 60 * 1000,
@@ -143,6 +144,7 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(Config.orchestrator.localOnly).toEqual({
             primaryDevSyncEnabled          : null,
             kbSyncEnabled                  : null,
+            githubWorkflowSyncEnabled      : null,
             chromaDaemonEnabled            : null,
             bridgeDaemonEnabled            : null,
             neuralLinkBridgeEnabled        : null,

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -85,6 +85,7 @@ function createTestOrchestrator(config = {}) {
     // Test defaults preserve the pre-refactor helper's defaults (600000ms intervals etc.).
     AiConfig.orchestrator.intervals.summarySweepMs   = config.summarySweepIntervalMs   ?? 600000;
     AiConfig.orchestrator.intervals.kbSyncMs         = config.kbSyncIntervalMs         ?? 600000;
+    AiConfig.orchestrator.intervals.githubWorkflowSyncMs = config.githubWorkflowSyncIntervalMs ?? 600000;
     AiConfig.orchestrator.intervals.backupMs         = config.backupIntervalMs         ?? 86400000;
     AiConfig.orchestrator.intervals.graphLogCompactionMs = config.graphLogCompactionIntervalMs ?? 86400000;
     AiConfig.orchestrator.intervals.primaryDevSyncMs = config.primaryDevSyncIntervalMs ?? 600000;
@@ -97,6 +98,10 @@ function createTestOrchestrator(config = {}) {
     if (config.deploymentMode !== undefined) AiConfig.orchestrator.deploymentMode = config.deploymentMode;
 
     AiConfig.orchestrator.localOnly.kbSyncEnabled                  = config.kbSyncEnabled                  ?? true;
+    // Default-disabled like primaryDevSyncEnabled: githubWorkflowSync is a heavy lane with its own
+    // dedicated coverage (registry.spec getDueTask). Keeping it off by default scopes every other
+    // test's scheduling to the lanes under test, so the new lane never competes in the picker.
+    AiConfig.orchestrator.localOnly.githubWorkflowSyncEnabled      = config.githubWorkflowSyncEnabled      ?? false;
     AiConfig.orchestrator.localOnly.primaryDevSyncEnabled          = config.primaryDevSyncEnabled          ?? false;
     AiConfig.orchestrator.localOnly.bridgeDaemonEnabled            = config.bridgeDaemonEnabled            ?? true;
     AiConfig.orchestrator.localOnly.neuralLinkBridgeEnabled        = Object.hasOwn(config, 'neuralLinkBridgeEnabled') ? config.neuralLinkBridgeEnabled : true;
@@ -218,7 +223,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             neuralLinkBridgeLivenessTimeoutMs: 50
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'neuralLinkBridge', 'embedDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat', 'embed-drain-liveness-watchdog']);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'neuralLinkBridge', 'embedDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'githubWorkflowSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat', 'embed-drain-liveness-watchdog']);
         expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
@@ -1211,6 +1216,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         // sorted-set assertion to decouple from declaration order.
         expect([...DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES].sort()).toEqual([
             'backup',
+            'githubWorkflowSync',
             'graphlog-compaction',
             'kbSync',
             'memory-summary-backfill',

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import fs from 'fs';
-import path from 'path';
+import fs             from 'fs';
+import path           from 'path';
 import '../../../../../../src/Neo.mjs';
 import '../../../../../../src/core/_export.mjs';
 import {
@@ -33,6 +33,10 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(tasks.kbSync.command).toBe('/test/node');
         expect(tasks.kbSync.args).toEqual([path.join(scriptDir, 'maintenance', 'syncKnowledgeBase.mjs')]);
         expect(tasks.kbSync.expectedCommand).toBe('syncKnowledgeBase.mjs');
+
+        expect(tasks.githubWorkflowSync.command).toBe('/test/node');
+        expect(tasks.githubWorkflowSync.args).toEqual([path.join(scriptDir, 'maintenance', 'syncGithubWorkflow.mjs')]);
+        expect(tasks.githubWorkflowSync.expectedCommand).toBe('syncGithubWorkflow.mjs');
 
         expect(tasks.backup.command).toBe('/test/node');
         expect(tasks.backup.args).toEqual([path.join(scriptDir, 'maintenance', 'backup.mjs')]);
@@ -166,13 +170,13 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
             // Explicit values are passed through verbatim; env-vars are still ignored.
             const explicitTasks = buildTaskDefinitions({
                 scriptDir,
-                nodeBin   : '/test/node',
-                lmsEnabled: true,
-                lmsModel  : 'explicit-model',
-                lmsModels : ['chat-model', 'embedding-model'],
-                lmsHost   : 'http://127.0.0.1:4242',
+                nodeBin          : '/test/node',
+                lmsEnabled       : true,
+                lmsModel         : 'explicit-model',
+                lmsModels        : ['chat-model', 'embedding-model'],
+                lmsHost          : 'http://127.0.0.1:4242',
                 providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50},
-                lmsPort   : 4242
+                lmsPort          : 4242
             });
 
             expect(explicitTasks.lms.command).toBe('lms');
@@ -288,7 +292,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
             aiConfig,
             existsSync: () => false
         })).resolves.toEqual({
-            loaded: false,
+            loaded    : false,
             configPath: '/tmp/missing-ai-config.mjs'
         });
 
@@ -297,7 +301,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
             aiConfig,
             existsSync: () => true
         })).resolves.toEqual({
-            loaded: true,
+            loaded    : true,
             configPath: '/tmp/local-ai-config.mjs'
         });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -41,7 +41,7 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
     test('expected scheduling lanes are registered (#11862 Prescription parity)', () => {
         const names = TASK_REGISTRY.map(d => d.taskName);
         expect(names).toEqual(expect.arrayContaining([
-            'summary', 'memory-summary-backfill', 'kbSync', 'backup', 'graphlog-compaction',
+            'summary', 'memory-summary-backfill', 'kbSync', 'githubWorkflowSync', 'backup', 'graphlog-compaction',
             'primary-dev-sync', 'tenant-repo-sync', 'dream',
             'golden-path', 'swarm-heartbeat'
         ]));
@@ -71,6 +71,23 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
             expect(descriptor.maintenanceClass, `${taskName} metadata`).toBe('heavy');
             expect(descriptor.backpressure, `${taskName} metadata`).toBe('exclusive-heavy');
         }
+    });
+
+    test('githubWorkflowSync getDueTask gates on enables + fires on elapsed cadence (#13626)', () => {
+        const descriptor = TASK_REGISTRY.find(d => d.taskName === 'githubWorkflowSync');
+        expect(descriptor, 'githubWorkflowSync is registered').toBeTruthy();
+        // Gated off (cloud profile) → never due, even when long overdue.
+        expect(descriptor.getDueTask({state: {}, now: 1e12, intervals: {githubWorkflowSync: 1000}, enables: {githubWorkflowSync: false}})).toBeNull();
+        // Enabled (local) + cadence elapsed → due.
+        expect(descriptor.getDueTask({
+            state    : {githubWorkflowSync: {lastRunAt: 0}}, now: 2000,
+            intervals: {githubWorkflowSync: 1000}, enables: {githubWorkflowSync: true}
+        })).toMatchObject({taskName: 'githubWorkflowSync', source: 'periodic-sync'});
+        // Enabled but within cadence → not yet due.
+        expect(descriptor.getDueTask({
+            state    : {githubWorkflowSync: {lastRunAt: 1500}}, now: 2000,
+            intervals: {githubWorkflowSync: 1000}, enables: {githubWorkflowSync: true}
+        })).toBeNull();
     });
 
     test('continuous tasks (chroma/bridgeDaemon/mlx) are intentionally NOT in registry', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -59,6 +59,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect([...DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES].sort()).toEqual([
             'backup',
             'dream',
+            'githubWorkflowSync',
             'graphlog-compaction',
             'kbSync',
             'memory-summary-backfill',
@@ -111,23 +112,23 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
     test('areHeavyMaintenanceTasksCompatible is symmetric and deny-by-default', () => {
         expect(areHeavyMaintenanceTasksCompatible({
-            taskName: 'kbSync',
-            otherTaskName: 'memory-summary-backfill',
+            taskName                           : 'kbSync',
+            otherTaskName                      : 'memory-summary-backfill',
             compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
         })).toBe(true);
         expect(areHeavyMaintenanceTasksCompatible({
-            taskName: 'memory-summary-backfill',
-            otherTaskName: 'kbSync',
+            taskName                           : 'memory-summary-backfill',
+            otherTaskName                      : 'kbSync',
             compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
         })).toBe(true);
         expect(areHeavyMaintenanceTasksCompatible({
-            taskName: 'summary',
-            otherTaskName: 'kbSync',
+            taskName                           : 'summary',
+            otherTaskName                      : 'kbSync',
             compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
         })).toBe(false);
         expect(areHeavyMaintenanceTasksCompatible({
-            taskName: 'kbSync',
-            otherTaskName: 'kbSync',
+            taskName                           : 'kbSync',
+            otherTaskName                      : 'kbSync',
             compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
         })).toBe(false);
     });
@@ -157,16 +158,16 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
     test('getActiveHeavyMaintenanceTask ignores compatible running heavy task for a candidate', () => {
         expect(getActiveHeavyMaintenanceTask({
-            heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
-            taskStateService         : buildTaskStateService({kbSync: {running: true}}),
-            candidateTaskName        : 'memory-summary-backfill',
+            heavyMaintenanceTaskNames          : DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+            taskStateService                   : buildTaskStateService({kbSync: {running: true}}),
+            candidateTaskName                  : 'memory-summary-backfill',
             compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
         })).toBeNull();
 
         expect(getActiveHeavyMaintenanceTask({
-            heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
-            taskStateService         : buildTaskStateService({summary: {running: true}, kbSync: {running: true}}),
-            candidateTaskName        : 'memory-summary-backfill',
+            heavyMaintenanceTaskNames          : DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+            taskStateService                   : buildTaskStateService({summary: {running: true}, kbSync: {running: true}}),
+            candidateTaskName                  : 'memory-summary-backfill',
             compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
         })).toBe('summary');
     });
@@ -235,22 +236,22 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         recordDeferral({
             deferralLogKeys,
-            taskName       : 'kbSync',
-            reasonCode     : 'heavy-maintenance-backpressure',
-            reasonText     : 'periodic-sync:1800000',
+            taskName        : 'kbSync',
+            reasonCode      : 'heavy-maintenance-backpressure',
+            reasonText      : 'periodic-sync:1800000',
             blockingTaskName: 'summary',
-            taskDefinitions: {summary: {label: 'Sunset summary'}, kbSync: {label: 'KB sync'}},
+            taskDefinitions : {summary: {label: 'Sunset summary'}, kbSync: {label: 'KB sync'}},
             writeLog,
             healthService
         });
         // Repeat — must dedupe the log line but still emit an outcome each time
         recordDeferral({
             deferralLogKeys,
-            taskName       : 'kbSync',
-            reasonCode     : 'heavy-maintenance-backpressure',
-            reasonText     : 'periodic-sync:1800000',
+            taskName        : 'kbSync',
+            reasonCode      : 'heavy-maintenance-backpressure',
+            reasonText      : 'periodic-sync:1800000',
             blockingTaskName: 'summary',
-            taskDefinitions: {summary: {label: 'Sunset summary'}, kbSync: {label: 'KB sync'}},
+            taskDefinitions : {summary: {label: 'Sunset summary'}, kbSync: {label: 'KB sync'}},
             writeLog,
             healthService
         });
@@ -317,11 +318,11 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         recordDeferral({
             deferralLogKeys,
-            taskName       : 'golden-path',
-            reasonCode     : 'golden-path-dependency-backpressure',
+            taskName  : 'golden-path',
+            reasonCode: 'golden-path-dependency-backpressure',
             reasonText     : `periodic-golden-path:1800000`,
             blockingTaskName: 'dream',
-            taskDefinitions: {
+            taskDefinitions : {
                 ['golden-path']: {label: 'Golden Path'},
                 ['dream']      : {label: 'Dream cycle'}
             },
@@ -337,9 +338,9 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         // No healthService → must not throw
         expect(() => recordDeferral({
             deferralLogKeys,
-            taskName       : 'kbSync',
-            reasonCode     : 'heavy-maintenance-backpressure',
-            reasonText     : 'periodic-sync',
+            taskName        : 'kbSync',
+            reasonCode      : 'heavy-maintenance-backpressure',
+            reasonText      : 'periodic-sync',
             blockingTaskName: 'summary'
         })).not.toThrow();
     });
@@ -360,9 +361,9 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         const activeHeavyTask = {name: null};
         const result = service.acquireLeaseAndExecute({
-            taskName       : NON_HEAVY_TASK_NAME,
-            executeFn      : (taskName, reason) => { executions.push({taskName, reason}); return true; },
-            reason         : 'periodic-heartbeat',
+            taskName : NON_HEAVY_TASK_NAME,
+            executeFn: (taskName, reason) => { executions.push({taskName, reason}); return true; },
+            reason   : 'periodic-heartbeat',
             activeHeavyTask
         });
 
@@ -383,9 +384,9 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         const activeHeavyTask = {name: 'summary'};
         const result = service.acquireLeaseAndExecute({
-            taskName       : 'kbSync',
-            executeFn      : () => { throw new Error('should not execute'); },
-            reason         : 'periodic-sync',
+            taskName : 'kbSync',
+            executeFn: () => { throw new Error('should not execute'); },
+            reason   : 'periodic-sync',
             activeHeavyTask
         });
 
@@ -437,9 +438,9 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         const activeHeavyTask = {name: null};
         const result = service.acquireLeaseAndExecute({
-            taskName       : 'backup',
-            executeFn      : () => { throw new Error('should not execute'); },
-            reason         : 'periodic-sweep',
+            taskName : 'backup',
+            executeFn: () => { throw new Error('should not execute'); },
+            reason   : 'periodic-sweep',
             activeHeavyTask
         });
 
@@ -513,9 +514,9 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         const activeHeavyTask = {name: null};
         const result = service.acquireLeaseAndExecute({
-            taskName       : 'kbSync',
-            executeFn      : () => false, // task self-declined → still must release
-            reason         : 'periodic-sync',
+            taskName : 'kbSync',
+            executeFn: () => false, // task self-declined → still must release
+            reason   : 'periodic-sync',
             activeHeavyTask
         });
 
@@ -535,9 +536,9 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         const activeHeavyTask = {name: null};
         const result = service.acquireLeaseAndExecute({
-            taskName       : 'kbSync',
-            executeFn      : async () => 'work-done',
-            reason         : 'periodic-sync',
+            taskName : 'kbSync',
+            executeFn: async () => 'work-done',
+            reason   : 'periodic-sync',
             activeHeavyTask
         });
 


### PR DESCRIPTION
Resolves #13626

Wires `syncGithubWorkflow` as a deployment-gated orchestrator task — a `githubWorkflowSync` heavy-maintenance lane that runs `ai/scripts/maintenance/syncGithubWorkflow.mjs` on a 30-min cadence, **enabled LOCAL-only** (cloud uses tenant-ingestion) via `resolveDeploymentEnabled` (ADR-0014). This is the golden-path-freshness keystone: the local Agent OS graph stays current, so gemma4's golden path + agent V-B-A queries compute on fresh state instead of stale data.

A **verbatim `kbSync` clone** — same `executionKind: 'supervised-child-process'`, `maintenanceClass: 'heavy'`, `backpressure: 'exclusive-heavy'`, gated `getDueTask`. The Contract Ledger + paint-by-numbers clone-site map are on #13626.

**V-B-A that shaped it:** `syncGithubWorkflow.mjs` self-acquires `withHeavyMaintenanceLease` and defers if held — but so does `kbSync`'s own `syncKnowledgeBase.mjs` (and `backup.mjs`), so the self-lease is the *proven* pattern, not a new double-lease risk. The orchestrator's backpressure compatibility check handles the same-owner re-acquire.

Evidence: L2 (committed unit tests — registry gate+cadence behavior, task-def wiring, every exact-list pin updated; full orchestrator + config suites green) → L3 required (the live local orchestrator runs the task on cadence and the graph freshens — observable only on the running daemon).

## Deltas

- Naming mirrors `kbSync`'s all-camelCase convention (`githubWorkflowSync` as taskName / state-key / enables-key / intervals-key) rather than the hyphenated style of `graphlog-compaction`; `pidFileName` stays hyphenated (`github-workflow-sync.pid`) like `kb-sync.pid`.
- Threaded across **every** `kbSync` clone-site found by census — including two the initial map missed: the `TASK_STALENESS_CADENCE_KEY` map (fair-picker staleness normalization) and the `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` SSOT (mandatory for a heavy task).
- `MaintenanceBackpressureService.{mjs,spec}.mjs` + `daemon.spec.mjs` also **pay down pre-existing block-alignment drift** — the guard's whole-file-on-touch enforcement is the intentional **boy-scout paradigm** (touching a file reduces its formatting debt), so the ~80 lines there are deliberate debt-reduction, not noise. The substantive #13626 change in each is a single line (the SSOT entry / the pin-array entry / the task-def assertions).
- No `maxRuntimeMs` watchdog (mirrors `kbSync`, which omits it); a watchdog is a follow-up only if network hangs prove an issue.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/ test/playwright/unit/ai/config.template.spec.mjs` → **520 passed**. The only non-pass is `DreamServiceGoldenPath` timing out, which **reproduces identically on clean dev with my changes stashed** — a pre-existing local-model/graph slowness (exactly the degraded state this task improves), not a regression.
- New `registry.spec.mjs` test — `githubWorkflowSync getDueTask gates on enables + fires on elapsed cadence`: gated-off → null, cadence-elapsed → due, within-cadence → null.
- `daemon.spec.mjs` — task-def asserts `command` / `args` (→ `syncGithubWorkflow.mjs`) / `expectedCommand`.
- Exact-list pins updated + green: heavy SSOT (Orchestrator.spec + MaintenanceBackpressureService.spec), task-state keys (Orchestrator.spec), config leaves (config.template.spec).
- `check-block-alignment` on all changed files → EXIT 0; husky pre-commit green (11 files).

## Post-Merge Validation

- [ ] **L3 (operator handoff)** — on the live LOCAL orchestrator: `githubWorkflowSync` enters the maintenance loop, runs on the `NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_INTERVAL_MS` cadence, and the local graph reflects recent GitHub activity (tickets/PRs) so the golden path computes fresh. Observable only on the running daemon. Each clone's gitignored `config.mjs` must re-materialize (`npm run prepare -- --migrate-config`) + the orchestrator restart to pick up the two new leaves.

## Cycle-2 — rebased on dev + test-setup scoping (clears @neo-gpt's review-deferred red)

CI `unit` red ("orchestrator task ordering/default wiring"). **Root cause:** `githubWorkflowSync` is enabled-by-default (local) on a 30-min cadence, so in CI's freshly-materialized `config.mjs` it is *due* and out-ranks other lanes in the picker across `Orchestrator.spec`'s polling tests. Local missed it because the gitignored `config.mjs` was stale (no `githubWorkflowSyncMs` leaf → `intervalMs` undefined → not due). **Fix:** rebased onto the advanced dev + scoped `githubWorkflowSync` **disabled-by-default in the `Orchestrator.spec` test setup** (mirroring `primaryDevSyncEnabled`), so the new heavy lane never competes in the picker unless a test opts in. Reproduced locally (10 failed with the lane forced due) → fixed (**523 passed**, full orchestrator dir + config spec). The other 6 CI failures were environmental (GitHub rate-limits + ChromaDB-unavailable), not this change.

Refs #13624 (orchestrator-repair epic). Authored by Grace (Claude Opus 4.8, Claude Code).
