### PR TITLE
feat(ai): who_is_online local-beacon mid-turn rescue (#13498)

### DIFF
--- a/ai/services/memory-core/TurnPresenceService.mjs
+++ b/ai/services/memory-core/TurnPresenceService.mjs
@@ -129,8 +129,8 @@ class TurnPresenceService extends Base {
               };
 
         GraphService.upsertNode({
-            id         : nodeId,
-            type       : 'AGENT_TURN_PRESENCE',
+            id  : nodeId,
+            type: 'AGENT_TURN_PRESENCE',
             name       : `TurnPresence ${agentIdentity}`,
             description: 'Bounded active-turn liveness interval emitted by a trusted harness hook.',
             properties
@@ -142,6 +142,34 @@ class TurnPresenceService extends Base {
             action,
             id    : nodeId
         };
+    }
+
+    /**
+     * @summary Public liveness read — the newest fresh active turn-presence beacon for an agent, or null.
+     *
+     * The LOCAL-ONLY corroboration primitive for `who_is_online`: where a turn-presence beacon is wired,
+     * a fresh one rescues a mid-turn agent whose last `add_memory` write has aged past the recency
+     * window — the consolidate-then-save gate lands the memory only at the turn boundary, so a long
+     * mid-turn agent can read `add_memory`-stale yet be live. Returns `null` when no beacon exists, so a
+     * beaconless deployment's memory-recency verdict is never gated on a signal it cannot emit.
+     *
+     * @param {String} agentIdentity AgentIdentity node id.
+     * @param {String|Date|Number} [now=new Date()] Clock source.
+     * @returns {{turnId: String, startedAt: String, lastProgressAt: String, fresh: Boolean}|null}
+     */
+    getFreshTurnPresence(agentIdentity, now = new Date()) {
+        if (!agentIdentity) return null;
+
+        const nowDate = this._coerceDate(now),
+              turnId  = this._findNewestActiveTurnId(agentIdentity, nowDate);
+        if (!turnId) return null;
+
+        const props = this._getTurnPresenceProperties(this._buildTurnPresenceId(agentIdentity, turnId));
+        if (!props) return null;
+
+        const fresh = !!props.freshUntil && this._coerceDate(props.freshUntil).getTime() > nowDate.getTime();
+
+        return {turnId, startedAt: props.startedAt, lastProgressAt: props.lastProgressAt, fresh};
     }
 
     /**

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -7,6 +7,7 @@ import aiConfig                                                                 
 import RequestContextService, {normalizeUserId}                                                 from '../../mcp/server/shared/services/RequestContextService.mjs';
 import logger                                                                                   from '../../mcp/server/memory-core/logger.mjs';
 import CoalescingEngineService                                                                  from './CoalescingEngineService.mjs';
+import TurnPresenceService                                                                      from './TurnPresenceService.mjs';
 import {HEARTBEAT_PULSE_ENTITY_PREFIX, HEARTBEAT_PULSE_ENTITY_TYPE, match, matchHeartbeatPulse} from './heartbeatPulseEvaluator.mjs';
 
 /**
@@ -446,8 +447,8 @@ class WakeSubscriptionService extends Base {
         };
 
         GraphService.upsertNode({
-            id         : this._buildHarnessPresenceId(owner, bootId),
-            type       : 'HARNESS_PRESENCE',
+            id  : this._buildHarnessPresenceId(owner, bootId),
+            type: 'HARNESS_PRESENCE',
             name       : `HarnessPresence ${owner}`,
             description: 'Volatile wake-routing presence overlay for a booted harness instance.',
             properties
@@ -651,6 +652,17 @@ class WakeSubscriptionService extends Base {
                 reason: 'no add_memory activity (dark — no AGENT_MEMORY write on record)', signals};
         }
         if (!activity.fresh) {
+            // Local-only mid-turn rescue: the consolidate-then-save gate lands add_memory only at the
+            // turn boundary, so a long mid-turn agent can read add_memory-stale yet be live. Where a
+            // local turn-presence beacon is wired, a fresh one rescues it. Local-only by construction —
+            // no beacon → the memory verdict stands (a beaconless deployment is never gated on a signal
+            // it cannot emit); the benched hard-gate above is never upgraded (only this stale branch).
+            const beacon = TurnPresenceService.getFreshTurnPresence(identity, nowMs);
+            signals.turnPresence = beacon;
+            if (beacon?.fresh) {
+                return {identity, name, family, participationStatus, online: true,
+                    reason: `local turn-presence beacon fresh (turn started ${beacon.startedAt}; add_memory stale) — mid-turn rescue`, signals};
+            }
             return {identity, name, family, participationStatus, online: false,
                 reason: `stale add_memory activity (last write ${activity.lastActivityAt} — none within the freshness window)`, signals};
         }

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -1721,6 +1721,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(entry.online).toBe(false);
             expect(entry.reason).toContain('stale add_memory activity');
             expect(entry.signals.activityRecency.fresh).toBe(false);
+            expect(entry.signals.turnPresence).toBeNull(); // no beacon → the rescue is a no-op, base verdict stands
         });
 
         test('stale add_memory but FRESH turn-presence beacon → online (local mid-turn rescue, verbose)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -13,12 +13,12 @@ setup({
     }
 });
 
-import {test, expect}        from '@playwright/test';
-import crypto                from 'crypto';
-import fs                    from 'fs-extra';
-import path                  from 'path';
-import Neo                   from '../../../../../../src/Neo.mjs';
-import * as core             from '../../../../../../src/core/_export.mjs';
+import {test, expect} from '@playwright/test';
+import crypto         from 'crypto';
+import fs             from 'fs-extra';
+import path           from 'path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
 
 // Stub Neo.get to keep data-record boot behavior from masking wake-subscription coverage.
 // The setup regression is outside this spec's delivery contract.
@@ -126,17 +126,17 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 harnessTargetMetadata,
                 createdAt,
                 updatedAt,
-                userId      : owner,
-                sharedEntity: false,
+                userId       : owner,
+                sharedEntity : false,
                 status
             }
         };
         const edgeId = `EDGE:${crypto.randomUUID()}`;
         const edge = {
-            id    : edgeId,
-            source: owner,
-            target: subscriptionId,
-            type  : 'SUBSCRIBES_TO',
+            id        : edgeId,
+            source    : owner,
+            target    : subscriptionId,
+            type      : 'SUBSCRIBES_TO',
             properties: {
                 weight: 1,
                 userId: owner
@@ -158,13 +158,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         test('creates new subscription from identity template', async () => {
             // Give Alice a template
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -184,13 +184,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('bootstraps a volatile HarnessPresence overlay from boot address metadata (#12422)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -234,13 +234,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         test('returns existing subscription if it matches template (idempotent)', async () => {
             // Give Alice a template
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -258,33 +258,33 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('bootId mismatch plus dead pid retires stale HarnessPresence before upsert (#12422)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
             });
 
             GraphService.upsertNode({
-                id  : 'HARNESS_PRESENCE:@alice:old-boot',
-                type: 'HARNESS_PRESENCE',
-                name: 'HarnessPresence @alice',
+                id        : 'HARNESS_PRESENCE:@alice:old-boot',
+                type      : 'HARNESS_PRESENCE',
+                name      : 'HarnessPresence @alice',
                 properties: {
-                    agentIdentity: '@alice',
+                    agentIdentity : '@alice',
                     subscriptionId: 'WAKE_SUB:old',
-                    state        : 'idle',
-                    wakePolicy   : 'immediate',
-                    source       : 'mcp-client',
-                    bootId       : 'old-boot',
-                    pid          : 999999,
-                    lastSeenAt   : '2026-06-04T00:00:00.000Z',
-                    expiresAt    : '2026-06-04T00:10:00.000Z',
-                    status       : 'active'
+                    state         : 'idle',
+                    wakePolicy    : 'immediate',
+                    source        : 'mcp-client',
+                    bootId        : 'old-boot',
+                    pid           : 999999,
+                    lastSeenAt    : '2026-06-04T00:00:00.000Z',
+                    expiresAt     : '2026-06-04T00:10:00.000Z',
+                    status        : 'active'
                 }
             });
 
@@ -307,32 +307,32 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('TTL backstop retires HarnessPresence even without a pid (#12422)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
             });
 
             GraphService.upsertNode({
-                id  : 'HARNESS_PRESENCE:@alice:expired-boot',
-                type: 'HARNESS_PRESENCE',
-                name: 'HarnessPresence @alice',
+                id        : 'HARNESS_PRESENCE:@alice:expired-boot',
+                type      : 'HARNESS_PRESENCE',
+                name      : 'HarnessPresence @alice',
                 properties: {
-                    agentIdentity: '@alice',
+                    agentIdentity : '@alice',
                     subscriptionId: 'WAKE_SUB:expired',
-                    state        : 'idle',
-                    wakePolicy   : 'immediate',
-                    source       : 'mcp-client',
-                    bootId       : 'expired-boot',
-                    lastSeenAt   : '2026-06-04T00:00:00.000Z',
-                    expiresAt    : '2026-06-04T00:10:00.000Z',
-                    status       : 'active'
+                    state         : 'idle',
+                    wakePolicy    : 'immediate',
+                    source        : 'mcp-client',
+                    bootId        : 'expired-boot',
+                    lastSeenAt    : '2026-06-04T00:00:00.000Z',
+                    expiresAt     : '2026-06-04T00:10:00.000Z',
+                    status        : 'active'
                 }
             });
 
@@ -352,19 +352,19 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('recovers template from durable AgentIdentity row when cache is stale', async () => {
             GraphService.upsertNode({
-                id: '@neo-gpt',
-                type: 'AgentIdentity',
-                name: 'Codex',
+                id        : '@neo-gpt',
+                type      : 'AgentIdentity',
+                name      : 'Codex',
                 properties: {
-                    displayName: 'Codex',
-                    modelFamily: 'gpt',
+                    displayName         : 'Codex',
+                    modelFamily         : 'gpt',
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: {
-                            adapter: 'osascript',
-                            appName: 'Codex',
-                            tabShortcut: null,
+                            adapter     : 'osascript',
+                            appName     : 'Codex',
+                            tabShortcut : null,
                             focusSeedKey: 'r'
                         }
                     }
@@ -409,13 +409,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         test('reconciles duplicate active subscriptions at bootstrap, keeping newest (#11182)', async () => {
             // Give Alice a template
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -424,18 +424,18 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             // Seed 2 active subscriptions for @alice with identical route-tuple but
             // different creation times; only the newest route should remain active.
             const older = insertDurableSubscription({
-                subscriptionId: 'WAKE_SUB:older-uuid',
-                owner         : '@alice',
+                subscriptionId       : 'WAKE_SUB:older-uuid',
+                owner                : '@alice',
                 harnessTargetMetadata: {appName: 'Antigravity'},
-                createdAt     : '2026-05-08T17:57:00.000Z',
-                updatedAt     : '2026-05-08T17:57:00.000Z'
+                createdAt            : '2026-05-08T17:57:00.000Z',
+                updatedAt            : '2026-05-08T17:57:00.000Z'
             });
             const newer = insertDurableSubscription({
-                subscriptionId: 'WAKE_SUB:newer-uuid',
-                owner         : '@alice',
+                subscriptionId       : 'WAKE_SUB:newer-uuid',
+                owner                : '@alice',
                 harnessTargetMetadata: {appName: 'Antigravity'},
-                createdAt     : '2026-05-10T17:09:00.000Z',
-                updatedAt     : '2026-05-10T17:09:00.000Z'
+                createdAt            : '2026-05-10T17:09:00.000Z',
+                updatedAt            : '2026-05-10T17:09:00.000Z'
             });
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
@@ -461,13 +461,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('reconciler is idempotent on canonical single-active state (#11182)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -494,13 +494,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('reconciler retires N-1 when 3+ duplicates exist, keeping newest (#11182)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -545,13 +545,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             // harnessTarget + appName), not flatten by owner. Two legitimate routes
             // for the same agent must BOTH survive.
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -595,13 +595,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('reconciler ignores already-retired or inactive subscriptions (#11182)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -708,8 +708,8 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     test('subscribe rejects non-canonical appName', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
             await expect(WakeSubscriptionService.subscribe({
-                trigger      : 'SENT_TO_ME',
-                harnessTarget: 'bridge-daemon',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'antigravity'}
             })).rejects.toThrow("Invalid appName 'antigravity'. Must be one of: Antigravity, Claude, Codex");
         });
@@ -721,7 +721,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 trigger              : 'SENT_TO_ME',
                 harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {
-                    appName: 'Antigravity',
+                    appName        : 'Antigravity',
                     instanceAddress: '4242'
                 }
             })).rejects.toThrow('Shape C instance addressing requires harnessTargetMetadata.addressType');
@@ -734,9 +734,9 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 trigger              : 'SENT_TO_ME',
                 harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {
-                    appName: 'Antigravity',
+                    appName        : 'Antigravity',
                     instanceAddress: 'frontmost',
-                    addressType: 'frontmost'
+                    addressType    : 'frontmost'
                 }
             })).rejects.toThrow("Invalid addressType 'frontmost'. Must be one of: userDataDir, pid, tmuxSession, webhookUrl");
         });
@@ -788,8 +788,8 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     test('subscribe accepts canonical appName Antigravity', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
             const res = await WakeSubscriptionService.subscribe({
-                trigger      : 'SENT_TO_ME',
-                harnessTarget: 'bridge-daemon',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'Antigravity'}
             });
             expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
@@ -799,8 +799,8 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     test('subscribe accepts canonical appName Claude', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
             const res = await WakeSubscriptionService.subscribe({
-                trigger      : 'SENT_TO_ME',
-                harnessTarget: 'bridge-daemon',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'Claude'}
             });
             expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
@@ -810,8 +810,8 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     test('subscribe accepts canonical appName Codex', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
             const res = await WakeSubscriptionService.subscribe({
-                trigger      : 'SENT_TO_ME',
-                harnessTarget: 'bridge-daemon',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'Codex'}
             });
             expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
@@ -1321,7 +1321,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 // mcp-notifications bypasses coalescing window and pushes immediately
                 await WakeSubscriptionService.subscribe({
-                    trigger: 'SENT_TO_ME',
+                    trigger      : 'SENT_TO_ME',
                     harnessTarget: 'mcp-notifications'
                 });
             });
@@ -1352,7 +1352,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({
-                    trigger: 'SENT_TO_ME',
+                    trigger      : 'SENT_TO_ME',
                     harnessTarget: 'mcp-notifications'
                 });
             });
@@ -1546,9 +1546,9 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({
-                    trigger: 'SENT_TO_ME',
+                    trigger      : 'SENT_TO_ME',
                     harnessTarget: 'mcp-notifications',
-                    filters: { priority: 'high' }
+                    filters      : { priority: 'high' }
                 });
             });
 
@@ -1666,6 +1666,25 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
         }
 
+        function seedBeacon(owner, {turnId = 'turn-1', startedAt = T0, freshUntil, expiresAt} = {}) {
+            // Mirrors TurnPresenceService.recordTurnPresence's active turn-presence node — the local
+            // beacon who_is_online consults for the mid-turn rescue (fresh = freshUntil > now).
+            GraphService.upsertNode({
+                id        : `AGENT_TURN_PRESENCE:${owner}:${turnId}`,
+                type      : 'AGENT_TURN_PRESENCE',
+                name      : `TurnPresence ${owner}`,
+                properties: {
+                    agentIdentity : owner,
+                    turnId,
+                    startedAt,
+                    lastProgressAt: startedAt,
+                    status        : 'active',
+                    freshUntil    : freshUntil || iso(T0ms + 5 * 60 * 1000),
+                    expiresAt     : expiresAt  || iso(T0ms + 60 * 60 * 1000)
+                }
+            });
+        }
+
         test('participationStatus hard gate: benched reports offline even with fresh activity (verbose)', async () => {
             seedAgent('@neo-benched', {participationStatus: 'operator_benched'});
             seedActivity('@neo-benched', {timestamp: T0});
@@ -1702,6 +1721,42 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(entry.online).toBe(false);
             expect(entry.reason).toContain('stale add_memory activity');
             expect(entry.signals.activityRecency.fresh).toBe(false);
+        });
+
+        test('stale add_memory but FRESH turn-presence beacon → online (local mid-turn rescue, verbose)', async () => {
+            seedAgent('@neo-midturn');
+            seedActivity('@neo-midturn', {timestamp: iso(T0ms - 20 * 60 * 1000)}); // memory stale
+            seedBeacon('@neo-midturn', {freshUntil: iso(T0ms + 5 * 60 * 1000)});    // beacon fresh
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-midturn');
+
+            expect(entry.online).toBe(true);
+            expect(entry.reason).toContain('mid-turn rescue');
+            expect(entry.signals.turnPresence.fresh).toBe(true);
+        });
+
+        test('stale add_memory + STALE beacon → offline (beacon non-gating, graceful, verbose)', async () => {
+            seedAgent('@neo-stalebeacon');
+            seedActivity('@neo-stalebeacon', {timestamp: iso(T0ms - 20 * 60 * 1000)}); // memory stale
+            seedBeacon('@neo-stalebeacon', {freshUntil: iso(T0ms - 5 * 60 * 1000)});    // beacon active but not fresh
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-stalebeacon');
+
+            expect(entry.online).toBe(false);
+            expect(entry.reason).toContain('stale add_memory activity');
+        });
+
+        test('benched hard-gate is NOT rescued by a fresh beacon (verbose)', async () => {
+            seedAgent('@neo-benched-beacon', {participationStatus: 'operator_benched'});
+            seedBeacon('@neo-benched-beacon', {freshUntil: iso(T0ms + 5 * 60 * 1000)}); // fresh beacon
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-benched-beacon');
+
+            expect(entry.online).toBe(false); // benched hard-gate sits above the rescue branch
+            expect(entry.reason).toContain('benched');
         });
 
         test('no add_memory activity → offline (dark) + signals.activityRecency null (verbose)', async () => {


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13733 — the AC2/AC3 read-side leaf (the local-only beacon READ + mid-turn rescue).

This is one slice of the broader who-is-online work tracked in #13498; its remaining **AC4** (the beacon emission — mid-turn progress-refresh + a Claude turn-start hook) stays open there as a separate slice.

## Summary
`who_is_online`'s AC1 (memory-recency PRIMARY — cross-topology, deployment-agnostic, no-beacon) was already shipped. This adds the AC2/AC3 layer: the LOCAL-ONLY turn-presence beacon as a mid-turn rescue, layered on the memory-recency base **without ever gating it**.

The gap it closes: the consolidate-then-save gate lands `add_memory` only at the turn boundary, so a long mid-turn agent can read `add_memory`-stale yet be live — the false-negative `_projectAgentLiveness`'s own comment names ("the window must exceed a typical turn to avoid marking a mid-turn agent dark"). Where a local turn-presence beacon is wired, a fresh one rescues that agent to `online`.

## Deltas
- `TurnPresenceService.getFreshTurnPresence(agentIdentity, now)` — public read: newest active turn within `freshUntil`; `null` when no beacon.
- `WakeSubscriptionService._projectAgentLiveness` — in the stale-memory branch, consult the beacon BEFORE returning offline; fresh → rescue to `online` with a beacon-cited reason (+ the `TurnPresenceService` import).
- **Local-only by construction:** no beacon → the memory verdict stands (a beaconless / remote deployment is never gated on a signal it cannot emit); the benched hard-gate (above the branch) is never upgraded.
- 3 tests + a `seedBeacon` helper: rescue fires (stale-memory + fresh-beacon); stale-beacon non-gating; benched-not-rescued.

## Test Evidence
Evidence: L2 — 13 `who_is_online` specs green (incl. the 3 new), 5 `TurnPresenceService` specs green. The rescue is observable: `online: true` + `reason` cites the beacon; graceful-absence + non-gating + benched-not-upgraded verified.

## Post-Merge Validation
- [ ] A memory-stale-but-mid-turn maintainer (with a wired beacon) reports `online` via `who_is_online`; a beaconless agent's verdict is unchanged.
