### PR TITLE
fix(orchestrator): serialize kbSync/miniSummary — inherited-token race skipped kb-sync embedding for days (#13757)

### DIFF
--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -28,15 +28,20 @@ export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
 
 /**
  * Heavy-maintenance pairs whose resource envelopes are compatible enough to run
- * concurrently. This is intentionally narrow: Memory Core miniSummary backfill
- * must not wait behind local-only KB embedding work, while every other heavy task
- * pair keeps the historical single-heavy invariant.
+ * concurrently.
+ *
+ * Currently EMPTY — the heavy-maintenance mutex is fully serialized. The prior
+ * `['kbSync','memory-summary-backfill']` pair raced on the inherited-lease-token bypass:
+ * `memory-summary-backfill` released the lease before the spawned `kbSync` child finished
+ * booting, so the inherited token went stale, `withHeavyMaintenanceLease` fell through, and
+ * `kbSync` SKIPPED its `syncDatabase` — a silent multi-day embedding stall. miniSummary
+ * serializing behind KB embedding is the lesser cost than a silent embed stall. Re-introduce
+ * a pair ONLY with a race-free handshake: the spawned child must be guaranteed its run
+ * regardless of parent-lease release timing.
  *
  * @type {ReadonlyArray<ReadonlyArray<String>>}
  */
-export const DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS = Object.freeze([
-    Object.freeze(['kbSync', 'memory-summary-backfill'])
-]);
+export const DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS = Object.freeze([]);
 
 /**
  * Tasks whose graph writes must complete before Golden Path frontier refresh runs.
@@ -273,10 +278,11 @@ export function recordDeferral({
  * replace them. Lease IO (acquire / release / inspect) remains in that service; this
  * service owns the policy of WHEN to acquire, defer, or record.
  *
- * `DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS` is the only compatibility
- * allow-list. It exists so local-only `kbSync` embedding work cannot starve Memory
- * Core miniSummary backfill. Any future pair must be justified explicitly at this
- * policy surface instead of weakening the whole heavy-maintenance mutex.
+ * `DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS` is the compatibility allow-list,
+ * currently EMPTY: the heavy-maintenance mutex is fully serialized after the prior
+ * `kbSync`/`memory-summary-backfill` pair raced on the inherited-lease-token bypass and
+ * silently skipped KB embedding. Any future pair must be justified here AND prove it is
+ * race-free (the spawned child guaranteed its run regardless of parent-lease timing).
  *
  * @class Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureService
  * @extends Neo.core.Base

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1341,7 +1341,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         });
     });
 
-    test('runs memory miniSummary backfill while kbSync is already running (#13358)', () => {
+    test('defers memory miniSummary backfill while kbSync is already running — compatible-pair reverted (#13358)', () => {
         const outcomes = [];
         const started  = [];
 
@@ -1381,11 +1381,14 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
         orchestrator.poll();
 
-        expect(started).toContainEqual({
+        // Regression revert: kbSync + memory-summary-backfill are no longer a compatible pair, so the
+        // backfill is DEFERRED (serialized) while kbSync runs rather than racing concurrently — the
+        // inherited-token race is what skipped kb-sync's embedding for days.
+        expect(started).not.toContainEqual({
             taskName: 'memory-summary-backfill',
             reason  : 'pending-memory-minisummary:3647'
         });
-        expect(outcomes).not.toContainEqual({
+        expect(outcomes).toContainEqual({
             taskName: 'memory-summary-backfill',
             status  : 'skipped',
             details : expect.objectContaining({

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -49,6 +49,11 @@ function buildService(overrides = {}) {
     });
 }
 
+// Explicit fixture for the compatible-pair MECHANISM tests. DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+// is now empty — the kbSync/backfill pair raced on the inherited-lease-token bypass and skipped KB
+// embedding — so the mechanism is exercised here with an explicit pair rather than the live default.
+const COMPATIBLE_PAIRS_FIXTURE = [['kbSync', 'memory-summary-backfill']];
+
 test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureService', () => {
 
     // ====================================================================
@@ -76,12 +81,12 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(Object.isFrozen(DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES)).toBe(true);
     });
 
-    test('DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS keeps miniSummary backfill independent of kbSync', () => {
-        expect(DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS).toEqual([
-            ['kbSync', 'memory-summary-backfill']
-        ]);
+    test('DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS is EMPTY — heavy maintenance fully serialized', () => {
+        // The prior ['kbSync','memory-summary-backfill'] pair raced on the inherited-lease-token bypass
+        // (parent released before the kb-sync child booted → kb-sync skipped syncDatabase → multi-day
+        // embedding stall). Serialized until a race-free handshake replaces the bypass.
+        expect(DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS).toEqual([]);
         expect(Object.isFrozen(DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS)).toBe(true);
-        expect(Object.isFrozen(DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS[0])).toBe(true);
     });
 
     // ====================================================================
@@ -114,22 +119,22 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(areHeavyMaintenanceTasksCompatible({
             taskName                           : 'kbSync',
             otherTaskName                      : 'memory-summary-backfill',
-            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+            compatibleHeavyMaintenanceTaskPairs: COMPATIBLE_PAIRS_FIXTURE
         })).toBe(true);
         expect(areHeavyMaintenanceTasksCompatible({
             taskName                           : 'memory-summary-backfill',
             otherTaskName                      : 'kbSync',
-            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+            compatibleHeavyMaintenanceTaskPairs: COMPATIBLE_PAIRS_FIXTURE
         })).toBe(true);
         expect(areHeavyMaintenanceTasksCompatible({
             taskName                           : 'summary',
             otherTaskName                      : 'kbSync',
-            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+            compatibleHeavyMaintenanceTaskPairs: COMPATIBLE_PAIRS_FIXTURE
         })).toBe(false);
         expect(areHeavyMaintenanceTasksCompatible({
             taskName                           : 'kbSync',
             otherTaskName                      : 'kbSync',
-            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+            compatibleHeavyMaintenanceTaskPairs: COMPATIBLE_PAIRS_FIXTURE
         })).toBe(false);
     });
 
@@ -161,14 +166,14 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
             heavyMaintenanceTaskNames          : DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
             taskStateService                   : buildTaskStateService({kbSync: {running: true}}),
             candidateTaskName                  : 'memory-summary-backfill',
-            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+            compatibleHeavyMaintenanceTaskPairs: COMPATIBLE_PAIRS_FIXTURE
         })).toBeNull();
 
         expect(getActiveHeavyMaintenanceTask({
             heavyMaintenanceTaskNames          : DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
             taskStateService                   : buildTaskStateService({summary: {running: true}, kbSync: {running: true}}),
             candidateTaskName                  : 'memory-summary-backfill',
-            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+            compatibleHeavyMaintenanceTaskPairs: COMPATIBLE_PAIRS_FIXTURE
         })).toBe('summary');
     });
 
@@ -400,10 +405,11 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         const outcomeCalls = [];
         const executions   = [];
         const service      = buildService({
-            taskStateService: buildTaskStateService({kbSync: {running: true}}),
-            healthService   : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})},
-            acquireLeaseFn  : () => ({acquired: true, lease: {token: 'memory-token'}}),
-            releaseLeaseFn  : () => {}
+            taskStateService                   : buildTaskStateService({kbSync: {running: true}}),
+            healthService                      : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})},
+            acquireLeaseFn                     : () => ({acquired: true, lease: {token: 'memory-token'}}),
+            releaseLeaseFn                     : () => {},
+            compatibleHeavyMaintenanceTaskPairs: COMPATIBLE_PAIRS_FIXTURE
         });
 
         const activeHeavyTask = {name: 'kbSync'};
@@ -454,10 +460,11 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         const executions   = [];
         const releases     = [];
         const service      = buildService({
-            taskStateService: buildTaskStateService({}),
-            healthService   : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})},
-            acquireLeaseFn  : () => ({acquired: false, lease: {owner: 'kbSync', pid: 77}}),
-            releaseLeaseFn  : opts => releases.push(opts)
+            taskStateService                   : buildTaskStateService({}),
+            healthService                      : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})},
+            acquireLeaseFn                     : () => ({acquired: false, lease: {owner: 'kbSync', pid: 77}}),
+            releaseLeaseFn                     : opts => releases.push(opts),
+            compatibleHeavyMaintenanceTaskPairs: COMPATIBLE_PAIRS_FIXTURE
         });
 
         const activeHeavyTask = {name: null};


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13757. Sub of #13755.

## Summary
**Regression fix.** kb-sync stopped embedding new items into the graph on **06-17** (it embedded daily for weeks before), so new issues/PRs never reached the Native Edge Graph → the Golden Path went stale → the swarm self-selected months-old #9xxx tickets.

Root cause: **#13358** (06-15) made `['kbSync','memory-summary-backfill']` a "compatible pair" that runs concurrently via a lease-token-inheritance bypass (`NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN`). `memory-summary-backfill` is short — it releases the lease before the spawned kb-sync child finishes booting (~148ms to connect ChromaDB). By then the inherited token is stale, `withHeavyMaintenanceLease` falls through (`HeavyMaintenanceLeaseService.mjs` ~526-552: the set-but-mismatched `inheritedToken` path has **no `else`** → falls through → `if(!acquired) return acquisition` returns `'held'` without running), and kb-sync **skips `syncDatabase` entirely** — a 148ms "completed" no-op.

Emptying the pairs makes the inherited token **never-set** for this pair → that fall-through becomes **unreachable**, not just patched (per @neo-opus-vega's trace). Mechanism confirmed code + live by @neo-opus-ada + @neo-opus-vega.

## Evidence (VBA'd from the live orchestrator log)
- kb-sync embedded daily through 06-16 (06-15: 43 batches, 06-16: 6) → **zero 06-17→06-20** → 2566-chunk accumulated delta when force-run 06-21.
- #13358 is the most-recent `INHERITED_TOKEN` change; the decline tracks the merge exactly.
- 06-17 log: `Starting kb sync` 06:12:25.686 → `completed successfully` 06:12:25.834 (148ms), ChromaDB connected, `syncDatabase`'s first log never fires.

## Deltas
- `MaintenanceBackpressureService.mjs`: empty `DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS` → fully serialize heavy maintenance (the pre-#13358 behavior that embedded for weeks). Both doc comments updated.
- `MaintenanceBackpressureService.spec.mjs`: content test asserts empty; the mechanism tests use an explicit `COMPATIBLE_PAIRS_FIXTURE` (mechanism kept, off-by-default).
- `Orchestrator.spec.mjs`: the integration test now asserts the serialized defer.

## Test Evidence
Evidence: **L2** — 112 orchestrator specs green locally (`UNIT_TEST_MODE=true npx playwright test`); @neo-opus-vega independently ran both modified specs at head → 81 passed. CI gates the formal approve.

## Companion
The `withHeavyMaintenanceLease` fall-through itself is hardened in **#13764** (a stale inherited token surfaces an `onInheritedTokenStale` hook + `previousStatus` instead of a silent skip) — defense-in-depth so the path can never silently stall even if a future pair re-enables it.

## Post-Merge Validation
- [ ] **Verify kb-sync embedding resumes** — `Processed and embedded batch N of M` reappears in the orchestrator log + the golden path surfaces #13xxx items.
- [ ] (separate lane, @neo-opus-vega) `PrimaryRepoSyncService.runKbSync` (:564) reads the same token from a distinct primary-dev-sync cascade — untouched by empty-pairs → stays open under #13755.
