### PR TITLE
fix(ai): steer Golden Path to current release focus (#13758)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -28,6 +28,7 @@ const COMPUTED_RECOMMENDATION_EXCLUDED_LABELS = Object.freeze(new Set([
 const CURRENT_FOCUS_EXCLUDED_LABELS = Object.freeze(new Set([
     'deferred-by-design',
     'duplicate',
+    'epic',
     'invalid',
     'needs-design',
     'needs-re-triage',
@@ -36,8 +37,6 @@ const CURRENT_FOCUS_EXCLUDED_LABELS = Object.freeze(new Set([
     'wontfix',
     'wont fix'
 ]));
-
-const CURRENT_FOCUS_TOPIC_PATTERN = /\b(?:agent\s*os|embed(?:der|ding)?|golden\s*path|orchestrator|prio[-\s]?zero|regression|wake)\b/i;
 
 /**
  * Social Name → `@`-stripped GitHub login, derived from the canonical identity roster. The PR-body
@@ -780,11 +779,6 @@ class GoldenPathSynthesizer extends Base {
         if (labels.some(label => ['architecture', 'model-experience', 'performance'].includes(label))) {
             score += 30;
             reasons.push('agent-os');
-            hasFocusSignal = true;
-        }
-        if (CURRENT_FOCUS_TOPIC_PATTERN.test(issueText)) {
-            score += 25;
-            reasons.push('topic');
             hasFocusSignal = true;
         }
         if (freshCreated || freshUpdated) {

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -15,6 +15,29 @@ import {buildGraphProvider, resolveGraphModelProvider}         from './providerD
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const DAY_MS     = 24 * 60 * 60 * 1000;
+const CURRENT_FOCUS_WINDOW_MS = 3 * DAY_MS;
+
+const COMPUTED_RECOMMENDATION_EXCLUDED_LABELS = Object.freeze(new Set([
+    'epic',
+    'needs-design',
+    'needs-re-triage',
+    'not-code-ready',
+    'not code ready'
+]));
+
+const CURRENT_FOCUS_EXCLUDED_LABELS = Object.freeze(new Set([
+    'deferred-by-design',
+    'duplicate',
+    'invalid',
+    'needs-design',
+    'needs-re-triage',
+    'not-code-ready',
+    'not code ready',
+    'wontfix',
+    'wont fix'
+]));
+
+const CURRENT_FOCUS_TOPIC_PATTERN = /\b(?:agent\s*os|embed(?:der|ding)?|golden\s*path|orchestrator|prio[-\s]?zero|regression|wake)\b/i;
 
 /**
  * Social Name → `@`-stripped GitHub login, derived from the canonical identity roster. The PR-body
@@ -663,6 +686,213 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Normalizes labels from graph nodes or synced issue frontmatter.
+     *
+     * Golden Path consumes labels from both JSON graph payloads and gray-matter
+     * frontmatter. Keeping normalization centralized prevents case / whitespace
+     * drift from routing non-actionable tickets back into computed work.
+     *
+     * @param {Array<*>} labels Raw label values.
+     * @returns {String[]} Lowercase label names.
+     */
+    static normalizeLabels(labels = []) {
+        return Array.isArray(labels)
+            ? labels.map(label => String(label).trim().toLowerCase()).filter(Boolean)
+            : []
+    }
+
+    /**
+     * @summary Determines whether a graph node can be an immediate computed recommendation.
+     *
+     * The Computed Golden Path is an execution steering surface. Discussions, epics,
+     * and tickets explicitly marked not-ready may still be important visibility, but
+     * presenting them as "next immediate focus" causes release-blind governance
+     * drift.
+     *
+     * @param {Object} nodeData Parsed graph node payload.
+     * @returns {Boolean}
+     */
+    static isActionableComputedRecommendation(nodeData) {
+        const nodeId = String(nodeData?.id || '');
+        const nodeType = String(nodeData?.type || nodeData?.properties?.type || '').toUpperCase();
+
+        if (nodeType === 'DISCUSSION' || nodeId.startsWith('discussion-')) return false;
+        if (nodeType && nodeType !== 'ISSUE') return false;
+        if (!nodeId.startsWith('issue-')) return false;
+
+        const labels = this.normalizeLabels(nodeData?.properties?.labels || nodeData?.labels);
+
+        return !labels.some(label => COMPUTED_RECOMMENDATION_EXCLUDED_LABELS.has(label))
+    }
+
+    /**
+     * @summary Scores one synced issue as a current release / incident focus candidate.
+     *
+     * This is deliberately a local-sync signal, not graph-centrality routing. It
+     * gives the handoff a deterministic "what is hot now" section even when the
+     * graph has not accumulated edges for a same-day regression or release ticket.
+     *
+     * @param {Object} options
+     * @param {Object} options.meta Issue frontmatter.
+     * @param {String} [options.content=''] Markdown body without frontmatter.
+     * @param {Date} [options.now=new Date()] Current clock.
+     * @param {Number} [options.windowMs=CURRENT_FOCUS_WINDOW_MS] Freshness window.
+     * @returns {Object|null}
+     */
+    static scoreCurrentFocusIssue({
+        meta,
+        content = '',
+        now = new Date(),
+        windowMs = CURRENT_FOCUS_WINDOW_MS
+    }) {
+        if (!meta || meta.state !== 'OPEN') return null;
+
+        const labels = this.normalizeLabels(meta.labels);
+        if (labels.some(label => CURRENT_FOCUS_EXCLUDED_LABELS.has(label))) return null;
+
+        const nowDate   = now instanceof Date ? now : new Date(now);
+        const createdAt = new Date(meta.createdAt);
+        const updatedAt = new Date(meta.updatedAt || meta.createdAt);
+        const freshCreated = !Number.isNaN(createdAt.getTime()) && nowDate - createdAt <= windowMs;
+        const freshUpdated = !Number.isNaN(updatedAt.getTime()) && nowDate - updatedAt <= windowMs;
+        const milestone = typeof meta.milestone === 'string' ? meta.milestone : meta.milestone?.title;
+        const issueText = `${meta.title || ''}\n${content || ''}`;
+
+        let score = 0;
+        const reasons = [];
+        let hasFocusSignal = false;
+
+        if (/\bPRIO[-\s]?ZERO\b/i.test(issueText)) {
+            score += 120;
+            reasons.push('prio-zero');
+            hasFocusSignal = true;
+        }
+        if (labels.includes('bug') || labels.includes('regression')) {
+            score += 90;
+            reasons.push('incident');
+            hasFocusSignal = true;
+        }
+        if (milestone === 'v13.1') {
+            score += 70;
+            reasons.push('v13.1');
+            hasFocusSignal = true;
+        }
+        if (labels.some(label => ['architecture', 'model-experience', 'performance'].includes(label))) {
+            score += 30;
+            reasons.push('agent-os');
+            hasFocusSignal = true;
+        }
+        if (CURRENT_FOCUS_TOPIC_PATTERN.test(issueText)) {
+            score += 25;
+            reasons.push('topic');
+            hasFocusSignal = true;
+        }
+        if (freshCreated || freshUpdated) {
+            score += freshCreated ? 20 : 10;
+            reasons.push(freshCreated ? 'fresh-created' : 'fresh-updated');
+        }
+
+        if (!hasFocusSignal || (!freshCreated && !freshUpdated && milestone !== 'v13.1')) return null;
+
+        const rawNumber = meta.id || meta.number;
+
+        return {
+            labels,
+            lastActivityAt: Number.isNaN(updatedAt.getTime()) ? null : updatedAt.toISOString(),
+            milestone,
+            number        : Number(rawNumber) || rawNumber,
+            reasons       : [...new Set(reasons)],
+            score,
+            title         : meta.title || '(no title)'
+        }
+    }
+
+    /**
+     * @summary Builds current release / incident focus candidates from synced issue markdown.
+     *
+     * @param {Object} options
+     * @param {String} options.issuesDir Local synced issue directory.
+     * @param {Date} [options.now=new Date()] Current clock for deterministic tests.
+     * @param {Number} [options.windowMs=CURRENT_FOCUS_WINDOW_MS] Freshness window.
+     * @returns {Array<Object>} Candidates sorted by score, freshness, then issue number.
+     */
+    static buildCurrentFocusCandidates({
+        issuesDir,
+        now = new Date(),
+        windowMs = CURRENT_FOCUS_WINDOW_MS
+    }) {
+        const candidates = [];
+
+        for (const filePath of this.collectIssueMarkdownFiles(issuesDir)) {
+            let parsed;
+            try {
+                parsed = matter(fs.readFileSync(filePath, 'utf-8'));
+            } catch (error) {
+                logger.warn(`[GoldenPathSynthesizer] Failed to parse issue markdown for Current Focus: ${filePath}`, error);
+                continue;
+            }
+
+            const candidate = this.scoreCurrentFocusIssue({
+                meta   : parsed.data || {},
+                content: parsed.content,
+                now,
+                windowMs
+            });
+
+            if (candidate) {
+                candidates.push(candidate);
+            }
+        }
+
+        candidates.sort((a, b) =>
+            b.score - a.score ||
+            new Date(b.lastActivityAt || 0) - new Date(a.lastActivityAt || 0) ||
+            Number(b.number) - Number(a.number)
+        );
+
+        return candidates
+    }
+
+    /**
+     * @summary Renders the current release / incident focus section.
+     *
+     * @param {Array<Object>} candidates Current focus candidates.
+     * @param {Object} options
+     * @param {Date} [options.capturedAt=new Date()] Capture timestamp.
+     * @param {Number} [options.limit=5] Maximum candidates to render.
+     * @returns {String}
+     */
+    static renderCurrentFocusCandidatesSection(candidates, {
+        capturedAt = new Date(),
+        limit = 5
+    } = {}) {
+        let section = `\n## Current Release / Incident Focus\n\n`;
+        section += `*Captured at: ${capturedAt.toISOString()} (Source: local issue sync; release/incident signal, not graph-centrality routing)*\n\n`;
+
+        if (candidates.length === 0) {
+            section += `No current release or incident focus candidates detected.\n`;
+            return section
+        }
+
+        const visibleCandidates = candidates.slice(0, limit);
+
+        if (candidates.length > visibleCandidates.length) {
+            section += `Showing ${visibleCandidates.length} of ${candidates.length} candidates, sorted by current-focus score.\n\n`;
+        }
+
+        for (const candidate of visibleCandidates) {
+            const labels = candidate.labels.length > 0 ? ` [\`${candidate.labels.join('`, `')}\`]` : '';
+            const milestone = candidate.milestone ? ` — milestone ${candidate.milestone}` : '';
+            const reasons = candidate.reasons.length > 0 ? ` — reasons: ${candidate.reasons.join(', ')}` : '';
+
+            section += `- **#${candidate.number}**${labels}${milestone} — score ${candidate.score}${reasons}\n`;
+            section += `  - *${candidate.title}*\n`;
+        }
+
+        return section
+    }
+
+    /**
      * @summary Extracts the canonical author login (`@`-stripped) from a PR body's `Authored by …`
      * self-id line, resolving both the Social-Name-led form and the legacy `@identity` form.
      *
@@ -919,11 +1149,9 @@ class GoldenPathSynthesizer extends Base {
 
                 let priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
 
-                // Apply the Negative ROI Protocol for automatically rejected Swarm tickets.
-                const labels = nodeData?.properties?.labels || [];
-                if (labels.includes('needs-re-triage')) {
-                    priority -= 10000;
-                    logger.debug(`[GoldenPathSynthesizer] Applied massive negative weight penalty to rejected node: ${issueId}`);
+                if (!this.constructor.isActionableComputedRecommendation(nodeData || {id: issueId})) {
+                    logger.debug(`[GoldenPathSynthesizer] Skipping non-actionable computed recommendation: ${issueId}`);
+                    continue;
                 }
 
                 scoredNodes.push({
@@ -1130,6 +1358,22 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             logger.warn(`[GoldenPathSynthesizer] ConsumerFriction section render failed: ${err.message}`);
         }
 
+        // --- Current Release / Incident Focus ---
+        let currentFocusAppend = '';
+        if (repoEnrichmentEnabled) {
+            try {
+                const Synthesizer = this.constructor;
+                const currentFocusCandidates = Synthesizer.buildCurrentFocusCandidates({
+                    issuesDir,
+                    now
+                });
+
+                currentFocusAppend = Synthesizer.renderCurrentFocusCandidatesSection(currentFocusCandidates, {capturedAt: now instanceof Date ? now : new Date(now)});
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Failed to generate Current Release / Incident Focus', e);
+            }
+        }
+
         // --- Stale Assignment Candidates ---
         let staleAssignmentAppend = '';
         if (repoEnrichmentEnabled) {
@@ -1291,7 +1535,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             }
         }
 
-        handoffContent += `${staleAssignmentAppend}${silentThreadsAppend}${prStateAppend}${backlogAppend}${markdownAppend}`;
+        handoffContent += `${currentFocusAppend}${staleAssignmentAppend}${silentThreadsAppend}${prStateAppend}${backlogAppend}${markdownAppend}`;
 
         const handoffFile = aiConfig.handoffFilePath;
         fs.mkdirSync(path.dirname(handoffFile), {recursive: true});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -1233,7 +1233,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         StorageRouter.getGraphCollection = async () => {
             return {
                 query: async () => ({
-                    ids      : [['epic-1', 'task-blocked', 'blocker', 'weak-task', 'rejected-task']],
+                    ids      : [['issue-epic-hero', 'issue-task-blocked', 'issue-blocker', 'issue-weak-task', 'issue-rejected-task']],
                     distances: [[0.1, 0.2, 0.9, 0.8, 0.05]]
                 }),
                 get   : async () => ({ ids: [], metadatas: [] }),
@@ -1247,11 +1247,11 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
                 // console.log('MOCK TRIGGERED Nodes SELECT!');
                 return {
                     all: () => [
-                        { id: 'epic-1', data: JSON.stringify({ id: 'epic-1', name: 'Epic Hero', properties: { state: 'OPEN'} }), struct_score: 5.0 },
-                        { id: 'task-blocked', data: JSON.stringify({ id: 'task-blocked', name: 'Blocked Task', properties: { state: 'OPEN'} }), struct_score: 10.0 },
-                        { id: 'blocker', data: JSON.stringify({ id: 'blocker', name: 'Blocker Bug', properties: { state: 'OPEN'} }), struct_score: 1.0 },
-                        { id: 'weak-task', data: JSON.stringify({ id: 'weak-task', name: 'Weak Task', properties: { state: 'OPEN'} }), struct_score: 0.1 },
-                        { id: 'rejected-task', data: JSON.stringify({ id: 'rejected-task', name: 'Massive Stale Feature', properties: { state: 'OPEN', labels: ['needs-re-triage']} }), struct_score: 1000.0 }
+                        { id: 'issue-epic-hero', data: JSON.stringify({ id: 'issue-epic-hero', name: 'Epic Hero', properties: { state: 'OPEN'} }), struct_score: 5.0 },
+                        { id: 'issue-task-blocked', data: JSON.stringify({ id: 'issue-task-blocked', name: 'Blocked Task', properties: { state: 'OPEN'} }), struct_score: 10.0 },
+                        { id: 'issue-blocker', data: JSON.stringify({ id: 'issue-blocker', name: 'Blocker Bug', properties: { state: 'OPEN'} }), struct_score: 1.0 },
+                        { id: 'issue-weak-task', data: JSON.stringify({ id: 'issue-weak-task', name: 'Weak Task', properties: { state: 'OPEN'} }), struct_score: 0.1 },
+                        { id: 'issue-rejected-task', data: JSON.stringify({ id: 'issue-rejected-task', name: 'Massive Stale Feature', properties: { state: 'OPEN', labels: ['needs-re-triage']} }), struct_score: 1000.0 }
                     ],
                     get: () => null,
                     run: () => {}
@@ -1262,15 +1262,15 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
 
         // GraphService mock topology
         GraphService.db.edges.items = [
-             { source: 'blocker', target: 'task-blocked', type: 'BLOCKS' }
+             { source: 'issue-blocker', target: 'issue-task-blocked', type: 'BLOCKS' }
         ];
 
         GraphService.db.nodes.items = [
-             { id: 'epic-1', properties: { state: 'OPEN' } },
-             { id: 'task-blocked', properties: { state: 'OPEN' } },
-             { id: 'blocker', properties: { state: 'OPEN' } },
-             { id: 'weak-task', properties: { state: 'OPEN' } },
-             { id: 'rejected-task', properties: { state: 'OPEN', labels: ['needs-re-triage'] } },
+             { id: 'issue-epic-hero', properties: { state: 'OPEN' } },
+             { id: 'issue-task-blocked', properties: { state: 'OPEN' } },
+             { id: 'issue-blocker', properties: { state: 'OPEN' } },
+             { id: 'issue-weak-task', properties: { state: 'OPEN' } },
+             { id: 'issue-rejected-task', properties: { state: 'OPEN', labels: ['needs-re-triage'] } },
              // Planted CONCEPT with ORPHAN_CONCEPT gap to verify the ⚠️ section renders
              // in sandman_handoff.md alongside the existing TEST/GUIDE/EXAMPLE sections.
              { id: 'concept-orphan-render-test', properties: {

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -388,6 +388,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
         const originalEmbedText = TextEmbeddingService.embedText;
         const originalFetchOpenPRs = GoldenPathSynthesizer.fetchOpenPRs;
+        const OpenAiCompatible = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate = OpenAiCompatible.prototype.generate;
         const Synthesizer = GoldenPathSynthesizer.constructor;
         const originalGetIssueStructuralWeight = Synthesizer.getIssueStructuralWeight;
         const originalHasOpenIssueBlocker = Synthesizer.hasOpenIssueBlocker;
@@ -440,6 +442,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         GoldenPathSynthesizer.fetchOpenPRs = async () => [];
         Synthesizer.getIssueStructuralWeight = issueId => issueId === 'issue-9401' ? 3 : 0;
         Synthesizer.hasOpenIssueBlocker = () => false;
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
 
         try {
             await GoldenPathSynthesizer.synthesizeGoldenPath({issuesDir, now});
@@ -448,6 +451,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             StorageRouter.getGraphCollection   = originalGetGraphCollection;
             StorageRouter.getSummaryCollection = originalGetSummaryCollection;
             TextEmbeddingService.embedText     = originalEmbedText;
+            OpenAiCompatible.prototype.generate = originalGenerate;
             Synthesizer.getIssueStructuralWeight = originalGetIssueStructuralWeight;
             Synthesizer.hasOpenIssueBlocker = originalHasOpenIssueBlocker;
             fs.rmSync(issuesDir, {recursive: true, force: true});
@@ -463,6 +467,138 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).not.toContain('Fresh unassigned issue');
         expect(handoffContent.indexOf('## Stale Assignment Candidates')).toBeLessThan(handoffContent.indexOf('## Silent Threads'));
         expect(handoffContent.indexOf('## Silent Threads')).toBeLessThan(handoffContent.indexOf('## Computed Golden Path'));
+    });
+
+    test('synthesizeGoldenPath surfaces current incidents and filters non-actionable computed recommendations', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
+        const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate             = OpenAiCompatible.prototype.generate;
+        const issuesDir                    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-current-focus-issues-'));
+        const chunkDir                     = path.join(issuesDir, 'chunk-1');
+        const now                          = new Date('2026-06-21T11:30:00Z');
+        const suffix                       = `${process.pid}-${Date.now()}`;
+        const readyId                      = `issue-ready-${suffix}`;
+        const discussionId                 = `discussion-governance-${suffix}`;
+        const epicId                       = `issue-epic-${suffix}`;
+        const notReadyId                   = `issue-not-ready-${suffix}`;
+        aiConfig.vectorDimension = 2;
+
+        fs.mkdirSync(chunkDir, {recursive: true});
+        fs.writeFileSync(path.join(chunkDir, 'issue-13750.md'), [
+            '---',
+            'id: 13750',
+            "title: 'PRIO-ZERO: Golden Path release steering regression'",
+            'state: OPEN',
+            'labels:',
+            '  - bug',
+            '  - ai',
+            '  - regression',
+            '  - architecture',
+            '  - model-experience',
+            "createdAt: '2026-06-21T10:20:34Z'",
+            "updatedAt: '2026-06-21T11:20:50Z'",
+            'assignees:',
+            '  - neo-gpt',
+            '---',
+            '# PRIO-ZERO: Golden Path release steering regression',
+            '',
+            'Agent OS orchestrator regression.'
+        ].join('\n'));
+        fs.writeFileSync(path.join(chunkDir, 'issue-13012.md'), [
+            '---',
+            'id: 13012',
+            "title: 'Agent Harness v13.1 release epic'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            '  - ai',
+            '  - architecture',
+            'assignees: []',
+            "createdAt: '2026-06-10T00:00:00Z'",
+            "updatedAt: '2026-06-21T09:00:00Z'",
+            'milestone: v13.1',
+            '---',
+            '# Agent Harness v13.1 release epic'
+        ].join('\n'));
+        fs.writeFileSync(path.join(chunkDir, 'issue-12000.md'), [
+            '---',
+            'id: 12000',
+            "title: 'Old generic AI enhancement'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            '  - ai',
+            'assignees: []',
+            "createdAt: '2026-05-01T00:00:00Z'",
+            "updatedAt: '2026-05-01T00:00:00Z'",
+            '---',
+            '# Old generic AI enhancement'
+        ].join('\n'));
+
+        GraphService.upsertNode({
+            id        : discussionId,
+            type      : 'DISCUSSION',
+            state     : 'OPEN',
+            properties: {state: 'OPEN', title: 'Governance discussion'}
+        });
+        GraphService.upsertNode({
+            id        : epicId,
+            type      : 'ISSUE',
+            properties: {state: 'OPEN', title: 'Epic should not be immediate work', labels: ['epic', 'ai']}
+        });
+        GraphService.upsertNode({
+            id        : notReadyId,
+            type      : 'ISSUE',
+            properties: {state: 'OPEN', title: 'Not ready should not be immediate work', labels: ['not-code-ready', 'ai']}
+        });
+        GraphService.upsertNode({
+            id        : readyId,
+            type      : 'ISSUE',
+            properties: {state: 'OPEN', title: 'Actionable release leaf', labels: ['bug', 'ai']}
+        });
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => ({
+                ids      : [[discussionId, epicId, notReadyId, readyId]],
+                distances: [[0.01, 0.02, 0.03, 0.5]]
+            })
+        });
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['Agent OS regression focus']})});
+        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs  = async () => [];
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({issuesDir, now});
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            OpenAiCompatible.prototype.generate = originalGenerate;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        const focusIndex     = handoffContent.indexOf('## Current Release / Incident Focus');
+        const staleIndex     = handoffContent.indexOf('## Stale Assignment Candidates');
+        const computedIndex  = handoffContent.indexOf('## Computed Golden Path');
+        const focusSection   = handoffContent.slice(focusIndex, staleIndex);
+
+        expect(focusIndex).toBeGreaterThan(-1);
+        expect(staleIndex).toBeGreaterThan(-1);
+        expect(computedIndex).toBeGreaterThan(-1);
+        expect(focusIndex).toBeLessThan(computedIndex);
+        expect(focusSection).toContain('**#13750**');
+        expect(focusSection).toContain('**#13012**');
+        expect(focusSection).not.toContain('Old generic AI enhancement');
+        expect(handoffContent).toContain(readyId);
+        expect(handoffContent).not.toContain(discussionId);
+        expect(handoffContent).not.toContain(epicId);
+        expect(handoffContent).not.toContain(notReadyId);
     });
 
     test('synthesizeGoldenPath lists the 5 most recent open PRs with cross-family status', async () => {
@@ -782,7 +918,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         }
     });
 
-    test('synthesizeGoldenPath excludes CLOSED discussion nodes from computed recommendations', async () => {
+    test('synthesizeGoldenPath excludes discussion nodes from computed recommendations', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
         const originalEmbedText            = TextEmbeddingService.embedText;
@@ -794,6 +930,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
 
         const openId   = `discussion-open-${Date.now()}`;
         const closedId = `discussion-closed-${Date.now()}`;
+        const issueId  = `issue-actionable-${Date.now()}`;
 
         GraphService.upsertNode({
             id        : openId,
@@ -809,9 +946,14 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             state     : 'CLOSED',
             properties: {state: 'CLOSED', title: 'Closed Discussion Fixture', closed: true}
         });
+        GraphService.upsertNode({
+            id        : issueId,
+            type      : 'ISSUE',
+            properties: {state: 'OPEN', title: 'Actionable Issue Fixture', labels: ['bug', 'ai']}
+        });
 
         StorageRouter.getGraphCollection = async () => ({
-            query: async () => ({ ids: [[openId, closedId]], distances: [[0.1, 0.01]] })
+            query: async () => ({ ids: [[openId, closedId, issueId]], distances: [[0.1, 0.01, 0.5]] })
         });
         StorageRouter.getSummaryCollection = async () => ({
             get: async () => ({documents: ['mock document']})
@@ -832,7 +974,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
 
         const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
 
-        expect(handoffContent).toContain(openId);
+        expect(handoffContent).toContain(issueId);
+        expect(handoffContent).not.toContain(openId);
         expect(handoffContent).not.toContain(closedId);
     });
 });


### PR DESCRIPTION
Resolves #13758

Related: #13750
Related: #13755
Related: #13757

Adds a deterministic current release / incident focus section to the generated Golden Path handoff and tightens computed recommendations so discussions, epics, and not-ready tickets are not presented as immediate execution work. This is the Golden Path steering/output slice from the broader orchestrator regression: it does not claim to fix the embedding, lease, or inherited-token root cause.

Evidence: L2 (unit synthesis fixtures + static syntax/diff checks) → L2 required (deterministic handoff-generation behavior). No residuals.

## Deltas from ticket

This PR follows the ticket exactly. During pre-commit, the hook rejected a durable JSDoc ticket citation; the code comment was corrected so ticket relationships live in the PR/ticket metadata instead of durable source prose.

## Test Evidence

- `node --check ai/services/graph/GoldenPathSynthesizer.mjs`
- `node --check test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` — 21/21 passed
- `git diff --check`
- pre-commit hook suite: whitespace, shorthand, aiConfig test mutation, JSDoc types, ticket archaeology, block alignment

## Post-Merge Validation

- [ ] After the orchestrator ingestion/embedding root-cause lanes land, verify a regenerated `resources/content/sandman_handoff.md` includes `## Current Release / Incident Focus` ahead of `## Computed Golden Path` on the live operator machine.
- [ ] Confirm the broad Golden Path/root-cause issue remains open until ingestion, graph freshness, idle, and lease fairness ACs are satisfied.

## Commits

- `a61bd1429d` — `fix(ai): steer golden path to current release focus (#13758)`

Authored by Euclid (GPT-5, Codex Desktop). Session 69f79662-2fbe-403a-a124-78bca1abdb16.