### PR TITLE
feat(ai): pure PR-outcome reward-computation core (#13724)

### DIFF
--- a/ai/services/ingestion/PrOutcomeReward.mjs
+++ b/ai/services/ingestion/PrOutcomeReward.mjs
@@ -1,0 +1,67 @@
+/**
+ * @summary Pure PR-outcome → RLAIF reward-signal mapping — the foundational slice of the PR Outcome
+ * Tracker. Maps a pull request's terminal merge outcome to a scalar reward, giving the RLAIF
+ * pipeline a ground-truth signal the LLM-estimated session quality/productivity scores cannot see
+ * (a session whose PRs were all reverted must not score as productive).
+ *
+ * Deliberately PURE — no I/O, no Chroma/graph write, no `gh` calls. The outcome SCAN (gh I/O),
+ * session-linking, the ChromaDB retroactive-tag write (RLS + dry-run-first), and the
+ * DreamService/runSandman integration are the rest of the tracker (the RLAIF/memory-core domain). Placed
+ * beside its eventual consumer (`MemorySessionIngestor`); relocate to a dedicated `rlaif/` module if
+ * the integration design warrants. Plain function exports (no Neo singleton) mirror this directory's
+ * local-pure-helper convention — a stateless mapping needs no instance.
+ *
+ * Reward table:
+ * | outcome             | reward | rationale                      |
+ * |---------------------|--------|--------------------------------|
+ * | `mergedClean`       |   1.0  | merge-ready code               |
+ * | `mergedWithChanges` |   0.7  | good work, minor polish        |
+ * | `closedUnmerged`    |   0.0  | wasted effort — wrong approach |
+ * | `reverted`          |  -1.0  | actively harmful — regression  |
+ *
+ * @module ai/services/ingestion/PrOutcomeReward
+ */
+
+/**
+ * @summary The canonical PR-outcome → reward scalar table. Frozen so callers cannot mutate
+ * the shared signal definition.
+ * @type {Readonly<Object<String,Number>>}
+ */
+export const PR_OUTCOME_REWARDS = Object.freeze({
+    mergedClean      : 1.0,
+    mergedWithChanges: 0.7,
+    closedUnmerged   : 0.0,
+    reverted         : -1.0
+});
+
+/**
+ * @summary Classifies a pull request's terminal state into one of the four reward outcomes. Revert
+ * dominates merge (a reverted PR is `reverted` regardless of how it merged); an unmerged PR is
+ * `closedUnmerged` regardless of any requested-changes history.
+ * @param {Object} [state={}]
+ * @param {Boolean} state.merged True if the PR was merged.
+ * @param {Boolean} [state.reverted=false] True if the merge was later reverted.
+ * @param {Boolean} [state.hadRequestedChanges=false] True if the PR carried a requested-changes review before merging.
+ * @returns {String} one of the `PR_OUTCOME_REWARDS` keys.
+ */
+export function classifyPrOutcome({merged, reverted = false, hadRequestedChanges = false} = {}) {
+    if (reverted) return 'reverted';
+    if (!merged)  return 'closedUnmerged';
+
+    return hadRequestedChanges ? 'mergedWithChanges' : 'mergedClean';
+}
+
+/**
+ * @summary Resolves the scalar reward for a PR-outcome key, or for a raw `classifyPrOutcome` state.
+ * @param {String|Object} outcomeOrState An outcome key, or a state object for `classifyPrOutcome`.
+ * @returns {Number|null} the reward scalar, or `null` for an unrecognized outcome key.
+ */
+export function computeOutcomeReward(outcomeOrState) {
+    const outcome = typeof outcomeOrState === 'string'
+        ? outcomeOrState
+        : classifyPrOutcome(outcomeOrState);
+
+    return Object.prototype.hasOwnProperty.call(PR_OUTCOME_REWARDS, outcome)
+        ? PR_OUTCOME_REWARDS[outcome]
+        : null;
+}

--- a/test/playwright/unit/ai/services/ingestion/PrOutcomeReward.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/PrOutcomeReward.spec.mjs
@@ -1,0 +1,62 @@
+import {test, expect}                                                from '@playwright/test';
+import {PR_OUTCOME_REWARDS, classifyPrOutcome, computeOutcomeReward} from '../../../../../../ai/services/ingestion/PrOutcomeReward.mjs';
+
+test.describe('ai/services/ingestion/PrOutcomeReward', () => {
+    test.describe('classifyPrOutcome', () => {
+        test('merged clean → mergedClean', () => {
+            expect(classifyPrOutcome({merged: true})).toBe('mergedClean');
+        });
+
+        test('merged with requested changes → mergedWithChanges', () => {
+            expect(classifyPrOutcome({merged: true, hadRequestedChanges: true})).toBe('mergedWithChanges');
+        });
+
+        test('closed unmerged → closedUnmerged', () => {
+            expect(classifyPrOutcome({merged: false})).toBe('closedUnmerged');
+        });
+
+        test('reverted dominates merge (regardless of requested-changes) → reverted', () => {
+            expect(classifyPrOutcome({merged: true, reverted: true})).toBe('reverted');
+            expect(classifyPrOutcome({merged: true, hadRequestedChanges: true, reverted: true})).toBe('reverted');
+        });
+
+        test('unmerged-and-not-reverted ignores requested-changes history', () => {
+            expect(classifyPrOutcome({merged: false, hadRequestedChanges: true})).toBe('closedUnmerged');
+        });
+
+        test('empty / no-arg defaults to closedUnmerged (merged is falsy)', () => {
+            expect(classifyPrOutcome()).toBe('closedUnmerged');
+            expect(classifyPrOutcome({})).toBe('closedUnmerged');
+        });
+    });
+
+    test.describe('computeOutcomeReward', () => {
+        test('maps each outcome key to its scalar', () => {
+            expect(computeOutcomeReward('mergedClean')).toBe(1.0);
+            expect(computeOutcomeReward('mergedWithChanges')).toBe(0.7);
+            expect(computeOutcomeReward('closedUnmerged')).toBe(0.0);
+            expect(computeOutcomeReward('reverted')).toBe(-1.0);
+        });
+
+        test('accepts a raw state object (classify + reward in one call)', () => {
+            expect(computeOutcomeReward({merged: true})).toBe(1.0);
+            expect(computeOutcomeReward({merged: true, reverted: true})).toBe(-1.0);
+            expect(computeOutcomeReward({merged: false})).toBe(0.0);
+        });
+
+        test('unrecognized outcome key → null', () => {
+            expect(computeOutcomeReward('bogus')).toBe(null);
+        });
+    });
+
+    test.describe('PR_OUTCOME_REWARDS', () => {
+        test('is frozen — callers cannot mutate the shared signal definition', () => {
+            expect(Object.isFrozen(PR_OUTCOME_REWARDS)).toBe(true);
+        });
+
+        test('reverted is the only negative (actively-harmful) signal', () => {
+            const negatives = Object.entries(PR_OUTCOME_REWARDS).filter(([, v]) => v < 0).map(([k]) => k);
+            expect(negatives).toEqual(['reverted']);
+        });
+    });
+});


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13724. Refs #9962.

## Summary

Slice 1 of #9962 (PR Outcome Tracker — the RLAIF reward signal). The pure PR-outcome → reward mapping core, deliberately carved as a self-contained, fully-tested unit so it lands independently of the integration design (which stays on #9962, @neo-opus-grace's RLAIF/memory-core domain).

The reward signal closes a real RLAIF blind-spot: the LLM-estimated session quality/productivity scores can't see merge outcomes — a session whose PRs were all reverted would still score as productive.

## Deltas

- `ai/services/ingestion/PrOutcomeReward.mjs` (new): pure exports — `PR_OUTCOME_REWARDS` (frozen table), `classifyPrOutcome({merged, reverted, hadRequestedChanges})`, `computeOutcomeReward(keyOrState)`. Reward table: 1.0 merged-clean / 0.7 merged-with-changes / 0.0 closed-unmerged / -1.0 reverted. Revert dominates merge; unmerged ignores requested-changes history.
- Plain function exports (no Neo singleton) per the directory's local-pure-helper convention; placed beside its eventual consumer `MemorySessionIngestor`, location-reversible.
- Test (new): 11 cases — classification, reward lookup (key + raw-state), frozen-table invariant, negative-signal invariant.

## Out of scope (stays on #9962, @neo-opus-grace's domain)

The PR-outcome scan (gh I/O), session-linking, the ChromaDB retroactive-tag write (RLS + dry-run-first), and the DreamService/runSandman integration.

## Test Evidence

Evidence: L2 — 11 unit tests green (`npm run test-unit -- PrOutcomeReward.spec.mjs`). Pure module, fully covered by unit tests (no runtime/integration surface in this slice).

## Post-Merge Validation

- `computeOutcomeReward` + `classifyPrOutcome` are importable and the reward scalars match the spec'd table; the #9962 integration can consume them without re-deriving the mapping.
