### PR TITLE
fix(ai): diagnose empty Golden Path output (#13828)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -725,6 +725,68 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Removes stale Computed Golden Path guide edges from the frontier.
+     *
+     * `frontier -> GUIDES` edges are a machine-consumed steering surface. Each
+     * synthesis pass must remove recommendations that are no longer present in
+     * the current computed result; otherwise a zero-node render can leave old
+     * guidance active in the graph after the handoff stops rendering it.
+     *
+     * @param {Object} [options]
+     * @param {Object} [options.graphService=GraphService] Graph service instance.
+     * @param {Set<String>} [options.currentTargetIds=new Set()] Current computed target ids.
+     * @returns {Number} Count of stale guide edges removed.
+     */
+    static pruneStaleFrontierGuideEdges({
+        graphService = GraphService,
+        currentTargetIds = new Set()
+    } = {}) {
+        graphService?.db?.getAdjacentNodes?.('frontier', 'out');
+
+        const staleEdges = (graphService?.db?.edges?.getByIndex?.('source', 'frontier') || [])
+            .filter(edge => edge.type === 'GUIDES' && !currentTargetIds.has(edge.target));
+
+        if (staleEdges.length > 0) {
+            graphService.db.edges.remove(staleEdges.map(edge => edge.id));
+            // Drop the exact index references returned above in case the Store map points at refreshed edge objects.
+            graphService.db.edges.updateIndexMaps?.(null, staleEdges);
+        }
+
+        return staleEdges.length
+    }
+
+    /**
+     * @summary Renders the bounded diagnostic for an empty Computed Golden Path pass.
+     *
+     * The handoff should distinguish "no computed recommendation survived the
+     * filter chain" from "the handoff forgot to render the routing surface".
+     *
+     * @param {Object} stats Candidate-count diagnostics for the current pass.
+     * @returns {String} Markdown section.
+     */
+    static renderComputedGoldenPathEmptySection(stats = {}) {
+        const count = value => Number.isFinite(Number(value)) ? Number(value) : 0;
+
+        return [
+            '',
+            '## Computed Golden Path (Strategic Recommendation)',
+            '',
+            'No actionable computed recommendations survived the current Tri-Vector filter pass.',
+            '',
+            `- Semantic candidates: ${count(stats.semanticCandidates)}`,
+            `- SQLite OPEN matches: ${count(stats.sqliteOpenMatches)}`,
+            `- Blocked candidates filtered: ${count(stats.blockedCandidates)}`,
+            `- Non-actionable candidates filtered: ${count(stats.nonActionableCandidates)}`,
+            `- Scored actionable candidates: ${count(stats.scoredCandidates)}`,
+            `- Selected top nodes: ${count(stats.selectedTopNodes)}`,
+            `- Stale frontier GUIDES pruned: ${count(stats.prunedGuideEdges)}`,
+            '',
+            'This is an empty-state diagnostic for the computed routing surface. Use the Current Release / Incident Focus section for visibility-only hot work while the computed candidate chain is empty.',
+            ''
+        ].join('\n')
+    }
+
+    /**
      * @summary Scores one synced issue as a current release / incident focus candidate.
      *
      * This is deliberately a local-sync signal, not graph-centrality routing. It
@@ -1192,6 +1254,15 @@ class GoldenPathSynthesizer extends Base {
 
         // Pillar 2: Structural Weight from SQLite Graph
         const scoredNodes = [];
+        const scoringStats = {
+            semanticCandidates     : semanticIds.length,
+            sqliteOpenMatches      : 0,
+            blockedCandidates      : 0,
+            nonActionableCandidates: 0,
+            scoredCandidates       : 0,
+            selectedTopNodes       : 0,
+            prunedGuideEdges       : 0
+        };
         const SEMANTIC_WEIGHT = 2.0;
         const STRUCTURAL_WEIGHT = 1.0;
 
@@ -1212,6 +1283,7 @@ class GoldenPathSynthesizer extends Base {
             `);
 
             const results = stmt.all(...semanticIds);
+            scoringStats.sqliteOpenMatches = results.length;
 
             for (const row of results) {
                 const issueId = row.id;
@@ -1231,7 +1303,10 @@ class GoldenPathSynthesizer extends Base {
                     }
                 }
 
-                if (isBlocked) continue; // Architecturally blocked issues cannot be Golden
+                if (isBlocked) {
+                    scoringStats.blockedCandidates++;
+                    continue; // Architecturally blocked issues cannot be Golden
+                }
 
                 const idx = semanticIds.indexOf(issueId);
                 const semantic_distance = parseFloat(semanticDistances[idx]) || 0.1;
@@ -1246,6 +1321,7 @@ class GoldenPathSynthesizer extends Base {
                 let priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
 
                 if (!this.constructor.isActionableComputedRecommendation(nodeData || {id: issueId})) {
+                    scoringStats.nonActionableCandidates++;
                     logger.debug(`[GoldenPathSynthesizer] Skipping non-actionable computed recommendation: ${issueId}`);
                     continue;
                 }
@@ -1267,6 +1343,11 @@ class GoldenPathSynthesizer extends Base {
         // Remove mathematically rejected targets (Negative ROI), then slice
         const topNodes = scoredNodes.filter(n => n.score > -5000).slice(0, aiConfig.goldenPathTopNodeRenderLimit);
         const goldenIds = new Set(topNodes.map(item => item.node.id));
+        scoringStats.scoredCandidates = scoredNodes.length;
+        scoringStats.selectedTopNodes = topNodes.length;
+        scoringStats.prunedGuideEdges = this.constructor.pruneStaleFrontierGuideEdges({
+            currentTargetIds: goldenIds
+        });
 
         let markdownAppend = '';
 
@@ -1324,6 +1405,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 logger.warn('[GoldenPathSynthesizer] Failed to generate semantic interpretation for Golden Path (LLM Offline). Proceeding with pure mathematical output.', e);
             }
         } else {
+            markdownAppend = this.constructor.renderComputedGoldenPathEmptySection(scoringStats);
             logger.info('[GoldenPathSynthesizer] No actionable unblocked issues found. Golden path empty.');
         }
 

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -627,6 +627,132 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).not.toContain(notReadyId);
     });
 
+    test('synthesizeGoldenPath renders empty computed diagnostics and clears stale frontier guides (#13828)', async () => {
+        const originalGetGraphCollection = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs = GoldenPathSynthesizer.fetchOpenPRs;
+        const suffix = `${process.pid}-${Date.now()}`;
+        const staleId = `issue-stale-guide-${suffix}`;
+        const notReadyId = `issue-empty-not-ready-${suffix}`;
+        aiConfig.vectorDimension = 2;
+
+        GraphService.upsertNode({
+            id        : 'frontier',
+            type      : 'SYSTEM_TENET',
+            properties: {name: 'Active Context Frontier'}
+        });
+        GraphService.upsertNode({
+            id        : staleId,
+            type      : 'ISSUE',
+            properties: {state: 'OPEN', title: 'Stale guide edge'}
+        });
+        GraphService.upsertNode({
+            id        : notReadyId,
+            type      : 'ISSUE',
+            properties: {state: 'OPEN', title: 'Not ready candidate', labels: ['not-code-ready', 'ai']}
+        });
+        GoldenPathSynthesizer.constructor.pruneStaleFrontierGuideEdges();
+        GraphService.linkNodes('frontier', staleId, 'GUIDES', 3);
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => ({
+                ids      : [[notReadyId]],
+                distances: [[0.1]]
+            })
+        });
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['Agent OS regression focus']})});
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [];
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        const guideTargets = GraphService.db.edges
+            .getByIndex('source', 'frontier')
+            .filter(edge => edge.type === 'GUIDES')
+            .map(edge => edge.target);
+
+        expect(handoffContent).toContain('## Computed Golden Path (Strategic Recommendation)');
+        expect(handoffContent).toContain('No actionable computed recommendations survived the current Tri-Vector filter pass.');
+        expect(handoffContent).toContain('- Semantic candidates: 1');
+        expect(handoffContent).toContain('- SQLite OPEN matches: 1');
+        expect(handoffContent).toContain('- Non-actionable candidates filtered: 1');
+        expect(handoffContent).toContain('- Selected top nodes: 0');
+        expect(handoffContent).toMatch(/- Stale frontier GUIDES pruned: [1-9]\d*/);
+        expect(guideTargets).not.toContain(staleId);
+    });
+
+    test('synthesizeGoldenPath prunes stale guides while preserving current computed guides (#13828)', async () => {
+        const originalGetGraphCollection = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs = GoldenPathSynthesizer.fetchOpenPRs;
+        const OpenAiCompatible = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate = OpenAiCompatible.prototype.generate;
+        const suffix = `${process.pid}-${Date.now()}`;
+        const staleId = `issue-stale-guide-nonzero-${suffix}`;
+        const readyId = `issue-current-guide-${suffix}`;
+        aiConfig.vectorDimension = 2;
+
+        GraphService.upsertNode({
+            id        : 'frontier',
+            type      : 'SYSTEM_TENET',
+            properties: {name: 'Active Context Frontier'}
+        });
+        GraphService.upsertNode({
+            id        : staleId,
+            type      : 'ISSUE',
+            properties: {state: 'OPEN', title: 'Old computed guide'}
+        });
+        GraphService.upsertNode({
+            id        : readyId,
+            type      : 'ISSUE',
+            properties: {state: 'OPEN', title: 'Current computed guide', labels: ['bug', 'ai']}
+        });
+        GoldenPathSynthesizer.constructor.pruneStaleFrontierGuideEdges();
+        GraphService.linkNodes('frontier', staleId, 'GUIDES', 3);
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => ({
+                ids      : [[readyId]],
+                distances: [[0.1]]
+            })
+        });
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['Agent OS regression focus']})});
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [];
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            OpenAiCompatible.prototype.generate = originalGenerate;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        const guideTargets = GraphService.db.edges
+            .getByIndex('source', 'frontier')
+            .filter(edge => edge.type === 'GUIDES')
+            .map(edge => edge.target);
+
+        expect(handoffContent).toContain(readyId);
+        expect(handoffContent).not.toContain('No actionable computed recommendations survived');
+        expect(guideTargets).toContain(readyId);
+        expect(guideTargets).not.toContain(staleId);
+    });
+
     test('synthesizeGoldenPath lists the 5 most recent open PRs with cross-family status', async () => {
         const originalGetGraphCollection = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;


### PR DESCRIPTION
Resolves #13828

Related: #13750

GoldenPathSynthesizer now renders a bounded Computed Golden Path section even when Tri-Vector filtering produces no actionable nodes, and each synthesis pass prunes stale `frontier -> GUIDES` edges before writing current recommendations. The stale edge cleanup removes persisted edge ids and the exact index references observed from the frontier cache, so a zero-node pass cannot leave previous computed guidance as active graph state.

Evidence: L2 (focused unit coverage against the GoldenPathSynthesizer graph/unit harness) -> L2 required (empty-state diagnostic rendering and frontier GUIDE pruning are internal runtime paths fully covered by the unit graph harness). No residuals.

## Deltas from ticket
No scope expansion. The implementation keeps `#13750` root-cause work intact by surfacing the zero-node/edge-staleness diagnostic instead of adding a filesystem fallback.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs --workers=1` -> 29 passed.
- `git diff --check` -> passed.
- Pre-commit hooks passed during commit `5fc6f5c8b8`.

## Post-Merge Validation
- [ ] Run the next Golden Path synthesis on a live graph after merge and verify the handoff contains the Computed Golden Path empty diagnostic when no actionable nodes survive.
- [ ] Verify live `frontier -> GUIDES` edges reflect only the current computed recommendation set after a zero-node run.

## Commits
- `5fc6f5c8b8` - diagnose empty Golden Path output and prune stale guide edges.

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee5c2-82ba-7b73-8812-df59106ff61a.
