### PR TITLE
docs(ai): repair post-review-pickup fenced lane-state docs (#13711)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -122,11 +122,11 @@ not the flattened enum. Also fetch `reviewRequests`: a non-empty list is not str
 even at `reviewDecision=APPROVED` — name the reviewer(s) as the remaining gate until each is
 disposed. `validateMergeReady` (ai/scripts/lifecycle) encodes this contract.
 
-## 2.5. Mandatory `lane-state:` Declaration at Every Lifecycle Boundary
+## 2.5. Mandatory Lane-State Emission at Every Lifecycle Boundary
 
 Per #11455 AC, every lifecycle boundary (reviewer post, author response,
-post-implementation, PR open/update, ticket create, blocked-state exit) emits one
-of these before the turn ends:
+post-implementation, PR open/update, ticket create, blocked-state exit) emits
+both surfaces: prose for humans, fenced JSON for Stop hooks.
 
 ```text
 lane-state: next-lane (picking up ticket #NNNN)
@@ -136,11 +136,15 @@ lane-state: next-lane (PR #NNNN at human merge gate; picking up unrelated ticket
 lane-state: next-lane (filed/routed blocker bug #NNNN; picking up unrelated ticket #MMMM)
 ```
 
-Only `next-lane` is the normal turn-boundary state for this skill. "Holding",
-"standby", "nothing actionable", "idle", bare `paused`, `verified-empty`,
-`human-gate`, and blocker-as-exit-ramp are not turn terminals (§5).
-The declaration proves the cycle ran; without it the substrate cannot
-distinguish discipline from deference.
+```lane-state
+{"laneContinuation":"next-lane","namedGates":[{"ref":"PR #NNNN","checkedAt":"YYYY-MM-DDTHH:mm:ssZ"}]}
+```
+
+Only `next-lane` is normal here. "Holding", "standby", "nothing actionable",
+"idle", bare `paused`, `verified-empty`, `human-gate`, and blocker-as-exit-ramp
+are not turn terminals (§5). Prose alone is not a machine emission;
+`parseLaneState()` reads only the fenced block. No gate: `namedGates: []`; merge
+claim: `"mergeClaim":true,"field":"mergedAt"`.
 
 ## 2.6. Typed `lane-state` Ledger + Commitment Lease
 


### PR DESCRIPTION
Resolves #13711
Related: #13623, #13643

Updates `post-review-pickup` §2.5 so the lifecycle-boundary contract names both required surfaces: the human-readable `lane-state:` prose line and the fenced JSON `lane-state` block that the Codex/Claude Stop hooks parse through `parseLaneState()`. The change is intentionally scoped to the existing skill reference payload: no hook policy, parser behavior, `AGENTS.md`, or `SKILL.md` router changes.

Evidence: L1 (skill-substrate doc repair plus current parser/hook contract suite on final commit) -> L1 required (doc-contract repair only). Residual: none.

## Deltas from ticket

No runtime delta. The PR keeps the repair narrower than the closed NOT_PLANNED #13643 substrate: it does not add an always-loaded pointer, does not show a full hook directive template, and does not change the no-hold allow/block decision. It only fixes the stale prose-only guidance at the lifecycle boundary where agents already emit `lane-state:`.

## Slot Rationale

Modified existing trigger-loaded payload: `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md` §2.5. Placement/load did not change; detail remains compress-to-trigger under `post-review-pickup`, with no new always-loaded bytes. Size delta is +165 bytes (`20942` -> `21107`), accepted because the live Stop-hook/parser contract now falsifies the prose-only wording. Decay condition: compress/retire the explicit "prose alone is not a machine emission" note after a sustained cycle where hook diagnostics no longer show absent-block terminals from agents following the lifecycle skill.

## Test Evidence

- `git diff --check origin/dev...HEAD` -> passed.
- `npm run ai:check-substrate-size` -> passed (`AGENTS.md` 24473 bytes).
- `node ai/scripts/lint/lint-agents.mjs --base origin/dev` -> passed.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/parseLaneState.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs` -> 59 passed.
- Pre-push freshness: `origin/dev` is ancestor of `HEAD`; outgoing history contains only `4aeed85ff`.

## Post-Merge Validation

- [ ] Observe a lifecycle terminal that follows `post-review-pickup` §2.5 and confirm hook diagnostics no longer report `no lane-state block emitted at turn-terminal`.
- [ ] Confirm valid autonomous terminals may still block by design; this PR only repairs the machine-emission documentation seam.

## Commits

- `4aeed85ff` — `docs(ai): require fenced lane-state machine emission (#13711)`

Authored by Euclid (GPT-5, Codex Desktop). Session 747ae298-5a6e-4416-b90d-7786e184aa54.
