### PR TITLE
fix(ai): accept micro-delta PR review bodies (#13910)

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-micro-delta-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-micro-delta-template.md
@@ -1,0 +1,24 @@
+# Pull Request Micro-Delta Review
+
+> **Context:** This review is using the Micro-Delta Approval format because the Review-Loop Cost Circuit Breaker has fired and the convergence assessment is state (a): the underlying PR has previously received thorough semantic review and has reached the mechanical-hygiene or metadata-drift phase.
+
+### State Vector
+- **Target SHA:** `[Insert precise SHA being reviewed]`
+- **Current reviewDecision:** `[Current GitHub reviewDecision]`
+- **Semantic Status:** `[e.g., APPROVED / ALIGNED]`
+- **CI Status:** `[e.g., GREEN / PENDING]`
+- **Remaining Blocker Class:** `[mechanical-hygiene | metadata-drift]`
+- **Measured Discussion Cost:** `[e.g., > 24KB]`
+
+### Micro-Delta Focus
+*Only defects classified as `mechanical-hygiene` or `metadata-drift` are reviewed here.*
+
+- `[ ]` **Issue 1:** [File path / line] - [Description of remaining hygiene defect]
+
+### Verdict
+- [ ] **APPROVED** (All mechanical-hygiene cleared. Merge-ready.)
+- [ ] **CHANGES_REQUESTED** (Mechanical-hygiene defects remain as listed above.)
+- [ ] **MAINTAINER POLISH FAST PATH APPLIED** (Reviewer unilaterally patched and pushed fixes. Approved.)
+
+---
+*Note: If a new semantic delta appears, this micro-delta format is invalidated and the reviewer MUST revert to the full `pr-review-followup-template.md` — or, if new distinct semantic blockers keep recurring across cycles, to the Step 2a break-up verdict.*

--- a/.agents/skills/pr-review/audits/review-cost-circuit-breaker.md
+++ b/.agents/skills/pr-review/audits/review-cost-circuit-breaker.md
@@ -15,7 +15,7 @@ These are **cost/attention** triggers: they say "this review loop has become exp
 At the trigger, classify the review history into exactly one of three states by looking at the **trajectory of distinct semantic blockers across cycles**:
 
 - **(a) Semantics cleared** — no `semantic-blocker` / `contract-blocker` / `5-layer-coverage-blocker` open; only `mechanical-hygiene` / `metadata-drift` remain.
-  → **Cost-compression path:** use the Micro-Delta Review Template (below). This is the original cost-saver.
+  → **Cost-compression path:** use the Micro-Delta Review Template in `../assets/pr-review-micro-delta-template.md`. This is the original cost-saver.
 - **(b) Semantic blocker, converging** — semantic/contract blockers are open but **narrowing**: each cycle resolves prior blockers and surfaces fewer (or no) new distinct ones.
   → **Full review** (`pr-review-followup-template.md`). The loop is making progress; let it finish.
 - **(c) Semantic churn NOT converging** — across ≥ 3 cycles, **new distinct** semantic / contract / shape blockers keep appearing (different concerns each cycle, no narrowing): the PR is an epic-in-disguise.
@@ -43,29 +43,4 @@ When the cost-compression path (state (a)) is active, reviewers may bypass the n
 
 ## Micro-Delta Review Template (state (a) only)
 
-```markdown
-# Pull Request Micro-Delta Review
-
-> **Context:** This review is using the Micro-Delta Approval format because the Review-Loop Cost Circuit Breaker has fired and the convergence assessment is state (a): the underlying PR has previously received thorough semantic review and has reached the mechanical-hygiene or metadata-drift phase.
-
-### State Vector
-- **Target SHA:** `[Insert precise SHA being reviewed]`
-- **Current reviewDecision:** `[Current GitHub reviewDecision]`
-- **Semantic Status:** `[e.g., APPROVED / ALIGNED]`
-- **CI Status:** `[e.g., GREEN / PENDING]`
-- **Remaining Blocker Class:** `[mechanical-hygiene | metadata-drift]`
-- **Measured Discussion Cost:** `[e.g., > 24KB]`
-
-### Micro-Delta Focus
-*Only defects classified as `mechanical-hygiene` or `metadata-drift` are reviewed here.*
-
-- `[ ]` **Issue 1:** [File path / line] - [Description of remaining hygiene defect]
-
-### Verdict
-- [ ] **APPROVED** (All mechanical-hygiene cleared. Merge-ready.)
-- [ ] **CHANGES_REQUESTED** (Mechanical-hygiene defects remain as listed above.)
-- [ ] **MAINTAINER POLISH FAST PATH APPLIED** (Reviewer unilaterally patched and pushed fixes. Approved.)
-
----
-*Note: If a new semantic delta appears, this micro-delta format is invalidated and the reviewer MUST revert to the full `pr-review-followup-template.md` — or, if new distinct semantic blockers keep recurring across cycles, to the Step 2a break-up verdict.*
-```
+Use `.agents/skills/pr-review/assets/pr-review-micro-delta-template.md`.

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -117,6 +117,13 @@ const FOLLOWUP_PR_REVIEW_SHAPE_HINTS = [
     '### Metrics Delta'
 ];
 
+const MICRO_DELTA_PR_REVIEW_SHAPE_HINTS = [
+    '# Pull Request Micro-Delta Review',
+    '### State Vector',
+    '### Micro-Delta Focus',
+    '### Verdict'
+];
+
 const FULL_PR_REVIEW_TEMPLATE_SKELETON_ANCHORS = [
     '# PR Review Summary',
     '### 🪜 Strategic-Fit Decision',
@@ -141,6 +148,26 @@ const FOLLOWUP_PR_REVIEW_TEMPLATE_SKELETON_ANCHORS = [
     '### 📋 Required Actions'
 ];
 
+const MICRO_DELTA_PR_REVIEW_TEMPLATE_SKELETON_ANCHORS = [
+    '# Pull Request Micro-Delta Review',
+    '> **Context:**',
+    '### State Vector',
+    '- **Target SHA:**',
+    '- **Current reviewDecision:**',
+    '- **Semantic Status:**',
+    '- **CI Status:**',
+    '- **Remaining Blocker Class:**',
+    '- **Measured Discussion Cost:**',
+    '### Micro-Delta Focus',
+    '*Only defects classified as `mechanical-hygiene` or `metadata-drift` are reviewed here.*',
+    '### Verdict',
+    '**APPROVED**',
+    '**CHANGES_REQUESTED**',
+    '**MAINTAINER POLISH FAST PATH APPLIED**'
+];
+
+const MICRO_DELTA_REVIEW_BLOCKER_CLASS_PATTERN = /(?:^|[^\w-])(mechanical-hygiene|metadata-drift)(?:$|[^\w-])/i;
+
 /**
  * @summary Returns missing cycle-template skeleton anchors for review-body validation.
  *
@@ -159,6 +186,164 @@ function getPrReviewTemplateSkeletonMisses(body) {
     }
 
     return FULL_PR_REVIEW_TEMPLATE_SKELETON_ANCHORS.filter(anchor => !body.includes(anchor));
+}
+
+/**
+ * @summary Returns `true` when a review body selects the Micro-Delta template.
+ *
+ * The Micro-Delta path is intentionally separate from full/follow-up review shapes: it is
+ * documented by the review-loop cost circuit breaker, not the normal pr-review templates,
+ * and carries a narrower state-vector contract instead of the full graph metric block.
+ *
+ * @param {String} body The candidate PR review body.
+ * @returns {Boolean} Whether the body appears to be a Micro-Delta review.
+ */
+function isMicroDeltaPrReview(body) {
+    return body.includes(MICRO_DELTA_PR_REVIEW_SHAPE_HINTS[0]) || (
+        body.includes('### State Vector') &&
+        body.includes('### Micro-Delta Focus')
+    );
+}
+
+/**
+ * @summary Returns missing documented Micro-Delta anchors.
+ *
+ * Micro-Delta reviews are only valid for review-loop cost-compression state (a), where
+ * semantics are already cleared and the remaining issue class is mechanical hygiene or
+ * metadata drift. The blocker-class token check prevents the short format from becoming
+ * a backdoor for semantic review shortcuts.
+ *
+ * @param {String} body The candidate Micro-Delta PR review body.
+ * @returns {String[]} Missing Micro-Delta anchors or state constraints.
+ */
+function getMicroDeltaPrReviewTemplateMisses(body) {
+    const misses = MICRO_DELTA_PR_REVIEW_TEMPLATE_SKELETON_ANCHORS
+        .filter(anchor => !body.includes(anchor));
+
+    const remainingBlockerLine = body
+        .split('\n')
+        .find(line => line.includes('- **Remaining Blocker Class:**')) || '';
+
+    if (!MICRO_DELTA_REVIEW_BLOCKER_CLASS_PATTERN.test(remainingBlockerLine)) {
+        misses.push('Remaining Blocker Class: mechanical-hygiene | metadata-drift');
+    }
+
+    return misses;
+}
+
+/**
+ * @summary Returns a structured validation failure for malformed Micro-Delta review bodies.
+ *
+ * @param {String} body The candidate Micro-Delta PR review body.
+ * @returns {Object|null} Validation failure payload or `null` when valid.
+ */
+function getMicroDeltaPrReviewTemplateValidationFailure(body) {
+    const missingMicroDelta = getMicroDeltaPrReviewTemplateMisses(body);
+
+    if (missingMicroDelta.length === 0) {
+        return null;
+    }
+
+    const skillPath      = '.agents/skills/pr-review/SKILL.md';
+    const microDeltaPath = '.agents/skills/pr-review/audits/review-cost-circuit-breaker.md';
+
+    const message = [
+        `Review body attempts the Micro-Delta Review format but does not match the documented circuit-breaker structure.`,
+        ``,
+        `**Required action**: read \`${skillPath}\` and \`${microDeltaPath}\` BEFORE retrying.`,
+        ``,
+        `Micro-Delta reviews are only valid after the Review-Loop Cost Circuit Breaker`,
+        `classifies the PR as state (a): semantics cleared, with only mechanical-hygiene`,
+        `or metadata-drift remaining. If a semantic or contract delta exists, use the`,
+        `full follow-up review template instead.`,
+        ``,
+        `Diagnostic hint: at least one required Micro-Delta state-vector or verdict anchor is missing or invalid.`
+    ].join('\n');
+
+    return {
+        error              : 'PR Review Template Validation Failed',
+        message,
+        code               : 'PR_REVIEW_TEMPLATE_VALIDATION_FAILED',
+        missing_micro_delta: missingMicroDelta,
+        skill              : skillPath,
+        template           : microDeltaPath
+    };
+}
+
+/**
+ * @summary Returns a structured validation failure for malformed full/follow-up review bodies.
+ *
+ * @param {String} body The candidate PR review body.
+ * @returns {Object|null} Validation failure payload or `null` when valid.
+ */
+function getCanonicalPrReviewTemplateValidationFailure(body) {
+    const missingVisible          = VISIBLE_PR_REVIEW_ANCHORS          .filter(anchor => !body.includes(anchor));
+    const missingInvisible        = INVISIBLE_PR_REVIEW_ANCHORS        .filter(anchor => !body.includes(anchor));
+    const missingTemplateSkeleton = getPrReviewTemplateSkeletonMisses(body);
+    const missingPremiseSnapshot  = REQUIRED_PR_REVIEW_PREMISE_ANCHORS
+        .filter(anchor => !body.includes(anchor.token))
+        .map(anchor => anchor.label);
+
+    if (
+        missingVisible.length === 0          &&
+        missingInvisible.length === 0        &&
+        missingTemplateSkeleton.length === 0 &&
+        missingPremiseSnapshot.length === 0
+    ) {
+        return null;
+    }
+
+    // Compose a message that guides toward the skill without enumerating invisible anchors.
+    // Even the visible-list naming is bounded — at most ONE diagnostic example, not the
+    // full list — to reduce the "stuff just these tags" attack surface further.
+    const diagnosticAnchor = missingVisible[0] ?? missingPremiseSnapshot[0] ?? null;
+
+    const skillPath    = '.agents/skills/pr-review/SKILL.md';
+    const templatePath = '.agents/skills/pr-review/assets/pr-review-template.md';
+    const followupPath = '.agents/skills/pr-review/assets/pr-review-followup-template.md';
+
+    const message = [
+        `Review body does not match the pr-review template structure.`,
+        ``,
+        `**Required action**: read \`${skillPath}\` BEFORE retrying. The skill points at:`,
+        `  - Cycle 1 (full template): \`${templatePath}\``,
+        `  - Cycle N (follow-up template): \`${followupPath}\``,
+        ``,
+        `Do NOT compose a substitute template or hallucinate section headings. The validator`,
+        `checks more structural anchors than this error names. The only reliable path to`,
+        `passing is reading the actual template file and following its structure.`,
+        missingPremiseSnapshot.length > 0
+            ? `\nPremise snapshot note: all four premise fields (incl. **Premise Coherence:**) are REQUIRED. The value-coherence field takes a specific verdict ("coheres: ..." / "conflicts: ...") OR a scoped "N/A — no value-surface (scope: ...)" for a trivial PR.`
+            : ``,
+        diagnosticAnchor
+            ? `\nDiagnostic hint: at least one recognized anchor like \`${diagnosticAnchor}\` is missing.`
+            : `\nDiagnostic hint: visible metric tags appear present but the structural template anchors do not.`
+    ].join('\n');
+
+    return {
+        error: 'PR Review Template Validation Failed',
+        message,
+        code : 'PR_REVIEW_TEMPLATE_VALIDATION_FAILED',
+        // `missing_visible` lists the named-in-message visible misses. Invisible misses
+        // are intentionally NOT enumerated in the response body — even programmatic
+        // callers should be nudged toward the skill rather than the anchor list.
+        missing_visible         : missingVisible,
+        missing_premise_snapshot: missingPremiseSnapshot,
+        skill                   : skillPath,
+        template                : templatePath
+    };
+}
+
+/**
+ * @summary Returns the selected review-template validation failure, if any.
+ *
+ * @param {String} body The candidate PR review body.
+ * @returns {Object|null} Validation failure payload or `null` when valid.
+ */
+function getPrReviewTemplateValidationFailure(body) {
+    return isMicroDeltaPrReview(body)
+        ? getMicroDeltaPrReviewTemplateValidationFailure(body)
+        : getCanonicalPrReviewTemplateValidationFailure(body);
 }
 
 function normalizeCheckoutOptions(options) {
@@ -246,10 +431,10 @@ function buildCheckoutPullRequest({
 
         try {
             const {stdout}       = await execFileFn('gh', ['pr', 'checkout', String(prNumber)], {cwd: gitTopLevel});
-            const branchResult   = await execFileFn('git', ['branch', '--show-current'], {cwd: gitTopLevel});
-            const headShaResult  = await execFileFn('git', ['rev-parse', 'HEAD'], {cwd: gitTopLevel});
-            const branch         = branchResult.stdout.trim();
-            const headSha        = headShaResult.stdout.trim();
+            const branchResult  = await execFileFn('git', ['branch', '--show-current'], {cwd: gitTopLevel});
+            const headShaResult = await execFileFn('git', ['rev-parse', 'HEAD'], {cwd: gitTopLevel});
+            const branch        = branchResult.stdout.trim();
+            const headSha       = headShaResult.stdout.trim();
 
             return {
                 message: `Successfully checked out PR #${prNumber}`,
@@ -478,10 +663,10 @@ class PullRequestService extends Base {
                     return { result: diffStdout };
                 }
 
-                const fileList = file.split(',').map(f => f.trim());
-                const lines = diffStdout.split('\n');
+                const fileList    = file.split(',').map(f => f.trim());
+                const lines       = diffStdout.split('\n');
                 const resultLines = [];
-                let capturing = false;
+                let   capturing   = false;
 
                 for (let i = 0; i < lines.length; i++) {
                     const line = lines[i];
@@ -545,7 +730,7 @@ class PullRequestService extends Base {
         };
 
         try {
-            const data = await GraphqlService.query(FETCH_PULL_REQUESTS, variables);
+            const data         = await GraphqlService.query(FETCH_PULL_REQUESTS, variables);
             const pullRequests = data.repository.pullRequests.nodes;
             return {
                 count: pullRequests.length,
@@ -611,72 +796,10 @@ class PullRequestService extends Base {
             };
         }
 
-        // Tool-boundary mechanical body-shape validation.
-        // The tool description points callers to the pr-review SKILL.md;
-        // this gate promotes that discipline-only guard to a mechanical floor with two layers:
-        //
-        // 1. VISIBLE layer — checked against VISIBLE_PR_REVIEW_ANCHORS; misses are named in the
-        //    error to guide good-faith authors back to the template.
-        // 2. INVISIBLE layer — checked against INVISIBLE_PR_REVIEW_ANCHORS; misses are NOT named
-        //    in the error. Defeats Goodhart anchor-stuffing where an agent receives a visible-only
-        //    error and hallucinates a body containing exactly the named anchors but skipping the
-        //    template structure. See INVISIBLE_PR_REVIEW_ANCHORS docstring for empirical anchor.
-        //
-        // Both layers point the agent at `.agents/skills/pr-review/SKILL.md` — the canonical
-        // primitive for resolving any validation failure is to read the skill + template, not
-        // to compose a substitute structure.
-        const missingVisible          = VISIBLE_PR_REVIEW_ANCHORS          .filter(anchor => !body.includes(anchor));
-        const missingInvisible        = INVISIBLE_PR_REVIEW_ANCHORS        .filter(anchor => !body.includes(anchor));
-        const missingTemplateSkeleton = getPrReviewTemplateSkeletonMisses(body);
-        const missingPremiseSnapshot  = REQUIRED_PR_REVIEW_PREMISE_ANCHORS
-            .filter(anchor => !body.includes(anchor.token))
-            .map(anchor => anchor.label);
+        const templateValidationFailure = getPrReviewTemplateValidationFailure(body);
 
-        if (
-            missingVisible.length > 0          ||
-            missingInvisible.length > 0        ||
-            missingTemplateSkeleton.length > 0 ||
-            missingPremiseSnapshot.length > 0
-        ) {
-            // Compose a message that guides toward the skill without enumerating invisible anchors.
-            // Even the visible-list naming is bounded — at most ONE diagnostic example, not the
-            // full list — to reduce the "stuff just these tags" attack surface further.
-            const diagnosticAnchor = missingVisible[0] ?? missingPremiseSnapshot[0] ?? null;
-
-            const skillPath    = '.agents/skills/pr-review/SKILL.md';
-            const templatePath = '.agents/skills/pr-review/assets/pr-review-template.md';
-            const followupPath = '.agents/skills/pr-review/assets/pr-review-followup-template.md';
-
-            const message = [
-                `Review body does not match the pr-review template structure.`,
-                ``,
-                `**Required action**: read \`${skillPath}\` BEFORE retrying. The skill points at:`,
-                `  - Cycle 1 (full template): \`${templatePath}\``,
-                `  - Cycle N (follow-up template): \`${followupPath}\``,
-                ``,
-                `Do NOT compose a substitute template or hallucinate section headings. The validator`,
-                `checks more structural anchors than this error names. The only reliable path to`,
-                `passing is reading the actual template file and following its structure.`,
-                missingPremiseSnapshot.length > 0
-                    ? `\nPremise snapshot note: all four premise fields (incl. **Premise Coherence:**) are REQUIRED. The value-coherence field takes a specific verdict ("coheres: ..." / "conflicts: ...") OR a scoped "N/A — no value-surface (scope: ...)" for a trivial PR.`
-                    : ``,
-                diagnosticAnchor
-                    ? `\nDiagnostic hint: at least one recognized anchor like \`${diagnosticAnchor}\` is missing.`
-                    : `\nDiagnostic hint: visible metric tags appear present but the structural template anchors do not.`
-            ].join('\n');
-
-            return {
-                error: 'PR Review Template Validation Failed',
-                message,
-                code : 'PR_REVIEW_TEMPLATE_VALIDATION_FAILED',
-                // `missing_visible` lists the named-in-message visible misses. Invisible misses
-                // are intentionally NOT enumerated in the response body — even programmatic
-                // callers should be nudged toward the skill rather than the anchor list.
-                missing_visible         : missingVisible,
-                missing_premise_snapshot: missingPremiseSnapshot,
-                skill                   : skillPath,
-                template                : templatePath
-            };
+        if (templateValidationFailure) {
+            return templateValidationFailure;
         }
 
         if (action === 'create') {
@@ -848,11 +971,11 @@ class PullRequestService extends Base {
             // fails for every agent on that credential class. REST needs only `repo`. Request body:
             // `reviewers[]` (user logins) + `team_reviewers[]` (bare team slugs — REST takes the slug, not
             // the `owner/slug` form `gh pr edit` requires).
-            const method        = action === 'add' ? 'POST' : 'DELETE';
+            const method = action === 'add' ? 'POST' : 'DELETE';
             const reviewerFlags = reviewerList.map(r => `-f 'reviewers[]=${r}'`).join(' ');
             const teamFlags     = teamReviewerList.map(t => `-f 'team_reviewers[]=${t}'`).join(' ');
-            const allFlags      = [reviewerFlags, teamFlags].filter(Boolean).join(' ');
-            const allTargets    = [...reviewerList, ...teamReviewerList];
+            const allFlags   = [reviewerFlags, teamFlags].filter(Boolean).join(' ');
+            const allTargets = [...reviewerList, ...teamReviewerList];
 
             const command = `gh api repos/${aiConfig.owner}/${aiConfig.repo}/pulls/${pr_number}/requested_reviewers -X ${method} ${allFlags}`;
             logger.info(`Attempting to ${action} reviewers on PR #${pr_number} via REST: ${allTargets.join(', ')}`);

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -245,19 +245,20 @@ function getMicroDeltaPrReviewTemplateValidationFailure(body) {
     }
 
     const skillPath      = '.agents/skills/pr-review/SKILL.md';
-    const microDeltaPath = '.agents/skills/pr-review/audits/review-cost-circuit-breaker.md';
+    const circuitPath    = '.agents/skills/pr-review/audits/review-cost-circuit-breaker.md';
+    const microDeltaPath = '.agents/skills/pr-review/assets/pr-review-micro-delta-template.md';
 
     const message = [
         `Review body attempts the Micro-Delta Review format but does not match the documented circuit-breaker structure.`,
         ``,
-        `**Required action**: read \`${skillPath}\` and \`${microDeltaPath}\` BEFORE retrying.`,
+        `**Required action**: read \`${skillPath}\`, \`${circuitPath}\`, and \`${microDeltaPath}\` BEFORE retrying.`,
         ``,
         `Micro-Delta reviews are only valid after the Review-Loop Cost Circuit Breaker`,
         `classifies the PR as state (a): semantics cleared, with only mechanical-hygiene`,
         `or metadata-drift remaining. If a semantic or contract delta exists, use the`,
         `full follow-up review template instead.`,
         ``,
-        `Diagnostic hint: at least one required Micro-Delta state-vector or verdict anchor is missing or invalid.`
+        `Diagnostic hint: at least one required Micro-Delta state-vector or verdict anchor from \`${microDeltaPath}\` is missing or invalid.`
     ].join('\n');
 
     return {
@@ -266,6 +267,7 @@ function getMicroDeltaPrReviewTemplateValidationFailure(body) {
         code               : 'PR_REVIEW_TEMPLATE_VALIDATION_FAILED',
         missing_micro_delta: missingMicroDelta,
         skill              : skillPath,
+        circuitBreaker     : circuitPath,
         template           : microDeltaPath
     };
 }

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -1051,9 +1051,10 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         });
 
         expect(result.code).toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
-        expect(result.template).toBe('.agents/skills/pr-review/audits/review-cost-circuit-breaker.md');
+        expect(result.circuitBreaker).toBe('.agents/skills/pr-review/audits/review-cost-circuit-breaker.md');
+        expect(result.template).toBe('.agents/skills/pr-review/assets/pr-review-micro-delta-template.md');
         expect(result.missing_micro_delta).toContain('- **Measured Discussion Cost:**');
-        expect(result.message).toContain('review-cost-circuit-breaker.md');
+        expect(result.message).toContain('pr-review-micro-delta-template.md');
         expect(graphqlCallCount).toBe(0);
     });
 

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -1,6 +1,6 @@
 import {setup} from '../../../../setup.mjs';
 
-const appName = 'PullRequestServiceTest';
+const appName          = 'PullRequestServiceTest';
 const skipCiGitHubAuth = !!process.env.NEO_TEST_SKIP_CI;
 
 setup({
@@ -29,7 +29,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — checkoutPu
     });
 
     test('refuses checkout when caller workspace repoPath is absent', async () => {
-        let execCalls = 0;
+        let   execCalls           = 0;
         const checkoutPullRequest = buildCheckoutPullRequest({
             projectRoot: '/server/shared-repo',
             log        : silentLogger,
@@ -49,7 +49,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — checkoutPu
     });
 
     test('rejects repoPath that is not the git top-level', async () => {
-        const calls = [];
+        const calls               = [];
         const checkoutPullRequest = buildCheckoutPullRequest({
             projectRoot: '/server/shared-repo',
             log        : silentLogger,
@@ -77,7 +77,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — checkoutPu
     });
 
     test('checks out explicit repoPath and returns read-back git state', async () => {
-        const calls = [];
+        const calls               = [];
         const checkoutPullRequest = buildCheckoutPullRequest({
             projectRoot: '/server/shared-repo',
             log        : silentLogger,
@@ -484,8 +484,8 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
     let GraphqlService;
     let originalQuery;
 
-    const PR_NODE_ID    = 'PR_kwDOABcD9999999999';
-    const REVIEW_NODE   = {
+    const PR_NODE_ID  = 'PR_kwDOABcD9999999999';
+    const REVIEW_NODE = {
         id         : 'PRR_kwDOABcD1111111111',
         url        : 'https://github.com/neomjs/neo/pull/11273#pullrequestreview-12345',
         state      : 'APPROVED',
@@ -591,6 +591,30 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         '### 📋 Required Actions',
         '',
         'No required actions — eligible for human merge.'
+    ].join('\n');
+
+    const VALID_MICRO_DELTA_REVIEW_BODY = [
+        '# Pull Request Micro-Delta Review',
+        '',
+        '> **Context:** This review is using the Micro-Delta Approval format because the Review-Loop Cost Circuit Breaker has fired and the convergence assessment is state (a): the underlying PR has previously received thorough semantic review and has reached the mechanical-hygiene or metadata-drift phase.',
+        '',
+        '### State Vector',
+        '- **Target SHA:** abc1234',
+        '- **Current reviewDecision:** CHANGES_REQUESTED',
+        '- **Semantic Status:** APPROVED',
+        '- **CI Status:** GREEN',
+        '- **Remaining Blocker Class:** mechanical-hygiene',
+        '- **Measured Discussion Cost:** > 24KB',
+        '',
+        '### Micro-Delta Focus',
+        '*Only defects classified as `mechanical-hygiene` or `metadata-drift` are reviewed here.*',
+        '',
+        '- `[x]` **Issue 1:** ai/config.template.mjs - stale wording repaired.',
+        '',
+        '### Verdict',
+        '- [ ] **APPROVED** (All mechanical-hygiene cleared. Merge-ready.)',
+        '- [x] **CHANGES_REQUESTED** (Mechanical-hygiene defects remain as listed above.)',
+        '- [ ] **MAINTAINER POLISH FAST PATH APPLIED** (Reviewer unilaterally patched and pushed fixes. Approved.)'
     ].join('\n');
 
     test.beforeAll(async () => {
@@ -986,6 +1010,74 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(result.error).toBeUndefined();
         expect(result.reviewId).toBe('PRR_kwDOABcD1111111111');
         expect(graphqlCallCount).toBe(2);
+    });
+
+    test('#13910: accepts documented Micro-Delta review without full metric anchors', async () => {
+        let graphqlCallCount = 0;
+        GraphqlService.query = async (queryString) => {
+            graphqlCallCount++;
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('AddPullRequestReview')) return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
+            return null;
+        };
+
+        const result = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 13910,
+            state    : 'REQUEST_CHANGES',
+            body     : VALID_MICRO_DELTA_REVIEW_BODY
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.reviewId).toBe('PRR_kwDOABcD1111111111');
+        expect(graphqlCallCount).toBe(2);
+    });
+
+    test('#13910: rejects incomplete Micro-Delta review before GraphQL dispatch', async () => {
+        const incompleteBody = VALID_MICRO_DELTA_REVIEW_BODY
+            .replace('- **Measured Discussion Cost:** > 24KB\n', '');
+
+        let graphqlCallCount = 0;
+        GraphqlService.query = async () => {
+            graphqlCallCount++;
+            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+        };
+
+        const result = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 13910,
+            state    : 'REQUEST_CHANGES',
+            body     : incompleteBody
+        });
+
+        expect(result.code).toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+        expect(result.template).toBe('.agents/skills/pr-review/audits/review-cost-circuit-breaker.md');
+        expect(result.missing_micro_delta).toContain('- **Measured Discussion Cost:**');
+        expect(result.message).toContain('review-cost-circuit-breaker.md');
+        expect(graphqlCallCount).toBe(0);
+    });
+
+    test('#13910: rejects Micro-Delta review with a semantic blocker class', async () => {
+        const semanticShortcutBody = VALID_MICRO_DELTA_REVIEW_BODY
+            .replace('- **Remaining Blocker Class:** mechanical-hygiene', '- **Remaining Blocker Class:** semantic-blocker');
+
+        let graphqlCallCount = 0;
+        GraphqlService.query = async () => {
+            graphqlCallCount++;
+            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+        };
+
+        const result = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 13910,
+            state    : 'REQUEST_CHANGES',
+            body     : semanticShortcutBody
+        });
+
+        expect(result.code).toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+        expect(result.missing_micro_delta).toContain('Remaining Blocker Class: mechanical-hygiene | metadata-drift');
+        expect(result.message).toContain('full follow-up review template instead');
+        expect(graphqlCallCount).toBe(0);
     });
 
     test('#13547: rejects old plain-heading follow-up review skeleton', async () => {


### PR DESCRIPTION
Resolves #13910

`managePrReview` now accepts the documented Micro-Delta Review format from the review-loop cost circuit breaker as a first-class review body shape. Full and follow-up reviews still use the existing canonical template validation; Micro-Delta reviews take their own narrower path with state-vector, focus, verdict, and remaining-blocker-class checks so they cannot become a semantic-review shortcut.

Evidence: L2 local unit/static evidence achieved for the close-target validator ACs. Residual: none.

## Deltas from ticket

- The implementation keeps the existing full/follow-up validator behavior intact by moving selected body-shape validation behind local helper functions.
- The Micro-Delta template is now discoverable as `.agents/skills/pr-review/assets/pr-review-micro-delta-template.md`.
- The circuit-breaker audit now points to the asset instead of burying the full template inline.
- Failed Micro-Delta attempts point callers at `.agents/skills/pr-review/SKILL.md`, `.agents/skills/pr-review/audits/review-cost-circuit-breaker.md`, and `.agents/skills/pr-review/assets/pr-review-micro-delta-template.md`.

## Turn-Memory Pre-Flight / Slot Rationale

Disposition: move. The detailed Micro-Delta template is not always-turn substrate and does not belong in `SKILL.md`; it is a conditional pr-review asset loaded only when the review-loop cost circuit breaker reaches state `(a)`. The always-loaded delta is minimal: the existing audit keeps a one-line pointer to the asset, while the reusable body lives in `.agents/skills/pr-review/assets`.

Source-ticket contract ledger posted on #13910.

## Test Evidence

- `node --check ai/services/github-workflow/PullRequestService.mjs`
- `node --check test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs`
- `git diff --check origin/dev...HEAD`
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev`
- `npm run agent-preflight -- .agents/skills/pr-review/audits/review-cost-circuit-breaker.md .agents/skills/pr-review/assets/pr-review-micro-delta-template.md ai/services/github-workflow/PullRequestService.mjs test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` -> 50 passed
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs --timeout=60000` -> 50 passed after rebase

## Post-Merge Validation

- [ ] Exercise `manage_pr_review` with the documented Micro-Delta body on the next real review-loop cost-compression event.

## Commits

- `0c172bd85c` - accept Micro-Delta review bodies in the validator.
- `6e6f65809d` - expose the Micro-Delta template as a pr-review asset and point validator failures at it.

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef100-77a2-7781-a83f-4f064a3c1aca.
