### PR TITLE
fix(ai): preserve sunset handover boot visibility (#13886)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/summary.mjs
+++ b/ai/daemons/orchestrator/scheduling/summary.mjs
@@ -1,6 +1,6 @@
 import {
     getUnreadSunsetHandovers,
-    markNodesAsRead
+    markSunsetHandoversSummaryProcessed
 } from '../../wake/queries.mjs';
 import {
     getPendingMemorySummaryBackfillJobs,
@@ -186,8 +186,8 @@ export function hasDrainableMemorySummaryBackfill({
 export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [], pendingJobs = [], totalPending, unsummarizedCount}) {
     if (handovers.length > 0) {
         return {
-            taskName     : 'summary',
-            source       : 'sunset-handover',
+            taskName: 'summary',
+            source  : 'sunset-handover',
             reason       : `sunset-handover:${handovers.length}`,
             handoverCount: handovers.length
         };
@@ -197,8 +197,8 @@ export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [],
         const backlog = Number.isInteger(totalPending) ? totalPending : pendingJobs.length;
 
         return {
-            taskName    : 'summary',
-            source      : 'pending-summarization',
+            taskName: 'summary',
+            source  : 'pending-summarization',
             reason      : `pending-summarization:${backlog}`,
             pendingCount: pendingJobs.length
         };
@@ -218,8 +218,8 @@ export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [],
 }
 
 /**
- * Resolves the next summary task trigger, including the post-success handover mark-read hook
- * when the trigger source is sunset-handover.
+ * Resolves the next summary task trigger, including the post-success handover summary-processed
+ * hook when the trigger source is sunset-handover.
  *
  * @param {Object} options
  * @param {Object} options.db SQLite database handle.
@@ -230,7 +230,8 @@ export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [],
  * @param {Function} [options.getPendingSummarizationJobsFn] Test seam for pending marker reads.
  * @param {Function} [options.getPendingMemorySummaryBackfillJobsFn] Test seam for miniSummary backlog.
  * @param {Function} [options.isMemorySummaryBackfillBackoffActiveFn] Test seam for miniSummary backoff.
- * @param {Function} [options.markNodesAsReadFn] Test seam for handover mark-read writes.
+ * @param {Function} [options.markSunsetHandoversSummaryProcessedFn] Test seam for handover
+ *     summary-consumed writes.
  * @param {Function} [options.log] Optional orchestrator log function.
  * @returns {Object|null} Task trigger with optional `onSuccess` callback, or null.
  */
@@ -245,7 +246,7 @@ export function getDueTask({
     getPendingSessionSummaryCountFn = getPendingSessionSummaryCount,
     getPendingMemorySummaryBackfillJobsFn = getPendingMemorySummaryBackfillJobs,
     isMemorySummaryBackfillBackoffActiveFn = isMemorySummaryBackfillBackoffActive,
-    markNodesAsReadFn          = markNodesAsRead,
+    markSunsetHandoversSummaryProcessedFn = markSunsetHandoversSummaryProcessed,
     log
 }) {
     const handovers = getUnreadSunsetHandoversFn(db);
@@ -286,8 +287,8 @@ export function getDueTask({
         return {
             ...trigger,
             onSuccess: () => {
-                markNodesAsReadFn(db, handovers);
-                log?.('INFO', `[Orchestrator] Marked ${handovers.length} sunset handovers as read.`);
+                markSunsetHandoversSummaryProcessedFn(db, handovers);
+                log?.('INFO', `[Orchestrator] Marked ${handovers.length} sunset handovers as summary-processed.`);
             }
         };
     }

--- a/ai/daemons/wake/queries.mjs
+++ b/ai/daemons/wake/queries.mjs
@@ -1,5 +1,5 @@
-import fs from 'fs-extra';
-import Database from 'better-sqlite3';
+import fs                              from 'fs-extra';
+import Database                        from 'better-sqlite3';
 import { SQLITE_IN_CLAUSE_BATCH_SIZE } from '../../graph/storage/constants.mjs';
 
 export function initializeDatabase(dbPath) {
@@ -294,6 +294,7 @@ export function getUnreadSunsetHandovers(db) {
         SELECT id, data FROM Nodes
         WHERE json_extract(data, '$.type') = 'MESSAGE'
           AND json_extract(data, '$.properties.readAt') IS NULL
+          AND json_extract(data, '$.properties.handoverSummaryProcessedAt') IS NULL
           AND json_extract(data, '$.properties.taggedConcepts') LIKE '%"sunset-protocol-handover"%'
     `);
     const rows = stmt.all();
@@ -313,6 +314,18 @@ export function getUnreadSunsetHandovers(db) {
         }
     }
     return unreadMessages;
+}
+
+export function markSunsetHandoversSummaryProcessed(db, nodes) {
+    if (nodes.length === 0) return;
+    const stmt = db.prepare('UPDATE Nodes SET data = ? WHERE id = ?');
+    db.transaction(() => {
+        for (const node of nodes) {
+            node.properties ??= {};
+            node.properties.handoverSummaryProcessedAt = new Date().toISOString();
+            stmt.run(JSON.stringify(node), node.id);
+        }
+    })();
 }
 
 export function markNodesAsRead(db, nodes) {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
@@ -115,13 +115,13 @@ test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
         const markCalls = [];
         const handovers = [{id: 'MESSAGE:1'}, {id: 'MESSAGE:2'}];
         const result = getDueTask({
-            db                        : 'mock-db',
-            state                     : {summary: {lastRunAt: 0}},
-            now                       : 100,
-            summarySweepIntervalMs    : 600000,
-            getUnreadSunsetHandoversFn: () => handovers,
-            markNodesAsReadFn         : (db, nodes) => markCalls.push({db, nodes}),
-            log                       : () => {}
+            db                                   : 'mock-db',
+            state                                : {summary: {lastRunAt: 0}},
+            now                                  : 100,
+            summarySweepIntervalMs               : 600000,
+            getUnreadSunsetHandoversFn           : () => handovers,
+            markSunsetHandoversSummaryProcessedFn: (db, nodes) => markCalls.push({db, nodes}),
+            log                                  : () => {}
         });
         expect(result.source).toBe('sunset-handover');
         expect(result.handoverCount).toBe(2);

--- a/test/playwright/unit/ai/daemons/wake/queries.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/queries.spec.mjs
@@ -1,9 +1,16 @@
 import { test, expect } from '@playwright/test';
-import Database from 'better-sqlite3';
-import fs from 'fs-extra';
-import os from 'os';
-import path from 'path';
-import { collapseDuplicateShapeCRoutes, getLastSyncId, getUnreadSunsetHandovers, markNodesAsRead, writeLastSyncId } from '../../../../../../ai/daemons/wake/queries.mjs';
+import Database         from 'better-sqlite3';
+import fs               from 'fs-extra';
+import os               from 'os';
+import path             from 'path';
+import {
+    collapseDuplicateShapeCRoutes,
+    getLastSyncId,
+    getUnreadSunsetHandovers,
+    markNodesAsRead,
+    markSunsetHandoversSummaryProcessed,
+    writeLastSyncId
+} from '../../../../../../ai/daemons/wake/queries.mjs';
 
 test.describe('ai/daemons/wake/queries', () => {
     let db;
@@ -28,7 +35,7 @@ test.describe('ai/daemons/wake/queries', () => {
     test.describe('getUnreadSunsetHandovers', () => {
         test('finds unread MESSAGE nodes tagged with sunset-protocol-handover', () => {
             const messageData = {
-                type: 'MESSAGE',
+                type      : 'MESSAGE',
                 properties: {
                     taggedConcepts: ['sunset-protocol-handover', 'other-concept']
                 }
@@ -42,10 +49,25 @@ test.describe('ai/daemons/wake/queries', () => {
 
         test('ignores read MESSAGE nodes', () => {
             const messageData = {
-                type: 'MESSAGE',
+                type      : 'MESSAGE',
                 properties: {
-                    readAt: new Date().toISOString(),
+                    readAt        : new Date().toISOString(),
                     taggedConcepts: ['sunset-protocol-handover']
+                }
+            };
+            db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run('msg-1', JSON.stringify(messageData));
+
+            const results = getUnreadSunsetHandovers(db);
+            expect(results.length).toBe(0);
+        });
+
+        test('ignores summary-processed handovers without marking recipient readAt', () => {
+            const messageData = {
+                type      : 'MESSAGE',
+                properties: {
+                    handoverSummaryProcessedAt: new Date().toISOString(),
+                    readAt                    : null,
+                    taggedConcepts            : ['sunset-protocol-handover']
                 }
             };
             db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run('msg-1', JSON.stringify(messageData));
@@ -56,7 +78,7 @@ test.describe('ai/daemons/wake/queries', () => {
 
         test('ignores nodes without the taggedConcept', () => {
             const messageData = {
-                type: 'MESSAGE',
+                type      : 'MESSAGE',
                 properties: {
                     taggedConcepts: ['some-other-concept']
                 }
@@ -69,7 +91,7 @@ test.describe('ai/daemons/wake/queries', () => {
 
         test('ignores non-MESSAGE nodes', () => {
             const nodeData = {
-                type: 'EPISODIC',
+                type      : 'EPISODIC',
                 properties: {
                     taggedConcepts: ['sunset-protocol-handover']
                 }
@@ -81,11 +103,34 @@ test.describe('ai/daemons/wake/queries', () => {
         });
     });
 
+    test.describe('markSunsetHandoversSummaryProcessed', () => {
+        test('sets the summary-processed marker without consuming the inbox read state', () => {
+            const node = {
+                id        : 'msg-1',
+                type      : 'MESSAGE',
+                properties: {
+                    readAt        : null,
+                    taggedConcepts: ['sunset-protocol-handover']
+                }
+            };
+            db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(node.id, JSON.stringify(node));
+
+            markSunsetHandoversSummaryProcessed(db, [node]);
+
+            const row = db.prepare('SELECT data FROM Nodes WHERE id = ?').get('msg-1');
+            const updatedNode = JSON.parse(row.data);
+
+            expect(updatedNode.properties.handoverSummaryProcessedAt).toBeDefined();
+            expect(new Date(updatedNode.properties.handoverSummaryProcessedAt).getTime()).not.toBeNaN();
+            expect(updatedNode.properties.readAt).toBeNull();
+        });
+    });
+
     test.describe('markNodesAsRead', () => {
         test('updates readAt for provided nodes', () => {
             const node = {
-                id: 'msg-1',
-                type: 'MESSAGE',
+                id        : 'msg-1',
+                type      : 'MESSAGE',
                 properties: {
                     taggedConcepts: ['sunset-protocol-handover']
                 }


### PR DESCRIPTION
Resolves #13886

Preserves session-sunset handover boot visibility by splitting summary consumption from recipient read state. The orchestrator summary task now marks sunset handover `MESSAGE` nodes with `handoverSummaryProcessedAt` after summarization succeeds, while leaving `readAt` untouched so the successor's normal unread mailbox check can still surface the self-DM. The wake query excludes already-summary-processed handovers to avoid repeatedly scheduling the summary lane.

Evidence: L2 (focused unit coverage for wake query filtering plus summary scheduler handover callback) -> L4 required (successor boot observes the unread handover after operator-controlled session-sunset flow). Residual: live successor boot handoff validation.

## Deltas from ticket

Current source already had `MailboxService` coverage for self-DM inbox visibility; the failing edge is the scheduler-side mark-read after summary. This PR fixes that narrower root cause instead of widening mailbox routing.

## Test Evidence

- `node --check ai/daemons/wake/queries.mjs`
- `node --check ai/daemons/orchestrator/scheduling/summary.mjs`
- `node --check test/playwright/unit/ai/daemons/wake/queries.spec.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs`
- `git diff --check`
- `npm run agent-preflight -- --pr-body /private/tmp/neo-pr-13886-body.md ai/daemons/wake/queries.mjs ai/daemons/orchestrator/scheduling/summary.mjs test/playwright/unit/ai/daemons/wake/queries.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/queries.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs` -> 45 passed

## Post-Merge Validation

- [ ] Run a session-sunset self-DM, allow summary handover processing, then verify the successor boot mailbox check still sees the unread handover ping while the summary task does not reprocess it.

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef100-77a2-7781-a83f-4f064a3c1aca.
