### PR TITLE
fix(ai): age-drain and repair unprojected sessions (#13697)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -1,27 +1,27 @@
-import fs from 'fs';
-import path from 'path';
-import yaml from 'js-yaml';
-import { fileURLToPath } from 'url';
-import crypto from 'crypto';
-import { Memory_Config as aiConfig } from '../../../services.mjs';
-import Base from '../../../../src/core/Base.mjs';
-import { Memory_StorageRouter as StorageRouter } from '../../../services.mjs';
+import fs                                                      from 'fs';
+import path                                                    from 'path';
+import yaml                                                    from 'js-yaml';
+import { fileURLToPath }                                       from 'url';
+import crypto                                                  from 'crypto';
+import { Memory_Config as aiConfig }                           from '../../../services.mjs';
+import Base                                                    from '../../../../src/core/Base.mjs';
+import { Memory_StorageRouter as StorageRouter }               from '../../../services.mjs';
 import { Memory_TextEmbeddingService as TextEmbeddingService } from '../../../services.mjs';
-import { Memory_GraphService as GraphService } from '../../../services.mjs';
-import Json from '../../../../src/util/Json.mjs';
-import logger from '../../../mcp/server/memory-core/logger.mjs';
-import AdrIngestor from '../../../services/ingestion/AdrIngestor.mjs';
-import ConceptDiscoveryService from '../../../services/ingestion/ConceptDiscoveryService.mjs';
-import ConceptIngestor from '../../../services/ingestion/ConceptIngestor.mjs';
-import FileSystemIngestor from '../../../services/memory-core/FileSystemIngestor.mjs';
-import GapInferenceEngine from '../../../services/graph/GapInferenceEngine.mjs';
-import GraphMaintenanceService from '../../../services/graph/GraphMaintenanceService.mjs';
-import IssueIngestor from '../../../services/ingestion/IssueIngestor.mjs';
-import MemorySessionIngestor from '../../../services/ingestion/MemorySessionIngestor.mjs';
-import SemanticGraphExtractor from '../../../services/graph/SemanticGraphExtractor.mjs';
-import TopologyInferenceEngine from '../../../services/graph/TopologyInferenceEngine.mjs';
-import GoldenPathSynthesizer from '../../../services/graph/GoldenPathSynthesizer.mjs';
-import AiConfig from '../../../config.mjs';
+import { Memory_GraphService as GraphService }                 from '../../../services.mjs';
+import Json                                                    from '../../../../src/util/Json.mjs';
+import logger                                                  from '../../../mcp/server/memory-core/logger.mjs';
+import AdrIngestor                                             from '../../../services/ingestion/AdrIngestor.mjs';
+import ConceptDiscoveryService                                 from '../../../services/ingestion/ConceptDiscoveryService.mjs';
+import ConceptIngestor                                         from '../../../services/ingestion/ConceptIngestor.mjs';
+import FileSystemIngestor                                      from '../../../services/memory-core/FileSystemIngestor.mjs';
+import GapInferenceEngine                                      from '../../../services/graph/GapInferenceEngine.mjs';
+import GraphMaintenanceService                                 from '../../../services/graph/GraphMaintenanceService.mjs';
+import IssueIngestor                                           from '../../../services/ingestion/IssueIngestor.mjs';
+import MemorySessionIngestor                                   from '../../../services/ingestion/MemorySessionIngestor.mjs';
+import SemanticGraphExtractor                                  from '../../../services/graph/SemanticGraphExtractor.mjs';
+import TopologyInferenceEngine                                 from '../../../services/graph/TopologyInferenceEngine.mjs';
+import GoldenPathSynthesizer                                   from '../../../services/graph/GoldenPathSynthesizer.mjs';
+import AiConfig                                                from '../../../config.mjs';
 import {
     assertProviderReadinessConfig,
     buildOllamaReadinessConfig,
@@ -39,6 +39,8 @@ import {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+const UNDIGESTED_SESSION_FRESH_RESERVE = 2;
 
 function estimatePayloadTokens(payload) {
     const text = payload === undefined || payload === null ? '' : String(payload);
@@ -85,6 +87,68 @@ function readRequiredNumberLeaf(leafName) {
     }
 
     return value;
+}
+
+function resolveSessionTimestamp(meta = {}) {
+    const value = meta.timestamp ?? meta.lastActivity ?? meta.updatedAt ?? meta.createdAt;
+
+    if (Number.isFinite(value)) {
+        return value;
+    }
+
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+        return numeric;
+    }
+
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function compareSessionRows(direction) {
+    return (a, b) => {
+        const diff = resolveSessionTimestamp(a.meta) - resolveSessionTimestamp(b.meta);
+
+        if (diff !== 0) {
+            return direction === 'ASC' ? diff : -diff;
+        }
+
+        return String(a.id).localeCompare(String(b.id));
+    }
+}
+
+function addUndigestedRowsFromBatch(batch, byId) {
+    if (!batch?.ids?.length) {
+        return;
+    }
+
+    for (let i = 0; i < batch.ids.length; i++) {
+        const meta = batch.metadatas?.[i];
+
+        if (meta && meta.graphDigested !== true && meta.graphDigested !== 'true') {
+            byId.set(batch.ids[i], {
+                id      : batch.ids[i],
+                document: batch.documents?.[i],
+                meta
+            });
+        }
+    }
+}
+
+function splitFreshAndAgedUndigested(rows, maxToProcess) {
+    if (maxToProcess <= 0 || rows.length === 0) {
+        return [];
+    }
+
+    const reserve = maxToProcess > 1 ? Math.min(UNDIGESTED_SESSION_FRESH_RESERVE, maxToProcess - 1) : maxToProcess;
+    const fresh   = [...rows].sort(compareSessionRows('DESC')).slice(0, reserve);
+    const freshIds = new Set(fresh.map(row => row.id));
+    const aged = [...rows]
+        .filter(row => !freshIds.has(row.id))
+        .sort(compareSessionRows('ASC'))
+        .slice(0, maxToProcess - fresh.length);
+
+    return [...fresh, ...aged];
 }
 
 /**
@@ -146,38 +210,54 @@ class DreamService extends Base {
 
     /**
      * Identifies session summaries that do not have the 'graphDigested' metadata flag set to true.
+     *
+     * The scan samples both the fresh head and aged tail of the Chroma summary collection, then splits
+     * the returned REM batch across newest and oldest undigested summaries. This mirrors the
+     * miniSummary backfill pattern: keep a small fresh reserve for recent work, while the aged drain
+     * steadily reaches long-lived projection lag instead of re-serving the same head window forever.
+     *
      * @returns {Promise<Object[]>} List of metadata objects for undigested sessions
      */
     async findUndigestedSessions() {
         // Since ChromaDB filtering on missing attributes can be tricky depending on version,
-        // we'll fetch recent sessions and filter in memory if the dataset is reasonable.
-        // For production, we will just query specifically.
-        const limit = readRequiredNumberLeaf('summarizationBatchLimit');
-        const maxToProcess = readRequiredNumberLeaf('remSleepBatchLimit');
+        // filter in memory after sampling the collection head and tail. Chroma does not expose
+        // SQL-style ORDER BY, so metadata timestamps define the fresh/aged split.
+        const limit        = Math.max(1, Math.floor(readRequiredNumberLeaf('summarizationBatchLimit')));
+        const maxToProcess = Math.max(0, Math.floor(readRequiredNumberLeaf('remSleepBatchLimit')));
+
+        if (maxToProcess === 0) {
+            return [];
+        }
 
         try {
-            const batch = await this.sessionsCollection.get({
+            const byId = new Map();
+            const readBatch = offset => this.sessionsCollection.get({
                 include: ['metadatas', 'documents'],
-                limit
+                limit,
+                offset
             });
 
-            if (!batch || !batch.ids.length) {
-                return [];
-            }
+            addUndigestedRowsFromBatch(await readBatch(0), byId);
 
-            const undigested = [];
-            for (let i = 0; i < batch.ids.length; i++) {
-                const meta = batch.metadatas[i];
-                if (meta && meta.graphDigested !== true && meta.graphDigested !== 'true') {
-                    undigested.push({
-                        id: batch.ids[i],
-                        document: batch.documents[i],
-                        meta
-                    });
+            let collectionCount = null;
+            if (typeof this.sessionsCollection.count === 'function') {
+                try {
+                    collectionCount = await this.sessionsCollection.count();
+                } catch (error) {
+                    logger.warn(`[DreamService] count() failed while preparing aged undigested-session scan; using head window only: ${error.message}`);
                 }
             }
 
-            return undigested.slice(0, maxToProcess);
+            const tailOffset = Number.isFinite(collectionCount) ? Math.max(0, collectionCount - limit) : 0;
+            if (tailOffset > 0) {
+                addUndigestedRowsFromBatch(await readBatch(tailOffset), byId);
+            }
+
+            if (byId.size === 0) {
+                return [];
+            }
+
+            return splitFreshAndAgedUndigested([...byId.values()], maxToProcess);
         } catch (error) {
             logger.error('[DreamService] Error querying undigested sessions:', error);
             return [];
@@ -287,7 +367,7 @@ class DreamService extends Base {
                         const memoryCollection = await StorageRouter.getMemoryCollection();
                         if (memoryCollection) {
                             const rawMemories = await memoryCollection.get({
-                                where: { sessionId: session.meta.sessionId },
+                                where  : { sessionId: session.meta.sessionId },
                                 include: ['documents']
                             });
                             if (rawMemories?.documents?.length > 0) {
@@ -444,7 +524,7 @@ class DreamService extends Base {
 
                     if (success && ingestErrors === 0) {
                         await this.sessionsCollection.update({
-                            ids: [session.id],
+                            ids      : [session.id],
                             metadatas: [{ ...session.meta, graphDigested: true }]
                         });
                         sessionState.graphDigestedFlag = true;
@@ -668,8 +748,8 @@ class DreamService extends Base {
                     const message = toErrorMessage(e);
                     perPhaseStates.push(finishPhase('decay', decayStart, 'failed', {error: message}));
                     return await finalize('failed', {
-                        reasonCode       : 'decay-failed',
-                        failurePhase     : 'decay',
+                        reasonCode  : 'decay-failed',
+                        failurePhase: 'decay',
                         error            : {message: `decayGlobalTopology threw on zero-session path: ${message}`, stack: e?.stack},
                         sessionsProcessed: 0
                     });

--- a/ai/scripts/maintenance/repairUnprojectedSessions.mjs
+++ b/ai/scripts/maintenance/repairUnprojectedSessions.mjs
@@ -1,0 +1,350 @@
+import {pathToFileURL} from 'url';
+
+export const DEFAULT_BATCH_SIZE = 500;
+export const DEFAULT_LIMIT      = 50;
+
+const SUCCESS_REASONS = new Set(['already-exists', 'backfilled', 'backfilled-minimal']);
+
+/**
+ * @param {*} value
+ * @param {Number} fallback
+ * @returns {Number}
+ */
+export function normalizePositiveInteger(value, fallback) {
+    const parsed = Number(value);
+
+    return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback
+}
+
+/**
+ * @param {*} value
+ * @param {Number|null} fallback
+ * @returns {Number|null}
+ */
+export function normalizeCandidateLimit(value, fallback = DEFAULT_LIMIT) {
+    if (value === 'all') {
+        return null
+    }
+
+    return normalizePositiveInteger(value, fallback)
+}
+
+/**
+ * @param {String} sessionId
+ * @returns {String|null}
+ */
+export function createSessionGraphId(sessionId) {
+    if (!sessionId || typeof sessionId !== 'string') {
+        return null
+    }
+
+    return 'session:' + sessionId.replace(/^session:/i, '')
+}
+
+/**
+ * @param {Object} meta
+ * @returns {Boolean}
+ */
+export function isGraphDigested(meta = {}) {
+    return meta.graphDigested === true || meta.graphDigested === 'true'
+}
+
+/**
+ * @param {Object} batch
+ * @returns {Object[]}
+ */
+export function extractSummaryRows(batch) {
+    if (!batch?.ids?.length) {
+        return []
+    }
+
+    return batch.ids.map((id, index) => ({
+        chromaId: id,
+        meta    : batch.metadatas?.[index] || {}
+    }))
+}
+
+/**
+ * @param {Object} options
+ * @param {Object} options.graphDb
+ * @param {String} options.graphNodeId
+ * @returns {Boolean}
+ */
+export function hasDurableSessionNode({graphDb, graphNodeId} = {}) {
+    if (!graphDb?.prepare || !graphNodeId) {
+        return false
+    }
+
+    const row = graphDb.prepare(`
+        SELECT 1 AS found
+        FROM Nodes
+        WHERE id = ?
+          AND json_extract(data, '$.label') = 'SESSION'
+        LIMIT 1
+    `).get(graphNodeId);
+
+    return Boolean(row)
+}
+
+/**
+ * @param {Number} count
+ * @param {Number|null} limit
+ * @returns {Boolean}
+ */
+function hasCandidateCapacity(count, limit) {
+    return limit === null || count < limit
+}
+
+/**
+ * @summary Scans Chroma session summaries for graphDigested rows whose durable SESSION graph
+ * node is missing. This targets the one-time hard-orphan repair: rows already marked digested
+ * will not be re-selected by DreamService, so they need explicit projection repair.
+ * @param {Object} options
+ * @param {Object} options.summaryCollection Chroma summary collection.
+ * @param {Object} options.graphDb SQLite graph database handle.
+ * @param {Number} [options.batchSize=DEFAULT_BATCH_SIZE]
+ * @param {Number|null} [options.limit=DEFAULT_LIMIT] Max candidates; `null` means no cap.
+ * @param {Boolean} [options.digestedOnly=true] True limits repair to `graphDigested:true` rows.
+ * @returns {Promise<Object>}
+ */
+export async function findUnprojectedSessions({
+    summaryCollection,
+    graphDb,
+    batchSize    = DEFAULT_BATCH_SIZE,
+    limit        = DEFAULT_LIMIT,
+    digestedOnly = true
+} = {}) {
+    if (!summaryCollection?.count || !summaryCollection?.get) {
+        throw new Error('repairUnprojectedSessions requires a Chroma summary collection with count() and get().')
+    }
+    if (!graphDb?.prepare) {
+        throw new Error('repairUnprojectedSessions requires a SQLite graph database handle.')
+    }
+
+    const
+        resolvedBatchSize = normalizePositiveInteger(batchSize, DEFAULT_BATCH_SIZE),
+        resolvedLimit     = limit === null ? null : normalizeCandidateLimit(limit),
+        total             = await summaryCollection.count(),
+        candidates        = [],
+        stats             = {
+            total,
+            scanned            : 0,
+            skippedNoSessionId : 0,
+            skippedNotDigested : 0,
+            skippedAlreadyGraph: 0
+        };
+
+    for (let offset = 0; offset < total && hasCandidateCapacity(candidates.length, resolvedLimit); offset += resolvedBatchSize) {
+        const page = await summaryCollection.get({
+            include: ['metadatas'],
+            limit  : Math.min(resolvedBatchSize, total - offset),
+            offset
+        });
+
+        for (const row of extractSummaryRows(page)) {
+            if (!hasCandidateCapacity(candidates.length, resolvedLimit)) {
+                break;
+            }
+
+            stats.scanned++;
+
+            if (digestedOnly && !isGraphDigested(row.meta)) {
+                stats.skippedNotDigested++;
+                continue;
+            }
+
+            const graphNodeId = createSessionGraphId(row.meta.sessionId);
+
+            if (!graphNodeId) {
+                stats.skippedNoSessionId++;
+                continue;
+            }
+
+            if (hasDurableSessionNode({graphDb, graphNodeId})) {
+                stats.skippedAlreadyGraph++;
+                continue;
+            }
+
+            candidates.push({
+                chromaId : row.chromaId,
+                sessionId: row.meta.sessionId,
+                graphNodeId
+            });
+        }
+    }
+
+    return {candidates, stats}
+}
+
+/**
+ * @param {Object} options
+ * @param {Object} options.summaryCollection
+ * @param {Object} options.graphDb
+ * @param {Object} [options.memorySessionIngestor]
+ * @param {Boolean} [options.apply=false]
+ * @param {Number} [options.batchSize=DEFAULT_BATCH_SIZE]
+ * @param {Number|null} [options.limit=DEFAULT_LIMIT]
+ * @param {Boolean} [options.digestedOnly=true]
+ * @returns {Promise<Object>}
+ */
+export async function repairUnprojectedSessions({
+    summaryCollection,
+    graphDb,
+    memorySessionIngestor,
+    apply        = false,
+    batchSize    = DEFAULT_BATCH_SIZE,
+    limit        = DEFAULT_LIMIT,
+    digestedOnly = true
+} = {}) {
+    const scan = await findUnprojectedSessions({
+        summaryCollection,
+        graphDb,
+        batchSize,
+        limit,
+        digestedOnly
+    });
+
+    const results = [];
+
+    if (apply) {
+        if (!memorySessionIngestor?.ingestSingleRow) {
+            throw new Error('repairUnprojectedSessions --apply requires MemorySessionIngestor.ingestSingleRow().')
+        }
+
+        for (const candidate of scan.candidates) {
+            const result = await memorySessionIngestor.ingestSingleRow(candidate.graphNodeId, {summaryCollection});
+
+            results.push({
+                ...candidate,
+                success: result?.success === true && SUCCESS_REASONS.has(result.reason),
+                reason : result?.reason || 'unknown',
+                error  : result?.error
+            });
+        }
+    }
+
+    const failed = results.filter(result => result.success === false);
+
+    return {
+        mode      : apply ? 'apply' : 'dry-run',
+        digestedOnly,
+        candidates: scan.candidates.length,
+        repaired  : results.filter(result => result.success === true).length,
+        failed    : failed.length,
+        stats     : scan.stats,
+        results   : apply ? results : scan.candidates
+    }
+}
+
+/**
+ * @param {String[]} argv
+ * @returns {Object}
+ */
+export function parseArgs(argv = []) {
+    const options = {
+        apply       : false,
+        batchSize   : DEFAULT_BATCH_SIZE,
+        digestedOnly: true,
+        help        : false,
+        limit       : DEFAULT_LIMIT
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+
+        if (arg === '--apply') {
+            options.apply = true;
+        } else if (arg === '--dry-run') {
+            options.apply = false;
+        } else if (arg === '--include-undigested') {
+            options.digestedOnly = false;
+        } else if (arg === '--help' || arg === '-h') {
+            options.help = true;
+        } else if (arg === '--batch-size') {
+            options.batchSize = normalizePositiveInteger(argv[++i], DEFAULT_BATCH_SIZE);
+        } else if (arg === '--limit') {
+            options.limit = normalizeCandidateLimit(argv[++i], DEFAULT_LIMIT);
+        } else {
+            throw new Error(`Unknown argument: ${arg}`)
+        }
+    }
+
+    return options
+}
+
+/**
+ * @returns {Promise<Object>}
+ */
+export async function createRuntime() {
+    await import('../../../src/Neo.mjs');
+    await import('../../../src/core/_export.mjs');
+
+    const {
+        Memory_GraphService    : GraphService,
+        Memory_LifecycleService: LifecycleService,
+        Memory_StorageRouter   : StorageRouter
+    } = await import('../../services.mjs');
+    const {default: MemorySessionIngestor} = await import('../../services/ingestion/MemorySessionIngestor.mjs');
+
+    await LifecycleService.initAsync();
+    await GraphService.initAsync();
+    await StorageRouter.initAsync();
+
+    const
+        summaryCollection = await StorageRouter.getSummaryCollection(),
+        graphDb           = GraphService.db?.storage?.db;
+
+    if (!graphDb) {
+        throw new Error('GraphService SQLite database is unavailable; cannot repair SESSION projection drift.')
+    }
+
+    return {
+        graphDb,
+        memorySessionIngestor: MemorySessionIngestor,
+        summaryCollection
+    }
+}
+
+export function usage() {
+    return [
+        'Usage: node ai/scripts/maintenance/repairUnprojectedSessions.mjs [--dry-run|--apply] [--limit N|all] [--batch-size N] [--include-undigested]',
+        '',
+        'Default: dry-run, --limit 50, only graphDigested=true rows.',
+        '--apply mutates the Native Edge Graph by backfilling missing session:<sessionId> nodes from Chroma summaries.',
+        '--include-undigested is diagnostic; the default avoids masking DreamService work still owed by graphDigested=false/unset rows.'
+    ].join('\n')
+}
+
+/**
+ * @param {String[]} [argv=process.argv.slice(2)]
+ * @param {Object} [deps]
+ * @returns {Promise<Number>} process exit code
+ */
+export async function runCli(argv = process.argv.slice(2), {
+    runtimeFactory = createRuntime,
+    stdout         = console.log,
+    stderr         = console.error
+} = {}) {
+    try {
+        const options = parseArgs(argv);
+
+        if (options.help) {
+            stdout(usage());
+            return 0
+        }
+
+        const runtime = await runtimeFactory();
+        const result  = await repairUnprojectedSessions({...runtime, ...options});
+
+        stdout(JSON.stringify(result, null, 2));
+
+        return result.failed === 0 ? 0 : 1
+    } catch (error) {
+        stderr(`[repairUnprojectedSessions] ${error.message}`);
+        return 2
+    }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    runCli().then(code => process.exit(code));
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -13,13 +13,13 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
-import fs             from 'fs';
-import path           from 'path';
-import os             from 'os';
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../../src/core/_export.mjs';
+import InstanceManager       from '../../../../../../../src/manager/Instance.mjs';
+import fs                    from 'fs';
+import path                  from 'path';
+import os                    from 'os';
 import {TestLifecycleHelper} from '../../../services/memory-core/util.mjs';
 
 test.describe('Neo.ai.services.memory-core.DreamService', () => {
@@ -93,7 +93,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             providerPrompt = prompt;
             return {
                 content: JSON.stringify({
-                    action: "alert",
+                    action : "alert",
                     message: "- **[Codebase Gap]** Node `ButtonFeature`: Mock Gap detected."
                 })
             };
@@ -187,17 +187,17 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             session_artifact: {
                 graph: {
                     nodes: [{
-                        id           : 'node-feature-1',
-                        type         : 'CLASS', // Changed from CONCEPT to bypass filter
-                        name         : 'ButtonFeature',
-                        description  : 'A newly formulated architectural concept.',
-                        confidence   : 0.9,
-                        logical_layer: 'UI Components',
-                        stability    : 'EXPERIMENTAL',
-                        gravity_well : true,
+                        id              : 'node-feature-1',
+                        type            : 'CLASS', // Changed from CONCEPT to bypass filter
+                        name            : 'ButtonFeature',
+                        description     : 'A newly formulated architectural concept.',
+                        confidence      : 0.9,
+                        logical_layer   : 'UI Components',
+                        stability       : 'EXPERIMENTAL',
+                        gravity_well    : true,
                         strategic_weight: 0.85,
-                        tags         : ['Frontend', 'button'],
-                        _resolvedId  : 'mock-file-1'
+                        tags            : ['Frontend', 'button'],
+                        _resolvedId     : 'mock-file-1'
                     }],
                     edges: []
                 }
@@ -340,6 +340,61 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         }
     });
 
+    test('findUndigestedSessions mixes a fresh reserve with the aged Chroma tail (#13697)', async () => {
+        const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const original = {
+            summarizationBatchLimit: aiConfig.summarizationBatchLimit,
+            remSleepBatchLimit     : aiConfig.remSleepBatchLimit,
+            sessionsCollection     : DreamService.sessionsCollection
+        };
+
+        const rows = [
+            {id: 'fresh-5', document: 'fresh 5', meta: {sessionId: 'fresh-5', timestamp: 5000}},
+            {id: 'fresh-4', document: 'fresh 4', meta: {sessionId: 'fresh-4', timestamp: 4000}},
+            {id: 'fresh-3', document: 'fresh 3', meta: {sessionId: 'fresh-3', timestamp: 3000}},
+            {id: 'fresh-2', document: 'fresh 2', meta: {sessionId: 'fresh-2', timestamp: 2000}},
+            {id: 'fresh-1', document: 'fresh 1', meta: {sessionId: 'fresh-1', timestamp: 1000}},
+            {id: 'digested-old', document: 'digested', meta: {sessionId: 'digested-old', timestamp: 5, graphDigested: 'true'}},
+            {id: 'old-3', document: 'old 3', meta: {sessionId: 'old-3', timestamp: 30}},
+            {id: 'old-2', document: 'old 2', meta: {sessionId: 'old-2', timestamp: 20}},
+            {id: 'old-1', document: 'old 1', meta: {sessionId: 'old-1', timestamp: 10}},
+            {id: 'mid', document: 'mid', meta: {sessionId: 'mid', timestamp: 500}}
+        ];
+        const calls = [];
+
+        aiConfig.summarizationBatchLimit = 6;
+        aiConfig.remSleepBatchLimit      = 4;
+        DreamService.sessionsCollection  = {
+            async count() {
+                return rows.length
+            },
+            async get({include, limit, offset = 0}) {
+                calls.push({include, limit, offset});
+                const page = rows.slice(offset, offset + limit);
+                return {
+                    ids      : page.map(row => row.id),
+                    documents: page.map(row => row.document),
+                    metadatas: page.map(row => row.meta)
+                }
+            }
+        };
+
+        try {
+            const result = await DreamService.findUndigestedSessions();
+
+            expect(calls).toEqual([
+                {include: ['metadatas', 'documents'], limit: 6, offset: 0},
+                {include: ['metadatas', 'documents'], limit: 6, offset: 4}
+            ]);
+            expect(result.map(row => row.id)).toEqual(['fresh-5', 'fresh-4', 'old-1', 'old-2']);
+            expect(result.map(row => row.meta.sessionId)).toEqual(['fresh-5', 'fresh-4', 'old-1', 'old-2']);
+        } finally {
+            aiConfig.summarizationBatchLimit = original.summarizationBatchLimit ?? 2000;
+            aiConfig.remSleepBatchLimit      = original.remSleepBatchLimit ?? 10;
+            DreamService.sessionsCollection  = original.sessionsCollection;
+        }
+    });
+
     test('should detect GUIDE_GAP via concept-graph edge traversal (no LLM verification)', async () => {
         // Capability-gap rewrite: replaces the pre-refactor regex + LLM Boolean verification path with
         // deterministic outbound-EXPLAINED_BY edge traversal. Two CONCEPT nodes planted in the
@@ -420,10 +475,10 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
 
         KBRecorderService.listAgentFaqs = () => ({
             faqs: [{
-                clusterId              : 'kb-demand-cluster',
-                canonicalQuery         : 'How should agents use ask_knowledge_base?',
-                count                  : 3,
-                relatedConceptIds      : ['concept-kb-demand'],
+                clusterId             : 'kb-demand-cluster',
+                canonicalQuery        : 'How should agents use ask_knowledge_base?',
+                count                 : 3,
+                relatedConceptIds     : ['concept-kb-demand'],
                 hasStrongGuideCoverage: false
             }]
         });
@@ -737,20 +792,20 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         let conceptGapCalledAfterLastSessionUpdate = false;
 
         const orig = {
-            provider           : aiConfig.modelProvider,
-            findUndigested     : DreamService.findUndigestedSessions,
-            sessionsCollection : DreamService.sessionsCollection,
-            inferTest          : DreamService.inferTestGapsFromSession,
-            inferConcept       : DreamService.inferConceptGraphGaps,
-            runGarbageCol      : DreamService.runGarbageCollection,
-            synthesizeGolden   : DreamService.synthesizeGoldenPath,
-            triVector          : SemanticGraphExtractor.executeTriVectorExtraction,
-            syncSession        : MemorySessionIngestor.syncSessionToGraph,
-            syncAdrs           : AdrIngestor.syncAdrsToGraph,
-            syncConcepts       : ConceptIngestor.syncConceptsToGraph,
-            syncFs             : FileSystemIngestor.syncWorkspaceToGraph,
-            extractTopo        : TopologyInferenceEngine.extractTopology,
-            isProcessing       : DreamService.isProcessing
+            provider          : aiConfig.modelProvider,
+            findUndigested    : DreamService.findUndigestedSessions,
+            sessionsCollection: DreamService.sessionsCollection,
+            inferTest         : DreamService.inferTestGapsFromSession,
+            inferConcept      : DreamService.inferConceptGraphGaps,
+            runGarbageCol     : DreamService.runGarbageCollection,
+            synthesizeGolden  : DreamService.synthesizeGoldenPath,
+            triVector         : SemanticGraphExtractor.executeTriVectorExtraction,
+            syncSession       : MemorySessionIngestor.syncSessionToGraph,
+            syncAdrs          : AdrIngestor.syncAdrsToGraph,
+            syncConcepts      : ConceptIngestor.syncConceptsToGraph,
+            syncFs            : FileSystemIngestor.syncWorkspaceToGraph,
+            extractTopo       : TopologyInferenceEngine.extractTopology,
+            isProcessing      : DreamService.isProcessing
         };
 
         try {
@@ -830,23 +885,23 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         const warnMessages   = [];
 
         const orig = {
-            provider           : aiConfig.modelProvider,
-            findUndigested     : DreamService.findUndigestedSessions,
-            sessionsCollection : DreamService.sessionsCollection,
-            inferTest          : DreamService.inferTestGapsFromSession,
-            inferConcept       : DreamService.inferConceptGraphGaps,
-            runGarbageCol      : DreamService.runGarbageCollection,
-            synthesizeGolden   : DreamService.synthesizeGoldenPath,
-            triVector          : SemanticGraphExtractor.executeTriVectorExtraction,
-            syncSession        : MemorySessionIngestor.syncSessionToGraph,
-            syncAdrs           : AdrIngestor.syncAdrsToGraph,
-            syncConcepts       : ConceptIngestor.syncConceptsToGraph,
-            syncFs             : FileSystemIngestor.syncWorkspaceToGraph,
-            extractTopo        : TopologyInferenceEngine.extractTopology,
-            getMemory          : StorageRouter.getMemoryCollection,
-            loggerInfo         : logger.info,
-            loggerWarn         : logger.warn,
-            isProcessing       : DreamService.isProcessing
+            provider          : aiConfig.modelProvider,
+            findUndigested    : DreamService.findUndigestedSessions,
+            sessionsCollection: DreamService.sessionsCollection,
+            inferTest         : DreamService.inferTestGapsFromSession,
+            inferConcept      : DreamService.inferConceptGraphGaps,
+            runGarbageCol     : DreamService.runGarbageCollection,
+            synthesizeGolden  : DreamService.synthesizeGoldenPath,
+            triVector         : SemanticGraphExtractor.executeTriVectorExtraction,
+            syncSession       : MemorySessionIngestor.syncSessionToGraph,
+            syncAdrs          : AdrIngestor.syncAdrsToGraph,
+            syncConcepts      : ConceptIngestor.syncConceptsToGraph,
+            syncFs            : FileSystemIngestor.syncWorkspaceToGraph,
+            extractTopo       : TopologyInferenceEngine.extractTopology,
+            getMemory         : StorageRouter.getMemoryCollection,
+            loggerInfo        : logger.info,
+            loggerWarn        : logger.warn,
+            isProcessing      : DreamService.isProcessing
         };
 
         try {
@@ -1178,10 +1233,10 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         StorageRouter.getGraphCollection = async () => {
             return {
                 query: async () => ({
-                    ids: [['epic-1', 'task-blocked', 'blocker', 'weak-task', 'rejected-task']],
+                    ids      : [['epic-1', 'task-blocked', 'blocker', 'weak-task', 'rejected-task']],
                     distances: [[0.1, 0.2, 0.9, 0.8, 0.05]]
                 }),
-                get: async () => ({ ids: [], metadatas: [] }),
+                get   : async () => ({ ids: [], metadatas: [] }),
                 upsert: async () => {}
             };
         };
@@ -1340,8 +1395,8 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             // On attempt 3, return valid Tri-Vector
             return {
                 content: JSON.stringify({
-                    a2a_version: "1.0",
-                    agent_id: "Antigravity",
+                    a2a_version     : "1.0",
+                    agent_id        : "Antigravity",
                     session_artifact: {
                         graph: {
                             nodes: [],
@@ -1356,7 +1411,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
 
         try {
             const session = {
-                meta: { sessionId: 'playwright-retry-test' },
+                meta    : { sessionId: 'playwright-retry-test' },
                 document: "Mock episodic history"
             };
 

--- a/test/playwright/unit/ai/scripts/maintenance/repairUnprojectedSessions.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairUnprojectedSessions.spec.mjs
@@ -1,0 +1,152 @@
+import {setup} from '../../../../setup.mjs';
+
+setup();
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    createSessionGraphId,
+    findUnprojectedSessions,
+    parseArgs,
+    repairUnprojectedSessions
+} from '../../../../../../ai/scripts/maintenance/repairUnprojectedSessions.mjs';
+
+void Neo;
+void core;
+
+function createSummaryCollection(rows, calls = []) {
+    return {
+        async count() {
+            return rows.length
+        },
+        async get({include, limit, offset = 0}) {
+            calls.push({include, limit, offset});
+
+            const page = rows.slice(offset, offset + limit);
+
+            return {
+                ids      : page.map(row => row.chromaId),
+                metadatas: page.map(row => row.meta)
+            }
+        }
+    }
+}
+
+function createGraphDb(existingIds = []) {
+    const existing = new Set(existingIds);
+
+    return {
+        prepare() {
+            return {
+                get(id) {
+                    return existing.has(id) ? {found: 1} : undefined
+                }
+            }
+        }
+    }
+}
+
+test.describe('ai/scripts/maintenance/repairUnprojectedSessions', () => {
+    test('parses safe dry-run defaults and explicit apply flags', () => {
+        expect(parseArgs([])).toEqual({
+            apply       : false,
+            batchSize   : 500,
+            digestedOnly: true,
+            help        : false,
+            limit       : 50
+        });
+
+        expect(parseArgs(['--apply', '--limit', 'all', '--batch-size', '25', '--include-undigested'])).toEqual({
+            apply       : true,
+            batchSize   : 25,
+            digestedOnly: false,
+            help        : false,
+            limit       : null
+        });
+    });
+
+    test('findUnprojectedSessions selects graphDigested rows with missing SESSION graph nodes', async () => {
+        const calls = [];
+        const rows  = [
+            {chromaId: 'summary-a', meta: {sessionId: 'a', graphDigested: true}},
+            {chromaId: 'summary-b', meta: {sessionId: 'b', graphDigested: 'true'}},
+            {chromaId: 'summary-c', meta: {sessionId: 'c'}},
+            {chromaId: 'summary-d', meta: {sessionId: 'd', graphDigested: true}},
+            {chromaId: 'summary-missing-session', meta: {graphDigested: true}}
+        ];
+
+        const result = await findUnprojectedSessions({
+            summaryCollection: createSummaryCollection(rows, calls),
+            graphDb          : createGraphDb(['session:b']),
+            batchSize        : 2,
+            limit            : 10
+        });
+
+        expect(calls).toEqual([
+            {include: ['metadatas'], limit: 2, offset: 0},
+            {include: ['metadatas'], limit: 2, offset: 2},
+            {include: ['metadatas'], limit: 1, offset: 4}
+        ]);
+        expect(result.candidates).toEqual([
+            {chromaId: 'summary-a', sessionId: 'a', graphNodeId: 'session:a'},
+            {chromaId: 'summary-d', sessionId: 'd', graphNodeId: 'session:d'}
+        ]);
+        expect(result.stats).toEqual({
+            total              : 5,
+            scanned            : 5,
+            skippedNoSessionId : 1,
+            skippedNotDigested : 1,
+            skippedAlreadyGraph: 1
+        });
+    });
+
+    test('repairUnprojectedSessions dry-runs candidates and apply mode backfills through MemorySessionIngestor', async () => {
+        const rows = [
+            {chromaId: 'summary-a', meta: {sessionId: 'a', graphDigested: true}},
+            {chromaId: 'summary-b', meta: {sessionId: 'b', graphDigested: true}}
+        ];
+        const summaryCollection = createSummaryCollection(rows);
+        const graphDb           = createGraphDb();
+        const calls             = [];
+
+        const dryRun = await repairUnprojectedSessions({
+            summaryCollection,
+            graphDb,
+            apply: false
+        });
+
+        expect(dryRun.mode).toBe('dry-run');
+        expect(dryRun.candidates).toBe(2);
+        expect(dryRun.repaired).toBe(0);
+        expect(dryRun.results.map(row => row.graphNodeId)).toEqual(['session:a', 'session:b']);
+
+        const apply = await repairUnprojectedSessions({
+            summaryCollection,
+            graphDb,
+            apply                : true,
+            memorySessionIngestor: {
+                async ingestSingleRow(graphNodeId, options) {
+                    calls.push({graphNodeId, sameCollection: options.summaryCollection === summaryCollection});
+                    return {success: true, reason: graphNodeId.endsWith(':a') ? 'backfilled' : 'already-exists'}
+                }
+            }
+        });
+
+        expect(apply.mode).toBe('apply');
+        expect(apply.candidates).toBe(2);
+        expect(apply.repaired).toBe(2);
+        expect(apply.failed).toBe(0);
+        expect(calls).toEqual([
+            {graphNodeId: 'session:a', sameCollection: true},
+            {graphNodeId: 'session:b', sameCollection: true}
+        ]);
+    });
+
+    test('createSessionGraphId normalizes existing prefixes', () => {
+        expect(createSessionGraphId('abc')).toBe('session:abc');
+        expect(createSessionGraphId('SESSION:abc')).toBe('session:abc');
+        expect(createSessionGraphId('session:abc')).toBe('session:abc');
+        expect(createSessionGraphId(null)).toBeNull();
+    });
+});


### PR DESCRIPTION
Resolves #13697
Related: #13624

This PR closes the two projection-backlog paths from `#13697`: `DreamService.findUndigestedSessions()` now samples both the Chroma summary head and tail, then returns a bounded fresh reserve plus an aged drain so unset `graphDigested` rows can no longer starve behind the same recent window; and a one-shot maintenance runner can repair hard-orphaned `graphDigested=true` summaries whose durable `session:<sessionId>` graph node is missing.

Evidence: L2 (focused unit coverage plus static/source gates for the recurring aged-drain and the one-time repair selector) -> L4 required (run the repair against healthy local/cloud Memory Core stores and verify pending-marker convergence). Residual: post-merge live dry-run/apply and marker convergence proof for `#13697`.

## Deltas from ticket

- Implemented part (a) in the existing DreamService hot path with Chroma `count()` + `get({limit, offset})`, deduping the sampled head/tail windows and sorting by summary timestamp for newest/oldest split.
- Implemented part (b) as `ai/scripts/maintenance/repairUnprojectedSessions.mjs`, defaulting to dry-run, `--limit 50`, and `graphDigested=true` rows only so it does not mask DreamService work still owed by unset rows.
- The repair runner fails closed when the graph SQLite handle is unavailable and uses `MemorySessionIngestor.ingestSingleRow()` for the actual SESSION projection instead of inventing a second projection writer.

## Test Evidence

- `node --check ai/daemons/orchestrator/services/DreamService.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs`
- `node --check ai/scripts/maintenance/repairUnprojectedSessions.mjs`
- `node --check test/playwright/unit/ai/scripts/maintenance/repairUnprojectedSessions.spec.mjs`
- `node ./buildScripts/util/check-block-alignment.mjs ai/daemons/orchestrator/services/DreamService.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs ai/scripts/maintenance/repairUnprojectedSessions.mjs test/playwright/unit/ai/scripts/maintenance/repairUnprojectedSessions.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs test/playwright/unit/ai/scripts/maintenance/repairUnprojectedSessions.spec.mjs` -> 25 passed

Local runtime note: `node ai/scripts/maintenance/repairUnprojectedSessions.mjs --dry-run --limit 5` was attempted but the local Memory Core logger hit `EPERM` before Chroma/graph access, so it is not counted as product evidence.

## Post-Merge Validation

- [ ] Once local Memory Core is healthy, run `node ai/scripts/maintenance/repairUnprojectedSessions.mjs --dry-run --limit all` and compare the hard-orphan candidate count against the `#13697` graph cross-reference.
- [ ] Run `node ai/scripts/maintenance/repairUnprojectedSessions.mjs --apply --limit all` on the intended local/cloud stores after the dry-run candidate set is reviewed.
- [ ] Let heavy maintenance drain unset `graphDigested` rows through the new aged-tail path and verify the pending marker converges to the genuine drift floor.

## Commits

- `c8b0197a9` - `fix(ai): age-drain undigested session scans (#13697)`
- `41dceddc9` - `fix(ai): add unprojected session repair runner (#13697)`

Authored by Euclid (GPT-5, Codex Desktop). Session 810318e6-b644-474e-a255-a07d19825aa5.
