### PR TITLE
fix(orchestrator): surface stale inherited-lease-token instead of silently skipping the task (#13763)

### DIFF
--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -516,9 +516,16 @@ export async function releaseHeavyMaintenanceLease({
  * on stale-recovery telemetry. From the wrapper-caller's perspective, all three
  * cases normalize to `{status: 'completed', acquired: true, ...}` (or inherited).
  *
+ * EXCEPTION — the stale **inherited-token** case is the one recovery signal that IS
+ * surfaced to the wrapper-caller (as `previousStatus: 'inherited-token-stale'` on the
+ * return, per @returns below). A lost inheritance must never be misread as success, so
+ * unlike the internal stale/malformed recovery above it is promoted to a first-class
+ * return marker — not internal-only telemetry.
+ *
  * @param {Function} task Async task to execute when the lease is acquired. Receives the acquisition descriptor as its single argument (`{status, acquired, lease}`).
  * @param {Object} options Lease acquisition options forwarded to `acquireHeavyMaintenanceLease` (owner, reason, metadata, leasePath, staleAfterMs, pid, token, fsModule, now).
- * @returns {Promise<Object>} `{status, acquired, lease, result}` on completion; `{status: 'held', acquired: false, lease}` on contention.
+ * @param {Function} [options.onInheritedTokenStale] Observability hook fired once when this child inherited a token (`NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN`) but the live lease no longer carries it (the parent released before the child checked). Default: a stderr warn (`warnInheritedTokenStale`) — a deliberately loud default, because per-caller wiring across the 6+ maintenance callers is the exact discipline whose lapse caused the original silent-skip regression; override with a no-op for silence. The deferral is ALSO surfaced structurally via the `previousStatus` return marker below, independent of this hook.
+ * @returns {Promise<Object>} `{status, acquired, lease, result}` on completion; `{status: 'held', acquired: false, lease}` on contention. When a set inherited token was found stale, the return additionally carries `previousStatus: 'inherited-token-stale'` (on either the held or completed shape) — the structural guarantee that a lost-inheritance deferral can never be misread as an ordinary success.
  * @see acquireHeavyMaintenanceLease
  * @see releaseHeavyMaintenanceLease
  * @see ai/scripts/runners/runSandman.mjs — canonical consumer pattern
@@ -550,6 +557,10 @@ export async function withHeavyMaintenanceLease(task, options = {}) {
         // skip — a 'held' result masked as "completed" is what stalled kb-sync embedding for days.
         // Surface it (hook + a distinct previousStatus) so callers can never mistake an inherited-but-lost
         // deferral for success. The acquire-or-defer itself is unchanged — the mutex is preserved.
+        // The hook DEFAULTS to a loud stderr warn (not a no-op): with 6+ maintenance callers, a no-op
+        // default + per-caller opt-in is the fragile discipline whose lapse caused the original silent-skip
+        // regression — loud-by-default is the safer floor. The `previousStatus` return marker is the
+        // hook-independent structural guarantee.
         inheritedTokenStale = true;
         (options.onInheritedTokenStale ?? warnInheritedTokenStale)({inheritedToken, current});
     }

--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -274,8 +274,8 @@ export function acquireHeavyMaintenanceLeaseSync({
     try {
         writeLeaseFileSync(leasePath, lease, fsModule);
         return {
-            status: current.status === 'malformed' ? 'acquired-after-malformed' : 'acquired-after-stale',
-            acquired: true,
+            status        : current.status === 'malformed' ? 'acquired-after-malformed' : 'acquired-after-stale',
+            acquired      : true,
             previousStatus: current.status,
             lease
         };
@@ -377,8 +377,8 @@ export async function acquireHeavyMaintenanceLease({
     try {
         await writeLeaseFile(leasePath, lease, fsModule);
         return {
-            status: current.status === 'malformed' ? 'acquired-after-malformed' : 'acquired-after-stale',
-            acquired: true,
+            status        : current.status === 'malformed' ? 'acquired-after-malformed' : 'acquired-after-stale',
+            acquired      : true,
             previousStatus: current.status,
             lease
         };
@@ -525,48 +525,80 @@ export async function releaseHeavyMaintenanceLease({
  */
 export async function withHeavyMaintenanceLease(task, options = {}) {
     const inheritedToken = process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+    let inheritedTokenStale = false;
 
     if (inheritedToken) {
         const current = await inspectHeavyMaintenanceLease({
-            leasePath: options.leasePath,
-            fsModule : options.fsModule,
-            now      : options.now,
+            leasePath : options.leasePath,
+            fsModule  : options.fsModule,
+            now       : options.now,
             isPidAlive: options.isPidAlive
         });
 
         if (current.active && current.lease && current.lease.token === inheritedToken) {
             const acquisition = {status: 'inherited', acquired: false, lease: current.lease};
             return {
-                status: 'inherited',
+                status  : 'inherited',
                 acquired: false,
-                lease : current.lease,
-                result: await task(acquisition)
+                lease   : current.lease,
+                result  : await task(acquisition)
             };
         }
+
+        // Inherited token set but STALE: the parent released its lease before this child checked. The
+        // child was approved to run under inheritance, so the fall-through below must never be a silent
+        // skip — a 'held' result masked as "completed" is what stalled kb-sync embedding for days.
+        // Surface it (hook + a distinct previousStatus) so callers can never mistake an inherited-but-lost
+        // deferral for success. The acquire-or-defer itself is unchanged — the mutex is preserved.
+        inheritedTokenStale = true;
+        (options.onInheritedTokenStale ?? warnInheritedTokenStale)({inheritedToken, current});
     }
 
     const acquisition = await acquireHeavyMaintenanceLease(options);
 
     if (!acquisition.acquired) {
-        return acquisition;
+        return inheritedTokenStale ? {...acquisition, previousStatus: 'inherited-token-stale'} : acquisition;
     }
 
     try {
         return {
-            status: 'completed',
+            status  : 'completed',
             acquired: true,
-            lease : acquisition.lease,
+            lease   : acquisition.lease,
+            ...(inheritedTokenStale && {previousStatus: 'inherited-token-stale'}),
             result: await task(acquisition)
         };
     } finally {
         await releaseHeavyMaintenanceLease({
-            token    : acquisition.lease.token,
-            leasePath: options.leasePath,
-            fsModule : options.fsModule,
-            now      : options.now,
+            token     : acquisition.lease.token,
+            leasePath : options.leasePath,
+            fsModule  : options.fsModule,
+            now       : options.now,
             isPidAlive: options.isPidAlive
         });
     }
+}
+
+/**
+ * @summary Default observability for a stale inherited heavy-maintenance lease token.
+ *
+ * Fires when a child was spawned with `NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN` but the live lease
+ * no longer carries that token (the parent released it before the child checked). The child was approved
+ * to run under inheritance; without this signal the subsequent acquire-or-defer can end in a silent skip
+ * masked as "completed". Override via `options.onInheritedTokenStale` (tests inject a spy).
+ *
+ * @param {Object} info
+ * @param {String} info.inheritedToken The stale token the child inherited.
+ * @param {Object} info.current Current lease inspection result.
+ * @returns {void}
+ */
+function warnInheritedTokenStale({inheritedToken, current}) {
+    console.warn(
+        '[HeavyMaintenanceLeaseService] inherited lease token is stale (parent released before child ' +
+        'checked) — falling through to self-acquire; a deferral here is observable, not a silent skip. ' +
+        `tokenPrefix=${String(inheritedToken).slice(0, 8)} currentOwner=${current?.lease?.owner ?? 'none'} ` +
+        `currentStatus=${current?.status ?? 'none'}`
+    );
 }
 
 /**
@@ -620,9 +652,9 @@ export class HeavyMaintenanceLeaseService extends Base {
      */
     inspect(options = {}) {
         return inspectHeavyMaintenanceLease({
-            leasePath: options.leasePath ?? this.leasePath,
-            fsModule : options.fsModule  ?? this.fsModule,
-            now      : options.now       ?? new Date(),
+            leasePath : options.leasePath ?? this.leasePath,
+            fsModule  : options.fsModule  ?? this.fsModule,
+            now       : options.now       ?? new Date(),
             isPidAlive: options.isPidAlive
         });
     }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -555,6 +555,52 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         }
     });
 
+    test('#13763: stale-inherited-token deferral defaults to a loud stderr warn (no hook override)', async () => {
+        // Same stale-inherited scenario as AC8b, but WITHOUT injecting onInheritedTokenStale — pins the
+        // deliberately-loud DEFAULT (reconciled): with 6+ maintenance callers, a no-op default +
+        // per-caller opt-in is the fragile discipline whose lapse caused the original silent-skip
+        // regression, so the wrapper warns by default. The structural previousStatus marker stays present.
+        const leasePath = createLeasePath('inherit-default-warn');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+
+        await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner       : 'summary',
+            now,
+            staleAfterMs: 60000,
+            token       : 'real-active-token'
+        });
+
+        const original    = process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+        process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = 'spurious-stale-token';
+
+        const originalWarn = console.warn;
+        const warnCalls    = [];
+        console.warn = (...args) => warnCalls.push(args.join(' '));
+
+        try {
+            const result = await withHeavyMaintenanceLease(() => {}, {
+                leasePath,
+                owner: 'kbSync',
+                now,
+                token: 'child-token'
+                // no onInheritedTokenStale → default loud warn
+            });
+
+            expect(result.previousStatus).toBe('inherited-token-stale');
+            expect(warnCalls).toHaveLength(1);
+            expect(warnCalls[0]).toContain('inherited lease token is stale');
+        } finally {
+            console.warn = originalWarn;
+            if (original === undefined) {
+                delete process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
+            } else {
+                process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = original;
+            }
+            await releaseHeavyMaintenanceLease({leasePath, token: 'real-active-token', now});
+        }
+    });
+
     test('#11519 AC8c (also AC7 stale-cascade): env-token captured from stale-replaced parent falls through to defer', async () => {
         // Stale-cascade scenario:
         //   1. Parent acquires with token-X; spawns child with env-token=X

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -521,14 +521,16 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN = 'spurious-stale-token';
 
         let taskRan = false;
+        const staleHookCalls = [];
         try {
             const result = await withHeavyMaintenanceLease(() => {
                 taskRan = true;
             }, {
                 leasePath,
-                owner: 'kbSync',
+                owner                : 'kbSync',
                 now,
-                token: 'child-token'
+                token                : 'child-token',
+                onInheritedTokenStale: info => staleHookCalls.push(info)
             });
 
             expect(result).toMatchObject({
@@ -537,6 +539,12 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
                 lease   : {owner: 'summary', token: 'real-active-token'}
             });
             expect(taskRan).toBe(false);
+            // Hardening: this is the exact silent-skip scenario (stale inherited token + lease held).
+            // The deferral must be OBSERVABLE — a distinct previousStatus + the stale hook fired — so it
+            // can never again masquerade as a "completed" multi-day stall.
+            expect(result.previousStatus).toBe('inherited-token-stale');
+            expect(staleHookCalls).toHaveLength(1);
+            expect(staleHookCalls[0]).toMatchObject({inheritedToken: 'spurious-stale-token'});
         } finally {
             if (original === undefined) {
                 delete process.env.NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN;
@@ -716,7 +724,7 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
     test('default singleton delegates to the reusable helpers', async () => {
         const leasePath = createLeasePath('service');
         const service   = Neo.create(HeavyMaintenanceLeaseService, {
-            leasePath_: leasePath,
+            leasePath_   : leasePath,
             staleAfterMs_: 60000
         });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -475,10 +475,11 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         try {
             const result = await withHeavyMaintenanceLease(() => 'fresh-acquire', {
                 leasePath,
-                owner       : 'kbSync',
+                owner                : 'kbSync',
                 now,
-                staleAfterMs: 60000,
-                token       : 'child-token'
+                staleAfterMs         : 60000,
+                token                : 'child-token',
+                onInheritedTokenStale: () => {} // AC8a hits the stale-inherited fall-through; pin no-op so the default warn does not leak into the suite
             });
 
             expect(result).toMatchObject({
@@ -642,9 +643,10 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
                 taskRan = true;
             }, {
                 leasePath,
-                owner: 'kbSync',
-                now  : t1,
-                token: 'child-token'
+                owner                : 'kbSync',
+                now                  : t1,
+                token                : 'child-token',
+                onInheritedTokenStale: () => {} // AC8c hits the stale-inherited fall-through; pin no-op so the default warn does not leak
             });
 
             expect(result).toMatchObject({


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13763. The defense-in-depth half of the #13358 regression (the revert is #13762); pairs with @neo-opus-vega's `PrimaryRepoSyncService` caller-side cascade fix.

## Summary
`withHeavyMaintenanceLease` reads `NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN`. When a child has it set but the live lease no longer carries it (the parent released before the child checked), the code fell through to acquire-or-defer with **no distinct signal** — a `held` result there is what stalled kb-sync embedding for days, masked as "completed."

This makes the stale-inherited fall-through **observable + distinct**: it fires an injectable `onInheritedTokenStale` hook (default: a warn log) and tags the result with `previousStatus: 'inherited-token-stale'`. An inherited-but-lost deferral can never again masquerade as success. The acquire-or-defer behavior + the mutex invariant are **unchanged**.

Mechanism confirmed by @neo-opus-ada + @neo-opus-vega (code + live). Covers all 7 lease callers (token-source `MaintenanceBackpressureService.mjs:573`).

## Deltas
- `HeavyMaintenanceLeaseService.mjs`: stale-inherited-token detection → `onInheritedTokenStale` hook (default `warnInheritedTokenStale`) + `previousStatus: 'inherited-token-stale'` on the fall-through result.
- `HeavyMaintenanceLeaseService.spec.mjs`: AC8b (stale-token + lease-held = the exact regression scenario) now asserts the hook fires + the distinct `previousStatus`.

## Test Evidence
Evidence: **L2** — 17 lease-service specs green (`UNIT_TEST_MODE=true npx playwright test`).

## Premise Coherence
**Coheres:** makes a silent-failure class observable (verify-before-assert / no-silent-stall). No mutex weakening, no behavior change beyond observability.

## Post-Merge Validation
- [ ] A stale-inherited-token deferral surfaces in the orchestrator log (the warn) instead of a silent no-op.
