### PR TITLE
feat(ai): diff-scope block-alignment to staged-added lines via --staged (#13720)

### DIFF
--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -1,4 +1,6 @@
-import fs from 'fs';
+import fs                    from 'fs';
+import {execFileSync}        from 'node:child_process';
+import {getStagedAddedLines} from './stagedDiff.mjs';
 
 /**
  * @module buildScripts/util/check-block-alignment
@@ -467,7 +469,7 @@ function formatViolation(file, {lineIndex, expectedColumn, kind}) {
  * @param {Boolean} fix
  * @returns {Boolean} whether the file had (check) or had-and-fixed (fix) drift.
  */
-function processFile(file, fix) {
+function processFile(file, fix, gitRoot = null) {
     const allViolations = [];
     let   lines         = fs.readFileSync(file, 'utf8').split('\n');
     const maskedLines   = computeTemplateLiteralLineMask(lines);
@@ -483,19 +485,42 @@ function processFile(file, fix) {
     if (fix) {
         fs.writeFileSync(file, lines.join('\n'), 'utf8');
         console.log(`Aligned ${allViolations.length} line(s) in ${file}`);
-    } else {
-        for (const violation of allViolations.sort((a, b) => a.lineIndex - b.lineIndex)) {
-            console.error(formatViolation(file, violation));
-        }
+        return true;
+    }
+
+    // Staged (pre-commit) check mode: report only drift the author introduced on staged-added lines,
+    // so a grandfathered misalignment on an untouched line never blocks an unrelated commit. Fail
+    // CLOSED: a null detection (git read failure) reports the whole file rather than suppressing drift.
+    // (gitRoot is set only in --staged check mode; --fix always rewrites whole-file.)
+    const added    = gitRoot ? getStagedAddedLines(file, gitRoot) : null;
+    const reported = added ? allViolations.filter(v => added.has(v.lineIndex + 1)) : allViolations;
+
+    if (reported.length === 0) return false;
+
+    for (const violation of reported.sort((a, b) => a.lineIndex - b.lineIndex)) {
+        console.error(formatViolation(file, violation));
     }
 
     return true;
 }
 
 const
-    args  = process.argv.slice(2),
-    fix   = args.includes('--fix'),
-    files = args.filter(arg => arg !== '--fix');
+    args   = process.argv.slice(2),
+    fix    = args.includes('--fix'),
+    staged = args.includes('--staged'),
+    files  = args.filter(arg => arg !== '--fix' && arg !== '--staged');
+
+// --staged (pre-commit) mode: resolve the repo root once so processFile can scope check-mode drift to
+// the author's staged-added lines. Fail-closed: a rev-parse failure → null gitRoot → whole-file (drift
+// is never suppressed by a git failure). Only meaningful in check mode; --fix always rewrites whole-file.
+let gitRoot = null;
+if (staged && !fix) {
+    try {
+        gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {encoding: 'utf8'}).trim();
+    } catch (e) {
+        gitRoot = null;
+    }
+}
 
 let
     hadDrift = false,
@@ -503,7 +528,7 @@ let
 
 for (const file of files) {
     try {
-        if (processFile(file, fix)) hadDrift = true;
+        if (processFile(file, fix, gitRoot)) hadDrift = true;
     } catch (err) {
         console.error(`Error processing ${file}: ${err.message}`);
         hadError = true;

--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -1,9 +1,10 @@
 import {program}             from 'commander';
-import {execSync, spawnSync}  from 'node:child_process';
-import {readFileSync}         from 'node:fs';
-import path                   from 'node:path';
-import process                from 'node:process';
-import {fileURLToPath}        from 'node:url';
+import {execSync, spawnSync} from 'node:child_process';
+import {readFileSync}        from 'node:fs';
+import path                  from 'node:path';
+import process               from 'node:process';
+import {fileURLToPath}       from 'node:url';
+import {getStagedAddedLines} from './stagedDiff.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -173,7 +174,8 @@ function main() {
         return result.stdout.trim().split('\n').filter(Boolean);
     }
 
-    const files = argvFiles.length > 0
+    const isStagedMode = argvFiles.length > 0;
+    const files = isStagedMode
         ? argvFiles.filter(f => f.endsWith('.mjs'))
         : collectDefaultFiles();
 
@@ -192,7 +194,13 @@ function main() {
             continue;
         }
 
-        findTicketRefs(content).forEach(({line, text}) => violations.push(`${file}:${line}: ${text}`));
+        // In staged (pre-commit) mode, scope findings to the author's added lines so we do not
+        // re-flag grandfathered refs on untouched lines; the default-dirs full audit stays whole-file.
+        const addedLines = isStagedMode ? getStagedAddedLines(file, gitRoot) : null;
+
+        findTicketRefs(content)
+            .filter(({line}) => !addedLines || addedLines.has(line))
+            .forEach(({line, text}) => violations.push(`${file}:${line}: ${text}`));
     }
 
     if (violations.length > 0) {

--- a/buildScripts/util/stagedDiff.mjs
+++ b/buildScripts/util/stagedDiff.mjs
@@ -1,4 +1,4 @@
-import {execSync} from 'node:child_process';
+import {execFileSync} from 'node:child_process';
 
 /**
  * @summary Parses unified-diff text (`git diff --unified=0`) into the set of ADDED line numbers.
@@ -42,19 +42,24 @@ export function parseAddedLines(diffText) {
  * @summary Returns the staged-ADDED line numbers for a file (the `+` side of `git diff --cached`).
  *
  * Lets pre-commit hygiene checks scope findings to the author's own change rather than
- * re-flagging grandfathered issues on untouched lines. Returns an empty set on any git failure;
- * the caller treats an empty set as "no added-line info" and should fall back to whole-file.
+ * re-flagging grandfathered issues on untouched lines.
+ *
+ * Uses `execFileSync` with an argv array (no shell) so a filename containing quotes or spaces
+ * cannot break the command into a silently-empty diff — that would fail OPEN in the hygiene
+ * filter (a missing diff suppressing real findings). On any detection failure this returns
+ * `null` (not an empty set), which the caller MUST treat as "fall back to whole-file scanning"
+ * — fail CLOSED: a diff-read failure must never suppress a ticket-ref finding.
  *
  * @param {String} file    Path to the staged file.
  * @param {String} gitRoot Repository root (cwd for the git invocation).
- * @returns {Set<Number>} 1-based staged-added line numbers.
+ * @returns {Set<Number>|null} 1-based staged-added line numbers, or `null` if detection failed.
  */
 export function getStagedAddedLines(file, gitRoot) {
     try {
-        const diff = execSync(`git diff --cached --unified=0 -- "${file}"`, {cwd: gitRoot, encoding: 'utf-8'});
+        const diff = execFileSync('git', ['diff', '--cached', '--unified=0', '--', file], {cwd: gitRoot, encoding: 'utf-8'});
 
         return parseAddedLines(diff);
     } catch (e) {
-        return new Set();
+        return null;
     }
 }

--- a/buildScripts/util/stagedDiff.mjs
+++ b/buildScripts/util/stagedDiff.mjs
@@ -1,0 +1,60 @@
+import {execSync} from 'node:child_process';
+
+/**
+ * @summary Parses unified-diff text (`git diff --unified=0`) into the set of ADDED line numbers.
+ *
+ * Reads each hunk header `@@ -a,b +c,d @@` and emits the new-side line numbers `c .. c+d-1`
+ * (`d` defaults to 1 when omitted; a `+c,0` pure-deletion hunk adds nothing). Pure and
+ * side-effect-free so it is unit-testable without a git repository — the caller supplies the
+ * diff text.
+ *
+ * @param {String} diffText Output of `git diff --unified=0 -- <file>` for a single file.
+ * @returns {Set<Number>} 1-based new-side line numbers that the diff adds.
+ */
+export function parseAddedLines(diffText) {
+    const added = new Set();
+
+    if (!diffText) {
+        return added;
+    }
+
+    const hunkRe = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+
+    for (const line of diffText.split('\n')) {
+        const match = hunkRe.exec(line);
+
+        if (!match) {
+            continue;
+        }
+
+        const start = Number(match[1]),
+              count = match[2] === undefined ? 1 : Number(match[2]);
+
+        for (let i = 0; i < count; i++) {
+            added.add(start + i);
+        }
+    }
+
+    return added;
+}
+
+/**
+ * @summary Returns the staged-ADDED line numbers for a file (the `+` side of `git diff --cached`).
+ *
+ * Lets pre-commit hygiene checks scope findings to the author's own change rather than
+ * re-flagging grandfathered issues on untouched lines. Returns an empty set on any git failure;
+ * the caller treats an empty set as "no added-line info" and should fall back to whole-file.
+ *
+ * @param {String} file    Path to the staged file.
+ * @param {String} gitRoot Repository root (cwd for the git invocation).
+ * @returns {Set<Number>} 1-based staged-added line numbers.
+ */
+export function getStagedAddedLines(file, gitRoot) {
+    try {
+        const diff = execSync(`git diff --cached --unified=0 -- "${file}"`, {cwd: gitRoot, encoding: 'utf-8'});
+
+        return parseAddedLines(diff);
+    } catch (e) {
+        return new Set();
+    }
+}

--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
             "node ./buildScripts/util/check-shorthand.mjs",
             "node ./buildScripts/util/check-jsdoc-types.mjs",
             "node ./buildScripts/util/check-ticket-archaeology.mjs",
-            "node ./buildScripts/util/check-block-alignment.mjs"
+            "node ./buildScripts/util/check-block-alignment.mjs --staged"
         ],
         "test/**/*.mjs": [
             "node ./buildScripts/util/check-aiconfig-test-mutation.mjs"

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -295,3 +295,57 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
         });
     });
 });
