### PR TITLE
fix(ai): keep Dream skips out of success accounting (#13767)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -479,7 +479,7 @@ async function runDreamTask({taskName, reason, services}) {
             services.healthService?.recordTaskOutcome?.(taskName, 'completed', recordPayload);
             break;
         case 'skipped':
-            services.taskStateService.markCompleted(taskName);
+            services.taskStateService.markSkipped(taskName);
             services.healthService?.recordTaskOutcome?.(taskName, 'skipped', {
                 ...recordPayload,
                 skipReason: outcome.skipReason

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -69,6 +69,7 @@ function makeServices(overrides = {}) {
             getTaskState: () => null,
             markCompleted() {},
             markFailed() {},
+            markSkipped() {},
             markStarted() {}
         },
         tenantRepoSyncService: {
@@ -296,6 +297,210 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
             level  : 'ERROR',
             message: '[Orchestrator] Unsupported executionKind: future-kind'
         }]);
+    });
+
+    test('records completed Dream outcomes as successful runs (#13767)', async () => {
+        const calls    = [];
+        const outcomes = [];
+
+        const result = runSchedulingPipeline({
+            registry: [
+                makeCandidateDescriptor({
+                    taskName        : 'dream',
+                    executionKind   : 'in-process-async',
+                    maintenanceClass: 'heavy'
+                })
+            ],
+            context : makeContext(),
+            services: makeServices({
+                dreamService: {
+                    executeRemCycle: () => Promise.resolve({
+                        status           : 'completed',
+                        completedAt      : '2026-06-21T12:00:00.000Z',
+                        durationMs       : 42,
+                        sessionsProcessed: 3,
+                        runId            : 'run-completed'
+                    })
+                },
+                healthService: {
+                    recordTaskOutcome(taskName, status, details) {
+                        outcomes.push({taskName, status, details});
+                    }
+                },
+                taskStateService: {
+                    getTaskState: () => null,
+                    markCompleted(taskName) { calls.push(['markCompleted', taskName]); },
+                    markFailed(taskName) { calls.push(['markFailed', taskName]); },
+                    markSkipped(taskName) { calls.push(['markSkipped', taskName]); },
+                    markStarted(taskName, reason) { calls.push(['markStarted', taskName, reason]); }
+                }
+            }),
+            runtime: makeRuntime()
+        });
+
+        await result.executed;
+
+        expect(calls).toEqual([
+            ['markStarted', 'dream', 'dream-reason'],
+            ['markCompleted', 'dream']
+        ]);
+        expect(outcomes).toEqual([
+            {
+                taskName: 'dream',
+                status  : 'running',
+                details : {reason: 'dream-reason', startedAt: expect.any(String)}
+            },
+            {
+                taskName: 'dream',
+                status  : 'completed',
+                details : {
+                    reason           : 'dream-reason',
+                    completedAt      : '2026-06-21T12:00:00.000Z',
+                    durationMs       : 42,
+                    sessionsProcessed: 3,
+                    runId            : 'run-completed'
+                }
+            }
+        ]);
+    });
+
+    test('records skipped Dream outcomes without marking success (#13767)', async () => {
+        const calls    = [];
+        const outcomes = [];
+
+        const result = runSchedulingPipeline({
+            registry: [
+                makeCandidateDescriptor({
+                    taskName        : 'dream',
+                    executionKind   : 'in-process-async',
+                    maintenanceClass: 'heavy'
+                })
+            ],
+            context : makeContext(),
+            services: makeServices({
+                dreamService: {
+                    executeRemCycle: () => Promise.resolve({
+                        status           : 'skipped',
+                        completedAt      : '2026-06-21T12:01:00.000Z',
+                        durationMs       : 7,
+                        sessionsProcessed: 0,
+                        runId            : 'run-skipped',
+                        skipReason       : 'no-actionable-sessions'
+                    })
+                },
+                healthService: {
+                    recordTaskOutcome(taskName, status, details) {
+                        outcomes.push({taskName, status, details});
+                    }
+                },
+                taskStateService: {
+                    getTaskState: () => null,
+                    markCompleted(taskName) { calls.push(['markCompleted', taskName]); },
+                    markFailed(taskName) { calls.push(['markFailed', taskName]); },
+                    markSkipped(taskName) { calls.push(['markSkipped', taskName]); },
+                    markStarted(taskName, reason) { calls.push(['markStarted', taskName, reason]); }
+                }
+            }),
+            runtime: makeRuntime()
+        });
+
+        await result.executed;
+
+        expect(calls).toEqual([
+            ['markStarted', 'dream', 'dream-reason'],
+            ['markSkipped', 'dream']
+        ]);
+        expect(outcomes).toEqual([
+            {
+                taskName: 'dream',
+                status  : 'running',
+                details : {reason: 'dream-reason', startedAt: expect.any(String)}
+            },
+            {
+                taskName: 'dream',
+                status  : 'skipped',
+                details : {
+                    reason           : 'dream-reason',
+                    completedAt      : '2026-06-21T12:01:00.000Z',
+                    durationMs       : 7,
+                    sessionsProcessed: 0,
+                    runId            : 'run-skipped',
+                    skipReason       : 'no-actionable-sessions'
+                }
+            }
+        ]);
+    });
+
+    test('records failed Dream outcomes as failures with diagnostics (#13767)', async () => {
+        const calls    = [];
+        const outcomes = [];
+        const state    = {};
+
+        const result = runSchedulingPipeline({
+            registry: [
+                makeCandidateDescriptor({
+                    taskName        : 'dream',
+                    executionKind   : 'in-process-async',
+                    maintenanceClass: 'heavy'
+                })
+            ],
+            context : makeContext(),
+            services: makeServices({
+                dreamService: {
+                    executeRemCycle: () => Promise.resolve({
+                        status           : 'failed',
+                        completedAt      : '2026-06-21T12:02:00.000Z',
+                        durationMs       : 11,
+                        sessionsProcessed: 0,
+                        runId            : 'run-failed',
+                        diagnostic       : {reason: 'provider-unready'}
+                    })
+                },
+                healthService: {
+                    recordTaskOutcome(taskName, status, details) {
+                        outcomes.push({taskName, status, details});
+                    }
+                },
+                taskStateService: {
+                    getTaskState: () => state,
+                    markCompleted(taskName) { calls.push(['markCompleted', taskName]); },
+                    markFailed(taskName, exitCode) { calls.push(['markFailed', taskName, exitCode]); },
+                    markSkipped(taskName) { calls.push(['markSkipped', taskName]); },
+                    markStarted(taskName, reason) { calls.push(['markStarted', taskName, reason]); }
+                }
+            }),
+            runtime: makeRuntime()
+        });
+
+        await result.executed;
+
+        expect(calls).toEqual([
+            ['markStarted', 'dream', 'dream-reason'],
+            ['markFailed', 'dream', 1]
+        ]);
+        expect(state.lastReason).toBe('provider-unready');
+        expect(outcomes).toEqual([
+            {
+                taskName: 'dream',
+                status  : 'running',
+                details : {reason: 'dream-reason', startedAt: expect.any(String)}
+            },
+            {
+                taskName: 'dream',
+                status  : 'failed',
+                details : {
+                    reason           : 'dream-reason',
+                    completedAt      : '2026-06-21T12:02:00.000Z',
+                    durationMs       : 11,
+                    sessionsProcessed: 0,
+                    runId            : 'run-failed',
+                    failedAt         : '2026-06-21T12:02:00.000Z',
+                    failurePhase     : 'provider-readiness',
+                    diagnostic       : {reason: 'provider-unready'},
+                    error            : undefined
+                }
+            }
+        ]);
     });
 });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
