### PR TITLE
feat(ai): dispatch REM liveness active alarm (#13839)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -200,6 +200,67 @@ export class Orchestrator extends Base {
     }
 
     /**
+     * @summary One-shot active alarm dispatcher for the REM consolidation-liveness watchdog.
+     *
+     * The watchdog's passive leg is the health record plus WARN log. This active leg mirrors
+     * {@link #embedDrainLivenessAlarmDispatcher}: a durable swarm/operator A2A alarm carries the
+     * consolidation-stall payload, then a best-effort wake pulse nudges the harness owner. Each leg is
+     * independently guarded so alarm transport failures never suppress the passive liveness record.
+     *
+     * @param {Object} payload
+     * @param {Boolean} payload.hasCycle Whether a successful REM cycle has ever been observed.
+     * @param {String|null} payload.lastCompletedAt ISO timestamp of the last successful REM cycle.
+     * @param {Number} payload.stalenessMs Age since the last successful REM cycle.
+     * @param {Number} payload.undigestedCount Count of sessions still waiting for graph digestion.
+     * @param {Number} payload.thresholdMs Stall threshold that tripped.
+     * @param {Number|null} payload.stalledSince Epoch ms the stall was first observed.
+     * @returns {Promise<void>}
+     */
+    remConsolidationLivenessAlarmDispatcher = async ({
+        hasCycle,
+        lastCompletedAt,
+        stalenessMs,
+        undigestedCount,
+        thresholdMs,
+        stalledSince
+    } = {}) => {
+        const sender = process.env.NEO_AGENT_IDENTITY
+            ? normalizeAgentIdentityNodeId(process.env.NEO_AGENT_IDENTITY)
+            : '@system';
+        const stalledSinceIso = Number.isFinite(stalledSince) ? new Date(stalledSince).toISOString() : 'unknown';
+        const staleHours      = (Number(stalenessMs || 0) / (60 * 60 * 1000)).toFixed(1);
+        const subject = hasCycle
+            ? `[rem-consolidation-stall] last REM cycle is ${staleHours}h stale`
+            : `[rem-consolidation-stall] no REM cycle recorded with ${undigestedCount} undigested sessions`;
+        const body =
+            `The REM consolidation-liveness watchdog detected a STALLED graph-digestion pipeline.\n\n` +
+            `- last successful REM cycle: ${lastCompletedAt || 'none recorded'}\n` +
+            `- age since last successful cycle: ${stalenessMs}ms (~${staleHours}h)\n` +
+            `- undigested session count: ${undigestedCount}\n` +
+            `- stall threshold: ${thresholdMs}ms\n` +
+            `- stalled since: ${stalledSinceIso}\n\n` +
+            `Golden Path can keep producing a fresh forecast while the graph stops absorbing sessions. ` +
+            `Investigate the dream / REM consolidation lane on the host that owns local graph digestion.`;
+
+        try {
+            await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
+                await MailboxService.addMessage({to: 'AGENT:*', subject, body, priority: 'high'});
+            });
+        } catch (e) {
+            this.writeLog('ERROR', `[Orchestrator] REM consolidation stall-alarm A2A broadcast failed: ${e.message}`);
+        }
+
+        const targetIdentity = this.swarmHeartbeatIdentity;
+        if (targetIdentity) {
+            try {
+                await WakeSubscriptionService.emitHeartbeatPulse({targetIdentity: normalizeAgentIdentityNodeId(targetIdentity)});
+            } catch (e) {
+                this.writeLog('ERROR', `[Orchestrator] REM consolidation stall-alarm wake pulse failed: ${e.message}`);
+            }
+        }
+    }
+
+    /**
      * @param {Neo.ai.daemons.services.ProcessSupervisorService|Object|null} value
      * @returns {Neo.ai.daemons.services.ProcessSupervisorService}
      */

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -1,6 +1,6 @@
-import {collectDueCandidates}                        from './collector.mjs';
-import {pickNextCandidate}                           from './picker.mjs';
-import {evaluateStallAlarm, getEmbedDrainPendingAge} from './embedDrainLivenessWatchdog.mjs';
+import {collectDueCandidates}                                  from './collector.mjs';
+import {pickNextCandidate}                                     from './picker.mjs';
+import {evaluateStallAlarm, getEmbedDrainPendingAge}           from './embedDrainLivenessWatchdog.mjs';
 import {evaluateConsolidationStallAlarm, getRemCycleStaleness} from './remConsolidationLivenessWatchdog.mjs';
 
 /**
@@ -123,16 +123,17 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
             }
         }),
         services: {
-            dreamService                     : orchestrator.dreamService,
-            goldenPathSynthesizer            : orchestrator.goldenPathSynthesizer,
-            healthService                    : orchestrator.healthService,
-            maintenanceBackpressureService   : orchestrator.maintenanceBackpressureService,
-            primaryRepoSyncService           : orchestrator.primaryRepoSyncService,
-            processSupervisorService         : orchestrator.processSupervisorService,
-            swarmHeartbeatService            : orchestrator.swarmHeartbeatService,
-            taskStateService                 : orchestrator.taskStateService,
-            tenantRepoSyncService            : orchestrator.tenantRepoSyncService,
-            embedDrainLivenessAlarmDispatcher: orchestrator.embedDrainLivenessAlarmDispatcher
+            dreamService                           : orchestrator.dreamService,
+            goldenPathSynthesizer                  : orchestrator.goldenPathSynthesizer,
+            healthService                          : orchestrator.healthService,
+            maintenanceBackpressureService         : orchestrator.maintenanceBackpressureService,
+            primaryRepoSyncService                 : orchestrator.primaryRepoSyncService,
+            processSupervisorService               : orchestrator.processSupervisorService,
+            swarmHeartbeatService                  : orchestrator.swarmHeartbeatService,
+            taskStateService                       : orchestrator.taskStateService,
+            tenantRepoSyncService                  : orchestrator.tenantRepoSyncService,
+            embedDrainLivenessAlarmDispatcher      : orchestrator.embedDrainLivenessAlarmDispatcher,
+            remConsolidationLivenessAlarmDispatcher: orchestrator.remConsolidationLivenessAlarmDispatcher
         },
         runtime: {
             goldenPathRepoEnrichmentEnabled       : orchestrator.goldenPathRepoEnrichmentEnabled,
@@ -144,6 +145,7 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
             embedDrainLivenessWatchdogAlarmEnabled: orchestrator.embedDaemonEnabled,
             remConsolidationWatchdogRunStateDir   : orchestrator.remConsolidationWatchdogRunStateDir,
             remConsolidationWatchdogThresholdMs   : orchestrator.remConsolidationWatchdogThresholdMs,
+            remConsolidationWatchdogAlarmEnabled  : config.orchestrator.intervals.dreamMs > 0,
             writeLog                              : orchestrator.writeLog.bind(orchestrator)
         }
     };
@@ -682,26 +684,25 @@ async function runEmbedDrainLivenessWatchdogTask({taskName, reason, services, ru
 
 /**
  * @summary Runs the REM consolidation-liveness watchdog: read-only staleness check against the REM
- * run-state store, a passive health-record every check, and a one-shot stall WARN log. Never throws.
+ * run-state store, a passive health-record every check, and a one-shot active alarm. Never throws.
  *
  * Consolidation-side analog of {@link runEmbedDrainLivenessWatchdogTask} (one subsystem over). The
  * dream cycle is decoupled from the Golden Path forecast, so a stalled consolidation is otherwise
  * silent ("green-but-rotting"). Dual signal: (1) PASSIVE — `healthService.recordTaskOutcome` every
  * check (`failed` when the last successful REM cycle is stale/absent, `completed` otherwise) — the
- * observable consolidation-liveness signal; (2) a one-shot WARN log fired only on
- * stall-onset (latched via the clock-free `evaluateConsolidationStallAlarm`), so consecutive stalled
- * checks do not re-log. The latch (`{alarmed, stalledSince}`) persists on the task-state envelope so it
- * survives poll cycles and restarts. The body is fully wrapped: a watchdog fault degrades to "no alarm"
- * and never breaks the scheduling loop. The active swarm/operator A2A escalation (the embed-drain
- * `embedDrainLivenessAlarmDispatcher` analog) is a deliberate follow-up; this ships the
- * consolidation-liveness observability via the health-record + WARN log.
+ * observable consolidation-liveness signal; (2) a one-shot active alarm fired only on stall-onset
+ * (latched via the clock-free `evaluateConsolidationStallAlarm`), so consecutive stalled checks do not
+ * re-alert. The latch (`{alarmed, stalledSince}`) persists on the task-state envelope so it survives poll
+ * cycles and restarts. The body is fully wrapped: a watchdog fault degrades to "no alarm" and never
+ * breaks the scheduling loop.
  *
  * @param {Object} options
  * @param {String} options.taskName
  * @param {String} options.reason Scheduling reason.
- * @param {Object} options.services Runtime collaborators (`taskStateService`, `healthService`).
+ * @param {Object} options.services Runtime collaborators (`taskStateService`, `healthService`,
+ *   `remConsolidationLivenessAlarmDispatcher`).
  * @param {Object} options.runtime Runtime policy (`remConsolidationWatchdogRunStateDir`,
- *   `remConsolidationWatchdogThresholdMs`, `writeLog`).
+ *   `remConsolidationWatchdogThresholdMs`, `remConsolidationWatchdogAlarmEnabled`, `writeLog`).
  * @returns {Promise<void>}
  */
 async function runRemConsolidationLivenessWatchdogTask({taskName, reason, services, runtime}) {
@@ -760,6 +761,18 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
 
             if (shouldAlarm) {
                 runtime.writeLog?.('WARN', `[Orchestrator] rem-consolidation-liveness-watchdog: REM consolidation STALLED (hasCycle=${hasCycle}, stalenessMs=${stalenessMs}, thresholdMs=${thresholdMs}) — the dream stopped laying trails; the graph is rotting while the forecast looks fresh.`);
+                if (runtime.remConsolidationWatchdogAlarmEnabled) {
+                    await dispatchRemConsolidationStallAlarm({
+                        dispatcher     : services.remConsolidationLivenessAlarmDispatcher,
+                        hasCycle,
+                        lastCompletedAt: details.lastCompletedAt,
+                        stalenessMs,
+                        undigestedCount,
+                        thresholdMs,
+                        stalledSince,
+                        writeLog       : runtime.writeLog
+                    });
+                }
             }
         } else {
             services.healthService?.recordTaskOutcome?.(taskName, 'completed', details);
@@ -797,6 +810,24 @@ async function dispatchEmbedDrainStallAlarm({dispatcher, ageMs, pendingCount, th
         await dispatcher({ageMs, pendingCount, thresholdMs, stalledSince});
     } catch (e) {
         writeLog?.('ERROR', `[Orchestrator] embed-drain stall-alarm dispatch failed: ${e.message}`);
+    }
+}
+
+async function dispatchRemConsolidationStallAlarm({
+    dispatcher,
+    hasCycle,
+    lastCompletedAt,
+    stalenessMs,
+    undigestedCount,
+    thresholdMs,
+    stalledSince,
+    writeLog
+}) {
+    if (typeof dispatcher !== 'function') return;
+    try {
+        await dispatcher({hasCycle, lastCompletedAt, stalenessMs, undigestedCount, thresholdMs, stalledSince});
+    } catch (e) {
+        writeLog?.('ERROR', `[Orchestrator] REM consolidation stall-alarm dispatch failed: ${e.message}`);
     }
 }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -1,5 +1,6 @@
 import {test, expect} from '@playwright/test';
 import {
+    buildOrchestratorSchedulingOptions,
     buildSchedulingContext,
     buildTaskStalenessMeta,
     runSchedulingPipeline,
@@ -90,7 +91,98 @@ function makeRuntime(overrides = {}) {
     };
 }
 
+function makeOrchestratorAdapterFixture(overrides = {}) {
+    return {
+        db              : {},
+        taskStateService: {
+            getState: () => ({})
+        },
+        writeLog                               : () => {},
+        summaryGetDueTask                      : () => null,
+        backupGetDueTask                       : () => null,
+        graphLogCompactionGetDueTask           : () => null,
+        primaryDevSyncGetDueTask               : () => null,
+        tenantRepoSyncGetDueTask               : () => null,
+        dreamGetDueTask                        : () => null,
+        goldenPathGetDueTask                   : () => null,
+        swarmHeartbeatGetDueTask               : () => null,
+        embedDrainLivenessWatchdogGetDueTask   : () => null,
+        dreamService                           : {},
+        goldenPathSynthesizer                  : {},
+        healthService                          : {},
+        maintenanceBackpressureService         : {},
+        primaryRepoSyncService                 : {},
+        processSupervisorService               : {},
+        swarmHeartbeatService                  : {initFailed: false},
+        tenantRepoSyncService                  : {},
+        embedDrainLivenessAlarmDispatcher      : () => {},
+        remConsolidationLivenessAlarmDispatcher: () => {},
+        goldenPathRepoEnrichmentEnabled        : true,
+        primaryDevSyncRootsConfig              : null,
+        tenantRepoSyncGlobalCadenceMs          : 10_000,
+        tenantRepoSyncJitterRatio              : 0.1,
+        embedDrainLivenessWatchdogWalDir       : '/tmp/wal',
+        embedDrainLivenessWatchdogThresholdMs  : 1_000,
+        embedDaemonEnabled                     : true,
+        remConsolidationWatchdogRunStateDir    : '/tmp/rem',
+        remConsolidationWatchdogThresholdMs    : 2_000,
+        ...overrides
+    };
+}
+
+function makeAdapterConfig({dreamMs = 3_600_000} = {}) {
+    return {
+        orchestrator: {
+            intervals: {
+                summarySweepMs                   : 1,
+                kbSyncMs                         : 1,
+                githubWorkflowSyncMs             : 1,
+                backupMs                         : 1,
+                graphLogCompactionMs             : 1,
+                primaryDevSyncMs                 : 1,
+                tenantRepoSyncMs                 : 1,
+                dreamMs,
+                dreamOverflowThreshold           : 0.8,
+                goldenPathMs                     : 1,
+                swarmHeartbeatMs                 : 1,
+                embedDrainLivenessWatchdogCheckMs: 1,
+                remConsolidationWatchdogCheckMs  : 1
+            },
+            tenantRepoSync: {
+                sweepCadenceMs: 1,
+                jitterRatio   : 0
+            }
+        }
+    };
+}
+
 test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
+    test('buildOrchestratorSchedulingOptions wires the REM liveness active alarm and dream-ownership gate (#13839)', () => {
+        const remDispatcher = () => {};
+        const orchestrator = makeOrchestratorAdapterFixture({
+            remConsolidationLivenessAlarmDispatcher: remDispatcher
+        });
+
+        const enabledOptions = buildOrchestratorSchedulingOptions({
+            orchestrator,
+            config  : makeAdapterConfig({dreamMs: 3_600_000}),
+            now     : 10,
+            registry: []
+        });
+
+        expect(enabledOptions.services.remConsolidationLivenessAlarmDispatcher).toBe(remDispatcher);
+        expect(enabledOptions.runtime.remConsolidationWatchdogAlarmEnabled).toBe(true);
+
+        const disabledOptions = buildOrchestratorSchedulingOptions({
+            orchestrator,
+            config  : makeAdapterConfig({dreamMs: 0}),
+            now     : 10,
+            registry: []
+        });
+
+        expect(disabledOptions.runtime.remConsolidationWatchdogAlarmEnabled).toBe(false);
+    });
+
     test('reports descriptor errors and still dispatches the selected candidate', () => {
         const outcomes = [];
         const started  = [];

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
@@ -1,9 +1,21 @@
-import {test, expect}                from '@playwright/test';
+import {test, expect} from '@playwright/test';
+import {mkdtemp, rm}  from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+
+import {appendRemRunState}           from '../../../../../../../ai/services/memory-core/helpers/remRunStateStore.mjs';
 import {
     getRemCycleStaleness,
     evaluateConsolidationStallAlarm,
     getDueTask
 }                                     from '../../../../../../../ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.mjs';
+import {
+    buildSchedulingContext,
+    runSchedulingPipeline
+}                                     from '../../../../../../../ai/daemons/orchestrator/scheduling/pipeline.mjs';
+import {TASK_REGISTRY}               from '../../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
+
+const HOUR_MS = 60 * 60 * 1000;
 
 test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog', () => {
     // ── getRemCycleStaleness (read-only, fail-soft) ──────────────────────────────────────────────
@@ -101,5 +113,161 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog', () => 
 
     test('getDueTask is disabled when the check cadence is <= 0', () => {
         expect(getDueTask({state: {lastRunAt: 0}, now: 1e12, remConsolidationWatchdogCheckMs: 0})).toBeNull();
+    });
+});
+
+test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipeline active alarm (#13839)', () => {
+    let remRunStateDir;
+
+    test.beforeEach(async () => {
+        remRunStateDir = await mkdtemp(path.join(os.tmpdir(), 'neo-rem-consolidation-watchdog-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(remRunStateDir, {recursive: true, force: true});
+    });
+
+    function makeTaskStateService() {
+        const taskState = {'rem-consolidation-liveness-watchdog': {lastRunAt: 0}};
+        return {
+            getState() { return taskState; },
+            getTaskState(name) { return taskState[name]; },
+            markStarted(name) { taskState[name].running = true; taskState[name].lastRunAt = Date.now(); },
+            markCompleted(name) { taskState[name].running = false; },
+            markFailed(name) { taskState[name].running = false; }
+        };
+    }
+
+    function makeServices({taskStateService, outcomes, dispatcher, undigestedCount = 5}) {
+        return {
+            dreamService: {
+                findUndigestedSessions: async () => Array.from({length: undigestedCount}, (_, index) => ({id: `s-${index}`}))
+            },
+            healthService: {
+                recordTaskOutcome(taskName, status, details) { outcomes.push({taskName, status, details}); }
+            },
+            maintenanceBackpressureService: {
+                getActiveHeavyMaintenanceTask() { return null; },
+                isHeavyMaintenanceTask() { return false; },
+                isHeavyMaintenanceConflict() { return false; },
+                recordDeferral() {}
+            },
+            taskStateService,
+            remConsolidationLivenessAlarmDispatcher: dispatcher
+        };
+    }
+
+    function makeRuntime(overrides = {}) {
+        return {
+            remConsolidationWatchdogRunStateDir : remRunStateDir,
+            remConsolidationWatchdogThresholdMs : 6 * HOUR_MS,
+            remConsolidationWatchdogAlarmEnabled: true,
+            writeLog                            : () => {},
+            ...overrides
+        };
+    }
+
+    async function runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime, undigestedCount = 5}) {
+        const context = buildSchedulingContext({
+            db       : {},
+            state    : taskStateService.getState(),
+            now      : Date.now(),
+            intervals: {remConsolidationWatchdogCheck: 1},
+            enables  : {},
+            hooks    : {}
+        });
+
+        runSchedulingPipeline({
+            registry: [TASK_REGISTRY.find(d => d.taskName === 'rem-consolidation-liveness-watchdog')],
+            context,
+            services: makeServices({taskStateService, outcomes, dispatcher, undigestedCount}),
+            runtime
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 20));
+    }
+
+    test('fires the active alarm once on stall-onset and latches subsequent stalled checks', async () => {
+        const outcomes = [];
+        const alarmCalls = [];
+        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const taskStateService = makeTaskStateService();
+        const runtime = makeRuntime();
+
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime});
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime});
+
+        expect(outcomes.some(o => o.status === 'failed')).toBe(true);
+        expect(alarmCalls).toHaveLength(1);
+        expect(alarmCalls[0]).toMatchObject({
+            hasCycle       : false,
+            lastCompletedAt: null,
+            stalenessMs    : 0,
+            undigestedCount: 5,
+            thresholdMs    : 6 * HOUR_MS
+        });
+        expect(typeof alarmCalls[0].stalledSince).toBe('number');
+        expect(taskStateService.getTaskState('rem-consolidation-liveness-watchdog').remConsolidationAlarm.alarmed).toBe(true);
+    });
+
+    test('suppresses the active alarm when the local dream lane is not owned here', async () => {
+        const outcomes = [];
+        const alarmCalls = [];
+        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const taskStateService = makeTaskStateService();
+
+        await runWatchdogOnce({
+            taskStateService, outcomes, dispatcher,
+            runtime: makeRuntime({remConsolidationWatchdogAlarmEnabled: false})
+        });
+
+        expect(outcomes.some(o => o.status === 'failed')).toBe(true);
+        expect(alarmCalls).toHaveLength(0);
+    });
+
+    test('dispatcher failures are logged and swallowed after the passive failed outcome', async () => {
+        const outcomes = [];
+        const logs = [];
+        const taskStateService = makeTaskStateService();
+
+        await runWatchdogOnce({
+            taskStateService,
+            outcomes,
+            dispatcher: async () => { throw new Error('a2a unavailable'); },
+            runtime   : makeRuntime({
+                writeLog(level, message) { logs.push({level, message}); }
+            })
+        });
+
+        expect(outcomes.some(o => o.status === 'failed')).toBe(true);
+        expect(logs).toContainEqual({
+            level  : 'ERROR',
+            message: '[Orchestrator] REM consolidation stall-alarm dispatch failed: a2a unavailable'
+        });
+    });
+
+    test('a healthy REM cycle clears the latch and does not dispatch', async () => {
+        const now = Date.now();
+        await appendRemRunState({runId: 'healthy', completedAt: now - HOUR_MS}, {dir: remRunStateDir});
+
+        const outcomes = [];
+        const alarmCalls = [];
+        const taskStateService = makeTaskStateService();
+        taskStateService.getTaskState('rem-consolidation-liveness-watchdog').remConsolidationAlarm = {
+            alarmed     : true,
+            stalledSince: now - 8 * HOUR_MS
+        };
+
+        await runWatchdogOnce({
+            taskStateService,
+            outcomes,
+            dispatcher: async payload => { alarmCalls.push(payload); },
+            runtime   : makeRuntime()
+        });
+
+        expect(outcomes.some(o => o.status === 'completed')).toBe(true);
+        expect(alarmCalls).toHaveLength(0);
+        expect(taskStateService.getTaskState('rem-consolidation-liveness-watchdog').remConsolidationAlarm)
+            .toEqual({alarmed: false, stalledSince: null});
     });
 });


