### PR TITLE
fix(ai): echo MCP startup failures to stderr (#13877)

### DIFF
--- a/ai/mcp/server/github-workflow/mcp-server.mjs
+++ b/ai/mcp/server/github-workflow/mcp-server.mjs
@@ -35,6 +35,6 @@ try {
         configFile: options.config
     }).ready();
 } catch (error) {
-    logger.error('Fatal error during server initialization:', error);
+    logger.fatalStartup('Fatal error during server initialization:', error);
     process.exit(1);
 }

--- a/ai/mcp/server/gitlab-workflow/mcp-server.mjs
+++ b/ai/mcp/server/gitlab-workflow/mcp-server.mjs
@@ -34,6 +34,6 @@ try {
         configFile: options.config
     }).ready();
 } catch (error) {
-    logger.error('Fatal error during server initialization:', error);
+    logger.fatalStartup('Fatal error during server initialization:', error);
     process.exit(1);
 }

--- a/ai/mcp/server/knowledge-base/mcp-server.mjs
+++ b/ai/mcp/server/knowledge-base/mcp-server.mjs
@@ -35,6 +35,6 @@ try {
         configFile: options.config
     }).ready();
 } catch (error) {
-    logger.error('Fatal error during server initialization:', error);
+    logger.fatalStartup('Fatal error during server initialization:', error);
     process.exit(1);
 }

--- a/ai/mcp/server/memory-core/mcp-server.mjs
+++ b/ai/mcp/server/memory-core/mcp-server.mjs
@@ -35,6 +35,6 @@ try {
         configFile: options.config
     }).ready();
 } catch (error) {
-    logger.error('Fatal error during server initialization:', error);
+    logger.fatalStartup('Fatal error during server initialization:', error);
     process.exit(1);
 }

--- a/ai/mcp/server/neural-link/mcp-server.mjs
+++ b/ai/mcp/server/neural-link/mcp-server.mjs
@@ -39,6 +39,6 @@ try {
         toolProjectionMode: resolveToolProjectionMode(options.toolProjectionMode)
     }).ready();
 } catch (error) {
-    logger.error('Fatal error during server initialization:', error);
+    logger.fatalStartup('Fatal error during server initialization:', error);
     process.exit(1);
 }

--- a/ai/mcp/server/shared/logger.mjs
+++ b/ai/mcp/server/shared/logger.mjs
@@ -18,6 +18,11 @@ const DEFAULT_LOGGER_CONFIG = {
     timestampStyle: 'plain'
 };
 
