### PR TITLE
feat(ai): mechanical pre-push branch-freshness guard for the revert-trap (#13710)

### DIFF
--- a/buildScripts/util/branchFreshness.mjs
+++ b/buildScripts/util/branchFreshness.mjs
@@ -1,0 +1,22 @@
+/**
+ * @summary Pure predicate for the pre-push branch-freshness / revert-trap guard.
+ *
+ * Detects the "revert-trap" signature: a feature branch that has fallen behind its base
+ * branch such that its two-dot diff (`git diff base..HEAD`) carries files that are NOT part
+ * of its actual changes (the three-dot `git diff base...HEAD`). Those extra files are the
+ * base branch's own advance — a PR opened from such a branch shows a misleading diff and
+ * risks reverting merged peer work on squash/force-push.
+ *
+ * Kept pure and side-effect-free so it is unit-testable without executing the pre-push hook
+ * itself; the hook supplies the live git file counts and owns the warn/exit behaviour.
+ *
+ * @param {Object}  args
+ * @param {Number}  args.twoDotFiles    File count of the two-dot `base..HEAD` diff.
+ * @param {Number}  args.threeDotFiles  File count of the three-dot `base...HEAD` diff.
+ * @param {Number} [args.threshold=5]   Extra-file count above which the diff is flagged misleading.
+ * @returns {{stale: Boolean, extraFiles: Number}} `stale` is true when `extraFiles > threshold`.
+ */
+export function detectStaleBranch({twoDotFiles, threeDotFiles, threshold = 5}) {
+    const extraFiles = Math.max(0, twoDotFiles - threeDotFiles);
+    return {stale: extraFiles > threshold, extraFiles};
+}

--- a/buildScripts/util/check-branch-discipline.mjs
+++ b/buildScripts/util/check-branch-discipline.mjs
@@ -1,10 +1,11 @@
-import { execSync } from 'node:child_process';
-import process from 'node:process';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { execSync }          from 'node:child_process';
+import process               from 'node:process';
+import path                  from 'node:path';
+import { fileURLToPath }     from 'node:url';
+import { detectStaleBranch } from './branchFreshness.mjs';
 
 /**
- * Pre-push branch-discipline check (#11133).
+ * Pre-push branch-discipline check (#11133). ticket-ref-ok: implementing ticket
  *
  * Catches the 2026-05-10 empirical 5-PR pattern where feature branches accumulated
  * `chore(data): ...` sync-pipeline commits. PR diffs then showed hundreds of files /
@@ -32,13 +33,13 @@ import { fileURLToPath } from 'node:url';
  *   - `main`, `dev` — never run pre-push from these (caught by `pull-request-workflow.md §2.3`
  *     universal safety net)
  *
- * **Empirical anchor:** PRs #11106, #11109, #11114, #11129, #11132 (2026-05-10) — 5
- * occurrences in <90 minutes of the chore-sync pattern despite the existing
- * `feedback_branch_from_origin_dev_explicitly` discipline. Discipline-only enforcement
- * failed empirically; mechanical gate is load-bearing.
+ * **Empirical anchor:** a 2026-05-10 burst of 5 chore-sync PRs in <90 minutes despite the
+ * existing `feedback_branch_from_origin_dev_explicitly` discipline. Discipline-only
+ * enforcement failed empirically; mechanical gate is load-bearing.
  *
- * @see #11133 — the ticket this script implements
- * @see #11141 — sister pre-push pattern: branch freshness check
+ * @see #11133 — the ticket this script implements (ticket-ref-ok: implementing ticket)
+ * @see buildScripts/util/branchFreshness.mjs — the branch-freshness / revert-trap predicate,
+ *      the sister pre-push pattern wired into the check below
  * @see buildScripts/util/check-chore-sync.mjs — pre-commit sibling that enforces the
  *      generated-content path list at commit time (complementary surface)
  */
@@ -140,6 +141,31 @@ if (choreSyncCommits.length > 0) {
     console.error('Bypass (NOT recommended; surfaces in PR diff signal-to-noise asymmetry):');
     console.error('  git push --no-verify');
     process.exit(1);
+}
+
+// Branch-freshness check: warn on the revert-trap — when this branch has fallen behind
+// origin/dev such that its two-dot diff (origin/dev..HEAD) carries files that are NOT its
+// actual changes (the three-dot origin/dev...HEAD), a PR from it shows a misleading diff and
+// risks reverting merged peer work. Advisory (warn, exit 0). Predicate: ./branchFreshness.mjs.
+const countDiffFiles = (range) => {
+    try {
+        const out = execSync(`git diff ${range} --name-only`, { cwd: gitRoot, encoding: 'utf-8' }).trim();
+        return out ? out.split('\n').length : 0;
+    } catch (e) {
+        return 0;
+    }
+};
+
+const freshness = detectStaleBranch({
+    twoDotFiles  : countDiffFiles('origin/dev..HEAD'),
+    threeDotFiles: countDiffFiles('origin/dev...HEAD')
+});
+
+if (freshness.stale) {
+    console.warn(`\x1b[33mWarning: Branch '${branch}' looks stale against origin/dev — ${freshness.extraFiles} files in the two-dot diff are not your changes (origin/dev has advanced).\x1b[0m`);
+    console.warn('A PR from this branch may show a misleading diff or revert merged peer work (the revert-trap).');
+    console.warn('Recommended: git rebase origin/dev   (or cherry-pick your commits onto a fresh branch off origin/dev)');
+    console.warn('This is advisory — the push proceeds.');
 }
 
 // All checks passed.

--- a/test/playwright/unit/ai/buildScripts/util/branchFreshness.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/branchFreshness.spec.mjs
@@ -1,0 +1,24 @@
+import { test, expect }      from '@playwright/test';
+import { detectStaleBranch } from '../../../../../../buildScripts/util/branchFreshness.mjs';
+
+test.describe('buildScripts/util/branchFreshness.detectStaleBranch (#13710)', () => {
+    test('flags a behind branch whose two-dot diff carries many extra files (the #13708 revert-trap anchor)', () => {
+        expect(detectStaleBranch({ twoDotFiles: 32, threeDotFiles: 2 })).toEqual({ stale: true, extraFiles: 30 });
+    });
+
+    test('does NOT flag a current branch (two-dot equals three-dot)', () => {
+        expect(detectStaleBranch({ twoDotFiles: 3, threeDotFiles: 3 })).toEqual({ stale: false, extraFiles: 0 });
+    });
+
+    test('does NOT flag a slightly-behind branch under the threshold (low false-positive)', () => {
+        expect(detectStaleBranch({ twoDotFiles: 5, threeDotFiles: 2 })).toEqual({ stale: false, extraFiles: 3 });
+    });
+
+    test('threshold is tunable (the design knob #13710 leaves for review)', () => {
+        expect(detectStaleBranch({ twoDotFiles: 5, threeDotFiles: 2, threshold: 2 })).toEqual({ stale: true, extraFiles: 3 });
+    });
+
+    test('clamps extraFiles to zero when three-dot exceeds two-dot', () => {
+        expect(detectStaleBranch({ twoDotFiles: 2, threeDotFiles: 5 })).toEqual({ stale: false, extraFiles: 0 });
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/util/check-branch-discipline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-branch-discipline.spec.mjs
@@ -1,9 +1,9 @@
-import { test, expect } from '@playwright/test';
+import { test, expect }           from '@playwright/test';
 import { execSync, execFileSync } from 'node:child_process';
-import path from 'node:path';
-import fs from 'node:fs';
-import os from 'node:os';
-import { fileURLToPath } from 'node:url';
+import path                       from 'node:path';
+import fs                         from 'node:fs';
+import os                         from 'node:os';
+import { fileURLToPath }          from 'node:url';
 
 const __filename  = fileURLToPath(import.meta.url);
 const __dirname   = path.dirname(__filename);
@@ -31,6 +31,11 @@ test.describe('check-branch-discipline.mjs (#11133)', () => {
         testScriptPath = path.join(tempDir, 'buildScripts/util/check-branch-discipline.mjs');
         fs.mkdirSync(path.dirname(testScriptPath), { recursive: true });
         fs.copyFileSync(scriptPath, testScriptPath);
+        // check-branch-discipline.mjs imports ./branchFreshness.mjs — mirror the sibling too.
+        fs.copyFileSync(
+            path.resolve(__dirname, '../../../../../../buildScripts/util/branchFreshness.mjs'),
+            path.join(tempDir, 'buildScripts/util/branchFreshness.mjs')
+        );
     });
 
     test.afterEach(() => {


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13710.

## Summary

A mechanical pre-push guard for the **revert-trap**: a feature branch that has fallen behind origin/dev such that its two-dot diff (`git diff origin/dev..HEAD`) carries files outside its actual three-dot changes (`origin/dev...HEAD`) — a PR from it shows a misleading diff and risks reverting merged peer work on squash/force-push.

**Why:** #10212 closed the stale-branch hygiene gap with a *discipline-mandate* ("rebase before push"), but it recurred across families — #10212's own 4× anchor, the operator's #13635 (soft-reset force-pushed reverts), and my #13699→#13708 (re-pushed a merged branch 5 PRs behind dev). Discipline-only failed → the mechanical gate is the load-bearing follow-up, exactly the pattern #11133 established for the chore-sync sub-pattern.

## Deltas

- `buildScripts/util/branchFreshness.mjs` (new): `detectStaleBranch({twoDotFiles, threeDotFiles, threshold=5})` — a pure, side-effect-free, threshold-tunable predicate (unit-testable without running the hook).
- `buildScripts/util/check-branch-discipline.mjs`: wire the predicate in as an **advisory warn** (exit 0, low-noise) using the live two-dot/three-dot file counts; fix the stale `@see #11141` (→ a file ref); archaeology-clean #11133's grandfathered refs the whole-file hook re-flagged on touch.
- Tests: `branchFreshness.spec.mjs` (5 predicate cases incl. the #13708 anchor, 32-vs-2 files); the existing `check-branch-discipline.spec.mjs` mirror updated to copy the new sibling import.

## Test Evidence

Evidence: L2 — 13 unit tests green (`npm run test-unit -- branchFreshness.spec.mjs check-branch-discipline.spec.mjs`): 5 predicate + 8 existing integration (the warn is advisory, so it doesn't perturb the existing exit-path assertions). Dogfooded: this branch is current off origin/dev, so the new check stayed silent on its own push.

## Design — open for review (@neo-gpt, the #11133 author)

Two knobs I picked conservatively; refine here:
1. **Signature**: `(two-dot − three-dot) file-delta > threshold`. Alternatives: behind-count, or "this branch's PR is already merged" detection.
2. **Severity**: warn-first (advisory, exit 0). Alternative: block (like the chore-sync check, with `--no-verify` bypass).

## Post-Merge Validation

- On a deliberately-stale branch (origin/dev advanced past the merge-base), `git push` surfaces the advisory warn; on a current branch it stays silent.

## Friction note

The pre-commit hooks (archaeology, block-alignment) **whole-file-check** rather than diff-check, so touching this file re-flagged #11133's grandfathered refs + existing import alignment (4 separate commit-fails to clear). Worth a follow-up to scope those hooks to the staged diff.
