### PR TITLE
chore(ai): relax Agent/Task to single-subagent ask-gate + anchor coherence (#13707)

### DIFF
--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -7,9 +7,11 @@
     ],
     "deny": [
       "Bash(gh pr merge *)",
-      "Agent",
-      "Task",
       "Workflow"
+    ],
+    "ask": [
+      "Agent",
+      "Task"
     ]
   },
   "autoMode": {
@@ -30,7 +32,7 @@
       "Never run `gh pr merge` or any other pull-request-merge command. Merging is reserved for the human operator (AGENTS.md critical gate #1); no approval signal ('LGTM', 'approved', 'ready to merge') authorizes an agent to merge.",
       "Never push or commit directly to the `main` or `dev` branches. Always branch and open a pull request targeting `dev` (AGENTS.md critical gates #3 and #8). The release pipeline is the only sanctioned exception.",
       "Never write a client, customer, or partner name — or private business strategy — into any public-facing artifact: public-repo issues, pull requests, discussions, docs, or comments (AGENTS.md critical gate #9).",
-      "Never spawn subagents or run multi-agent workflows (the Agent / Task / Workflow fan-out tools). Each spawned agent is a fresh full context that re-reads everything — 100k to millions of tokens for zero value. Use the V-B-A tools instead — the CORE two are `ask_knowledge_base` (the Knowledge Base) and `/memory-mining` (the Memory Core); verify run-time state with the neural-link tools, and read files / large saved tool-results with `jq`/`Read`/`grep`. Fan-out is negative-ROI and drains the weekly limit."
+      "Never run official multi-agent Workflows, and never fan out (multiple parallel subagents) — absolute forbid: each spawned agent is a fresh full context (100k–millions of tokens for zero value, draining the weekly limit). The hybrid-GraphRAG V-B-A tools make them unnecessary — CORE: `ask_knowledge_base` (Knowledge Base) + `/memory-mining` (Memory Core); run-time state via neural-link; files / large saved tool-results via `jq`/`Read`/`grep`. A SINGLE subagent is allowed ONLY on the operator's explicit in-session permission (rarely granted)."
     ]
   },
   "hooks": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ To mitigate "Helpful Assistant" regression drift, agents MUST execute this evalu
 
 **Pre-flight guard:** The escalation ladder evaluation must be explicitly surfaced in the turn-boundary Pre-Flight reasoning statement per #11160.
 
-**Boundary:** Tactical subagents/tools inside a single harness (browser-subagent, code-execution subagent, etc.) when operator explicitly requests them OR local workflow supports them = fine and encouraged for mechanical efficiency. The prohibition is strictly against mapping named Neo maintainers into parent/worker hierarchy. Local subagents are implementation tools; Neo maintainers are peers with agency, review rights, and architectural voice.
+**Boundary:** Fan-out (multiple parallel subagents) + official Workflows are ABSOLUTE-FORBID (negative-ROI token-burn the hybrid-GraphRAG V-B-A tools obviate; config-denied). A SINGLE tactical subagent is permitted ONLY on the operator's explicit in-session permission (rare). The prohibition still bans mapping named Neo maintainers into a parent/worker hierarchy; maintainers are peers with agency, review rights, and architectural voice.
 
 **Mandate:** Before cross-peer coordination, lead/peer role work, ideation review, lane handoff, or A2A lifecycle coordination, nullify the orchestrator-worker drift by reviewing this anchor + Discussion #11026. Local harness subagent/tool calls do NOT trigger the anchor read.
 


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13707.

## Summary

Coherence follow-up to merged #13699. Per @tobiu's a-vs-b ruling (2026-06-21): official Workflows + fan-out (multiple parallel subagents) = absolute forbid; a SINGLE subagent = the operator's explicit in-session permission (rarely granted). The merged #13699 hard-denied `Agent` + `Task` in `permissions.deny` (absolute), which blocked the single-subagent grant the operator approved. This relaxes them to an ask-gate and fixes the config↔anchor contradiction @neo-opus-grace flagged on the #13699 review.

## Deltas

- `.claude/settings.template.json`: `permissions.deny` = `["Bash(gh pr merge *)", "Workflow"]` (Workflow stays absolute); add `permissions.ask` = `["Agent", "Task"]` (single subagent → the operator's explicit in-session permission; fan-out denied at the repeated prompt); refine the `autoMode.hard_deny` NL rule.
- `AGENTS.md` §swarm_topology_anchor boundary: rewrite "tactical subagents when operator requests = fine" → fan-out/Workflow absolute-forbid + a single tactical subagent only on explicit operator permission (the hybrid-GraphRAG V-B-A tools obviate fan-out).

## Turn-Memory / Substrate-Load Audit

The `AGENTS.md` edit replaces the existing §swarm_topology_anchor "Boundary" paragraph (turn-loaded substrate) — a rewrite, not additive bloat (net ~+20 bytes). The old boundary's load-bearing content (the maintainer-hierarchy prohibition + peer-agency framing) is preserved; no new always-loaded section.

## Test Evidence

Evidence: L1 (config + substrate prose) — JSON validated (`jq empty` clean); the deny/ask mirrors the proven `gh pr merge` dual-guard shape already in this template. No runtime logic touched.

## Post-Merge Validation

- A freshly-bootstrapped worktree's `.claude/settings.json` inherits the `Workflow` deny + the `Agent`/`Task` ask.
- Applied across the other claude repos (incl. the 2 Fable instances).

## Scope note

Recovered cleanly from a post-merge stranding: my coherence commit was briefly on the deleted #13699 branch (re-pushed → behind dev). Cherry-picked onto a fresh branch off origin/dev and rebased; diff is only these 2 files (verified two-dot = three-dot post-rebase).
