### PR TITLE
feat(mcp): add github workflow handbook slice (#13736)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -70,6 +70,50 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /tool/handbook:
+    post:
+      summary: Tool Handbook
+      operationId: get_mcp_tool_handbook
+      x-annotations:
+        readOnlyHint: true
+      description: Returns lazy-loaded usage detail for one GitHub Workflow MCP tool.
+      tags: [Repository]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [toolId]
+              properties:
+                toolId:
+                  type: string
+                  description: Tool operation id to inspect.
+      responses:
+        '200':
+          description: Tool handbook lookup result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  toolId:
+                    type: string
+                  found:
+                    type: boolean
+                  title:
+                    type: string
+                  description:
+                    type: string
+                  handbook:
+                    type: string
+                  source:
+                    type: string
+                  code:
+                    type: string
+                  message:
+                    type: string
+
   /labels:
     get:
       summary: List Repository Labels
@@ -292,6 +336,7 @@ paths:
     get:
       summary: Get Conversation (Issue or PR)
       operationId: get_conversation
+      x-neo-tool-summary: Fetch a pull request or issue conversation with optional comment-window selectors.
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
@@ -663,6 +708,7 @@ paths:
     post:
       summary: Manage PR Review (Create or Update — atomic body + formal-state in one call)
       operationId: manage_pr_review
+      x-neo-tool-summary: Create or update one formal PR review with body and review state validation.
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
@@ -1435,6 +1481,7 @@ paths:
     post:
       summary: Manage Issue Relationships (Parent-Child and Blocked-By)
       operationId: update_issue_relationship
+      x-neo-tool-summary: Create, replace, or remove issue parent-child and blocked-by relationships.
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false

--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -43,6 +43,7 @@ const GITHUB_TOOL_ACCESS = Object.freeze({
     get_conversation           : NON_PUBLIC_GITHUB_WRITE_ACCESS,
     get_discussion_conversation: NON_PUBLIC_GITHUB_WRITE_ACCESS,
     get_local_issue_by_id      : NON_PUBLIC_GITHUB_WRITE_ACCESS,
+    get_mcp_tool_handbook      : NON_PUBLIC_GITHUB_WRITE_ACCESS,
     get_pull_request_diff      : NON_PUBLIC_GITHUB_WRITE_ACCESS,
     get_viewer_permission      : NON_PUBLIC_GITHUB_WRITE_ACCESS,
     healthcheck                : NON_PUBLIC_GITHUB_WRITE_ACCESS,
@@ -393,6 +394,7 @@ const serviceMapping = {
     get_conversation           : getConversationRouter,
     get_discussion_conversation: DiscussionService .getConversation        .bind(DiscussionService),
     get_local_issue_by_id      : LocalFileService  .getIssueById           .bind(LocalFileService),
+    get_mcp_tool_handbook      : toolId => toolService.getToolHandbook(toolId),
     get_pull_request_diff      : PullRequestService.getPullRequestDiff     .bind(PullRequestService),
     get_viewer_permission      : RepositoryService .getViewerPermission    .bind(RepositoryService),
     healthcheck                : HealthService     .healthcheck            .bind(HealthService),
@@ -432,8 +434,10 @@ export {
 };
 
 const toolService = Neo.create(ToolService, {
+    compactToolDescriptions    : true,
     openApiFilePath,
-    serviceMapping: guardedServiceMapping
+    serviceMapping: guardedServiceMapping,
+    toolListDescriptionMaxLength: 120
 });
 
 const callTool  = toolService.callTool .bind(toolService);

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -285,13 +285,53 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
 
     test('unmigrated servers keep their existing list description behavior (#13268)', async () => {
         const
-            server     = servers.find(item => item.name === 'github-workflow'),
+            server     = servers.find(item => item.name === 'memory-core'),
             {tools}    = await listTools(server),
-            tool       = tools.find(item => item.name === 'update_issue_relationship'),
+            tool       = tools.find(item => item.name === 'resume_session'),
             operations = getOperationsById(server);
 
-        expect(tool.description).toBe(operations.update_issue_relationship.description);
+        expect(tool.description).toBe(operations.resume_session.description);
         expect(tool.description.length).toBeGreaterThan(120);
+    });
+
+    test('github-workflow exposes compact list descriptions plus lazy-loaded handbook detail (#13736)', async () => {
+        const
+            server        = servers.find(item => item.name === 'github-workflow'),
+            {tools}       = await listTools(server),
+            byName        = Object.fromEntries(tools.map(tool => [tool.name, tool])),
+            moduleUrl     = pathToFileURL(path.join(repoRoot, server.toolServicePath)).href,
+            {callTool}    = await import(moduleUrl),
+            handbook      = await callTool('get_mcp_tool_handbook', {toolId: 'update_issue_relationship'}),
+            missing       = await callTool('get_mcp_tool_handbook', {toolId: 'missing_tool'}),
+            relationship  = byName.update_issue_relationship,
+            conversation  = byName.get_conversation,
+            review        = byName.manage_pr_review,
+            handbookTool  = byName.get_mcp_tool_handbook;
+
+        expect(handbookTool.description.length).toBeLessThanOrEqual(120);
+        expect(handbookTool.annotations.readOnlyHint).toBe(true);
+        expect(relationship.description).toBe('Create, replace, or remove issue parent-child and blocked-by relationships.');
+        expect(relationship.description).not.toContain('Run `sync_all`');
+        expect(conversation.description).toBe('Fetch a pull request or issue conversation with optional comment-window selectors.');
+        expect(review.description).toBe('Create or update one formal PR review with body and review state validation.');
+
+        for (const tool of tools) {
+            expect(tool.description.length, `github-workflow.${tool.name} description is not compact`).toBeLessThanOrEqual(120);
+        }
+
+        expect(handbook).toMatchObject({
+            toolId: 'update_issue_relationship',
+            found : true,
+            source: 'description'
+        });
+        expect(handbook.handbook.replace(/\s+/g, ' ')).toContain('Run `sync_all` to update local markdown files');
+
+        expect(missing).toEqual({
+            toolId: 'missing_tool',
+            found : false,
+            code  : 'TOOL_NOT_FOUND',
+            message: 'Tool "missing_tool" does not exist in this MCP server.'
+        });
     });
 
     test('neural-link embedded-harness projection lists only default-visible tier tools (#13084)', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
@@ -387,6 +387,7 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
             'get_conversation',
             'get_discussion_conversation',
             'get_local_issue_by_id',
+            'get_mcp_tool_handbook',
             'get_pull_request_diff',
             'get_viewer_permission',
             'healthcheck',


### PR DESCRIPTION
Resolves #13736

Adds the GitHub Workflow MCP server to the existing progressive-disclosure handbook seam: `tools/list` now emits compact routing descriptions, while `get_mcp_tool_handbook` lazy-loads the full OpenAPI description for detailed usage guidance. The new handbook tool is service-mapped, classified as non-public-write, and covered by the existing GitHub Workflow access-policy guard.

Evidence: L2 (focused unit + static contract validation in the Codex worktree) -> L2 required (MCP OpenAPI/serviceMapping/access-policy behavior for the close-target ACs). Residual: none.

## Deltas from ticket

No scope expansion. The unmigrated-server smoke assertion moved from `github-workflow` to `memory-core` because GitHub Workflow is now migrated.

Related: #9953
Related: #13735

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 22 passed before rebase and 22 passed after rebase.
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs` -> 22 passed before rebase and 22 passed after rebase.
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` -> 31 passed before rebase and 31 passed after rebase.
- `npm run ai:lint-mcp-test-locations` -> OK.
- `git diff --check` -> passed.

## Post-Merge Validation

- [ ] Restart/refresh the GitHub Workflow MCP server and confirm `tools/list` uses compact descriptions in a live harness.

## Commits

- `a1ee6e7a4` — `feat(mcp): add github workflow handbook slice (#13736)`

Authored by Euclid (GPT-5, Codex Desktop). Session 747ae298-5a6e-4416-b90d-7786e184aa54.