### PR TITLE
fix(ai): recover generated sync rebase conflicts (#13798)

### DIFF
--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -284,8 +284,14 @@ class SyncService extends Base {
                         await this.commitRebaseAndPushGeneratedContent(cwd);
                         return;
                     } catch (error) {
-                        if (!error.generatedSyncDeliveryFailure || attempt >= maxAttempts) {
+                        if (!error.generatedSyncDeliveryFailure) {
                             logger.error('[SyncService] Auto-commit and push failed:', error.message);
+                            return;
+                        }
+
+                        if (attempt >= maxAttempts) {
+                            logger.error(`[SyncService] Auto-push exhausted ${maxAttempts} attempts; recovering checkout before giving up: ${error.message}`);
+                            await this.recoverGeneratedContentCheckout(cwd);
                             return;
                         }
 

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -99,10 +99,23 @@ class SyncService extends Base {
     }
 
     /**
-     * The main public entry point for the synchronization process.
+     * @summary Executes a git command inside the sync checkout.
+     * @param {String} command Git command to run.
+     * @param {String} cwd Working directory for the command.
+     * @returns {Promise<{stdout: String, stderr: String}>}
+     */
+    async execGit(command, cwd) {
+        return execAsync(command, {cwd});
+    }
+
+    /**
+     * @summary Emits the generated GitHub Workflow content and derived Portal artifacts.
      *
-     * This method orchestrates the entire bi-directional sync workflow in a specific order
-     * to ensure data integrity and minimize conflicts:
+     * This method orchestrates the generated-content half of the full sync in a specific order
+     * to ensure data integrity and minimize conflicts. It is intentionally separated from the
+     * git delivery step so a failed rebase can reset the checkout, re-emit the generated files,
+     * and retry without leaving the repository mid-rebase.
+     *
      * 1.  Loads the persistent metadata from the last sync via `MetadataManager`.
      * 2.  Fetches and caches GitHub release data via `ReleaseNotesSyncer`.
      * 3.  Reconciles closed issue locations (archives stale issues) via `IssueSyncer`.
@@ -115,12 +128,10 @@ class SyncService extends Base {
      *     per-syncer cache populations survive `MetadataManager.save`.
      * 10. Caches releases in `newMetadata` for next run.
      * 11. Saves the updated, pruned metadata to disk via `MetadataManager`.
-     * @returns {Promise<object>} A comprehensive object containing detailed statistics and timing
-     * information about all operations performed during the sync.
+     * 12. Rebuilds Portal content indexes and SEO artifacts from the emitted content.
+     * @returns {Promise<object>} Statistics for the emitted generated content.
      */
-    async runFullSync() {
-        const startTime = new Date();
-
+    async emitGeneratedContentAndDerive() {
         const metadata = await MetadataManager.load();
 
         // 1. Fetch releases first, as they are needed for issue archiving
@@ -179,48 +190,131 @@ class SyncService extends Base {
 
         await this.rebuildContentIndexesAndSeo();
 
+        return {
+            reconcileStats,
+            pullReconcileStats,
+            pushStats,
+            pullStats,
+            releaseStats,
+            discussionStats,
+            pullStats2
+        };
+    }
+
+    /**
+     * @summary Commits, rebases, and pushes generated GitHub Workflow content changes.
+     * @param {String} cwd Git checkout root.
+     * @returns {Promise<Boolean>} `true` when a generated-data commit was pushed.
+     */
+    async commitRebaseAndPushGeneratedContent(cwd) {
+        const {stdout} = await this.execGit(`git status --porcelain ${generatedSyncStatusPaths}`, cwd);
+        const lines    = stdout.trim().split('\n').filter(Boolean);
+
+        if (lines.length === 0) {
+            return false;
+        }
+
+        const onlyMetaChanged = lines.every(line => line.endsWith('.sync-metadata.json'));
+
+        if (onlyMetaChanged) {
+            logger.info('[SyncService] Only metadata changed. Rolling back metadata.');
+            await this.execGit('git restore resources/content/.sync-metadata.json', cwd);
+            return false;
+        }
+
+        logger.info('[SyncService] Detected real content changes. Committing and pushing.');
+        await this.execGit(`git add ${generatedSyncStatusPaths}`, cwd);
+        const {stdout: stagedStdout} = await this.execGit('git diff --cached --name-only', cwd);
+        const nonSyncFiles = stagedStdout.trim().split('\n').filter(Boolean).filter(file =>
+            !isGeneratedSyncFile(file)
+        );
+
+        if (nonSyncFiles.length > 0) {
+            throw new Error(`Automated sync commit rejected: non-sync files are staged: ${nonSyncFiles.join(', ')}`);
+        }
+
+        // Automated generated-data commits bypass Husky; hooks are human-lane guards.
+        await this.execGit('git commit --no-verify -m "chore: ticket sync [skip ci]"', cwd);
+
+        try {
+            await this.execGit('git pull --rebase --autostash', cwd);
+            await this.execGit('git push', cwd);
+        } catch (error) {
+            error.generatedSyncDeliveryFailure = true;
+            throw error;
+        }
+
+        logger.info('[SyncService] Successfully pushed changes to GitHub.');
+
+        return true;
+    }
+
+    /**
+     * @summary Restores the generated-data checkout to the latest remote `dev` after delivery failure.
+     * @param {String} cwd Git checkout root.
+     * @returns {Promise<void>}
+     */
+    async recoverGeneratedContentCheckout(cwd) {
+        try {
+            await this.execGit('git rebase --abort', cwd);
+        } catch (error) {
+            logger.warn(`[SyncService] git rebase --abort did not complete: ${error.message}`);
+        }
+
+        await this.execGit('git fetch origin dev:refs/remotes/origin/dev', cwd);
+        await this.execGit('git reset --hard origin/dev', cwd);
+    }
+
+    /**
+     * @summary Delivers generated GitHub Workflow content to git with bounded rebase recovery.
+     * @param {Function} rerunEmission Re-emits generated content after a reset.
+     * @param {Number}   [maxAttempts=2] Maximum commit/rebase/push attempts.
+     * @returns {Promise<void>}
+     */
+    async autoPushGeneratedContent({rerunEmission, maxAttempts = 2}) {
         if (aiConfig.pushToRepoAfterSync) {
             const {permission} = await RepositoryService.getViewerPermission();
             const writePermissions = ['ADMIN', 'MAINTAIN', 'WRITE'];
 
             if (writePermissions.includes(permission)) {
-                try {
-                    const cwd = aiConfig.projectRoot;
-                    const {stdout} = await execAsync(`git status --porcelain ${generatedSyncStatusPaths}`, {cwd});
-                    const lines = stdout.trim().split('\n').filter(Boolean);
+                const cwd = aiConfig.projectRoot;
 
-                    if (lines.length > 0) {
-                        const onlyMetaChanged = lines.every(line => line.endsWith('.sync-metadata.json'));
-
-                        if (onlyMetaChanged) {
-                            logger.info('[SyncService] Only metadata changed. Rolling back metadata.');
-                            await execAsync('git restore resources/content/.sync-metadata.json', {cwd});
-                        } else {
-                            logger.info('[SyncService] Detected real content changes. Committing and pushing.');
-                            await execAsync(`git add ${generatedSyncStatusPaths}`, {cwd});
-                            const {stdout: stagedStdout} = await execAsync('git diff --cached --name-only', {cwd});
-                            const nonSyncFiles = stagedStdout.trim().split('\n').filter(Boolean).filter(file =>
-                                !isGeneratedSyncFile(file)
-                            );
-
-                            if (nonSyncFiles.length > 0) {
-                                throw new Error(`Automated sync commit rejected: non-sync files are staged: ${nonSyncFiles.join(', ')}`);
-                            }
-
-                            // Automated generated-data commits bypass Husky; hooks are human-lane guards.
-                            await execAsync('git commit --no-verify -m "chore: ticket sync [skip ci]"', {cwd});
-                            await execAsync('git pull --rebase --autostash', {cwd});
-                            await execAsync('git push', {cwd});
-                            logger.info('[SyncService] Successfully pushed changes to GitHub.');
+                for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+                    try {
+                        await this.commitRebaseAndPushGeneratedContent(cwd);
+                        return;
+                    } catch (error) {
+                        if (!error.generatedSyncDeliveryFailure || attempt >= maxAttempts) {
+                            logger.error('[SyncService] Auto-commit and push failed:', error.message);
+                            return;
                         }
+
+                        logger.warn(`[SyncService] Auto-push attempt ${attempt} failed; aborting rebase, resetting to origin/dev, and re-emitting generated content before retry: ${error.message}`);
+                        await this.recoverGeneratedContentCheckout(cwd);
+                        await rerunEmission();
                     }
-                } catch (error) {
-                    logger.error('[SyncService] Auto-commit and push failed:', error.message);
                 }
             } else {
                 logger.info(`[SyncService] Skipping auto-push. Viewer permission '${permission}' lacks write access.`);
             }
         }
+    }
+
+    /**
+     * The main public entry point for the synchronization process.
+     *
+     * @returns {Promise<object>} A comprehensive object containing detailed statistics and timing
+     * information about all operations performed during the sync.
+     */
+    async runFullSync() {
+        const startTime = new Date();
+        let syncStats   = await this.emitGeneratedContentAndDerive();
+
+        await this.autoPushGeneratedContent({
+            rerunEmission: async () => {
+                syncStats = await this.emitGeneratedContentAndDerive();
+            }
+        });
 
         // Stage 2: Ingest into Native Graph Database
         try {
@@ -241,14 +335,14 @@ class SyncService extends Base {
         const durationMs = endTime - startTime;
 
         const finalStats = {
-            reconciled     : reconcileStats,
-            reconciledPulls: pullReconcileStats,
-            pushed         : pushStats,
-            pulled      : pullStats.pulled,
-            dropped     : pullStats.dropped,
-            releases    : releaseStats,
-            discussions : discussionStats,
-            pulls       : pullStats2
+            reconciled     : syncStats.reconcileStats,
+            reconciledPulls: syncStats.pullReconcileStats,
+            pushed         : syncStats.pushStats,
+            pulled         : syncStats.pullStats.pulled,
+            dropped        : syncStats.pullStats.dropped,
+            releases       : syncStats.releaseStats,
+            discussions    : syncStats.discussionStats,
+            pulls          : syncStats.pullStats2
         };
 
         const timing = {

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -260,6 +260,78 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         expect(commands).toContain('git reset --hard origin/dev');
     });
 
+    test('auto-push recovers the checkout when delivery retries are exhausted (#13798)', async () => {
+        const commands = [];
+        let pullRuns = 0;
+        let saves = 0;
+        let derives = 0;
+
+        RepositoryService.getViewerPermission = async () => ({permission: 'WRITE'});
+
+        IssueSyncer.pullFromGitHub = async (md) => {
+            pullRuns++;
+
+            return {
+                newMetadata: {
+                    ...(md || {}),
+                    issues      : {},
+                    pushFailures: [],
+                    lastSync    : `run-${pullRuns}`
+                },
+                stats: {
+                    pulled : {count: pullRuns, created: 0, updated: 0, moved: 0},
+                    dropped: {count: 0}
+                }
+            };
+        };
+
+        MetadataManager.save = async () => {
+            saves++;
+        };
+
+        SyncService.rebuildContentIndexesAndSeo = async () => {
+            derives++;
+        };
+
+        SyncService.execGit = async (command) => {
+            commands.push(command);
+
+            if (command.startsWith('git status --porcelain ')) {
+                return {stdout: ' M resources/content/issues/active/issue-13798.md\n', stderr: ''};
+            }
+
+            if (command === 'git diff --cached --name-only') {
+                return {stdout: 'resources/content/issues/active/issue-13798.md\n', stderr: ''};
+            }
+
+            if (command === 'git pull --rebase --autostash') {
+                throw new Error('persistent rebase conflict');
+            }
+
+            return {stdout: '', stderr: ''};
+        };
+
+        const result = await SyncService.runFullSync();
+
+        expect(result.success).toBe(true);
+        expect(result.statistics.pulled.count).toBe(2);
+        expect(pullRuns).toBe(2);
+        expect(saves).toBe(2);
+        expect(derives).toBe(2);
+        expect(stage2Calls).toEqual({
+            issueStates        : 1,
+            discussionStates   : 1,
+            pullRequestFeedback: 1
+        });
+        expect(commands.filter(command => command.startsWith('git status --porcelain '))).toHaveLength(2);
+        expect(commands.filter(command => command === 'git commit --no-verify -m "chore: ticket sync [skip ci]"')).toHaveLength(2);
+        expect(commands.filter(command => command === 'git pull --rebase --autostash')).toHaveLength(2);
+        expect(commands).not.toContain('git push');
+        expect(commands.filter(command => command === 'git rebase --abort')).toHaveLength(2);
+        expect(commands.filter(command => command === 'git fetch origin dev:refs/remotes/origin/dev')).toHaveLength(2);
+        expect(commands.filter(command => command === 'git reset --hard origin/dev')).toHaveLength(2);
+    });
+
     test('auto-push does not hard-reset the checkout for allowlist guard failures (#13798)', async () => {
         const commands = [];
 

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -20,6 +20,8 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 test.describe('SyncService — Stage 2 Ingestion', () => {
+    test.describe.configure({mode: 'serial'});
+
     let SyncService;
     let IssueSyncer;
     let ReleaseNotesSyncer;
@@ -39,6 +41,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
     let originalSyncPullRequests;
     let originalGetViewerPermission;
     let originalRebuildContentIndexesAndSeo;
+    let originalExecGit;
 
     let originalIngestIssueStates;
     let originalIngestDiscussionStates;
@@ -80,6 +83,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         originalSyncPullRequests = PullRequestSyncer.syncPullRequests;
         originalGetViewerPermission = RepositoryService.getViewerPermission;
         originalRebuildContentIndexesAndSeo = SyncService.rebuildContentIndexesAndSeo;
+        originalExecGit = SyncService.execGit;
         originalLoadMetadata = MetadataManager.load;
         originalSaveMetadata = MetadataManager.save;
 
@@ -114,6 +118,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         PullRequestSyncer.syncPullRequests = originalSyncPullRequests;
         RepositoryService.getViewerPermission = originalGetViewerPermission;
         SyncService.rebuildContentIndexesAndSeo = originalRebuildContentIndexesAndSeo;
+        SyncService.execGit = originalExecGit;
         MetadataManager.load = originalLoadMetadata;
         MetadataManager.save = originalSaveMetadata;
 
@@ -176,6 +181,112 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         expect(source).toContain("'apps/portal/llms.txt'");
         expect(source).toContain('git status --porcelain ${generatedSyncStatusPaths}');
         expect(source).toContain('git add ${generatedSyncStatusPaths}');
+    });
+
+    test('auto-push aborts failed rebase, resets, re-emits, and retries once (#13798)', async () => {
+        const commands = [];
+        let pullRuns = 0;
+        let saves = 0;
+        let derives = 0;
+        let rebaseAttempts = 0;
+
+        RepositoryService.getViewerPermission = async () => ({permission: 'WRITE'});
+
+        IssueSyncer.pullFromGitHub = async (md) => {
+            pullRuns++;
+
+            return {
+                newMetadata: {
+                    ...(md || {}),
+                    issues      : {},
+                    pushFailures: [],
+                    lastSync    : `run-${pullRuns}`
+                },
+                stats: {
+                    pulled : {count: pullRuns, created: 0, updated: 0, moved: 0},
+                    dropped: {count: 0}
+                }
+            };
+        };
+
+        MetadataManager.save = async () => {
+            saves++;
+        };
+
+        SyncService.rebuildContentIndexesAndSeo = async () => {
+            derives++;
+        };
+
+        SyncService.execGit = async (command) => {
+            commands.push(command);
+
+            if (command.startsWith('git status --porcelain ')) {
+                return {stdout: ' M resources/content/issues/active/issue-13798.md\n', stderr: ''};
+            }
+
+            if (command === 'git diff --cached --name-only') {
+                return {stdout: 'resources/content/issues/active/issue-13798.md\n', stderr: ''};
+            }
+
+            if (command === 'git pull --rebase --autostash') {
+                rebaseAttempts++;
+
+                if (rebaseAttempts === 1) {
+                    throw new Error('simulated rebase conflict');
+                }
+            }
+
+            return {stdout: '', stderr: ''};
+        };
+
+        const result = await SyncService.runFullSync();
+
+        expect(result.success).toBe(true);
+        expect(result.statistics.pulled.count).toBe(2);
+        expect(pullRuns).toBe(2);
+        expect(saves).toBe(2);
+        expect(derives).toBe(2);
+        expect(stage2Calls).toEqual({
+            issueStates        : 1,
+            discussionStates   : 1,
+            pullRequestFeedback: 1
+        });
+        expect(commands.filter(command => command.startsWith('git status --porcelain '))).toHaveLength(2);
+        expect(commands.filter(command => command === 'git commit --no-verify -m "chore: ticket sync [skip ci]"')).toHaveLength(2);
+        expect(commands.filter(command => command === 'git pull --rebase --autostash')).toHaveLength(2);
+        expect(commands.filter(command => command === 'git push')).toHaveLength(1);
+        expect(commands).toContain('git rebase --abort');
+        expect(commands).toContain('git fetch origin dev:refs/remotes/origin/dev');
+        expect(commands).toContain('git reset --hard origin/dev');
+    });
+
+    test('auto-push does not hard-reset the checkout for allowlist guard failures (#13798)', async () => {
+        const commands = [];
+
+        RepositoryService.getViewerPermission = async () => ({permission: 'WRITE'});
+
+        SyncService.execGit = async (command) => {
+            commands.push(command);
+
+            if (command.startsWith('git status --porcelain ')) {
+                return {stdout: ' M resources/content/issues/active/issue-13798.md\n', stderr: ''};
+            }
+
+            if (command === 'git diff --cached --name-only') {
+                return {stdout: 'resources/content/issues/active/issue-13798.md\nsrc/unrelated/ManualEdit.mjs\n', stderr: ''};
+            }
+
+            return {stdout: '', stderr: ''};
+        };
+
+        const result = await SyncService.runFullSync();
+
+        expect(result.success).toBe(true);
+        expect(commands).not.toContain('git rebase --abort');
+        expect(commands).not.toContain('git fetch origin dev:refs/remotes/origin/dev');
+        expect(commands).not.toContain('git reset --hard origin/dev');
+        expect(commands).not.toContain('git pull --rebase --autostash');
+        expect(commands).not.toContain('git push');
     });
 
     /**


### PR DESCRIPTION
Resolves #13798

SyncService now separates generated-content emission from git delivery so the generated-data auto-push path can recover from failed `git pull --rebase --autostash` or `git push` delivery failures without leaving the checkout mid-rebase. Recoverable delivery failures abort any active rebase, refresh `origin/dev`, hard-reset to `origin/dev`, re-run the sync/derive emission, and retry once; if the final retry also fails, the checkout is still recovered before the auto-push path gives up. Allowlist/staging guard failures still fail logged without invoking the destructive recovery path.

Evidence: L2 (focused unit coverage simulating failed rebase recovery, retry-exhaustion recovery, and allowlist non-recovery; syntax checks; diff whitespace check) -> L2 required (close-target ACs are deterministic SyncService recovery behavior). No residuals.

## Deltas from ticket
- Added a serial execution declaration to `SyncService.Stage2.spec.mjs`; the file mutates singleton services and the normal parallel worker model was already causing import/setup instability under the focused test command.
- Recovery only runs for rebase/push delivery failures after the generated commit path reaches git delivery. Non-sync staged-file guard failures do not hard-reset the checkout.
- Cycle 2: retry exhaustion now also recovers the checkout before returning, so the never-mid-rebase invariant holds on the final failure path.

## Test Evidence
- `node --check ai/services/github-workflow/SyncService.mjs`
- `node --check test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs` - 9 passed on rebased head.

## Post-Merge Validation
- [ ] Next generated-data sync rebase conflict leaves the checkout clean (no active `.git/rebase-*`) and either retries successfully or logs final failure after bounded retry.

## Commits
- `2d3a3bb5bf` - recover generated sync rebase conflicts
- `4ebf796673` - recover sync checkout after retry exhaustion

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee050-c834-7503-b895-527ad55dd8c5.
