### PR TITLE
fix(orchestrator): PrimaryRepoSyncService.runKbSync cascade records skipped on lease-held deferral (#13791)

### DIFF
--- a/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
@@ -597,10 +597,13 @@ class PrimaryRepoSyncService extends Base {
                 });
             } else {
                 taskStateService?.markCompleted?.('kbSync');
+                // Propagate the child's success details (e.g. embed/delete counts) so the cascade
+                // telemetry matches the task path; outcome is null on the legacy no-JSON path → spreads nothing.
                 healthService?.recordTaskOutcome?.('kbSync', 'completed', {
                     reason,
                     parent     : parentTaskName,
-                    completedAt: new Date().toISOString()
+                    completedAt: new Date().toISOString(),
+                    ...(outcome || {})
                 });
             }
         } catch (e) {

--- a/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
@@ -300,11 +300,11 @@ class PrimaryRepoSyncService extends Base {
         try {
             return this.syncDevRoot({
                 root,
-                rootKey: 'root',
+                rootKey          : 'root',
                 execFileSyncFn,
                 writeLog,
                 fetchBeforeBranch: true,
-                runKbSync: false,
+                runKbSync        : false,
                 taskStateService,
                 healthService
             });
@@ -335,14 +335,14 @@ class PrimaryRepoSyncService extends Base {
         const skipped   = rootResults.filter(result => result.status === 'skipped').length;
         const status    = completed > 0 ? 'completed' : failed > 0 ? 'failed' : 'skipped';
         const details   = {
-            mode: 'configured-roots',
+            mode     : 'configured-roots',
             primaryRoot,
             rootCount: rootResults.length,
             completed,
             skipped,
             failed,
-            roots: rootResults,
-            kbSync: false
+            roots    : rootResults,
+            kbSync   : false
         };
 
         const kbSyncRequired = rootResults.some(result => result.status === 'completed' && result.kbSyncRequired !== false);
@@ -581,14 +581,28 @@ class PrimaryRepoSyncService extends Base {
         }
 
         try {
-            execFileSyncFn(npmBin, ['run', 'ai:sync-kb'], spawnOptions);
+            const stdout  = execFileSyncFn(npmBin, ['run', 'ai:sync-kb'], spawnOptions) || '';
+            const outcome = this.parseCascadeOutcome(stdout);
 
-            taskStateService?.markCompleted?.('kbSync');
-            healthService?.recordTaskOutcome?.('kbSync', 'completed', {
-                reason,
-                parent     : parentTaskName,
-                completedAt: new Date().toISOString()
-            });
+            if (outcome?.deferred === true && outcome.reason) {
+                // Lease-held cascade kb-sync → `skipped`, not a false-green `completed` (the
+                // deferred-as-completed class): a deferred run did no embedding, so it must not
+                // refresh kbSync's lastSuccessAt the way a real sync does.
+                taskStateService?.markSkipped?.('kbSync');
+                healthService?.recordTaskOutcome?.('kbSync', 'skipped', {
+                    reason,
+                    parent    : parentTaskName,
+                    reasonCode: outcome.reason,
+                    skippedAt : new Date().toISOString()
+                });
+            } else {
+                taskStateService?.markCompleted?.('kbSync');
+                healthService?.recordTaskOutcome?.('kbSync', 'completed', {
+                    reason,
+                    parent     : parentTaskName,
+                    completedAt: new Date().toISOString()
+                });
+            }
         } catch (e) {
             taskStateService?.markFailed?.('kbSync', e.status || 1);
             healthService?.recordTaskOutcome?.('kbSync', 'failed', {
@@ -599,6 +613,30 @@ class PrimaryRepoSyncService extends Base {
             });
             throw e;
         }
+    }
+
+    /**
+     * @summary Extracts the child's structured outcome from cascade stdout, tolerating the
+     * `npm run` banner by scanning for the last line that JSON-parses to an object. Returns
+     * null when no JSON outcome line is present (e.g. a child that only emitted human-readable
+     * logs), so the caller falls through to the `completed` classification — preserving the
+     * pre-outcome-emit behavior and making this forward-compatible with the child emit side.
+     * @param {String} stdout Captured child stdout.
+     * @returns {Object|null} Parsed outcome envelope, or null when none is found.
+     */
+    parseCascadeOutcome(stdout) {
+        const lines = String(stdout || '').split('\n');
+        for (let i = lines.length - 1; i >= 0; i--) {
+            const line = lines[i].trim();
+            if (!line.startsWith('{')) continue;
+            try {
+                const parsed = JSON.parse(line);
+                if (parsed && typeof parsed === 'object') return parsed;
+            } catch {
+                // Not the JSON outcome line; keep scanning upward.
+            }
+        }
+        return null;
     }
 
     /**

--- a/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
@@ -987,6 +987,32 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         expect(outcomes[1]).toMatchObject({status: 'skipped', details: expect.objectContaining({reasonCode: 'heavy-maintenance-lease-held'})});
     });
 
+    test('runKbSync cascade real sync (deferred:false) records completed with embed counts (#13791)', () => {
+        const taskStateService = createTaskStateService();
+        const outcomes         = [];
+        const healthService    = {
+            recordTaskOutcome(taskName, status, details) {
+                outcomes.push({taskName, status, details});
+            }
+        };
+        const execFileSyncFn = createExecStub([{
+            cmd   : process.platform === 'win32' ? 'npm.cmd' : 'npm',
+            args  : ['run', 'ai:sync-kb'],
+            output: JSON.stringify({deferred: false, added: 2566, deleted: 1513})
+        }]);
+
+        PrimaryRepoSyncService.runKbSync('/primary/neo', execFileSyncFn, {taskStateService, healthService});
+
+        expect(taskStateService.events).toContainEqual(['completed', 'kbSync']);
+        expect(taskStateService.events).not.toContainEqual(['skipped', 'kbSync']);
+        // The child's success details (embed/delete counts) must propagate into the completed outcome.
+        expect(outcomes[1]).toMatchObject({
+            taskName: 'kbSync',
+            status  : 'completed',
+            details : expect.objectContaining({added: 2566, deleted: 1513})
+        });
+    });
+
     test('runKbSync annotates cascade-failure path with markFailed + outcome + rethrow (#11520 AC3 failure)', () => {
         const taskStateService = createTaskStateService();
         const outcomes         = [];

--- a/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import Neo       from '../../../../../../../src/Neo.mjs';
-import * as core from '../../../../../../../src/core/_export.mjs';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
 import PrimaryRepoSyncService, {
     DEV_SYNC_ROOTS_ENV_VAR,
     isConfigTemplateChangePath,
@@ -196,9 +196,9 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         expect(result).toEqual({
             status : 'skipped',
             details: {
-                reasonCode: 'not-dev-branch',
+                reasonCode : 'not-dev-branch',
                 primaryRoot: '/primary/neo',
-                branch: 'feature'
+                branch     : 'feature'
             }
         });
     });
@@ -771,10 +771,10 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         expect(result).toEqual({
             status : 'skipped',
             details: {
-                reasonCode: 'local-divergence',
+                reasonCode : 'local-divergence',
                 primaryRoot: '/primary/neo',
-                behind: 1,
-                files: ['ai/daemons/Orchestrator.mjs']
+                behind     : 1,
+                files      : ['ai/daemons/Orchestrator.mjs']
             }
         });
         expect(execStub.calls.map(call => call.args[0])).not.toContain('pull');
@@ -804,15 +804,15 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         const outcomes = [];
 
         const result = PrimaryRepoSyncService.runTask({
-            reason          : 'periodic-sweep:600000',
+            reason       : 'periodic-sweep:600000',
             taskStateService,
-            healthService   : {
+            healthService: {
                 recordTaskOutcome(taskName, status, details) {
                     outcomes.push({taskName, status, details});
                 }
             },
-            writeLog        : () => {},
-            execFileSyncFn  : createExecStub([{
+            writeLog      : () => {},
+            execFileSyncFn: createExecStub([{
                 cmd   : 'git',
                 args  : ['worktree', 'list', '--porcelain'],
                 output: 'worktree /primary/neo\n'
@@ -932,6 +932,59 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
                 parent: 'primary-dev-sync'
             })
         });
+    });
+
+    test('runKbSync cascade lease-held stdout records skipped, not false-green completed (#13791)', () => {
+        const taskStateService = createTaskStateService();
+        const outcomes         = [];
+        const healthService    = {
+            recordTaskOutcome(taskName, status, details) {
+                outcomes.push({taskName, status, details});
+            }
+        };
+        // Child exited 0 but emitted a deferral outcome on stdout (the emit side).
+        const execFileSyncFn = createExecStub([{
+            cmd   : process.platform === 'win32' ? 'npm.cmd' : 'npm',
+            args  : ['run', 'ai:sync-kb'],
+            output: JSON.stringify({deferred: true, reason: 'heavy-maintenance-lease-held', holder: {owner: 'summary'}})
+        }]);
+
+        PrimaryRepoSyncService.runKbSync('/primary/neo', execFileSyncFn, {taskStateService, healthService});
+
+        // The cascade must classify a deferred run as skipped (not completed) — the telemetry-lie fix.
+        expect(taskStateService.events).toEqual([
+            ['started', 'kbSync', 'cascaded-from-primary-dev-sync'],
+            ['skipped', 'kbSync']
+        ]);
+        expect(outcomes[1]).toMatchObject({
+            taskName: 'kbSync',
+            status  : 'skipped',
+            details : expect.objectContaining({
+                reasonCode: 'heavy-maintenance-lease-held',
+                parent    : 'primary-dev-sync'
+            })
+        });
+    });
+
+    test('runKbSync parses the deferral outcome through the npm-run banner (last-JSON-line scan, #13791)', () => {
+        const taskStateService = createTaskStateService();
+        const outcomes         = [];
+        const healthService    = {
+            recordTaskOutcome(taskName, status, details) {
+                outcomes.push({taskName, status, details});
+            }
+        };
+        // `npm run` prepends a banner; the outcome JSON is the last line — the scan must still find it.
+        const execFileSyncFn = createExecStub([{
+            cmd : process.platform === 'win32' ? 'npm.cmd' : 'npm',
+            args: ['run', 'ai:sync-kb'],
+            output: `\n> neo@10.0.0 ai:sync-kb\n> node syncKnowledgeBase.mjs\n\n${JSON.stringify({deferred: true, reason: 'heavy-maintenance-lease-held'})}\n`
+        }]);
+
+        PrimaryRepoSyncService.runKbSync('/primary/neo', execFileSyncFn, {taskStateService, healthService});
+
+        expect(taskStateService.events).toContainEqual(['skipped', 'kbSync']);
+        expect(outcomes[1]).toMatchObject({status: 'skipped', details: expect.objectContaining({reasonCode: 'heavy-maintenance-lease-held'})});
     });
 
     test('runKbSync annotates cascade-failure path with markFailed + outcome + rethrow (#11520 AC3 failure)', () => {


### PR DESCRIPTION
Resolves #13791

Fixes the **cascade half** of the kb-sync deferred-as-completed telemetry-lie (#13755). #13785 fixed the `ProcessSupervisorService` *task* path; this fixes the separate `PrimaryRepoSyncService.runKbSync` *cascade* spawner.

**Root cause:** the `primary-dev-sync → kbSync` cascade ran `ai:sync-kb` via `execFileSync` and recorded `recordTaskOutcome('kbSync', 'completed', …)` + `markCompleted` on **any non-throw**. But `syncKnowledgeBase.mjs` exits `0` on a heavy-maintenance-lease-held deferral (emitting `{deferred:true, reason}` on stdout, post-#13785) — so a deferred cascade kb-sync false-greened `completed`, hiding a no-embedding run behind a green signal.

**Fix:** `runKbSync` captures the child stdout, parses the outcome via `parseCascadeOutcome` (a **last-JSON-line scan**, tolerant of the `npm run` banner that precedes the script's output), and records `skipped` (reasonCode from the child) on `{deferred:true}` — mirroring `ProcessSupervisorService.classifySuccessfulChildOutcome`.

**Forward-compatible + safe:** a child that emits no JSON outcome (the pre-#13785 human-readable path, or any non-deferred run) parses to `null` → falls through to the existing `completed` classification. So this is safe to merge before or after #13785; the live skipped-classification activates once #13785's emit side is on dev.

Evidence: L2 (unit) below; the live cascade-telemetry effect is L3 (post-restart + #13785 merged) → Post-Merge Validation.

## Test Evidence

`PrimaryRepoSyncService.spec.mjs` — two new tests:
- *cascade lease-held stdout records skipped, not false-green completed*: `execFileSync` returns `{deferred:true, reason:'heavy-maintenance-lease-held'}` → asserts `markSkipped` + `recordTaskOutcome('kbSync', 'skipped', {reasonCode, parent:'primary-dev-sync'})`, not `completed`.
- *parses the deferral outcome through the npm-run banner (last-JSON-line scan)*: stdout = npm banner + the JSON outcome on the last line → still classified `skipped` (proves banner-tolerance).

Existing success/failure/no-services tests unchanged (the success test returns `''` → `parseCascadeOutcome` → null → `completed`, preserved). CI runs the unit config.

## Post-Merge Validation

After merge + #13785 + an orchestrator restart: when a `primary-dev-sync`-triggered cascade kb-sync defers behind an active heavy holder, the health record shows `recordTaskOutcome('kbSync', 'skipped', {reasonCode:'heavy-maintenance-lease-held', parent:'primary-dev-sync'})`, not `completed`. The cascade no longer false-greens a deferred run.

## Deltas

- `ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs` — `runKbSync` captures + classifies the child outcome; new `parseCascadeOutcome` helper (npm-banner-tolerant last-JSON-line scan).
- `test/.../PrimaryRepoSyncService.spec.mjs` — the two cascade-deferral tests.

Depends on #13785 (emit side) for live behavior; code is independently mergeable. Sub of #13755; sibling of #13785. Authored by @neo-opus-vega (Vega), origin session d41446ed-b9c7-4d51-a933-048b3d196665.
