### PR TITLE
feat(ai): wire contentTrust into sync ingestion (#13691)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -1,5 +1,5 @@
-import path            from 'path';
-import {fileURLToPath} from 'url';
+import path                                        from 'path';
+import {fileURLToPath}                             from 'url';
 import ConfigProvider, { createConfigProxy, leaf } from '../../../ConfigProvider.mjs';
 
 const __filename     = fileURLToPath(import.meta.url);
@@ -154,6 +154,13 @@ class Config extends ConfigProvider {
                  * @type {{numbers: Number[], authors: String[]}}
                  */
                 discussionDenylist: leaf({numbers: [], authors: []}),
+                /**
+                 * Product names to redact from untrusted GitHub-authored content when the content-trust
+                 * sanitizer projects sync/write-boundary Markdown. Empty by default; policy values belong
+                 * in local config, not in syncer code.
+                 * @type {string[]}
+                 */
+                productNameDenylist: leaf([]),
                 /**
                  * The date from which to start synchronizing issues and releases.
                  * @type {string}

--- a/ai/services/github-workflow/shared/conversationTrust.mjs
+++ b/ai/services/github-workflow/shared/conversationTrust.mjs
@@ -22,6 +22,14 @@ import {sanitizeContent}     from '../../shared/contentTrust/astroturfSanitizer.
  */
 
 /**
+ * @summary Creates the machine-readable summary accumulated by content trust projection.
+ * @returns {{projected: Boolean, quarantined: Number, signals: Object[]}}
+ */
+export function createContentTrustSummary() {
+    return {projected: true, quarantined: 0, signals: []}
+}
+
+/**
  * Projects one authored node (`{author, body, ...}`): stamps `authorTrust`, sanitizes an untrusted
  * author's `body`, and records redaction counts plus stealth-intent signals against `path`.
  * Non-object nodes pass through untouched so sparse / null GraphQL entries never change shape.
@@ -56,6 +64,28 @@ function projectNode(node, ctx, path) {
 }
 
 /**
+ * @summary Projects one authored GitHub node through the shared content-trust policy.
+ * @param {Object} node The authored node carrying optional `author.login` and `body`.
+ * @param {Object} [opts]
+ * @param {Set<String>|String[]} [opts.collaborators] repo collaborator logins for REPO_TRUSTED.
+ * @param {String[]} [opts.productNameDenylist] product names redacted from untrusted content.
+ * @param {Object} [opts.summary] Existing summary accumulator; created when omitted.
+ * @param {String} [opts.path='body'] Signal location label.
+ * @returns {{node: Object, contentTrust: Object}} Projected node plus the summary accumulator.
+ */
+export function projectAuthoredNodeTrust(node, {
+    collaborators,
+    productNameDenylist = [],
+    summary = createContentTrustSummary(),
+    path = 'body'
+} = {}) {
+    return {
+        node        : projectNode(node, {collaborators, productNameDenylist, summary}, path),
+        contentTrust: summary
+    }
+}
+
+/**
  * @summary Projects a fetched conversation payload into its trust-aware shape.
  *
  * Apply BEFORE selector filtering so every return path (full conversation plus all selector shapes)
@@ -77,7 +107,7 @@ export function projectConversationTrust(conversation, {collaborators, productNa
         return conversation
     }
 
-    const summary = {projected: true, quarantined: 0, signals: []};
+    const summary = createContentTrustSummary();
     const ctx     = {collaborators, productNameDenylist, summary};
 
     const projected = projectNode(conversation, ctx, 'body');

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -1,20 +1,21 @@
-import aiConfig                   from '../../../mcp/server/github-workflow/config.mjs';
-import Base                       from '../../../../src/core/Base.mjs';
-import crypto                     from 'crypto';
-import fs                         from 'fs/promises';
-import logger                     from '../../../mcp/server/github-workflow/logger.mjs';
-import matter                     from 'gray-matter';
-import path                       from 'path';
-import GraphqlService             from '../GraphqlService.mjs';
-import ReleaseNotesSyncer         from './ReleaseNotesSyncer.mjs';
+import aiConfig                     from '../../../mcp/server/github-workflow/config.mjs';
+import Base                         from '../../../../src/core/Base.mjs';
+import crypto                       from 'crypto';
+import fs                           from 'fs/promises';
+import logger                       from '../../../mcp/server/github-workflow/logger.mjs';
+import matter                       from 'gray-matter';
+import path                         from 'path';
+import GraphqlService               from '../GraphqlService.mjs';
+import ReleaseNotesSyncer           from './ReleaseNotesSyncer.mjs';
 import {FETCH_DISCUSSIONS_FOR_SYNC} from '../queries/discussionQueries.mjs';
 import contentPath                  from '../shared/contentPath.mjs';
 import {
     createContentIndexEntry,
     updateContentIndex
 } from '../shared/contentIndex.mjs';
-import pruneEmptyDirs               from '../shared/pruneEmptyDirs.mjs';
-import {verifyDiscussionFrontmatter} from './verifyFrontmatterIntegrity.mjs';
+import {createContentTrustSummary, projectAuthoredNodeTrust} from '../shared/conversationTrust.mjs';
+import pruneEmptyDirs                                        from '../shared/pruneEmptyDirs.mjs';
+import {verifyDiscussionFrontmatter}                         from './verifyFrontmatterIntegrity.mjs';
 
 const issueSyncConfig = aiConfig.issueSync;
 
@@ -78,6 +79,22 @@ class DiscussionSyncer extends Base {
     }
 
     /**
+     * @summary Projects one GitHub-authored discussion sync node through content trust policy.
+     * @param {Object} node GitHub authored node carrying optional `author.login` and `body`.
+     * @param {Object} summary Machine-readable content-trust summary accumulator.
+     * @param {String} signalPath Stable path label for sanitizer signal metadata.
+     * @returns {Object} Projected node with sanitized body for untrusted authors.
+     * @private
+     */
+    #projectAuthoredNode(node, summary, signalPath) {
+        return projectAuthoredNodeTrust(node, {
+            summary,
+            path               : signalPath,
+            productNameDenylist: issueSyncConfig.productNameDenylist || []
+        }).node;
+    }
+
+    /**
      * @summary Pre-computes bucket counts and indices for all discussions based on historical releases.
      * @param {Object} metadata The sync metadata.
      * @param {Array} fetchedDiscussions The delta discussions fetched from GitHub.
@@ -89,16 +106,16 @@ class DiscussionSyncer extends Base {
 
         for (const [idStr, discussion] of Object.entries(metadata.discussions || {})) {
             combined.set(parseInt(idStr, 10), {
-                number: parseInt(idStr, 10),
-                closed: discussion.closed,
+                number  : parseInt(idStr, 10),
+                closed  : discussion.closed,
                 closedAt: discussion.closedAt
             });
         }
 
         for (const discussion of fetchedDiscussions) {
             combined.set(discussion.number, {
-                number: discussion.number,
-                closed: discussion.closed,
+                number  : discussion.number,
+                closed  : discussion.closed,
                 closedAt: discussion.closedAt
             });
         }
@@ -230,9 +247,9 @@ class DiscussionSyncer extends Base {
 
         while (hasNextPage) {
             const data = await GraphqlService.query(FETCH_DISCUSSIONS_FOR_SYNC, {
-                owner: aiConfig.owner,
-                repo : aiConfig.repo,
-                limit: 50,
+                owner      : aiConfig.owner,
+                repo       : aiConfig.repo,
+                limit      : 50,
                 cursor,
                 maxComments: 50,
                 maxReplies : 20
@@ -296,38 +313,53 @@ class DiscussionSyncer extends Base {
             try {
                 const targetPath  = this.#getDiscussionPath(discussion, planBuckets);
                 if (!targetPath) continue;
+                const contentTrust = createContentTrustSummary();
+                const projectedDiscussion = this.#projectAuthoredNode(discussion, contentTrust, 'body');
 
                 const frontmatter = {
-                    number     : discussion.number,
-                    title      : discussion.title,
-                    author     : discussion.author?.login || 'unknown',
-                    category   : discussion.category?.name || 'Uncategorized',
-                    createdAt  : discussion.createdAt,
-                    updatedAt  : discussion.updatedAt,
-                    closed     : discussion.closed,
-                    closedAt   : discussion.closedAt
+                    number   : discussion.number,
+                    title    : discussion.title,
+                    author   : discussion.author?.login || 'unknown',
+                    category : discussion.category?.name || 'Uncategorized',
+                    createdAt: discussion.createdAt,
+                    updatedAt: discussion.updatedAt,
+                    closed   : discussion.closed,
+                    closedAt : discussion.closedAt,
+                    contentTrust
                 };
 
-                let body = discussion.body || '';
+                let body = projectedDiscussion.body || '';
 
                 // Build comments structure
                 if (discussion.comments && discussion.comments.nodes && discussion.comments.nodes.length > 0) {
                     body += '\n\n## Comments\n\n';
                     for (const comment of discussion.comments.nodes) {
+                        const projectedComment = this.#projectAuthoredNode(
+                            comment,
+                            contentTrust,
+                            `comment:${comment.id || comment.createdAt || 'unknown'}`
+                        );
+
                         body += `### \`@${comment.author?.login || 'unknown'}\` commented on ${comment.createdAt}\n\n`;
                         if (comment.isAnswer) {
                             body += '> [!ANSWER]\n\n';
                         }
-                        body += `${comment.body}\n\n`;
+                        body += `${projectedComment.body}\n\n`;
 
                         // Parse replies if any
                         if (comment.replies && comment.replies.nodes && comment.replies.nodes.length > 0) {
                             for (const reply of comment.replies.nodes) {
+                                const projectedReply = this.#projectAuthoredNode(
+                                    reply,
+                                    contentTrust,
+                                    `comment:${comment.id || comment.createdAt || 'unknown'}/reply:${reply.id || reply.createdAt || 'unknown'}`
+                                );
+
                                 body += `#### Reply depth=1 by \`@${reply.author?.login || 'unknown'}\` on ${reply.createdAt}\n\n`;
                                 if (reply.isAnswer) {
                                     body += '> [!ANSWER]\n\n';
                                 }
-                                body += `${reply.body}\n\n`;
+                                body += `${projectedReply.body}\n\n`;
                             }
                         }
                         body += '---\n\n';
@@ -401,23 +433,23 @@ class DiscussionSyncer extends Base {
 
         allDiscussions.forEach(d => {
             metadata.discussions[d.number] = {
-                number: d.number,
-                closed: d.closed,
-                closedAt: d.closedAt,
+                number     : d.number,
+                closed     : d.closed,
+                closedAt   : d.closedAt,
                 contentHash: d.contentHash,
-                path: d.relativeOutputPath
+                path       : d.relativeOutputPath
             };
 
             const plan = planBuckets.get(d.number);
 
             indexEntries.push(createContentIndexEntry({
                 issueSyncConfig,
-                type: 'discussions',
-                id: d.number,
-                filePath: path.resolve(aiConfig.projectRoot, d.relativeOutputPath),
+                type     : 'discussions',
+                id       : d.number,
+                filePath : path.resolve(aiConfig.projectRoot, d.relativeOutputPath),
                 itemIndex: plan ? plan.itemIndex : 0,
-                version: plan?.version || null,
-                bucket: null
+                version  : plan?.version || null,
+                bucket   : null
             }));
         });
 

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -1,19 +1,20 @@
-import aiConfig                                      from '../../../mcp/server/github-workflow/config.mjs';
-import Base                                          from '../../../../src/core/Base.mjs';
-import crypto                                        from 'crypto';
-import {existsSync}                                  from 'fs';
-import fs                                            from 'fs/promises';
-import logger                                        from '../../../mcp/server/github-workflow/logger.mjs';
-import matter                                        from 'gray-matter';
-import path                                          from 'path';
-import semver                                        from 'semver';
-import GraphqlService                                from '../GraphqlService.mjs';
-import ReleaseNotesSyncer                                 from './ReleaseNotesSyncer.mjs';
+import aiConfig                                                               from '../../../mcp/server/github-workflow/config.mjs';
+import Base                                                                   from '../../../../src/core/Base.mjs';
+import crypto                                                                 from 'crypto';
+import {existsSync}                                                           from 'fs';
+import fs                                                                     from 'fs/promises';
+import logger                                                                 from '../../../mcp/server/github-workflow/logger.mjs';
+import matter                                                                 from 'gray-matter';
+import path                                                                   from 'path';
+import semver                                                                 from 'semver';
+import GraphqlService                                                         from '../GraphqlService.mjs';
+import ReleaseNotesSyncer                                                     from './ReleaseNotesSyncer.mjs';
 import {FETCH_ISSUE_TIMELINE_PAGE, FETCH_ISSUES_FOR_SYNC, FETCH_SINGLE_ISSUE} from '../queries/issueQueries.mjs';
-import {GET_ISSUE_ID, UPDATE_ISSUE}                                                                        from '../queries/mutations.mjs';
-import contentPath                                      from '../shared/contentPath.mjs';
-import {createContentIndexEntry, updateContentIndex}    from '../shared/contentIndex.mjs';
-import pruneEmptyDirs                                  from '../shared/pruneEmptyDirs.mjs';
+import {GET_ISSUE_ID, UPDATE_ISSUE}                                           from '../queries/mutations.mjs';
+import contentPath                                                            from '../shared/contentPath.mjs';
+import {createContentIndexEntry, updateContentIndex}                          from '../shared/contentIndex.mjs';
+import {createContentTrustSummary, projectAuthoredNodeTrust}                  from '../shared/conversationTrust.mjs';
+import pruneEmptyDirs                                                         from '../shared/pruneEmptyDirs.mjs';
 
 const issueSyncConfig = aiConfig.issueSync;
 const lineBreaksRegex = /[\r\n]+/g;
@@ -175,6 +176,22 @@ class IssueSyncer extends Base {
     }
 
     /**
+     * @summary Projects one GitHub-authored issue-sync node through the shared content-trust policy.
+     * @param {Object} node GitHub authored node carrying optional `author.login` and `body`.
+     * @param {Object} summary Machine-readable content-trust summary accumulator.
+     * @param {String} signalPath Stable path label for sanitizer signal metadata.
+     * @returns {Object} Projected node with sanitized body for untrusted authors.
+     * @private
+     */
+    #projectAuthoredNode(node, summary, signalPath) {
+        return projectAuthoredNodeTrust(node, {
+            summary,
+            path               : signalPath,
+            productNameDenylist: issueSyncConfig.productNameDenylist || []
+        }).node;
+    }
+
+    /**
      * Formats a GitHub issue and its comments into a single Markdown string with YAML frontmatter.
      * @param {object}   issue    The GitHub issue object.
      * @param {object[]} comments An array of comment objects associated with the issue.
@@ -182,27 +199,30 @@ class IssueSyncer extends Base {
      * @private
      */
     #formatIssueMarkdown(issue) {
