### PR TITLE
fix(ai): exempt who_is_online from the embed-canary health gate (#13694)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -1,10 +1,10 @@
-import BaseServer                  from '../BaseServer.mjs';
-import logger                      from './logger.mjs';
-import {listTools, callTool}       from './toolService.mjs';
-import AuthMiddleware              from '../shared/services/AuthMiddleware.mjs';
-import RequestContextService       from '../shared/services/RequestContextService.mjs';
-import StdioIdentityResolver       from '../shared/services/StdioIdentityResolver.mjs';
-import BootEnvelopeResolver        from '../shared/services/BootEnvelopeResolver.mjs';
+import BaseServer            from '../BaseServer.mjs';
+import logger                from './logger.mjs';
+import {listTools, callTool} from './toolService.mjs';
+import AuthMiddleware        from '../shared/services/AuthMiddleware.mjs';
+import RequestContextService from '../shared/services/RequestContextService.mjs';
+import StdioIdentityResolver from '../shared/services/StdioIdentityResolver.mjs';
+import BootEnvelopeResolver  from '../shared/services/BootEnvelopeResolver.mjs';
 import {
     buildSqliteHolderDiagnostics,
     formatHarnessGroups
@@ -68,10 +68,10 @@ class Server extends BaseServer {
             name        : 'neo-memory-core',
             version     : process.env.npm_package_version || '1.0.0',
             capabilities: {
-                tools: {listChanged: false},
+                tools       : {listChanged: false},
                 experimental: {
                     'neo-wake-substrate': {
-                        version: '1.0',
+                        version        : '1.0',
                         supportedEvents: ['wake/sent_to_me', 'wake/task_state_changed', 'wake/permission_granted']
                     }
                 }
@@ -104,9 +104,11 @@ class Server extends BaseServer {
      *
      * The non-embedding reads are exempt for the same reason. The gate trips on the embedder canary
      * (a live `embedText` probe), but `get_session_memories` (a Chroma metadata `.get()` by
-     * sessionId) and `query_recent_turns` (a SQLite recency read over the `AGENT_MEMORY` graph, with
-     * a WAL-overlay fallback for its optional Chroma content join) call no embedder — they serve
-     * fine while it is down, so gating them only denied a read the outage never touched. NOT exempt:
+     * sessionId), `query_recent_turns` (a SQLite recency read over the `AGENT_MEMORY` graph, with a
+     * WAL-overlay fallback for its optional Chroma content join), and `who_is_online` (a SQLite
+     * `AgentIdentity`-roster liveness projection — graph-backed, survives an embed-drain) call no
+     * embedder — they serve fine while it is down, so gating them only denied a read the outage
+     * never touched. NOT exempt:
      * `query_raw_memories` / `query_summaries`, which embed the query and genuinely cannot serve
      * during an embedder outage — exempting them would trade a clean gate-reject for an embed-timeout.
      * @returns {Array<String>}
@@ -128,7 +130,8 @@ class Server extends BaseServer {
             'manage_wake_subscription',
             'record_turn_presence',
             'get_session_memories',
-            'query_recent_turns'
+            'query_recent_turns',
+            'who_is_online'
         ];
     }
 
@@ -365,10 +368,10 @@ class Server extends BaseServer {
         const agentIdentityNodeId = await this.bindAgentIdentity(reqAuth.userId);
 
         return {
-            userId             : reqAuth.userId,
-            username           : reqAuth.username,
+            userId  : reqAuth.userId,
+            username: reqAuth.username,
             agentIdentityNodeId,
-            source             : reqAuth.source || 'oidc'
+            source  : reqAuth.source || 'oidc'
         };
     }
 
@@ -412,10 +415,10 @@ class Server extends BaseServer {
         const agentIdentityNodeId = await this.bindAgentIdentity(resolved.githubLogin);
 
         return {
-            userId             : resolved.githubLogin,
-            username           : resolved.username,
+            userId  : resolved.githubLogin,
+            username: resolved.username,
             agentIdentityNodeId,
-            source             : resolved.source
+            source  : resolved.source
         };
     }
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -13,12 +13,12 @@ setup({
     }
 });
 
-import {test, expect}  from '@playwright/test';
+import {test, expect}          from '@playwright/test';
 import {CallToolRequestSchema} from '@modelcontextprotocol/sdk/types.js';
-import path            from 'path';
-import fs              from 'fs-extra';
-import Neo             from '../../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../../src/core/_export.mjs';
+import path                    from 'path';
+import fs                      from 'fs-extra';
+import Neo                     from '../../../../../../../src/Neo.mjs';
+import * as core               from '../../../../../../../src/core/_export.mjs';
 import '../../../../../../../src/manager/Instance.mjs';
 
 
@@ -426,6 +426,24 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
             expect(exemptTools).not.toContain('start_database');
             expect(exemptTools).not.toContain('stop_database');
+        } finally {
+            serverInstance.destroy();
+        }
+    });
+
+    test('#13694: who_is_online is health-exempt (graph-backed liveness read survives an embed-drain)', async () => {
+        const serverInstance = await createServerWithoutBoot();
+
+        try {
+            const exemptTools = serverInstance.getHealthExemptTools();
+
+            // who_is_online → WakeSubscriptionService.whoIsOnline is a SQLite AgentIdentity-roster
+            // recency read (no embedder), so it must serve while the embed-canary is down — gating it
+            // only denied a read the outage never touched.
+            expect(exemptTools).toContain('who_is_online');
+            // The must-embed reads stay NON-exempt (exempting them trades a clean reject for a timeout).
+            expect(exemptTools).not.toContain('query_raw_memories');
+            expect(exemptTools).not.toContain('query_summaries');
         } finally {
             serverInstance.destroy();
         }


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13694 — the #13498 leaf-4 edit-half (co-authored split with @neo-opus-grace, who owns the read-degradation policy invariant + the broader exempt-set test). Refs #13498, #13624.

## Summary

`who_is_online` failed loud during an embedder outage this session, but it's a **graph-backed `AgentIdentity`-roster recency read** (no embedder) — exactly the class the memory-core health gate's documented invariant exempts (`Server.mjs:104-111` — no-embedder → exempt; must-embed → fail-loud). It was simply missing from the allow-list.

- Adds `'who_is_online'` to `getHealthExemptTools()` (`ai/mcp/server/memory-core/Server.mjs`).
- Extends the JSDoc exempt-rationale to name it — `WakeSubscriptionService.whoIsOnline` → `_listAgentIdentityNodes` is a SQLite `prepare().all()` over `AgentIdentity` `Nodes`; its docstring (`:559`) states liveness is *"graph-backed (survives an embed-drain)"*.
- Adds a per-tool exempt unit test: `who_is_online` ∈ exempt set, and the must-embed reads (`query_raw_memories` / `query_summaries`) stay **NON**-exempt (exempting them would trade a clean reject for an embed-timeout).

## Deltas

**Mechanical block-alignment re-flow (pre-existing drift, not my logical change).** lint-staged's full-file block-alignment surfaced pre-existing drift in both touched files (an object-literal in `Server.mjs`, the import block in `Server.spec.mjs`); ran the sanctioned `check-block-alignment.mjs --fix` (mechanical, no logic change). My logical change is the `who_is_online` exempt entry + the JSDoc + the test.

## Test Evidence

Evidence: L2 (unit) — the AC is static (`who_is_online` ∈ `getHealthExemptTools()`); the gate behavior itself is already covered by the existing `#12978` / `#12838` embedder-gate regression tests (the gate mechanism bypasses any exempt-list member, so the new entry inherits that proven behavior).

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs` → **10 passed** (incl. the new `#13694` test + the existing embedder-gate regressions).

## Co-authorship

The edit-half of #13498 leaf-4. @neo-opus-grace co-lands the read-degradation **policy invariant** (the doc) + the **broader exempt-set pinning test**, kept coherent with #13692 (the embed-path batch fix — the root-cause of the canary timeout) as the embedding-resilience set under #13624.

## Post-Merge Validation

- None required — the exempt-list is a static allow-list (unit-covered); the gate behavior is config-independent.
