### PR TITLE
fix(ai): diagnose Golden Path focus contradictions (#13849)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -40,6 +40,20 @@ const COMPUTED_RECOMMENDATION_EXCLUDED_LABELS = Object.freeze(new Set([
     'not code ready'
 ]));
 
+const COMPUTED_CONTENT_CONTRADICTION_LABELS = Object.freeze(new Set([
+    'blog post',
+    'documentation',
+    'docs',
+    'guide',
+    'content'
+]));
+
+const CURRENT_FOCUS_ROUTING_CONFLICT_REASONS = Object.freeze(new Set([
+    'incident',
+    'prio-zero',
+    'v13.1'
+]));
+
 /**
  * Social Name → `@`-stripped GitHub login, derived from the canonical identity roster. The PR-body
  * self-id leads with the Social Name (`Authored by <Social Name> (…)`); this resolves it to the login
@@ -352,6 +366,120 @@ class GoldenPathSynthesizer extends Base {
         const labels = this.normalizeLabels(nodeData?.properties?.labels || nodeData?.labels);
 
         return !labels.some(label => COMPUTED_RECOMMENDATION_EXCLUDED_LABELS.has(label))
+    }
+
+    /**
+     * @summary Determines whether a Current Focus candidate is strong enough to guard computed routing.
+     *
+     * Current Focus remains visibility-only. This guard does not boost focus nodes into
+     * routing; it only prevents contradictory content recommendations from being rendered
+     * as the machine-consumed immediate route while unresolved incident/release focus exists.
+     *
+     * @param {Object} candidate Current Focus candidate.
+     * @returns {Boolean}
+     */
+    static isRoutingConflictFocusCandidate(candidate) {
+        return Array.isArray(candidate?.reasons) &&
+            candidate.reasons.some(reason => CURRENT_FOCUS_ROUTING_CONFLICT_REASONS.has(reason))
+    }
+
+    /**
+     * @summary Detects computed recommendations that are narrative/content work.
+     *
+     * Blog and docs tickets are valid Golden Path work when incident/release focus permits
+     * it. They become contradictory only when a live Current Focus incident/release signal
+     * exists and the computed section would otherwise route agents away from it.
+     *
+     * @param {Object} nodeData Parsed computed recommendation node.
+     * @returns {Boolean}
+     */
+    static isContentComputedRecommendation(nodeData) {
+        const labels = this.normalizeLabels(nodeData?.properties?.labels || nodeData?.labels);
+        if (labels.some(label => COMPUTED_CONTENT_CONTRADICTION_LABELS.has(label))) return true;
+
+        const title = String(nodeData?.properties?.title || nodeData?.properties?.name || nodeData?.title || nodeData?.name || '');
+
+        return /\b(?:blog|docs?|documentation|guide|narrative)\b/i.test(title)
+    }
+
+    /**
+     * @summary Finds content recommendations that contradict live Current Focus incident work.
+     *
+     * @param {Object} options
+     * @param {Array<Object>} [options.topNodes=[]] Computed Golden Path recommendations.
+     * @param {Array<Object>} [options.currentFocusCandidates=[]] Current Focus candidates.
+     * @returns {{focusCandidates: Array<Object>, blockedNodes: Array<Object>, blockedIds: Set<String>}|null}
+     */
+    static findComputedFocusContradiction({
+        topNodes = [],
+        currentFocusCandidates = []
+    } = {}) {
+        const focusCandidates = currentFocusCandidates.filter(candidate =>
+            this.isRoutingConflictFocusCandidate(candidate)
+        );
+
+        if (focusCandidates.length === 0 || topNodes.length === 0) return null;
+
+        const focusIds = new Set(focusCandidates.map(candidate => `issue-${candidate.number}`));
+        const blockedNodes = topNodes.filter(item => {
+            const nodeId = String(item?.node?.id || '');
+
+            return nodeId &&
+                !focusIds.has(nodeId) &&
+                this.isContentComputedRecommendation(item.node)
+        });
+
+        if (blockedNodes.length === 0) return null;
+
+        return {
+            blockedIds: new Set(blockedNodes.map(item => item.node.id)),
+            blockedNodes,
+            focusCandidates
+        }
+    }
+
+    /**
+     * @summary Renders the computed-route contradiction diagnostic.
+     *
+     * The section intentionally contains no numbered `**issue-N**:` entries, so
+     * `AgentOrchestrator.parseGoldenPath()` will not treat filtered content work
+     * as an immediate route.
+     *
+     * @param {Object} options
+     * @param {Object} options.contradiction Result from `findComputedFocusContradiction`.
+     * @param {Object} [options.stats={}] Candidate-count diagnostics for the current pass.
+     * @returns {String} Markdown section.
+     */
+    static renderComputedGoldenPathContradictionSection({
+        contradiction,
+        stats = {}
+    } = {}) {
+        const count = value => Number.isFinite(Number(value)) ? Number(value) : 0;
+        const focusRefs = (contradiction?.focusCandidates || [])
+            .slice(0, 3)
+            .map(candidate => `#${candidate.number}`)
+            .join(', ') || 'none';
+        const blockedRefs = (contradiction?.blockedNodes || [])
+            .map(item => item.node.id)
+            .join(', ') || 'none';
+
+        return [
+            '',
+            '## Computed Golden Path (Strategic Recommendation)',
+            '',
+            'Computed routing paused because the surviving content/narrative recommendation contradicts live Current Release / Incident Focus.',
+            '',
+            `- Active incident/release focus candidates: ${focusRefs}`,
+            `- Contradictory computed candidates filtered: ${blockedRefs}`,
+            `- Semantic candidates: ${count(stats.semanticCandidates)}`,
+            `- SQLite OPEN matches: ${count(stats.sqliteOpenMatches)}`,
+            `- Scored actionable candidates: ${count(stats.scoredCandidates)}`,
+            `- Selected routed nodes: ${count(stats.selectedTopNodes)}`,
+            `- Stale frontier GUIDES pruned: ${count(stats.prunedGuideEdges)}`,
+            '',
+            'No numbered immediate recommendation is rendered for this pass; use the Current Release / Incident Focus section for visibility and rerun after the incident/release focus clears or the computed route aligns.',
+            ''
+        ].join('\n')
     }
 
     /**
@@ -852,29 +980,54 @@ class GoldenPathSynthesizer extends Base {
 
         // Remove mathematically rejected targets (Negative ROI), then slice
         const topNodes = scoredNodes.filter(n => n.score > -5000).slice(0, aiConfig.goldenPathTopNodeRenderLimit);
-        const goldenIds = new Set(topNodes.map(item => item.node.id));
+
+        let currentFocusCandidates = [];
+        if (repoEnrichmentEnabled) {
+            try {
+                currentFocusCandidates = this.constructor.buildCurrentFocusCandidates({
+                    issuesDir,
+                    now
+                });
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Failed to generate Current Release / Incident Focus', e);
+            }
+        }
+
+        const focusContradiction = this.constructor.findComputedFocusContradiction({
+            currentFocusCandidates,
+            topNodes
+        });
+        const routedTopNodes = focusContradiction
+            ? topNodes.filter(item => !focusContradiction.blockedIds.has(item.node.id))
+            : topNodes;
+        const goldenIds = new Set(routedTopNodes.map(item => item.node.id));
         scoringStats.scoredCandidates = scoredNodes.length;
-        scoringStats.selectedTopNodes = topNodes.length;
+        scoringStats.selectedTopNodes = routedTopNodes.length;
         scoringStats.prunedGuideEdges = this.constructor.pruneStaleFrontierGuideEdges({
             currentTargetIds: goldenIds
         });
 
         let markdownAppend = '';
 
-        if (topNodes.length > 0) {
-            logger.info(`[GoldenPathSynthesizer] Top Issue 1 (${topNodes[0].node.id}): Priority ${topNodes[0].score.toFixed(2)} [Sem: ${topNodes[0].semantic.toFixed(2)} / Struc: ${topNodes[0].structural.toFixed(2)}]`);
+        if (routedTopNodes.length > 0) {
+            logger.info(`[GoldenPathSynthesizer] Top Issue 1 (${routedTopNodes[0].node.id}): Priority ${routedTopNodes[0].score.toFixed(2)} [Sem: ${routedTopNodes[0].semantic.toFixed(2)} / Struc: ${routedTopNodes[0].structural.toFixed(2)}]`);
 
             // Explicitly anchor this to the frontier context so the Agent NEVER loses sight of it
             markdownAppend = `\n## Computed Golden Path (Strategic Recommendation)\n\n`;
             markdownAppend += `Based on the latest Tri-Vector Synthesis and Topological Priorities, the following tasks are mathematically recommended as the next immediate focus:\n\n`;
 
-            topNodes.forEach((item, index) => {
+            routedTopNodes.forEach((item, index) => {
                 if (item.node && item.node.id) {
                     GraphService.linkNodes('frontier', item.node.id, 'GUIDES', item.score);
                     const title = item.node.properties?.title || item.node.properties?.name || item.node.name || 'Unknown Title';
                     markdownAppend += `${index + 1}. **${item.node.id}**: Score ${item.score.toFixed(2)} (Semantic: ${item.semantic.toFixed(2)}, Structural: ${item.structural.toFixed(2)})\n   - *${title}*\n`;
                 }
             });
+
+            if (focusContradiction) {
+                const blockedRefs = focusContradiction.blockedNodes.map(item => item.node.id).join(', ');
+                markdownAppend += `\n> **Routing Guard:** Filtered content/narrative computed candidate(s) ${blockedRefs} because live Current Release / Incident Focus would make them contradictory immediate routes.\n\n`;
+            }
 
             try {
                 const graphProvider = resolveGraphModelProvider(aiConfig);
@@ -914,6 +1067,12 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             } catch (e) {
                 logger.warn('[GoldenPathSynthesizer] Failed to generate semantic interpretation for Golden Path (LLM Offline). Proceeding with pure mathematical output.', e);
             }
+        } else if (focusContradiction) {
+            markdownAppend = this.constructor.renderComputedGoldenPathContradictionSection({
+                contradiction: focusContradiction,
+                stats        : scoringStats
+            });
+            logger.info('[GoldenPathSynthesizer] Computed route contradicted Current Focus; rendered diagnostic instead of routing content work.');
         } else {
             markdownAppend = this.constructor.renderComputedGoldenPathEmptySection(scoringStats);
             logger.info('[GoldenPathSynthesizer] No actionable unblocked issues found. Golden path empty.');
@@ -1060,13 +1219,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         let currentFocusAppend = '';
         if (repoEnrichmentEnabled) {
             try {
-                const Synthesizer = this.constructor;
-                const currentFocusCandidates = Synthesizer.buildCurrentFocusCandidates({
-                    issuesDir,
-                    now
-                });
-
-                currentFocusAppend = Synthesizer.renderCurrentFocusCandidatesSection(currentFocusCandidates, {capturedAt: now instanceof Date ? now : new Date(now)});
+                currentFocusAppend = this.constructor.renderCurrentFocusCandidatesSection(currentFocusCandidates, {capturedAt: now instanceof Date ? now : new Date(now)});
             } catch (e) {
                 logger.warn('[GoldenPathSynthesizer] Failed to generate Current Release / Incident Focus', e);
             }

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -632,6 +632,89 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).not.toContain(notReadyId);
     });
 
+    test('synthesizeGoldenPath renders a contradiction diagnostic for blog routing during PRIO-zero focus (#13849)', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
+        const issuesDir                    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-current-focus-contradiction-'));
+        const chunkDir                     = path.join(issuesDir, 'chunk-1');
+        const now                          = new Date('2026-06-22T02:55:31Z');
+        const blogId                       = 'issue-10074';
+        aiConfig.vectorDimension = 2;
+
+        fs.mkdirSync(chunkDir, {recursive: true});
+        fs.writeFileSync(path.join(chunkDir, 'issue-13750.md'), [
+            '---',
+            'id: 13750',
+            "title: 'PRIO-ZERO: Golden Path frozen 18 days'",
+            'state: OPEN',
+            'labels:',
+            '  - bug',
+            '  - ai',
+            '  - architecture',
+            '  - model-experience',
+            "createdAt: '2026-06-22T02:30:00Z'",
+            "updatedAt: '2026-06-22T02:50:55Z'",
+            'assignees:',
+            '  - neo-opus-grace',
+            '---',
+            '# PRIO-ZERO: Golden Path frozen 18 days',
+            '',
+            'PRIO-ZERO incident focus: graph steering must not route agents away from the drain fix.'
+        ].join('\n'));
+
+        GraphService.upsertNode({
+            id        : 'frontier',
+            type      : 'SYSTEM_TENET',
+            properties: {name: 'Active Context Frontier'}
+        });
+        GraphService.upsertNode({
+            id        : blogId,
+            type      : 'ISSUE',
+            properties: {
+                labels: ['documentation', 'Blog Post', 'ai'],
+                state : 'OPEN',
+                title : '[blog] Claude Code x Neo.mjs'
+            }
+        });
+        GoldenPathSynthesizer.constructor.pruneStaleFrontierGuideEdges();
+        GraphService.linkNodes('frontier', blogId, 'GUIDES', 7);
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => ({
+                ids      : [[blogId]],
+                distances: [[0.1]]
+            })
+        });
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['Golden Path stale forecast still routes blog work']})});
+        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [];
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({issuesDir, now});
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        const guideTargets = GraphService.db.edges
+            .getByIndex('source', 'frontier')
+            .filter(edge => edge.type === 'GUIDES')
+            .map(edge => edge.target);
+
+        expect(handoffContent).toContain('## Current Release / Incident Focus');
+        expect(handoffContent).toContain('**#13750**');
+        expect(handoffContent).toContain('Computed routing paused because the surviving content/narrative recommendation contradicts live Current Release / Incident Focus.');
+        expect(handoffContent).toContain('Contradictory computed candidates filtered: issue-10074');
+        expect(handoffContent).not.toMatch(/1\.\s+\*\*issue-10074\*\*:/);
+        expect(guideTargets).not.toContain(blogId);
+    });
+
     test('synthesizeGoldenPath renders empty computed diagnostics and clears stale frontier guides (#13828)', async () => {
         const originalGetGraphCollection = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;


### PR DESCRIPTION
Resolves #13849

Adds a bounded Golden Path routing guard for the failure where `## Current Release / Incident Focus` is fresh and incident-focused while `## Computed Golden Path` would silently route the orchestrator to unrelated blog/docs/narrative work. The implementation builds Current Focus before finalizing computed routing, filters only contradictory content recommendations while incident/release focus exists, prunes stale `frontier -> GUIDES` edges against the routed set, and renders an explicit diagnostic section with no numbered `**issue-N**:` entry when no aligned computed route remains.

Evidence: L2 focused unit/static evidence achieved -> L2 required for the GoldenPathSynthesizer render/edge contract. Residual: production graph readback is post-merge validation because live Golden Path contents depend on current Memory Core state.

## Deltas from ticket

Chose the explicit diagnostic/filter policy, not a score boost or permanent Blog Post exclusion. Blog/docs work remains valid Golden Path work when no live incident/release Current Focus candidate is present; this guard only blocks contradictory immediate routing during PRIO-zero/release focus.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs --workers=1` -> 30 passed.
- `git diff --check` -> passed.
- Commit hooks passed: whitespace, shorthand, AiConfig test-mutation, JSDoc types, ticket archaeology, block alignment.

## Post-Merge Validation

- [ ] Run the next Golden Path synthesis / Sandman pass while #13750-class incident focus is active and confirm the computed section does not present #10074-style blog/docs work as a normal immediate route.
- [ ] Confirm stale `frontier -> GUIDES` edges for filtered content recommendations are absent after synthesis.

## Commits

- `c66650f0fa` — `fix(ai): diagnose Golden Path focus contradictions (#13849)`

Authored by Euclid (GPT-5, Codex Desktop). Session b9a8f817-9a9e-4243-abfb-62e762a94964.