### PR TITLE
feat(mcp): add knowledge-base tool handbook slice (#13734)

### DIFF
--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -56,6 +56,50 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /tool/handbook:
+    post:
+      summary: Tool Handbook
+      operationId: get_mcp_tool_handbook
+      x-annotations:
+        readOnlyHint: true
+      description: Returns lazy-loaded usage detail for one Knowledge Base MCP tool.
+      tags: [Documents]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [toolId]
+              properties:
+                toolId:
+                  type: string
+                  description: Tool operation id to inspect.
+      responses:
+        '200':
+          description: Tool handbook lookup result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  toolId:
+                    type: string
+                  found:
+                    type: boolean
+                  title:
+                    type: string
+                  description:
+                    type: string
+                  handbook:
+                    type: string
+                  source:
+                    type: string
+                  code:
+                    type: string
+                  message:
+                    type: string
+
   /db/data/manage:
     post:
       summary: Manage Knowledge Base Data
@@ -149,6 +193,7 @@ paths:
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
+      x-neo-tool-summary: Search the Knowledge Base and return ranked source references.
       description: |
         Performs a semantic search on the knowledge base using a natural language query.
         Returns a scored and ranked list of the most relevant source files.
@@ -280,6 +325,7 @@ paths:
       summary: Ask Knowledge Base (RAG)
       operationId: ask_knowledge_base
       x-pass-as-object: true
+      x-neo-tool-summary: Ask the Knowledge Base for a synthesized answer with cited references.
       description: |
         Performs a semantic search and uses an LLM to synthesize an answer based on the top results.
         Use this tool to get a high-level answer without manually reading multiple files.

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -54,6 +54,7 @@ const serviceMapping = {
     ask_knowledge_base   : SearchService           .ask                .bind(SearchService),
     get_class_hierarchy  : QueryService            .getClassHierarchy  .bind(QueryService),
     get_document_by_id   : DocumentService         .getDocumentById    .bind(DocumentService),
+    get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
     healthcheck          : HealthService           .healthcheck        .bind(HealthService),
     list_documents       : DocumentService         .listDocuments      .bind(DocumentService),
     list_agent_faqs      : KBRecorderService       .listAgentFaqs      .bind(KBRecorderService),
@@ -67,8 +68,10 @@ const serviceMapping = {
 };
 
 const toolService = Neo.create(ToolService, {
+    compactToolDescriptions    : true,
     openApiFilePath,
-    serviceMapping
+    serviceMapping,
+    toolListDescriptionMaxLength: 120
 });
 
 const _callTool = toolService.callTool.bind(toolService);

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -283,6 +283,45 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         });
     });
 
+    test('knowledge-base exposes compact list descriptions plus lazy-loaded handbook detail (#9953)', async () => {
+        const
+            server        = servers.find(item => item.name === 'knowledge-base'),
+            {tools}       = await listTools(server),
+            byName        = Object.fromEntries(tools.map(tool => [tool.name, tool])),
+            moduleUrl     = pathToFileURL(path.join(repoRoot, server.toolServicePath)).href,
+            {callTool}    = await import(moduleUrl),
+            handbook      = await callTool('get_mcp_tool_handbook', {toolId: 'query_documents'}),
+            missing       = await callTool('get_mcp_tool_handbook', {toolId: 'missing_tool'}),
+            queryDocs     = byName.query_documents,
+            askKnowledge  = byName.ask_knowledge_base,
+            handbookTool  = byName.get_mcp_tool_handbook;
+
+        expect(handbookTool.description.length).toBeLessThanOrEqual(120);
+        expect(queryDocs.description).toBe('Search the Knowledge Base and return ranked source references.');
+        expect(queryDocs.description).not.toContain('Prefer `ask_knowledge_base`');
+        expect(askKnowledge.description).toBe('Ask the Knowledge Base for a synthesized answer with cited references.');
+        expect(askKnowledge.description).not.toContain('zero-cost RAG subagent');
+        expect(handbookTool.annotations.readOnlyHint).toBe(true);
+
+        for (const tool of tools) {
+            expect(tool.description.length, `knowledge-base.${tool.name} description is not compact`).toBeLessThanOrEqual(120);
+        }
+
+        expect(handbook).toMatchObject({
+            toolId: 'query_documents',
+            found : true,
+            source: 'description'
+        });
+        expect(handbook.handbook.replace(/\s+/g, ' ')).toContain('Prefer `ask_knowledge_base` for most queries');
+
+        expect(missing).toEqual({
+            toolId: 'missing_tool',
+            found : false,
+            code  : 'TOOL_NOT_FOUND',
+            message: 'Tool "missing_tool" does not exist in this MCP server.'
+        });
+    });
+
     test('unmigrated servers keep their existing list description behavior (#13268)', async () => {
         const
             server     = servers.find(item => item.name === 'github-workflow'),


### PR DESCRIPTION
Resolves #13734

Adds the Knowledge Base MCP server to the existing progressive-disclosure tool handbook path. `knowledge-base` now exposes `get_mcp_tool_handbook`, emits compact routing descriptions through `tools/list`, and keeps the heavy `query_documents` / `ask_knowledge_base` guidance available through lazy-loaded handbook detail.

Related: #9953
Related: #10757
Related: #13268

Evidence: L2 (focused MCP list-tools smoke + OpenAPI validator compliance specs cover the new server contract) -> L2 required (MCP tool surface change with schema/list projection behavior). Residual: #9953 remains open for remaining MCP server migrations.

## Deltas from ticket
The branch began from the broad #9953 intake, but #9953 is not a valid close target for one server migration. I created #13734 as the delivered leaf and amended the commit/PR close target accordingly.

The slice uses the shared #13268 `ToolService` seam instead of adding a second handbook mechanism. The existing long Knowledge Base descriptions remain the handbook source via the `description` fallback; only the always-loaded list projection becomes compact.

## Test Evidence
- `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` -> materialized temp-worktree MCP configs for local test execution.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 22 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` -> 31 passed.
- `git diff --check` -> clean.
- `node ./buildScripts/util/check-whitespace.mjs ai/mcp/server/knowledge-base/toolService.mjs ai/mcp/server/knowledge-base/openapi.yaml test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> passed.
- `node ./buildScripts/util/check-shorthand.mjs ai/mcp/server/knowledge-base/toolService.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 0 violations.
- `node ./buildScripts/util/check-ticket-archaeology.mjs ai/mcp/server/knowledge-base/toolService.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 0 violations.
- `npm run ai:lint-mcp-test-locations` -> OK.
- Branch freshness: `merge-base HEAD origin/dev == origin/dev`.
- Commit hygiene: `origin/dev..HEAD` contains one commit, `ad19b84b1 feat(mcp): add knowledge-base tool handbook slice (#13734)`.

## Post-Merge Validation
- [ ] A live Knowledge Base MCP client can call `get_mcp_tool_handbook` for `query_documents` and receive the detailed guidance while `tools/list` stays compact.

## Residuals
#9953 remains open for the remaining MCP server rollout, especially `github-workflow`, `memory-core`, `neural-link`, and `gitlab-workflow`.

Authored by Euclid (GPT-5, Codex Desktop). Session 747ae298-5a6e-4416-b90d-7786e184aa54.
