### PR TITLE
fix(ai): prevent Golden Path sync starvation (#13750)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -180,7 +180,7 @@ export const TASK_REGISTRY = Object.freeze([
         executionKind   : 'in-process-async',
         maintenanceClass: 'graph-dependent',
         backpressure    : 'after-heavy',
-        dependencies    : ['dream'],
+        dependencies    : ['dream', 'githubWorkflowSync'],
         getDueTask({state, now, intervals, hooks}) {
             return (hooks.goldenPathGetDueTask || getGoldenPathDueTask)({
                 state               : state['golden-path'] ?? {},

--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -493,7 +493,8 @@ export async function releaseHeavyMaintenanceLease({
  * |---------------|------------|-------------------|------------------------------------------------------------------------------|
  * | `'completed'` | `true`     | the task's return | Lease acquired (including after stale/malformed recovery); task ran to completion (success or graceful-return). |
  * | `'inherited'` | `false`    | the task's return | Inherited via matching env-var token; lease was acquired by a parent process; task ran to completion. |
- * | `'held'`      | `false`    | absent            | Another active owner holds the lease; task NOT executed. `lease` carries that owner's descriptor. |
+ * | `'compatible'`| `false`    | the task's return | Another active owner holds the lease, but its owner is in `compatibleLeaseOwners`; task ran without acquiring/releasing that lease. |
+ * | `'held'`      | `false`    | absent            | Another active owner holds the lease and is not compatible; task NOT executed. `lease` carries that owner's descriptor. |
  *
  * Note: when `acquireHeavyMaintenanceLease` returns a non-`'acquired'` non-`'held'`
  * acquisition descriptor (e.g., an `'unreadable'` IO-failure shape — theoretical
@@ -518,13 +519,17 @@ export async function releaseHeavyMaintenanceLease({
  *
  * @param {Function} task Async task to execute when the lease is acquired. Receives the acquisition descriptor as its single argument (`{status, acquired, lease}`).
  * @param {Object} options Lease acquisition options forwarded to `acquireHeavyMaintenanceLease` (owner, reason, metadata, leasePath, staleAfterMs, pid, token, fsModule, now).
- * @returns {Promise<Object>} `{status, acquired, lease, result}` on completion; `{status: 'held', acquired: false, lease}` on contention.
+ * @param {String[]} [options.compatibleLeaseOwners] Active lease owners whose resource envelope is compatible with this task.
+ * @returns {Promise<Object>} `{status, acquired, lease, result}` on completion or compatible execution; `{status: 'held', acquired: false, lease}` on incompatible contention.
  * @see acquireHeavyMaintenanceLease
  * @see releaseHeavyMaintenanceLease
  * @see ai/scripts/runners/runSandman.mjs — canonical consumer pattern
  */
 export async function withHeavyMaintenanceLease(task, options = {}) {
     const inheritedToken = process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+    const compatibleLeaseOwners = new Set(
+        Array.isArray(options.compatibleLeaseOwners) ? options.compatibleLeaseOwners : []
+    );
 
     if (inheritedToken) {
         const current = await inspectHeavyMaintenanceLease({
@@ -548,6 +553,16 @@ export async function withHeavyMaintenanceLease(task, options = {}) {
     const acquisition = await acquireHeavyMaintenanceLease(options);
 
     if (!acquisition.acquired) {
+        if (acquisition.status === 'held' && compatibleLeaseOwners.has(acquisition.lease?.owner)) {
+            const compatibleAcquisition = {status: 'compatible', acquired: false, lease: acquisition.lease};
+            return {
+                status  : 'compatible',
+                acquired: false,
+                lease   : acquisition.lease,
+                result  : await task(compatibleAcquisition)
+            };
+        }
+
         return acquisition;
     }
 

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -29,13 +29,15 @@ export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
 /**
  * Heavy-maintenance pairs whose resource envelopes are compatible enough to run
  * concurrently. This is intentionally narrow: Memory Core miniSummary backfill
- * must not wait behind local-only KB embedding work, while every other heavy task
- * pair keeps the historical single-heavy invariant.
+ * and GitHub workflow issue-to-graph ingestion must not wait behind local-only KB
+ * embedding work, while every other heavy task pair keeps the historical
+ * single-heavy invariant.
  *
  * @type {ReadonlyArray<ReadonlyArray<String>>}
  */
 export const DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS = Object.freeze([
-    Object.freeze(['kbSync', 'memory-summary-backfill'])
+    Object.freeze(['kbSync', 'memory-summary-backfill']),
+    Object.freeze(['kbSync', 'githubWorkflowSync'])
 ]);
 
 /**
@@ -44,7 +46,8 @@ export const DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS = Object.freeze([
  * @type {ReadonlyArray<String>}
  */
 export const DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES = Object.freeze([
-    'dream'
+    'dream',
+    'githubWorkflowSync'
 ]);
 
 // ============================================================================

--- a/ai/scripts/lifecycle/backfill-memory-summaries.mjs
+++ b/ai/scripts/lifecycle/backfill-memory-summaries.mjs
@@ -26,9 +26,10 @@ async function main() {
             return MemoryService.backfillMiniSummaries();
         },
         {
-            owner   : 'memory-summary-backfill',
-            reason  : 'manual-cli',
-            metadata: {script: 'ai/scripts/lifecycle/backfill-memory-summaries.mjs'}
+            owner                : 'memory-summary-backfill',
+            reason               : 'manual-cli',
+            compatibleLeaseOwners: ['kbSync'],
+            metadata             : {script: 'ai/scripts/lifecycle/backfill-memory-summaries.mjs'}
         }
     );
 

--- a/ai/scripts/maintenance/syncGithubWorkflow.mjs
+++ b/ai/scripts/maintenance/syncGithubWorkflow.mjs
@@ -81,14 +81,19 @@ async function syncGithubWorkflow() {
     console.log('🔄 Starting full GitHub Workflow sync via GH_SyncService.runFullSync()...');
 
     // Run the full workflow sync under the shared heavy-maintenance lease so this CLI
-    // cannot collide with orchestrator maintenance tasks or another manual graph-heavy
-    // script. The whole-run guard keeps graph ingestion protected until the sync stages
-    // have a narrower concurrency boundary.
+    // cannot collide with incompatible maintenance tasks or another manual graph-heavy
+    // script. `kbSync` is explicitly compatible: local KB embedding must not starve
+    // issue graph refresh, and Golden Path waits on this task before reading the graph.
     let outcome;
     try {
         outcome = await withHeavyMaintenanceLease(
             async () => GH_SyncService.runFullSync(),
-            {owner: 'syncGithubWorkflow', reason: 'manual-cli', metadata: {script: 'ai/scripts/maintenance/syncGithubWorkflow.mjs', verbose}}
+            {
+                owner                : 'syncGithubWorkflow',
+                reason               : 'manual-cli',
+                compatibleLeaseOwners: ['kbSync'],
+                metadata             : {script: 'ai/scripts/maintenance/syncGithubWorkflow.mjs', verbose}
+            }
         );
     } catch (e) {
         console.error('❌ Sync failed:', e);

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -58,8 +58,9 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         );
 
         expect(source).toContain('withHeavyMaintenanceLease');
-        expect(source).toContain("owner   : 'memory-summary-backfill'");
-        expect(source).toContain("reason  : 'manual-cli'");
+        expect(source).toMatch(/owner\s*:\s*'memory-summary-backfill'/);
+        expect(source).toMatch(/reason\s*:\s*'manual-cli'/);
+        expect(source).toContain("compatibleLeaseOwners: ['kbSync']");
     });
 
     test('buildTaskDefinitions is pure: tasks.mlx is omitted when mlxEnabled is false', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs
@@ -118,6 +118,15 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
         expect(winner.taskName).toBe('summary');
     });
 
+    test('filterUnmetDependencies: drops golden-path when githubWorkflowSync is running (#13750)', () => {
+        const candidates = [
+            makeCandidate('golden-path', {dependencies: ['dream', 'githubWorkflowSync']}),
+            makeCandidate('summary')
+        ];
+        const winner = pickNextCandidate({candidates, runningTasks: ['githubWorkflowSync']});
+        expect(winner.taskName).toBe('summary');
+    });
+
     test('filterUnmetDependencies: passes golden-path when dream is NOT running', () => {
         const candidates = [
             makeCandidate('golden-path', {dependencies: ['dream']}),

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -221,6 +221,54 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
         }]);
     });
 
+    test('does not record picker deferral for githubWorkflowSync while compatible kbSync runs (#13750)', () => {
+        const deferrals = [];
+        const started   = [];
+
+        const result = runSchedulingPipeline({
+            registry: [
+                makeCandidateDescriptor({taskName: 'githubWorkflowSync', maintenanceClass: 'heavy'})
+            ],
+            context : makeContext({
+                state: {
+                    kbSync            : {running: true},
+                    githubWorkflowSync: {running: false}
+                }
+            }),
+            services: makeServices({
+                maintenanceBackpressureService: {
+                    acquireLeaseAndExecute({executeFn, taskName, reason, onSuccess, activeHeavyTask}) {
+                        return executeFn(taskName, reason, onSuccess, {activeHeavyTask});
+                    },
+                    getActiveHeavyMaintenanceTask() { return null; },
+                    isHeavyMaintenanceTask(taskName) {
+                        return taskName === 'kbSync' || taskName === 'githubWorkflowSync';
+                    },
+                    isHeavyMaintenanceConflict(taskName, otherTaskName) {
+                        return !(taskName === 'githubWorkflowSync' && otherTaskName === 'kbSync');
+                    },
+                    recordDeferral(deferral) {
+                        deferrals.push(deferral);
+                    }
+                },
+                processSupervisorService: {
+                    runTask(taskName, reason) {
+                        started.push({taskName, reason});
+                        return true;
+                    }
+                }
+            }),
+            runtime: makeRuntime()
+        });
+
+        expect(result.winner.taskName).toBe('githubWorkflowSync');
+        expect(deferrals).toEqual([]);
+        expect(started).toEqual([{
+            taskName: 'githubWorkflowSync',
+            reason  : 'githubWorkflowSync-reason'
+        }]);
+    });
+
     test('dispatches service-runner candidates through runtime-provided collaborators', () => {
         const calls = [];
 

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -90,6 +90,11 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
         })).toBeNull();
     });
 
+    test('golden-path waits for graph-producing sync tasks before synthesis (#13750)', () => {
+        const descriptor = TASK_REGISTRY.find(d => d.taskName === 'golden-path');
+        expect(descriptor.dependencies).toEqual(['dream', 'githubWorkflowSync']);
+    });
+
     test('continuous tasks (chroma/bridgeDaemon/mlx) are intentionally NOT in registry', () => {
         const names = TASK_REGISTRY.map(d => d.taskName);
         expect(names).not.toContain('chroma');

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -323,6 +323,46 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         expect(ran).toBe(false);
     });
 
+    test('withLease runs against an explicitly compatible held owner without releasing that owner (#13750)', async () => {
+        const leasePath = createLeasePath('compatible-held-owner');
+        const now       = new Date('2026-06-21T10:30:00.000Z');
+
+        await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner: 'kbSync',
+            now,
+            token: 'kb-token'
+        });
+
+        let observedAcquisition = null;
+        const outcome = await withHeavyMaintenanceLease(acquisition => {
+            observedAcquisition = acquisition;
+            return 'github-sync-ran';
+        }, {
+            leasePath,
+            owner                : 'syncGithubWorkflow',
+            now,
+            token                : 'github-token',
+            compatibleLeaseOwners: ['kbSync']
+        });
+
+        expect(outcome).toMatchObject({
+            status  : 'compatible',
+            acquired: false,
+            lease   : {owner: 'kbSync', token: 'kb-token'},
+            result  : 'github-sync-ran'
+        });
+        expect(observedAcquisition).toMatchObject({
+            status  : 'compatible',
+            acquired: false,
+            lease   : {owner: 'kbSync', token: 'kb-token'}
+        });
+        await expect(inspectHeavyMaintenanceLease({leasePath, now})).resolves.toMatchObject({
+            status: 'active',
+            lease : {owner: 'kbSync', token: 'kb-token'}
+        });
+    });
+
     test('withLease release-timing invariant: task inner finally runs INSIDE the lease window (#11515)', async () => {
         // Empirical anchor: prior review cycles surfaced the same root failure-mode at two
         // different surfaces: substrate mutation placed AFTER `await withHeavyMaintenanceLease(...)`

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -72,16 +72,18 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
     });
 
     test('DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES pins the dependency set', () => {
-        expect([...DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES]).toEqual(['dream']);
+        expect([...DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES]).toEqual(['dream', 'githubWorkflowSync']);
         expect(Object.isFrozen(DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES)).toBe(true);
     });
 
-    test('DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS keeps miniSummary backfill independent of kbSync', () => {
+    test('DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS keeps graph-refresh lanes independent of kbSync', () => {
         expect(DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS).toEqual([
-            ['kbSync', 'memory-summary-backfill']
+            ['kbSync', 'memory-summary-backfill'],
+            ['kbSync', 'githubWorkflowSync']
         ]);
         expect(Object.isFrozen(DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS)).toBe(true);
         expect(Object.isFrozen(DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS[0])).toBe(true);
+        expect(Object.isFrozen(DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS[1])).toBe(true);
     });
 
     // ====================================================================
@@ -102,6 +104,10 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
     test('isGoldenPathDependencyTask returns membership in dependency set', () => {
         expect(isGoldenPathDependencyTask({
             taskName                     : 'dream',
+            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
+        })).toBe(true);
+        expect(isGoldenPathDependencyTask({
+            taskName                     : 'githubWorkflowSync',
             goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
         })).toBe(true);
         expect(isGoldenPathDependencyTask({
@@ -181,6 +187,11 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
             taskStateService,
             activeTaskName               : 'dream'
         })).toBe('dream');
+        expect(getActiveGoldenPathDependencyTask({
+            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+            taskStateService,
+            activeTaskName               : 'githubWorkflowSync'
+        })).toBe('githubWorkflowSync');
 
         // activeTaskName is NOT a dependency → fall back to state scan
         expect(getActiveGoldenPathDependencyTask({
@@ -427,6 +438,34 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(activeHeavyTask.name).toBe('memory-summary-backfill');
     });
 
+    test('acquireLeaseAndExecute allows githubWorkflowSync behind active kbSync (#13750)', () => {
+        const executions = [];
+        const service    = buildService({
+            taskStateService: buildTaskStateService({kbSync: {running: true}}),
+            acquireLeaseFn  : () => ({acquired: true, lease: {token: 'github-sync-token'}}),
+            releaseLeaseFn  : () => {}
+        });
+
+        const activeHeavyTask = {name: 'kbSync'};
+        const result = service.acquireLeaseAndExecute({
+            taskName : 'githubWorkflowSync',
+            executeFn: (taskName, reason, onSuccess, taskOptions) => {
+                executions.push({taskName, reason, env: taskOptions.env});
+                return true;
+            },
+            reason: 'periodic-sync:1800000',
+            activeHeavyTask
+        });
+
+        expect(result).toBe(true);
+        expect(executions).toEqual([{
+            taskName: 'githubWorkflowSync',
+            reason  : 'periodic-sync:1800000',
+            env     : {NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: 'github-sync-token'}
+        }]);
+        expect(activeHeavyTask.name).toBe('githubWorkflowSync');
+    });
+
     test('Sub 9 hypotheses 4 and 5: acquireLeaseAndExecute records held lease as skipped (#12617)', () => {
         const outcomeCalls = [];
         const service      = buildService({
@@ -480,6 +519,39 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(outcomeCalls).toEqual([]);
         expect(releases).toEqual([]);
         expect(activeHeavyTask.name).toBe('memory-summary-backfill');
+    });
+
+    test('acquireLeaseAndExecute allows githubWorkflowSync when compatible kbSync owns the lease (#13750)', () => {
+        const outcomeCalls = [];
+        const executions   = [];
+        const releases     = [];
+        const service      = buildService({
+            taskStateService: buildTaskStateService({}),
+            healthService   : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})},
+            acquireLeaseFn  : () => ({acquired: false, lease: {owner: 'kbSync', pid: 77}}),
+            releaseLeaseFn  : opts => releases.push(opts)
+        });
+
+        const activeHeavyTask = {name: null};
+        const result = service.acquireLeaseAndExecute({
+            taskName : 'githubWorkflowSync',
+            executeFn: (taskName, reason, onSuccess, taskOptions) => {
+                executions.push({taskName, reason, env: taskOptions.env});
+                return true;
+            },
+            reason: 'periodic-sync:1800000',
+            activeHeavyTask
+        });
+
+        expect(result).toBe(true);
+        expect(executions).toEqual([{
+            taskName: 'githubWorkflowSync',
+            reason  : 'periodic-sync:1800000',
+            env     : {}
+        }]);
+        expect(outcomeCalls).toEqual([]);
+        expect(releases).toEqual([]);
+        expect(activeHeavyTask.name).toBe('githubWorkflowSync');
     });
 
     test('acquireLeaseAndExecute records failure outcome on lease-acquire throw', () => {

--- a/test/playwright/unit/ai/scripts/maintenance/syncGithubWorkflow.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/syncGithubWorkflow.spec.mjs
@@ -97,4 +97,17 @@ test.describe('syncGithubWorkflow CLI dev-branch guard (#12780)', () => {
         expect(guardIndex).toBeLessThan(leaseIndex);
         expect(guardIndex).toBeLessThan(syncIndex);
     });
+
+    test('declares kbSync as a compatible lease owner for issue graph refresh (#13750)', async () => {
+        const source = await fs.readFile(cliScriptPath, 'utf8');
+
+        const leaseIndex        = source.indexOf('outcome = await withHeavyMaintenanceLease(');
+        const compatibleIndex   = source.indexOf("compatibleLeaseOwners: ['kbSync']");
+        const syncDelegateIndex = source.indexOf('async () => GH_SyncService.runFullSync()');
+
+        expect(leaseIndex, 'heavy-maintenance lease call must exist').toBeGreaterThan(-1);
+        expect(compatibleIndex, 'compatible kbSync owner declaration must exist').toBeGreaterThan(-1);
+        expect(syncDelegateIndex, 'real sync delegate must exist').toBeGreaterThan(-1);
+        expect(syncDelegateIndex).toBeLessThan(compatibleIndex);
+    });
 });


### PR DESCRIPTION
Resolves #13750

Fixes the Golden Path freeze at the scheduler / lease root instead of adding a filesystem fallback. The shared heavy-maintenance lease now supports explicit compatible-owner execution, so `githubWorkflowSync` can run while local `kbSync` owns the lease and refresh issue graph state instead of self-deferring. Golden Path now treats `githubWorkflowSync` as a graph-producing dependency, so synthesis waits for the sync/ingest path rather than reading stale graph state mid-refresh.

Evidence: L2 focused unit coverage -> L4 post-merge daemon validation required for live cadence. Residual: #13624 still owns the broader net-progress / idle-condition accounting beyond this starvation mechanism.

## Deltas from ticket

- Delivers the heavy-maintenance lease starvation path named in the #13750 bisect.
- Keeps Golden Path graph-authoritative: no synced-markdown fallback, no handoff rendering workaround.
- Extends the existing `memory-summary-backfill` / `kbSync` compatibility through the child CLI layer too, because the same self-deferral bug class existed there.

## Test Evidence

- `node --check ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs`
- `node --check ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs`
- `node --check ai/scripts/maintenance/syncGithubWorkflow.mjs`
- `node --check ai/scripts/lifecycle/backfill-memory-summaries.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs test/playwright/unit/ai/scripts/maintenance/syncGithubWorkflow.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs` — 111 passed after rebase onto `origin/dev`
- `git diff --check`

## Post-Merge Validation

- [ ] Restart the live orchestrator and verify `githubWorkflowSync` runs when `kbSync` is active or holds the heavy-maintenance lease.
- [ ] Verify issue-to-graph ingestion catches current #137xx issues and Golden Path no longer recommends stale non-board work.
- [ ] Verify the next `resources/content/sandman_handoff.md` refresh is produced by the graph path, not a fallback.

## Commits

- `6f564fdd9c` — `fix(ai): prevent Golden Path sync starvation (#13750)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee5c2-82ba-7b73-8812-df59106ff61a.
