### PR TITLE
fix(ai): remove inline per-message/per-memory chat-model calls to free the orchestrator idle window (#13834)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -7,7 +7,6 @@ import WakeSubscriptionService                  from './WakeSubscriptionService.
 import {execFile}                               from 'child_process';
 import {promisify}                              from 'util';
 import crypto                                   from 'crypto';
-import SemanticGraphExtractor                   from '../../services/graph/SemanticGraphExtractor.mjs';
 
 const
     execFileAsync                     = promisify(execFile),
@@ -673,26 +672,13 @@ class MailboxService extends Base {
         for (const t of relatedTickets) GraphService.linkNodes(messageId, t, 'REFERENCES_TICKET', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
         for (const c of taggedConcepts) GraphService.linkNodes(messageId, c, 'TAGGED_CONCEPT', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
 
-        // 4. Auto-emit TAGGED_CONCEPT edges asynchronously without blocking delivery
-        SemanticGraphExtractor.extractMessageConcepts(body).then(concepts => {
-            if (concepts && concepts.length > 0) {
-                for (const c of concepts) {
-                    // Ensure the concept node exists before linking
-                    if (!db.nodes.has(c)) {
-                        let type = c.split(':')[0];
-                        let name = c.split(':').slice(1).join(':');
-                        GraphService.upsertNode({
-                            id        : c,
-                            type,
-                            name      : name || c,
-                            properties: { auto_extracted: true }
-                        });
-                    }
-                    // Use slightly lower weight for auto-extracted concepts
-                    GraphService.linkNodes(messageId, c, 'TAGGED_CONCEPT', 0.8, { timestamp, userId: senderUserId, sharedEntity: true });
-                }
-            }
-        }).catch(() => { /* error logged internally */ });
+        // Per-message auto concept-extraction is intentionally NOT run inline: it fired a chat-model
+        // call (up to 2 attempts) on EVERY message, in parallel with the orchestrator's exclusive-heavy
+        // tasks — starving the model of an idle window. The curated `taggedConcepts` edges (weight 1.0)
+        // are already linked above; the low-confidence auto-extracted concepts (weight 0.8) were the
+        // bulk of the non-curated graph population and are dropped here as redundant noise. Concept
+        // mining stays orchestrator-driven (scheduled, lease-gated), keeping model inference off the
+        // message hot path.
 
         WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
 

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -525,28 +525,11 @@ class MemoryService extends Base {
                 activeSegmentKey: segmentKey
             }).catch(() => {});
 
-            // 4. Best-effort inline tweet-summary via the configured chat model (the modelProvider
-            //    SSOT — reads the resolved leaf at the use site, never aliases it). Fire-and-forget
-            //    so the per-turn write stays fast: the memory is already WAL-accepted and visible
-            //    through the pending recency overlay; this only enriches graph projection
-            //    asynchronously. Fully self-contained —
-            //    errors/timeouts never touch the write path, and a null summary never hides the turn
-            //    (recency recall falls back to raw content). The summarizer choice (local gemma4 OR
-            //    remote gemini-flash) is the user's deployment-agnostic provider setting → cloud-ready.
-            this.buildMiniSummary({prompt, response}).then(miniSummary => {
-                if (miniSummary) {
-                    GraphService.upsertNode({
-                        id              : memoryId,
-                        type            : 'AGENT_MEMORY',
-                        name            : `Memory: ${timestamp}`,
-                        description     : `Agent thought flow inside session ${sessionId}.`,
-                        semanticVectorId: memoryId,
-                        // Archive-aware re-upsert: a tombstone set between the initial projection and this
-                        // post-summary re-mint must not be dropped (see _withArchiveState).
-                        properties: this._withArchiveState({...memoryProperties, miniSummary})
-                    });
-                }
-            }).catch(() => {});
+            // The per-turn miniSummary is NOT generated inline: that fired a chat-model call on every
+            // memory write, in parallel with the orchestrator's exclusive-heavy tasks — starving the
+            // model of an idle window. The AGENT_MEMORY node is already projected by
+            // `_projectMemoryToGraph` (with a null miniSummary); the scheduled `backfillMiniSummaries`
+            // pass enriches it under the heavy lease. Model inference stays orchestrator-driven.
 
             // 5. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
             //    Non-fatal — buildMailboxDelta swallows its own errors and returns null on failure,

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -622,45 +622,6 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         });
     });
 