+
+/**
+ * Real-git integration for the --staged diff-scope. In lint-staged (pre-commit) mode the check
+ * reports only drift on the author's staged-ADDED lines — a grandfathered misalignment on an
+ * untouched line must not block an unrelated commit — reusing the shared stagedDiff helper.
+ */
+test.describe('check-block-alignment.mjs --staged diff-scope (#13720)', () => {
+    let stagedDir;
+
+    const git = (...a) => execFileSync('git', a, {cwd: stagedDir, stdio: 'ignore'});
+
+    const runStaged = (file) => {
+        try {
+            return {status: 0, output: execFileSync('node', [scriptPath, '--staged', file], {cwd: stagedDir, encoding: 'utf8', stdio: 'pipe'})};
+        } catch (error) {
+            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
+        }
+    };
+
+    test.beforeEach(() => {
+        stagedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-blockalign-staged-'));
+        git('init');
+        git('config', 'user.email', 'test@example.com');
+        git('config', 'user.name', 'Test User');
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(stagedDir, {recursive: true, force: true});
+    });
+
+    test('does NOT flag a grandfathered misalignment on an untouched line', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+        // Two misaligned imports (line 1 drifts), committed = grandfathered.
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'init');
+        // Stage an unrelated added line (line 3); the grandfathered drift on line 1 stays untouched.
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\nexport const x = 1;\n", 'utf8');
+        git('add', 'src.mjs');
+
+        expect(runStaged('src.mjs').status).toBe(0);
+    });
+
+    test('flags a misalignment on a staged-ADDED line', () => {
+        const file = path.join(stagedDir, 'src.mjs');
+        // New file: both misaligned imports are staged-added, so line 1's drift is in scope.
+        fs.writeFileSync(file, "import a from 'a';\nimport bb from 'b';\n", 'utf8');
+        git('add', 'src.mjs');
+
+        const r = runStaged('src.mjs');
+        expect(r.status).toBe(1);
+        expect(r.output).toContain('Misaligned');
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
@@ -1,5 +1,10 @@
-import {test, expect}                    from '@playwright/test';
-import {extractComment, findTicketRefs}  from '../../../../../../buildScripts/util/check-ticket-archaeology.mjs';
+import {test, expect}                       from '@playwright/test';
+import {execFileSync}                       from 'node:child_process';
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir}                             from 'node:os';
+import path                                 from 'node:path';
+import {extractComment, findTicketRefs}     from '../../../../../../buildScripts/util/check-ticket-archaeology.mjs';
+import {getStagedAddedLines}                from '../../../../../../buildScripts/util/stagedDiff.mjs';
 
 /**
  * Self-test for the ticket-archaeology guard: the mechanical replacement for the discipline-only
@@ -67,5 +72,76 @@ test.describe('check-ticket-archaeology guard', () => {
         const state = {inBlock: false};
         extractComment('/** opens */', state);
         expect(state.inBlock).toBe(false)
+    });
+});
+
+/**
+ * Real-git integration for the staged-mode diff-scope. Exercises the exact filter
+ * composition main() runs in argv-files mode — findTicketRefs scoped to getStagedAddedLines —
+ * against a real staged repo, without invoking the commander CLI (the tempDir has no node_modules).
+ * Covers: refs scoped to staged-added lines, grandfathered refs on untouched lines NOT re-flagged,
+ * a quoted filename (the shell-interpolation fail-open regression), and the null fail-closed path.
+ */
+test.describe('check-ticket-archaeology staged-mode diff-scope (#13717)', () => {
+    let tempDir;
+
+    const git = (...args) => execFileSync('git', args, {cwd: tempDir, stdio: 'ignore'});
+
+    const stagedHits = (content, file) => {
+        const added = getStagedAddedLines(file, tempDir);
+        return findTicketRefs(content).filter(({line}) => !added || added.has(line));
+    };
+
+    test.beforeEach(() => {
+        tempDir = mkdtempSync(path.join(tmpdir(), 'neo-archaeology-staged-'));
+        git('init');
+        git('config', 'user.email', 'test@example.com');
+        git('config', 'user.name', 'Test User');
+    });
+
+    test.afterEach(() => {
+        rmSync(tempDir, {recursive: true, force: true});
+    });
+
+    test('scopes a flagged ref to a staged-ADDED line', () => {
+        const content = '// see #12345\nexport const a = 1;\n';
+        writeFileSync(path.join(tempDir, 'src.mjs'), content);
+        git('add', 'src.mjs');
+
+        expect(stagedHits(content, 'src.mjs').map(h => h.line)).toEqual([1]);
+    });
+
+    test('does NOT flag a grandfathered ref on an untouched line', () => {
+        const filePath = path.join(tempDir, 'src.mjs');
+        writeFileSync(filePath, '// legacy ref #11111\nexport const a = 1;\n');
+        git('add', 'src.mjs');
+        git('commit', '-m', 'init');
+
+        const content = '// legacy ref #11111\nexport const a = 1;\nexport const b = 2;\n';
+        writeFileSync(filePath, content);
+        git('add', 'src.mjs');
+
+        // findTicketRefs still sees the legacy ref on line 1, but it is not a staged-added line → dropped.
+        expect(findTicketRefs(content).map(h => h.line)).toEqual([1]);
+        expect(stagedHits(content, 'src.mjs')).toEqual([]);
+    });
+
+    test('fails CLOSED on a quoted filename — execFileSync reads the diff so the added ref stays scoped in', () => {
+        const name    = 'a"b.mjs';
+        const content = '// added ref #12345\nexport const a = 1;\n';
+        writeFileSync(path.join(tempDir, name), content);
+        git('add', name);
+
+        // The old shell-interpolated git command broke on the quote (empty diff → fail-open);
+        // execFileSync (argv array) reads it correctly, so the added ref stays flagged.
+        expect(stagedHits(content, name).map(h => h.line)).toEqual([1]);
+    });
+
+    test('fails CLOSED when detection is unavailable — null added-lines flags every finding', () => {
+        const content = '// see #12345\nexport const a = 1;\n';
+        const added   = getStagedAddedLines('nope.mjs', '/nonexistent-neo-dir');
+
+        expect(added).toBeNull();
+        expect(findTicketRefs(content).filter(({line}) => !added || added.has(line)).map(h => h.line)).toEqual([1]);
     });
 });