+const FATAL_STARTUP_LOGGER_CONFIG = {
+    ...DEFAULT_LOGGER_CONFIG,
+    stderrMode: 'force'
+};
+
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
@@ -194,9 +199,9 @@ export const listHistoricalLogFiles = ({
             const filePath = path.join(logDir, entry.name);
 
             return {
-                name    : entry.name,
+                name: entry.name,
                 filePath,
-                date    : match[1],
+                date: match[1],
                 time    : Date.parse(`${match[1]}T00:00:00.000Z`),
                 size    : includeSize ? statFile(filePath).size : undefined
             };
@@ -389,6 +394,11 @@ export const createLogger = (aiConfig = {}, fallbackLoggerConfig = {}) => {
     const writeStderr = (level, args, loggerConfig) => {
         const data = getConfigData(aiConfig);
 
+        if (loggerConfig.stderrMode === 'force') {
+            process.stderr.write(formatLogLine(level, args, loggerConfig));
+            return;
+        }
+
         if (loggerConfig.stderrMode === 'debug') {
             if (data.debug) {
                 console.error(`[${level.toUpperCase()}]`, ...args);
@@ -412,19 +422,23 @@ export const createLogger = (aiConfig = {}, fallbackLoggerConfig = {}) => {
         }
     };
 
-    const createLogMethod = level => (...args) => {
+    const createLogMethod = (level, options = {}) => (...args) => {
         const loggerConfig = getLoggerConfig(aiConfig, fallbackLoggerConfig);
 
         writeFile(level, args, loggerConfig);
-        writeStderr(level, args, loggerConfig);
+        writeStderr(level, args, options.forceStderr ? {
+            ...loggerConfig,
+            ...FATAL_STARTUP_LOGGER_CONFIG
+        } : loggerConfig);
     };
 
     const logger = {
-        debug: createLogMethod('debug'),
-        error: createLogMethod('error'),
-        info : createLogMethod('info'),
-        log  : createLogMethod('log'),
-        warn : createLogMethod('warn')
+        debug       : createLogMethod('debug'),
+        error       : createLogMethod('error'),
+        fatalStartup: createLogMethod('error', {forceStderr: true}),
+        info        : createLogMethod('info'),
+        log         : createLogMethod('log'),
+        warn        : createLogMethod('warn')
     };
 
     if (getLoggerConfig(aiConfig, fallbackLoggerConfig).flush) {

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -13,16 +13,16 @@ setup({
     }
 });
 
-import {test, expect}    from '@playwright/test';
-import {parse}           from 'acorn';
-import fs                from 'fs';
-import path              from 'path';
+import {test, expect} from '@playwright/test';
+import {parse}        from 'acorn';
+import fs             from 'fs';
+import path           from 'path';
 import {fileURLToPath,
         pathToFileURL}   from 'url';
-import yaml              from 'js-yaml';
-import Neo               from '../../../../../../src/Neo.mjs';
-import * as core         from '../../../../../../src/core/_export.mjs';
-import ToolService       from '../../../../../../ai/mcp/ToolService.mjs';
+import yaml        from 'js-yaml';
+import Neo         from '../../../../../../src/Neo.mjs';
+import * as core   from '../../../../../../src/core/_export.mjs';
+import ToolService from '../../../../../../ai/mcp/ToolService.mjs';
 
 const
     __filename = fileURLToPath(import.meta.url),
@@ -38,6 +38,7 @@ const
         },
         {
             name           : 'gitlab-workflow',
+            guardedStartup : true,
             toolServicePath: 'ai/mcp/server/gitlab-workflow/toolService.mjs',
             openApiPath    : 'ai/mcp/server/gitlab-workflow/openapi.yaml',
             mcpServerPath  : 'ai/mcp/server/gitlab-workflow/mcp-server.mjs',
@@ -45,6 +46,7 @@ const
         },
         {
             name           : 'github-workflow',
+            guardedStartup : true,
             toolServicePath: 'ai/mcp/server/github-workflow/toolService.mjs',
             openApiPath    : 'ai/mcp/server/github-workflow/openapi.yaml',
             mcpServerPath  : 'ai/mcp/server/github-workflow/mcp-server.mjs',
@@ -52,6 +54,7 @@ const
         },
         {
             name           : 'knowledge-base',
+            guardedStartup : true,
             toolServicePath: 'ai/mcp/server/knowledge-base/toolService.mjs',
             openApiPath    : 'ai/mcp/server/knowledge-base/openapi.yaml',
             mcpServerPath  : 'ai/mcp/server/knowledge-base/mcp-server.mjs',
@@ -59,6 +62,7 @@ const
         },
         {
             name           : 'memory-core',
+            guardedStartup : true,
             toolServicePath: 'ai/mcp/server/memory-core/toolService.mjs',
             openApiPath    : 'ai/mcp/server/memory-core/openapi.yaml',
             mcpServerPath  : 'ai/mcp/server/memory-core/mcp-server.mjs',
@@ -66,6 +70,7 @@ const
         },
         {
             name           : 'neural-link',
+            guardedStartup : true,
             toolServicePath: 'ai/mcp/server/neural-link/toolService.mjs',
             openApiPath    : 'ai/mcp/server/neural-link/openapi.yaml',
             mcpServerPath  : 'ai/mcp/server/neural-link/mcp-server.mjs',
@@ -80,8 +85,8 @@ const
  */
 function getOperationIds(server) {
     const
-        openApiFile = path.join(repoRoot, server.openApiPath),
-        doc         = yaml.load(fs.readFileSync(openApiFile, 'utf8')),
+        openApiFile  = path.join(repoRoot, server.openApiPath),
+        doc          = yaml.load(fs.readFileSync(openApiFile, 'utf8')),
         operationIds = [];
 
     for (const pathItem of Object.values(doc.paths || {})) {
@@ -253,6 +258,16 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         });
     }
 
+    test('guarded MCP entrypoints force fatal startup errors to stderr (#13877)', () => {
+        for (const server of servers.filter(item => item.guardedStartup)) {
+            const source = fs.readFileSync(path.join(repoRoot, server.mcpServerPath), 'utf8');
+
+            expect(source, `${server.name} must keep the stale-config boot guard`).toContain('assertConfigFresh');
+            expect(source, `${server.name} fatal startup errors must reach MCP-client stderr`).toContain('logger.fatalStartup');
+            expect(source, `${server.name} must not regress to logger-only fatal exits`).not.toContain("logger.error('Fatal error during server initialization:'");
+        }
+    });
+
     test('file-system exposes compact list descriptions plus lazy-loaded handbook detail (#13268)', async () => {
         const
             server        = servers.find(item => item.name === 'file-system'),
@@ -284,9 +299,9 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(handbook.handbook.replace(/\s+/g, ' ')).toContain('directory traversal outside the permitted workspace');
 
         expect(missing).toEqual({
-            toolId: 'missing_tool',
-            found : false,
-            code  : 'TOOL_NOT_FOUND',
+            toolId : 'missing_tool',
+            found  : false,
+            code   : 'TOOL_NOT_FOUND',
             message: 'Tool "missing_tool" does not exist in this MCP server.'
         });
     });
@@ -323,9 +338,9 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(handbook.handbook.replace(/\s+/g, ' ')).toContain('Prefer `ask_knowledge_base` for most queries');
 
         expect(missing).toEqual({
-            toolId: 'missing_tool',
-            found : false,
-            code  : 'TOOL_NOT_FOUND',
+            toolId : 'missing_tool',
+            found  : false,
+            code   : 'TOOL_NOT_FOUND',
             message: 'Tool "missing_tool" does not exist in this MCP server.'
         });
     });
@@ -362,9 +377,9 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(handbook.handbook).toContain('SESSION_BUSY');
 
         expect(missing).toEqual({
-            toolId: 'missing_tool',
-            found : false,
-            code  : 'TOOL_NOT_FOUND',
+            toolId : 'missing_tool',
+            found  : false,
+            code   : 'TOOL_NOT_FOUND',
             message: 'Tool "missing_tool" does not exist in this MCP server.'
         });
     });
@@ -398,9 +413,9 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(handbook.handbook).toContain('GitLab GraphQL API');
 
         expect(missing).toEqual({
-            toolId: 'missing_tool',
-            found : false,
-            code  : 'TOOL_NOT_FOUND',
+            toolId : 'missing_tool',
+            found  : false,
+            code   : 'TOOL_NOT_FOUND',
             message: 'Tool "missing_tool" does not exist in this MCP server.'
         });
     });