-    test('addMessage auto-emits TAGGED_CONCEPT edges via SemanticGraphExtractor', async () => {
-        const SemanticGraphExtractor = (await import('../../../../../../ai/services/graph/SemanticGraphExtractor.mjs')).default;
-
-        // Mock the extractor to resolve immediately with predefined concepts
-        const originalExtract = SemanticGraphExtractor.extractMessageConcepts;
-        try {
-            SemanticGraphExtractor.extractMessageConcepts = async (body) => {
-                return ['CONCEPT:mcp-integration', 'CLASS:Neo.ai.services.memory-core.MailboxService'];
-            };
-
-            await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
-                await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
-            });
-
-            let msgId;
-            await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
-                const res = await MailboxService.addMessage({ to: '@bob', subject: 'Integration', body: 'Let us build MCP integrations' });
-                msgId = res.messageId;
-            });
-
-            // The extractor runs asynchronously in a detached .then(), so we yield to the microtask queue
-            await new Promise(resolve => setTimeout(resolve, 0));
-
-            // Verify TAGGED_CONCEPT edges were created
-            const edges = GraphService.db.edges.items.filter(e => e.source === msgId && e.type === 'TAGGED_CONCEPT');
-            expect(edges.length).toBe(2);
-            expect(edges.find(e => e.target === 'CONCEPT:mcp-integration')).toBeDefined();
-            expect(edges.find(e => e.target === 'CLASS:Neo.ai.services.memory-core.MailboxService')).toBeDefined();
-
-            // Verify nodes were created and have auto_extracted provenance
-            const conceptNode = GraphService.db.nodes.get('CONCEPT:mcp-integration');
-            expect(conceptNode).toBeDefined();
-            expect(conceptNode.properties.auto_extracted).toBe(true);
-
-        } finally {
-            SemanticGraphExtractor.extractMessageConcepts = originalExtract;
-        }
-    });
-
     test('#10180 AC4: countMessages matches listMessages.length for small inbox', async () => {
         // Pin equivalence between the direct-SQL count and the in-memory listMessages
         // length so future drift between the two paths surfaces as a test failure.


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13834.

## Summary

Operator-flagged live reality: *"the current scheduling is NUTS. there are no free slots and gemma4 gets hammered all the time… we NEED an idle window where gemma4 does not get hammered with other tasks in PARALLEL."* Root cause (V-B-A'd): two hot-path tool calls fired chat-model inference **fire-and-forget**, bypassing the `exclusive-heavy` serialization the registry heavy-tasks respect — so the swarm's own coordination saturated the model the swarm depends on.

## Deltas

- **`MailboxService.addMessage`** — removed the inline `extractMessageConcepts` call (a gemma4 chat call, up to 2 attempts, on *every* A2A message).
  - **Retained** (orchestrator-scheduled, untouched): the concept *population* — `DreamService` runs `ConceptDiscoveryService.runDiscoveryCycle()` (auto-mining) + `ConceptIngestor.syncConceptsToGraph()` (curated sync) under the heavy lease; the curated `taggedConcepts@1.0` edges still link inline above.
  - **Retired** (intentional, not relocated): the per-message `TAGGED_CONCEPT@0.8` auto-*tagging* edges — the bulk of the non-curated ~19.5k CONCEPT bloat. They were a redundant hot-path duplicate of the scheduled discovery, not a unique signal. (This corrects the original #13834 ACs' "no-loss @0.8" clause — see the ticket's Evolution section.)
- **`MemoryService.addMemory`** — removed the inline `buildMiniSummary` call (a gemma4 chat call per memory write). The `AGENT_MEMORY` node is already projected by `_projectMemoryToGraph` (awaited, L614); the scheduled `backfillMiniSummaries` pass enriches it under the heavy lease.
- Removed the now-dead `SemanticGraphExtractor` import + the spec that covered the removed inline behavior.

## Test Evidence

Evidence: L2 (unit) — verified the data isn't lost before removing: `_projectMemoryToGraph` (awaited) creates the `AGENT_MEMORY` node, and `backfillMiniSummaries` queries `miniSummary IS NULL` to fill it; curated concept edges link independently of the removed auto path.

**L2** — 71/71 `MailboxService` + `MemoryService` specs green (`UNIT_TEST_MODE=true npx playwright test … -c test/playwright/playwright.config.mjs`). Removed the `addMessage auto-emits TAGGED_CONCEPT via SemanticGraphExtractor` spec (it asserted the deleted behavior); all others pass unchanged. Pre-commit hooks (whitespace / shorthand / jsdoc-types / ticket-archaeology / block-alignment) green.

## Premise Coherence

**Coheres:** the operator-flagged idle-window starvation traced to two ungated hot-path model calls; removing them makes model inference **orchestrator-driven (scheduled, lease-gated) only** → the idle window emerges by construction. Double win on the mailbox path: also de-noises the graph (drops the `@0.8` auto-concept bloat that inflated the CONCEPT population).

## Post-Merge Validation

- [ ] Confirm gemma4 utilization shows idle gaps between heavy tasks (the operator's "free slot").
- [ ] Confirm the scheduled `backfillMiniSummaries` still fills miniSummaries (no regression in recency-recall quality on a session).
- [ ] Run the `gemma4-rem-benchmark` / `keep-alive-probe` in the now-available idle window (the #12439 OQ1 critical path).
