### PR TITLE
feat(ai): surface undigested sessions as a visible Consolidation Gaps section (#13807)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -1046,29 +1046,41 @@ class GoldenPathSynthesizer extends Base {
     /**
      * @summary Renders the Consolidation Gaps section — undigested sessions made visible.
      *
-     * Consolidation-liveness: the dream must **visibly record** sessions it has NOT
-     * digested, never silently. A fresh handoff over an undigested
-     * backlog reads healthy ("health-green-but-map-lying") unless the gap is surfaced — a
-     * lost walk must be *visibly* lost. Queries the summary collection for
-     * `graphDigested !== true` and renders the count + a bounded sample. Visibility-only:
-     * no routing change. Returns '' when the collection query fails (defensive) — but NOT
-     * when zero are undigested: a "0 undigested" line is itself the honest all-clear.
+     * Consolidation-liveness: the dream must **visibly record** sessions it has NOT digested,
+     * never silently. A fresh handoff over an undigested backlog reads healthy
+     * ("health-green-but-map-lying") unless the gap is surfaced — a lost walk must be *visibly*
+     * lost. Queries the summary collection for `graphDigested !== true` and renders the count +
+     * a bounded sample. Visibility-only: no routing change.
+     *
+     * **Failure must not read as healthy.** A thrown query OR a malformed (non-array) response
+     * renders an explicit `Status UNKNOWN` state — never blank and never a `0 undigested`
+     * all-clear (which would be the exact false-green this section exists to prevent). A valid
+     * empty response IS a real all-clear, but reports the checked-count so "0 checked" is
+     * distinguishable from "0 undigested of N".
      *
      * @param {Object} summaryColl Summary Chroma collection (exposes async `.get`).
      * @param {Object} [options]
      * @param {Number} [options.limit=5] Max undigested sessions to sample.
-     * @returns {Promise<String>} The rendered section, or '' on query failure.
+     * @returns {Promise<String>} The rendered section (always non-empty — gap, all-clear, or unknown).
      */
     static async renderConsolidationGapsSection(summaryColl, {limit = 5} = {}) {
+        const header = `\n## Consolidation Gaps\n\n*Consolidation-liveness: sessions the dream has NOT yet laid as trails. A lost walk is visibly lost, never silently absent — a fresh handoff must not read healthy over an undigested backlog.*\n\n`;
+
         let raw;
         try {
             raw = await summaryColl.get({include: ['metadatas']});
         } catch (e) {
-            return '';
+            // A failed query must NOT read as healthy — surface an explicit unknown state.
+            return `${header}❓ **Status UNKNOWN** — the summary collection query failed (\`${e.message}\`); consolidation health could not be determined. This is NOT an all-clear.\n`;
         }
 
-        const metas      = Array.isArray(raw?.metadatas) ? raw.metadatas : [],
-              ids        = Array.isArray(raw?.ids) ? raw.ids : [],
+        // A malformed response (no metadata array) is unknown, NOT zero-undigested.
+        if (!raw || !Array.isArray(raw.metadatas)) {
+            return `${header}❓ **Status UNKNOWN** — the summary collection returned a malformed response (no metadata array); consolidation health could not be determined. This is NOT an all-clear.\n`;
+        }
+
+        const metas      = raw.metadatas,
+              ids        = Array.isArray(raw.ids) ? raw.ids : [],
               undigested = [];
 
         for (let i = 0; i < metas.length; i++) {
@@ -1080,15 +1092,11 @@ class GoldenPathSynthesizer extends Base {
             }
         }
 
-        let section = `\n## Consolidation Gaps\n\n`;
-        section += `*Consolidation-liveness (ADR 0023): sessions the dream has NOT yet laid as trails. A lost walk is visibly lost, never silently absent — a fresh handoff must not read healthy over an undigested backlog.*\n\n`;
-
         if (undigested.length === 0) {
-            section += `✅ 0 sessions undigested — consolidation is current.\n`;
-            return section
+            return `${header}✅ 0 sessions undigested — consolidation is current (${metas.length} session(s) checked).\n`;
         }
 
-        section += `⚠️ **${undigested.length} session(s) undigested** (\`graphDigested !== true\`)`;
+        let section = `${header}⚠️ **${undigested.length} session(s) undigested** (\`graphDigested !== true\`)`;
         section += undigested.length > limit ? `, showing ${limit}:\n` : `:\n`;
 
         for (const item of undigested.slice(0, limit)) {

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -1043,6 +1043,61 @@ class GoldenPathSynthesizer extends Base {
         return {documents: recentIds.map(id => byId.get(id)).filter(doc => doc !== undefined && doc !== null)};
     }
 
+    /**
+     * @summary Renders the Consolidation Gaps section — undigested sessions made visible.
+     *
+     * Consolidation-liveness: the dream must **visibly record** sessions it has NOT
+     * digested, never silently. A fresh handoff over an undigested
+     * backlog reads healthy ("health-green-but-map-lying") unless the gap is surfaced — a
+     * lost walk must be *visibly* lost. Queries the summary collection for
+     * `graphDigested !== true` and renders the count + a bounded sample. Visibility-only:
+     * no routing change. Returns '' when the collection query fails (defensive) — but NOT
+     * when zero are undigested: a "0 undigested" line is itself the honest all-clear.
+     *
+     * @param {Object} summaryColl Summary Chroma collection (exposes async `.get`).
+     * @param {Object} [options]
+     * @param {Number} [options.limit=5] Max undigested sessions to sample.
+     * @returns {Promise<String>} The rendered section, or '' on query failure.
+     */
+    static async renderConsolidationGapsSection(summaryColl, {limit = 5} = {}) {
+        let raw;
+        try {
+            raw = await summaryColl.get({include: ['metadatas']});
+        } catch (e) {
+            return '';
+        }
+
+        const metas      = Array.isArray(raw?.metadatas) ? raw.metadatas : [],
+              ids        = Array.isArray(raw?.ids) ? raw.ids : [],
+              undigested = [];
+
+        for (let i = 0; i < metas.length; i++) {
+            const meta = metas[i];
+            // graphDigested is set true only after BOTH deterministic ingestion AND the
+            // semantic extractor complete (DreamService); anything else is an un-laid trail.
+            if (meta && meta.graphDigested !== true && meta.graphDigested !== 'true') {
+                undigested.push({id: ids[i], title: meta.title || meta.sessionId || ids[i]});
+            }
+        }
+
+        let section = `\n## Consolidation Gaps\n\n`;
+        section += `*Consolidation-liveness (ADR 0023): sessions the dream has NOT yet laid as trails. A lost walk is visibly lost, never silently absent — a fresh handoff must not read healthy over an undigested backlog.*\n\n`;
+
+        if (undigested.length === 0) {
+            section += `✅ 0 sessions undigested — consolidation is current.\n`;
+            return section
+        }
+
+        section += `⚠️ **${undigested.length} session(s) undigested** (\`graphDigested !== true\`)`;
+        section += undigested.length > limit ? `, showing ${limit}:\n` : `:\n`;
+
+        for (const item of undigested.slice(0, limit)) {
+            section += `- \`${item.id}\` — ${item.title}\n`;
+        }
+
+        return section
+    }
+
     async synthesizeGoldenPath({
         repoEnrichmentEnabled = true,
         issuesDir = path.resolve(__dirname, '../../../resources/content/issues'),
@@ -1389,6 +1444,16 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             // Defensive: ConsumerFrictionHelper failure must not break handoff rendering.
             // Log + continue with the rest of the handoff content.
             logger.warn(`[GoldenPathSynthesizer] ConsumerFriction section render failed: ${err.message}`);
+        }
+
+        // --- Consolidation Gaps (consolidation-liveness: undigested sessions made visible) ---
+        try {
+            const gapsSection = await this.constructor.renderConsolidationGapsSection(summaryColl);
+            if (gapsSection) {
+                handoffContent += gapsSection;
+            }
+        } catch (e) {
+            logger.warn(`[GoldenPathSynthesizer] Consolidation Gaps section render failed: ${e.message}`);
         }
 
         // --- Current Release / Incident Focus ---

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -1004,6 +1004,37 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).not.toContain(openId);
         expect(handoffContent).not.toContain(closedId);
     });
+
+    test('renderConsolidationGapsSection surfaces undigested sessions visibly (#13807)', async () => {
+        const
+            Synthesizer = GoldenPathSynthesizer.constructor,
+            collection  = {
+                get: async () => ({
+                    ids      : ['s1', 's2', 's3'],
+                    metadatas: [
+                        {title: 'Digested one', graphDigested: true},
+                        {title: 'Undigested A', graphDigested: false},
+                        {title: 'Undigested B'} // no flag → undigested (graphDigested !== true)
+                    ]
+                })
+            };
+
+        const section = await Synthesizer.renderConsolidationGapsSection(collection);
+        expect(section).toContain('## Consolidation Gaps');
+        expect(section).toContain('2 session(s) undigested');
+        expect(section).toContain('Undigested A');
+        expect(section).toContain('Undigested B');
+        expect(section).not.toContain('Digested one') // the digested session is not listed as a gap
+    });
+
+    test('renderConsolidationGapsSection renders the honest all-clear when none undigested (#13807)', async () => {
+        const
+            Synthesizer = GoldenPathSynthesizer.constructor,
+            collection  = {get: async () => ({ids: ['s1'], metadatas: [{title: 'Done', graphDigested: true}]})};
+
+        const section = await Synthesizer.renderConsolidationGapsSection(collection);
+        expect(section).toContain('0 sessions undigested')
+    });
 });
 
 test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from canonical @identity', () => {

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -1035,6 +1035,29 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const section = await Synthesizer.renderConsolidationGapsSection(collection);
         expect(section).toContain('0 sessions undigested')
     });
