### PR TITLE
feat(ai): refetchDiscussionsByNumber force-refetch for stale discussion mirrors (#13811)

### DIFF
--- a/ai/scripts/migrations/refetchStaleDiscussions.mjs
+++ b/ai/scripts/migrations/refetchStaleDiscussions.mjs
@@ -1,0 +1,49 @@
+/**
+ * @summary Force-refetches the given discussion numbers from GitHub to heal local mirror drift.
+ *
+ * Discussion analogue of `refetchStalePulls.mjs` / `refetchTruncatedIssues.mjs`. Discussion mirrors
+ * are pull-only and the bulk sync is delta-gated by `updatedAt`, so a discussion whose upstream body
+ * was edited (an edit that does NOT bump `updatedAt`) is never re-pulled. This script bypasses that gate:
+ *
+ *   node ai/scripts/migrations/refetchStaleDiscussions.mjs 10119 10137 9999
+ *
+ * Delegates to `GH_SyncService.refetchDiscussionsByNumber`, which re-renders each local markdown file
+ * from current GitHub state and persists updated metadata. Idempotent: refetching a current discussion
+ * is a no-op writeback.
+ *
+ * @see ai/scripts/migrations/refetchStalePulls.mjs
+ * @see ai/services/github-workflow/SyncService.mjs
+ */
+import {GH_SyncService} from '../../services.mjs';
+
+async function main() {
+    const argv    = process.argv.slice(2);
+    const numbers = argv.map(a => Number(a)).filter(n => Number.isInteger(n) && n > 0);
+
+    if (numbers.length === 0) {
+        console.error('Usage:');
+        console.error('  node ai/scripts/migrations/refetchStaleDiscussions.mjs <num> [<num> ...]');
+        process.exit(1);
+    }
+
+    console.log(`Force-refetching ${numbers.length} discussion(s): ${numbers.join(', ')}`);
+
+    const stats = await GH_SyncService.refetchDiscussionsByNumber({numbers});
+
+    console.log(`\nRefetched ${stats.refetched.count}/${numbers.length}`);
+    if (stats.refetched.discussions.length > 0) {
+        console.log(`  OK: ${stats.refetched.discussions.join(', ')}`);
+    }
+    if (stats.errors.length > 0) {
+        console.log(`  FAIL: ${stats.errors.length} error(s)`);
+        for (const {discussionNumber, error} of stats.errors) {
+            console.log(`    #${discussionNumber}: ${error}`);
+        }
+        process.exit(1);
+    }
+}
+
+main().catch(e => {
+    console.error('Error:', e);
+    process.exit(1);
+});

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -436,6 +436,33 @@ class SyncService extends Base {
     }
 
     /**
+     * @summary Facade for the standalone discussion force-refetch (archive-mirror drift healing).
+     *
+     * Loads metadata, delegates to `DiscussionSyncer.refetchDiscussionsByNumber`, persists the updated
+     * metadata. Bypasses the bulk delta-by-`updatedAt` gate so known-stale discussion mirrors — which
+     * the pull-only bulk sync never re-pulls once their `updatedAt` is past the high-water mark — can be
+     * re-rendered from current GitHub state. Invoked out-of-band by
+     * `ai/scripts/migrations/refetchStaleDiscussions.mjs` — never the regular `runFullSync` loop.
+     *
+     * @param {object}   params
+     * @param {number[]} params.numbers Discussion numbers to force-refetch.
+     * @returns {Promise<{refetched: {count: number, discussions: number[]}, errors: Array<{discussionNumber: number, error: string}>}>}
+     */
+    async refetchDiscussionsByNumber({numbers}) {
+        if (!Array.isArray(numbers) || numbers.length === 0) {
+            return {refetched: {count: 0, discussions: []}, errors: []};
+        }
+
+        const metadata = await MetadataManager.load();
+        const stats    = await DiscussionSyncer.refetchDiscussionsByNumber(numbers, metadata);
+        await MetadataManager.save(metadata);
+
+        logger.info(`✨ Force-refetch complete: ${stats.refetched.count}/${numbers.length} discussions refetched`);
+
+        return stats;
+    }
+
+    /**
      * Facade for the one-time archive re-bucket migration. Loads metadata, delegates to
      * `IssueSyncer.migrateArchiveBuckets`, then persists the updated metadata (unless `dryRun`).
      * Invoked out-of-band by `ai/scripts/migrations/rebucketArchive.mjs` — never the regular sync loop.

--- a/ai/services/github-workflow/queries/discussionQueries.mjs
+++ b/ai/services/github-workflow/queries/discussionQueries.mjs
@@ -185,3 +185,68 @@ export const FETCH_DISCUSSIONS_FOR_SYNC = `
     }
   }
 `;
+
+/**
+ * @summary Single-discussion variant of {@link FETCH_DISCUSSIONS_FOR_SYNC} for the force-refetch path.
+ *
+ * Returns the identical sync node shape (body + comments + nested replies + frontmatter fields) for
+ * ONE discussion by number, bypassing the bulk delta-by-`updatedAt` gating so a known-stale local
+ * mirror can be force-re-rendered from current GitHub state.
+ *
+ * Variables required:
+ * - $owner: String!
+ * - $repo: String!
+ * - $number: Int!
+ * - $maxComments: Int!
+ * - $maxReplies: Int!
+ */
+export const FETCH_SINGLE_DISCUSSION_FOR_SYNC = `
+  query FetchSingleDiscussionForSync(
+    $owner: String!
+    $repo: String!
+    $number: Int!
+    $maxComments: Int!
+    $maxReplies: Int!
+  ) {
+    repository(owner: $owner, name: $repo) {
+      discussion(number: $number) {
+        number
+        title
+        body
+        closed
+        closedAt
+        createdAt
+        updatedAt
+
+        author {
+          login
+        }
+
+        category {
+          name
+        }
+
+        comments(first: $maxComments) {
+          nodes {
+            author {
+              login
+            }
+            body
+            createdAt
+            isAnswer
+            replies(first: $maxReplies) {
+              nodes {
+                author {
+                  login
+                }
+                body
+                createdAt
+                isAnswer
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -1,14 +1,14 @@
-import aiConfig                     from '../../../mcp/server/github-workflow/config.mjs';
-import Base                         from '../../../../src/core/Base.mjs';
-import crypto                       from 'crypto';
-import fs                           from 'fs/promises';
-import logger                       from '../../../mcp/server/github-workflow/logger.mjs';
-import matter                       from 'gray-matter';
-import path                         from 'path';
-import GraphqlService               from '../GraphqlService.mjs';
-import ReleaseNotesSyncer           from './ReleaseNotesSyncer.mjs';
-import {FETCH_DISCUSSIONS_FOR_SYNC} from '../queries/discussionQueries.mjs';
-import contentPath                  from '../shared/contentPath.mjs';
+import aiConfig                                                       from '../../../mcp/server/github-workflow/config.mjs';
+import Base                                                           from '../../../../src/core/Base.mjs';
+import crypto                                                         from 'crypto';
+import fs                                                             from 'fs/promises';
+import logger                                                         from '../../../mcp/server/github-workflow/logger.mjs';
+import matter                                                         from 'gray-matter';
+import path                                                           from 'path';
+import GraphqlService                                                 from '../GraphqlService.mjs';
+import ReleaseNotesSyncer                                             from './ReleaseNotesSyncer.mjs';
+import {FETCH_DISCUSSIONS_FOR_SYNC, FETCH_SINGLE_DISCUSSION_FOR_SYNC} from '../queries/discussionQueries.mjs';
+import contentPath                                                    from '../shared/contentPath.mjs';
 import {
     createContentIndexEntry,
     updateContentIndex
@@ -475,6 +475,94 @@ class DiscussionSyncer extends Base {
             logger.info(`✨ Interacted and synced ${stats.count} modified discussions to disk.`);
         } else {
             logger.info(`✅ Synced 0 discussions (all up to date).`);
+        }
+
+        return stats;
+    }
+
+    /**
+     * @summary Force-refetches specific discussions from GitHub, bypassing the delta-by-`updatedAt`
+     * gate, and re-renders their local Markdown mirrors from current GitHub state.
+     *
+     * The bulk {@link #syncDiscussions} path is delta-gated and discussion mirrors are pull-only, so a
+     * mirror that drifted for a reason that does NOT bump `updatedAt` is never re-pulled. This is the
+     * single recovery primitive: it fetches each discussion via {@link FETCH_SINGLE_DISCUSSION_FOR_SYNC},
+     * re-renders via {@link #renderDiscussionMarkdown}, writes the file, and mutates the passed
+     * `metadata` in place. The caller persists metadata afterwards. Mirrors
+     * `PullRequestSyncer#refetchPullsByNumber` / `IssueSyncer#refetchIssuesByNumber`.
+     *
+     * @param {Array<Number>|Set<Number>} numbers The discussion numbers to refetch.
+     * @param {Object} metadata The sync metadata object (mutated in place).
+     * @param {Object} [indexMutations=null] Optional accumulator for `_index.json` updates.
+     * @returns {Promise<{refetched: {count: Number, discussions: Number[]}, errors: Array<{discussionNumber: Number, error: String}>}>}
+     */
+    async refetchDiscussionsByNumber(numbers, metadata, indexMutations = null) {
+        const stats = {refetched: {count: 0, discussions: []}, errors: []};
+        const list  = [...numbers];
+
+        for (const discussionNumber of list) {
+            try {
+                const data = await GraphqlService.query(
+                    FETCH_SINGLE_DISCUSSION_FOR_SYNC,
+                    {
+                        owner      : aiConfig.owner,
+                        repo       : aiConfig.repo,
+                        number     : discussionNumber,
+                        maxComments: 50,
+                        maxReplies : 20
+                    },
+                    true
+                );
+
+                const discussion = data.repository.discussion;
+                if (!discussion) {
+                    logger.warn(`Discussion #${discussionNumber} not found on GitHub, skipping refetch`);
+                    continue;
+                }
+
+                const planBuckets = this.#planBuckets(metadata, [discussion]);
+                const targetPath  = this.#getDiscussionPath(discussion, planBuckets);
+                if (!targetPath) {
+                    if (indexMutations) {
+                        indexMutations.remove.push({type: 'discussions', id: discussionNumber});
+                    }
+                    continue;
+                }
+
+                const content     = this.#renderDiscussionMarkdown(discussion);
+                const contentHash = this.#calculateContentHash(content);
+
+                await fs.mkdir(path.dirname(targetPath), {recursive: true});
+                await fs.writeFile(targetPath, content, 'utf-8');
+
+                stats.refetched.count++;
+                stats.refetched.discussions.push(discussionNumber);
+                logger.debug(`✅ Refetched discussion #${discussionNumber}`);
+
+                metadata.discussions[discussionNumber] = {
+                    number  : discussion.number,
+                    closed  : discussion.closed,
+                    closedAt: discussion.closedAt,
+                    contentHash,
+                    path    : this.#relativePath(targetPath)
+                };
+
+                if (indexMutations) {
+                    const plan = planBuckets.get(discussionNumber);
+                    indexMutations.upsert.push(createContentIndexEntry({
+                        issueSyncConfig,
+                        type     : 'discussions',
+                        id       : discussionNumber,
+                        filePath : this.#resolvePath(this.#relativePath(targetPath)),
+                        itemIndex: plan ? plan.itemIndex : 0,
+                        version  : plan?.version || null,
+                        bucket   : null
+                    }));
+                }
+            } catch (e) {
+                logger.error(`Failed to refetch discussion #${discussionNumber}: ${e.message}`);
+                stats.errors.push({discussionNumber, error: e.message});
+            }
         }
 
         return stats;

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -222,6 +222,81 @@ class DiscussionSyncer extends Base {
     }
 
     /**
+     * @summary Renders a fetched discussion node to its synced Markdown (frontmatter + body + comments +
+     * nested replies), applying the content-trust sanitizer + the frontmatter integrity gate.
+     * Extracted from {@link #syncDiscussions} so the single-discussion force-refetch path renders
+     * identically (no bulk-sync-vs-refetch drift).
+     * @param {Object} discussion The discussion node (with `comments.nodes[].replies.nodes`).
+     * @returns {String} The gray-matter-serialized Markdown content.
+     * @throws {Error} When the serialized content is missing required frontmatter keys (a frontmatter-contract violation — likely a stale daemon code path).
+     */
+    #renderDiscussionMarkdown(discussion) {
+        const contentTrust = createContentTrustSummary();
+        const projectedDiscussion = this.#projectAuthoredNode(discussion, contentTrust, 'body');
+
+        const frontmatter = {
+            number   : discussion.number,
+            title    : discussion.title,
+            author   : discussion.author?.login || 'unknown',
+            category : discussion.category?.name || 'Uncategorized',
+            createdAt: discussion.createdAt,
+            updatedAt: discussion.updatedAt,
+            closed   : discussion.closed,
+            closedAt : discussion.closedAt,
+            contentTrust
+        };
+
+        let body = projectedDiscussion.body || '';
+
+        // Build comments structure
+        if (discussion.comments && discussion.comments.nodes && discussion.comments.nodes.length > 0) {
+            body += '\n\n## Comments\n\n';
+            for (const comment of discussion.comments.nodes) {
+                const projectedComment = this.#projectAuthoredNode(
+                    comment,
+                    contentTrust,
+                    `comment:${comment.id || comment.createdAt || 'unknown'}`
+                );
+
+                body += `### \`@${comment.author?.login || 'unknown'}\` commented on ${comment.createdAt}\n\n`;
+                if (comment.isAnswer) {
+                    body += '> [!ANSWER]\n\n';
+                }
+                body += `${projectedComment.body}\n\n`;
+
+                // Parse replies if any
+                if (comment.replies && comment.replies.nodes && comment.replies.nodes.length > 0) {
+                    for (const reply of comment.replies.nodes) {
+                        const projectedReply = this.#projectAuthoredNode(
+                            reply,
+                            contentTrust,
+                            `comment:${comment.id || comment.createdAt || 'unknown'}/reply:${reply.id || reply.createdAt || 'unknown'}`
+                        );
+
+                        body += `#### Reply depth=1 by \`@${reply.author?.login || 'unknown'}\` on ${reply.createdAt}\n\n`;
+                        if (reply.isAnswer) {
+                            body += '> [!ANSWER]\n\n';
+                        }
+                        body += `${projectedReply.body}\n\n`;
+                    }
+                }
+                body += '---\n\n';
+            }
+        }
+
+        // Gray-matter serialization
+        const content = matter.stringify(body, frontmatter);
+
+        // Integrity gate: catches stale daemon code paths that silently drop frontmatter fields.
+        const integrity = verifyDiscussionFrontmatter(content);
+        if (!integrity.ok) {
+            throw new Error(`Discussion #${discussion.number} serialized content missing required frontmatter keys: ${integrity.missing.join(', ')}. Frontmatter contract violation — likely stale MCP daemon code path.`);
+        }
+
+        return content;
+    }
+
+    /**
      * Fetches discussions from GitHub and syncs them to local markdown.
      * @param {object} metadata The sync metadata containing cached records.
      * @returns {Promise<object>} Statistics about the operation.
@@ -313,71 +388,8 @@ class DiscussionSyncer extends Base {
             try {
                 const targetPath  = this.#getDiscussionPath(discussion, planBuckets);
                 if (!targetPath) continue;
-                const contentTrust = createContentTrustSummary();
-                const projectedDiscussion = this.#projectAuthoredNode(discussion, contentTrust, 'body');
 
-                const frontmatter = {
-                    number   : discussion.number,
-                    title    : discussion.title,
-                    author   : discussion.author?.login || 'unknown',
-                    category : discussion.category?.name || 'Uncategorized',
-                    createdAt: discussion.createdAt,
-                    updatedAt: discussion.updatedAt,
-                    closed   : discussion.closed,
-                    closedAt : discussion.closedAt,
-                    contentTrust
-                };
-
-                let body = projectedDiscussion.body || '';
-
-                // Build comments structure
-                if (discussion.comments && discussion.comments.nodes && discussion.comments.nodes.length > 0) {
-                    body += '\n\n## Comments\n\n';
-                    for (const comment of discussion.comments.nodes) {
-                        const projectedComment = this.#projectAuthoredNode(
-                            comment,
-                            contentTrust,
-                            `comment:${comment.id || comment.createdAt || 'unknown'}`
-                        );
-
-                        body += `### \`@${comment.author?.login || 'unknown'}\` commented on ${comment.createdAt}\n\n`;
-                        if (comment.isAnswer) {
-                            body += '> [!ANSWER]\n\n';
-                        }
-                        body += `${projectedComment.body}\n\n`;
-
-                        // Parse replies if any
-                        if (comment.replies && comment.replies.nodes && comment.replies.nodes.length > 0) {
-                            for (const reply of comment.replies.nodes) {
-                                const projectedReply = this.#projectAuthoredNode(
-                                    reply,
-                                    contentTrust,
-                                    `comment:${comment.id || comment.createdAt || 'unknown'}/reply:${reply.id || reply.createdAt || 'unknown'}`
-                                );
-
-                                body += `#### Reply depth=1 by \`@${reply.author?.login || 'unknown'}\` on ${reply.createdAt}\n\n`;
-                                if (reply.isAnswer) {
-                                    body += '> [!ANSWER]\n\n';
-                                }
-                                body += `${projectedReply.body}\n\n`;
-                            }
-                        }
-                        body += '---\n\n';
-                    }
-                }
-
-                // Gray-matter serialization
-                const content = matter.stringify(body, frontmatter);
-
-                // Integrity gate: catches stale daemon code paths that silently drop frontmatter fields.
-                // The per-discussion `try { ... } catch (e)` at the loop boundary catches the throw,
-                // logs the warning, and skips the write, so broken-frontmatter files are never
-                // persisted while the sync run continues with other discussions.
-                const integrity = verifyDiscussionFrontmatter(content);
-                if (!integrity.ok) {
-                    throw new Error(`Discussion #${discussion.number} serialized content missing required frontmatter keys: ${integrity.missing.join(', ')}. ADR 0011 / #11573 contract violation — likely stale MCP daemon code path.`);
-                }
-
+                const content     = this.#renderDiscussionMarkdown(discussion);
                 const currentHash = this.#calculateContentHash(content);
 
                 const cachedDiscussion = cachedDiscussions[discussion.number];

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -528,6 +528,62 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         expect(stats.synced).toEqual([25005]);
         await expect(fs.pathExists(targetPath)).resolves.toBe(true);
     });
+    test('refetchDiscussionsByNumber force-re-renders a stale discussion mirror, bypassing the delta/hash gate (#13794)', async () => {
+        const discussionNumber = 24050;
+
+        // Cached as current with a STALE contentHash — the bulk delta-sync would skip it.
+        // refetchDiscussionsByNumber must force a re-render from live GitHub state regardless.
+        const metadata = {
+            discussions: {
+                [discussionNumber]: {
+                    number     : discussionNumber,
+                    closed     : false,
+                    closedAt   : null,
+                    contentHash: 'STALE-HASH',
+                    path       : `resources/content/discussions/chunk-1/discussion-${discussionNumber}.md`
+                }
+            }
+        };
+
+        let capturedQuery = null;
+        let capturedVars  = null;
+        GraphqlService.query = async (query, vars) => {
+            capturedQuery = query;
+            capturedVars  = vars;
+
+            return {repository: {discussion: buildDiscussion(discussionNumber, {closed: false})}};
+        };
+
+        const stats = await DiscussionSyncer.refetchDiscussionsByNumber([discussionNumber], metadata);
+
+        // Used the single-discussion query with the right number — not the bulk pagination query.
+        expect(capturedQuery).toContain('FetchSingleDiscussionForSync');
+        expect(capturedVars.number).toBe(discussionNumber);
+
+        // Re-rendered + written to the active bucket.
+        expect(stats.refetched).toEqual({count: 1, discussions: [discussionNumber]});
+        const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', `discussion-${discussionNumber}.md`);
+        await expect(fs.pathExists(targetPath)).resolves.toBe(true);
+
+        const parsed = matter(await fs.readFile(targetPath, 'utf8'));
+        expect(parsed.data.number).toBe(discussionNumber);
+
+        // Metadata refreshed with the live hash (no longer the stale one) + the resolved path.
+        expect(metadata.discussions[discussionNumber].contentHash).not.toBe('STALE-HASH');
+        expect(metadata.discussions[discussionNumber].path).toBe(path.relative(aiConfig.projectRoot, targetPath));
+    });
+
+    test('refetchDiscussionsByNumber skips a discussion that no longer exists on GitHub (#13794)', async () => {
+        const discussionNumber = 24051;
+        const metadata = {discussions: {}};
+
+        GraphqlService.query = async () => ({repository: {discussion: null}});
+
+        const stats = await DiscussionSyncer.refetchDiscussionsByNumber([discussionNumber], metadata);
+
+        expect(stats.refetched).toEqual({count: 0, discussions: []});
+        expect(metadata.discussions[discussionNumber]).toBeUndefined();
+    });
 });
 
 function buildDiscussion(number, config = {}) {


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13811. Refs #13794.

## Summary

The discussion analogue of the shipped `refetchIssuesByNumber` and the pulls `refetchPullsByNumber` (#13804): a standalone, out-of-band, idempotent force-refetch that re-renders a known-stale discussion mirror from current GitHub state, bypassing the bulk delta-`updatedAt` gate (which never re-pulls already-synced discussions). Discussion mirrors are pull-only, so a body edit that does NOT bump `updatedAt` can otherwise only be healed by a full clean-slate traversal.

This is the **discussions** half of #13794 (the pulls half is #13804 / #13803); together they complete #13794. The discussions half was handed off by @neo-gpt (the #13794 claim-holder).

## Deltas

- **`FETCH_SINGLE_DISCUSSION_FOR_SYNC`**: single-discussion variant of `FETCH_DISCUSSIONS_FOR_SYNC` — identical node shape (body + comments + nested replies + frontmatter fields), keyed by `$number`.
- **`DiscussionSyncer#renderDiscussionMarkdown(discussion)`**: behavior-preserving extraction of the inline render (frontmatter + body + comments + nested replies + the frontmatter integrity gate) from `syncDiscussions`, so bulk-sync and refetch render identically.
- **`DiscussionSyncer.refetchDiscussionsByNumber(numbers, metadata, indexMutations?)`**: the recovery primitive — mirrors `refetchPullsByNumber`.
- **`SyncService.refetchDiscussionsByNumber({numbers})`**: facade (load metadata → delegate → persist).
- **`ai/scripts/migrations/refetchStaleDiscussions.mjs`**: standalone CLI (pull-only, no orchestrator/lease).

## Test Evidence

Evidence: **L2** — `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs` → **16 passed** (14 existing + 2 new):
- `refetchDiscussionsByNumber force-re-renders a stale discussion mirror, bypassing the delta/hash gate` — asserts the single-discussion query is used with the right number, the file is re-written, and `metadata.discussions[n]` is refreshed with the live hash (not the cached `STALE-HASH`).
- `refetchDiscussionsByNumber skips a discussion that no longer exists on GitHub` — `discussion: null` → no write, no metadata entry, `count: 0`.

`node --check` clean on all touched files; `check-block-alignment --staged` clean on my hunks.

## Post-Merge Validation

- [ ] Out-of-band (live GitHub + sync env): run `node ai/scripts/migrations/refetchStaleDiscussions.mjs <N>` on a known-drifted discussion mirror → the local file re-renders to match the current GitHub discussion body and `metadata.discussions[N]` carries the refreshed `contentHash`. Idempotent: a second run is a no-op writeback (`refetched.count` unchanged on the re-run).

## Notes

- **Pre-existing `dev` debt (not introduced here):** the whole-file `check-block-alignment` flags import-misalignments + an object-literal at `SyncService.mjs:247-251` that **also exist on `dev`** — I only added the facade method (the `--staged` gate that actually blocks commits is clean on my hunks).
- The `DiscussionSyncer.mjs` import block re-aligned (project `--fix` formatter) because the new combined query import is the longest single-line import — whitespace-only.

Contract Ledger on #13811. Completes #13794 together with #13804 / #13803.
