### PR TITLE
feat(build): add agent preflight helper (#13813)

### DIFF
--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -1,5 +1,6 @@
 import {execFileSync}             from 'node:child_process';
 import {existsSync, readFileSync} from 'node:fs';
+import {Command}                  from 'commander/esm.mjs';
 import path                       from 'node:path';
 import process                    from 'node:process';
 import {fileURLToPath}            from 'node:url';
@@ -21,61 +22,46 @@ export const INVISIBLE_PR_BODY_ANCHORS = [
 
 const
     RESOLVES_PATTERN        = /\bResolves:?\s+#\d+/i,
-    FORBIDDEN_CLOSE_PATTERN = /\b(Closes|Fixes):?\s+#\d+/i,
-    USAGE                   = [
-        'Usage: node buildScripts/util/agent-preflight.mjs [--pr-body <file>] [--no-fix] [files...]',
-        '',
-        'Runs the agent commit/PR preflight gates in one pass:',
-        '  - check-ticket-archaeology on scoped .mjs files',
-        '  - check-block-alignment --fix, then a staged-scope check',
-        '  - optional local PR-body template lint when --pr-body is provided',
-        '',
-        'When files are omitted, staged ACMR files are read from git.'
-    ].join('\n');
+    FORBIDDEN_CLOSE_PATTERN = /\b(Closes|Fixes):?\s+#\d+/i;
 
 /**
- * @summary Parses the agent-preflight command line without pulling in another CLI dependency.
+ * @summary Builds the Commander program for the agent preflight helper.
+ * @returns {Command}
+ */
+export function createProgram() {
+    return new Command()
+        .name('agent-preflight')
+        .description('Runs the agent commit/PR preflight gates in one pass.')
+        .usage('[options] [files...]')
+        .option('--pr-body <file>', 'Run local PR-body template lint against the given markdown file.')
+        .option('--no-fix', 'Skip the check-block-alignment --fix pass.')
+        .argument('[files...]', 'Optional file paths. When omitted, staged ACMR files are read from git.')
+}
+
+/**
+ * @summary Parses the agent-preflight command line with the shared Commander dependency.
  * @param {String[]} argv
  * @returns {Object}
  */
 export function parseArgs(argv) {
-    const options = {
-        files : [],
-        fix   : true,
+    const program = createProgram();
+
+    program.exitOverride();
+    program.configureOutput({writeOut: () => {}, writeErr: () => {}});
+    program.parse(argv, {from: 'user'});
+
+    const options = program.opts();
+
+    return {
+        files : program.args,
+        fix   : options.fix,
         help  : false,
-        prBody: null
-    };
-
-    for (let i = 0; i < argv.length; i++) {
-        const arg = argv[i];
-
-        if (arg === '-h' || arg === '--help') {
-            options.help = true;
-            continue
-        }
-
-        if (arg === '--no-fix') {
-            options.fix = false;
-            continue
-        }
-
-        if (arg === '--pr-body') {
-            const value = argv[++i];
-            if (!value) {
-                throw new Error('--pr-body requires a file path')
-            }
-            options.prBody = value;
-            continue
-        }
-
-        if (arg.startsWith('-')) {
-            throw new Error(`unknown option: ${arg}`)
-        }
-
-        options.files.push(arg)
+        prBody: options.prBody || null
     }
+}
 
-    return options
+function writeUsage(stream) {
+    stream.write(createProgram().helpInformation())
 }
 
 /**
@@ -190,14 +176,14 @@ export function runAgentPreflight({
     try {
         options = parseArgs(argv)
     } catch (error) {
-        writeLine(stderr, `agent-preflight: ${error.message}`);
-        writeLine(stderr, USAGE);
-        return 2
-    }
+        if (error.code === 'commander.helpDisplayed') {
+            writeUsage(stdout);
+            return 0
+        }
 
-    if (options.help) {
-        writeLine(stdout, USAGE);
-        return 0
+        writeLine(stderr, `agent-preflight: ${error.message}`);
+        writeUsage(stderr);
+        return 2
     }
 
     const failures = [];

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -1,0 +1,289 @@
+import {execFileSync}             from 'node:child_process';
+import {existsSync, readFileSync} from 'node:fs';
+import path                       from 'node:path';
+import process                    from 'node:process';
+import {fileURLToPath}            from 'node:url';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename);
+
+export const VISIBLE_PR_BODY_ANCHORS = [
+    'Evidence:',
+    '## Test Evidence',
+    '## Post-Merge Validation'
+];
+
+export const INVISIBLE_PR_BODY_ANCHORS = [
+    'Authored by ',
+    '## Deltas'
+];
+
+const
+    RESOLVES_PATTERN        = /\bResolves:?\s+#\d+/i,
+    FORBIDDEN_CLOSE_PATTERN = /\b(Closes|Fixes):?\s+#\d+/i,
+    USAGE                   = [
+        'Usage: node buildScripts/util/agent-preflight.mjs [--pr-body <file>] [--no-fix] [files...]',
+        '',
+        'Runs the agent commit/PR preflight gates in one pass:',
+        '  - check-ticket-archaeology on scoped .mjs files',
+        '  - check-block-alignment --fix, then a staged-scope check',
+        '  - optional local PR-body template lint when --pr-body is provided',
+        '',
+        'When files are omitted, staged ACMR files are read from git.'
+    ].join('\n');
+
+/**
+ * @summary Parses the agent-preflight command line without pulling in another CLI dependency.
+ * @param {String[]} argv
+ * @returns {Object}
+ */
+export function parseArgs(argv) {
+    const options = {
+        files : [],
+        fix   : true,
+        help  : false,
+        prBody: null
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+
+        if (arg === '-h' || arg === '--help') {
+            options.help = true;
+            continue
+        }
+
+        if (arg === '--no-fix') {
+            options.fix = false;
+            continue
+        }
+
+        if (arg === '--pr-body') {
+            const value = argv[++i];
+            if (!value) {
+                throw new Error('--pr-body requires a file path')
+            }
+            options.prBody = value;
+            continue
+        }
+
+        if (arg.startsWith('-')) {
+            throw new Error(`unknown option: ${arg}`)
+        }
+
+        options.files.push(arg)
+    }
+
+    return options
+}
+
+/**
+ * @summary Reads staged ACMR file paths from git when the caller does not provide an explicit file list.
+ * @param {Object} deps
+ * @param {String} deps.cwd
+ * @param {Function} deps.execFileSyncImpl
+ * @returns {String[]}
+ */
+export function getStagedFiles({cwd, execFileSyncImpl = execFileSync}) {
+    const output = execFileSyncImpl(
+        'git',
+        ['diff', '--cached', '--name-only', '--diff-filter=ACMR'],
+        {cwd, encoding: 'utf8'}
+    );
+
+    return String(output).trim().split('\n').map(file => file.trim()).filter(Boolean)
+}
+
+/**
+ * @summary Keeps the source gates scoped to JavaScript module files.
+ * @param {String[]} files
+ * @returns {String[]}
+ */
+export function filterMjsFiles(files) {
+    return files.filter(file => file.endsWith('.mjs'))
+}
+
+/**
+ * @summary Mirrors the Agent PR Body Lint workflow's local body-shape checks.
+ * @param {String} body
+ * @returns {Object}
+ */
+export function validatePrBody(body) {
+    const
+        missingVisible   = VISIBLE_PR_BODY_ANCHORS.filter(anchor => !body.includes(anchor)),
+        missingInvisible = INVISIBLE_PR_BODY_ANCHORS.filter(anchor => !body.includes(anchor)),
+        forbiddenClose   = body.match(FORBIDDEN_CLOSE_PATTERN);
+
+    if (forbiddenClose) {
+        missingVisible.push(`\`${forbiddenClose[1]} #N\` is forbidden; use \`Resolves #N\``)
+    }
+
+    if (!RESOLVES_PATTERN.test(body)) {
+        missingVisible.push('`Resolves #N` is required')
+    }
+
+    return {
+        missingInvisible,
+        missingVisible,
+        valid: missingVisible.length === 0 && missingInvisible.length === 0
+    }
+}
+
+function writeLine(stream, line = '') {
+    stream.write(line + '\n')
+}
+
+function writeOutput(stream, output) {
+    if (!output) {
+        return
+    }
+
+    stream.write(output.endsWith('\n') ? output : output + '\n')
+}
+
+function runNodeGate({args, cwd, execFileSyncImpl, name}) {
+    try {
+        const output = execFileSyncImpl(process.execPath, args, {cwd, encoding: 'utf8', stdio: 'pipe'});
+        return {name, ok: true, output: String(output || '')}
+    } catch (error) {
+        return {
+            name,
+            ok    : false,
+            output: [error.stdout, error.stderr, error.message].filter(Boolean).join('\n'),
+            status: error.status || 1
+        }
+    }
+}
+
+function runPrBodyGate({cwd, existsSyncImpl, prBody, readFileSyncImpl}) {
+    const filePath = path.resolve(cwd, prBody);
+
+    if (!existsSyncImpl(filePath)) {
+        return {
+            missingInvisible: [],
+            missingVisible  : [`PR body file not found: ${prBody}`],
+            valid           : false
+        }
+    }
+
+    return validatePrBody(readFileSyncImpl(filePath, 'utf8'))
+}
+
+/**
+ * @summary Runs the bundled agent preflight gates and returns a process-style status code.
+ * @param {Object} deps
+ * @returns {Number}
+ */
+export function runAgentPreflight({
+    argv             = process.argv.slice(2),
+    cwd              = process.cwd(),
+    execFileSyncImpl = execFileSync,
+    existsSyncImpl   = existsSync,
+    readFileSyncImpl = readFileSync,
+    scriptDir        = __dirname,
+    stderr           = process.stderr,
+    stdout           = process.stdout
+} = {}) {
+    let options;
+
+    try {
+        options = parseArgs(argv)
+    } catch (error) {
+        writeLine(stderr, `agent-preflight: ${error.message}`);
+        writeLine(stderr, USAGE);
+        return 2
+    }
+
+    if (options.help) {
+        writeLine(stdout, USAGE);
+        return 0
+    }
+
+    const failures = [];
+
+    let files = options.files;
+    if (files.length === 0) {
+        try {
+            files = getStagedFiles({cwd, execFileSyncImpl})
+        } catch (error) {
+            writeLine(stderr, `agent-preflight: could not read staged files: ${error.message}`);
+            return 1
+        }
+    }
+
+    const mjsFiles = filterMjsFiles(files);
+
+    if (mjsFiles.length === 0) {
+        writeLine(stdout, 'agent-preflight: 0 .mjs files in scope; skipped source gates.');
+    } else {
+        const gateRuns = [
+            runNodeGate({
+                args: [path.join(scriptDir, 'check-ticket-archaeology.mjs'), ...mjsFiles],
+                cwd,
+                execFileSyncImpl,
+                name: 'check-ticket-archaeology'
+            })
+        ];
+
+        if (options.fix) {
+            gateRuns.push(runNodeGate({
+                args: [path.join(scriptDir, 'check-block-alignment.mjs'), '--fix', ...mjsFiles],
+                cwd,
+                execFileSyncImpl,
+                name: 'check-block-alignment --fix'
+            }))
+        }
+
+        gateRuns.push(runNodeGate({
+            args: [path.join(scriptDir, 'check-block-alignment.mjs'), '--staged', ...mjsFiles],
+            cwd,
+            execFileSyncImpl,
+            name: 'check-block-alignment --staged'
+        }));
+
+        for (const result of gateRuns) {
+            writeOutput(result.ok ? stdout : stderr, result.output);
+            if (!result.ok) {
+                failures.push(result.name)
+            }
+        }
+    }
+
+    if (options.prBody) {
+        const result = runPrBodyGate({
+            cwd,
+            existsSyncImpl,
+            prBody: options.prBody,
+            readFileSyncImpl
+        });
+
+        if (result.valid) {
+            writeLine(stdout, 'agent-preflight: PR body contains the required template anchors.');
+        } else {
+            failures.push('pr-body');
+            writeLine(stderr, 'agent-preflight: PR body template lint failed.');
+            if (result.missingVisible.length > 0) {
+                writeLine(stderr, 'Visible/body-closing misses:');
+                result.missingVisible.forEach(anchor => writeLine(stderr, `  - ${anchor}`));
+            }
+            if (result.missingInvisible.length > 0) {
+                writeLine(stderr, 'Structural template anchors are missing; reread .agents/skills/pull-request/SKILL.md before editing the body.');
+            }
+        }
+    } else {
+        writeLine(stdout, 'agent-preflight: no --pr-body provided; skipped PR-body lint.');
+    }
+
+    if (failures.length > 0) {
+        writeLine(stderr, `agent-preflight: ${failures.length} gate(s) failed: ${failures.join(', ')}`);
+        return 1
+    }
+
+    writeLine(stdout, 'agent-preflight: all requested gates passed.');
+    return 0
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    process.exitCode = runAgentPreflight()
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     },
     "scripts"        : {
         "add-config"                   : "node ./buildScripts/create/addConfig.mjs",
+        "agent-preflight"              : "node ./buildScripts/util/agent-preflight.mjs",
         "add-reactive-tags"            : "node ./buildScripts/helpers/addReactiveTags.mjs",
         "ai:agent"                     : "node ./ai/scripts/runners/runAgent.mjs",
         "ai:analyze-nl-telemetry"      : "node ./ai/scripts/diagnostics/analyzeNlTelemetry.mjs",

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect} from '@playwright/test';
 import path           from 'node:path';
 import {
+    createProgram,
     filterMjsFiles,
     parseArgs,
     runAgentPreflight,
@@ -25,13 +26,26 @@ const validBody = [
 ].join('\n');
 
 test.describe('agent-preflight utility', () => {
-    test('parses files, optional PR body, and fix mode', () => {
+    test('builds the Commander program with the expected option surface', () => {
+        const program = createProgram();
+
+        expect(program.helpInformation()).toContain('Usage: agent-preflight [options] [files...]');
+        expect(program.helpInformation()).toContain('--pr-body <file>');
+        expect(program.helpInformation()).toContain('--no-fix')
+    });
+
+    test('parses files, optional PR body, and fix mode through Commander', () => {
         expect(parseArgs(['--pr-body', 'body.md', '--no-fix', 'src/a.mjs'])).toEqual({
             files : ['src/a.mjs'],
             fix   : false,
             help  : false,
             prBody: 'body.md'
         });
+    });
+
+    test('uses Commander option validation for unknown flags and missing values', () => {
+        expect(() => parseArgs(['--bogus'])).toThrow();
+        expect(() => parseArgs(['--pr-body'])).toThrow()
     });
 
     test('filters source gates to .mjs files', () => {

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -1,0 +1,143 @@
+import {test, expect} from '@playwright/test';
+import path           from 'node:path';
+import {
+    filterMjsFiles,
+    parseArgs,
+    runAgentPreflight,
+    validatePrBody
+}                     from '../../../../../../buildScripts/util/agent-preflight.mjs';
+
+const validBody = [
+    'Resolves #12345',
+    '',
+    'Authored by Euclid (GPT-5, Codex Desktop). Session test.',
+    '',
+    'Evidence: L2 local unit coverage.',
+    '',
+    '## Deltas from ticket',
+    '- Delivered as requested.',
+    '',
+    '## Test Evidence',
+    '- npm run test-unit -- test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs',
+    '',
+    '## Post-Merge Validation',
+    '- None.'
+].join('\n');
+
+test.describe('agent-preflight utility', () => {
+    test('parses files, optional PR body, and fix mode', () => {
+        expect(parseArgs(['--pr-body', 'body.md', '--no-fix', 'src/a.mjs'])).toEqual({
+            files : ['src/a.mjs'],
+            fix   : false,
+            help  : false,
+            prBody: 'body.md'
+        });
+    });
+
+    test('filters source gates to .mjs files', () => {
+        expect(filterMjsFiles(['src/a.mjs', 'README.md', 'test/spec.mjs'])).toEqual(['src/a.mjs', 'test/spec.mjs'])
+    });
+
+    test('accepts a PR body that mirrors the template anchors', () => {
+        expect(validatePrBody(validBody).valid).toBe(true)
+    });
+
+    test('reports visible misses and forbidden close keywords without naming structural anchors', () => {
+        const result = validatePrBody([
+            'Closes #12345',
+            '',
+            '## Test Evidence',
+            '## Post-Merge Validation'
+        ].join('\n'));
+
+        expect(result.valid).toBe(false);
+        expect(result.missingVisible).toContain('Evidence:');
+        expect(result.missingVisible).toContain('`Closes #N` is forbidden; use `Resolves #N`');
+        expect(result.missingVisible).toContain('`Resolves #N` is required');
+        expect(result.missingInvisible.length).toBe(2)
+    });
+
+    test('uses staged files by default and runs archaeology plus block-alignment gates in order', () => {
+        const calls = [];
+
+        const execFileSyncImpl = (cmd, args) => {
+            calls.push({cmd, args});
+
+            if (cmd === 'git') {
+                return 'src/a.mjs\nREADME.md\ntest/spec.mjs\n'
+            }
+
+            return `${path.basename(args[0])} ok\n`
+        };
+
+        let stdout = '';
+        let stderr = '';
+
+        const status = runAgentPreflight({
+            cwd             : '/repo',
+            execFileSyncImpl,
+            existsSyncImpl  : () => false,
+            readFileSyncImpl: () => '',
+            scriptDir       : '/repo/buildScripts/util',
+            stderr          : {write: value => { stderr += value }},
+            stdout          : {write: value => { stdout += value }}
+        });
+
+        expect(status).toBe(0);
+        expect(stderr).toBe('');
+        expect(calls[0]).toEqual({
+            cmd : 'git',
+            args: ['diff', '--cached', '--name-only', '--diff-filter=ACMR']
+        });
+        expect(calls.slice(1).map(call => path.basename(call.args[0]))).toEqual([
+            'check-ticket-archaeology.mjs',
+            'check-block-alignment.mjs',
+            'check-block-alignment.mjs'
+        ]);
+        expect(calls[2].args).toContain('--fix');
+        expect(calls[3].args).toContain('--staged');
+        expect(stdout).toContain('agent-preflight: no --pr-body provided; skipped PR-body lint.');
+        expect(stdout).toContain('agent-preflight: all requested gates passed.')
+    });
+
+    test('runs the PR body gate when requested', () => {
+        let stdout = '';
+        let stderr = '';
+
+        const status = runAgentPreflight({
+            argv            : ['--pr-body', 'body.md'],
+            cwd             : '/repo',
+            execFileSyncImpl: cmd => cmd === 'git' ? '' : '',
+            existsSyncImpl  : () => true,
+            readFileSyncImpl: () => validBody,
+            stderr          : {write: value => { stderr += value }},
+            stdout          : {write: value => { stdout += value }}
+        });
+
+        expect(status).toBe(0);
+        expect(stderr).toBe('');
+        expect(stdout).toContain('agent-preflight: 0 .mjs files in scope; skipped source gates.');
+        expect(stdout).toContain('agent-preflight: PR body contains the required template anchors.')
+    });
+
+    test('returns failure when the local PR body is missing required anchors', () => {
+        let stderr = '';
+
+        const status = runAgentPreflight({
+            argv            : ['--pr-body', 'body.md', 'src/a.mjs'],
+            cwd             : '/repo',
+            execFileSyncImpl: () => '',
+            existsSyncImpl  : () => true,
+            readFileSyncImpl: () => 'Refs #12345',
+            scriptDir       : '/repo/buildScripts/util',
+            stderr          : {write: value => { stderr += value }},
+            stdout          : {write: () => {}}
+        });
+
+        expect(status).toBe(1);
+        expect(stderr).toContain('agent-preflight: PR body template lint failed.');
+        expect(stderr).toContain('Visible/body-closing misses:');
+        expect(stderr).toContain('Structural template anchors are missing');
+        expect(stderr).toContain('agent-preflight: 1 gate(s) failed: pr-body')
+    })
+});


### PR DESCRIPTION
Resolves #13813

Adds a standalone `agent-preflight` command that bundles the agent source hygiene checks before the first commit or PR-body edit cycle. The helper composes the existing archaeology gate, block-alignment fix/check path, and optional local PR-body template lint without extending husky or touching the data-sync bypass path.

Evidence: L2 (focused unit coverage, Commander CLI smoke check, dogfooded command execution, staged preflight, and lint-staged commit hooks) -> L2 required (developer tooling helper with local command behavior). Residuals are explicit: discovery wiring and PR-body anchor drift guard remain follow-ups; the parser dependency correction is handled in this head.

## Deltas from ticket (if any)
- Kept the delivery as a standalone npm script: `npm run agent-preflight -- [--pr-body <file>] [files...]`.
- Uses the existing repo `commander` dependency for CLI parsing; no hand-rolled `parseArgs` loop remains.
- The PR-body gate mirrors the CI-visible anchors and reports structural-template misses without enumerating the structural anchor names in CLI output.
- The source gates default to staged ACMR files when no explicit file list is supplied.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs` - 9 passed after the Commander fix, then 9 passed again after rebasing onto current `origin/dev`.
- `node buildScripts/util/agent-preflight.mjs --help` - Commander-generated usage prints the expected option surface.
- `git diff --check` - passed before commit.
- `git commit -m "fix(build): use Commander for agent preflight CLI (#13813)"` - lint-staged hooks passed, including ticket archaeology and block alignment.
- Branch freshness before final push: `merge-base HEAD origin/dev == origin/dev` at `3bcc1662d4c02209b614f63b37da899d0ab16a51`; pushed head `a93eff224eec317d39e9839ddd29c374a126e4e7`.

## Post-Merge Validation
- [ ] Run `npm run agent-preflight -- <changed .mjs files>` during the next agent PR cycle and confirm it surfaces the bundled source gates before commit/PR retries.

## Commits
- `edfcb06cf6` - `feat(build): add agent preflight helper (#13813)`
- `a93eff224e` - `fix(build): use Commander for agent preflight CLI (#13813)`

Authored by Euclid (GPT-5, Codex Desktop). Session 43e8ab91-e980-4303-b70f-898d8c4ae98e.