### PR TITLE
feat(ai): golden-path recency de-bias mechanism (dark-launched)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -457,6 +457,24 @@ class Config extends ConfigProvider {
              */
             goldenPathTopNodeRenderLimit: leaf(10, 'NEO_GOLDEN_PATH_TOP_NODE_RENDER_LIMIT', 'number'),
             /**
+             * Golden-path recency de-bias: additive recency boost on each scored node's priority —
+             * `priority += recencyScore × goldenPathRecencyWeight`, where
+             * `recencyScore = 1 / (1 + daysSinceUpdate / goldenPathRecencyHalfLifeDays)` ∈ (0,1].
+             * Counters the structural-weight bias that surfaces old high-weight meta over fresh
+             * release work. Defaults to 0 (disabled / dark-launched) — enable + tune from the live
+             * computed-score data so the weight surfaces current work without over-surfacing recent
+             * noise.
+             * @type {number}
+             */
+            goldenPathRecencyWeight: leaf(0, 'NEO_GOLDEN_PATH_RECENCY_WEIGHT', 'number'),
+            /**
+             * Half-life (in days) of the golden-path recency boost: an issue idle this many days
+             * since `updatedAt` gets half the boost of a just-updated one. Active only when
+             * `goldenPathRecencyWeight > 0`.
+             * @type {number}
+             */
+            goldenPathRecencyHalfLifeDays: leaf(30, 'NEO_GOLDEN_PATH_RECENCY_HALF_LIFE_DAYS', 'number'),
+            /**
              * The Hebbian decay factor applied every 24 hours to the edge graph (e.g., 0.98 for ~79 day half-life).
              * @type {number}
              */

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -142,6 +142,34 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Recency de-bias score for the Golden Path ranking.
+     *
+     * Returns a bounded recency factor in (0, 1]: `1 / (1 + daysSinceUpdate / halfLifeDays)` —
+     * a just-updated node scores ~1.0; one idle `halfLifeDays` days scores 0.5. The caller adds
+     * `recencyScore × goldenPathRecencyWeight` to the priority so fresh release work isn't
+     * structurally out-ranked by old high-weight meta. Pure + defensive: a missing/unparseable
+     * `updatedAt` returns 0 (no boost), so a node without a timestamp is never falsely promoted.
+     *
+     * @param {Object} options
+     * @param {String|Number|undefined} options.updatedAt Node `properties.updatedAt`.
+     * @param {Number} options.now Current epoch ms.
+     * @param {Number} options.halfLifeDays Days at which the boost halves (> 0).
+     * @returns {Number} Recency factor in [0, 1].
+     */
+    static computeRecencyScore({updatedAt, now, halfLifeDays}) {
+        const updatedMs = updatedAt === undefined || updatedAt === null ? NaN : new Date(updatedAt).getTime();
+        const halfLife  = Number(halfLifeDays);
+
+        if (!Number.isFinite(updatedMs) || !Number.isFinite(now) || !Number.isFinite(halfLife) || halfLife <= 0) {
+            return 0;
+        }
+
+        const daysSinceUpdate = Math.max(0, (now - updatedMs) / 86400000);
+
+        return 1 / (1 + daysSinceUpdate / halfLife);
+    }
+
+    /**
      * @summary Derives the core swarm login-to-family map from the AgentIdentity registry.
      *
      * `identityRoots.mjs` is the canonical handle indirection seam for named Neo maintainers.
@@ -1092,6 +1120,11 @@ class GoldenPathSynthesizer extends Base {
         const scoredNodes = [];
         const SEMANTIC_WEIGHT = 2.0;
         const STRUCTURAL_WEIGHT = 1.0;
+        // Recency de-bias inputs — read once. Defaults keep the ranking unchanged
+        // (recencyWeight 0 = dark-launched) when the config leaves are absent or stale.
+        const recencyWeight       = Number(aiConfig.goldenPathRecencyWeight) || 0;
+        const recencyHalfLifeDays = Number(aiConfig.goldenPathRecencyHalfLifeDays) || 30;
+        const recencyNowMs        = now instanceof Date ? now.getTime() : new Date(now).getTime();
 
         try {
             const placeholders = semanticIds.map(() => '?').join(',');
@@ -1142,6 +1175,17 @@ class GoldenPathSynthesizer extends Base {
                 try { nodeData = JSON.parse(row.data); } catch (e) { }
 
                 let priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
+
+                // Recency de-bias: additive boost so fresh release work isn't structurally
+                // out-ranked by old high-weight meta. No effect until goldenPathRecencyWeight > 0
+                // (dark-launched; tuned from live computed-score data).
+                if (recencyWeight > 0) {
+                    priority += this.constructor.computeRecencyScore({
+                        updatedAt   : nodeData?.properties?.updatedAt,
+                        now         : recencyNowMs,
+                        halfLifeDays: recencyHalfLifeDays
+                    }) * recencyWeight;
+                }
 
                 if (!this.constructor.isActionableComputedRecommendation(nodeData || {id: issueId})) {
                     logger.debug(`[GoldenPathSynthesizer] Skipping non-actionable computed recommendation: ${issueId}`);

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -130,6 +130,31 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
     });
 
+    test('computeRecencyScore is a bounded, defensive recency factor (#13750)', () => {
+        const recency = GoldenPathSynthesizer.constructor.computeRecencyScore.bind(GoldenPathSynthesizer.constructor);
+        const now     = Date.parse('2026-06-21T00:00:00.000Z');
+        const DAY     = 86400000;
+
+        // just-updated → ~1.0
+        expect(recency({updatedAt: new Date(now).toISOString(), now, halfLifeDays: 30})).toBeCloseTo(1.0, 5);
+        // idle exactly one half-life (30d) → 0.5
+        expect(recency({updatedAt: new Date(now - 30 * DAY).toISOString(), now, halfLifeDays: 30})).toBeCloseTo(0.5, 5);
+        // idle two half-lives (60d) → 1/3
+        expect(recency({updatedAt: new Date(now - 60 * DAY).toISOString(), now, halfLifeDays: 30})).toBeCloseTo(1 / 3, 5);
+        // very old → bounded in (0, 0.05)
+        const old = recency({updatedAt: new Date(now - 3650 * DAY).toISOString(), now, halfLifeDays: 30});
+        expect(old).toBeGreaterThan(0);
+        expect(old).toBeLessThan(0.05);
+        // future updatedAt clamps to 0 days idle → ~1.0 (never exceeds 1)
+        expect(recency({updatedAt: new Date(now + 10 * DAY).toISOString(), now, halfLifeDays: 30})).toBeCloseTo(1.0, 5);
+
+        // defensive: missing / unparseable / bad-half-life / bad-now → 0 (no false promotion)
+        expect(recency({updatedAt: undefined, now, halfLifeDays: 30})).toBe(0);
+        expect(recency({updatedAt: 'not-a-date', now, halfLifeDays: 30})).toBe(0);
+        expect(recency({updatedAt: new Date(now).toISOString(), now, halfLifeDays: 0})).toBe(0);
+        expect(recency({updatedAt: new Date(now).toISOString(), now: NaN, halfLifeDays: 30})).toBe(0);
+    });
+
     test('derives repo-enrichment identity projections from identityRoots', () => {
         const Synthesizer = GoldenPathSynthesizer.constructor;
 


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13750 (the ranking half of "surface #13k" — #13755 Sub-4). Complementary to the now-merged #13783 decouple (the freshness half): #13783 makes the golden-path RUN hourly on the fresh graph; this makes it RANK fresh release work over old high-weight meta.

## Summary
GPT's post-#13783-merge V-B-A confirmed the gap: even on a fresh graph, the Computed Golden Path still topped out at old `issue-9864` (11.29, structural 9.00). The ranking was `priority = semanticScore×2 + struct_score×1` with **no temporal/label term**, so a high-structural-weight old meta node structurally out-ranks a fresh low-weight #13k release issue.

This adds the **recency de-bias mechanism, dark-launched** — the ranking is byte-unchanged until tuned, so it carries zero risk to the #1 system while landing the foundation.

## Deltas
- `GoldenPathSynthesizer.computeRecencyScore` (new static, pure) — `1 / (1 + daysSinceUpdate / halfLifeDays)` ∈ (0,1]; a just-updated node ~1.0, one half-life 0.5; defensive: missing/unparseable `updatedAt` → 0 (never falsely promotes a timestamp-less node); future `updatedAt` clamps to 0 days idle.
- `synthesizeGoldenPath` ranking — reads `nodeData.properties.updatedAt` (the `upsertNode` stamp), adds `recencyScore × goldenPathRecencyWeight` to the priority **only when `recencyWeight > 0`**.
- `config.template.mjs` — `goldenPathRecencyWeight` (default **0 = disabled / dark-launch**) + `goldenPathRecencyHalfLifeDays` (default 30) leaves, env-overridable.

## Guardrails
- **Zero ranking change at default** — `recencyWeight 0` skips the term entirely; the existing synthesizeGoldenPath tests pass unchanged (verified).
- **Robust to stale config** — `Number(aiConfig.goldenPathRecencyWeight) || 0` defaults to disabled if the leaf is absent (e.g. a not-yet-rematerialized `config.mjs`).
- **Tuning deferred, not guessed** — the weight is set from live computed-score data (`issue-9864` at 11.29 to beat) via the config leaf — a config change, no code. Requested the #13k scores from @neo-gpt to set it precisely.

## Test Evidence
Evidence: L2 (unit — the pure `computeRecencyScore` fully unit-covered: half-life math, bounds, future-clamp, defensive→0) → L2 required (the mechanism is unit-coverable; the live ranking QUALITY is the post-merge tuning step). Residual: the weight tuning (config, post-merge).

**L2** — 22/22 `GoldenPathSynthesizer` specs green (`UNIT_TEST_MODE=true … -c test/playwright/playwright.config.mjs`), incl. the new `computeRecencyScore` test + the unchanged synthesizeGoldenPath integration tests (dark-launch confirmed). Block-alignment clean; syntax-checked.

## Premise Coherence
**Coheres:** the confirmed root-cause fix for the operator's #1 proof-blocker (the computed golden-path surfacing old meta), landed mechanism-first + dark-launched so the high-blast tuning is a safe, data-driven config step rather than a guessed code change.

## Post-Merge Validation
- [ ] Set `goldenPathRecencyWeight` from the live #13k scores (the value that surfaces current work without over-surfacing recent noise); confirm the Computed Golden Path surfaces #13k.
- [ ] (follow-on slices) release-label boost + stale-meta decay (the other two #13750 levers).
