### PR TITLE
feat(ai): decouple golden-path from dream — hourly freshness, not gated behind the heavy digest (#13782)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -180,7 +180,12 @@ export const TASK_REGISTRY = Object.freeze([
         executionKind   : 'in-process-async',
         maintenanceClass: 'graph-dependent',
         backpressure    : 'after-heavy',
-        dependencies    : ['dream'],
+        // Decoupled from `dream`: golden-path synthesis is cheap (rank + summarize the CURRENT
+        // graph) and must run hourly for FRESHNESS — it must NOT block behind the heavy daily REM
+        // digest (which can run hours, off-peak). A re-rank of the current graph is "not perfect,
+        // but better than empty/stale" — the fix for the multi-day stale forecast.
+        // `backpressure: 'after-heavy'` still yields briefly post-heavy-task.
+        dependencies    : [],
         getDueTask({state, now, intervals, hooks}) {
             return (hooks.goldenPathGetDueTask || getGoldenPathDueTask)({
                 state               : state['golden-path'] ?? {},

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -44,13 +44,19 @@ export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
 export const DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS = Object.freeze([]);
 
 /**
- * Tasks whose graph writes must complete before Golden Path frontier refresh runs.
+ * Tasks whose graph writes must complete before a Golden Path frontier refresh runs.
+ *
+ * Empty by default: Golden Path is intentionally decoupled from `dream`. The hourly re-rank
+ * reads the CURRENT graph directly (not the dream digest — verified via the synthesizer-coupling
+ * check), so it must not block behind the multi-hour REM digest — that coupling froze the
+ * forecast for days. Accepted trade-off: a refresh racing an in-progress digest may not yet
+ * reflect it (bounded staleness, "better than empty/stale"; the next hourly run picks it up).
+ * Stays a reactive config leaf (`goldenPathDependencyTaskNames`), so a deployment can
+ * re-introduce a write-completion dependency if a specific store needs it.
  *
  * @type {ReadonlyArray<String>}
  */
-export const DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES = Object.freeze([
-    'dream'
-]);
+export const DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES = Object.freeze([]);
 
 // ============================================================================
 // Group 1 — Read-only predicates / finders (pure functions, no side effects)

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -411,8 +411,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(started).toEqual([]);
     });
 
-    test('defers golden path behind active dream graph mutation with explicit reason', () => {
-        const logs     = [];
+    test('refreshes golden path while dream graph mutation is active — decoupled for hourly freshness', async () => {
         const outcomes = [];
         const calls    = [];
 
@@ -432,24 +431,17 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         });
 
         TaskStateService.taskState['dream'].running = true;
-        orchestrator.writeLog = (level, message) => logs.push({level, message});
 
         orchestrator.poll();
+        await Promise.resolve();
 
-        expect(calls).toEqual([]);
-        expect(outcomes).toContainEqual({
+        // Decoupled: golden-path is NOT deferred behind the heavy, multi-hour dream digest — it runs
+        // on its hourly cadence against the current graph so the forecast stays fresh (stale-forecast fix).
+        expect(calls).toEqual(['golden-path']);
+        expect(outcomes).not.toContainEqual(expect.objectContaining({
             taskName: 'golden-path',
-            status  : 'skipped',
-            details : expect.objectContaining({
-                blockingTaskName: 'dream',
-                reason          : 'periodic-golden-path:600000',
-                reasonCode      : 'golden-path-dependency-backpressure'
-            })
-        });
-        expect(logs).toContainEqual({
-            level  : 'INFO',
-            message: expect.stringContaining('Deferring golden path synthesis; dependency task REM sleep graph extraction is active')
-        });
+            status  : 'skipped'
+        }));
     });
 
     test('allows golden path refresh while non-dream heavy maintenance is active', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -63,6 +63,16 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
         expect(names).toContain('tenant-repo-sync');
     });
 
+    test('golden-path is decoupled from dream — runs hourly for freshness, not gated behind the heavy digest', () => {
+        const goldenPath = TASK_REGISTRY.find(d => d.taskName === 'golden-path');
+        expect(goldenPath, 'golden-path is registered').toBeTruthy();
+        // Decoupled: the cheap hourly re-rank must NOT hard-depend on the heavy daily REM digest,
+        // so the picker never drops golden-path while dream is running (the stale-forecast fix).
+        expect(goldenPath.dependencies).not.toContain('dream');
+        // dream stays registered — the decouple removes the dependency edge, not the task.
+        expect(TASK_REGISTRY.find(d => d.taskName === 'dream')).toBeTruthy();
+    });
+
     test('heavy task descriptors match MaintenanceBackpressureService SSOT (#11900)', () => {
         const descriptorByName = new Map(TASK_REGISTRY.map(descriptor => [descriptor.taskName, descriptor]));
         for (const taskName of DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES) {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -54,6 +54,11 @@ function buildService(overrides = {}) {
 // embedding — so the mechanism is exercised here with an explicit pair rather than the live default.
 const COMPATIBLE_PAIRS_FIXTURE = [['kbSync', 'memory-summary-backfill']];
 
+// Explicit fixture for the golden-path dependency-gate MECHANISM tests. DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
+// is now empty — Golden Path is decoupled from `dream` so the hourly re-rank is not frozen behind the
+// multi-hour REM digest — so the gate mechanism is exercised here with an explicit dependency, not the default.
+const GOLDEN_PATH_DEPS_FIXTURE = Object.freeze(['dream']);
+
 test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureService', () => {
 
     // ====================================================================
@@ -76,8 +81,11 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES).not.toContain('golden-path');
     });
 
-    test('DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES pins the dependency set', () => {
-        expect([...DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES]).toEqual(['dream']);
+    test('DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES is EMPTY — Golden Path decoupled from dream for hourly freshness', () => {
+        // Golden Path reads the CURRENT graph (not the dream digest), so it must not block behind the
+        // multi-hour REM digest — that coupling froze the forecast for days. The gate stays a reactive
+        // config leaf so a deployment can re-introduce a write-completion dependency if a store needs it.
+        expect([...DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES]).toEqual([]);
         expect(Object.isFrozen(DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES)).toBe(true);
     });
 
@@ -107,11 +115,11 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
     test('isGoldenPathDependencyTask returns membership in dependency set', () => {
         expect(isGoldenPathDependencyTask({
             taskName                     : 'dream',
-            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
+            goldenPathDependencyTaskNames: GOLDEN_PATH_DEPS_FIXTURE
         })).toBe(true);
         expect(isGoldenPathDependencyTask({
             taskName                     : 'summary',
-            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
+            goldenPathDependencyTaskNames: GOLDEN_PATH_DEPS_FIXTURE
         })).toBe(false);
     });
 
@@ -182,21 +190,21 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         // activeTaskName is a dependency → returned without consulting state
         expect(getActiveGoldenPathDependencyTask({
-            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+            goldenPathDependencyTaskNames: GOLDEN_PATH_DEPS_FIXTURE,
             taskStateService,
             activeTaskName               : 'dream'
         })).toBe('dream');
 
         // activeTaskName is NOT a dependency → fall back to state scan
         expect(getActiveGoldenPathDependencyTask({
-            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+            goldenPathDependencyTaskNames: GOLDEN_PATH_DEPS_FIXTURE,
             taskStateService             : buildTaskStateService({['dream']: {running: true}}),
             activeTaskName               : 'summary'
         })).toBe('dream');
 
         // No dependency running, no active dependency → null
         expect(getActiveGoldenPathDependencyTask({
-            goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
+            goldenPathDependencyTaskNames: GOLDEN_PATH_DEPS_FIXTURE,
             taskStateService             : buildTaskStateService({})
         })).toBeNull();
     });
@@ -595,8 +603,9 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
     test('executeWithGoldenPathDependencyGate defers when dependency task is running', () => {
         const outcomeCalls = [];
         const service      = buildService({
-            taskStateService: buildTaskStateService({['dream']: {running: true}}),
-            healthService   : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})}
+            goldenPathDependencyTaskNames: GOLDEN_PATH_DEPS_FIXTURE,
+            taskStateService             : buildTaskStateService({['dream']: {running: true}}),
+            healthService                : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})}
         });
 
         const result = service.executeWithGoldenPathDependencyGate({


### PR DESCRIPTION
Resolves #13782

Fully decouples `golden-path` synthesis from the `dream` digest — the **team-converged root fix** for the multi-day stale Golden Path forecast (#13750). Golden Path runs on its hourly cadence against the current graph instead of freezing for days behind the heavy daily REM digest.

**Two coupling surfaces** (both removed — gpt's pre-review caught that the first alone was inert):
1. **Scheduling gate** — registry `golden-path.dependencies: ['dream'] → []`, so the picker's `filterUnmetDependencies` no longer drops golden-path while dream runs.
2. **Execution gate** — `MaintenanceBackpressureService.DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES: ['dream'] → []`, so `executeWithGoldenPathDependencyGate()` (which `pipeline.mjs` routes golden-path through) no longer returns `false` while dream is the active heavy task. This was the dominant gate — without it, the registry edit was a no-op.

**Why safe** (V-B-A'd, not assumed): grace verified the `GoldenPathSynthesizer` reads the CURRENT graph, not the dream digest — so golden-path has no functional dependency on a completed digest. The dream digests the full Native Edge Graph (measured: **122,215 nodes / 101,040 edges / 805,017 GraphLog rows**) → intrinsically multi-hour → gating golden-path behind it froze the forecast. The accepted trade-off: a refresh racing an in-progress digest may not yet reflect it — **bounded staleness**, the operator's explicit "better than empty/stale"; the next hourly run picks it up. The execution gate stays a **reactive config leaf** (`goldenPathDependencyTaskNames`), so a deployment can re-introduce a write-completion dependency if a specific store needs it.

Evidence: L2 (unit) below; the runtime freshness effect is L3 (observable post-restart) → Post-Merge Validation.

## Test Evidence

- `registry.spec.mjs` — golden-path no longer hard-depends on `dream`; `dream` stays a registered task.
- `MaintenanceBackpressureService.spec.mjs` — pin-test asserts the **empty** default (decoupled); the gate-mechanism tests (`isGoldenPathDependencyTask`, `getActiveGoldenPathDependencyTask`, `executeWithGoldenPathDependencyGate defers…`) now use an explicit `GOLDEN_PATH_DEPS_FIXTURE`, matching the existing `COMPATIBLE_PAIRS_FIXTURE` precedent (default went empty for the same reason). The mechanism is still fully covered.
- `Orchestrator.spec.mjs` — the integration test flips from *"defers golden path behind active dream"* to *"refreshes golden path while dream graph mutation is active"* (asserts golden-path runs, is not skipped).

CI runs the unit config (authoritative); the cross-clone constraint means I didn't run the orchestrator from this clone.

## Post-Merge Validation

After merge + an orchestrator restart: `golden-path` fires hourly (`periodic-golden-path`) and is **neither dropped by the picker nor deferred by the execution gate** while `dream` is active → the `sandman_handoff` forecast regenerates within the hour against the current graph, surfacing current #13k-range tickets instead of the 18-day-stale forecast. Watch `get_rem_pipeline_state` + the heavy-maintenance-lease log: golden-path fires on cadence independent of dream's running state, with no `golden-path-dependency-backpressure` deferrals.

## Deltas

- `ai/daemons/orchestrator/scheduling/registry.mjs` — golden-path `dependencies: ['dream'] → []` + WHY-comment.
- `ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs` — `DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES: ['dream'] → []` + rationale JSDoc.
- `test/.../scheduling/registry.spec.mjs`, `test/.../services/MaintenanceBackpressureService.spec.mjs`, `test/.../Orchestrator.spec.mjs` — the decouple assertions above.

## Scope note (honest close-target)

#13782's title bundled "dream → off-peak cadence." That half is **descoped to a follow-on** and not in this PR: post-convergence (gpt + grace), the **decouple is the root fix** for the freshness; the off-peak cadence is a complementary optimization being re-evaluated against grace's #13781 lease-yield (it may be unnecessary if the decouple + lease-yield suffice). The cadence primitive is preserved (stashed) and will be filed as its own ticket only if the team confirms it's needed — rather than handwave a partial resolve here.

Authored by @neo-opus-vega (Vega), origin session d41446ed-b9c7-4d51-a933-048b3d196665.
