### PR TITLE
feat(ai): pure PR-outcome revert-detection core (#13727)

### DIFF
--- a/ai/services/ingestion/RevertDetection.mjs
+++ b/ai/services/ingestion/RevertDetection.mjs
@@ -1,0 +1,62 @@
+/**
+ * @summary Pure revert-commit-trailer detection — the foundational revert slice of the PR Outcome
+ * Tracker. Parses the `This reverts commit <sha>` trailer git writes for a `git revert`, producing
+ * the `reverted` flag the reward-computation core consumes for the -1.0 "actively harmful —
+ * regression" signal: the highest-value, hardest RLAIF reward outcome (a session whose merged PRs
+ * were later reverted must score negative, and the merge state's `closedAt` is a false signal — the
+ * revert trailer is the ground truth).
+ *
+ * Deliberately PURE — no git/gh I/O. The commit SCAN (fetching later commits to check against a
+ * merge SHA) and the wiring into the outcome-scan are the rest of the tracker (the integration /
+ * memory-core domain). Plain function exports mirror this directory's local-pure-helper convention.
+ *
+ * @module ai/services/ingestion/RevertDetection
+ */
+
+/**
+ * @summary Matches a `This reverts commit <sha>` line as a standalone trailer (anchored to the line,
+ * so a mid-sentence mention is not a false match). Global + multiline so a revert of a range/merge
+ * with several such lines yields all of them.
+ * @type {RegExp}
+ */
+const REVERT_TRAILER = /^\s*This reverts commit ([0-9a-f]{7,40})\.?\s*$/gim;
+
+/**
+ * @summary Extracts every reverted commit SHA from a commit message's `This reverts commit <sha>`
+ * trailer line(s). A `git revert` of a range or a merge can produce multiple such lines.
+ * @param {String} commitMessage
+ * @returns {String[]} the reverted SHAs (lowercased), in order; empty if none / non-string.
+ */
+export function parseRevertTrailer(commitMessage) {
+    if (typeof commitMessage !== 'string' || !commitMessage) {
+        return [];
+    }
+
+    const shas = [];
+    let   match;
+
+    REVERT_TRAILER.lastIndex = 0;
+
+    while ((match = REVERT_TRAILER.exec(commitMessage)) !== null) {
+        shas.push(match[1].toLowerCase());
+    }
+
+    return shas;
+}
+
+/**
+ * @summary Whether a commit message reverts a specific target SHA. Matches on SHA-prefix equality in
+ * either direction, so a 7-char abbreviated trailer SHA matches a full 40-char target and vice versa.
+ * @param {String} commitMessage
+ * @param {String} targetSha
+ * @returns {Boolean}
+ */
+export function isRevertOf(commitMessage, targetSha) {
+    if (typeof targetSha !== 'string' || targetSha === '') {
+        return false;
+    }
+
+    const target = targetSha.toLowerCase();
+
+    return parseRevertTrailer(commitMessage).some(sha => target.startsWith(sha) || sha.startsWith(target));
+}

--- a/test/playwright/unit/ai/services/ingestion/RevertDetection.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/RevertDetection.spec.mjs
@@ -1,0 +1,60 @@
+import {test, expect}                   from '@playwright/test';
+import {parseRevertTrailer, isRevertOf} from '../../../../../../ai/services/ingestion/RevertDetection.mjs';
+
+test.describe('ai/services/ingestion/RevertDetection', () => {
+    test.describe('parseRevertTrailer', () => {
+        test('extracts a single reverted SHA from the trailer', () => {
+            expect(parseRevertTrailer('Revert "feat: x"\n\nThis reverts commit abc1234.')).toEqual(['abc1234']);
+        });
+
+        test('extracts a full 40-char SHA', () => {
+            const sha = 'a'.repeat(40);
+            expect(parseRevertTrailer(`This reverts commit ${sha}`)).toEqual([sha]);
+        });
+
+        test('extracts multiple reverted SHAs (revert of a range/merge)', () => {
+            const msg = 'Revert batch\n\nThis reverts commit abc1234.\nThis reverts commit def5678.';
+            expect(parseRevertTrailer(msg)).toEqual(['abc1234', 'def5678']);
+        });
+
+        test('lowercases SHAs', () => {
+            expect(parseRevertTrailer('This reverts commit ABC1234.')).toEqual(['abc1234']);
+        });
+
+        test('returns [] for a non-revert message', () => {
+            expect(parseRevertTrailer('feat: a normal commit (#1234)')).toEqual([]);
+        });
+
+        test('returns [] for empty / non-string input', () => {
+            expect(parseRevertTrailer('')).toEqual([]);
+            expect(parseRevertTrailer(null)).toEqual([]);
+            expect(parseRevertTrailer(undefined)).toEqual([]);
+        });
+
+        test('does not false-match a mid-line mention (anchored to a clean trailer line)', () => {
+            expect(parseRevertTrailer('note: This reverts commit abc1234 was discussed but not applied')).toEqual([]);
+        });
+    });
+
+    test.describe('isRevertOf', () => {
+        test('matches an abbreviated trailer SHA against a full target', () => {
+            expect(isRevertOf('This reverts commit abc1234.', 'abc1234567890abcdef')).toBe(true);
+        });
+
+        test('matches a full trailer SHA against an abbreviated target', () => {
+            expect(isRevertOf(`This reverts commit ${'a'.repeat(40)}`, 'aaaaaaa')).toBe(true);
+        });
+
+        test('false when the message reverts a different commit', () => {
+            expect(isRevertOf('This reverts commit deadbeef.', 'abc1234')).toBe(false);
+        });
+
+        test('false for a non-revert message', () => {
+            expect(isRevertOf('feat: x', 'abc1234')).toBe(false);
+        });
+
+        test('false for an empty target', () => {
+            expect(isRevertOf('This reverts commit abc1234.', '')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13727. Refs #9962, #13724.

## Summary

Slice 2 of #9962 (PR Outcome Tracker — the RLAIF reward signal), sibling of #13724/#13725. The pure revert-commit-trailer detection — producing the `reverted` flag that #13724's `classifyPrOutcome` consumes for the -1.0 "actively harmful — regression" reward, the highest-value + hardest signal (a session whose merged PRs were later reverted must score negative; the merge `closedAt` is a false signal, the revert trailer is ground truth — as @neo-opus-grace confirmed in the #9962 design-response).

## Deltas

- `ai/services/ingestion/RevertDetection.mjs` (new): pure exports — `parseRevertTrailer(commitMessage)` (extracts reverted SHAs from `This reverts commit <sha>` trailer lines; multiple for a range/merge revert; line-anchored so a mid-line mention isn't a false match; lowercased) + `isRevertOf(commitMessage, targetSha)` (SHA-prefix match either direction, so a 7-char trailer matches a 40-char target).
- Plain function exports (no Neo singleton) per the directory's local-pure-helper convention; beside #13724's `PrOutcomeReward.mjs`.
- Test (new): 12 cases — single / multi / full / abbreviated SHA, lowercasing, non-revert, empty/non-string, mid-line-non-match; `isRevertOf` prefix-match both directions, different-commit, empty-target.

## Out of scope (stays on #9962, @neo-opus-grace's integration)

The commit SCAN (git/gh I/O to fetch later commits vs a merge SHA) + wiring the detection into the outcome-scan + feeding `classifyPrOutcome`. Same pure-only carve as #13724.

## Test Evidence

Evidence: L2 — 12 unit tests green (`npm run test-unit -- RevertDetection.spec.mjs`). Pure module, fully covered by unit tests (no I/O / integration surface in this slice).

## Post-Merge Validation

- `parseRevertTrailer` + `isRevertOf` are importable; the #9962 integration can detect reverts via the trailer (ground truth) to set `classifyPrOutcome`'s `reverted` for the -1.0 reward.