--- a/test/playwright/unit/ai/buildScripts/util/stagedDiff.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/stagedDiff.spec.mjs
@@ -1,5 +1,5 @@
-import {test, expect}    from '@playwright/test';
-import {parseAddedLines} from '../../../../../../buildScripts/util/stagedDiff.mjs';
+import {test, expect}                         from '@playwright/test';
+import {getStagedAddedLines, parseAddedLines} from '../../../../../../buildScripts/util/stagedDiff.mjs';
 
 test.describe('buildScripts/util/stagedDiff.parseAddedLines (#13717)', () => {
     test('returns an empty set for empty diff text', () => {
@@ -21,5 +21,13 @@ test.describe('buildScripts/util/stagedDiff.parseAddedLines (#13717)', () => {
 
     test('pure-deletion hunk (+c,0) adds nothing', () => {
         expect([...parseAddedLines('@@ -5,2 +4,0 @@\n-gone\n-gone2')]).toEqual([]);
+    });
+});
+
+test.describe('buildScripts/util/stagedDiff.getStagedAddedLines (#13717)', () => {
+    test('returns null (not an empty set) on git failure so the caller falls back to whole-file', () => {
+        // A non-repo cwd makes `git diff` fail; null is the fail-closed signal (detection unavailable),
+        // which the archaeology filter treats as "flag all findings" rather than suppressing them.
+        expect(getStagedAddedLines('any.mjs', '/nonexistent-neo-archaeology-dir')).toBeNull();
     });
 });

--- a/test/playwright/unit/ai/buildScripts/util/stagedDiff.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/stagedDiff.spec.mjs
@@ -1,0 +1,25 @@
+import {test, expect}    from '@playwright/test';
+import {parseAddedLines} from '../../../../../../buildScripts/util/stagedDiff.mjs';
+
+test.describe('buildScripts/util/stagedDiff.parseAddedLines (#13717)', () => {
+    test('returns an empty set for empty diff text', () => {
+        expect([...parseAddedLines('')]).toEqual([]);
+    });
+
+    test('single-line add (count omitted → defaults to 1)', () => {
+        expect([...parseAddedLines('@@ -0,0 +5 @@\n+new line')].sort((a, b) => a - b)).toEqual([5]);
+    });
+
+    test('multi-line add range', () => {
+        expect([...parseAddedLines('@@ -10,0 +11,3 @@\n+a\n+b\n+c')].sort((a, b) => a - b)).toEqual([11, 12, 13]);
+    });
+
+    test('multiple hunks union their added lines', () => {
+        const diff = '@@ -1,0 +2,1 @@\n+x\n@@ -20,0 +30,2 @@\n+y\n+z';
+        expect([...parseAddedLines(diff)].sort((a, b) => a - b)).toEqual([2, 30, 31]);
+    });
+
+    test('pure-deletion hunk (+c,0) adds nothing', () => {
+        expect([...parseAddedLines('@@ -5,2 +4,0 @@\n-gone\n-gone2')]).toEqual([]);
+    });
+});


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13720.

> **Stacked on #13718** (base = `claude/13717-hook-diff-scope`) — #13720 reuses the `stagedDiff` helper #13718 introduces. Retarget to `dev` once #13718 merges.

## Summary

Sibling of #13717 / #13718 — the block-alignment pre-commit check had the same whole-file friction: touching a file re-flagged grandfathered misalignment on untouched lines, forcing `--fix` of unrelated lines (empirically: #13710 + #13716 both carried that noise in their diffs).

## Deltas

- `buildScripts/util/check-block-alignment.mjs`: add a `--staged` flag. In `--staged` check mode, violations are filtered to the author's staged-added lines via `stagedDiff.getStagedAddedLines` (fail-closed: a null detection → whole-file). `--fix` and manual/non-staged checks stay whole-file.
- `package.json`: lint-staged passes `--staged` (block-align is lint-staged-only — no CI full-check to weaken).
- Test: a real-git `--staged` describe (grandfathered-untouched-not-flagged + staged-added-flagged).

## Test Evidence

Evidence: L2 — 18 unit tests green (`npm run test-unit -- check-block-alignment.spec.mjs`), incl. the new `--staged` real-git integration. Dogfooded: the husky ran block-align `--staged` on this very commit and passed clean.

## Post-Merge Validation

- Touching a file with grandfathered block-align drift on untouched lines no longer blocks an unrelated commit; new drift on staged-added lines still fails.