### PR DESCRIPTION
Resolves #13839

Related: #13624

Adds the active REM consolidation-liveness alarm leg that #13838 deliberately left passive: the orchestrator now has `remConsolidationLivenessAlarmDispatcher`, the scheduling adapter passes it through, and the REM watchdog fires it once on stall onset after the passive failed health record and WARN log. The active leg mirrors the embed-drain pattern with durable A2A plus best-effort wake pulse, and transport failures are logged/swallowed so liveness observation never breaks the scheduler.

Evidence: L2 (mocked pipeline dispatcher, adapter wiring, latch/gate/throw-swallow unit coverage, and sibling embed-drain regression) -> L2 required (close-target ACs require unit coverage for active alarm semantics). No residuals.

## Deltas from ticket

The active-alarm gate is derived from the existing local dream ownership signal, `config.orchestrator.intervals.dreamMs > 0`, instead of adding a new config key. That keeps the contract surface unchanged: a host that disables the local dream lane also suppresses active REM-stall wake dispatch, while passive health/WARN observability stays intact.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs --workers=1` -> 19 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs --workers=1` -> 14 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs --workers=1` -> 20 passed
- `git diff --cached --check` passed before commit
- pre-commit hooks passed: whitespace, shorthand, AiConfig test-mutation guard, JSDoc types, ticket archaeology, block alignment

## Post-Merge Validation

- [ ] Confirm CI green on GitHub and one cross-family approval before human merge.

## Commits

- `ec006dc1bd` — `feat(ai): dispatch REM liveness active alarm (#13839)`

Authored by Euclid (GPT-5, Codex Desktop). Session b9a8f817-9a9e-4243-abfb-62e762a94964.