### PR TITLE
fix(ai): make repair dry-run runtime readonly (#13722)

### DIFF
--- a/ai/scripts/maintenance/repairUnprojectedSessions.mjs
+++ b/ai/scripts/maintenance/repairUnprojectedSessions.mjs
@@ -273,9 +273,42 @@ export function parseArgs(argv = []) {
 }
 
 /**
+ * @summary Builds the read-only runtime used by `--dry-run`, avoiding GraphService's writable
+ * SQLite initialization while preserving the same summary-collection scan inputs.
  * @returns {Promise<Object>}
  */
-export async function createRuntime() {
+export async function createDryRunRuntime() {
+    await import('../../../src/Neo.mjs');
+    await import('../../../src/core/_export.mjs');
+
+    const {default: aiConfig}      = await import('../../mcp/server/memory-core/config.mjs');
+    const {default: ChromaManager} = await import('../../services/memory-core/managers/ChromaManager.mjs');
+    const {default: Database}      = await import('better-sqlite3');
+
+    await ChromaManager.initAsync();
+
+    const
+        summaryCollection = await ChromaManager.getSummaryCollection(),
+        graphDb           = new Database(aiConfig.storagePaths.graph, {
+            readonly     : true,
+            fileMustExist: true
+        });
+
+    return {
+        graphDb,
+        summaryCollection,
+        cleanup() {
+            graphDb.close();
+        }
+    }
+}
+
+/**
+ * @summary Builds the writable repair runtime used by `--apply`, where GraphService and
+ * MemorySessionIngestor are required to backfill SESSION projections.
+ * @returns {Promise<Object>}
+ */
+export async function createApplyRuntime() {
     await import('../../../src/Neo.mjs');
     await import('../../../src/core/_export.mjs');
 
@@ -305,6 +338,24 @@ export async function createRuntime() {
     }
 }
 
+/**
+ * @summary Selects the dry-run or apply runtime after CLI argument parsing.
+ * @param {Object} [options]
+ * @param {Boolean} [options.apply=false]
+ * @param {Object} [factories]
+ * @param {Function} [factories.dryRunRuntimeFactory]
+ * @param {Function} [factories.applyRuntimeFactory]
+ * @returns {Promise<Object>}
+ */
+export function createRuntime({
+    apply = false
+} = {}, {
+    dryRunRuntimeFactory = createDryRunRuntime,
+    applyRuntimeFactory  = createApplyRuntime
+} = {}) {
+    return (apply ? applyRuntimeFactory : dryRunRuntimeFactory)()
+}
+
 export function usage() {
     return [
         'Usage: node ai/scripts/maintenance/repairUnprojectedSessions.mjs [--dry-run|--apply] [--limit N|all] [--batch-size N] [--include-undigested]',
@@ -325,6 +376,8 @@ export async function runCli(argv = process.argv.slice(2), {
     stdout         = console.log,
     stderr         = console.error
 } = {}) {
+    let runtime;
+
     try {
         const options = parseArgs(argv);
 
@@ -333,8 +386,9 @@ export async function runCli(argv = process.argv.slice(2), {
             return 0
         }
 
-        const runtime = await runtimeFactory();
-        const result  = await repairUnprojectedSessions({...runtime, ...options});
+        runtime = await runtimeFactory(options);
+
+        const result = await repairUnprojectedSessions({...runtime, ...options});
 
         stdout(JSON.stringify(result, null, 2));
 
@@ -342,6 +396,14 @@ export async function runCli(argv = process.argv.slice(2), {
     } catch (error) {
         stderr(`[repairUnprojectedSessions] ${error.message}`);
         return 2
+    } finally {
+        if (runtime?.cleanup) {
+            try {
+                await runtime.cleanup();
+            } catch (error) {
+                stderr(`[repairUnprojectedSessions] cleanup failed: ${error.message}`);
+            }
+        }
     }
 }
 

--- a/test/playwright/unit/ai/scripts/maintenance/repairUnprojectedSessions.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairUnprojectedSessions.spec.mjs
@@ -6,10 +6,12 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import {
+    createRuntime,
     createSessionGraphId,
     findUnprojectedSessions,
     parseArgs,
-    repairUnprojectedSessions
+    repairUnprojectedSessions,
+    runCli
 } from '../../../../../../ai/scripts/maintenance/repairUnprojectedSessions.mjs';
 
 void Neo;
@@ -64,6 +66,73 @@ test.describe('ai/scripts/maintenance/repairUnprojectedSessions', () => {
             help        : false,
             limit       : null
         });
+    });
+
+    test('createRuntime selects readonly dry-run runtime unless apply mode is requested', async () => {
+        const
+            calls      = [],
+            dryRuntime = {mode: 'dry'},
+            appRuntime = {mode: 'apply'},
+            factories  = {
+                async dryRunRuntimeFactory() {
+                    calls.push('dry');
+                    return dryRuntime
+                },
+                async applyRuntimeFactory() {
+                    calls.push('apply');
+                    return appRuntime
+                }
+            };
+
+        await expect(createRuntime({}, factories)).resolves.toBe(dryRuntime);
+        await expect(createRuntime({apply: false}, factories)).resolves.toBe(dryRuntime);
+        await expect(createRuntime({apply: true}, factories)).resolves.toBe(appRuntime);
+        expect(calls).toEqual(['dry', 'dry', 'apply']);
+    });
+
+    test('runCli passes parsed dry-run options to the runtime factory and cleans up runtime handles', async () => {
+        const
+            rows = [
+                {chromaId: 'summary-a', meta: {sessionId: 'a', graphDigested: true}}
+            ],
+            stdout = [],
+            stderr = [],
+            cleanupCalls = [],
+            optionsSeen  = [];
+
+        const exitCode = await runCli(['--dry-run', '--limit', 'all'], {
+            stdout: line => stdout.push(line),
+            stderr: line => stderr.push(line),
+            async runtimeFactory(options) {
+                optionsSeen.push(options);
+
+                return {
+                    summaryCollection: createSummaryCollection(rows),
+                    graphDb          : createGraphDb(),
+                    cleanup() {
+                        cleanupCalls.push('cleanup');
+                    }
+                }
+            }
+        });
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toEqual([]);
+        expect(optionsSeen).toEqual([{
+            apply       : false,
+            batchSize   : 500,
+            digestedOnly: true,
+            help        : false,
+            limit       : null
+        }]);
+        expect(cleanupCalls).toEqual(['cleanup']);
+
+        const payload = JSON.parse(stdout[0]);
+        expect(payload.mode).toBe('dry-run');
+        expect(payload.candidates).toBe(1);
+        expect(payload.results).toEqual([
+            {chromaId: 'summary-a', sessionId: 'a', graphNodeId: 'session:a'}
+        ]);
     });
 
     test('findUnprojectedSessions selects graphDigested rows with missing SESSION graph nodes', async () => {


### PR DESCRIPTION
Authored by Euclid (GPT-5, Codex Desktop). Session 019ee5c2-82ba-7b73-8812-df59106ff61a.

Resolves #13722
Related: #13624
Related: #13697
Related: #13701

**Does this PR resolve an issue?** (Required)

Resolves #13722

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills this requirement:**

- [x] It is submitted to the `dev` branch, not the `main` branch

If adding a **new feature**, the PR description includes:
- [ ] A convincing reason for adding this feature

**Other information:**

## Deltas

- Splits `repairUnprojectedSessions` runtime creation into a readonly dry-run runtime and the existing writable apply runtime.
- Opens the graph database with `better-sqlite3` readonly/fileMustExist for `--dry-run`, avoiding `GraphService` writable SQLite initialization.
- Passes parsed CLI options into `runtimeFactory` so dry-run/apply selection happens after argument parsing.
- Adds runtime cleanup so the direct readonly SQLite handle is closed after CLI execution.

Evidence: L2 (focused unit coverage plus a process-level dry-run probe against the live local stores with Memory Core logPath redirected inside the workspace). L3/L4 residual: the default host CLI should still be run post-merge from a non-sandbox or writable-log environment because the local `.neo-ai-data/logs` symlink permission issue is separate from this `SQLITE_READONLY` repair; `--apply` remains operator-gated and was not run.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/repairUnprojectedSessions.spec.mjs` -> 6 passed on the rebased head.
- `git diff --check origin/dev...HEAD` -> passed.
- Process-level `runCli` dry-run probe with `mcCfg.logPath` redirected to `/Users/Shared/codex/neomjs/neo/tmp/mc-logs` -> `mode: dry-run`, `candidates: 416`, `total: 1338`, `scanned: 1338`, `skippedNoSessionId: 0`, `skippedNotDigested: 319`, `skippedAlreadyGraph: 603`; no `SQLITE_READONLY` failure.

## Post-Merge Validation

- Run `node ai/scripts/maintenance/repairUnprojectedSessions.mjs --dry-run --limit all` from a host/default environment where the Memory Core log path is writable.
- Review the emitted candidate set before any `--apply` run; do not run apply automatically.
