### PR TITLE
feat(core): import MicroLoader config as JSON module (#5756)

### DIFF
--- a/buildScripts/webpack/production/webpack.config.appworker.mjs
+++ b/buildScripts/webpack/production/webpack.config.appworker.mjs
@@ -2,6 +2,7 @@ import fs           from 'fs-extra';
 import path         from 'path';
 import {spawnSync}  from 'child_process';
 import {minifyHtml} from '../../util/minifyHtml.mjs';
+import * as Terser  from 'terser';
 import webpack      from 'webpack';
 
 const
@@ -31,9 +32,14 @@ export default async function(env) {
     inputPath  = path.resolve(cwd, 'src/MicroLoader.mjs');
     outputPath = path.resolve(cwd, buildTarget.folder, 'src/MicroLoader.mjs');
 
-    content = fs.readFileSync(inputPath).toString().replace(/\s/gm, '');
+    content = await Terser.minify(fs.readFileSync(inputPath, 'utf-8'), {module: true});
+
+    if (content.error) {
+        throw content.error
+    }
+
     fs.mkdirpSync(path.resolve(cwd, buildTarget.folder, 'src/'));
-    fs.writeFileSync(outputPath, content);
+    fs.writeFileSync(outputPath, content.code);
 
     const copyResources = resourcesPath => {
         let inputPath  = path.resolve(cwd, resourcesPath),
@@ -186,7 +192,7 @@ export default async function(env) {
             rules: [
                 {
                     test: /\.mjs$/,
-                    use: [{
+                    use : [{
                         loader: path.resolve(neoPath, 'buildScripts/webpack/loader/template-loader.mjs')
                     }]
                 }

--- a/learn/benefits/OffTheMainThread.md
+++ b/learn/benefits/OffTheMainThread.md
@@ -105,7 +105,7 @@ Each thread has its fixed scope. Let us take a quick look into each of them.
 ### Main Thread
 
 The `index.html` file of your Neo.mjs App will by default have an empty body tag and only import the
-`MicroLoader.mjs` file. The loader will fetch your `neo-config.json` and afterwards dynamically import the
+`MicroLoader.mjs` file. The loader will import your `neo-config.json` as a JSON module and afterwards dynamically import the
 main thread part of the engine. This part is as lightweight as possible: around 40KB in dist/production.
 
 * Main will start the workers

--- a/learn/guides/fundamentals/ApplicationBootstrap.md
+++ b/learn/guides/fundamentals/ApplicationBootstrap.md
@@ -49,19 +49,19 @@ The only JavaScript file imported is the `MicroLoader.mjs`, which is loaded as a
 
 ### 2. MicroLoader: Configuration Loading
 
-The `MicroLoader.mjs` is a small script that fetches the application configuration and bootstraps the main thread:
+The `MicroLoader.mjs` is a small script that imports the application configuration and bootstraps the main thread:
 
 ```javascript readonly
-fetch('./neo-config.json').then(r => r.json()).then(d => {
+import(new URL('./neo-config.json', document.baseURI).href, {with: {type: 'json'}}).then(({default: d}) => {
     globalThis.Neo = {config: {...d}};
     import(d.mainPath)
 })
 ```
 
 It performs these steps:
-1. Fetches the `neo-config.json` file from the current directory
-2. Parses the JSON response
-3. Creates a global `Neo` object with the `config` property set to the parsed JSON
+1. Imports the `neo-config.json` file from the application document directory as a JSON module
+2. Reads the module's default export
+3. Creates a global `Neo` object with the `config` property set to the imported JSON data
 4. Dynamically imports the module specified by the `mainPath` property from the config
 
 ### 3. Configuration: neo-config.json

--- a/src/MicroLoader.mjs
+++ b/src/MicroLoader.mjs
@@ -1,4 +1,4 @@
-fetch('./neo-config.json').then(r => r.json()).then(d => {
+import(new URL('./neo-config.json', document.baseURI).href, {with: {type: 'json'}}).then(({default: d}) => {
     globalThis.Neo = {config: {...d}};
     import(d.mainPath)
 })


### PR DESCRIPTION
Resolves #5756

`MicroLoader.mjs` now imports the app-local `neo-config.json` as a JSON module using import attributes, while preserving the previous document-relative lookup semantics via `document.baseURI` before bootstrapping `mainPath`.

The production appworker build now minifies the copied `src/MicroLoader.mjs` with Terser instead of deleting all whitespace. The old production copy step transformed `new URL(...)` into `newURL(...)`, which broke `dist/production` at runtime.

Evidence: L3 (post-rebase build-all, local browser portal matrix, and focused whitebox e2e) -> L3 required (MicroLoader browser bootstrap and generated dist portal output). Residual: GitHub CI on pushed head.

## Deltas from ticket

- Preserved the old `fetch('./neo-config.json')` document-relative behavior by resolving the dynamic import specifier with `new URL('./neo-config.json', document.baseURI).href`.
- Updated bootstrap docs that explicitly described the retired fetch/json parse path.
- Replaced production MicroLoader whitespace stripping with Terser module minification so generated `dist/production/src/MicroLoader.mjs` preserves valid JavaScript syntax.

## Test Evidence

- `git diff --check`
- `node --check src/MicroLoader.mjs`
- `node --check buildScripts/webpack/production/webpack.config.appworker.mjs`
- `npm run build-all -- -l no` (post-rebase, passed; total time 31.49s)
- Browser smoke against local exact-head server: `/apps/portal/`, `/apps/portal/index.html`, `/dist/development/apps/portal/`, `/dist/esm/apps/portal/`, and `/dist/production/apps/portal/` all rendered `.neo-viewport` with expected `Neo.config.environment` / `mainPath` values.
- `npm run test-e2e -- test/playwright/e2e/NeuralLink.spec.mjs` (post-rebase, 1 passed)
- `npm run test-e2e -- test/playwright/e2e/LivePreviewMultiWindow.spec.mjs` (post-rebase, 12 passed)

## Post-Merge Validation

- [ ] GitHub CI confirms PR-body lint, source lint, CodeQL, and test-scope jobs on the pushed branch.

## Commits

- `df3c4d354a` — `feat(core): import MicroLoader config as JSON module (#5756)`
- `590dfd7f6a` — `fix(build): preserve production MicroLoader syntax (#5756)`

Authored by Euclid (GPT-5, Codex Desktop). Session db5b2ecf-db91-4b7d-9498-ccef00426a1c.
