### PR TITLE
fix(ai): route Chroma batch embeds through embedTexts, not the interactive path (#13692)

### DIFF
--- a/ai/services/shared/vector/chromaClientPrimitives.mjs
+++ b/ai/services/shared/vector/chromaClientPrimitives.mjs
@@ -50,7 +50,12 @@ export function createDynamicTextEmbeddingFunction({providerResolver = null} = {
             const {default: aiConfig}             = await import('../../../mcp/server/memory-core/config.mjs');
             const provider                        = providerResolver?.() ?? aiConfig.embeddingProvider;
 
-            return Promise.all(texts.map(text => TextEmbeddingService.embedText(text, provider)))
+            // Route the whole batch through embedTexts (the batch path: 1h request timeout,
+            // sequential chunks of batchEmbeddingChunkSize) — NOT per-text embedText fan-out. The
+            // interactive embedText path applies the 15s contentionTimeoutMs, and a Promise.all over
+            // the batch storms the single local embedder into self-contention, cutting bulk adds
+            // (WAL drain / graph ingestion) short with spurious timeouts.
+            return TextEmbeddingService.embedTexts(texts, provider)
         },
         name       : CHROMA_DYNAMIC_TEXT_EMBEDDING_FUNCTION_NAME,
         getConfig  : () => ({}),

--- a/test/playwright/unit/ai/services/shared/vector/chromaClientPrimitives.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/chromaClientPrimitives.spec.mjs
@@ -1,0 +1,54 @@
+import { setup } from '../../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'ChromaEmbeddingFunctionTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}                       from '@playwright/test';
+import Neo                                  from '../../../../../../../src/Neo.mjs';
+import * as core                            from '../../../../../../../src/core/_export.mjs';
+import {createDynamicTextEmbeddingFunction} from '../../../../../../../ai/services/shared/vector/chromaClientPrimitives.mjs';
+import TextEmbeddingService                 from '../../../../../../../ai/services/memory-core/TextEmbeddingService.mjs';
+
+test.describe('Neo.ai.services.shared.vector.chromaClientPrimitives — dynamic embedding function (#13692)', () => {
+    test('generate() routes a batch through embedTexts (1h batch path), not per-text embedText (interactive 15s path)', async () => {
+        // Regression guard: Chroma's generate(texts) used to be
+        // `Promise.all(texts.map(t => embedText(t)))` — fanning every batch out as parallel
+        // INTERACTIVE embeds. That applied the 15s contentionTimeoutMs to bulk work AND stormed
+        // the single local embedder into self-contention. It must instead make ONE embedTexts
+        // batch call (the path with the 1h timeout + sequential chunks).
+        const calls    = {embedTexts: [], embedText: []},
+              origTexts = TextEmbeddingService.embedTexts,
+              origText  = TextEmbeddingService.embedText;
+
+        TextEmbeddingService.embedTexts = async (texts, provider) => {
+            calls.embedTexts.push({texts, provider});
+            return texts.map((_, i) => [i]); // ordered number[][], Chroma's generate contract
+        };
+        TextEmbeddingService.embedText = async (text, provider) => {
+            calls.embedText.push({text, provider});
+            return [0];
+        };
+
+        try {
+            const fn     = createDynamicTextEmbeddingFunction({providerResolver: () => 'openAiCompatible'}),
+                  result = await fn.generate(['a', 'b', 'c']);
+
+            expect(calls.embedText.length).toBe(0);              // never fan out to the interactive path
+            expect(calls.embedTexts.length).toBe(1);             // exactly one batch call
+            expect(calls.embedTexts[0].texts).toEqual(['a', 'b', 'c']);
+            expect(calls.embedTexts[0].provider).toBe('openAiCompatible');
+            expect(result).toEqual([[0], [1], [2]]);             // ordered embeddings flow back through
+        } finally {
+            TextEmbeddingService.embedTexts = origTexts;
+            TextEmbeddingService.embedText  = origText;
+        }
+    });
+});


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13692

## Summary
The shared Chroma dynamic embedding-function (`createDynamicTextEmbeddingFunction.generate`, behind every `collection.add()`) fanned each batch out as `Promise.all(texts.map(t => embedText(t)))` — the **interactive** embed path. That applied the 15s `contentionTimeoutMs` to bulk work AND stormed the single local embedder into self-contention, so bulk adds (the `add_memory` WAL drain, graph ingestion) timed out at 15s under load — surfacing as `Batch embed exhausted 6 attempts (… timed out after 15000ms)` and starving `who_is_online`'s health canary during the live heavy-maintenance incident.

Routing `generate()` through `embedTexts` (the batch path: 1h request timeout, sequential chunks of `batchEmbeddingChunkSize`, no parallel storm) fixes it at the root. `embedTexts` returns ordered `number[][]` — exactly Chroma's `generate` contract; the WAL drain's per-record isolation (`drainCycle.mjs:107`) still surfaces poison records.

## Deltas
- One-line routing change at `chromaClientPrimitives.mjs` (`Promise.all(map(embedText))` → `embedTexts(texts, provider)`), with a WHY comment.
- New regression spec — there was no prior coverage for the embed-function.
- No change to the interactive `embedText` 15s path (single latency-sensitive embeds keep it). **Out of scope:** raising `contentionTimeoutMs` — the path-swap removes the contention that made 15s fail; revisit only if interactive single-embeds still contend afterward.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/shared/vector/chromaClientPrimitives.spec.mjs` → **1 passed** (535ms). Asserts a multi-text `generate()` makes exactly one `embedTexts` call and zero `embedText` calls.
- Husky pre-commit green (jsdoc-types, ticket-archaeology, block-alignment).

Evidence: L2 (committed regression test exercising the routing) → L2 sufficient — a routing one-liner verified by a behavior test; the new contract (`embedTexts` → ordered `number[][]`) matches the prior `Promise.all(map(embedText))` output shape, so no caller sees a different return.

## Post-Merge Validation
- [ ] On the live MC under heavy-maintenance load (the github-workflow-sync holding the lease), the `add_memory` WAL drain no longer logs `Batch embed … timed out after 15000ms`; bulk embeds ride the 1h batch path. Observable in the orchestrator embed-daemon log, not in CI.

Refs #13624 (heavy-maintenance incident), #13498 (who_is_online canary leaf-4 — co-lands as the embedding-resilience set).
