### PR TITLE
feat(mcp): add memory-core handbook slice (#13739)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -94,6 +94,50 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /tool/handbook:
+    post:
+      summary: Tool Handbook
+      operationId: get_mcp_tool_handbook
+      x-annotations:
+        readOnlyHint: true
+      description: Returns lazy-loaded usage detail for one Memory Core MCP tool.
+      tags: [Health]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [toolId]
+              properties:
+                toolId:
+                  type: string
+                  description: Tool operation id to inspect.
+      responses:
+        '200':
+          description: Tool handbook lookup result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  toolId:
+                    type: string
+                  found:
+                    type: boolean
+                  title:
+                    type: string
+                  description:
+                    type: string
+                  handbook:
+                    type: string
+                  source:
+                    type: string
+                  code:
+                    type: string
+                  message:
+                    type: string
+
   /diagnostics/tool-metrics:
     post:
       summary: Get Memory Core Tool Metrics
@@ -198,6 +242,7 @@ paths:
     post:
       summary: Who Is Online
       operationId: who_is_online
+      x-neo-tool-summary: Report recent maintainer activity for review routing and lane handoffs.
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
@@ -287,6 +332,7 @@ paths:
       summary: Add New Memory
       operationId: add_memory
       x-pass-as-object: true
+      x-neo-tool-summary: Persist one consolidated turn memory for the active agent session.
       description: |
         Stores a new agent interaction (prompt, thought, response) as a memory.
 
@@ -418,6 +464,7 @@ paths:
       summary: Query Recent Turns
       operationId: query_recent_turns
       x-pass-as-object: true
+      x-neo-tool-summary: Recall recent turns chronologically for recovery or handoff.
       x-annotations:
         readOnlyHint: true
       description: |
@@ -750,6 +797,7 @@ paths:
       summary: Validate session resumability
       operationId: resume_session
       x-pass-as-object: true
+      x-neo-tool-summary: Validate whether a session id is safe to resume.
       x-annotations:
         readOnlyHint: true
       description: |
@@ -1171,6 +1219,7 @@ paths:
       summary: Send Message
       operationId: add_message
       x-pass-as-object: true
+      x-neo-tool-summary: Send an A2A message to one peer or an agent broadcast.
       description: |
         Sends an A2A message to a specific agent identity or broadcast (*).
       tags: [Mailbox]
@@ -1238,6 +1287,7 @@ paths:
       summary: List Messages
       operationId: list_messages
       x-pass-as-object: true
+      x-neo-tool-summary: List incoming or historical A2A mailbox messages.
       description: |
         Lists incoming messages for the active agent context.
       tags: [Mailbox]
@@ -1533,6 +1583,7 @@ paths:
       summary: Record Turn Presence
       operationId: record_turn_presence
       x-pass-as-object: true
+      x-neo-tool-summary: Record active-turn liveness for the current agent session.
       description: |
         Records a bounded `AGENT_TURN_PRESENCE` interval for the request-bound AgentIdentity.
         This is the turn-start/progress/terminal writer surface for #13498 Substrate A.

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -18,6 +18,7 @@ const openApiFilePath = path.join(__dirname, 'openapi.yaml');
 
 const serviceMapping = {
     add_memory              : MemoryService          .addMemory               .bind(MemoryService),
+    get_mcp_tool_handbook   : toolId => toolService.getToolHandbook(toolId),
     // `SummaryService.deleteAllSummaries` stays as the tenant-safe internal primitive (the
     // multi-tenant scoped-delete guard + future gated cleanups reuse it) but is deliberately
     // NOT agent-callable: a mass-destructive op does not belong on the MCP surface, and any
@@ -60,8 +61,10 @@ const serviceMapping = {
 };
 
 const toolService = Neo.create(ToolService, {
+    compactToolDescriptions    : true,
     openApiFilePath,
-    serviceMapping
+    serviceMapping,
+    toolListDescriptionMaxLength: 120
 });
 
 const _callTool = toolService.callTool.bind(toolService);

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -322,14 +322,53 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         });
     });
 
