### PR TITLE
feat(ai): hung-lease watchdog integration — orchestrator lease-monitor (sub of #13624)

### DIFF
--- a/ai/daemons/orchestrator/services/leaseMonitor.mjs
+++ b/ai/daemons/orchestrator/services/leaseMonitor.mjs
@@ -84,7 +84,7 @@ export function createLeaseMonitor({
             if (isHungLeaseHolder({cpuPercentSamples: samples, idleThresholdPct, minConsecutiveIdle})) {
                 await releaseLease(lease);
                 recordOutcome(owner, 'skipped', {
-                    reason     : 'watchdog-released-hung-holder',
+                    skipReason : 'watchdog-released-hung-holder',
                     pid,
                     idleSamples: samples.length,
                     releasedAt : new Date().toISOString()

--- a/ai/daemons/orchestrator/services/leaseMonitor.mjs
+++ b/ai/daemons/orchestrator/services/leaseMonitor.mjs
@@ -50,9 +50,10 @@ export function createLeaseMonitor({
 
     return {
         /**
-         * @summary One monitor pass. Returns a terminal action tag for observability + tests. Never
-         * throws: a failed lease-read or cpu-sample is fail-SAFE (returns without releasing — the
-         * watchdog must never force-release on missing/bad data).
+         * @summary One monitor pass. Returns a terminal action tag for observability + tests. Never throws:
+         * a failed lease-read, cpu-sample, OR release/record seam is fail-SAFE — a bad/non-finite sample
+         * RESETS the idle window (never bridges a gap into a false consecutive-idle run) and a release/record
+         * exception returns `release-failed` without breaking the orchestrator loop. Never force-releases on bad data.
          * @returns {Promise<Object>} A terminal action tag — `{action}` plus `pid`/`owner` when a holder was seen.
          */
         async tick() {
@@ -71,29 +72,42 @@ export function createLeaseMonitor({
 
             const {pid, owner} = lease;
 
+            // A bad or non-finite cpu sample RESETS the per-pid idle window (history.delete) — it must NOT
+            // be silently dropped while the prior window survives, which would bridge a gap into a false
+            // 'consecutive-idle' run (the 0,0,0,NaN,0 false-positive). Fail-SAFE: never release on bad data.
             let cpu;
             try {
                 cpu = await sampleCpuPercent(pid);
             } catch {
+                history.delete(pid);
                 return {action: 'sample-failed', pid};
             }
-            if (!Number.isFinite(cpu)) return {action: 'sample-failed', pid};
+            if (!Number.isFinite(cpu)) {
+                history.delete(pid);
+                return {action: 'sample-failed', pid};
+            }
 
             const samples = [...(history.get(pid) || []), cpu].slice(-maxHistory);
             history.set(pid, samples);
 
             if (isHungLeaseHolder({cpuPercentSamples: samples, idleThresholdPct, minConsecutiveIdle})) {
-                await releaseLease(lease);
-                // A hung holder RAN (it held the lease) but stalled — that is a FAILURE, not a skip
-                // (skipped = never ran). Honoring the typed-outcome vocabulary separation: a force-released
-                // hung holder records 'failed', so it is not collapsed into a green-looking skipped no-op.
-                recordOutcome(owner, 'failed', {
-                    reason      : 'watchdog-released-hung-holder',
-                    failurePhase: 'hung-lease-holder',
-                    pid,
-                    idleSamples : samples.length,
-                    releasedAt  : new Date().toISOString()
-                });
+                // The no-throw contract: a release/record seam exception must NOT break the orchestrator
+                // loop. On failure keep the history (a still-hung holder is retried next tick) + report it.
+                try {
+                    await releaseLease(lease);
+                    // A hung holder RAN (it held the lease) but stalled — that is a FAILURE, not a skip
+                    // (skipped = never ran). Honoring the typed-outcome vocabulary separation: a force-released
+                    // hung holder records 'failed', so it is not collapsed into a green-looking skipped no-op.
+                    recordOutcome(owner, 'failed', {
+                        reason      : 'watchdog-released-hung-holder',
+                        failurePhase: 'hung-lease-holder',
+                        pid,
+                        idleSamples : samples.length,
+                        releasedAt  : new Date().toISOString()
+                    });
+                } catch {
+                    return {action: 'release-failed', pid, owner};
+                }
                 history.delete(pid);
                 return {action: 'released-hung', pid, owner};
             }

--- a/ai/daemons/orchestrator/services/leaseMonitor.mjs
+++ b/ai/daemons/orchestrator/services/leaseMonitor.mjs
@@ -2,7 +2,7 @@
  * @module Neo.ai.daemons.orchestrator.services.leaseMonitor
  * @summary The hung-lease watchdog INTEGRATION — wires the pure `isHungLeaseHolder` decision into a
  * periodic lease-monitor that ps-samples the active heavy-lease holder's cpu and force-releases +
- * records a `skipped` outcome when the holder is HUNG (alive + within-TTL but sustained-idle), which
+ * records a `failed` outcome when the holder is HUNG (alive + within-TTL but sustained-idle), which
  * the pid-death / TTL stale-check (HeavyMaintenanceLeaseService) cannot catch. The 2026-06-21 incident:
  * a heavy task hung ~59min at 0% cpu holding the lease idle, starving all periodic maintenance until
  * the Golden Path froze.
@@ -13,9 +13,10 @@
  * monitor therefore samples on its OWN slow cadence — the caller drives `tick()` at the sample
  * interval (minutes), NOT the fast daemon tick.
  *
- * The recorded outcome uses the EXISTING `recordTaskOutcome` `'skipped'` state (the orchestration
- * observability convergence refines the typed-outcome — `deferred` / provenance — later; this uses the
- * live primitive now).
+ * The recorded outcome uses the EXISTING `recordTaskOutcome` `'failed'` state — a hung holder ran then
+ * stalled (a FAILURE, distinct from `skipped`=never-ran, `deferred`=postponed, task-state `markSkipped`).
+ * The observability convergence may add a hung-specific typed-outcome later; this uses the live primitive
+ * now without overloading `skipped` into a green-looking no-op.
  */
 
 import {isHungLeaseHolder} from './leaseWatchdog.mjs';
@@ -83,11 +84,15 @@ export function createLeaseMonitor({
 
             if (isHungLeaseHolder({cpuPercentSamples: samples, idleThresholdPct, minConsecutiveIdle})) {
                 await releaseLease(lease);
-                recordOutcome(owner, 'skipped', {
-                    skipReason : 'watchdog-released-hung-holder',
+                // A hung holder RAN (it held the lease) but stalled — that is a FAILURE, not a skip
+                // (skipped = never ran). Honoring the typed-outcome vocabulary separation: a force-released
+                // hung holder records 'failed', so it is not collapsed into a green-looking skipped no-op.
+                recordOutcome(owner, 'failed', {
+                    reason      : 'watchdog-released-hung-holder',
+                    failurePhase: 'hung-lease-holder',
                     pid,
-                    idleSamples: samples.length,
-                    releasedAt : new Date().toISOString()
+                    idleSamples : samples.length,
+                    releasedAt  : new Date().toISOString()
                 });
                 history.delete(pid);
                 return {action: 'released-hung', pid, owner};

--- a/ai/daemons/orchestrator/services/leaseMonitor.mjs
+++ b/ai/daemons/orchestrator/services/leaseMonitor.mjs
@@ -1,0 +1,99 @@
+/**
+ * @module Neo.ai.daemons.orchestrator.services.leaseMonitor
+ * @summary The hung-lease watchdog INTEGRATION — wires the pure `isHungLeaseHolder` decision into a
+ * periodic lease-monitor that ps-samples the active heavy-lease holder's cpu and force-releases +
+ * records a `skipped` outcome when the holder is HUNG (alive + within-TTL but sustained-idle), which
+ * the pid-death / TTL stale-check (HeavyMaintenanceLeaseService) cannot catch. The 2026-06-21 incident:
+ * a heavy task hung ~59min at 0% cpu holding the lease idle, starving all periodic maintenance until
+ * the Golden Path froze.
+ *
+ * INTERVAL-COUPLING (critical, per the watchdog review's forward-flag): `minConsecutiveIdle` × the
+ * sample interval MUST be minutes-scale. A tight window (e.g. 3 × the daemon's 250ms tick = 750ms)
+ * would force-release a holder legitimately I/O-blocked for <1s, ironically re-creating the DRAIN. The
+ * monitor therefore samples on its OWN slow cadence — the caller drives `tick()` at the sample
+ * interval (minutes), NOT the fast daemon tick.
+ *
+ * The recorded outcome uses the EXISTING `recordTaskOutcome` `'skipped'` state (the orchestration
+ * observability convergence refines the typed-outcome — `deferred` / provenance — later; this uses the
+ * live primitive now).
+ */
+
+import {isHungLeaseHolder} from './leaseWatchdog.mjs';
+
+/**
+ * @summary Creates a lease-monitor with injected seams (`inspectLease` / `sampleCpuPercent` /
+ * `releaseLease` / `recordOutcome`) plus a closure-held per-pid cpu-sample history. Each `tick()`
+ * samples the active holder's cpu and force-releases a sustained-idle hung holder. All I/O is
+ * seam-injected, so the monitor is fully unit-testable; the orchestrator wires the real seams and
+ * drives `tick()` at the (slow) sample interval. The history resets whenever there is no active holder.
+ * @param {Object} [options]
+ * @param {Function} options.inspectLease `async () → {active: Boolean, lease: {pid: Number, owner: String}} | falsy` — the live lease.
+ * @param {Function} options.sampleCpuPercent `async (pid) → Number` — the holder's instantaneous cpu%.
+ * @param {Function} options.releaseLease `async (lease) → void` — force-release the held lease.
+ * @param {Function} options.recordOutcome `(owner, state, details) → void` — the HealthService outcome record.
+ * @param {Number} [options.idleThresholdPct=1] At-or-below this cpu% counts as idle (forwarded to `isHungLeaseHolder`).
+ * @param {Number} [options.minConsecutiveIdle=4] Trailing idle samples required to call it hung (× the interval = minutes).
+ * @param {Number} [options.maxHistory=12] Cap on retained per-pid cpu samples.
+ * @returns {{tick: Function}}
+ */
+export function createLeaseMonitor({
+    inspectLease,
+    sampleCpuPercent,
+    releaseLease,
+    recordOutcome,
+    idleThresholdPct   = 1,
+    minConsecutiveIdle = 4,
+    maxHistory         = 12
+} = {}) {
+    const history = new Map();
+
+    return {
+        /**
+         * @summary One monitor pass. Returns a terminal action tag for observability + tests. Never
+         * throws: a failed lease-read or cpu-sample is fail-SAFE (returns without releasing — the
+         * watchdog must never force-release on missing/bad data).
+         * @returns {Promise<Object>} A terminal action tag — `{action}` plus `pid`/`owner` when a holder was seen.
+         */
+        async tick() {
+            let current;
+            try {
+                current = await inspectLease();
+            } catch {
+                return {action: 'inspect-failed'};
+            }
+
+            const lease = current && current.active ? current.lease : null;
+            if (!lease || typeof lease.pid !== 'number') {
+                history.clear();
+                return {action: 'no-active-lease'};
+            }
+
+            const {pid, owner} = lease;
+
+            let cpu;
+            try {
+                cpu = await sampleCpuPercent(pid);
+            } catch {
+                return {action: 'sample-failed', pid};
+            }
+            if (!Number.isFinite(cpu)) return {action: 'sample-failed', pid};
+
+            const samples = [...(history.get(pid) || []), cpu].slice(-maxHistory);
+            history.set(pid, samples);
+
+            if (isHungLeaseHolder({cpuPercentSamples: samples, idleThresholdPct, minConsecutiveIdle})) {
+                await releaseLease(lease);
+                recordOutcome(owner, 'skipped', {
+                    reason     : 'watchdog-released-hung-holder',
+                    pid,
+                    idleSamples: samples.length,
+                    releasedAt : new Date().toISOString()
+                });
+                history.delete(pid);
+                return {action: 'released-hung', pid, owner};
+            }
+
+            return {action: 'monitoring', pid, owner};
+        }
+    };
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/leaseMonitor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/leaseMonitor.spec.mjs
@@ -90,4 +90,43 @@ test.describe('ai/daemons/orchestrator/services/leaseMonitor — createLeaseMoni
         for (let t = 0; t < 5; t++) await monitor.tick();
         expect(released).toHaveLength(0);
     });
+
+    test('a bad sample RESETS the idle window — 0,0,0,NaN,0 does NOT release (the gap is not bridged)', async () => {
+        const released = [], cpuSeq = [0, 0, 0, NaN, 0]; // the NaN must break the consecutive-idle run
+        let i = 0;
+        const monitor = createLeaseMonitor({
+            inspectLease    : async () => leaseOf(11),
+            sampleCpuPercent: async () => cpuSeq[i++],
+            releaseLease    : async l => released.push(l),
+            recordOutcome   : () => {}
+        });
+        let last;
+        for (let t = 0; t < 5; t++) last = await monitor.tick();
+        expect(released).toHaveLength(0); // only 1 valid idle sample survives the NaN reset
+        expect(last.action).toBe('monitoring');
+    });
+
+    test('no-throw contract: a releaseLease exception returns release-failed (never breaks the loop)', async () => {
+        const monitor = createLeaseMonitor({
+            inspectLease    : async () => leaseOf(13),
+            sampleCpuPercent: async () => 0,
+            releaseLease    : async () => { throw new Error('release seam failed'); },
+            recordOutcome   : () => {}
+        });
+        let last;
+        for (let t = 0; t < 4; t++) last = await monitor.tick(); // resolves, does not throw
+        expect(last.action).toBe('release-failed');
+    });
+
+    test('no-throw contract: a recordOutcome exception returns release-failed (never breaks the loop)', async () => {
+        const monitor = createLeaseMonitor({
+            inspectLease    : async () => leaseOf(17),
+            sampleCpuPercent: async () => 0,
+            releaseLease    : async () => {},
+            recordOutcome   : () => { throw new Error('record seam failed'); }
+        });
+        let last;
+        for (let t = 0; t < 4; t++) last = await monitor.tick();
+        expect(last.action).toBe('release-failed');
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/leaseMonitor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/leaseMonitor.spec.mjs
@@ -10,7 +10,7 @@ import {createLeaseMonitor} from '../../../../../../../ai/daemons/orchestrator/s
 test.describe('ai/daemons/orchestrator/services/leaseMonitor — createLeaseMonitor', () => {
     const leaseOf = (pid, owner = 'kbSync') => ({active: true, lease: {pid, owner}});
 
-    test('a sustained-idle holder → force-released + outcome recorded skipped', async () => {
+    test('a sustained-idle holder → force-released + outcome recorded failed', async () => {
         const released = [], outcomes = [], cpuSeq = [0, 0, 0, 0]; // 4 idle = minConsecutiveIdle default
         let i = 0;
         const monitor = createLeaseMonitor({
@@ -24,9 +24,10 @@ test.describe('ai/daemons/orchestrator/services/leaseMonitor — createLeaseMoni
         expect(last.action).toBe('released-hung');
         expect(released).toHaveLength(1);
         expect(outcomes).toHaveLength(1);
-        expect(outcomes[0]).toMatchObject({owner: 'kbSync', state: 'skipped'});
-        // skipReason matches the established pipeline.mjs skipped-outcome shape (uniform health-endpoint reads)
-        expect(outcomes[0].d.skipReason).toBe('watchdog-released-hung-holder');
+        // a hung holder ran-then-stalled → 'failed' (not 'skipped'=never-ran); preserves the typed-outcome separation
+        expect(outcomes[0]).toMatchObject({owner: 'kbSync', state: 'failed'});
+        expect(outcomes[0].d.reason).toBe('watchdog-released-hung-holder');
+        expect(outcomes[0].d.failurePhase).toBe('hung-lease-holder');
     });
 
     test('a slow-but-progressing holder → NOT released (Grace interval-coupling guard)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/leaseMonitor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/leaseMonitor.spec.mjs
@@ -1,0 +1,91 @@
+import {test, expect}       from '@playwright/test';
+import {createLeaseMonitor} from '../../../../../../../ai/daemons/orchestrator/services/leaseMonitor.mjs';
+
+/**
+ * Coverage for the hung-lease watchdog integration (the orchestrator lease-monitor). All I/O is
+ * seam-injected. Pins: sustained-idle → release + recorded outcome; the slow-but-progressing guard
+ * (Grace's interval-coupling flag); and the fail-SAFE contract (a bad lease-read / cpu-sample never
+ * force-releases).
+ */
+test.describe('ai/daemons/orchestrator/services/leaseMonitor — createLeaseMonitor', () => {
+    const leaseOf = (pid, owner = 'kbSync') => ({active: true, lease: {pid, owner}});
+
+    test('a sustained-idle holder → force-released + outcome recorded skipped', async () => {
+        const released = [], outcomes = [], cpuSeq = [0, 0, 0, 0]; // 4 idle = minConsecutiveIdle default
+        let i = 0;
+        const monitor = createLeaseMonitor({
+            inspectLease    : async () => leaseOf(4242),
+            sampleCpuPercent: async () => cpuSeq[i++],
+            releaseLease    : async l => released.push(l),
+            recordOutcome   : (owner, state, d) => outcomes.push({owner, state, d})
+        });
+        let last;
+        for (let t = 0; t < 4; t++) last = await monitor.tick();
+        expect(last.action).toBe('released-hung');
+        expect(released).toHaveLength(1);
+        expect(outcomes).toHaveLength(1);
+        expect(outcomes[0]).toMatchObject({owner: 'kbSync', state: 'skipped'});
+        expect(outcomes[0].d.reason).toBe('watchdog-released-hung-holder');
+    });
+
+    test('a slow-but-progressing holder → NOT released (Grace interval-coupling guard)', async () => {
+        const released = [], cpuSeq = [0, 0, 35, 0, 0]; // an active sample within the window
+        let i = 0;
+        const monitor = createLeaseMonitor({
+            inspectLease    : async () => leaseOf(7),
+            sampleCpuPercent: async () => cpuSeq[i++],
+            releaseLease    : async l => released.push(l),
+            recordOutcome   : () => {}
+        });
+        let last;
+        for (let t = 0; t < 5; t++) last = await monitor.tick();
+        expect(released).toHaveLength(0);
+        expect(last.action).toBe('monitoring');
+    });
+
+    test('no active lease → no-op (and resets the window)', async () => {
+        const monitor = createLeaseMonitor({
+            inspectLease    : async () => ({active: false, lease: null}),
+            sampleCpuPercent: async () => 0,
+            releaseLease    : async () => { throw new Error('should not release'); },
+            recordOutcome   : () => {}
+        });
+        expect((await monitor.tick()).action).toBe('no-active-lease');
+    });
+
+    test('fail-SAFE: a cpu-sample failure never force-releases', async () => {
+        const released = [];
+        const monitor = createLeaseMonitor({
+            inspectLease    : async () => leaseOf(9),
+            sampleCpuPercent: async () => { throw new Error('ps failed'); },
+            releaseLease    : async l => released.push(l),
+            recordOutcome   : () => {}
+        });
+        expect((await monitor.tick()).action).toBe('sample-failed');
+        expect(released).toHaveLength(0);
+    });
+
+    test('fail-SAFE: a lease-inspect failure never force-releases', async () => {
+        const released = [];
+        const monitor = createLeaseMonitor({
+            inspectLease    : async () => { throw new Error('read failed'); },
+            sampleCpuPercent: async () => 0,
+            releaseLease    : async l => released.push(l),
+            recordOutcome   : () => {}
+        });
+        expect((await monitor.tick()).action).toBe('inspect-failed');
+        expect(released).toHaveLength(0);
+    });
+
+    test('fail-SAFE: a non-finite cpu reading is not treated as idle', async () => {
+        const released = [];
+        const monitor = createLeaseMonitor({
+            inspectLease    : async () => leaseOf(5),
+            sampleCpuPercent: async () => NaN,
+            releaseLease    : async l => released.push(l),
+            recordOutcome   : () => {}
+        });
+        for (let t = 0; t < 5; t++) await monitor.tick();
+        expect(released).toHaveLength(0);
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/leaseMonitor.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/leaseMonitor.spec.mjs
@@ -25,7 +25,8 @@ test.describe('ai/daemons/orchestrator/services/leaseMonitor — createLeaseMoni
         expect(released).toHaveLength(1);
         expect(outcomes).toHaveLength(1);
         expect(outcomes[0]).toMatchObject({owner: 'kbSync', state: 'skipped'});
-        expect(outcomes[0].d.reason).toBe('watchdog-released-hung-holder');
+        // skipReason matches the established pipeline.mjs skipped-outcome shape (uniform health-endpoint reads)
+        expect(outcomes[0].d.skipReason).toBe('watchdog-released-hung-holder');
     });
 
     test('a slow-but-progressing holder → NOT released (Grace interval-coupling guard)', async () => {


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13766. Refs #13624, #13761.

## Summary

The INTEGRATION of #13761's pure hung-lease watchdog into the live orchestrator: a periodic lease-monitor that ps-samples the active heavy-lease holder's cpu, then force-releases + records a `skipped` outcome when the holder is HUNG (alive + within-TTL but sustained-idle — the 2026-06-21 01:17 incident the pid/TTL stale-check can't catch).

## Builds on #13761 (now MERGED)

#13761 (the pure `isHungLeaseHolder` carve) merged to dev at 12:23, so this bases cleanly on dev — the diff is exactly the 2 new `leaseMonitor` files (it imports `isHungLeaseHolder` from dev).

## Deltas

- `ai/daemons/orchestrator/services/leaseMonitor.mjs` (new): `createLeaseMonitor({inspectLease, sampleCpuPercent, releaseLease, recordOutcome, ...}) → {tick}`. Factory with injected seams (fully unit-testable) + a closure per-pid cpu-history. Each `tick()`: inspect the active lease → ps-sample the holder pid → push to history → `isHungLeaseHolder` → if hung: `releaseLease` + `recordOutcome('failed')`. Fail-SAFE (a bad inspect/sample never force-releases).
- **Grace's interval-coupling guard honored:** the monitor samples on its OWN slow cadence (the caller drives `tick()` at the minutes-scale sample interval, NOT the 250ms daemon tick) — so `minConsecutiveIdle × interval` = minutes, never the 750ms that would false-positive a working holder and re-create the DRAIN.
- **Typed-outcome vocabulary separation honored (#13765 boundary-5 / @neo-gpt):** a hung holder RAN (held the lease) then stalled — that is a `'failed'` outcome (`{reason, failurePhase: 'hung-lease-holder'}`), NOT `'skipped'` (= never-ran). This deliberately does not overload `skipped` into a green-looking no-op; it uses the EXISTING `recordTaskOutcome` `'failed'` state (the convergence may add a hung-specific typed-outcome later).

## Out of scope (the last bit)

The daemon-loop hook (the 1-line `monitor.tick()` wiring at the sample interval) lands last — minimizing the live-daemon blast.

## Test Evidence

Evidence: L2 — 9 unit tests green (`npm run test-unit -- leaseMonitor.spec.mjs`): sustained-idle → released + outcome `failed`; slow-but-progressing → NOT released (Grace's guard); **`0,0,0,NaN,0` → NOT released (bad-sample window-reset)**; no-active-lease → no-op; fail-safe on ps-failure / inspect-failure / non-finite-cpu; **`release`-throws / `record`-throws → `release-failed`, no throw**. `check-jsdoc-types` clean; `check-block-alignment` clean.

### Review-cycle 2 (CHANGES_REQUESTED cleared, @neo-gpt)

Two real fail-safe defects + a close-target reconciliation, all addressed (commit `14d43c806`):
1. **Bad-data window** — a bad/non-finite sample now RESETS the per-pid history, so `0,0,0,NaN,0` can't bridge a gap into a false consecutive-idle run (+test).
2. **No-throw contract** — `releaseLease`/`recordOutcome` wrapped → a seam exception returns `release-failed` (keeps history for retry) without breaking the orchestrator loop (+2 tests). JSDoc updated.
3. **Close-target** — #13766 body reconciled to `failed` + the fail-safe semantics + the #13769 interop contract.

## Post-Merge Validation

- [ ] `createLeaseMonitor` importable; the orchestrator wires the real seams (`inspectHeavyMaintenanceLease` / a ps-cpu sampler / `releaseHeavyMaintenanceLease` / `HealthService.recordTaskOutcome`) + drives `tick()` at a minutes-scale interval → a hung holder is force-released + recorded within the window (vs waiting the full 6h TTL).
