### PR TITLE
feat(ai): digest Neural Link action evidence (#9890)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -532,6 +532,26 @@ class DreamService extends Base {
                     }
                 }
 
+                // Neural Link action digest is cycle-scoped: it reads the shared forward audit
+                // ledger once per REM cycle and adds weak runtime-interaction evidence without
+                // erasing TEST_GAPs or synthesizing permanent Playwright coverage.
+                const nlActionDigestStart = Date.now();
+                try {
+                    const nlActionDigest = await this.executeNLActionDigest();
+                    logger.info(`[DreamService] Cycle-scope NL_ACTION Digest took: ${((Date.now() - nlActionDigestStart) / 1000).toFixed(1)}s`);
+                    perPhaseStates.push(finishPhase(
+                        'nlActionDigest',
+                        nlActionDigestStart,
+                        nlActionDigest?.status === 'skipped' ? 'skipped' : 'completed',
+                        nlActionDigest
+                    ));
+                } catch (e) {
+                    perPhaseStates.push(finishPhase('nlActionDigest', nlActionDigestStart, 'failed', {
+                        error: toErrorMessage(e)
+                    }));
+                    throw e;
+                }
+
                 // Concept-graph gap inference is ontology-scoped: the output is identical
                 // for every invocation within a single REM cycle, so running it once after
                 // the session loop replaces redundant traversals.
