### PR TITLE
test(ai): add contentTrust reader regression (#13703)

### DIFF
--- a/test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs
@@ -18,6 +18,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const repoRoot   = path.resolve(__dirname, '../../../../../../..');
 
+const RAW_EXTERNAL_URL = 'https://arkforge.tech/payload';
+const QUARANTINED_URL  = '[QUARANTINED_URL: arkforge.tech]';
+
 test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
     let IssueIngestor;
     let StorageRouter;
@@ -44,9 +47,21 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
     ];
 
     const mockFiles = {
-        'resources/content/issues/issue-2001.md': '---\nstate: OPEN\n---\n# Active Issue',
+        'resources/content/issues/issue-2001.md': [
+            '---',
+            'id: 2001',
+            'title: Active Issue',
+            'state: OPEN',
+            'contentTrust:',
+            '  projected: true',
+            '  quarantined: 1',
+            '---',
+            '# Active Issue',
+            '',
+            `External source was defanged as ${QUARANTINED_URL}.`
+        ].join('\n'),
         'resources/content/archive/issues/v1.0.0/issue-2002.md': '---\nstate: CLOSED\n---\n# Archive Issue',
-        'resources/content/discussions/discussion-3001.md': [
+        'resources/content/discussions/discussion-3001.md'     : [
             '---',
             'number: 3001',
             'title: Open Discussion',
@@ -94,11 +109,11 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
         _originalGraphDb = GraphService.db;
         _originalGetGraphCollection = StorageRouter.getGraphCollection;
         GraphService.db = {
-            nodes: { get: () => null },
-            edges: { items: [] },
+            nodes           : { get: () => null },
+            edges           : { items: [] },
             getAdjacentNodes: () => {},
-            addNode: node => graphNodes.push(node),
-            updateNode: () => {}
+            addNode         : node => graphNodes.push(node),
+            updateNode      : () => {}
         };
 
         _originalExistsSync = fs.existsSync;
@@ -217,8 +232,8 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
     test('ingestIssueStates() maps issues correctly through _index.json', async () => {
         StorageRouter.getGraphCollection = async () => ({
             upsert: async () => {},
-            get: async () => ({ ids: [], metadatas: [], documents: [] }),
-            add: async () => {}
+            get   : async () => ({ ids: [], metadatas: [], documents: [] }),
+            add   : async () => {}
         });
 
         try {
@@ -234,12 +249,35 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
         }
     });
 
+    test('ingestIssueStates() emits sanitized persisted issue content without raw external URLs (#13703)', async () => {
+        const upserts = [];
+
+        StorageRouter.getGraphCollection = async () => ({
+            upsert: async payload => upserts.push(payload),
+            get   : async () => ({ ids: [], metadatas: [], documents: [] }),
+            add   : async () => {}
+        });
+
+        try {
+            const result = await IssueIngestor.ingestIssueStates();
+            const activeIssue = result.find(issue => issue.issueId === 'issue-2001');
+            const activeUpsert = upserts.find(payload => payload.ids[0] === 'issue-2001');
+
+            expect(activeIssue.body).toContain(QUARANTINED_URL);
+            expect(activeIssue.body).not.toContain(RAW_EXTERNAL_URL);
+            expect(activeUpsert.documents[0]).toContain(QUARANTINED_URL);
+            expect(activeUpsert.documents[0]).not.toContain(RAW_EXTERNAL_URL);
+        } finally {
+            StorageRouter.getGraphCollection = _originalGetGraphCollection;
+        }
+    });
+
     test('ingestDiscussionStates() maps closed frontmatter into graph and vector lifecycle metadata', async () => {
         const upserts = [];
 
         StorageRouter.getGraphCollection = async () => ({
             upsert: async payload => upserts.push(payload),
-            get: async () => ({ ids: [], metadatas: [], documents: [] })
+            get   : async () => ({ ids: [], metadatas: [], documents: [] })
         });
 
         try {

--- a/test/playwright/unit/ai/services/knowledge-base/source/TicketSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/TicketSource.spec.mjs
@@ -18,6 +18,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const repoRoot   = path.resolve(__dirname, '../../../../../../..');
 
+const RAW_EXTERNAL_URL = 'https://arkforge.tech/payload';
+const QUARANTINED_URL  = '[QUARANTINED_URL: arkforge.tech]';
+
 test.describe('Neo.ai.services.knowledge-base.source.TicketSource', () => {
     let TicketSource;
     let aiConfig;
@@ -41,10 +44,22 @@ test.describe('Neo.ai.services.knowledge-base.source.TicketSource', () => {
         fs.ensureDirSync(archiveDir);
 
         fs.writeFileSync(path.join(activeDir, 'issue-1001.md'), '# First');
+        fs.writeFileSync(path.join(activeDir, 'issue-1003.md'), [
+            '---',
+            'id: 1003',
+            'title: Sanitized external issue',
+            'state: OPEN',
+            'contentTrust:',
+            '  projected: true',
+            '  quarantined: 1',
+            '---',
+            `External source was defanged as ${QUARANTINED_URL}.`
+        ].join('\n'));
         fs.writeFileSync(path.join(archiveDir, 'issue-1002.md'), '# Second');
 
         const indexMap = [
             { type: 'issues', id: 1001, path: 'issues/chunk-1/issue-1001.md' },
+            { type: 'issues', id: 1003, path: 'issues/chunk-1/issue-1003.md' },
             { type: 'issues', id: 1002, path: 'archive/issues/v1.0.0/chunk-2/issue-1002.md' }
         ];
 
@@ -64,9 +79,21 @@ test.describe('Neo.ai.services.knowledge-base.source.TicketSource', () => {
 
         const count = await TicketSource.extract(writeStream, chunk => 'hash');
 
-        expect(count).toBe(2);
+        expect(count).toBe(3);
 
         const ids = written.map(w => w.name).sort();
-        expect(ids).toEqual(['issue-1001', 'issue-1002']);
+        expect(ids).toEqual(['issue-1001', 'issue-1002', 'issue-1003']);
+    });
+
+    test('extract() emits persisted contentTrust-sanitized issue content without raw external URLs (#13703)', async () => {
+        const written = [];
+        const writeStream = { write(str) { written.push(JSON.parse(str.trim())); return true; } };
+
+        await TicketSource.extract(writeStream, chunk => 'hash');
+
+        const sanitized = written.find(chunk => chunk.name === 'issue-1003');
+
+        expect(sanitized.content).toContain(QUARANTINED_URL);
+        expect(sanitized.content).not.toContain(RAW_EXTERNAL_URL);
     });
 });


### PR DESCRIPTION
Resolves #13703

Related: #13691
Related: #13693
Related: #10476

Adds the reader-level regression guard requested from the #13693 Approve+Follow-Up review. `TicketSource` now has direct coverage that persisted contentTrust-sanitized issue Markdown reaches KB chunk output with `[QUARANTINED_URL: domain]` and without the original raw URL. `IssueIngestor` now has matching coverage for both returned open-issue body and graph vector upsert documents.

Evidence: L2 (focused Playwright unit regressions for TicketSource and IssueIngestor reader outputs) -> L2 required (#13703 reader-regression ACs). Residual: none.

## Deltas from ticket
- Implemented both reader checks, not just `TicketSource`, because `IssueIngestor` reads local issue Markdown independently and can embed/open-issue output directly.
- No production sanitizer path was added; the tests pin inherited sanitized persisted content at the reader boundary.

## Test Evidence
- `node buildScripts/util/check-block-alignment.mjs test/playwright/unit/ai/services/knowledge-base/source/TicketSource.spec.mjs test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs`
- `git diff --check origin/dev..HEAD`
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/TicketSource.spec.mjs test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs` - 11 passed
- Pre-commit hooks passed, including whitespace, shorthand, AiConfig test-mutation guard, JSDoc types, ticket archaeology, and block alignment.

## Post-Merge Validation
- [ ] Confirm PR CI stays green on the same two-spec test scope plus repo lint gates.

## Commit
- `042b815fe` - `test(ai): add contentTrust reader regression (#13703)`

Authored by Euclid (GPT-5, Codex Desktop). Session f6102a4d-6cb4-4aa4-9365-a10ea794e1e4.
