### PR TITLE
fix(neural-link): route bridge logs to data dir (#13899)

### DIFF
--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -1,16 +1,16 @@
-import fs               from 'fs-extra';
-import path             from 'path';
-import {fileURLToPath}  from 'url';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
 
 // Bootstrap Neo namespace BEFORE importing services that depend on Neo.gatekeep
 // (Compare.mjs:166). Without these two imports, ai/services.mjs → Compare.mjs
 // triggers `ReferenceError: Neo is not defined`. Mirrors the AI unit-test pattern
 // (e.g., restore-filters.spec.mjs).
-import Neo              from '../../../src/Neo.mjs';
-import * as core        from '../../../src/core/_export.mjs';
+import Neo       from '../../../src/Neo.mjs';
+import * as core from '../../../src/core/_export.mjs';
 
-import kbConfig         from '../../mcp/server/knowledge-base/config.mjs';
-import mcConfig         from '../../mcp/server/memory-core/config.mjs';
+import kbConfig from '../../mcp/server/knowledge-base/config.mjs';
+import mcConfig from '../../mcp/server/memory-core/config.mjs';
 
 import {
     KB_DatabaseService,
@@ -79,8 +79,8 @@ import {
  *
  * ## Intentionally-out-of-scope
  *
- * - Wake-daemon operational state (`bridge.log`, `lastSyncId`, `inflight-*.txt`) — owned
- *   by the live-orchestration recovery track, not substrate restore.
+ * - Wake-daemon operational state (`.neo-ai-data/wake-daemon/bridge.log`, `lastSyncId`,
+ *   `inflight-*.txt`) — owned by the live-orchestration recovery track, not substrate restore.
  * - Physical Chroma data dir snapshots — those live at `dist/chromadb-backups/` under
  *   `defragChromaDB.mjs`'s peer-architecture lockdown.
  * - Cross-version schema migrations — `bundle-meta.neoVersion` and `gitSha` are surfaced
@@ -182,7 +182,7 @@ export async function runRestore({
     // Per-substrate gate: null `onlySubstrate` = all subsystems (existing behavior).
     // Non-null array restricts to listed names. Validates against the known substrate set
     // so typos fail fast instead of silently no-op'ing the entire restore.
-    const ALL_SUBSTRATES   = ['kb', 'mc', 'graph', 'concepts', 'trajectories', 'mailbox'];
+    const ALL_SUBSTRATES = ['kb', 'mc', 'graph', 'concepts', 'trajectories', 'mailbox'];
     if (Array.isArray(onlySubstrate)) {
         const unknown = onlySubstrate.filter(s => !ALL_SUBSTRATES.includes(s));
         if (unknown.length > 0) {
@@ -216,8 +216,8 @@ export async function runRestore({
         // Stream-filter into a temp dir matching the bundle layout. Idempotent on re-run.
         // Filter goes through the FK-safe Stage-1/2/3 algorithm (per @neo-gpt review).
         // Empty filter sets short-circuit to original layout.graph (no extra work / no live read).
-        const filterStats   = {filteredNodes: 0, filteredEdges: 0, orphanEdges: 0, acceptedNodes: 0};
-        const filterActive  = filterLabels.length > 0 || filterEdgeTypes.length > 0;
+        const filterStats  = {filteredNodes: 0, filteredEdges: 0, orphanEdges: 0, acceptedNodes: 0};
+        const filterActive = filterLabels.length > 0 || filterEdgeTypes.length > 0;
 
         let graphInputDir = layout.graph;
         if (filterActive) {
@@ -225,11 +225,11 @@ export async function runRestore({
             // WAL mode lets us read concurrently with the running MC daemon.
             const liveNodeIds = await collectLiveGraphNodeIds({dbPath: mcConfig.storagePaths.graph});
             graphInputDir = await prepareFilteredGraphDir({
-                sourceDir       : layout.graph,
+                sourceDir: layout.graph,
                 filterLabels,
                 filterEdgeTypes,
                 liveNodeIds,
-                stats           : filterStats,
+                stats    : filterStats,
                 logger
             });
         }
@@ -251,12 +251,12 @@ export async function runRestore({
 
     if (shouldRestore('concepts')) {
         subsystems.concepts = await restoreFlatDir({
-            sourceDir : layout.concepts,
-            targetDir : conceptsTargetDir,
+            sourceDir: layout.concepts,
+            targetDir: conceptsTargetDir,
             mode,
             force,
             confirmation,
-            subsystem : 'concepts',
+            subsystem: 'concepts',
             logger
         });
     }
@@ -344,7 +344,7 @@ export async function validateBundle(bundleRoot, layout, logger = console) {
     // Stream-read the first non-empty line for JSONL parseability sanity-check.
     // Full-file readFile fails on JSONL files >512MB (V8 max-string-length cap):
     // empirical anchor 2026-05-10, kb backup 586MB → ERR_STRING_TOO_LONG.
-    const readline = (await import('readline')).default;
+    const readline   = (await import('readline')).default;
     const allSubdirs = [...REQUIRED_BUNDLE_SUBDIRS, ...OPTIONAL_BUNDLE_SUBDIRS];
     for (const subdir of allSubdirs) {
         const dir = layout[subdir];
@@ -352,9 +352,9 @@ export async function validateBundle(bundleRoot, layout, logger = console) {
         const entries    = await fs.readdir(dir);
         const jsonlFiles = entries.filter(f => f.endsWith('.jsonl'));
         for (const file of jsonlFiles) {
-            const stream = fs.createReadStream(path.join(dir, file), {encoding: 'utf8'});
-            const rl     = readline.createInterface({input: stream, crlfDelay: Infinity});
-            let firstLine = null;
+            const stream    = fs.createReadStream(path.join(dir, file), {encoding: 'utf8'});
+            const rl        = readline.createInterface({input: stream, crlfDelay: Infinity});
+            let   firstLine = null;
             for await (const line of rl) {
                 if (line.trim()) { firstLine = line; break; }
             }
@@ -497,9 +497,9 @@ async function restoreFlatDir({sourceDir, targetDir, mode, force, confirmation, 
         await Shared_DestructiveOperationGuard.assertDestructiveTargetAllowed({
             operation: `restore.${subsystem}.replace`,
             subsystem,
-            mode     : 'replace',
-            target   : {path: targetDir, repoRoot: PROJECT_ROOT},
-            source   : {path: sourceDir},
+            mode  : 'replace',
+            target: {path: targetDir, repoRoot: PROJECT_ROOT},
+            source: {path: sourceDir},
             confirmation
         });
         await fs.emptyDir(targetDir);
@@ -557,9 +557,9 @@ async function restoreFlatFile({sourceDir, targetFile, mode, force, confirmation
         await Shared_DestructiveOperationGuard.assertDestructiveTargetAllowed({
             operation: `restore.${subsystem}.replace`,
             subsystem,
-            mode     : 'replace',
-            target   : {path: targetFile, repoRoot: PROJECT_ROOT},
-            source   : {path: sourceFile},
+            mode  : 'replace',
+            target: {path: targetFile, repoRoot: PROJECT_ROOT},
+            source: {path: sourceFile},
             confirmation
         });
     } else if (await fs.pathExists(targetFile)) {
@@ -649,8 +649,8 @@ export async function prepareFilteredGraphDir({sourceDir, filterLabels, filterEd
     for (const fileName of sourceFiles) {
         const inPath  = path.join(sourceDir, fileName);
         const outPath = path.join(tempDir, fileName);
-        const rl  = readline.createInterface({input: fs.createReadStream(inPath), crlfDelay: Infinity});
-        const out = fs.createWriteStream(outPath);
+        const rl      = readline.createInterface({input: fs.createReadStream(inPath), crlfDelay: Infinity});
+        const out     = fs.createWriteStream(outPath);
         for await (const line of rl) {
             if (!line.trim()) continue;
             try {
@@ -741,14 +741,14 @@ export async function dispatchPostRestoreHook({hook, logger = console}) {
  * @returns {Object}
  */
 export function parseArgs(argv) {
-    const positional = [];
-    let mode                    = 'merge';
-    let force                   = false;
-    let forceTopologyMismatch   = false;
-    let filterLabels            = [];
-    let filterEdgeTypes         = [];
-    let onlySubstrate           = null;
-    let postRestoreHook         = null;
+    const positional            = [];
+    let   mode                  = 'merge';
+    let   force                 = false;
+    let   forceTopologyMismatch = false;
+    let   filterLabels          = [];
+    let   filterEdgeTypes       = [];
+    let   onlySubstrate         = null;
+    let   postRestoreHook       = null;
 
     const splitCsv = s => String(s).split(',').map(t => t.trim()).filter(Boolean);
 

--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -223,7 +223,7 @@ export async function resolveMainCheckout(cwd, {explicitRoot} = {}) {
     if (explicitRoot) return path.resolve(explicitRoot);
 
     const {stdout} = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {cwd});
-    const match    = stdout.match(/^worktree (.+)$/m);
+    const match = stdout.match(/^worktree (.+)$/m);
     return match ? match[1] : null;
 }
 
@@ -340,7 +340,7 @@ async function exists(p) {
  * The `wake-daemon/` subdir is critical for PID-lock singleton enforcement to
  * span worktrees — without symlinking, each worktree has its own `bridge-daemon.pid` and
  * daemons spawned from different worktrees can't see each other's locks. Same logic for
- * the persistent `bridge.log` substrate.
+ * the persistent `.neo-ai-data/wake-daemon/bridge.log` substrate.
  *
  * Idempotent per-subdir by design: an existing symlink reports `'already-linked'`; a
  * missing canonical source reports `'skip-no-source'` (graceful for fresh repos that
@@ -623,7 +623,7 @@ export async function runBuildAll({projectRoot, log = console.log, exec = execFi
  */
 export function parseWorktreePorcelain(output) {
     const records = [];
-    let current   = null;
+    let   current = null;
 
     for (const line of output.split(/\r?\n/)) {
         if (!line.trim()) {
@@ -635,7 +635,7 @@ export function parseWorktreePorcelain(output) {
         }
 
         const [key, ...rest] = line.split(' ');
-        const value          = rest.join(' ');
+        const value = rest.join(' ');
 
         if (key === 'worktree') {
             if (current) records.push(current);
@@ -720,7 +720,7 @@ export async function classifyWorktree({
     const current               = isSamePath(worktree.path, currentPath);
     const primaryMainCheckout   = isSamePath(worktree.path, mainCheckout);
     const protectedCheckoutPath = current || primaryMainCheckout;
-    const classification = {
+    const classification        = {
         remove: !protectedCheckoutPath,
         status: current ? 'current' : (primaryMainCheckout ? 'main-checkout' : 'remove'),
         reason: current
@@ -787,7 +787,7 @@ export async function pruneStaleWorktrees({
     log           = console.log,
     hydrate       = hydrateCurrentWorktree
 }) {
-    const worktrees = await listClaudeWorktrees({projectRoot, worktreesRoot, exec});
+    const worktrees  = await listClaudeWorktrees({projectRoot, worktreesRoot, exec});
     const classified = [];
 
     for (const worktree of worktrees) {
@@ -887,7 +887,7 @@ export async function runLocalPruneWorktreeSchedule({intervalMs, log = console.l
 
     log(`WARNING: --schedule-local repeatedly prunes non-current worktrees on every tick, ${dirtyPolicy}.`);
 
-    let running = false;
+    let   running = false;
     const runOnce = async () => {
         if (running) {
             log(`Skipping prune tick: prior run still active.`);
@@ -918,7 +918,7 @@ export async function runLocalPruneWorktreeSchedule({intervalMs, log = console.l
 async function getPathSizeBytes(targetPath, {exec = execFileAsync} = {}) {
     try {
         const {stdout} = await exec('du', ['-sk', targetPath]);
-        const kb       = Number.parseInt(stdout.trim().split(/\s+/)[0], 10);
+        const kb = Number.parseInt(stdout.trim().split(/\s+/)[0], 10);
         return Number.isFinite(kb) ? kb * 1024 : 0;
     } catch {
         return 0;
@@ -975,9 +975,9 @@ function isPathInside(rootPath, candidatePath) {
 }
 
 function formatBytes(bytes) {
-    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-    let value   = bytes;
-    let unitIdx = 0;
+    const units   = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let   value   = bytes;
+    let   unitIdx = 0;
 
     while (value >= 1024 && unitIdx < units.length - 1) {
         value /= 1024;
@@ -999,10 +999,10 @@ if (isMain) {
     const __dirname   = path.dirname(__filename);
     const projectRoot = resolveCliProjectRoot(__dirname); // ai/scripts/migrations/ → scripts/ → ai/ → root
 
-    const argv     = process.argv.slice(2);
-    const args     = new Set(argv);
-    const linkData = args.has('--link-data');
-    const force    = args.has('--force');
+    const argv       = process.argv.slice(2);
+    const args       = new Set(argv);
+    const linkData   = args.has('--link-data');
+    const force      = args.has('--force');
     const pruneStale = args.has('--prune-stale') || argv.includes('--mode=prune-stale') ||
         (argv.includes('--mode') && argv[argv.indexOf('--mode') + 1] === 'prune-stale');
     const dryRun        = args.has('--dry-run');
@@ -1015,8 +1015,8 @@ if (isMain) {
     // git-worktree-list resolution path is the natural primary). They activate the
     // independent-clone topology where canonical lives in a sibling
     // checkout that `git worktree list` doesn't surface.
-    const flagIdx       = argv.indexOf('--canonical-root');
-    const explicitRoot  = (flagIdx !== -1 && argv[flagIdx + 1])
+    const flagIdx      = argv.indexOf('--canonical-root');
+    const explicitRoot = (flagIdx !== -1 && argv[flagIdx + 1])
         ? argv[flagIdx + 1]
         : (process.env.NEO_AI_CANONICAL_ROOT || null);
 

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -2,9 +2,10 @@ import aiConfig  from '../../mcp/server/neural-link/config.mjs';
 import {spawn}   from 'child_process';
 import crypto    from 'crypto';
 import fs        from 'fs';
+import path      from 'path';
 import WebSocket from 'ws';
-import Base              from '../../../src/core/Base.mjs';
-import logger            from '../../mcp/server/neural-link/logger.mjs';
+import Base      from '../../../src/core/Base.mjs';
+import logger    from '../../mcp/server/neural-link/logger.mjs';
 import {
     BRIDGE_INFO_TYPE,
     STALE_BRIDGE_ERROR_CODE,
@@ -69,6 +70,24 @@ export const getBridgePayloadByteLength = payload => {
     } catch {
         return null
     }
+};
+
+/**
+ * @summary Resolves the detached Bridge process stdout/stderr log file.
+ * @param {Object} [options={}]
+ * @param {String} [options.logPath=aiConfig.logPath]
+ * @param {String} [options.neoRootDir=aiConfig.neoRootDir]
+ * @param {String} [options.cwd=process.cwd()]
+ * @returns {String}
+ */
+export const getBridgeStdioLogPath = ({
+    logPath   = aiConfig.logPath,
+    neoRootDir = aiConfig.neoRootDir,
+    cwd       = process.cwd()
+} = {}) => {
+    const logDir = logPath || path.resolve(neoRootDir || cwd, '.neo-ai-data/logs');
+
+    return path.join(logDir, 'neural-link-bridge-stdio.log')
 };
 
 /**
@@ -238,7 +257,7 @@ class ConnectionService extends Base {
         // Resolve the target session (explicit target honored; silent multi-session auto-targeting denied).
         sessionId = resolveCallTarget(sessionId, Array.from(this.sessionData.keys()));
 
-        const id = ++this.msgId;
+        const id         = ++this.msgId;
         const rpcMessage = {
             jsonrpc: '2.0',
             method,
@@ -689,16 +708,44 @@ class ConnectionService extends Base {
     }
 
     /**
+     * Opens the detached Bridge stdout/stderr log file.
+     * @param {String} [filePath=getBridgeStdioLogPath()]
+     * @returns {Number}
+     */
+    openBridgeLogFile(filePath = getBridgeStdioLogPath()) {
+        fs.mkdirSync(path.dirname(filePath), {recursive: true});
+
+        return fs.openSync(filePath, 'a')
+    }
+
+    /**
+     * Spawns a detached child process. Kept as a method so tests can verify spawn wiring without
+     * launching the live Bridge.
+     * @param {String} command
+     * @param {String[]} args
+     * @param {Object} options
+     * @returns {Object}
+     */
+    spawnBridgeProcess(command, args, options) {
+        return spawn(command, args, options)
+    }
+
+    /**
      * Spawns the Bridge process.
+     * @param {Object} [options={}]
+     * @param {String} [options.logPath=aiConfig.logPath] Directory for spawned Bridge stdout/stderr.
+     * @param {String} [options.neoRootDir=aiConfig.neoRootDir] Repo root fallback for log path resolution.
+     * @param {Number} [options.startupDelayMs=2000] Delay before resolving after spawning.
      * @returns {Promise<void>}
      */
-    async spawnBridge() {
-        return new Promise((resolve, reject) => {
+    async spawnBridge({logPath = aiConfig.logPath, neoRootDir = aiConfig.neoRootDir, startupDelayMs = 2000} = {}) {
+        return new Promise(resolve => {
             const args    = ['run', 'ai:server-neural-link'];
-            const logFile = fs.openSync('./bridge.log', 'a');
+            const file    = getBridgeStdioLogPath({logPath, neoRootDir});
+            const logFile = this.openBridgeLogFile(file);
             const port    = aiConfig.port;
 
-            this.bridgeProcess = spawn('npm', args, {
+            this.bridgeProcess = this.spawnBridgeProcess('npm', args, {
                 cwd     : this.cwd || process.cwd(),
                 detached: true,
                 env     : {...process.env, NEO_NL_PORT: String(port)},
@@ -736,7 +783,7 @@ class ConnectionService extends Base {
 
         return new Promise((resolve, reject) => {
             const startTime = Date.now();
-            const interval = setInterval(() => {
+            const interval  = setInterval(() => {
                 found = check();
                 if (found) {
                     clearInterval(interval);

--- a/learn/agentos/NeuralLink.md
+++ b/learn/agentos/NeuralLink.md
@@ -117,7 +117,7 @@ npm run ai:server-neural-link
 - If the Bridge is already running, the MCP server detects and connects to it automatically
 - If not running, the MCP server spawns a managed Bridge process in the background
 - The Bridge runs detached and persists even if the MCP server exits
-- Bridge logs are written to `./bridge.log` in your project root
+- Bridge child-process stdout/stderr is written to `.neo-ai-data/logs/neural-link-bridge-stdio.log`; the MCP server logger writes daily `nl-server-YYYY-MM-DD.log` files in the same directory
 - To stop: Use the `manage_connection` tool with `action: 'stop'` or manually kill the process
 
 **Multi-Agent Coordination:**
@@ -351,7 +351,7 @@ The Neural Link is a powerful capability, designed for **local development and t
 
 ### Connection Issues
 
-- **"Connection Refused":** Ensure the Bridge is running (`npm run ai:server-neural-link`). Check `./bridge.log` for errors.
+- **"Connection Refused":** Ensure the Bridge is running (`npm run ai:server-neural-link`). Check `.neo-ai-data/logs/neural-link-bridge-stdio.log` and the current `nl-server-YYYY-MM-DD.log` for errors.
 - **"Connection Lost" (Automatic Recovery):** The client retries up to 5 times with exponential backoff (max 30 seconds between attempts). Check browser console for reconnection logs.
 - **"Max reconnection attempts reached":** Bridge or network is unstable. Restart the Bridge and check firewall settings.
 

--- a/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
@@ -32,10 +32,11 @@ test.describe('Neo.ai.services.neural-link.ComponentService — createComponent 
 
     test.beforeAll(async () => {
         // Prevent the ConnectionService singleton from auto-spawning a Bridge process at import time
-        // (autoConnect → initAsync → spawnBridge) — it pollutes the unit run (port 8081 EPERM / bridge.log)
-        // and is the isolation blocker. Set autoConnect=false on the shared NL config BEFORE importing
-        // ConnectionService (mirrors McpServerListToolsSmoke.spec). A post-import ready-stub alone is too
-        // late: the spawn fires from ConnectionService's own initAsync, gated by this config leaf.
+        // (autoConnect → initAsync → spawnBridge) — it pollutes the unit run (port 8081 EPERM and
+        // `.neo-ai-data/logs/neural-link-bridge-stdio.log`) and is the isolation blocker. Set
+        // autoConnect=false on the shared NL config BEFORE importing ConnectionService (mirrors
+        // McpServerListToolsSmoke.spec). A post-import ready-stub alone is too late: the spawn fires
+        // from ConnectionService's own initAsync, gated by this config leaf.
         (await import('../../../../../../ai/mcp/server/neural-link/config.mjs')).default.data.autoConnect = false;
 
         ConnectionService = (await import('../../../../../../ai/services/neural-link/ConnectionService.mjs')).default;

--- a/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
@@ -11,9 +11,12 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {test, expect}            from '@playwright/test';
+import fs                        from 'fs';
+import os                        from 'os';
+import path                      from 'path';
+import Neo                       from '../../../../../../src/Neo.mjs';
+import * as core                 from '../../../../../../src/core/_export.mjs';
 import {STALE_BRIDGE_ERROR_CODE} from '../../../../../../ai/mcp/server/neural-link/BridgeProtocol.mjs';
 
 /**
@@ -24,29 +27,38 @@ import {STALE_BRIDGE_ERROR_CODE} from '../../../../../../ai/mcp/server/neural-li
  * is what decides whether a stale shared Bridge is reused, spawned over, or failed loudly.
  */
 test.describe('Neo.ai.services.neural-link.ConnectionService — bridge freshness gate (#13299)', () => {
-    let ConnectionService, logBridgePayload,
+    let ConnectionService, getBridgeStdioLogPath, logBridgePayload,
         normalizeBridgePayloadDebugMaxChars, stringifyBridgePayloadForDebug,
-        originalConnectToBridge, originalSpawnBridge;
+        originalConnectToBridge, originalCwd, originalOpenBridgeLogFile,
+        originalSpawnBridge, originalSpawnBridgeProcess;
 
     test.beforeAll(async () => {
         const module = await import('../../../../../../ai/services/neural-link/ConnectionService.mjs');
 
         ConnectionService                    = module.default;
+        getBridgeStdioLogPath                = module.getBridgeStdioLogPath;
         logBridgePayload                     = module.logBridgePayload;
         normalizeBridgePayloadDebugMaxChars  = module.normalizeBridgePayloadDebugMaxChars;
         stringifyBridgePayloadForDebug       = module.stringifyBridgePayloadForDebug;
     });
 
     test.beforeEach(() => {
-        originalConnectToBridge = ConnectionService.connectToBridge;
-        originalSpawnBridge     = ConnectionService.spawnBridge;
+        originalConnectToBridge    = ConnectionService.connectToBridge;
+        originalCwd                = ConnectionService.cwd;
+        originalOpenBridgeLogFile  = ConnectionService.openBridgeLogFile;
+        originalSpawnBridge        = ConnectionService.spawnBridge;
+        originalSpawnBridgeProcess = ConnectionService.spawnBridgeProcess;
         ConnectionService.bridgeSocket = null;
     });
 
     test.afterEach(() => {
-        ConnectionService.connectToBridge = originalConnectToBridge;
-        ConnectionService.spawnBridge     = originalSpawnBridge;
-        ConnectionService.bridgeSocket    = null;
+        ConnectionService.connectToBridge      = originalConnectToBridge;
+        ConnectionService.cwd                  = originalCwd;
+        ConnectionService.openBridgeLogFile    = originalOpenBridgeLogFile;
+        ConnectionService.spawnBridge          = originalSpawnBridge;
+        ConnectionService.spawnBridgeProcess   = originalSpawnBridgeProcess;
+        ConnectionService.bridgeProcess        = null;
+        ConnectionService.bridgeSocket         = null;
     });
 
     test('builds the Bridge URL from an explicit port and encoded fleet token', () => {
@@ -57,6 +69,59 @@ test.describe('Neo.ai.services.neural-link.ConnectionService — bridge freshnes
         });
 
         expect(url).toBe('ws://127.0.0.1:19081/?role=agent&id=agent-test&token=token+with+spaces');
+    });
+
+    test('resolves Bridge stdio logs under the configured Neural Link log directory (#13899)', () => {
+        const logDir = path.resolve(os.tmpdir(), `nl-bridge-stdio-path-${process.pid}`);
+
+        expect(getBridgeStdioLogPath({logPath: logDir}))
+            .toBe(path.join(logDir, 'neural-link-bridge-stdio.log'));
+        expect(getBridgeStdioLogPath({logPath: '', neoRootDir: '/repo'}))
+            .toBe(path.join('/repo', '.neo-ai-data/logs/neural-link-bridge-stdio.log'));
+    });
+
+    test('creates the configured Bridge stdio log directory before opening the file (#13899)', () => {
+        const logDir  = path.join(os.tmpdir(), `nl-bridge-stdio-open-${process.pid}-${Date.now()}`);
+        const logPath = getBridgeStdioLogPath({logPath: logDir});
+        const fd      = ConnectionService.openBridgeLogFile(logPath);
+
+        fs.closeSync(fd);
+
+        try {
+            expect(fs.existsSync(logDir)).toBe(true);
+            expect(fs.existsSync(logPath)).toBe(true);
+        } finally {
+            fs.rmSync(logDir, {recursive: true, force: true});
+        }
+    });
+
+    test('wires spawned Bridge stdio to the configured log file without launching it (#13899)', async () => {
+        const logDir = path.resolve(os.tmpdir(), `nl-bridge-stdio-spawn-${process.pid}-${Date.now()}`);
+
+        let openedPath, spawnCall, unrefCalled = false;
+
+        ConnectionService.openBridgeLogFile = filePath => {
+            openedPath = filePath;
+            return 42
+        };
+        ConnectionService.spawnBridgeProcess = (command, args, options) => {
+            spawnCall = {command, args, options};
+
+            return {
+                unref() {
+                    unrefCalled = true
+                }
+            }
+        };
+
+        await ConnectionService.spawnBridge({logPath: logDir, startupDelayMs: 0});
+
+        expect(openedPath).toBe(path.join(logDir, 'neural-link-bridge-stdio.log'));
+        expect(path.basename(openedPath)).not.toBe('bridge.log');
+        expect(spawnCall.command).toBe('npm');
+        expect(spawnCall.args).toEqual(['run', 'ai:server-neural-link']);
+        expect(spawnCall.options.stdio).toEqual(['ignore', 42, 42]);
+        expect(unrefCalled).toBe(true);
     });
 
     test('logs bridge receives as bounded metadata when debug is disabled (#13473)', () => {
@@ -160,7 +225,7 @@ test.describe('Neo.ai.services.neural-link.ConnectionService — bridge freshnes
     });
 
     test('fails loudly instead of spawning over a reachable stale Bridge', async () => {
-        let spawned = false;
+        let   spawned    = false;
         const staleError = new Error('Stale Neural Link Bridge on port 8081: missing bridge_info freshness handshake.');
         staleError.code  = STALE_BRIDGE_ERROR_CODE;
 


### PR DESCRIPTION
Resolves #13899

Routes detached Neural Link Bridge child-process stdout/stderr into the configured data-log directory instead of a cwd-relative `./bridge.log`. `ConnectionService.spawnBridge()` now resolves `.neo-ai-data/logs/neural-link-bridge-stdio.log`, creates the directory before opening the fd, and keeps overridable open/spawn seams so the unit test can verify wiring without launching a real bridge. Current Neural Link docs now point operators at the data-log path, while wake-daemon comments explicitly name their separate `.neo-ai-data/wake-daemon/bridge.log` substrate.

Evidence: L2 (unit-level spawn/open wiring plus static checks in the sandbox; no live Bridge launch) -> L2 required (the close-target ACs require log-path wiring and unit coverage, not an operator-gated runtime handoff). No residuals.

## Deltas from ticket

- Added an explicit `spawnBridge({logPath, neoRootDir})` override for tests so coverage does not mutate shared AiConfig state.
- Kept the existing shared MCP logger unchanged; this only redirects the spawned child-process stdout/stderr sink.
- Ran the repository block-alignment fixer on touched `.mjs` files; it also normalized pre-existing alignment in the two touched maintenance-script files.

## Test Evidence

- `node buildScripts/util/check-block-alignment.mjs --fix ai/services/neural-link/ConnectionService.mjs test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs ai/scripts/maintenance/restore.mjs ai/scripts/migrations/bootstrapWorktree.mjs`
- `node buildScripts/util/check-aiconfig-test-mutation.mjs test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs`
- `node buildScripts/util/check-jsdoc-types.mjs ai/services/neural-link/ConnectionService.mjs`
- `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config`
- `node ./ai/scripts/setup/initServerConfigs.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs` -> 18 passed
- `npm run agent-preflight -- ai/services/neural-link/ConnectionService.mjs test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs learn/agentos/NeuralLink.md ai/scripts/maintenance/restore.mjs ai/scripts/migrations/bootstrapWorktree.mjs`
- Pre-commit hook passed on the final staged diff.

Attempted but not accepted as PR evidence: full `npm run test-unit` before local ignored-config refresh. It was interrupted after `3504 passed`, `59 failed`, `6 interrupted`, and `1210 did not run`; the first failure class was stale local materialized config overlays missing new Memory Core leaves. The ignored configs were refreshed with `initServerConfigs.mjs --migrate-config`, and the PR-scoped tests passed afterward.

## Slot Rationale

Modified `learn/agentos/NeuralLink.md`: disposition `keep`. This is an existing operational reference doc, not new turn-loaded substrate; the edit updates stale troubleshooting text so future Neural Link users inspect the configured data-log path rather than reintroducing repo-root `bridge.log` assumptions.

## Post-Merge Validation

- [ ] From a checkout with no live Neural Link Bridge, run a whitebox/e2e path that starts the bridge and confirm no new repo-root `bridge.log` is created.
- [ ] Confirm `.neo-ai-data/logs/neural-link-bridge-stdio.log` captures spawned bridge stdout/stderr during that run.

## Commits

- `ac44bfc80c` — `fix(neural-link): route bridge logs to data dir (#13899)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef100-77a2-7781-a83f-4f064a3c1aca.
