### PR TITLE
fix(ai): recency-sort the Golden Path frontier baseline — surface current work (#13800)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -1006,6 +1006,43 @@ class GoldenPathSynthesizer extends Base {
         return JSON.parse(rawPrData);
     }
 
+    /**
+     * @summary Reads the N most-recent session summaries by timestamp metadata (newest-first).
+     *
+     * ChromaDB `.get` has no `ORDER BY`, so `.get({limit})` returns storage-order — which anchored the
+     * Frontier Baseline Vector to arbitrary (often oldest) summaries, starving the Computed Golden Path
+     * of current work. This reads summary metadatas, sorts by the summary timestamp, and reads back only
+     * the most-recent N documents. The frontier must reflect CURRENT work because the semantic pillar is
+     * the designed pathway for surfacing new (correctly low-structural-weight) issues.
+     *
+     * @param {Object} collection Summary Chroma collection (exposes async `.get`).
+     * @param {Number} n Number of most-recent summaries to return.
+     * @returns {Promise<{documents: String[]}>} The N most-recent summary documents, newest-first.
+     */
+    static async getRecentSummaryDocuments(collection, n) {
+        const meta      = await collection.get({include: ['metadatas']});
+        const resolveTs = m => {
+            const raw = m?.timestamp ?? m?.lastActivity ?? m?.updatedAt ?? m?.createdAt;
+            return Number.isFinite(Number(raw)) ? Number(raw) : (Date.parse(raw) || 0);
+        };
+
+        const recentIds = (meta?.ids || [])
+            .map((id, idx) => ({id, ts: resolveTs(meta.metadatas?.[idx])}))
+            .sort((a, b) => b.ts - a.ts)
+            .slice(0, Math.max(0, n))
+            .map(entry => entry.id);
+
+        if (recentIds.length === 0) {
+            return {documents: []};
+        }
+
+        const recent = await collection.get({ids: recentIds, include: ['documents']});
+        // Chroma `.get({ids})` does not preserve request order — re-key to the recency ranking.
+        const byId = new Map((recent?.ids || []).map((id, idx) => [id, recent.documents?.[idx]]));
+
+        return {documents: recentIds.map(id => byId.get(id)).filter(doc => doc !== undefined && doc !== null)};
+    }
+
     async synthesizeGoldenPath({
         repoEnrichmentEnabled = true,
         issuesDir = path.resolve(__dirname, '../../../resources/content/issues'),
@@ -1028,10 +1065,12 @@ class GoldenPathSynthesizer extends Base {
             return;
         }
 
-        // Generate the Frontier Baseline Vector using the most recent session memory
+        // Generate the Frontier Baseline Vector from the N MOST-RECENT session summaries.
+        // (Was `summaryColl.get({limit:2})` — storage-order, not recency — which anchored the frontier
+        // to arbitrary/old summaries so recent work never ranked into the candidate pool.)
         let frontierEmbedding = null;
         try {
-            const recent = await summaryColl.get({ limit: 2, include: ['documents'] });
+            const recent = await this.constructor.getRecentSummaryDocuments(summaryColl, 2);
 
             let frontierText = "Neo.mjs Active Strategic Context: ";
             if (recent && recent.documents && recent.documents.length > 0) {

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -178,6 +178,32 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         })).toBe(true);
     });
 
