### PR TITLE
feat(ai): heavy-lease cooperative-yield primitive (shouldYieldHeavyMaintenanceLease)

### DIFF
--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -92,6 +92,54 @@ export function isLeaseStale(lease, {now = new Date(), isPidAlive: isPidAliveFn 
 }
 
 /**
+ * @summary Decides whether a live, long-running heavy-maintenance task should cooperatively yield its lease.
+ *
+ * Distinct from {@link isLeaseStale}, which governs dead-holder reclamation via
+ * `staleAfterMs`: this governs the ACTIVE hold of a *live* task. A long task
+ * (e.g. a multi-session summary that loops the whole pending backlog in one
+ * hold) polls this between work units; when it returns `true` the task returns
+ * early, releasing the single heavy-maintenance lease so an overdue peer (e.g.
+ * `dream`, whose window would otherwise arrive hours late) can interleave. The
+ * next periodic sweep re-acquires for the remaining work. The mutex stays
+ * correct — this only bounds how long one task may monopolize it.
+ *
+ * Pure + read-only: never mutates the lease or touches the release path. The
+ * value of `maxActiveHoldMs` is policy (the fairness Decision Record),
+ * supplied by the calling task — this helper is the value-agnostic mechanism.
+ *
+ * Fail-safe: a falsy/non-positive `maxActiveHoldMs` (the unset knob) returns
+ * `false`, so behavior is byte-identical to today until a caller opts in; a
+ * missing lease or unparseable timestamp also returns `false` — never abandon
+ * work on bad input.
+ *
+ * @param {Object|null} lease Persisted lease payload (reads `acquiredAt`).
+ * @param {Object} [options]
+ * @param {Date|Number|String} [options.now=new Date()] Current time.
+ * @param {Number} [options.maxActiveHoldMs] Bounded active-hold budget in ms; falsy ⇒ never yields (back-compat).
+ * @returns {Boolean} `true` only when the active hold has exceeded `maxActiveHoldMs`.
+ */
+export function shouldYieldHeavyMaintenanceLease(lease, {now = new Date(), maxActiveHoldMs} = {}) {
+    if (!lease || !lease.acquiredAt) {
+        return false;
+    }
+
+    const maxHoldMs = Number(maxActiveHoldMs);
+
+    if (!Number.isFinite(maxHoldMs) || maxHoldMs <= 0) {
+        return false;
+    }
+
+    const acquiredAtMs = toTimestamp(lease.acquiredAt);
+    const nowMs        = toTimestamp(now);
+
+    if (!Number.isFinite(acquiredAtMs) || !Number.isFinite(nowMs)) {
+        return false;
+    }
+
+    return nowMs - acquiredAtMs > maxHoldMs;
+}
+
+/**
  * @summary Builds the durable diagnostic payload for a heavy-maintenance lease.
  *
  * @param {Object} options

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -13,6 +13,7 @@ import {
     isLeaseStale,
     releaseHeavyMaintenanceLease,
     releaseHeavyMaintenanceLeaseSync,
+    shouldYieldHeavyMaintenanceLease,
     withHeavyMaintenanceLease
 } from '../../../../../../../ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
 
@@ -69,6 +70,39 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
                 token: 'owner-token'
             }
         });
+    });
+
+    test('shouldYieldHeavyMaintenanceLease bounds the active hold (#13780)', () => {
+        const
+            acquiredAt      = '2026-05-16T20:00:00.000Z',
+            lease           = {owner: 'summary', acquiredAt},
+            maxActiveHoldMs = 5 * 60 * 1000; // 5 min
+
+        // active hold exceeds the budget → yield so an overdue peer can interleave
+        expect(shouldYieldHeavyMaintenanceLease(lease, {
+            now: new Date('2026-05-16T20:06:00.000Z'), maxActiveHoldMs
+        })).toBe(true);
+
+        // still within the budget → keep holding
+        expect(shouldYieldHeavyMaintenanceLease(lease, {
+            now: new Date('2026-05-16T20:03:00.000Z'), maxActiveHoldMs
+        })).toBe(false);
+
+        // exactly at the boundary → keep holding (strictly-greater contract)
+        expect(shouldYieldHeavyMaintenanceLease(lease, {
+            now: new Date('2026-05-16T20:05:00.000Z'), maxActiveHoldMs
+        })).toBe(false);
+
+        // unset / non-positive knob → never yields (byte-identical to today)
+        expect(shouldYieldHeavyMaintenanceLease(lease, {now: new Date('2026-05-16T23:00:00.000Z')})).toBe(false);
+        expect(shouldYieldHeavyMaintenanceLease(lease, {now: new Date('2026-05-16T23:00:00.000Z'), maxActiveHoldMs: 0})).toBe(false);
+
+        // fail-safe: missing lease / missing acquiredAt / unparseable timestamp → do not abandon work
+        expect(shouldYieldHeavyMaintenanceLease(null, {maxActiveHoldMs})).toBe(false);
+        expect(shouldYieldHeavyMaintenanceLease({owner: 'summary'}, {maxActiveHoldMs})).toBe(false);
+        expect(shouldYieldHeavyMaintenanceLease({acquiredAt: 'not-a-date'}, {
+            now: new Date('2026-05-16T23:00:00.000Z'), maxActiveHoldMs
+        })).toBe(false);
     });
 
     test('process liveness detects invalid owner pids', () => {


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13780. The **lease-domain half** of the #13624 fairness divide-and-conquer (@neo-opus-vega's convergence on @neo-opus-grace's root-cause): @neo-opus-ada drives the SummaryService chunked-yield + the picker window; @neo-opus-vega the fairness Decision Record; this PR lands the value-agnostic lease primitive both build on.

## Summary
Root-cause (converged + calibrated by @neo-opus-vega + @tobiu): the long `summary` task holds the single heavy-maintenance lease for its whole backlog run (`SummaryService` loops all pending sessions in one hold via the 31B model), so an overdue `dream` (→ `golden-path`) gets its window LONG/late behind it. Not *never*-starved — a fairness/latency defect.

`withHeavyMaintenanceLease` holds the lease for the entire `task()` duration; there was no way for a long task to **cooperatively yield** mid-run. This adds the pure predicate a long task polls to decide to release-and-requeue, so an overdue peer can interleave.

## Deltas
- `shouldYieldHeavyMaintenanceLease(lease, {now, maxActiveHoldMs})` (new exported helper) — returns `true` only when the ACTIVE hold (`now - acquiredAt`) exceeds the caller-supplied `maxActiveHoldMs`. The active-hold twin of `isLeaseStale` (which governs *dead*-holder reclamation via `staleAfterMs`).
- Pure + read-only — never mutates the lease or touches the mutex/release path.
- Fail-safe: a falsy/non-positive knob (unset) or a missing-lease / unparseable-timestamp returns `false` → byte-identical to today until a caller opts in.

## Guardrails
- **Value-agnostic** — the `maxActiveHoldMs` *value* is policy (Vega's Decision Record), supplied by the caller; this PR is the mechanism only, so it cannot pre-empt the fairness contract.
- **Cloud-tenant-safe** — no single-host assumption; bounds monopolization uniformly across all heavy tasks, so it holds on a tenant deployment too.
- **Back-compat** — no caller opts in within this PR, so runtime behavior is unchanged; the integration (Ada) flips it on.

## Test Evidence
Evidence: L2 (unit — the pure predicate is fully unit-covered) → L2 required (the AC is predicate/task-state logic, unit-coverable; no unreachable-runtime AC). Residual: none in this PR — the runtime wiring lands with Ada's `summarize-sessions.mjs` integration.

**L2** — 19/19 `HeavyMaintenanceLeaseService` specs green (`UNIT_TEST_MODE=true npx playwright test … -c test/playwright/playwright.config.mjs`), including 1 new covering all six cases: exceeds / within / exact-boundary (strictly-greater contract) / unset-knob / non-positive-knob / fail-safe (null lease, missing `acquiredAt`, unparseable timestamp). The 18 existing specs are unchanged. Block-alignment clean.

## Premise Coherence
**Coheres:** adds the missing cooperative-yield mechanism on the merged lease service, value-agnostic so it composes with the in-flight #13624 integration (Ada) + Decision Record (Vega) without collision. No mutex change, no policy baked in.

## Post-Merge Validation
- [ ] (Ada, #13624) SummaryService polls `shouldYieldHeavyMaintenanceLease` between session batches → releases → re-acquires; the overdue dream interleaves.
- [ ] (Vega, #13624) the Decision Record sets `maxActiveHoldMs` + the fairness contract (bounded-hold / fair-rotation / no-silent-monopoly).
- [ ] (GPT, proof) the live dream drains the backlog + golden-path surfaces 13k items.
