### PR TITLE
feat(ai): surface lane-state schema in stop hooks (#13731)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -45,6 +45,7 @@ import {pathToFileURL} from 'node:url';
 import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneState.mjs';
 import {decideStopHookAction,
         isOperatorInLoop,
+        LANE_STATE_SCHEMA_HINT,
         parseOutcomeToVerdict}     from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
@@ -128,7 +129,9 @@ Declaring a lane is NOT driving it. Do the next concrete action NOW:
 Teeth-test: does this advance a NAMED lane right now? If you can't name the lane, it isn't driving.
 Collaboration (review · ideation · A2A) counts ONLY when it advances a named lane AND ends with a return to your own lane or an explicit lane-swap — it is an interruption, not a replacement for your own PRs.
 Passive waiting (a merge · a review · CI) is parked, not driven — take another lane.
-The only stop is a hard external limit: context-sunset, an operator halt, or a live operator reply.`;
+The only stop is a hard external limit: context-sunset, an operator halt, or a live operator reply.
+
+${LANE_STATE_SCHEMA_HINT}`;
 
 // The discoverability/mirror pointer — injected on EVERY block so a fresh session that has never seen
 // this hook recognizes it as a mirror of maintainer-identity, not an arbitrary leash. Without it an

--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -17,6 +17,7 @@ import {pathToFileURL} from 'node:url';
 import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneState.mjs';
 import {decideStopHookAction,
         isOperatorInLoop,
+        LANE_STATE_SCHEMA_HINT,
         parseOutcomeToVerdict}     from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
@@ -279,7 +280,9 @@ export function extractPromptingText(input = {}) {
  * @returns {String}
  */
 export function buildNoHoldReminder(verdictReason) {
-    return `No-hold reminder: ${verdictReason}. There is no hold state: continue concrete work on the active lane, perform an assigned review that advances a named lane, or pick a fresh claimable lane. Passive waiting is not a terminal.`;
+    return `No-hold reminder: ${verdictReason}. There is no hold state: continue concrete work on the active lane, perform an assigned review that advances a named lane, or pick a fresh claimable lane. Passive waiting is not a terminal.
+
+${LANE_STATE_SCHEMA_HINT}`;
 }
 
 /**

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -8,6 +8,17 @@
  */
 
 /**
+ * Compact runtime hint for the fenced JSON block consumed by `parseLaneState`. Prose `lane-state:`
+ * lines remain useful for humans, but hooks only parse this machine block.
+ * @type {String}
+ */
+export const LANE_STATE_SCHEMA_HINT = `Machine lane-state block to emit with your response:
+\`\`\`lane-state
+{"wakeDisposition":"awareness","laneContinuation":"next-lane","namedGates":[],"awaitingOwnPrOnly":false}
+\`\`\`
+Validator gotchas: if an own PR is only awaiting merge/review/CI, use laneContinuation "next-lane"; "active-lane" + awaitingOwnPrOnly:true is invalid. Every namedGates[] entry needs a same-turn checkedAt; mergeClaim must use field "mergedAt".`;
+
+/**
  * @summary Pure mapping of a parse OUTCOME to a terminal verdict — the 3-bucket chain. A malformed
  * emission (parseLaneState threw) and an absent emission (null) are distinct idle-out failures from an
  * invalid descriptor, each with its own reason; a parsed descriptor is delegated to `validate`.

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -51,6 +51,19 @@ test.describe('codex-lane-state-stop - contract boundary', () => {
         expect(reason).toContain('Passive waiting is not a terminal');
     });
 
+    test('the no-hold reminder shows the fenced lane-state JSON schema', () => {
+        const reason = buildNoHoldReminder('no lane-state block emitted at turn-terminal');
+
+        expect(reason).toContain('```lane-state');
+        expect(reason).toContain('"wakeDisposition":"awareness"');
+        expect(reason).toContain('"laneContinuation":"next-lane"');
+        expect(reason).toContain('"namedGates":[]');
+        expect(reason).toContain('"awaitingOwnPrOnly":false');
+        expect(reason).toContain('awaitingOwnPrOnly:true is invalid');
+        expect(reason).toContain('same-turn checkedAt');
+        expect(reason).toContain('field "mergedAt"');
+    });
+
     test('payload shape capture is redacted to field names and value types', () => {
         expect(summarizePayloadShape({
             session_id            : 's',

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -101,6 +101,18 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
             expect(directive).toContain('no lane-state block emitted at turn-terminal');
         });
 
+        test('shows the fenced lane-state JSON schema the parser actually consumes', () => {
+            const directive = composeBlockDirective('no lane-state block emitted at turn-terminal');
+            expect(directive).toContain('```lane-state');
+            expect(directive).toContain('"wakeDisposition":"awareness"');
+            expect(directive).toContain('"laneContinuation":"next-lane"');
+            expect(directive).toContain('"namedGates":[]');
+            expect(directive).toContain('"awaitingOwnPrOnly":false');
+            expect(directive).toContain('awaitingOwnPrOnly:true is invalid');
+            expect(directive).toContain('same-turn checkedAt');
+            expect(directive).toContain('field "mergedAt"');
+        });
+
         test('always carries the discoverability/mirror pointer (a hit = recognize, not obey)', () => {
             const directive = composeBlockDirective('no lane-state block emitted at turn-terminal');
             expect(directive).toContain('MIRROR, not a leash');

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -2,6 +2,7 @@ import {test, expect} from '@playwright/test';
 import {
     decideStopHookAction,
     isOperatorInLoop,
+    LANE_STATE_SCHEMA_HINT,
     parseOutcomeToVerdict
 }                        from '../../../../ai/scripts/lifecycle/stopHookDecision.mjs';
 
@@ -13,6 +14,17 @@ import {
  * silently drift while the hook-level tests stay green. Pure functions — no hook, no I/O.
  */
 test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision primitives', () => {
+    test('LANE_STATE_SCHEMA_HINT: shows the fenced machine block shape consumed by parseLaneState', () => {
+        expect(LANE_STATE_SCHEMA_HINT).toContain('```lane-state');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('"wakeDisposition":"awareness"');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('"laneContinuation":"next-lane"');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('"namedGates":[]');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('"awaitingOwnPrOnly":false');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('awaitingOwnPrOnly:true is invalid');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('same-turn checkedAt');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('field "mergedAt"');
+    });
+
     // ── parseOutcomeToVerdict: the 3-bucket parse → verdict chain ──────────────────────────────
     test('parseOutcomeToVerdict: a parse error is a malformed-emission verdict (not valid)', () => {
         const verdict = parseOutcomeToVerdict({descriptor: null, parseError: new Error('bad json')}, () => ({valid: true}));


### PR DESCRIPTION
Resolves #13731

Adds a shared lane-state schema hint to the stop-hook decision module and renders it in both Claude and Codex no-hold reminders. The reminder now shows the fenced `lane-state` JSON example plus the validator gotchas Vega flagged: own-PR-only waiting must continue as `next-lane`, each `namedGates[]` entry needs same-turn `checkedAt`, and merge claims use `mergedAt`.

Related: #13623

Evidence: L2 (focused hook unit specs cover the shared helper plus Claude/Codex reminder text) -> L2 required (runtime reminder schema/gotcha display is unit-coverable). No residuals for #13731.

## Deltas from ticket
The ticket was created after implementation to provide the required narrow leaf close target. It codifies the #13623 Contract Ledger comment and preserves the #13643 boundary: no loaded skill-rule re-expansion, only runtime on-block reminder content.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/hooks/laneStateStopHook.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/stopHookDecision.spec.mjs` -> 70 passed.
- `git diff --check` -> clean.
- Branch freshness: `merge-base HEAD origin/dev == origin/dev`.
- Commit hygiene: `origin/dev..HEAD` contains one commit, `abfb86347 feat(ai): surface lane-state schema in stop hooks (#13731)`.

## Post-Merge Validation
- [ ] Next live Claude/Codex Stop-hook block prompt visibly includes the fenced lane-state schema and validator gotchas.

## Residuals
#13623 remains open for the broader AC4 ratio-over-window and COP observability work.

Authored by Euclid (GPT-5, Codex Desktop). Session 747ae298-5a6e-4416-b90d-7786e184aa54.