### PR TITLE
refactor(main): DRY DomAccess script-element creation via createAndAppendElement

### DIFF
--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -29,10 +29,10 @@ const
     ],
 
     modifierKeys = {
-        Shift   : 1,
-        Alt     : 1,
-        Meta    : 1,
-        Control : 1
+        Shift  : 1,
+        Alt    : 1,
+        Meta   : 1,
+        Control: 1
     };
 
 /**
@@ -180,15 +180,29 @@ class DomAccess extends Base {
      * @param {String} [data.src=true]
      */
     addScript(data) {
-        let script = document.createElement('script');
-
         if (!data.hasOwnProperty('async')) {
             data.async = true
         }
 
-        Object.assign(script, data);
+        this.createAndAppendElement('script', data)
+    }
 
-        document.head.appendChild(script)
+    /**
+     * Shared DOM-element factory: creates an element of the given tag, assigns the props onto it via
+     * Object.assign, and appends it to document.head. The common primitive behind addScript() and
+     * loadScript() (loadStylesheet() can adopt it in a follow-up). Returns the element for any
+     * post-append work the caller needs.
+     * @param {String} tag The element tag, e.g. 'script'.
+     * @param {Object} props Properties assigned onto the element.
+     * @returns {Element} The created + appended element.
+     */
+    createAndAppendElement(tag, props) {
+        const element = document.createElement(tag);
+
+        Object.assign(element, props);
+        document.head.appendChild(element);
+
+        return element
     }
 
     /**
@@ -232,8 +246,8 @@ class DomAccess extends Base {
             result = data.result = myRect.alignTo(align);
 
         Object.assign(style, {
-            top       : 0,
-            left      : 0,
+            top : 0,
+            left: 0,
             transform : `translate(${result.x}px,${result.y}px)`
         });
 
@@ -538,19 +552,13 @@ class DomAccess extends Base {
      * @returns {Promise<unknown>}
      */
     loadScript(src, opts={defer:true}) {
-        let script;
-
         return new Promise((resolve, reject) => {
-            script = document.createElement('script');
-
-            Object.assign(script, {
+            this.createAndAppendElement('script', {
                 ...opts,
                 onerror: reject,
                 onload : resolve,
                 src
-            });
-
-            document.head.appendChild(script)
+            })
         })
     }
 


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13797. Refs #8152 (slice — the shared create/append primitive; #8152's full unified public API + Promise loading-state stays open, per @neo-gpt's review).

## Summary

DRY the duplicated DOM-script-element creation in `DomAccess`. Per my premise V-B-A on #8152 (the two methods have different public signatures, `addScript` is remote-method-exposed, and `loadScript` has 19 consumers), this is **option (b)**: a shared internal helper both methods delegate to — NOT a breaking public-API merge. Behavior-preserving by construction.

## Deltas

- `src/main/DomAccess.mjs`: new `createAndAppendElement(tag, props)` — the shared `createElement → Object.assign → document.head.appendChild` primitive (returns the element for any post-append work). `addScript` + `loadScript` now delegate to it. Both public APIs are unchanged — the remote-method contract (addScript) and the 19 `loadScript` consumers (CesiumJS/AmCharts/GoogleMaps/MapboxGL/…) are preserved. `loadStylesheet` can adopt the helper in a follow-up (its post-create `dataset` handling is a separate wrinkle, out of scope).

## Test Evidence

Evidence: L1 — behavior-preserving pure-extract (the helper performs the identical create+assign+append both methods already did; the diff is a 1:1 delegation, verifiable by reading it). No `DomAccess` unit-spec exists (it's a main-thread DOM singleton); `loadScript` is exercised by the addon e2e. `check-block-alignment` clean.

## Post-Merge Validation

- [ ] The addons (CesiumJS/AmCharts/GoogleMaps/MapboxGL) still load their scripts via `loadScript` — the `createAndAppendElement` delegation is behavior-identical.

