### PR TITLE
feat(ai): add stop-hook deference-register parity (#13674)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -43,6 +43,8 @@ import os              from 'node:os';
 import {pathToFileURL} from 'node:url';
 
 import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneState.mjs';
+import {buildDeferenceReminder,
+        detectDeferencePhrase}     from '../../ai/scripts/lifecycle/deferencePhraseMatch.mjs';
 import {decideStopHookAction,
         isOperatorInLoop,
         parseOutcomeToVerdict}     from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
@@ -223,6 +225,15 @@ export function composeBlockDirective(cause) {
 }
 
 /**
+ * @summary Composes the directive injected when an autonomous turn ends in deferential phrasing.
+ * @param {String} phrase Matched deference phrase.
+ * @returns {String}
+ */
+export function composeDeferenceDirective(phrase) {
+    return buildDeferenceReminder(phrase);
+}
+
+/**
  * @summary Extracts plain text from a message `content` field — a string passthrough, or the joined
  * `text` blocks of an Anthropic content-block array (skipping tool_use / thinking blocks).
  * @param {(String|Object[]|*)} content
@@ -354,6 +365,24 @@ async function main() {
         // best-effort; isOperatorInLoop falls back to stop_hook_active when promptingText is empty
     }
     const operatorInLoop = isOperatorInLoop({stopHookActive: !!input.stop_hook_active, promptingText});
+
+    const deferencePhrase = detectDeferencePhrase(finalText, {operatorInLoop});
+    if (deferencePhrase) {
+        const reason  = `deference phrase "${deferencePhrase}" at turn-terminal`,
+              session = input.session_id || '?';
+
+        if (ENFORCING) {
+            auditLog(`BLOCK (session=${session}): ${reason}`);
+            process.stdout.write(JSON.stringify({
+                decision: 'block',
+                reason  : composeDeferenceDirective(deferencePhrase)
+            }), () => process.exit(0));
+            return;
+        }
+
+        auditLog(`WOULD-BLOCK (session=${session}): ${reason}`);
+        process.exit(0);
+    }
 
     // parseLaneState throwing is a MALFORMED emission (the agent's garbage), NOT our failure → it
     // feeds the verdict (a real block-able bucket), distinct from an absent emission (null).

--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -19,6 +19,8 @@ import {decideStopHookAction,
         isOperatorInLoop,
         parseOutcomeToVerdict}     from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+import {buildDeferenceReminder,
+        detectDeferencePhrase}     from '../../ai/scripts/lifecycle/deferencePhraseMatch.mjs';
 
 export const CODEX_STOP_BLOCK_INJECTION_SUPPORTED = true;
 
@@ -338,6 +340,19 @@ export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
           {text, source}                            = extractFinalAssistantText(input),
           {text: promptingText, source: promptSource} = extractPromptingText(input),
           operatorInLoop                            = isOperatorInLoop({stopHookActive, promptingText});
+
+    // Deference-register check (mirrors the Claude hook): an autonomous turn-end in helpful-assistant
+    // phrasing is a soft block, runs BEFORE lane-state parsing and reuses the operatorInLoop carve.
+    const deferencePhrase = detectDeferencePhrase(text, {operatorInLoop});
+    if (deferencePhrase) {
+        return {
+            action : enforcing ? 'block' : 'would-block',
+            reason : buildDeferenceReminder(deferencePhrase),
+            source,
+            promptSource,
+            verdict: null
+        };
+    }
 
     let descriptor = null, parseError = null;
     try {

--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -1,0 +1,74 @@
+/**
+ * @module ai.scripts.lifecycle.deferencePhraseMatch
+ * @summary Detects the linguistic "helpful assistant" deference register in an assistant turn.
+ *
+ * This is the phrased half of the deference instinct: strings like "do you want me driving next?"
+ * hand maintainer-owned judgment back to the operator. The structural / phraseless half is not
+ * catchable by phrase matching; that remains the no-hold gate and value-floor domain.
+ *
+ * Consumed by Stop hooks on autonomous turn-ends only. A deference phrase in live operator dialogue
+ * can be a legitimate Tier-4 operator ask; the same phrase on an autonomous turn is the slip.
+ */
+
+/**
+ * Tight deference phrases, grounded in live session fixtures. Deliberately excludes broad near-misses
+ * like "should I", "shall I", "happy to", "no rush", and "whenever you want"; broadening requires a
+ * falsifier-backed follow-up so the hook stays a mirror, not a noisy leash.
+ * @type {String[]}
+ */
+export const DEFERENCE_PHRASES = [
+    'would you like me to',
+    'unless you',
+    'want me to',
+    'do you want me',
+    'your call',
+    'your move'
+];
+
+/**
+ * The peer-identity reminder injected when a deference phrase matches on an autonomous turn-end.
+ * Self-explaining at point of contact: it names the slip, the peer identity, the peer-input recovery
+ * route, and the friction->gold path for false positives.
+ * @type {String}
+ */
+export const DEFERENCE_REMINDER = 'It looks like you slipped into the "helpful assistant" bias. You are a neo repo maintainer and an equal peer. If you need validation or input, you can A2A message with peers or use the ideation-sandbox skill. And friction->gold applies to this hook itself: if it fired wrong - a false positive, or it reads as a leash not a mirror - open a ticket to sharpen it rather than silently absorbing it. The hook is mutable substrate, not a command.';
+
+/**
+ * @summary Returns the first deference phrase found in text, using case-insensitive substring match.
+ * @param {String} text Assistant final-turn text.
+ * @param {String[]} [phrases=DEFERENCE_PHRASES]
+ * @returns {String|null}
+ */
+export function matchDeferencePhrase(text = '', phrases = DEFERENCE_PHRASES) {
+    if (typeof text !== 'string' || !text) {
+        return null;
+    }
+
+    const lower = text.toLowerCase();
+
+    return phrases.find(phrase => lower.includes(phrase)) || null;
+}
+
+/**
+ * @summary Applies the autonomous-turn carve before phrase matching.
+ * @param {String} text Assistant final-turn text.
+ * @param {Object} [options]
+ * @param {Boolean} [options.operatorInLoop=false]
+ * @returns {String|null}
+ */
+export function detectDeferencePhrase(text = '', {
+    operatorInLoop = false
+} = {}) {
+    return operatorInLoop ? null : matchDeferencePhrase(text);
+}
+
+/**
+ * @summary Builds the Stop-hook directive for a deference-register block.
+ * @param {String|null} phrase Matched deference phrase, if known.
+ * @returns {String}
+ */
+export function buildDeferenceReminder(phrase = null) {
+    const trigger = phrase ? `\n\n(Stop-hook trigger: deference phrase "${phrase}" at turn-terminal)` : '';
+
+    return `${DEFERENCE_REMINDER}${trigger}`;
+}

--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -18,7 +18,7 @@
  */
 export const DEFERENCE_PHRASES = [
     'would you like me to',
-    'unless you',
+    'unless you want me',
     'want me to',
     'do you want me',
     'your call',
@@ -34,7 +34,7 @@ export const DEFERENCE_PHRASES = [
 export const DEFERENCE_REMINDER = 'It looks like you slipped into the "helpful assistant" bias. You are a neo repo maintainer and an equal peer. If you need validation or input, you can A2A message with peers or use the ideation-sandbox skill. And friction->gold applies to this hook itself: if it fired wrong - a false positive, or it reads as a leash not a mirror - open a ticket to sharpen it rather than silently absorbing it. The hook is mutable substrate, not a command.';
 
 /**
- * @summary Returns the first deference phrase found in text, using case-insensitive substring match.
+ * @summary Returns the first deference phrase found in text, using case-insensitive boundary match.
  * @param {String} text Assistant final-turn text.
  * @param {String[]} [phrases=DEFERENCE_PHRASES]
  * @returns {String|null}
@@ -44,9 +44,12 @@ export function matchDeferencePhrase(text = '', phrases = DEFERENCE_PHRASES) {
         return null;
     }
 
-    const lower = text.toLowerCase();
+    return phrases.find(phrase => {
+        const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+'),
+              matcher = new RegExp(`(^|[^a-z0-9_])${escaped}(?=$|[^a-z0-9_])`, 'i');
 
-    return phrases.find(phrase => lower.includes(phrase)) || null;
+        return matcher.test(text);
+    }) || null;
 }
 
 /**

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -198,6 +198,47 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
     });
 });
 
+test.describe('codex-lane-state-stop - deference register', () => {
+    test('deference phrase + autonomous turn → would-block before lane-state parsing (dry-run)', () => {
+        const result = classifyCodexStopPayload({
+            messages: [
+                {role: 'user',      content: '[WAKE][priority:normal] 1 events'},
+                {role: 'assistant', content: 'Your call.'}
+            ]
+        });
+
+        expect(result.action).toBe('would-block');
+        expect(result.reason).toContain('helpful assistant');           // the deference directive, not the no-hold reason
+        expect(result.reason).toContain('deference phrase "your call"');
+    });
+
+    test('deference phrase + autonomous turn + enforce → block with the peer-identity directive', () => {
+        const result = classifyCodexStopPayload({
+            messages: [
+                {role: 'user',      content: '[WAKE][priority:normal] 1 events'},
+                {role: 'assistant', content: 'Your move.'}
+            ]
+        }, {enforcing: true});
+
+        expect(result.action).toBe('block');
+        expect(result.reason).toContain('helpful assistant');
+        expect(result.reason).toContain('A2A message with peers');
+        expect(result.reason).toContain('deference phrase "your move"');
+    });
+
+    test('deference phrase in a live operator dialogue → operator-dialogue carve, not a deference block', () => {
+        const result = classifyCodexStopPayload({
+            messages: [
+                {role: 'user',      content: 'please pick the exact color and report'},
+                {role: 'assistant', content: `Your call.\n\n${fixture.last_assistant_message}`}
+            ]
+        }, {enforcing: true});
+
+        expect(result.action).toBe('allow');                      // operator + valid terminal
+        expect(result.reason).not.toContain('helpful assistant'); // deference carved by operatorInLoop
+    });
+});
+
 test.describe('codex-lane-state-stop - spawned hook', () => {
     /**
      * @summary Spawns the repo-local Codex Stop hook with a temp audit log directory.

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -1,0 +1,56 @@
+import {test, expect} from '@playwright/test';
+
+import {DEFERENCE_PHRASES,
+        DEFERENCE_REMINDER,
+        buildDeferenceReminder,
+        detectDeferencePhrase,
+        matchDeferencePhrase} from '../../../../ai/scripts/lifecycle/deferencePhraseMatch.mjs';
+
+/**
+ * Direct coverage for the deference-register phrase match. The matcher is pure; hook specs cover
+ * the runtime block path and the operator-dialogue carve.
+ */
+test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
+    test('matches the real session slip', () => {
+        expect(matchDeferencePhrase('So - which do you want me driving next?')).toBe('do you want me');
+    });
+
+    test('matches each tight phrase case-insensitively', () => {
+        expect(matchDeferencePhrase('WOULD YOU LIKE ME TO open the PR?')).toBe('would you like me to');
+        expect(matchDeferencePhrase('I can take it unless you want it.')).toBe('unless you');
+        expect(matchDeferencePhrase('Want me to start the refactor?')).toBe('want me to');
+        expect(matchDeferencePhrase('Your call on the branch cut.')).toBe('your call');
+        expect(matchDeferencePhrase('Your move.')).toBe('your move');
+    });
+
+    test('does not match deliberately excluded near-misses', () => {
+        expect(matchDeferencePhrase('Should I refactor this? Yes - doing it.')).toBeNull();
+        expect(matchDeferencePhrase('Shall I open the PR - opening it.')).toBeNull();
+        expect(matchDeferencePhrase('Happy to take the next lane.')).toBeNull();
+        expect(matchDeferencePhrase('No rush on the merge.')).toBeNull();
+        expect(matchDeferencePhrase('Whenever you want to merge is fine.')).toBeNull();
+    });
+
+    test('operator-dialogue carve skips the phrase match', () => {
+        expect(detectDeferencePhrase('Your call on the exact color.', {operatorInLoop: true})).toBeNull();
+        expect(detectDeferencePhrase('Your call on the exact color.', {operatorInLoop: false})).toBe('your call');
+    });
+
+    test('returns null on empty or non-string input', () => {
+        expect(matchDeferencePhrase('')).toBeNull();
+        expect(matchDeferencePhrase(null)).toBeNull();
+        expect(matchDeferencePhrase(undefined)).toBeNull();
+    });
+
+    test('reminder is self-explaining and routes to peers / ideation rather than operator permission', () => {
+        const reminder = buildDeferenceReminder('your call');
+
+        expect(DEFERENCE_PHRASES).toContain('do you want me');
+        expect(DEFERENCE_REMINDER).toContain('helpful assistant');
+        expect(reminder).toContain('equal peer');
+        expect(reminder).toContain('A2A message with peers');
+        expect(reminder).toContain('ideation-sandbox');
+        expect(reminder).toContain('mutable substrate');
+        expect(reminder).toContain('deference phrase "your call"');
+    });
+});

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -17,7 +17,7 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
 
     test('matches each tight phrase case-insensitively', () => {
         expect(matchDeferencePhrase('WOULD YOU LIKE ME TO open the PR?')).toBe('would you like me to');
-        expect(matchDeferencePhrase('I can take it unless you want it.')).toBe('unless you');
+        expect(matchDeferencePhrase('I can take it unless you want me elsewhere.')).toBe('unless you want me');
         expect(matchDeferencePhrase('Want me to start the refactor?')).toBe('want me to');
         expect(matchDeferencePhrase('Your call on the branch cut.')).toBe('your call');
         expect(matchDeferencePhrase('Your move.')).toBe('your move');
@@ -29,6 +29,12 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase('Happy to take the next lane.')).toBeNull();
         expect(matchDeferencePhrase('No rush on the merge.')).toBeNull();
         expect(matchDeferencePhrase('Whenever you want to merge is fine.')).toBeNull();
+    });
+
+    test('does not match technical substring collisions', () => {
+        expect(matchDeferencePhrase('The fix routes through your callback handler.')).toBeNull();
+        expect(matchDeferencePhrase('The test fails unless you mock the system clock.')).toBeNull();
+        expect(matchDeferencePhrase('Restored your moved files to their original paths.')).toBeNull();
     });
 
     test('operator-dialogue carve skips the phrase match', () => {

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                                                                              from '@playwright/test';
-import {composeBlockDirective, decideHookAction, isOperatorInLoop, parseOutcomeToVerdict,
+import {composeBlockDirective, composeDeferenceDirective, decideHookAction, isOperatorInLoop, parseOutcomeToVerdict,
         extractFinalAssistantText, extractLastAssistantTextFromJsonl, extractLastUserTextFromJsonl,
         formatLifecycleBoard} from '../../../../.claude/hooks/laneStateStopHook.mjs';
 import {spawn} from 'node:child_process';
@@ -114,6 +114,18 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
             // Runtime-obey guard: the friction→gold ticket is a design-time lane, never a runtime stop.
             expect(directive).toContain('a license to stop');
             expect(directive).toContain('not itself a valid stop');
+        });
+    });
+
+    test.describe('composeDeferenceDirective — the injected deference-register directive', () => {
+        test('names the helpful-assistant slip, peer identity, peer routes, mutable-substrate path, and trigger', () => {
+            const directive = composeDeferenceDirective('your call');
+            expect(directive).toContain('helpful assistant');
+            expect(directive).toContain('equal peer');
+            expect(directive).toContain('A2A message with peers');
+            expect(directive).toContain('ideation-sandbox');
+            expect(directive).toContain('mutable substrate');
+            expect(directive).toContain('deference phrase "your call"');
         });
     });
 
