### PR TITLE
fix(ai): supervise native Ollama serve lifecycle (#13867)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -634,6 +634,22 @@ class Config extends ConfigProvider {
                     port   : leaf('11435', 'NEO_ORCHESTRATOR_MLX_PORT', 'string')
                 },
                 /**
+                 * Orchestrator-owned native Ollama server config. Operators tune via gitignored
+                 * `ai/config.mjs` or env var `NEO_ORCHESTRATOR_OLLAMA_ENABLED`.
+                 *
+                 * - `enabled`: whether the orchestrator may supervise `ollama serve` for local-dev
+                 *   roles explicitly routed through the native `ollama` provider. The task is
+                 *   still omitted when no configured chat / embedding role targets `ollama`, so
+                 *   this default does not start Ollama for the standard OpenAI-compatible setup.
+                 *   When active, `OLLAMA_HOST`, `OLLAMA_KEEP_ALIVE`, `OLLAMA_CONTEXT_LENGTH`, and
+                 *   `OLLAMA_MAX_LOADED_MODELS` are derived from the canonical provider and
+                 *   local-model config leaves.
+                 * @type {Object}
+                 */
+                ollama: {
+                    enabled: leaf(true, 'NEO_ORCHESTRATOR_OLLAMA_ENABLED', 'boolean')
+                },
+                /**
                  * Orchestrator-owned LM Studio CLI (`lms`) inference server config. Operators
                  * tune via gitignored `ai/config.mjs` or env vars (`NEO_ORCHESTRATOR_LMS_ENABLED`,
                  * `NEO_ORCHESTRATOR_LMS_MODEL`, `NEO_ORCHESTRATOR_LMS_PORT`).

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -7,7 +7,10 @@ import Base                    from '../../../src/core/Base.mjs';
 import ClassSystemUtil         from '../../../src/util/ClassSystem.mjs';
 import AiConfig                from '../../config.mjs';
 import neuralLinkConfig        from '../../mcp/server/neural-link/config.mjs';
-import {buildLmsPreloadConfig} from '../../services/graph/providerReadinessHelper.mjs';
+import {
+    buildLmsPreloadConfig,
+    buildOllamaReadinessConfig
+} from '../../services/graph/providerReadinessHelper.mjs';
 import HealthService           from '../../services/memory-core/HealthService.mjs';
 import SQLite                  from '../../graph/storage/SQLite.mjs';
 import MaintenanceBackpressureService, {
@@ -345,8 +348,11 @@ export class Orchestrator extends Base {
 
     get mlxEnabled() { return !!AiConfig.orchestrator.mlx.enabled; }
     get lmsEnabled() { return !!AiConfig.orchestrator.lms.enabled; }
+    get ollamaEnabled() { return !!AiConfig.orchestrator.ollama?.enabled; }
     get lmsPreloadConfig() { return buildLmsPreloadConfig(AiConfig); }
     get lmsModels()        { return this.lmsPreloadConfig.models;      }
+    get ollamaReadinessConfig() { return buildOllamaReadinessConfig(AiConfig); }
+    get ollamaModels()          { return this.ollamaReadinessConfig.models;     }
 
     /** @summary Starts the orchestrator timer loop after the wrapper selects this process. */
     async start(options = {}) {
@@ -358,8 +364,9 @@ export class Orchestrator extends Base {
         const scriptDir = options.scriptDir || DEFAULT_SCRIPT_DIR;
         const dataDir   = options.dataDir   || DEFAULT_DATA_DIR;
 
-        this.dataDir           = dataDir;
-        const lmsPreloadConfig = this.lmsPreloadConfig;
+        this.dataDir                   = dataDir;
+        const lmsPreloadConfig         = this.lmsPreloadConfig;
+        const ollamaReadinessConfig    = this.ollamaReadinessConfig;
         this.taskDefinitions   = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
             nodeBin                          : options.nodeBin || process.argv[0],
@@ -378,6 +385,11 @@ export class Orchestrator extends Base {
             lmsPort                          : AiConfig.orchestrator.lms.port,
             lmsContextLengths                : lmsPreloadConfig.contextLengths,
             lmsParallels                     : lmsPreloadConfig.parallels,
+            ollamaEnabled                    : this.ollamaEnabled,
+            ollamaHost                       : ollamaReadinessConfig.host,
+            ollamaRoles                      : ollamaReadinessConfig.roles,
+            ollamaKeepAlive                  : ollamaReadinessConfig.keepAlive,
+            ollamaRequireParallelModels      : ollamaReadinessConfig.requireParallelModels,
             providerReadiness                : AiConfig.orchestrator.providerReadiness,
             graphLogCompactionVacuum         : AiConfig.orchestrator.graphLogCompaction.vacuum
         });
@@ -494,6 +506,7 @@ export class Orchestrator extends Base {
             ...(this.neuralLinkBridgeEnabled ? ['neuralLinkBridge'] : []),
             ...(this.embedDaemonEnabled  ? ['embedDaemon'] : []),
             'mlx',
+            'ollama',
             'lms'
         ];
         const RESTART_COOLDOWN_MS = 15000;

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -1,18 +1,18 @@
 // Class bootstrap belongs to `daemon.mjs`; this consumed class relies on global Neo.
-import fs                      from 'fs-extra';
-import {spawn}                 from 'child_process';
-import net                     from 'net';
-import path                    from 'path';
-import Base                    from '../../../src/core/Base.mjs';
-import ClassSystemUtil         from '../../../src/util/ClassSystem.mjs';
-import AiConfig                from '../../config.mjs';
-import neuralLinkConfig        from '../../mcp/server/neural-link/config.mjs';
+import fs               from 'fs-extra';
+import {spawn}          from 'child_process';
+import net              from 'net';
+import path             from 'path';
+import Base             from '../../../src/core/Base.mjs';
+import ClassSystemUtil  from '../../../src/util/ClassSystem.mjs';
+import AiConfig         from '../../config.mjs';
+import neuralLinkConfig from '../../mcp/server/neural-link/config.mjs';
 import {
     buildLmsPreloadConfig,
     buildOllamaReadinessConfig
 } from '../../services/graph/providerReadinessHelper.mjs';
-import HealthService           from '../../services/memory-core/HealthService.mjs';
-import SQLite                  from '../../graph/storage/SQLite.mjs';
+import HealthService from '../../services/memory-core/HealthService.mjs';
+import SQLite        from '../../graph/storage/SQLite.mjs';
 import MaintenanceBackpressureService, {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
     DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
@@ -46,6 +46,9 @@ import {
     DEFAULT_DB_PATH,
     DEFAULT_DATA_DIR,
     DEFAULT_SCRIPT_DIR,
+    buildOllamaServeEnv,
+    getMaxOllamaContextLength,
+    resolveOllamaHostPort,
     buildTaskDefinitions
 } from './taskDefinitions.mjs';
 
@@ -346,13 +349,219 @@ export class Orchestrator extends Base {
     get graphLogCompactionEnabled()      { return AiConfig.orchestrator.graphLogCompaction.enabled;      }
     get neuralLinkBridgeLivenessTimeoutMs() { return AiConfig.orchestrator.neuralLinkBridge.livenessProbeTimeoutMs; }
 
-    get mlxEnabled() { return !!AiConfig.orchestrator.mlx.enabled; }
-    get lmsEnabled() { return !!AiConfig.orchestrator.lms.enabled; }
-    get ollamaEnabled() { return !!AiConfig.orchestrator.ollama?.enabled; }
-    get lmsPreloadConfig() { return buildLmsPreloadConfig(AiConfig); }
-    get lmsModels()        { return this.lmsPreloadConfig.models;      }
-    get ollamaReadinessConfig() { return buildOllamaReadinessConfig(AiConfig); }
-    get ollamaModels()          { return this.ollamaReadinessConfig.models;     }
+    /**
+     * @summary Builds the supervised task table from the daemon entrypoint's config authorities.
+     * @param {Object} options
+     * @param {String} options.scriptDir Script directory.
+     * @param {String} options.nodeBin Node executable.
+     * @returns {Object}
+     */
+    buildConfiguredTaskDefinitions({scriptDir, nodeBin}) {
+        const tasks = buildTaskDefinitions({
+            scriptDir,
+            nodeBin,
+            chromaPort                       : AiConfig.engines.chroma.port,
+            devServerPort                    : AiConfig.orchestrator.devServer.port,
+            devServerLivenessTimeoutMs       : AiConfig.orchestrator.devServer.livenessProbeTimeoutMs,
+            neuralLinkBridgePort             : neuralLinkConfig.port,
+            neuralLinkBridgeLivenessTimeoutMs: this.neuralLinkBridgeLivenessTimeoutMs
+        });
+
+        this.applyConfiguredGraphLogCompaction(tasks);
+        this.applyConfiguredMlxTask(tasks, {scriptDir});
+        this.applyConfiguredLmsTask(tasks);
+        this.applyConfiguredOllamaTask(tasks);
+
+        return tasks;
+    }
+
+    /**
+     * @summary Applies the graph-log compaction flags owned by AiConfig.
+     * @param {Object} tasks Task table.
+     * @returns {void}
+     */
+    applyConfiguredGraphLogCompaction(tasks) {
+        if (AiConfig.orchestrator.graphLogCompaction.vacuum) {
+            tasks['graphlog-compaction'].args.push('--vacuum');
+        }
+    }
+
+    /**
+     * @summary Adds the orchestrator-owned MLX server task when enabled.
+     * @param {Object} tasks Task table.
+     * @param {Object} options
+     * @param {String} options.scriptDir Script directory.
+     * @returns {void}
+     */
+    applyConfiguredMlxTask(tasks, {scriptDir}) {
+        if (!AiConfig.orchestrator.mlx.enabled) {
+            return;
+        }
+
+        tasks.mlx = {
+            label  : 'mlx inference',
+            command: path.resolve(scriptDir, '../mcp/server/memory-core/.venv/bin/python'),
+            args   : [
+                '-m',
+                'mlx_lm.server',
+                '--model',
+                AiConfig.orchestrator.mlx.model,
+                '--port',
+                String(AiConfig.orchestrator.mlx.port)
+            ],
+            pidFileName    : 'mlx.pid',
+            expectedCommand: 'mlx_lm.server'
+        };
+    }
+
+    /**
+     * @summary Adds the orchestrator-owned LM Studio server task when enabled.
+     * @param {Object} tasks Task table.
+     * @returns {void}
+     */
+    applyConfiguredLmsTask(tasks) {
+        if (!AiConfig.orchestrator.lms.enabled) {
+            return;
+        }
+
+        const preloadConfig  = buildLmsPreloadConfig(AiConfig),
+              requiredModels = Array.isArray(preloadConfig.models)
+                  ? [...new Set(preloadConfig.models.filter(Boolean))]
+                  : [AiConfig.orchestrator.lms.model].filter(Boolean);
+
+        tasks.lms = {
+            label          : 'lms server (LM Studio CLI)',
+            command        : 'lms',
+            args           : ['server', 'start', '--port', String(AiConfig.orchestrator.lms.port)],
+            pidFileName    : 'lms.pid',
+            expectedCommand: 'lms server',
+            requiredModels,
+            // `lms server start` is fire-and-exit: it wakes the LM Studio service and returns, so
+            // the launched server never matches `expectedCommand` for the supervisor's
+            // process-liveness check (`!state.running` stays permanently true). Liveness is the
+            // HTTP endpoint instead — the supervisor gates the restart on this probe so a healthy
+            // server is a silent no-op rather than a re-spawn loop.
+            livenessProbe  : async () => {
+                const {fetchOpenAiCompatibleModelIds} = await import('../../services/graph/providerReadinessHelper.mjs');
+
+                try {
+                    await fetchOpenAiCompatibleModelIds({
+                        host     : AiConfig.openAiCompatible.host,
+                        timeoutMs: AiConfig.orchestrator.providerReadiness.timeoutMs ?? 2000
+                    });
+                    return true;
+                } catch {
+                    return false;
+                }
+            },
+            postSpawn      : async () => {
+                const {ensureLmsModelsLoaded} = await import('../../services/graph/providerReadinessHelper.mjs');
+
+                if (requiredModels.length === 0) {
+                    return {
+                        ready          : true,
+                        loadedModels   : [],
+                        requiredModels,
+                        availableModels: [],
+                        attempts       : 0,
+                        skipped        : true,
+                        reason         : 'no-openai-compatible-local-roles'
+                    };
+                }
+
+                return ensureLmsModelsLoaded({
+                    host          : AiConfig.openAiCompatible.host,
+                    models        : requiredModels,
+                    contextLengths: preloadConfig.contextLengths,
+                    parallels     : preloadConfig.parallels,
+                    allowPartial  : true,
+                    attempts      : AiConfig.orchestrator.providerReadiness.attempts,
+                    delayMs       : AiConfig.orchestrator.providerReadiness.delayMs,
+                    timeoutMs     : AiConfig.orchestrator.providerReadiness.timeoutMs
+                });
+            }
+        };
+    }
+
+    /**
+     * @summary Adds the orchestrator-owned native Ollama server task when enabled.
+     * @param {Object} tasks Task table.
+     * @returns {void}
+     */
+    applyConfiguredOllamaTask(tasks) {
+        if (!AiConfig.orchestrator.ollama.enabled) {
+            return;
+        }
+
+        const readinessConfig = buildOllamaReadinessConfig(AiConfig),
+              roles           = Array.isArray(readinessConfig.roles)
+                  ? readinessConfig.roles.filter(role => role.model)
+                  : [],
+              requiredModels  = [...new Set(roles.map(role => role.model))];
+
+        if (requiredModels.length === 0) {
+            return;
+        }
+
+        tasks.ollama = {
+            label                  : 'ollama server',
+            command                : 'ollama',
+            args                   : ['serve'],
+            pidFileName            : 'ollama.pid',
+            expectedCommand        : 'ollama serve',
+            requiredModels,
+            singletonPort          : resolveOllamaHostPort(readinessConfig.host),
+            duplicateListenerPolicy: 'defer',
+            env                    : buildOllamaServeEnv({
+                host                 : readinessConfig.host,
+                keepAlive            : readinessConfig.keepAlive,
+                contextLength        : getMaxOllamaContextLength(roles),
+                requireParallelModels: readinessConfig.requireParallelModels
+            }),
+            livenessProbe          : async () => {
+                const {ensureOllamaModelsReady} = await import('../../services/graph/providerReadinessHelper.mjs');
+
+                try {
+                    const result = await ensureOllamaModelsReady({
+                        host                 : readinessConfig.host,
+                        roles,
+                        keepAlive            : readinessConfig.keepAlive,
+                        requireParallelModels: readinessConfig.requireParallelModels,
+                        allowPartial         : true,
+                        attempts             : AiConfig.orchestrator.providerReadiness.attempts,
+                        delayMs              : AiConfig.orchestrator.providerReadiness.delayMs,
+                        timeoutMs            : AiConfig.orchestrator.providerReadiness.timeoutMs
+                    });
+
+                    if (
+                        result.error &&
+                        result.availableModels?.length === 0 &&
+                        result.attemptedModels?.length === 0
+                    ) {
+                        return false;
+                    }
+
+                    return true;
+                } catch {
+                    return false;
+                }
+            },
+            postSpawn              : async () => {
+                const {ensureOllamaModelsReady} = await import('../../services/graph/providerReadinessHelper.mjs');
+
+                return ensureOllamaModelsReady({
+                    host                 : readinessConfig.host,
+                    roles,
+                    keepAlive            : readinessConfig.keepAlive,
+                    requireParallelModels: readinessConfig.requireParallelModels,
+                    allowPartial         : true,
+                    attempts             : AiConfig.orchestrator.providerReadiness.attempts,
+                    delayMs              : AiConfig.orchestrator.providerReadiness.delayMs,
+                    timeoutMs            : AiConfig.orchestrator.providerReadiness.timeoutMs
+                });
+            }
+        };
+    }
 
     /** @summary Starts the orchestrator timer loop after the wrapper selects this process. */
     async start(options = {}) {
@@ -365,33 +574,9 @@ export class Orchestrator extends Base {
         const dataDir   = options.dataDir   || DEFAULT_DATA_DIR;
 
         this.dataDir                   = dataDir;
-        const lmsPreloadConfig         = this.lmsPreloadConfig;
-        const ollamaReadinessConfig    = this.ollamaReadinessConfig;
-        this.taskDefinitions   = options.taskDefinitions || buildTaskDefinitions({
+        this.taskDefinitions   = options.taskDefinitions || this.buildConfiguredTaskDefinitions({
             scriptDir,
-            nodeBin                          : options.nodeBin || process.argv[0],
-            chromaPort                       : AiConfig.engines.chroma.port,
-            devServerPort                    : AiConfig.orchestrator.devServer.port,
-            devServerLivenessTimeoutMs       : AiConfig.orchestrator.devServer.livenessProbeTimeoutMs,
-            neuralLinkBridgePort             : neuralLinkConfig.port,
-            neuralLinkBridgeLivenessTimeoutMs: this.neuralLinkBridgeLivenessTimeoutMs,
-            mlxEnabled                       : this.mlxEnabled,
-            mlxModel                         : AiConfig.orchestrator.mlx.model,
-            mlxPort                          : AiConfig.orchestrator.mlx.port,
-            lmsEnabled                       : this.lmsEnabled,
-            lmsModel                         : AiConfig.orchestrator.lms.model,
-            lmsModels                        : lmsPreloadConfig.models,
-            lmsHost                          : AiConfig.openAiCompatible.host,
-            lmsPort                          : AiConfig.orchestrator.lms.port,
-            lmsContextLengths                : lmsPreloadConfig.contextLengths,
-            lmsParallels                     : lmsPreloadConfig.parallels,
-            ollamaEnabled                    : this.ollamaEnabled,
-            ollamaHost                       : ollamaReadinessConfig.host,
-            ollamaRoles                      : ollamaReadinessConfig.roles,
-            ollamaKeepAlive                  : ollamaReadinessConfig.keepAlive,
-            ollamaRequireParallelModels      : ollamaReadinessConfig.requireParallelModels,
-            providerReadiness                : AiConfig.orchestrator.providerReadiness,
-            graphLogCompactionVacuum         : AiConfig.orchestrator.graphLogCompaction.vacuum
+            nodeBin: options.nodeBin || process.argv[0]
         });
 
         this.dbPath                    = options.dbPath   || DEFAULT_DB_PATH;

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -49,7 +49,7 @@ function probeTcpPort({port, timeoutMs}) {
  * @param {String} host Configured Ollama API host.
  * @returns {String|undefined}
  */
-function resolveOllamaHostEnv(host) {
+export function resolveOllamaHostEnv(host) {
     if (!host) {
         return undefined;
     }
@@ -66,7 +66,7 @@ function resolveOllamaHostEnv(host) {
  * @param {String} host Configured Ollama API host.
  * @returns {Number|undefined}
  */
-function resolveOllamaHostPort(host) {
+export function resolveOllamaHostPort(host) {
     const hostEnv = resolveOllamaHostEnv(host),
           match   = hostEnv?.match(/:(\d+)$/);
 
@@ -78,7 +78,7 @@ function resolveOllamaHostPort(host) {
  * @param {Object[]} roles Native Ollama readiness roles.
  * @returns {Number|undefined}
  */
-function getMaxOllamaContextLength(roles) {
+export function getMaxOllamaContextLength(roles) {
     const lengths = (Array.isArray(roles) ? roles : [])
         .map(role => Number(role?.contextLength))
         .filter(value => Number.isFinite(value) && value > 0);
@@ -95,7 +95,7 @@ function getMaxOllamaContextLength(roles) {
  * @param {Number} options.requireParallelModels Minimum resident-model count.
  * @returns {Object}
  */
-function buildOllamaServeEnv({host, keepAlive, contextLength, requireParallelModels}) {
+export function buildOllamaServeEnv({host, keepAlive, contextLength, requireParallelModels}) {
     const env     = {},
           hostEnv = resolveOllamaHostEnv(host);
 
@@ -118,14 +118,9 @@ function buildOllamaServeEnv({host, keepAlive, contextLength, requireParallelMod
 /**
  * @summary Builds child-process commands for orchestrator-owned maintenance tasks.
  *
- * Pure function: receives concrete `mlxEnabled` / `mlxModel` / `mlxPort` and
- * `lmsEnabled` / `lmsModel` / `lmsPort` / `ollamaEnabled` / `ollamaHost` values
- * from the caller; performs no env-var lookups and carries no embedded local-model
- * defaults. The canonical defaults live in `ai/config.template.mjs` under
- * `orchestrator.mlx`, `orchestrator.lms`, and `orchestrator.ollama`;
- * `Orchestrator` exposes them via env-overrideable getters
- * (`mlxEnabled`/`mlxModel`/`mlxPort`/`lmsEnabled`/`lmsModel`/`lmsPort`/
- * `ollamaEnabled`) and forwards the resolved values via `Orchestrator.start()`.
+ * Pure function: performs no env-var lookups and carries no embedded local-model
+ * defaults. Config-backed local inference tasks are composed by `Orchestrator`, which
+ * is the daemon entrypoint that may read the reactive AiConfig Provider SSOT.
  *
  * The orchestrator intentionally shells out to existing manual maintenance scripts for
  * Piece C instead of reimplementing their internals. This keeps orchestration separate
@@ -140,23 +135,6 @@ function buildOllamaServeEnv({host, keepAlive, contextLength, requireParallelMod
  * @param {Number} [options.devServerLivenessTimeoutMs] TCP liveness probe timeout.
  * @param {String|Number} [options.neuralLinkBridgePort] Neural Link Bridge port — sourced from the Neural Link config provider by the orchestrator entrypoint.
  * @param {Number} [options.neuralLinkBridgeLivenessTimeoutMs] TCP liveness probe timeout.
- * @param {Boolean} [options.mlxEnabled=false] Whether to launch an orchestrator-owned mlx_lm.server.
- * @param {String} [options.mlxModel] MLX launch model: a Hugging Face repo id or local path.
- * @param {String|Number} [options.mlxPort] MLX OpenAI-compatible local inference port.
- * @param {Boolean} [options.lmsEnabled=false] Whether to launch an orchestrator-owned LM Studio CLI server.
- * @param {String} [options.lmsModel] Legacy single LM Studio model identifier.
- * @param {String[]} [options.lmsModels] LM Studio model identifiers that must be resident after spawn.
- * @param {String} [options.lmsHost] OpenAI-compatible host exposed by the LM Studio server.
- * @param {String|Number} [options.lmsPort] LM Studio OpenAI-compatible local inference port (CLI default `1234`).
- * @param {Object} [options.lmsContextLengths] Per-model `--context-length` override map keyed by model id (chat + embedding from `aiConfig.localModels.{chat,embedding}.contextLimitTokens`).
- * @param {Object} [options.lmsParallels] Per-model `--parallel` slot-count override map keyed by model id (chat-only, from `aiConfig.localModels.chat.parallel`).
- * @param {Boolean} [options.ollamaEnabled=false] Whether to launch an orchestrator-owned native Ollama server.
- * @param {String} [options.ollamaHost] Native Ollama API host; also translated to `OLLAMA_HOST` for `ollama serve`.
- * @param {Object[]} [options.ollamaRoles] Native Ollama readiness roles from `buildOllamaReadinessConfig()`.
- * @param {String|Number} [options.ollamaKeepAlive] Ollama keep-alive policy.
- * @param {Number} [options.ollamaRequireParallelModels] Minimum resident-model count for native Ollama.
- * @param {Object} [options.providerReadiness] Provider-readiness retry / timeout config.
- * @param {Boolean} [options.graphLogCompactionVacuum] Whether scheduled GraphLog compaction also runs SQLite VACUUM.
  * @returns {Object}
  */
 export function buildTaskDefinitions({
@@ -166,24 +144,7 @@ export function buildTaskDefinitions({
     devServerPort,
     devServerLivenessTimeoutMs,
     neuralLinkBridgePort,
-    neuralLinkBridgeLivenessTimeoutMs,
-    mlxEnabled = false,
-    mlxModel,
-    mlxPort,
-    lmsEnabled = false,
-    lmsModel,
-    lmsModels,
-    lmsHost,
-    lmsPort,
-    lmsContextLengths,
-    lmsParallels,
-    ollamaEnabled = false,
-    ollamaHost,
-    ollamaRoles,
-    ollamaKeepAlive,
-    ollamaRequireParallelModels,
-    providerReadiness,
-    graphLogCompactionVacuum
+    neuralLinkBridgeLivenessTimeoutMs
 } = {}) {
     const hasDevServerPort = devServerPort !== undefined && devServerPort !== null;
     const hasNeuralLinkBridgePort = neuralLinkBridgePort !== undefined && neuralLinkBridgePort !== null;
@@ -301,8 +262,7 @@ export function buildTaskDefinitions({
             command: nodeBin,
             args   : [
                 path.join(scriptDir, 'maintenance', 'compactGraphLog.mjs'),
-                '--apply',
-                ...(graphLogCompactionVacuum ? ['--vacuum'] : [])
+                '--apply'
             ],
             pidFileName    : 'graphlog-compaction.pid',
             expectedCommand: 'compactGraphLog.mjs'
@@ -370,140 +330,6 @@ export function buildTaskDefinitions({
             serviceTask    : true
         }
     };
-
-    if (mlxEnabled) {
-        tasks.mlx = {
-            label          : 'mlx inference',
-            command        : path.resolve(scriptDir, '../mcp/server/memory-core/.venv/bin/python'),
-            args           : ['-m', 'mlx_lm.server', '--model', mlxModel, '--port', String(mlxPort)],
-            pidFileName    : 'mlx.pid',
-            expectedCommand: 'mlx_lm.server'
-        };
-    }
-
-    if (lmsEnabled) {
-        const requiredModels = Array.isArray(lmsModels)
-            ? [...new Set(lmsModels.filter(Boolean))]
-            : [lmsModel].filter(Boolean);
-
-        tasks.lms = {
-            label          : 'lms server (LM Studio CLI)',
-            command        : 'lms',
-            args           : ['server', 'start', '--port', String(lmsPort)],
-            pidFileName    : 'lms.pid',
-            expectedCommand: 'lms server',
-            requiredModels,
-            // `lms server start` is fire-and-exit: it wakes the LM Studio service and returns, so
-            // the launched server never matches `expectedCommand` for the supervisor's
-            // process-liveness check (`!state.running` stays permanently true). Liveness is the
-            // HTTP endpoint instead — the supervisor gates the restart on this probe so a healthy
-            // server is a silent no-op rather than a re-spawn loop.
-            livenessProbe  : async () => {
-                const {fetchOpenAiCompatibleModelIds} = await import('../../services/graph/providerReadinessHelper.mjs');
-
-                try {
-                    await fetchOpenAiCompatibleModelIds({host: lmsHost, timeoutMs: providerReadiness?.timeoutMs ?? 2000});
-                    return true;
-                } catch {
-                    return false;
-                }
-            },
-            postSpawn      : async () => {
-                const {ensureLmsModelsLoaded} = await import('../../services/graph/providerReadinessHelper.mjs');
-
-                if (requiredModels.length === 0) {
-                    return {
-                        ready          : true,
-                        loadedModels   : [],
-                        requiredModels,
-                        availableModels: [],
-                        attempts       : 0,
-                        skipped        : true,
-                        reason         : 'no-openai-compatible-local-roles'
-                    };
-                }
-
-                return ensureLmsModelsLoaded({
-                    host          : lmsHost,
-                    models        : requiredModels,
-                    contextLengths: lmsContextLengths,
-                    parallels     : lmsParallels,
-                    allowPartial  : true,
-                    attempts      : providerReadiness?.attempts,
-                    delayMs       : providerReadiness?.delayMs,
-                    timeoutMs     : providerReadiness?.timeoutMs
-                });
-            }
-        };
-    }
-
-    if (ollamaEnabled) {
-        const roles          = Array.isArray(ollamaRoles) ? ollamaRoles.filter(role => role?.model) : [],
-              requiredModels = [...new Set(roles.map(role => role.model))];
-
-        if (requiredModels.length) {
-            const contextLength = getMaxOllamaContextLength(roles);
-
-            tasks.ollama = {
-                label                  : 'ollama server',
-                command                : 'ollama',
-                args                   : ['serve'],
-                pidFileName            : 'ollama.pid',
-                expectedCommand        : 'ollama serve',
-                requiredModels,
-                singletonPort          : resolveOllamaHostPort(ollamaHost),
-                duplicateListenerPolicy: 'defer',
-                env                    : buildOllamaServeEnv({
-                    host                 : ollamaHost,
-                    keepAlive            : ollamaKeepAlive,
-                    contextLength,
-                    requireParallelModels: ollamaRequireParallelModels
-                }),
-                livenessProbe          : async () => {
-                    const {ensureOllamaModelsReady} = await import('../../services/graph/providerReadinessHelper.mjs');
-
-                    try {
-                        const result = await ensureOllamaModelsReady({
-                            host                 : ollamaHost,
-                            roles,
-                            keepAlive            : ollamaKeepAlive,
-                            requireParallelModels: ollamaRequireParallelModels,
-                            allowPartial         : true,
-                            attempts             : providerReadiness?.attempts,
-                            delayMs              : providerReadiness?.delayMs,
-                            timeoutMs            : providerReadiness?.timeoutMs
-                        });
-
-                        if (
-                            result.error &&
-                            result.availableModels?.length === 0 &&
-                            result.attemptedModels?.length === 0
-                        ) {
-                            return false;
-                        }
-
-                        return true;
-                    } catch {
-                        return false;
-                    }
-                },
-                postSpawn              : async () => {
-                    const {ensureOllamaModelsReady} = await import('../../services/graph/providerReadinessHelper.mjs');
-
-                    return ensureOllamaModelsReady({
-                        host                 : ollamaHost,
-                        roles,
-                        keepAlive            : ollamaKeepAlive,
-                        requireParallelModels: ollamaRequireParallelModels,
-                        allowPartial         : true,
-                        attempts             : providerReadiness?.attempts,
-                        delayMs              : providerReadiness?.delayMs,
-                        timeoutMs            : providerReadiness?.timeoutMs
-                    });
-                }
-            };
-        }
-    }
 
     return tasks;
 }

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -45,15 +45,87 @@ function probeTcpPort({port, timeoutMs}) {
 }
 
 /**
+ * @summary Converts an Ollama API host URL into the `OLLAMA_HOST` bind value.
+ * @param {String} host Configured Ollama API host.
+ * @returns {String|undefined}
+ */
+function resolveOllamaHostEnv(host) {
+    if (!host) {
+        return undefined;
+    }
+
+    try {
+        return new URL(host).host || undefined;
+    } catch {
+        return String(host).replace(/^https?:\/\//, '').replace(/\/.*$/, '') || undefined;
+    }
+}
+
+/**
+ * @summary Extracts a numeric port from an Ollama host config.
+ * @param {String} host Configured Ollama API host.
+ * @returns {Number|undefined}
+ */
+function resolveOllamaHostPort(host) {
+    const hostEnv = resolveOllamaHostEnv(host),
+          match   = hostEnv?.match(/:(\d+)$/);
+
+    return match ? Number(match[1]) : undefined;
+}
+
+/**
+ * @summary Computes the largest requested Ollama role context window.
+ * @param {Object[]} roles Native Ollama readiness roles.
+ * @returns {Number|undefined}
+ */
+function getMaxOllamaContextLength(roles) {
+    const lengths = (Array.isArray(roles) ? roles : [])
+        .map(role => Number(role?.contextLength))
+        .filter(value => Number.isFinite(value) && value > 0);
+
+    return lengths.length ? Math.max(...lengths) : undefined;
+}
+
+/**
+ * @summary Builds the server environment for orchestrator-owned `ollama serve`.
+ * @param {Object} options
+ * @param {String} options.host Configured Ollama API host.
+ * @param {String|Number} options.keepAlive Ollama keep-alive policy.
+ * @param {Number} options.contextLength Largest configured local-model context.
+ * @param {Number} options.requireParallelModels Minimum resident-model count.
+ * @returns {Object}
+ */
+function buildOllamaServeEnv({host, keepAlive, contextLength, requireParallelModels}) {
+    const env     = {},
+          hostEnv = resolveOllamaHostEnv(host);
+
+    if (hostEnv) {
+        env.OLLAMA_HOST = hostEnv;
+    }
+    if (keepAlive !== undefined && keepAlive !== null && keepAlive !== '') {
+        env.OLLAMA_KEEP_ALIVE = String(keepAlive);
+    }
+    if (Number.isFinite(Number(contextLength)) && Number(contextLength) > 0) {
+        env.OLLAMA_CONTEXT_LENGTH = String(Number(contextLength));
+    }
+    if (Number.isFinite(Number(requireParallelModels)) && Number(requireParallelModels) > 0) {
+        env.OLLAMA_MAX_LOADED_MODELS = String(Number(requireParallelModels));
+    }
+
+    return env;
+}
+
+/**
  * @summary Builds child-process commands for orchestrator-owned maintenance tasks.
  *
  * Pure function: receives concrete `mlxEnabled` / `mlxModel` / `mlxPort` and
- * `lmsEnabled` / `lmsModel` / `lmsPort` values from the caller; performs no env-var
- * lookups and carries no embedded MLX or LM Studio defaults. The canonical defaults
- * live in `ai/config.template.mjs` under `orchestrator.mlx` and `orchestrator.lms`;
+ * `lmsEnabled` / `lmsModel` / `lmsPort` / `ollamaEnabled` / `ollamaHost` values
+ * from the caller; performs no env-var lookups and carries no embedded local-model
+ * defaults. The canonical defaults live in `ai/config.template.mjs` under
+ * `orchestrator.mlx`, `orchestrator.lms`, and `orchestrator.ollama`;
  * `Orchestrator` exposes them via env-overrideable getters
- * (`mlxEnabled`/`mlxModel`/`mlxPort`/`lmsEnabled`/`lmsModel`/`lmsPort`) and forwards
- * the resolved values via `Orchestrator.start()`.
+ * (`mlxEnabled`/`mlxModel`/`mlxPort`/`lmsEnabled`/`lmsModel`/`lmsPort`/
+ * `ollamaEnabled`) and forwards the resolved values via `Orchestrator.start()`.
  *
  * The orchestrator intentionally shells out to existing manual maintenance scripts for
  * Piece C instead of reimplementing their internals. This keeps orchestration separate
@@ -78,6 +150,11 @@ function probeTcpPort({port, timeoutMs}) {
  * @param {String|Number} [options.lmsPort] LM Studio OpenAI-compatible local inference port (CLI default `1234`).
  * @param {Object} [options.lmsContextLengths] Per-model `--context-length` override map keyed by model id (chat + embedding from `aiConfig.localModels.{chat,embedding}.contextLimitTokens`).
  * @param {Object} [options.lmsParallels] Per-model `--parallel` slot-count override map keyed by model id (chat-only, from `aiConfig.localModels.chat.parallel`).
+ * @param {Boolean} [options.ollamaEnabled=false] Whether to launch an orchestrator-owned native Ollama server.
+ * @param {String} [options.ollamaHost] Native Ollama API host; also translated to `OLLAMA_HOST` for `ollama serve`.
+ * @param {Object[]} [options.ollamaRoles] Native Ollama readiness roles from `buildOllamaReadinessConfig()`.
+ * @param {String|Number} [options.ollamaKeepAlive] Ollama keep-alive policy.
+ * @param {Number} [options.ollamaRequireParallelModels] Minimum resident-model count for native Ollama.
  * @param {Object} [options.providerReadiness] Provider-readiness retry / timeout config.
  * @param {Boolean} [options.graphLogCompactionVacuum] Whether scheduled GraphLog compaction also runs SQLite VACUUM.
  * @returns {Object}
@@ -100,6 +177,11 @@ export function buildTaskDefinitions({
     lmsPort,
     lmsContextLengths,
     lmsParallels,
+    ollamaEnabled = false,
+    ollamaHost,
+    ollamaRoles,
+    ollamaKeepAlive,
+    ollamaRequireParallelModels,
     providerReadiness,
     graphLogCompactionVacuum
 } = {}) {
@@ -353,6 +435,74 @@ export function buildTaskDefinitions({
                 });
             }
         };
+    }
+
+    if (ollamaEnabled) {
+        const roles          = Array.isArray(ollamaRoles) ? ollamaRoles.filter(role => role?.model) : [],
+              requiredModels = [...new Set(roles.map(role => role.model))];
+
+        if (requiredModels.length) {
+            const contextLength = getMaxOllamaContextLength(roles);
+
+            tasks.ollama = {
+                label                  : 'ollama server',
+                command                : 'ollama',
+                args                   : ['serve'],
+                pidFileName            : 'ollama.pid',
+                expectedCommand        : 'ollama serve',
+                requiredModels,
+                singletonPort          : resolveOllamaHostPort(ollamaHost),
+                duplicateListenerPolicy: 'defer',
+                env                    : buildOllamaServeEnv({
+                    host                 : ollamaHost,
+                    keepAlive            : ollamaKeepAlive,
+                    contextLength,
+                    requireParallelModels: ollamaRequireParallelModels
+                }),
+                livenessProbe          : async () => {
+                    const {ensureOllamaModelsReady} = await import('../../services/graph/providerReadinessHelper.mjs');
+
+                    try {
+                        const result = await ensureOllamaModelsReady({
+                            host                 : ollamaHost,
+                            roles,
+                            keepAlive            : ollamaKeepAlive,
+                            requireParallelModels: ollamaRequireParallelModels,
+                            allowPartial         : true,
+                            attempts             : providerReadiness?.attempts,
+                            delayMs              : providerReadiness?.delayMs,
+                            timeoutMs            : providerReadiness?.timeoutMs
+                        });
+
+                        if (
+                            result.error &&
+                            result.availableModels?.length === 0 &&
+                            result.attemptedModels?.length === 0
+                        ) {
+                            return false;
+                        }
+
+                        return true;
+                    } catch {
+                        return false;
+                    }
+                },
+                postSpawn              : async () => {
+                    const {ensureOllamaModelsReady} = await import('../../services/graph/providerReadinessHelper.mjs');
+
+                    return ensureOllamaModelsReady({
+                        host                 : ollamaHost,
+                        roles,
+                        keepAlive            : ollamaKeepAlive,
+                        requireParallelModels: ollamaRequireParallelModels,
+                        allowPartial         : true,
+                        attempts             : providerReadiness?.attempts,
+                        delayMs              : providerReadiness?.delayMs,
+                        timeoutMs            : providerReadiness?.timeoutMs
+                    });
+                }
+            };
+        }
     }
 
     return tasks;

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -76,7 +76,7 @@ test.describe('Tier 1 Config Immutability', () => {
         });
         expect(Config.openAiCompatible).toMatchObject({
             host                   : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-            model                  : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+            model                  : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'google/gemma-4-26b-a4b',
             embeddingModel         : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
             apiKey                 : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
             unloadRetryCount       : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
@@ -192,6 +192,13 @@ test.describe('Tier 1 Config Immutability', () => {
             delayMs  : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS)   || 1000,
             timeoutMs: Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS) || 3000
         });
+        const ollamaEnabledEnv = process.env.NEO_ORCHESTRATOR_OLLAMA_ENABLED?.trim().toLowerCase();
+        const ollamaDisabled   = ['false', 'no', 'off', '0'].includes(ollamaEnabledEnv);
+
+        expect(Config.orchestrator.ollama).toEqual({
+            enabled: ollamaEnabledEnv === undefined ? true : !ollamaDisabled
+        });
+
         const lmsEnabledEnv = process.env.NEO_ORCHESTRATOR_LMS_ENABLED?.trim().toLowerCase();
         const lmsDisabled   = ['false', 'no', 'off', '0'].includes(lmsEnabledEnv);
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -8,7 +8,10 @@ import AiConfig        from '../../../../../../ai/config.mjs';
 import {
     Orchestrator
 } from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
-import {buildLmsPreloadConfig} from '../../../../../../ai/services/graph/providerReadinessHelper.mjs';
+import {
+    buildLmsPreloadConfig,
+    buildOllamaReadinessConfig
+} from '../../../../../../ai/services/graph/providerReadinessHelper.mjs';
 import {
     buildTaskDefinitions
 } from '../../../../../../ai/daemons/orchestrator/taskDefinitions.mjs';
@@ -35,6 +38,8 @@ let savedCloudOnly       = null;
 let savedDeploymentMode  = null;
 let savedMlxConfig                   = undefined;
 let savedLmsConfig                   = undefined;
+let savedOrchestratorOllamaConfig    = undefined;
+let savedProviderOllamaConfig        = undefined;
 let savedOpenAiCompatibleConfig      = undefined;
 let savedChatProvider                = undefined;
 let savedModelProvider               = undefined;
@@ -51,6 +56,7 @@ let savedEnvMlxPort                  = undefined;
 let savedEnvLmsEnabled               = undefined;
 let savedEnvLmsModel                 = undefined;
 let savedEnvLmsPort                  = undefined;
+let savedEnvOllamaEnabled            = undefined;
 
 function createMinimalOrchestrator() {
     const taskDefinitions = buildTaskDefinitions({
@@ -84,6 +90,8 @@ test.beforeEach(() => {
     savedDeploymentMode = AiConfig.orchestrator.deploymentMode;
     savedMlxConfig      = AiConfig.orchestrator.mlx ? {...AiConfig.orchestrator.mlx} : undefined;
     savedLmsConfig      = AiConfig.orchestrator.lms ? {...AiConfig.orchestrator.lms} : undefined;
+    savedOrchestratorOllamaConfig = AiConfig.orchestrator.ollama ? {...AiConfig.orchestrator.ollama} : undefined;
+    savedProviderOllamaConfig     = AiConfig.ollama ? {...AiConfig.ollama} : undefined;
     savedOpenAiCompatibleConfig = AiConfig.openAiCompatible ? {...AiConfig.openAiCompatible} : undefined;
     savedChatProvider           = AiConfig.chatProvider;
     savedModelProvider          = AiConfig.modelProvider;
@@ -101,6 +109,7 @@ test.beforeEach(() => {
     savedEnvLmsEnabled             = process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
     savedEnvLmsModel               = process.env.NEO_ORCHESTRATOR_LMS_MODEL;
     savedEnvLmsPort                = process.env.NEO_ORCHESTRATOR_LMS_PORT;
+    savedEnvOllamaEnabled          = process.env.NEO_ORCHESTRATOR_OLLAMA_ENABLED;
 });
 
 test.afterEach(() => {
@@ -111,15 +120,23 @@ test.afterEach(() => {
     }
     AiConfig.orchestrator.deploymentMode = savedDeploymentMode;
 
-    // Restore the full mlx/lms objects (overwrites every leaf on the still-healthy parent).
-    // These leaves are data-seeded and always present on the singleton, so
-    // there is no `delete`-to-absent branch — the verbatim tests above only swap object
-    // values, never null the parent.
+    // Restore full supervised-server config objects. Stale local overlays may not yet carry
+    // `orchestrator.ollama`, so keep its absent-state distinct from mlx/lms.
     if (savedMlxConfig !== undefined) {
         AiConfig.orchestrator.mlx = savedMlxConfig;
     }
     if (savedLmsConfig !== undefined) {
         AiConfig.orchestrator.lms = savedLmsConfig;
+    }
+    if (savedOrchestratorOllamaConfig === undefined) {
+        delete AiConfig.orchestrator.ollama;
+    } else {
+        AiConfig.orchestrator.ollama = savedOrchestratorOllamaConfig;
+    }
+    if (savedProviderOllamaConfig === undefined) {
+        delete AiConfig.ollama;
+    } else {
+        AiConfig.ollama = savedProviderOllamaConfig;
     }
     if (savedOpenAiCompatibleConfig === undefined) {
         delete AiConfig.openAiCompatible;
@@ -142,6 +159,7 @@ test.afterEach(() => {
     restoreEnv('NEO_ORCHESTRATOR_LMS_ENABLED',               savedEnvLmsEnabled);
     restoreEnv('NEO_ORCHESTRATOR_LMS_MODEL',                 savedEnvLmsModel);
     restoreEnv('NEO_ORCHESTRATOR_LMS_PORT',                  savedEnvLmsPort);
+    restoreEnv('NEO_ORCHESTRATOR_OLLAMA_ENABLED',            savedEnvOllamaEnabled);
 });
 
 function restoreEnv(name, prior) {
@@ -209,8 +227,8 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
         expect(AiConfig.orchestrator.localOnly.kbSyncEnabled).toBe(!baselineLocalKbs);
     });
 
-    // === mlx + lms supervised-server lane getters ===
-    // AiConfig.orchestrator.mlx + .lms + the 6 NEO_ORCHESTRATOR_{MLX,LMS}_{ENABLED,MODEL,PORT}
+    // === mlx + lms + ollama supervised-server lane getters ===
+    // AiConfig.orchestrator.mlx/.lms/.ollama + NEO_ORCHESTRATOR_* env vars
     // env vars are saved/restored by the file-level beforeEach/afterEach hooks above —
     // individual tests can mutate freely without leak risk.
 
@@ -245,6 +263,34 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
 
         AiConfig.orchestrator.lms = {enabled: false, model: 'qwen', port: '1234'};
         expect(createMinimalOrchestrator().lmsEnabled).toBe(false);
+    });
+
+    test('ollamaEnabled coerces to boolean + ollamaModels follow native provider role selectors (host/env inlined at call sites)', () => {
+        AiConfig.orchestrator.ollama = {enabled: true};
+        AiConfig.ollama = {
+            host                 : 'http://127.0.0.1:11434',
+            model                : 'ollama-chat-from-config',
+            embeddingModel       : 'ollama-embedding-from-config',
+            keep_alive           : -1,
+            requireParallelModels: 2
+        };
+        AiConfig.modelProvider     = 'gemini';
+        AiConfig.graphProvider     = 'ollama';
+        AiConfig.embeddingProvider = 'ollama';
+
+        const o = createMinimalOrchestrator();
+        expect(o.ollamaEnabled).toBe(true);
+        expect(o.ollamaModels).toEqual(['ollama-chat-from-config', 'ollama-embedding-from-config']);
+        expect(o.ollamaReadinessConfig).toMatchObject(buildOllamaReadinessConfig(AiConfig));
+
+        AiConfig.embeddingProvider = 'gemini';
+        expect(createMinimalOrchestrator().ollamaModels).toEqual(['ollama-chat-from-config']);
+
+        AiConfig.graphProvider = 'openAiCompatible';
+        expect(createMinimalOrchestrator().ollamaModels).toEqual([]);
+
+        AiConfig.orchestrator.ollama = {enabled: false};
+        expect(createMinimalOrchestrator().ollamaEnabled).toBe(false);
     });
 
     test('buildLmsPreloadConfig only reads provider-role selectors, not non-null model leaves (#12264)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -9,8 +9,7 @@ import {
     Orchestrator
 } from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
 import {
-    buildLmsPreloadConfig,
-    buildOllamaReadinessConfig
+    buildLmsPreloadConfig
 } from '../../../../../../ai/services/graph/providerReadinessHelper.mjs';
 import {
     buildTaskDefinitions
@@ -227,20 +226,36 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
         expect(AiConfig.orchestrator.localOnly.kbSyncEnabled).toBe(!baselineLocalKbs);
     });
 
-    // === mlx + lms + ollama supervised-server lane getters ===
+    // === mlx + lms + ollama supervised-server task composition ===
     // AiConfig.orchestrator.mlx/.lms/.ollama + NEO_ORCHESTRATOR_* env vars
     // env vars are saved/restored by the file-level beforeEach/afterEach hooks above —
     // individual tests can mutate freely without leak risk.
 
-    test('mlxEnabled getter coerces AiConfig.orchestrator.mlx.enabled to boolean (model/port are inlined at call sites)', () => {
+    test('buildConfiguredTaskDefinitions reads AiConfig.orchestrator.mlx at the daemon use site', () => {
         AiConfig.orchestrator.mlx = {enabled: true, model: 'mlx-from-config', port: '11999'};
-        expect(createMinimalOrchestrator().mlxEnabled).toBe(true);
+        const enabledTasks = createMinimalOrchestrator().buildConfiguredTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        });
+
+        expect(enabledTasks.mlx.args).toEqual([
+            '-m',
+            'mlx_lm.server',
+            '--model',
+            'mlx-from-config',
+            '--port',
+            '11999'
+        ]);
 
         AiConfig.orchestrator.mlx = {enabled: false, model: 'm', port: '11435'};
-        expect(createMinimalOrchestrator().mlxEnabled).toBe(false);
+        const disabledTasks = createMinimalOrchestrator().buildConfiguredTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        });
+        expect(disabledTasks.mlx).toBeUndefined();
     });
 
-    test('lmsEnabled coerces to boolean + lmsModels follow state-provider role selectors (model/port/host inlined at call sites)', () => {
+    test('buildConfiguredTaskDefinitions composes LMS from AiConfig provider-role selectors', () => {
         AiConfig.orchestrator.lms = {enabled: true, model: 'lms-from-config', port: '4242'};
         AiConfig.openAiCompatible = {
             host          : 'http://127.0.0.1:4242',
@@ -252,20 +267,35 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
         AiConfig.embeddingProvider = 'openAiCompatible';
 
         const o = createMinimalOrchestrator();
-        expect(o.lmsEnabled).toBe(true);
-        expect(o.lmsModels).toEqual(['chat-from-config', 'embedding-from-config']);
+        expect(o.buildConfiguredTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        }).lms).toMatchObject({
+            command       : 'lms',
+            args          : ['server', 'start', '--port', '4242'],
+            requiredModels: ['chat-from-config', 'embedding-from-config']
+        });
 
         AiConfig.embeddingProvider = 'gemini';
-        expect(createMinimalOrchestrator().lmsModels).toEqual(['chat-from-config']);
+        expect(createMinimalOrchestrator().buildConfiguredTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        }).lms.requiredModels).toEqual(['chat-from-config']);
 
         AiConfig.graphProvider = 'ollama';
-        expect(createMinimalOrchestrator().lmsModels).toEqual([]);
+        expect(createMinimalOrchestrator().buildConfiguredTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        }).lms.requiredModels).toEqual([]);
 
         AiConfig.orchestrator.lms = {enabled: false, model: 'qwen', port: '1234'};
-        expect(createMinimalOrchestrator().lmsEnabled).toBe(false);
+        expect(createMinimalOrchestrator().buildConfiguredTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        }).lms).toBeUndefined();
     });
 
-    test('ollamaEnabled coerces to boolean + ollamaModels follow native provider role selectors (host/env inlined at call sites)', () => {
+    test('buildConfiguredTaskDefinitions composes native Ollama from AiConfig provider-role selectors', () => {
         AiConfig.orchestrator.ollama = {enabled: true};
         AiConfig.ollama = {
             host                 : 'http://127.0.0.1:11434',
@@ -279,18 +309,38 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
         AiConfig.embeddingProvider = 'ollama';
 
         const o = createMinimalOrchestrator();
-        expect(o.ollamaEnabled).toBe(true);
-        expect(o.ollamaModels).toEqual(['ollama-chat-from-config', 'ollama-embedding-from-config']);
-        expect(o.ollamaReadinessConfig).toMatchObject(buildOllamaReadinessConfig(AiConfig));
+        expect(o.buildConfiguredTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        }).ollama).toMatchObject({
+            command       : 'ollama',
+            args          : ['serve'],
+            requiredModels: ['ollama-chat-from-config', 'ollama-embedding-from-config'],
+            singletonPort : 11434,
+            env           : {
+                OLLAMA_HOST             : '127.0.0.1:11434',
+                OLLAMA_KEEP_ALIVE       : '-1',
+                OLLAMA_MAX_LOADED_MODELS: '2'
+            }
+        });
 
         AiConfig.embeddingProvider = 'gemini';
-        expect(createMinimalOrchestrator().ollamaModels).toEqual(['ollama-chat-from-config']);
+        expect(createMinimalOrchestrator().buildConfiguredTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        }).ollama.requiredModels).toEqual(['ollama-chat-from-config']);
 
         AiConfig.graphProvider = 'openAiCompatible';
-        expect(createMinimalOrchestrator().ollamaModels).toEqual([]);
+        expect(createMinimalOrchestrator().buildConfiguredTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        }).ollama).toBeUndefined();
 
         AiConfig.orchestrator.ollama = {enabled: false};
-        expect(createMinimalOrchestrator().ollamaEnabled).toBe(false);
+        expect(createMinimalOrchestrator().buildConfiguredTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        }).ollama).toBeUndefined();
     });
 
     test('buildLmsPreloadConfig only reads provider-role selectors, not non-null model leaves (#12264)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -57,7 +57,7 @@ function createTestOrchestrator(config = {}) {
         writeLogFn: () => {}
     });
     TaskStateService.taskState = createInitialTaskState(taskDefinitions);
-    ['chroma', 'bridgeDaemon', 'devServer', 'neuralLinkBridge', 'mlx', 'lms'].forEach(name => {
+    ['chroma', 'bridgeDaemon', 'devServer', 'neuralLinkBridge', 'mlx', 'ollama', 'lms'].forEach(name => {
         if (TaskStateService.taskState[name]) {
             TaskStateService.taskState[name].running = true;
         }

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -44,8 +44,7 @@ function createTestOrchestrator(config = {}) {
         devServerPort                    : config.devServerPort ?? TEST_DEV_SERVER_PORT,
         devServerLivenessTimeoutMs       : config.devServerLivenessTimeoutMs ?? 50,
         neuralLinkBridgePort             : config.neuralLinkBridgePort ?? TEST_NEURAL_LINK_BRIDGE_PORT,
-        neuralLinkBridgeLivenessTimeoutMs: config.neuralLinkBridgeLivenessTimeoutMs ?? 50,
-        graphLogCompactionVacuum         : config.graphLogCompactionVacuum ?? false
+        neuralLinkBridgeLivenessTimeoutMs: config.neuralLinkBridgeLivenessTimeoutMs ?? 50
     });
 
     const heavyMaintenanceLeasePath = config.heavyMaintenanceLeasePath
@@ -764,45 +763,76 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('supervises lms via the supervisor HTTP liveness probe — (re)start only when the endpoint is down (#12262 / #12090)', async () => {
-        const taskDefinitions = buildTaskDefinitions({
-            scriptDir        : path.resolve(process.cwd(), 'ai/scripts'),
-            nodeBin          : process.argv[0],
-            lmsEnabled       : true,
-            lmsModels        : ['chat-model', 'embedding-model'],
-            lmsHost          : 'http://127.0.0.1:1234',
-            lmsPort          : 1234,
-            providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50}
-        });
-        // `lms server start` is fire-and-exit, so liveness is the HTTP endpoint, not the launcher
-        // child. Stub the probe for determinism (no real :1234) and drive both branches.
-        let probeUp = false;
-        taskDefinitions.lms.livenessProbe = async () => probeUp;
-
-        const orchestrator = createTestOrchestrator({taskDefinitions, kbSyncEnabled: false});
-        const flushProbe   = () => new Promise(resolve => setTimeout(resolve, 0));
-
-        // A fresh supervisor per case resets the probe-gate state without the test reaching into
-        // its internals; `runTask` is the restart spy. The supervisor owns the probe decision now.
-        const pollDownLms = async () => {
-            const started = [];
-            orchestrator.processSupervisorService = {
-                runTask(taskName, reason) { started.push({taskName, reason}); return true; }
-            };
-            TaskStateService.taskState.lms.running   = false;
-            TaskStateService.taskState.lms.lastRunAt = 0;
-            orchestrator.poll();
-            await flushProbe();
-            return started;
+        const saved = {
+            lms              : {...AiConfig.orchestrator.lms},
+            openAiCompatible : {...AiConfig.openAiCompatible},
+            providerReadiness: {...AiConfig.orchestrator.providerReadiness},
+            modelProvider    : AiConfig.modelProvider,
+            graphProvider    : AiConfig.graphProvider,
+            embeddingProvider: AiConfig.embeddingProvider
         };
 
-        // Endpoint DOWN → the lane is (re)started.
-        probeUp = false;
-        expect(await pollDownLms()).toContainEqual({taskName: 'lms', reason: 'supervisor-restart'});
+        try {
+            AiConfig.orchestrator.lms = {enabled: true, model: 'legacy-model', port: '1234'};
+            AiConfig.openAiCompatible = {
+                host          : 'http://127.0.0.1:1234',
+                model         : 'chat-model',
+                embeddingModel: 'embedding-model'
+            };
+            AiConfig.orchestrator.providerReadiness = {attempts: 2, delayMs: 0, timeoutMs: 50};
+            AiConfig.modelProvider     = 'openAiCompatible';
+            AiConfig.graphProvider     = 'openAiCompatible';
+            AiConfig.embeddingProvider = 'openAiCompatible';
 
-        // Endpoint UP → silent no-op, NO restart (a healthy fire-and-exit lane must not re-spawn
-        // every cooldown).
-        probeUp = true;
-        expect((await pollDownLms()).find(entry => entry.taskName === 'lms')).toBeUndefined();
+            const orchestrator = createTestOrchestrator({kbSyncEnabled: false});
+            const taskDefinitions = orchestrator.buildConfiguredTaskDefinitions({
+                scriptDir: path.resolve(process.cwd(), 'ai/scripts'),
+                nodeBin  : process.argv[0]
+            });
+            // `lms server start` is fire-and-exit, so liveness is the HTTP endpoint, not the launcher
+            // child. Stub the probe for determinism (no real :1234) and drive both branches.
+            let probeUp = false;
+            taskDefinitions.lms.livenessProbe = async () => probeUp;
+            orchestrator.taskDefinitions = taskDefinitions;
+            TaskStateService.configure({
+                stateFile : '/tmp/orchestrator-test/state.json',
+                taskDefinitions,
+                writeLogFn: () => {}
+            });
+            TaskStateService.taskState = createInitialTaskState(taskDefinitions);
+
+            const flushProbe = () => new Promise(resolve => setTimeout(resolve, 0));
+
+            // A fresh supervisor per case resets the probe-gate state without the test reaching into
+            // its internals; `runTask` is the restart spy. The supervisor owns the probe decision now.
+            const pollDownLms = async () => {
+                const started = [];
+                orchestrator.processSupervisorService = {
+                    runTask(taskName, reason) { started.push({taskName, reason}); return true; }
+                };
+                TaskStateService.taskState.lms.running   = false;
+                TaskStateService.taskState.lms.lastRunAt = 0;
+                orchestrator.poll();
+                await flushProbe();
+                return started;
+            };
+
+            // Endpoint DOWN → the lane is (re)started.
+            probeUp = false;
+            expect(await pollDownLms()).toContainEqual({taskName: 'lms', reason: 'supervisor-restart'});
+
+            // Endpoint UP → silent no-op, NO restart (a healthy fire-and-exit lane must not re-spawn
+            // every cooldown).
+            probeUp = true;
+            expect((await pollDownLms()).find(entry => entry.taskName === 'lms')).toBeUndefined();
+        } finally {
+            AiConfig.orchestrator.lms = saved.lms;
+            AiConfig.openAiCompatible = saved.openAiCompatible;
+            AiConfig.orchestrator.providerReadiness = saved.providerReadiness;
+            AiConfig.modelProvider     = saved.modelProvider;
+            AiConfig.graphProvider     = saved.graphProvider;
+            AiConfig.embeddingProvider = saved.embeddingProvider;
+        }
     });
 
     test('skips chroma daemon supervision in cloud mode while keeping local default (#12019)', () => {
@@ -900,10 +930,13 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             expectedCommand: 'compactGraphLog.mjs'
         });
 
-        expect(buildTaskDefinitions({
-            scriptDir               : '/repo/ai/scripts',
-            nodeBin                 : '/node',
+        const orchestrator = createTestOrchestrator({
             graphLogCompactionVacuum: true
+        });
+
+        expect(orchestrator.buildConfiguredTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
         })['graphlog-compaction'].args).toEqual([
             '/repo/ai/scripts/maintenance/compactGraphLog.mjs',
             '--apply',
@@ -1041,37 +1074,70 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('passes local mlx launch model config into task definitions', () => {
-        const orchestrator = Neo.create(Orchestrator);
-        orchestrator.dataDir         = '/tmp/orchestrator-test-mlx-model';
-        orchestrator.taskDefinitions = buildTaskDefinitions({
-            scriptDir : path.resolve(process.cwd(), 'ai/scripts'),
-            nodeBin   : process.argv[0],
-            mlxEnabled: true,
-            mlxModel  : 'operator-configured-mlx-model'
-        });
+        const savedMlx = {...AiConfig.orchestrator.mlx};
 
-        expect(orchestrator.taskDefinitions.mlx.args).toContain('operator-configured-mlx-model');
-        expect(orchestrator.taskDefinitions.mlx.args).not.toContain('gemma-4-31b-it');
+        try {
+            AiConfig.orchestrator.mlx = {
+                enabled: true,
+                model  : 'operator-configured-mlx-model',
+                port   : '11435'
+            };
+
+            const orchestrator = Neo.create(Orchestrator);
+            orchestrator.dataDir         = '/tmp/orchestrator-test-mlx-model';
+            orchestrator.taskDefinitions = orchestrator.buildConfiguredTaskDefinitions({
+                scriptDir: path.resolve(process.cwd(), 'ai/scripts'),
+                nodeBin  : process.argv[0]
+            });
+
+            expect(orchestrator.taskDefinitions.mlx.args).toContain('operator-configured-mlx-model');
+            expect(orchestrator.taskDefinitions.mlx.args).not.toContain('gemma-4-31b-it');
+        } finally {
+            AiConfig.orchestrator.mlx = savedMlx;
+        }
     });
 
     test('passes local lms launch port config into task definitions (#11986)', () => {
-        const orchestrator = Neo.create(Orchestrator);
-        orchestrator.dataDir         = '/tmp/orchestrator-test-lms-port';
-        orchestrator.taskDefinitions = buildTaskDefinitions({
-            scriptDir        : path.resolve(process.cwd(), 'ai/scripts'),
-            nodeBin          : process.argv[0],
-            lmsEnabled       : true,
-            lmsModel         : 'qwen3-embedding-8b',
-            lmsModels        : ['gemma4-31b', 'qwen3-8b'],
-            lmsHost          : 'http://127.0.0.1:4242',
-            providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50},
-            lmsPort          : 4242
-        });
+        const saved = {
+            lms              : {...AiConfig.orchestrator.lms},
+            openAiCompatible : {...AiConfig.openAiCompatible},
+            providerReadiness: {...AiConfig.orchestrator.providerReadiness},
+            modelProvider    : AiConfig.modelProvider,
+            graphProvider    : AiConfig.graphProvider,
+            embeddingProvider: AiConfig.embeddingProvider
+        };
 
-        expect(orchestrator.taskDefinitions.lms.command).toBe('lms');
-        expect(orchestrator.taskDefinitions.lms.args).toEqual(['server', 'start', '--port', '4242']);
-        expect(orchestrator.taskDefinitions.lms.pidFileName).toBe('lms.pid');
-        expect(orchestrator.taskDefinitions.lms.requiredModels).toEqual(['gemma4-31b', 'qwen3-8b']);
+        try {
+            AiConfig.orchestrator.lms = {enabled: true, model: 'qwen3-embedding-8b', port: '4242'};
+            AiConfig.openAiCompatible = {
+                host          : 'http://127.0.0.1:4242',
+                model         : 'gemma4-31b',
+                embeddingModel: 'qwen3-8b'
+            };
+            AiConfig.orchestrator.providerReadiness = {attempts: 2, delayMs: 0, timeoutMs: 50};
+            AiConfig.modelProvider     = 'openAiCompatible';
+            AiConfig.graphProvider     = 'openAiCompatible';
+            AiConfig.embeddingProvider = 'openAiCompatible';
+
+            const orchestrator = Neo.create(Orchestrator);
+            orchestrator.dataDir         = '/tmp/orchestrator-test-lms-port';
+            orchestrator.taskDefinitions = orchestrator.buildConfiguredTaskDefinitions({
+                scriptDir: path.resolve(process.cwd(), 'ai/scripts'),
+                nodeBin  : process.argv[0]
+            });
+
+            expect(orchestrator.taskDefinitions.lms.command).toBe('lms');
+            expect(orchestrator.taskDefinitions.lms.args).toEqual(['server', 'start', '--port', '4242']);
+            expect(orchestrator.taskDefinitions.lms.pidFileName).toBe('lms.pid');
+            expect(orchestrator.taskDefinitions.lms.requiredModels).toEqual(['gemma4-31b', 'qwen3-8b']);
+        } finally {
+            AiConfig.orchestrator.lms = saved.lms;
+            AiConfig.openAiCompatible = saved.openAiCompatible;
+            AiConfig.orchestrator.providerReadiness = saved.providerReadiness;
+            AiConfig.modelProvider     = saved.modelProvider;
+            AiConfig.graphProvider     = saved.graphProvider;
+            AiConfig.embeddingProvider = saved.embeddingProvider;
+        }
     });
 
     test('routes primary-dev-sync through its service coordinator', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -234,6 +234,93 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         );
     });
 
+    // -----------------------------------------------------------------------------
+    // Native Ollama (`ollama serve`) orchestrator-managed lifecycle (local-dev only)
+    // -----------------------------------------------------------------------------
+
+    test('buildTaskDefinitions is pure: tasks.ollama is omitted when disabled or no Ollama roles exist', () => {
+        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
+
+        expect(buildTaskDefinitions({scriptDir, nodeBin: '/test/node'}).ollama).toBeUndefined();
+        expect(buildTaskDefinitions({
+            scriptDir,
+            nodeBin      : '/test/node',
+            ollamaEnabled: true,
+            ollamaHost   : 'http://127.0.0.1:11434',
+            ollamaRoles  : []
+        }).ollama).toBeUndefined();
+    });
+
+    test('buildTaskDefinitions is pure: native Ollama serve env comes from explicit caller config', () => {
+        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
+        const originalEnv = {
+            OLLAMA_HOST                    : process.env.OLLAMA_HOST,
+            OLLAMA_CONTEXT_LENGTH          : process.env.OLLAMA_CONTEXT_LENGTH,
+            OLLAMA_MAX_LOADED_MODELS       : process.env.OLLAMA_MAX_LOADED_MODELS,
+            NEO_ORCHESTRATOR_OLLAMA_ENABLED: process.env.NEO_ORCHESTRATOR_OLLAMA_ENABLED
+        };
+
+        process.env.OLLAMA_HOST = 'env-leaked-host:9999';
+        process.env.OLLAMA_CONTEXT_LENGTH = '777';
+        process.env.OLLAMA_MAX_LOADED_MODELS = '9';
+        process.env.NEO_ORCHESTRATOR_OLLAMA_ENABLED = 'false';
+
+        try {
+            const tasks = buildTaskDefinitions({
+                scriptDir,
+                nodeBin      : '/test/node',
+                ollamaEnabled: true,
+                ollamaHost   : 'http://127.0.0.1:11445',
+                ollamaRoles  : [{
+                    role         : 'chat',
+                    providerRole : 'graphProvider',
+                    model        : 'gemma4:31b',
+                    contextLength: 131072
+                }, {
+                    role         : 'embedding',
+                    providerRole : 'embeddingProvider',
+                    model        : 'qwen3-embedding',
+                    contextLength: 32768
+                }],
+                ollamaKeepAlive            : -1,
+                ollamaRequireParallelModels: 2,
+                providerReadiness          : {attempts: 2, delayMs: 0, timeoutMs: 50}
+            });
+
+            expect(tasks.ollama.command).toBe('ollama');
+            expect(tasks.ollama.args).toEqual(['serve']);
+            expect(tasks.ollama.expectedCommand).toBe('ollama serve');
+            expect(tasks.ollama.pidFileName).toBe('ollama.pid');
+            expect(tasks.ollama.requiredModels).toEqual(['gemma4:31b', 'qwen3-embedding']);
+            expect(tasks.ollama.singletonPort).toBe(11445);
+            expect(tasks.ollama.duplicateListenerPolicy).toBe('defer');
+            expect(tasks.ollama.env).toEqual({
+                OLLAMA_HOST             : '127.0.0.1:11445',
+                OLLAMA_KEEP_ALIVE       : '-1',
+                OLLAMA_CONTEXT_LENGTH   : '131072',
+                OLLAMA_MAX_LOADED_MODELS: '2'
+            });
+            expect(typeof tasks.ollama.livenessProbe).toBe('function');
+            expect(typeof tasks.ollama.postSpawn).toBe('function');
+        } finally {
+            for (const [key, value] of Object.entries(originalEnv)) {
+                if (value === undefined) {
+                    delete process.env[key];
+                } else {
+                    process.env[key] = value;
+                }
+            }
+        }
+    });
+
+    test('AiConfig.orchestrator.ollama ships default-enabled local-dev launch gate', () => {
+        const templateSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/config.template.mjs'), 'utf8');
+
+        expect(templateSource).toMatch(
+            /ollama:\s*\{[\s\S]*?leaf\(true,\s*'NEO_ORCHESTRATOR_OLLAMA_ENABLED'/
+        );
+    });
+
     test('keeps wake-daemon wake-only and routes maintenance ownership to the daemon class', () => {
         const bridgeSource       = fs.readFileSync(path.resolve(process.cwd(), 'ai/daemons/wake/daemon.mjs'), 'utf8');
         const orchestratorSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/daemons/orchestrator/daemon.mjs'), 'utf8');

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -9,6 +9,9 @@ import {
     loadLocalAiConfig
 } from '../../../../../../ai/daemons/orchestrator/daemon.mjs';
 import {
+    buildOllamaServeEnv,
+    getMaxOllamaContextLength,
+    resolveOllamaHostPort,
     buildTaskDefinitions
 } from '../../../../../../ai/daemons/orchestrator/taskDefinitions.mjs';
 
@@ -69,12 +72,10 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(tasks.mlx).toBeUndefined();
     });
 
-    test('buildTaskDefinitions is pure: no env-var lookups; concrete mlxModel/mlxPort flow through', () => {
-        // Architectural contract: taskDefinitions.mjs has no embedded MLX
-        // defaults and no env-var reads. Caller (Orchestrator via its mlx* getters
-        // reading AiConfig + env-vars) forwards concrete values. This test documents
-        // the pure-function contract by setting env-vars that would have been picked
-        // up by the old behavior and verifying they are ignored.
+    test('buildTaskDefinitions is pure: MLX composition stays outside the task table', () => {
+        // Architectural contract: taskDefinitions.mjs has no embedded MLX defaults
+        // and no env-var reads. The daemon entrypoint composes MLX after reading
+        // AiConfig, so stale caller params and env-vars are ignored here.
         const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
         const originalMlxModel   = process.env.NEO_ORCHESTRATOR_MLX_MODEL;
         const originalMlxEnabled = process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
@@ -85,29 +86,17 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         process.env.NEO_ORCHESTRATOR_MLX_PORT    = '99999';
 
         try {
-            // Default: mlxEnabled=false; env-vars are ignored.
             const tasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
             expect(tasks.mlx).toBeUndefined();
 
-            // Explicit values are passed through verbatim; env-vars are still ignored.
-            const explicitTasks = buildTaskDefinitions({
+            const staleCallerParams = buildTaskDefinitions({
                 scriptDir,
                 nodeBin   : '/test/node',
                 mlxEnabled: true,
                 mlxModel  : 'explicit-model',
                 mlxPort   : 12345
             });
-
-            expect(explicitTasks.mlx.args).toEqual([
-                '-m',
-                'mlx_lm.server',
-                '--model',
-                'explicit-model',
-                '--port',
-                '12345'
-            ]);
-            expect(explicitTasks.mlx.args).not.toContain('env-leaked-model');
-            expect(explicitTasks.mlx.args).not.toContain('99999');
+            expect(staleCallerParams.mlx).toBeUndefined();
         } finally {
             for (const [key, value] of [
                 ['NEO_ORCHESTRATOR_MLX_MODEL',   originalMlxModel],
@@ -147,12 +136,10 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(tasks.lms).toBeUndefined();
     });
 
-    test('buildTaskDefinitions is pure: no env-var lookups; concrete lmsModel/lmsPort flow through', () => {
+    test('buildTaskDefinitions is pure: LM Studio composition stays outside the task table', () => {
         // Architectural contract: taskDefinitions.mjs has no embedded LM Studio
-        // defaults and no env-var reads. Caller (Orchestrator via its lms* getters
-        // reading AiConfig + env-vars) forwards concrete values. This test documents
-        // the pure-function contract by setting env-vars that would have been picked
-        // up if the implementation leaked and verifying they are ignored.
+        // defaults and no env-var reads. The daemon entrypoint composes LMS after
+        // reading AiConfig, so stale caller params and env-vars are ignored here.
         const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
         const originalLmsModel   = process.env.NEO_ORCHESTRATOR_LMS_MODEL;
         const originalLmsEnabled = process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
@@ -163,12 +150,10 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         process.env.NEO_ORCHESTRATOR_LMS_PORT    = '99999';
 
         try {
-            // Default: lmsEnabled=false; env-vars are ignored.
             const tasks = buildTaskDefinitions({scriptDir, nodeBin: '/test/node'});
             expect(tasks.lms).toBeUndefined();
 
-            // Explicit values are passed through verbatim; env-vars are still ignored.
-            const explicitTasks = buildTaskDefinitions({
+            const staleCallerParams = buildTaskDefinitions({
                 scriptDir,
                 nodeBin          : '/test/node',
                 lmsEnabled       : true,
@@ -178,14 +163,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
                 providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50},
                 lmsPort          : 4242
             });
-
-            expect(explicitTasks.lms.command).toBe('lms');
-            expect(explicitTasks.lms.args).toEqual(['server', 'start', '--port', '4242']);
-            expect(explicitTasks.lms.expectedCommand).toBe('lms server');
-            expect(explicitTasks.lms.pidFileName).toBe('lms.pid');
-            expect(explicitTasks.lms.requiredModels).toEqual(['chat-model', 'embedding-model']);
-            expect(typeof explicitTasks.lms.postSpawn).toBe('function');
-            expect(explicitTasks.lms.args).not.toContain('99999');
+            expect(staleCallerParams.lms).toBeUndefined();
         } finally {
             for (const [key, value] of [
                 ['NEO_ORCHESTRATOR_LMS_MODEL',   originalLmsModel],
@@ -201,7 +179,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         }
     });
 
-    test('buildTaskDefinitions honors an explicit empty lmsModels list without legacy fallback (#12264)', async () => {
+    test('buildTaskDefinitions ignores legacy LMS params, including an explicit empty lmsModels list (#12264)', () => {
         const tasks = buildTaskDefinitions({
             scriptDir : path.resolve(process.cwd(), 'ai/scripts'),
             nodeBin   : '/test/node',
@@ -212,13 +190,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
             lmsPort   : 4242
         });
 
-        expect(tasks.lms.requiredModels).toEqual([]);
-        await expect(tasks.lms.postSpawn()).resolves.toMatchObject({
-            ready         : true,
-            requiredModels: [],
-            skipped       : true,
-            reason        : 'no-openai-compatible-local-roles'
-        });
+        expect(tasks.lms).toBeUndefined();
     });
 
     test('AiConfig.orchestrator.lms ships default-enabled LM Studio launch defaults', () => {
@@ -238,7 +210,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
     // Native Ollama (`ollama serve`) orchestrator-managed lifecycle (local-dev only)
     // -----------------------------------------------------------------------------
 
-    test('buildTaskDefinitions is pure: tasks.ollama is omitted when disabled or no Ollama roles exist', () => {
+    test('buildTaskDefinitions is pure: Ollama composition stays outside the task table', () => {
         const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
 
         expect(buildTaskDefinitions({scriptDir, nodeBin: '/test/node'}).ollama).toBeUndefined();
@@ -247,12 +219,11 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
             nodeBin      : '/test/node',
             ollamaEnabled: true,
             ollamaHost   : 'http://127.0.0.1:11434',
-            ollamaRoles  : []
+            ollamaRoles  : [{model: 'gemma4:31b'}]
         }).ollama).toBeUndefined();
     });
 
-    test('buildTaskDefinitions is pure: native Ollama serve env comes from explicit caller config', () => {
-        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
+    test('native Ollama serve env helpers are pure and ignore process env', () => {
         const originalEnv = {
             OLLAMA_HOST                    : process.env.OLLAMA_HOST,
             OLLAMA_CONTEXT_LENGTH          : process.env.OLLAMA_CONTEXT_LENGTH,
@@ -266,42 +237,31 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         process.env.NEO_ORCHESTRATOR_OLLAMA_ENABLED = 'false';
 
         try {
-            const tasks = buildTaskDefinitions({
-                scriptDir,
-                nodeBin      : '/test/node',
-                ollamaEnabled: true,
-                ollamaHost   : 'http://127.0.0.1:11445',
-                ollamaRoles  : [{
-                    role         : 'chat',
-                    providerRole : 'graphProvider',
-                    model        : 'gemma4:31b',
-                    contextLength: 131072
-                }, {
-                    role         : 'embedding',
-                    providerRole : 'embeddingProvider',
-                    model        : 'qwen3-embedding',
-                    contextLength: 32768
-                }],
-                ollamaKeepAlive            : -1,
-                ollamaRequireParallelModels: 2,
-                providerReadiness          : {attempts: 2, delayMs: 0, timeoutMs: 50}
-            });
+            const roles = [{
+                role         : 'chat',
+                providerRole : 'graphProvider',
+                model        : 'gemma4:31b',
+                contextLength: 131072
+            }, {
+                role         : 'embedding',
+                providerRole : 'embeddingProvider',
+                model        : 'qwen3-embedding',
+                contextLength: 32768
+            }];
 
-            expect(tasks.ollama.command).toBe('ollama');
-            expect(tasks.ollama.args).toEqual(['serve']);
-            expect(tasks.ollama.expectedCommand).toBe('ollama serve');
-            expect(tasks.ollama.pidFileName).toBe('ollama.pid');
-            expect(tasks.ollama.requiredModels).toEqual(['gemma4:31b', 'qwen3-embedding']);
-            expect(tasks.ollama.singletonPort).toBe(11445);
-            expect(tasks.ollama.duplicateListenerPolicy).toBe('defer');
-            expect(tasks.ollama.env).toEqual({
+            expect(resolveOllamaHostPort('http://127.0.0.1:11445')).toBe(11445);
+            expect(getMaxOllamaContextLength(roles)).toBe(131072);
+            expect(buildOllamaServeEnv({
+                host                 : 'http://127.0.0.1:11445',
+                keepAlive            : -1,
+                contextLength        : getMaxOllamaContextLength(roles),
+                requireParallelModels: 2
+            })).toEqual({
                 OLLAMA_HOST             : '127.0.0.1:11445',
                 OLLAMA_KEEP_ALIVE       : '-1',
                 OLLAMA_CONTEXT_LENGTH   : '131072',
                 OLLAMA_MAX_LOADED_MODELS: '2'
             });
-            expect(typeof tasks.ollama.livenessProbe).toBe('function');
-            expect(typeof tasks.ollama.postSpawn).toBe('function');
         } finally {
             for (const [key, value] of Object.entries(originalEnv)) {
                 if (value === undefined) {


### PR DESCRIPTION
Resolves #13867

Related: #13852
Related: #13865
Related: #13624

Adds the local-dev native Ollama serving lifecycle lane that #13852 needs before its remaining live-validation AC can be exercised. The Orchestrator now reads the shared native Ollama readiness config, forwards concrete values into pure task definitions, and supervises an `ollama serve` continuous task only when at least one configured role targets provider `ollama`.

Evidence: L2 (focused unit coverage for config, task construction, Orchestrator getters, and continuous-task scheduling) -> L2 required for #13867. Residual: #13852 remains open for live heavy-session native-Ollama digestion evidence.

## Deltas from ticket

- Created #13867 as the exact close target for this L2 wiring slice after confirming #13852 still contains a live-evidence AC.
- Reuses `buildOllamaReadinessConfig()` / `ensureOllamaModelsReady()` from #13865 instead of inventing an alternate readiness path.
- Adds `orchestrator.ollama.enabled` to Tier-1 config, but task creation remains role-gated so the default OpenAI-compatible setup does not start Ollama.
- Treats an already-running Ollama endpoint as shared local infrastructure: no duplicate listener reaping; liveness converges residency/context before deciding whether to spawn.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/config.template.spec.mjs` -> 45 passed on rebased head.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` -> 54 passed on rebased head.
- `git diff --check origin/dev..HEAD` -> passed.
- Pre-commit staged hooks passed before commit; commit `d11cee1c7f`.

## Post-Merge Validation

- [ ] Parent #13852: run native-Ollama provider boot with a heavy session and verify non-null tri-vector digestion after orchestrator startup.

## Commit

- `d11cee1c7f` - `fix(ai): supervise native ollama serve lifecycle (#13867)`

## Evolution

The first implementation pass was scoped under #13852, but a close-target audit found #13852 still carries live-evidence acceptance criteria. #13867 is the split leaf for the L2 Orchestrator lifecycle substrate delivered here; #13852 stays open for the runtime proof.

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee5c2-82ba-7b73-8812-df59106ff61a.