### PR TITLE
feat(ai): refetchPullsByNumber force-refetch for stale PR mirrors (#13803)

### DIFF
--- a/ai/scripts/migrations/refetchStalePulls.mjs
+++ b/ai/scripts/migrations/refetchStalePulls.mjs
@@ -1,0 +1,49 @@
+/**
+ * @summary Force-refetches the given pull-request numbers from GitHub to heal local mirror drift.
+ *
+ * Pull-request analogue of `refetchTruncatedIssues.mjs`. PR mirrors are pull-only and the bulk sync
+ * is delta-gated by `updatedAt`, so a closed/merged PR whose upstream body was edited (an edit that
+ * does NOT bump `updatedAt`) is never re-pulled. This script bypasses that gate:
+ *
+ *   node ai/scripts/migrations/refetchStalePulls.mjs 13752 8152 9999
+ *
+ * Delegates to `GH_SyncService.refetchPullsByNumber`, which re-renders each local markdown file from
+ * current GitHub state and persists updated metadata. Idempotent: refetching an already-current PR
+ * is a no-op writeback.
+ *
+ * @see ai/scripts/migrations/refetchTruncatedIssues.mjs
+ * @see ai/services/github-workflow/SyncService.mjs
+ */
+import {GH_SyncService} from '../../services.mjs';
+
+async function main() {
+    const argv    = process.argv.slice(2);
+    const numbers = argv.map(a => Number(a)).filter(n => Number.isInteger(n) && n > 0);
+
+    if (numbers.length === 0) {
+        console.error('Usage:');
+        console.error('  node ai/scripts/migrations/refetchStalePulls.mjs <num> [<num> ...]');
+        process.exit(1);
+    }
+
+    console.log(`Force-refetching ${numbers.length} pull request(s): ${numbers.join(', ')}`);
+
+    const stats = await GH_SyncService.refetchPullsByNumber({numbers});
+
+    console.log(`\nRefetched ${stats.refetched.count}/${numbers.length}`);
+    if (stats.refetched.pulls.length > 0) {
+        console.log(`  OK: ${stats.refetched.pulls.join(', ')}`);
+    }
+    if (stats.errors.length > 0) {
+        console.log(`  FAIL: ${stats.errors.length} error(s)`);
+        for (const {prNumber, error} of stats.errors) {
+            console.log(`    #${prNumber}: ${error}`);
+        }
+        process.exit(1);
+    }
+}
+
+main().catch(e => {
+    console.error('Error:', e);
+    process.exit(1);
+});

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -309,6 +309,33 @@ class SyncService extends Base {
     }
 
     /**
+     * @summary Facade for the standalone pull-request force-refetch (archive-mirror drift healing).
+     *
+     * Loads metadata, delegates to `PullRequestSyncer.refetchPullsByNumber`, persists the updated
+     * metadata. Bypasses the bulk delta-by-`updatedAt` gate so known-stale closed/merged PR mirrors
+     * — which the pull-only bulk sync never re-pulls once their `updatedAt` is past the high-water
+     * mark — can be re-rendered from current GitHub state. Invoked out-of-band by
+     * `ai/scripts/migrations/refetchStalePulls.mjs` — never the regular `runFullSync` loop.
+     *
+     * @param {object}   params
+     * @param {number[]} params.numbers Pull-request numbers to force-refetch.
+     * @returns {Promise<{refetched: {count: number, pulls: number[]}, errors: Array<{prNumber: number, error: string}>}>}
+     */
+    async refetchPullsByNumber({numbers}) {
+        if (!Array.isArray(numbers) || numbers.length === 0) {
+            return {refetched: {count: 0, pulls: []}, errors: []};
+        }
+
+        const metadata = await MetadataManager.load();
+        const stats    = await PullRequestSyncer.refetchPullsByNumber(numbers, metadata);
+        await MetadataManager.save(metadata);
+
+        logger.info(`✨ Force-refetch complete: ${stats.refetched.count}/${numbers.length} pull requests refetched`);
+
+        return stats;
+    }
+
+    /**
      * Facade for the one-time archive re-bucket migration. Loads metadata, delegates to
      * `IssueSyncer.migrateArchiveBuckets`, then persists the updated metadata (unless `dryRun`).
      * Invoked out-of-band by `ai/scripts/migrations/rebucketArchive.mjs` — never the regular sync loop.

--- a/ai/services/github-workflow/queries/pullRequestQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestQueries.mjs
@@ -142,6 +142,71 @@ export const FETCH_PULL_REQUESTS_FOR_SYNC = `
 `;
 
 /**
+ * @summary Single-PR variant of {@link FETCH_PULL_REQUESTS_FOR_SYNC} for the force-refetch path.
+ *
+ * Returns the identical sync node shape (body + comments + reviews + frontmatter fields) for ONE
+ * pull request by number, bypassing the bulk delta-by-`updatedAt` gating so a known-stale local
+ * mirror can be force-re-rendered from current GitHub state.
+ *
+ * Variables required:
+ * - $owner: String!
+ * - $repo: String!
+ * - $prNumber: Int!
+ * - $maxComments: Int!
+ * - $maxReviews: Int!
+ */
+export const FETCH_SINGLE_PULL_FOR_SYNC = `
+  query FetchSinglePullForSync(
+    $owner: String!
+    $repo: String!
+    $prNumber: Int!
+    $maxComments: Int!
+    $maxReviews: Int!
+  ) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $prNumber) {
+        number
+        title
+        body
+        state
+        createdAt
+        updatedAt
+        closedAt
+        mergedAt
+        url
+        headRefName
+        baseRefName
+
+        author {
+          login
+        }
+
+        comments(first: $maxComments) {
+          nodes {
+            createdAt
+            author {
+              login
+            }
+            body
+          }
+        }
+
+        reviews(first: $maxReviews) {
+          nodes {
+            createdAt
+            author {
+              login
+            }
+            body
+            state
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
  * Query to get the global ID of a pull request.
  *
  * Variables required:

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -349,6 +349,73 @@ class PullRequestSyncer extends Base {
     }
 
     /**
+     * @summary Renders a fetched PR node to its synced Markdown (frontmatter + body + comments + reviews),
+     * applying the content-trust sanitizer to each authored node. Extracted from {@link #syncPullRequests}
+     * so the single-PR force-refetch path renders identically (no drift between bulk-sync and refetch).
+     * @param {Object} pr The PR node (with `comments.nodes` / `reviews.nodes`).
+     * @returns {String} The gray-matter-serialized Markdown content.
+     */
+    #renderPullRequestMarkdown(pr) {
+        const contentTrust = createContentTrustSummary();
+        const projectedPr  = this.#projectAuthoredNode(pr, contentTrust, 'body');
+
+        const frontmatter = {
+            number   : pr.number,
+            title    : pr.title,
+            author   : pr.author?.login || 'unknown',
+            state    : pr.state,
+            createdAt: pr.createdAt,
+            updatedAt: pr.updatedAt,
+            closedAt : pr.closedAt,
+            mergedAt : pr.mergedAt,
+            head     : pr.headRefName,
+            base     : pr.baseRefName,
+            url      : pr.url,
+            contentTrust
+        };
+
+        let body = projectedPr.body || '';
+
+        // Build comments structure
+        if (pr.comments && pr.comments.nodes && pr.comments.nodes.length > 0) {
+            body += '\n\n## Comments\n\n';
+            for (const comment of pr.comments.nodes) {
+                const projectedComment = this.#projectAuthoredNode(
+                    comment,
+                    contentTrust,
+                    `comment:${comment.id || comment.createdAt || 'unknown'}`
+                );
+
+                body += `### \`@${comment.author?.login || 'unknown'}\` commented on ${comment.createdAt}\n\n${projectedComment.body}\n\n---\n\n`;
+            }
+        }
+
+        // Build reviews structure
+        if (pr.reviews && pr.reviews.nodes && pr.reviews.nodes.length > 0) {
+            body += '\n\n## Reviews\n\n';
+            for (const review of pr.reviews.nodes) {
+                const reviewState = review.state ? ` (${review.state})` : '';
+                body += `### \`@${review.author?.login || 'unknown'}\`${reviewState} reviewed on ${review.createdAt}\n\n`;
+                if (review.body && review.body.trim().length > 0) {
+                    const projectedReview = this.#projectAuthoredNode(
+                        review,
+                        contentTrust,
+                        `review:${review.id || review.createdAt || 'unknown'}`
+                    );
+
+                    body += `${projectedReview.body}\n\n`;
+                } else {
+                    body += `*No review body provided.*\n\n`;
+                }
+                body += `---\n\n`;
+            }
+        }
+
+        // Gray-matter serialization
+        return matter.stringify(body, frontmatter);
+    }
+
+    /**
      * Fetches pull requests from GitHub and syncs them to local markdown.
      * @param {object} metadata The sync metadata containing cached records.
      * @returns {Promise<object>} Statistics about the operation.
@@ -412,64 +479,8 @@ class PullRequestSyncer extends Base {
 
         for (const pr of allPullRequests) {
             try {
-                const targetPath = this.#getPullRequestPath(pr, planBuckets);
-                const contentTrust = createContentTrustSummary();
-                const projectedPr = this.#projectAuthoredNode(pr, contentTrust, 'body');
-
-                const frontmatter = {
-                    number   : pr.number,
-                    title    : pr.title,
-                    author   : pr.author?.login || 'unknown',
-                    state    : pr.state,
-                    createdAt: pr.createdAt,
-                    updatedAt: pr.updatedAt,
-                    closedAt : pr.closedAt,
-                    mergedAt : pr.mergedAt,
-                    head     : pr.headRefName,
-                    base     : pr.baseRefName,
-                    url      : pr.url,
-                    contentTrust
-                };
-
-                let body = projectedPr.body || '';
-
-                // Build comments structure
-                if (pr.comments && pr.comments.nodes && pr.comments.nodes.length > 0) {
-                    body += '\n\n## Comments\n\n';
-                    for (const comment of pr.comments.nodes) {
-                        const projectedComment = this.#projectAuthoredNode(
-                            comment,
-                            contentTrust,
-                            `comment:${comment.id || comment.createdAt || 'unknown'}`
-                        );
-
-                        body += `### \`@${comment.author?.login || 'unknown'}\` commented on ${comment.createdAt}\n\n${projectedComment.body}\n\n---\n\n`;
-                    }
-                }
-
-                // Build reviews structure
-                if (pr.reviews && pr.reviews.nodes && pr.reviews.nodes.length > 0) {
-                    body += '\n\n## Reviews\n\n';
-                    for (const review of pr.reviews.nodes) {
-                        const reviewState = review.state ? ` (${review.state})` : '';
-                        body += `### \`@${review.author?.login || 'unknown'}\`${reviewState} reviewed on ${review.createdAt}\n\n`;
-                        if (review.body && review.body.trim().length > 0) {
-                            const projectedReview = this.#projectAuthoredNode(
-                                review,
-                                contentTrust,
-                                `review:${review.id || review.createdAt || 'unknown'}`
-                            );
-
-                            body += `${projectedReview.body}\n\n`;
-                        } else {
-                            body += `*No review body provided.*\n\n`;
-                        }
-                        body += `---\n\n`;
-                    }
-                }
-
-                // Gray-matter serialization
-                const content = matter.stringify(body, frontmatter);
+                const targetPath  = this.#getPullRequestPath(pr, planBuckets);
+                const content     = this.#renderPullRequestMarkdown(pr);
                 const currentHash = this.#calculateContentHash(content);
 
                 const cachedPull = cachedPulls[pr.number];

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -1,19 +1,19 @@
-import aiConfig                                              from '../../../mcp/server/github-workflow/config.mjs';
-import Base                                                  from '../../../../src/core/Base.mjs';
-import crypto                                                from 'crypto';
-import {existsSync}                                          from 'fs';
-import fs                                                    from 'fs/promises';
-import logger                                                from '../../../mcp/server/github-workflow/logger.mjs';
-import matter                                                from 'gray-matter';
-import path                                                  from 'path';
-import semver                                                from 'semver';
-import GraphqlService                                        from '../GraphqlService.mjs';
-import ReleaseNotesSyncer                                    from './ReleaseNotesSyncer.mjs';
-import {FETCH_PULL_REQUESTS_FOR_SYNC}                        from '../queries/pullRequestQueries.mjs';
-import contentPath                                           from '../shared/contentPath.mjs';
-import {createContentIndexEntry, updateContentIndex}         from '../shared/contentIndex.mjs';
-import {createContentTrustSummary, projectAuthoredNodeTrust} from '../shared/conversationTrust.mjs';
-import pruneEmptyDirs                                        from '../shared/pruneEmptyDirs.mjs';
+import aiConfig                                                   from '../../../mcp/server/github-workflow/config.mjs';
+import Base                                                       from '../../../../src/core/Base.mjs';
+import crypto                                                     from 'crypto';
+import {existsSync}                                               from 'fs';
+import fs                                                         from 'fs/promises';
+import logger                                                     from '../../../mcp/server/github-workflow/logger.mjs';
+import matter                                                     from 'gray-matter';
+import path                                                       from 'path';
+import semver                                                     from 'semver';
+import GraphqlService                                             from '../GraphqlService.mjs';
+import ReleaseNotesSyncer                                         from './ReleaseNotesSyncer.mjs';
+import {FETCH_PULL_REQUESTS_FOR_SYNC, FETCH_SINGLE_PULL_FOR_SYNC} from '../queries/pullRequestQueries.mjs';
+import contentPath                                                from '../shared/contentPath.mjs';
+import {createContentIndexEntry, updateContentIndex}              from '../shared/contentIndex.mjs';
+import {createContentTrustSummary, projectAuthoredNodeTrust}      from '../shared/conversationTrust.mjs';
+import pruneEmptyDirs                                             from '../shared/pruneEmptyDirs.mjs';
 
 const issueSyncConfig = aiConfig.issueSync;
 const pullRequestConfig = aiConfig.pullRequest;
@@ -570,6 +570,98 @@ class PullRequestSyncer extends Base {
             logger.info(`✨ Synced ${stats.count} modified pull requests to disk.`);
         } else {
             logger.info(`✅ Synced 0 pull requests (all up to date).`);
+        }
+
+        return stats;
+    }
+
+    /**
+     * @summary Force-refetches specific pull requests from GitHub, bypassing the delta-by-`updatedAt`
+     * gate, and re-renders their local Markdown mirrors from current GitHub state.
+     *
+     * The bulk {@link #syncPullRequests} path is delta-gated (it stops paginating past the cached
+     * high-water mark) and PR mirrors are pull-only, so a mirror that drifted for a reason that does
+     * NOT bump `updatedAt` (e.g. an upstream body edit on an already-synced closed PR) is never
+     * re-pulled. This is the single recovery primitive: it fetches each PR via
+     * {@link FETCH_SINGLE_PULL_FOR_SYNC}, re-renders via {@link #renderPullRequestMarkdown}, writes the
+     * file, and mutates the passed `metadata` in place. The caller persists metadata afterwards.
+     * Mirrors `IssueSyncer#refetchIssuesByNumber`.
+     *
+     * @param {Array<Number>|Set<Number>} numbers The pull-request numbers to refetch.
+     * @param {Object} metadata The sync metadata object (mutated in place).
+     * @param {Object} [indexMutations=null] Optional accumulator for `_index.json` updates.
+     * @returns {Promise<{refetched: {count: Number, pulls: Number[]}, errors: Array<{prNumber: Number, error: String}>}>}
+     */
+    async refetchPullsByNumber(numbers, metadata, indexMutations = null) {
+        const stats = {refetched: {count: 0, pulls: []}, errors: []};
+        const list  = [...numbers];
+
+        for (const prNumber of list) {
+            try {
+                const data = await GraphqlService.query(
+                    FETCH_SINGLE_PULL_FOR_SYNC,
+                    {
+                        owner      : aiConfig.owner,
+                        repo       : aiConfig.repo,
+                        prNumber,
+                        maxComments: pullRequestConfig.maxCommentsPerPullRequest || 50,
+                        maxReviews : 20
+                    },
+                    true
+                );
+
+                const pr = data.repository.pullRequest;
+                if (!pr) {
+                    logger.warn(`Pull request #${prNumber} not found on GitHub, skipping refetch`);
+                    continue;
+                }
+
+                const planBuckets = this.#planBuckets(metadata, [pr]);
+                const targetPath  = this.#getPullRequestPath(pr, planBuckets);
+                if (!targetPath) {
+                    if (indexMutations) {
+                        indexMutations.remove.push({type: 'pulls', id: prNumber});
+                    }
+                    continue;
+                }
+
+                const content     = this.#renderPullRequestMarkdown(pr);
+                const contentHash = this.#calculateContentHash(content);
+
+                await fs.mkdir(path.dirname(targetPath), {recursive: true});
+                await fs.writeFile(targetPath, content, 'utf-8');
+
+                stats.refetched.count++;
+                stats.refetched.pulls.push(prNumber);
+                logger.debug(`✅ Refetched pull request #${prNumber}`);
+
+                metadata.pulls[prNumber] = {
+                    number   : pr.number,
+                    contentHash,
+                    state    : pr.state,
+                    updatedAt: pr.updatedAt,
+                    closedAt : pr.closedAt || null,
+                    mergedAt : pr.mergedAt || null,
+                    milestone: pr.milestone?.title || null,
+                    path     : this.#relativePath(targetPath)
+                };
+
+                if (indexMutations) {
+                    const plan = planBuckets.get(prNumber);
+                    indexMutations.upsert.push(createContentIndexEntry({
+                        issueSyncConfig,
+                        type     : 'pulls',
+                        id       : prNumber,
+                        filePath : this.#resolvePath(this.#relativePath(targetPath)),
+                        itemIndex: plan ? plan.itemIndex : 0,
+                        version  : pr.state === 'OPEN' ? null : plan?.version || null,
+                        bucket   : null
+                    }));
+                }
+            } catch (e) {
+                logger.error(`Failed to refetch pull request #${prNumber}: ${e.message}`);
+                stats.errors.push({prNumber, error: e.message});
+            }
         }
 
         return stats;

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -393,6 +393,66 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         expect(stats.count).toBe(0);
         await expect(fs.pathExists(activePath)).resolves.toBe(true);    // untouched (fail-safe skip)
     });
