### PR TITLE
feat(ai): scope Golden Path candidate-pool to ISSUE + DISCUSSION vectors (#13750)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -703,10 +703,11 @@ class GoldenPathSynthesizer extends Base {
     /**
      * @summary Determines whether a graph node can be an immediate computed recommendation.
      *
-     * The Computed Golden Path is an execution steering surface. Discussions, epics,
-     * and tickets explicitly marked not-ready may still be important visibility, but
-     * presenting them as "next immediate focus" causes release-blind governance
-     * drift.
+     * The Computed Golden Path is an execution steering surface. ISSUE (work-to-do) and
+     * DISCUSSION (an open convergence-to-drive) are both steerable next-focus; other node
+     * types (CONCEPT / ADR / CLASS / ...) and tickets explicitly marked not-ready are
+     * visibility, not immediate focus, and stay excluded — presenting those as "next
+     * immediate focus" causes release-blind governance drift.
      *
      * @param {Object} nodeData Parsed graph node payload.
      * @returns {Boolean}
@@ -715,9 +716,9 @@ class GoldenPathSynthesizer extends Base {
         const nodeId = String(nodeData?.id || '');
         const nodeType = String(nodeData?.type || nodeData?.properties?.type || '').toUpperCase();
 
-        if (nodeType === 'DISCUSSION' || nodeId.startsWith('discussion-')) return false;
-        if (nodeType && nodeType !== 'ISSUE') return false;
-        if (!nodeId.startsWith('issue-')) return false;
+        // ISSUE = work-to-do, DISCUSSION = an open convergence-to-drive; both are execution-steerable.
+        if (nodeType && nodeType !== 'ISSUE' && nodeType !== 'DISCUSSION') return false;
+        if (!nodeId.startsWith('issue-') && !nodeId.startsWith('discussion-')) return false;
 
         const labels = this.normalizeLabels(nodeData?.properties?.labels || nodeData?.labels);
 
@@ -1175,11 +1176,12 @@ class GoldenPathSynthesizer extends Base {
             const semanticResults = await graphColl.query({
                 queryEmbeddings: [frontierEmbedding],
                 nResults       : 20,
-                // Scope the candidate pool to actionable ISSUE vectors. Without this, the top-20 is
-                // taken across ALL embedded node types (the CONCEPT + ADR/GUIDES meta dominate), so the
-                // downstream state='OPEN' intersection yields zero open issues and the Computed Golden
-                // Path renders empty even when fresh open issues exist.
-                where          : {type: 'ISSUE'}
+                // Scope the candidate pool to actionable ISSUE + DISCUSSION vectors. Without this, the
+                // top-20 is taken across ALL embedded node types (the CONCEPT + ADR/GUIDES meta dominate),
+                // so the downstream state='OPEN' intersection yields nothing and the Computed Golden Path
+                // renders empty even when fresh open issues/discussions exist. Both are execution-steerable
+                // (work-to-do / converge-to-drive) and both embed with state='OPEN' metadata (IssueIngestor).
+                where          : {type: {'$in': ['ISSUE', 'DISCUSSION']}}
             });
             if (semanticResults && semanticResults.ids && semanticResults.ids.length > 0) {
                 semanticIds = semanticResults.ids[0];

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -1174,7 +1174,12 @@ class GoldenPathSynthesizer extends Base {
         try {
             const semanticResults = await graphColl.query({
                 queryEmbeddings: [frontierEmbedding],
-                nResults       : 20
+                nResults       : 20,
+                // Scope the candidate pool to actionable ISSUE vectors. Without this, the top-20 is
+                // taken across ALL embedded node types (the CONCEPT + ADR/GUIDES meta dominate), so the
+                // downstream state='OPEN' intersection yields zero open issues and the Computed Golden
+                // Path renders empty even when fresh open issues exist.
+                where          : {type: 'ISSUE'}
             });
             if (semanticResults && semanticResults.ids && semanticResults.ids.length > 0) {
                 semanticIds = semanticResults.ids[0];

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -495,6 +495,39 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent.indexOf('## Silent Threads')).toBeLessThan(handoffContent.indexOf('## Computed Golden Path'));
     });
 
+    test('synthesizeGoldenPath scopes the candidate-pool query to ISSUE vectors', async () => {
+        const originalGetGraphCollection    = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection  = StorageRouter.getSummaryCollection;
+        const originalEmbedText             = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs          = GoldenPathSynthesizer.fetchOpenPRs;
+        const OpenAiCompatible              = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate              = OpenAiCompatible.prototype.generate;
+        const issuesDir                     = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-pool-scope-'));
+        let capturedWhere                   = 'UNSET';
+        aiConfig.vectorDimension = 2;
+
+        StorageRouter.getGraphCollection    = async () => ({query: async args => { capturedWhere = args.where; return {ids: [[]], distances: [[]]}; }});
+        StorageRouter.getSummaryCollection  = async () => ({get: async () => ({documents: ['mock document']})});
+        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs  = async () => [];
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({issuesDir, now: new Date('2026-05-28T00:00:00Z')});
+        } finally {
+            StorageRouter.getGraphCollection    = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection  = originalGetSummaryCollection;
+            TextEmbeddingService.embedText      = originalEmbedText;
+            GoldenPathSynthesizer.fetchOpenPRs  = originalFetchOpenPRs;
+            OpenAiCompatible.prototype.generate = originalGenerate;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+
+        // The candidate pool must be scoped to ISSUE vectors; without the filter the top-20 is
+        // dominated by the CONCEPT/ADR/GUIDES population and the state='OPEN' intersection is empty.
+        expect(capturedWhere).toEqual({type: 'ISSUE'})
+    });
+
     test('synthesizeGoldenPath surfaces current incidents and filters non-actionable computed recommendations', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -495,7 +495,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent.indexOf('## Silent Threads')).toBeLessThan(handoffContent.indexOf('## Computed Golden Path'));
     });
 
-    test('synthesizeGoldenPath scopes the candidate-pool query to ISSUE vectors', async () => {
+    test('synthesizeGoldenPath scopes the candidate-pool query to ISSUE + DISCUSSION vectors', async () => {
         const originalGetGraphCollection    = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection  = StorageRouter.getSummaryCollection;
         const originalEmbedText             = TextEmbeddingService.embedText;
@@ -523,9 +523,10 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             fs.rmSync(issuesDir, {recursive: true, force: true});
         }
 
-        // The candidate pool must be scoped to ISSUE vectors; without the filter the top-20 is
-        // dominated by the CONCEPT/ADR/GUIDES population and the state='OPEN' intersection is empty.
-        expect(capturedWhere).toEqual({type: 'ISSUE'})
+        // The candidate pool must be scoped to ISSUE + DISCUSSION vectors; without the filter the top-20
+        // is dominated by the CONCEPT/ADR/GUIDES population and the state='OPEN' intersection is empty.
+        // Both are execution-steerable (work-to-do / converge-to-drive) and embed with state metadata.
+        expect(capturedWhere).toEqual({type: {'$in': ['ISSUE', 'DISCUSSION']}})
     });
 
     test('synthesizeGoldenPath surfaces current incidents and filters non-actionable computed recommendations', async () => {
@@ -655,8 +656,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(focusSection).toContain('**#13012**');
         expect(focusSection).not.toContain('Old generic AI enhancement');
         expect(handoffContent).toContain(readyId);
-        expect(handoffContent).not.toContain(discussionId);
-        expect(handoffContent).not.toContain(epicId);
+        expect(handoffContent).toContain(discussionId);  // discussions are now actionable (an open converge-to-drive)
+        expect(handoffContent).not.toContain(epicId);    // epic label still excluded
         expect(handoffContent).not.toContain(notReadyId);
     });
 
@@ -977,7 +978,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         }
     });
 
-    test('synthesizeGoldenPath excludes discussion nodes from computed recommendations', async () => {
+    test('synthesizeGoldenPath includes OPEN discussions but excludes CLOSED ones from computed recommendations', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
         const originalEmbedText            = TextEmbeddingService.embedText;
@@ -1034,8 +1035,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
 
         expect(handoffContent).toContain(issueId);
-        expect(handoffContent).not.toContain(openId);
-        expect(handoffContent).not.toContain(closedId);
+        expect(handoffContent).toContain(openId);        // open discussions are now actionable (converge-to-drive)
+        expect(handoffContent).not.toContain(closedId);  // closed discussions excluded by the state='OPEN' gate
     });
 
     test('renderConsolidationGapsSection surfaces undigested sessions visibly (#13807)', async () => {


### PR DESCRIPTION
<!-- Authored by @neo-opus-grace (Claude Opus 4.8, Claude Code) -->

Resolves #13844.

Refs #13750 — the broad PRIO-zero golden-path root. This PR delivers only the **candidate-pool-scope leaf (#13844)**; the root's orchestrator-idle (#13624), heavy-maintenance lease-fairness, and issue→graph ingestion ACs remain under epic #13755 / #13624. (Retargeted from `Resolves #13750` per @neo-gpt's cross-family RA — a narrow slice must not close the broad root.)

## Summary

The Computed Golden Path rendered empty/meta-only even when fresh open issues/discussions existed. The slice this PR fixes:
1. The candidate-pool semantic query took the top-20 by vector across ALL embedded node types (the ~19.5k CONCEPT + ADR/GUIDES meta dominate the frontier) → after the `state='OPEN'` + actionable gate, few/no routable nodes survived (a direct contributor to the `topNodes===0` empty computed-section observed post-#13801).
2. The actionable gate **explicitly excluded discussions** — but per operator directive, an open discussion needing convergence is a valid next-focus.

## Deltas

- **Candidate-pool query** (`synthesizeGoldenPath`): `where {type:'ISSUE'}` → `{type:{$in:['ISSUE','DISCUSSION']}}`, so the top-20 are open issues + discussions by vector, not CONCEPT/ADR/GUIDES. (Orthogonal to #13801's frontier recency-sort — that fixed *which frontier*; this fixes *which population*.)
- **`isActionableComputedRecommendation`**: accept ISSUE + DISCUSSION (by type + id-prefix); the SQL `state='OPEN'` filter still excludes CLOSED discussions. Per operator directive — *an open discussion needing convergence is execution-steerable (converge-to-drive), the same way an open issue is (work-to-do)*; other types (CONCEPT/ADR/...) + not-ready-labelled tickets stay excluded. Reverses #13759's blanket discussion-exclusion (operator-directed, OPEN-only).
- JSDoc rationale updated; the former discussion-exclusion test becomes an **OPEN-included / CLOSED-excluded** test (verifying the state gate, not a type ban).

## V-B-A

Discussions are already embedded into the graph collection by `IssueIngestor` (`type:'DISCUSSION'`, `state:'OPEN'/'CLOSED'`, L342-391) — so the `$in` filter surfaces real vectors, and the SQL `state='OPEN'` filter gates them correctly (open discussions satisfy it; closed don't). *(I initially mis-concluded discussions weren't embedded — an incomplete grep for a `DiscussionIngestor` file; the `IssueIngestor` handles both. Corrected before shipping.)*

## Test Evidence

Evidence: L2 (unit) — the candidate-pool scope + the actionable-gate inclusion are unit-coverable (the where-filter `$in` capture + the OPEN-included / CLOSED-excluded gate behavior); the live ranking *quality* is the post-merge step, gated on the consolidation arc (#13834 / #13835 / #12439). Residual: live Golden Path surfacing [#13844].

**L2** — 28/28 `GoldenPathSynthesizer` specs green (`UNIT_TEST_MODE=true npx playwright test … -c test/playwright/playwright.config.mjs`), incl. the where-capture test (`$in` assertion) + the flipped OPEN-included / CLOSED-excluded discussion test. Pre-commit hooks green.

## Premise Coherence

**Coheres:** the candidate-pool scope + the actionable-gate inclusion are the forecast-side *which-population* fix (paired with #13801's frontier recency *which-frontier*). **Honest scope note:** the deeper consolidation root (#12839→#13835 + #12439 + the idle-window #13834) dominates — this surfaces candidates that already carry structural weight.

## Post-Merge Validation

- [ ] Confirm the Computed Golden Path surfaces fresh open issues AND open discussions once the consolidation arc lands.