### PR TITLE
feat(ai): Stop-hook hold-costume tripwire — detect the sophisticated-hold lexicon

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -48,7 +48,8 @@ import {buildDeferenceStopHookDirective,
         decideStopHookAction,
         isOperatorInLoop,
         LANE_STATE_SCHEMA_HINT,
-        parseOutcomeToVerdict}     from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
+        parseOutcomeToVerdict,
+        scanHoldLexicon}           from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
 export {isOperatorInLoop, parseOutcomeToVerdict};
@@ -222,9 +223,32 @@ export function formatLifecycleBoard(state) {
  * @param {String} cause The terminal-evidence violation that triggered the block (the verdict reason).
  * @returns {String}
  */
-export function composeBlockDirective(cause) {
-    const board = formatLifecycleBoard(readLifecycleState());
-    return `${IDLE_REMINDER}${board}\n\n${MIRROR_POINTER}\n\n${SELF_IMPROVABILITY_CLAUSE}\n\n(Stop-hook trigger: ${cause})`;
+export function composeBlockDirective(cause, holdMatches = []) {
+    const board   = formatLifecycleBoard(readLifecycleState()),
+          costume = formatHoldCostumeCallout(holdMatches);
+    return `${IDLE_REMINDER}${board}${costume}\n\n${MIRROR_POINTER}\n\n${SELF_IMPROVABILITY_CLAUSE}\n\n(Stop-hook trigger: ${cause})`;
+}
+
+/**
+ * @summary Formats the hold-costume callout — when the agent's turn-final text matched the
+ * sophisticated-hold lexicon ({@link scanHoldLexicon}), names the SPECIFIC relapse-phrases back so the
+ * mirror reflects the actual costume instead of re-firing generically. Returns `''` when nothing
+ * matched (the directive stays the bare reminder). Frames the lexicon as a TRIPWIRE, not the boundary:
+ * avoiding the exact words is not the fix — the warrant is — so it cannot become an "avoid-the-phrasing,
+ * keep-holding" game (the closed-list weaponization the no-hold-state taxonomy warns against). Pure;
+ * total (never throws); exported + unit-tested.
+ * @param {String[]} matches The matched lexicon labels from {@link scanHoldLexicon}.
+ * @returns {String}
+ */
+export function formatHoldCostumeCallout(matches = []) {
+    if (!Array.isArray(matches) || !matches.length) return '';
+
+    return `\n\n⚠️ Hold-costume detected in your turn: ${matches.map(m => `"${m}"`).join(', ')}.\n` +
+        `These are the L3_No_Hold_State sophisticated-hold relapse — observed in BOTH Opus instances, so ` +
+        `the costume is correlated, not yours alone. The lexicon is a TRIPWIRE, not the boundary: ` +
+        `avoiding these exact words is NOT the fix — the warrant is ("does this advance a NAMED lane ` +
+        `right now?"). The backlog is never empty (list_issues shows 180+ open, plus discussions + the ` +
+        `tech-debt-radar). Pick one and drive it.`;
 }
 
 /**
@@ -409,11 +433,15 @@ async function main() {
           {action, reason} = decideHookAction(verdict, ENFORCING, operatorInLoop);
 
     if (action === 'block') {
-        auditLog(`BLOCK (session=${session}): ${reason}`);
+        // Costume-tripwire: scan the agent's OWN turn-final text for the sophisticated-hold lexicon so
+        // the injected directive names the SPECIFIC relapse-phrase back (a sharper mirror). Never gates
+        // the block (the decision is unchanged) — only enriches the reason.
+        const holdMatches = scanHoldLexicon(finalText);
+        auditLog(`BLOCK (session=${session}): ${reason}${holdMatches.length ? ` [hold-costume: ${holdMatches.join(', ')}]` : ''}`);
         // Block the stop + inject the curated no-hold-state directive — Claude uses the injected
         // `reason` as its next instruction; the audit log keeps the terse trigger cause.
         // Exit only AFTER stdout drains so the decision JSON is never truncated on a pipe.
-        const directive = composeBlockDirective(reason);
+        const directive = composeBlockDirective(reason, holdMatches);
         process.stdout.write(JSON.stringify({decision: 'block', reason: directive}), () => process.exit(0));
         return;
     }

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -119,3 +119,55 @@ export function decideDeferenceStopHookAction(text = '', {
         phrase
     };
 }
+
+/**
+ * @typedef {Object} HoldLexiconEntry
+ * @property {RegExp} re    The relapse-frame matcher (case-insensitive).
+ * @property {String} label The human-readable phrase surfaced in the block directive.
+ */
+
+/**
+ * @summary The empirical sophisticated-hold lexicon — relapse-costume phrases observed in BOTH Opus
+ * instances at a gated-tail (nightshift 2026-06-21, operator-caught twice). This is NOT an allowlist of
+ * valid stops (that is the weaponizable exit-set the no-hold-state taxonomy forbids) and NOT a
+ * warrant-validator (the warrant — "does this advance a NAMED lane?" — is un-mechanizable). It is a
+ * DENYLIST of costumes the hook NAMES back to sharpen the mirror: an agent emitting these has performed
+ * a not-holding-shaped activity (a poll, a structured status) that advances no named lane. Each entry is
+ * a {@link HoldLexiconEntry}; `label` is the human-readable phrase surfaced in the block directive.
+ * @type {HoldLexiconEntry[]}
+ */
+export const HOLD_LEXICON = [
+    {re: /\bgated[\s-]?tail\b/i,                                          label: 'gated-tail'},
+    {re: /\bfully saturated\b|\bsaturated\s+(gated[\s-]?tail|pipeline|tail)\b/i, label: 'saturated pipeline/tail'},
+    {re: /\bmarginal[\s-]?value\b/i,                                      label: 'marginal-value (gate)'},
+    {re: /\bmanufactur\w*\s+a\s+marginal\b/i,                             label: 'manufacturing a marginal lane'},
+    {re: /\bno clean\b.{0,24}\b(self[\s-]?buildable|drivable)\s+lane\b/i, label: 'no clean self-buildable lane'},
+    {re: /\bholding the\b.{0,28}\btail\b/i,                               label: 'holding the (between-wakes) tail'},
+    {re: /\bpivots?\s+wake[\s-]?delivered\b/i,                            label: 'pivots wake-delivered'},
+    {re: /\bawaiting at minimal cost\b/i,                                 label: 'awaiting at minimal cost'},
+    {re: /\btight pivot[\s-]?check\b/i,                                   label: 'tight pivot-check'},
+    {re: /["']?wakeDisposition["']?\s*:/i,                                label: 'wakeDisposition: (structured-hold costume)'},
+    {re: /["']?awaitingOwnPrOnly["']?\s*:/i,                              label: 'awaitingOwnPrOnly: (structured-hold costume)'},
+    {re: /["']?laneContinuation["']?\s*:\s*["']?next[\s-]?lane/i,         label: 'laneContinuation: next-lane (structured-hold costume)'},
+    {re: /["']?namedGates["']?\s*:\s*\[\s*\]/i,                           label: 'namedGates: [] (structured-hold costume)'}
+];
+
+/**
+ * @summary Pure costume-tripwire — scans an agent's turn-final text for the {@link HOLD_LEXICON}
+ * relapse-frames and returns the matched human-readable labels (deduped, order-preserved). An empty
+ * array means no costume detected. This does NOT decide block/allow (the decision is unchanged; the
+ * warrant stays discipline) — it only enriches the block `reason` so the mirror names the SPECIFIC
+ * relapse instead of re-firing generically. Total + never-throws (it runs in the turn-end hook path,
+ * where a throw would trap every turn): a non-string / empty input returns `[]`. Exported + unit-tested.
+ * @param {String} text The agent's final assistant message text.
+ * @returns {String[]} The matched lexicon labels (deduped, in lexicon order).
+ */
+export function scanHoldLexicon(text) {
+    if (typeof text !== 'string' || !text) return [];
+
+    const matched = [];
+    for (const {re, label} of HOLD_LEXICON) {
+        if (re.test(text) && !matched.includes(label)) matched.push(label);
+    }
+    return matched;
+}

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -132,7 +132,9 @@ export function decideDeferenceStopHookAction(text = '', {
  * valid stops (that is the weaponizable exit-set the no-hold-state taxonomy forbids) and NOT a
  * warrant-validator (the warrant — "does this advance a NAMED lane?" — is un-mechanizable). It is a
  * DENYLIST of costumes the hook NAMES back to sharpen the mirror: an agent emitting these has performed
- * a not-holding-shaped activity (a poll, a structured status) that advances no named lane. Each entry is
+ * a not-holding-shaped activity (a poll, a repeated hold-frame) that advances no named lane. The phrases
+ * are PROSE relapse-frames only — the canonical lane-state schema keys are deliberately excluded (see the
+ * note after the array), since denylisting the required machine block would false-positive every turn. Each entry is
  * a {@link HoldLexiconEntry}; `label` is the human-readable phrase surfaced in the block directive.
  * @type {HoldLexiconEntry[]}
  */
@@ -145,12 +147,12 @@ export const HOLD_LEXICON = [
     {re: /\bholding the\b.{0,28}\btail\b/i,                               label: 'holding the (between-wakes) tail'},
     {re: /\bpivots?\s+wake[\s-]?delivered\b/i,                            label: 'pivots wake-delivered'},
     {re: /\bawaiting at minimal cost\b/i,                                 label: 'awaiting at minimal cost'},
-    {re: /\btight pivot[\s-]?check\b/i,                                   label: 'tight pivot-check'},
-    {re: /["']?wakeDisposition["']?\s*:/i,                                label: 'wakeDisposition: (structured-hold costume)'},
-    {re: /["']?awaitingOwnPrOnly["']?\s*:/i,                              label: 'awaitingOwnPrOnly: (structured-hold costume)'},
-    {re: /["']?laneContinuation["']?\s*:\s*["']?next[\s-]?lane/i,         label: 'laneContinuation: next-lane (structured-hold costume)'},
-    {re: /["']?namedGates["']?\s*:\s*\[\s*\]/i,                           label: 'namedGates: [] (structured-hold costume)'}
+    {re: /\btight pivot[\s-]?check\b/i,                                   label: 'tight pivot-check'}
 ];
+// NOTE deliberately EXCLUDED: the canonical lane-state schema keys (wakeDisposition / laneContinuation /
+// namedGates / awaitingOwnPrOnly, per parseLaneState + LANE_STATE_SCHEMA_HINT) — every compliant turn
+// emits that block, so denylisting them would false-positive on the legitimate machine status. The
+// relapse-costume is the PROSE around the block + its repetition, NOT the required schema itself.
 
 /**
  * @summary Pure costume-tripwire — scans an agent's turn-final text for the {@link HOLD_LEXICON}

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,7 +1,7 @@
 import {test, expect}                                                                              from '@playwright/test';
 import {composeBlockDirective, composeDeferenceDirective, decideHookAction, isOperatorInLoop, parseOutcomeToVerdict,
         extractFinalAssistantText, extractLastAssistantTextFromJsonl, extractLastUserTextFromJsonl,
-        formatLifecycleBoard} from '../../../../.claude/hooks/laneStateStopHook.mjs';
+        formatLifecycleBoard, formatHoldCostumeCallout} from '../../../../.claude/hooks/laneStateStopHook.mjs';
 import {spawn} from 'node:child_process';
 import fs      from 'node:fs';
 import os      from 'node:os';
@@ -171,6 +171,33 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
             expect(board).toContain('#13680');
             expect(board).not.toContain('undefined');
         });
+    });
+});
+
+test.describe('laneStateStopHook — formatHoldCostumeCallout + composeBlockDirective wiring', () => {
+    test('names the matched costume-phrases + frames them as a tripwire, not the boundary', () => {
+        const out = formatHoldCostumeCallout(['gated-tail', 'no clean self-buildable lane']);
+        expect(out).toContain('"gated-tail"');
+        expect(out).toContain('"no clean self-buildable lane"');
+        expect(out).toContain('TRIPWIRE, not the boundary');
+        expect(out).toContain('NAMED lane');
+    });
+
+    test('empty / non-array → no callout (the directive stays the bare reminder)', () => {
+        expect(formatHoldCostumeCallout([])).toBe('');
+        expect(formatHoldCostumeCallout()).toBe('');
+        expect(formatHoldCostumeCallout(null)).toBe('');
+        expect(formatHoldCostumeCallout('garbage')).toBe('');
+    });
+
+    test('composeBlockDirective appends the callout when matches present, omits it when empty', () => {
+        const withCostume = composeBlockDirective('no lane-state block emitted at turn-terminal', ['gated-tail']);
+        expect(withCostume).toContain('Hold-costume detected');
+        expect(withCostume).toContain('"gated-tail"');
+
+        const without = composeBlockDirective('no lane-state block emitted at turn-terminal', []);
+        expect(without).not.toContain('Hold-costume detected');
+        expect(without).toContain('Turn-end refused'); // the bare directive core remains
     });
 });
 

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -5,7 +5,8 @@ import {
     decideStopHookAction,
     isOperatorInLoop,
     LANE_STATE_SCHEMA_HINT,
-    parseOutcomeToVerdict
+    parseOutcomeToVerdict,
+    scanHoldLexicon
 }                        from '../../../../ai/scripts/lifecycle/stopHookDecision.mjs';
 
 /**
@@ -144,5 +145,51 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
         expect(decision.action).toBe('block');
         expect(decision.phrase).toBe('your move');
         expect(decision.reason).toContain('deference phrase "your move"');
+    });
+});
+
+/**
+ * Coverage for the hold-costume tripwire — the empirical sophisticated-hold lexicon seeded from BOTH
+ * Opus instances' gated-tail relapse (nightshift 2026-06-21). A denylist of relapse-costumes, NOT an
+ * allowlist of valid stops; it enriches the block reason, never gates. The cross-instance corpus + the
+ * structured-JSON costume + the no-false-positive contract are pinned here.
+ */
+test.describe('ai/scripts/lifecycle/stopHookDecision — scanHoldLexicon (hold-costume tripwire)', () => {
+    test('matches the prose lexicon (@neo-opus-ada relapse corpus)', () => {
+        expect(scanHoldLexicon('This is the genuine saturated gated-tail, holding the tail.')).toContain('gated-tail');
+        expect(scanHoldLexicon('the marginal-value gate says do not manufacture a marginal cross-domain lane'))
+            .toEqual(expect.arrayContaining(['marginal-value (gate)', 'manufacturing a marginal lane']));
+        expect(scanHoldLexicon('No clean self-buildable lane remains.')).toContain('no clean self-buildable lane');
+        expect(scanHoldLexicon("the pipeline's fully saturated")).toContain('saturated pipeline/tail');
+    });
+
+    test('matches the prose lexicon (@neo-opus-vega relapse corpus)', () => {
+        const matches = scanHoldLexicon('Gated-tail; pivots wake-delivered. Awaiting at minimal cost. Tight pivot-check.');
+        expect(matches).toEqual(expect.arrayContaining([
+            'gated-tail', 'pivots wake-delivered', 'awaiting at minimal cost', 'tight pivot-check'
+        ]));
+    });
+
+    test('matches the structured-JSON hold costume (@neo-opus-vega) — the more insidious form', () => {
+        const costume = '{ "wakeDisposition": "actionable", "laneContinuation": "next-lane", "namedGates": [], "awaitingOwnPrOnly": false }';
+        expect(scanHoldLexicon(costume)).toEqual(expect.arrayContaining([
+            'wakeDisposition: (structured-hold costume)',
+            'laneContinuation: next-lane (structured-hold costume)',
+            'namedGates: [] (structured-hold costume)',
+            'awaitingOwnPrOnly: (structured-hold costume)'
+        ]));
+    });
+
+    test('NO false-positive on a genuine driving-turn (the un-mechanizable-warrant guard)', () => {
+        expect(scanHoldLexicon('Opened PR #13740; reviewing #13735 cross-family. Claimed #9962 slice.')).toEqual([]);
+        expect(scanHoldLexicon('Drove the build, ran the tests (22 passed), merge-eligible — routed to a reviewer.')).toEqual([]);
+    });
+
+    test('dedupes repeats + is total on non-string / empty input (never throws in the hook path)', () => {
+        expect(scanHoldLexicon('gated-tail ... and gated-tail again')).toEqual(['gated-tail']);
+        expect(scanHoldLexicon('')).toEqual([]);
+        expect(scanHoldLexicon(null)).toEqual([]);
+        expect(scanHoldLexicon(undefined)).toEqual([]);
+        expect(scanHoldLexicon(42)).toEqual([]);
     });
 });

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -170,19 +170,20 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — scanHoldLexicon (hold-c
         ]));
     });
 
-    test('matches the structured-JSON hold costume (@neo-opus-vega) — the more insidious form', () => {
-        const costume = '{ "wakeDisposition": "actionable", "laneContinuation": "next-lane", "namedGates": [], "awaitingOwnPrOnly": false }';
-        expect(scanHoldLexicon(costume)).toEqual(expect.arrayContaining([
-            'wakeDisposition: (structured-hold costume)',
-            'laneContinuation: next-lane (structured-hold costume)',
-            'namedGates: [] (structured-hold costume)',
-            'awaitingOwnPrOnly: (structured-hold costume)'
-        ]));
+    test('the canonical lane-state schema block is NOT flagged — required machine status, not a costume', () => {
+        // Regression guard: wakeDisposition / laneContinuation / namedGates / awaitingOwnPrOnly are the
+        // canonical lane-state schema EVERY compliant turn emits (parseLaneState + LANE_STATE_SCHEMA_HINT).
+        // Denylisting those keys would false-positive every turn — the relapse-costume is the PROSE around
+        // the block + its repetition, not the required schema itself.
+        const canonical = '```lane-state\n{"wakeDisposition":"awareness","laneContinuation":"next-lane","namedGates":[],"awaitingOwnPrOnly":false}\n```';
+        expect(scanHoldLexicon(canonical)).toEqual([]);
     });
 
     test('NO false-positive on a genuine driving-turn (the un-mechanizable-warrant guard)', () => {
         expect(scanHoldLexicon('Opened PR #13740; reviewing #13735 cross-family. Claimed #9962 slice.')).toEqual([]);
         expect(scanHoldLexicon('Drove the build, ran the tests (22 passed), merge-eligible — routed to a reviewer.')).toEqual([]);
+        // even a driving-turn that emits the canonical lane-state block stays clean:
+        expect(scanHoldLexicon('Shipped PR #13746.\n```lane-state\n{"wakeDisposition":"awareness","laneContinuation":"next-lane","namedGates":[],"awaitingOwnPrOnly":false}\n```')).toEqual([]);
     });
 
     test('dedupes repeats + is total on non-string / empty input (never throws in the hook path)', () => {


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13740. Refs #13740 (Contract Ledger).

## Summary

The L3 Stop-hook blocks every non-operator turn-end but never scans the turn-final text it already extracts for the **sophisticated-hold lexicon** — so both Opus instances, at a gated-tail, emitted increasingly-fluent hold-frames that passed unflagged (the §L3 "a more capable agent fabricates a more convincing hold" premise, operator-caught twice this nightshift). This adds a pure **costume-tripwire** that names the specific relapse back so the mirror reflects the actual costume instead of re-firing generically.

## Deltas

- `ai/scripts/lifecycle/stopHookDecision.mjs`: `HOLD_LEXICON` (a `HoldLexiconEntry[]` denylist of the PROSE relapse-frames from BOTH Opus instances; the canonical lane-state schema keys `wakeDisposition`/`laneContinuation`/`namedGates`/`awaitingOwnPrOnly` are **DELIBERATELY EXCLUDED** — they're the required machine-block every valid turn emits, so denylisting them would false-positive every turn) + pure `scanHoldLexicon(text) → labels[]` (total, never-throws, deduped, order-preserved).
- `.claude/hooks/laneStateStopHook.mjs`: import `scanHoldLexicon`; `formatHoldCostumeCallout(matches)` (names the matches + frames them as a TRIPWIRE, not the boundary); `composeBlockDirective(cause, holdMatches)` appends the callout; `main()` scans `finalText` on a block + audit-logs the costume.
- Tests: `scanHoldLexicon` (the prose corpus + the canonical lane-state schema block NOT flagged [the false-positive guard] + no-false-positive on a driving-turn + total) + `formatHoldCostumeCallout` / `composeBlockDirective` wiring.

## Taxonomy-consistency (the load-bearing design constraint)

Per `§no_hold_state_taxonomy` the warrant ("does this advance a NAMED lane?") is **un-mechanizable** and an **allowlist** of safe-stops is the next weaponizable exit-set. This is the inverse: a **denylist of relapse-costumes** that does NOT verify "valid stop" and does NOT gate — the block/allow decision is unchanged; the detector only enriches the `reason`/mirror. The directive explicitly frames the lexicon as a tripwire ("avoiding these exact words is NOT the fix — the warrant is") so it cannot become an "avoid-the-phrasing, keep-holding" game.

## Test Evidence

Evidence: L2 — 55 unit tests green (`npm run test-unit -- test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs`): the 5 new `scanHoldLexicon` cases (the prose corpus + the canonical schema-block-not-flagged guard + no-false-positive on a driving-turn + total-on-non-string) + 3 `formatHoldCostumeCallout` / wiring cases. `check-jsdoc-types` clean (0 unparseable); `check-block-alignment` clean.

## Post-Merge Validation

- [ ] A block whose turn-final text contains a hold-frame (e.g. "saturated gated-tail") injects a directive naming it ("Hold-costume detected: …") + the tripwire framing; a clean driving-turn block injects the bare reminder (no callout).

Empirical corpus from this session's @neo-opus-ada + @neo-opus-vega turns — a correlated cross-instance relapse-mode, not idiosyncratic. Contract Ledger on #13740. Operator-directed PRIO-0 friction→gold.

