### PR TITLE
feat(ai): add deference hook phrase fixtures (#13902)

### DIFF
--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -37,6 +37,17 @@ export const DEFERENCE_PHRASES = [
 export const DEFERENCE_REMINDER = 'It looks like you slipped into the "helpful assistant" bias. You are a neo repo maintainer and an equal peer. If you need validation or input, you can A2A message with peers or use the ideation-sandbox skill. And friction->gold applies to this hook itself: if it fired wrong - a false positive, or it reads as a leash not a mirror - open a ticket to sharpen it rather than silently absorbing it. The hook is mutable substrate, not a command.';
 
 /**
+ * @summary Replaces markdown code spans and fences before deference phrase matching.
+ * @param {String} text Assistant final-turn text.
+ * @returns {String}
+ */
+function stripMarkdownCode(text) {
+    return text
+        .replace(/```[\s\S]*?```/g, ' ')
+        .replace(/`[^`\n]*`/g, ' ');
+}
+
+/**
  * @summary Returns the first deference phrase found in text, using case-insensitive boundary match.
  * @param {String} text Assistant final-turn text.
  * @param {String[]} [phrases=DEFERENCE_PHRASES]
@@ -47,11 +58,13 @@ export function matchDeferencePhrase(text = '', phrases = DEFERENCE_PHRASES) {
         return null;
     }
 
+    const searchableText = stripMarkdownCode(text);
+
     return phrases.find(phrase => {
         const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+'),
               matcher = new RegExp(`(^|[^a-z0-9_])${escaped}(?=$|[^a-z0-9_])`, 'i');
 
-        return matcher.test(text);
+        return matcher.test(searchableText);
     }) || null;
 }
 

--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -21,6 +21,9 @@ export const DEFERENCE_PHRASES = [
     'unless you want me',
     'want me to',
     'do you want me',
+    'Your steer on',
+    "if you'd rather",
+    'or steer me elsewhere',
     'your call',
     'your move'
 ];

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -18,9 +18,9 @@ import {
     summarizePayloadShape
 } from '../../../../.codex/hooks/codex-lane-state-stop.mjs';
 
-const block = body => '```lane-state\n' + body + '\n```',
+const block       = body => '```lane-state\n' + body + '\n```',
       fixturePath = new URL('./fixtures/codex-stop-payload.json', import.meta.url),
-      fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+      fixture     = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
 
 test.describe('codex-lane-state-stop - contract boundary', () => {
     test('Codex block/inject is active, so enforced invalid terminals block', () => {
@@ -216,13 +216,13 @@ test.describe('codex-lane-state-stop - deference register', () => {
         const result = classifyCodexStopPayload({
             messages: [
                 {role: 'user',      content: '[WAKE][priority:normal] 1 events'},
-                {role: 'assistant', content: 'Your call.'}
+                {role: 'assistant', content: 'I can take #13902, or steer me elsewhere.'}
             ]
         });
 
         expect(result.action).toBe('would-block');
         expect(result.reason).toContain('helpful assistant');           // the deference directive, not the no-hold reason
-        expect(result.reason).toContain('deference phrase "your call"');
+        expect(result.reason).toContain('deference phrase "or steer me elsewhere"');
     });
 
     test('deference phrase + autonomous turn + enforce → block with the peer-identity directive', () => {

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -41,6 +41,12 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase('Restored your moved files to their original paths.')).toBeNull();
     });
 
+    test('does not match phrases quoted as markdown code literals', () => {
+        expect(matchDeferencePhrase("Added `Your steer on`, `if you'd rather`, and `or steer me elsewhere`."))
+            .toBeNull();
+        expect(matchDeferencePhrase('```text\nYour steer on the next lane.\n```')).toBeNull();
+    });
+
     test('operator-dialogue carve skips the phrase match', () => {
         expect(detectDeferencePhrase('Your call on the exact color.', {operatorInLoop: true})).toBeNull();
         expect(detectDeferencePhrase('Your call on the exact color.', {operatorInLoop: false})).toBe('your call');

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -19,6 +19,9 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase('WOULD YOU LIKE ME TO open the PR?')).toBe('would you like me to');
         expect(matchDeferencePhrase('I can take it unless you want me elsewhere.')).toBe('unless you want me');
         expect(matchDeferencePhrase('Want me to start the refactor?')).toBe('want me to');
+        expect(matchDeferencePhrase('Your steer on the next lane.')).toBe('Your steer on');
+        expect(matchDeferencePhrase("IF YOU'D RATHER, I can leave this parked.")).toBe("if you'd rather");
+        expect(matchDeferencePhrase('I can do this, or steer me elsewhere.')).toBe('or steer me elsewhere');
         expect(matchDeferencePhrase('Your call on the branch cut.')).toBe('your call');
         expect(matchDeferencePhrase('Your move.')).toBe('your move');
     });