@@ -91,6 +91,27 @@ test.describe('Neo.ai.daemons.services.TaskStateService', () => {
         expect(stateData.mockTask.lastErrorAt).toEqual(expect.any(String));
     });
 
+    test('markSkipped clears running state without recording a new success (#13767)', () => {
+        const { service, stateFile } = createTestService();
+
+        service.markStarted('mockTask', 'successful-run');
+        service.markCompleted('mockTask');
+
+        const previousStateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        const previousSuccessAt = previousStateData.mockTask.lastSuccessAt;
+
+        service.markStarted('mockTask', 'deferred-run');
+        service.markSkipped('mockTask');
+
+        const stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+
+        expect(stateData.mockTask.running).toBe(false);
+        expect(stateData.mockTask.pid).toBe(null);
+        expect(stateData.mockTask.lastExitCode).toBe(null);
+        expect(stateData.mockTask.lastReason).toBe('deferred-run');
+        expect(stateData.mockTask.lastSuccessAt).toBe(previousSuccessAt);
+    });
+
     test('adoptRunning sets state without immediately writing to disk', () => {
         const { service, stateFile } = createTestService();
 


### PR DESCRIPTION
Resolves #13767

Related: #13755
Related: #13624

This PR routes typed Dream `skipped` outcomes through `TaskStateService.markSkipped()` instead of `markCompleted()`. Health reporting still records `skipped` plus `skipReason`, but deferred/no-op Dream cycles no longer write successful-run accounting through `lastSuccessAt`.

Evidence: L2 (focused unit/static validation in sandbox) -> L2 required (scheduler and task-state accounting contracts are covered by unit tests). Residual: none for `#13767`. `lastRunAt` start-time semantics were inspected: `markStarted()` still records the attempted cycle start, and this leaf intentionally changes only success accounting rather than redesigning scheduler freshness.

## Interop with #13768
`#13768` records a watchdog-released hung lease as a HealthService `skipped` outcome. That is complementary, not duplicative: this PR fixes the separate task-state surface so a typed `skipped` result does not also look like a successful run.

Future daemon wiring for the hung-lease monitor should keep the same two-surface shape: health records the `skipped` observability event, while task state uses a non-success cleanup path such as `markSkipped()` for the affected owner, unless that wiring deliberately documents why the owner has no task-state row to clear.

## Deltas from ticket
- Added scheduler coverage for typed Dream `completed`, `skipped`, and `failed` outcomes.
- Added direct `TaskStateService.markSkipped()` coverage proving it clears running state without recording a new success timestamp.
- Kept `lastRunAt` semantics unchanged and documented the scope boundary above.

## Test Evidence
- `node --check ai/daemons/orchestrator/scheduling/pipeline.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs` — 18 passed. Ambient Node warning observed: `NO_COLOR` is ignored when `FORCE_COLOR` is set.

## Post-Merge Validation
- [ ] Observe the next real Dream `skipped` cycle: health should record `skipped`, while task-state `lastSuccessAt` should not advance from that skipped cycle.

## Commits
- `153518f1ec` — route Dream skips through non-success task-state accounting and pin scheduler/service tests.

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee050-c834-7503-b895-527ad55dd8c5.
