### PR TITLE
fix(ai): enforce native Ollama loaded context (#13865)

### DIFF
--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -53,13 +53,41 @@ export function getOpenAiCompatibleModelIds(payload) {
  * @returns {String[]}
  */
 export function getOllamaRunningModelIds(payload) {
+    return getOllamaRunningModels(payload).map(item => item.id);
+}
+
+/**
+ * @summary Extracts resident native Ollama model metadata from `/api/ps`.
+ *
+ * Ollama reports the loaded context as `context_length` per running model. The
+ * readiness layer preserves it so a model that is merely resident at the default
+ * 4K-ish context window cannot satisfy Neo's configured local-model context cap.
+ *
+ * @param {Object} payload Parsed `/api/ps` response.
+ * @returns {Object[]}
+ */
+export function getOllamaRunningModels(payload) {
     if (!Array.isArray(payload?.models)) {
         return [];
     }
 
-    return [...new Set(payload.models
-        .map(item => item?.name || item?.model || item?.id)
-        .filter(Boolean))];
+    const models = [];
+    const seen   = new Set();
+
+    for (const item of payload.models) {
+        const id = item?.name || item?.model || item?.id;
+        if (!id || seen.has(id)) {
+            continue;
+        }
+
+        seen.add(id);
+        models.push({
+            id,
+            contextLength: Neo.isNumber(item?.context_length) ? item.context_length : undefined
+        });
+    }
+
+    return models;
 }
 
 /**
@@ -103,11 +131,23 @@ export async function fetchOpenAiCompatibleModelIds({host, timeoutMs, fetchFn = 
  * @returns {Promise<String[]>}
  */
 export async function fetchOllamaRunningModelIds({host, timeoutMs, fetchFn = fetch} = {}) {
+    return (await fetchOllamaRunningModels({host, timeoutMs, fetchFn})).map(item => item.id);
+}
+
+/**
+ * @summary Fetches resident native Ollama model metadata from `/api/ps`.
+ * @param {Object} options
+ * @param {String} options.host Provider host.
+ * @param {Number} options.timeoutMs HTTP timeout. Required; no module-level default.
+ * @param {Function} [options.fetchFn=fetch] Fetch seam for tests.
+ * @returns {Promise<Object[]>}
+ */
+export async function fetchOllamaRunningModels({host, timeoutMs, fetchFn = fetch} = {}) {
     if (!host) {
-        throw new TypeError('fetchOllamaRunningModelIds: host is required');
+        throw new TypeError('fetchOllamaRunningModels: host is required');
     }
     if (typeof timeoutMs !== 'number') {
-        throw new TypeError('fetchOllamaRunningModelIds: timeoutMs is required');
+        throw new TypeError('fetchOllamaRunningModels: timeoutMs is required');
     }
 
     const url      = new URL('/api/ps', host).toString();
@@ -121,7 +161,7 @@ export async function fetchOllamaRunningModelIds({host, timeoutMs, fetchFn = fet
         throw new Error(`Ollama running-model enumeration failed: HTTP ${response.status}${text ? ` - ${text}` : ''}`);
     }
 
-    return getOllamaRunningModelIds(await response.json());
+    return getOllamaRunningModels(await response.json());
 }
 
 /**
@@ -137,6 +177,7 @@ export async function fetchOllamaRunningModelIds({host, timeoutMs, fetchFn = fet
  * @param {String} options.model Ollama model identifier.
  * @param {String} options.role Either `'chat'` or `'embedding'`.
  * @param {String|Number} [options.keepAlive] Ollama keep_alive value.
+ * @param {Number} [options.contextLength] Native Ollama `options.num_ctx` warm-up override.
  * @param {Number} options.timeoutMs HTTP timeout. Required; no module-level default.
  * @param {Function} [options.fetchFn=fetch] Fetch seam for tests.
  * @returns {Promise<Object>}
@@ -146,6 +187,7 @@ export async function warmOllamaRoleModel({
     model,
     role,
     keepAlive,
+    contextLength,
     timeoutMs,
     fetchFn = fetch
 } = {}) {
@@ -169,6 +211,12 @@ export async function warmOllamaRoleModel({
 
     if (keepAlive !== undefined) {
         payload.keep_alive = keepAlive;
+    }
+    if (Neo.isNumber(contextLength)) {
+        payload.options = {
+            ...(payload.options || {}),
+            num_ctx: contextLength
+        };
     }
 
     const response = await fetchFn(new URL(endpoint, host).toString(), {
@@ -348,27 +396,32 @@ export function buildLmsPreloadConfig(config = aiConfig) {
  * chat, graph, or embedding is routed to another provider family.
  *
  * @param {Object} config aiConfig-shaped provider config.
- * @returns {{provider: String, host: String, keepAlive: *, requireParallelModels: Number, model: String, embeddingModel: String, roles: Object[], models: String[]}}
+ * @returns {{provider: String, host: String, keepAlive: *, requireParallelModels: Number, model: String, embeddingModel: String, roles: Object[], models: String[], contextLengths: Object}}
  */
 export function buildOllamaReadinessConfig(config = aiConfig) {
-    const ollamaConfig   = config.ollama ?? {},
-          chatModel      = ollamaConfig.model,
-          embeddingModel = ollamaConfig.embeddingModel,
-          roles          = [{
-              provider    : config.modelProvider,
-              providerRole: 'modelProvider',
-              role        : 'chat',
-              model       : chatModel
+    const ollamaConfig           = config.ollama ?? {},
+          chatModel              = ollamaConfig.model,
+          embeddingModel         = ollamaConfig.embeddingModel,
+          chatContextLength      = config.localModels?.chat?.contextLimitTokens,
+          embeddingContextLength = config.localModels?.embedding?.contextLimitTokens,
+          roles                  = [{
+              provider     : config.modelProvider,
+              providerRole : 'modelProvider',
+              role         : 'chat',
+              model        : chatModel,
+              contextLength: chatContextLength
           }, {
-              provider    : config.graphProvider,
-              providerRole: 'graphProvider',
-              role        : 'chat',
-              model       : chatModel
+              provider     : config.graphProvider,
+              providerRole : 'graphProvider',
+              role         : 'chat',
+              model        : chatModel,
+              contextLength: chatContextLength
           }, {
-              provider    : config.embeddingProvider,
-              providerRole: 'embeddingProvider',
-              role        : 'embedding',
-              model       : embeddingModel
+              provider     : config.embeddingProvider,
+              providerRole : 'embeddingProvider',
+              role         : 'embedding',
+              model        : embeddingModel,
+              contextLength: embeddingContextLength
           }].filter(role => role.provider === 'ollama' && role.model);
 
     const dedupedRoles = [];
@@ -390,7 +443,13 @@ export function buildOllamaReadinessConfig(config = aiConfig) {
         model                : chatModel,
         embeddingModel,
         roles                : dedupedRoles,
-        models               : [...new Set(dedupedRoles.map(role => role.model))]
+        models               : [...new Set(dedupedRoles.map(role => role.model))],
+        contextLengths       : buildLmsContextLengthsMap({
+            chatModel     : dedupedRoles.some(role => role.role === 'chat') ? chatModel : undefined,
+            embeddingModel: dedupedRoles.some(role => role.role === 'embedding') ? embeddingModel : undefined,
+            chatContextLength,
+            embeddingContextLength
+        })
     }
 }
 
@@ -592,9 +651,9 @@ export async function ensureLmsModelsLoaded({
  * @summary Ensures native Ollama has all configured role models resident.
  *
  * Ollama has no `lms load` equivalent and must be warmed through its native API.
- * This helper probes `/api/ps`, warms only missing role/model pairs through
+ * This helper probes `/api/ps`, warms missing or under-context role/model pairs through
  * `/api/chat` or `/api/embed`, and then verifies that the required chat and
- * embedding models are resident together. Partial failure returns a degraded
+ * embedding models are resident together at the configured context. Partial failure returns a degraded
  * readiness envelope when `allowPartial` is true so callers can fail readiness
  * with operator-actionable diagnostics instead of emitting warning-only drift.
  *
@@ -607,7 +666,7 @@ export async function ensureLmsModelsLoaded({
  * @param {Number} options.timeoutMs HTTP probe timeout.
  * @param {String|Number} [options.keepAlive] Ollama keep_alive value.
  * @param {Boolean} [options.allowPartial=false] Return degraded readiness instead of throwing when one role cannot be warmed.
- * @param {Function} [options.fetchModelIds] Injectable `/api/ps` probe.
+ * @param {Function} [options.fetchModelIds] Injectable `/api/ps` probe. May return model ids or `{id, contextLength}` entries.
  * @param {Function} [options.warmModel] Injectable warm-up function.
  * @param {Object} [options.log=logger] Logger seam.
  * @returns {Promise<Object>}
@@ -621,7 +680,7 @@ export async function ensureOllamaModelsReady({
     timeoutMs,
     keepAlive,
     allowPartial = false,
-    fetchModelIds = opts => fetchOllamaRunningModelIds(opts),
+    fetchModelIds = opts => fetchOllamaRunningModels(opts),
     warmModel     = (role, options) => warmOllamaRoleModel({...role, ...options}),
     log           = logger
 } = {}) {
@@ -641,7 +700,44 @@ export async function ensureOllamaModelsReady({
     }
 
     const requiredResidentModels = Math.min(requireParallelModels, requiredModels.length);
-    const getMissing             = available => requiredModels.filter(model => !available.includes(model));
+    const normalizeAvailable = available => [...new Map((Array.isArray(available) ? available : []).map(item => {
+        if (typeof item === 'string') {
+            return [item, {id: item, contextLength: undefined}];
+        }
+        const id = item?.id || item?.name || item?.model;
+        return id ? [id, {
+            id,
+            contextLength: Neo.isNumber(item.contextLength) ? item.contextLength :
+                Neo.isNumber(item.context_length) ? item.context_length : undefined
+        }] : null;
+    }).filter(Boolean)).values()];
+    const toIds               = available => available.map(item => item.id);
+    const contextRequirements = roles.reduce((map, role) => {
+        if (!role.model || !Neo.isNumber(role.contextLength)) {
+            return map;
+        }
+
+        const current = map.get(role.model);
+        if (!Neo.isNumber(current) || role.contextLength > current) {
+            map.set(role.model, role.contextLength);
+        }
+
+        return map;
+    }, new Map());
+    const toRoleEnvelope = role => ({
+        model       : role.model,
+        role        : role.role,
+        providerRole: role.providerRole,
+        ...(Neo.isNumber(role.contextLength) ? {contextLength: role.contextLength} : {})
+    });
+    const getMissing             = available => requiredModels.filter(model => !toIds(available).includes(model));
+    const getInsufficientContext = available => available
+        .filter(item => contextRequirements.has(item.id) && (!Neo.isNumber(item.contextLength) || item.contextLength < contextRequirements.get(item.id)))
+        .map(item => ({
+            model                : item.id,
+            contextLength        : item.contextLength,
+            requiredContextLength: contextRequirements.get(item.id)
+        }));
     const getWarning = ({availableModels, missingModels}) => createParallelModelCapacityWarning({
         provider             : 'ollama',
         model                : roles.find(role => role.role === 'chat')?.model,
@@ -660,7 +756,7 @@ export async function ensureOllamaModelsReady({
             try {
                 return {
                     attempt,
-                    availableModels: [...new Set(await fetchModelIds({host, timeoutMs}))]
+                    availableModels: normalizeAvailable(await fetchModelIds({host, timeoutMs}))
                 };
             } catch (error) {
                 lastError = error;
@@ -684,20 +780,21 @@ export async function ensureOllamaModelsReady({
         }
 
         return {
-            ready          : false,
-            degraded       : true,
-            provider       : 'ollama',
+            ready                    : false,
+            degraded                 : true,
+            provider                 : 'ollama',
             host,
             requiredModels,
-            availableModels: [],
-            missingModels  : requiredModels,
-            observedCount  : 0,
+            availableModels          : [],
+            missingModels            : requiredModels,
+            insufficientContextModels: [],
+            observedCount            : 0,
             requireParallelModels,
             requiredResidentModels,
-            warmedModels   : [],
-            attemptedModels: [],
-            failedModels   : [],
-            error          : {message: error.message},
+            warmedModels             : [],
+            attemptedModels          : [],
+            failedModels             : [],
+            error                    : {message: error.message},
             warning              : `[provider/ollama] model residency probe failed: ${error.message}`,
             attempts,
             elapsedMs            : Date.now() - startedAt
@@ -705,24 +802,32 @@ export async function ensureOllamaModelsReady({
     }
 
     const initialMissing = getMissing(availableModels);
-    const rolesToWarm    = roles.filter(role => initialMissing.includes(role.model));
+    const initialInsufficientContext = getInsufficientContext(availableModels);
+    const initialContextModelIds     = new Set(initialInsufficientContext.map(item => item.model));
+    const rolesToWarm    = roles.filter(role => initialMissing.includes(role.model) || initialContextModelIds.has(role.model));
     const warmedModels   = [];
     const failedModels   = [];
     const attemptedModels = [];
 
     for (const role of rolesToWarm) {
-        attemptedModels.push({model: role.model, role: role.role, providerRole: role.providerRole});
-        log.info?.(`[ProviderReadinessHelper] Warming native Ollama ${role.role} model '${role.model}' via ${role.role === 'embedding' ? '/api/embed' : '/api/chat'}.`);
+        const roleEnvelope = toRoleEnvelope(role);
+
+        attemptedModels.push(roleEnvelope);
+        const contextSuffix = Neo.isNumber(role.contextLength) ? ` with num_ctx ${role.contextLength}` : '';
+        log.info?.(`[ProviderReadinessHelper] Warming native Ollama ${role.role} model '${role.model}'${contextSuffix} via ${role.role === 'embedding' ? '/api/embed' : '/api/chat'}.`);
 
         try {
-            await warmModel(role, {host, keepAlive, timeoutMs});
-            warmedModels.push({model: role.model, role: role.role, providerRole: role.providerRole});
+            const warmOptions = {host, keepAlive, timeoutMs};
+            if (Neo.isNumber(role.contextLength)) {
+                warmOptions.contextLength = role.contextLength;
+            }
+
+            await warmModel(role, warmOptions);
+            warmedModels.push(roleEnvelope);
         } catch (error) {
             failedModels.push({
-                model       : role.model,
-                role        : role.role,
-                providerRole: role.providerRole,
-                error       : error.message
+                ...roleEnvelope,
+                error: error.message
             });
             log.warn?.(`[ProviderReadinessHelper] Ollama ${role.role} model '${role.model}' warm-up failed: ${error.message}`);
 
@@ -733,37 +838,47 @@ export async function ensureOllamaModelsReady({
     }
 
     let missingModels = initialMissing;
+    let insufficientContextModels = initialInsufficientContext;
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
         ({availableModels} = await probeModels('post-warm /api/ps probe'));
         missingModels = getMissing(availableModels);
+        insufficientContextModels = getInsufficientContext(availableModels);
 
         const failedModelIds     = new Set(failedModels.map(item => item.model));
         const serviceableMissing = missingModels.filter(model => !failedModelIds.has(model));
+        const serviceableContext = insufficientContextModels.filter(item => !failedModelIds.has(item.model));
         const observedCount      = availableModels.length;
         const capacityReady      = observedCount >= requiredResidentModels;
-        const ready              = capacityReady && missingModels.length === 0 && failedModels.length === 0;
+        const ready              = capacityReady && missingModels.length === 0 && insufficientContextModels.length === 0 && failedModels.length === 0;
         const capacityOnlyGap    = missingModels.length === 0 && !capacityReady;
 
-        if (ready || (allowPartial && (serviceableMissing.length === 0 || capacityOnlyGap))) {
+        const contextOnlyGap = missingModels.length === 0 && serviceableContext.length > 0;
+
+        if (ready || (allowPartial && (serviceableMissing.length === 0 || capacityOnlyGap || contextOnlyGap))) {
             const degraded = !ready;
+            const contextWarning = serviceableContext.length
+                ? `[provider/ollama] loaded context too small: ${serviceableContext.map(item => `${item.model} observed=${item.contextLength ?? 'unknown'} required>=${item.requiredContextLength}`).join(', ')}; warm with options.num_ctx matching localModels context caps.`
+                : null;
             return {
                 ready,
                 degraded,
-                provider : 'ollama',
+                provider       : 'ollama',
                 host,
                 warmedModels,
                 attemptedModels,
                 failedModels,
                 missingModels,
+                insufficientContextModels,
                 requiredModels,
-                availableModels,
+                availableModels: toIds(availableModels),
+                loadedContexts : Object.fromEntries(availableModels.map(item => [item.id, item.contextLength])),
                 observedCount,
                 requireParallelModels,
                 requiredResidentModels,
-                warning  : degraded ? getWarning({availableModels, missingModels}) : null,
-                attempts : attempt,
-                elapsedMs: Date.now() - startedAt
+                warning        : degraded ? (contextWarning || getWarning({availableModels: toIds(availableModels), missingModels})) : null,
+                attempts       : attempt,
+                elapsedMs      : Date.now() - startedAt
             };
         }
 
@@ -772,25 +887,30 @@ export async function ensureOllamaModelsReady({
         }
     }
 
-    const warning = getWarning({availableModels, missingModels});
+    const contextWarning = insufficientContextModels.length
+        ? `[provider/ollama] loaded context too small: ${insufficientContextModels.map(item => `${item.model} observed=${item.contextLength ?? 'unknown'} required>=${item.requiredContextLength}`).join(', ')}; warm with options.num_ctx matching localModels context caps.`
+        : null;
+    const warning = contextWarning || getWarning({availableModels: toIds(availableModels), missingModels});
     if (allowPartial) {
         return {
-            ready        : false,
-            degraded     : true,
-            provider     : 'ollama',
+            ready          : false,
+            degraded       : true,
+            provider       : 'ollama',
             host,
             warmedModels,
             attemptedModels,
             failedModels,
             missingModels,
+            insufficientContextModels,
             requiredModels,
-            availableModels,
-            observedCount: availableModels.length,
+            availableModels: toIds(availableModels),
+            loadedContexts : Object.fromEntries(availableModels.map(item => [item.id, item.contextLength])),
+            observedCount  : availableModels.length,
             requireParallelModels,
             requiredResidentModels,
             warning,
             attempts,
-            elapsedMs    : Date.now() - startedAt
+            elapsedMs      : Date.now() - startedAt
         };
     }
 

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -172,15 +172,34 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     test('extracts native Ollama resident model ids from /api/ps variants', () => {
         expect(providerReadinessHelper.getOllamaRunningModelIds({
             models: [
-                {name: 'gemma4:31b'},
-                {model: 'qwen3-embedding'},
+                {name: 'gemma4:31b', context_length: 131072},
+                {model: 'qwen3-embedding', context_length: 32768},
                 {id: 'fallback-model'},
                 {name: 'gemma4:31b'},
                 {}
             ]
         })).toEqual(['gemma4:31b', 'qwen3-embedding', 'fallback-model']);
 
+        expect(providerReadinessHelper.getOllamaRunningModels({
+            models: [
+                {name: 'gemma4:31b', context_length: 131072},
+                {model: 'qwen3-embedding', context_length: 32768},
+                {id: 'fallback-model'},
+                {name: 'gemma4:31b', context_length: 4096}
+            ]
+        })).toEqual([{
+            id           : 'gemma4:31b',
+            contextLength: 131072
+        }, {
+            id           : 'qwen3-embedding',
+            contextLength: 32768
+        }, {
+            id           : 'fallback-model',
+            contextLength: undefined
+        }]);
+
         expect(providerReadinessHelper.getOllamaRunningModelIds({models: null})).toEqual([]);
+        expect(providerReadinessHelper.getOllamaRunningModels({models: null})).toEqual([]);
     });
 
     test('fetchOllamaRunningModelIds probes native Ollama /api/ps', async () => {
@@ -193,7 +212,10 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 return {
                     ok  : true,
                     json: async () => ({
-                        models: [{name: 'gemma4:31b'}, {name: 'qwen3-embedding'}]
+                        models: [
+                            {name: 'gemma4:31b', context_length: 131072},
+                            {name: 'qwen3-embedding', context_length: 32768}
+                        ]
                     })
                 };
             }
@@ -253,6 +275,54 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 model     : 'qwen3-embedding',
                 input     : '',
                 keep_alive: '-1'
+            }
+        }]);
+    });
+
+    test('warmOllamaRoleModel threads native num_ctx for chat and embedding warm-ups (#13865)', async () => {
+        const calls = [];
+        const fetchFn = async (url, options) => {
+            calls.push({
+                url,
+                body: JSON.parse(options.body)
+            });
+            return {
+                ok  : true,
+                text: async () => ''
+            };
+        };
+
+        await providerReadinessHelper.warmOllamaRoleModel({
+            host         : 'http://ollama.test',
+            model        : 'gemma4:31b',
+            role         : 'chat',
+            contextLength: 131072,
+            timeoutMs    : 25,
+            fetchFn
+        });
+        await providerReadinessHelper.warmOllamaRoleModel({
+            host         : 'http://ollama.test',
+            model        : 'qwen3-embedding',
+            role         : 'embedding',
+            contextLength: 32768,
+            timeoutMs    : 25,
+            fetchFn
+        });
+
+        expect(calls).toEqual([{
+            url : 'http://ollama.test/api/chat',
+            body: {
+                model   : 'gemma4:31b',
+                messages: [{role: 'user', content: ''}],
+                stream  : false,
+                options : {num_ctx: 131072}
+            }
+        }, {
+            url : 'http://ollama.test/api/embed',
+            body: {
+                model  : 'qwen3-embedding',
+                input  : '',
+                options: {num_ctx: 32768}
             }
         }]);
     });
@@ -590,69 +660,140 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         const warmCalls = [];
         const modelSnapshots = [
             [],
-            ['gemma4:31b', 'qwen3-embedding']
+            [
+                {id: 'gemma4:31b', contextLength: 131072},
+                {id: 'qwen3-embedding', contextLength: 32768}
+            ]
         ];
 
         const result = await providerReadinessHelper.ensureOllamaModelsReady({
             host : 'http://ollama.test',
             roles: [{
-                providerRole: 'modelProvider',
-                role        : 'chat',
-                model       : 'gemma4:31b'
+                providerRole : 'modelProvider',
+                role         : 'chat',
+                model        : 'gemma4:31b',
+                contextLength: 131072
             }, {
-                providerRole: 'embeddingProvider',
-                role        : 'embedding',
-                model       : 'qwen3-embedding'
+                providerRole : 'embeddingProvider',
+                role         : 'embedding',
+                model        : 'qwen3-embedding',
+                contextLength: 32768
             }],
             requireParallelModels: 2,
             attempts             : 2,
             delayMs              : 0,
             timeoutMs            : 25,
             keepAlive            : '-1',
-            fetchModelIds        : async () => modelSnapshots.shift() || ['gemma4:31b', 'qwen3-embedding'],
-            warmModel            : async (role, options) => warmCalls.push({role, options}),
-            log                  : {info: () => {}}
+            fetchModelIds        : async () => modelSnapshots.shift() || [
+                {id: 'gemma4:31b', contextLength: 131072},
+                {id: 'qwen3-embedding', contextLength: 32768}
+            ],
+            warmModel: async (role, options) => warmCalls.push({role, options}),
+            log      : {info: () => {}}
         });
 
         expect(warmCalls).toEqual([{
             role: {
-                providerRole: 'modelProvider',
-                role        : 'chat',
-                model       : 'gemma4:31b'
+                providerRole : 'modelProvider',
+                role         : 'chat',
+                model        : 'gemma4:31b',
+                contextLength: 131072
             },
             options: {
-                host     : 'http://ollama.test',
-                keepAlive: '-1',
-                timeoutMs: 25
+                host         : 'http://ollama.test',
+                keepAlive    : '-1',
+                timeoutMs    : 25,
+                contextLength: 131072
             }
         }, {
             role: {
-                providerRole: 'embeddingProvider',
-                role        : 'embedding',
-                model       : 'qwen3-embedding'
+                providerRole : 'embeddingProvider',
+                role         : 'embedding',
+                model        : 'qwen3-embedding',
+                contextLength: 32768
             },
             options: {
-                host     : 'http://ollama.test',
-                keepAlive: '-1',
-                timeoutMs: 25
+                host         : 'http://ollama.test',
+                keepAlive    : '-1',
+                timeoutMs    : 25,
+                contextLength: 32768
             }
         }]);
         expect(result).toMatchObject({
             ready       : true,
             provider    : 'ollama',
             warmedModels: [{
-                model       : 'gemma4:31b',
-                role        : 'chat',
-                providerRole: 'modelProvider'
+                model        : 'gemma4:31b',
+                role         : 'chat',
+                providerRole : 'modelProvider',
+                contextLength: 131072
             }, {
-                model       : 'qwen3-embedding',
-                role        : 'embedding',
-                providerRole: 'embeddingProvider'
+                model        : 'qwen3-embedding',
+                role         : 'embedding',
+                providerRole : 'embeddingProvider',
+                contextLength: 32768
             }],
-            requiredModels       : ['gemma4:31b', 'qwen3-embedding'],
-            availableModels      : ['gemma4:31b', 'qwen3-embedding'],
+            requiredModels : ['gemma4:31b', 'qwen3-embedding'],
+            availableModels: ['gemma4:31b', 'qwen3-embedding'],
+            loadedContexts : {
+                'gemma4:31b'     : 131072,
+                'qwen3-embedding': 32768
+            },
             requireParallelModels: 2
         });
+    });
+
+    test('ensureOllamaModelsReady degrades resident models loaded below configured context (#13865)', async () => {
+        const warmCalls = [];
+        const modelSnapshots = [
+            [{id: 'gemma4:31b', contextLength: 4096}],
+            [{id: 'gemma4:31b', contextLength: 4096}]
+        ];
+
+        const result = await providerReadinessHelper.ensureOllamaModelsReady({
+            host : 'http://ollama.test',
+            roles: [{
+                providerRole : 'graphProvider',
+                role         : 'chat',
+                model        : 'gemma4:31b',
+                contextLength: 131072
+            }],
+            requireParallelModels: 1,
+            allowPartial         : true,
+            attempts             : 1,
+            delayMs              : 0,
+            timeoutMs            : 25,
+            keepAlive            : '-1',
+            fetchModelIds        : async () => modelSnapshots.shift() || [{id: 'gemma4:31b', contextLength: 4096}],
+            warmModel            : async (role, options) => warmCalls.push({role, options}),
+            log                  : {info: () => {}}
+        });
+
+        expect(warmCalls).toEqual([{
+            role: {
+                providerRole : 'graphProvider',
+                role         : 'chat',
+                model        : 'gemma4:31b',
+                contextLength: 131072
+            },
+            options: {
+                host         : 'http://ollama.test',
+                keepAlive    : '-1',
+                timeoutMs    : 25,
+                contextLength: 131072
+            }
+        }]);
+        expect(result.ready).toBe(false);
+        expect(result.degraded).toBe(true);
+        expect(result.missingModels).toEqual([]);
+        expect(result.insufficientContextModels).toEqual([{
+            model                : 'gemma4:31b',
+            contextLength        : 4096,
+            requiredContextLength: 131072
+        }]);
+        expect(result.loadedContexts).toEqual({'gemma4:31b': 4096});
+        expect(result.warning).toContain('loaded context too small');
+        expect(result.warning).toContain('observed=4096 required>=131072');
     });
 
     test('ensureOllamaModelsReady returns degraded when one native role cannot be warmed (#12285)', async () => {
@@ -874,6 +1015,14 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             openAiCompatible: {
                 model         : 'gemma-openai',
                 embeddingModel: 'openai-embedding'
+            },
+            localModels: {
+                chat: {
+                    contextLimitTokens: 131072
+                },
+                embedding: {
+                    contextLimitTokens: 32768
+                }
             }
         })).toEqual({
             provider             : 'ollama',
@@ -883,17 +1032,23 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             model                : 'gemma4:31b',
             embeddingModel       : 'qwen3-embedding',
             roles                : [{
-                provider    : 'ollama',
-                providerRole: 'graphProvider',
-                role        : 'chat',
-                model       : 'gemma4:31b'
+                provider     : 'ollama',
+                providerRole : 'graphProvider',
+                role         : 'chat',
+                model        : 'gemma4:31b',
+                contextLength: 131072
             }, {
-                provider    : 'ollama',
-                providerRole: 'embeddingProvider',
-                role        : 'embedding',
-                model       : 'qwen3-embedding'
+                provider     : 'ollama',
+                providerRole : 'embeddingProvider',
+                role         : 'embedding',
+                model        : 'qwen3-embedding',
+                contextLength: 32768
             }],
-            models               : ['gemma4:31b', 'qwen3-embedding']
+            models        : ['gemma4:31b', 'qwen3-embedding'],
+            contextLengths: {
+                'gemma4:31b'     : 131072,
+                'qwen3-embedding': 32768
+            }
         });
 
         expect(providerReadinessHelper.buildOllamaReadinessConfig({


### PR DESCRIPTION
Resolves #13865

Native Ollama readiness now treats resident model IDs as insufficient when `/api/ps` reports a loaded context below the configured `localModels` context cap. The helper carries role context requirements from `buildOllamaReadinessConfig`, warms chat/embedding via native endpoints with `options.num_ctx` when configured, and returns degraded/actionable context diagnostics when the loaded model stays under-cap.

Evidence: L2 (mocked `/api/ps` `context_length` plus native `/api/chat` and `/api/embed` warm-up dispatch in unit coverage) → L2 required (#13865 helper-level readiness contract). No residuals.

## Deltas from ticket
- Added `getOllamaRunningModels()` / `fetchOllamaRunningModels()` while preserving `getOllamaRunningModelIds()` compatibility.
- Kept the role-selection rule provider-selector driven; non-selected Ollama leaves do not participate.
- Did not add `ollama serve` supervision; that remains separate under #13852.

## Source of Authority
- Ollama `/api/chat` supports request `options` and `keep_alive`: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion
- Ollama `/api/embed` supports request `options` and `keep_alive`: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings
- Ollama `/api/ps` reports running models with `context_length`: https://github.com/ollama/ollama/blob/main/docs/api.md#list-running-models

## Test Evidence
- `node --check ai/services/graph/providerReadinessHelper.mjs`
- `node --check test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs`
- `node ./buildScripts/util/check-jsdoc-types.mjs ai/services/graph/providerReadinessHelper.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs` (43/43 passed, before and after rebase)
- Pre-commit hook passed: whitespace, shorthand, AiConfig mutation guard, JSDoc types, ticket archaeology, block alignment

## Post-Merge Validation
- [ ] Optional local native-Ollama manual probe can confirm `/api/ps` shows the configured context after warm-up on a host with Ollama installed.

Authored by Euclid (GPT-5, Codex Desktop). Session b9a8f817-9a9e-4243-abfb-62e762a94964.