### PR TITLE
fix(orchestrator): propagate miniSummary child outcomes (#13777)

### DIFF
--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -3,6 +3,8 @@ import fs from 'fs-extra';
 import path from 'path';
 import {execSync} from 'child_process';
 
+const DEFAULT_STDOUT_JSON_MAX_BYTES = 65536;
+
 /**
  * @class Neo.ai.daemons.services.ProcessSupervisorService
  * @extends Neo.core.Base
@@ -348,14 +350,18 @@ export class ProcessSupervisorService extends Base {
         this.writeLog?.('INFO', `[ProcessSupervisor] Starting ${task.label} (${reason}).`);
 
         let child;
+        const stdoutCapture = this.createStdoutJsonCapture(task);
         try {
             const env = task.env || options.env
                 ? {...process.env, ...(task.env || {}), ...(options.env || {})}
                 : process.env;
-            child = this.spawnFn(task.command, task.args, {stdio: ['ignore', 'ignore', 'pipe'], env});
+            child = this.spawnFn(task.command, task.args, {stdio: stdoutCapture ? ['ignore', 'pipe', 'pipe'] : ['ignore', 'ignore', 'pipe'], env});
 
             child.stderr?.on('data', data => {
                 this.writeChildStderr(task, data);
+            });
+            child.stdout?.on('data', data => {
+                this.captureStdoutJsonChunk(stdoutCapture, data);
             });
         } catch (e) {
             this.taskStateService.markSpawnFailed(taskName);
@@ -403,12 +409,33 @@ export class ProcessSupervisorService extends Base {
                 this.recordTaskOutcome(taskName, 'failed', {reason, phase, error: error.message});
             } else if (code === 0) {
                 try {
-                    const completedAt = new Date().toISOString();
+                    const completedAt   = new Date().toISOString();
+                    const stdoutOutcome = this.parseCapturedStdoutJson(stdoutCapture);
+                    const disposition   = this.classifySuccessfulChildOutcome(taskName, stdoutOutcome.outcome);
+
                     onSuccess?.();
-                    this.taskStateService.markCompleted(taskName);
-                    this.writeLog?.('INFO', `[ProcessSupervisor] ${task.label} completed successfully.`);
-                    if (readinessOutcome !== 'degraded') {
-                        this.recordTaskOutcome(taskName, 'completed', {reason, code, completedAt});
+
+                    if (disposition.status === 'skipped') {
+                        this.taskStateService.markSkipped(taskName);
+                        this.writeLog?.('INFO', `[ProcessSupervisor] ${task.label} skipped (${disposition.reasonCode}).`);
+                        this.recordTaskOutcome(taskName, 'skipped', {
+                            reason,
+                            code,
+                            reasonCode: disposition.reasonCode,
+                            skippedAt : completedAt,
+                            ...stdoutOutcome.details
+                        });
+                    } else {
+                        this.taskStateService.markCompleted(taskName);
+                        this.writeLog?.('INFO', `[ProcessSupervisor] ${task.label} completed successfully.`);
+                        if (readinessOutcome !== 'degraded') {
+                            this.recordTaskOutcome(taskName, 'completed', {
+                                reason,
+                                code,
+                                completedAt,
+                                ...stdoutOutcome.details
+                            });
+                        }
                     }
                 } catch (e) {
                     this.taskStateService.markFailed(taskName, null);
@@ -477,6 +504,133 @@ export class ProcessSupervisorService extends Base {
         }
 
         return true;
+    }
+
+    /**
+     * Creates the bounded stdout buffer for task definitions with a JSON outcome contract.
+     * @param {Object} task Task definition.
+     * @returns {Object|null}
+     */
+    createStdoutJsonCapture(task) {
+        if (!task.captureStdoutJson) {
+            return null;
+        }
+
+        return {
+            chunks  : [],
+            overflow: false,
+            bytes   : 0,
+            maxBytes: task.stdoutJsonMaxBytes || DEFAULT_STDOUT_JSON_MAX_BYTES
+        };
+    }
+
+    /**
+     * Buffers stdout for opted-in JSON outcome tasks without allowing unbounded child output.
+     * @param {Object|null} capture Active stdout capture state.
+     * @param {Buffer|String} data Child stdout chunk.
+     * @returns {void}
+     */
+    captureStdoutJsonChunk(capture, data) {
+        if (!capture || capture.overflow) {
+            return;
+        }
+
+        const chunk = Buffer.isBuffer(data) ? data : Buffer.from(String(data));
+        capture.bytes += chunk.length;
+
+        if (capture.bytes > capture.maxBytes) {
+            capture.overflow = true;
+            capture.chunks.length = 0;
+            return;
+        }
+
+        capture.chunks.push(chunk);
+    }
+
+    /**
+     * Parses the opted-in child stdout JSON and converts parse failures into bounded details.
+     * @param {Object|null} capture Active stdout capture state.
+     * @returns {{details: Object, outcome: Object|null}}
+     */
+    parseCapturedStdoutJson(capture) {
+        if (!capture) {
+            return {details: {}, outcome: null};
+        }
+
+        if (capture.overflow) {
+            return {
+                details: {
+                    stdoutJsonBytes   : capture.bytes,
+                    stdoutJsonMaxBytes: capture.maxBytes,
+                    stdoutJsonOverflow: true
+                },
+                outcome: null
+            };
+        }
+
+        const stdout = Buffer.concat(capture.chunks).toString('utf8').trim();
+
+        if (!stdout) {
+            return {details: {stdoutJsonMissing: true}, outcome: null};
+        }
+
+        try {
+            const outcome = JSON.parse(stdout);
+            return {
+                details: this.buildChildOutcomeDetails(outcome),
+                outcome
+            };
+        } catch (e) {
+            return {
+                details: {
+                    stdoutJsonParseError: e.message,
+                    stdoutJsonBytes     : Buffer.byteLength(stdout, 'utf8')
+                },
+                outcome: null
+            };
+        }
+    }
+
+    /**
+     * Flattens child outcome fields into task health details without overwriting scheduler fields.
+     * @param {Object} outcome Parsed child stdout JSON.
+     * @returns {Object}
+     */
+    buildChildOutcomeDetails(outcome) {
+        const details = {childOutcome: outcome};
+
+        for (const [key, value] of Object.entries(outcome)) {
+            details[key === 'reason' ? 'childReason' : key] = value;
+        }
+
+        return details;
+    }
+
+    /**
+     * Classifies successful child exits whose structured outcome is actually a deferred/no-op.
+     * @param {String} taskName Task key.
+     * @param {Object|null} outcome Parsed child stdout JSON.
+     * @returns {Object}
+     */
+    classifySuccessfulChildOutcome(taskName, outcome) {
+        if (taskName !== 'memory-summary-backfill' || !outcome) {
+            return {status: 'completed'};
+        }
+
+        if (outcome.deferred === true && outcome.reason) {
+            return {status: 'skipped', reasonCode: outcome.reason};
+        }
+
+        const processed      = Number(outcome.processed || 0);
+        const updated        = Number(outcome.updated || 0);
+        const deferred       = Number(outcome.deferred || 0);
+        const missingContent = Number(outcome.missingContent || 0);
+
+        if (processed > 0 && updated === 0 && missingContent === 0 && deferred > 0) {
+            return {status: 'skipped', reasonCode: 'all-deferred'};
+        }
+
+        return {status: 'completed'};
     }
 
     /**

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -182,14 +182,15 @@ export function buildTaskDefinitions({
             expectedCommand: 'summarize-sessions.mjs'
         },
         'memory-summary-backfill': {
-            label          : 'memory miniSummary backfill',
-            command        : nodeBin,
-            args           : [path.join(scriptDir, 'lifecycle', 'backfill-memory-summaries.mjs')],
-            pidFileName    : 'memory-summary-backfill.pid',
-            expectedCommand: 'backfill-memory-summaries.mjs',
+            label            : 'memory miniSummary backfill',
+            command          : nodeBin,
+            args             : [path.join(scriptDir, 'lifecycle', 'backfill-memory-summaries.mjs')],
+            pidFileName      : 'memory-summary-backfill.pid',
+            expectedCommand  : 'backfill-memory-summaries.mjs',
+            captureStdoutJson: true,
             // Watchdog backstop: a healthy 50-item backfill finishes in minutes. 15min bounds a
             // hang the per-call timeouts miss so one wedged child can't starve the maintenance loop.
-            maxRuntimeMs   : 900000
+            maxRuntimeMs     : 900000
         },
         kbSync: {
             label          : 'knowledge base sync',

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -9,28 +9,38 @@ function createTestService() {
     const dataDir = `/tmp/process-supervisor-service-test-${Date.now()}-${Math.random()}`;
     fs.ensureDirSync(dataDir);
     const logEntries = [];
+    const stateCalls = [];
     const taskOutcomes = [];
 
     const taskDefinitions = {
         mockTask: {
-            label: 'Mock Task',
-            command: 'echo',
-            args: ['hello'],
-            pidFileName: 'mockTask.pid',
+            label          : 'Mock Task',
+            command        : 'echo',
+            args           : ['hello'],
+            pidFileName    : 'mockTask.pid',
             expectedCommand: 'echo'
+        },
+        'memory-summary-backfill': {
+            label            : 'memory miniSummary backfill',
+            command          : 'node',
+            args             : ['backfill-memory-summaries.mjs'],
+            pidFileName      : 'memory-summary-backfill.pid',
+            expectedCommand  : 'backfill-memory-summaries.mjs',
+            captureStdoutJson: true
         }
     };
 
     const mockTaskStateService = {
-        getTaskState: (name) => ({ running: false, pid: null }),
-        markStarted: () => {},
+        getTaskState   : (name) => ({ running: false, pid: null }),
+        markStarted    : () => {},
         markSpawnFailed: () => {},
-        markSpawned: () => {},
-        markFailed: () => {},
-        markCompleted: () => {},
-        markReady: () => {},
-        clearRecovered: () => true,
-        adoptRunning: () => {}
+        markSpawned    : () => {},
+        markFailed     : () => {},
+        markCompleted  : taskName => stateCalls.push({action: 'completed', taskName}),
+        markSkipped    : taskName => stateCalls.push({action: 'skipped', taskName}),
+        markReady      : () => {},
+        clearRecovered : () => true,
+        adoptRunning   : () => {}
     };
 
     const mockHealthService = {
@@ -47,7 +57,37 @@ function createTestService() {
         processCommand: (pid) => 'echo hello'
     });
 
-    return { service, dataDir, logEntries, mockTaskStateService, taskOutcomes };
+    return { service, dataDir, logEntries, mockTaskStateService, stateCalls, taskOutcomes };
+}
+
+function createManualChild() {
+    let closeHandler;
+    let stdoutHandler;
+
+    return {
+        child: {
+            pid   : 9999,
+            stderr: {on: () => {}},
+            stdout: {
+                on(eventName, handler) {
+                    if (eventName === 'data') {
+                        stdoutHandler = handler;
+                    }
+                }
+            },
+            on(eventName, handler) {
+                if (eventName === 'close') {
+                    closeHandler = handler;
+                }
+            }
+        },
+        close(code = 0) {
+            closeHandler?.(code);
+        },
+        writeStdout(payload) {
+            stdoutHandler?.(Buffer.from(payload));
+        }
+    };
 }
 
 test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
@@ -171,6 +211,123 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         const stderrLogs = logEntries.filter(entry => entry.message.includes('stderr:'));
 
         expect(stderrLogs.map(entry => entry.level)).toEqual(['INFO', 'INFO', 'WARN', 'ERROR', 'ERROR']);
+    });
+
+    test('#13777: opted-in stdout JSON is recorded on successful child completion', () => {
+        const { service, stateCalls, taskOutcomes } = createTestService();
+        const manualChild = createManualChild();
+
+        service.taskDefinitions.mockTask.captureStdoutJson = true;
+        service.spawnFn = (command, args, options) => {
+            expect(options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+            return manualChild.child;
+        };
+
+        expect(service.runTask('mockTask', 'test-reason')).toBe(true);
+        manualChild.writeStdout(JSON.stringify({
+            success       : true,
+            processed     : 8,
+            updated       : 2,
+            deferred      : 6,
+            missingContent: 0,
+            runBudgetHit  : false
+        }));
+        manualChild.close(0);
+
+        expect(stateCalls).toContainEqual({action: 'completed', taskName: 'mockTask'});
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status  : 'completed',
+            taskName: 'mockTask',
+            details : expect.objectContaining({
+                processed     : 8,
+                updated       : 2,
+                deferred      : 6,
+                missingContent: 0,
+                runBudgetHit  : false
+            })
+        }));
+    });
+
+    test('#13777: memory-summary-backfill all-deferred stdout marks skipped, not completed', () => {
+        const { service, stateCalls, taskOutcomes } = createTestService();
+        const manualChild = createManualChild();
+        let successHooks = 0;
+
+        service.spawnFn = () => manualChild.child;
+
+        expect(service.runTask('memory-summary-backfill', 'pending-memory-minisummary:6', () => { successHooks++; })).toBe(true);
+        manualChild.writeStdout(JSON.stringify({
+            success       : true,
+            processed     : 6,
+            updated       : 0,
+            deferred      : 6,
+            missingContent: 0,
+            runBudgetHit  : false
+        }));
+        manualChild.close(0);
+
+        expect(successHooks).toBe(1);
+        expect(stateCalls).toContainEqual({action: 'skipped', taskName: 'memory-summary-backfill'});
+        expect(stateCalls).not.toContainEqual({action: 'completed', taskName: 'memory-summary-backfill'});
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status  : 'skipped',
+            taskName: 'memory-summary-backfill',
+            details : expect.objectContaining({
+                reasonCode    : 'all-deferred',
+                processed     : 6,
+                updated       : 0,
+                deferred      : 6,
+                missingContent: 0
+            })
+        }));
+    });
+
+    test('#13777: memory-summary-backfill lease-held stdout marks skipped with child reason', () => {
+        const { service, stateCalls, taskOutcomes } = createTestService();
+        const manualChild = createManualChild();
+
+        service.spawnFn = () => manualChild.child;
+
+        expect(service.runTask('memory-summary-backfill', 'pending-memory-minisummary:50')).toBe(true);
+        manualChild.writeStdout(JSON.stringify({
+            success : true,
+            deferred: true,
+            reason  : 'heavy-maintenance-lease-held',
+            holder  : {owner: 'summary'}
+        }));
+        manualChild.close(0);
+
+        expect(stateCalls).toContainEqual({action: 'skipped', taskName: 'memory-summary-backfill'});
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status  : 'skipped',
+            taskName: 'memory-summary-backfill',
+            details : expect.objectContaining({
+                reasonCode : 'heavy-maintenance-lease-held',
+                childReason: 'heavy-maintenance-lease-held',
+                deferred   : true
+            })
+        }));
+    });
+
+    test('#13777: malformed opted-in stdout fails soft and preserves success classification', () => {
+        const { service, stateCalls, taskOutcomes } = createTestService();
+        const manualChild = createManualChild();
+
+        service.taskDefinitions.mockTask.captureStdoutJson = true;
+        service.spawnFn = () => manualChild.child;
+
+        expect(service.runTask('mockTask', 'test-reason')).toBe(true);
+        manualChild.writeStdout('{not-json');
+        manualChild.close(0);
+
+        expect(stateCalls).toContainEqual({action: 'completed', taskName: 'mockTask'});
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status : 'completed',
+            details: expect.objectContaining({
+                stdoutJsonParseError: expect.any(String),
+                stdoutJsonBytes     : 9
+            })
+        }));
     });
 
     test('runTask dedupes repeated already-running skip logs', () => {


### PR DESCRIPTION
Resolves #13777
Related: #13755
Related: #13624

Propagates the existing miniSummary backfill child outcome into the orchestrator supervisor instead of treating every exit-0 child as a completed maintenance run. The supervisor now captures bounded stdout JSON for opted-in tasks, records all-deferred and lease-held `memory-summary-backfill` children as `skipped`, preserves the no-progress success hook, and keeps malformed stdout fail-soft.

Evidence: L2 (unit-level ProcessSupervisor child stdout/state classification plus static/syntax/pre-commit hooks) -> L2 required (close-target asks for supervisor outcome propagation and regression coverage). No residuals.

## Deltas from ticket
- Kept stdout capture opt-in through `captureStdoutJson`; only `memory-summary-backfill` enables it.
- Malformed captured stdout records byte count and parse error, not content preview.

## Test Evidence
- `git diff --check`
- `node --check ai/daemons/orchestrator/services/ProcessSupervisorService.mjs`
- `node --check ai/daemons/orchestrator/taskDefinitions.mjs`
- `node ./buildScripts/util/check-block-alignment.mjs --staged`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs` (27 passed)
- Pre-commit hooks passed on `ad5bf0dd0c`: whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, block alignment.

## Post-Merge Validation
- [ ] After the branch is deployed/restarted, confirm a lease-held or all-deferred miniSummary backfill writes `skipped` task health and does not refresh `lastSuccessAt`.

## Commits
- `ad5bf0dd0c` - propagate miniSummary child outcomes.

Authored by Euclid (GPT-5, Codex Desktop). Session 69f79662-2fbe-403a-a124-78bca1abdb16.