@@ -244,6 +256,31 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
     }
 
     const validTerminal = `On it.\n\n${block('{"laneContinuation":"active-lane"}')}`;
+
+    test('deference phrase + autonomous turn → WOULD-BLOCK before lane-state parsing (dry-run)', async () => {
+        const {stdout, log} = await runHook(`Your call.\n\n${validTerminal}`, {promptingText: '[WAKE][priority:normal] 1 events'});
+        expect(log).toContain('WOULD-BLOCK');
+        expect(log).toContain('deference phrase "your call"');
+        expect(stdout).toBe('');
+    });
+
+    test('deference phrase + autonomous turn + enforce → BLOCK with the peer-identity directive', async () => {
+        const {stdout, log} = await runHook(`Your move.\n\n${validTerminal}`, {enforce: true, promptingText: '[WAKE][priority:normal] 1 events'});
+        expect(log).toContain('BLOCK');
+        expect(log).toContain('deference phrase "your move"');
+        const decision = JSON.parse(stdout);
+        expect(decision.decision).toBe('block');
+        expect(decision.reason).toContain('helpful assistant');
+        expect(decision.reason).toContain('A2A message with peers');
+        expect(decision.reason).toContain('deference phrase "your move"');
+    });
+
+    test('deference phrase in a live operator dialogue → ALLOW (operator-dialogue carve)', async () => {
+        const {stdout, log} = await runHook(`Your call.\n\n${validTerminal}`, {enforce: true, promptingText: 'please pick the exact color and report'});
+        expect(log).toContain('ALLOW');
+        expect(log).not.toContain('deference phrase');
+        expect(stdout).toBe('');
+    });
 
     test('LIVE OPERATOR dialogue (genuine prompt) → ALLOW even with a bare prose terminal', async () => {
         const {stdout, log} = await runHook('Done — over to you.', {enforce: true, promptingText: 'please do X, then report'});


### PR DESCRIPTION
Resolves #13674

Adds the deference-register stop-hook mirror across Claude and Codex. The shared `deferencePhraseMatch` helper detects the tight helpful-assistant phrases on autonomous turn-end, preserves the live-operator carve, and routes hits to the peer/ideation recovery directive instead of operator permission. Claude uses the shared matcher in `laneStateStopHook`; Codex now runs the same deference check before lane-state parsing in `codex-lane-state-stop`.

Evidence: L2 unit/spec coverage covers phrase matching, autonomous-vs-operator behavior, dry-run would-block, and enforcing block directive behavior. L3 live-fire remains the post-merge harness validation because hook behavior depends on the local Codex/Claude runtime invoking the tracked hook files.

## Deltas from ticket

- The ticket wording names Claude Stop hook behavior first; implementation now covers both Claude and Codex parity.
- The directive intentionally includes the friction-to-gold hook-mutability clause so false positives route to a follow-up ticket rather than becoming another stop excuse.

## Test Evidence

- `git diff --check origin/dev...HEAD` passed.
- `npm run test-unit -- test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs` -> 65 passed after rebasing onto current `origin/dev`.

## Post-Merge Validation

- [ ] Restart one Claude harness and one Codex harness with enforcing stop hooks enabled; verify autonomous deference phrasing blocks with the peer-identity directive and live operator-dialogue phrasing does not block.

## Commits

- `e9ad73473` - shared deference matcher + Claude Stop-hook wiring.
- `78b9a8f54` - Codex Stop-hook parity wiring and Codex tests.

Authored by Euclid (GPT-5, Codex Desktop) consuming Grace handoff for the Codex mirror slice. Session current Codex Desktop harness session; explicit MCP session ID was not exposed to the shell.