### PR TITLE
feat(ai): add message WAL drain topology (#13890)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -561,6 +561,10 @@ class Config extends ConfigProvider {
                     // process; cloud deployments own their drain story per-container (mirror of
                     // the chromaDaemonEnabled split).
                     embedDaemonEnabled             : leaf(null, 'NEO_ORCHESTRATOR_EMBED_DAEMON_ENABLED', 'boolean'),
+                    // The message daemon observes the accepted A2A-message WAL. Local profile may
+                    // supervise it as a child process; cloud deployments use Memory Core's
+                    // messageWal.inProcessDrain host mode instead.
+                    messageDaemonEnabled           : leaf(null, 'NEO_ORCHESTRATOR_MESSAGE_DAEMON_ENABLED', 'boolean'),
                     goldenPathRepoEnrichmentEnabled: leaf(null, 'NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED', 'boolean'),
                     // `null` = use the deployment-profile default (local enables, cloud disables);
                     // the swarm-heartbeat lane emits wake-substrate pulses through bridge delivery.

--- a/ai/daemons/embed/drainLock.mjs
+++ b/ai/daemons/embed/drainLock.mjs
@@ -34,19 +34,23 @@ import path from 'path';
  */
 export const DRAIN_LOCK_FILENAME = '.drain-lock';
 
+const DEFAULT_LOCK_LABEL = 'WAL';
+const DEFAULT_REMEDIATION =
+    'Disable one drain host for this deployment — the embed daemon OR memoryWal.inProcessDrain.';
+
 /**
  * @summary Error thrown when the drain lock is already held by a DIFFERENT live host. Carries the
  * holder descriptor so the caller can fail loud with an actionable, holder-naming message.
  */
 export class DrainLockHeldError extends Error {
-    constructor({lockPath, holder, requester}) {
+    constructor({lockPath, holder, requester, lockLabel = DEFAULT_LOCK_LABEL, remediation = DEFAULT_REMEDIATION}) {
         const who = holder
             ? `${holder.owner} pid ${holder.pid} (since ${holder.startedAt})`
             : 'an unknown live process';
 
-        super(`WAL drain lock ${lockPath} is held by ${who}; ${requester.owner} pid ${requester.pid} ` +
+        super(`${lockLabel} drain lock ${lockPath} is held by ${who}; ${requester.owner} pid ${requester.pid} ` +
             'refuses to start a second drain loop on the same WAL directory (sole-drainer invariant). ' +
-            'Disable one drain host for this deployment — the embed daemon OR memoryWal.inProcessDrain.');
+            remediation);
 
         this.name      = 'DrainLockHeldError';
         this.code      = 'DRAIN_LOCK_HELD';
@@ -150,7 +154,9 @@ export function acquireDrainLock({
     now        = Date.now,
     fs: fsImpl = fs,
     isAlive    = defaultIsAlive,
-    log        = () => {}
+    log        = () => {},
+    lockLabel  = DEFAULT_LOCK_LABEL,
+    remediation = DEFAULT_REMEDIATION
 } = {}) {
     const lockPath = path.join(dir, DRAIN_LOCK_FILENAME);
 
@@ -172,7 +178,7 @@ export function acquireDrainLock({
             const holder = readHolder(lockPath, fsImpl);
 
             if (holder && holder.pid !== pid && isAlive(holder.pid)) {
-                throw new DrainLockHeldError({lockPath, holder, requester: {owner, pid}});
+                throw new DrainLockHeldError({lockPath, holder, requester: {owner, pid}, lockLabel, remediation});
             }
 
             // Stale (dead holder), our own leftover, or corrupt → reclaim and retry the wx claim.
@@ -186,5 +192,5 @@ export function acquireDrainLock({
     }
 
     // Both passes lost the wx race: another host re-claimed between our unlink and re-claim.
-    throw new DrainLockHeldError({lockPath, holder: readHolder(lockPath, fsImpl), requester: {owner, pid}});
+    throw new DrainLockHeldError({lockPath, holder: readHolder(lockPath, fsImpl), requester: {owner, pid}, lockLabel, remediation});
 }

--- a/ai/daemons/message/daemon.mjs
+++ b/ai/daemons/message/daemon.mjs
@@ -1,0 +1,200 @@
+/**
+ * @summary Local supervised daemon for the A2A message WAL drain topology.
+ *
+ * Mirrors the memory embed daemon's deployment shape: local/orchestrator-managed profiles run this
+ * process with PID/log state under `.neo-ai-data`, while containerized/single-process deployments
+ * host the same loop inside Memory Core via `messageWal.inProcessDrain`. The graph replay
+ * processor is intentionally injectable so topology can land before projection semantics.
+ */
+import Neo              from '../../../src/Neo.mjs';
+import * as core        from '../../../src/core/_export.mjs';
+import InstanceManager  from '../../../src/manager/Instance.mjs';
+import memoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
+
+import fs         from 'fs-extra';
+import path       from 'path';
+import {execSync} from 'child_process';
+
+import {startMessageDrainLoop}      from './drainCycle.mjs';
+import {acquireMessageDrainLock}    from './drainLock.mjs';
+import {getMissingMessageWalLeaves} from '../../services/memory-core/helpers/messageWalStore.mjs';
+
+const missingLeaves = getMissingMessageWalLeaves(memoryCoreConfig.messageWal,
+    ['dir', 'daemonDataDir', 'pollIntervalMs', 'batchSize', 'maxRetries', 'backoffBaseMs']);
+
+if (missingLeaves.length > 0) {
+    console.error(`[Message Daemon] messageWal config leaves missing: ${missingLeaves.join(', ')} — ` +
+        'sync the messageWal block from config.template.mjs into the local config.mjs ' +
+        '(node ai/scripts/setup/initServerConfigs.mjs --migrate-config) and restart. Exiting.');
+    process.exit(1);
+}
+
+const DAEMON_DATA_DIR    = memoryCoreConfig.messageWal.daemonDataDir;
+const LOG_FILE           = path.join(DAEMON_DATA_DIR, 'message-daemon.log');
+const PID_FILE           = path.join(DAEMON_DATA_DIR, 'message-daemon.pid');
+const LOG_RETENTION_DAYS = 30;
+
+fs.ensureDirSync(DAEMON_DATA_DIR);
+
+function rotateLogIfNewDay() {
+    if (!fs.existsSync(LOG_FILE)) return;
+    try {
+        const stats    = fs.statSync(LOG_FILE);
+        const fileDay  = stats.mtime.toISOString().split('T')[0];
+        const todayDay = new Date().toISOString().split('T')[0];
+        if (fileDay !== todayDay) {
+            fs.renameSync(LOG_FILE, `${LOG_FILE}.${fileDay}`);
+        }
+    } catch (e) {
+        process.stderr.write(`[Message Daemon] Log rotation failed: ${e.message}\n`);
+    }
+}
+
+function pruneOldLogs() {
+    const cutoff = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    try {
+        for (const entry of fs.readdirSync(DAEMON_DATA_DIR)) {
+            if (!entry.startsWith('message-daemon.log.') || entry === 'message-daemon.log') continue;
+            const fullPath = path.join(DAEMON_DATA_DIR, entry);
+            try {
+                if (fs.statSync(fullPath).mtime.getTime() < cutoff) {
+                    fs.unlinkSync(fullPath);
+                }
+            } catch (e) {}
+        }
+    } catch (e) {}
+}
+
+function writeLog(level, message) {
+    rotateLogIfNewDay();
+    const line = `[${new Date().toISOString()}] [PID:${process.pid}] [${level}] ${message}`;
+
+    try {
+        fs.appendFileSync(LOG_FILE, line + '\n', 'utf8');
+    } catch (e) {}
+
+    if (level === 'ERROR') {
+        console.error(line);
+    } else {
+        console.log(line);
+    }
+}
+
+pruneOldLogs();
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+async function enforceSingleton() {
+    if (fs.existsSync(PID_FILE)) {
+        try {
+            const oldPid = parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10);
+            if (!isNaN(oldPid) && oldPid > 0 && oldPid !== process.pid) {
+                let isAlive = false;
+                try {
+                    process.kill(oldPid, 0);
+                    isAlive = true;
+                } catch (e) {}
+
+                if (isAlive) {
+                    try {
+                        const cmd = execSync(`ps -p ${oldPid} -o command=`).toString().trim();
+                        if (cmd.includes('daemons/message/daemon.mjs')) {
+                            writeLog('INFO', `[Message Daemon] Found existing instance (PID: ${oldPid}). Sending SIGTERM...`);
+                            process.kill(oldPid, 'SIGTERM');
+                        } else {
+                            writeLog('INFO', `[Message Daemon] Stale PID file found. PID ${oldPid} used by a different process. Proceeding.`);
+                            isAlive = false;
+                        }
+                    } catch (psErr) {
+                        writeLog('INFO', `[Message Daemon] Could not verify process name. Sending SIGTERM to PID ${oldPid} to be safe...`);
+                        process.kill(oldPid, 'SIGTERM');
+                    }
+                }
+
+                if (isAlive) {
+                    let alive = true;
+                    for (let i = 0; i < 30; i++) {
+                        await wait(100);
+                        try {
+                            process.kill(oldPid, 0);
+                        } catch (e) {
+                            alive = false;
+                            break;
+                        }
+                    }
+                    if (alive) {
+                        writeLog('INFO', `[Message Daemon] PID ${oldPid} did not exit after 3s. Escalating to SIGKILL...`);
+                        try {
+                            process.kill(oldPid, 'SIGKILL');
+                        } catch (e) {}
+                    }
+                }
+
+                try {
+                    fs.unlinkSync(PID_FILE);
+                } catch (e) {}
+            }
+        } catch (e) {
+            writeLog('ERROR', `[Message Daemon] Failed to check existing PID file: ${e.message || e}`);
+        }
+    }
+
+    try {
+        fs.writeFileSync(PID_FILE, process.pid.toString(), {encoding: 'utf8', flag: 'wx'});
+    } catch (e) {
+        if (e.code === 'EEXIST') {
+            writeLog('ERROR', '[Message Daemon] Failed to claim PID file (EEXIST). Another instance started simultaneously. Exiting.');
+            process.exit(1);
+        }
+        throw e;
+    }
+
+    let   cleanedUp = false;
+    const cleanup   = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        try {
+            if (fs.existsSync(PID_FILE)) {
+                const currentPid = parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10);
+                if (currentPid === process.pid) {
+                    fs.unlinkSync(PID_FILE);
+                }
+            }
+        } catch (e) {}
+        process.exit();
+    };
+
+    process.on('SIGINT', cleanup);
+    process.on('SIGTERM', cleanup);
+    process.on('exit', cleanup);
+    process.on('uncaughtException', err => {
+        writeLog('ERROR', `[Message Daemon] Uncaught exception: ${err && err.stack ? err.stack : err}`);
+        cleanup();
+    });
+}
+
+async function main() {
+    await enforceSingleton();
+
+    let drainLock;
+    try {
+        drainLock = acquireMessageDrainLock({dir: memoryCoreConfig.messageWal.dir, owner: 'daemon', log: writeLog});
+    } catch (err) {
+        if (err.code === 'DRAIN_LOCK_HELD') {
+            writeLog('ERROR', `[Message Daemon] ${err.message} Exiting.`);
+            process.exit(1);
+        }
+        throw err;
+    }
+
+    process.on('exit', () => drainLock.release());
+
+    writeLog('INFO', `[Message Daemon] Started. Observing message WAL dir: ${memoryCoreConfig.messageWal.dir} (poll: ${memoryCoreConfig.messageWal.pollIntervalMs}ms, batch: ${memoryCoreConfig.messageWal.batchSize})`);
+
+    startMessageDrainLoop({
+        getConfig: () => memoryCoreConfig.messageWal,
+        log      : writeLog
+    });
+}
+
+main();

--- a/ai/daemons/message/drainCycle.mjs
+++ b/ai/daemons/message/drainCycle.mjs
@@ -9,8 +9,9 @@ import {readWalMessages} from '../../services/memory-core/helpers/messageWalStor
  * host that both the local daemon and in-process Memory Core mode can share.
  *
  * Full graph replay/idempotency is a separate projection concern. Until that processor is wired,
- * cycles report records as `deferred` and never mark or mutate them, preserving the WAL as the
- * authority. A2A-message vector/search population is likewise outside this topology layer.
+ * cycles stay inactive and skip WAL reads entirely, preserving the WAL as the authority without
+ * adding a growing no-op scan to live deployments. A2A-message vector/search population is likewise
+ * outside this topology layer.
  */
 
 /**
@@ -34,8 +35,8 @@ function normalizeProcessResult(records, result = {}) {
 /**
  * @summary Processes one batch of accepted message WAL records via an injected replay processor.
  *
- * Missing processor is a deliberate non-mutating state: the host topology can run in both
- * deployment realities without claiming graph-projection completion semantics.
+ * Missing processor is a deliberate non-mutating state for direct unit use. The hosted drain cycle
+ * short-circuits before reading WAL segments when no processor is wired.
  *
  * @param {Object} options
  * @param {Object[]} options.records Message WAL records.
@@ -89,7 +90,8 @@ export async function processMessageBatch({
  * @param {Function|null} [options.processRecords] Optional replay processor.
  * @param {Function} [options.log] Log sink.
  * @param {Function} [options.sleep] Delay primitive.
- * @returns {Promise<{observed: Number, drained: Number, failed: Number, deferred: Number}>}
+ * @param {Function} [options.readMessages] WAL reader injection for tests.
+ * @returns {Promise<{observed: Number, drained: Number, failed: Number, deferred: Number, inactive: Boolean}>}
  */
 export async function drainMessageWalOnce({
     dir,
@@ -98,15 +100,21 @@ export async function drainMessageWalOnce({
     backoffBaseMs,
     processRecords,
     log,
-    sleep
+    sleep,
+    readMessages = readWalMessages
 } = {}) {
-    const records = await readWalMessages({dir});
+    if (!processRecords) {
+        return {observed: 0, drained: 0, failed: 0, deferred: 0, inactive: true};
+    }
+
+    const records = await readMessages({dir});
     const bounded = Number.isFinite(batchSize) && batchSize > 0 ? batchSize : records.length;
     const batch   = records.slice(0, bounded);
     const result  = await processMessageBatch({records: batch, processRecords, maxRetries, backoffBaseMs, sleep, log});
 
     return {
         observed: records.length,
+        inactive: false,
         ...result
     };
 }
@@ -121,10 +129,12 @@ export async function drainMessageWalOnce({
  */
 export function startMessageDrainLoop({getConfig, getProcessor = () => null, log = () => {}}) {
     let stopped = false,
-        timer   = null;
+        timer   = null,
+        inactiveLogged = false;
 
     const tick = async () => {
         const {dir, batchSize, maxRetries, backoffBaseMs, pollIntervalMs} = getConfig();
+        const processRecords = getProcessor();
 
         try {
             const summary = await drainMessageWalOnce({
@@ -132,9 +142,18 @@ export function startMessageDrainLoop({getConfig, getProcessor = () => null, log
                 batchSize,
                 maxRetries,
                 backoffBaseMs,
-                processRecords: getProcessor(),
+                processRecords,
                 log
             });
+
+            if (summary.inactive) {
+                if (!inactiveLogged) {
+                    inactiveLogged = true;
+                    log('INFO', 'Message WAL drain inactive: replay processor is not wired; skipping WAL reads until the projection leaf supplies one.');
+                }
+            } else {
+                inactiveLogged = false;
+            }
 
             if (summary.drained > 0 || summary.failed > 0) {
                 log('INFO', `Message WAL drain cycle: ${JSON.stringify(summary)}`);

--- a/ai/daemons/message/drainCycle.mjs
+++ b/ai/daemons/message/drainCycle.mjs
@@ -1,0 +1,159 @@
+import {readWalMessages} from '../../services/memory-core/helpers/messageWalStore.mjs';
+
+/**
+ * @module ai/daemons/message/drainCycle
+ * @summary Host-agnostic message WAL drain loop topology.
+ *
+ * This module intentionally owns only the drain-host mechanics: read the accepted message WAL
+ * from the configured directory, batch it, retry the injected replay processor, and expose a loop
+ * host that both the local daemon and in-process Memory Core mode can share.
+ *
+ * Full graph replay/idempotency is a separate projection concern. Until that processor is wired,
+ * cycles report records as `deferred` and never mark or mutate them, preserving the WAL as the
+ * authority. A2A-message vector/search population is likewise outside this topology layer.
+ */
+
+/**
+ * @summary Computes the exponential backoff delay for a message replay retry.
+ * @param {Number} backoffBaseMs Base delay.
+ * @param {Number} attempt Zero-based retry attempt.
+ * @returns {Number}
+ */
+export function getMessageDrainBackoffDelayMs(backoffBaseMs, attempt) {
+    return backoffBaseMs * 2 ** attempt;
+}
+
+function normalizeProcessResult(records, result = {}) {
+    const drained  = Number.isFinite(result.drained)  ? result.drained  : records.length,
+          failed   = Number.isFinite(result.failed)   ? result.failed   : 0,
+          deferred = Number.isFinite(result.deferred) ? result.deferred : 0;
+
+    return {drained, failed, deferred};
+}
+
+/**
+ * @summary Processes one batch of accepted message WAL records via an injected replay processor.
+ *
+ * Missing processor is a deliberate non-mutating state: the host topology can run in both
+ * deployment realities without claiming graph-projection completion semantics.
+ *
+ * @param {Object} options
+ * @param {Object[]} options.records Message WAL records.
+ * @param {Function|null} [options.processRecords] Optional replay processor.
+ * @param {Number} options.maxRetries In-cycle retry bound.
+ * @param {Number} options.backoffBaseMs Retry backoff base.
+ * @param {Function} [options.sleep] Delay primitive.
+ * @param {Function} [options.log] Log sink.
+ * @returns {Promise<{drained: Number, failed: Number, deferred: Number}>}
+ */
+export async function processMessageBatch({
+    records,
+    processRecords,
+    maxRetries,
+    backoffBaseMs,
+    sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    log   = () => {}
+} = {}) {
+    if (!records?.length) {
+        return {drained: 0, failed: 0, deferred: 0};
+    }
+
+    if (!processRecords) {
+        return {drained: 0, failed: 0, deferred: records.length};
+    }
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+            return normalizeProcessResult(records, await processRecords(records));
+        } catch (error) {
+            if (attempt < maxRetries) {
+                const delay = getMessageDrainBackoffDelayMs(backoffBaseMs, attempt);
+                log('INFO', `Message WAL replay attempt ${attempt + 1}/${maxRetries + 1} failed (${error.message}) — backing off ${delay}ms`);
+                await sleep(delay);
+            } else {
+                log('ERROR', `Message WAL replay exhausted ${maxRetries + 1} attempts (${error.message})`);
+            }
+        }
+    }
+
+    return {drained: 0, failed: records.length, deferred: 0};
+}
+
+/**
+ * @summary Executes one message WAL drain cycle.
+ * @param {Object} options
+ * @param {String} options.dir Message WAL directory.
+ * @param {Number} options.batchSize Maximum records observed this cycle.
+ * @param {Number} options.maxRetries Replay retry bound.
+ * @param {Number} options.backoffBaseMs Replay retry backoff base.
+ * @param {Function|null} [options.processRecords] Optional replay processor.
+ * @param {Function} [options.log] Log sink.
+ * @param {Function} [options.sleep] Delay primitive.
+ * @returns {Promise<{observed: Number, drained: Number, failed: Number, deferred: Number}>}
+ */
+export async function drainMessageWalOnce({
+    dir,
+    batchSize,
+    maxRetries,
+    backoffBaseMs,
+    processRecords,
+    log,
+    sleep
+} = {}) {
+    const records = await readWalMessages({dir});
+    const bounded = Number.isFinite(batchSize) && batchSize > 0 ? batchSize : records.length;
+    const batch   = records.slice(0, bounded);
+    const result  = await processMessageBatch({records: batch, processRecords, maxRetries, backoffBaseMs, sleep, log});
+
+    return {
+        observed: records.length,
+        ...result
+    };
+}
+
+/**
+ * @summary Hosts the message WAL drain loop in either daemon or in-process mode.
+ * @param {Object} options
+ * @param {Function} options.getConfig Returns the `messageWal` config slice.
+ * @param {Function} [options.getProcessor] Optional resolver for the replay processor.
+ * @param {Function} [options.log] Log sink.
+ * @returns {{stop: Function}}
+ */
+export function startMessageDrainLoop({getConfig, getProcessor = () => null, log = () => {}}) {
+    let stopped = false,
+        timer   = null;
+
+    const tick = async () => {
+        const {dir, batchSize, maxRetries, backoffBaseMs, pollIntervalMs} = getConfig();
+
+        try {
+            const summary = await drainMessageWalOnce({
+                dir,
+                batchSize,
+                maxRetries,
+                backoffBaseMs,
+                processRecords: getProcessor(),
+                log
+            });
+
+            if (summary.drained > 0 || summary.failed > 0) {
+                log('INFO', `Message WAL drain cycle: ${JSON.stringify(summary)}`);
+            }
+        } catch (error) {
+            log('ERROR', `Message WAL drain cycle failed: ${error.message || error}`);
+        }
+
+        if (!stopped) {
+            timer = setTimeout(tick, pollIntervalMs);
+        }
+    };
+
+    timer = setTimeout(tick, 0);
+
+    return {
+        stop() {
+            stopped = true;
+            clearTimeout(timer);
+        }
+    };
+}

--- a/ai/daemons/message/drainLock.mjs
+++ b/ai/daemons/message/drainLock.mjs
@@ -1,0 +1,34 @@
+import {
+    acquireDrainLock as acquireBaseDrainLock,
+    DrainLockHeldError,
+    DRAIN_LOCK_FILENAME
+} from '../embed/drainLock.mjs';
+
+/**
+ * @module ai/daemons/message/drainLock
+ * @summary Message WAL drain-lock wrapper with message-specific remediation text.
+ *
+ * The mechanical lock primitive is shared with the memory embed daemon: one atomic
+ * `<dir>/.drain-lock`, live-holder refusal, stale-holder reclaim, and idempotent release. This
+ * wrapper keeps message-drain diagnostics domain-correct instead of telling operators to disable
+ * the embed daemon when the conflict is between the local message daemon and
+ * `messageWal.inProcessDrain`.
+ */
+
+export {DrainLockHeldError, DRAIN_LOCK_FILENAME};
+
+const MESSAGE_DRAIN_LOCK_REMEDIATION =
+    'Disable one message drain host for this deployment — the message daemon OR messageWal.inProcessDrain.';
+
+/**
+ * @summary Atomically claims the message WAL drain lock for one host.
+ * @param {Object} options Same options as `ai/daemons/embed/drainLock.acquireDrainLock`.
+ * @returns {{lockPath: String, pid: Number, owner: String, release: Function}}
+ */
+export function acquireMessageDrainLock(options = {}) {
+    return acquireBaseDrainLock({
+        ...options,
+        lockLabel  : 'Message WAL',
+        remediation: MESSAGE_DRAIN_LOCK_REMEDIATION
+    });
+}

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -228,7 +228,7 @@ export class Orchestrator extends Base {
             : '@system';
         const stalledSinceIso = Number.isFinite(stalledSince) ? new Date(stalledSince).toISOString() : 'unknown';
         const staleHours      = (Number(stalenessMs || 0) / (60 * 60 * 1000)).toFixed(1);
-        const subject = hasCycle
+        const subject         = hasCycle
             ? `[rem-consolidation-stall] last REM cycle is ${staleHours}h stale`
             : `[rem-consolidation-stall] no REM cycle recorded with ${undigestedCount} undigested sessions`;
         const body =
@@ -333,6 +333,7 @@ export class Orchestrator extends Base {
     get devServerEnabled()               { return resolveLocalDeploymentDefault(AiConfig.orchestrator.devServer.enabled); }
     get neuralLinkBridgeEnabled()        { return resolveDeploymentEnabled('neuralLinkBridgeEnabled');        }
     get embedDaemonEnabled()             { return resolveDeploymentEnabled('embedDaemonEnabled');             }
+    get messageDaemonEnabled()           { return resolveDeploymentEnabled('messageDaemonEnabled');           }
     get embedDrainLivenessWatchdogWalDir()      { return memoryCoreConfig.memoryWal.dir; }
     get embedDrainLivenessWatchdogThresholdMs() { return memoryCoreConfig.memoryWal.embedDrainStallThresholdMs; }
     get remConsolidationWatchdogRunStateDir()   { return memoryCoreConfig.remRunStateDir; }
@@ -475,7 +476,7 @@ export class Orchestrator extends Base {
      * @returns {void}
      */
     poll() {
-        const now = Date.now();
+        const now         = Date.now();
         const executeTask = this.processSupervisorService.runTask.bind(this.processSupervisorService);
 
         const continuousTasks = [
@@ -484,6 +485,7 @@ export class Orchestrator extends Base {
             ...(this.devServerEnabled    ? ['devServer'] : []),
             ...(this.neuralLinkBridgeEnabled ? ['neuralLinkBridge'] : []),
             ...(this.embedDaemonEnabled  ? ['embedDaemon'] : []),
+            ...(this.messageDaemonEnabled ? ['messageDaemon'] : []),
             'mlx',
             'ollama',
             'lms'

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -24,8 +24,8 @@ function probeTcpPort({port, timeoutMs}) {
     }
 
     return new Promise(resolve => {
-        const socket = net.connect({host: '127.0.0.1', port: normalizedPort});
-        let settled  = false;
+        const socket  = net.connect({host: '127.0.0.1', port: normalizedPort});
+        let   settled = false;
 
         const finish = result => {
             if (settled) return;
@@ -146,7 +146,7 @@ export function buildTaskDefinitions({
     neuralLinkBridgePort,
     neuralLinkBridgeLivenessTimeoutMs
 } = {}) {
-    const hasDevServerPort = devServerPort !== undefined && devServerPort !== null;
+    const hasDevServerPort        = devServerPort !== undefined && devServerPort !== null;
     const hasNeuralLinkBridgePort = neuralLinkBridgePort !== undefined && neuralLinkBridgePort !== null;
 
     const tasks = {
@@ -216,6 +216,13 @@ export function buildTaskDefinitions({
             args           : [path.resolve(scriptDir, '../daemons/embed/daemon.mjs')],
             pidFileName    : 'embed-daemon.pid',
             expectedCommand: 'daemons/embed/daemon.mjs'
+        },
+        messageDaemon: {
+            label          : 'message daemon (A2A message WAL drain)',
+            command        : nodeBin,
+            args           : [path.resolve(scriptDir, '../daemons/message/daemon.mjs')],
+            pidFileName    : 'message-daemon.pid',
+            expectedCommand: 'daemons/message/daemon.mjs'
         },
         summary: {
             label          : 'session summarization',

--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -85,6 +85,9 @@ services:
       # daemon. Dev bind-mounts the source at /app, so the default WAL dir persists on the host.
       - NEO_MEMORY_WAL_IN_PROCESS_DRAIN=true
       - NEO_MEMORY_WAL_POLL_INTERVAL_MS=250
+      # Message WAL drain mirrors memory WAL topology; default dir derives from memoryWal.dir.
+      - NEO_MESSAGE_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MESSAGE_WAL_POLL_INTERVAL_MS=250
 
     volumes:
       - ../..:/app

--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -158,6 +158,9 @@ services:
       - NEO_MEMORY_WAL_IN_PROCESS_DRAIN=true
       - NEO_MEMORY_WAL_POLL_INTERVAL_MS=250
       - NEO_MEMORY_WAL_DIR=/tmp/neo-integration/memory-wal
+      - NEO_MESSAGE_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MESSAGE_WAL_POLL_INTERVAL_MS=250
+      - NEO_MESSAGE_WAL_DIR=/tmp/neo-integration/memory-wal/messages
     tmpfs:
       - /tmp/neo-integration
     depends_on:
@@ -218,6 +221,9 @@ services:
       - NEO_MEMORY_WAL_IN_PROCESS_DRAIN=true
       - NEO_MEMORY_WAL_POLL_INTERVAL_MS=250
       - NEO_MEMORY_WAL_DIR=/tmp/neo-integration/memory-wal-oidc
+      - NEO_MESSAGE_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MESSAGE_WAL_POLL_INTERVAL_MS=250
+      - NEO_MESSAGE_WAL_DIR=/tmp/neo-integration/memory-wal-oidc/messages
     tmpfs:
       - /tmp/neo-integration
     depends_on:

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -127,6 +127,11 @@ services:
       - NEO_MEMORY_WAL_IN_PROCESS_DRAIN=true
       - NEO_MEMORY_WAL_POLL_INTERVAL_MS=250
       - NEO_MEMORY_WAL_DIR=/app/.neo-ai-data/sqlite/memory-wal
+      # Mirror the memory WAL host mode for accepted A2A messages. Defaults derive the message
+      # WAL below NEO_MEMORY_WAL_DIR, but the explicit path documents the shared volume boundary.
+      - NEO_MESSAGE_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MESSAGE_WAL_POLL_INTERVAL_MS=250
+      - NEO_MESSAGE_WAL_DIR=/app/.neo-ai-data/sqlite/memory-wal/messages
       - NEO_MODEL_PROVIDER=${NEO_MODEL_PROVIDER:-}
       - NEO_EMBEDDING_PROVIDER=${NEO_EMBEDDING_PROVIDER:-}
       - NEO_OPENAI_COMPATIBLE_HOST=${NEO_OPENAI_COMPATIBLE_HOST:-}

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -21,8 +21,11 @@ import {
     Memory_WakeSubscriptionService    as WakeSubscriptionService,
     Memory_CoalescingEngineService    as CoalescingEngineService
 } from '../../../services.mjs';
-import {startDrainLoop}   from '../../../daemons/embed/drainCycle.mjs';
-import {acquireDrainLock} from '../../../daemons/embed/drainLock.mjs';
+import {startDrainLoop}             from '../../../daemons/embed/drainCycle.mjs';
+import {acquireDrainLock}           from '../../../daemons/embed/drainLock.mjs';
+import {startMessageDrainLoop}      from '../../../daemons/message/drainCycle.mjs';
+import {acquireMessageDrainLock}    from '../../../daemons/message/drainLock.mjs';
+import {getMissingMessageWalLeaves} from '../../../services/memory-core/helpers/messageWalStore.mjs';
 
 /**
  * @summary The Memory Core MCP Server application.
@@ -281,6 +284,35 @@ class Server extends BaseServer {
             }
         }
 
+        // In-process message WAL drain (containerized / single-process deployments): mirrors the
+        // memory WAL host-mode split, but deliberately keeps replay semantics injectable; graph
+        // projection is a separate completion concern.
+        if (aiConfig.messageWal && aiConfig.messageWal.inProcessDrain) {
+            const messageDrainLog = (level, message) => logger[level === 'ERROR' ? 'error' : 'info'](`[neo-memory-core MCP] ${message}`);
+            const missingLeaves = getMissingMessageWalLeaves(aiConfig.messageWal,
+                ['dir', 'pollIntervalMs', 'batchSize', 'maxRetries', 'backoffBaseMs']);
+
+            if (missingLeaves.length > 0) {
+                logger.error(`[neo-memory-core MCP] In-process message WAL drain NOT started: messageWal config leaves missing: ${missingLeaves.join(', ')} — sync the messageWal block from config.template.mjs into the local config.mjs (node ai/scripts/setup/initServerConfigs.mjs --migrate-config) and restart memory-core.`);
+            } else {
+                try {
+                    this.messageWalDrainLock = acquireMessageDrainLock({dir: aiConfig.messageWal.dir, owner: 'in-process', log: messageDrainLog});
+                } catch (err) {
+                    if (err.code !== 'DRAIN_LOCK_HELD') throw err;
+                    logger.error(`[neo-memory-core MCP] In-process message WAL drain NOT started: ${err.message}`);
+                }
+
+                if (this.messageWalDrainLock) {
+                    this.messageWalDrainLoop = startMessageDrainLoop({
+                        getConfig: () => aiConfig.messageWal,
+                        log      : messageDrainLog
+                    });
+                    process.on('exit', () => this.messageWalDrainLock?.release());
+                    logger.info('[neo-memory-core MCP] In-process message WAL drain loop active (messageWal.inProcessDrain)');
+                }
+            }
+        }
+
         // Stdio identity resolution BEFORE healthcheck snapshot.
         if (aiConfig.transport !== 'sse') {
             this.stdioIdentity = await this.resolveStdioIdentity();
@@ -448,7 +480,7 @@ class Server extends BaseServer {
             await GraphService.ready();
 
             let retries = 3;
-            let node = null;
+            let node    = null;
 
             while (retries > 0) {
                 node = await GraphService.getNode({id: graphNodeId});

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -424,6 +424,71 @@ class Config extends ConfigProvider {
                 inProcessDrain : leaf(false, 'NEO_MEMORY_WAL_IN_PROCESS_DRAIN', 'boolean')
             },
             /**
+             * Durable JSONL write-ahead store for accepted A2A mailbox messages.
+             *
+             * `dir` defaults by formula to `${memoryWal.dir}/messages`, so the message WAL follows
+             * the same local/cloud volume reachability as the proven memory WAL unless a deployment
+             * deliberately overrides it. The drain-host leaves mirror `memoryWal`: local setups can
+             * run an orchestrator-supervised daemon, while containerized/single-process deployments
+             * can host the loop inside Memory Core via `messageWal.inProcessDrain`.
+             */
+            messageWal: {
+                /**
+                 * Optional production message WAL directory override. Null means derive from
+                 * `memoryWal.dir` by formula; deployments should override only when the alternate
+                 * path is reachable by the configured drain host.
+                 * @type {string|null}
+                 */
+                dirProd       : leaf(null, 'NEO_MESSAGE_WAL_DIR', 'string'),
+                /**
+                 * Optional unit-test message WAL directory override. Null means derive from the
+                 * active test `memoryWal.dir`, preserving by-construction test isolation.
+                 * @type {string|null}
+                 */
+                dirTest       : leaf(null, 'NEO_MESSAGE_WAL_DIR_TEST', 'string'),
+                /**
+                 * Test-mode toggle (env-driven via `UNIT_TEST_MODE`). The `messageWal.dir` formula
+                 * reads this to select `dirTest`/`dirProd` override leaves before falling back to
+                 * the active `memoryWal.dir` sibling.
+                 * @type {boolean}
+                 */
+                useTestDatabase: leaf(false, 'UNIT_TEST_MODE', 'boolean'),
+                /**
+                 * Data directory (PID file, rotating log) for the local message WAL drain daemon.
+                 * @type {string}
+                 */
+                daemonDataDir : leaf(path.resolve(cwd, '.neo-ai-data/message-daemon'), 'NEO_MESSAGE_WAL_DAEMON_DIR', 'string'),
+                /**
+                 * Message WAL drain cadence. Mirrors memory WAL cadence; the replay semantics are
+                 * owned by the message drain processor, while this leaf owns host scheduling.
+                 * @type {number}
+                 */
+                pollIntervalMs: leaf(5000, 'NEO_MESSAGE_WAL_POLL_INTERVAL_MS', 'number'),
+                /**
+                 * Maximum message WAL records observed by one drain cycle.
+                 * @type {number}
+                 */
+                batchSize     : leaf(20, 'NEO_MESSAGE_WAL_BATCH_SIZE', 'number'),
+                /**
+                 * In-cycle whole-batch retry bound for transient message replay failures.
+                 * @type {number}
+                 */
+                maxRetries    : leaf(5, 'NEO_MESSAGE_WAL_MAX_RETRIES', 'number'),
+                /**
+                 * Exponential-backoff base for message replay retries.
+                 * @type {number}
+                 */
+                backoffBaseMs : leaf(1000, 'NEO_MESSAGE_WAL_BACKOFF_BASE_MS', 'number'),
+                /**
+                 * Hosts the message WAL drain loop INSIDE the memory-core server process. This is
+                 * the containerized / single-process shape where no orchestrator-supervised message
+                 * daemon exists. A per-directory drain lock enforces exactly one live message drain
+                 * host per message WAL directory.
+                 * @type {boolean}
+                 */
+                inProcessDrain: leaf(false, 'NEO_MESSAGE_WAL_IN_PROCESS_DRAIN', 'boolean')
+            },
+            /**
              * Production handoff markdown file — autonomous agent-to-user reporting (offline jobs).
              * The active `handoffFilePath` consumers read is a formula (below) resolving Prod/Test by
              * construction from `UNIT_TEST_MODE`, so test runs that WRITE the handoff (runSandman /
@@ -671,6 +736,13 @@ class Config extends ConfigProvider {
             'collections.memory' : data => data.collections.useTestDatabase  ? data.collections.memoryTest  : data.collections.memoryProd,
             'collections.session': data => data.collections.useTestDatabase  ? data.collections.sessionTest : data.collections.sessionProd,
             'memoryWal.dir'      : data => data.memoryWal.useTestDatabase    ? data.memoryWal.dirTest       : data.memoryWal.dirProd,
+            'messageWal.dir'     : data => {
+                const configuredDir = data.messageWal.useTestDatabase ? data.messageWal.dirTest : data.messageWal.dirProd;
+                if (configuredDir) return configuredDir;
+
+                const memoryWalDir = data.memoryWal.useTestDatabase ? data.memoryWal.dirTest : data.memoryWal.dirProd;
+                return path.join(memoryWalDir, 'messages');
+            },
             // The active handoff path, resolved BY CONSTRUCTION from the canonical UNIT_TEST_MODE toggle
             // (`storagePaths.useTestDatabase` — every `useTestDatabase` leaf binds the same env). Keeps
             // test-mode handoff writes off the tracked `resources/content/sandman_handoff.md`.

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1,15 +1,15 @@
-import Base                                     from '../../../src/core/Base.mjs';
-import aiConfig                                 from '../../mcp/server/memory-core/config.mjs';
-import logger                                   from '../../mcp/server/memory-core/logger.mjs';
-import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
-import GraphService                             from './GraphService.mjs';
-import PermissionService                        from './PermissionService.mjs';
-import WakeSubscriptionService                  from './WakeSubscriptionService.mjs';
-import {appendWalMessage, getMessageWalDir}     from './helpers/messageWalStore.mjs';
-import {getMissingMemoryWalLeaves}              from './helpers/memoryWalStore.mjs';
-import {execFile}                               from 'child_process';
-import {promisify}                              from 'util';
-import crypto                                   from 'crypto';
+import Base                                           from '../../../src/core/Base.mjs';
+import aiConfig                                       from '../../mcp/server/memory-core/config.mjs';
+import logger                                         from '../../mcp/server/memory-core/logger.mjs';
+import RequestContextService, {normalizeUserId}       from '../../mcp/server/shared/services/RequestContextService.mjs';
+import GraphService                                   from './GraphService.mjs';
+import PermissionService                              from './PermissionService.mjs';
+import WakeSubscriptionService                        from './WakeSubscriptionService.mjs';
+import {appendWalMessage, getMissingMessageWalLeaves} from './helpers/messageWalStore.mjs';
+import {getMissingMemoryWalLeaves}                    from './helpers/memoryWalStore.mjs';
+import {execFile}                                     from 'child_process';
+import {promisify}                                    from 'util';
+import crypto                                         from 'crypto';
 
 const
     execFileAsync                     = promisify(execFile),
@@ -684,12 +684,15 @@ class MailboxService extends Base {
             messageProperties.relatedTickets = [...new Set(relatedTickets)].sort();
         }
 
-        const missingLeaves = getMissingMemoryWalLeaves(aiConfig.memoryWal, ['dir']);
+        const missingMemoryLeaves  = getMissingMemoryWalLeaves(aiConfig.memoryWal, ['dir']);
+        const missingMessageLeaves = getMissingMessageWalLeaves(aiConfig.messageWal, ['dir']);
+        const missingLeaves        = [
+            ...missingMemoryLeaves.map(leaf => `memoryWal.${leaf}`),
+            ...missingMessageLeaves.map(leaf => `messageWal.${leaf}`)
+        ];
         if (missingLeaves.length > 0) {
-            throw new Error(`message WAL config leaves missing: ${missingLeaves.join(', ')} — sync the memoryWal block from config.template.mjs into the local config.mjs (node ai/scripts/setup/initServerConfigs.mjs --migrate-config) and restart memory-core.`);
+            throw new Error(`message WAL config leaves missing: ${missingLeaves.join(', ')} — sync the memoryWal/messageWal blocks from config.template.mjs into the local config.mjs (node ai/scripts/setup/initServerConfigs.mjs --migrate-config) and restart memory-core.`);
         }
-
-        const messageWalDir = getMessageWalDir(aiConfig.memoryWal.dir);
 
         await appendWalMessage(
             buildMessageWalRecord({
@@ -703,7 +706,7 @@ class MailboxService extends Base {
                 timestamp,
                 to
             }),
-            {dir: messageWalDir}
+            {dir: aiConfig.messageWal.dir}
         );
 
         let projectionStatus = 'projected';

--- a/ai/services/memory-core/helpers/messageWalStore.mjs
+++ b/ai/services/memory-core/helpers/messageWalStore.mjs
@@ -38,19 +38,6 @@ export function getMissingMessageWalLeaves(messageWal, requiredLeaves) {
 }
 
 /**
- * @summary Derives the message WAL directory from the active memory WAL directory.
- * @param {String} memoryWalDir Active `memoryWal.dir`.
- * @returns {String}
- */
-export function getMessageWalDir(memoryWalDir) {
-    if (!memoryWalDir) {
-        throw new TypeError('getMessageWalDir: memoryWalDir is required');
-    }
-
-    return path.join(memoryWalDir, 'messages');
-}
-
-/**
  * @summary Derives the UTC-day segment key for a write timestamp.
  * @param {Date|Number} [now=new Date()] Clock source (epoch ms or Date).
  * @returns {String} `YYYY-MM-DD` UTC day key.

--- a/ai/services/memory-core/helpers/messageWalStore.mjs
+++ b/ai/services/memory-core/helpers/messageWalStore.mjs
@@ -20,6 +20,24 @@ import {withAppendLock} from './walAppendLock.mjs';
 const MESSAGE_WAL_SEGMENT_RE = /^message-wal-(\d{4}-\d{2}-\d{2})\.jsonl$/;
 
 /**
+ * @summary Names the `messageWal` config leaves missing from a config slice.
+ *
+ * Mirrors `memoryWal` stale-overlay diagnostics: local `config.mjs` files are materialized
+ * template copies, so a deployment whose overlay predates the message WAL drain leaves would
+ * otherwise fail later with a generic TypeError. Consumers call this before touching the leaves
+ * and fail loud with the exact missing keys plus the config-migration remediation.
+ *
+ * @param {Object|undefined} messageWal The resolved `messageWal` config slice.
+ * @param {String[]} requiredLeaves Leaf names the caller is about to read.
+ * @returns {String[]} Missing leaf names; empty when the slice satisfies the caller.
+ */
+export function getMissingMessageWalLeaves(messageWal, requiredLeaves) {
+    if (!messageWal) return [...requiredLeaves];
+
+    return requiredLeaves.filter(leaf => messageWal[leaf] === undefined || messageWal[leaf] === null);
+}
+
+/**
  * @summary Derives the message WAL directory from the active memory WAL directory.
  * @param {String} memoryWalDir Active `memoryWal.dir`.
  * @returns {String}

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -2,8 +2,8 @@ import path            from 'path';
 import {fileURLToPath} from 'url';
 import Neo             from '../../../src/Neo.mjs';
 
-const HOUR_MS = 60 * 60 * 1000;
-const DAY_MS  = 24 * HOUR_MS;
+const HOUR_MS    = 60 * 60 * 1000;
+const DAY_MS     = 24 * HOUR_MS;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../../..');
@@ -109,7 +109,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     },
     openAiCompatible: {
         host                   : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-        model                  : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+        model                  : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'google/gemma-4-26b-a4b',
         embeddingModel         : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
         apiKey                 : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
         unloadRetryCount       : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -149,6 +149,7 @@ test.describe('Tier 1 Config Immutability', () => {
             bridgeDaemonEnabled            : null,
             neuralLinkBridgeEnabled        : null,
             embedDaemonEnabled             : null,
+            messageDaemonEnabled           : null,
             goldenPathRepoEnrichmentEnabled: null,
             swarmHeartbeatEnabled          : null,
             wakeDispatchEnabled            : null

--- a/test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs
@@ -1,0 +1,119 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {mkdtemp, rm}  from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+
+import {appendWalMessage} from '../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs';
+import {
+    drainMessageWalOnce,
+    getMessageDrainBackoffDelayMs,
+    processMessageBatch
+} from '../../../../../../ai/daemons/message/drainCycle.mjs';
+
+/**
+ * Message WAL drain topology — host-agnostic cycle coverage. The replay processor is deliberately
+ * injected because idempotent mailbox graph projection is a separate concern.
+ */
+test.describe('Neo.ai.daemons.message.drainCycle', () => {
+    let tmpDir;
+
+    test.beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), 'neo-message-drain-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(tmpDir, {recursive: true, force: true});
+    });
+
+    const record = id => ({
+        id,
+        timestamp: Date.now(),
+        message  : {
+            id,
+            type      : 'MESSAGE',
+            name      : `subject ${id}`,
+            properties: {subject: `subject ${id}`}
+        },
+        routing      : {sentBy: '@alice', to: '@bob', senderUserId: 'alice', broadcastRecipients: []},
+        optionalEdges: {relatedTickets: [], relatedSessions: [], taggedConcepts: []}
+    });
+
+    const seed = id => appendWalMessage(record(id), {dir: tmpDir});
+
+    test('without a replay processor, records are observed but left deferred', async () => {
+        await seed('MESSAGE:deferred');
+
+        const summary = await drainMessageWalOnce({
+            dir          : tmpDir,
+            batchSize    : 20,
+            maxRetries   : 1,
+            backoffBaseMs: 1000
+        });
+
+        expect(summary).toEqual({observed: 1, drained: 0, failed: 0, deferred: 1});
+    });
+
+    test('batchSize bounds the records passed to the replay processor', async () => {
+        await seed('MESSAGE:a');
+        await seed('MESSAGE:b');
+        await seed('MESSAGE:c');
+
+        const seen    = [];
+        const summary = await drainMessageWalOnce({
+            dir          : tmpDir,
+            batchSize    : 2,
+            maxRetries   : 1,
+            backoffBaseMs: 1000,
+            processRecords(records) {
+                seen.push(...records.map(item => item.id));
+                return {drained: records.length, failed: 0, deferred: 0};
+            }
+        });
+
+        expect(summary).toEqual({observed: 3, drained: 2, failed: 0, deferred: 0});
+        expect(seen).toHaveLength(2);
+    });
+
+    test('processor failures retry with exponential backoff, then succeed', async () => {
+        const records  = [record('MESSAGE:retry')];
+        const sleeps   = [];
+        let   attempts = 0;
+
+        const summary = await processMessageBatch({
+            records,
+            maxRetries   : 2,
+            backoffBaseMs: 1000,
+            sleep        : async ms => sleeps.push(ms),
+            processRecords() {
+                attempts++;
+                if (attempts < 3) throw new Error('graph temporarily down');
+                return {drained: 1, failed: 0, deferred: 0};
+            }
+        });
+
+        expect(summary).toEqual({drained: 1, failed: 0, deferred: 0});
+        expect(attempts).toBe(3);
+        expect(sleeps).toEqual([
+            getMessageDrainBackoffDelayMs(1000, 0),
+            getMessageDrainBackoffDelayMs(1000, 1)
+        ]);
+    });
+
+    test('exhausted processor failures leave the whole batch failed and retryable', async () => {
+        const records = [record('MESSAGE:failed')];
+
+        const summary = await processMessageBatch({
+            records,
+            maxRetries   : 1,
+            backoffBaseMs: 1000,
+            sleep        : async () => {},
+            processRecords() {
+                throw new Error('still down');
+            }
+        });
+
+        expect(summary).toEqual({drained: 0, failed: 1, deferred: 0});
+    });
+});

--- a/test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs
@@ -42,17 +42,23 @@ test.describe('Neo.ai.daemons.message.drainCycle', () => {
 
     const seed = id => appendWalMessage(record(id), {dir: tmpDir});
 
-    test('without a replay processor, records are observed but left deferred', async () => {
+    test('without a replay processor, the cycle skips WAL reads instead of doing active no-op work', async () => {
         await seed('MESSAGE:deferred');
 
+        let readCalled = false;
         const summary = await drainMessageWalOnce({
             dir          : tmpDir,
             batchSize    : 20,
             maxRetries   : 1,
-            backoffBaseMs: 1000
+            backoffBaseMs: 1000,
+            readMessages : async () => {
+                readCalled = true;
+                throw new Error('readMessages should not be called without a processor');
+            }
         });
 
-        expect(summary).toEqual({observed: 1, drained: 0, failed: 0, deferred: 1});
+        expect(summary).toEqual({observed: 0, drained: 0, failed: 0, deferred: 0, inactive: true});
+        expect(readCalled).toBe(false);
     });
 
     test('batchSize bounds the records passed to the replay processor', async () => {
@@ -72,7 +78,7 @@ test.describe('Neo.ai.daemons.message.drainCycle', () => {
             }
         });
 
-        expect(summary).toEqual({observed: 3, drained: 2, failed: 0, deferred: 0});
+        expect(summary).toEqual({observed: 3, inactive: false, drained: 2, failed: 0, deferred: 0});
         expect(seen).toHaveLength(2);
     });
 

--- a/test/playwright/unit/ai/daemons/message/drainLock.spec.mjs
+++ b/test/playwright/unit/ai/daemons/message/drainLock.spec.mjs
@@ -1,0 +1,62 @@
+import {test, expect}                  from '@playwright/test';
+import Neo                             from '../../../../../../src/Neo.mjs';
+import * as core                       from '../../../../../../src/core/_export.mjs';
+import {mkdtemp, rm, readFile, access} from 'fs/promises';
+import os                              from 'os';
+import path                            from 'path';
+
+import {
+    acquireMessageDrainLock,
+    DrainLockHeldError,
+    DRAIN_LOCK_FILENAME
+} from '../../../../../../ai/daemons/message/drainLock.mjs';
+
+/**
+ * Message drain-lock wrapper — proves the message WAL topology reuses the mechanical sole-drainer
+ * lock while emitting message-domain remediation text.
+ */
+test.describe('Neo.ai.daemons.message.drainLock', () => {
+    let dir;
+
+    test.beforeEach(async () => {
+        dir = await mkdtemp(path.join(os.tmpdir(), 'neo-message-drain-lock-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(dir, {recursive: true, force: true});
+    });
+
+    const lockPath  = () => path.join(dir, DRAIN_LOCK_FILENAME);
+    const alive     = () => true;
+    const dead      = () => false;
+    const holderNow = async () => JSON.parse(await readFile(lockPath(), 'utf8'));
+
+    test('claims and releases the message WAL drain lock', async () => {
+        const handle = acquireMessageDrainLock({dir, owner: 'daemon', pid: 4242, isAlive: dead});
+
+        expect(handle.owner).toBe('daemon');
+        expect((await holderNow()).pid).toBe(4242);
+
+        handle.release();
+        await expect(access(lockPath())).rejects.toThrow();
+    });
+
+    test('second live message drain host refuses with message-specific remediation', async () => {
+        acquireMessageDrainLock({dir, owner: 'daemon', pid: 4242, isAlive: alive});
+
+        let thrown;
+        try {
+            acquireMessageDrainLock({dir, owner: 'in-process', pid: 7777, isAlive: alive});
+        } catch (err) {
+            thrown = err;
+        }
+
+        expect(thrown).toBeInstanceOf(DrainLockHeldError);
+        expect(thrown.code).toBe('DRAIN_LOCK_HELD');
+        expect(thrown.message).toContain('Message WAL drain lock');
+        expect(thrown.message).toContain('daemon pid 4242');
+        expect(thrown.message).toContain('in-process pid 7777');
+        expect(thrown.message).toContain('message daemon OR messageWal.inProcessDrain');
+        expect((await holderNow()).pid).toBe(4242);
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -13,19 +13,19 @@ import {
 } from '../../../../../../ai/daemons/orchestrator/taskDefinitions.mjs';
 import TaskStateService, { createInitialTaskState } from '../../../../../../ai/daemons/orchestrator/services/TaskStateService.mjs';
 
-let testOrchestratorSeq = 0;
-const TEST_DEV_SERVER_PORT = 18080;
-const TEST_NEURAL_LINK_BRIDGE_PORT = 18081;
-let savedIntervals = null;
-let savedLocalOnly = null;
-let savedCloudOnly = null;
-let savedDevServer = null;
-let savedDevServerMissing = false;
-let savedGraphLogCompaction = null;
-let savedGraphLogCompactionMissing = false;
-let savedNeuralLinkBridge = null;
-let savedNeuralLinkBridgeMissing = false;
-let savedDeploymentMode = null;
+let   testOrchestratorSeq            = 0;
+const TEST_DEV_SERVER_PORT           = 18080;
+const TEST_NEURAL_LINK_BRIDGE_PORT   = 18081;
+let   savedIntervals                 = null;
+let   savedLocalOnly                 = null;
+let   savedCloudOnly                 = null;
+let   savedDevServer                 = null;
+let   savedDevServerMissing          = false;
+let   savedGraphLogCompaction        = null;
+let   savedGraphLogCompactionMissing = false;
+let   savedNeuralLinkBridge          = null;
+let   savedNeuralLinkBridgeMissing   = false;
+let   savedDeploymentMode            = null;
 
 /**
  * Test helper for the Orchestrator refactor shape:
@@ -107,6 +107,7 @@ function createTestOrchestrator(config = {}) {
     // Default-disabled like primaryDevSyncEnabled: the embed-daemon lane has its own dedicated
     // test; every other test's supervision expectations stay scoped to the lanes under test.
     AiConfig.orchestrator.localOnly.embedDaemonEnabled             = config.embedDaemonEnabled             ?? false;
+    AiConfig.orchestrator.localOnly.messageDaemonEnabled           = config.messageDaemonEnabled           ?? false;
     AiConfig.orchestrator.localOnly.swarmHeartbeatEnabled          = config.swarmHeartbeatEnabled          ?? true;
     AiConfig.orchestrator.localOnly.goldenPathRepoEnrichmentEnabled = config.goldenPathRepoEnrichmentEnabled ?? true;
 
@@ -222,7 +223,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             neuralLinkBridgeLivenessTimeoutMs: 50
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'neuralLinkBridge', 'embedDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'githubWorkflowSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat', 'embed-drain-liveness-watchdog', 'rem-consolidation-liveness-watchdog']);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'neuralLinkBridge', 'embedDaemon', 'messageDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'githubWorkflowSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat', 'embed-drain-liveness-watchdog', 'rem-consolidation-liveness-watchdog']);
         expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
@@ -559,8 +560,8 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('supervises the local dev-server in local mode and skips it in cloud mode (#13482)', async () => {
-        const flushProbe = () => new Promise(resolve => setTimeout(resolve, 0));
-        const cloudStarted = [];
+        const flushProbe        = () => new Promise(resolve => setTimeout(resolve, 0));
+        const cloudStarted      = [];
         const cloudOrchestrator = createTestOrchestrator({
             deploymentMode  : 'cloud',
             kbSyncEnabled   : false,
@@ -581,7 +582,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
         expect(cloudStarted.find(entry => entry.taskName === 'devServer')).toBeUndefined();
 
-        const localStarted = [];
+        const localStarted      = [];
         const localOrchestrator = createTestOrchestrator({
             deploymentMode  : 'local',
             kbSyncEnabled   : false,
@@ -607,7 +608,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('does not spawn over a healthy manually started dev-server (#13482)', async () => {
-        const started = [];
+        const started      = [];
         const orchestrator = createTestOrchestrator({
             deploymentMode: 'local',
             kbSyncEnabled : false
@@ -650,8 +651,8 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('supervises Neural Link Bridge in local mode and skips it in cloud mode (#13483)', async () => {
-        const flushProbe = () => new Promise(resolve => setTimeout(resolve, 0));
-        const localStarted = [];
+        const flushProbe        = () => new Promise(resolve => setTimeout(resolve, 0));
+        const localStarted      = [];
         const localOrchestrator = createTestOrchestrator({
             deploymentMode: 'local',
             kbSyncEnabled : false
@@ -672,7 +673,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             entry.reason === 'supervisor-restart'
         ), {timeout: 5000}).toBe(true);
 
-        const cloudStarted = [];
+        const cloudStarted      = [];
         const cloudOrchestrator = createTestOrchestrator({
             deploymentMode         : 'cloud',
             kbSyncEnabled          : false,
@@ -693,7 +694,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('does not kill externally owned Neural Link Bridge listeners (#13483)', () => {
-        const killed = [];
+        const killed     = [];
         const supervisor = Neo.create(ProcessSupervisorService, {
             dataDir        : '/tmp/orchestrator-test',
             taskDefinitions: {
@@ -723,9 +724,9 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('passes task-level environment variables to spawned children (#13483)', () => {
-        const spawned = [];
-        const taskState = {running: false, pid: null};
-        const noop = () => {};
+        const spawned    = [];
+        const taskState  = {running: false, pid: null};
+        const noop       = () => {};
         const supervisor = Neo.create(ProcessSupervisorService, {
             dataDir        : '/tmp/orchestrator-test',
             taskDefinitions: {
@@ -784,7 +785,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             AiConfig.graphProvider     = 'openAiCompatible';
             AiConfig.embeddingProvider = 'openAiCompatible';
 
-            const orchestrator = createTestOrchestrator({kbSyncEnabled: false});
+            const orchestrator    = createTestOrchestrator({kbSyncEnabled: false});
             const taskDefinitions = orchestrator.buildConfiguredTaskDefinitions({
                 scriptDir: path.resolve(process.cwd(), 'ai/scripts'),
                 nodeBin  : process.argv[0]
@@ -836,7 +837,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('skips chroma daemon supervision in cloud mode while keeping local default (#12019)', () => {
-        const cloudStarted = [];
+        const cloudStarted      = [];
         const cloudOrchestrator = createTestOrchestrator({
             deploymentMode: 'cloud',
             kbSyncEnabled : false
@@ -855,7 +856,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
         expect(cloudStarted).toEqual([]);
 
-        const localStarted = [];
+        const localStarted      = [];
         const localOrchestrator = createTestOrchestrator({
             deploymentMode: 'local',
             kbSyncEnabled : false
@@ -945,8 +946,8 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('routes graphlog-compaction through Orchestrator.poll() in cloud deployment (#12394)', () => {
-        const started = [];
-        const dueCalls = [];
+        const started      = [];
+        const dueCalls     = [];
         const orchestrator = createTestOrchestrator({
             deploymentMode              : 'cloud',
             kbSyncIntervalMs            : 0,
@@ -988,7 +989,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('passes graphlog-compaction cadence from config verbatim (#12394 / #12061)', () => {
-        const dueCalls = [];
+        const dueCalls     = [];
         const orchestrator = createTestOrchestrator({
             kbSyncIntervalMs            : 0,
             backupIntervalMs            : 123456,
@@ -1012,8 +1013,8 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('skips graphlog-compaction when config disables the lane (#12394)', () => {
-        const started = [];
-        const dueCalls = [];
+        const started      = [];
+        const dueCalls     = [];
         const orchestrator = createTestOrchestrator({
             kbSyncIntervalMs            : 0,
             backupIntervalMs            : 0,
@@ -1051,9 +1052,9 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         // assignment + buildTaskDefinitions(), mirroring the substrate-correct shape used
         // in `start()`. No side-effecting orchestrator.start() needed for path tests.
         const orchestrator = Neo.create(Orchestrator);
-        const dataDir = '/tmp/orchestrator-test-defaults';
-        const repoRoot = path.resolve(process.cwd());
-        const scriptDir = path.resolve(repoRoot, 'ai/scripts');
+        const dataDir      = '/tmp/orchestrator-test-defaults';
+        const repoRoot     = path.resolve(process.cwd());
+        const scriptDir    = path.resolve(repoRoot, 'ai/scripts');
 
         orchestrator.dataDir         = dataDir;
         orchestrator.logFile         = path.join(dataDir, 'orchestrator.log');
@@ -1063,7 +1064,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(orchestrator.logFile).toBe(path.join(dataDir, 'orchestrator.log'));
         expect(orchestrator.stateFile).toBe(path.join(dataDir, 'orchestrator-state.json'));
 
-        const expectedSummaryScript = path.resolve(repoRoot, 'ai/scripts/lifecycle/summarize-sessions.mjs');
+        const expectedSummaryScript  = path.resolve(repoRoot, 'ai/scripts/lifecycle/summarize-sessions.mjs');
         const expectedBackfillScript = path.resolve(repoRoot, 'ai/scripts/lifecycle/backfill-memory-summaries.mjs');
         const expectedKbSyncScript   = path.resolve(repoRoot, 'ai/scripts/maintenance/syncKnowledgeBase.mjs');
 
@@ -1141,7 +1142,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('routes primary-dev-sync through its service coordinator', () => {
-        const started = [];
+        const started      = [];
         const orchestrator = createTestOrchestrator({
             kbSyncIntervalMs        : 0,
             backupIntervalMs        : 0,
@@ -1171,7 +1172,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('routes tenant-repo-sync through Orchestrator.poll() when enabled + interval elapsed (#11790 AC2 poll-wiring)', () => {
-        const started = [];
+        const started      = [];
         const orchestrator = createTestOrchestrator({
             kbSyncIntervalMs        : 0,
             backupIntervalMs        : 0,
@@ -1202,7 +1203,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('skips tenant-repo-sync when disabled (local deployment default — Contract Ledger row 2)', () => {
-        const started = [];
+        const started      = [];
         const orchestrator = createTestOrchestrator({
             kbSyncIntervalMs        : 0,
             backupIntervalMs        : 0,
@@ -1225,7 +1226,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('delegates the configured dev-sync roots to PrimaryRepoSyncService via options.devSyncRootsConfig', () => {
-        const received = [];
+        const received     = [];
         const orchestrator = createTestOrchestrator({
             kbSyncIntervalMs         : 0,
             backupIntervalMs         : 0,

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -170,7 +170,7 @@ test.describe('Memory Core Config (#10010)', () => {
         const prevRoot  = Neo.ai?.Config;
         const freshRoot = Neo.create(ConfigProvider, {data: Neo.ai.Config._data});
         Neo.ai.Config   = freshRoot;
-        const freshMC   = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+        const freshMC = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 
         try {
             expect(freshMC.modelProvider).toBe('openAiCompatible');
@@ -234,6 +234,30 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.handoffFilePathTest).toContain('neo-sandman-handoff-test-'); // per-worker-unique OS-temp file (fullyParallel race-safe)
         expect(config.handoffFilePath).toBe(config.handoffFilePathTest);
         expect(config.handoffFilePath).not.toContain('resources/content/sandman_handoff.md');
+    });
+
+    test('messageWal.dir resolves by construction from memoryWal.dir unless explicitly overridden (#13890)', () => {
+        expect(config.memoryWal.useTestDatabase).toBe(true);
+        expect(config.messageWal.useTestDatabase).toBe(true);
+        expect(config.messageWal.dirProd).toBe(null);
+        expect(config.messageWal.dirTest).toBe(null);
+        expect(config.messageWal.dir).toBe(path.join(config.memoryWal.dir, 'messages'));
+        expect(config.messageWal.daemonDataDir).toContain('.neo-ai-data/message-daemon');
+        expect(config.messageWal.inProcessDrain).toBe(false);
+
+        process.env.NEO_MESSAGE_WAL_DIR_TEST = '/tmp/neo-message-wal-override';
+        process.env.NEO_MESSAGE_WAL_IN_PROCESS_DRAIN = 'true';
+        process.env.NEO_MESSAGE_WAL_POLL_INTERVAL_MS = '250';
+
+        const freshCfg = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(freshCfg.messageWal.dirTest).toBe('/tmp/neo-message-wal-override');
+            expect(freshCfg.messageWal.inProcessDrain).toBe(true);
+            expect(freshCfg.messageWal.pollIntervalMs).toBe(250);
+        } finally {
+            freshCfg.destroy();
+        }
     });
 
     test('collections.memory/session resolve by construction to per-worker-unique test names under the toggle (#12499)', () => {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -50,7 +50,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         buildMailboxDelta = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).buildMailboxDelta;
         const messageWalStore = await import('../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs');
         readWalMessages = messageWalStore.readWalMessages;
-        messageWalDir   = messageWalStore.getMessageWalDir(mailboxAiConfig.memoryWal.dir);
+        messageWalDir   = mailboxAiConfig.messageWal.dir;
 
         // Pin this suite to strict-isolation mode. These tests predate the
         // config-gated default and assert `'blocked'`-mode behavior (Unauthorized


### PR DESCRIPTION
Resolves #13890

Adds a dedicated A2A message WAL drain topology that mirrors the existing memory WAL split: local profiles get an orchestrator-supervised message daemon, while containerized/single-process deployments can host the same loop inside Memory Core through `messageWal.inProcessDrain`. The drain loop is intentionally processor-injectable: topology, locking, config, and deployment reachability land here; idempotent mailbox graph projection remains the replay leaf.

Evidence: L2 (unit/config/orchestrator coverage plus static lint) achieved for local daemon, in-process host mode, lock refusal, stale-config diagnostics, and compose wiring. L3 cloud-runtime smoke remains post-merge/operator-residual because this sandbox cannot start the production multi-container deployment. Residual: real cloud smoke for #13890 after merge.

## Deltas from ticket

- The message WAL path now resolves from `messageWal.dir`, which defaults by formula to `${memoryWal.dir}/messages`; `MailboxService.addMessage()` reads that resolved leaf instead of deriving locally.
- Graph replay is deliberately not implemented in this PR. The processor hook leaves records deferred until the replay leaf wires idempotent projection.
- A2A-message Chroma/search population is deferred to #10150 / later drain work; this topology adds no synchronous chat/embed/model calls to `add_message`.
- Synced the Tier-1 defaults fixture to the already-tracked `openAiCompatible.model` template default so Memory Core config inheritance tests remain meaningful.

## Config / Deployment Notes

Changed config keys:
- `messageWal.dirProd` / `NEO_MESSAGE_WAL_DIR`
- `messageWal.dirTest` / `NEO_MESSAGE_WAL_DIR_TEST`
- `messageWal.useTestDatabase` / `UNIT_TEST_MODE`
- `messageWal.daemonDataDir` / `NEO_MESSAGE_WAL_DAEMON_DIR`
- `messageWal.pollIntervalMs` / `NEO_MESSAGE_WAL_POLL_INTERVAL_MS`
- `messageWal.batchSize` / `NEO_MESSAGE_WAL_BATCH_SIZE`
- `messageWal.maxRetries` / `NEO_MESSAGE_WAL_MAX_RETRIES`
- `messageWal.backoffBaseMs` / `NEO_MESSAGE_WAL_BACKOFF_BASE_MS`
- `messageWal.inProcessDrain` / `NEO_MESSAGE_WAL_IN_PROCESS_DRAIN`
- `orchestrator.localOnly.messageDaemonEnabled` / `NEO_ORCHESTRATOR_MESSAGE_DAEMON_ENABLED`

Local `config.mjs` files need shape migration after merge:

```bash
node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config
```

Restart Memory Core and the orchestrator after migration so live processes see `messageWal` and the local `messageDaemon` gate. The compose profiles set `NEO_MESSAGE_WAL_IN_PROCESS_DRAIN=true` and keep the message WAL under the same persistent memory WAL volume.

## Test Evidence

- `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config`
- `node --check ai/daemons/message/drainCycle.mjs`
- `node --check ai/daemons/message/drainLock.mjs`
- `node --check ai/daemons/message/daemon.mjs`
- `node --check ai/mcp/server/memory-core/config.template.mjs`
- `node --check ai/services/memory-core/MailboxService.mjs`
- `npm run agent-preflight -- <changed files>`
- `npm run ai:lint-config-template-ssot`
- `npm run ai:lint-mcp-test-locations`
- `npm run test-unit -- test/playwright/unit/ai/daemons/message/drainLock.spec.mjs test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` — 154 passed
- `git diff --check`
- `git diff --cached --check`

## Post-Merge Validation

- [ ] Run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` in active clones and restart Memory Core/orchestrator.
- [ ] Cloud compose smoke: confirm Memory Core starts the in-process message WAL drain and acquires one message WAL drain lock without a local daemon double-host.
- [ ] Follow the replay leaf to wire the idempotent mailbox graph projection processor into this topology before claiming MESSAGE projection closeout.

## Commits

- `6f20bea830` — `feat(ai): add message WAL drain topology (#13890)`

Authored by Euclid (GPT-5, Codex Desktop). Session db5b2ecf-db91-4b7d-9498-ccef00426a1c.