+        const contentTrust = createContentTrustSummary();
+        const projectedIssue = this.#projectAuthoredNode(issue, contentTrust, 'body');
         // GitHub GraphQL may return null authors or relationship nodes after users, labels, or
         // linked issues are deleted. Each dereference site uses optional chaining plus stable
         // fallback conventions: `Ghost` for users, `(no title)` for missing titles, and filtering
         // for null list entries so structured fields keep only real entities.
         const frontmatter = {
-            id                : issue.number,
-            title             : issue.title?.replace(lineBreaksRegex, ' ') || '(no title)',
-            state             : issue.state,
-            labels            : (issue.labels?.nodes || []).map(l => l?.name).filter(Boolean),
-            assignees         : (issue.assignees?.nodes || []).map(a => a?.login).filter(Boolean),
-            createdAt         : issue.createdAt,
-            updatedAt         : issue.updatedAt,
-            githubUrl         : issue.url,
-            author            : issue.author?.login || 'Ghost',
-            commentsCount     : this.#countTimelineComments(issue), // Derived from the exhausted timeline.
-            parentIssue       : issue.parent?.number ?? null,
-            subIssues         : (issue.subIssues?.nodes || []).map(sub =>
+            id           : issue.number,
+            title        : issue.title?.replace(lineBreaksRegex, ' ') || '(no title)',
+            state        : issue.state,
+            labels       : (issue.labels?.nodes || []).map(l => l?.name).filter(Boolean),
+            assignees    : (issue.assignees?.nodes || []).map(a => a?.login).filter(Boolean),
+            createdAt    : issue.createdAt,
+            updatedAt    : issue.updatedAt,
+            githubUrl    : issue.url,
+            author       : issue.author?.login || 'Ghost',
+            commentsCount: this.#countTimelineComments(issue), // Derived from the exhausted timeline.
+            parentIssue  : issue.parent?.number ?? null,
+            subIssues    : (issue.subIssues?.nodes || []).map(sub =>
                 sub ? `[${sub.state === 'CLOSED' ? 'x' : ' '}] ${sub.number} ${sub.title?.replace(lineBreaksRegex, ' ') || '(no title)'}` : null
             ).filter(Boolean),
             subIssuesCompleted: issue.subIssuesSummary?.completed || 0,
             subIssuesTotal    : issue.subIssuesSummary?.total || 0,
+            contentTrust,
             blockedBy         : (issue.blockedBy?.nodes || []).map(b =>
                 b ? `[${b.state === 'CLOSED' ? 'x' : ' '}] ${b.number} ${b.title?.replace(lineBreaksRegex, ' ') || '(no title)'}` : null
             ).filter(Boolean),
@@ -220,14 +240,14 @@ class IssueSyncer extends Base {
 
         let body = `# ${issue.title || '(no title)'}\n\n`;
 
-        body += issue.body || '*(No description provided)*';
+        body += projectedIssue.body || '*(No description provided)*';
         body += '\n\n';
 
         // Add Activity Log / Timeline section
         if (issue.timelineItems?.nodes.length > 0) {
             body += '## Timeline\n\n';
             for (const event of issue.timelineItems.nodes) {
-                body += this.#formatTimelineEvent(event);
+                body += this.#formatTimelineEvent(event, contentTrust);
             }
             body += '\n';
         }
@@ -238,14 +258,21 @@ class IssueSyncer extends Base {
     /**
      * Formats a single timeline event into a human-readable Markdown string.
      * @param {object} event The timeline event object.
+     * @param {object} contentTrust Content-trust summary accumulator for authored comments.
      * @returns {string} The formatted Markdown string for the event.
      * @private
      */
-    #formatTimelineEvent(event) {
+    #formatTimelineEvent(event, contentTrust) {
         const actor = event.actor?.login || event.author?.login || 'Ghost';
 
         if (event.__typename === 'IssueComment') {
-            return `### @${actor} - ${event.createdAt}\n\n${event.body}\n\n`;
+            const projected = this.#projectAuthoredNode(
+                event,
+                contentTrust,
+                `timeline:${event.id || event.createdAt || 'unknown'}`
+            );
+
+            return `### @${actor} - ${event.createdAt}\n\n${projected.body}\n\n`;
         }
 
         let details = '';
@@ -349,10 +376,10 @@ class IssueSyncer extends Base {
             }
 
             combined.set(parseInt(idStr, 10), {
-                number: parseInt(idStr, 10),
-                state: issue.state,
-                milestone: issue.milestone ? { title: issue.milestone } : null,
-                closedAt: issue.closedAt,
+                number     : parseInt(idStr, 10),
+                state      : issue.state,
+                milestone  : issue.milestone ? { title: issue.milestone } : null,
+                closedAt   : issue.closedAt,
                 oldVersion,
                 fromFetched: false
             });
@@ -380,11 +407,11 @@ class IssueSyncer extends Base {
                 existing.fromFetched = true;
             } else {
                 combined.set(issue.number, {
-                    number: issue.number,
-                    state: issue.state,
-                    milestone: issue.milestone,
-                    closedAt: issue.closedAt,
-                    oldVersion: null,
+                    number     : issue.number,
+                    state      : issue.state,
+                    milestone  : issue.milestone,
+                    closedAt   : issue.closedAt,
+                    oldVersion : null,
                     fromFetched: true
                 });
             }
@@ -452,7 +479,7 @@ class IssueSyncer extends Base {
         const activeItemCount = activeItems.length;
         activeItems.forEach((issue, index) => {
             plans.set(issue.number, {
-                version: null,
+                version  : null,
                 itemCount: activeItemCount,
                 itemIndex: index
             });
@@ -498,12 +525,12 @@ class IssueSyncer extends Base {
         const plan = planBuckets.get(issue.number);
 
         const config = {
-            contentRoot: issueSyncConfig.contentRoot,
-            type: 'issues',
+            contentRoot  : issueSyncConfig.contentRoot,
+            type         : 'issues',
             filename,
-            itemIndex: plan?.itemIndex || 0,
+            itemIndex    : plan?.itemIndex || 0,
             itemsPerChunk: issueSyncConfig.archiveChunkThreshold,
-            chunkPrefix: issueSyncConfig.archiveChunkPrefix
+            chunkPrefix  : issueSyncConfig.archiveChunkPrefix
         };
 
         if (plan?.version) {
@@ -561,11 +588,11 @@ class IssueSyncer extends Base {
             const data = await GraphqlService.query(
                 FETCH_ISSUES_FOR_SYNC,
                 {
-                    owner           : aiConfig.owner,
-                    repo            : aiConfig.repo,
-                    limit           : 100,
+                    owner : aiConfig.owner,
+                    repo  : aiConfig.repo,
+                    limit : 100,
                     cursor,
-                    states          : ['OPEN', 'CLOSED'],
+                    states: ['OPEN', 'CLOSED'],
                     // Clean-slate sync (`metadata.lastSync === null`) must traverse the full repo
                     // history per ADR 0004 (ticket-ref-ok: file-owned decision record). Falling back to the normal syncStartDate would miss old
                     // issues that have not been touched since that date. Use an explicit pre-Neo date,
@@ -706,12 +733,12 @@ class IssueSyncer extends Base {
             }
 
             newMetadata.issues[issueNumber] = {
-                state        : issue.state,
-                path         : this.#relativePath(targetPath), // Store relative path
-                updatedAt    : issue.updatedAt,
-                closedAt     : issue.closedAt || null,
-                milestone    : issue.milestone?.title || null,
-                title        : issue.title,
+                state    : issue.state,
+                path     : this.#relativePath(targetPath), // Store relative path
+                updatedAt: issue.updatedAt,
+                closedAt : issue.closedAt || null,
+                milestone: issue.milestone?.title || null,
+                title    : issue.title,
                 contentHash,                                    // Store hash for push comparison
                 commentsTotal: this.#countTimelineComments(issue) // Derived from the exhausted timeline.
             };
@@ -719,12 +746,12 @@ class IssueSyncer extends Base {
             const plan = planBuckets.get(issueNumber);
             indexMutations.upsert.push(createContentIndexEntry({
                 issueSyncConfig,
-                type: 'issues',
-                id: issueNumber,
-                filePath: this.#resolvePath(this.#relativePath(targetPath)),
+                type     : 'issues',
+                id       : issueNumber,
+                filePath : this.#resolvePath(this.#relativePath(targetPath)),
                 itemIndex: plan ? plan.itemIndex : issueNumber,
-                version: issue.state === 'OPEN' ? null : plan?.version || null,
-                bucket: null
+                version  : issue.state === 'OPEN' ? null : plan?.version || null,
+                bucket   : null
             }));
         }
 
@@ -891,12 +918,12 @@ class IssueSyncer extends Base {
                     const plan = planBuckets.get(issueNumber);
                     indexMutations.upsert.push(createContentIndexEntry({
                         issueSyncConfig,
-                        type: 'issues',
-                        id: issueNumber,
-                        filePath: this.#resolvePath(this.#relativePath(targetPath)),
+                        type     : 'issues',
+                        id       : issueNumber,
+                        filePath : this.#resolvePath(this.#relativePath(targetPath)),
                         itemIndex: plan ? plan.itemIndex : issueNumber,
-                        version: issue.state === 'OPEN' ? null : plan?.version || null,
-                        bucket: null
+                        version  : issue.state === 'OPEN' ? null : plan?.version || null,
+                        bucket   : null
                     }));
                 }
             } catch (e) {
@@ -1178,11 +1205,11 @@ class IssueSyncer extends Base {
         }
 
         const summary = {
-            moved    : dryRun ? 0 : moves.length,
+            moved: dryRun ? 0 : moves.length,
             unchanged,
             dryRun,
             byVersion,
-            moves    : moves.map(({number, from, to}) => ({number, from, to}))
+            moves: moves.map(({number, from, to}) => ({number, from, to}))
         };
 
         if (dryRun) {

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -1,18 +1,19 @@
-import aiConfig                   from '../../../mcp/server/github-workflow/config.mjs';
-import Base                       from '../../../../src/core/Base.mjs';
-import crypto                     from 'crypto';
-import {existsSync}               from 'fs';
-import fs                         from 'fs/promises';
-import logger                     from '../../../mcp/server/github-workflow/logger.mjs';
-import matter                     from 'gray-matter';
-import path                       from 'path';
-import semver                     from 'semver';
-import GraphqlService             from '../GraphqlService.mjs';
-import ReleaseNotesSyncer         from './ReleaseNotesSyncer.mjs';
-import {FETCH_PULL_REQUESTS_FOR_SYNC} from '../queries/pullRequestQueries.mjs';
-import contentPath                from '../shared/contentPath.mjs';
-import {createContentIndexEntry, updateContentIndex} from '../shared/contentIndex.mjs';
-import pruneEmptyDirs             from '../shared/pruneEmptyDirs.mjs';
+import aiConfig                                              from '../../../mcp/server/github-workflow/config.mjs';
+import Base                                                  from '../../../../src/core/Base.mjs';
+import crypto                                                from 'crypto';
+import {existsSync}                                          from 'fs';
+import fs                                                    from 'fs/promises';
+import logger                                                from '../../../mcp/server/github-workflow/logger.mjs';
+import matter                                                from 'gray-matter';
+import path                                                  from 'path';
+import semver                                                from 'semver';
+import GraphqlService                                        from '../GraphqlService.mjs';
+import ReleaseNotesSyncer                                    from './ReleaseNotesSyncer.mjs';
+import {FETCH_PULL_REQUESTS_FOR_SYNC}                        from '../queries/pullRequestQueries.mjs';
+import contentPath                                           from '../shared/contentPath.mjs';
+import {createContentIndexEntry, updateContentIndex}         from '../shared/contentIndex.mjs';
+import {createContentTrustSummary, projectAuthoredNodeTrust} from '../shared/conversationTrust.mjs';
+import pruneEmptyDirs                                        from '../shared/pruneEmptyDirs.mjs';
 
 const issueSyncConfig = aiConfig.issueSync;
 const pullRequestConfig = aiConfig.pullRequest;
@@ -117,6 +118,22 @@ class PullRequestSyncer extends Base {
     }
 
     /**
+     * @summary Projects one GitHub-authored pull-request sync node through content trust policy.
+     * @param {Object} node GitHub authored node carrying optional `author.login` and `body`.
+     * @param {Object} summary Machine-readable content-trust summary accumulator.
+     * @param {String} signalPath Stable path label for sanitizer signal metadata.
+     * @returns {Object} Projected node with sanitized body for untrusted authors.
+     * @private
+     */
+    #projectAuthoredNode(node, summary, signalPath) {
+        return projectAuthoredNodeTrust(node, {
+            summary,
+            path               : signalPath,
+            productNameDenylist: issueSyncConfig.productNameDenylist || []
+        }).node;
+    }
+
+    /**
      * @summary Pre-computes bucket distribution for all pull requests based on historical milestones/releases.
      * @param {object} metadata Current sync metadata
      * @param {Array<object>} fetchedPullRequests PRs fetched in the current sync run
@@ -174,7 +191,7 @@ class PullRequestSyncer extends Base {
         const activeItemCount = activeItems.length;
         activeItems.forEach((pr, index) => {
             plans.set(pr.number, {
-                version: null,
+                version  : null,
                 itemCount: activeItemCount,
                 itemIndex: index
             });
@@ -208,12 +225,12 @@ class PullRequestSyncer extends Base {
         const plan = planBuckets.get(pr.number);
 
         const config = {
-            contentRoot: issueSyncConfig.contentRoot,
-            type: 'pulls',
+            contentRoot  : issueSyncConfig.contentRoot,
+            type         : 'pulls',
             filename,
-            itemIndex: plan?.itemIndex || 0,
+            itemIndex    : plan?.itemIndex || 0,
             itemsPerChunk: issueSyncConfig.archiveChunkThreshold,
-            chunkPrefix: issueSyncConfig.archiveChunkPrefix
+            chunkPrefix  : issueSyncConfig.archiveChunkPrefix
         };
 
         if (plan?.version) {
@@ -358,13 +375,13 @@ class PullRequestSyncer extends Base {
 
         while (hasNextPage) {
             const data = await GraphqlService.query(FETCH_PULL_REQUESTS_FOR_SYNC, {
-                owner: aiConfig.owner,
-                repo : aiConfig.repo,
-                limit: pullRequestConfig.defaults.limit || 30,
+                owner      : aiConfig.owner,
+                repo       : aiConfig.repo,
+                limit      : pullRequestConfig.defaults.limit || 30,
                 cursor,
-                states: ['OPEN', 'CLOSED', 'MERGED'],
+                states     : ['OPEN', 'CLOSED', 'MERGED'],
                 maxComments: pullRequestConfig.maxCommentsPerPullRequest || 50,
-                maxReviews: 20
+                maxReviews : 20
             });
 
             const pullRequests = data.repository.pullRequests;
@@ -396,28 +413,37 @@ class PullRequestSyncer extends Base {
         for (const pr of allPullRequests) {
             try {
                 const targetPath = this.#getPullRequestPath(pr, planBuckets);
+                const contentTrust = createContentTrustSummary();
+                const projectedPr = this.#projectAuthoredNode(pr, contentTrust, 'body');
 
                 const frontmatter = {
-                    number     : pr.number,
-                    title      : pr.title,
-                    author     : pr.author?.login || 'unknown',
-                    state      : pr.state,
-                    createdAt  : pr.createdAt,
-                    updatedAt  : pr.updatedAt,
-                    closedAt   : pr.closedAt,
-                    mergedAt   : pr.mergedAt,
-                    head       : pr.headRefName,
-                    base       : pr.baseRefName,
-                    url        : pr.url
+                    number   : pr.number,
+                    title    : pr.title,
+                    author   : pr.author?.login || 'unknown',
+                    state    : pr.state,
+                    createdAt: pr.createdAt,
+                    updatedAt: pr.updatedAt,
+                    closedAt : pr.closedAt,
+                    mergedAt : pr.mergedAt,
+                    head     : pr.headRefName,
+                    base     : pr.baseRefName,
+                    url      : pr.url,
+                    contentTrust
                 };
 
-                let body = pr.body || '';
+                let body = projectedPr.body || '';
 
                 // Build comments structure
                 if (pr.comments && pr.comments.nodes && pr.comments.nodes.length > 0) {
                     body += '\n\n## Comments\n\n';
                     for (const comment of pr.comments.nodes) {
-                        body += `### \`@${comment.author?.login || 'unknown'}\` commented on ${comment.createdAt}\n\n${comment.body}\n\n---\n\n`;
+                        const projectedComment = this.#projectAuthoredNode(
+                            comment,
+                            contentTrust,
+                            `comment:${comment.id || comment.createdAt || 'unknown'}`
+                        );
+
+                        body += `### \`@${comment.author?.login || 'unknown'}\` commented on ${comment.createdAt}\n\n${projectedComment.body}\n\n---\n\n`;
                     }
                 }
 
@@ -428,7 +454,13 @@ class PullRequestSyncer extends Base {
                         const reviewState = review.state ? ` (${review.state})` : '';
                         body += `### \`@${review.author?.login || 'unknown'}\`${reviewState} reviewed on ${review.createdAt}\n\n`;
                         if (review.body && review.body.trim().length > 0) {
-                            body += `${review.body}\n\n`;
+                            const projectedReview = this.#projectAuthoredNode(
+                                review,
+                                contentTrust,
+                                `review:${review.id || review.createdAt || 'unknown'}`
+                            );
+
+                            body += `${projectedReview.body}\n\n`;
                         } else {
                             body += `*No review body provided.*\n\n`;
                         }
@@ -508,12 +540,12 @@ class PullRequestSyncer extends Base {
 
             indexEntries.push(createContentIndexEntry({
                 issueSyncConfig,
-                type: 'pulls',
-                id: p.number,
-                filePath: path.resolve(aiConfig.projectRoot, p.relativeOutputPath),
+                type     : 'pulls',
+                id       : p.number,
+                filePath : path.resolve(aiConfig.projectRoot, p.relativeOutputPath),
                 itemIndex: plan ? plan.itemIndex : 0,
-                version: p.state === 'OPEN' ? null : plan?.version || null,
-                bucket: null
+                version  : p.state === 'OPEN' ? null : plan?.version || null,
+                bucket   : null
             }));
         });
 

--- a/test/playwright/unit/ai/services/github-workflow/ConversationTrust.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/ConversationTrust.spec.mjs
@@ -13,11 +13,11 @@ setup({
     }
 });
 
-import {test, expect}             from '@playwright/test';
-import Neo                        from '../../../../../../src/Neo.mjs';
-import * as core                  from '../../../../../../src/core/_export.mjs';
-import {TRUST_TIERS}              from '../../../../../../ai/graph/identityRoots.mjs';
-import {projectConversationTrust} from '../../../../../../ai/services/github-workflow/shared/conversationTrust.mjs';
+import {test, expect}                                                                  from '@playwright/test';
+import Neo                                                                             from '../../../../../../src/Neo.mjs';
+import * as core                                                                       from '../../../../../../src/core/_export.mjs';
+import {TRUST_TIERS}                                                                   from '../../../../../../ai/graph/identityRoots.mjs';
+import {createContentTrustSummary, projectAuthoredNodeTrust, projectConversationTrust} from '../../../../../../ai/services/github-workflow/shared/conversationTrust.mjs';
 
 /**
  * @summary Read-boundary trust-projection fixtures — the pure helper + its wiring into the three
@@ -134,6 +134,37 @@ test.describe('Neo.ai.services.github-workflow.shared.conversationTrust — pure
         projectConversationTrust(conversation);
 
         expect(conversation).toEqual(snapshot)
+    });
+
+    test('standalone authored-node projection reuses an injected summary accumulator', () => {
+        const summary = createContentTrustSummary();
+
+        const projectedRoot = projectAuthoredNodeTrust({
+            id    : 'root',
+            author: {login: 'external-writer'},
+            body  : 'Architecture note with product seed: Memorly. More at https://payload.example/path'
+        }, {
+            summary,
+            path               : 'body',
+            productNameDenylist: ['Memorly']
+        });
+
+        const projectedTrusted = projectAuthoredNodeTrust({
+            id    : 'trusted',
+            author: {login: 'neo-gpt'},
+            body  : 'Trusted maintainer reference stays raw: https://github.com/neomjs/neo'
+        }, {
+            summary,
+            path               : 'comment:trusted',
+            productNameDenylist: ['Memorly']
+        });
+
+        expect(projectedRoot.contentTrust).toBe(summary);
+        expect(projectedRoot.node.body).toContain('[QUARANTINED_URL: payload.example]');
+        expect(projectedRoot.node.body).toContain('[external product name redacted]');
+        expect(projectedTrusted.node.body).toContain('https://github.com/neomjs/neo');
+        expect(summary.projected).toBe(true);
+        expect(summary.quarantined).toBe(2)
     });
 });
 

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -13,11 +13,12 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import fs             from 'fs-extra';
-import path           from 'path';
+import {test, expect}               from '@playwright/test';
+import Neo                          from '../../../../../../src/Neo.mjs';
+import * as core                    from '../../../../../../src/core/_export.mjs';
+import fs                           from 'fs-extra';
+import matter                       from 'gray-matter';
+import path                         from 'path';
 import {FETCH_DISCUSSIONS_FOR_SYNC} from '../../../../../../ai/services/github-workflow/queries/discussionQueries.mjs';
 
 test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
@@ -79,7 +80,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         GraphqlService.query = async () => ({
             repository: {
                 discussions: {
-                    nodes: [discussion],
+                    nodes   : [discussion],
                     pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }
@@ -94,11 +95,11 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         await expect(fs.pathExists(targetPath)).resolves.toBe(true);
         expect(metadata.discussions[24001].path).toBe(path.relative(aiConfig.projectRoot, targetPath));
         expect(index).toContainEqual({
-            type: 'discussions',
-            id: 24001,
-            version: null,
+            type       : 'discussions',
+            id         : 24001,
+            version    : null,
             chunkNumber: 1,
-            path: path.join('discussions', 'chunk-1', 'discussion-24001.md')
+            path       : path.join('discussions', 'chunk-1', 'discussion-24001.md')
         });
 
         const content = await fs.readFile(targetPath, 'utf8');
@@ -116,21 +117,21 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         const discussion = buildDiscussion(24003, {
             category: 'Q&A',
             comments: {nodes: [{
-                author: {login: 'neo-answer'},
-                body: 'Accepted answer body.',
+                author   : {login: 'neo-answer'},
+                body     : 'Accepted answer body.',
                 createdAt: '2026-05-02T01:00:00Z',
-                isAnswer: true,
-                replies: {nodes: []}
+                isAnswer : true,
+                replies  : {nodes: []}
             }, {
-                author: {login: 'neo-thread'},
-                body: 'Regular follow-up.',
+                author   : {login: 'neo-thread'},
+                body     : 'Regular follow-up.',
                 createdAt: '2026-05-02T02:00:00Z',
-                isAnswer: false,
-                replies: {nodes: [{
-                    author: {login: 'neo-reply-answer'},
-                    body: 'Nested accepted answer.',
+                isAnswer : false,
+                replies  : {nodes: [{
+                    author   : {login: 'neo-reply-answer'},
+                    body     : 'Nested accepted answer.',
                     createdAt: '2026-05-02T03:00:00Z',
-                    isAnswer: true
+                    isAnswer : true
                 }]}
             }]}
         });
@@ -138,7 +139,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         GraphqlService.query = async () => ({
             repository: {
                 discussions: {
-                    nodes: [discussion],
+                    nodes   : [discussion],
                     pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }
@@ -168,12 +169,12 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
     test('emits structured reply markers that preserve parent comment identity', async () => {
         const discussion = buildDiscussion(24005, {
             comments: {nodes: [{
-                author: {login: 'neo-parent'},
-                body: 'Parent comment body.',
+                author   : {login: 'neo-parent'},
+                body     : 'Parent comment body.',
                 createdAt: '2026-05-02T01:00:00Z',
-                replies: {nodes: [{
+                replies  : {nodes: [{
                     author: {login: 'neo-child'},
-                    body: [
+                    body  : [
                         'Reply body.',
                         '',
                         '### Inner heading remains reply markdown.'
@@ -186,7 +187,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         GraphqlService.query = async () => ({
             repository: {
                 discussions: {
-                    nodes: [discussion],
+                    nodes   : [discussion],
                     pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }
@@ -210,21 +211,72 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         ].join('\n'));
     });
 
+    test('sync write-boundary defangs untrusted discussion bodies, comments, and replies before local markdown persistence (#13691)', async () => {
+        const discussionNumber = 24006;
+        const discussion = buildDiscussion(discussionNumber, {
+            comments: {nodes: [{
+                id       : 'DC_external',
+                author   : {login: 'external-commenter'},
+                body     : 'External discussion comment https://discussion-comment.example/payload',
+                createdAt: '2026-05-02T01:00:00Z',
+                replies  : {nodes: [{
+                    id       : 'DCR_external',
+                    author   : {login: 'external-replier'},
+                    body     : 'External discussion reply https://discussion-reply.example/payload',
+                    createdAt: '2026-05-02T02:00:00Z'
+                }]}
+            }, {
+                id       : 'DC_trusted',
+                author   : {login: 'neo-gpt'},
+                body     : 'Trusted discussion link remains raw https://github.com/neomjs/neo',
+                createdAt: '2026-05-02T03:00:00Z',
+                replies  : {nodes: []}
+            }]}
+        });
+
+        discussion.author = {login: 'external-discussion-author'};
+        discussion.body   = 'External discussion root https://discussion-root.example/landing';
+
+        GraphqlService.query = async () => ({
+            repository: {
+                discussions: {
+                    nodes   : [discussion],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        const stats      = await DiscussionSyncer.syncDiscussions({discussions: {}});
+        const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', `discussion-${discussionNumber}.md`);
+        const parsed     = matter(await fs.readFile(targetPath, 'utf8'));
+
+        expect(stats.synced).toEqual([discussionNumber]);
+        expect(parsed.data.contentTrust.projected).toBe(true);
+        expect(parsed.data.contentTrust.quarantined).toBe(3);
+        expect(parsed.content).toContain('[QUARANTINED_URL: discussion-root.example]');
+        expect(parsed.content).toContain('[QUARANTINED_URL: discussion-comment.example]');
+        expect(parsed.content).toContain('[QUARANTINED_URL: discussion-reply.example]');
+        expect(parsed.content).not.toContain('https://discussion-root.example');
+        expect(parsed.content).not.toContain('https://discussion-comment.example');
+        expect(parsed.content).not.toContain('https://discussion-reply.example');
+        expect(parsed.content).toContain('https://github.com/neomjs/neo');
+    });
+
     test('does not add answer markers for regular non-Q&A comments', async () => {
         const discussion = buildDiscussion(24004, {
             category: 'General',
             comments: {nodes: [{
-                author: {login: 'neo-comment'},
-                body: 'Regular discussion comment.',
+                author   : {login: 'neo-comment'},
+                body     : 'Regular discussion comment.',
                 createdAt: '2026-05-02T01:00:00Z',
-                replies: {nodes: []}
+                replies  : {nodes: []}
             }]}
         });
 
         GraphqlService.query = async () => ({
             repository: {
                 discussions: {
-                    nodes: [discussion],
+                    nodes   : [discussion],
                     pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }
@@ -241,14 +293,14 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
 
     test('writes archived discussions through contentPath and maintains _index.json', async () => {
         const discussion = buildDiscussion(24002, {
-            closed: true,
+            closed  : true,
             closedAt: '2026-05-01T00:00:00Z'
         });
 
         GraphqlService.query = async () => ({
             repository: {
                 discussions: {
-                    nodes: [discussion],
+                    nodes   : [discussion],
                     pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }
@@ -263,11 +315,11 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         await expect(fs.pathExists(targetPath)).resolves.toBe(true);
         expect(metadata.discussions[24002].path).toBe(path.relative(aiConfig.projectRoot, targetPath));
         expect(index).toContainEqual({
-            type: 'discussions',
-            id: 24002,
-            version: 'v13.0.0',
+            type       : 'discussions',
+            id         : 24002,
+            version    : 'v13.0.0',
             chunkNumber: 1,
-            path: path.join('archive', 'discussions', 'v13.0.0', 'chunk-1', 'discussion-24002.md')
+            path       : path.join('archive', 'discussions', 'v13.0.0', 'chunk-1', 'discussion-24002.md')
         });
 
         const content = await fs.readFile(targetPath, 'utf8');
@@ -320,7 +372,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
     test('delta cutoff stops discussion pagination once a batch predates the cached high-water mark (#12190)', async () => {
         // Mirror of the PR/issue delta: order UPDATED_AT DESC + stop at the cached high-water mark.
         const metadata = {
-            lastSync: '2026-05-01T00:00:00Z',
+            lastSync   : '2026-05-01T00:00:00Z',
             discussions: {
                 9001: {updatedAt: '2026-05-01T00:00:00Z', path: 'resources/content/discussions/chunk-1/discussion-9001.md'}
             }
@@ -351,7 +403,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         GraphqlService.query = async () => ({
             repository: {
                 discussions: {
-                    nodes: [allowed, denied],
+                    nodes   : [allowed, denied],
                     pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }
@@ -381,7 +433,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         GraphqlService.query = async () => ({
             repository: {
                 discussions: {
-                    nodes: [denied],
+                    nodes   : [denied],
                     pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }
@@ -402,7 +454,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         GraphqlService.query = async () => ({
             repository: {
                 discussions: {
-                    nodes: [discussion],
+                    nodes   : [discussion],
                     pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }
@@ -431,7 +483,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         GraphqlService.query = async () => ({
             repository: {
                 discussions: {
-                    nodes: [buildDiscussion(25006, {closed: false})],
+                    nodes   : [buildDiscussion(25006, {closed: false})],
                     pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }
@@ -462,7 +514,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         GraphqlService.query = async () => ({
             repository: {
                 discussions: {
-                    nodes: [discussion],
+                    nodes   : [discussion],
                     pageInfo: {hasNextPage: false, endCursor: null}
                 }
             }
@@ -489,11 +541,11 @@ function buildDiscussion(number, config = {}) {
     return {
         number,
         title: `Discussion ${number}`,
-        body : 'Discussion body',
+        body     : 'Discussion body',
         closed,
         closedAt,
-        author: {login: 'neo-test'},
-        category: {name: category},
+        author   : {login: 'neo-test'},
+        category : {name: category},
         createdAt: '2026-05-01T00:00:00Z',
         updatedAt: '2026-05-02T00:00:00Z',
         comments

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -18,6 +18,7 @@ import Neo             from '../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 import fs              from 'fs-extra';
+import matter          from 'gray-matter';
 import path            from 'path';
 
 /**
@@ -200,6 +201,56 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         const writtenPath = path.join(issueSyncConfig.issuesDir, `chunk-${chunkNumber}`, `issue-${mockIssue.number}.md`);
         const written     = await fs.readFile(writtenPath, 'utf-8');
         expect(written).toContain(`commentsCount: ${COMMENT_COUNT}`);
+    });
+
+    test('sync write-boundary defangs untrusted issue bodies and comments before local markdown persistence (#13691)', async () => {
+        const externalComment = buildComment(1);
+        externalComment.id     = 'IC_external';
+        externalComment.author = {login: 'external-reviewer'};
+        externalComment.body   = 'Useful critique, then a watering-hole URL: https://comment.example/payload';
+
+        const trustedComment = buildComment(2);
+        trustedComment.id     = 'IC_trusted';
+        trustedComment.author = {login: 'neo-gpt'};
+        trustedComment.body   = 'Trusted maintainer source link stays raw: https://github.com/neomjs/neo';
+
+        const mockIssue = buildMockIssue({
+            number       : 42045,
+            title        : 'Mock issue — contentTrust sync persistence #13691',
+            timelineFirst: [externalComment, trustedComment],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+
+        mockIssue.author = {login: 'external-author'};
+        mockIssue.body   = 'External root payload with URL https://root.example/landing';
+
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchSingleIssue')) {
+                return {repository: {issue: structuredClone(mockIssue)}};
+            }
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        const metadata = {issues: {}};
+        const stats    = await IssueSyncer.refetchIssuesByNumber([mockIssue.number], metadata);
+
+        expect(stats.refetched.count).toBe(1);
+        expect(stats.errors).toHaveLength(0);
+
+        const writtenPath = path.resolve(aiConfig.projectRoot, metadata.issues[mockIssue.number].path);
+        const written     = await fs.readFile(writtenPath, 'utf-8');
+        const parsed      = matter(written);
+
+        expect(parsed.data.contentTrust.projected).toBe(true);
+        expect(parsed.data.contentTrust.quarantined).toBe(2);
+
+        expect(parsed.content).toContain('[QUARANTINED_URL: root.example]');
+        expect(parsed.content).toContain('[QUARANTINED_URL: comment.example]');
+        expect(parsed.content).not.toContain('https://root.example');
+        expect(parsed.content).not.toContain('https://comment.example');
+
+        expect(parsed.content).toContain('https://github.com/neomjs/neo');
     });
 
     test('closed-post-latest-release issue lands in active when no archive-version applies (#11360 supersedes #11288 unversioned-target scenario)', async () => {
@@ -458,11 +509,11 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         GraphqlService.query = async (query) => {
             if (query.includes('FetchIssuesForSync')) {
                 return {
-                    rateLimit: { cost: 1, remaining: 4999, resetAt: '2026-05-13T11:00:00Z' },
+                    rateLimit : { cost: 1, remaining: 4999, resetAt: '2026-05-13T11:00:00Z' },
                     repository: {
                         issues: {
                             pageInfo: { hasNextPage: false, endCursor: null },
-                            nodes: [structuredClone(mockIssue)]
+                            nodes   : [structuredClone(mockIssue)]
                         }
                     }
                 };
@@ -485,13 +536,13 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         const metadata = {
             issues: {
                 [mockIssue.number]: {
-                    state: 'CLOSED',
-                    path: originalOldPath,
-                    updatedAt: '2026-05-12T10:00:00Z',
-                    closedAt: '2026-05-12T10:00:00Z', // original date
-                    milestone: null, // original milestone
-                    title: mockIssue.title,
-                    contentHash: 'somehash',
+                    state        : 'CLOSED',
+                    path         : originalOldPath,
+                    updatedAt    : '2026-05-12T10:00:00Z',
+                    closedAt     : '2026-05-12T10:00:00Z', // original date
+                    milestone    : null, // original milestone
+                    title        : mockIssue.title,
+                    contentHash  : 'somehash',
                     commentsTotal: 0
                 }
             }
@@ -538,11 +589,11 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         GraphqlService.query = async (query) => {
             if (query.includes('FetchIssuesForSync')) {
                 return {
-                    rateLimit: { cost: 1, remaining: 4999, resetAt: '2026-05-13T11:00:00Z' },
+                    rateLimit : { cost: 1, remaining: 4999, resetAt: '2026-05-13T11:00:00Z' },
                     repository: {
                         issues: {
                             pageInfo: { hasNextPage: false, endCursor: null },
-                            nodes: [structuredClone(mockIssueDropped), structuredClone(mockIssueStored)]
+                            nodes   : [structuredClone(mockIssueDropped), structuredClone(mockIssueStored)]
                         }
                     }
                 };
@@ -606,8 +657,8 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
                     source    : null // deleted source
                 }
             ],
-            hasNextPage  : false,
-            endCursor    : null
+            hasNextPage: false,
+            endCursor  : null
         });
 
         GraphqlService.query = async (query) => {
@@ -649,19 +700,19 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         // This test exercises EVERY nullable frontmatter site simultaneously ("ghost issue")
         // to prevent future whack-a-mole regressions.
         const ghostIssue = {
-            number   : 42044,
-            title    : null, // null title
-            body     : 'Mock body for ghost issue regression #11481.',
-            state    : 'CLOSED',
-            createdAt: '2026-05-16T17:00:00Z',
-            updatedAt: '2026-05-16T18:00:00Z',
-            closedAt : '2026-05-16T17:30:00Z',
-            url      : 'https://github.com/neomjs/neo/issues/42044',
-            author   : null, // deleted GitHub user (Ghost) — the empirical crash
-            labels   : {nodes: [null, {name: null}, {name: 'bug'}]}, // null entries + null-name + valid
-            assignees: {nodes: [null, {login: null}, {login: 'tobiu'}]}, // same shape: null entries + null-login + valid
-            milestone: null,
-            parent   : null,
+            number          : 42044,
+            title           : null, // null title
+            body            : 'Mock body for ghost issue regression #11481.',
+            state           : 'CLOSED',
+            createdAt       : '2026-05-16T17:00:00Z',
+            updatedAt       : '2026-05-16T18:00:00Z',
+            closedAt        : '2026-05-16T17:30:00Z',
+            url             : 'https://github.com/neomjs/neo/issues/42044',
+            author          : null, // deleted GitHub user (Ghost) — the empirical crash
+            labels          : {nodes: [null, {name: null}, {name: 'bug'}]}, // null entries + null-name + valid
+            assignees       : {nodes: [null, {login: null}, {login: 'tobiu'}]}, // same shape: null entries + null-login + valid
+            milestone       : null,
+            parent          : null,
             subIssues       : {nodes: [null, {state: 'OPEN', number: 100, title: null}, {state: 'CLOSED', number: 101, title: 'valid sub'}]},
             subIssuesSummary: {total: 2, completed: 1, percentCompleted: 50},
             blockedBy       : {nodes: [null, {state: 'OPEN', number: 200, title: null}]},
@@ -789,23 +840,23 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         const metadata = {
             issues: {
                 [issueAMigrationShape.number]: {
-                    state       : 'CLOSED',
-                    path        : issueAOldRelPath,
-                    updatedAt   : '2026-05-14T10:00:00Z',
-                    closedAt    : '2026-05-15T10:00:00Z',
-                    milestone   : null,
-                    title       : issueAMigrationShape.title,
-                    contentHash : 'hashA',
+                    state        : 'CLOSED',
+                    path         : issueAOldRelPath,
+                    updatedAt    : '2026-05-14T10:00:00Z',
+                    closedAt     : '2026-05-15T10:00:00Z',
+                    milestone    : null,
+                    title        : issueAMigrationShape.title,
+                    contentHash  : 'hashA',
                     commentsTotal: 0
                 },
                 [issueBSemverShift.number]: {
-                    state       : 'CLOSED',
-                    path        : issueBOldRelPath,
-                    updatedAt   : '2026-05-14T10:00:00Z',
-                    closedAt    : '2026-05-15T10:00:00Z',
-                    milestone   : null,
-                    title       : issueBSemverShift.title,
-                    contentHash : 'hashB',
+                    state        : 'CLOSED',
+                    path         : issueBOldRelPath,
+                    updatedAt    : '2026-05-14T10:00:00Z',
+                    closedAt     : '2026-05-15T10:00:00Z',
+                    milestone    : null,
+                    title        : issueBSemverShift.title,
+                    contentHash  : 'hashB',
                     commentsTotal: 0
                 }
             }
@@ -912,13 +963,13 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         const metadata = {
             issues: {
                 [issueUnchangedAtCanonicalBucket.number]: {
-                    state       : 'CLOSED',
-                    path        : issueRelPath,
-                    updatedAt   : '2025-11-29T11:44:14Z',
-                    closedAt    : '2025-11-29T11:41:17Z',
-                    milestone   : null, // KEY: legacy entry with no milestone data
-                    title       : issueUnchangedAtCanonicalBucket.title,
-                    contentHash : 'hashUnchanged',
+                    state        : 'CLOSED',
+                    path         : issueRelPath,
+                    updatedAt    : '2025-11-29T11:44:14Z',
+                    closedAt     : '2025-11-29T11:41:17Z',
+                    milestone    : null, // KEY: legacy entry with no milestone data
+                    title        : issueUnchangedAtCanonicalBucket.title,
+                    contentHash  : 'hashUnchanged',
                     commentsTotal: 0
                 }
             }
@@ -983,7 +1034,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
 
         const metadata = {
             lastSync: '2026-01-01T00:00:00Z',
-            issues: {
+            issues  : {
                 [N]: {state: 'CLOSED', updatedAt: ts, closedAt: ts, milestone: 'v12.0.0', path: cachedRel, contentHash: 'h', commentsTotal: 0}
             }
         };
@@ -1019,7 +1070,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
 
         const metadata = {
             releases: {},
-            issues: {
+            issues  : {
                 [N]: {state: 'CLOSED', closedAt: '2024-09-15T00:00:00Z', updatedAt: '2024-09-15T00:00:00Z', milestone: null, path: wrongRel, contentHash: 'h'}
             }
         };
@@ -1065,7 +1116,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
 
         const metadata = {
             releases: {},
-            issues: {[N]: {state: 'CLOSED', closedAt: '2024-09-15T00:00:00Z', updatedAt: '2024-09-15T00:00:00Z', milestone: null, path: wrongRel, contentHash: 'h'}}
+            issues  : {[N]: {state: 'CLOSED', closedAt: '2024-09-15T00:00:00Z', updatedAt: '2024-09-15T00:00:00Z', milestone: null, path: wrongRel, contentHash: 'h'}}
         };
 
         try {
@@ -1114,8 +1165,8 @@ function buildCrossRef(i) {
     return {
         __typename: 'CrossReferencedEvent',
         createdAt : `2026-04-19T11:${minute}:00Z`,
-        actor     : {login: 'tobiu'},
-        source    : {__typename: 'Issue', number: 10000 + i}
+        actor : {login: 'tobiu'},
+        source: {__typename: 'Issue', number: 10000 + i}
     };
 }
 
@@ -1133,11 +1184,11 @@ function buildMockIssue({number, title, timelineFirst, hasNextPage, endCursor}) 
         updatedAt: '2026-04-19T12:00:00Z',
         closedAt : null,
         url      : `https://github.com/neomjs/neo/issues/${number}`,
-        author   : {login: 'tobiu'},
-        labels   : {nodes: [{name: 'bug'}]},
-        assignees: {nodes: [{login: 'tobiu'}]},
-        milestone: null,
-        parent   : null,
+        author          : {login: 'tobiu'},
+        labels          : {nodes: [{name: 'bug'}]},
+        assignees       : {nodes: [{login: 'tobiu'}]},
+        milestone       : null,
+        parent          : null,
         subIssues       : {nodes: []},
         subIssuesSummary: {total: 0, completed: 0, percentCompleted: 0},
         blockedBy       : {nodes: []},

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -17,6 +17,7 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs-extra';
+import matter         from 'gray-matter';
 import path           from 'path';
 
 test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
@@ -100,7 +101,7 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         GraphqlService.query = async () => ({
             repository: {
                 pullRequests: {
-                    nodes: [buildPullRequest(prNumber)],
+                    nodes   : [buildPullRequest(prNumber)],
                     pageInfo: {
                         hasNextPage: false,
                         endCursor  : null
@@ -178,6 +179,56 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         await expect(fs.pathExists(archivePath)).resolves.toBe(false);
     });
 
+    test('sync write-boundary defangs untrusted PR bodies, comments, and reviews before local markdown persistence (#13691)', async () => {
+        const prNumber = 3292;
+        const pr       = buildPullRequest(prNumber);
+
+        pr.author = {login: 'external-pr-author'};
+        pr.body   = 'External PR root body https://pr-root.example/landing';
+        pr.comments = {nodes: [{
+            id       : 'PC_external',
+            author   : {login: 'external-commenter'},
+            body     : 'External PR comment https://pr-comment.example/payload',
+            createdAt: '2026-05-02T01:00:00Z'
+        }, {
+            id       : 'PC_trusted',
+            author   : {login: 'neo-gpt'},
+            body     : 'Trusted maintainer link remains raw https://github.com/neomjs/neo',
+            createdAt: '2026-05-02T02:00:00Z'
+        }]};
+        pr.reviews = {nodes: [{
+            id       : 'PRR_external',
+            author   : {login: 'external-reviewer'},
+            body     : 'External review body https://pr-review.example/payload',
+            state    : 'COMMENTED',
+            createdAt: '2026-05-02T03:00:00Z'
+        }]};
+
+        GraphqlService.query = async () => ({
+            repository: {
+                pullRequests: {
+                    nodes   : [pr],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        const stats      = await PullRequestSyncer.syncPullRequests({pulls: {}});
+        const targetPath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
+        const parsed     = matter(await fs.readFile(targetPath, 'utf8'));
+
+        expect(stats.synced).toEqual([prNumber]);
+        expect(parsed.data.contentTrust.projected).toBe(true);
+        expect(parsed.data.contentTrust.quarantined).toBe(3);
+        expect(parsed.content).toContain('[QUARANTINED_URL: pr-root.example]');
+        expect(parsed.content).toContain('[QUARANTINED_URL: pr-comment.example]');
+        expect(parsed.content).toContain('[QUARANTINED_URL: pr-review.example]');
+        expect(parsed.content).not.toContain('https://pr-root.example');
+        expect(parsed.content).not.toContain('https://pr-comment.example');
+        expect(parsed.content).not.toContain('https://pr-review.example');
+        expect(parsed.content).toContain('https://github.com/neomjs/neo');
+    });
+
     test('routeByMilestone=true only routes semver milestones into already-cut archive buckets', async () => {
         const missingBucketPr = buildPullRequest(3289);
         missingBucketPr.milestone = {title: 'v99.0.0'};
@@ -252,7 +303,7 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         // DESC and stops paginating at the cached high-water mark. Pre-fix it scanned the full corpus.
         const metadata = {
             lastSync: '2026-05-01T00:00:00Z',
-            pulls: {
+            pulls   : {
                 9001: {state: 'MERGED', updatedAt: '2026-05-01T00:00:00Z', path: 'resources/content/archive/pulls/v12.0.0/chunk-1/pr-9001.md'}
             }
         };
@@ -357,9 +408,9 @@ function buildPullRequest(number) {
         headRefName: 'feature',
         baseRefName: 'dev',
         url        : `https://github.com/neomjs/neo/pull/${number}`,
-        body       : 'Merged body',
-        milestone  : null,
-        comments   : {nodes: []},
-        reviews    : {nodes: []}
+        body     : 'Merged body',
+        milestone: null,
+        comments : {nodes: []},
+        reviews  : {nodes: []}
     }
 }


### PR DESCRIPTION
Resolves #13691

Related: #10476

Wires the existing `contentTrust` trust projection into the GitHub workflow sync/write boundary. Issue, PR, and Discussion sync now sanitize untrusted authored bodies before persisting Markdown into `resources/content/*`, while trusted authored content remains byte-identical. Persisted frontmatter carries a `contentTrust` summary so downstream KB and graph ingestion can distinguish projected content from legacy unsanitized files.

Evidence: L2 (focused unit specs over shared projection plus issue/PR/discussion sync persistence) -> L2 required (write-boundary sanitizer ACs are unit-testable without live GitHub mutation). No residuals.

## Deltas from ticket
- Reused `ai/services/github-workflow/shared/conversationTrust.mjs` for sync persistence instead of adding a second sanitizer path.
- Added `issueSync.productNameDenylist` to `ai/mcp/server/github-workflow/config.template.mjs` with an empty safe default.
- Left historical `resources/content/*` rewrite and the AGENTS external traversal-prohibition residual out of scope, matching the ticket.

## Config Template Impact
- Changed key: `issueSync.productNameDenylist`.
- Local `ai/mcp/server/github-workflow/config.mjs` files do not need an immediate manual update for safety; code falls back to `[]` when the key is absent.
- Active clones that want product-name redaction values should add the key to their gitignored local config or rerun config migration, then restart/reload the github-workflow MCP process for the new values to take effect.

## Test Evidence
- `node buildScripts/util/check-block-alignment.mjs ai/mcp/server/github-workflow/config.template.mjs ai/services/github-workflow/shared/conversationTrust.mjs ai/services/github-workflow/sync/DiscussionSyncer.mjs ai/services/github-workflow/sync/IssueSyncer.mjs ai/services/github-workflow/sync/PullRequestSyncer.mjs test/playwright/unit/ai/services/github-workflow/ConversationTrust.spec.mjs test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/ConversationTrust.spec.mjs test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs` - 57 passed
- Pre-commit hooks passed, including whitespace, shorthand, AiConfig test-mutation guard, JSDoc types, ticket archaeology, and block alignment.

## Post-Merge Validation
- [ ] Active clones that need non-empty product-name redaction configure `issueSync.productNameDenylist` locally and restart/reload github-workflow MCP.
- [ ] Next GitHub workflow sync writes `contentTrust` frontmatter for newly synced issue/PR/discussion files without rewriting historical archives as a separate bulk migration.

## Commit
- `c8b855b4a` - `feat(ai): wire contentTrust into sync ingestion (#13691)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee6d0-9fa6-7e12-a96b-3ac11e40aee3.