@@ -899,6 +919,18 @@ class DreamService extends Base {
      */
     async inferConceptGraphGaps() {
         return GapInferenceEngine.inferConceptGraphGaps();
+    }
+
+    /**
+     * Cycle-scoped Neural Link action digest entry point. Delegates to `GapInferenceEngine`
+     * for deterministic `nl_action_log` inspection and weak `NL_ACTION_SEQUENCE -> VALIDATES`
+     * evidence edges. Invoked once per REM cycle after the per-session TEST_GAP pass and before
+     * concept-graph gap inference; it never removes TEST_GAPs because live agent interaction is
+     * weaker than durable Playwright coverage.
+     * @param {Object} [options] Optional digest window / threshold overrides for tests.
+     */
+    async executeNLActionDigest(options) {
+        return GapInferenceEngine.inferNlActionDigest(options);
     }
 
     /**

--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -927,10 +927,9 @@ class DreamService extends Base {
      * evidence edges. Invoked once per REM cycle after the per-session TEST_GAP pass and before
      * concept-graph gap inference; it never removes TEST_GAPs because live agent interaction is
      * weaker than durable Playwright coverage.
-     * @param {Object} [options] Optional digest window / threshold overrides for tests.
      */
-    async executeNLActionDigest(options) {
-        return GapInferenceEngine.inferNlActionDigest(options);
+    async executeNLActionDigest() {
+        return GapInferenceEngine.inferNlActionDigest();
     }
 
     /**

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -477,6 +477,31 @@ class Config extends ConfigProvider {
              */
             guideGapWeightThreshold: leaf(0.8, 'NEO_GUIDE_GAP_WEIGHT_THRESHOLD', 'number'),
             /**
+             * Cycle-scoped Neural Link action digest tuning. The digest reads recent
+             * `nl_action_log` sequences and emits weak `NL_ACTION_SEQUENCE -> VALIDATES`
+             * evidence without removing `[TEST_GAP]`. Leaves stay in AiConfig so the REM
+             * pipeline can tune freshness, volume, success gate, and weak edge strength
+             * without re-deriving constants in `GapInferenceEngine`.
+             * @type {number}
+             */
+            nlActionDigestLookbackMs: leaf(14 * DAY_MS, 'NEO_NL_ACTION_DIGEST_LOOKBACK_MS', 'number'),
+            /**
+             * Maximum recent Neural Link action sequences inspected per digest pass.
+             * @type {number}
+             */
+            nlActionDigestSequenceLimit: leaf(1000, 'NEO_NL_ACTION_DIGEST_SEQUENCE_LIMIT', 'number'),
+            /**
+             * Minimum successful-action ratio for a sequence to qualify as weak evidence.
+             * @type {number}
+             */
+            nlActionDigestMinSuccessRate: leaf(0.8, 'NEO_NL_ACTION_DIGEST_MIN_SUCCESS_RATE', 'number'),
+            /**
+             * Decaying graph-edge weight for weak Neural Link runtime-interaction evidence.
+             * Permanent Playwright evidence remains stronger (`1.0`).
+             * @type {number}
+             */
+            nlActionDigestEvidenceWeight: leaf(0.35, 'NEO_NL_ACTION_DIGEST_EVIDENCE_WEIGHT', 'number'),
+            /**
              * Operator-tuning knobs for `ConceptDiscoveryService`. Both values are read live
              * at method-call time (not captured at module load) so tests + runtime overrides are honored.
              *

--- a/ai/services/graph/GapInferenceEngine.mjs
+++ b/ai/services/graph/GapInferenceEngine.mjs
@@ -517,10 +517,31 @@ class GapInferenceEngine extends Base {
         const targets = {classNames: new Set(), componentIds: new Set()};
 
         for (const row of rows) {
+            if (!this.isNlActionValidationTool(row.tool)) continue;
+
             this.collectNlActionTargets(this.parseJsonValue(row.args), row.tool, targets);
         }
 
         return targets;
+    }
+
+    /**
+     * @summary Determines whether an NL tool can provide weak validation evidence.
+     *
+     * Read/orientation tools can mention broad component ids or class names without exercising
+     * the returned surface. Only write/interaction tools are allowed to mint weak runtime evidence.
+     * @param {String} tool Neural Link tool name.
+     * @returns {Boolean} `true` when the tool has target-bearing mutation or interaction intent.
+     * @protected
+     */
+    isNlActionValidationTool(tool = '') {
+        const name = String(tool || '');
+
+        if (/^(get|list|inspect|query|read|health|who|manage)_/i.test(name)) {
+            return false;
+        }
+
+        return /^(create|set|update|remove|destroy|call|patch|simulate|trigger|click|type|drag|select|focus|blur|undo|redo|commit|abort|begin)_/i.test(name);
     }
 
     /**
@@ -544,6 +565,19 @@ class GapInferenceEngine extends Base {
                     .forEach(componentId => targets.componentIds.add(componentId));
             } else if (key === 'id' && isComponentTool && typeof item === 'string' && item.length > 0) {
                 targets.componentIds.add(item);
+            }
+        }
+
+        for (const key of ['config', 'properties']) {
+            const item = value[key];
+            if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+
+            if (typeof item.className === 'string' && item.className.length > 0) {
+                targets.classNames.add(item.className);
+            }
+
+            if (typeof item.componentId === 'string' && item.componentId.length > 0) {
+                targets.componentIds.add(item.componentId);
             }
         }
     }

--- a/ai/services/graph/GapInferenceEngine.mjs
+++ b/ai/services/graph/GapInferenceEngine.mjs
@@ -12,6 +12,10 @@ import logger                                                      from '../../m
  * @private
  */
 const CONCEPT_REVERIFY_INTERVAL_MS = 90 * 24 * 60 * 60 * 1000;
+const NL_ACTION_DIGEST_LOOKBACK_MS = 14 * 24 * 60 * 60 * 1000;
+const NL_ACTION_DIGEST_LIMIT = 1000;
+const NL_ACTION_DIGEST_MIN_SUCCESS_RATE = 0.8;
+const NL_ACTION_WEAK_EVIDENCE_TAG = '[NL_ACTION_WEAK_EVIDENCE]';
 
 /**
  * ISO freshness stamps accept either a date-only value (`YYYY-MM-DD`) or the canonical
@@ -330,6 +334,406 @@ class GapInferenceEngine extends Base {
             gaps.push(...(kbDemandGaps.get(concept.id) || []));
 
             this.applyGapsToNode(concept, gaps);
+        }
+    }
+
+    /**
+     * @summary Digests successful Neural Link action sequences into weak TEST_GAP evidence.
+     *
+     * `nl_action_log` is structured relational telemetry from the Neural Link MCP server, not
+     * semantic prose. This pass therefore reads the existing SQLite table directly through the
+     * already-mounted Memory Core graph handle instead of importing `RecorderService` or opening a
+     * second MCP-side connection. Qualifying sequences create `NL_ACTION_SEQUENCE -> VALIDATES ->
+     * CLASS/COMPONENT` edges with `evidenceKind: neural-link-action-sequence` and annotate existing
+     * `[TEST_GAP]` strings with a weak-evidence marker. They never remove the gap: live agent
+     * interaction is useful signal, but permanent Playwright coverage remains the stronger evidence.
+     *
+     * @param {Object} [options]
+     * @param {Number} [options.sinceTimestamp] Minimum action timestamp to consider.
+     * @param {Number} [options.limit] Maximum action rows to inspect.
+     * @param {Number} [options.minSuccessRate] Minimum sequence success rate, default 0.8.
+     * @returns {Object} Digest stats.
+     */
+    async inferNlActionDigest({
+        sinceTimestamp = Date.now() - NL_ACTION_DIGEST_LOOKBACK_MS,
+        limit = NL_ACTION_DIGEST_LIMIT,
+        minSuccessRate = NL_ACTION_DIGEST_MIN_SUCCESS_RATE
+    } = {}) {
+        const rows = this.readNlActionRows({sinceTimestamp, limit});
+
+        if (rows.status !== 'ok') {
+            return rows;
+        }
+
+        const sequences = this.groupNlActionRowsBySequence(rows.rows);
+        let qualifyingSequences = 0,
+            linkedEdges         = 0,
+            downgradedGaps      = 0,
+            targetMatches       = 0;
+
+        for (const [sequenceId, sequenceRows] of sequences) {
+            const sequence = this.buildNlActionSequenceEvidence({sequenceId, rows: sequenceRows, minSuccessRate});
+            if (!sequence) continue;
+
+            qualifyingSequences++;
+
+            const targets = this.findNlActionTargetNodes(sequence.targets);
+            targetMatches += targets.length;
+
+            for (const target of targets) {
+                if (this.linkNlActionEvidenceToStructuralNode(sequence, target)) {
+                    linkedEdges++;
+                }
+
+                if (this.annotateTestGapWithNlActionEvidence(target, sequence)) {
+                    downgradedGaps++;
+                }
+            }
+        }
+
+        return {
+            status       : 'completed',
+            rowsRead     : rows.rows.length,
+            sequencesRead: sequences.size,
+            qualifyingSequences,
+            targetMatches,
+            linkedEdges,
+            downgradedGaps
+        };
+    }
+
+    /**
+     * @param {Object} options
+     * @returns {Object}
+     * @protected
+     */
+    readNlActionRows({sinceTimestamp, limit}) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite) {
+            return {status: 'skipped', reason: 'graph-sqlite-unavailable'};
+        }
+
+        try {
+            const table = sqlite.prepare(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'nl_action_log'"
+            ).get();
+            if (!table) {
+                return {status: 'skipped', reason: 'nl-action-log-missing'};
+            }
+
+            const safeLimit = Math.max(1, Number(limit) || NL_ACTION_DIGEST_LIMIT);
+            const rows = sqlite.prepare(`
+                SELECT sequence_id, session_id, timestamp, tool, args, result, success, duration_ms, app_name
+                FROM nl_action_log
+                WHERE timestamp >= ?
+                ORDER BY timestamp ASC
+                LIMIT ?
+            `).all(Number(sinceTimestamp) || 0, safeLimit);
+
+            return {status: 'ok', rows};
+        } catch (err) {
+            logger.debug('[GapInferenceEngine] NL action digest skipped:', err.message);
+            return {status: 'skipped', reason: 'nl-action-log-read-failed', error: err.message};
+        }
+    }
+
+    /**
+     * @param {Object[]} rows
+     * @returns {Map<String, Object[]>}
+     * @protected
+     */
+    groupNlActionRowsBySequence(rows = []) {
+        const grouped = new Map();
+
+        for (const row of rows) {
+            const sequenceId = row?.sequence_id;
+            if (!sequenceId) continue;
+            if (!grouped.has(sequenceId)) {
+                grouped.set(sequenceId, []);
+            }
+            grouped.get(sequenceId).push(row);
+        }
+
+        return grouped;
+    }
+
+    /**
+     * @param {Object} options
+     * @returns {Object|null}
+     * @protected
+     */
+    buildNlActionSequenceEvidence({sequenceId, rows, minSuccessRate}) {
+        if (!Array.isArray(rows) || rows.length === 0) return null;
+
+        const successfulRows = rows.filter(row => Number(row.success) === 1);
+        const successRate = successfulRows.length / rows.length;
+
+        if (successRate < minSuccessRate) {
+            return null;
+        }
+
+        const targets = this.extractNlActionTargets(successfulRows);
+        if (targets.classNames.size === 0 && targets.componentIds.size === 0) {
+            return null;
+        }
+
+        return {
+            sequenceId,
+            nodeId: `nl-action-sequence:${sequenceId}`,
+            rows,
+            targets,
+            actionCount      : rows.length,
+            successfulActions: successfulRows.length,
+            successRate,
+            firstTimestamp   : rows[0]?.timestamp ?? null,
+            lastTimestamp    : rows[rows.length - 1]?.timestamp ?? null,
+            tools            : [...new Set(rows.map(row => row.tool).filter(Boolean))],
+            sessionIds       : [...new Set(rows.map(row => row.session_id).filter(Boolean))],
+            appNames         : [...new Set(rows.map(row => row.app_name).filter(Boolean))]
+        };
+    }
+
+    /**
+     * @param {Object[]} rows
+     * @returns {{classNames: Set<String>, componentIds: Set<String>}}
+     * @protected
+     */
+    extractNlActionTargets(rows = []) {
+        const targets = {classNames: new Set(), componentIds: new Set()};
+
+        for (const row of rows) {
+            this.collectNlActionTargets(this.parseJsonValue(row.args), row.tool, targets);
+            this.collectNlActionTargets(this.parseJsonValue(row.result), row.tool, targets);
+        }
+
+        return targets;
+    }
+
+    /**
+     * @param {*} value Parsed JSON value.
+     * @param {String} tool Neural Link tool name.
+     * @param {Object} targets Mutable target accumulator.
+     * @protected
+     */
+    collectNlActionTargets(value, tool, targets) {
+        if (Array.isArray(value)) {
+            value.forEach(item => this.collectNlActionTargets(item, tool, targets));
+            return;
+        }
+
+        if (!value || typeof value !== 'object') return;
+
+        const isComponentTool = /component|instance/i.test(tool || '');
+
+        for (const [key, item] of Object.entries(value)) {
+            if (key === 'className' && typeof item === 'string' && item.length > 0) {
+                targets.classNames.add(item);
+            } else if ((key === 'componentId' || key === 'component_id') && typeof item === 'string' && item.length > 0) {
+                targets.componentIds.add(item);
+            } else if (key === 'componentIds' && Array.isArray(item)) {
+                item.filter(componentId => typeof componentId === 'string' && componentId.length > 0)
+                    .forEach(componentId => targets.componentIds.add(componentId));
+            } else if (key === 'id' && isComponentTool && typeof item === 'string' && item.length > 0) {
+                targets.componentIds.add(item);
+            }
+
+            this.collectNlActionTargets(item, tool, targets);
+        }
+    }
+
+    /**
+     * @param {String|null} text
+     * @returns {*}
+     * @protected
+     */
+    parseJsonValue(text) {
+        if (text == null || text === '') return null;
+        if (typeof text !== 'string') return text;
+        try {
+            return JSON.parse(text);
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * @param {Object} targets
+     * @returns {Object[]}
+     * @protected
+     */
+    findNlActionTargetNodes(targets) {
+        const targetNodes = [];
+        const seen = new Set();
+
+        for (const node of GraphService.db.nodes.items) {
+            const label = node.label || node.get?.('label');
+            if (label !== 'CLASS' && label !== 'COMPONENT') continue;
+
+            if (!this.doesNlActionTargetStructuralNode(node, targets)) continue;
+
+            const nodeId = node.id || node.get?.('id');
+            if (!nodeId || seen.has(nodeId)) continue;
+            seen.add(nodeId);
+            targetNodes.push(node);
+        }
+
+        return targetNodes;
+    }
+
+    /**
+     * @param {Object} node
+     * @param {Object} targets
+     * @returns {Boolean}
+     * @protected
+     */
+    doesNlActionTargetStructuralNode(node, targets) {
+        const
+            label      = node.label || node.get?.('label'),
+            id         = node.id || node.get?.('id'),
+            properties = (node.properties || node.get?.('properties') || {}),
+            name       = properties.name || node.name || '';
+
+        const candidateValues = new Set([
+            id,
+            name,
+            properties.className,
+            properties.componentId,
+            properties.id,
+            id && label ? `${label}:${name}` : null
+        ].filter(Boolean));
+
+        if (label === 'CLASS') {
+            for (const className of targets.classNames) {
+                if (candidateValues.has(className) || candidateValues.has(`CLASS:${className}`)) {
+                    return true;
+                }
+            }
+        }
+
+        for (const componentId of targets.componentIds) {
+            if (candidateValues.has(componentId)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param {Object} sequence
+     * @param {Object} dbNode
+     * @returns {Boolean} true when a new weak validation edge was added.
+     * @protected
+     */
+    linkNlActionEvidenceToStructuralNode(sequence, dbNode) {
+        const targetId = dbNode.id || dbNode.get?.('id');
+        if (!targetId || !sequence?.nodeId) return false;
+
+        const existing = GraphService.db.edges.items.find(edge =>
+            edge.source === sequence.nodeId &&
+            edge.target === targetId &&
+            edge.type === 'VALIDATES' &&
+            edge.properties?.evidenceKind === 'neural-link-action-sequence'
+        );
+
+        if (existing) return false;
+
+        GraphService.upsertNode({
+            id        : sequence.nodeId,
+            type      : 'NL_ACTION_SEQUENCE',
+            name      : sequence.sequenceId,
+            properties: {
+                sequenceId       : sequence.sequenceId,
+                actionCount      : sequence.actionCount,
+                successfulActions: sequence.successfulActions,
+                successRate      : sequence.successRate,
+                firstTimestamp   : sequence.firstTimestamp,
+                lastTimestamp    : sequence.lastTimestamp,
+                tools            : sequence.tools,
+                sessionIds       : sequence.sessionIds,
+                appNames         : sequence.appNames,
+                evidenceKind     : 'neural-link-action-sequence',
+                weakEvidence     : true
+            }
+        });
+
+        GraphService.linkNodes(sequence.nodeId, targetId, 'VALIDATES', 0.35, {
+            evidenceKind      : 'neural-link-action-sequence',
+            weakEvidence      : true,
+            successRate       : sequence.successRate,
+            actionCount       : sequence.actionCount,
+            successfulActions : sequence.successfulActions,
+            sequenceId        : sequence.sequenceId,
+            inferredBy        : 'GapInferenceEngine.inferNlActionDigest',
+            validationStrength: 'weak-runtime-interaction'
+        });
+
+        return true;
+    }
+
+    /**
+     * @param {Object} dbNode
+     * @param {Object} sequence
+     * @returns {Boolean}
+     * @protected
+     */
+    annotateTestGapWithNlActionEvidence(dbNode, sequence) {
+        const properties = dbNode.properties || dbNode.get?.('properties') || {};
+        const gaps = this.parseCapabilityGaps(properties.capabilityGap);
+        if (gaps.length === 0) return false;
+
+        let changed = false;
+        const updatedGaps = gaps.map(gap => {
+            if (!gap.includes('[TEST_GAP]') || gap.includes(NL_ACTION_WEAK_EVIDENCE_TAG)) {
+                return gap;
+            }
+            changed = true;
+            return `${gap} ${NL_ACTION_WEAK_EVIDENCE_TAG} Successful Neural Link action sequence '${sequence.sequenceId}' provides weak runtime-interaction evidence (${Math.round(sequence.successRate * 100)}% success), but permanent Playwright coverage is still required.`;
+        });
+
+        if (!changed) return false;
+
+        const targetId = dbNode.id || dbNode.get?.('id');
+        const label    = dbNode.label || dbNode.get?.('label');
+        const existingEvidence = Array.isArray(properties.nlActionEvidence) ? properties.nlActionEvidence : [];
+
+        GraphService.upsertNode({
+            id        : targetId,
+            type      : label,
+            properties: {
+                ...properties,
+                capabilityGap   : JSON.stringify(updatedGaps),
+                nlActionEvidence: [
+                    ...existingEvidence.filter(item => item.sequenceId !== sequence.sequenceId),
+                    {
+                        sequenceId       : sequence.sequenceId,
+                        successRate      : sequence.successRate,
+                        actionCount      : sequence.actionCount,
+                        successfulActions: sequence.successfulActions,
+                        evidenceKind     : 'neural-link-action-sequence',
+                        weakEvidence     : true,
+                        checkedAt        : Date.now()
+                    }
+                ]
+            }
+        });
+
+        return true;
+    }
+
+    /**
+     * @param {String|String[]} value
+     * @returns {String[]}
+     * @protected
+     */
+    parseCapabilityGaps(value) {
+        if (Array.isArray(value)) return value.filter(item => typeof item === 'string');
+        if (typeof value !== 'string' || value.length === 0) return [];
+        try {
+            const parsed = JSON.parse(value);
+            return Array.isArray(parsed) ? parsed.filter(item => typeof item === 'string') : [];
+        } catch {
+            return [];
         }
     }
 

--- a/ai/services/graph/GapInferenceEngine.mjs
+++ b/ai/services/graph/GapInferenceEngine.mjs
@@ -1,7 +1,7 @@
-import Base                                                        from '../../../src/core/Base.mjs';
+import Base                                                             from '../../../src/core/Base.mjs';
 import {Memory_Config as aiConfig, Memory_GraphService as GraphService} from '../../services.mjs';
-import KBRecorderService                                           from '../../services/knowledge-base/KBRecorderService.mjs';
-import logger                                                      from '../../mcp/server/memory-core/logger.mjs';
+import KBRecorderService                                                from '../../services/knowledge-base/KBRecorderService.mjs';
+import logger                                                           from '../../mcp/server/memory-core/logger.mjs';
 
 /**
  * Default freshness window for Concept Ontology source-grounding. Concepts with missing,
@@ -12,9 +12,6 @@ import logger                                                      from '../../m
  * @private
  */
 const CONCEPT_REVERIFY_INTERVAL_MS = 90 * 24 * 60 * 60 * 1000;
-const NL_ACTION_DIGEST_LOOKBACK_MS = 14 * 24 * 60 * 60 * 1000;
-const NL_ACTION_DIGEST_LIMIT = 1000;
-const NL_ACTION_DIGEST_MIN_SUCCESS_RATE = 0.8;
 const NL_ACTION_WEAK_EVIDENCE_TAG = '[NL_ACTION_WEAK_EVIDENCE]';
 
 /**
@@ -229,11 +226,11 @@ class GapInferenceEngine extends Base {
             linkedIds.add(testFile.id);
 
             GraphService.linkNodes(testFile.id, dbNode.id, 'VALIDATES', 1.0, {
-                evidenceKind      : 'permanent-test-file',
-                evidencePath      : testFile.path,
-                inferredBy        : 'GapInferenceEngine.inferTestGapsFromSession',
-                validatedNodeName : sourceNode.name,
-                validatedNodeType : sourceNode.type
+                evidenceKind     : 'permanent-test-file',
+                evidencePath     : testFile.path,
+                inferredBy       : 'GapInferenceEngine.inferTestGapsFromSession',
+                validatedNodeName: sourceNode.name,
+                validatedNodeType: sourceNode.type
             });
         }
     }
@@ -302,13 +299,13 @@ class GapInferenceEngine extends Base {
             if (concept.properties?.validated === false) continue;
 
             const
-                outboundEdges       = GraphService.db.edges.getByIndex('source', concept.id),
-                explainedByEdges    = outboundEdges.filter(e => e.type === 'EXPLAINED_BY'),
-                exemplifiedByEdges  = outboundEdges.filter(e => e.type === 'EXEMPLIFIED_BY'),
-                implementedByEdges  = outboundEdges.filter(e => e.type === 'IMPLEMENTED_BY'),
-                weight              = concept.properties?.weight ?? 0,
-                gaps                = [],
-                name                = concept.properties?.name || concept.name || concept.id;
+                outboundEdges      = GraphService.db.edges.getByIndex('source', concept.id),
+                explainedByEdges   = outboundEdges.filter(e => e.type === 'EXPLAINED_BY'),
+                exemplifiedByEdges = outboundEdges.filter(e => e.type === 'EXEMPLIFIED_BY'),
+                implementedByEdges = outboundEdges.filter(e => e.type === 'IMPLEMENTED_BY'),
+                weight             = concept.properties?.weight ?? 0,
+                gaps               = [],
+                name               = concept.properties?.name || concept.name || concept.id;
 
             if (this.isConceptReverifyDue(concept, now)) {
                 const verifiedAt = concept.properties?.verifiedAt ?? null;
@@ -348,24 +345,23 @@ class GapInferenceEngine extends Base {
      * `[TEST_GAP]` strings with a weak-evidence marker. They never remove the gap: live agent
      * interaction is useful signal, but permanent Playwright coverage remains the stronger evidence.
      *
-     * @param {Object} [options]
-     * @param {Number} [options.sinceTimestamp] Minimum action timestamp to consider.
-     * @param {Number} [options.limit] Maximum action rows to inspect.
-     * @param {Number} [options.minSuccessRate] Minimum sequence success rate, default 0.8.
      * @returns {Object} Digest stats.
      */
-    async inferNlActionDigest({
-        sinceTimestamp = Date.now() - NL_ACTION_DIGEST_LOOKBACK_MS,
-        limit = NL_ACTION_DIGEST_LIMIT,
-        minSuccessRate = NL_ACTION_DIGEST_MIN_SUCCESS_RATE
-    } = {}) {
-        const rows = this.readNlActionRows({sinceTimestamp, limit});
+    async inferNlActionDigest() {
+        const
+            lookbackMs     = aiConfig.nlActionDigestLookbackMs,
+            sequenceLimit  = aiConfig.nlActionDigestSequenceLimit,
+            minSuccessRate = aiConfig.nlActionDigestMinSuccessRate,
+            evidenceWeight = aiConfig.nlActionDigestEvidenceWeight,
+            sinceTimestamp = Date.now() - lookbackMs,
+            rows           = this.readNlActionRows({sinceTimestamp, sequenceLimit});
 
         if (rows.status !== 'ok') {
             return rows;
         }
 
         const sequences = this.groupNlActionRowsBySequence(rows.rows);
+        const resetWeakEvidenceAnnotations = this.resetNlActionWeakEvidenceAnnotations();
         let qualifyingSequences = 0,
             linkedEdges         = 0,
             downgradedGaps      = 0,
@@ -381,7 +377,7 @@ class GapInferenceEngine extends Base {
             targetMatches += targets.length;
 
             for (const target of targets) {
-                if (this.linkNlActionEvidenceToStructuralNode(sequence, target)) {
+                if (this.linkNlActionEvidenceToStructuralNode(sequence, target, evidenceWeight)) {
                     linkedEdges++;
                 }
 
@@ -398,7 +394,8 @@ class GapInferenceEngine extends Base {
             qualifyingSequences,
             targetMatches,
             linkedEdges,
-            downgradedGaps
+            downgradedGaps,
+            resetWeakEvidenceAnnotations
         };
     }
 
@@ -407,7 +404,7 @@ class GapInferenceEngine extends Base {
      * @returns {Object}
      * @protected
      */
-    readNlActionRows({sinceTimestamp, limit}) {
+    readNlActionRows({sinceTimestamp, sequenceLimit}) {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite) {
             return {status: 'skipped', reason: 'graph-sqlite-unavailable'};
@@ -421,14 +418,28 @@ class GapInferenceEngine extends Base {
                 return {status: 'skipped', reason: 'nl-action-log-missing'};
             }
 
-            const safeLimit = Math.max(1, Number(limit) || NL_ACTION_DIGEST_LIMIT);
+            const safeLimit = Math.max(1, Number(sequenceLimit) || aiConfig.nlActionDigestSequenceLimit);
+            const sequenceRows = sqlite.prepare(`
+                SELECT sequence_id, MAX(timestamp) AS latest_timestamp
+                FROM nl_action_log
+                WHERE timestamp >= ?
+                GROUP BY sequence_id
+                ORDER BY latest_timestamp DESC
+                LIMIT ?
+            `).all(Number(sinceTimestamp) || 0, safeLimit);
+            const sequenceIds = sequenceRows.map(row => row.sequence_id).filter(Boolean);
+
+            if (sequenceIds.length === 0) {
+                return {status: 'ok', rows: []};
+            }
+
+            const placeholders = sequenceIds.map(() => '?').join(',');
             const rows = sqlite.prepare(`
                 SELECT sequence_id, session_id, timestamp, tool, args, result, success, duration_ms, app_name
                 FROM nl_action_log
-                WHERE timestamp >= ?
+                WHERE sequence_id IN (${placeholders})
                 ORDER BY timestamp ASC
-                LIMIT ?
-            `).all(Number(sinceTimestamp) || 0, safeLimit);
+            `).all(...sequenceIds);
 
             return {status: 'ok', rows};
         } catch (err) {
@@ -452,6 +463,10 @@ class GapInferenceEngine extends Base {
                 grouped.set(sequenceId, []);
             }
             grouped.get(sequenceId).push(row);
+        }
+
+        for (const sequenceRows of grouped.values()) {
+            sequenceRows.sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
         }
 
         return grouped;
@@ -503,7 +518,6 @@ class GapInferenceEngine extends Base {
 
         for (const row of rows) {
             this.collectNlActionTargets(this.parseJsonValue(row.args), row.tool, targets);
-            this.collectNlActionTargets(this.parseJsonValue(row.result), row.tool, targets);
         }
 
         return targets;
@@ -516,12 +530,7 @@ class GapInferenceEngine extends Base {
      * @protected
      */
     collectNlActionTargets(value, tool, targets) {
-        if (Array.isArray(value)) {
-            value.forEach(item => this.collectNlActionTargets(item, tool, targets));
-            return;
-        }
-
-        if (!value || typeof value !== 'object') return;
+        if (!value || typeof value !== 'object' || Array.isArray(value)) return;
 
         const isComponentTool = /component|instance/i.test(tool || '');
 
@@ -536,8 +545,6 @@ class GapInferenceEngine extends Base {
             } else if (key === 'id' && isComponentTool && typeof item === 'string' && item.length > 0) {
                 targets.componentIds.add(item);
             }
-
-            this.collectNlActionTargets(item, tool, targets);
         }
     }
 
@@ -622,10 +629,11 @@ class GapInferenceEngine extends Base {
     /**
      * @param {Object} sequence
      * @param {Object} dbNode
+     * @param {Number} evidenceWeight Weak validation edge weight.
      * @returns {Boolean} true when a new weak validation edge was added.
      * @protected
      */
-    linkNlActionEvidenceToStructuralNode(sequence, dbNode) {
+    linkNlActionEvidenceToStructuralNode(sequence, dbNode, evidenceWeight) {
         const targetId = dbNode.id || dbNode.get?.('id');
         if (!targetId || !sequence?.nodeId) return false;
 
@@ -657,7 +665,7 @@ class GapInferenceEngine extends Base {
             }
         });
 
-        GraphService.linkNodes(sequence.nodeId, targetId, 'VALIDATES', 0.35, {
+        GraphService.linkNodes(sequence.nodeId, targetId, 'VALIDATES', evidenceWeight, {
             evidenceKind      : 'neural-link-action-sequence',
             weakEvidence      : true,
             successRate       : sequence.successRate,
@@ -669,6 +677,60 @@ class GapInferenceEngine extends Base {
         });
 
         return true;
+    }
+
+    /**
+     * @summary Clears stale NL weak-evidence annotations before applying the current digest.
+     *
+     * NL action evidence is intentionally weaker and more volatile than permanent Playwright
+     * coverage. Recomputing the marker per successful digest keeps the annotation aligned with
+     * the decaying `VALIDATES` edge instead of leaving permanent text after the evidence ages out.
+     * @returns {Number} Number of nodes whose weak-evidence annotation state changed.
+     * @protected
+     */
+    resetNlActionWeakEvidenceAnnotations() {
+        let resetCount = 0;
+
+        for (const node of GraphService.db.nodes.items) {
+            const properties = node.properties || node.get?.('properties') || {};
+            const gaps       = this.parseCapabilityGaps(properties.capabilityGap);
+            const evidence   = Array.isArray(properties.nlActionEvidence) ? properties.nlActionEvidence : [];
+
+            if (gaps.length === 0 && evidence.length === 0) continue;
+
+            const cleanedGaps = gaps.map(gap => this.stripNlActionWeakEvidence(gap));
+            const gapChanged  = cleanedGaps.some((gap, index) => gap !== gaps[index]);
+
+            if (!gapChanged && evidence.length === 0) continue;
+
+            const nextProperties = {
+                ...properties,
+                nlActionEvidence: []
+            };
+
+            if (cleanedGaps.length > 0) {
+                nextProperties.capabilityGap = JSON.stringify(cleanedGaps);
+            } else {
+                delete nextProperties.capabilityGap;
+            }
+
+            node.properties = nextProperties;
+
+            GraphService.upsertNode(node);
+            resetCount++;
+        }
+
+        return resetCount;
+    }
+
+    /**
+     * @param {String} gap Capability-gap string.
+     * @returns {String}
+     * @protected
+     */
+    stripNlActionWeakEvidence(gap) {
+        const index = String(gap).indexOf(NL_ACTION_WEAK_EVIDENCE_TAG);
+        return index === -1 ? gap : gap.slice(0, index).trim();
     }
 
     /**

--- a/learn/agentos/decisions/0024-native-edge-graph-model.md
+++ b/learn/agentos/decisions/0024-native-edge-graph-model.md
@@ -33,7 +33,7 @@ Three layers. Source-of-truth in the right column (so this snapshot is re-verifi
 |---|---|---|
 | **Knowledge** | `CONCEPT`, `CLASS`, `METHOD`, `FILE`, `GUIDE`, `BLOG`, `TEST`, `ADR` | `SemanticGraphExtractor.VALID_TYPES` (LLM-extracted) + curated `nodes.jsonl` (`CONCEPT`) + `AdrIngestor` (`ADR`, deterministic) |
 | **Work** | `SESSION`, `MEMORY`, `ARTIFACT_PLAN`, `ARTIFACT_TASK`, `ISSUE`, `STRATEGY` | `VALID_TYPES` + GitHub / session sync |
-| **System** | `SYSTEM_ANCHOR`, `[Frontier]`, `AgentIdentity`, `MESSAGE`, `WAKE_SUBSCRIPTION` | operational (`GraphService`, `MailboxService`, `IdentitySchema` — ADR 0018) |
+| **System** | `SYSTEM_ANCHOR`, `[Frontier]`, `AgentIdentity`, `MESSAGE`, `WAKE_SUBSCRIPTION`, `NL_ACTION_SEQUENCE` | operational (`GraphService`, `MailboxService`, `IdentitySchema` — ADR 0018, `GapInferenceEngine` Neural Link evidence digest) |
 
 The LLM extractor's `VALID_TYPES` enum is **14** (`SemanticGraphExtractor:265`); an unrecognized extracted type defaults to `CONCEPT`. `ADR` is added **deterministically** by `AdrIngestor` (no LLM inference), so decision records are graph-queryable without widening the extractor enum (ADR 0006). (`SYSTEM_ANCHOR` is grouped under System for its operational role but is itself one of the 14 `VALID_TYPES` — both LLM-extractable and operational.)
 
@@ -46,7 +46,7 @@ The LLM extractor's `VALID_TYPES` enum is **14** (`SemanticGraphExtractor:265`);
 | **Concept ontology** | `PARENT_CONCEPT`, `IMPLEMENTED_BY`, `EXPLAINED_BY`, `EXEMPLIFIED_BY`, `REQUIRES`, `ANALOGOUS_TO` | `CONCEPT_EDGE_TYPES` (`ConceptIngestor`) | yes |
 | **ADR** | `GOVERNS`, `CITES_AUTHORITY`, `IMPLEMENTS_DECISION`, `GRADUATED_FROM`, `CODIFIES_CONCEPT` | `ADR_EDGE_TYPES` (`AdrIngestor`) | yes |
 | **Structural (protected)** | `IMPLEMENTS`, `EXTENDS`, `SYSTEM_TENET`, `RESOLVES` | `PROTECTED_EDGE_TYPES` (`GraphService:73`) | **NO — facts** |
-| **Provenance / semantic** | `TAGGED_CONCEPT` (1.0 curated / 0.8 auto), `MENTIONED_IN`, `AUTHORED_BY`, `SUPERSEDES`, `OBSOLETES`, `DUPLICATE` | REM extraction + `TopologyInferenceEngine` | yes |
+| **Provenance / semantic** | `TAGGED_CONCEPT` (1.0 curated / 0.8 auto), `MENTIONED_IN`, `AUTHORED_BY`, `SUPERSEDES`, `OBSOLETES`, `DUPLICATE`, `VALIDATES` | REM extraction + `TopologyInferenceEngine` + `GapInferenceEngine` | yes |
 | **Work / lifecycle** | `BLOCKED_BY`, `CONTAINED_PLAN`, `IMPLEMENTATION_PLAN`, `SESSION_*`, `EVALUATED_BY` | sync + lifecycle services | yes |
 | **Mailbox / A2A** | `DELIVERED_TO`, `SENT_BY`, `SENT_TO` | `MailboxService` | yes |
 | **Permission (auth, RLS)** | `CAN_READ_INBOX_OF`, `CAN_READ_MEMORIES_OF`, `CAN_READ_SESSIONS_OF`, `CAN_REPLY_TO` (+ `BLOCKED_BY`, cross-listed with work/lifecycle) | **`PermissionService.validScopes`** (authoritative source); `heartbeatPulseEvaluator.PERMISSION_EDGE_TYPES` is the **wake-firing subset** (the 3 `CAN_*` a `PERMISSION_GRANTED` wake fires on) | n/a (auth) |

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -411,7 +411,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             success   : 0
         });
 
-        const result = await DreamService.executeNLActionDigest({sinceTimestamp: 0});
+        const result = await DreamService.executeNLActionDigest();
 
         const
             classNode    = GraphService.db.nodes.get('class-neo-button-base'),
@@ -436,6 +436,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         expect(edge).toBeTruthy();
         expect(edge.properties.evidenceKind).toBe('neural-link-action-sequence');
         expect(edge.properties.weakEvidence).toBe(true);
+        expect(edge.properties.weight).toBe(0.35);
         expect(edge.properties.successRate).toBe(0.8);
         expect(edge.properties.validationStrength).toBe('weak-runtime-interaction');
         expect(edge.properties.inferredBy).toBe('GapInferenceEngine.inferNlActionDigest');
@@ -486,7 +487,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             });
         }
 
-        const result = await DreamService.executeNLActionDigest({sinceTimestamp: 0});
+        const result = await DreamService.executeNLActionDigest();
 
         const
             classNode = GraphService.db.nodes.get('class-low-success'),
@@ -507,12 +508,103 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     });
 
     test('executeNLActionDigest skips cleanly when nl_action_log is absent (#9890)', async () => {
-        const result = await DreamService.executeNLActionDigest({sinceTimestamp: 0});
+        const result = await DreamService.executeNLActionDigest();
 
         expect(result).toEqual({
             status: 'skipped',
             reason: 'nl-action-log-missing'
         });
+    });
+
+    test('executeNLActionDigest ignores nested result payload targets (#9890)', async () => {
+        createNlActionLogTable();
+
+        GraphService.upsertNode({
+            id        : 'class-targeted-action',
+            type      : 'CLASS',
+            name      : 'Neo.button.TargetedAction',
+            properties: {
+                name         : 'Neo.button.TargetedAction',
+                capabilityGap: JSON.stringify([
+                    "[TEST_GAP] Structural node 'Neo.button.TargetedAction' lacks permanent Playwright coverage."
+                ])
+            }
+        });
+        GraphService.upsertNode({
+            id        : 'class-result-only',
+            type      : 'CLASS',
+            name      : 'Neo.panel.ResultOnly',
+            properties: {
+                name         : 'Neo.panel.ResultOnly',
+                capabilityGap: JSON.stringify([
+                    "[TEST_GAP] Structural node 'Neo.panel.ResultOnly' lacks permanent Playwright coverage."
+                ])
+            }
+        });
+
+        insertNlActionLogRow({
+            id        : 'result-overharvest-regression',
+            sequenceId: 'seq-result-overharvest',
+            timestamp : Date.now() - 5000,
+            tool      : 'get_component_tree',
+            args      : {className: 'Neo.button.TargetedAction'},
+            result    : {
+                root: {
+                    className: 'Neo.panel.ResultOnly',
+                    children : [{className: 'Neo.panel.ResultOnly'}]
+                }
+            }
+        });
+
+        const result = await DreamService.executeNLActionDigest();
+
+        const
+            targetEdge = GraphService.db.edges.items.find(item =>
+                item.source === 'nl-action-sequence:seq-result-overharvest' &&
+                item.target === 'class-targeted-action' &&
+                item.type === 'VALIDATES'
+            ),
+            resultOnlyEdge = GraphService.db.edges.items.find(item =>
+                item.source === 'nl-action-sequence:seq-result-overharvest' &&
+                item.target === 'class-result-only' &&
+                item.type === 'VALIDATES'
+            ),
+            targetNode     = GraphService.db.nodes.get('class-targeted-action'),
+            resultOnlyNode = GraphService.db.nodes.get('class-result-only');
+
+        expect(result.qualifyingSequences).toBe(1);
+        expect(result.targetMatches).toBe(1);
+        expect(targetEdge).toBeTruthy();
+        expect(resultOnlyEdge).toBeUndefined();
+        expect(targetNode.properties.capabilityGap).toContain('[NL_ACTION_WEAK_EVIDENCE]');
+        expect(resultOnlyNode.properties.capabilityGap).toContain('[TEST_GAP]');
+        expect(resultOnlyNode.properties.capabilityGap).not.toContain('[NL_ACTION_WEAK_EVIDENCE]');
+    });
+
+    test('executeNLActionDigest recomputes stale weak-evidence annotations (#9890)', async () => {
+        createNlActionLogTable();
+
+        GraphService.upsertNode({
+            id        : 'class-stale-nl-evidence',
+            type      : 'CLASS',
+            name      : 'Neo.panel.StaleEvidence',
+            properties: {
+                name         : 'Neo.panel.StaleEvidence',
+                capabilityGap: JSON.stringify([
+                    "[TEST_GAP] Structural node 'Neo.panel.StaleEvidence' lacks permanent Playwright coverage. [NL_ACTION_WEAK_EVIDENCE] Old sequence evidence."
+                ]),
+                nlActionEvidence: [{sequenceId: 'old-seq'}]
+            }
+        });
+
+        const result = await DreamService.executeNLActionDigest();
+        const classNode = GraphService.db.nodes.get('class-stale-nl-evidence');
+
+        expect(result.resetWeakEvidenceAnnotations).toBe(1);
+        expect(result.qualifyingSequences).toBe(0);
+        expect(classNode.properties.capabilityGap).toContain('[TEST_GAP]');
+        expect(classNode.properties.capabilityGap).not.toContain('[NL_ACTION_WEAK_EVIDENCE]');
+        expect(classNode.properties.nlActionEvidence).toEqual([]);
     });
 
     test('findUndigestedSessions fails loud when remSleepBatchLimit is malformed in the imported config', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -398,7 +398,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
                 id        : `nl-success-${i}`,
                 sequenceId: 'seq-weak-evidence',
                 timestamp : baseTimestamp + i,
-                args      : {className: 'Neo.button.Base', componentId: 'button-instance-1'},
+                args      : {parentId: 'root-container', config: {className: 'Neo.button.Base', componentId: 'button-instance-1'}},
                 result    : {ok: true}
             });
         }
@@ -406,7 +406,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             id        : 'nl-failure-0',
             sequenceId: 'seq-weak-evidence',
             timestamp : baseTimestamp + 10,
-            args      : {className: 'Neo.button.Base', componentId: 'button-instance-1'},
+            args      : {parentId: 'root-container', config: {className: 'Neo.button.Base', componentId: 'button-instance-1'}},
             result    : {error: 'synthetic failure'},
             success   : 0
         });
@@ -516,7 +516,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         });
     });
 
-    test('executeNLActionDigest ignores nested result payload targets (#9890)', async () => {
+    test('executeNLActionDigest ignores read-tool args and nested result payload targets (#9890)', async () => {
         createNlActionLogTable();
 
         GraphService.upsertNode({
@@ -547,10 +547,11 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             sequenceId: 'seq-result-overharvest',
             timestamp : Date.now() - 5000,
             tool      : 'get_component_tree',
-            args      : {className: 'Neo.button.TargetedAction'},
+            args      : {className: 'Neo.button.TargetedAction', id: 'result-only-component'},
             result    : {
                 root: {
                     className: 'Neo.panel.ResultOnly',
+                    id       : 'result-only-component',
                     children : [{className: 'Neo.panel.ResultOnly'}]
                 }
             }
@@ -572,11 +573,12 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             targetNode     = GraphService.db.nodes.get('class-targeted-action'),
             resultOnlyNode = GraphService.db.nodes.get('class-result-only');
 
-        expect(result.qualifyingSequences).toBe(1);
-        expect(result.targetMatches).toBe(1);
-        expect(targetEdge).toBeTruthy();
+        expect(result.qualifyingSequences).toBe(0);
+        expect(result.targetMatches).toBe(0);
+        expect(targetEdge).toBeUndefined();
         expect(resultOnlyEdge).toBeUndefined();
-        expect(targetNode.properties.capabilityGap).toContain('[NL_ACTION_WEAK_EVIDENCE]');
+        expect(targetNode.properties.capabilityGap).toContain('[TEST_GAP]');
+        expect(targetNode.properties.capabilityGap).not.toContain('[NL_ACTION_WEAK_EVIDENCE]');
         expect(resultOnlyNode.properties.capabilityGap).toContain('[TEST_GAP]');
         expect(resultOnlyNode.properties.capabilityGap).not.toContain('[NL_ACTION_WEAK_EVIDENCE]');
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -42,6 +42,56 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     let providerPrompt = '';
     const freshVerifiedAt = new Date().toISOString();
 
+    function createNlActionLogTable() {
+        GraphService.db.storage.db.exec(`
+            CREATE TABLE IF NOT EXISTS nl_action_log (
+                id          TEXT PRIMARY KEY,
+                agent_id    TEXT NOT NULL,
+                session_id  TEXT,
+                sequence_id TEXT NOT NULL,
+                timestamp   INTEGER NOT NULL,
+                tool        TEXT NOT NULL,
+                args        TEXT NOT NULL,
+                result      TEXT,
+                success     INTEGER DEFAULT 0,
+                duration_ms INTEGER,
+                app_name    TEXT,
+                reward      REAL DEFAULT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_nl_action_log_sequence  ON nl_action_log(sequence_id);
+            CREATE INDEX IF NOT EXISTS idx_nl_action_log_session   ON nl_action_log(session_id);
+            CREATE INDEX IF NOT EXISTS idx_nl_action_log_timestamp ON nl_action_log(timestamp);
+        `);
+    }
+
+    function insertNlActionLogRow({
+        id,
+        sequenceId,
+        timestamp,
+        tool = 'create_component',
+        args = {},
+        result = {},
+        success = 1
+    }) {
+        GraphService.db.storage.db.prepare(`
+            INSERT INTO nl_action_log (
+                id, agent_id, session_id, sequence_id, timestamp,
+                tool, args, result, success, duration_ms, app_name
+            ) VALUES (
+                @id, 'neo-gpt-test', 'nl-action-digest-test', @sequenceId, @timestamp,
+                @tool, @args, @result, @success, 12, 'DreamServiceTest'
+            )
+        `).run({
+            id,
+            sequenceId,
+            timestamp,
+            tool,
+            args   : JSON.stringify(args),
+            result : JSON.stringify(result),
+            success: success ? 1 : 0
+        });
+    }
+
     test.beforeAll(async () => {
         const
             aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
@@ -121,7 +171,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
 
             if (GraphService.db.storage?.db) {
                 await GraphService.db.storage.clear();
-                GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog; DROP TABLE IF EXISTS nl_action_log;');
                 GraphService.db.lastSyncId = 0;
             }
         }
@@ -144,7 +194,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
 
             if (GraphService.db.storage?.db) {
                 await GraphService.db.storage.clear();
-                GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog; DROP TABLE IF EXISTS nl_action_log;');
                 GraphService.db.lastSyncId = 0;
             }
         }
@@ -325,6 +375,144 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         expect(featureEdge).toBeUndefined();
         expect(storeNode.properties.capabilityGap).toBeUndefined();
         expect(storeEdge).toBeTruthy();
+    });
+
+    test('executeNLActionDigest adds weak NL action VALIDATES evidence without erasing TEST_GAP (#9890)', async () => {
+        createNlActionLogTable();
+
+        GraphService.upsertNode({
+            id        : 'class-neo-button-base',
+            type      : 'CLASS',
+            name      : 'Neo.button.Base',
+            properties: {
+                name         : 'Neo.button.Base',
+                capabilityGap: JSON.stringify([
+                    "[TEST_GAP] Structural node 'Neo.button.Base' lacks permanent Playwright coverage."
+                ])
+            }
+        });
+
+        const baseTimestamp = Date.now() - 5000;
+        for (let i = 0; i < 4; i++) {
+            insertNlActionLogRow({
+                id        : `nl-success-${i}`,
+                sequenceId: 'seq-weak-evidence',
+                timestamp : baseTimestamp + i,
+                args      : {className: 'Neo.button.Base', componentId: 'button-instance-1'},
+                result    : {ok: true}
+            });
+        }
+        insertNlActionLogRow({
+            id        : 'nl-failure-0',
+            sequenceId: 'seq-weak-evidence',
+            timestamp : baseTimestamp + 10,
+            args      : {className: 'Neo.button.Base', componentId: 'button-instance-1'},
+            result    : {error: 'synthetic failure'},
+            success   : 0
+        });
+
+        const result = await DreamService.executeNLActionDigest({sinceTimestamp: 0});
+
+        const
+            classNode    = GraphService.db.nodes.get('class-neo-button-base'),
+            sequenceNode = GraphService.db.nodes.get('nl-action-sequence:seq-weak-evidence'),
+            edge         = GraphService.db.edges.items.find(item =>
+                item.source === 'nl-action-sequence:seq-weak-evidence' &&
+                item.target === 'class-neo-button-base' &&
+                item.type === 'VALIDATES'
+            );
+
+        expect(result.status).toBe('completed');
+        expect(result.sequencesRead).toBe(1);
+        expect(result.qualifyingSequences).toBe(1);
+        expect(result.linkedEdges).toBe(1);
+        expect(result.downgradedGaps).toBe(1);
+
+        expect(sequenceNode).toBeTruthy();
+        expect(sequenceNode.label).toBe('NL_ACTION_SEQUENCE');
+        expect(sequenceNode.properties.successRate).toBe(0.8);
+        expect(sequenceNode.properties.weakEvidence).toBe(true);
+
+        expect(edge).toBeTruthy();
+        expect(edge.properties.evidenceKind).toBe('neural-link-action-sequence');
+        expect(edge.properties.weakEvidence).toBe(true);
+        expect(edge.properties.successRate).toBe(0.8);
+        expect(edge.properties.validationStrength).toBe('weak-runtime-interaction');
+        expect(edge.properties.inferredBy).toBe('GapInferenceEngine.inferNlActionDigest');
+
+        expect(classNode.properties.capabilityGap).toContain('[TEST_GAP]');
+        expect(classNode.properties.capabilityGap).toContain('[NL_ACTION_WEAK_EVIDENCE]');
+        expect(classNode.properties.nlActionEvidence).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                sequenceId  : 'seq-weak-evidence',
+                successRate : 0.8,
+                weakEvidence: true,
+                evidenceKind: 'neural-link-action-sequence'
+            })
+        ]));
+    });
+
+    test('executeNLActionDigest ignores sequences below the success threshold (#9890)', async () => {
+        createNlActionLogTable();
+
+        GraphService.upsertNode({
+            id        : 'class-low-success',
+            type      : 'CLASS',
+            name      : 'Neo.grid.Container',
+            properties: {
+                name         : 'Neo.grid.Container',
+                capabilityGap: JSON.stringify([
+                    "[TEST_GAP] Structural node 'Neo.grid.Container' lacks permanent Playwright coverage."
+                ])
+            }
+        });
+
+        const baseTimestamp = Date.now() - 5000;
+        for (let i = 0; i < 3; i++) {
+            insertNlActionLogRow({
+                id        : `low-success-${i}`,
+                sequenceId: 'seq-low-success',
+                timestamp : baseTimestamp + i,
+                args      : {className: 'Neo.grid.Container'}
+            });
+        }
+        for (let i = 0; i < 2; i++) {
+            insertNlActionLogRow({
+                id        : `low-failure-${i}`,
+                sequenceId: 'seq-low-success',
+                timestamp : baseTimestamp + 10 + i,
+                args      : {className: 'Neo.grid.Container'},
+                success   : 0
+            });
+        }
+
+        const result = await DreamService.executeNLActionDigest({sinceTimestamp: 0});
+
+        const
+            classNode = GraphService.db.nodes.get('class-low-success'),
+            edge      = GraphService.db.edges.items.find(item =>
+                item.source === 'nl-action-sequence:seq-low-success' &&
+                item.target === 'class-low-success' &&
+                item.type === 'VALIDATES'
+            );
+
+        expect(result.status).toBe('completed');
+        expect(result.sequencesRead).toBe(1);
+        expect(result.qualifyingSequences).toBe(0);
+        expect(result.linkedEdges).toBe(0);
+        expect(result.downgradedGaps).toBe(0);
+        expect(edge).toBeUndefined();
+        expect(classNode.properties.capabilityGap).toContain('[TEST_GAP]');
+        expect(classNode.properties.capabilityGap).not.toContain('[NL_ACTION_WEAK_EVIDENCE]');
+    });
+
+    test('executeNLActionDigest skips cleanly when nl_action_log is absent (#9890)', async () => {
+        const result = await DreamService.executeNLActionDigest({sinceTimestamp: 0});
+
+        expect(result).toEqual({
+            status: 'skipped',
+            reason: 'nl-action-log-missing'
+        });
     });
 
     test('findUndigestedSessions fails loud when remSleepBatchLimit is malformed in the imported config', async () => {
@@ -787,15 +975,19 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         }));
 
         let testGapCalls                           = 0;
+        let nlActionDigestCalls                    = 0;
         let conceptGapCalls                        = 0;
         let sessionUpdateCount                     = 0;
+        let nlDigestCalledAfterLastSessionUpdate   = false;
         let conceptGapCalledAfterLastSessionUpdate = false;
+        let conceptGapCalledAfterNlDigest          = false;
 
         const orig = {
             provider          : aiConfig.modelProvider,
             findUndigested    : DreamService.findUndigestedSessions,
             sessionsCollection: DreamService.sessionsCollection,
             inferTest         : DreamService.inferTestGapsFromSession,
+            executeNlDigest   : DreamService.executeNLActionDigest,
             inferConcept      : DreamService.inferConceptGraphGaps,
             runGarbageCol     : DreamService.runGarbageCollection,
             synthesizeGolden  : DreamService.synthesizeGoldenPath,
@@ -817,9 +1009,15 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
                 update: async () => { sessionUpdateCount++; }
             };
             DreamService.inferTestGapsFromSession = async () => { testGapCalls++; };
+            DreamService.executeNLActionDigest     = async () => {
+                nlActionDigestCalls++;
+                nlDigestCalledAfterLastSessionUpdate = (sessionUpdateCount === sessionCount);
+                return {status: 'completed'};
+            };
             DreamService.inferConceptGraphGaps    = async () => {
                 conceptGapCalls++;
                 conceptGapCalledAfterLastSessionUpdate = (sessionUpdateCount === sessionCount);
+                conceptGapCalledAfterNlDigest          = (nlActionDigestCalls === 1);
             };
             DreamService.runGarbageCollection = async () => {};
             DreamService.synthesizeGoldenPath = async () => {};
@@ -840,13 +1038,17 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             await DreamService.processUndigestedSessions();
 
             expect(testGapCalls).toBe(sessionCount);
+            expect(nlActionDigestCalls).toBe(1);
             expect(conceptGapCalls).toBe(1);
+            expect(nlDigestCalledAfterLastSessionUpdate).toBe(true);
             expect(conceptGapCalledAfterLastSessionUpdate).toBe(true);
+            expect(conceptGapCalledAfterNlDigest).toBe(true);
         } finally {
             aiConfig.modelProvider                            = orig.provider;
             DreamService.findUndigestedSessions               = orig.findUndigested;
             DreamService.sessionsCollection                   = orig.sessionsCollection;
             DreamService.inferTestGapsFromSession             = orig.inferTest;
+            DreamService.executeNLActionDigest                = orig.executeNlDigest;
             DreamService.inferConceptGraphGaps                = orig.inferConcept;
             DreamService.runGarbageCollection                 = orig.runGarbageCol;
             DreamService.synthesizeGoldenPath                 = orig.synthesizeGolden;


### PR DESCRIPTION
Resolves #9890

Adds `DreamService.executeNLActionDigest()` as the fourth REM vector. The digest reads the shared `nl_action_log` SQLite table through the already-mounted graph handle, groups recent action rows by sequence, requires the configured success-rate threshold, and materializes weak `NL_ACTION_SEQUENCE -> VALIDATES -> CLASS/COMPONENT` evidence. Existing `[TEST_GAP]` entries are annotated with `[NL_ACTION_WEAK_EVIDENCE]` and kept in place; Neural Link interaction is signal, not permanent Playwright coverage.

Evidence: L2 (focused Playwright unit coverage over synthetic `nl_action_log` rows, graph node/edge mutation, success-threshold/no-table paths, result/read-tool over-harvest prevention, weak-evidence recomputation, and REM cycle call ordering) -> L2 required (deterministic digest wiring and regression coverage). Residual: post-merge manual REM-cycle validation against a local DB containing live `nl_action_log` rows.

## Deltas from ticket
- Delivered severity downgrade semantics rather than gap removal, matching the ticket constraint that live agent interaction is weaker than durable Playwright coverage.
- Kept this PR out of Playwright synthesis scope; it only materializes graph evidence.
- After review, bounded NL target extraction to action arguments and ignores `result` payload trees so read tools cannot validate every returned subtree.
- After review addendum, gated weak validation evidence to write/interaction tools; read/orientation tools such as `get_component_tree` no longer mint weak evidence from selector args or returned trees.
- After review, made weak NL annotations cycle-recomputed: old `[NL_ACTION_WEAK_EVIDENCE]` markers and `nlActionEvidence` entries are cleared before current qualifying sequences are reapplied.
- After review, registered `NL_ACTION_SEQUENCE` / `VALIDATES` in ADR 0024's graph model catalog.

## Config Template Sync
Changed `ai/mcp/server/memory-core/config.template.mjs` keys:
- `nlActionDigestLookbackMs` (`NEO_NL_ACTION_DIGEST_LOOKBACK_MS`)
- `nlActionDigestSequenceLimit` (`NEO_NL_ACTION_DIGEST_SEQUENCE_LIMIT`)
- `nlActionDigestMinSuccessRate` (`NEO_NL_ACTION_DIGEST_MIN_SUCCESS_RATE`)
- `nlActionDigestEvidenceWeight` (`NEO_NL_ACTION_DIGEST_EVIDENCE_WEIGHT`)

Local clone follow-up after merge: run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` in each active clone so gitignored `ai/mcp/server/memory-core/config.mjs` learns the new leaves. Restart any already-running Memory Core / orchestrator process before expecting the new digest behavior; cold agent harness restart is recommended if the harness keeps long-lived MCP processes.

## Concept currency
Weak NL runtime evidence still earns a graph-digest role even with NL tests in place because it feeds RLAIF/map-fidelity with observed live interaction trails while preserving the stronger Playwright coverage gap. The digest never removes `[TEST_GAP]`; it only adds weak, recomputable validation context.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs --workers=1` — 24 passed before rebase.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs --workers=1` — 24 passed after rebase onto `origin/dev`.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs --workers=1` — 26 passed after cycle-2 review fixes on commit `4bdf25ae1a`.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs --workers=1` — 26 passed after read-tool gate fix on rebased head `2b48d58924`.
- `npm run ai:lint-config-template-ssot` — passed after adding the NL digest leaves.
- `npm run ai:lint-mcp-test-locations` — passed.
- `git diff --check` — passed before commit.
- Pre-commit hooks passed on commits `4bdf25ae1a` and `2b48d58924`: whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, and block alignment.

## Post-Merge Validation
- [ ] Run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` in active clones and restart any long-lived Memory Core / orchestrator process using the old config object.
- [ ] Run a manual REM cycle on a local DB containing live `nl_action_log` rows and inspect that `NL_ACTION_SEQUENCE` edges appear without deleting `[TEST_GAP]`.

## Commits
- `8ab3cccdea` — `feat(ai): digest Neural Link action evidence (#9890)`
- `4bdf25ae1a` — `fix(ai): tighten NL action digest evidence (#9890)`
- `2b48d58924` — `fix(ai): gate NL action digest read tools (#9890)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee5c2-82ba-7b73-8812-df59106ff61a.
