### PR TITLE
feat(ai): premise-coherence required-verdict review forcing-function (#13144 AC1)

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-followup-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-followup-template.md
@@ -15,6 +15,7 @@
 *   **Inputs Read Before Patch:** [Prior review anchor / author response / changed-file list / current `dev` source / source-of-authority substrate checked before treating the delta as evidence.]
 *   **Expected Solution Shape:** [1-3 sentences naming the expected delta shape, what boundary this must NOT hardcode, and what test isolation should exist.]
 *   **Patch Verdict:** [Matches / improves / contradicts the expected shape, with the evidence that confirmed or changed your premise.]
+*   **Premise Coherence:** [Does this delta's premise cohere with our core values — verify-before-assert · friction→gold · flat-peer-team · no-hold · the four pillars? A specific verdict naming the value ("coheres: ..." / "conflicts: ..."), NOT a bare yes/no. OR a scoped "N/A — no value-surface (scope: ...)". A green checklist over a wrong premise is theater.]
 
 ---
 

--- a/.agents/skills/pr-review/assets/pr-review-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-template.md
@@ -25,6 +25,7 @@ Per §9 Strategic-Fit Step-Back:
 *   **Inputs Read Before Patch:** [Ticket / issue, changed-file list, current `dev` source, sibling precedent, source-of-authority substrate read before treating the patch as evidence.]
 *   **Expected Solution Shape:** [1-3 sentences: expected surface, simplest acceptable shape, what boundary this must NOT hardcode, and what test isolation should exist.]
 *   **Patch Verdict:** [Matches / improves / contradicts the expected shape, with the specific diff/source evidence that confirmed or changed your premise.]
+*   **Premise Coherence:** [Does this PR's premise cohere with our core values — verify-before-assert · friction→gold · flat-peer-team · no-hold · the four pillars? A specific verdict naming the value ("coheres: lead stays facilitator-not-delegator" / "conflicts: adds surveillance vs flat-peer-team"), NOT a bare yes/no. OR a scoped "N/A — no value-surface (scope: ...)" for a trivial PR. A green checklist over a wrong premise is theater.]
 
 ---
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -12,11 +12,12 @@ This protocol ensures that feedback is:
 
 ## §0 — Patch-blind premise snapshot (BEFORE the diff)
 
-Build — and write down — your premise of the change **before** reading the patch as the source of truth. You can reject a toaster-when-we-need-a-car before reading a line; a green checklist over a wrong premise is theater, and nothing below substitutes for this. Capture three fields. The snapshot is **patch-blind**, NOT a temporally-guaranteed pre-commitment — claiming "I wrote this before I looked" is itself theater; the discipline is that the *premise authority* is the substrate, not the patch.
+Build — and write down — your premise of the change **before** reading the patch as the source of truth. You can reject a toaster-when-we-need-a-car before reading a line; a green checklist over a wrong premise is theater. Capture four fields. The snapshot is **patch-blind** — the *premise authority* is the substrate, not the patch (NOT a temporal pre-commitment; "I wrote this first" is itself theater).
 
 1. **Inputs read before the patch** — the ticket/issue, the changed-file list, the current `dev` source of the touched files, sibling precedent, and the source-of-authority substrate (ADRs, `learn/`, the owning service). **NOT the PR's own self-description as the primary premise** — the PR body is a claim to verify, not the authority. Build the premise from the affected files (intent belongs in their JSDoc — `src/core/Base.mjs` is the bar), their neighbors, and their imports; use `memory-mining` / `ask_knowledge_base` when the code is thin. Intent you can't find anywhere is the finding: ticket the gap.
 2. **Expected solution-shape** (1–3 sentences) — what *should* a correct change here look like? Explicitly include **"what boundary should this NOT hardcode?"** and **"what test-isolation should exist?"**, so the snapshot reaches the portability + test-isolation dimensions before the diff frames them away.
 3. **Patch-verdict** — does the diff **match / improve / contradict** the expected shape? Name the specific evidence that changed (or confirmed) your mind. "Matches" with no evidence is not a verdict.
+4. **Premise-coherence** — the value-coherence verdict, or a scoped "N/A — no value-surface".
 
 **Night-shift provisional marker:** when the approval is single-family / human-asleep (no cross-family reviewer awake), label it `single-family — calibration-deferred-to-merge-gate`. §12 (Typed Calibration Loop) reads this marker at the merge-gate to apply calibration to a single-family / calibration-deferred approval.
 

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -671,7 +671,7 @@ paths:
 
         Mandatory pre-step: read `.agents/skills/pr-review/SKILL.md` and use the cycle-appropriate template.
 
-        Validation: `body` must include the 7 visible metric anchors plus silent structural template anchors and preserve the selected template's canonical skeleton; failures return `PR_REVIEW_TEMPLATE_VALIDATION_FAILED` pointing at the skill/template. Do not synthesize substitute headings. #12448 premise-snapshot fields (`Inputs Read Before Patch`, `Expected Solution Shape`, `Patch Verdict`) are optional during migration: omit all three or include all three together.
+        Validation: `body` must include the 7 visible metric anchors plus silent structural template anchors and preserve the selected template's canonical skeleton; failures return `PR_REVIEW_TEMPLATE_VALIDATION_FAILED` pointing at the skill/template. Do not synthesize substitute headings. The four premise-snapshot fields (`Inputs Read Before Patch`, `Expected Solution Shape`, `Patch Verdict`, `Premise Coherence`) are ALL REQUIRED; `Premise Coherence` is the value-coherence verdict (does the PR's premise cohere with the core values?) — a specific verdict OR a scoped `N/A — no value-surface` for a trivial PR.
       tags: [PullRequests]
       parameters:
         - name: pr_number

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -1,17 +1,17 @@
-import {exec, execFile}                        from 'child_process';
-import path                                    from 'path';
-import {promisify}                             from 'util';
-import Base                                    from '../../../src/core/Base.mjs';
-import GraphqlService                          from './GraphqlService.mjs';
-import aiConfig                                from '../../mcp/server/github-workflow/config.mjs';
-import logger                                  from '../../mcp/server/github-workflow/logger.mjs';
+import {exec, execFile} from 'child_process';
+import path             from 'path';
+import {promisify}      from 'util';
+import Base             from '../../../src/core/Base.mjs';
+import GraphqlService   from './GraphqlService.mjs';
+import aiConfig         from '../../mcp/server/github-workflow/config.mjs';
+import logger           from '../../mcp/server/github-workflow/logger.mjs';
 import {
     ADD_PULL_REQUEST_REVIEW,
     GET_PULL_REQUEST_ID,
     UPDATE_PULL_REQUEST_REVIEW
 }                                              from './queries/mutations.mjs';
 import {FETCH_PULL_REQUESTS, GET_CONVERSATION} from './queries/pullRequestQueries.mjs';
-import {projectConversationTrust}             from './shared/conversationTrust.mjs';
+import {projectConversationTrust}              from './shared/conversationTrust.mjs';
 
 const execAsync     = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -86,18 +86,20 @@ const INVISIBLE_PR_REVIEW_ANCHORS = [
 ];
 
 /**
- * Optional-first premise-snapshot anchors for the patch-blind review migration.
- *
- * Absence of all three labels is valid during the add-optional phase so in-flight reviews keep
- * passing. If an author starts emitting the snapshot, all three fields must be present together;
- * otherwise a partial snapshot reintroduces the same back-rationalized theater the snapshot is
- * meant to expose. Match the distinctive bold template labels, not bare prose, so incidental
- * phrases like "Patch Verdict" do not activate the partial-snapshot gate.
+ * REQUIRED premise-snapshot anchors — every agent PR review must carry all four. The fourth,
+ * **Premise Coherence**, forces the value-coherence verdict ("does this PR's premise cohere with our
+ * core values?") that fit-shape review skips — a green checklist over a wrong premise is theater.
+ * The forcing-function raises the floor by forcing ARTICULATION, not depth: the field is satisfied
+ * by a specific verdict ("coheres: lead stays facilitator-not-delegator" / "conflicts: adds
+ * surveillance vs flat-peer-team") OR a scoped "N/A — no value-surface (scope: ...)" for a trivial
+ * PR with no value-surface (the marginal-value skip). Match the distinctive bold template labels,
+ * not bare prose, so incidental phrases do not satisfy the gate.
  */
-const OPTIONAL_PR_REVIEW_PREMISE_ANCHORS = [
+const REQUIRED_PR_REVIEW_PREMISE_ANCHORS = [
     {label: 'Inputs Read Before Patch',  token: '**Inputs Read Before Patch:**'},
     {label: 'Expected Solution Shape',   token: '**Expected Solution Shape:**'},
-    {label: 'Patch Verdict',             token: '**Patch Verdict:**'}
+    {label: 'Patch Verdict',             token: '**Patch Verdict:**'},
+    {label: 'Premise Coherence',         token: '**Premise Coherence:**'}
 ];
 
 const FOLLOWUP_PR_REVIEW_SHAPE_HINTS = [
@@ -223,7 +225,7 @@ function buildCheckoutPullRequest({
             return {
                 error  : 'Invalid repoPath',
                 message: `repoPath '${normalizedRepoPath}' is not a readable git worktree root.`,
-                code   : 'INVALID_REPO_PATH',
+                code    : 'INVALID_REPO_PATH',
                 repoPath: normalizedRepoPath,
                 details : error.stderr || error.message
             };
@@ -231,13 +233,13 @@ function buildCheckoutPullRequest({
 
         if (gitTopLevel !== normalizedRepoPath) {
             return {
-                error      : 'Unsafe checkout refused',
-                message    : [
+                error  : 'Unsafe checkout refused',
+                message: [
                     `repoPath '${normalizedRepoPath}' resolves to git top-level '${gitTopLevel}'. `,
                     'Pass the git top-level explicitly so the checkout target is unambiguous.'
                 ].join(''),
-                code       : 'REPO_PATH_NOT_GIT_ROOT',
-                repoPath   : normalizedRepoPath,
+                code    : 'REPO_PATH_NOT_GIT_ROOT',
+                repoPath: normalizedRepoPath,
                 gitTopLevel
             };
         }
@@ -251,7 +253,7 @@ function buildCheckoutPullRequest({
 
             return {
                 message: `Successfully checked out PR #${prNumber}`,
-                details: stdout.trim(),
+                details : stdout.trim(),
                 repoPath: gitTopLevel,
                 branch,
                 headSha
@@ -261,7 +263,7 @@ function buildCheckoutPullRequest({
             return {
                 error  : 'GitHub CLI command failed',
                 message: `gh pr checkout ${prNumber} failed with exit code ${error.code}`,
-                code   : 'GH_CLI_ERROR',
+                code    : 'GH_CLI_ERROR',
                 repoPath: gitTopLevel,
                 details : error.stderr || error.message
             };
@@ -626,12 +628,9 @@ class PullRequestService extends Base {
         const missingVisible          = VISIBLE_PR_REVIEW_ANCHORS          .filter(anchor => !body.includes(anchor));
         const missingInvisible        = INVISIBLE_PR_REVIEW_ANCHORS        .filter(anchor => !body.includes(anchor));
         const missingTemplateSkeleton = getPrReviewTemplateSkeletonMisses(body);
-        const presentPremiseSnapshot  = OPTIONAL_PR_REVIEW_PREMISE_ANCHORS .filter(anchor =>  body.includes(anchor.token));
-        const missingPremiseSnapshot  = presentPremiseSnapshot.length === 0
-            ? []
-            : OPTIONAL_PR_REVIEW_PREMISE_ANCHORS
-                .filter(anchor => !body.includes(anchor.token))
-                .map(anchor => anchor.label);
+        const missingPremiseSnapshot  = REQUIRED_PR_REVIEW_PREMISE_ANCHORS
+            .filter(anchor => !body.includes(anchor.token))
+            .map(anchor => anchor.label);
 
         if (
             missingVisible.length > 0          ||
@@ -659,7 +658,7 @@ class PullRequestService extends Base {
                 `checks more structural anchors than this error names. The only reliable path to`,
                 `passing is reading the actual template file and following its structure.`,
                 missingPremiseSnapshot.length > 0
-                    ? `\nPremise snapshot note: the snapshot is optional during migration, but partial snapshots are invalid. Either omit it entirely or include all three fields.`
+                    ? `\nPremise snapshot note: all four premise fields (incl. **Premise Coherence:**) are REQUIRED. The value-coherence field takes a specific verdict ("coheres: ..." / "conflicts: ...") OR a scoped "N/A — no value-surface (scope: ...)" for a trivial PR.`
                     : ``,
                 diagnosticAnchor
                     ? `\nDiagnostic hint: at least one recognized anchor like \`${diagnosticAnchor}\` is missing.`
@@ -667,9 +666,9 @@ class PullRequestService extends Base {
             ].join('\n');
 
             return {
-                error   : 'PR Review Template Validation Failed',
+                error: 'PR Review Template Validation Failed',
                 message,
-                code    : 'PR_REVIEW_TEMPLATE_VALIDATION_FAILED',
+                code : 'PR_REVIEW_TEMPLATE_VALIDATION_FAILED',
                 // `missing_visible` lists the named-in-message visible misses. Invisible misses
                 // are intentionally NOT enumerated in the response body — even programmatic
                 // callers should be nudged toward the skill rather than the anchor list.

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -515,6 +515,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         '* **Inputs Read Before Patch:** ticket, changed-file list, current dev source.',
         '* **Expected Solution Shape:** preserve the selected review template skeleton.',
         '* **Patch Verdict:** matches the expected shape.',
+        '* **Premise Coherence:** coheres: a substrate validator fix; flat-peer-team / facilitator-not-delegator unaffected.',
         '',
         '### 🕸️ Context & Graph Linking',
         '* **Target Epic / Issue ID:** Resolves #11273',
@@ -554,6 +555,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         '* **Inputs Read Before Patch:** prior review, author response, changed-file list.',
         '* **Expected Solution Shape:** narrow delta preserves prior approval anchors.',
         '* **Patch Verdict:** matches the expected delta.',
+        '* **Premise Coherence:** coheres: a narrow delta; no value-surface change.',
         '',
         '### 🪜 Strategic-Fit Decision',
         '- **Decision**: Approve',
@@ -864,6 +866,11 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         // structural-only-stuffing IS rejected without naming the invisible anchors in test prose.
         const stuffedBody = [
             'Approval granted.',
+            // Premise snapshot complete, so the structural-skeleton miss (not the premise) is the isolated failure.
+            '* **Inputs Read Before Patch:** ticket, changed-file list, current dev source.',
+            '* **Expected Solution Shape:** preserve the selected review template skeleton.',
+            '* **Patch Verdict:** matches the expected shape.',
+            '* **Premise Coherence:** coheres: a stuffing-regression fixture; no value-surface.',
             '[ARCH_ALIGNMENT]: 100',
             '[CONTENT_COMPLETENESS]: 100',
             '[EXECUTION_QUALITY]: 100',
@@ -914,6 +921,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
             '* **Inputs Read Before Patch:** ticket, changed-file list, current dev source.',
             '* **Expected Solution Shape:** preserve the selected review template skeleton.',
             '* **Patch Verdict:** matches the expected shape.',
+            '* **Premise Coherence:** coheres: a plain-heading regression fixture; no value-surface.',
             '',
             '### Context & Graph Linking',
             '* **Target Epic / Issue ID:** Resolves #13547',
@@ -1069,9 +1077,9 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(graphqlCallCount).toBe(2);
     });
 
-    test('#12448: accepts complete optional premise snapshot during add-first migration', async () => {
-        // Premise-snapshot anchors are optional-first: old review bodies still pass,
-        // but migrated templates may emit all three fields together before a later enforcement PR.
+    test('#12448: accepts a complete required premise snapshot (all four fields)', async () => {
+        // The premise snapshot is REQUIRED: a body carrying all four bold-label fields passes
+        // (here via VALID_REVIEW_BODY, which now includes the Premise Coherence field).
         let graphqlCallCount = 0;
         GraphqlService.query = async (queryString) => {
             graphqlCallCount++;
@@ -1102,9 +1110,8 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
     });
 
     test('#12448: rejects partial premise snapshot without making a GitHub call', async () => {
-        // Omit-all remains valid in the add-optional phase, but once the snapshot appears it must
-        // include the complete three-field shape. A partial snapshot is the exact theater risk the
-        // migration is meant to expose.
+        // All four premise fields are now REQUIRED. A partial snapshot (here: only Inputs Read
+        // Before Patch) is the exact back-rationalization theater the required gate is meant to expose.
         let graphqlCallCount = 0;
         GraphqlService.query = async () => {
             graphqlCallCount++;
@@ -1155,7 +1162,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
 
         expect(result.code).toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
         expect(result.missing_visible).toEqual([]);
-        expect(result.missing_premise_snapshot).toEqual(['Expected Solution Shape', 'Patch Verdict']);
+        expect(result.missing_premise_snapshot).toEqual(['Expected Solution Shape', 'Patch Verdict', 'Premise Coherence']);
         expect(result.message).toContain('Premise snapshot note');
         expect(graphqlCallCount).toBe(0);
     });


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13790 — the AC1 slice of #13144 (the premise-coherence forcing-function in the PR-review-body contract). AC2 (the SEEN-firewall `AGENTS.md` L1 trigger scope-widen) stays the separate higher-blast slice on parent #13144, per the cross-family convergence with @neo-opus-ada + @neo-gpt.

## Summary
Fit-shape review (the existing §0 premise snapshot: Inputs / Expected Shape / Patch Verdict) checks *is the patch the right shape* — but a green checklist over a wrong premise is theater. This adds a 4th **REQUIRED** premise field, **Premise Coherence**: the value-coherence verdict — *should this premise exist at all*, measured against our core values. It forces ARTICULATION, not depth: a specific verdict OR a scoped `N/A — no value-surface` for a trivial PR (the marginal-value skip — the author's call, expressed as a valid token, since the validator can't know value-relevance).

The validator flips the premise snapshot from optional-during-migration (omit-all-valid) to always-required (all four fields).

## Deltas
- `PullRequestService.mjs` — `REQUIRED_PR_REVIEW_PREMISE_ANCHORS` (renamed from `OPTIONAL_`, + the `Premise Coherence` anchor); the gate flipped optional→always-required; JSDoc + error-message updated.
- `pr-review-template.md` + `pr-review-followup-template.md` — both carry the `**Premise Coherence:**` field after Patch Verdict (fill-in guidance + an example).
- `PullRequestService.spec.mjs` — **47 green**: fixtures carry the 4th anchor; the optional-snapshot tests reframed to required-semantics (the partial-snapshot now also lists `Premise Coherence`; omit-all is invalid); the Goodhart-stuffed body gets a complete premise so its structural-skeleton miss stays the isolated failure.
- `pr-review-guide.md` §0 — the 4th field as a terse pointer (the guide is at its per-file payload cap; the fuller guidance lives in the template + JSDoc, de-duplicated).
- `openapi.yaml` — `manage_pr_review` description: the premise fields flip optional-3 → required-4.

Substrate growth is `[skill-growth-justified]` (a new load-bearing required field).

## Test Evidence
Evidence: **L2** — 47 `PullRequestService` specs green (`UNIT_TEST_MODE=true npx playwright test`). `lint-skill-manifest` **OK** (the guide stays under its per-file cap; the two template-field additions are the justified growth). The value-coherence token is satisfied by EITHER a specific verdict OR a scoped `N/A — no value-surface`.

## Premise Coherence
**Coheres:** this IS the forcing-function for the core value (verify-before-assert / premise-coherence-over-rubber-stamping); it operationalizes the §0 "right-premise" check the swarm converged on. No conflict with flat-peer-team — it forces *articulation*, not a gate that silences peers; the scoped-N/A keeps it from becoming busywork on trivial PRs.

## Post-Merge Validation
- [ ] The next agent PR review carries a `**Premise Coherence:**` verdict (or a scoped N/A); a review omitting it returns `PR_REVIEW_TEMPLATE_VALIDATION_FAILED`.

