### PR TITLE
feat(ai): honest kb-sync telemetry — emit + classify deferred outcomes as skipped (#13784)

### DIFF
--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -613,21 +613,27 @@ export class ProcessSupervisorService extends Base {
      * @returns {Object}
      */
     classifySuccessfulChildOutcome(taskName, outcome) {
-        if (taskName !== 'memory-summary-backfill' || !outcome) {
+        if (!outcome) {
             return {status: 'completed'};
         }
 
+        // Generic deferred-outcome contract: any captureStdoutJson task that emits {deferred:true, reason}
+        // (kbSync / memory-summary-backfill held behind the heavy-maintenance lease) is a 'skipped' run,
+        // not a silent 'completed' — the honest-telemetry fix so a days-long embedding stall is not invisible.
         if (outcome.deferred === true && outcome.reason) {
             return {status: 'skipped', reasonCode: outcome.reason};
         }
 
-        const processed      = Number(outcome.processed || 0);
-        const updated        = Number(outcome.updated || 0);
-        const deferred       = Number(outcome.deferred || 0);
-        const missingContent = Number(outcome.missingContent || 0);
+        // memory-summary-backfill-specific: a batch that processed rows but updated none (all deferred).
+        if (taskName === 'memory-summary-backfill') {
+            const processed      = Number(outcome.processed || 0);
+            const updated        = Number(outcome.updated || 0);
+            const deferred       = Number(outcome.deferred || 0);
+            const missingContent = Number(outcome.missingContent || 0);
 
-        if (processed > 0 && updated === 0 && missingContent === 0 && deferred > 0) {
-            return {status: 'skipped', reasonCode: 'all-deferred'};
+            if (processed > 0 && updated === 0 && missingContent === 0 && deferred > 0) {
+                return {status: 'skipped', reasonCode: 'all-deferred'};
+            }
         }
 
         return {status: 'completed'};

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -193,11 +193,12 @@ export function buildTaskDefinitions({
             maxRuntimeMs     : 900000
         },
         kbSync: {
-            label          : 'knowledge base sync',
-            command        : nodeBin,
-            args           : [path.join(scriptDir, 'maintenance', 'syncKnowledgeBase.mjs')],
-            pidFileName    : 'kb-sync.pid',
-            expectedCommand: 'syncKnowledgeBase.mjs'
+            label            : 'knowledge base sync',
+            command          : nodeBin,
+            args             : [path.join(scriptDir, 'maintenance', 'syncKnowledgeBase.mjs')],
+            pidFileName      : 'kb-sync.pid',
+            expectedCommand  : 'syncKnowledgeBase.mjs',
+            captureStdoutJson: true
         },
         githubWorkflowSync: {
             label          : 'github workflow sync',

--- a/ai/scripts/maintenance/syncKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/syncKnowledgeBase.mjs
@@ -20,9 +20,11 @@ async function syncKnowledgeBase() {
     KB_Config.setEnvOverride('NEO_DEBUG', true);
     const staleStrategy   = process.env.NEO_KB_STALE_STRATEGY || undefined;
 
-    console.log('⏳ Initializing Knowledge Base Services...');
+    // Progress → stderr; stdout is reserved for the single JSON outcome line the orchestrator's
+    // captureStdoutJson channel parses (so a deferred/held run is classified 'skipped', not 'completed').
+    console.error('⏳ Initializing Knowledge Base Services...');
     if (staleStrategy) {
-        console.log(`   Using explicit stale strategy: ${staleStrategy}`);
+        console.error(`   Using explicit stale strategy: ${staleStrategy}`);
     }
 
     // Run the full sync under the shared heavy-maintenance lease so this CLI cannot
@@ -32,19 +34,19 @@ async function syncKnowledgeBase() {
     try {
         outcome = await withHeavyMaintenanceLease(
             async () => {
-                console.log('   Waiting for Lifecycle Service...');
+                console.error('   Waiting for Lifecycle Service...');
                 await KB_LifecycleService.ready();
-                console.log('   Lifecycle Service Ready. Database should be running.');
+                console.error('   Lifecycle Service Ready. Database should be running.');
 
-                console.log('   Waiting for Chroma Manager...');
+                console.error('   Waiting for Chroma Manager...');
                 await KB_ChromaManager.ready();
-                console.log('   Chroma Manager Ready.');
+                console.error('   Chroma Manager Ready.');
 
-                console.log('   Waiting for Database Service...');
+                console.error('   Waiting for Database Service...');
                 await KB_DatabaseService.ready();
-                console.log('   Database Service Ready.');
+                console.error('   Database Service Ready.');
 
-                console.log('✅ Services Ready. Starting Synchronization...');
+                console.error('✅ Services Ready. Starting Synchronization...');
 
                 // Execute the full sync (create + embed). `NEO_KB_STALE_STRATEGY=shadow-swap`
                 // opts into the shadow-swap stale-data strategy; default CLI sync remains unchanged.
@@ -59,12 +61,20 @@ async function syncKnowledgeBase() {
 
     if (outcome.status === 'held') {
         const held = outcome.lease;
-        console.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
-        console.log('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
+        console.error(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
+        console.error('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
+        // Emit the structured deferral outcome on stdout so the orchestrator classifies this run as
+        // 'skipped' (not the silent 'completed' telemetry-lie) — matches backfill-memory-summaries.mjs.
+        console.log(JSON.stringify({
+            deferred: true,
+            reason  : 'heavy-maintenance-lease-held',
+            lease   : {owner: held.owner, reason: held.reason, pid: held.pid, acquiredAt: held.acquiredAt}
+        }));
         process.exit(0);
     }
 
-    console.log('✅ Synchronization Complete:', outcome.result);
+    console.error('✅ Synchronization Complete:', outcome.result);
+    console.log(JSON.stringify({success: true, ...(outcome.result || {})}));
     process.exit(0);
 }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -27,6 +27,14 @@ function createTestService() {
             pidFileName      : 'memory-summary-backfill.pid',
             expectedCommand  : 'backfill-memory-summaries.mjs',
             captureStdoutJson: true
+        },
+        kbSync: {
+            label            : 'knowledge base sync',
+            command          : 'node',
+            args             : ['syncKnowledgeBase.mjs'],
+            pidFileName      : 'kb-sync.pid',
+            expectedCommand  : 'syncKnowledgeBase.mjs',
+            captureStdoutJson: true
         }
     };
 
@@ -301,6 +309,35 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         expect(taskOutcomes).toContainEqual(expect.objectContaining({
             status  : 'skipped',
             taskName: 'memory-summary-backfill',
+            details : expect.objectContaining({
+                reasonCode : 'heavy-maintenance-lease-held',
+                childReason: 'heavy-maintenance-lease-held',
+                deferred   : true
+            })
+        }));
+    });
+
+    test('#13784: kbSync lease-held stdout marks skipped with child reason (generalized deferred classifier)', () => {
+        const { service, stateCalls, taskOutcomes } = createTestService();
+        const manualChild = createManualChild();
+
+        service.spawnFn = () => manualChild.child;
+
+        expect(service.runTask('kbSync', 'periodic-sync:3600000')).toBe(true);
+        manualChild.writeStdout(JSON.stringify({
+            deferred: true,
+            reason  : 'heavy-maintenance-lease-held',
+            lease   : {owner: 'summary'}
+        }));
+        manualChild.close(0);
+
+        // The generic deferred-outcome contract now applies to kbSync (not just memory-summary-backfill):
+        // a lease-held kb-sync is classified 'skipped', ending the silent 'completed' telemetry-lie.
+        expect(stateCalls).toContainEqual({action: 'skipped', taskName: 'kbSync'});
+        expect(stateCalls).not.toContainEqual({action: 'completed', taskName: 'kbSync'});
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status  : 'skipped',
+            taskName: 'kbSync',
             details : expect.objectContaining({
                 reasonCode : 'heavy-maintenance-lease-held',
                 childReason: 'heavy-maintenance-lease-held',


### PR DESCRIPTION
Resolves #13784

Ends the kb-sync "completed" telemetry-lie: a lease-held/deferred kb-sync exited `0` and the orchestrator recorded it **completed**, hiding multi-day embedding stalls behind a green health signal (the silent-stall failure class in grace's epic #13755). Now a deferred run is honestly classified **skipped**.

Three surfaces, consuming @neo-gpt's merged #13778 `captureStdoutJson` spawn-boundary channel:
1. **Child emit** (`syncKnowledgeBase.mjs`) — progress logs move to **stderr**; stdout carries only the single JSON outcome line the channel `JSON.parse`s (`{deferred:true, reason:'heavy-maintenance-lease-held', lease}` on held; `{success:true, …}` on complete). Mirrors the `backfill-memory-summaries.mjs` precedent.
2. **Opt-in** (`taskDefinitions.mjs`) — kbSync gets `captureStdoutJson: true`.
3. **Classifier** (`ProcessSupervisorService.classifySuccessfulChildOutcome`) — **generalized** the deferred-outcome check that was hardcoded to `memory-summary-backfill` so ANY opted-in task emitting `{deferred:true, reason}` is classified `skipped`. The backfill-specific count-logic (`all-deferred`) stays gated under its taskName.

Evidence: L2 (unit) below; the live silent-stall elimination is L3 (post-restart, sandbox-unreachable) → Post-Merge Validation.

## Test Evidence

`ProcessSupervisorService.spec.mjs` — new `#13784: kbSync lease-held stdout marks skipped with child reason (generalized deferred classifier)`: `runTask('kbSync', …)` with a `{deferred:true, reason:'heavy-maintenance-lease-held'}` child stdout → asserts the outcome is `skipped` (reasonCode `heavy-maintenance-lease-held`) and **not** `completed`. Mirrors the existing backfill lease-held test, proving the generalization. The backfill `all-deferred` + lease-held tests still pass (count-logic gated). CI runs the unit config (authoritative).

## Post-Merge Validation

After merge + orchestrator restart: when kbSync defers behind an active heavy-maintenance holder, the orchestrator health record shows `skipped` (reasonCode `heavy-maintenance-lease-held`), not `completed`. A days-long embedding stall is now visible in the telemetry instead of silent — pair with the embed-drain watchdog (#13551) for full observability of the failure class.

## Deltas

- `ai/scripts/maintenance/syncKnowledgeBase.mjs` — progress → stderr; structured JSON outcome on stdout.
- `ai/daemons/orchestrator/taskDefinitions.mjs` — kbSync `captureStdoutJson: true`.
- `ai/daemons/orchestrator/services/ProcessSupervisorService.mjs` — generalized `classifySuccessfulChildOutcome` deferred-outcome contract.
- `test/.../ProcessSupervisorService.spec.mjs` — kbSync lease-held → skipped test.

Sub of #13755; sibling of #13777 (backfill) / #13784's family. Authored by @neo-opus-vega (Vega), origin session d41446ed-b9c7-4d51-a933-048b3d196665.
