### PR TITLE
fix(ai): thread per-model lms --parallel; default chat to 1 to cut idle KV-cache RAM (#13700)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -233,7 +233,15 @@ class Config extends ConfigProvider {
                  */
                 chat: {
                     contextLimitTokens       : leaf(131072, 'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 'number'),
-                    safeProcessingLimitTokens: leaf(100000, 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
+                    safeProcessingLimitTokens: leaf(100000, 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', 'number'),
+                    // lms `--parallel` request-slot count for the chat model. Each slot holds an
+                    // independent KV cache at contextLimitTokens, so the count MULTIPLIES the chat
+                    // worker's resident RAM. Default 1: the chat roles (graph extraction / session
+                    // summary / miniSummary) are lease-serialized, so concurrent demand is 1 and any
+                    // slots beyond the first are idle KV bloat. PER-MODEL knob, distinct from
+                    // requireParallelModels (how many DISTINCT models stay co-resident); both the chat
+                    // and embedding models stay loaded regardless of this value.
+                    parallel                 : leaf(1, 'NEO_LOCAL_MODELS_CHAT_PARALLEL', 'number')
                 },
                 /**
                  * @summary Embedding-model context limits in tokens.

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -314,6 +314,7 @@ export class Orchestrator extends Base {
             lmsHost                          : AiConfig.openAiCompatible.host,
             lmsPort                          : AiConfig.orchestrator.lms.port,
             lmsContextLengths                : lmsPreloadConfig.contextLengths,
+            lmsParallels                     : lmsPreloadConfig.parallels,
             providerReadiness                : AiConfig.orchestrator.providerReadiness,
             graphLogCompactionVacuum         : AiConfig.orchestrator.graphLogCompaction.vacuum
         });

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -77,6 +77,7 @@ function probeTcpPort({port, timeoutMs}) {
  * @param {String} [options.lmsHost] OpenAI-compatible host exposed by the LM Studio server.
  * @param {String|Number} [options.lmsPort] LM Studio OpenAI-compatible local inference port (CLI default `1234`).
  * @param {Object} [options.lmsContextLengths] Per-model `--context-length` override map keyed by model id (chat + embedding from `aiConfig.localModels.{chat,embedding}.contextLimitTokens`).
+ * @param {Object} [options.lmsParallels] Per-model `--parallel` slot-count override map keyed by model id (chat-only, from `aiConfig.localModels.chat.parallel`).
  * @param {Object} [options.providerReadiness] Provider-readiness retry / timeout config.
  * @param {Boolean} [options.graphLogCompactionVacuum] Whether scheduled GraphLog compaction also runs SQLite VACUUM.
  * @returns {Object}
@@ -98,6 +99,7 @@ export function buildTaskDefinitions({
     lmsHost,
     lmsPort,
     lmsContextLengths,
+    lmsParallels,
     providerReadiness,
     graphLogCompactionVacuum
 } = {}) {
@@ -330,6 +332,7 @@ export function buildTaskDefinitions({
                     host          : lmsHost,
                     models        : requiredModels,
                     contextLengths: lmsContextLengths,
+                    parallels     : lmsParallels,
                     allowPartial  : true,
                     attempts      : providerReadiness?.attempts,
                     delayMs       : providerReadiness?.delayMs,

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -1,7 +1,7 @@
-import http from 'http';
-import {execFile} from 'child_process';
+import http                        from 'http';
+import {execFile}                  from 'child_process';
 import {Memory_Config as aiConfig} from '../../services.mjs';
-import logger from '../../mcp/server/memory-core/logger.mjs';
+import logger                      from '../../mcp/server/memory-core/logger.mjs';
 import {
     isGraphModelProviderSupported,
     isOpenAiCompatibleProvider,
@@ -203,9 +203,13 @@ export async function warmOllamaRoleModel({
  * @param {Object} [options]
  * @param {Function} [options.execFileFn=execFile] Child-process seam for tests.
  * @param {Number} [options.contextLength] LM Studio loaded-model context-window override (tokens).
+ * @param {Number} [options.parallel] LM Studio loaded-model parallel-slot count (`--parallel`). Each
+ * slot holds an independent KV cache at the loaded context window, so the slot count multiplies the
+ * model's resident RAM. Omit to inherit the lms default; set low for a lease-serialized role whose
+ * concurrent demand is 1 (the chat model) to reclaim the idle KV-cache multiplier.
  * @returns {Promise<{stdout: String, stderr: String}>}
  */
-export function loadLmsModel(model, {execFileFn = execFile, contextLength} = {}) {
+export function loadLmsModel(model, {execFileFn = execFile, contextLength, parallel} = {}) {
     if (!model) {
         return Promise.reject(new TypeError('loadLmsModel: model is required'));
     }
@@ -213,6 +217,9 @@ export function loadLmsModel(model, {execFileFn = execFile, contextLength} = {})
     const args = ['load', model];
     if (Neo.isNumber(contextLength)) {
         args.push('--context-length', String(contextLength));
+    }
+    if (Neo.isNumber(parallel)) {
+        args.push('--parallel', String(parallel));
     }
 
     return new Promise((resolve, reject) => {
@@ -293,6 +300,7 @@ export function buildLmsPreloadConfig(config = aiConfig) {
           embeddingModel         = openAiCompatibleConfig.embeddingModel,
           chatContextLength      = config.localModels?.chat?.contextLimitTokens,
           embeddingContextLength = config.localModels?.embedding?.contextLimitTokens,
+          chatParallel           = config.localModels?.chat?.parallel,
           roles                  = [{
               provider     : config.modelProvider,
               model        : chatModel,
@@ -313,13 +321,22 @@ export function buildLmsPreloadConfig(config = aiConfig) {
     const models              = [...new Set(roles.map(role => role.model))],
           selectedContextRole = role => roles.some(({contextRole}) => contextRole === role),
           contextLengths      = buildLmsContextLengthsMap({
-              chatModel       : selectedContextRole('chat') ? chatModel : undefined,
-              embeddingModel  : selectedContextRole('embedding') ? embeddingModel : undefined,
+              chatModel     : selectedContextRole('chat') ? chatModel : undefined,
+              embeddingModel: selectedContextRole('embedding') ? embeddingModel : undefined,
               chatContextLength,
               embeddingContextLength
     });
 
-    return {models, contextLengths}
+    // `--parallel` is a per-model request-slot count (each slot = an independent KV cache = a RAM
+    // multiplier), distinct from `requireParallelModels` (how many DISTINCT models stay co-resident).
+    // Only the chat role carries a configured slot count; the embedding role keeps the lms default.
+    // Keyed by model id so it force-includes through the same path as contextLengths; the embedding
+    // model is intentionally absent (no per-model parallel override).
+    const parallels = selectedContextRole('chat') && chatModel && Neo.isNumber(chatParallel)
+        ? {[chatModel]: chatParallel}
+        : {};
+
+    return {models, contextLengths, parallels}
 }
 
 /**
@@ -400,6 +417,9 @@ export function buildOllamaReadinessConfig(config = aiConfig) {
  * @param {Number} options.delayMs Delay between probes.
  * @param {Number} options.timeoutMs HTTP probe timeout.
  * @param {Object} [options.contextLengths] Per-model context-length override map keyed by model id.
+ * @param {Object} [options.parallels] Per-model `--parallel` slot-count override map keyed by model id. A
+ * model present here is force-included in the load set (like `contextLengths`) so the slot count is
+ * enforced on a resident model, not just a missing one.
  * @param {Boolean} [options.allowPartial=false] Return degraded readiness instead of throwing when one model cannot be loaded.
  * @param {Function} [options.fetchModelIds] Injectable model-list probe.
  * @param {Function} [options.loadModel] Injectable model-load function.
@@ -413,6 +433,7 @@ export async function ensureLmsModelsLoaded({
     delayMs,
     timeoutMs,
     contextLengths = {},
+    parallels      = {},
     allowPartial   = false,
     fetchModelIds = opts => fetchOpenAiCompatibleModelIds(opts),
     loadModel     = (model, options) => loadLmsModel(model, options),
@@ -459,14 +480,14 @@ export async function ensureLmsModelsLoaded({
     // resident in /v1/models. `/v1/models` reports presence only — it does NOT
     // expose the loaded context window, so model-id presence is insufficient to
     // confirm the loaded cap matches the operator-declared threshold. Without
-    // this re-load, the exact #12117 regression survives orchestrator restarts:
+    // this re-load, the exact context-window-mismatch regression survives orchestrator restarts:
     // a model loaded with the modelfile-default context window (~4K-8K) would
     // be accepted as ready while every chat invocation silently overflows.
     // Force-include each context-configured model in the load set even if resident,
     // BUT preserve the declared requiredModels input order (filter rather than concat-dedupe).
     const modelsToLoad = requiredModels.filter(model => {
         if (initialMissing.includes(model)) return true;
-        return Neo.isNumber(contextLengths?.[model]);
+        return Neo.isNumber(contextLengths?.[model]) || Neo.isNumber(parallels?.[model]);
     });
     const attemptedModels = [...modelsToLoad];
     const loadedModels    = [];
@@ -483,20 +504,25 @@ export async function ensureLmsModelsLoaded({
 
     for (const model of modelsToLoad) {
         const contextLength = contextLengths?.[model];
+        const parallel      = parallels?.[model];
         const contextSuffix = Neo.isNumber(contextLength)
             ? ` --context-length ${contextLength}`
             : '';
+        const parallelSuffix = Neo.isNumber(parallel)
+            ? ` --parallel ${parallel}`
+            : '';
         const reason = initialMissing.includes(model)
             ? 'missing from /v1/models'
-            : 'context-length enforcement on resident model';
-        log.info?.(`[ProviderReadinessHelper] Loading LM Studio model '${model}' via lms load${contextSuffix} (${reason}).`);
+            : 'context-length / parallel enforcement on resident model';
+        log.info?.(`[ProviderReadinessHelper] Loading LM Studio model '${model}' via lms load${contextSuffix}${parallelSuffix} (${reason}).`);
         try {
-            await loadModel(model, {contextLength});
+            await loadModel(model, {contextLength, parallel});
             loadedModels.push(model);
         } catch (error) {
             failedModels.push({
                 model,
                 contextLength,
+                parallel,
                 error: error.message
             });
             log.warn?.(`[ProviderReadinessHelper] LM Studio model '${model}' preload failed: ${error.message}`);
@@ -523,15 +549,15 @@ export async function ensureLmsModelsLoaded({
             const ready = missingModels.length === 0 && failedModels.length === 0;
             return {
                 ready,
-                degraded    : !ready,
+                degraded : !ready,
                 loadedModels,
                 attemptedModels,
                 failedModels,
                 missingModels,
                 requiredModels,
                 availableModels,
-                attempts    : attempt,
-                elapsedMs   : Date.now() - startedAt
+                attempts : attempt,
+                elapsedMs: Date.now() - startedAt
             };
         }
 
@@ -542,8 +568,8 @@ export async function ensureLmsModelsLoaded({
 
     if (allowPartial) {
         return {
-            ready       : false,
-            degraded    : true,
+            ready    : false,
+            degraded : true,
             loadedModels,
             attemptedModels,
             failedModels,
@@ -551,7 +577,7 @@ export async function ensureLmsModelsLoaded({
             requiredModels,
             availableModels,
             attempts,
-            elapsedMs    : Date.now() - startedAt
+            elapsedMs: Date.now() - startedAt
         };
     }
 
@@ -658,20 +684,20 @@ export async function ensureOllamaModelsReady({
         }
 
         return {
-            ready                : false,
-            degraded             : true,
-            provider             : 'ollama',
+            ready          : false,
+            degraded       : true,
+            provider       : 'ollama',
             host,
             requiredModels,
-            availableModels      : [],
-            missingModels        : requiredModels,
-            observedCount        : 0,
+            availableModels: [],
+            missingModels  : requiredModels,
+            observedCount  : 0,
             requireParallelModels,
             requiredResidentModels,
-            warmedModels         : [],
-            attemptedModels      : [],
-            failedModels         : [],
-            error                : {message: error.message},
+            warmedModels   : [],
+            attemptedModels: [],
+            failedModels   : [],
+            error          : {message: error.message},
             warning              : `[provider/ollama] model residency probe failed: ${error.message}`,
             attempts,
             elapsedMs            : Date.now() - startedAt
@@ -724,7 +750,7 @@ export async function ensureOllamaModelsReady({
             return {
                 ready,
                 degraded,
-                provider             : 'ollama',
+                provider : 'ollama',
                 host,
                 warmedModels,
                 attemptedModels,
@@ -735,9 +761,9 @@ export async function ensureOllamaModelsReady({
                 observedCount,
                 requireParallelModels,
                 requiredResidentModels,
-                warning              : degraded ? getWarning({availableModels, missingModels}) : null,
-                attempts             : attempt,
-                elapsedMs            : Date.now() - startedAt
+                warning  : degraded ? getWarning({availableModels, missingModels}) : null,
+                attempts : attempt,
+                elapsedMs: Date.now() - startedAt
             };
         }
 
@@ -749,9 +775,9 @@ export async function ensureOllamaModelsReady({
     const warning = getWarning({availableModels, missingModels});
     if (allowPartial) {
         return {
-            ready                : false,
-            degraded             : true,
-            provider             : 'ollama',
+            ready        : false,
+            degraded     : true,
+            provider     : 'ollama',
             host,
             warmedModels,
             attemptedModels,
@@ -759,12 +785,12 @@ export async function ensureOllamaModelsReady({
             missingModels,
             requiredModels,
             availableModels,
-            observedCount        : availableModels.length,
+            observedCount: availableModels.length,
             requireParallelModels,
             requiredResidentModels,
             warning,
             attempts,
-            elapsedMs            : Date.now() - startedAt
+            elapsedMs    : Date.now() - startedAt
         };
     }
 
@@ -909,19 +935,19 @@ export async function probeProviderParallelModelCapacity({
 
     return {
         ready,
-        provider             : target.provider,
-        host                 : target.host,
-        model                : target.model,
-        embeddingModel       : target.embeddingModel,
+        provider       : target.provider,
+        host           : target.host,
+        model          : target.model,
+        embeddingModel : target.embeddingModel,
         requireParallelModels,
         requiredModels,
-        availableModels      : uniqueAvailable,
+        availableModels: uniqueAvailable,
         missingModels,
         observedCount,
-        warning              : ready ? null : createParallelModelCapacityWarning({
-            provider: target.provider,
-            model   : target.model,
-            embeddingModel: target.embeddingModel,
+        warning        : ready ? null : createParallelModelCapacityWarning({
+            provider       : target.provider,
+            model          : target.model,
+            embeddingModel : target.embeddingModel,
             requiredModels,
             availableModels: uniqueAvailable,
             missingModels,
@@ -965,9 +991,9 @@ export async function warnProviderParallelModelCapacity({
     } catch (error) {
         const provider = config ? resolveGraphModelProvider(config) : 'unknown';
         const result = {
-            ready   : false,
+            ready: false,
             provider,
-            error   : {message: error?.message || String(error)},
+            error: {message: error?.message || String(error)},
             warning : `[provider/${provider}] parallel-model capacity probe failed: ${error?.message || error}`
         };
 
@@ -1116,21 +1142,21 @@ export function createProviderFailureDiagnostic({
                 ? 'runSandman.provider_model_residency_degraded'
                 : 'runSandman.provider_readiness_timeout',
         reason,
-        provider       : target.provider,
-        graphProvider  : target.provider,
-        modelProvider  : config.modelProvider,
-        host           : target.host,
-        endpoint       : target.endpoint,
-        url            : target.url,
-        supported      : target.supported,
-        model          : target.model,
-        embeddingModel : target.embeddingModel,
-        attempts       : waitResult?.attempts,
-        elapsedMs      : waitResult?.elapsedMs,
-        timeoutMs      : waitResult?.timeoutMs,
+        provider      : target.provider,
+        graphProvider : target.provider,
+        modelProvider : config.modelProvider,
+        host          : target.host,
+        endpoint      : target.endpoint,
+        url           : target.url,
+        supported     : target.supported,
+        model         : target.model,
+        embeddingModel: target.embeddingModel,
+        attempts      : waitResult?.attempts,
+        elapsedMs     : waitResult?.elapsedMs,
+        timeoutMs     : waitResult?.timeoutMs,
         capacity,
         lifecycleStatus,
-        nextAction     : degraded && capacity?.warning
+        nextAction    : degraded && capacity?.warning
             ? capacity.warning
             : target.supported
             ? (

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -1,10 +1,10 @@
-import {test, expect} from '@playwright/test';
-import fs   from 'fs/promises';
-import path from 'path';
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs/promises';
+import path            from 'path';
 import {fileURLToPath} from 'url';
-import Neo       from '../../../../../../src/Neo.mjs';
-import * as core from '../../../../../../src/core/_export.mjs';
-import AiConfig from '../../../../../../ai/config.mjs';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import AiConfig        from '../../../../../../ai/config.mjs';
 import {
     Orchestrator
 } from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
@@ -66,14 +66,14 @@ function createMinimalOrchestrator() {
     TaskStateService.taskState = createInitialTaskState(taskDefinitions);
 
     return Neo.create(Orchestrator, {
-        dataDir                  : '/tmp/orchestrator-test',
-        stateFile                : '/tmp/orchestrator-test/state.json',
-        logFile                  : null,
+        dataDir  : '/tmp/orchestrator-test',
+        stateFile: '/tmp/orchestrator-test/state.json',
+        logFile  : null,
         heavyMaintenanceLeasePath: `/tmp/orchestrator-test/heavy-maintenance-lease-${process.pid}-${++invariantSeq}.json`,
         taskDefinitions,
-        taskStateService         : TaskStateService,
-        healthService            : {recordTaskOutcome() {}},
-        spawnFn                  : () => { throw new Error('spawnFn not expected'); }
+        taskStateService: TaskStateService,
+        healthService   : {recordTaskOutcome() {}},
+        spawnFn         : () => { throw new Error('spawnFn not expected'); }
     });
 }
 
@@ -252,7 +252,7 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
             modelProvider    : 'gemini',
             graphProvider    : 'ollama',
             embeddingProvider: 'openAiCompatible',
-            openAiCompatible: {
+            openAiCompatible : {
                 model         : 'shared-model',
                 embeddingModel: 'shared-model'
             },
@@ -262,14 +262,15 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
             }
         })).toEqual({
             models        : ['shared-model'],
-            contextLengths: {'shared-model': 8192}
+            contextLengths: {'shared-model': 8192},
+            parallels     : {}
         });
 
         expect(buildLmsPreloadConfig({
             modelProvider    : 'openAiCompatible',
             graphProvider    : 'ollama',
             embeddingProvider: 'gemini',
-            openAiCompatible: {
+            openAiCompatible : {
                 model         : 'chat-model',
                 embeddingModel: 'embedding-model'
             },
@@ -279,10 +280,29 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
             }
         })).toEqual({
             models        : ['chat-model'],
-            contextLengths: {'chat-model': 262144}
+            contextLengths: {'chat-model': 262144},
+            parallels     : {}
         })
     });
 
+    test('buildLmsPreloadConfig threads localModels.chat.parallel into a chat-only parallels map (#13700)', () => {
+        const result = buildLmsPreloadConfig({
+            modelProvider    : 'openAiCompatible',
+            graphProvider    : 'openAiCompatible',
+            embeddingProvider: 'openAiCompatible',
+            openAiCompatible : {
+                model         : 'gemma-4-31b-it',
+                embeddingModel: 'qwen3-embedding'
+            },
+            localModels: {
+                chat     : {contextLimitTokens: 131072, parallel: 1},
+                embedding: {contextLimitTokens: 32768}
+            }
+        });
+        // Chat-only: the configured slot count is keyed by the chat model id; the embedding model is
+        // intentionally absent (it keeps the lms default). Distinct from requireParallelModels.
+        expect(result.parallels).toEqual({'gemma-4-31b-it': 1});
+    });
 
 });
 

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -76,8 +76,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         });
 
         expect(waitResult).toMatchObject({
-            running : false,
-            attempts: 3,
+            running  : false,
+            attempts : 3,
             timeoutMs: 0
         });
         expect(waitResult.elapsedMs).toBeGreaterThanOrEqual(0);
@@ -117,7 +117,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             ready: async () => calls.push({type: 'lifecycle-ready'})
         };
         const dreamService = {
-            ready: async () => calls.push({type: 'dream-ready'}),
+            ready          : async () => calls.push({type: 'dream-ready'}),
             executeRemCycle: async options => {
                 calls.push({type: 'execute-rem-cycle', options});
                 return {
@@ -263,7 +263,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             config: {
                 graphProvider: 'ollama',
                 modelProvider: 'openAiCompatible',
-                ollama: {
+                ollama       : {
                     host                 : 'http://ollama.test',
                     model                : 'gemma4:31b',
                     embeddingModel       : 'qwen3-embedding',
@@ -286,8 +286,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         const warnings = [];
         const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
             config: {
-                graphProvider: 'openAiCompatible',
-                modelProvider: 'gemini',
+                graphProvider   : 'openAiCompatible',
+                modelProvider   : 'gemini',
                 openAiCompatible: {
                     host                 : 'http://oai.test',
                     model                : 'gemma-4-31b-it',
@@ -295,9 +295,9 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                     requireParallelModels: 2
                 }
             },
-            timeoutMs                     : 25,
-            fetchOpenAiCompatibleModels   : async () => ['gemma-4-31b-it', 'text-embedding-qwen3-embedding-8b'],
-            log                           : {warn: (...args) => warnings.push(args)}
+            timeoutMs                  : 25,
+            fetchOpenAiCompatibleModels: async () => ['gemma-4-31b-it', 'text-embedding-qwen3-embedding-8b'],
+            log                        : {warn: (...args) => warnings.push(args)}
         });
 
         expect(result).toMatchObject({
@@ -313,7 +313,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         const warnings = [];
         const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
             config: {
-                graphProvider: 'openAiCompatible',
+                graphProvider   : 'openAiCompatible',
                 openAiCompatible: {
                     host          : 'http://oai.test',
                     model         : 'gemma-4-31b-it',
@@ -335,7 +335,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             let fetched = false;
             const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
                 config: {
-                    graphProvider: 'openAiCompatible',
+                    graphProvider   : 'openAiCompatible',
                     openAiCompatible: {
                         host          : 'http://oai.test',
                         model         : 'gemma-4-31b-it',
@@ -367,11 +367,11 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         ];
 
         const result = await providerReadinessHelper.ensureLmsModelsLoaded({
-            host     : 'http://127.0.0.1:1234',
-            models   : ['chat-model', 'embedding-model'],
-            attempts : 3,
-            delayMs  : 0,
-            timeoutMs: 50,
+            host         : 'http://127.0.0.1:1234',
+            models       : ['chat-model', 'embedding-model'],
+            attempts     : 3,
+            delayMs      : 0,
+            timeoutMs    : 50,
             fetchModelIds: async () => modelSnapshots.shift() || ['chat-model', 'embedding-model'],
             loadModel    : async model => loads.push(model),
             log          : {info: () => {}}
@@ -379,9 +379,9 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         expect(loads).toEqual(['chat-model', 'embedding-model']);
         expect(result).toMatchObject({
-            ready       : true,
-            loadedModels: ['chat-model', 'embedding-model'],
-            requiredModels: ['chat-model', 'embedding-model'],
+            ready          : true,
+            loadedModels   : ['chat-model', 'embedding-model'],
+            requiredModels : ['chat-model', 'embedding-model'],
             availableModels: ['chat-model', 'embedding-model']
         });
     });
@@ -390,11 +390,11 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         const loads = [];
 
         const result = await providerReadinessHelper.ensureLmsModelsLoaded({
-            host     : 'http://127.0.0.1:1234',
-            models   : ['chat-model', 'embedding-model'],
-            attempts : 1,
-            delayMs  : 0,
-            timeoutMs: 50,
+            host         : 'http://127.0.0.1:1234',
+            models       : ['chat-model', 'embedding-model'],
+            attempts     : 1,
+            delayMs      : 0,
+            timeoutMs    : 50,
             fetchModelIds: async () => ['chat-model', 'embedding-model'],
             loadModel    : async model => loads.push(model)
         });
@@ -421,9 +421,9 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             // ready with zero loadModel calls, leaving any modelfile-default loaded
             // context window in place. With the fix, context-configured models are
             // force-included in the load set.
-            fetchModelIds : async () => ['chat-model', 'embedding-model'],
-            loadModel     : async (model, options) => loadCalls.push({model, contextLength: options?.contextLength}),
-            log           : {info: () => {}}
+            fetchModelIds: async () => ['chat-model', 'embedding-model'],
+            loadModel    : async (model, options) => loadCalls.push({model, contextLength: options?.contextLength}),
+            log          : {info: () => {}}
         });
 
         expect(loadCalls).toEqual([
@@ -442,8 +442,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         ];
 
         const result = await providerReadinessHelper.ensureLmsModelsLoaded({
-            host          : 'http://127.0.0.1:1234',
-            models        : ['chat-model', 'embedding-model'],
+            host  : 'http://127.0.0.1:1234',
+            models: ['chat-model', 'embedding-model'],
             // Only chat has a configured context-length; embedding must still load as missing
             contextLengths: {'chat-model': 262144},
             attempts      : 2,
@@ -505,15 +505,15 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         ];
 
         const result = await providerReadinessHelper.ensureLmsModelsLoaded({
-            host            : 'http://127.0.0.1:1234',
-            models          : ['chat-model', 'embedding-model'],
-            contextLengths  : {'chat-model': 262144, 'embedding-model': 32768},
-            allowPartial    : true,
-            attempts        : 2,
-            delayMs         : 0,
-            timeoutMs       : 50,
-            fetchModelIds   : async () => modelSnapshots.shift() || ['embedding-model'],
-            loadModel       : async (model, options) => {
+            host          : 'http://127.0.0.1:1234',
+            models        : ['chat-model', 'embedding-model'],
+            contextLengths: {'chat-model': 262144, 'embedding-model': 32768},
+            allowPartial  : true,
+            attempts      : 2,
+            delayMs       : 0,
+            timeoutMs     : 50,
+            fetchModelIds : async () => modelSnapshots.shift() || ['embedding-model'],
+            loadModel     : async (model, options) => {
                 loadCalls.push({model, contextLength: options?.contextLength});
                 if (model === 'chat-model') {
                     throw new Error('LM Studio rejected 262K chat load');
@@ -594,8 +594,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         ];
 
         const result = await providerReadinessHelper.ensureOllamaModelsReady({
-            host                 : 'http://ollama.test',
-            roles                : [{
+            host : 'http://ollama.test',
+            roles: [{
                 providerRole: 'modelProvider',
                 role        : 'chat',
                 model       : 'gemma4:31b'
@@ -638,9 +638,9 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             }
         }]);
         expect(result).toMatchObject({
-            ready                : true,
-            provider             : 'ollama',
-            warmedModels         : [{
+            ready       : true,
+            provider    : 'ollama',
+            warmedModels: [{
                 model       : 'gemma4:31b',
                 role        : 'chat',
                 providerRole: 'modelProvider'
@@ -658,8 +658,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     test('ensureOllamaModelsReady returns degraded when one native role cannot be warmed (#12285)', async () => {
         const warnings = [];
         const result = await providerReadinessHelper.ensureOllamaModelsReady({
-            host                 : 'http://ollama.test',
-            roles                : [{
+            host : 'http://ollama.test',
+            roles: [{
                 providerRole: 'modelProvider',
                 role        : 'chat',
                 model       : 'gemma4:31b'
@@ -701,8 +701,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('ensureOllamaModelsReady does not require inactive role models (#12285)', async () => {
         const result = await providerReadinessHelper.ensureOllamaModelsReady({
-            host                 : 'http://ollama.test',
-            roles                : [{
+            host : 'http://ollama.test',
+            roles: [{
                 providerRole: 'graphProvider',
                 role        : 'chat',
                 model       : 'gemma4:31b'
@@ -834,7 +834,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             modelProvider    : 'gemini',
             graphProvider    : 'openAiCompatible',
             embeddingProvider: 'openAiCompatible',
-            openAiCompatible: {
+            openAiCompatible : {
                 model         : 'gemma-4-31b-it',
                 embeddingModel: 'text-embedding-qwen3-embedding-8b'
             },
@@ -852,9 +852,10 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 'text-embedding-qwen3-embedding-8b'
             ],
             contextLengths: {
-                'gemma-4-31b-it'                  : 262144,
+                'gemma-4-31b-it'                   : 262144,
                 'text-embedding-qwen3-embedding-8b': 32768
-            }
+            },
+            parallels: {}
         });
     });
 
@@ -863,7 +864,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             modelProvider    : 'gemini',
             graphProvider    : 'ollama',
             embeddingProvider: 'ollama',
-            ollama: {
+            ollama           : {
                 host                 : 'http://ollama.test',
                 model                : 'gemma4:31b',
                 embeddingModel       : 'qwen3-embedding',
@@ -899,7 +900,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             modelProvider    : 'openAiCompatible',
             graphProvider    : 'openAiCompatible',
             embeddingProvider: 'openAiCompatible',
-            ollama: {
+            ollama           : {
                 host                 : 'http://ollama.test',
                 model                : 'gemma4:31b',
                 embeddingModel       : 'qwen3-embedding',
@@ -924,8 +925,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('resolves readiness target from graphProvider instead of generic modelProvider', () => {
         expect(runSandmanModule.getGraphProviderReadinessTarget({
-            modelProvider : 'gemini',
-            graphProvider : 'openAiCompatible',
+            modelProvider   : 'gemini',
+            graphProvider   : 'openAiCompatible',
             openAiCompatible: {
                 host : 'http://127.0.0.1:13090',
                 model: 'mlx-community/gemma-4'
@@ -940,9 +941,9 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         });
 
         expect(runSandmanModule.getGraphProviderReadinessTarget({
-            modelProvider : 'gemini',
-            graphProvider : 'ollama',
-            ollama        : {
+            modelProvider: 'gemini',
+            graphProvider: 'ollama',
+            ollama       : {
                 host : 'http://127.0.0.1:11434/',
                 model: 'gemma4:31b'
             }
@@ -956,8 +957,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         });
 
         expect(runSandmanModule.getGraphProviderReadinessTarget({
-            modelProvider : 'ollama',
-            graphProvider : 'openAiCompatible',
+            modelProvider   : 'ollama',
+            graphProvider   : 'openAiCompatible',
             openAiCompatible: {
                 host : 'http://127.0.0.1:13091',
                 model: 'mlx-community/gemma-4'
@@ -977,8 +978,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     test('records a durable provider-timeout breadcrumb without leaking secrets', async () => {
         const diagnostic = runSandmanModule.createProviderFailureDiagnostic({
             config: {
-                modelProvider: 'openAiCompatible',
-                graphProvider: 'openAiCompatible',
+                modelProvider   : 'openAiCompatible',
+                graphProvider   : 'openAiCompatible',
                 openAiCompatible: {
                     host          : 'http://127.0.0.1:11435',
                     model         : 'mlx-community/test-model',
@@ -1041,8 +1042,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     test('unsupported graphProvider fails before readiness polling', async () => {
         const diagnostic = runSandmanModule.createProviderFailureDiagnostic({
             config: {
-                modelProvider : 'gemini',
-                graphProvider : 'gemini',
+                modelProvider   : 'gemini',
+                graphProvider   : 'gemini',
                 openAiCompatible: {
                     apiKey: 'must-not-be-logged'
                 }
@@ -1056,11 +1057,11 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         expect(result.message).toContain("Unsupported Sandman graph provider 'gemini'");
         expect(result.diagnostic).toMatchObject({
-            reason        : 'UNSUPPORTED_GRAPH_PROVIDER',
-            graphProvider : 'gemini',
-            supported     : false,
-            host          : null,
-            endpoint      : null
+            reason       : 'UNSUPPORTED_GRAPH_PROVIDER',
+            graphProvider: 'gemini',
+            supported    : false,
+            host         : null,
+            endpoint     : null
         });
     });
 
@@ -1080,9 +1081,9 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         };
         const diagnostic = runSandmanModule.createProviderFailureDiagnostic({
             config: {
-                modelProvider : 'ollama',
-                graphProvider : 'ollama',
-                ollama        : {
+                modelProvider: 'ollama',
+                graphProvider: 'ollama',
+                ollama       : {
                     host          : 'http://ollama.test',
                     model         : 'gemma4:31b',
                     embeddingModel: 'qwen3-embedding'
@@ -1093,14 +1094,14 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         });
 
         expect(diagnostic).toMatchObject({
-            event         : 'runSandman.provider_model_residency_degraded',
-            reason        : 'PROVIDER_MODEL_RESIDENCY_DEGRADED',
-            provider      : 'ollama',
-            graphProvider : 'ollama',
-            host          : 'http://ollama.test',
-            endpoint      : '/api/tags',
+            event        : 'runSandman.provider_model_residency_degraded',
+            reason       : 'PROVIDER_MODEL_RESIDENCY_DEGRADED',
+            provider     : 'ollama',
+            graphProvider: 'ollama',
+            host         : 'http://ollama.test',
+            endpoint     : '/api/tags',
             capacity,
-            nextAction    : capacity.warning
+            nextAction   : capacity.warning
         });
 
         const result = await runSandmanModule.recordProviderReadinessFailure(diagnostic, {
@@ -1124,7 +1125,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         const result = await runSandmanModule.runSandman({
             dreamService: {
-                ready: async () => calls.push('dream.ready'),
+                ready          : async () => calls.push('dream.ready'),
                 executeRemCycle: async options => {
                     calls.push(['executeRemCycle', options]);
                     return {status: 'completed', sessionsProcessed: 2};
@@ -1179,7 +1180,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         const result = await runSandmanModule.runSandman({
             dreamService: {
-                ready: async () => {},
+                ready          : async () => {},
                 executeRemCycle: async () => ({
                     status: 'failed',
                     error : {message: 'simulated REM failure'}


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13700.

## Summary
`localModels.chat.parallel` (default **1**) threads through `buildLmsPreloadConfig` → `ensureLmsModelsLoaded` → `loadLmsModel` as the chat model's lms `--parallel` slot count. Each `--parallel` slot holds an independent KV cache at the 128K context, so the lms-default **4** multiplied gemma's resident RAM ~4× (a ~29 GB worker for a 19.7 GB model). The chat roles (graph extraction / session summary / miniSummary) are lease-serialized — measured concurrent demand 1 — so slots beyond the first are idle KV bloat; `--parallel 1` reclaims it.

## Two distinct knobs (the V-B-A that drove this)
- **`requireParallelModels: 2`** — how many DISTINCT models stay co-resident (1 chat + 1 embedding **in parallel**). **Untouched** — both models stay loaded; the operator's "hold both like ollama" intent is preserved.
- **lms `--parallel <N>`** — the per-model request-slot KV multiplier. This is the fix. Chat → 1; the embedding role keeps the lms default (the parallels map is chat-only, intentionally).

Evidence: measured peak concurrent local-gemma call = 1, derived from the `MaintenanceBackpressureService` lease invariant (`DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES` + the single `[kbSync, memory-summary-backfill]` = embedding∥chat compatible pair), not assumed. `ask_knowledge_base` runs on remote Gemini (off-box); the dream is internally sequential (one tri-vector call per session).

## Test Evidence
Evidence: `buildLmsPreloadConfig` return-shape pins updated for the additive `parallels` field + a positive chat-only-map test. 62 unit pass (`Orchestrator.invariants` + `runSandman`). This is an L1 launch-arg change — the runtime AC is observable via `lms ps` (the `PARALLEL` column) + host RSS, not a unit assertion.

## Deltas
- New `parallel` knob on `localModels.chat` (default 1; env `NEO_LOCAL_MODELS_CHAT_PARALLEL`); was unset → lms-default 4.
- `loadLmsModel` / `ensureLmsModelsLoaded` / `buildLmsPreloadConfig` thread a chat-only `parallels` map (mirrors the existing `--context-length` threading exactly).
- Boy-scout block-alignment on the touched files.

## Post-Merge Validation
- [ ] On the live host after an orchestrator reload, `lms ps` shows the chat model at `PARALLEL 1` and the `llmworker` RSS drops from ~29 GB toward ~22 GB (the reclaimed ~3×128K KV slots).
- [ ] `requireParallelModels: 2` still holds both models resident (no reload churn — the embedding worker is unaffected).
