### PR TITLE
feat(ai): wire agent preflight discovery (#13847)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -14,6 +14,11 @@ The act of opening a PR is an irreversible state transition in the Agent OS. Bef
 
 *If and only if* you pass this reflection phase, proceed to the Git execution sequence.
 
+Before the first commit or PR-body attempt on an agent-authored PR, run
+`npm run agent-preflight -- [files...]`; when a local PR body draft exists,
+include `-- --pr-body <draft-body.md>` so local source and PR-body gate failures
+surface before CI.
+
 ### 1.1 The Substrate-Mutation Pre-Flight Gate
 
 If your PR touches memory substrate per `/turn-memory-pre-flight` (`AGENTS.md`,

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -9,6 +9,9 @@ const
     __filename = fileURLToPath(import.meta.url),
     __dirname  = path.dirname(__filename);
 
+// Source-to-mirror: keep these PR-body anchors in sync with
+// `.github/workflows/agent-pr-body-lint.yml`. Do not reintroduce a shared
+// `prReviewAnchors.mjs`; sync-by-convention is deliberate.
 export const VISIBLE_PR_BODY_ANCHORS = [
     'Evidence:',
     '## Test Evidence',


### PR DESCRIPTION
Resolves #13847

Wires the shipped `agent-preflight` helper into the agent pull-request workflow and adds a stable source-to-mirror pointer beside the helper's PR-body anchor mirror. The change keeps the accepted sync-by-convention shape intact: no shared `prReviewAnchors.mjs`, no GitHub Action rewrite, and no husky/CI gate expansion.

Evidence: L2 (focused unit spec, skill-manifest lint, diff hygiene, and commit hook checks) -> L2 required (workflow/helper substrate wiring with local static/unit validation). No residuals.

## Deltas from ticket
- Used the ticket-allowed explicit source-pointer comment instead of adding a new parity parser test.
- Posted the source-ticket contract ledger comment before PR open: https://github.com/neomjs/neo/issues/13847#issuecomment-4769192938
- Turn-memory-pre-flight audit: the only agent-memory mutation is a 4-line conditional payload pointer inside the existing `pull-request` workflow map. `SKILL.md`, AGENTS, Codex, and Claude always-loaded surfaces are unchanged.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs` -> 9 passed.
- `npm run ai:lint-skill-manifest -- --base origin/dev` -> `[lint-skill-manifest] OK`.
- `node ./buildScripts/util/check-ticket-archaeology.mjs buildScripts/util/agent-preflight.mjs` -> 1 file scanned, 0 violations.
- `git diff --check` -> passed.
- Commit hook passed whitespace, shorthand, JSDoc type, ticket archaeology, and block-alignment checks.

## Post-Merge Validation
- [ ] Next agent-authored PR can discover `npm run agent-preflight` from the pull-request workflow before the first commit / PR-body attempt.

## Commits
- `dad2920a1c` - `feat(ai): wire agent preflight discovery (#13847)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee5c2-82ba-7b73-8812-df59106ff61a.
