### PR TITLE
refactor(ai): share deference stop-hook decision (#13742)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -43,9 +43,9 @@ import os              from 'node:os';
 import {pathToFileURL} from 'node:url';
 
 import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneState.mjs';
-import {buildDeferenceReminder,
-        detectDeferencePhrase}     from '../../ai/scripts/lifecycle/deferencePhraseMatch.mjs';
-import {decideStopHookAction,
+import {buildDeferenceStopHookDirective,
+        decideDeferenceStopHookAction,
+        decideStopHookAction,
         isOperatorInLoop,
         LANE_STATE_SCHEMA_HINT,
         parseOutcomeToVerdict}     from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
@@ -233,7 +233,7 @@ export function composeBlockDirective(cause) {
  * @returns {String}
  */
 export function composeDeferenceDirective(phrase) {
-    return buildDeferenceReminder(phrase);
+    return buildDeferenceStopHookDirective(phrase);
 }
 
 /**
@@ -369,16 +369,16 @@ async function main() {
     }
     const operatorInLoop = isOperatorInLoop({stopHookActive: !!input.stop_hook_active, promptingText});
 
-    const deferencePhrase = detectDeferencePhrase(finalText, {operatorInLoop});
-    if (deferencePhrase) {
-        const reason  = `deference phrase "${deferencePhrase}" at turn-terminal`,
+    const deferenceDecision = decideDeferenceStopHookAction(finalText, {operatorInLoop, enforcing: ENFORCING});
+    if (deferenceDecision) {
+        const reason  = `deference phrase "${deferenceDecision.phrase}" at turn-terminal`,
               session = input.session_id || '?';
 
-        if (ENFORCING) {
+        if (deferenceDecision.action === 'block') {
             auditLog(`BLOCK (session=${session}): ${reason}`);
             process.stdout.write(JSON.stringify({
                 decision: 'block',
-                reason  : composeDeferenceDirective(deferencePhrase)
+                reason  : deferenceDecision.reason
             }), () => process.exit(0));
             return;
         }

--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -15,13 +15,12 @@ import os              from 'node:os';
 import {pathToFileURL} from 'node:url';
 
 import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneState.mjs';
-import {decideStopHookAction,
+import {decideDeferenceStopHookAction,
+        decideStopHookAction,
         isOperatorInLoop,
         LANE_STATE_SCHEMA_HINT,
         parseOutcomeToVerdict}     from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
-import {buildDeferenceReminder,
-        detectDeferencePhrase}     from '../../ai/scripts/lifecycle/deferencePhraseMatch.mjs';
 
 export const CODEX_STOP_BLOCK_INJECTION_SUPPORTED = true;
 
@@ -336,7 +335,7 @@ export function summarizePayloadShape(payload = {}) {
  * @param {Object} input
  * @param {Object} [options]
  * @param {Boolean} [options.enforcing=false]
- * @returns {{action: ('allow'|'block'|'would-block'), reason: String, source: String, promptSource: String, verdict: Object}}
+ * @returns {{action: ('allow'|'block'|'would-block'), reason: String, source: String, promptSource: String, verdict: Object, phrase: (String|undefined)}}
  */
 export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
     const stopHookActive                            = !!(input.stop_hook_active || input.stopHookActive),
@@ -344,13 +343,11 @@ export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
           {text: promptingText, source: promptSource} = extractPromptingText(input),
           operatorInLoop                            = isOperatorInLoop({stopHookActive, promptingText});
 
-    // Deference-register check (mirrors the Claude hook): an autonomous turn-end in helpful-assistant
-    // phrasing is a soft block, runs BEFORE lane-state parsing and reuses the operatorInLoop carve.
-    const deferencePhrase = detectDeferencePhrase(text, {operatorInLoop});
-    if (deferencePhrase) {
+    // Deference-register check: shared decision, adapter-owned payload/source metadata.
+    const deferenceDecision = decideDeferenceStopHookAction(text, {operatorInLoop, enforcing});
+    if (deferenceDecision) {
         return {
-            action : enforcing ? 'block' : 'would-block',
-            reason : buildDeferenceReminder(deferencePhrase),
+            ...deferenceDecision,
             source,
             promptSource,
             verdict: null

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -6,6 +6,7 @@
  *
  * @module Neo.ai.scripts.lifecycle.stopHookDecision
  */
+import {buildDeferenceReminder, detectDeferencePhrase} from './deferencePhraseMatch.mjs';
 
 /**
  * Compact runtime hint for the fenced JSON block consumed by `parseLaneState`. Prose `lane-state:`
@@ -82,4 +83,39 @@ export function decideStopHookAction(verdict, {
         : verdict.reason;
 
     return {action: 'would-block', reason};
+}
+
+/**
+ * @summary Builds the shared Stop-hook directive for autonomous deference-register slips.
+ * @param {String|null} phrase Matched deference phrase, if known.
+ * @returns {String}
+ */
+export function buildDeferenceStopHookDirective(phrase = null) {
+    return buildDeferenceReminder(phrase);
+}
+
+/**
+ * @summary Shared deference-register Stop-hook decision. Returns `null` when no autonomous
+ * deference slip exists; otherwise maps the match to the same dry-run/enforcing action for every
+ * Stop-hook adapter. Operator dialogue is carved before matching, so adapters cannot drift on that
+ * business rule.
+ * @param {String} text Assistant final-turn text.
+ * @param {Object} [options]
+ * @param {Boolean} [options.enforcing=false]
+ * @param {Boolean} [options.operatorInLoop=false]
+ * @returns {{action: ('block'|'would-block'), reason: String, phrase: String}|null}
+ */
+export function decideDeferenceStopHookAction(text = '', {
+    enforcing      = false,
+    operatorInLoop = false
+} = {}) {
+    const phrase = detectDeferencePhrase(text, {operatorInLoop});
+
+    if (!phrase) return null;
+
+    return {
+        action: enforcing ? 'block' : 'would-block',
+        reason: buildDeferenceStopHookDirective(phrase),
+        phrase
+    };
 }

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -1,5 +1,7 @@
 import {test, expect} from '@playwright/test';
 import {
+    buildDeferenceStopHookDirective,
+    decideDeferenceStopHookAction,
     decideStopHookAction,
     isOperatorInLoop,
     LANE_STATE_SCHEMA_HINT,
@@ -109,5 +111,38 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
 
     test('decideStopHookAction: defaults (no options) → would-block, never a fail-open allow', () => {
         expect(decideStopHookAction(verdict).action).toBe('would-block');
+    });
+
+    // ── decideDeferenceStopHookAction: shared autonomous deference decision for all adapters ─────
+    test('buildDeferenceStopHookDirective: carries the peer-identity reminder and trigger phrase', () => {
+        const directive = buildDeferenceStopHookDirective('your call');
+        expect(directive).toContain('helpful assistant');
+        expect(directive).toContain('equal peer');
+        expect(directive).toContain('deference phrase "your call"');
+    });
+
+    test('decideDeferenceStopHookAction: no phrase → null, leaving lane-state parsing to proceed', () => {
+        expect(decideDeferenceStopHookAction('plain final text')).toBe(null);
+    });
+
+    test('decideDeferenceStopHookAction: operator dialogue carves deference phrases before action', () => {
+        expect(decideDeferenceStopHookAction('Your call.', {operatorInLoop: true, enforcing: true})).toBe(null);
+    });
+
+    test('decideDeferenceStopHookAction: dry-run autonomous phrase → would-block directive', () => {
+        const decision = decideDeferenceStopHookAction('Your call.', {operatorInLoop: false, enforcing: false});
+
+        expect(decision.action).toBe('would-block');
+        expect(decision.phrase).toBe('your call');
+        expect(decision.reason).toContain('helpful assistant');
+        expect(decision.reason).toContain('deference phrase "your call"');
+    });
+
+    test('decideDeferenceStopHookAction: enforcing autonomous phrase → block with same directive', () => {
+        const decision = decideDeferenceStopHookAction('Your move.', {operatorInLoop: false, enforcing: true});
+
+        expect(decision.action).toBe('block');
+        expect(decision.phrase).toBe('your move');
+        expect(decision.reason).toContain('deference phrase "your move"');
     });
 });


### PR DESCRIPTION
Resolves #13742

Related: #13726, #13740

Extracts the autonomous deference-register Stop-hook decision into the shared lifecycle decision module so Claude and Codex consume the same business logic. The adapters still own payload extraction, audit logging, and transport shape; phrase detection, operator-dialogue carve, dry-run vs enforcing action, and directive composition now come from `ai/scripts/lifecycle/stopHookDecision.mjs`.

Evidence: L2 focused hook/unit evidence covers the shared helper and both adapters. Residual: none for #13742.

## Deltas from ticket

- Kept `deferencePhraseMatch.mjs` as the low-level phrase/reminder primitive and moved only the Stop-hook decision wrapper into `stopHookDecision.mjs`, preserving the existing source-of-authority split.
- Preserved the existing Claude `composeDeferenceDirective` export as a thin compatibility wrapper over the shared directive builder.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs` -> 89 passed.
- `git diff --check` -> passed.
- Freshness check: `merge-base HEAD origin/dev == origin/dev` at `f79c86d78` before push.

## Post-Merge Validation

- [ ] Observe one Claude and one Codex autonomous deference-hook hit after merge and confirm both reports use the same shared directive semantics.

## Commits

- `99907e1d2` - `refactor(ai): share deference stop-hook decision (#13742)`

Authored by Euclid (GPT-5, Codex Desktop). Session 747ae298-5a6e-4416-b90d-7786e184aa54.