### PR TITLE
fix(ai): add no-content graph cleanup script (#13675)

### DIFF
--- a/ai/scripts/maintenance/purgeNoContentGraphMemories.mjs
+++ b/ai/scripts/maintenance/purgeNoContentGraphMemories.mjs
@@ -1,0 +1,309 @@
+// Bootstrap Neo namespace BEFORE importing Memory Core services; runtime config evaluates
+// through the Neo singleton namespace during service setup.
+import Neo             from '../../../src/Neo.mjs';
+import * as core       from '../../../src/core/_export.mjs';
+import {Command}       from 'commander';
+import {pathToFileURL} from 'url';
+
+import {getPendingSessionSummaryCount} from '../../daemons/orchestrator/scheduling/summary.mjs';
+import {
+    Memory_GraphService as GraphService,
+    Memory_LifecycleService as LifecycleService,
+    Memory_StorageRouter as StorageRouter
+} from '../../services.mjs';
+
+/**
+ * @module ai.scripts.maintenance.purgeNoContentGraphMemories
+ * @summary Dry-run-first one-shot cleanup for archived no-content `AGENT_MEMORY` graph nodes.
+ *
+ * This script targets only the confirmed destructive subset: graph `AGENT_MEMORY`
+ * nodes already archived with `archivedReason = 'no-content'` and missing from the active
+ * Chroma memory collection. It is dry-run by default. Destructive execution requires both
+ * `--apply` and the explicit confirmation token, then routes deletion through
+ * {@link GraphService#removeNodes} so graph cache and SQLite edge cascades stay coherent.
+ *
+ * Usage:
+ *   node ai/scripts/maintenance/purgeNoContentGraphMemories.mjs
+ *   node ai/scripts/maintenance/purgeNoContentGraphMemories.mjs --apply --confirm CONFIRM_ARCHIVED_NO_CONTENT_GRAPH_DELETE
+ */
+
+export const DEFAULT_CHROMA_FETCH_CHUNK_SIZE = 500;
+export const APPLY_CONFIRMATION_TOKEN        = 'CONFIRM_ARCHIVED_NO_CONTENT_GRAPH_DELETE';
+
+/**
+ * @summary Splits an array into fixed-size chunks.
+ * @param {Array} items Source items.
+ * @param {Number} size Positive chunk size.
+ * @returns {Array[]}
+ */
+export function chunk(items, size) {
+    const boundedSize = Number.isInteger(size) && size > 0 ? size : DEFAULT_CHROMA_FETCH_CHUNK_SIZE;
+    const chunks      = [];
+
+    for (let i = 0; i < items.length; i += boundedSize) {
+        chunks.push(items.slice(i, i + boundedSize));
+    }
+
+    return chunks;
+}
+
+/**
+ * @summary Finds graph memories already marked as archived no-content cleanup candidates.
+ * @param {Object} options
+ * @param {Object} options.db Better-SQLite3 graph handle.
+ * @returns {Object[]}
+ */
+export function listArchivedNoContentMemoryRows({db}) {
+    if (!db?.prepare) {
+        throw new TypeError('A Better-SQLite3 graph handle is required.');
+    }
+
+    return db.prepare(`
+        SELECT
+            id,
+            json_extract(data, '$.properties.sessionId')      AS sessionId,
+            json_extract(data, '$.properties.agentIdentity')  AS agentIdentity,
+            json_extract(data, '$.properties.timestamp')      AS timestamp,
+            json_extract(data, '$.properties.archivedAt')     AS archivedAt,
+            json_extract(data, '$.properties.archivedReason') AS archivedReason
+        FROM Nodes
+        WHERE json_extract(data, '$.label') = 'AGENT_MEMORY'
+          AND json_extract(data, '$.properties.archivedAt') IS NOT NULL
+          AND json_extract(data, '$.properties.archivedReason') = 'no-content'
+        ORDER BY sessionId, id
+    `).all();
+}
+
+/**
+ * @summary Reads which candidate ids still exist in Chroma memory content.
+ * @param {Object} options
+ * @param {Object} options.collection Chroma collection or compatible seam.
+ * @param {String[]} options.ids Candidate graph node ids.
+ * @param {Number} [options.chunkSize]
+ * @returns {Promise<Set<String>>}
+ */
+export async function collectExistingMemoryIds({collection, ids, chunkSize = DEFAULT_CHROMA_FETCH_CHUNK_SIZE}) {
+    if (!collection?.get) {
+        throw new TypeError('A Chroma memory collection handle is required.');
+    }
+
+    const existing = new Set();
+
+    for (const slice of chunk(ids, chunkSize)) {
+        if (slice.length === 0) continue;
+
+        const page = await collection.get({ids: slice, include: []});
+
+        for (const id of page?.ids || []) {
+            existing.add(id);
+        }
+    }
+
+    return existing;
+}
+
+/**
+ * @summary Counts graph edges attached to the selected node ids before deletion.
+ * @param {Object} options
+ * @param {Object} options.db Better-SQLite3 graph handle.
+ * @param {String[]} options.nodeIds
+ * @param {Number} [options.chunkSize]
+ * @returns {Number}
+ */
+export function countIncidentEdges({db, nodeIds, chunkSize = DEFAULT_CHROMA_FETCH_CHUNK_SIZE}) {
+    if (!db?.prepare || !Array.isArray(nodeIds) || nodeIds.length === 0) {
+        return 0;
+    }
+
+    let count = 0;
+
+    for (const slice of chunk(nodeIds, chunkSize)) {
+        const placeholders = slice.map(() => '?').join(',');
+        const row = db.prepare(`
+            SELECT COUNT(*) AS count
+            FROM Edges
+            WHERE source IN (${placeholders})
+               OR target IN (${placeholders})
+        `).get(...slice, ...slice);
+
+        count += Number(row?.count || 0);
+    }
+
+    return count;
+}
+
+/**
+ * @summary Builds the dry-run/apply plan for archived no-content graph memory cleanup.
+ * @param {Object} options
+ * @param {Object} options.db Better-SQLite3 graph handle.
+ * @param {Object} options.collection Chroma memory collection or compatible seam.
+ * @param {Number} [options.chunkSize]
+ * @returns {Promise<Object>}
+ */
+export async function buildCleanupPlan({db, collection, chunkSize = DEFAULT_CHROMA_FETCH_CHUNK_SIZE}) {
+    const archivedRows = listArchivedNoContentMemoryRows({db});
+    const existingIds  = await collectExistingMemoryIds({
+        collection,
+        ids: archivedRows.map(row => row.id),
+        chunkSize
+    });
+    const deletableRows = archivedRows.filter(row => !existingIds.has(row.id));
+    const nodeIds       = deletableRows.map(row => row.id);
+
+    return {
+        scannedArchivedNoContent  : archivedRows.length,
+        protectedWithChromaContent: existingIds.size,
+        deletableNodes            : nodeIds.length,
+        deletableSessions         : new Set(deletableRows.map(row => row.sessionId).filter(Boolean)).size,
+        deletableAgents           : new Set(deletableRows.map(row => row.agentIdentity).filter(Boolean)).size,
+        incidentEdges             : countIncidentEdges({db, nodeIds, chunkSize}),
+        nodeIds,
+        sample                    : deletableRows.slice(0, 10).map(row => ({
+            id           : row.id,
+            sessionId    : row.sessionId,
+            agentIdentity: row.agentIdentity,
+            timestamp    : row.timestamp
+        }))
+    };
+}
+
+/**
+ * @summary Requires the explicit destructive confirmation token.
+ * @param {String} confirmation Operator-provided confirmation.
+ */
+export function assertApplyConfirmed(confirmation) {
+    if (confirmation !== APPLY_CONFIRMATION_TOKEN) {
+        throw new Error(
+            `Refusing destructive graph cleanup without --confirm ${APPLY_CONFIRMATION_TOKEN}.`
+        );
+    }
+}
+
+/**
+ * @summary Runs the dry-run-first graph cleanup.
+ * @param {Object} [options]
+ * @returns {Promise<Object>}
+ */
+export async function runNoContentGraphMemoryCleanup({
+    apply = false,
+    confirmation = '',
+    chunkSize = DEFAULT_CHROMA_FETCH_CHUNK_SIZE,
+    lifecycle = LifecycleService,
+    graphService = GraphService,
+    storageRouter = StorageRouter,
+    collection = null,
+    logger = console
+} = {}) {
+    if (apply) {
+        assertApplyConfirmed(confirmation);
+    }
+
+    await lifecycle?.ready?.();
+    await graphService?.initAsync?.();
+
+    const db = graphService?.db?.storage?.db;
+
+    if (!db?.prepare) {
+        throw new Error('Graph SQLite storage is unavailable; cannot build cleanup plan.');
+    }
+
+    collection ??= await storageRouter.getMemoryCollection();
+
+    const beforePendingSessionSummaryCount = getPendingSessionSummaryCount(db);
+    const plan = await buildCleanupPlan({db, collection, chunkSize});
+
+    let deletedNodes = 0;
+
+    if (apply && plan.nodeIds.length > 0) {
+        graphService.removeNodes(plan.nodeIds);
+        deletedNodes = plan.nodeIds.length;
+    }
+
+    const afterPendingSessionSummaryCount = getPendingSessionSummaryCount(db);
+    const result = {
+        apply,
+        dryRun: !apply,
+        beforePendingSessionSummaryCount,
+        afterPendingSessionSummaryCount,
+        ...plan,
+        deletedNodes
+    };
+
+    logCleanupResult(result, {logger});
+
+    return result;
+}
+
+/**
+ * @summary Prints the operator-facing cleanup report.
+ * @param {Object} result Cleanup result.
+ * @param {Object} options
+ */
+export function logCleanupResult(result, {logger = console} = {}) {
+    logger.log(`No-content graph memory cleanup ${result.apply ? 'APPLY' : 'DRY-RUN'}`);
+    logger.log(`  archived no-content graph rows scanned: ${result.scannedArchivedNoContent}`);
+    logger.log(`  protected because Chroma content exists: ${result.protectedWithChromaContent}`);
+    logger.log(`  deletable graph nodes: ${result.deletableNodes}`);
+    logger.log(`  distinct sessions: ${result.deletableSessions}`);
+    logger.log(`  distinct agents: ${result.deletableAgents}`);
+    logger.log(`  incident edges: ${result.incidentEdges}`);
+    logger.log(
+        `  pending-session-summary marker: ${result.beforePendingSessionSummaryCount} -> ` +
+        `${result.afterPendingSessionSummaryCount}`
+    );
+
+    if (result.sample.length > 0) {
+        logger.log('  sample:');
+        for (const row of result.sample) {
+            logger.log(`    ${row.id} session=${row.sessionId || '(none)'} agent=${row.agentIdentity || '(none)'}`);
+        }
+    }
+
+    if (!result.apply) {
+        logger.log(`  dry-run only; re-run with --apply --confirm ${APPLY_CONFIRMATION_TOKEN} to delete eligible nodes.`);
+        return;
+    }
+
+    logger.log(`  deleted graph nodes: ${result.deletedNodes}`);
+}
+
+/**
+ * @summary Creates the CLI command object.
+ * @returns {Command}
+ */
+export function createCommand() {
+    return new Command()
+        .name('purgeNoContentGraphMemories')
+        .description('Dry-run-first cleanup for archived no-content AGENT_MEMORY graph nodes.')
+        .option('--apply', 'Actually delete eligible graph nodes. Without this flag the script is dry-run only.', false)
+        .option('--confirm <token>', `Required with --apply: ${APPLY_CONFIRMATION_TOKEN}.`, '')
+        .option('--chunk-size <n>', 'Candidate id batch size for Chroma/SQLite probes.', String(DEFAULT_CHROMA_FETCH_CHUNK_SIZE));
+}
+
+/**
+ * @summary Runs the CLI from process argv.
+ * @param {String[]} argv
+ * @returns {Promise<Object>}
+ */
+export async function runCli(argv = process.argv) {
+    const command = createCommand();
+
+    command.parse(argv);
+
+    const options = command.opts();
+    const chunkSize = Number(options.chunkSize);
+
+    if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+        throw new Error(`chunk-size must be a positive integer; received ${options.chunkSize}`);
+    }
+
+    return runNoContentGraphMemoryCleanup({
+        apply       : options.apply,
+        confirmation: options.confirm,
+        chunkSize
+    });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    await runCli();
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "ai:prune-worktrees"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
         "ai:prune-worktrees:dry-run"   : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --dry-run",
         "ai:prune-worktrees:schedule-dangerous": "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --schedule-local --include-dirty --interval-ms 21600000",
+        "ai:purge-no-content-graph-memories": "node ./ai/scripts/maintenance/purgeNoContentGraphMemories.mjs",
         "ai:purge-test-collections"    : "node ./ai/scripts/maintenance/purgeTestCollections.mjs",
         "ai:lint-agents"               : "node ./ai/scripts/lint/lint-agents.mjs",
         "ai:lint-config-template-ssot" : "node ./ai/scripts/lint/lint-config-template-ssot.mjs",

--- a/test/playwright/unit/ai/scripts/maintenance/purgeNoContentGraphMemories.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/purgeNoContentGraphMemories.spec.mjs
@@ -1,0 +1,198 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AiPurgeNoContentGraphMemoriesTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import Database       from 'better-sqlite3';
+
+import {
+    APPLY_CONFIRMATION_TOKEN,
+    buildCleanupPlan,
+    collectExistingMemoryIds,
+    listArchivedNoContentMemoryRows,
+    runNoContentGraphMemoryCleanup
+} from '../../../../../../ai/scripts/maintenance/purgeNoContentGraphMemories.mjs';
+
+/**
+ * @summary Regression coverage for the archived no-content graph cleanup.
+ */
+test.describe('purgeNoContentGraphMemories.mjs', () => {
+    let db;
+
+    test.beforeEach(() => {
+        db = new Database(':memory:');
+        db.pragma('foreign_keys = ON');
+        db.exec(`
+            CREATE TABLE Nodes (
+                id TEXT PRIMARY KEY,
+                data TEXT NOT NULL
+            );
+            CREATE TABLE Edges (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                target TEXT NOT NULL,
+                type TEXT NOT NULL,
+                data TEXT NOT NULL,
+                FOREIGN KEY (source) REFERENCES Nodes(id) ON DELETE CASCADE,
+                FOREIGN KEY (target) REFERENCES Nodes(id) ON DELETE CASCADE
+            );
+        `);
+    });
+
+    test.afterEach(() => {
+        db?.close();
+        db = null;
+    });
+
+    function insertNode(id, label, properties = {}) {
+        db.prepare('INSERT INTO Nodes(id, data) VALUES (?, ?)').run(id, JSON.stringify({
+            id,
+            label,
+            properties
+        }));
+    }
+
+    function insertMemory(id, properties = {}) {
+        insertNode(id, 'AGENT_MEMORY', {
+            sessionId     : 'session-1',
+            agentIdentity : '@neo-gpt',
+            timestamp     : '2026-06-20T22:00:00.000Z',
+            archivedAt    : '2026-06-20T22:01:00.000Z',
+            archivedReason: 'no-content',
+            ...properties
+        });
+    }
+
+    function fakeCollection(existingIds = []) {
+        const existing = new Set(existingIds);
+
+        return {
+            get: async ({ids}) => ({
+                ids: ids.filter(id => existing.has(id))
+            })
+        };
+    }
+
+    test('selects only archived AGENT_MEMORY rows with archivedReason no-content', () => {
+        insertMemory('memory-delete');
+        insertMemory('memory-blank-reason', {archivedReason: ''});
+        insertMemory('memory-live', {archivedAt: null, archivedReason: null});
+        insertNode('summary_session-1', 'SESSION_SUMMARY', {sessionId: 'session-1'});
+
+        const rows = listArchivedNoContentMemoryRows({db});
+
+        expect(rows.map(row => row.id)).toEqual(['memory-delete']);
+    });
+
+    test('protects archived no-content rows when Chroma content still exists', async () => {
+        insertMemory('memory-delete');
+        insertMemory('memory-protect', {sessionId: 'session-2'});
+        db.prepare('INSERT INTO Edges(id, source, target, type, data) VALUES (?, ?, ?, ?, ?)').run(
+            'edge-1', 'memory-delete', 'memory-protect', 'RELATED_TO', '{}'
+        );
+
+        const plan = await buildCleanupPlan({
+            db,
+            collection: fakeCollection(['memory-protect'])
+        });
+
+        expect(plan.scannedArchivedNoContent).toBe(2);
+        expect(plan.protectedWithChromaContent).toBe(1);
+        expect(plan.deletableNodes).toBe(1);
+        expect(plan.nodeIds).toEqual(['memory-delete']);
+        expect(plan.incidentEdges).toBe(1);
+    });
+
+    test('collectExistingMemoryIds chunks collection probes', async () => {
+        const calls = [];
+        const collection = {
+            get: async ({ids}) => {
+                calls.push(ids);
+                return {ids: ids.filter(id => id.endsWith('2'))};
+            }
+        };
+
+        const existing = await collectExistingMemoryIds({
+            collection,
+            ids      : ['memory-1', 'memory-2', 'memory-3', 'memory-4'],
+            chunkSize: 2
+        });
+
+        expect(calls).toEqual([
+            ['memory-1', 'memory-2'],
+            ['memory-3', 'memory-4']
+        ]);
+        expect([...existing]).toEqual(['memory-2']);
+    });
+
+    test('dry-run reports deletable rows without removing graph nodes', async () => {
+        insertMemory('memory-delete');
+
+        const removed = [];
+        const result = await runNoContentGraphMemoryCleanup({
+            lifecycle   : {ready: async () => {}},
+            graphService: {
+                initAsync  : async () => {},
+                db         : {storage: {db}},
+                removeNodes: ids => removed.push(...ids)
+            },
+            collection: fakeCollection(),
+            logger    : {log: () => {}}
+        });
+
+        expect(result.dryRun).toBe(true);
+        expect(result.deletableNodes).toBe(1);
+        expect(result.deletedNodes).toBe(0);
+        expect(removed).toEqual([]);
+        expect(db.prepare('SELECT COUNT(*) AS count FROM Nodes').get().count).toBe(1);
+    });
+
+    test('apply requires the explicit operator confirmation token', async () => {
+        await expect(runNoContentGraphMemoryCleanup({
+            apply       : true,
+            confirmation: 'wrong-token',
+            lifecycle   : {ready: async () => {}},
+            graphService: {db: {storage: {db}}},
+            collection  : fakeCollection(),
+            logger      : {log: () => {}}
+        })).rejects.toThrow(APPLY_CONFIRMATION_TOKEN);
+    });
+
+    test('apply deletes through graphService.removeNodes and cascades incident edges', async () => {
+        insertMemory('memory-delete');
+        insertNode('memory-other', 'AGENT_MEMORY', {sessionId: 'session-2'});
+        db.prepare('INSERT INTO Edges(id, source, target, type, data) VALUES (?, ?, ?, ?, ?)').run(
+            'edge-1', 'memory-delete', 'memory-other', 'RELATED_TO', '{}'
+        );
+
+        const removed = [];
+        const result = await runNoContentGraphMemoryCleanup({
+            apply       : true,
+            confirmation: APPLY_CONFIRMATION_TOKEN,
+            lifecycle   : {ready: async () => {}},
+            graphService: {
+                initAsync  : async () => {},
+                db         : {storage: {db}},
+                removeNodes: ids => {
+                    removed.push(...ids);
+                    for (const id of ids) {
+                        db.prepare('DELETE FROM Nodes WHERE id = ?').run(id);
+                    }
+                }
+            },
+            collection: fakeCollection(),
+            logger    : {log: () => {}}
+        });
+
+        expect(result.deletedNodes).toBe(1);
+        expect(removed).toEqual(['memory-delete']);
+        expect(db.prepare('SELECT id FROM Nodes ORDER BY id ASC').all().map(row => row.id)).toEqual(['memory-other']);
+        expect(db.prepare('SELECT COUNT(*) AS count FROM Edges').get().count).toBe(0);
+    });
+});


### PR DESCRIPTION
Resolves #13675

Adds a dry-run-first Memory Core maintenance CLI for purging archived `no-content` `AGENT_MEMORY` graph nodes. The script selects only graph rows already archived with `archivedReason = 'no-content'`, protects any candidate that still has Chroma memory content, reports the exact node/session/agent/edge census, and requires `--apply --confirm CONFIRM_ARCHIVED_NO_CONTENT_GRAPH_DELETE` before routing deletion through `GraphService.removeNodes()`.

Evidence: L3 (live non-destructive dry-run against the configured Memory Core stores, plus focused unit coverage) -> L4 required (operator-gated destructive apply run on the shared graph). Residual: destructive apply/post-delete verification [#13675].

Related: #13624
Related: #13639

## Deltas from ticket

The ticket body originally mentioned `purgeSession`; the live issue-thread amendment superseded that primitive. This PR implements the corrected contract: graph `AGENT_MEMORY` nodes plus incident edges via the graph deletion primitive, not Chroma/session-summary cleanup.

The deletion selector is intentionally narrower than a broad graph-vs-Chroma anti-join. It targets only the already archived `no-content` subset and leaves unarchived / blank-reason tails for a separate explicit decision.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/purgeNoContentGraphMemories.spec.mjs` -> 6 passed
- `node --check ai/scripts/maintenance/purgeNoContentGraphMemories.mjs` -> passed
- `node --check test/playwright/unit/ai/scripts/maintenance/purgeNoContentGraphMemories.spec.mjs` -> passed
- `node buildScripts/util/check-block-alignment.mjs ai/scripts/maintenance/purgeNoContentGraphMemories.mjs test/playwright/unit/ai/scripts/maintenance/purgeNoContentGraphMemories.spec.mjs` -> passed
- `git diff --cached --check` -> passed before commit
- `npm run ai:purge-no-content-graph-memories` -> dry-run report:
  - archived no-content graph rows scanned: 3332
  - protected because Chroma content exists: 0
  - deletable graph nodes: 3332
  - distinct sessions: 248
  - distinct agents: 20
  - incident edges: 30
  - pending-session-summary marker: 46 -> 46

Note: the first sandboxed dry-run hit `EPERM` on `.neo-ai-data/logs/mc-server-2026-06-20.log`; rerunning the same dry-run with approved escalation succeeded. No destructive `--apply` run was executed.

## Post-Merge Validation

- [ ] Operator runs `npm run ai:purge-no-content-graph-memories -- --apply --confirm CONFIRM_ARCHIVED_NO_CONTENT_GRAPH_DELETE` against the intended shared graph.
- [ ] Append the post-delete report to `#13675`, including deleted node count, incident-edge count, and post-delete graph census.

## Commit

- `17012fe09` - `fix(ai): add no-content graph cleanup script (#13675)`

Authored by Euclid (GPT-5, Codex Desktop). Session 586740b0-1f91-42bd-ad40-893f7fdcfb33.
