### PR TITLE
fix(ai): guard concept-ontology writes + recognize os.tmpdir() as disposable (#13683)

### DIFF
--- a/ai/services/ingestion/ConceptDiscoveryService.mjs
+++ b/ai/services/ingestion/ConceptDiscoveryService.mjs
@@ -1,13 +1,14 @@
-import fs                                                              from 'fs';
-import path                                                            from 'path';
-import yaml                                                             from 'js-yaml';
-import {fileURLToPath}                                                 from 'url';
-import Base                                                             from '../../../src/core/Base.mjs';
-import ConceptService                                                   from '../../services/ConceptService.mjs';
-import {Memory_Config as aiConfig}                                      from '../../services.mjs';
-import Json                                                             from '../../../src/util/Json.mjs';
-import logger                                                           from '../../mcp/server/memory-core/logger.mjs';
-import OpenAiCompatible                                                 from '../../provider/OpenAiCompatible.mjs';
+import fs                          from 'fs';
+import path                        from 'path';
+import yaml                        from 'js-yaml';
+import {fileURLToPath}             from 'url';
+import Base                        from '../../../src/core/Base.mjs';
+import ConceptService              from '../../services/ConceptService.mjs';
+import {Memory_Config as aiConfig} from '../../services.mjs';
+import Json                        from '../../../src/util/Json.mjs';
+import logger                      from '../../mcp/server/memory-core/logger.mjs';
+import OpenAiCompatible            from '../../provider/OpenAiCompatible.mjs';
+import {assertTestWriteIsolated}   from '../shared/storeWriteGuard.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -236,12 +237,12 @@ class ConceptDiscoveryService extends Base {
             if (ConceptService.nodes.has(raw.id)) continue;
 
             accepted.push({
-                id         : raw.id,
-                name       : raw.name,
+                id  : raw.id,
+                name: raw.name,
                 description: raw.description || `Mined candidate from ${sourceRef}. Awaiting curator review — promote by flipping \`validated: true\` and adjusting tier/weight in nodes.jsonl.`,
-                aliases    : Array.isArray(raw.aliases) ? raw.aliases : [],
-                source     : sourceRef,
-                reasoning  : raw.reasoning || '',
+                aliases  : Array.isArray(raw.aliases) ? raw.aliases : [],
+                source   : sourceRef,
+                reasoning: raw.reasoning || '',
                 ...CANDIDATE_DEFAULTS,
                 ...(extractionMetadata ? {extraction_metadata: extractionMetadata} : {})
             });
@@ -453,12 +454,20 @@ class ConceptDiscoveryService extends Base {
      * File is flush-written via `fs.promises.appendFile` which is atomic at the per-line level
      * on POSIX filesystems — safe for the single-writer REM pipeline pattern.
      * @param {Object[]} candidates
+     * @throws {Error} `STORE_WRITE_GUARD` when invoked from a test-runner context against the
+     *   production concepts dir (defense-in-depth via `assertTestWriteIsolated`) — never in production runtime.
      * @protected
      */
     async appendCandidates(candidates) {
         const
             conceptsDir = ConceptService.defaultConceptsDir || path.resolve(__dirname, '../../../.neo-ai-data/concepts'),
             nodesPath   = path.join(conceptsDir, 'nodes.jsonl');
+
+        // Defense-in-depth: refuse a concept-ontology write to the production concepts dir from a
+        // test-runner context (the orphan-bleed / backlog-corruption class). No-op in production
+        // runtime (no test signal) and for disposable/tmp dirs — the file-store parallel to the
+        // graph write-guard in SQLite.mjs.
+        assertTestWriteIsolated({storePath: conceptsDir, subsystem: 'concept-ontology'});
 
         let existing = '';
         try {

--- a/ai/services/shared/storeWriteGuard.mjs
+++ b/ai/services/shared/storeWriteGuard.mjs
@@ -13,17 +13,22 @@
  * reach that bypass; this guard is the config-INDEPENDENT defense-in-depth that fires regardless of harness.
  */
 
+import os from 'node:os';
+
 /**
  * @summary Classifies a store path as disposable (test-isolated) versus a live production store.
  *
- * Disposable = SQLite `:memory:`, an OS-temp / repo-`tmp/` path, or any `*test*` path. The broad substring
- * match deliberately mirrors the graph store's `clear()` production-wipe guard so the destructive- and
- * write-isolation guards classify production paths identically.
+ * Disposable = SQLite `:memory:`, a path under `os.tmpdir()` (the canonical OS temp dir — macOS's
+ * `/var/folders/.../T` carries no `tmp`/`test` substring, so this prefix arm is load-bearing for any
+ * file-store guard whose tests use `os.tmpdir()`), a repo-`tmp/` path, or any `*test*` path. This shared
+ * classifier is what the graph store's `clear()` production-wipe guard also consults, so the destructive-
+ * and write-isolation guards classify production paths identically.
  * @param {String|null} storePath
  * @returns {Boolean}
  */
 export function isDisposableStorePath(storePath) {
-    return !storePath || storePath === ':memory:' || storePath.includes('tmp') || storePath.includes('test');
+    return !storePath || storePath === ':memory:' || storePath.includes('tmp') ||
+        storePath.includes('test') || storePath.startsWith(os.tmpdir());
 }
 
 /**

--- a/test/playwright/unit/ai/services/ingestion/ConceptDiscoveryService.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/ConceptDiscoveryService.spec.mjs
@@ -368,4 +368,29 @@ test.describe('Neo.ai.daemons.services.ConceptDiscoveryService', () => {
             confidence_score    : null  // 5 (outside [0,1]) → null
         });
     });
+
+    test('appendCandidates refuses a write to a production-like concepts dir from a test context (#13683 guard)', async () => {
+        // The guard keys on the test-runner signal (UNIT_TEST_MODE, set by the test-unit config)
+        // against a production-like (non-disposable) concepts dir. Point defaultConceptsDir at a
+        // production path and confirm the write is refused before it can pollute the live ontology.
+        ConceptService.defaultConceptsDir = '/var/neo-ai-data/concepts';
+
+        await expect(
+            ConceptDiscoveryService.appendCandidates([{id: 'should-not-write', name: 'X'}])
+        ).rejects.toThrow(/STORE_WRITE_GUARD/);
+
+        // The guard threw before the append — nothing was written at the production path.
+        expect(fs.existsSync('/var/neo-ai-data/concepts/nodes.jsonl')).toBe(false);
+    });
+
+    test('appendCandidates writes normally to a disposable (tmp) concepts dir — no false positive', async () => {
+        // The beforeEach default is an os.tmpdir() path (disposable) — the guard must be a no-op so
+        // the legitimate REM-pipeline append (and every other test here) is unaffected.
+        ConceptService.defaultConceptsDir = tmpConceptsDir;
+
+        await ConceptDiscoveryService.appendCandidates([{id: 'disposable-ok', name: 'Disposable OK'}]);
+
+        const nodesContent = fs.readFileSync(path.join(tmpConceptsDir, 'nodes.jsonl'), 'utf8');
+        expect(nodesContent).toContain('"disposable-ok"');
+    });
 });

--- a/test/playwright/unit/ai/services/shared/storeWriteGuard.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/storeWriteGuard.spec.mjs
@@ -1,5 +1,7 @@
 import {test, expect}                                                        from '@playwright/test';
 import {isDisposableStorePath, isTestRunnerContext, assertTestWriteIsolated} from '../../../../../../ai/services/shared/storeWriteGuard.mjs';
+import os                                                                    from 'node:os';
+import path                                                                  from 'node:path';
 
 // A production-like absolute path: not :memory:, no tmp/test segment.
 const PROD_PATH = '/srv/neo/.neo-ai-data/datasets/rlaif/trajectories.jsonl';
@@ -12,6 +14,14 @@ test.describe('ai/services/shared/storeWriteGuard', () => {
         expect(isDisposableStorePath(null)).toBe(true);
         expect(isDisposableStorePath('')).toBe(true);
         expect(isDisposableStorePath(PROD_PATH)).toBe(false);
+    });
+
+    test('isDisposableStorePath: a real os.tmpdir() path is disposable even without a tmp/test segment', () => {
+        // macOS os.tmpdir() is /var/folders/.../T — no `tmp`/`test` substring — so the substring arms miss
+        // it; the os.tmpdir() prefix arm is what classifies it disposable. A file-store guard whose tests
+        // use os.tmpdir() (e.g. ConceptDiscoveryService) would false-positive on every run without this.
+        expect(isDisposableStorePath(os.tmpdir())).toBe(true);
+        expect(isDisposableStorePath(path.join(os.tmpdir(), 'neo-store-xyz', 'nodes.jsonl'))).toBe(true);
     });
 
     test('isTestRunnerContext: TEST_WORKER_INDEX or UNIT_TEST_MODE → true; neither → false', () => {


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13683

## Summary

`ConceptDiscoveryService.appendCandidates` writes concept candidates to `conceptsDir/nodes.jsonl`, where `conceptsDir` defaults to the **production** `.neo-ai-data/concepts`. A test that exercises `appendCandidates` without overriding `conceptsDir` appends to the **live** concept ontology — the orphan-bleed / backlog-corruption class (#12335 / #13624). This wires the shared `assertTestWriteIsolated` guard (#13665) at the funnel — the file-store parallel to the merged graph write-guard (#13639 / #13658).

- **`appendCandidates`** calls `assertTestWriteIsolated({storePath: conceptsDir, subsystem: 'concept-ontology'})` right after `conceptsDir` resolves (+ `@throws` JSDoc). Throws on a test-runner context (`TEST_WORKER_INDEX` / `UNIT_TEST_MODE`) against a production-like `conceptsDir`; no-op in production runtime + for disposable dirs.

## Deltas from ticket

**1. A real gap the adoption surfaced in the shared classifier `isDisposableStorePath` (#13665):** macOS `os.tmpdir()` is `/var/folders/.../T` — it carries **no `tmp`/`test` substring** — so the substring-only check false-positived on *every* `os.tmpdir()`-based test (the concept spec uses `os.tmpdir()`). The graph guard never hit it (it used `:memory:`). Fixed by adding an `os.tmpdir()` **prefix arm** — which aligns the implementation with the docstring's already-documented "OS-temp" intent — plus a regression test. Zero production blast: production stores live under `.neo-ai-data`, not `os.tmpdir()`; the merged graph-guard spec still passes. **In-scope** because the file-store adoption cannot function without it.

**2. Mechanical block-alignment re-flow.** The lint (incl. the merged backtick-mask #13676) re-aligned `ConceptDiscoveryService`'s import block + the `accepted.push` object literal — the mask now correctly excludes the backtick-bearing `description` line from the alignment run. No logic change. This PR also **validates #13676 end-to-end on the original #13670 `--fix`-corruption victim**: the `CONCEPT_EXTRACTION_SYSTEM_PROMPT` template JSON is untouched.

## Test Evidence

Evidence: L2 (unit) — ACs fully unit-covered (a pure throw/no-op on a resolved path; no runtime/host residual).

- `npm run test-unit -- …/ConceptDiscoveryService.spec.mjs …/storeWriteGuard.spec.mjs …/ai/graph/SQLiteWriteGuard.spec.mjs` → **23 passed**.
  - **Concept:** production-`conceptsDir` × test-context → throws `STORE_WRITE_GUARD`; disposable (`os.tmpdir()`) → writes (no false positive); all existing `runDiscoveryCycle` / `mineFrom*` tests still green.
  - **Util:** a real `os.tmpdir()` path (no `tmp`/`test` segment) is now classified disposable.
  - **Graph-guard regression:** `SQLiteWriteGuard.spec` still green (the shared-util change only *adds* recognition).
- Block-alignment lint CLEAN on all 4 files; the prompt-template region confirmed untouched by `--fix`.

## Post-Merge Validation

- None required — the guard is a config-independent, unit-level defense-in-depth; no operator-gated runtime step.

<!-- ## Deltas: the os.tmpdir() shared-util fix + the mechanical alignment re-flow are the only deltas beyond the literal AC — the util fix is necessary for the file-store adoption to function. -->
