### PR TITLE
feat(ai): embed ADR nodes into the graph collection for hybrid-GraphRAG queryability (#13819)

### DIFF
--- a/ai/services/ingestion/AdrIngestor.mjs
+++ b/ai/services/ingestion/AdrIngestor.mjs
@@ -1,9 +1,9 @@
-import crypto                                from 'crypto';
-import fs                                    from 'fs';
-import path                                  from 'path';
-import Base                                  from '../../../src/core/Base.mjs';
+import crypto                                                                       from 'crypto';
+import fs                                                                           from 'fs';
+import path                                                                         from 'path';
+import Base                                                                         from '../../../src/core/Base.mjs';
 import {Memory_GraphService as GraphService, Memory_StorageRouter as StorageRouter} from '../../services.mjs';
-import logger                                from '../../mcp/server/memory-core/logger.mjs';
+import logger                                                                       from '../../mcp/server/memory-core/logger.mjs';
 
 const
     ADR_EDGE_TYPES = Object.freeze({
@@ -287,9 +287,11 @@ class AdrIngestor extends Base {
 
             const files = (await fs.promises.readdir(adrDir)).filter(file => ADR_FILE_REGEX.test(file)).sort();
 
-            // ADR nodes embed into the graph collection so they surface in hybrid GraphRAG
-            // (query_hybrid_graph / search_nodes); without this the node is inserted but inert
-            // to semantic queries. Mirrors IssueIngestor's embed-write pattern.
+            // ADR nodes embed into the graph collection so they surface in the candidate-pool
+            // semantic search (the graph collection's vector query — e.g. GoldenPathSynthesizer's
+            // hybrid traversal). Without this the node is inserted but inert to vector retrieval.
+            // (NB: `search_nodes` is SQLite fuzzy text + `query_hybrid_graph` is topology-by-node-id;
+            // neither is the vector path — the collection query is.) Mirrors IssueIngestor.
             const nodesCollection = StorageRouter ? await StorageRouter.getGraphCollection() : null;
 
             for (const file of files) {
@@ -304,7 +306,24 @@ class AdrIngestor extends Base {
                         payloadHash  = this.computePayloadHash(adr),
                         existingNode = GraphService.db.nodes.get(adr.id);
 
-                    if (existingNode?.properties?.payloadHash === payloadHash) {
+                    // The vector tracks the FULL document (title + body); `payloadHash` deliberately
+                    // excludes the body, so a body-only edit must still re-embed. Compute embed
+                    // freshness first (an md5 over the document) so the skip below cannot strand a
+                    // stale vector behind an unchanged-metadata skip.
+                    let docText = null, contentHash = null, embedCurrent = false;
+                    if (nodesCollection) {
+                        docText     = `${adr.title}\n\n${content}`;
+                        contentHash = crypto.createHash('md5').update(docText).digest('hex');
+                        try {
+                            const existing = await nodesCollection.get({ids: [adr.id], include: ['metadatas']});
+                            embedCurrent = existing?.ids?.length > 0 && (existing.metadatas[0] || {}).hash === contentHash;
+                        } catch (e) {
+                            logger.warn(`[AdrIngestor] graph-collection GET failed for ${adr.id}: ${e.message}`);
+                        }
+                    }
+
+                    // Skip only when BOTH the node metadata AND the embedded document are current.
+                    if (existingNode?.properties?.payloadHash === payloadHash && (embedCurrent || !nodesCollection)) {
                         stats.adrsSkipped++;
                         continue;
                     }
@@ -318,38 +337,24 @@ class AdrIngestor extends Base {
                             adrNumberValue: Number(adr.adrNumber),
                             payloadHash,
                             rawStatus     : adr.rawStatus,
-                            source        : adr.source,
-                            status        : adr.status,
-                            supersedes    : adr.supersedes,
-                            title         : adr.title
+                            // The node points at its own document vector (keyed by the ADR id in the
+                            // graph collection) so a consumer reading the SQLite node knows it is embedded.
+                            semanticVectorId: adr.id,
+                            source          : adr.source,
+                            status          : adr.status,
+                            supersedes      : adr.supersedes,
+                            title           : adr.title
                         }
                     });
 
-                    // Embed the ADR document into the graph collection (the collection auto-embeds
-                    // the `documents` text). Idempotent via an md5 content hash + upsert-by-id, so a
-                    // re-ingest of unchanged content writes no duplicate vector.
-                    if (nodesCollection) {
-                        const
-                            docText     = `${adr.title}\n\n${content}`,
-                            contentHash = crypto.createHash('md5').update(docText).digest('hex');
-
-                        let needsEmbedding = true;
-                        try {
-                            const existing = await nodesCollection.get({ids: [adr.id], include: ['metadatas']});
-                            if (existing?.ids?.length > 0 && (existing.metadatas[0] || {}).hash === contentHash) {
-                                needsEmbedding = false;
-                            }
-                        } catch (e) {
-                            logger.warn(`[AdrIngestor] graph-collection GET failed for ${adr.id}: ${e.message}`);
-                        }
-
-                        if (needsEmbedding) {
-                            await nodesCollection.upsert({
-                                ids      : [adr.id],
-                                documents: [docText],
-                                metadatas: [{hash: contentHash, title: adr.title, type: 'ADR'}]
-                            });
-                        }
+                    // Re-embed the document whenever its content changed (the collection auto-embeds
+                    // the `documents` text; upsert-by-id keeps it idempotent).
+                    if (nodesCollection && !embedCurrent) {
+                        await nodesCollection.upsert({
+                            ids      : [adr.id],
+                            documents: [docText],
+                            metadatas: [{hash: contentHash, title: adr.title, type: 'ADR'}]
+                        });
                     }
 
                     stats.adrsUpserted++;

--- a/ai/services/ingestion/AdrIngestor.mjs
+++ b/ai/services/ingestion/AdrIngestor.mjs
@@ -2,7 +2,7 @@ import crypto                                from 'crypto';
 import fs                                    from 'fs';
 import path                                  from 'path';
 import Base                                  from '../../../src/core/Base.mjs';
-import {Memory_GraphService as GraphService} from '../../services.mjs';
+import {Memory_GraphService as GraphService, Memory_StorageRouter as StorageRouter} from '../../services.mjs';
 import logger                                from '../../mcp/server/memory-core/logger.mjs';
 
 const
@@ -287,6 +287,11 @@ class AdrIngestor extends Base {
 
             const files = (await fs.promises.readdir(adrDir)).filter(file => ADR_FILE_REGEX.test(file)).sort();
 
+            // ADR nodes embed into the graph collection so they surface in hybrid GraphRAG
+            // (query_hybrid_graph / search_nodes); without this the node is inserted but inert
+            // to semantic queries. Mirrors IssueIngestor's embed-write pattern.
+            const nodesCollection = StorageRouter ? await StorageRouter.getGraphCollection() : null;
+
             for (const file of files) {
                 stats.adrsProcessed++;
 
@@ -319,6 +324,33 @@ class AdrIngestor extends Base {
                             title         : adr.title
                         }
                     });
+
+                    // Embed the ADR document into the graph collection (the collection auto-embeds
+                    // the `documents` text). Idempotent via an md5 content hash + upsert-by-id, so a
+                    // re-ingest of unchanged content writes no duplicate vector.
+                    if (nodesCollection) {
+                        const
+                            docText     = `${adr.title}\n\n${content}`,
+                            contentHash = crypto.createHash('md5').update(docText).digest('hex');
+
+                        let needsEmbedding = true;
+                        try {
+                            const existing = await nodesCollection.get({ids: [adr.id], include: ['metadatas']});
+                            if (existing?.ids?.length > 0 && (existing.metadatas[0] || {}).hash === contentHash) {
+                                needsEmbedding = false;
+                            }
+                        } catch (e) {
+                            logger.warn(`[AdrIngestor] graph-collection GET failed for ${adr.id}: ${e.message}`);
+                        }
+
+                        if (needsEmbedding) {
+                            await nodesCollection.upsert({
+                                ids      : [adr.id],
+                                documents: [docText],
+                                metadatas: [{hash: contentHash, title: adr.title, type: 'ADR'}]
+                            });
+                        }
+                    }
 
                     stats.adrsUpserted++;
                     this.replaceAdrEdges(adr.id, adr.edges);

--- a/test/playwright/unit/ai/services/ingestion/AdrIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/AdrIngestor.spec.mjs
@@ -29,6 +29,9 @@ test.describe('Neo.ai.daemons.services.AdrIngestor', () => {
 
     let tmpRoot;
     let decisionsDir;
+    let StorageRouter;
+    let upsertedDocs = [];
+    let _originalGetGraphCollection;
 
     let originalWarn;
     let warnMessages = [];
@@ -47,6 +50,7 @@ test.describe('Neo.ai.daemons.services.AdrIngestor', () => {
         AdrIngestor            = (await import('../../../../../../ai/services/ingestion/AdrIngestor.mjs')).default;
         logger                 = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
+        StorageRouter          = (await import('../../../../../../ai/services.mjs')).Memory_StorageRouter;
 
         // Reactive provider SSOT: under UNIT_TEST_MODE the Memory Core config resolves
         // storagePaths.graph to `:memory:` by construction. Do not mutate the shared AiConfig
@@ -87,10 +91,21 @@ test.describe('Neo.ai.daemons.services.AdrIngestor', () => {
         logger.warn  = (...args) => {
             warnMessages.push(args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' '));
         };
+
+        // Stub the graph collection so the embed-write records documents WITHOUT invoking the
+        // real embedder (which would otherwise embed every ADR and time the corpus ingest out).
+        upsertedDocs                = [];
+        _originalGetGraphCollection = StorageRouter.getGraphCollection;
+
+        StorageRouter.getGraphCollection = async () => ({
+            get   : async () => ({ids: [], metadatas: []}),
+            upsert: async ({ids, documents, metadatas}) => { upsertedDocs.push({ids, documents, metadatas}); }
+        });
     });
 
     test.afterEach(() => {
         if (originalWarn) logger.warn = originalWarn;
+        if (_originalGetGraphCollection) StorageRouter.getGraphCollection = _originalGetGraphCollection;
 
         if (tmpRoot && fs.existsSync(tmpRoot)) {
             try { fs.rmSync(tmpRoot, {recursive: true}); } catch (e) {}
@@ -140,6 +155,30 @@ Body.
         expect(node.properties.source).toBe('learn/agentos/decisions/0099-test-decision.md');
         expect(node.properties.supersedes).toEqual(['old decision', 'obsolete note']);
         expect(node.properties.payloadHash).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    test('should embed each ADR document into the graph collection (idempotent)', async () => {
+        writeAdr('0099-test-decision.md', `
+# ADR 0099: Test Decision Shape
+
+| **Status** | Proposed |
+
+Body content for embedding.
+        `);
+
+        await AdrIngestor.syncAdrsToGraph(syncOptions());
+
+        // The ADR document is upserted into the graph collection → semantically queryable.
+        const adrUpsert = upsertedDocs.find(u => u.ids[0] === 'adr-0099');
+        expect(adrUpsert).toBeTruthy();
+        expect(adrUpsert.documents[0]).toContain('Test Decision Shape');
+        expect(adrUpsert.metadatas[0].type).toBe('ADR');
+        expect(adrUpsert.metadatas[0].hash).toMatch(/^[a-f0-9]{32}$/); // md5 content hash
+
+        // Idempotent: a re-sync of unchanged content skips via payloadHash → no new vector.
+        upsertedDocs.length = 0;
+        await AdrIngestor.syncAdrsToGraph(syncOptions());
+        expect(upsertedDocs.find(u => u.ids[0] === 'adr-0099')).toBeFalsy();
     });
 
     test('should emit only deterministic ADR 0006 edge taxonomy rows', async () => {

--- a/test/playwright/unit/ai/services/ingestion/AdrIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/AdrIngestor.spec.mjs
@@ -31,6 +31,7 @@ test.describe('Neo.ai.daemons.services.AdrIngestor', () => {
     let decisionsDir;
     let StorageRouter;
     let upsertedDocs = [];
+    let embeddedStore = new Map();
     let _originalGetGraphCollection;
 
     let originalWarn;
@@ -97,9 +98,19 @@ test.describe('Neo.ai.daemons.services.AdrIngestor', () => {
         upsertedDocs                = [];
         _originalGetGraphCollection = StorageRouter.getGraphCollection;
 
+        embeddedStore.clear();
         StorageRouter.getGraphCollection = async () => ({
-            get   : async () => ({ids: [], metadatas: []}),
-            upsert: async ({ids, documents, metadatas}) => { upsertedDocs.push({ids, documents, metadatas}); }
+            get   : async ({ids = []}) => {
+                const out = {ids: [], metadatas: []};
+                for (const id of ids) {
+                    if (embeddedStore.has(id)) { out.ids.push(id); out.metadatas.push(embeddedStore.get(id)); }
+                }
+                return out;
+            },
+            upsert: async ({ids, documents, metadatas}) => {
+                ids.forEach((id, i) => embeddedStore.set(id, metadatas[i]));
+                upsertedDocs.push({ids, documents, metadatas});
+            }
         });
     });
 
@@ -175,10 +186,40 @@ Body content for embedding.
         expect(adrUpsert.metadatas[0].type).toBe('ADR');
         expect(adrUpsert.metadatas[0].hash).toMatch(/^[a-f0-9]{32}$/); // md5 content hash
 
-        // Idempotent: a re-sync of unchanged content skips via payloadHash → no new vector.
+        // The SQLite node carries semanticVectorId → the node knows it is embedded (not detached).
+        expect(GraphService.db.nodes.get('adr-0099').properties.semanticVectorId).toBe('adr-0099');
+
+        // Idempotent: a re-sync of unchanged content (node + body) writes no new vector.
         upsertedDocs.length = 0;
         await AdrIngestor.syncAdrsToGraph(syncOptions());
         expect(upsertedDocs.find(u => u.ids[0] === 'adr-0099')).toBeFalsy();
+    });
+
+    test('should re-embed on a body-only edit even when payloadHash (metadata) is unchanged', async () => {
+        writeAdr('0099-test-decision.md', `
+# ADR 0099: Test Decision Shape
+
+| **Status** | Proposed |
+
+Original body.
+        `);
+        await AdrIngestor.syncAdrsToGraph(syncOptions());
+
+        // Edit ONLY the body (title/status/metadata unchanged → payloadHash identical).
+        upsertedDocs.length = 0;
+        writeAdr('0099-test-decision.md', `
+# ADR 0099: Test Decision Shape
+
+| **Status** | Proposed |
+
+Completely different body content.
+        `);
+        await AdrIngestor.syncAdrsToGraph(syncOptions());
+
+        // The vector MUST update — the old guard skipped before the md5 check, stranding a stale vector.
+        const reEmbed = upsertedDocs.find(u => u.ids[0] === 'adr-0099');
+        expect(reEmbed).toBeTruthy();
+        expect(reEmbed.documents[0]).toContain('different body content');
     });
 
     test('should emit only deterministic ADR 0006 edge taxonomy rows', async () => {


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13819. The first build that dogfoods ADR 0024 (#13815) + ADR 0023 (#13806): ADR nodes become first-class queryable via the graph collection's semantic (vector) search.

## Summary

`AdrIngestor` inserted ADR nodes (ADR 0006 / #11377) but never embedded them — the 23 ADR nodes carried no vector, so they were inert to the candidate-pool semantic query. An agent asking *"what governs the golden path?"* could not surface ADR 0023/0024. This adds the embed-write, mirroring the proven `IssueIngestor` pattern.

## Deltas

- `AdrIngestor` — upserts each ADR document (title + body) into the graph collection (`StorageRouter.getGraphCollection()`; the collection auto-embeds the `documents` text), and sets `semanticVectorId = adr.id` on the SQLite node so the node knows it is embedded (not detached). Embed-freshness (an md5 over title+body) is computed **first**, so a body-only edit re-embeds even when the metadata `payloadHash` is unchanged; the skip fires only when BOTH are current.
- Spec — stateful collection stub (records + returns hashes) + tests: embed-write, idempotency, a body-only-edit regression (re-embeds despite identical `payloadHash`), and a node-`semanticVectorId` assertion.

## Test Evidence

Evidence: L2 (unit) — the embed-write path is covered including the two failure-shaped cases GPT's review surfaced (a body-only edit must re-embed; the node must carry `semanticVectorId`). The auto-embed mechanism is the collection's own (proven in production by `IssueIngestor`); the stub isolates the AdrIngestor logic from the real embedder.

**L2** — 7/7 `AdrIngestor` specs green (`UNIT_TEST_MODE=true npx playwright test … -c test/playwright/playwright.config.mjs`), incl. the body-edit regression + the corpus test (was timing out at 30s with the real embedder before the stub, now ~1.8s). Pre-commit hooks all green.

## Premise Coherence

**Coheres:** the first concrete implementation of the ADR-node-embedding target named in *both* new ADRs (0024 §2.8 / 0023 §2.5). Makes the architecture self-documenting — the graph indexes its own decision records, so an ADR-governance query surfaces the ADRs themselves.

## Post-Merge Validation

- [ ] Confirm the candidate-pool semantic query (GoldenPathSynthesizer's graph-collection vector search) surfaces the ADR nodes for an ADR topic (e.g. "golden path map-fidelity") after the orchestrator re-ingests ADRs on the next sync. (NB: `search_nodes` is SQLite fuzzy text and `query_hybrid_graph` is topology-by-node-id — neither is the vector path.)
