### PR TITLE
fix(ai): map Ollama reasoning effort to think (#13869)

### DIFF
--- a/ai/provider/Ollama.mjs
+++ b/ai/provider/Ollama.mjs
@@ -8,7 +8,8 @@ import {createTimeoutError} from './createTimeoutError.mjs';
  * Ollama's `/api/chat` accepts `format` as either `'json'` or a JSON schema.
  * OpenAI-compatible callers may instead provide `response_format`, while Gemini
  * callers historically use `responseSchema`; normalize those into Ollama's
- * native field without leaking them into `payload.options`.
+ * native field without leaking them into `payload.options`. Provider-neutral
+ * `reasoning_effort: 'none'` maps to Ollama's native `think:false` switch.
  *
  * @param {Object} options Cloned options object that may be mutated by deletion.
  * @returns {Object}
@@ -47,7 +48,10 @@ function extractNativeOllamaFields(options) {
     if (options.think !== undefined) {
         fields.think = options.think;
         delete options.think;
+    } else if (options.reasoning_effort === 'none') {
+        fields.think = false;
     }
+    delete options.reasoning_effort;
 
     return fields;
 }
@@ -154,14 +158,12 @@ class OllamaProvider extends Base {
         payload.keep_alive = clonedOptions.keep_alive === undefined ? this.keepAlive : clonedOptions.keep_alive;
         delete clonedOptions.keep_alive;
 
-        // Caller options this provider does not yet consume — drop them so they don't leak into
-        // ollama's `options` bag. Ollama's native structured-output (`format` schema) + the no-think
-        // wiring are a separate follow-up; until then these keys are inert here, not forwarded.
+        // Caller options this provider does not consume — drop them so they don't leak into
+        // ollama's `options` bag.
         delete clonedOptions.responseSchema;
         delete clonedOptions.responseSchemaName;
         delete clonedOptions.responseSchemaStrict;
         delete clonedOptions.response_format;
-        delete clonedOptions.reasoning_effort;
 
         if (Object.keys(clonedOptions).length > 0) {
             payload.options = clonedOptions;

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -268,6 +268,54 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
         expect(payload.options.think).toBeUndefined();
     });
 
+    test('Ollama.preparePayload() maps reasoning_effort none to native think false (#13854)', () => {
+        const provider = Neo.create(OllamaProvider, {
+            host     : 'http://ollama.test',
+            modelName: 'gemma4-test'
+        });
+
+        const payload = provider.preparePayload('hello', {
+            reasoning_effort: 'none',
+            temperature     : 0
+        }, false);
+
+        expect(payload).toMatchObject({
+            model     : 'gemma4-test',
+            stream    : false,
+            think     : false,
+            keep_alive: -1,
+            options   : {
+                temperature: 0
+            }
+        });
+        expect(payload.options.reasoning_effort).toBeUndefined();
+    });
+
+    test('Ollama.preparePayload() preserves explicit think over reasoning_effort (#13854)', () => {
+        const provider = Neo.create(OllamaProvider, {
+            host     : 'http://ollama.test',
+            modelName: 'gemma4-test'
+        });
+
+        const payload = provider.preparePayload('hello', {
+            reasoning_effort: 'none',
+            think           : true,
+            temperature     : 0
+        }, false);
+
+        expect(payload).toMatchObject({
+            model     : 'gemma4-test',
+            stream    : false,
+            think     : true,
+            keep_alive: -1,
+            options   : {
+                temperature: 0
+            }
+        });
+        expect(payload.options.reasoning_effort).toBeUndefined();
+        expect(payload.options.think).toBeUndefined();
+    });
+
     test('Ollama.preparePayload() preserves plain JSON extraction for response_format json_object (#13855)', () => {
         const provider = Neo.create(OllamaProvider, {
             host     : 'http://ollama.test',


### PR DESCRIPTION
Resolves #13869

Related: #13854
Related: #13853
Related: #13856

Maps provider-neutral `reasoning_effort: none` to native Ollama top-level `think:false` inside `OllamaProvider.preparePayload()`. Explicit caller `think` remains the stronger override, and unsupported `reasoning_effort` values still do not leak into the Ollama `options` bag.

Evidence: L2 (focused provider payload-shape unit coverage) -> L2 required for #13869. Residual: parent #13854 remains open for cloud benchmark evidence and any verified non-none Ollama reasoning controls.

## Deltas from ticket

- Split #13869 from #13854 because #13854 still owns cloud/runtime benchmark evidence.
- Used official Ollama API shape (`think` top-level field) as the native no-think target.
- Preserved explicit caller `think` over the provider-neutral compatibility mapping.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs` -> 18 passed, 1 live-Ollama test skipped by env gate.
- `node --check ai/provider/Ollama.mjs` -> passed.
- `git diff --check` -> passed.
- Pre-commit hooks passed: whitespace, shorthand, AiConfig mutation guard, JSDoc types, ticket archaeology, block alignment.

## Post-Merge Validation

- [ ] Parent #13854: run cloud/native Ollama benchmark evidence against the configured deployment.

## Commit

- `56eaac095d` - `fix(ai): map Ollama reasoning effort to think (#13869)`

## Evolution

#13854 originally bundled native Ollama model/schema/no-think plus cloud benchmark. #13853 and #13856 already delivered the shared leaves and native schema/explicit-think payload support; this PR closes only the remaining repo-local `reasoning_effort: none` mapping.

Authored by Euclid (GPT-5, Codex Desktop). Session b9a8f817-9a9e-4243-abfb-62e762a94964.