### PR TITLE
fix(orchestrator): propagate kbSync child outcomes — lease-held deferrals record skipped, not false-green completed

### DIFF
--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -1,6 +1,6 @@
-import Base from '../../../../src/core/Base.mjs';
-import fs from 'fs-extra';
-import path from 'path';
+import Base       from '../../../../src/core/Base.mjs';
+import fs         from 'fs-extra';
+import path       from 'path';
 import {execSync} from 'child_process';
 
 const DEFAULT_STDOUT_JSON_MAX_BYTES = 65536;
@@ -470,7 +470,7 @@ export class ProcessSupervisorService extends Base {
             reason,
             child,
             clear,
-            isCleared: () => cleared,
+            isCleared         : () => cleared,
             onReadinessOutcome: status => { readinessOutcome = status; }
         })?.finally(() => {
             readinessPending = false;
@@ -613,21 +613,27 @@ export class ProcessSupervisorService extends Base {
      * @returns {Object}
      */
     classifySuccessfulChildOutcome(taskName, outcome) {
-        if (taskName !== 'memory-summary-backfill' || !outcome) {
+        if (!outcome || (taskName !== 'memory-summary-backfill' && taskName !== 'kbSync')) {
             return {status: 'completed'};
         }
 
+        // Generic deferred envelope: a child that exited 0 without doing work (lease-held /
+        // no-op) emits `{deferred: true, reason}`. Both kbSync (lease-held → no embedding) and
+        // the summary backfill use it — the false-green case that must NOT refresh lastSuccessAt.
         if (outcome.deferred === true && outcome.reason) {
             return {status: 'skipped', reasonCode: outcome.reason};
         }
 
-        const processed      = Number(outcome.processed || 0);
-        const updated        = Number(outcome.updated || 0);
-        const deferred       = Number(outcome.deferred || 0);
-        const missingContent = Number(outcome.missingContent || 0);
+        // Summary-specific: an all-deferred no-progress run (rows attempted, none updated).
+        if (taskName === 'memory-summary-backfill') {
+            const processed      = Number(outcome.processed || 0);
+            const updated        = Number(outcome.updated || 0);
+            const deferred       = Number(outcome.deferred || 0);
+            const missingContent = Number(outcome.missingContent || 0);
 
-        if (processed > 0 && updated === 0 && missingContent === 0 && deferred > 0) {
-            return {status: 'skipped', reasonCode: 'all-deferred'};
+            if (processed > 0 && updated === 0 && missingContent === 0 && deferred > 0) {
+                return {status: 'skipped', reasonCode: 'all-deferred'};
+            }
         }
 
         return {status: 'completed'};

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -193,11 +193,12 @@ export function buildTaskDefinitions({
             maxRuntimeMs     : 900000
         },
         kbSync: {
-            label          : 'knowledge base sync',
-            command        : nodeBin,
-            args           : [path.join(scriptDir, 'maintenance', 'syncKnowledgeBase.mjs')],
-            pidFileName    : 'kb-sync.pid',
-            expectedCommand: 'syncKnowledgeBase.mjs'
+            label            : 'knowledge base sync',
+            command          : nodeBin,
+            args             : [path.join(scriptDir, 'maintenance', 'syncKnowledgeBase.mjs')],
+            pidFileName      : 'kb-sync.pid',
+            expectedCommand  : 'syncKnowledgeBase.mjs',
+            captureStdoutJson: true
         },
         githubWorkflowSync: {
             label          : 'github workflow sync',

--- a/ai/scripts/maintenance/syncKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/syncKnowledgeBase.mjs
@@ -1,28 +1,33 @@
 // Neo namespace bootstrap (entry-point invariant) — orchestrator spawn-child.
 // `InstanceManager` binds Neo.find/findFirst/get aliases + consumes pre-singleton
 // `Neo.idMap`; required for any consumer of the Neo singleton API.
-import Neo                          from '../../../src/Neo.mjs';
-import * as core                    from '../../../src/core/_export.mjs';
-import InstanceManager              from '../../../src/manager/Instance.mjs';
-import KB_Config                    from '../../mcp/server/knowledge-base/config.mjs';
-import KB_DatabaseService           from '../../services/knowledge-base/DatabaseService.mjs';
-import KB_ChromaManager             from '../../services/knowledge-base/ChromaManager.mjs';
-import KB_LifecycleService          from '../../services/knowledge-base/DatabaseLifecycleService.mjs';
-import {withHeavyMaintenanceLease}  from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
+import Neo                         from '../../../src/Neo.mjs';
+import * as core                   from '../../../src/core/_export.mjs';
+import InstanceManager             from '../../../src/manager/Instance.mjs';
+import KB_Config                   from '../../mcp/server/knowledge-base/config.mjs';
+import KB_DatabaseService          from '../../services/knowledge-base/DatabaseService.mjs';
+import KB_ChromaManager            from '../../services/knowledge-base/ChromaManager.mjs';
+import KB_LifecycleService         from '../../services/knowledge-base/DatabaseLifecycleService.mjs';
+import {withHeavyMaintenanceLease} from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
 
 /**
  * @module ai/scripts/maintenance/syncKnowledgeBase
+ *
+ * Progress/diagnostic logs go to STDERR; STDOUT carries exactly one structured outcome JSON
+ * the orchestrator's `ProcessSupervisorService` captures (`captureStdoutJson`). A lease-held
+ * deferral therefore records `skipped` (not a false-green `completed` that refreshes
+ * `lastSuccessAt`) — the kb-sync half of the deferred-as-completed fix.
  */
 
 async function syncKnowledgeBase() {
     // Enable debug logging to see progress. B4-safe activation: drive NEO_DEBUG via the Provider
     // override API, never mutate the read-only reactive Provider.
     KB_Config.setEnvOverride('NEO_DEBUG', true);
-    const staleStrategy   = process.env.NEO_KB_STALE_STRATEGY || undefined;
+    const staleStrategy = process.env.NEO_KB_STALE_STRATEGY || undefined;
 
-    console.log('⏳ Initializing Knowledge Base Services...');
+    console.error('⏳ Initializing Knowledge Base Services...');
     if (staleStrategy) {
-        console.log(`   Using explicit stale strategy: ${staleStrategy}`);
+        console.error(`   Using explicit stale strategy: ${staleStrategy}`);
     }
 
     // Run the full sync under the shared heavy-maintenance lease so this CLI cannot
@@ -32,19 +37,19 @@ async function syncKnowledgeBase() {
     try {
         outcome = await withHeavyMaintenanceLease(
             async () => {
-                console.log('   Waiting for Lifecycle Service...');
+                console.error('   Waiting for Lifecycle Service...');
                 await KB_LifecycleService.ready();
-                console.log('   Lifecycle Service Ready. Database should be running.');
+                console.error('   Lifecycle Service Ready. Database should be running.');
 
-                console.log('   Waiting for Chroma Manager...');
+                console.error('   Waiting for Chroma Manager...');
                 await KB_ChromaManager.ready();
-                console.log('   Chroma Manager Ready.');
+                console.error('   Chroma Manager Ready.');
 
-                console.log('   Waiting for Database Service...');
+                console.error('   Waiting for Database Service...');
                 await KB_DatabaseService.ready();
-                console.log('   Database Service Ready.');
+                console.error('   Database Service Ready.');
 
-                console.log('✅ Services Ready. Starting Synchronization...');
+                console.error('✅ Services Ready. Starting Synchronization...');
 
                 // Execute the full sync (create + embed). `NEO_KB_STALE_STRATEGY=shadow-swap`
                 // opts into the shadow-swap stale-data strategy; default CLI sync remains unchanged.
@@ -59,12 +64,21 @@ async function syncKnowledgeBase() {
 
     if (outcome.status === 'held') {
         const held = outcome.lease;
-        console.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
-        console.log('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
+        console.error(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
+        console.error('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
+        // Structured outcome → ProcessSupervisorService records `skipped` (not false-green
+        // `completed`), so a lease-held run does not refresh kbSync's lastSuccessAt.
+        console.log(JSON.stringify({
+            deferred: true,
+            reason  : 'heavy-maintenance-lease-held',
+            holder  : {owner: held.owner, reason: held.reason, pid: held.pid, acquiredAt: held.acquiredAt}
+        }));
         process.exit(0);
     }
 
-    console.log('✅ Synchronization Complete:', outcome.result);
+    console.error('✅ Synchronization Complete:', outcome.result);
+    // Real run → `completed` (falls through the classify) + the embed/delete counts as details.
+    console.log(JSON.stringify({deferred: false, ...(outcome.result || {})}));
     process.exit(0);
 }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -1,8 +1,8 @@
-import {test, expect} from '@playwright/test';
-import fs from 'fs-extra';
-import path from 'path';
-import Neo from '../../../../../../../src/Neo.mjs';
-import * as core from '../../../../../../../src/core/_export.mjs';
+import {test, expect}               from '@playwright/test';
+import fs                           from 'fs-extra';
+import path                         from 'path';
+import Neo                          from '../../../../../../../src/Neo.mjs';
+import * as core                    from '../../../../../../../src/core/_export.mjs';
 import { ProcessSupervisorService } from '../../../../../../../ai/daemons/orchestrator/services/ProcessSupervisorService.mjs';
 
 function createTestService() {
@@ -26,6 +26,14 @@ function createTestService() {
             args             : ['backfill-memory-summaries.mjs'],
             pidFileName      : 'memory-summary-backfill.pid',
             expectedCommand  : 'backfill-memory-summaries.mjs',
+            captureStdoutJson: true
+        },
+        kbSync: {
+            label            : 'knowledge base sync',
+            command          : 'node',
+            args             : ['syncKnowledgeBase.mjs'],
+            pidFileName      : 'kb-sync.pid',
+            expectedCommand  : 'syncKnowledgeBase.mjs',
             captureStdoutJson: true
         }
     };
@@ -51,10 +59,10 @@ function createTestService() {
         dataDir,
         taskDefinitions,
         taskStateService: mockTaskStateService,
-        healthService: mockHealthService,
-        writeLog: (level, message) => logEntries.push({level, message}),
-        spawnFn: () => ({ pid: 1234, on: () => {} }),
-        processCommand: (pid) => 'echo hello'
+        healthService   : mockHealthService,
+        writeLog        : (level, message) => logEntries.push({level, message}),
+        spawnFn         : () => ({ pid: 1234, on: () => {} }),
+        processCommand  : (pid) => 'echo hello'
     });
 
     return { service, dataDir, logEntries, mockTaskStateService, stateCalls, taskOutcomes };
@@ -327,6 +335,52 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
                 stdoutJsonParseError: expect.any(String),
                 stdoutJsonBytes     : 9
             })
+        }));
+    });
+
+    test('#13784: kbSync lease-held stdout records skipped, not false-green completed', () => {
+        const { service, stateCalls, taskOutcomes } = createTestService();
+        const manualChild = createManualChild();
+
+        service.spawnFn = () => manualChild.child;
+
+        expect(service.runTask('kbSync', 'periodic-sync:1800000')).toBe(true);
+        manualChild.writeStdout(JSON.stringify({
+            deferred: true,
+            reason  : 'heavy-maintenance-lease-held',
+            holder  : {owner: 'summary', reason: 'periodic-sweep', pid: 6988}
+        }));
+        manualChild.close(0);
+
+        expect(stateCalls).toContainEqual({action: 'skipped', taskName: 'kbSync'});
+        expect(stateCalls).not.toContainEqual({action: 'completed', taskName: 'kbSync'});
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status  : 'skipped',
+            taskName: 'kbSync',
+            details : expect.objectContaining({
+                reasonCode : 'heavy-maintenance-lease-held',
+                childReason: 'heavy-maintenance-lease-held',
+                deferred   : true
+            })
+        }));
+    });
+
+    test('#13784: kbSync real sync (deferred:false) records completed with embed counts', () => {
+        const { service, stateCalls, taskOutcomes } = createTestService();
+        const manualChild = createManualChild();
+
+        service.spawnFn = () => manualChild.child;
+
+        expect(service.runTask('kbSync', 'periodic-sync:1800000')).toBe(true);
+        manualChild.writeStdout(JSON.stringify({deferred: false, added: 2566, deleted: 1513}));
+        manualChild.close(0);
+
+        expect(stateCalls).toContainEqual({action: 'completed', taskName: 'kbSync'});
+        expect(stateCalls).not.toContainEqual({action: 'skipped', taskName: 'kbSync'});
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status  : 'completed',
+            taskName: 'kbSync',
+            details : expect.objectContaining({added: 2566, deleted: 1513})
         }));
     });
 


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13784. Sub of #13755 (heavy-lease deferred-as-completed epic); the kb-sync sibling of #13778 (miniSummary), closing GPT's #13755 epic-review topology gap (the kb-sync child-outcome should be an explicit native sub, not comment-only).

## Summary
`kbSync` spawns `syncKnowledgeBase.mjs`, which runs the sync under `withHeavyMaintenanceLease`. On a lease-held deferral the child exited 0 with only a human-readable `⏸️ Deferred` log — no structured JSON — so `ProcessSupervisorService` recorded a false-green `completed` and refreshed `lastSuccessAt` for a run that did NO embedding. That is the documented #13755 root: kb-sync deferred 502× with a multi-day embedding gap, every "completed successfully" line a deferral-masked-as-completion.

Same C.2 channel #13778 landed for `memory-summary-backfill` — but kbSync needed BOTH halves (miniSummary's child already emitted JSON; kbSync's did not).

## Deltas
- `syncKnowledgeBase.mjs` — routes progress logs to **stderr**; emits exactly one structured outcome JSON on **stdout**: `{deferred:true, reason:'heavy-maintenance-lease-held', holder}` on lease-held, `{deferred:false, ...result}` on a real run.
- `taskDefinitions.mjs` — `kbSync` opts into `captureStdoutJson: true`.
- `ProcessSupervisorService.classifySuccessfulChildOutcome` — admits `kbSync` through the **generic** deferred-envelope gate (`deferred:true && reason → skipped`); the summary-specific all-deferred count logic stays scoped to `memory-summary-backfill`.

## Guardrails
- **Back-compat:** non-opted tasks unchanged (the gate still defaults to `completed`); a real kbSync run (`deferred:false`) still records `completed` with the embed/delete counts.
- **Fail-soft:** malformed/oversized stdout falls back to `completed` per the #13778 bounded-capture contract — an oversized real sync is still correctly `completed`.

## Test Evidence
Evidence: L2 (unit — the classify + capture path fully unit-covered) → L2 required (the AC is task-state semantics, unit-coverable; the live re-embedding is post-merge observable). Residual: none in this PR.

**L2** — 29/29 `ProcessSupervisorService` specs green (`UNIT_TEST_MODE=true … -c test/playwright/playwright.config.mjs`), incl. 2 new: kbSync lease-held → `skipped` (with `not.toContainEqual({completed})`), kbSync real sync → `completed` with counts. `syncKnowledgeBase.mjs` syntax-checked; block-alignment clean.

## Premise Coherence
**Coheres:** extends the merged C.2 channel (#13778) to kbSync — the false-green observability #13755 needs. No new mechanism; the generic deferred-envelope gate already existed, kbSync just joins it + emits the envelope.

## Post-Merge Validation
- [ ] A live lease-held kbSync run records `skipped` (does not refresh `lastSuccessAt`); the freshness metric reflects real embedding, not deferred attempts.
- [ ] (sibling) PrimaryRepoSyncService — if it has the same surface, a follow-on sub.
