### PR TITLE
feat(ai): behavioral-source digest closes the runtime-freshness source blind spot (#13289)

### DIFF
--- a/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
+++ b/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
@@ -1,8 +1,9 @@
-import {execFile, execFileSync} from 'child_process';
-import {createHash}             from 'crypto';
-import {readFileSync}           from 'fs';
-import {promisify}              from 'util';
-import Base                     from '../../../../../src/core/Base.mjs';
+import {execFile, execFileSync}    from 'child_process';
+import {createHash}                from 'crypto';
+import {readdirSync, readFileSync} from 'fs';
+import {join}                      from 'path';
+import {promisify}                 from 'util';
+import Base                        from '../../../../../src/core/Base.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -41,13 +42,15 @@ function compareIdentityField(field, boot, current) {
 }
 
 /**
- * @summary Normalizes runtime identity file descriptors.
+ * @summary Normalizes runtime identity descriptors.
  *
- * Each file descriptor contributes one SHA-256 digest field to the runtime identity block.
- * The descriptor label is used only for compact diagnostic errors; the digest value itself
- * stays private to the boot/current comparison and is not echoed in public healthcheck output.
+ * Each descriptor contributes one SHA-256 digest field to the runtime identity block — either a
+ * single `path` (a file digest, e.g. config/OpenAPI) or a set of `dirs` (a manifest digest over the
+ * behavioral `.mjs` source under those directories). The descriptor label is used only for compact
+ * diagnostic errors; the digest value itself stays private to the boot/current comparison and is not
+ * echoed in public healthcheck output.
  *
- * @param {Object[]} files File descriptors.
+ * @param {Object[]} files Identity descriptors (`{key, path}` or `{key, dirs}`).
  * @returns {Object[]}
  */
 function normalizeIdentityFiles(files = []) {
@@ -56,8 +59,34 @@ function normalizeIdentityFiles(files = []) {
         .map(file => ({
             key       : file.key,
             path      : file.path,
+            dirs      : file.dirs,
             errorLabel: file.errorLabel || file.key
         }));
+}
+
+/**
+ * @summary Recursively collects `.mjs` source files under a directory for manifest digesting.
+ *
+ * Excludes spec files and node_modules/test trees so the digest tracks behavioral source only. A
+ * missing directory yields an empty list (the caller still records it), so a deleted source dir
+ * changes the manifest rather than throwing.
+ *
+ * @param {String} dir Absolute directory to walk.
+ * @returns {String[]} Absolute `.mjs` file paths (unsorted; the caller sorts the manifest).
+ */
+function collectSourceFiles(dir) {
+    let entries;
+
+    try {
+        entries = readdirSync(dir, {recursive: true, withFileTypes: true});
+    } catch (e) {
+        return [];
+    }
+
+    return entries
+        .filter(entry => entry.isFile() && entry.name.endsWith('.mjs') && !entry.name.endsWith('.spec.mjs'))
+        .map(entry => join(entry.parentPath || entry.path, entry.name))
+        .filter(filePath => !filePath.includes('/node_modules/') && !filePath.includes('/test/'));
 }
 
 /**
@@ -184,36 +213,36 @@ export class RuntimeFreshnessTracker {
                 : [identity.errors].filter(Boolean);
 
             freshness = this.#runtimeService.classifyRuntimeFreshness({
-                assertionFacts  : this.assertionFacts,
-                boot            : identity.boot || this.bootRuntimeIdentity,
-                current         : identity.current || {},
-                errors          : [
+                assertionFacts: this.assertionFacts,
+                boot          : identity.boot || this.bootRuntimeIdentity,
+                current       : identity.current || {},
+                errors        : [
                     ...this.bootRuntimeFreshnessErrors,
                     ...runtimeErrors
                 ],
-                fieldKeys       : this.#fieldKeys,
-                identityLabel   : this.identityLabel,
-                restartScope    : this.restartScope,
-                serviceName     : this.serviceName,
-                startedAt       : this.startedAt,
-                statusFields    : [...this.#statusFieldSet],
+                fieldKeys         : this.#fieldKeys,
+                identityLabel     : this.identityLabel,
+                restartScope      : this.restartScope,
+                serviceName       : this.serviceName,
+                startedAt         : this.startedAt,
+                statusFields      : [...this.#statusFieldSet],
                 unavailableSummary: this.unavailableSummary
             });
         } catch (e) {
             freshness = this.#runtimeService.classifyRuntimeFreshness({
-                assertionFacts  : this.assertionFacts,
-                boot            : this.bootRuntimeIdentity,
-                current         : {},
-                errors          : [
+                assertionFacts: this.assertionFacts,
+                boot          : this.bootRuntimeIdentity,
+                current       : {},
+                errors        : [
                     ...this.bootRuntimeFreshnessErrors,
                     `runtime freshness reader failed: ${e.message}`
                 ],
-                fieldKeys       : this.#fieldKeys,
-                identityLabel   : this.identityLabel,
-                restartScope    : this.restartScope,
-                serviceName     : this.serviceName,
-                startedAt       : this.startedAt,
-                statusFields    : [...this.#statusFieldSet],
+                fieldKeys         : this.#fieldKeys,
+                identityLabel     : this.identityLabel,
+                restartScope      : this.restartScope,
+                serviceName       : this.serviceName,
+                startedAt         : this.startedAt,
+                statusFields      : [...this.#statusFieldSet],
                 unavailableSummary: this.unavailableSummary
             });
         }
@@ -361,6 +390,48 @@ class RuntimeFreshnessService extends Base {
     }
 
     /**
+     * @summary Computes a stable SHA-256 digest over a set of source directories' `.mjs` contents.
+     *
+     * The behavioral-source counterpart to {@link createFileDigest}: where a file digest tracks one
+     * config/schema file, the manifest digest tracks the SOURCE CODE a long-lived MCP process loaded
+     * at boot. A pure-source change (e.g. a fixed embed path) leaves the config/OpenAPI digests
+     * untouched — the freshness signal's historic blind spot — so a stale process can run pre-merge
+     * code while reporting `status:'current'`. Hashing each file's path + content (sorted for a stable
+     * order) closes that gap: any add/remove/edit under the declared dirs flips the digest.
+     *
+     * Path + CONTENT pairs are hashed (not mtimes), so the signal is checkout-stable — a clone or
+     * rebase that rewrites mtimes without changing bytes does not cause a false stale. Boot and
+     * current are both computed in the same process against the same absolute dirs, so absolute paths
+     * compare cleanly.
+     *
+     * @param {String[]} dirs Absolute source directories to digest.
+     * @returns {String} `sha256:<hex>` over the sorted (path, content-hash) manifest.
+     */
+    createManifestDigest(dirs = []) {
+        const fileHashes = [];
+
+        for (const dir of dirs) {
+            for (const filePath of collectSourceFiles(dir)) {
+                try {
+                    fileHashes.push([filePath, createHash('sha256').update(readFileSync(filePath)).digest('hex')]);
+                } catch (e) {
+                    fileHashes.push([filePath, `unreadable:${e.code || 'ERR'}`]);
+                }
+            }
+        }
+
+        fileHashes.sort((a, b) => a[0].localeCompare(b[0]));
+
+        const manifest = createHash('sha256');
+
+        for (const [filePath, contentHash] of fileHashes) {
+            manifest.update(filePath).update('\0').update(contentHash).update('\0');
+        }
+
+        return `sha256:${manifest.digest('hex')}`;
+    }
+
+    /**
      * Creates a per-consumer runtime freshness tracker.
      *
      * @param {Object} options Tracker configuration.
@@ -399,7 +470,9 @@ class RuntimeFreshnessService extends Base {
 
         for (const file of normalizeIdentityFiles(files)) {
             try {
-                identity[file.key] = this.createFileDigest(file.path);
+                identity[file.key] = Array.isArray(file.dirs)
+                    ? this.createManifestDigest(file.dirs)
+                    : this.createFileDigest(file.path);
             } catch (e) {
                 errors.push(`${phase} ${file.errorLabel} unavailable: ${e.message}`);
             }
@@ -437,7 +510,9 @@ class RuntimeFreshnessService extends Base {
 
         for (const file of normalizeIdentityFiles(files)) {
             try {
-                identity[file.key] = this.createFileDigest(file.path);
+                identity[file.key] = Array.isArray(file.dirs)
+                    ? this.createManifestDigest(file.dirs)
+                    : this.createFileDigest(file.path);
             } catch (e) {
                 errors.push(`${phase} ${file.errorLabel} unavailable: ${e.message}`);
             }

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1,15 +1,15 @@
-import fs                       from 'fs/promises';
-import fsExtra                  from 'fs-extra';
-import path                     from 'path';
-import {fileURLToPath}          from 'url';
-import aiConfig                 from '../../mcp/server/memory-core/config.mjs';
-import Base                     from '../../../src/core/Base.mjs';
-import RuntimeFreshnessService  from '../../mcp/server/shared/services/RuntimeFreshnessService.mjs';
-import ChromaManager            from './managers/ChromaManager.mjs';
-import StorageRouter            from './managers/StorageRouter.mjs';
-import ChromaLifecycleService   from './lifecycle/ChromaLifecycleService.mjs';
-import logger                   from '../../mcp/server/memory-core/logger.mjs';
-import {readGateState}          from '../../scripts/lifecycle/wakeSafetyGate.mjs';
+import fs                      from 'fs/promises';
+import fsExtra                 from 'fs-extra';
+import path                    from 'path';
+import {fileURLToPath}         from 'url';
+import aiConfig                from '../../mcp/server/memory-core/config.mjs';
+import Base                    from '../../../src/core/Base.mjs';
+import RuntimeFreshnessService from '../../mcp/server/shared/services/RuntimeFreshnessService.mjs';
+import ChromaManager           from './managers/ChromaManager.mjs';
+import StorageRouter           from './managers/StorageRouter.mjs';
+import ChromaLifecycleService  from './lifecycle/ChromaLifecycleService.mjs';
+import logger                  from '../../mcp/server/memory-core/logger.mjs';
+import {readGateState}         from '../../scripts/lifecycle/wakeSafetyGate.mjs';
 import {
     SHARED_USER_ID,
     hasCoreSwarmParticipant,
@@ -24,6 +24,16 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const
     configPath  = path.resolve(__dirname, '../../config.mjs'),
     openApiPath = path.resolve(__dirname, '../../mcp/server/memory-core/openapi.yaml'),
+    // Behavioral-source dirs the Memory Core loads. A pure source-code change here (e.g. a fixed
+    // shared embed path) leaves config + OpenAPI digests untouched, so without a source digest a
+    // long-lived process can run pre-merge code while reporting freshness 'current'. Shared dirs are
+    // included because a shared-module edit makes every dependent process stale.
+    sourceDirs  = [
+        path.resolve(__dirname),                                  // ai/services/memory-core
+        path.resolve(__dirname, '../shared'),                     // ai/services/shared (vector / embed path)
+        path.resolve(__dirname, '../../mcp/server/memory-core'),
+        path.resolve(__dirname, '../../mcp/server/shared')
+    ],
     runtimeFreshnessTracker = RuntimeFreshnessService.createTracker({
         files  : [{
             key       : 'configDigest',
@@ -33,12 +43,16 @@ const
             key       : 'openApiDigest',
             path      : openApiPath,
             errorLabel: 'OpenAPI digest'
+        }, {
+            key       : 'sourceDigest',
+            dirs      : sourceDirs,
+            errorLabel: 'source digest'
         }],
         serviceName       : 'Memory Core MCP server',
         identityLabel     : 'source/config identity',
         assertionFacts    : 'provider, config, or tool-schema facts',
         restartScope      : 'cached provider/config state',
-        statusFields      : ['configDigest', 'openApiDigest'],
+        statusFields      : ['configDigest', 'openApiDigest', 'sourceDigest'],
         unavailableSummary: 'config digest and OpenAPI digest'
     });
 
@@ -124,9 +138,9 @@ export function buildIdentityBlock(stdioIdentityState) {
               : null;
 
     return {
-        source : resolvedSource,
-        bound  : !!agentIdentityNodeId,
-        nodeId : agentIdentityNodeId || null,
+        source: resolvedSource,
+        bound : !!agentIdentityNodeId,
+        nodeId: agentIdentityNodeId || null,
         warning
     };
 }
@@ -259,29 +273,29 @@ function buildSingleEmbeddingProviderBlock(cfg, active, configName) {
         case 'openAiCompatible':
             return {
                 active,
-                host      : cfg.openAiCompatible?.host || null,
-                model     : cfg.openAiCompatible?.embeddingModel || null,
+                host : cfg.openAiCompatible?.host || null,
+                model: cfg.openAiCompatible?.embeddingModel || null,
                 dimensions
             };
         case 'ollama':
             return {
                 active,
-                host      : cfg.ollama?.host || null,
-                model     : cfg.ollama?.embeddingModel || null,
+                host : cfg.ollama?.host || null,
+                model: cfg.ollama?.embeddingModel || null,
                 dimensions
             };
         case 'gemini':
             return {
                 active,
-                host      : null,
-                model     : cfg.embeddingModel || null,
+                host : null,
+                model: cfg.embeddingModel || null,
                 dimensions
             };
         default:
             return {
                 active,
-                host      : null,
-                model     : null,
+                host : null,
+                model: null,
                 dimensions,
                 error     : `Unrecognized ${configName}: '${active}'. Expected 'gemini' | 'openAiCompatible' | 'ollama'.`
             };
@@ -389,7 +403,7 @@ export function buildProviderPrerequisiteBlock(cfg, env = process.env) {
           details = [summary.detail, embedding.detail].filter(Boolean);
 
     return {
-        ready: summary.ready && embedding.ready,
+        ready  : summary.ready && embedding.ready,
         summary: {
             provider: summaryProvider,
             ready   : summary.ready
@@ -566,13 +580,13 @@ export async function buildBackupStateBlock(backupPath, fs, path) {
 
         return {
             lastSuccessful: timestamp,
-            count: backupDirs.length
+            count         : backupDirs.length
         };
     } catch (e) {
         return {
             lastSuccessful: null,
-            count: 0,
-            error: e.message
+            count         : 0,
+            error         : e.message
         };
     }
 }
@@ -1496,10 +1510,10 @@ class HealthService extends Base {
             startup : {
                 dependencies: this.getStartupDependencyState()
             },
-            backup   : await buildBackupStateBlock(aiConfig.backupPath, fsExtra, path),
-            details  : [],
-            version  : process.env.npm_package_version || '1.0.0',
-            uptime   : process.uptime()
+            backup : await buildBackupStateBlock(aiConfig.backupPath, fsExtra, path),
+            details: [],
+            version: process.env.npm_package_version || '1.0.0',
+            uptime : process.uptime()
         };
 
         // Step 1: Check Database connectivity

--- a/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
@@ -13,12 +13,14 @@ setup({
     }
 });
 
-import {test, expect}          from '@playwright/test';
-import path                    from 'path';
-import {fileURLToPath}         from 'url';
-import Neo                     from '../../../../../../../../src/Neo.mjs';
-import * as core               from '../../../../../../../../src/core/_export.mjs';
-import RuntimeFreshnessService from '../../../../../../../../ai/mcp/server/shared/services/RuntimeFreshnessService.mjs';
+import {test, expect}                                  from '@playwright/test';
+import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'fs';
+import {tmpdir}                                        from 'os';
+import path                                            from 'path';
+import {fileURLToPath}                                 from 'url';
+import Neo                                             from '../../../../../../../../src/Neo.mjs';
+import * as core                                       from '../../../../../../../../src/core/_export.mjs';
+import RuntimeFreshnessService                         from '../../../../../../../../ai/mcp/server/shared/services/RuntimeFreshnessService.mjs';
 
 const
     testDir  = path.dirname(fileURLToPath(import.meta.url)),
@@ -34,8 +36,8 @@ const
 test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776)', () => {
     test('keeps gitHead drift contextual when status-driving fields match', () => {
         const result = RuntimeFreshnessService.classifyRuntimeFreshness({
-            startedAt       : '2026-06-08T00:00:00.000Z',
-            boot            : {
+            startedAt: '2026-06-08T00:00:00.000Z',
+            boot     : {
                 gitHead      : 'old-head',
                 openApiDigest: 'sha256:same-openapi'
             },
@@ -43,12 +45,12 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
                 gitHead      : 'new-head',
                 openApiDigest: 'sha256:same-openapi'
             },
-            fieldKeys       : ['gitHead', 'openApiDigest'],
-            statusFields    : ['openApiDigest'],
-            serviceName     : 'Test MCP server',
-            identityLabel   : 'source/schema identity',
-            assertionFacts  : 'tool-schema/source facts',
-            restartScope    : 'cached tool definitions',
+            fieldKeys         : ['gitHead', 'openApiDigest'],
+            statusFields      : ['openApiDigest'],
+            serviceName       : 'Test MCP server',
+            identityLabel     : 'source/schema identity',
+            assertionFacts    : 'tool-schema/source facts',
+            restartScope      : 'cached tool definitions',
             unavailableSummary: 'git metadata and OpenAPI digest'
         });
 
@@ -69,8 +71,8 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
 
     test('marks stale when a status-driving digest differs', () => {
         const result = RuntimeFreshnessService.classifyRuntimeFreshness({
-            startedAt       : '2026-06-08T00:00:00.000Z',
-            boot            : {
+            startedAt: '2026-06-08T00:00:00.000Z',
+            boot     : {
                 gitHead      : 'same-head',
                 configDigest : 'sha256:old-config',
                 openApiDigest: 'sha256:same-openapi'
@@ -80,12 +82,12 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
                 configDigest : 'sha256:new-config',
                 openApiDigest: 'sha256:same-openapi'
             },
-            fieldKeys       : ['gitHead', 'configDigest', 'openApiDigest'],
-            statusFields    : ['configDigest', 'openApiDigest'],
-            serviceName     : 'Test MCP server',
-            identityLabel   : 'source/config identity',
-            assertionFacts  : 'provider/config facts',
-            restartScope    : 'cached provider/config state',
+            fieldKeys         : ['gitHead', 'configDigest', 'openApiDigest'],
+            statusFields      : ['configDigest', 'openApiDigest'],
+            serviceName       : 'Test MCP server',
+            identityLabel     : 'source/config identity',
+            assertionFacts    : 'provider/config facts',
+            restartScope      : 'cached provider/config state',
             unavailableSummary: 'git metadata, config digest, and OpenAPI digest'
         });
 
@@ -103,20 +105,20 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
 
     test('reports unknown when only contextual gitHead can be compared', () => {
         const result = RuntimeFreshnessService.classifyRuntimeFreshness({
-            startedAt       : '2026-06-08T00:00:00.000Z',
-            boot            : {
+            startedAt: '2026-06-08T00:00:00.000Z',
+            boot     : {
                 gitHead: 'same-head'
             },
             current         : {
                 gitHead: 'same-head'
             },
-            errors          : ['current OpenAPI digest unavailable: fixture'],
-            fieldKeys       : ['gitHead', 'openApiDigest'],
-            statusFields    : ['openApiDigest'],
-            serviceName     : 'Test MCP server',
-            identityLabel   : 'source/schema identity',
-            assertionFacts  : 'tool-schema/source facts',
-            restartScope    : 'cached tool definitions',
+            errors            : ['current OpenAPI digest unavailable: fixture'],
+            fieldKeys         : ['gitHead', 'openApiDigest'],
+            statusFields      : ['openApiDigest'],
+            serviceName       : 'Test MCP server',
+            identityLabel     : 'source/schema identity',
+            assertionFacts    : 'tool-schema/source facts',
+            restartScope      : 'cached tool definitions',
             unavailableSummary: 'git metadata and OpenAPI digest'
         });
 
@@ -217,5 +219,87 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
 
         expect(result.status).toBe('current');
         expect(result.stale).not.toHaveProperty('gitHead');
+    });
+});
+
+/**
+ * @summary Behavioral-source freshness — the manifest digest closes the source blind spot.
+ *
+ * Config/OpenAPI file digests cannot see a pure `.mjs` source change, so a long-lived process can run
+ * pre-merge code while reporting `status:'current'`. The manifest digest hashes the source tree's
+ * path+content so any add/remove/edit flips it and marks the process stale.
+ */
+test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService source manifest digest (#13289)', () => {
+    test('createManifestDigest flips on any content/add change and is otherwise stable', () => {
+        const dir = mkdtempSync(path.join(tmpdir(), 'neo-srcdigest-'));
+
+        mkdirSync(path.join(dir, 'nested'), {recursive: true});
+        writeFileSync(path.join(dir, 'a.mjs'), 'export const a = 1;');
+        writeFileSync(path.join(dir, 'nested', 'b.mjs'), 'export const b = 2;');
+
+        const d1 = RuntimeFreshnessService.createManifestDigest([dir]);
+
+        // Same content → same digest (checkout-stable).
+        expect(RuntimeFreshnessService.createManifestDigest([dir])).toBe(d1);
+
+        // A content change flips it (the pre-merge-source class, e.g. a fixed embed path).
+        writeFileSync(path.join(dir, 'nested', 'b.mjs'), 'export const b = 3;');
+        const d2 = RuntimeFreshnessService.createManifestDigest([dir]);
+        expect(d2).not.toBe(d1);
+
+        // Adding a source file also flips it.
+        writeFileSync(path.join(dir, 'c.mjs'), 'export const c = 4;');
+        expect(RuntimeFreshnessService.createManifestDigest([dir])).not.toBe(d2);
+
+        rmSync(dir, {recursive: true, force: true});
+    });
+
+    test('createManifestDigest excludes .spec.mjs and treats a missing dir as an empty, non-throwing contribution', () => {
+        const dir = mkdtempSync(path.join(tmpdir(), 'neo-srcdigest-'));
+
+        writeFileSync(path.join(dir, 'a.mjs'), 'export const a = 1;');
+        const base = RuntimeFreshnessService.createManifestDigest([dir]);
+
+        // Spec files are not behavioral source — adding one must not change the digest.
+        writeFileSync(path.join(dir, 'a.spec.mjs'), 'test fixture');
+        expect(RuntimeFreshnessService.createManifestDigest([dir])).toBe(base);
+
+        // A missing dir contributes nothing and never throws.
+        const missing = path.join(dir, 'does-not-exist');
+        expect(() => RuntimeFreshnessService.createManifestDigest([missing])).not.toThrow();
+        expect(RuntimeFreshnessService.createManifestDigest([missing])).toBe(RuntimeFreshnessService.createManifestDigest([]));
+
+        rmSync(dir, {recursive: true, force: true});
+    });
+
+    test('a sourceDigest descriptor drives stale status when source changes after boot', async () => {
+        const dir = mkdtempSync(path.join(tmpdir(), 'neo-srcdigest-'));
+
+        writeFileSync(path.join(dir, 'embedPath.mjs'), 'export const embed = "v1";');
+
+        const tracker = RuntimeFreshnessService.createTracker({
+            files: [{
+                key       : 'sourceDigest',
+                dirs      : [dir],
+                errorLabel: 'source digest'
+            }],
+            serviceName       : 'Test MCP server',
+            identityLabel     : 'source identity',
+            assertionFacts    : 'source-code facts',
+            restartScope      : 'cached source',
+            statusFields      : ['sourceDigest'],
+            unavailableSummary: 'source digest'
+        });
+
+        // Boot captured v1; current still v1 → current.
+        const fresh = await tracker.resolve({now: 1000});
+        expect(fresh.status).toBe('current');
+
+        // A behavioral-source edit lands after boot → the next resolve (past the cache TTL) is stale.
+        writeFileSync(path.join(dir, 'embedPath.mjs'), 'export const embed = "v2-fixed";');
+        const stale = await tracker.resolve({now: 1000 + 60_000});
+        expect(stale).toMatchObject({status: 'stale', stale: {sourceDigest: true}});
+
+        rmSync(dir, {recursive: true, force: true});
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -13,13 +13,13 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../../../src/manager/Instance.mjs';
-import AiConfig        from '../../../../../../ai/config.mjs';
-import ChromaManager   from '../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
-import StorageRouter   from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
+import {test, expect}         from '@playwright/test';
+import Neo                    from '../../../../../../src/Neo.mjs';
+import * as core              from '../../../../../../src/core/_export.mjs';
+import InstanceManager        from '../../../../../../src/manager/Instance.mjs';
+import AiConfig               from '../../../../../../ai/config.mjs';
+import ChromaManager          from '../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
+import StorageRouter          from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
 import ChromaLifecycleService from '../../../../../../ai/services/memory-core/lifecycle/ChromaLifecycleService.mjs';
 
 /**
@@ -285,12 +285,14 @@ test.describe.serial('HealthService #12772 — runtimeFreshness', () => {
             boot: {
                 gitHead      : 'old-head',
                 configDigest : 'sha256:same-config',
-                openApiDigest: 'sha256:same-openapi'
+                openApiDigest: 'sha256:same-openapi',
+                sourceDigest : 'sha256:same-source'
             },
             current: {
                 gitHead      : 'new-head',
                 configDigest : 'sha256:same-config',
-                openApiDigest: 'sha256:same-openapi'
+                openApiDigest: 'sha256:same-openapi',
+                sourceDigest : 'sha256:same-source'
             }
         });
 
@@ -298,7 +300,7 @@ test.describe.serial('HealthService #12772 — runtimeFreshness', () => {
 
         expect(result.status).toBe('current');
         expect(result.stale).not.toHaveProperty('gitHead');
-        expect(result.stale).toEqual({configDigest: false, openApiDigest: false});
+        expect(result.stale).toEqual({configDigest: false, openApiDigest: false, sourceDigest: false});
         expect(result.details.join(' ')).not.toContain('informational');
     });
 
@@ -375,13 +377,13 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         const summaryCollection = makeCollection(() => summaryCount);
 
         originals = {
-            chromaConnected         : ChromaManager.connected,
-            chromaReady             : ChromaManager.ready,
-            chromaConnect           : ChromaManager.connect,
+            chromaConnected          : ChromaManager.connected,
+            chromaReady              : ChromaManager.ready,
+            chromaConnect            : ChromaManager.connect,
             invalidateCollectionCache: ChromaManager.invalidateCollectionCache,
-            getMemoryCollection     : StorageRouter.getMemoryCollection,
-            getSummaryCollection    : StorageRouter.getSummaryCollection,
-            getDatabaseStatus       : ChromaLifecycleService.getDatabaseStatus
+            getMemoryCollection      : StorageRouter.getMemoryCollection,
+            getSummaryCollection     : StorageRouter.getSummaryCollection,
+            getDatabaseStatus        : ChromaLifecycleService.getDatabaseStatus
         };
 
         ChromaManager.connected = true;
@@ -579,9 +581,9 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
 
         expect(result.status).toBe('degraded');
         expect(result.identity).toMatchObject({
-            source : 'env-var',
-            bound  : false,
-            nodeId : null
+            source: 'env-var',
+            bound : false,
+            nodeId: null
         });
         expect(result.identity.warning).toContain("NEO_AGENT_IDENTITY is pinned to 'neo-opus-grace'");
         expect(result.details).toContain(`WARN: ${result.identity.warning}`);
@@ -959,7 +961,7 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
                 vectorDimension  : 4096
             },
             embedText: async () => new Promise(() => {}),
-            now: () => 100,
+            now      : () => 100,
             timeoutMs: 5
         });
 
@@ -980,7 +982,7 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
                 vectorDimension  : 4096
             },
             embedText: async () => [],
-            now: () => 100
+            now      : () => 100
         });
 
         expect(result).toMatchObject({
@@ -999,7 +1001,7 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
                 vectorDimension  : 4096
             },
             embedText: async () => [0.1, 0.2, 0.3],
-            now: () => 100
+            now      : () => 100
         });
 
         expect(result).toMatchObject({
@@ -1053,7 +1055,7 @@ test.describe('HealthService #10724 — buildSummaryProviderBlock', () => {
 
     test('openAiCompatible config surfaces the lean local-route shape without leaking API key value', () => {
         const result = buildSummaryProviderBlock({
-            modelProvider: 'openAiCompatible',
+            modelProvider   : 'openAiCompatible',
             openAiCompatible: {
                 host  : 'http://127.0.0.1:11434',
                 model : 'qwen3-8b',
@@ -1185,7 +1187,7 @@ test.describe('HealthService #10844 — buildBackupStateBlock', () => {
     test('returns null if no backup directories exist', async () => {
         const mockFs = {
             pathExists: async () => true,
-            readdir: async () => [
+            readdir   : async () => [
                 { isDirectory: () => false, name: 'backup-2023' },
                 { isDirectory: () => true, name: 'other-dir' }
             ]


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13289.

## Summary
The runtime-freshness signal could report `status:'current'` while a long-lived MCP process ran pre-merge code. Its digests covered named *files* (`configDigest`, `openApiDigest`) but never the behavioral *source* the process loaded — so a pure `.mjs` change (e.g. a fixed embed path) was invisible. **Proven live this session:** during a post-restart incident, a stale Memory Core reported `runtimeFreshness:"current"` while running pre-#13695 source — embeddings degraded, but the freshness gate said "current."

This adds a behavioral-**source** digest that closes the blind spot.

## Scope — #13289 reduced to gap-2 (V-B-A)
The ticket named two gaps. **Gap-1 (neural-link isn't a freshness consumer) is already shipped** since the ticket was rescoped 2026-06-15 — verified live: `ai/services/neural-link/HealthService.mjs` now builds a `RuntimeFreshnessService.createTracker(...)` identical to the memory-core pattern. So this PR closes only **gap-2 — the digest's source blind spot.**

## Mechanism
- `RuntimeFreshnessService.createManifestDigest(dirs)`: a stable SHA-256 over the sorted `(path, content-hash)` manifest of `.mjs` under the declared dirs (excludes `.spec.mjs` / `test` / `node_modules`). **Path + content** hashing (not mtime) keeps it checkout-stable — a clone/rebase that rewrites mtimes without changing bytes does NOT false-stale.
- An identity descriptor now accepts `{key, dirs}` (manifest) alongside `{key, path}` (single file), dispatched in both the sync (boot) and async (resolve) read paths. Additive — existing file-digest consumers untouched.
- **Memory Core opts in**: declares its behavioral-source dirs (`ai/services/memory-core`, `ai/services/shared` incl. the vector/embed path, `ai/mcp/server/{memory-core,shared}`) and adds `sourceDigest` to `statusFields`. A shared-module edit correctly marks every dependent process stale.

## Design notes for review
- **Cost**: the boot digest is sync; measured ~55 files / ~1.1 MB hash in **single-digit ms**, then cached at the existing 30s/5min TTL. Opt-in, so only adopting services pay it.
- **Scope is dir-based** (robust to intra-dir transitive deps) but does NOT cover the framework (`src/`) — a deliberate boundary (service-source freshness, not framework). Flagging for review.
- **Self-contained** (runtime tree-hash, no build/commit-step infra). A committed-manifest variant (offload hashing to commit-time) is a possible future optimization — noted, not built.
- The other services (KB, GH, neural-link, gitlab) opt in via follow-up; the shared mechanism is the hard part.

Evidence: L2 — unit-tested mechanism + the live incident as the motivating proof. The runtime effect (a real stale process flipping to `status:'stale'`) is observable post-restart but not neo-CI-reachable.

## Test Evidence
Evidence: 3 new source-digest tests (digest flips on content/add change + is stable; excludes spec/missing-dir; a `sourceDigest` descriptor drives `stale` end-to-end via boot-v1 → source-edit → resolve-stale) + 1 updated MC seam (sourceDigest in the stale shape). **117 pass** across the shared spec + every RuntimeFreshness consumer (MC / neural-link / KB HealthServices + Server + rem-observability).

## Deltas
- New `createManifestDigest(dirs)` + `collectSourceFiles(dir)` on the shared service; `{key, dirs}` descriptor variant.
- MC HealthService opts into `sourceDigest` (4 source dirs) + `statusFields`.
- Boy-scout block-alignment on the touched files.

## Post-Merge Validation
- [ ] On a live host, after a source-only merge WITHOUT restarting the MC, `healthcheck.runtimeFreshness` flips to `status:'stale'` with `stale.sourceDigest:true` (where pre-this-PR it stayed `'current'`).
- [ ] A restart clears it back to `'current'`.
