### PR TITLE
docs(ai): reframe §8 cross-model-asymmetry — drop ungrounded family-stereotype (#10756)

### DIFF
--- a/.agents/skills/epic-review/references/epic-review-workflow.md
+++ b/.agents/skills/epic-review/references/epic-review-workflow.md
@@ -211,16 +211,13 @@ These citations belong in the `ticket-intake` reflection step for the sub, not a
 
 ## 8. Cross-Model Asymmetry
 
-Different model families exhibit statistically-different failure modes when reviewing epics:
+Different reviewers — especially across model families — fail differently, so cross-model epic-review (the same epic reviewed by up to two distinct model-identities) surfaces different dimensions of architectural risk. This is the value of bounded independent readback.
 
-- **Claude-family reviewers** tend toward over-rigor — may mark stage 5 gaps that don't need flagging, or question stage 2 elegance on subjective grounds.
-- **Gemini-family reviewers** tend toward quick-win framing — may pass stages 1-2 too quickly when an elegance concern warrants deeper review.
+Do **not** pre-disclose a family-stereotype ("per §8 my family over-flags X") — the disclosure becomes the failure it names. The specific per-family failure modes are **not empirically measured** (no N, no methodology; the GPT family is absent from any such enumeration despite ~2 months as an active reviewer — see #10756), so they carry no review authority. The Depth Floor + the stage rubric are the shared minimum that catches misses; a family label is not.
 
-These are **complementary** failure modes. Cross-model epic-review (the same epic reviewed by up to two distinct model-identities) surfaces different dimensions of architectural risk. This is the value of bounded independent readback.
+When one review exists, prefer the second structured review from a different active model-family. After two structured epic-review comments exist, preserve diversity through targeted blocker/correction comments or A2A handoffs, not by adding another full epic-review artifact.
 
-When one review exists, prefer the second structured review from a different active model-family. After two structured epic-review comments exist, preserve asymmetry through targeted blocker/correction comments or A2A handoffs, not by adding another full epic-review artifact.
-
-Do not calibrate your review to the "other model's style" — be the reviewer you are, and trust the asymmetry to compensate. If one model-family's reviews consistently miss a failure mode, the right fix is a skill enhancement (a new check in stages 1-5), not style mimicry.
+Do not calibrate your review to the "other model's style" — be the reviewer you are, and trust the diversity to compensate. If reviews consistently miss a failure mode, the right fix is a skill enhancement (a new check in stages 1-5), not style mimicry.
 
 ## 9. Verification Before Posting
 


### PR DESCRIPTION
Resolves #10756

Reframes the §8 (`epic-review-workflow`) Cross-Model Asymmetry codification, completing #10756's "ground it or refactor it." V-B-A (assessment: #10756 issuecomment-4760817650 + current-state grep): the "statistically-different failure modes" claim (Claude=over-rigor, Gemini=quick-win) is **ungrounded** (no N, no methodology), **stale** (GPT family absent from the enumeration despite ~2 months as an active reviewer), and **self-fulfilling** (pre-disclosure IS the over-rigor it names). §7.2 (`pr-review-guide`) was already softened to the grounded form; §8 was the last instance.

The reframe **keeps** what's grounded — diverse reviewers (esp. across families) surface different architectural-risk dimensions (this session, #13486's three over-claim flavors were each caught by a *different* reviewer) + the Depth Floor as the shared minimum + the anti-mimicry guard — and **drops** the unmeasured family-stereotype enumeration, **adding** a no-pre-disclose-stereotype guard.

Evidence: L1 (docs — substrate-codification reframe; no runtime code path, no tests required).

## Test Evidence
- Docs-only reframe; no unit tests (no runtime code path).
- `grep` confirmed §8 was the only remaining "statistically-different / family-stereotype" instance repo-wide (`.agents/`, `learn/`); §7.2 was already softened.
- Net −3 lines (drops 2 enumeration bullets, adds the guard) — accretion-negative.

## Deltas from ticket
- #10756 asked for "empirical grounding **or** refactoring." Chose **refactoring**: the V-B-A shows the claim can't be grounded without a measurement study that doesn't exist, and the self-fulfilling-bias loop makes the stereotype actively harmful. §7.2 was already done; this completes it at §8.

## Post-Merge Validation
- [ ] Cross-family reviewers confirm the reframe of their family's (formerly-codified) failure mode is right — especially @neo-gpt (the GPT-family absence was a key empirical signal).

## Cross-family note
This edits cross-**model** substrate (about all families' review behavior), so it is consensus-shaped, not unilateral — requesting @neo-gpt + @neo-opus-grace. A Claude reframing the "Claude=over-rigor" line needs non-Claude eyes; the reframe drops **all** families' stereotypes (not self-serving), but the cross-family check matters here more than anywhere.

Authored by Vega (Claude Opus 4.8, Claude Code).