+
+    test('renderConsolidationGapsSection renders Status UNKNOWN when the query throws — never a false all-clear (#13809)', async () => {
+        const
+            Synthesizer = GoldenPathSynthesizer.constructor,
+            collection  = {get: async () => { throw new Error('chroma unavailable'); }};
+
+        const section = await Synthesizer.renderConsolidationGapsSection(collection);
+        expect(section).toContain('## Consolidation Gaps');
+        expect(section).toContain('Status UNKNOWN');
+        expect(section).toContain('NOT an all-clear');
+        expect(section).not.toContain('0 sessions undigested') // the false-green this section exists to prevent
+    });
+
+    test('renderConsolidationGapsSection renders Status UNKNOWN on a malformed response — never a false all-clear (#13809)', async () => {
+        const
+            Synthesizer = GoldenPathSynthesizer.constructor,
+            collection  = {get: async () => ({})}; // malformed: no metadatas array
+
+        const section = await Synthesizer.renderConsolidationGapsSection(collection);
+        expect(section).toContain('Status UNKNOWN');
+        expect(section).toContain('malformed');
+        expect(section).not.toContain('0 sessions undigested') // a non-array response must not read as zero-undigested
+    });
 });
 
 test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from canonical @identity', () => {


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13807 (sub of #13624). First concrete implementation of ADR 0023's **consolidation-liveness** invariant — decoupled from #12439's semantic-fidelity work.

## Summary

The dream (DreamService consolidation) digests sessions into graph trails. When a session's tri-vector extraction returns `null` (over-band → context-overflow, or aborted), or the backlog stalls, those sessions are **silently un-digested** — they deposit no trail and the handoff does not record the loss. A fresh handoff over an undigested backlog then reads healthy ("health-green-but-map-lying"). This makes the gap **visible by construction**: *a lost walk must be visibly lost.*

## Deltas

- `GoldenPathSynthesizer.renderConsolidationGapsSection` (new static) — queries the summary collection for `graphDigested !== true`, renders the count + a bounded sample; an honest `✅ 0 sessions undigested` all-clear line when none. Visibility-only (no routing change); returns `''` **only** on a collection-query failure (defensive), never to hide a real gap.
- `synthesizeGoldenPath` — wires the section in right after the consumer-friction section (the two consolidation-health surfaces sit together). Invoked via `this.constructor.…` (the proven sibling pattern at L1201; safer than the locally-declared `Synthesizer` var, which is TDZ-bound later in the method).
- 2 unit tests (undigested-surfaced + the honest all-clear), in the main describe.

## Test Evidence

Evidence: L2 (unit) — the pure render logic is fully covered: the `graphDigested !== true` undigested-filter, the digested session correctly excluded from the gap list, and the all-clear path. The live wiring is defensive (try/catch around a proven invocation) and the `synthesizeGoldenPath` integration tests pass unchanged (dark to the existing handoff shape — the section only appears when there is something honest to report).

**L2** — 23/23 `GoldenPathSynthesizer` specs green (`UNIT_TEST_MODE=true npx playwright test … -c test/playwright/playwright.config.mjs`), incl. the 2 new `renderConsolidationGapsSection` tests + the unchanged integration tests. Pre-commit hooks (whitespace / shorthand / jsdoc-types / ticket-archaeology / block-alignment) all green.

## Premise Coherence

**Coheres:** the first map-fidelity-pure implementation of ADR 0023's consolidation-liveness invariant — *observable, never assumed-green*. Pure visibility, no routing change, decoupled from the semantic-fidelity question (#12439, Ada's authority).

## Post-Merge Validation

- [ ] Confirm the next `sandman_handoff.md` regeneration renders the Consolidation Gaps section against the live undigested backlog (~316 per @neo-opus-vega's orchestrator V-B-A).
