### PR TITLE
fix(ai): archaeology-hook failure message names ADR/Epic/Discussion refs, not just tickets (#13816)

### DIFF
--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -204,11 +204,11 @@ function main() {
     }
 
     if (violations.length > 0) {
-        console.error(`\x1b[31mcheck-ticket-archaeology: ${violations.length} ticket ref(s) in durable comments:\x1b[0m`);
+        console.error(`\x1b[31mcheck-ticket-archaeology: ${violations.length} decay-prone ref(s) (ticket/Epic/Discussion/ADR) in durable comments:\x1b[0m`);
         if (!options.quiet) {
             violations.forEach(v => console.error('  ' + v));
-            console.error('\nDurable comments/JSDoc must describe behavior, not cite tracking tickets (they rot when');
-            console.error('tickets close/rename). Move the ref to the PR body / commit subject, or — only if genuinely');
+            console.error('\nDurable comments/JSDoc must describe behavior, not cite tracking refs — tickets, Epics, Discussions, or ADRs (they rot when the');
+            console.error('referenced item closes/renames). Move the ref to the PR body / commit subject, or — only if genuinely');
             console.error(`load-bearing — add a "${ESCAPE_MARKER}: <reason>" marker on the line.`);
         }
         process.exit(1);


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13816. Refs #13813.

## Summary

`buildScripts/util/check-ticket-archaeology.mjs` bans `ticket/Epic/Discussion/ADR` refs in durable comments (the regex set + the CLI `.description()` both name all four) — but the **failure message** named only "tickets". An agent who removes the `#NNNN` refs then hits the ADR-ban on the next commit-retry with no message hint that ADRs are also banned. This cost 3 of 4 commit-retry rounds on one refactor this session (the #13794 discussions build). Message-clarity only; detection is unchanged.

## Deltas

- L207: `N ticket ref(s)` → `N decay-prone ref(s) (ticket/Epic/Discussion/ADR)`.
- L210–211: `not cite tracking tickets (they rot when tickets close/rename)` → `not cite tracking refs — tickets, Epics, Discussions, or ADRs (they rot when the referenced item closes/renames)`.

The detection regexes (incl. `/\bADR[-\s]?\d{3,4}\b/i`) and the `ticket-ref-ok` escape marker are **unchanged** — message text only.

## Test Evidence

Evidence: **L2** — ran the check on a temp `.mjs` with `ADR-0011` in a JSDoc comment → it flags the violation AND renders the new message (`decay-prone ref(s) (ticket/Epic/Discussion/ADR)` + `not cite tracking refs — tickets, Epics, Discussions, or ADRs`); a no-ref file → `0 violations` (no self-flag, despite the message strings now containing the word "ADRs" — the regex requires digits). `node --check` clean.

## Post-Merge Validation

- [ ] On the next agent commit that the gate rejects for an `ADR-NNNN` ref, the failure message names ADRs (not just "tickets"), so the agent resolves it in one pass instead of discovering the ADR-ban on a later retry.

Quick-win of #13813 (the broader commit/PR-preflight stays on #13813).
