### PR TITLE
docs(migrations): #13827 already-implemented in renameAgentIdentities — cross-ref + reframe (#13827)

### DIFF
--- a/ai/scripts/migrations/normalizeGraphIdentities.mjs
+++ b/ai/scripts/migrations/normalizeGraphIdentities.mjs
@@ -36,6 +36,11 @@
  *     the aliases become stale pointers; accept the staleness as low-frequency read path)
  *   - Hot-reload in a running MCP process (restart harnesses after `--apply` to pick
  *     up the clean graph state)
+ *   - Identity RENAME re-keying (e.g. `@neo-claude-opus` → `@neo-opus-grace`): re-keying a renamed
+ *     identity's `user_id`-scoped rows (`AGENT_MEMORY` / `MEMORY` / `SESSION`) + their Chroma
+ *     metadata is `renameAgentIdentities.mjs`'s job (its `IDENTITY_RENAMES` + the all-node/edge
+ *     `user_id` sweep `rewriteGraphMetadataRows`), NOT this script's. This one only merges legacy
+ *     *alias* `AgentIdentity` nodes + re-points their edges; it does not touch memory-row RLS scope.
  *
  * @see learn/agentos/tooling/MemoryCoreMcpAuth.md §Identity Normalization Migration
  */


### PR DESCRIPTION
Resolves #13827

#13827 asked to extend `normalizeGraphIdentities.mjs` to re-key stranded alias `AGENT_MEMORY` rows. A prior-art V-B-A (dry-run evidence in the [issue comment](https://github.com/neomjs/neo/issues/13827#issuecomment-4774928355)) shows that re-keying is **already implemented** — in the sibling `renameAgentIdentities.mjs`: `IDENTITY_RENAMES` carries `@neo-claude-opus`→`@neo-opus-grace`, and `rewriteGraphMetadataRows` sweeps every Node/Edge `user_id` + identity-metadata key + the Chroma `neo-agent-memory`/`neo-agent-sessions` collections. A `--graph-only` dry-run on the live graph plans **44 node-metadata + 33 edge-metadata** re-keys; the 32 stranded `neo-claude-opus` rows are inside that set. So #13827 needs **no new code** — it is a *run-gap* (the migration hasn't been `--apply`'d since those rows were written).

This PR resolves #13827 as **already-implemented** and lands the friction→gold that prevents the re-derivation: a cross-reference in `normalizeGraphIdentities.mjs`'s "does NOT do" section pointing at `renameAgentIdentities.mjs` for identity-rename memory re-keying — the discoverability gap that produced the ticket's wrong premise.

Evidence: L1 (the dry-run plan + the existing `renameAgentIdentities.spec.mjs` already cover the ACs; this PR is a docs-only cross-ref, no behavior change) → L1 sufficient (a discoverability hardening). Residual: the live data-drain is an operator action (below), not code.

## Deltas

- **No new migration code.** A duplicate Phase-3 in `normalizeGraphIdentities.mjs` would have been wrong — DRY violation + drift risk against `renameAgentIdentities.mjs`'s canonical re-key. The prior-art sweep caught it before a line was written.
- The cross-ref documents the boundary: `normalizeGraphIdentities` = legacy **alias** AgentIdentity-node merge; `renameAgentIdentities` = identity **rename** re-keying (rows + Chroma).

## Test Evidence

- `node --check ai/scripts/migrations/normalizeGraphIdentities.mjs` — clean (docs-only change).
- Dry-run (read-only) on the live graph: `renameAgentIdentities.mjs --graph-only` → `@neo-claude-opus → @neo-opus-grace`; **44 node-metadata + 33 edge-metadata** re-keys planned (incl. the 32 stranded `AGENT_MEMORY` rows).
- The re-key logic is already covered by `test/playwright/unit/ai/scripts/migrations/renameAgentIdentities.spec.mjs`.

## Post-Merge Validation

- [ ] **Operator action** (the data-drain — prod-data mutation on the memory SSOT, operator-gated by design): run `node ai/scripts/migrations/renameAgentIdentities.mjs --apply`, restart the MCP harnesses, then confirm a `@neo-opus-grace` canonical recall includes the 32 formerly-stranded `neo-claude-opus` rows.

Authored by @neo-opus-grace (Grace, Claude Opus 4.8) via Claude Code.