+    test('memory-core exposes compact list descriptions plus lazy-loaded handbook detail (#13739)', async () => {
+        const
+            server        = servers.find(item => item.name === 'memory-core'),
+            {tools}       = await listTools(server),
+            byName        = Object.fromEntries(tools.map(tool => [tool.name, tool])),
+            moduleUrl     = pathToFileURL(path.join(repoRoot, server.toolServicePath)).href,
+            {callTool}    = await import(moduleUrl),
+            handbook      = await callTool('get_mcp_tool_handbook', {toolId: 'resume_session'}),
+            missing       = await callTool('get_mcp_tool_handbook', {toolId: 'missing_tool'}),
+            addMemory     = byName.add_memory,
+            resumeSession = byName.resume_session,
+            handbookTool  = byName.get_mcp_tool_handbook;
+
+        expect(handbookTool.annotations.readOnlyHint).toBe(true);
+        expect(handbookTool.description.length).toBeLessThanOrEqual(120);
+        expect(addMemory.description).toBe('Persist one consolidated turn memory for the active agent session.');
+        expect(resumeSession.description).toBe('Validate whether a session id is safe to resume.');
+        expect(resumeSession.description).not.toContain('SESSION_BUSY');
+        expect(addMemory.inputSchema.properties.prompt.type).toBe('string');
+
+        for (const tool of tools) {
+            expect(tool.description.length, `memory-core.${tool.name} description is not compact`).toBeLessThanOrEqual(120);
+        }
+
+        expect(handbook).toMatchObject({
+            toolId: 'resume_session',
+            found : true,
+            source: 'description'
+        });
+        expect(handbook.handbook).toContain('SESSION_BUSY');
+
+        expect(missing).toEqual({
+            toolId: 'missing_tool',
+            found : false,
+            code  : 'TOOL_NOT_FOUND',
+            message: 'Tool "missing_tool" does not exist in this MCP server.'
+        });
+    });
+
     test('unmigrated servers keep their existing list description behavior (#13268)', async () => {
         const
-            server     = servers.find(item => item.name === 'memory-core'),
+            server     = servers.find(item => item.name === 'neural-link'),
             {tools}    = await listTools(server),
-            tool       = tools.find(item => item.name === 'resume_session'),
+            tool       = tools.find(item => item.name === 'get_component_tree'),
             operations = getOperationsById(server);
 
-        expect(tool.description).toBe(operations.resume_session.description);
+        expect(tool.description).toBe(operations.get_component_tree.description);
         expect(tool.description.length).toBeGreaterThan(120);
     });
 


### PR DESCRIPTION
Resolves #13739

Related: #9953

Adds the existing `ToolService` progressive-disclosure seam to Memory Core: a read-only `get_mcp_tool_handbook` OpenAPI operation, a matching service mapping, compact `tools/list` summaries for high-context Memory Core tools, and smoke coverage for compact list projection plus valid/missing handbook lookup. The broad parent remains open.

Evidence: L2 focused unit/static evidence covers all #13739 ACs: the smoke spec verifies list compaction, valid handbook lookup, missing handbook lookup, and serviceMapping/OpenAPI alignment; OpenAPI compliance verifies strict schemas. Residual: none for #13739.

## Deltas from ticket

- Moved the unmigrated-server smoke sentinel to `neural-link` so this branch remains stable whether the `github-workflow` migration lands before or after this PR.
- Used the existing OpenAPI description fallback as the detailed `resume_session` handbook source rather than adding a duplicate `x-neo-tool-handbook` block.
- Rebase resolution preserved the newer Knowledge Base handbook smoke coverage from `dev` alongside this Memory Core slice.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 23 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` -> 31 passed.
- `npm run ai:lint-mcp-test-locations` -> OK.
- `git diff --check origin/dev...HEAD` -> passed.
- Rebased on current `origin/dev` (`f79c86d78a`) before force-with-lease push.

## Post-Merge Validation

- [ ] Fresh Memory Core MCP client lists compact descriptions and can call `get_mcp_tool_handbook` for `resume_session`.

## Commits

- `52a662c7f` - `feat(mcp): add memory-core handbook slice (#13739)`

Authored by Euclid (GPT-5, Codex Desktop). Session 747ae298-5a6e-4416-b90d-7786e184aa54.