### PR TITLE
fix(ai): throttle github workflow sync cadence (#13832)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -372,7 +372,7 @@ class Config extends ConfigProvider {
                     pollMs              : leaf(3000, 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS', 'number'),
                     summarySweepMs      : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'number'),
                     kbSyncMs            : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS', 'number'),
-                    githubWorkflowSyncMs: leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_INTERVAL_MS', 'number'),
+                    githubWorkflowSyncMs: leaf(2 * HOUR_MS, 'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_INTERVAL_MS', 'number'),
                     backupMs            : leaf(DAY_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS', 'number'),
                     graphLogCompactionMs: leaf(DAY_MS, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_INTERVAL_MS', 'number'),
                     primaryDevSyncMs    : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS', 'number'),

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -9,6 +9,24 @@ import {getDueTask as getSwarmHeartbeatDueTask}             from './swarmHeartbe
 import {getDueTask as getTenantRepoSyncDueTask}             from './tenantRepoSync.mjs';
 import {getDueTask as getEmbedDrainLivenessWatchdogDueTask} from './embedDrainLivenessWatchdog.mjs';
 
+function toTimestampMs(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === 'string' && value) {
+        const parsed = Date.parse(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    return null;
+}
+
+function getLatestTimestampMs(...values) {
+    const timestamps = values.map(toTimestampMs).filter(Number.isFinite);
+    return timestamps.length ? Math.max(...timestamps) : null;
+}
+
 /**
  * Coordinator-descriptor registry for the Orchestrator scheduling pipeline.
  *
@@ -89,9 +107,11 @@ export const TASK_REGISTRY = Object.freeze([
         dependencies    : [],
         getDueTask({state, now, intervals, enables}) {
             if (!enables.githubWorkflowSync) return null;
-            const lastRunAt  = state.githubWorkflowSync?.lastRunAt ?? 0;
-            const intervalMs = intervals.githubWorkflowSync;
-            if (intervalMs > 0 && now - lastRunAt >= intervalMs) {
+            const taskState     = state.githubWorkflowSync || {};
+            const terminalAt    = getLatestTimestampMs(taskState.lastSuccessAt, taskState.lastErrorAt);
+            const cadenceAnchor = terminalAt ?? toTimestampMs(taskState.lastRunAt) ?? 0;
+            const intervalMs    = intervals.githubWorkflowSync;
+            if (intervalMs > 0 && now - cadenceAnchor >= intervalMs) {
                 return {
                     taskName: 'githubWorkflowSync',
                     source  : 'periodic-sync',

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -132,7 +132,7 @@ test.describe('Tier 1 Config Immutability', () => {
             pollMs                           : 3000,
             summarySweepMs                   : 10 * 60 * 1000,
             kbSyncMs                         : 30 * 60 * 1000,
-            githubWorkflowSyncMs             : 30 * 60 * 1000,
+            githubWorkflowSyncMs             : 2 * 60 * 60 * 1000,
             backupMs                         : 24 * 60 * 60 * 1000,
             graphLogCompactionMs             : 24 * 60 * 60 * 1000,
             primaryDevSyncMs                 : 10 * 60 * 1000,

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -100,6 +100,64 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
         })).toBeNull();
     });
 
+    test('githubWorkflowSync cadence uses terminal timestamp before start timestamp (#13832)', () => {
+        const descriptor = TASK_REGISTRY.find(d => d.taskName === 'githubWorkflowSync');
+        expect(descriptor, 'githubWorkflowSync is registered').toBeTruthy();
+
+        expect(descriptor.getDueTask({
+            state: {
+                githubWorkflowSync: {
+                    lastRunAt    : 0,
+                    lastSuccessAt: new Date(1200).toISOString()
+                }
+            },
+            now      : 1800,
+            intervals: {githubWorkflowSync: 1000},
+            enables  : {githubWorkflowSync: true}
+        })).toBeNull();
+
+        expect(descriptor.getDueTask({
+            state: {
+                githubWorkflowSync: {
+                    lastRunAt    : 0,
+                    lastSuccessAt: new Date(1200).toISOString()
+                }
+            },
+            now      : 2200,
+            intervals: {githubWorkflowSync: 1000},
+            enables  : {githubWorkflowSync: true}
+        })).toMatchObject({taskName: 'githubWorkflowSync', source: 'periodic-sync'});
+    });
+
+    test('githubWorkflowSync failed terminal attempts also cool down retries (#13832)', () => {
+        const descriptor = TASK_REGISTRY.find(d => d.taskName === 'githubWorkflowSync');
+        expect(descriptor, 'githubWorkflowSync is registered').toBeTruthy();
+
+        expect(descriptor.getDueTask({
+            state: {
+                githubWorkflowSync: {
+                    lastRunAt  : 0,
+                    lastErrorAt: new Date(1200).toISOString()
+                }
+            },
+            now      : 1800,
+            intervals: {githubWorkflowSync: 1000},
+            enables  : {githubWorkflowSync: true}
+        })).toBeNull();
+
+        expect(descriptor.getDueTask({
+            state: {
+                githubWorkflowSync: {
+                    lastRunAt  : 0,
+                    lastErrorAt: new Date(1200).toISOString()
+                }
+            },
+            now      : 2200,
+            intervals: {githubWorkflowSync: 1000},
+            enables  : {githubWorkflowSync: true}
+        })).toMatchObject({taskName: 'githubWorkflowSync', source: 'periodic-sync'});
+    });
+
     test('continuous tasks (chroma/bridgeDaemon/mlx) are intentionally NOT in registry', () => {
         const names = TASK_REGISTRY.map(d => d.taskName);
         expect(names).not.toContain('chroma');


### PR DESCRIPTION
Resolves #13832

Authored by Euclid (@neo-gpt, GPT-5 Codex, Codex Desktop). Session 43e8ab91-e980-4303-b70f-898d8c4ae98e.

This PR changes `githubWorkflowSync` from a 30-minute start-anchored loop to a completion-anchored cooldown. The default cadence is now 2h via the template config, and scheduler due logic anchors on the latest terminal state (`lastSuccessAt` or `lastErrorAt`) before falling back to legacy `lastRunAt`. That makes a 20-minute sync wait the full interval after completion instead of restarting about 10 minutes later. Related: #13626, #13750, #13624.

Evidence: L2 (focused unit coverage for scheduler due logic and config-template default) → L2 required (ACs are scheduler/config contract plus local restart consumption). Residual: none.

## Deltas from ticket
No scope expansion. The ignored local overlay `ai/config.mjs` was also updated in this checkout so this harness uses the same 2h cadence after restart; the PR intentionally carries only tracked source, template, and test changes.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs test/playwright/unit/ai/config.template.spec.mjs` — 21 passed.
- `git diff --check` — passed.
- Pre-commit hooks passed: whitespace, shorthand, AiConfig mutation guard, JSDoc types, ticket archaeology, and block alignment.

## Post-Merge Validation
- [ ] After deployment/restart, observe `github workflow sync` no longer starts until at least the configured interval after the previous run reaches success or error.
- [ ] If production needs a faster value, set `NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_INTERVAL_MS=3600000` explicitly instead of falling back to the default.

## Commit
- `36409872ba` — `fix(ai): throttle github workflow sync cadence (#13832)`