@@ -438,9 +453,9 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(handbook.handbook.replace(/\s+/g, ' ')).toContain('Run `sync_all` to update local markdown files');
 
         expect(missing).toEqual({
-            toolId: 'missing_tool',
-            found : false,
-            code  : 'TOOL_NOT_FOUND',
+            toolId : 'missing_tool',
+            found  : false,
+            code   : 'TOOL_NOT_FOUND',
             message: 'Tool "missing_tool" does not exist in this MCP server.'
         });
     });
@@ -474,9 +489,9 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(handbook.handbook).toContain('StateProviders');
 
         expect(missing).toEqual({
-            toolId: 'missing_tool',
-            found : false,
-            code  : 'TOOL_NOT_FOUND',
+            toolId : 'missing_tool',
+            found  : false,
+            code   : 'TOOL_NOT_FOUND',
             message: 'Tool "missing_tool" does not exist in this MCP server.'
         });
     });
@@ -563,9 +578,9 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
 
     test('forced harness-embedded mode lists only read-tier tools end-to-end, even with omitted _meta (#13106)', async () => {
         const
-            server        = servers.find(item => item.name === 'neural-link'),
-            nlModuleUrl   = pathToFileURL(path.join(repoRoot, 'ai/mcp/server/neural-link/Server.mjs')).href,
-            Server        = (await import(nlModuleUrl)).default,
+            server      = servers.find(item => item.name === 'neural-link'),
+            nlModuleUrl = pathToFileURL(path.join(repoRoot, 'ai/mcp/server/neural-link/Server.mjs')).href,
+            Server      = (await import(nlModuleUrl)).default,
             // server pinned to harness-embedded; client sends NO _meta (the omitted-_meta bypass path)
             forcedContext = Server.prototype.buildToolProjectionContext.call(
                 {toolProjectionMode: 'harness-embedded'}, {request: {params: {}}}

--- a/test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs
@@ -13,12 +13,12 @@ setup({
     }
 });
 
-import {test, expect}  from '@playwright/test';
-import fs              from 'fs-extra';
-import os              from 'os';
-import path            from 'path';
-import Neo             from '../../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../../src/core/_export.mjs';
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
     createLogger,
     pruneLoggerRetention,
@@ -126,6 +126,37 @@ test.describe('Neo.ai.mcp.server.shared.Logger', () => {
         expect(stderrWrites.join('')).toContain('[INFO] nl-info-visible');
         expect(stderrWrites.join('')).toContain('[WARN] nl-warn-visible');
         expect(stderrWrites.join('')).toContain('[ERROR] nl-error-visible');
+    });
+
+    test('fatalStartup forces stderr while keeping stdout protocol-clean (#13877)', () => {
+        const stderrWrites = [];
+        const stdoutCalls  = [];
+
+        process.stderr.write = value => {
+            stderrWrites.push(String(value));
+            return true;
+        };
+        process.stdout.write = (...args) => {
+            stdoutCalls.push(args);
+            return true;
+        };
+
+        const logger = createLogger({
+            debug : false,
+            logger: {
+                fileSink      : false,
+                stderrMode    : 'debug',
+                timestampStyle: 'plain'
+            }
+        });
+
+        logger.error('debug-muted-error', new Error('hidden'));
+        logger.fatalStartup('Fatal error during server initialization:', new Error('stale config overlay'));
+
+        expect(stdoutCalls).toHaveLength(0);
+        expect(stderrWrites.join('')).not.toContain('debug-muted-error');
+        expect(stderrWrites.join('')).toContain('[ERROR] Fatal error during server initialization: Error: stale config overlay');
+        expect(stderrWrites.join('')).toContain('at ');
     });
 
     test('writes durable file logs, preserves Error details, and flushes when enabled', async () => {


### PR DESCRIPTION
Resolves #13877

Fatal startup failures in guarded MCP entrypoints now use the shared logger's `fatalStartup()` path, which preserves the existing per-server log sink and also forces one operator-visible line to stderr before the process exits. stdout remains untouched for stdio MCP protocol frames. This turns stale-config overlay crashes from a generic client-side `Server disconnected` into an actionable stderr message that includes the `--migrate-config` remediation already produced by `assertConfigFresh()`.

Evidence: L2 (logger behavior unit coverage + cross-server guarded-entrypoint source invariant + reproduced local stale-overlay repair) -> L2 required (MCP startup diagnostics contract). No residuals.

## Deltas from ticket
The implementation keeps the fix inside the existing shared MCP logger instead of adding one-off `console.error()` calls to each entrypoint. The entrypoints still call the shared fatal path explicitly, so normal runtime logging behavior is unchanged.

## Test Evidence
- Reproduced the original failure against current `dev`: Knowledge Base exited code 1 with empty stderr; repo log showed `Stale config overlay` and the `npm run prepare -- --migrate-config` fix.
- Ran `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` in the affected sibling checkouts; the same Knowledge Base and GitHub Workflow initialize probes then stayed alive after timeout.
- `npm run agent-preflight -- ai/mcp/server/shared/logger.mjs ai/mcp/server/memory-core/mcp-server.mjs ai/mcp/server/knowledge-base/mcp-server.mjs ai/mcp/server/github-workflow/mcp-server.mjs ai/mcp/server/gitlab-workflow/mcp-server.mjs ai/mcp/server/neural-link/mcp-server.mjs test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` passed after rebase: 37 tests.
- `git diff --cached --check` passed before commit; `git diff --check origin/dev..HEAD` passed after rebase.

## Post-Merge Validation
- [ ] Restart a stale-overlay MCP server from a GUI client and confirm the client log includes the actionable stderr line rather than only `Server disconnected`.

## Commit
- `cb9641351d` — `fix(ai): echo MCP startup failures to stderr (#13877)`

Authored by Euclid (GPT-5, Codex Desktop). Session db5b2ecf-db91-4b7d-9498-ccef00426a1c.
