### PR TITLE
feat(mcp): complete handbook coverage for remaining servers (#9953)

### DIFF
--- a/ai/mcp/server/gitlab-workflow/openapi.yaml
+++ b/ai/mcp/server/gitlab-workflow/openapi.yaml
@@ -19,6 +19,50 @@ paths:
               schema:
                 $ref: '#/components/schemas/HealthResponse'
 
+  /tool/handbook:
+    post:
+      operationId: get_mcp_tool_handbook
+      summary: Tool Handbook
+      description: Returns lazy-loaded usage detail for one GitLab Workflow MCP tool.
+      tags: [System]
+      x-annotations:
+        readOnlyHint: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [toolId]
+              properties:
+                toolId:
+                  type: string
+                  description: Tool operation id to inspect.
+      responses:
+        '200':
+          description: Tool handbook lookup result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  toolId:
+                    type: string
+                  found:
+                    type: boolean
+                  title:
+                    type: string
+                  description:
+                    type: string
+                  handbook:
+                    type: string
+                  source:
+                    type: string
+                  code:
+                    type: string
+                  message:
+                    type: string
+
   /issues:
     get:
       operationId: list_issues

--- a/ai/mcp/server/gitlab-workflow/toolService.mjs
+++ b/ai/mcp/server/gitlab-workflow/toolService.mjs
@@ -20,6 +20,7 @@ const openApiFilePath = path.join(__dirname, 'openapi.yaml');
 const serviceMapping = {
     create_issue           : IssueService       .createIssue                .bind(IssueService),
     get_local_issue_by_id  : LocalFileService   .getIssueById               .bind(LocalFileService),
+    get_mcp_tool_handbook  : toolId => toolService.getToolHandbook(toolId),
     get_merge_request      : MergeRequestService.getMergeRequest            .bind(MergeRequestService),
     healthcheck            : HealthService      .healthcheck                .bind(HealthService),
     list_issues            : IssueService       .listIssues                 .bind(IssueService),
@@ -34,8 +35,10 @@ const serviceMapping = {
 };
 
 const toolService = Neo.create(ToolService, {
+    compactToolDescriptions    : true,
     openApiFilePath,
-    serviceMapping
+    serviceMapping,
+    toolListDescriptionMaxLength: 120
 });
 
 const callTool  = toolService.callTool .bind(toolService);

--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -48,6 +48,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /tool/handbook:
+    post:
+      summary: Tool Handbook
+      operationId: get_mcp_tool_handbook
+      x-neo-tool-tier: read
+      x-annotations:
+        readOnlyHint: true
+      description: Returns lazy-loaded usage detail for one Neural Link MCP tool.
+      tags: [Health]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [toolId]
+              properties:
+                toolId:
+                  type: string
+                  description: Tool operation id to inspect.
+      responses:
+        '200':
+          description: Tool handbook lookup result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  toolId:
+                    type: string
+                  found:
+                    type: boolean
+                  title:
+                    type: string
+                  description:
+                    type: string
+                  handbook:
+                    type: string
+                  source:
+                    type: string
+                  code:
+                    type: string
+                  message:
+                    type: string
+
   /check_namespace:
     post:
       summary: Checks if a namespace exists in the current environment.

--- a/ai/mcp/server/neural-link/toolService.mjs
+++ b/ai/mcp/server/neural-link/toolService.mjs
@@ -35,6 +35,7 @@ const serviceMapping = {
     get_drag_state               : InteractionService.getDragState              .bind(InteractionService),
     get_drag_trace               : InteractionService.getDragTrace              .bind(InteractionService),
     get_instance_properties      : InstanceService   .getInstanceProperties     .bind(InstanceService),
+    get_mcp_tool_handbook        : toolId => toolService.getToolHandbook(toolId),
     get_method_source            : RuntimeService    .getMethodSource           .bind(RuntimeService),
     get_namespace_tree           : RuntimeService    .getNamespaceTree          .bind(RuntimeService),
     get_record                   : DataService       .getRecord                 .bind(DataService),
@@ -69,8 +70,10 @@ const serviceMapping = {
 };
 
 const toolService = Neo.create(ToolService, {
+    compactToolDescriptions    : true,
     openApiFilePath,
-    serviceMapping
+    serviceMapping,
+    toolListDescriptionMaxLength: 120
 });
 
 const _callTool = toolService.callTool.bind(toolService);

--- a/learn/agentos/NeuralLink.md
+++ b/learn/agentos/NeuralLink.md
@@ -252,6 +252,7 @@ Tools for understanding the environment, topology, and execution flow.
 | `open_component_window` | Opens a known live dashboard widget or pane in a browser popup through the app's existing popup primitive. |
 | `position_window` | Moves a topology-discovered popup when the runtime exposes an addressable native window handle; otherwise returns a recoverable unsupported result. |
 | `focus_window` | Focuses a topology-discovered popup when the runtime exposes an addressable native window handle; otherwise returns a recoverable unsupported result. |
+| `get_mcp_tool_handbook` | Returns full handbook details for one MCP tool after the compact tool list identifies the operation to inspect. |
 | `healthcheck` | Health probe for the Neural Link bridge + App Worker — a first-step connectivity diagnostic. |
 | `reload_page` | Forces a full reload of the application window. |
 | `manage_neo_config` | Reads or updates the global `Neo.config` object at runtime. |

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -37,6 +37,13 @@ const
             stdioReason    : 'toolService smoke is CI-friendly; full stdio boot remains covered by bucket-D McpServersHealth.spec.mjs because process transport needs harness env.'
         },
         {
+            name           : 'gitlab-workflow',
+            toolServicePath: 'ai/mcp/server/gitlab-workflow/toolService.mjs',
+            openApiPath    : 'ai/mcp/server/gitlab-workflow/openapi.yaml',
+            mcpServerPath  : 'ai/mcp/server/gitlab-workflow/mcp-server.mjs',
+            stdioReason    : 'toolService smoke is CI-friendly; full stdio boot requires GitLab token/project env and remains bucket-D coverage.'
+        },
+        {
             name           : 'github-workflow',
             toolServicePath: 'ai/mcp/server/github-workflow/toolService.mjs',
             openApiPath    : 'ai/mcp/server/github-workflow/openapi.yaml',
@@ -197,6 +204,7 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(servers.map(server => server.name).sort()).toEqual([
             'file-system',
             'github-workflow',
+            'gitlab-workflow',
             'knowledge-base',
             'memory-core',
             'neural-link'
@@ -361,15 +369,40 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         });
     });
 
-    test('unmigrated servers keep their existing list description behavior (#13268)', async () => {
+    test('gitlab-workflow exposes compact list descriptions plus lazy-loaded handbook detail (#9953)', async () => {
         const
-            server     = servers.find(item => item.name === 'neural-link'),
-            {tools}    = await listTools(server),
-            tool       = tools.find(item => item.name === 'get_component_tree'),
-            operations = getOperationsById(server);
+            server       = servers.find(item => item.name === 'gitlab-workflow'),
+            {tools}      = await listTools(server),
+            byName       = Object.fromEntries(tools.map(tool => [tool.name, tool])),
+            moduleUrl    = pathToFileURL(path.join(repoRoot, server.toolServicePath)).href,
+            {callTool}   = await import(moduleUrl),
+            handbook     = await callTool('get_mcp_tool_handbook', {toolId: 'create_issue'}),
+            missing      = await callTool('get_mcp_tool_handbook', {toolId: 'missing_tool'}),
+            createIssue  = byName.create_issue,
+            handbookTool = byName.get_mcp_tool_handbook;
 
-        expect(tool.description).toBe(operations.get_component_tree.description);
-        expect(tool.description.length).toBeGreaterThan(120);
+        expect(handbookTool.description.length).toBeLessThanOrEqual(120);
+        expect(handbookTool.annotations.readOnlyHint).toBe(true);
+        expect(createIssue.description).toBe('Create a GitLab issue');
+        expect(createIssue.description).not.toContain('GitLab GraphQL API');
+
+        for (const tool of tools) {
+            expect(tool.description.length, `gitlab-workflow.${tool.name} description is not compact`).toBeLessThanOrEqual(120);
+        }
+
+        expect(handbook).toMatchObject({
+            toolId: 'create_issue',
+            found : true,
+            source: 'description'
+        });
+        expect(handbook.handbook).toContain('GitLab GraphQL API');
+
+        expect(missing).toEqual({
+            toolId: 'missing_tool',
+            found : false,
+            code  : 'TOOL_NOT_FOUND',
+            message: 'Tool "missing_tool" does not exist in this MCP server.'
+        });
     });
 
     test('github-workflow exposes compact list descriptions plus lazy-loaded handbook detail (#13736)', async () => {
@@ -403,6 +436,42 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
             source: 'description'
         });
         expect(handbook.handbook.replace(/\s+/g, ' ')).toContain('Run `sync_all` to update local markdown files');
+
+        expect(missing).toEqual({
+            toolId: 'missing_tool',
+            found : false,
+            code  : 'TOOL_NOT_FOUND',
+            message: 'Tool "missing_tool" does not exist in this MCP server.'
+        });
+    });
+
+    test('neural-link exposes compact list descriptions plus lazy-loaded handbook detail (#9953)', async () => {
+        const
+            server       = servers.find(item => item.name === 'neural-link'),
+            {tools}      = await listTools(server),
+            byName       = Object.fromEntries(tools.map(tool => [tool.name, tool])),
+            moduleUrl    = pathToFileURL(path.join(repoRoot, server.toolServicePath)).href,
+            {callTool}   = await import(moduleUrl),
+            handbook     = await callTool('get_mcp_tool_handbook', {toolId: 'find_instances'}),
+            missing       = await callTool('get_mcp_tool_handbook', {toolId: 'missing_tool'}),
+            findInstances = byName.find_instances,
+            handbookTool  = byName.get_mcp_tool_handbook;
+
+        expect(handbookTool.description.length).toBeLessThanOrEqual(120);
+        expect(handbookTool.annotations.readOnlyHint).toBe(true);
+        expect(findInstances.description).toBe('Find Instances');
+        expect(findInstances.description).not.toContain('StateProviders');
+
+        for (const tool of tools) {
+            expect(tool.description.length, `neural-link.${tool.name} description is not compact`).toBeLessThanOrEqual(120);
+        }
+
+        expect(handbook).toMatchObject({
+            toolId: 'find_instances',
+            found : true,
+            source: 'description'
+        });
+        expect(handbook.handbook).toContain('StateProviders');
 
         expect(missing).toEqual({
             toolId: 'missing_tool',

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -107,6 +107,7 @@ const expectedNeuralLinkToolTiers = {
     get_drag_state               : 'read',
     get_drag_trace               : 'read',
     get_instance_properties      : 'read',
+    get_mcp_tool_handbook        : 'read',
     get_method_source            : 'read',
     get_namespace_tree           : 'read',
     get_record                   : 'read',


### PR DESCRIPTION
Resolves #9953

Completes the MCP handbook rollout for the remaining active server surfaces by adding `get_mcp_tool_handbook` to `gitlab-workflow` and `neural-link`, enabling compact list descriptions on both, extending the cross-server smoke fixture so every active MCP server is covered by the compact-list plus lazy-handbook contract, and reconciling the Neural Link guide/tier validation surfaces that enforce the OpenAPI contract.

Evidence: L2 (focused unit coverage for all active MCP server list/handbook/guide/tier contracts) -> L2 required (MCP tool-surface and context-budget behavior are locally testable). Residual: CI full-suite confirmation on current head `df09479c4e`.

## Deltas from ticket
No new handbook primitive was introduced. This reuses the existing shared `ToolService` handbook path and applies it to the two remaining active MCP servers after the earlier merged slices covered the other server manifests. CI surfaced two Neural Link validation surfaces that also needed reconciliation: `learn/agentos/NeuralLink.md` guide parity and the strict read-tier expectation map.

## Test Evidence
- `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` completed before implementation.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` initially exposed the expected-fixture ordering gap after adding `gitlab-workflow`; fixed before commit.
- `git diff --check origin/dev..HEAD` passed before the first push.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` passed on the first rebased head: 27/27.
- GitHub unit on `e49fb1e0fb` failed on Neural Link guide parity and strict tier expectation drift; both addressed in `df09479c4e`.
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/GuideToolParity.spec.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` passed after the fix and after rebase: 32/32.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` passed after the fix and after rebase: 27/27.

## Post-Merge Validation
- [ ] GitHub CI remains green for current head `df09479c4e`.
- [ ] `#9953` can close after merge because all active MCP server manifests expose compact list descriptions plus lazy-loaded handbook detail, and the Neural Link guide/tier validation surfaces stay in parity.

## Commits
- `1a2cf22c12` - complete handbook coverage for remaining MCP servers.
- `df09479c4e` - align Neural Link guide/tier validation with the new handbook tool.

Authored by Euclid (GPT-5 Codex, Codex Desktop). Session 69f79662-2fbe-403a-a124-78bca1abdb16.