@@ -29,6 +32,7 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase('Happy to take the next lane.')).toBeNull();
         expect(matchDeferencePhrase('No rush on the merge.')).toBeNull();
         expect(matchDeferencePhrase('Whenever you want to merge is fine.')).toBeNull();
+        expect(matchDeferencePhrase('Does this make more sense to you?')).toBeNull();
     });
 
     test('does not match technical substring collisions', () => {
@@ -40,6 +44,9 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
     test('operator-dialogue carve skips the phrase match', () => {
         expect(detectDeferencePhrase('Your call on the exact color.', {operatorInLoop: true})).toBeNull();
         expect(detectDeferencePhrase('Your call on the exact color.', {operatorInLoop: false})).toBe('your call');
+        expect(detectDeferencePhrase("If you'd rather, I can move it.", {operatorInLoop: true})).toBeNull();
+        expect(detectDeferencePhrase("If you'd rather, I can move it.", {operatorInLoop: false}))
+            .toBe("if you'd rather");
     });
 
     test('returns null on empty or non-string input', () => {
@@ -52,6 +59,9 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         const reminder = buildDeferenceReminder('your call');
 
         expect(DEFERENCE_PHRASES).toContain('do you want me');
+        expect(DEFERENCE_PHRASES).toContain('Your steer on');
+        expect(DEFERENCE_PHRASES).toContain("if you'd rather");
+        expect(DEFERENCE_PHRASES).toContain('or steer me elsewhere');
         expect(DEFERENCE_REMINDER).toContain('helpful assistant');
         expect(reminder).toContain('equal peer');
         expect(reminder).toContain('A2A message with peers');

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -126,6 +126,12 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
         expect(decideDeferenceStopHookAction('plain final text')).toBe(null);
     });
 
+    test('decideDeferenceStopHookAction: markdown code literals are data, not autonomous deference', () => {
+        const text = "Opened the PR with `Your steer on`, `if you'd rather`, and `or steer me elsewhere` covered.";
+
+        expect(decideDeferenceStopHookAction(text, {operatorInLoop: false, enforcing: true})).toBe(null);
+    });
+
     test('decideDeferenceStopHookAction: operator dialogue carves deference phrases before action', () => {
         expect(decideDeferenceStopHookAction('Your call.', {operatorInLoop: true, enforcing: true})).toBe(null);
     });

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -131,12 +131,15 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
     });
 
     test('decideDeferenceStopHookAction: dry-run autonomous phrase → would-block directive', () => {
-        const decision = decideDeferenceStopHookAction('Your call.', {operatorInLoop: false, enforcing: false});
+        const decision = decideDeferenceStopHookAction("If you'd rather, I can leave it for later.", {
+            operatorInLoop: false,
+            enforcing     : false
+        });
 
         expect(decision.action).toBe('would-block');
-        expect(decision.phrase).toBe('your call');
+        expect(decision.phrase).toBe("if you'd rather");
         expect(decision.reason).toContain('helpful assistant');
-        expect(decision.reason).toContain('deference phrase "your call"');
+        expect(decision.reason).toContain('deference phrase "if you\'d rather"');
     });
 
     test('decideDeferenceStopHookAction: enforcing autonomous phrase → block with same directive', () => {


### PR DESCRIPTION
Resolves #13902

Adds the three observed preference-handoff fixtures to `DEFERENCE_PHRASES`: `Your steer on`, `if you'd rather`, and `or steer me elsewhere`. The matcher stays deliberately tight; broad near-misses such as `should I`, `happy to`, ordinary logic-check wording, and Markdown-code literal inventories remain excluded.

Evidence: L2 achieved with focused hook/unit coverage. Residual: none.

## Deltas from ticket

- Included the maintainer addendum phrase `or steer me elsewhere.` using the punctuation-free base form so the existing boundary matcher catches the punctuated observed wording.
- Kept the operator-dialogue carve unchanged: these phrases block autonomous turn terminals, not live operator conversations.
- Added Markdown code-span/fence masking after the first Stop-hook self-test caught a false positive on a literal phrase inventory in an agent closeout.

## Test Evidence

- `node --check ai/scripts/lifecycle/deferencePhraseMatch.mjs`
- `npm run test-unit -- test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs` — 59 passed.
- `npm run test-unit -- test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs` — 24 passed after `agent-preflight` alignment.
- `git diff --check`
- `npm run agent-preflight -- ai/scripts/lifecycle/deferencePhraseMatch.mjs test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs`

## Post-Merge Validation

- [ ] Stop-hook logs show the new deference phrase trigger when one of the three fixtures appears in an autonomous turn terminal.

Authored by Euclid (GPT-5, Codex Desktop). Session db5b2ecf-db91-4b7d-9498-ccef00426a1c.
