### PR TITLE
refactor(ai): extract configured task composition (#13875)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -1,43 +1,39 @@
 // Class bootstrap belongs to `daemon.mjs`; this consumed class relies on global Neo.
-import fs               from 'fs-extra';
-import {spawn}          from 'child_process';
-import net              from 'net';
-import path             from 'path';
-import Base             from '../../../src/core/Base.mjs';
-import ClassSystemUtil  from '../../../src/util/ClassSystem.mjs';
-import AiConfig         from '../../config.mjs';
-import neuralLinkConfig from '../../mcp/server/neural-link/config.mjs';
-import {
-    buildLmsPreloadConfig,
-    buildOllamaReadinessConfig
-} from '../../services/graph/providerReadinessHelper.mjs';
-import HealthService from '../../services/memory-core/HealthService.mjs';
-import SQLite        from '../../graph/storage/SQLite.mjs';
+import fs              from 'fs-extra';
+import {spawn}         from 'child_process';
+import net             from 'net';
+import path            from 'path';
+import Base            from '../../../src/core/Base.mjs';
+import ClassSystemUtil from '../../../src/util/ClassSystem.mjs';
+import AiConfig        from '../../config.mjs';
+import HealthService   from '../../services/memory-core/HealthService.mjs';
+import SQLite          from '../../graph/storage/SQLite.mjs';
 import MaintenanceBackpressureService, {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
     DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
 } from './services/MaintenanceBackpressureService.mjs';
-import PrimaryRepoSyncService                                     from './services/PrimaryRepoSyncService.mjs';
-import TenantRepoSyncService                                      from './services/TenantRepoSyncService.mjs';
-import {getDueTask as summaryGetDueTaskImport}                    from './scheduling/summary.mjs';
-import {getDueTask as backupGetDueTaskImport}                     from './scheduling/backup.mjs';
-import {getDueTask as graphLogCompactionGetDueTaskImport}         from './scheduling/graphLogCompaction.mjs';
-import {getDueTask as primaryDevSyncGetDueTaskImport}             from './scheduling/primaryDevSync.mjs';
-import {getDueTask as goldenPathGetDueTaskImport}                 from './scheduling/goldenPath.mjs';
-import {getDueTask as dreamGetDueTaskImport}                      from './scheduling/dream.mjs';
-import {getDueTask as embedDrainLivenessWatchdogGetDueTaskImport} from './scheduling/embedDrainLivenessWatchdog.mjs';
-import memoryCoreConfig                                           from '../../mcp/server/memory-core/config.mjs';
-import MailboxService                                             from '../../services/memory-core/MailboxService.mjs';
-import WakeSubscriptionService                                    from '../../services/memory-core/WakeSubscriptionService.mjs';
-import RequestContextService                                      from '../../mcp/server/shared/services/RequestContextService.mjs';
-import {normalizeAgentIdentityNodeId}                             from '../../scripts/lifecycle/resumeHarness.mjs';
-import TaskStateService                                           from './services/TaskStateService.mjs';
-import ProcessSupervisorService                                   from './services/ProcessSupervisorService.mjs';
-import DreamService                                               from './services/DreamService.mjs';
-import SwarmHeartbeatService                                      from './services/SwarmHeartbeatService.mjs';
-import GoldenPathSynthesizer                                      from '../../services/graph/GoldenPathSynthesizer.mjs';
-import {getDueTask as tenantRepoSyncGetDueTaskImport}             from './scheduling/tenantRepoSync.mjs';
-import {TASK_REGISTRY}                                            from './scheduling/registry.mjs';
+import {buildConfiguredTaskDefinitions as buildConfiguredTaskDefinitionsImport} from './services/ConfiguredTaskDefinitionsService.mjs';
+import PrimaryRepoSyncService                                                   from './services/PrimaryRepoSyncService.mjs';
+import TenantRepoSyncService                                                    from './services/TenantRepoSyncService.mjs';
+import {getDueTask as summaryGetDueTaskImport}                                  from './scheduling/summary.mjs';
+import {getDueTask as backupGetDueTaskImport}                                   from './scheduling/backup.mjs';
+import {getDueTask as graphLogCompactionGetDueTaskImport}                       from './scheduling/graphLogCompaction.mjs';
+import {getDueTask as primaryDevSyncGetDueTaskImport}                           from './scheduling/primaryDevSync.mjs';
+import {getDueTask as goldenPathGetDueTaskImport}                               from './scheduling/goldenPath.mjs';
+import {getDueTask as dreamGetDueTaskImport}                                    from './scheduling/dream.mjs';
+import {getDueTask as embedDrainLivenessWatchdogGetDueTaskImport}               from './scheduling/embedDrainLivenessWatchdog.mjs';
+import memoryCoreConfig                                                         from '../../mcp/server/memory-core/config.mjs';
+import MailboxService                                                           from '../../services/memory-core/MailboxService.mjs';
+import WakeSubscriptionService                                                  from '../../services/memory-core/WakeSubscriptionService.mjs';
+import RequestContextService                                                    from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {normalizeAgentIdentityNodeId}                                           from '../../scripts/lifecycle/resumeHarness.mjs';
+import TaskStateService                                                         from './services/TaskStateService.mjs';
+import ProcessSupervisorService                                                 from './services/ProcessSupervisorService.mjs';
+import DreamService                                                             from './services/DreamService.mjs';
+import SwarmHeartbeatService                                                    from './services/SwarmHeartbeatService.mjs';
+import GoldenPathSynthesizer                                                    from '../../services/graph/GoldenPathSynthesizer.mjs';
+import {getDueTask as tenantRepoSyncGetDueTaskImport}                           from './scheduling/tenantRepoSync.mjs';
+import {TASK_REGISTRY}                                                          from './scheduling/registry.mjs';
 import {
     buildOrchestratorSchedulingOptions,
     runSchedulingPipeline
@@ -45,11 +41,7 @@ import {
 import {
     DEFAULT_DB_PATH,
     DEFAULT_DATA_DIR,
-    DEFAULT_SCRIPT_DIR,
-    buildOllamaServeEnv,
-    getMaxOllamaContextLength,
-    resolveOllamaHostPort,
-    buildTaskDefinitions
+    DEFAULT_SCRIPT_DIR
 } from './taskDefinitions.mjs';
 
 /** @summary Opens/creates the orchestrator sqlite DB via the shared Memory Core schema bootstrap. */
@@ -135,6 +127,7 @@ export class Orchestrator extends Base {
     dreamGetDueTask          = dreamGetDueTaskImport
     goldenPathGetDueTask     = goldenPathGetDueTaskImport
     embedDrainLivenessWatchdogGetDueTask = embedDrainLivenessWatchdogGetDueTaskImport
+    buildConfiguredTaskDefinitionsService = buildConfiguredTaskDefinitionsImport
 
     isPolling                     = false
     pollHandle                    = null
@@ -350,217 +343,18 @@ export class Orchestrator extends Base {
     get neuralLinkBridgeLivenessTimeoutMs() { return AiConfig.orchestrator.neuralLinkBridge.livenessProbeTimeoutMs; }
 
     /**
-     * @summary Builds the supervised task table from the daemon entrypoint's config authorities.
+     * @summary Delegates config-backed task-table construction to the orchestrator task builder.
      * @param {Object} options
      * @param {String} options.scriptDir Script directory.
      * @param {String} options.nodeBin Node executable.
      * @returns {Object}
      */
     buildConfiguredTaskDefinitions({scriptDir, nodeBin}) {
-        const tasks = buildTaskDefinitions({
+        return this.buildConfiguredTaskDefinitionsService({
             scriptDir,
             nodeBin,
-            chromaPort                       : AiConfig.engines.chroma.port,
-            devServerPort                    : AiConfig.orchestrator.devServer.port,
-            devServerLivenessTimeoutMs       : AiConfig.orchestrator.devServer.livenessProbeTimeoutMs,
-            neuralLinkBridgePort             : neuralLinkConfig.port,
             neuralLinkBridgeLivenessTimeoutMs: this.neuralLinkBridgeLivenessTimeoutMs
         });
-
-        this.applyConfiguredGraphLogCompaction(tasks);
-        this.applyConfiguredMlxTask(tasks, {scriptDir});
-        this.applyConfiguredLmsTask(tasks);
-        this.applyConfiguredOllamaTask(tasks);
-
-        return tasks;
-    }
-
-    /**
-     * @summary Applies the graph-log compaction flags owned by AiConfig.
-     * @param {Object} tasks Task table.
-     * @returns {void}
-     */
-    applyConfiguredGraphLogCompaction(tasks) {
-        if (AiConfig.orchestrator.graphLogCompaction.vacuum) {
-            tasks['graphlog-compaction'].args.push('--vacuum');
-        }
-    }
-
-    /**
-     * @summary Adds the orchestrator-owned MLX server task when enabled.
-     * @param {Object} tasks Task table.
-     * @param {Object} options
-     * @param {String} options.scriptDir Script directory.
-     * @returns {void}
-     */
-    applyConfiguredMlxTask(tasks, {scriptDir}) {
-        if (!AiConfig.orchestrator.mlx.enabled) {
-            return;
-        }
-
-        tasks.mlx = {
-            label  : 'mlx inference',
-            command: path.resolve(scriptDir, '../mcp/server/memory-core/.venv/bin/python'),
-            args   : [
-                '-m',
-                'mlx_lm.server',
-                '--model',
-                AiConfig.orchestrator.mlx.model,
-                '--port',
-                String(AiConfig.orchestrator.mlx.port)
-            ],
-            pidFileName    : 'mlx.pid',
-            expectedCommand: 'mlx_lm.server'
-        };
-    }
-
-    /**
-     * @summary Adds the orchestrator-owned LM Studio server task when enabled.
-     * @param {Object} tasks Task table.
-     * @returns {void}
-     */
-    applyConfiguredLmsTask(tasks) {
-        if (!AiConfig.orchestrator.lms.enabled) {
-            return;
-        }
-
-        const preloadConfig  = buildLmsPreloadConfig(AiConfig),
-              requiredModels = Array.isArray(preloadConfig.models)
-                  ? [...new Set(preloadConfig.models.filter(Boolean))]
-                  : [AiConfig.orchestrator.lms.model].filter(Boolean);
-
-        tasks.lms = {
-            label          : 'lms server (LM Studio CLI)',
-            command        : 'lms',
-            args           : ['server', 'start', '--port', String(AiConfig.orchestrator.lms.port)],
-            pidFileName    : 'lms.pid',
-            expectedCommand: 'lms server',
-            requiredModels,
-            // `lms server start` is fire-and-exit: it wakes the LM Studio service and returns, so
-            // the launched server never matches `expectedCommand` for the supervisor's
-            // process-liveness check (`!state.running` stays permanently true). Liveness is the
-            // HTTP endpoint instead — the supervisor gates the restart on this probe so a healthy
-            // server is a silent no-op rather than a re-spawn loop.
-            livenessProbe  : async () => {
-                const {fetchOpenAiCompatibleModelIds} = await import('../../services/graph/providerReadinessHelper.mjs');
-
-                try {
-                    await fetchOpenAiCompatibleModelIds({
-                        host     : AiConfig.openAiCompatible.host,
-                        timeoutMs: AiConfig.orchestrator.providerReadiness.timeoutMs ?? 2000
-                    });
-                    return true;
-                } catch {
-                    return false;
-                }
-            },
-            postSpawn      : async () => {
-                const {ensureLmsModelsLoaded} = await import('../../services/graph/providerReadinessHelper.mjs');
-
-                if (requiredModels.length === 0) {
-                    return {
-                        ready          : true,
-                        loadedModels   : [],
-                        requiredModels,
-                        availableModels: [],
-                        attempts       : 0,
-                        skipped        : true,
-                        reason         : 'no-openai-compatible-local-roles'
-                    };
-                }
-
-                return ensureLmsModelsLoaded({
-                    host          : AiConfig.openAiCompatible.host,
-                    models        : requiredModels,
-                    contextLengths: preloadConfig.contextLengths,
-                    parallels     : preloadConfig.parallels,
-                    allowPartial  : true,
-                    attempts      : AiConfig.orchestrator.providerReadiness.attempts,
-                    delayMs       : AiConfig.orchestrator.providerReadiness.delayMs,
-                    timeoutMs     : AiConfig.orchestrator.providerReadiness.timeoutMs
-                });
-            }
-        };
-    }
-
-    /**
-     * @summary Adds the orchestrator-owned native Ollama server task when enabled.
-     * @param {Object} tasks Task table.
-     * @returns {void}
-     */
-    applyConfiguredOllamaTask(tasks) {
-        if (!AiConfig.orchestrator.ollama.enabled) {
-            return;
-        }
-
-        const readinessConfig = buildOllamaReadinessConfig(AiConfig),
-              roles           = Array.isArray(readinessConfig.roles)
-                  ? readinessConfig.roles.filter(role => role.model)
-                  : [],
-              requiredModels  = [...new Set(roles.map(role => role.model))];
-
-        if (requiredModels.length === 0) {
-            return;
-        }
-
-        tasks.ollama = {
-            label                  : 'ollama server',
-            command                : 'ollama',
-            args                   : ['serve'],
-            pidFileName            : 'ollama.pid',
-            expectedCommand        : 'ollama serve',
-            requiredModels,
-            singletonPort          : resolveOllamaHostPort(readinessConfig.host),
-            duplicateListenerPolicy: 'defer',
-            env                    : buildOllamaServeEnv({
-                host                 : readinessConfig.host,
-                keepAlive            : readinessConfig.keepAlive,
-                contextLength        : getMaxOllamaContextLength(roles),
-                requireParallelModels: readinessConfig.requireParallelModels
-            }),
-            livenessProbe          : async () => {
-                const {ensureOllamaModelsReady} = await import('../../services/graph/providerReadinessHelper.mjs');
-
-                try {
-                    const result = await ensureOllamaModelsReady({
-                        host                 : readinessConfig.host,
-                        roles,
-                        keepAlive            : readinessConfig.keepAlive,
-                        requireParallelModels: readinessConfig.requireParallelModels,
-                        allowPartial         : true,
-                        attempts             : AiConfig.orchestrator.providerReadiness.attempts,
-                        delayMs              : AiConfig.orchestrator.providerReadiness.delayMs,
-                        timeoutMs            : AiConfig.orchestrator.providerReadiness.timeoutMs
-                    });
-
-                    if (
-                        result.error &&
-                        result.availableModels?.length === 0 &&
-                        result.attemptedModels?.length === 0
-                    ) {
-                        return false;
-                    }
-
-                    return true;
-                } catch {
-                    return false;
-                }
-            },
-            postSpawn              : async () => {
-                const {ensureOllamaModelsReady} = await import('../../services/graph/providerReadinessHelper.mjs');
-
-                return ensureOllamaModelsReady({
-                    host                 : readinessConfig.host,
-                    roles,
-                    keepAlive            : readinessConfig.keepAlive,
-                    requireParallelModels: readinessConfig.requireParallelModels,
-                    allowPartial         : true,
-                    attempts             : AiConfig.orchestrator.providerReadiness.attempts,
-                    delayMs              : AiConfig.orchestrator.providerReadiness.delayMs,
-                    timeoutMs            : AiConfig.orchestrator.providerReadiness.timeoutMs
-                });
-            }
-        };
     }
 
     /** @summary Starts the orchestrator timer loop after the wrapper selects this process. */

--- a/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
+++ b/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
@@ -1,0 +1,238 @@
+import path             from 'path';
+import AiConfig         from '../../../config.mjs';
+import neuralLinkConfig from '../../../mcp/server/neural-link/config.mjs';
+import {
+    buildLmsPreloadConfig,
+    buildOllamaReadinessConfig
+} from '../../../services/graph/providerReadinessHelper.mjs';
+import {
+    buildOllamaServeEnv,
+    buildTaskDefinitions,
+    getMaxOllamaContextLength,
+    resolveOllamaHostPort
+} from '../taskDefinitions.mjs';
+
+/**
+ * @summary Builds the orchestrator's config-backed child-process task table.
+ *
+ * `taskDefinitions.mjs` remains the pure descriptor/default layer. This service
+ * is the daemon-side use site for config-backed task composition, so it reads
+ * resolved `AiConfig` leaves directly instead of threading broad value objects
+ * through `Orchestrator`.
+ *
+ * @param {Object} options
+ * @param {String} options.scriptDir Script directory.
+ * @param {String} options.nodeBin Node executable.
+ * @param {Number} options.neuralLinkBridgeLivenessTimeoutMs Neural Link Bridge liveness timeout.
+ * @returns {Object}
+ */
+export function buildConfiguredTaskDefinitions({
+    scriptDir,
+    nodeBin,
+    neuralLinkBridgeLivenessTimeoutMs
+}) {
+    const tasks = buildTaskDefinitions({
+        scriptDir,
+        nodeBin,
+        chromaPort                : AiConfig.engines.chroma.port,
+        devServerPort             : AiConfig.orchestrator.devServer.port,
+        devServerLivenessTimeoutMs: AiConfig.orchestrator.devServer.livenessProbeTimeoutMs,
+        neuralLinkBridgePort      : neuralLinkConfig.port,
+        neuralLinkBridgeLivenessTimeoutMs
+    });
+
+    applyConfiguredGraphLogCompaction(tasks);
+    applyConfiguredMlxTask(tasks, {scriptDir});
+    applyConfiguredLmsTask(tasks);
+    applyConfiguredOllamaTask(tasks);
+
+    return tasks;
+}
+
+/**
+ * @summary Applies the graph-log compaction flags owned by AiConfig.
+ * @param {Object} tasks Task table.
+ * @returns {void}
+ */
+function applyConfiguredGraphLogCompaction(tasks) {
+    if (AiConfig.orchestrator.graphLogCompaction.vacuum) {
+        tasks['graphlog-compaction'].args.push('--vacuum');
+    }
+}
+
+/**
+ * @summary Adds the orchestrator-owned MLX server task when enabled.
+ * @param {Object} tasks Task table.
+ * @param {Object} options
+ * @param {String} options.scriptDir Script directory.
+ * @returns {void}
+ */
+function applyConfiguredMlxTask(tasks, {scriptDir}) {
+    if (!AiConfig.orchestrator.mlx.enabled) {
+        return;
+    }
+
+    tasks.mlx = {
+        label  : 'mlx inference',
+        command: path.resolve(scriptDir, '../mcp/server/memory-core/.venv/bin/python'),
+        args   : [
+            '-m',
+            'mlx_lm.server',
+            '--model',
+            AiConfig.orchestrator.mlx.model,
+            '--port',
+            String(AiConfig.orchestrator.mlx.port)
+        ],
+        pidFileName    : 'mlx.pid',
+        expectedCommand: 'mlx_lm.server'
+    };
+}
+
+/**
+ * @summary Adds the orchestrator-owned LM Studio server task when enabled.
+ * @param {Object} tasks Task table.
+ * @returns {void}
+ */
+function applyConfiguredLmsTask(tasks) {
+    if (!AiConfig.orchestrator.lms.enabled) {
+        return;
+    }
+
+    const preloadConfig  = buildLmsPreloadConfig(AiConfig),
+          requiredModels = Array.isArray(preloadConfig.models)
+              ? [...new Set(preloadConfig.models.filter(Boolean))]
+              : [AiConfig.orchestrator.lms.model].filter(Boolean);
+
+    tasks.lms = {
+        label          : 'lms server (LM Studio CLI)',
+        command        : 'lms',
+        args           : ['server', 'start', '--port', String(AiConfig.orchestrator.lms.port)],
+        pidFileName    : 'lms.pid',
+        expectedCommand: 'lms server',
+        requiredModels,
+        // `lms server start` is fire-and-exit: it wakes the LM Studio service and returns, so
+        // the launched server never matches `expectedCommand` for the supervisor's
+        // process-liveness check (`!state.running` stays permanently true). Liveness is the
+        // HTTP endpoint instead — the supervisor gates the restart on this probe so a healthy
+        // server is a silent no-op rather than a re-spawn loop.
+        livenessProbe  : async () => {
+            const {fetchOpenAiCompatibleModelIds} = await import('../../../services/graph/providerReadinessHelper.mjs');
+
+            try {
+                await fetchOpenAiCompatibleModelIds({
+                    host     : AiConfig.openAiCompatible.host,
+                    timeoutMs: AiConfig.orchestrator.providerReadiness.timeoutMs ?? 2000
+                });
+                return true;
+            } catch {
+                return false;
+            }
+        },
+        postSpawn      : async () => {
+            const {ensureLmsModelsLoaded} = await import('../../../services/graph/providerReadinessHelper.mjs');
+
+            if (requiredModels.length === 0) {
+                return {
+                    ready          : true,
+                    loadedModels   : [],
+                    requiredModels,
+                    availableModels: [],
+                    attempts       : 0,
+                    skipped        : true,
+                    reason         : 'no-openai-compatible-local-roles'
+                };
+            }
+
+            return ensureLmsModelsLoaded({
+                host          : AiConfig.openAiCompatible.host,
+                models        : requiredModels,
+                contextLengths: preloadConfig.contextLengths,
+                parallels     : preloadConfig.parallels,
+                allowPartial  : true,
+                attempts      : AiConfig.orchestrator.providerReadiness.attempts,
+                delayMs       : AiConfig.orchestrator.providerReadiness.delayMs,
+                timeoutMs     : AiConfig.orchestrator.providerReadiness.timeoutMs
+            });
+        }
+    };
+}
+
+/**
+ * @summary Adds the orchestrator-owned native Ollama server task when enabled.
+ * @param {Object} tasks Task table.
+ * @returns {void}
+ */
+function applyConfiguredOllamaTask(tasks) {
+    if (!AiConfig.orchestrator.ollama.enabled) {
+        return;
+    }
+
+    const readinessConfig = buildOllamaReadinessConfig(AiConfig),
+          roles           = Array.isArray(readinessConfig.roles)
+              ? readinessConfig.roles.filter(role => role.model)
+              : [],
+          requiredModels  = [...new Set(roles.map(role => role.model))];
+
+    if (requiredModels.length === 0) {
+        return;
+    }
+
+    tasks.ollama = {
+        label                  : 'ollama server',
+        command                : 'ollama',
+        args                   : ['serve'],
+        pidFileName            : 'ollama.pid',
+        expectedCommand        : 'ollama serve',
+        requiredModels,
+        singletonPort          : resolveOllamaHostPort(readinessConfig.host),
+        duplicateListenerPolicy: 'defer',
+        env                    : buildOllamaServeEnv({
+            host                 : readinessConfig.host,
+            keepAlive            : readinessConfig.keepAlive,
+            contextLength        : getMaxOllamaContextLength(roles),
+            requireParallelModels: readinessConfig.requireParallelModels
+        }),
+        livenessProbe          : async () => {
+            const {ensureOllamaModelsReady} = await import('../../../services/graph/providerReadinessHelper.mjs');
+
+            try {
+                const result = await ensureOllamaModelsReady({
+                    host                 : readinessConfig.host,
+                    roles,
+                    keepAlive            : readinessConfig.keepAlive,
+                    requireParallelModels: readinessConfig.requireParallelModels,
+                    allowPartial         : true,
+                    attempts             : AiConfig.orchestrator.providerReadiness.attempts,
+                    delayMs              : AiConfig.orchestrator.providerReadiness.delayMs,
+                    timeoutMs            : AiConfig.orchestrator.providerReadiness.timeoutMs
+                });
+
+                if (
+                    result.error &&
+                    result.availableModels?.length === 0 &&
+                    result.attemptedModels?.length === 0
+                ) {
+                    return false;
+                }
+
+                return true;
+            } catch {
+                return false;
+            }
+        },
+        postSpawn              : async () => {
+            const {ensureOllamaModelsReady} = await import('../../../services/graph/providerReadinessHelper.mjs');
+
+            return ensureOllamaModelsReady({
+                host                 : readinessConfig.host,
+                roles,
+                keepAlive            : readinessConfig.keepAlive,
+                requireParallelModels: readinessConfig.requireParallelModels,
+                allowPartial         : true,
+                attempts             : AiConfig.orchestrator.providerReadiness.attempts,
+                delayMs              : AiConfig.orchestrator.providerReadiness.delayMs,
+                timeoutMs            : AiConfig.orchestrator.providerReadiness.timeoutMs
+            });
+        }
+    };
+}

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -162,8 +162,8 @@ services:
   # The Agent OS maintenance orchestrator (ADR 0014 §2.3). Built from the shared
   # image via the generalized `SERVICE_ENTRYPOINT` arg. `NEO_AI_DEPLOYMENT_MODE=cloud`
   # activates the cloud-safe scheduler profile — only the cloud-deployable lanes
-  # (summary, backup, dream, golden-path) run; the local-only lanes (primary-dev-sync,
-  # kbSync, bridgeDaemon) are disabled via the Sub A #11722 deployment-mode toggles.
+  # (summary, backup, dream, golden-path) run; local-only lanes and local inference
+  # launchers (primary-dev-sync, kbSync, bridgeDaemon, MLX/LMS/Ollama) are disabled.
   # `cloud` profile — started by `docker compose --profile cloud up`.
   orchestrator:
     build:
@@ -179,6 +179,8 @@ services:
       - NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=false
       - NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED=false
       - NEO_ORCHESTRATOR_MLX_ENABLED=false
+      - NEO_ORCHESTRATOR_LMS_ENABLED=false
+      - NEO_ORCHESTRATOR_OLLAMA_ENABLED=false
       - NEO_TENANT_REPO_MIRROR_ROOT=/app/.neo-ai-data
       - NEO_MODEL_PROVIDER=${NEO_MODEL_PROVIDER:-}
       - NEO_EMBEDDING_PROVIDER=${NEO_EMBEDDING_PROVIDER:-}

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -23,6 +23,10 @@ const REPO_ROOT  = path.resolve(__dirname, '../../../../../..');
 const ORCHESTRATOR_MJS_PATH    = path.join(REPO_ROOT, 'ai/daemons/orchestrator/Orchestrator.mjs');
 const ORCHESTRATOR_DAEMON_PATH = path.join(REPO_ROOT, 'ai/daemons/orchestrator/daemon.mjs');
 const TASK_DEFINITIONS_MJS_PATH = path.join(REPO_ROOT, 'ai/daemons/orchestrator/taskDefinitions.mjs');
+const CONFIGURED_TASK_DEFINITIONS_SERVICE_PATH = path.join(
+    REPO_ROOT,
+    'ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs'
+);
 const SIBLING_DAEMON_CONFIG_PATHS = {
     'SwarmHeartbeatService.mjs'     : path.join(REPO_ROOT, 'ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs'),
     'KbAlertingService.mjs'         : path.join(REPO_ROOT, 'ai/daemons/kb-alerting/KbAlertingService.mjs'),
@@ -503,30 +507,55 @@ test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
         expect(matches, 'Orchestrator.mjs must NOT spread `this` into `processSupervisorService.set({...})` (Sub-1 anti-pattern; `afterSetX` parent-prop propagation hooks supersede the start()-time context replay).').toHaveLength(0);
     });
 
-    test('orchestrator AiConfig reads are fail-loud direct reads on declared subtrees (#12515)', async () => {
+    test('orchestrator config reads are fail-loud direct reads on declared subtrees (#12515 / #13875)', async () => {
         const orchestratorSource = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8'));
-        const daemonSource       = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_DAEMON_PATH, 'utf8'));
+        const configuredTaskDefinitionsSource = stripCommentsAndStrings(
+            await fs.readFile(CONFIGURED_TASK_DEFINITIONS_SERVICE_PATH, 'utf8')
+        );
+        const daemonSource = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_DAEMON_PATH, 'utf8'));
+        const configReadSource = `${orchestratorSource}\n${configuredTaskDefinitionsSource}`;
 
         for (const snippet of [
             'AiConfig.orchestrator.swarmHeartbeat?.',
             'AiConfig.orchestrator.mlx?.',
             'AiConfig.orchestrator.lms?.',
+            'AiConfig.orchestrator.ollama?.',
             'AiConfig.orchestrator.chroma?.',
             'AiConfig.engines.chroma?.',
             'AiConfig.openAiCompatible?.'
         ]) {
-            expect(orchestratorSource, `Orchestrator.mjs must not defend declared AiConfig subtree ${snippet}`).not.toContain(snippet);
+            expect(configReadSource, `orchestrator config readers must not defend declared AiConfig subtree ${snippet}`).not.toContain(snippet);
         }
 
         expect(daemonSource, 'daemon.mjs must read AiConfig.orchestrator.devSyncRoots directly').not.toContain('AiConfig.orchestrator?.devSyncRoots');
 
         expect(orchestratorSource).toContain('AiConfig.orchestrator.swarmHeartbeat.targets');
-        expect(orchestratorSource).toContain('AiConfig.orchestrator.mlx.enabled');
-        expect(orchestratorSource).toContain('AiConfig.orchestrator.lms.enabled');
-        expect(orchestratorSource).toContain('AiConfig.engines.chroma.port');
-        expect(orchestratorSource).toContain('AiConfig.openAiCompatible.host');
         expect(orchestratorSource).toContain('AiConfig.orchestrator.chroma.maxRuntimeMs');
+        expect(configuredTaskDefinitionsSource).toContain('AiConfig.orchestrator.mlx.enabled');
+        expect(configuredTaskDefinitionsSource).toContain('AiConfig.orchestrator.lms.enabled');
+        expect(configuredTaskDefinitionsSource).toContain('AiConfig.orchestrator.ollama.enabled');
+        expect(configuredTaskDefinitionsSource).toContain('AiConfig.engines.chroma.port');
+        expect(configuredTaskDefinitionsSource).toContain('AiConfig.openAiCompatible.host');
         expect(daemonSource).toContain('AiConfig.orchestrator.devSyncRoots');
+    });
+
+    test('Orchestrator.mjs delegates configured child-process task composition (#13875)', async () => {
+        const orchestratorSource = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8'));
+
+        expect(orchestratorSource).toContain('buildConfiguredTaskDefinitionsService');
+
+        for (const snippet of [
+            'applyConfiguredMlxTask',
+            'applyConfiguredLmsTask',
+            'applyConfiguredOllamaTask',
+            'buildLmsPreloadConfig',
+            'buildOllamaReadinessConfig',
+            'ensureLmsModelsLoaded',
+            'ensureOllamaModelsReady',
+            'OLLAMA_CONTEXT_LENGTH'
+        ]) {
+            expect(orchestratorSource, `Orchestrator.mjs must not own configured task composition detail: ${snippet}`).not.toContain(snippet);
+        }
     });
 
     test('Orchestrator.mjs has no `_`-suffix reactive config slot without a corresponding `beforeSet*` or `afterSet*` hook', async () => {

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -264,12 +264,14 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
         const memoryCoreEnv     = environmentMap(compose.services['mc-server']);
 
         expect(orchestratorEnv).toMatchObject({
-            NEO_AI_DEPLOYMENT_MODE: 'cloud',
-            NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED: 'false',
-            NEO_ORCHESTRATOR_KB_SYNC_ENABLED: 'false',
-            NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED: 'false',
+            NEO_AI_DEPLOYMENT_MODE                              : 'cloud',
+            NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED           : 'false',
+            NEO_ORCHESTRATOR_KB_SYNC_ENABLED                    : 'false',
+            NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED              : 'false',
             NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED: 'false',
-            NEO_ORCHESTRATOR_MLX_ENABLED: 'false'
+            NEO_ORCHESTRATOR_MLX_ENABLED                        : 'false',
+            NEO_ORCHESTRATOR_LMS_ENABLED                        : 'false',
+            NEO_ORCHESTRATOR_OLLAMA_ENABLED                     : 'false'
         });
 
         expect(memoryCoreEnv.NEO_MAILBOX_DEFAULT_REPLY_POLICY).toBe('blocked');
@@ -303,14 +305,14 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
 
         for (const env of [knowledgeBaseEnv, memoryCoreEnv, orchestratorEnv]) {
             expect(env).toMatchObject({
-                NEO_MODEL_PROVIDER                     : '${NEO_MODEL_PROVIDER:-}',
-                NEO_EMBEDDING_PROVIDER                 : '${NEO_EMBEDDING_PROVIDER:-}',
-                NEO_OPENAI_COMPATIBLE_HOST             : '${NEO_OPENAI_COMPATIBLE_HOST:-}',
-                NEO_OPENAI_COMPATIBLE_MODEL            : '${NEO_OPENAI_COMPATIBLE_MODEL:-}',
-                NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL  : '${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}',
-                NEO_OPENAI_COMPATIBLE_API_KEY          : '${NEO_OPENAI_COMPATIBLE_API_KEY:-}',
-                NEO_OLLAMA_KEEP_ALIVE                  : '${NEO_OLLAMA_KEEP_ALIVE:-}',
-                NEO_OPENAI_COMPATIBLE_KEEP_ALIVE       : '${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}'
+                NEO_MODEL_PROVIDER                   : '${NEO_MODEL_PROVIDER:-}',
+                NEO_EMBEDDING_PROVIDER               : '${NEO_EMBEDDING_PROVIDER:-}',
+                NEO_OPENAI_COMPATIBLE_HOST           : '${NEO_OPENAI_COMPATIBLE_HOST:-}',
+                NEO_OPENAI_COMPATIBLE_MODEL          : '${NEO_OPENAI_COMPATIBLE_MODEL:-}',
+                NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: '${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}',
+                NEO_OPENAI_COMPATIBLE_API_KEY        : '${NEO_OPENAI_COMPATIBLE_API_KEY:-}',
+                NEO_OLLAMA_KEEP_ALIVE                : '${NEO_OLLAMA_KEEP_ALIVE:-}',
+                NEO_OPENAI_COMPATIBLE_KEEP_ALIVE     : '${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}'
             });
         }
 


### PR DESCRIPTION
Resolves #13875

Extracts the config-backed child-process task composition out of `Orchestrator.mjs` into `ConfiguredTaskDefinitionsService.mjs`, keeping `taskDefinitions.mjs` as the pure descriptor/default layer and leaving Orchestrator as the cadence/backpressure/delegation surface. The task contracts for graph-log compaction, MLX, LMS, Ollama, Chroma, dev-server, and Neural Link Bridge stay covered by the existing orchestrator tests, while the new source invariant prevents the configured launch details from drifting back into Orchestrator.

Evidence: L2 (focused unit/static coverage for task composition delegation and cloud compose profile guards) -> L2 required (refactor preserves configured task contracts without live cloud handoff). No residuals.

## Deltas from ticket
Adds an explicit cloud compose guard for LMS/Ollama local launchers alongside the existing MLX/local-only disables. That is the narrow cloud-safety follow-through from the ticket discussion, not a topology rewrite.

## Test Evidence
- `npm run agent-preflight -- ai/daemons/orchestrator/Orchestrator.mjs ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs ai/deploy/docker-compose.yml test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs` passed: 90 tests.
- `git diff --cached --check` passed before commit.

## Post-Merge Validation
- [ ] Cloud compose profile starts the orchestrator with local inference launchers disabled in deployment smoke.

## Commit
- `edff9e1aeb` — `refactor(ai): extract configured task composition (#13875)`

Authored by Euclid (GPT-5, Codex Desktop). Session db5b2ecf-db91-4b7d-9498-ccef00426a1c.