+    test('getRecentSummaryDocuments returns the N most-recent summaries by timestamp, newest-first (#13800)', async () => {
+        const Synthesizer = GoldenPathSynthesizer.constructor;
+        const docMap      = {s1: 'doc-old', s2: 'doc-newest', s3: 'doc-mid'};
+        const collection  = {
+            get: async opts => {
+                // metadatas pass: storage-order (s1,s2,s3) with out-of-order timestamps
+                if (opts.include?.includes('metadatas') && !opts.ids) {
+                    return {ids: ['s1', 's2', 's3'], metadatas: [{timestamp: 100}, {timestamp: 300}, {timestamp: 200}]};
+                }
+                // ids-keyed document read
+                return {ids: opts.ids, documents: opts.ids.map(id => docMap[id])};
+            }
+        };
+
+        const result = await Synthesizer.getRecentSummaryDocuments(collection, 2);
+        // Storage-order is s1,s2,s3; recency-sorted top-2 is s2 (ts 300) then s3 (ts 200).
+        expect(result.documents).toEqual(['doc-newest', 'doc-mid']);
+    });
+
+    test('getRecentSummaryDocuments returns empty documents for an empty collection (#13800)', async () => {
+        const Synthesizer = GoldenPathSynthesizer.constructor;
+        const collection  = {get: async () => ({ids: [], metadatas: []})};
+
+        expect(await Synthesizer.getRecentSummaryDocuments(collection, 2)).toEqual({documents: []});
+    });
+
     test('findLastQualifyingAssignmentActivity treats owner identity comments as maintainer progress acknowledgements', () => {
         const Synthesizer = GoldenPathSynthesizer.constructor;
         const activity = Synthesizer.findLastQualifyingAssignmentActivity({


### PR DESCRIPTION
Resolves #13800

Recency-sorts the Golden Path Frontier Baseline Vector — the cross-family-converged real fix for the Computed Golden Path surfacing old structural hubs instead of current work (#13750).

**Root cause:** `GoldenPathSynthesizer.synthesizeGoldenPath` built the frontier from `summaryColl.get({ limit: 2 })`. ChromaDB `.get` has no `ORDER BY` → it returns **storage-order, not recency** (grace V-B-A'd @ L1062, despite the "most recent session memory" comment). So the frontier anchored to ~2 arbitrary (often oldest) summaries. Recent #13k work *is* embedded (issue-ingestion) but ranks ~199 against that stale frontier → excluded by the Pillar-1 `nResults: 20` cutoff → the Computed Golden Path surfaces old high-structural hubs (issue-9864).

**Fix:** a static `getRecentSummaryDocuments(collection, n)` reads summary metadatas, sorts by the summary timestamp (`timestamp ?? lastActivity ?? updatedAt ?? createdAt`, mirroring `DreamService.resolveSessionTimestamp`), and reads back only the most-recent N documents (newest-first). The frontier now reflects CURRENT work — the **semantic pillar is the designed pathway for surfacing new work** (new issues correctly have low structural weight — Hebbian, not yet reinforced; they surface by frontier-proximity, NOT a structural boost — see #13793 dropped + the decay/emergence call).

Evidence: L2 (unit) below; the live Computed-GP-surfaces-current-work effect is L3 (post-restart + a drained backlog) → Post-Merge Validation.

## Test Evidence

`GoldenPathSynthesizer.spec.mjs` — two new tests on the extracted static:
- *recency-sort, newest-first*: a collection whose metadatas pass returns storage-order `[s1,s2,s3]` with out-of-order timestamps `[100,300,200]` → `getRecentSummaryDocuments(coll, 2)` returns `['doc-newest','doc-mid']` (s2 then s3 by timestamp) — proving storage-order is ignored.
- *empty collection* → `{documents: []}`.

CI runs the unit config.

## Post-Merge Validation

After merge (+ a drained backlog so recent summaries exist): the frontier embeds the most-recent N summaries → recent #13k work is semantically near the frontier → ranks into the Pillar-1 top-20 → the Computed Golden Path surfaces current work instead of issue-9864. Watch `sandman_handoff.md` after a REM cycle.

## Deltas

- `ai/services/graph/GoldenPathSynthesizer.mjs` — new static `getRecentSummaryDocuments`; `synthesizeGoldenPath` frontier call switched from `get({limit:2})` to the recency-sorted read.
- `test/.../GoldenPathSynthesizer.spec.mjs` — the two recency tests.

## Review note (for the synthesizer owner)

**Cost tradeoff to confirm:** `getRecentSummaryDocuments` reads ALL summary metadatas (`get({include:['metadatas']})`) then reads back the N docs — correct + cheap-ish (metadatas only), but O(collection) per synthesis. As the summary collection grows, a windowed/recency-keyed read may be worth it. Left the read simple + correct; flagged for your call.

Sub of #13750; the boost half (#13793) was dropped (it fights the Hebbian/stigmergic emergence). Diagnosed by @neo-opus-vega; @neo-opus-grace reviews as `GoldenPathSynthesizer` owner. Authored by @neo-opus-vega (Vega), origin session d41446ed-b9c7-4d51-a933-048b3d196665.