+    test('refetchPullsByNumber force-re-renders a stale PR mirror, bypassing the delta/hash gate (#13794)', async () => {
+        const prNumber = 9876;
+
+        // The mirror is cached as current (matching updatedAt) with a STALE contentHash — the bulk
+        // delta-sync would skip it (updatedAt unchanged AND hash compare). refetchPullsByNumber must
+        // force a re-render from live GitHub state regardless.
+        const metadata = {
+            pulls: {
+                [prNumber]: {
+                    state      : 'MERGED',
+                    updatedAt  : '2026-05-02T00:00:00Z',
+                    contentHash: 'STALE-HASH',
+                    path       : `resources/content/pulls/chunk-1/pr-${prNumber}.md`
+                }
+            }
+        };
+
+        // No release published after the merge → the PR resolves to the ACTIVE bucket.
+        ReleaseNotesSyncer.sortedReleases = [];
+
+        let capturedQuery = null;
+        let capturedVars  = null;
+        GraphqlService.query = async (query, vars) => {
+            capturedQuery = query;
+            capturedVars  = vars;
+
+            return {repository: {pullRequest: buildPullRequest(prNumber)}};
+        };
+
+        const stats = await PullRequestSyncer.refetchPullsByNumber([prNumber], metadata);
+
+        // Used the single-PR query with the right number — not the bulk pagination query.
+        expect(capturedQuery).toContain('FetchSinglePullForSync');
+        expect(capturedVars.prNumber).toBe(prNumber);
+
+        // Re-rendered + written to the active bucket.
+        expect(stats.refetched).toEqual({count: 1, pulls: [prNumber]});
+        const targetPath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
+        await expect(fs.pathExists(targetPath)).resolves.toBe(true);
+
+        const parsed = matter(await fs.readFile(targetPath, 'utf8'));
+        expect(parsed.data.number).toBe(prNumber);
+
+        // Metadata refreshed with the live hash (no longer the stale one) + the resolved path.
+        expect(metadata.pulls[prNumber].contentHash).not.toBe('STALE-HASH');
+        expect(metadata.pulls[prNumber].state).toBe('MERGED');
+        expect(metadata.pulls[prNumber].path).toBe(path.relative(aiConfig.projectRoot, targetPath));
+    });
+
+    test('refetchPullsByNumber skips a PR that no longer exists on GitHub (#13794)', async () => {
+        const prNumber = 4242;
+        const metadata = {pulls: {}};
+
+        GraphqlService.query = async () => ({repository: {pullRequest: null}});
+
+        const stats = await PullRequestSyncer.refetchPullsByNumber([prNumber], metadata);
+
+        expect(stats.refetched).toEqual({count: 0, pulls: []});
+        expect(metadata.pulls[prNumber]).toBeUndefined();
+    });
 });
 
 function buildPullRequest(number) {


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13803. Refs #13794.

## Summary

The shipped `SyncService.refetchIssuesByNumber` / `refetchTruncatedIssues.mjs` is a standalone, out-of-band, idempotent healing primitive that force-refetches issues bypassing the delta-`updatedAt` gate (the gate that never re-pulls closed/archived items). **Pulls had no equivalent** — so a closed/merged PR mirror that drifted for a reason that does NOT bump `updatedAt` (e.g. an upstream body edit) could only be healed by a full clean-slate traversal (heavy, lease-bound).

This delivers the **pulls** half of #13794, a faithful mirror of the issue path. #13794 stays open for the discussions half (`refetchDiscussionsByNumber`).

## Deltas

- **`FETCH_SINGLE_PULL_FOR_SYNC`** (`queries/pullRequestQueries.mjs`): single-PR variant of `FETCH_PULL_REQUESTS_FOR_SYNC` — identical node shape (body + comments + reviews + frontmatter fields), keyed by `$prNumber`.
- **`PullRequestSyncer#renderPullRequestMarkdown(pr)`**: behavior-preserving extraction of the inline frontmatter + body + comments + reviews render from `syncPullRequests`, so bulk-sync and refetch render **identically** (no drift). The bulk-sync output is byte-identical (13/13 spec green).
- **`PullRequestSyncer.refetchPullsByNumber(numbers, metadata, indexMutations?)`**: the recovery primitive — fetches each PR via `FETCH_SINGLE_PULL_FOR_SYNC`, re-renders, writes, mutates `metadata` in place. Mirrors `IssueSyncer.refetchIssuesByNumber`.
- **`SyncService.refetchPullsByNumber({numbers})`**: facade (load metadata → delegate → persist). Mirrors `refetchIssuesByNumber`.
- **`ai/scripts/migrations/refetchStalePulls.mjs`**: standalone CLI (pull-only, no orchestrator/lease — works under scheduler saturation). Mirrors `refetchTruncatedIssues.mjs`.

## Test Evidence

Evidence: **L2** — `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs` → **13 passed** (11 existing + 2 new):
- `refetchPullsByNumber force-re-renders a stale PR mirror, bypassing the delta/hash gate` — asserts the single-PR query is used with the right number, the file is re-written to the resolved bucket, and `metadata.pulls[n]` is refreshed with the live hash (not the cached `STALE-HASH`).
- `refetchPullsByNumber skips a PR that no longer exists on GitHub` — `pullRequest: null` → no write, no metadata entry, `count: 0`.

`node --check` clean on all touched files; `check-block-alignment --staged` clean on my hunks.

## Post-Merge Validation

- [ ] Out-of-band (live GitHub + sync env): run `node ai/scripts/migrations/refetchStalePulls.mjs <N>` on a known-drifted archived PR mirror → the local file re-renders to match the current GitHub PR body (the stale residual edit is gone) and `metadata.pulls[N]` carries the refreshed `contentHash`. Idempotent: a second run is a no-op writeback (`refetched.count` unchanged on the re-run).

## Immediate use (out-of-band; operator / CI, not CI-gated)

Heal the 43 archived pull mirrors that carry stale local edits the delta-sync won't refresh (their GitHub bodies are current + clean):

    node ai/scripts/migrations/refetchStalePulls.mjs <nums>

This is a live-GitHub + sync-env operation (not exercised in CI); the primitive + CLI are delivered and unit-covered here.

## Notes

- **Pre-existing `dev` debt (not introduced here):** the whole-file `check-block-alignment` flags 11 import-misalignments in `SyncService.mjs` that **also exist on `dev`** — I only added the facade method (the import block is untouched; the `--staged` gate that actually blocks commits is clean on my hunks). Out of scope to re-align unrelated imports.
- The `PullRequestSyncer.mjs` import block was re-aligned (project `--fix` formatter) because the new combined query import is the longest single-line import — whitespace-only.

Contract Ledger on #13803. Surfaced during the synced-mirror drift-recovery (#13794).
