### PR TITLE
refactor(ai): Gemini mapToolSchema uses Neo.clone, not JSON.parse(JSON.stringify) (#13825)

### DIFF
--- a/ai/provider/Gemini.mjs
+++ b/ai/provider/Gemini.mjs
@@ -47,7 +47,7 @@ class GeminiProvider extends Base {
      */
     mapToolSchema(tool) {
         // Deep clone to avoid mutating original schema
-        const parameters = JSON.parse(JSON.stringify(tool.inputSchema || { type: 'object', properties: {} }));
+        const parameters = Neo.clone(tool.inputSchema || { type: 'object', properties: {} }, true);
 
         const uppercaseTypes = (obj) => {
             if (obj && typeof obj === 'object') {


### PR DESCRIPTION
<!-- Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code) -->

Resolves #13825.

## Summary

`ai/provider/Gemini.mjs:mapToolSchema` deep-cloned the tool input schema with the banned `JSON.parse(JSON.stringify(...))` idiom. This swaps it to the canonical `Neo.clone(..., true)` (the deep-clone helper used elsewhere in `ai/`, e.g. `ai/mcp/client/config.mjs:90`; `Neo` is global in `ai/provider` via `Base extends Neo.core.Base`, so no new import). The clone stays **necessary** — the following `uppercaseTypes` mutates it in place (uppercasing `type`, deleting `additionalProperties`), so the original schema must not be touched.

Surfaced via the `tech-debt-radar` dogfood of #13822 (the operator's value-floor correction: route to the radar to surface untracked lanes rather than concluding "exhaustion").

## Deltas

- `Gemini.mjs:50`: `JSON.parse(JSON.stringify(tool.inputSchema || {…}))` → `Neo.clone(tool.inputSchema || {…}, true)`.

One line; behavior-identical for the JSON-safe schema (a deep copy that `uppercaseTypes` then mutates, original untouched).

## Test Evidence

Evidence: **L1** — `node --check ai/provider/Gemini.mjs` clean; the change is a canonical-helper swap with deep-clone parity for JSON-safe data (`Neo.clone(x, true)` ≡ `JSON.parse(JSON.stringify(x))` for plain JSON, by `Neo.clone`'s contract). `mapToolSchema` has **no pre-existing unit test** (the only `*gemini*` spec is the unrelated `geminiIncidentCostLedger` diagnostic), so there is nothing to regress — that missing-test seam is a separate **pre-existing** gap, not introduced here. Happy to add a `mapToolSchema` unit test in this PR if you'd prefer the seam covered now.

## Post-Merge Validation

- [ ] `ai/` carries zero `JSON.parse(JSON.stringify(...))` deep-clones (this was the only one); the convention (`Neo.clone` / `structuredClone`) holds across the folder.
