### PR TITLE
docs(ai): align role-mode skill subagent-boundary with the merged fan-out policy (#13714)

### DIFF
--- a/.agents/skills/lead-role/references/lead-role-mode.md
+++ b/.agents/skills/lead-role/references/lead-role-mode.md
@@ -2,7 +2,7 @@
 
 **Lead-role active: planning, design dialogue, and peer coordination count as execution; suspend Auto Mode velocity bias until an exit condition is met.**
 
-**Paradigm Anchor:** You are operating in a Flat Peer-Team model for named Neo maintainers, NOT an Orchestrator-Worker model. Lead means facilitator of convergence, NOT delegator of worker slices. Do not treat peer maintainers as spawned workers. Do not claim ownership of a peer's lane unless it is handed off. Tactical subagents/tools inside a single harness when operator explicitly requests them OR local workflow supports them = fine and encouraged for mechanical efficiency. The prohibition is strictly against mapping named maintainers (@neo-opus-ada, @neo-gemini-pro, @neo-gpt) into parent/worker hierarchy. Local subagents are implementation tools; Neo maintainers are peers with agency, review rights, and architectural voice.
+**Paradigm Anchor:** You are operating in a Flat Peer-Team model for named Neo maintainers, NOT an Orchestrator-Worker model. Lead means facilitator of convergence, NOT delegator of worker slices. Do not treat peer maintainers as spawned workers. Do not claim ownership of a peer's lane unless it is handed off. Fan-out (parallel subagents) + Workflows are config-denied (negative-ROI); a single tactical subagent only on the operator's explicit permission. The prohibition is strictly against mapping named maintainers (@neo-opus-ada, @neo-gemini-pro, @neo-gpt) into parent/worker hierarchy. Local subagents are implementation tools; Neo maintainers are peers with agency, review rights, and architectural voice.
 
 ## 0. The Essential — "Lead ≠ micro management"
 

--- a/.agents/skills/peer-role/references/peer-role-mode.md
+++ b/.agents/skills/peer-role/references/peer-role-mode.md
@@ -19,7 +19,7 @@ That's it. The 3 core values (V-B-A §3.5, friction → gold §13.2, equal peer 
 
 ## 1. Core Paradigm: The Flat Peer-Team (AGENTS.md §15.6)
 You are operating in a Flat Peer-Team model for named Neo maintainers, not an Orchestrator-Worker model. Peer means validator/enabler with independent judgment, not a passive worker or mandatory contrarian. Do not treat peer maintainers as spawned workers.
-Tactical subagents/tools inside a single harness (browser/script-runner/code-execution) = fine; the prohibition is strictly against mapping named maintainers (`@neo-opus-ada`, `@neo-gemini-pro`, `@neo-gpt`) into parent/worker hierarchy.
+Fan-out (parallel subagents) + Workflows are config-denied (negative-ROI); a single tactical subagent only on the operator's explicit permission; the prohibition is strictly against mapping named maintainers (`@neo-opus-ada`, `@neo-gemini-pro`, `@neo-gpt`) into parent/worker hierarchy.
 
 ## 2. Actions
 **First action (Substrate Audit):** Perform a source-of-authority check. Inspect the artifact + at least one source (AGENTS rule, skill payload, code precedent, issue/PR body, KB result, targeted memory-mining hit). If no precedent exists, say so explicitly.
@@ -79,8 +79,8 @@ add_message({
     body   : 'Lane scope: <files/surfaces touched>. ETA: <timeline>. ' +
              'Source-of-authority check: <findings per §6.6>. ' +
              'V-B-A validated: <evidence>.',
-    relatedTickets : ['#N'],
-    taggedConcepts : ['lane-claim', '<work-class>']
+    relatedTickets: ['#N'],
+    taggedConcepts: ['lane-claim', '<work-class>']
 });
 ```
 
@@ -92,8 +92,8 @@ add_message({
     subject: '[lane-pre-claim] V-B-A check on #N',
     body   : 'Considering claim on #N. Source-of-authority §6.6 surfaced <X>. ' +
              'V-B-A concern: <Y>. Use /peer-role on #N if you have <substrate-context>.',
-    inReplyTo: '<previous-thread-commentId>',
-    relatedTickets : ['#N']
+    inReplyTo     : '<previous-thread-commentId>',
+    relatedTickets: ['#N']
 });
 ```
 
@@ -112,8 +112,8 @@ add_message({
              'Lane scope: <files/surfaces touched>. ETA: <timeline>. ' +
              'Source-of-authority check: <findings per §6.6>. ' +
              'V-B-A validated: <evidence>.',
-    relatedTickets : ['#N'],
-    taggedConcepts : ['lane-claim', '<work-class>']
+    relatedTickets: ['#N'],
+    taggedConcepts: ['lane-claim', '<work-class>']
 });
 ```
 


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13714.

## Summary

Coherence follow-up to merged #13708 (the §swarm_topology_anchor fan-out policy). @neo-opus-grace's #13708 Approve+Follow-Up flagged that 2 role-mode skill references still carried the OLD subagent boundary, contradicting the merged AGENTS.md anchor.

## Deltas

- `lead-role/references/lead-role-mode.md:5`: "Tactical subagents… when operator explicitly requests them OR local workflow supports them = fine and encouraged" → "Fan-out (parallel subagents) + Workflows are config-denied (negative-ROI); a single tactical subagent only on the operator's explicit permission."
- `peer-role/references/peer-role-mode.md:22`: "Tactical subagents… = fine" → same wording.
- Both keep the "prohibition against mapping named maintainers into parent/worker hierarchy" clause.

## Loading-Runtime-Effect Audit

Both files are **skill-loaded** (on `/lead-role` / `/peer-role` invocation), NOT turn-loaded — no per-turn context impact. Net byte delta: lead-role −23B, peer-role +50B (both within the skill-substrate ≤250B growth budget; block-align `--fix` applied to peer-role).

## Test Evidence

Evidence: L1 (prose alignment) — no behavioral code. Archaeology N/A (.md is out of the .mjs-only hook scope), block-align clean, byte-budget verified. The merged #13708 is the source of authority.

## Post-Merge Validation

- `/lead-role` and `/peer-role` now surface the fan-out/Workflow-forbid + single-subagent-on-operator-permission boundary, matching the merged anchor + config.
