### PR TITLE
fix(build): catch declaration alignment drift (#13896)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/summary.mjs
+++ b/ai/daemons/orchestrator/scheduling/summary.mjs
@@ -249,7 +249,7 @@ export function getDueTask({
     markSunsetHandoversSummaryProcessedFn = markSunsetHandoversSummaryProcessed,
     log
 }) {
-    const handovers = getUnreadSunsetHandoversFn(db);
+    const handovers   = getUnreadSunsetHandoversFn(db);
     const pendingJobs = handovers.length > 0 ? [] : getPendingSummarizationJobsFn(db);
     const lastRunAt   = state.summary?.lastRunAt || 0;
     // Only count the unsummarized-session backlog when the periodic sweep is the path that will
@@ -269,7 +269,7 @@ export function getDueTask({
         return null;
     }
 
-    const trigger   = buildSummaryTrigger({
+    const trigger = buildSummaryTrigger({
         now,
         handovers,
         pendingJobs,

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -308,7 +308,7 @@ export function buildLmsContextLengthsMap({
     chatContextLength,
     embeddingContextLength
 } = {}) {
-    const map = {};
+    const map    = {};
     const setMax = (modelId, value) => {
         if (!modelId || !Neo.isNumber(value)) {
             return;
@@ -510,7 +510,7 @@ export async function ensureLmsModelsLoaded({
         throw new TypeError('ensureLmsModelsLoaded: models must contain at least one configured model');
     }
 
-    const getMissing = available => requiredModels.filter(model => !available.includes(model));
+    const getMissing  = available => requiredModels.filter(model => !available.includes(model));
     const probeModels = async phase => {
         let lastError;
 
@@ -532,7 +532,7 @@ export async function ensureLmsModelsLoaded({
     };
 
     let {availableModels} = await probeModels('initial /v1/models probe');
-    const initialMissing  = getMissing(availableModels);
+    const initialMissing = getMissing(availableModels);
     const failedModels   = [];
 
     // Force-include context-configured models in the load set even when already
@@ -701,7 +701,7 @@ export async function ensureOllamaModelsReady({
 
     const requiredResidentModels = Math.min(requireParallelModels, requiredModels.length);
     const requiredModelSet       = new Set(requiredModels);
-    const normalizeAvailable = available => [...new Map((Array.isArray(available) ? available : []).map(item => {
+    const normalizeAvailable     = available => [...new Map((Array.isArray(available) ? available : []).map(item => {
         if (typeof item === 'string') {
             return [item, {id: item, contextLength: undefined}];
         }
@@ -712,10 +712,10 @@ export async function ensureOllamaModelsReady({
                 Neo.isNumber(item.context_length) ? item.context_length : undefined
         }] : null;
     }).filter(Boolean)).values()];
-    const toIds               = available => available.map(item => item.id);
+    const toIds                = available => available.map(item => item.id);
     const getRequiredAvailable = available => available.filter(item => requiredModelSet.has(item.id));
     const getExtraModels       = available => toIds(available.filter(item => !requiredModelSet.has(item.id)));
-    const contextRequirements = roles.reduce((map, role) => {
+    const contextRequirements  = roles.reduce((map, role) => {
         if (!role.model || !Neo.isNumber(role.contextLength)) {
             return map;
         }
@@ -812,13 +812,13 @@ export async function ensureOllamaModelsReady({
         };
     }
 
-    const initialMissing = getMissing(availableModels);
+    const initialMissing             = getMissing(availableModels);
     const initialInsufficientContext = getInsufficientContext(availableModels);
     const initialContextModelIds     = new Set(initialInsufficientContext.map(item => item.model));
-    const rolesToWarm    = roles.filter(role => initialMissing.includes(role.model) || initialContextModelIds.has(role.model));
-    const warmedModels   = [];
-    const failedModels   = [];
-    const attemptedModels = [];
+    const rolesToWarm                = roles.filter(role => initialMissing.includes(role.model) || initialContextModelIds.has(role.model));
+    const warmedModels               = [];
+    const failedModels               = [];
+    const attemptedModels            = [];
 
     for (const role of rolesToWarm) {
         const roleEnvelope = toRoleEnvelope(role);
@@ -848,7 +848,7 @@ export async function ensureOllamaModelsReady({
         }
     }
 
-    let missingModels = initialMissing;
+    let missingModels             = initialMissing;
     let insufficientContextModels = initialInsufficientContext;
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
@@ -856,19 +856,19 @@ export async function ensureOllamaModelsReady({
         missingModels = getMissing(availableModels);
         insufficientContextModels = getInsufficientContext(availableModels);
 
-        const failedModelIds     = new Set(failedModels.map(item => item.model));
-        const serviceableMissing = missingModels.filter(model => !failedModelIds.has(model));
-        const serviceableContext = insufficientContextModels.filter(item => !failedModelIds.has(item.model));
-        const observedCount      = availableModels.length;
+        const failedModelIds        = new Set(failedModels.map(item => item.model));
+        const serviceableMissing    = missingModels.filter(model => !failedModelIds.has(model));
+        const serviceableContext    = insufficientContextModels.filter(item => !failedModelIds.has(item.model));
+        const observedCount         = availableModels.length;
         const observedRequiredCount = getRequiredAvailable(availableModels).length;
-        const capacityReady      = observedRequiredCount >= requiredResidentModels;
-        const ready              = capacityReady && missingModels.length === 0 && insufficientContextModels.length === 0 && failedModels.length === 0;
-        const capacityOnlyGap    = missingModels.length === 0 && !capacityReady;
+        const capacityReady         = observedRequiredCount >= requiredResidentModels;
+        const ready                 = capacityReady && missingModels.length === 0 && insufficientContextModels.length === 0 && failedModels.length === 0;
+        const capacityOnlyGap       = missingModels.length === 0 && !capacityReady;
 
         const contextOnlyGap = missingModels.length === 0 && serviceableContext.length > 0;
 
         if (ready || (allowPartial && (serviceableMissing.length === 0 || capacityOnlyGap || contextOnlyGap))) {
-            const degraded = !ready;
+            const degraded       = !ready;
             const contextWarning = serviceableContext.length
                 ? `[provider/ollama] loaded context too small: ${serviceableContext.map(item => `${item.model} observed=${item.contextLength ?? 'unknown'} required>=${item.requiredContextLength}`).join(', ')}; warm with options.num_ctx matching localModels context caps.`
                 : null;
@@ -905,7 +905,7 @@ export async function ensureOllamaModelsReady({
         ? `[provider/ollama] loaded context too small: ${insufficientContextModels.map(item => `${item.model} observed=${item.contextLength ?? 'unknown'} required>=${item.requiredContextLength}`).join(', ')}; warm with options.num_ctx matching localModels context caps.`
         : null;
     const observedRequiredCount = getRequiredAvailable(availableModels).length;
-    const warning = contextWarning || getWarning({availableModels, missingModels, observedRequiredCount});
+    const warning               = contextWarning || getWarning({availableModels, missingModels, observedRequiredCount});
     if (allowPartial) {
         return {
             ready          : false,
@@ -961,12 +961,12 @@ export function getGraphProviderReadinessTarget(config = aiConfig) {
     const host     = isOllama
         ? config.ollama?.host
         : getOpenAiCompatibleHost(config);
-    const endpoint = isOllama ? '/api/tags' : '/v1/models';
-    const model    = isOllama ? config.ollama?.model : config.openAiCompatible?.model;
+    const endpoint       = isOllama ? '/api/tags' : '/v1/models';
+    const model          = isOllama ? config.ollama?.model : config.openAiCompatible?.model;
     const embeddingModel = isOllama
         ? config.ollama?.embeddingModel
         : config.openAiCompatible?.embeddingModel;
-    const url      = host ? `${host.replace(/\/+$/, '')}${endpoint}` : null;
+    const url = host ? `${host.replace(/\/+$/, '')}${endpoint}` : null;
 
     return {
         provider,
@@ -1005,9 +1005,9 @@ export function createParallelModelCapacityWarning({
     observedRequiredCount,
     requireParallelModels
 }) {
-    const available = availableModels.length ? availableModels.join(', ') : 'none';
-    const missing   = missingModels.length ? missingModels.join(', ') : 'none';
-    const extra     = extraModels.length ? extraModels.join(', ') : 'none';
+    const available        = availableModels.length ? availableModels.join(', ') : 'none';
+    const missing          = missingModels.length ? missingModels.join(', ') : 'none';
+    const extra            = extraModels.length ? extraModels.join(', ') : 'none';
     const requiredObserved = Neo.isNumber(observedRequiredCount) ? observedRequiredCount : observedCount;
     const base      = `[provider/${provider}] expected ${requireParallelModels}+ required models loaded ` +
         `(chat=${model || 'unset'}, embedding=${embeddingModel || 'unset'}); observed ${requiredObserved} required / ${observedCount} total loaded ` +
@@ -1062,25 +1062,25 @@ export async function probeProviderParallelModelCapacity({
         };
     }
 
-    const providerConfig = config[target.provider];
+    const providerConfig        = config[target.provider];
     const requireParallelModels = providerConfig?.requireParallelModels;
 
     if (!Neo.isNumber(requireParallelModels)) {
         throw new TypeError(`probeProviderParallelModelCapacity: config.${target.provider}.requireParallelModels must be configured as a number`);
     }
 
-    const requiredModels = getRequiredProviderModels(target);
+    const requiredModels  = getRequiredProviderModels(target);
     const availableModels = target.provider === 'ollama'
         ? await fetchOllamaModels({host: target.host, timeoutMs})
         : await fetchOpenAiCompatibleModels({host: target.host, timeoutMs});
-    const uniqueAvailable = [...new Set(availableModels)];
-    const missingModels   = requiredModels.filter(model => !uniqueAvailable.includes(model));
-    const requiredModelSet = new Set(requiredModels);
-    const extraModels     = uniqueAvailable.filter(model => !requiredModelSet.has(model));
-    const observedCount   = uniqueAvailable.length;
-    const observedRequiredCount = uniqueAvailable.filter(model => requiredModelSet.has(model)).length;
+    const uniqueAvailable        = [...new Set(availableModels)];
+    const missingModels          = requiredModels.filter(model => !uniqueAvailable.includes(model));
+    const requiredModelSet       = new Set(requiredModels);
+    const extraModels            = uniqueAvailable.filter(model => !requiredModelSet.has(model));
+    const observedCount          = uniqueAvailable.length;
+    const observedRequiredCount  = uniqueAvailable.filter(model => requiredModelSet.has(model)).length;
     const requiredResidentModels = Math.min(requireParallelModels, requiredModels.length);
-    const ready           = observedRequiredCount >= requiredResidentModels && missingModels.length === 0;
+    const ready                  = observedRequiredCount >= requiredResidentModels && missingModels.length === 0;
 
     return {
         ready,
@@ -1144,7 +1144,7 @@ export async function warnProviderParallelModelCapacity({
         return result;
     } catch (error) {
         const provider = config ? resolveGraphModelProvider(config) : 'unknown';
-        const result = {
+        const result   = {
             ready: false,
             provider,
             error: {message: error?.message || String(error)},
@@ -1174,8 +1174,8 @@ export function checkProvider({config, timeoutMs} = {}) {
     }
 
     return new Promise(resolve => {
-        let settled = false;
-        const settle = value => {
+        let   settled = false;
+        const settle  = value => {
             if (!settled) {
                 settled = true;
                 resolve(value);
@@ -1221,7 +1221,7 @@ export async function waitForProvider({
         throw new TypeError('waitForProvider: attempts, delayMs, and timeoutMs are required (pass from config.orchestrator.providerReadiness)');
     }
 
-    const probe = providerCheck ?? (() => checkProvider({timeoutMs}));
+    const probe     = providerCheck ?? (() => checkProvider({timeoutMs}));
     const startedAt = Date.now();
 
     for (let i = 0; i < attempts; i++) {
@@ -1285,7 +1285,7 @@ export function createProviderFailureDiagnostic({
     reason = 'PROVIDER_READINESS_TIMEOUT',
     capacity
 } = {}) {
-    const target = getGraphProviderReadinessTarget(config);
+    const target      = getGraphProviderReadinessTarget(config);
     const unsupported = reason === 'UNSUPPORTED_GRAPH_PROVIDER';
     const degraded    = reason === 'PROVIDER_MODEL_RESIDENCY_DEGRADED';
 

--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -16,10 +16,10 @@ import {getStagedAddedLines} from './stagedDiff.mjs';
  * 2. **object-literal colons** (v1b) — within a run of ≥ 2 consecutive same-indent object properties,
  *    the key `:` aligns to one column = the widest key. Shorthand properties (`foo,`) stay in the run
  *    but are not themselves aligned; nested objects re-group at their own indent.
- * 3. **`=` comma-blocks** (v1b) — within a single-keyword comma-block (a lone `const`/`let`/`var`
- *    line + its indented `name = value` continuations), the `=` aligns to one column. Only this
- *    rule-35 unit is grouped — separate consecutive declarations and bare assignments are left alone,
- *    so the gate never re-aligns unrelated statements. A block-opening value (`{`/`(`/`[`) is excluded.
+ * 3. **`=` declaration blocks** (v1b) — aligns the `=` column for both house-style
+ *    repeated-keyword declarations (`let   a = …; const b = …;`) and single-keyword comma-blocks.
+ *    Bare assignments remain out of scope. The legacy lone-keyword comma-block keeps its
+ *    block-opening exclusion; keyworded declaration runs include block-opening call/object values.
  *
  * Conservative grouping (≥ 2 members, same indent, broken by any non-conforming line) so the gate
  * never touches an un-alignable shape and cannot false-positive. The column math is the entire point.
@@ -206,6 +206,10 @@ const
     LONE_KEYWORD = /^\s*(?:const|let|var)\s*$/,        // a lone `const`/`let`/`var` line (opens a comma-block)
     BARE_DECL    = /^(\s+)[A-Za-z_$][\w$]*\s*=\s*.+$/; // its indented `name = value` comma-block continuation
 
+const
+    KEYWORD_DECL           = /^(\s*)(const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(.+)$/,
+    BARE_DECL_CONTINUATION = /^(\s+)[A-Za-z_$][\w$]*\s*=\s*.+$/;
+
 /**
  * @summary The leading whitespace of a line.
  * @param {String} line
@@ -231,6 +235,39 @@ function splitAssignment(line) {
 }
 
 /**
+ * @summary Parses one keyworded variable declaration line. The returned `left` deliberately includes
+ * the keyword (`const foo`) so mixed `let`/`const` blocks align exactly like the coding-guideline
+ * example. Destructuring declarations are intentionally out of scope for this mechanical rule.
+ * @param {String} line
+ * @returns {{indent: String, kind: String, keyword: String, name: String, left: String, value: String}|null}
+ */
+function parseKeywordDeclaration(line) {
+    const match = KEYWORD_DECL.exec(line);
+    if (!match) return null;
+
+    return {
+        indent : match[1],
+        kind   : 'keyword',
+        keyword: match[2],
+        name   : match[3],
+        left   : line.slice(0, line.indexOf('=')).replace(/\s+$/, ''),
+        value  : match[4]
+    };
+}
+
+/**
+ * @summary Parses a bare `name = value` continuation under a keyworded comma-block.
+ * @param {String} line
+ * @returns {{indent: String, kind: String, left: String, value: String}|null}
+ */
+function parseBareDeclaration(line) {
+    const match = BARE_DECL_CONTINUATION.exec(line);
+    if (!match) return null;
+
+    return {indent: match[1], kind: 'bare', ...splitAssignment(line)};
+}
+
+/**
  * @summary Whether an assignment value opens a multi-line block — its last non-space char is an
  * (unclosed) `{`, `(`, or `[`. Such members are excluded from `=`-alignment: the house style leaves a
  * block-opening `=` unaligned beside its simple-valued siblings (e.g. `cloneMap = {` next to an
@@ -244,22 +281,22 @@ function opensMultilineBlock(value) {
 }
 
 /**
- * @summary Splits lines into single-keyword comma-block assignment runs: the indented `<name> = …`
- * continuations under a lone `const`/`let`/`var` keyword line (the rule-35 house-style unit). Separate
- * consecutive declarations (`let a = …; const b = …;`) and bare assignments are deliberately NOT
- * collected — only the comma-block is an alignment group, so unrelated statements are never re-aligned.
+ * @summary Splits lines into declaration assignment runs. Supported house-style units:
+ *
+ * - legacy lone-keyword comma-blocks (`const` then indented bare `name = …` continuations);
+ * - keyword-head comma-blocks (`const first = …,` then indented bare continuations);
+ * - repeated-keyword declaration blocks (`let foo = …; const longerName = …;`).
+ *
+ * Bare assignments are still deliberately NOT collected without a keyword anchor.
  * @param {String[]} lines
  * @param {Boolean[]} [maskedLines]
- * @returns {Array<Number[]>} runs of line indices (length ≥ 2)
+ * @returns {Array<{entries: Array<{lineIndex: Number, left: String, value: String}>, includeBlockOpeners: Boolean, mode: String}>}
  */
 function collectAssignmentRuns(lines, maskedLines = []) {
     const runs = [];
     let   i    = 0;
 
     while (i < lines.length) {
-        // The single-keyword comma-block — a lone `const`/`let`/`var` line, then its indented
-        // `name = value` continuations at one deeper indent — is the only `=`-alignment unit (rule 35).
-        // Separate consecutive declarations and bare assignments are NOT grouped.
         if (!maskedLines[i] && LONE_KEYWORD.test(lines[i])) {
             const keywordIndent = leadingWhitespace(lines[i]);
             const run           = [];
@@ -271,15 +308,58 @@ function collectAssignmentRuns(lines, maskedLines = []) {
                 if (indent.length <= keywordIndent.length) break; // continuations must be deeper
                 if (runIndent === null) runIndent = indent;
                 if (indent !== runIndent) break;                  // uniform indent only
-                run.push(j);
+                run.push({lineIndex: j, ...splitAssignment(lines[j])});
                 j++;
             }
 
             if (run.length >= 2) {
-                runs.push(run);
+                runs.push({entries: run, includeBlockOpeners: false, mode: 'comma'});
                 i = j;
                 continue;
             }
+        }
+
+        const keywordDeclaration = !maskedLines[i] ? parseKeywordDeclaration(lines[i]) : null;
+        if (keywordDeclaration) {
+            const keywordRun = [{lineIndex: i, ...keywordDeclaration}];
+            let   j          = i + 1;
+
+            if (keywordDeclaration.value.replace(/\s+$/, '').endsWith(',')) {
+                while (j < lines.length && !maskedLines[j]) {
+                    const bareDeclaration = parseBareDeclaration(lines[j]);
+                    if (!bareDeclaration || bareDeclaration.indent.length <= keywordDeclaration.indent.length) {
+                        break;
+                    }
+
+                    keywordRun.push({lineIndex: j, ...bareDeclaration});
+                    j++;
+                }
+            }
+
+            if (keywordRun.length >= 2) {
+                runs.push({entries: keywordRun, includeBlockOpeners: true, mode: 'comma'});
+                i = j;
+                continue;
+            }
+
+            j = i + 1;
+            while (j < lines.length && !maskedLines[j]) {
+                const nextDeclaration = parseKeywordDeclaration(lines[j]);
+                if (!nextDeclaration || nextDeclaration.indent !== keywordDeclaration.indent) {
+                    break;
+                }
+
+                keywordRun.push({lineIndex: j, ...nextDeclaration});
+                j++;
+            }
+
+            if (keywordRun.length >= 2) {
+                runs.push({entries: keywordRun, includeBlockOpeners: true, mode: 'keyword'});
+                i = j;
+                continue;
+            }
+
+            runs.push({entries: keywordRun, includeBlockOpeners: true, mode: 'keyword'});
         }
 
         i++;
@@ -300,19 +380,29 @@ function evaluateAssignmentAlignment(lines, maskedLines = []) {
         violations = [],
         fixedLines = lines.slice();
 
-    for (const run of collectAssignmentRuns(lines, maskedLines)) {
+    for (const {entries, includeBlockOpeners, mode} of collectAssignmentRuns(lines, maskedLines)) {
         // Align the simple-valued members only; a block-opening value keeps its `=` unaligned (house
-        // style). Require ≥ 2 simple members so a lone simple declaration is not an alignment group.
-        const simpleParts = run
-            .map(lineIndex => ({lineIndex, ...splitAssignment(lines[lineIndex])}))
-            .filter(part => !opensMultilineBlock(part.value));
+        // style) for legacy lone-keyword comma-blocks. Keyworded declaration blocks include block
+        // openers because that is how existing source aligns `const response = fetch(..., {`.
+        const simpleParts = includeBlockOpeners
+            ? entries
+            : entries.filter(part => !opensMultilineBlock(part.value));
 
-        if (simpleParts.length < 2) continue;
+        if (simpleParts.length === 0) continue;
+        if (simpleParts.length < 2 && lines[simpleParts[0].lineIndex] === `${simpleParts[0].left} = ${simpleParts[0].value}`) continue;
 
-        const leftWidth = Math.max(...simpleParts.map(part => part.left.length));
+        const
+            keywordWidth = mode === 'keyword' ? Math.max(...simpleParts.map(part => part.keyword.length)) : 0,
+            nameWidth    = mode === 'keyword' ? Math.max(...simpleParts.map(part => part.name.length)) : 0,
+            leftWidth    = mode === 'keyword'
+                ? Math.max(...simpleParts.map(part => part.indent.length + keywordWidth + 1 + nameWidth))
+                : Math.max(...simpleParts.map(part => part.left.length));
 
-        for (const {lineIndex, left, value} of simpleParts) {
-            const expected = `${left.padEnd(leftWidth)} = ${value}`;
+        for (const {lineIndex, left, value, indent, keyword, name} of simpleParts) {
+            const normalizedLeft = mode === 'keyword'
+                ? `${indent}${keyword.padEnd(keywordWidth)} ${name.padEnd(nameWidth)}`
+                : left;
+            const expected = `${normalizedLeft.padEnd(leftWidth)} = ${value}`;
             if (expected !== lines[lineIndex]) {
                 violations.push({lineIndex, expectedColumn: leftWidth + 1, kind: 'assignment'});
                 fixedLines[lineIndex] = expected;

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -12,7 +12,7 @@ const
 
 /**
  * check-block-alignment.mjs — the lint that mechanizes Neo's block alignment (import-`from`,
- * object-literal colons, `=` declaration blocks) so it is never hand-counted. Coverage is constructed
+ * object-literal colons, declaration `=` blocks) so it is never hand-counted. Coverage is constructed
  * WITHOUT any hand-aligned fixture (the exact error class
  * this gate removes): the misaligned input is trivial to write, the aligned form is DERIVED via `--fix`,
  * and the false-positive guards use ungrouped inputs that pass regardless of spacing.
@@ -51,7 +51,7 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
     ].join('\n');
 
     test('flags a misaligned import-from group with a file:line + expected-column diagnostic (exit 1)', () => {
-        const file             = write('m.mjs', MISALIGNED);
+        const file = write('m.mjs', MISALIGNED);
         const {status, output} = run(file);
 
         expect(status).toBe(1);
@@ -237,17 +237,85 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
             expect(run('--fix', file).status).toBe(0);   // idempotent
         });
 
+        test('--fix aligns a keyword-head comma-block with bare continuations', () => {
+            const file = write('d.mjs', [
+                'const short = 1,',
+                '      muchLongerName = 2,',
+                '      blockValue = {',
+                '          a: 1',
+                '      };'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const
+                lines    = fs.readFileSync(file, 'utf8').split('\n'),
+                shortEq  = lines.find(line => /short/.test(line)).indexOf('='),
+                longerEq = lines.find(line => /muchLongerName/.test(line)).indexOf('='),
+                blockEq  = lines.find(line => /blockValue/.test(line)).indexOf('=');
+
+            expect(shortEq).toBe(longerEq);
+            expect(blockEq).toBe(longerEq);
+            expect(run(file).status).toBe(0);
+        });
+
+        test('#13896: --fix aligns repeated-keyword declaration blocks', () => {
+            const file = write('d.mjs', [
+                "const extra     = extraModels.length ? extraModels.join(', ') : 'none';",
+                'const requiredObserved = Neo.isNumber(observedRequiredCount) ? observedRequiredCount : observedCount;'
+            ].join('\n'));
+
+            expect(run(file).status).toBe(1);
+            expect(run('--fix', file).status).toBe(0);
+
+            const
+                lines      = fs.readFileSync(file, 'utf8').split('\n'),
+                extraEq    = lines[0].indexOf('='),
+                observedEq = lines[1].indexOf('=');
+
+            expect(extraEq).toBe(observedEq);
+            expect(lines[0]).toBe("const extra            = extraModels.length ? extraModels.join(', ') : 'none';");
+            expect(run(file).status).toBe(0);
+        });
+
+        test('#13896: --fix aligns repeated declarations when a new longer binding resets the block', () => {
+            const file = write('d.mjs', [
+                'const observedCount = availableModels.length;',
+                'const observedRequiredCount = getRequiredAvailable(availableModels).length;',
+                'const capacityReady      = observedRequiredCount >= requiredResidentModels;'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const eqCols = fs.readFileSync(file, 'utf8').split('\n').map(line => line.indexOf('='));
+
+            expect(new Set(eqCols).size).toBe(1);
+            expect(run(file).status).toBe(0);
+        });
+
+        test('#13896: a lone keyword declaration normalizes stale padding', () => {
+            const file = write('d.mjs', 'const trigger   = buildSummaryTrigger({\n    now\n});\n');
+
+            expect(run(file).status).toBe(1);
+            expect(run('--fix', file).status).toBe(0);
+            expect(fs.readFileSync(file, 'utf8').split('\n')[0]).toBe('const trigger = buildSummaryTrigger({');
+            expect(run(file).status).toBe(0);
+        });
+
         test('bare non-declaration assignments are NOT aligned (declaration-anchored only)', () => {
             // No const/let/var anchor → arbitrary assignments must never be re-aligned (false-positive guard).
             const file = write('d.mjs', 'obj.a = 1;\nobj.bbb = 2;\n');
             expect(run(file).status).toBe(0);
         });
 
-        test('separate consecutive declarations are NOT grouped (only the comma-block aligns)', () => {
-            // `let aaa = …; const b = …;` are distinct statements — the house-style `=` unit is the
-            // single-keyword comma-block, not every adjacent declaration. Must pass unchanged.
+        test('mixed repeated-keyword declarations align keyword, name, and equals columns', () => {
             const file = write('d.mjs', 'let aaa = 1;\nconst b = 2;\nlet cc = 3;\n');
-            expect(run(file).status).toBe(0);
+            expect(run('--fix', file).status).toBe(0);
+
+            const aligned = fs.readFileSync(file, 'utf8');
+            expect(aligned).toContain('let   aaa = 1;');
+            expect(aligned).toContain('const b   = 2;');
+            expect(aligned).toContain('let   cc  = 3;');
         });
 
         test('a computed key participates in colon alignment (the [isDescriptor] config pattern)', () => {


### PR DESCRIPTION
Resolves #13896

Extends `check-block-alignment.mjs` so the formatter now catches declaration-alignment drift that previously escaped review: repeated keyword declaration runs, keyword-head comma-blocks with bare continuations, and stale padding in lone keyword declarations. The branch also dogfoods the new rule on the merged files that exposed the gap.

Evidence: L2 local static + focused unit evidence covers the close-target ACs. Residual: none.

## Deltas from ticket

- Added repeated-keyword declaration block support and keyword-head comma-block support.
- Kept bare assignments out of scope, preserved template-line masking, and kept the legacy lone-keyword comma-block block-opener exclusion.
- Ran `--fix` against `ai/services/graph/providerReadinessHelper.mjs` and `ai/daemons/orchestrator/scheduling/summary.mjs` so the merged drift from PRs `#13885` and `#13888` is mechanically corrected by the improved linter.

## Test Evidence

- `node --check buildScripts/util/check-block-alignment.mjs`
- `node --check test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs`
- `node --check ai/services/graph/providerReadinessHelper.mjs`
- `node --check ai/daemons/orchestrator/scheduling/summary.mjs`
- `node ./buildScripts/util/check-block-alignment.mjs buildScripts/util/check-block-alignment.mjs test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs ai/services/graph/providerReadinessHelper.mjs ai/daemons/orchestrator/scheduling/summary.mjs`
- `npm run agent-preflight -- buildScripts/util/check-block-alignment.mjs test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs ai/services/graph/providerReadinessHelper.mjs ai/daemons/orchestrator/scheduling/summary.mjs`
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs` — 110 passed
- `git diff --check`
- Pre-commit hook passed: `check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, `check-jsdoc-types`, `check-ticket-archaeology`, and `check-block-alignment --staged`.

## Post-Merge Validation

- [ ] Confirm GitHub CI remains green with the new declaration alignment contract.

## Commits

- `ebc0cebccf` — `fix(build): catch declaration alignment drift (#13896)`

Authored by Euclid (GPT-5, Codex Desktop). Session db5b2ecf-db91-4b7d-9498-ccef00426a1c.
