### PR TITLE
feat(ai): add Ollama native format schema slice (#13855)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -162,7 +162,7 @@ class Config extends ConfigProvider {
              */
             ollama: {
                 host                 : leaf('http://127.0.0.1:11434', 'NEO_OLLAMA_HOST', 'string'),
-                model                : leaf('gemma4:31b', 'NEO_OLLAMA_MODEL', 'string'),
+                model                : leaf('gemma4:26b', 'NEO_OLLAMA_MODEL', 'string'),
                 embeddingModel       : leaf('qwen3-embedding', 'NEO_OLLAMA_EMBEDDING_MODEL', 'string'),
                 keep_alive           : leaf(-1, 'NEO_OLLAMA_KEEP_ALIVE', 'keepAlive'),
                 requireParallelModels: leaf(2, 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS', 'number')

--- a/ai/provider/Ollama.mjs
+++ b/ai/provider/Ollama.mjs
@@ -2,6 +2,57 @@ import Base                 from './Base.mjs';
 import {createTimeoutError} from './createTimeoutError.mjs';
 
 /**
+ * @summary Extracts native Ollama top-level request fields from generic
+ * provider options while preserving caller-owned option objects.
+ *
+ * Ollama's `/api/chat` accepts `format` as either `'json'` or a JSON schema.
+ * OpenAI-compatible callers may instead provide `response_format`, while Gemini
+ * callers historically use `responseSchema`; normalize those into Ollama's
+ * native field without leaking them into `payload.options`.
+ *
+ * @param {Object} options Cloned options object that may be mutated by deletion.
+ * @returns {Object}
+ */
+function extractNativeOllamaFields(options) {
+    const fields = {};
+
+    if (options.format !== undefined) {
+        fields.format = options.format;
+        delete options.format;
+    } else if (options.responseSchema !== undefined || options.response_schema !== undefined) {
+        fields.format = options.responseSchema ?? options.response_schema;
+        delete options.responseSchema;
+        delete options.response_schema;
+    } else if (options.response_format !== undefined) {
+        const responseFormat = options.response_format;
+
+        if (responseFormat?.type === 'json_object') {
+            fields.format = 'json';
+        } else if (responseFormat?.type === 'json_schema') {
+            fields.format = responseFormat.json_schema?.schema ?? responseFormat.schema ?? responseFormat.json_schema;
+        } else {
+            fields.format = responseFormat;
+        }
+
+        delete options.response_format;
+    } else if (options.responseMimeType === 'application/json' || options.response_mime_type === 'application/json') {
+        fields.format = 'json';
+    }
+
+    if (options.responseMimeType !== undefined || options.response_mime_type !== undefined) {
+        delete options.responseMimeType;
+        delete options.response_mime_type;
+    }
+
+    if (options.think !== undefined) {
+        fields.think = options.think;
+        delete options.think;
+    }
+
+    return fields;
+}
+
+/**
  * Concrete AI provider for a local Ollama daemon.
  * Uses the native JS Fetch API.
  *
@@ -47,7 +98,12 @@ class OllamaProvider extends Base {
     }
 
     /**
-     * Helper to prepare the payload for Ollama.
+     * @summary Prepares the native Ollama `/api/chat` payload.
+     *
+     * Provider-neutral JSON hints are normalized into Ollama's top-level
+     * `format` field, preserving legacy `format: 'json'` extraction and adding
+     * schema passthrough for callers that can supply structured-output schemas.
+     *
      * @param {String|Array} input
      * @param {Object} options
      * @param {Boolean} stream
@@ -81,12 +137,7 @@ class OllamaProvider extends Base {
         delete clonedOptions.signal;
         delete clonedOptions.timeoutMs;
 
-        // Handle JSON extraction mirroring Gemini provider
-        if (clonedOptions.responseMimeType === 'application/json' || clonedOptions.response_mime_type === 'application/json') {
-            payload.format = 'json';
-            delete clonedOptions.responseMimeType;
-            delete clonedOptions.response_mime_type;
-        }
+        Object.assign(payload, extractNativeOllamaFields(clonedOptions));
 
         if (clonedOptions.tools && clonedOptions.tools.length > 0) {
             payload.tools = clonedOptions.tools.map(tool => ({

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -102,7 +102,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     embeddingProvider: process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible',
     ollama           : {
         host                 : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',
-        model                : process.env.NEO_OLLAMA_MODEL || 'gemma4:31b',
+        model                : process.env.NEO_OLLAMA_MODEL || 'gemma4:26b',
         embeddingModel       : process.env.NEO_OLLAMA_EMBEDDING_MODEL || 'qwen3-embedding',
         keep_alive           : parseKeepAlive(process.env.NEO_OLLAMA_KEEP_ALIVE, -1),
         requireParallelModels: Number(process.env.NEO_OLLAMA_REQUIRE_PARALLEL_MODELS) || 2

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -69,7 +69,7 @@ test.describe('Tier 1 Config Immutability', () => {
 
         expect(Config.ollama).toMatchObject({
             host                 : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',
-            model                : process.env.NEO_OLLAMA_MODEL || 'gemma4:31b',
+            model                : process.env.NEO_OLLAMA_MODEL || 'gemma4:26b',
             embeddingModel       : process.env.NEO_OLLAMA_EMBEDDING_MODEL || 'qwen3-embedding',
             keep_alive           : TIER1_DEFAULTS.ollama.keep_alive,
             requireParallelModels: TIER1_DEFAULTS.ollama.requireParallelModels

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -1,6 +1,14 @@
 import {setup} from '../../../setup.mjs';
 
 const appName = 'AiProviderKeepAliveTest';
+const statusSchema = {
+    type      : 'object',
+    properties: {
+        status: {type: 'string'}
+    },
+    required            : ['status'],
+    additionalProperties: false
+};
 
 setup({
     neoConfig: {
@@ -198,6 +206,108 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
                 temperature: 0.2
             }
         });
+    });
+
+    test('Ollama.preparePayload() promotes responseSchema to native format without mutating caller options (#13855)', () => {
+        const provider = Neo.create(OllamaProvider, {
+            host     : 'http://ollama.test',
+            modelName: 'gemma4-test'
+        });
+        const options = {
+            responseMimeType: 'application/json',
+            responseSchema  : statusSchema,
+            temperature     : 0
+        };
+
+        const payload = provider.preparePayload('hello', options, false);
+
+        expect(payload).toMatchObject({
+            model     : 'gemma4-test',
+            stream    : false,
+            format    : statusSchema,
+            keep_alive: -1,
+            options   : {
+                temperature: 0
+            }
+        });
+        expect(payload.options.responseMimeType).toBeUndefined();
+        expect(payload.options.responseSchema).toBeUndefined();
+        expect(options.responseSchema).toBe(statusSchema);
+    });
+
+    test('Ollama.preparePayload() maps OpenAI-compatible JSON schema and think to native top-level fields (#13855)', () => {
+        const provider = Neo.create(OllamaProvider, {
+            host     : 'http://ollama.test',
+            modelName: 'gemma4-test'
+        });
+
+        const payload = provider.preparePayload('hello', {
+            response_format: {
+                type       : 'json_schema',
+                json_schema: {
+                    name  : 'StatusPayload',
+                    schema: statusSchema,
+                    strict: true
+                }
+            },
+            think      : false,
+            temperature: 0
+        }, false);
+
+        expect(payload).toMatchObject({
+            model     : 'gemma4-test',
+            stream    : false,
+            format    : statusSchema,
+            think     : false,
+            keep_alive: -1,
+            options   : {
+                temperature: 0
+            }
+        });
+        expect(payload.options.response_format).toBeUndefined();
+        expect(payload.options.think).toBeUndefined();
+    });
+
+    test('Ollama.preparePayload() preserves plain JSON extraction for response_format json_object (#13855)', () => {
+        const provider = Neo.create(OllamaProvider, {
+            host     : 'http://ollama.test',
+            modelName: 'gemma4-test'
+        });
+
+        const payload = provider.preparePayload('hello', {
+            response_format: {type: 'json_object'},
+            temperature    : 0
+        }, false);
+
+        expect(payload).toMatchObject({
+            model     : 'gemma4-test',
+            stream    : false,
+            format    : 'json',
+            keep_alive: -1,
+            options   : {
+                temperature: 0
+            }
+        });
+        expect(payload.options.response_format).toBeUndefined();
+    });
+
+    test('Ollama.generate() can verify native format against a live env-configured daemon (#13855)', async () => {
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: live Ollama daemon is an operator-local dependency');
+        test.skip(process.env.NEO_RUN_LIVE_OLLAMA_TESTS !== '1', 'Skipping live Ollama test; set NEO_RUN_LIVE_OLLAMA_TESTS=1 to run');
+
+        const host      = process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434';
+        const modelName = process.env.NEO_OLLAMA_MODEL || 'gemma4:26b';
+        const timeoutMs = Number(process.env.NEO_OLLAMA_TEST_TIMEOUT_MS) || 120000;
+        const provider  = Neo.create(OllamaProvider, {host, modelName});
+
+        const result = await provider.generate('Return exactly this JSON object: {"status":"ok"}', {
+            responseSchema: statusSchema,
+            temperature   : 0,
+            think         : false,
+            timeoutMs
+        });
+
+        expect(JSON.parse(result.content)).toEqual({status: 'ok'});
     });
 
     test('Ollama.stream() defaults keep_alive to top-level payload', async () => {


### PR DESCRIPTION
Resolves #13855

Related: #13854
Related: #12740

Adds the repo-local native Ollama slice split from #13854: the Tier-1 Ollama chat model default now uses the verified Ollama MoE registry tag `gemma4:26b`, and `Ollama.preparePayload()` maps provider-neutral structured-output hints onto native Ollama top-level fields. Schema hints from `responseSchema`, `response_schema`, and OpenAI-compatible `response_format: {type: "json_schema"}` now become `payload.format`; plain JSON hints still become `format: "json"`; explicit caller-provided `think` is promoted top-level without inventing a `reasoningEffort` mapping ahead of #13853.

Evidence: L2 (focused config/provider unit specs + pre-commit static hooks) -> L2 required (#13855 AC1-AC6). Residual: optional L3 live Ollama inference is provided as an env-gated test, but it was not run because the local daemon currently has `gemma4:31b` and `qwen3-embedding:latest`, not `gemma4:26b`.

## Deltas from ticket

The original #13854 ticket remains open for the cloud benchmark and #13853-dependent `reasoningEffort` leaves. This PR deliberately closes only the extracted leaf #13855.

Ollama model naming V-B-A: official Ollama docs publish the MoE as `gemma4:26b`; "26B A4B MoE" is the model description, not the registry tag.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs test/playwright/unit/ai/config.template.spec.mjs` -> 23 passed, 1 skipped.
- `git diff --check` -> passed.
- Pre-commit hooks passed during `git commit`: whitespace, shorthand, AiConfig test-mutation, JSDoc types, ticket archaeology, and block alignment.
- `curl -L http://127.0.0.1:11434/api/tags` -> local daemon reachable; `gemma4:26b` not currently pulled.

## Post-Merge Validation

- [ ] Operator/local live probe after `ollama pull gemma4:26b`: `NEO_RUN_LIVE_OLLAMA_TESTS=1 NEO_OLLAMA_MODEL=gemma4:26b npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs`.

## Commits

- `95e4856833` - `feat(ai): add Ollama MoE schema format slice (#13855)`

Authored by Euclid (GPT-5, Codex Desktop). Session b9a8f817-9a9e-4243-abfb-62e762a94964.