### PR TITLE
fix(memory-core): make add_message WAL-first (#13891)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1,9 +1,12 @@
 import Base                                     from '../../../src/core/Base.mjs';
 import aiConfig                                 from '../../mcp/server/memory-core/config.mjs';
+import logger                                   from '../../mcp/server/memory-core/logger.mjs';
 import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
 import GraphService                             from './GraphService.mjs';
 import PermissionService                        from './PermissionService.mjs';
 import WakeSubscriptionService                  from './WakeSubscriptionService.mjs';
+import {appendWalMessage, getMessageWalDir}     from './helpers/messageWalStore.mjs';
+import {getMissingMemoryWalLeaves}              from './helpers/memoryWalStore.mjs';
 import {execFile}                               from 'child_process';
 import {promisify}                              from 'util';
 import crypto                                   from 'crypto';
@@ -235,6 +238,50 @@ function getWakeSuppressionRisk({wakeSuppressed, to, subject = '', priority = 'n
 }
 
 /**
+ * @summary Builds the durable message WAL record used as the authority for later graph replay.
+ * @param {Object} args
+ * @returns {Object}
+ */
+function buildMessageWalRecord({
+    messageId,
+    messageProperties,
+    originSessionId,
+    relatedSessions,
+    relatedTickets,
+    sentBy,
+    senderUserId,
+    timestamp,
+    to
+}) {
+    return {
+        id                    : messageId,
+        timestamp             : Date.parse(timestamp),
+        sentAt                : timestamp,
+        graphProjectionVersion: 1,
+        message               : {
+            id        : messageId,
+            type      : 'MESSAGE',
+            name      : messageProperties.subject,
+            properties: messageProperties
+        },
+        routing: {
+            sentBy,
+            to,
+            senderUserId,
+            broadcastRecipients: to === 'AGENT:*' ? getBroadcastAudience(sentBy) : []
+        },
+        optionalEdges: {
+            originSessionId: originSessionId || null,
+            inReplyTo      : messageProperties.inReplyTo,
+            partOfThread   : messageProperties.partOfThread,
+            relatedSessions: [...relatedSessions],
+            relatedTickets : [...relatedTickets],
+            taggedConcepts : [...messageProperties.taggedConcepts]
+        }
+    }
+}
+
+/**
  * @summary Returns the current broadcast delivery audience for a MESSAGE sent to `AGENT:*`.
  *
  * Broadcasts remain one semantic MESSAGE + SENT_TO->AGENT:* edge, while per-recipient
@@ -250,10 +297,10 @@ function getBroadcastAudience(sentBy) {
 
     return nodes
         .map(node => {
-            const id         = getRecordField(node, 'id'),
-                label        = getRecordField(node, 'label'),
-                properties   = getRecordProperties(node),
-                accountType  = properties.accountType;
+            const id        = getRecordField(node, 'id'),
+                label       = getRecordField(node, 'label'),
+                properties  = getRecordProperties(node),
+                accountType = properties.accountType;
 
             if (!id || id === sentBy || id === 'AGENT:*' || !id.startsWith('@')) {
                 return null;
@@ -493,9 +540,9 @@ class MailboxService extends Base {
      * @returns {Promise<Object>}
      */
     async addMessage({ to, subject, body, originSessionId, relatedSessions = [], relatedTickets = [], inReplyTo, priority = 'normal', partOfThread, taggedConcepts = [], wakeSuppressed = false, task }) {
-        const db = GraphService.requireDb('MailboxService.addMessage');
+        const db             = GraphService.requireDb('MailboxService.addMessage');
         const preNormalizeTo = to; // diagnostic payload captures caller-supplied target
-        const sentBy = RequestContextService.getAgentIdentityNodeId();
+        const sentBy         = RequestContextService.getAgentIdentityNodeId();
         if (!sentBy) {
             throw RequestContextService.unboundIdentityError('send message');
         }
@@ -608,7 +655,7 @@ class MailboxService extends Base {
             throw new Error(`Cannot suppress wake for ${wakeSuppressionRisk}. Omit wakeSuppressed or set it to false; mailbox-only suppression is reserved for awareness/FYI, session-sunset handover, lead-role baton, and audit-alert messages.`);
         }
 
-        // 1. Create the Message Node
+        // 1. Build the accepted Message intent
         // The optional `task` property carries an A2A-Task-object-shaped JSON payload. When
         // present, downstream consumers surface it for programmatic agent coordination. The
         // payload follows Neo's hybrid contract: A2A spec subset + Neo extensions like
@@ -637,52 +684,91 @@ class MailboxService extends Base {
             messageProperties.relatedTickets = [...new Set(relatedTickets)].sort();
         }
 
-        GraphService.upsertNode({
-            id        : messageId,
-            type      : 'MESSAGE',
-            name      : subject,
-            properties: messageProperties
-        });
-
-        // 2. Map the delivery-critical routing edges. These must fail loudly if
-        // GraphService's FK guard culls them; otherwise `addMessage()` can return a
-        // misleading success for an unroutable MESSAGE.
-        const routingDiagnostics = {preNormalizeTo, postNormalizeTo};
-        linkRequiredMailboxEdgeOrThrow(messageId, sentBy, 'SENT_BY', 1.0, { timestamp, userId: senderUserId, sharedEntity: true }, routingDiagnostics);
-        linkRequiredMailboxEdgeOrThrow(messageId, to, 'SENT_TO', 1.0, { timestamp, userId: senderUserId, sharedEntity: true }, routingDiagnostics);
-        if (to === 'AGENT:*') {
-            for (const recipient of getBroadcastAudience(sentBy)) {
-                linkRequiredMailboxEdgeOrThrow(messageId, recipient, 'DELIVERED_TO', 1.0, {
-                    deliveredAt : timestamp,
-                    readAt      : null,
-                    deliveryKind: 'broadcast',
-                    userId      : senderUserId,
-                    sharedEntity: true
-                }, routingDiagnostics);
-            }
+        const missingLeaves = getMissingMemoryWalLeaves(aiConfig.memoryWal, ['dir']);
+        if (missingLeaves.length > 0) {
+            throw new Error(`message WAL config leaves missing: ${missingLeaves.join(', ')} — sync the memoryWal block from config.template.mjs into the local config.mjs (node ai/scripts/setup/initServerConfigs.mjs --migrate-config) and restart memory-core.`);
         }
 
-        // 3. Map additional graph semantic edges. These remain cull-tolerant:
-        // mailbox delivery does not depend on optional provenance/thread/concept links.
-        if (originSessionId) GraphService.linkNodes(messageId, originSessionId, 'ORIGINATES_IN', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
-        if (inReplyTo) GraphService.linkNodes(messageId, inReplyTo, 'IN_REPLY_TO', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
-        if (partOfThread) GraphService.linkNodes(messageId, partOfThread, 'PART_OF_THREAD', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
+        const messageWalDir = getMessageWalDir(aiConfig.memoryWal.dir);
 
-        for (const s of relatedSessions) GraphService.linkNodes(messageId, s, 'RELATED_SESSION', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
-        for (const t of relatedTickets) GraphService.linkNodes(messageId, t, 'REFERENCES_TICKET', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
-        for (const c of taggedConcepts) GraphService.linkNodes(messageId, c, 'TAGGED_CONCEPT', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
+        await appendWalMessage(
+            buildMessageWalRecord({
+                messageId,
+                messageProperties,
+                originSessionId,
+                relatedSessions,
+                relatedTickets,
+                sentBy,
+                senderUserId,
+                timestamp,
+                to
+            }),
+            {dir: messageWalDir}
+        );
 
-        // Per-message auto concept-extraction is intentionally NOT run inline: it fired a chat-model
-        // call (up to 2 attempts) on EVERY message, in parallel with the orchestrator's exclusive-heavy
-        // tasks — starving the model of an idle window. The curated `taggedConcepts` edges (weight 1.0)
-        // are already linked above; the low-confidence auto-extracted concepts (weight 0.8) were the
-        // bulk of the non-curated graph population and are dropped here as redundant noise. Concept
-        // mining stays orchestrator-driven (scheduled, lease-gated), keeping model inference off the
-        // message hot path.
+        let projectionStatus = 'projected';
 
-        WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
+        try {
+            // 2. Project the accepted Message intent to the graph. This is derived work after the
+            // durable WAL append; if projection fails, the accepted `MESSAGE:*` id stays replayable.
+            GraphService.upsertNode({
+                id        : messageId,
+                type      : 'MESSAGE',
+                name      : subject,
+                properties: messageProperties
+            });
 
-        return { messageId, sentAt: timestamp, priority, status: 'sent' };
+            // 3. Map the delivery-critical routing edges. These still fail loudly inside projection
+            // so a replay/drain can retry the complete delivery-critical graph state.
+            const routingDiagnostics = {preNormalizeTo, postNormalizeTo};
+            linkRequiredMailboxEdgeOrThrow(messageId, sentBy, 'SENT_BY', 1.0, { timestamp, userId: senderUserId, sharedEntity: true }, routingDiagnostics);
+            linkRequiredMailboxEdgeOrThrow(messageId, to, 'SENT_TO', 1.0, { timestamp, userId: senderUserId, sharedEntity: true }, routingDiagnostics);
+            if (to === 'AGENT:*') {
+                for (const recipient of getBroadcastAudience(sentBy)) {
+                    linkRequiredMailboxEdgeOrThrow(messageId, recipient, 'DELIVERED_TO', 1.0, {
+                        deliveredAt : timestamp,
+                        readAt      : null,
+                        deliveryKind: 'broadcast',
+                        userId      : senderUserId,
+                        sharedEntity: true
+                    }, routingDiagnostics);
+                }
+            }
+
+            // 4. Map additional graph semantic edges. These remain cull-tolerant:
+            // mailbox delivery does not depend on optional provenance/thread/concept links.
+            if (originSessionId) GraphService.linkNodes(messageId, originSessionId, 'ORIGINATES_IN', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
+            if (inReplyTo) GraphService.linkNodes(messageId, inReplyTo, 'IN_REPLY_TO', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
+            if (partOfThread) GraphService.linkNodes(messageId, partOfThread, 'PART_OF_THREAD', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
+
+            for (const s of relatedSessions) GraphService.linkNodes(messageId, s, 'RELATED_SESSION', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
+            for (const t of relatedTickets) GraphService.linkNodes(messageId, t, 'REFERENCES_TICKET', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
+            for (const c of taggedConcepts) GraphService.linkNodes(messageId, c, 'TAGGED_CONCEPT', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
+
+            // Per-message auto concept-extraction is intentionally NOT run inline: it fired a chat-model
+            // call (up to 2 attempts) on EVERY message, in parallel with the orchestrator's exclusive-heavy
+            // tasks — starving the model of an idle window. The curated `taggedConcepts` edges (weight 1.0)
+            // are already linked above; the low-confidence auto-extracted concepts (weight 0.8) were the
+            // bulk of the non-curated graph population and are dropped here as redundant noise. Concept
+            // mining stays orchestrator-driven (scheduled, lease-gated), keeping model inference off the
+            // message hot path.
+
+            WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
+        } catch (e) {
+            projectionStatus = 'pending';
+            logger.error('[MailboxService.addMessage] graph projection failed after message WAL append', {
+                messageId,
+                error: e?.message || String(e)
+            });
+        }
+
+        return {
+            messageId,
+            sentAt: timestamp,
+            priority,
+            status: 'sent',
+            ...(projectionStatus === 'pending' ? {projectionStatus} : {})
+        };
     }
 
     /**
@@ -747,9 +833,9 @@ class MailboxService extends Base {
                 edgeSource = getRecordField(edge, 'source'),
                 edgeTarget = getRecordField(edge, 'target');
 
-            let isMatch = false,
-                targetNode = null,
-                senderNode = null,
+            let isMatch      = false,
+                targetNode   = null,
+                senderNode   = null,
                 deliveryEdge = null;
 
             if (edgeType === 'DELIVERED_TO') {
@@ -797,7 +883,7 @@ class MailboxService extends Base {
                 if (messageNode && messageNode.label === 'MESSAGE') {
                     deliveryEdge = deliveryEdge || getBroadcastDeliveryEdge(messageNodeId, target);
 
-                    const readAt = getReadAtForMessage(messageNode, deliveryEdge);
+                    const readAt   = getReadAtForMessage(messageNode, deliveryEdge);
                     const isUnread = !readAt;
                     if (status === 'unread' && !isUnread) continue;
                     if (status === 'read' && isUnread) continue;
@@ -810,9 +896,9 @@ class MailboxService extends Base {
                     const archivedAt = getArchivedAtForMessage(messageNode, deliveryEdge);
                     if (!includeArchived && archivedAt) continue;
 
-                    let sentByNodeId = senderNode;
-                    let sentToNodeId = targetNode;
-                    let foundThreadId = null;
+                    let sentByNodeId          = senderNode;
+                    let sentToNodeId          = targetNode;
+                    let foundThreadId         = null;
                     let messageTaggedConcepts = [];
 
                     for (const sourceEdge of db.edges.items) {
@@ -900,8 +986,8 @@ class MailboxService extends Base {
             throw new Error(`Message not found: ${messageId}`);
         }
 
-        let sentBy = null,
-            sentTo = null,
+        let sentBy            = null,
+            sentTo            = null,
             isDirectRecipient = false;
 
         for (const edge of db.edges.items) {
@@ -922,7 +1008,7 @@ class MailboxService extends Base {
         }
 
         const deliveryEdge = getBroadcastDeliveryEdge(messageId, me);
-        let isAuthorized = sentBy === me || isDirectRecipient;
+        let   isAuthorized = sentBy === me || isDirectRecipient;
 
         if (!isAuthorized && sentTo === 'AGENT:*') {
             // Legacy broadcasts without per-recipient receipts retain their historical
@@ -1000,7 +1086,7 @@ class MailboxService extends Base {
     async resolvePullRequestStateCached(number) {
         if (aiConfig.orchestrator.deploymentMode === 'cloud') return null;
 
-        const now = Date.now(),
+        const now  = Date.now(),
             cached = relatedPullRequestStateCache.get(number);
 
         if (cached && now - cached.cachedAt < RELATED_PULL_REQUEST_CACHE_TTL_MS) {
@@ -1084,7 +1170,7 @@ class MailboxService extends Base {
             throw new Error(`Message not found: ${messageId}`);
         }
 
-        let isDirectRecipient = false,
+        let isDirectRecipient    = false,
             isBroadcastRecipient = false;
 
         for (const edge of db.edges.items) {
@@ -1163,7 +1249,7 @@ class MailboxService extends Base {
             throw new Error(`Message not found: ${messageId}`);
         }
 
-        let isDirectRecipient = false,
+        let isDirectRecipient    = false,
             isBroadcastRecipient = false;
 
         for (const edge of db.edges.items) {
@@ -1314,7 +1400,7 @@ class MailboxService extends Base {
         }
 
         let isOriginator = false;
-        let isAssignee = false;
+        let isAssignee   = false;
 
         for (const edge of db.edges.items) {
             if (edge.source === taskId) {
@@ -1581,7 +1667,7 @@ class MailboxService extends Base {
             }
 
             // Inbox: 3-way UNION mirroring buildMailboxDelta's unread-message taxonomy.
-            const params = [];
+            const params   = [];
             const inboxSql = `
                 WITH inbox_messages AS (
                     SELECT n.id AS messageId
@@ -1658,8 +1744,8 @@ class MailboxService extends Base {
         }
 
         const { count: unreadCount } = await this.countMessages({ box: 'inbox', status: 'unread' });
-        const inboxResult            = await this.listMessages({ box: 'inbox',  limit: 3 });
-        const outboxResult           = await this.listMessages({ box: 'outbox', limit: 3 });
+        const inboxResult  = await this.listMessages({ box: 'inbox',  limit: 3 });
+        const outboxResult = await this.listMessages({ box: 'outbox', limit: 3 });
 
         const inboxPreview = inboxResult.messages.map(msg => ({
             id: msg.messageId,

--- a/ai/services/memory-core/helpers/messageWalStore.mjs
+++ b/ai/services/memory-core/helpers/messageWalStore.mjs
@@ -1,0 +1,132 @@
+import fs               from 'fs/promises';
+import path             from 'path';
+import {withAppendLock} from './walAppendLock.mjs';
+
+/**
+ * @summary Durable JSONL write-ahead store for accepted A2A mailbox messages.
+ *
+ * `MailboxService.addMessage` appends the canonical message intent here after all deliberate
+ * pre-ack validation has passed and before derived graph projection starts. A graph write, wake
+ * pump, or later vector/search failure can leave the record pending, but cannot erase the accepted
+ * `MESSAGE:*` id.
+ *
+ * Message WAL records intentionally live under the existing memory WAL root for this acceptance
+ * boundary. That keeps local/test/cloud volume reachability aligned with the proven memory WAL
+ * substrate until the dedicated message drain topology promotes its own host-mode config.
+ *
+ * @module ai/services/memory-core/helpers/messageWalStore
+ */
+
+const MESSAGE_WAL_SEGMENT_RE = /^message-wal-(\d{4}-\d{2}-\d{2})\.jsonl$/;
+
+/**
+ * @summary Derives the message WAL directory from the active memory WAL directory.
+ * @param {String} memoryWalDir Active `memoryWal.dir`.
+ * @returns {String}
+ */
+export function getMessageWalDir(memoryWalDir) {
+    if (!memoryWalDir) {
+        throw new TypeError('getMessageWalDir: memoryWalDir is required');
+    }
+
+    return path.join(memoryWalDir, 'messages');
+}
+
+/**
+ * @summary Derives the UTC-day segment key for a write timestamp.
+ * @param {Date|Number} [now=new Date()] Clock source (epoch ms or Date).
+ * @returns {String} `YYYY-MM-DD` UTC day key.
+ */
+export function getMessageWalSegmentKey(now = new Date()) {
+    return new Date(now).toISOString().slice(0, 10);
+}
+
+/**
+ * @summary Builds the message WAL records file name for a segment key.
+ * @param {String} segmentKey `YYYY-MM-DD` day key.
+ * @returns {String} JSONL records file name.
+ */
+export function getMessageWalRecordsFileName(segmentKey) {
+    return `message-wal-${segmentKey}.jsonl`;
+}
+
+/**
+ * @summary Appends one accepted A2A message intent to its UTC-day WAL segment.
+ * @param {Object} record
+ * @param {String} record.id Stable `MESSAGE:*` id.
+ * @param {Number} record.timestamp Epoch-ms write time.
+ * @param {Object} options
+ * @param {String} options.dir Message WAL directory.
+ * @param {Date|Number} [options.now] Clock source for the segment key.
+ * @param {Object} [options.lockOptions] Forwarded to {@link withAppendLock}.
+ * @returns {Promise<{filePath: String, segmentKey: String}>}
+ */
+export async function appendWalMessage(record, {dir, now, lockOptions} = {}) {
+    if (!dir) {
+        throw new TypeError('appendWalMessage: dir is required');
+    }
+    if (typeof record?.id !== 'string' || !record.id.startsWith('MESSAGE:')) {
+        throw new TypeError('appendWalMessage: record.id must be a MESSAGE:* id');
+    }
+
+    await fs.mkdir(dir, {recursive: true});
+
+    const segmentKey = getMessageWalSegmentKey(now ?? record.timestamp ?? new Date());
+    const filePath   = path.join(dir, getMessageWalRecordsFileName(segmentKey));
+    const line       = `${JSON.stringify({...record, segmentKey})}\n`;
+
+    await withAppendLock(filePath, () => fs.appendFile(filePath, line, 'utf8'), lockOptions);
+
+    return {filePath, segmentKey};
+}
+
+/**
+ * @summary Reads message WAL records from newest segment to oldest, skipping corrupt lines.
+ * @param {Object} options
+ * @param {String} options.dir Message WAL directory.
+ * @returns {Promise<Object[]>}
+ */
+export async function readWalMessages({dir} = {}) {
+    if (!dir) {
+        throw new TypeError('readWalMessages: dir is required');
+    }
+
+    let names;
+    try {
+        names = await fs.readdir(dir);
+    } catch (e) {
+        if (e?.code === 'ENOENT') return [];
+        throw e;
+    }
+
+    const segmentNames = names
+        .filter(name => MESSAGE_WAL_SEGMENT_RE.test(name))
+        .sort()
+        .reverse();
+
+    const records = [];
+
+    for (const name of segmentNames) {
+        const filePath = path.join(dir, name);
+        let text;
+
+        try {
+            text = await fs.readFile(filePath, 'utf8');
+        } catch (e) {
+            if (e?.code === 'ENOENT') continue;
+            throw e;
+        }
+
+        for (const line of text.split('\n')) {
+            if (!line.trim()) continue;
+            try {
+                records.push(JSON.parse(line));
+            } catch (e) {
+                // Torn/corrupt line: skip. A partial append must not make other accepted
+                // message records unreadable.
+            }
+        }
+    }
+
+    return records;
+}

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -23,8 +23,8 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
 
 test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     test.describe.configure({ mode: 'serial' });
-    let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, originalAutoSave, mailboxAiConfig, originalMailboxPolicy;
-    let dbPath;
+    let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, originalAutoSave, mailboxAiConfig, originalMailboxPolicy, readWalMessages;
+    let dbPath, messageWalDir;
 
     test.beforeAll(async () => {
         // Build an isolated tmp path for the database file tests
@@ -48,6 +48,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         SwarmHeartbeatService = (await import('../../../../../../ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs')).default;
         buildMailboxDelta = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).buildMailboxDelta;
+        const messageWalStore = await import('../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs');
+        readWalMessages = messageWalStore.readWalMessages;
+        messageWalDir   = messageWalStore.getMessageWalDir(mailboxAiConfig.memoryWal.dir);
 
         // Pin this suite to strict-isolation mode. These tests predate the
         // config-gated default and assert `'blocked'`-mode behavior (Unauthorized
@@ -84,6 +87,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             try { fs.unlinkSync(dbPath + '-wal'); } catch (e) {}
             try { fs.unlinkSync(dbPath + '-shm'); } catch (e) {}
         }
+        fs.removeSync(messageWalDir);
     });
 
     test.beforeEach(async () => {
@@ -99,6 +103,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 GraphService.db.storage.db.exec('DELETE FROM GraphLog');
             }
         }
+        fs.removeSync(messageWalDir);
 
         // Seed agents
         GraphService.upsertNode({ id: '@alice', type: 'AGENT', name: 'Alice', properties: {} });
@@ -138,6 +143,12 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         }
         expect(sentBy).toBe('@alice');
         expect(sentTo).toBe('@bob');
+
+        const records = await readWalMessages({dir: messageWalDir});
+        expect(records).toHaveLength(1);
+        expect(records[0].id).toBe(res.messageId);
+        expect(records[0].message.properties.subject).toBe('Hello');
+        expect(records[0].routing).toMatchObject({sentBy: '@alice', to: '@bob', senderUserId: 'alice'});
     });
 
     test('addMessage stamps the normalized canonical user_id, keeping @-form only as the sender label (#13578)', async () => {
@@ -159,7 +170,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(sentByEdge.properties.userId).toBe('alice');
     });
 
-    test('addMessage throws when a required SENT_TO routing edge is culled (#10284)', async () => {
+    test('addMessage accepts durably when a required SENT_TO projection edge is culled (#13891)', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
         });
@@ -175,19 +186,29 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 return originalLinkNodes.call(GraphService, source, target, relationship, weight, properties);
             };
 
-            await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
-                await expect(MailboxService.addMessage({
+            const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+                return await MailboxService.addMessage({
                     to     : '@bob',
                     subject: 'culled route',
                     body   : 'body'
-                })).rejects.toThrow(/Routing edge creation failed: MESSAGE:.* -\[SENT_TO\]-> @bob/);
+                });
             });
+
+            expect(res.status).toBe('sent');
+            expect(res.projectionStatus).toBe('pending');
+            expect(res.messageId).toMatch(/^MESSAGE:/);
+
+            const records = await readWalMessages({dir: messageWalDir});
+            expect(records).toHaveLength(1);
+            expect(records[0].id).toBe(res.messageId);
+            expect(records[0].message.properties.subject).toBe('culled route');
+            expect(records[0].routing.to).toBe('@bob');
         } finally {
             GraphService.linkNodes = originalLinkNodes;
         }
     });
 
-    test('addMessage throws when a required broadcast DELIVERED_TO edge is culled (#10284)', async () => {
+    test('addMessage accepts durably when a required broadcast DELIVERED_TO projection edge is culled (#13891)', async () => {
         const originalLinkNodes = GraphService.linkNodes;
 
         try {
@@ -199,13 +220,23 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 return originalLinkNodes.call(GraphService, source, target, relationship, weight, properties);
             };
 
-            await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
-                await expect(MailboxService.addMessage({
+            const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+                return await MailboxService.addMessage({
                     to     : 'AGENT:*',
                     subject: 'culled broadcast',
                     body   : 'body'
-                })).rejects.toThrow(/Routing edge creation failed: MESSAGE:.* -\[DELIVERED_TO\]-> @bob/);
+                });
             });
+
+            expect(res.status).toBe('sent');
+            expect(res.projectionStatus).toBe('pending');
+            expect(res.messageId).toMatch(/^MESSAGE:/);
+
+            const records = await readWalMessages({dir: messageWalDir});
+            expect(records).toHaveLength(1);
+            expect(records[0].id).toBe(res.messageId);
+            expect(records[0].routing.to).toBe('AGENT:*');
+            expect(records[0].routing.broadcastRecipients).toEqual(expect.arrayContaining(['@bob']));
         } finally {
             GraphService.linkNodes = originalLinkNodes;
         }
@@ -599,7 +630,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         // Verify they were dispatched
         let librarianCount = 0;
-        let humanCount = 0;
+        let humanCount     = 0;
         for (const edge of GraphService.db.edges.items) {
             if (edge.type === 'SENT_TO') {
                 if (edge.target === 'role:librarian') librarianCount++;
@@ -653,8 +684,8 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         // previously fetched `listMessages({limit: 100})` and counted unreads. An inbox
         // with > 100 unread messages would silently under-report. countMessages must
         // return the true value via direct SQL.
-        const RECIPIENT = '@countmany-bob';
-        const SENDER    = '@countmany-alice';
+        const RECIPIENT    = '@countmany-bob';
+        const SENDER       = '@countmany-alice';
         const TARGET_DEPTH = 150;
 
         // Seed agent identities matching the production convention.
@@ -757,7 +788,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
             // includeArchived: true surfaces it with archivedAt in summary
             const withArchived = await MailboxService.listMessages({ box: 'inbox', includeArchived: true });
-            const archived = withArchived.messages.find(m => m.messageId === messageId);
+            const archived     = withArchived.messages.find(m => m.messageId === messageId);
             expect(archived).toBeDefined();
             expect(archived.archivedAt).toBe(archiveResult.archivedAt);
         });
@@ -898,7 +929,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         // Thread context preserved: SENT_BY + SENT_TO + reply's inReplyTo edges survive
         const edgesFromOriginal = [];
-        const edgesToOriginal = [];
+        const edgesToOriginal   = [];
         for (const e of GraphService.db.edges.items) {
             if (GraphService.db.edges.items.constructor) {} // no-op, shape sanity
             const src = e.isRecord ? e.get('source') : e.source;
@@ -915,7 +946,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         // Receiver views the retracted message with placeholder subject + retracted flag
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
-            const list = await MailboxService.listMessages({ box: 'inbox' });
+            const list             = await MailboxService.listMessages({ box: 'inbox' });
             const retractedSummary = list.messages.find(m => m.messageId === originalId);
             expect(retractedSummary).toBeDefined();
             expect(retractedSummary.subject).toBe('[retracted by sender]');
@@ -1326,7 +1357,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             expect(gptUnread.messages.map(msg => msg.messageId)).toContain(messageId);
 
             const geminiDelta = await RequestContextService.run({ agentIdentityNodeId: readIdentity }, () => buildMailboxDelta());
-            const gptDelta = await RequestContextService.run({ agentIdentityNodeId: unreadIdentity }, () => buildMailboxDelta());
+            const gptDelta    = await RequestContextService.run({ agentIdentityNodeId: unreadIdentity }, () => buildMailboxDelta());
             expect(geminiDelta.unreadCount).toBe(0);
             expect(gptDelta.unreadCount).toBe(1);
 
@@ -1846,7 +1877,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
         });
 
         const originalResolvePullRequestState = MailboxService.resolvePullRequestState,
-            calls = [];
+            calls                             = [];
 
         MailboxService.resolvePullRequestState = async (number) => {
             calls.push(number);
@@ -1896,7 +1927,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
         });
 
         const originalResolvePullRequestState = MailboxService.resolvePullRequestState;
-        let calls = 0;
+        let   calls                           = 0;
         MailboxService.resolvePullRequestState = async () => {
             calls++;
             return null
@@ -1934,7 +1965,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
 
     test('#13411 related PR state echo: cloud deployment mode skips GitHub CLI resolution', async () => {
         const originalResolvePullRequestState = MailboxService.resolvePullRequestState,
-            originalDeploymentMode = mailboxAiConfig.orchestrator.deploymentMode;
+            originalDeploymentMode            = mailboxAiConfig.orchestrator.deploymentMode;
         let calls = 0;
 
         MailboxService.resolvePullRequestState = async (number) => {
@@ -2294,10 +2325,10 @@ test.describe('Neo.ai.services.memory-core.MailboxService — TTL Sweeper (#1033
     }
 
     test('sweep transitions Submitted/Working/InputRequired tasks past expiresAt to Expired', async () => {
-        const past = '2020-01-01T00:00:00Z';
-        const submittedId      = await seedTask({ state: 'Submitted',     expiresAt: past });
-        const workingId        = await seedTask({ state: 'Working',       expiresAt: past });
-        const inputRequiredId  = await seedTask({ state: 'InputRequired', expiresAt: past });
+        const past            = '2020-01-01T00:00:00Z';
+        const submittedId     = await seedTask({ state: 'Submitted',     expiresAt: past });
+        const workingId       = await seedTask({ state: 'Working',       expiresAt: past });
+        const inputRequiredId = await seedTask({ state: 'InputRequired', expiresAt: past });
 
         // Sanity: seeds visible in cache pre-sweep, with proper task envelope. Diagnostic
         // assertions catch cross-spec contamination (e.g., agent identity nodes leaking
@@ -2370,7 +2401,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — TTL Sweeper (#1033
 
     test('sweep is idempotent across consecutive cycles', async () => {
         const past = '2020-01-01T00:00:00Z';
-        const id = await seedTask({ state: 'Submitted', expiresAt: past });
+        const id   = await seedTask({ state: 'Submitted', expiresAt: past });
 
         const first = await MailboxService.sweepExpiredTasks();
         expect(first.sweptCount).toBe(1);
@@ -2385,7 +2416,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — TTL Sweeper (#1033
 
     test('sweep updates lastModifiedAt atomically with state', async () => {
         const past = '2020-01-01T00:00:00Z';
-        const id = await seedTask({ state: 'Submitted', expiresAt: past });
+        const id   = await seedTask({ state: 'Submitted', expiresAt: past });
 
         const before = new Date().toISOString();
         const result = await MailboxService.sweepExpiredTasks();
@@ -2404,7 +2435,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — TTL Sweeper (#1033
 
     test('sweep does not require an identity context (maintenance role bypasses RBAC)', async () => {
         const past = '2020-01-01T00:00:00Z';
-        const id = await seedTask({ state: 'Submitted', expiresAt: past });
+        const id   = await seedTask({ state: 'Submitted', expiresAt: past });
 
         // Run sweep WITHOUT a RequestContextService.run wrapper — proves identity binding
         // is not consulted. Mirrors the cron-process invocation (no MCP request context).


### PR DESCRIPTION
Resolves #13891

Makes `MailboxService.addMessage()` WAL-first after deliberate pre-ack validation: the stable `MESSAGE:*` id and canonical message intent are appended to a durable JSONL message WAL before the existing graph projection runs. Inline graph projection remains the fast path, but projection failures now return an accepted durable message with `projectionStatus: pending` instead of losing the acknowledged id.

Evidence: L2 local static + unit evidence covers the WAL-first acceptance contract; L3 restart/process replay remains residual because replay/idempotency belongs to sibling #13892. Residual: real cloud drain topology belongs to sibling #13890.

Related: #13889
Related: #13890
Related: #13892

## Deltas from ticket

- Added `ai/services/memory-core/helpers/messageWalStore.mjs` as the durable message WAL helper, sibling to the existing memory WAL helper.
- Stores message WAL records under the existing resolved `memoryWal.dir` (`messages/`) for this acceptance-boundary leaf. Dedicated message drain host/config parity remains scoped to #13890.
- Keeps current graph projection in `addMessage()` as best-effort derived work after the WAL append. Full replay/idempotency and pending-WAL read visibility remain scoped to #13892.
- Message vector/search population is deliberately deferred to #10150 / later drain work; this PR does not add model-dependent work to the request path.

## Test Evidence

- `node --check ai/services/memory-core/helpers/messageWalStore.mjs`
- `node --check ai/services/memory-core/MailboxService.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs`
- `node ./buildScripts/util/check-block-alignment.mjs ai/services/memory-core/helpers/messageWalStore.mjs ai/services/memory-core/MailboxService.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs`
- `git diff --check`
- `npm run agent-preflight -- ai/services/memory-core/helpers/messageWalStore.mjs ai/services/memory-core/MailboxService.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — 71 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/services/memory-core/GraphServiceUnavailable.spec.mjs test/playwright/unit/ai/services/memory-core/WriteSideInvariant.spec.mjs` — 77 passed
- Pre-commit hook passed: `check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, `check-jsdoc-types`, `check-ticket-archaeology`, and `check-block-alignment --staged`.

## Post-Merge Validation

- [ ] Confirm GitHub CI stays green.
- [ ] Confirm sibling #13892 consumes the message WAL record shape for replay/idempotent graph projection.
- [ ] Confirm sibling #13890 either preserves the `memoryWal.dir/messages` placement or promotes it into explicit message-drain config without splitting local/cloud WAL reachability.

## Commits

- `42ce95a55f` — `fix(memory-core): make add_message WAL-first (#13891)`

Authored by Euclid (GPT-5, Codex Desktop). Session db5b2ecf-db91-4b7d-9498-ccef00426a1c.
