### PR TITLE
feat(ai): CI-failure file-level dedup parser (pure) — slice 1 of #9888

### DIFF
--- a/ai/services/ingestion/parseCiFailures.mjs
+++ b/ai/services/ingestion/parseCiFailures.mjs
@@ -1,0 +1,55 @@
+/**
+ * @module Neo.ai.services.ingestion.parseCiFailures
+ * @summary Pure file-level dedup of CI test failures — slice 1 of the Autonomous CI Failure Triaging
+ * lane. Per the file-level-dedup design: a cascading failure (one structural break → many failing tests
+ * across a file) collapses to ONE entry per failing spec-file, keeping the tracker's signal-to-noise
+ * clean. The graph-check ("does this file have an OPEN ticket bound?") + the ticket-create + the report
+ * fetch are the integration's; this slice is the pure parse only.
+ */
+
+/**
+ * @summary Extracts the unique failing spec-file paths from a Playwright JSON report. The report shape
+ * (the `reporter: [['json', ...]]` output, V-B-A'd against a live run) is nested `suites[]` each with
+ * `specs[]` carrying `spec.ok` (boolean) + `spec.file` (path); suites nest via `suite.suites[]`. A spec
+ * is failing when `spec.ok === false`. File-level deduped via a Set, so N failing tests in one file
+ * yield ONE path (the dedup key the downstream graph-check binds to). Accepts the parsed report object
+ * OR the raw JSON string. Total — a non-object / unparseable / shapeless input returns `[]` (it runs in
+ * an ingestion path where a throw would abort the triage sweep, so a total function is the contract).
+ * @param {(Object|String)} report The Playwright JSON report — parsed object or raw JSON string.
+ * @returns {String[]} The unique failing spec-file paths (the file-level dedup keys).
+ */
+export function parseCiFailures(report) {
+    let parsed = report;
+
+    if (typeof report === 'string') {
+        try {
+            parsed = JSON.parse(report);
+        } catch {
+            return [];
+        }
+    }
+
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.suites)) {
+        return [];
+    }
+
+    const failing = new Set();
+
+    const walk = suites => {
+        for (const suite of suites) {
+            if (!suite || typeof suite !== 'object') continue;
+
+            for (const spec of (Array.isArray(suite.specs) ? suite.specs : [])) {
+                if (spec && spec.ok === false && typeof spec.file === 'string') {
+                    failing.add(spec.file);
+                }
+            }
+
+            if (Array.isArray(suite.suites)) walk(suite.suites);
+        }
+    };
+
+    walk(parsed.suites);
+
+    return [...failing];
+}

--- a/test/playwright/unit/ai/services/ingestion/parseCiFailures.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/parseCiFailures.spec.mjs
@@ -1,0 +1,55 @@
+import {test, expect}    from '@playwright/test';
+import {parseCiFailures} from '../../../../../../ai/services/ingestion/parseCiFailures.mjs';
+
+/**
+ * Coverage for the pure file-level CI-failure dedup parser (slice 1 of the CI-triage lane). The report shape is
+ * V-B-A'd against a live Playwright JSON report (nested suites[].specs[] with spec.ok + spec.file).
+ * The file-level dedup + the total-on-malformed contract are pinned here.
+ */
+test.describe('ai/services/ingestion/parseCiFailures', () => {
+    const report = specs => ({suites: [{specs}]});
+
+    test('extracts a single failing spec-file', () => {
+        expect(parseCiFailures(report([{file: 'data/Store.spec.mjs', ok: false}]))).toEqual(['data/Store.spec.mjs']);
+    });
+
+    test('file-level dedup: N failing tests in one file → ONE path', () => {
+        const r = {suites: [{specs: [
+            {file: 'data/Store.spec.mjs', ok: false},
+            {file: 'data/Store.spec.mjs', ok: false},
+            {file: 'data/Store.spec.mjs', ok: false}
+        ]}]};
+        expect(parseCiFailures(r)).toEqual(['data/Store.spec.mjs']);
+    });
+
+    test('multiple failing files → unique paths; passing specs excluded', () => {
+        const r = {suites: [{specs: [
+            {file: 'a.spec.mjs', ok: false},
+            {file: 'b.spec.mjs', ok: true},
+            {file: 'c.spec.mjs', ok: false}
+        ]}]};
+        expect(parseCiFailures(r).sort()).toEqual(['a.spec.mjs', 'c.spec.mjs']);
+    });
+
+    test('walks NESTED suites (suite.suites[])', () => {
+        const r = {suites: [{specs: [], suites: [{specs: [{file: 'nested.spec.mjs', ok: false}]}]}]};
+        expect(parseCiFailures(r)).toEqual(['nested.spec.mjs']);
+    });
+
+    test('accepts a raw JSON string', () => {
+        expect(parseCiFailures(JSON.stringify(report([{file: 'x.spec.mjs', ok: false}])))).toEqual(['x.spec.mjs']);
+    });
+
+    test('all-passing report → []', () => {
+        expect(parseCiFailures(report([{file: 'x.spec.mjs', ok: true}]))).toEqual([]);
+    });
+
+    test('total on malformed / non-object / unparseable input (never throws in the ingestion path)', () => {
+        expect(parseCiFailures(null)).toEqual([]);
+        expect(parseCiFailures(undefined)).toEqual([]);
+        expect(parseCiFailures(42)).toEqual([]);
+        expect(parseCiFailures('not json')).toEqual([]);
+        expect(parseCiFailures({})).toEqual([]);
+        expect(parseCiFailures({suites: 'bad'})).toEqual([]);
+    });
+});


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13746. Refs #9888.

## Summary

Slice 1 of #9888 (Autonomous CI Failure Triaging) — the pure file-level dedup parser, per the operator + Gemini (Antigravity) file-level-dedup design refinement on #9888: a cascading failure (one structural break → many failing tests across a file) collapses to ONE entry per failing spec-file, keeping the tracker's signal-to-noise clean.

## Deltas

- `ai/services/ingestion/parseCiFailures.mjs` (new): pure `parseCiFailures(report) → string[]` — extracts the unique failing spec-file paths from a Playwright JSON report, file-level deduped via a Set (N failing tests in one file → ONE path). Accepts the parsed object OR a raw JSON string. Total (malformed / non-object / unparseable → `[]`).
- **The input format was V-B-A'd against a live report, not guessed:** `playwright.config.mjs` uses `reporter: [['json', {outputFile: 'test-results/all/test-results.json'}]]`, and I read an actual report to confirm the shape (nested `suites[].specs[]`, `spec.ok === false` = failing, `spec.file` = path). This applies the same-session #13740 don't-guess-a-format lesson directly.

## Out of scope (stays on #9888, the integration)

The graph-check ("does this file have an OPEN ticket bound?") + the ticket-create + the report fetch (the I/O). Same pure-only carve as the RLAIF cores (#13724 / #13727).

## Test Evidence

Evidence: L2 — 7 unit tests green (`npm run test-unit -- parseCiFailures.spec.mjs`): single failure, file-level dedup (N→1), multi-files (passing excluded), nested suites, raw-JSON-string, all-passing → `[]`, total-on-malformed. `check-jsdoc-types` clean; `check-block-alignment` clean.

## Post-Merge Validation

- [ ] `parseCiFailures` is importable; the #9888 integration can feed it a Playwright JSON report to get the unique failing spec-files (the file-level dedup keys for the graph-check).
