### PR TITLE
feat(ai): clean legacy generic named-peer wake routes (#13744)

### DIFF
--- a/ai/scripts/migrations/migrateWakeSubscriptions.mjs
+++ b/ai/scripts/migrations/migrateWakeSubscriptions.mjs
@@ -12,6 +12,7 @@
  * **Usage**:
  *   node ai/scripts/migrations/migrateWakeSubscriptions.mjs             # dry-run (default)
  *   node ai/scripts/migrations/migrateWakeSubscriptions.mjs --apply     # commit the migration
+ *   node ai/scripts/migrations/migrateWakeSubscriptions.mjs --skip-generic-cleanup
  *   node ai/scripts/migrations/migrateWakeSubscriptions.mjs --db <path> # override SQLite path
  *   node ai/scripts/migrations/migrateWakeSubscriptions.mjs --help      # print usage
  */
@@ -30,6 +31,7 @@ program
     .description('Patch legacy bridge-daemon wake subscriptions onto identity-template route metadata (dry-run by default).')
     .option('--apply', 'Commit the migration atomically in a single transaction')
     .option('--audit', 'Read-only audit — report instance-addressing-unsafe wake routes (no changes)')
+    .option('--skip-generic-cleanup', 'Skip unresolved generic named-peer default-instance cleanup planning/apply')
     .option('--db <path>', 'Override the SQLite file path (default: .neo-ai-data/sqlite/memory-core-graph.sqlite)')
     .addHelpText('after', '\n  (no flags)  Dry-run — print the migration plan without committing.');
 
@@ -50,10 +52,17 @@ function resolveSubscriptionTemplate(agentId, agentData) {
     return sourceTemplate || agentData.properties?.subscriptionTemplate;
 }
 
-export function runMigration(db, apply) {
+export function runMigration(db, applyOrOptions = false) {
+    const options = typeof applyOrOptions === 'boolean' ? {apply: applyOrOptions} : applyOrOptions,
+          apply   = options.apply === true,
+          now     = options.now || new Date().toISOString();
+
     const stats = {
-        subscriptionsPatched: 0,
-        subscriptionsSkipped: 0
+        subscriptionsPatched       : 0,
+        subscriptionsSkipped       : 0,
+        genericDefaultMarked       : 0,
+        genericDuplicatesRetired   : 0,
+        genericNamedPeerUnresolved : 0
     };
 
     const work = () => {
@@ -135,6 +144,13 @@ export function runMigration(db, apply) {
                 stats.subscriptionsSkipped++;
             }
         }
+
+        if (options.cleanupGenericNamedPeer !== false) {
+            const cleanup = cleanupGenericNamedPeerRoutes(db, {apply, now});
+            stats.genericDefaultMarked       += cleanup.defaultMarked;
+            stats.genericDuplicatesRetired   += cleanup.duplicatesRetired;
+            stats.genericNamedPeerUnresolved += cleanup.unresolved;
+        }
     };
 
     if (apply) {
@@ -145,6 +161,163 @@ export function runMigration(db, apply) {
     }
 
     return stats;
+}
+
+/**
+ * @summary Cleans active app-only named-peer wake routes without writing operator-local paths.
+ *
+ * A generic app-only Shape C route can be valid only as the default app instance. This maintenance
+ * pass makes that intent durable (`defaultInstance: true`) and retires duplicate active rows that
+ * share the same owner/trigger/filter/app tuple. Instance-addressed rows remain untouched.
+ *
+ * @param {Object} db Open better-sqlite3 connection.
+ * @param {Object} [options]
+ * @param {Boolean} [options.apply=false] Whether to commit planned mutations.
+ * @param {String} [options.now] ISO timestamp used for durable mutation metadata.
+ * @returns {{defaultMarked: Number, duplicatesRetired: Number, unresolved: Number}}
+ */
+export function cleanupGenericNamedPeerRoutes(db, {apply = false, now = new Date().toISOString()} = {}) {
+    const groups = new Map();
+
+    for (const record of readBridgeSubscriptionRecords(db)) {
+        const props = record.data.properties || {};
+
+        if (!isActiveSubscription(props) || !isUnresolvedGenericNamedPeer(record)) continue;
+
+        const key = buildGenericNamedPeerCleanupKey(record);
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(record);
+    }
+
+    const stats = {defaultMarked: 0, duplicatesRetired: 0, unresolved: 0};
+
+    for (const group of groups.values()) {
+        const ordered = group.sort(compareNewestSubscriptionFirst),
+              keeper  = ordered[0],
+              retired = ordered.slice(1);
+
+        markDefaultInstance(keeper, {apply, db, now});
+        stats.defaultMarked++;
+
+        for (const record of retired) {
+            retireDuplicateGenericRoute(record, {apply, db, now});
+            stats.duplicatesRetired++;
+        }
+    }
+
+    stats.unresolved = auditWakeRoutes(db).genericNamedPeer.length;
+
+    return stats;
+}
+
+/**
+ * @summary Reads parsed bridge-daemon WAKE_SUBSCRIPTION rows from the graph.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @returns {Object[]} Parsed subscription records.
+ */
+function readBridgeSubscriptionRecords(db) {
+    const rows = db.prepare(`SELECT id, data FROM Nodes WHERE json_extract(data, '$.label') = ?`).all('WAKE_SUBSCRIPTION'),
+          out  = [];
+
+    for (const row of rows) {
+        let data;
+        try {
+            data = JSON.parse(row.data);
+        } catch (e) {
+            continue;
+        }
+
+        const props = data.properties || {};
+        if (props.harnessTarget !== 'bridge-daemon') continue;
+
+        out.push({id: row.id, data});
+    }
+
+    return out;
+}
+
+function isActiveSubscription(props = {}) {
+    return (props.status || 'active') === 'active';
+}
+
+function isDefaultInstanceRoute(meta = {}) {
+    return meta.defaultInstance === true || meta.routeResolution === 'default-instance';
+}
+
+function isUnresolvedGenericNamedPeer(record) {
+    const namedIds = new Set(IDENTITIES.map(identity => identity.id)),
+          props    = record.data.properties || {},
+          meta     = props.harnessTargetMetadata || {},
+          {addressType} = resolveRouteAddress(meta);
+
+    return !addressType && meta.appName && namedIds.has(props.agentIdentity) && !isDefaultInstanceRoute(meta);
+}
+
+function buildGenericNamedPeerCleanupKey(record) {
+    const props = record.data.properties || {},
+          meta  = props.harnessTargetMetadata || {};
+
+    return stableStringify({
+        agentIdentity: props.agentIdentity,
+        trigger      : props.trigger,
+        filters      : props.filters || {},
+        appName      : meta.appName
+    });
+}
+
+function compareNewestSubscriptionFirst(a, b) {
+    const timeDelta = readSubscriptionTime(b) - readSubscriptionTime(a);
+    if (timeDelta !== 0) return timeDelta;
+
+    return a.id.localeCompare(b.id);
+}
+
+function readSubscriptionTime(record) {
+    const props = record.data.properties || {},
+          time  = Date.parse(props.updatedAt || props.createdAt || '');
+
+    return Number.isFinite(time) ? time : 0;
+}
+
+function markDefaultInstance(record, {apply, db, now}) {
+    const props = record.data.properties || {},
+          meta  = props.harnessTargetMetadata || {};
+
+    console.log(`  [MARK-DEFAULT] Subscription ${record.id} (Owner: ${props.agentIdentity}) | defaultInstance: ${meta.defaultInstance === true ? 'true' : 'none'} → true, routeResolution: ${meta.routeResolution || 'none'} → default-instance`);
+
+    if (!apply) return;
+
+    props.harnessTargetMetadata = {
+        ...meta,
+        defaultInstance : true,
+        routeResolution : 'default-instance',
+        routeResolvedAt : now,
+        routeResolvedBy : 'migrateWakeSubscriptions#genericNamedPeer'
+    };
+    props.updatedAt = now;
+    record.data.properties = props;
+
+    writeSubscriptionRecord(db, record);
+}
+
+function retireDuplicateGenericRoute(record, {apply, db, now}) {
+    const props = record.data.properties || {};
+
+    console.log(`  [RETIRE-GENERIC] Subscription ${record.id} (Owner: ${props.agentIdentity}) | status: ${props.status || 'active'} → inactive duplicate generic default-instance route`);
+
+    if (!apply) return;
+
+    props.status        = 'inactive';
+    props.retiredAt     = now;
+    props.retiredReason = 'duplicate generic named-peer default-instance route (#13744)';
+    props.updatedAt     = now;
+    record.data.properties = props;
+
+    writeSubscriptionRecord(db, record);
+}
+
+function writeSubscriptionRecord(db, record) {
+    db.prepare('UPDATE Nodes SET data = ? WHERE id = ?').run(JSON.stringify(record.data), record.id);
 }
 
 /**
@@ -177,26 +350,20 @@ export function resolveRouteAddress(meta = {}) {
  * which blocks NEW unsafe rows; this audit surfaces pre-existing ones for cleanup.
  *
  * @param {Object} db Open better-sqlite3 connection.
- * @returns {{emptyAddress: Object[], genericNamedPeer: Object[], scanned: Number}}
+ * @returns {{emptyAddress: Object[], genericNamedPeer: Object[], defaultInstance: Object[], scanned: Number}}
  */
 export function auditWakeRoutes(db) {
     const namedIds         = new Set(IDENTITIES.map(identity => identity.id)),
-          subs             = db.prepare(`SELECT id, data FROM Nodes WHERE json_extract(data, '$.label') = ?`).all('WAKE_SUBSCRIPTION'),
+          subs             = readBridgeSubscriptionRecords(db),
           emptyAddress     = [],
-          genericNamedPeer = [];
+          genericNamedPeer = [],
+          defaultInstance  = [];
 
     let scanned = 0;
 
     for (const sub of subs) {
-        let data;
-        try {
-            data = JSON.parse(sub.data);
-        } catch (e) {
-            continue;
-        }
-
-        const props = data.properties || {};
-        if (props.harnessTarget !== 'bridge-daemon') continue;
+        const props = sub.data.properties || {};
+        if (!isActiveSubscription(props)) continue;
         scanned++;
 
         const meta = props.harnessTargetMetadata || {},
@@ -204,20 +371,22 @@ export function auditWakeRoutes(db) {
 
         if (addressType && !instanceAddress) {
             emptyAddress.push({id: sub.id, agentIdentity: props.agentIdentity || null, addressType, appName: meta.appName || null});
+        } else if (!addressType && meta.appName && namedIds.has(props.agentIdentity) && isDefaultInstanceRoute(meta)) {
+            defaultInstance.push({id: sub.id, agentIdentity: props.agentIdentity, appName: meta.appName});
         } else if (!addressType && meta.appName && namedIds.has(props.agentIdentity)) {
             genericNamedPeer.push({id: sub.id, agentIdentity: props.agentIdentity, appName: meta.appName});
         }
     }
 
-    return {emptyAddress, genericNamedPeer, scanned};
+    return {emptyAddress, genericNamedPeer, defaultInstance, scanned};
 }
 
 /**
  * @summary Print an {@link auditWakeRoutes} result to stdout.
- * @param {{emptyAddress: Object[], genericNamedPeer: Object[], scanned: Number}} audit
+ * @param {{emptyAddress: Object[], genericNamedPeer: Object[], defaultInstance: Object[], scanned: Number}} audit
  * @returns {void}
  */
-function reportAudit({emptyAddress, genericNamedPeer, scanned}) {
+function reportAudit({emptyAddress, genericNamedPeer, defaultInstance = [], scanned}) {
     console.log(`[migrateWakeSubscriptions] AUDIT — scanned ${scanned} bridge-daemon wake route(s)`);
     console.log();
     console.log(`  empty-address (addressType set, no resolvable instance address → fails closed at delivery, peer misses wakes): ${emptyAddress.length}`);
@@ -230,7 +399,31 @@ function reportAudit({emptyAddress, genericNamedPeer, scanned}) {
         console.log(`    [GENERIC] ${r.id}  owner=${r.agentIdentity}  app=${r.appName}`);
     }
     console.log();
+    console.log(`  default-instance (named identity on an appName-only route explicitly marked as intentional default instance): ${defaultInstance.length}`);
+    for (const r of defaultInstance) {
+        console.log(`    [DEFAULT] ${r.id}  owner=${r.agentIdentity}  app=${r.appName}`);
+    }
+    console.log();
     console.log(`[migrateWakeSubscriptions] AUDIT complete (read-only; no changes).`);
+}
+
+function stableStringify(value) {
+    return JSON.stringify(stableNormalize(value));
+}
+
+function stableNormalize(value) {
+    if (Array.isArray(value)) {
+        return value.map(stableNormalize);
+    }
+
+    if (value && typeof value === 'object') {
+        return Object.keys(value).sort().reduce((out, key) => {
+            out[key] = stableNormalize(value[key]);
+            return out;
+        }, {});
+    }
+
+    return value;
 }
 
 async function main() {
@@ -251,12 +444,18 @@ async function main() {
             return;
         }
 
-        const stats = runMigration(db, args.apply);
+        const stats = runMigration(db, {
+            apply                  : args.apply,
+            cleanupGenericNamedPeer: !args.skipGenericCleanup
+        });
 
         console.log();
         console.log(`[migrateWakeSubscriptions] summary:`);
-        console.log(`  subscriptions patched: ${stats.subscriptionsPatched}`);
-        console.log(`  subscriptions skipped: ${stats.subscriptionsSkipped}`);
+        console.log(`  subscriptions patched       : ${stats.subscriptionsPatched}`);
+        console.log(`  subscriptions skipped       : ${stats.subscriptionsSkipped}`);
+        console.log(`  generic default marked      : ${stats.genericDefaultMarked}`);
+        console.log(`  generic duplicates retired  : ${stats.genericDuplicatesRetired}`);
+        console.log(`  generic unresolved remaining: ${stats.genericNamedPeerUnresolved}`);
 
         if (!args.apply) {
             console.log();

--- a/test/playwright/unit/ai/scripts/migrations/migrateWakeSubscriptions.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/migrateWakeSubscriptions.spec.mjs
@@ -43,6 +43,65 @@ function insertNode(db, node) {
 }
 
 /**
+ * @summary Inserts an AgentIdentity fixture with a bridge-daemon subscription template.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @param {String} id Agent identity id.
+ * @param {Object} harnessTargetMetadata Route metadata template.
+ */
+function insertAgentIdentity(db, id, harnessTargetMetadata) {
+    insertNode(db, {
+        id,
+        data: {
+            id,
+            label     : 'AgentIdentity',
+            properties: {
+                subscriptionTemplate: {
+                    trigger      : 'SENT_TO_ME',
+                    harnessTarget: 'bridge-daemon',
+                    harnessTargetMetadata
+                }
+            }
+        }
+    });
+}
+
+/**
+ * @summary Inserts a WAKE_SUBSCRIPTION fixture owned by an agent identity.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @param {Object} config Subscription fixture config.
+ */
+function insertSubscription(db, config) {
+    const {
+        id,
+        agentIdentity,
+        harnessTargetMetadata,
+        createdAt,
+        updatedAt,
+        filters,
+        status = 'active',
+        trigger = 'SENT_TO_ME'
+    } = config;
+
+    insertNode(db, {
+        id,
+        data: {
+            id,
+            label     : 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity,
+                trigger,
+                filters,
+                harnessTarget: 'bridge-daemon',
+                harnessTargetMetadata,
+                status,
+                createdAt,
+                updatedAt
+            }
+        }
+    });
+}
+
+/**
  * @summary Reads and parses a graph node fixture by id.
  * @param {Object} db Open better-sqlite3 connection.
  * @param {String} id Node id.
@@ -57,41 +116,17 @@ test.describe('ai/scripts/migrations/migrateWakeSubscriptions', () => {
         const db = new Database(':memory:');
         createGraphSchema(db);
 
-        insertNode(db, {
-            id  : '@neo-gpt',
-            data: {
-                id        : '@neo-gpt',
-                label     : 'AgentIdentity',
-                properties: {
-                    subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
-                        harnessTargetMetadata: {
-                            appName: 'Codex'
-                        }
-                    }
-                }
-            }
-        });
-        insertNode(db, {
-            id  : 'WAKE_SUB:codex-legacy',
-            data: {
-                id        : 'WAKE_SUB:codex-legacy',
-                label     : 'WAKE_SUBSCRIPTION',
-                properties: {
-                    agentIdentity: '@neo-gpt',
-                    trigger: 'SENT_TO_ME',
-                    harnessTarget: 'bridge-daemon',
-                    harnessTargetMetadata: {
-                        appName: 'Codex',
-                        focusSeedKey: 'r'
-                    },
-                    status: 'active'
-                }
+        insertAgentIdentity(db, '@neo-gpt', {appName: 'Codex'});
+        insertSubscription(db, {
+            id                   : 'WAKE_SUB:codex-legacy',
+            agentIdentity        : '@neo-gpt',
+            harnessTargetMetadata: {
+                appName: 'Codex',
+                focusSeedKey: 'r'
             }
         });
 
-        const stats = runMigration(db, true);
+        const stats = runMigration(db, {apply: true, cleanupGenericNamedPeer: false});
         const migrated = getNode(db, 'WAKE_SUB:codex-legacy');
 
         expect(stats.subscriptionsPatched).toBe(1);
@@ -107,42 +142,20 @@ test.describe('ai/scripts/migrations/migrateWakeSubscriptions', () => {
         const db = new Database(':memory:');
         createGraphSchema(db);
 
-        insertNode(db, {
-            id  : '@neo-gpt',
-            data: {
-                id        : '@neo-gpt',
-                label     : 'AgentIdentity',
-                properties: {
-                    subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
-                        harnessTargetMetadata: {
-                            adapter: 'codex-app-server',
-                            appName: 'Codex',
-                            tabShortcut: null
-                        }
-                    }
-                }
-            }
+        insertAgentIdentity(db, '@neo-gpt', {
+            adapter: 'codex-app-server',
+            appName: 'Codex',
+            tabShortcut: null
         });
-        insertNode(db, {
-            id  : 'WAKE_SUB:codex-dry-run',
-            data: {
-                id        : 'WAKE_SUB:codex-dry-run',
-                label     : 'WAKE_SUBSCRIPTION',
-                properties: {
-                    agentIdentity: '@neo-gpt',
-                    trigger: 'SENT_TO_ME',
-                    harnessTarget: 'bridge-daemon',
-                    harnessTargetMetadata: {
-                        appName: 'Codex'
-                    },
-                    status: 'active'
-                }
+        insertSubscription(db, {
+            id                   : 'WAKE_SUB:codex-dry-run',
+            agentIdentity        : '@neo-gpt',
+            harnessTargetMetadata: {
+                appName: 'Codex'
             }
         });
 
-        const stats = runMigration(db, false);
+        const stats = runMigration(db, {apply: false, cleanupGenericNamedPeer: false});
         const unchanged = getNode(db, 'WAKE_SUB:codex-dry-run');
 
         expect(stats.subscriptionsPatched).toBe(1);
@@ -151,15 +164,97 @@ test.describe('ai/scripts/migrations/migrateWakeSubscriptions', () => {
         });
     });
 
-    test.describe('auditWakeRoutes (read-only #13481 audit)', () => {
-        const insertSub = (db, id, agentIdentity, harnessTargetMetadata) => insertNode(db, {
-            id,
-            data: {
-                id,
-                label     : 'WAKE_SUBSCRIPTION',
-                properties: {agentIdentity, trigger: 'SENT_TO_ME', harnessTarget: 'bridge-daemon', harnessTargetMetadata, status: 'active'}
+    test('dry-run reports generic named-peer cleanup without mutating durable route rows (#13744)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+        insertAgentIdentity(db, '@neo-opus-ada', {appName: 'Claude'});
+        insertSubscription(db, {
+            id                   : 'WAKE_SUB:ada-generic',
+            agentIdentity        : '@neo-opus-ada',
+            harnessTargetMetadata: {appName: 'Claude'},
+            updatedAt            : '2026-06-21T10:00:00.000Z'
+        });
+
+        const stats     = runMigration(db, {apply: false, now: '2026-06-21T12:00:00.000Z'}),
+              unchanged = getNode(db, 'WAKE_SUB:ada-generic');
+
+        expect(stats.genericDefaultMarked).toBe(1);
+        expect(stats.genericDuplicatesRetired).toBe(0);
+        expect(stats.genericNamedPeerUnresolved).toBe(1);
+        expect(unchanged.properties.harnessTargetMetadata).toEqual({appName: 'Claude'});
+        expect(unchanged.properties.status).toBe('active');
+    });
+
+    test('apply marks a generic named-peer keeper as default-instance and retires duplicate rows (#13744)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+        insertAgentIdentity(db, '@neo-opus-ada', {appName: 'Claude'});
+        insertSubscription(db, {
+            id                   : 'WAKE_SUB:ada-old',
+            agentIdentity        : '@neo-opus-ada',
+            harnessTargetMetadata: {appName: 'Claude'},
+            filters              : {channel: 'direct'},
+            updatedAt            : '2026-06-21T09:00:00.000Z'
+        });
+        insertSubscription(db, {
+            id                   : 'WAKE_SUB:ada-new',
+            agentIdentity        : '@neo-opus-ada',
+            harnessTargetMetadata: {appName: 'Claude'},
+            filters              : {channel: 'direct'},
+            updatedAt            : '2026-06-21T10:00:00.000Z'
+        });
+
+        const now   = '2026-06-21T12:00:00.000Z',
+              stats = runMigration(db, {apply: true, now});
+
+        const keeper  = getNode(db, 'WAKE_SUB:ada-new'),
+              retired = getNode(db, 'WAKE_SUB:ada-old'),
+              audit   = auditWakeRoutes(db);
+
+        expect(stats.genericDefaultMarked).toBe(1);
+        expect(stats.genericDuplicatesRetired).toBe(1);
+        expect(stats.genericNamedPeerUnresolved).toBe(0);
+        expect(keeper.properties.harnessTargetMetadata).toMatchObject({
+            appName        : 'Claude',
+            defaultInstance: true,
+            routeResolution: 'default-instance',
+            routeResolvedAt: now,
+            routeResolvedBy: 'migrateWakeSubscriptions#genericNamedPeer'
+        });
+        expect(keeper.properties.harnessTargetMetadata.userDataDir).toBeUndefined();
+        expect(keeper.properties.harnessTargetMetadata.instanceAddress).toBeUndefined();
+        expect(keeper.properties.status).toBe('active');
+        expect(retired.properties.status).toBe('inactive');
+        expect(retired.properties.retiredReason).toBe('duplicate generic named-peer default-instance route (#13744)');
+        expect(audit.genericNamedPeer).toEqual([]);
+        expect(audit.defaultInstance).toEqual([{id: 'WAKE_SUB:ada-new', agentIdentity: '@neo-opus-ada', appName: 'Claude'}]);
+    });
+
+    test('does not default-mark instance-addressed named-peer routes during generic cleanup (#13744)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+        insertAgentIdentity(db, '@neo-opus-ada', {appName: 'Claude'});
+        insertSubscription(db, {
+            id                   : 'WAKE_SUB:ada-instance',
+            agentIdentity        : '@neo-opus-ada',
+            harnessTargetMetadata: {
+                appName        : 'Claude',
+                addressType    : 'userDataDir',
+                instanceAddress: '/tmp/test-claude-ada'
             }
         });
+
+        const stats = runMigration(db, {apply: true, now: '2026-06-21T12:00:00.000Z'}),
+              route = getNode(db, 'WAKE_SUB:ada-instance');
+
+        expect(stats.genericDefaultMarked).toBe(0);
+        expect(stats.genericDuplicatesRetired).toBe(0);
+        expect(stats.genericNamedPeerUnresolved).toBe(0);
+        expect(route.properties.harnessTargetMetadata.defaultInstance).toBeUndefined();
+    });
+
+    test.describe('auditWakeRoutes (read-only #13481 audit)', () => {
+        const insertSub = (db, id, agentIdentity, harnessTargetMetadata) => insertSubscription(db, {id, agentIdentity, harnessTargetMetadata});
 
         test('flags an addressType route that resolves to no instance address (empty-address)', () => {
             const db = new Database(':memory:');
@@ -181,6 +276,16 @@ test.describe('ai/scripts/migrations/migrateWakeSubscriptions', () => {
             expect(audit.genericNamedPeer.length).toBe(1);
             expect(audit.genericNamedPeer[0].agentIdentity).toBe('@neo-opus-ada');
             expect(audit.emptyAddress.length).toBe(0);
+        });
+
+        test('reports an explicitly default-marked named-peer route separately from unresolved generic findings', () => {
+            const db = new Database(':memory:');
+            createGraphSchema(db);
+            insertSub(db, 'WAKE_SUB:default', '@neo-opus-ada', {appName: 'Claude', defaultInstance: true, routeResolution: 'default-instance'});
+
+            const audit = auditWakeRoutes(db);
+            expect(audit.genericNamedPeer.length).toBe(0);
+            expect(audit.defaultInstance).toEqual([{id: 'WAKE_SUB:default', agentIdentity: '@neo-opus-ada', appName: 'Claude'}]);
         });
 
         test('does not flag an instance-addressed route', () => {


### PR DESCRIPTION
Resolves #13744

Extends `migrateWakeSubscriptions` so generic named-peer wake-route findings are no longer audit-only. Dry-run now reports an explicit cleanup plan, apply mode can mark app-only named-peer routes as portable default-instance routes, and duplicate active generic routes are retired deterministically. The implementation preserves the invariant that committed identity templates stay machine-agnostic: no operator-local `userDataDir` or instance path is written into `identityRoots.mjs`.

Evidence: L2 (focused unit coverage + script syntax/diff checks + live before/after command evidence) -> L2 required (migration semantics are unit-coverable; live graph cleanup is command evidence). Residual: none for #13744.

## Deltas from ticket

- Kept the cleanup inside the existing migration script instead of adding a sibling command, so the audit/dry-run/apply path remains one maintenance surface.
- Chose the portable default-instance marker path for still-valid app-only routes: `defaultInstance: true`, `routeResolution: default-instance`, plus resolution metadata.
- Live cleanup has already been applied to the shared Codex Memory Core DB. Evidence was posted on #13481: `IC_kwDODSospM8AAAABG9_2LA` / https://github.com/neomjs/neo/issues/13481#issuecomment-4762629676

## Test Evidence

- `git diff --check` — passed.
- `node --check ai/scripts/migrations/migrateWakeSubscriptions.mjs` — passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/migrations/migrateWakeSubscriptions.spec.mjs` — 11/11 passed.
- Live read-only before audit against `/Users/Shared/codex/neomjs/neo/.neo-ai-data/sqlite/memory-core-graph.sqlite`: `empty-address: 0`, unresolved `generic-named-peer: 3`, `default-instance: 0`.
- Live dry-run plan: patch 1 legacy Codex adapter row, mark 3 generic named-peer rows as default-instance, retire duplicates: 0.
- Live apply result: `subscriptions patched: 1`, `generic default marked: 3`, `generic duplicates retired: 0`, `generic unresolved remaining: 0`.
- Live read-only after audit: `empty-address: 0`, unresolved `generic-named-peer: 0`, `default-instance: 3`.

## Post-Merge Validation

- [ ] Re-run `node ai/scripts/migrations/migrateWakeSubscriptions.mjs --audit --db /Users/Shared/codex/neomjs/neo/.neo-ai-data/sqlite/memory-core-graph.sqlite` on the target deployment and confirm `empty-address: 0` plus unresolved `generic-named-peer: 0`.
- [ ] Confirm #13481 can be closed or dispositioned using the posted live cleanup evidence.

## Commits

- `36d52e5a75` — `feat(ai): clean generic named-peer wake routes (#13744)`

Authored by Euclid (GPT-5, Codex Desktop). Session 69f79662-2fbe-403a-a124-78bca1abdb16.