### PR TITLE
feat(ai): add supervised recovery actuator (#13883)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -29,6 +29,7 @@ import RequestContextService                                                    
 import {normalizeAgentIdentityNodeId}                                           from '../../scripts/lifecycle/resumeHarness.mjs';
 import TaskStateService                                                         from './services/TaskStateService.mjs';
 import ProcessSupervisorService                                                 from './services/ProcessSupervisorService.mjs';
+import RecoveryActuatorService                                                  from './services/RecoveryActuatorService.mjs';
 import DreamService                                                             from './services/DreamService.mjs';
 import SwarmHeartbeatService                                                    from './services/SwarmHeartbeatService.mjs';
 import GoldenPathSynthesizer                                                    from '../../services/graph/GoldenPathSynthesizer.mjs';
@@ -104,6 +105,7 @@ export class Orchestrator extends Base {
         className                      : 'Neo.ai.daemons.Orchestrator',
         singleton                      : true,
         processSupervisorService_      : null,
+        recoveryActuatorService_       : RecoveryActuatorService,
         maintenanceBackpressureService_: MaintenanceBackpressureService,
         dataDir_                       : DEFAULT_DATA_DIR,
         taskDefinitions_               : null,
@@ -141,6 +143,7 @@ export class Orchestrator extends Base {
     goldenPathDependencyTaskNames = DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
 
     processSupervisorWriteLog = (level, msg) => this.writeLog(level, msg)
+    recoveryActuatorWriteLog  = (level, msg) => this.writeLog(level, msg)
     maintenanceBackpressureWriteLog = (level, msg) => this.writeLog(level, msg)
 
     /**
@@ -228,7 +231,7 @@ export class Orchestrator extends Base {
             : '@system';
         const stalledSinceIso = Number.isFinite(stalledSince) ? new Date(stalledSince).toISOString() : 'unknown';
         const staleHours      = (Number(stalenessMs || 0) / (60 * 60 * 1000)).toFixed(1);
-        const subject = hasCycle
+        const subject         = hasCycle
             ? `[rem-consolidation-stall] last REM cycle is ${staleHours}h stale`
             : `[rem-consolidation-stall] no REM cycle recorded with ${undigestedCount} undigested sessions`;
         const body =
@@ -274,6 +277,19 @@ export class Orchestrator extends Base {
         });
     }
 
+    /**
+     * @param {Neo.ai.daemons.services.RecoveryActuatorService|Object|null} value
+     * @returns {Neo.ai.daemons.services.RecoveryActuatorService}
+     */
+    beforeSetRecoveryActuatorService(value) {
+        return ClassSystemUtil.beforeSetInstance(value, RecoveryActuatorService, {
+            healthService           : this.healthService,
+            processSupervisorService: this.processSupervisorService,
+            recoveryRunStateDir     : this.recoveryRunStateDir,
+            writeLog                : this.recoveryActuatorWriteLog
+        });
+    }
+
     beforeSetMaintenanceBackpressureService(value) {
         return ClassSystemUtil.beforeSetInstance(value, MaintenanceBackpressureService, {
             heavyMaintenanceTaskNames    : this.heavyMaintenanceTaskNames,
@@ -287,10 +303,15 @@ export class Orchestrator extends Base {
         });
     }
 
+    afterSetProcessSupervisorService(value, oldValue) {
+        if (oldValue === undefined) return;
+        this.recoveryActuatorService.processSupervisorService = value;
+    }
     afterSetDataDir(value, oldValue) {
         if (oldValue === undefined) return;
         this.processSupervisorService.dataDir          = value;
         this.maintenanceBackpressureService.dataDir    = value;
+        this.recoveryActuatorService.recoveryRunStateDir = this.recoveryRunStateDir;
     }
     afterSetTaskDefinitions(value, oldValue) {
         if (oldValue === undefined) return;
@@ -305,6 +326,7 @@ export class Orchestrator extends Base {
     afterSetHealthService(value, oldValue) {
         if (oldValue === undefined) return;
         this.processSupervisorService.healthService       = value;
+        this.recoveryActuatorService.healthService        = value;
         this.maintenanceBackpressureService.healthService = value;
     }
     afterSetSpawnFn(value, oldValue) {
@@ -333,6 +355,7 @@ export class Orchestrator extends Base {
     get devServerEnabled()               { return resolveLocalDeploymentDefault(AiConfig.orchestrator.devServer.enabled); }
     get neuralLinkBridgeEnabled()        { return resolveDeploymentEnabled('neuralLinkBridgeEnabled');        }
     get embedDaemonEnabled()             { return resolveDeploymentEnabled('embedDaemonEnabled');             }
+    get recoveryRunStateDir()            { return path.join(this.dataDir, 'recovery-runs');                   }
     get embedDrainLivenessWatchdogWalDir()      { return memoryCoreConfig.memoryWal.dir; }
     get embedDrainLivenessWatchdogThresholdMs() { return memoryCoreConfig.memoryWal.embedDrainStallThresholdMs; }
     get remConsolidationWatchdogRunStateDir()   { return memoryCoreConfig.remRunStateDir; }
@@ -475,7 +498,7 @@ export class Orchestrator extends Base {
      * @returns {void}
      */
     poll() {
-        const now = Date.now();
+        const now         = Date.now();
         const executeTask = this.processSupervisorService.runTask.bind(this.processSupervisorService);
 
         const continuousTasks = [

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -1,0 +1,428 @@
+import Base from '../../../../src/core/Base.mjs';
+import {
+    appendRecoveryRunState,
+    createRecoveryReobserveRequest,
+    createRecoveryRunStateEntry,
+    readRecentRecoveryRunStates
+} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+
+export const DEFAULT_RECOVERY_RESTART_COOLDOWN_MS = 15000;
+export const DEFAULT_SUPERVISED_RECOVERY_ATTEMPT_LIMIT = 3;
+
+const SUPERVISED_RECOVERY_CLASSES = Object.freeze(['crash', 'exhaustion']);
+
+/**
+ * @class Neo.ai.daemons.services.RecoveryActuatorService
+ * @extends Neo.core.Base
+ *
+ * @summary Routes typed recovery diagnoses to bounded actuator calls.
+ *
+ * The service owns policy and ledger state. The low-level B0 action stays inside
+ * {@link Neo.ai.daemons.services.ProcessSupervisorService}: this class only accepts
+ * a typed `supervised-task` diagnosis, writes the recovery-run ledger first, delegates
+ * to `superviseTask()`, and records the cooldown-to-reobserve handshake.
+ */
+export class RecoveryActuatorService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.RecoveryActuatorService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.RecoveryActuatorService',
+        /**
+         * @member {Object|null} processSupervisorService_=null
+         * @protected
+         * @reactive
+         */
+        processSupervisorService_: null,
+        /**
+         * @member {Object|null} healthService_=null
+         * @protected
+         * @reactive
+         */
+        healthService_: null,
+        /**
+         * @member {String} healthTaskName_='recovery-actuator'
+         * @protected
+         * @reactive
+         */
+        healthTaskName_: 'recovery-actuator',
+        /**
+         * @member {String|null} recoveryRunStateDir_=null
+         * @protected
+         * @reactive
+         */
+        recoveryRunStateDir_: null,
+        /**
+         * @member {Number} recoveryRunRetentionLimit_=100
+         * @protected
+         * @reactive
+         */
+        recoveryRunRetentionLimit_: 100,
+        /**
+         * @member {Number} restartCooldownMs_=15000
+         * @protected
+         * @reactive
+         */
+        restartCooldownMs_: DEFAULT_RECOVERY_RESTART_COOLDOWN_MS,
+        /**
+         * @member {Number} maxSupervisedAttempts_=3
+         * @protected
+         * @reactive
+         */
+        maxSupervisedAttempts_: DEFAULT_SUPERVISED_RECOVERY_ATTEMPT_LIMIT,
+        /**
+         * @member {Number} healthyObservationThreshold_=1
+         * @protected
+         * @reactive
+         */
+        healthyObservationThreshold_: 1,
+        /**
+         * @member {Function} nowFn_=Date.now
+         * @protected
+         * @reactive
+         */
+        nowFn_: Date.now,
+        /**
+         * @member {Function|null} writeLog_=null
+         * @protected
+         * @reactive
+         */
+        writeLog_: null
+    }
+
+    /**
+     * @summary Applies one typed recovery diagnosis through the lowest-privilege actuator.
+     * @param {Object} diagnosisEvent Typed `recovery-diagnosis` event.
+     * @param {Object} [options]
+     * @param {String} [options.recoveryRunId] Stable run id override.
+     * @param {Number} [options.cooldownMs] Reobserve/restart cooldown override.
+     * @returns {Promise<Object>} Recovery outcome summary.
+     */
+    async applyDiagnosis(diagnosisEvent, options = {}) {
+        const now           = this.getNow(),
+              cooldownMs    = options.cooldownMs ?? this.restartCooldownMs,
+              recoveryRunId = options.recoveryRunId || this.buildRecoveryRunId(diagnosisEvent),
+              route         = await this.resolveSupervisedRoute(diagnosisEvent, recoveryRunId);
+
+        if (!route.actionable) {
+            return this.recordTerminalOutcome({
+                recoveryRunId,
+                diagnosisEvent,
+                attempt: 1,
+                rung   : 'rung-2',
+                status : route.status,
+                now,
+                details: route.details
+            });
+        }
+
+        const attempt = await this.getNextSupervisedAttempt(diagnosisEvent);
+
+        if (attempt > this.maxSupervisedAttempts) {
+            return this.recordTerminalOutcome({
+                recoveryRunId,
+                diagnosisEvent,
+                attempt,
+                rung   : 'rung-3',
+                status : 'escalated',
+                now,
+                details: {
+                    action     : 'escalate-supervised-process',
+                    reason     : 'max-supervised-attempts-exceeded',
+                    taskName   : route.taskName,
+                    attempt,
+                    maxAttempts: this.maxSupervisedAttempts
+                }
+            });
+        }
+
+        await this.recordState({
+            recoveryRunId,
+            diagnosisEvent,
+            rung     : 'rung-2',
+            attempt,
+            status   : 'pending',
+            startedAt: now,
+            updatedAt: now,
+            details  : {
+                action  : 'restart-supervised-process',
+                taskName: route.taskName,
+                tier    : 'B0',
+                cooldownMs
+            }
+        });
+
+        try {
+            this.processSupervisorService.superviseTask(route.taskName, now, cooldownMs);
+        } catch (error) {
+            return this.recordTerminalOutcome({
+                recoveryRunId,
+                diagnosisEvent,
+                attempt,
+                rung   : 'rung-2',
+                status : 'failed',
+                now,
+                details: {
+                    action  : 'restart-supervised-process',
+                    reason  : 'supervise-task-failed',
+                    taskName: route.taskName,
+                    error   : error.message,
+                    tier    : 'B0',
+                    cooldownMs
+                }
+            });
+        }
+
+        const reobserveRequest = createRecoveryReobserveRequest({
+            recoveryRunId,
+            diagnosisEvent,
+            requestedAt                : now,
+            cooldownMs,
+            healthyObservationThreshold: this.healthyObservationThreshold
+        });
+
+        const entry = await this.recordState({
+            recoveryRunId,
+            diagnosisEvent,
+            rung       : 'rung-2',
+            attempt,
+            status     : 'reobserve-requested',
+            startedAt  : now,
+            updatedAt  : now,
+            completedAt: now,
+            reobserveRequest,
+            details    : {
+                action  : 'restart-supervised-process',
+                taskName: route.taskName,
+                tier    : 'B0',
+                cooldownMs
+            }
+        });
+
+        this.recordRecoveryOutcome('completed', {
+            action        : 'restart-supervised-process',
+            cooldownMs,
+            diagnosisId   : diagnosisEvent.diagnosisId,
+            recoveryClass : diagnosisEvent.recoveryClass,
+            recoveryRunId,
+            rung          : 'rung-2',
+            status        : 'reobserve-requested',
+            targetIdentity: diagnosisEvent.targetIdentity,
+            taskName      : route.taskName,
+            tier          : 'B0'
+        });
+
+        return {
+            action  : 'restart-supervised-process',
+            attempt,
+            entry,
+            recoveryRunId,
+            reobserveRequest,
+            rung    : 'rung-2',
+            status  : 'reobserve-requested',
+            taskName: route.taskName
+        };
+    }
+
+    /**
+     * @summary Builds a stable run id for one diagnosis event.
+     * @param {Object} diagnosisEvent
+     * @returns {String}
+     */
+    buildRecoveryRunId(diagnosisEvent) {
+        const target = diagnosisEvent?.targetIdentity || {};
+        return `recovery:${target.kind || 'unknown'}:${target.id || 'unknown'}:${diagnosisEvent?.diagnosisId || 'unknown'}`;
+    }
+
+    /**
+     * @summary Returns current epoch milliseconds through the configured seam.
+     * @returns {Number}
+     */
+    getNow() {
+        return this.nowFn();
+    }
+
+    /**
+     * @summary Counts prior B0 restart attempts for the same supervised target.
+     * @param {Object} diagnosisEvent
+     * @returns {Promise<Number>}
+     */
+    async getNextSupervisedAttempt(diagnosisEvent) {
+        const entries = await readRecentRecoveryRunStates({
+            dir  : this.recoveryRunStateDir,
+            limit: this.recoveryRunRetentionLimit
+        });
+
+        const target   = diagnosisEvent.targetIdentity;
+        const attempts = entries
+            .filter(entry => entry?.targetIdentity?.kind === target.kind)
+            .filter(entry => entry?.targetIdentity?.id === target.id)
+            .filter(entry => entry?.rung === 'rung-2')
+            .filter(entry => entry?.details?.action === 'restart-supervised-process')
+            .map(entry => entry.attempt || 0);
+
+        return Math.max(0, ...attempts) + 1;
+    }
+
+    /**
+     * @summary Resolves whether a diagnosis is eligible for B0 supervised-process recovery.
+     * @param {Object} diagnosisEvent
+     * @param {String} recoveryRunId
+     * @returns {Promise<Object>}
+     */
+    async resolveSupervisedRoute(diagnosisEvent, recoveryRunId) {
+        // Build a pending-shaped entry to validate the typed diagnosis before any action.
+        createRecoveryRunStateEntry({
+            recoveryRunId,
+            diagnosisEvent,
+            rung     : 'rung-2',
+            attempt  : 1,
+            status   : 'pending',
+            startedAt: this.getNow(),
+            updatedAt: this.getNow()
+        });
+
+        const target = diagnosisEvent.targetIdentity;
+
+        if (target.kind !== 'supervised-task') {
+            return {
+                actionable: false,
+                status    : 'no-action',
+                details   : {
+                    action    : 'none',
+                    reason    : 'unsupported-target-kind',
+                    targetKind: target.kind
+                }
+            };
+        }
+
+        if (!SUPERVISED_RECOVERY_CLASSES.includes(diagnosisEvent.recoveryClass)) {
+            return {
+                actionable: false,
+                status    : 'no-action',
+                details   : {
+                    action       : 'none',
+                    reason       : 'unsupported-recovery-class',
+                    recoveryClass: diagnosisEvent.recoveryClass,
+                    taskName     : target.id
+                }
+            };
+        }
+
+        if (!this.processSupervisorService) {
+            return {
+                actionable: false,
+                status    : 'failed',
+                details   : {
+                    action  : 'restart-supervised-process',
+                    reason  : 'missing-process-supervisor',
+                    taskName: target.id
+                }
+            };
+        }
+
+        if (!this.processSupervisorService.taskDefinitions?.[target.id]) {
+            return {
+                actionable: false,
+                status    : 'failed',
+                details   : {
+                    action  : 'restart-supervised-process',
+                    reason  : 'unknown-supervised-task',
+                    taskName: target.id
+                }
+            };
+        }
+
+        return {
+            actionable: true,
+            taskName  : target.id
+        };
+    }
+
+    /**
+     * @summary Records a terminal no-op/failed/escalated recovery outcome.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async recordTerminalOutcome({recoveryRunId, diagnosisEvent, attempt, rung, status, now, details}) {
+        const entry = await this.recordState({
+            recoveryRunId,
+            diagnosisEvent,
+            rung,
+            attempt,
+            status,
+            startedAt  : now,
+            updatedAt  : now,
+            completedAt: now,
+            details
+        });
+
+        this.recordRecoveryOutcome(this.resolveHealthOutcomeStatus(status), {
+            ...details,
+            attempt,
+            diagnosisId   : diagnosisEvent.diagnosisId,
+            recoveryClass : diagnosisEvent.recoveryClass,
+            recoveryRunId,
+            rung,
+            status,
+            targetIdentity: diagnosisEvent.targetIdentity
+        });
+
+        return {
+            action: details.action,
+            attempt,
+            entry,
+            recoveryRunId,
+            rung,
+            status
+        };
+    }
+
+    /**
+     * @summary Appends one recovery-run state entry using the configured retention policy.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async recordState(options) {
+        const entry = createRecoveryRunStateEntry(options);
+
+        await appendRecoveryRunState(entry, {
+            dir           : this.recoveryRunStateDir,
+            retentionLimit: this.recoveryRunRetentionLimit
+        });
+
+        return entry;
+    }
+
+    /**
+     * @summary Records the recovery-action outcome without letting observability failures affect recovery.
+     * @param {String} status HealthService task outcome status.
+     * @param {Object} details Recovery outcome details.
+     * @returns {void}
+     */
+    recordRecoveryOutcome(status, details) {
+        try {
+            this.healthService?.recordTaskOutcome?.(this.healthTaskName, status, details);
+        } catch (error) {
+            this.writeLog?.('ERROR', `[RecoveryActuator] Failed to record recovery outcome: ${error.message}`);
+        }
+    }
+
+    /**
+     * @summary Maps recovery-run statuses onto HealthService task-outcome statuses.
+     * @param {String} status Recovery-run status.
+     * @returns {String}
+     */
+    resolveHealthOutcomeStatus(status) {
+        if (status === 'no-action') {
+            return 'skipped';
+        }
+        if (status === 'failed' || status === 'escalated') {
+            return 'failed';
+        }
+        return 'completed';
+    }
+}
+
+export default Neo.setupClass(RecoveryActuatorService);

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -20,9 +20,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const REPO_ROOT  = path.resolve(__dirname, '../../../../../..');
 
-const ORCHESTRATOR_MJS_PATH    = path.join(REPO_ROOT, 'ai/daemons/orchestrator/Orchestrator.mjs');
-const ORCHESTRATOR_DAEMON_PATH = path.join(REPO_ROOT, 'ai/daemons/orchestrator/daemon.mjs');
-const TASK_DEFINITIONS_MJS_PATH = path.join(REPO_ROOT, 'ai/daemons/orchestrator/taskDefinitions.mjs');
+const ORCHESTRATOR_MJS_PATH                    = path.join(REPO_ROOT, 'ai/daemons/orchestrator/Orchestrator.mjs');
+const ORCHESTRATOR_DAEMON_PATH                 = path.join(REPO_ROOT, 'ai/daemons/orchestrator/daemon.mjs');
+const TASK_DEFINITIONS_MJS_PATH                = path.join(REPO_ROOT, 'ai/daemons/orchestrator/taskDefinitions.mjs');
 const CONFIGURED_TASK_DEFINITIONS_SERVICE_PATH = path.join(
     REPO_ROOT,
     'ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs'
@@ -34,32 +34,32 @@ const SIBLING_DAEMON_CONFIG_PATHS = {
     'KbGarbageCollectionService.mjs': path.join(REPO_ROOT, 'ai/daemons/kb-gc/KbGarbageCollectionService.mjs')
 };
 
-let invariantSeq         = 0;
-let savedIntervals       = null;
-let savedLocalOnly       = null;
-let savedCloudOnly       = null;
-let savedDeploymentMode  = null;
-let savedMlxConfig                   = undefined;
-let savedLmsConfig                   = undefined;
-let savedOrchestratorOllamaConfig    = undefined;
-let savedProviderOllamaConfig        = undefined;
-let savedOpenAiCompatibleConfig      = undefined;
-let savedChatProvider                = undefined;
-let savedModelProvider               = undefined;
-let savedGraphProvider               = undefined;
-let savedEmbeddingProvider           = undefined;
-let savedEnvKbSyncEnabled            = undefined;
-let savedEnvKbSyncInterval           = undefined;
-let savedEnvTenantRepoSyncEnabled    = undefined;
-let savedEnvTenantRepoSyncInterval   = undefined;
-let savedEnvChromaDaemonEnabled      = undefined;
-let savedEnvMlxEnabled               = undefined;
-let savedEnvMlxModel                 = undefined;
-let savedEnvMlxPort                  = undefined;
-let savedEnvLmsEnabled               = undefined;
-let savedEnvLmsModel                 = undefined;
-let savedEnvLmsPort                  = undefined;
-let savedEnvOllamaEnabled            = undefined;
+let invariantSeq                   = 0;
+let savedIntervals                 = null;
+let savedLocalOnly                 = null;
+let savedCloudOnly                 = null;
+let savedDeploymentMode            = null;
+let savedMlxConfig                 = undefined;
+let savedLmsConfig                 = undefined;
+let savedOrchestratorOllamaConfig  = undefined;
+let savedProviderOllamaConfig      = undefined;
+let savedOpenAiCompatibleConfig    = undefined;
+let savedChatProvider              = undefined;
+let savedModelProvider             = undefined;
+let savedGraphProvider             = undefined;
+let savedEmbeddingProvider         = undefined;
+let savedEnvKbSyncEnabled          = undefined;
+let savedEnvKbSyncInterval         = undefined;
+let savedEnvTenantRepoSyncEnabled  = undefined;
+let savedEnvTenantRepoSyncInterval = undefined;
+let savedEnvChromaDaemonEnabled    = undefined;
+let savedEnvMlxEnabled             = undefined;
+let savedEnvMlxModel               = undefined;
+let savedEnvMlxPort                = undefined;
+let savedEnvLmsEnabled             = undefined;
+let savedEnvLmsModel               = undefined;
+let savedEnvLmsPort                = undefined;
+let savedEnvOllamaEnabled          = undefined;
 
 function createMinimalOrchestrator() {
     const taskDefinitions = buildTaskDefinitions({
@@ -414,7 +414,7 @@ test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
 
     test('mutating orchestrator.taskDefinitions propagates to processSupervisorService via afterSetTaskDefinitions hook', () => {
         const orchestrator = createMinimalOrchestrator();
-        const newDefs = buildTaskDefinitions({
+        const newDefs      = buildTaskDefinitions({
             scriptDir: '/repo/ai/scripts/mutated',
             nodeBin  : '/node'
         });
@@ -432,20 +432,22 @@ test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
 
         expect(orchestrator.processSupervisorService.dataDir).toBe('/tmp/orchestrator-test-mutated');
         expect(orchestrator.maintenanceBackpressureService.dataDir).toBe('/tmp/orchestrator-test-mutated');
+        expect(orchestrator.recoveryActuatorService.recoveryRunStateDir).toBe('/tmp/orchestrator-test-mutated/recovery-runs');
     });
 
-    test('mutating orchestrator.healthService propagates to processSupervisorService + maintenanceBackpressureService', () => {
+    test('mutating orchestrator.healthService propagates to processSupervisorService + recoveryActuatorService + maintenanceBackpressureService', () => {
         const orchestrator = createMinimalOrchestrator();
-        const newHealth = {recordTaskOutcome() {}, marker: 'mutated-healthservice'};
+        const newHealth    = {recordTaskOutcome() {}, marker: 'mutated-healthservice'};
         orchestrator.healthService = newHealth;
 
         expect(orchestrator.processSupervisorService.healthService?.marker).toBe('mutated-healthservice');
+        expect(orchestrator.recoveryActuatorService.healthService?.marker).toBe('mutated-healthservice');
         expect(orchestrator.maintenanceBackpressureService.healthService?.marker).toBe('mutated-healthservice');
     });
 
     test('mutating orchestrator.taskStateService propagates to processSupervisorService + maintenanceBackpressureService', () => {
         const orchestrator = createMinimalOrchestrator();
-        const newTss = {
+        const newTss       = {
             marker: 'mutated-taskstateservice',
             getState() {return {};},
             getTaskState() {return null;}
@@ -458,16 +460,27 @@ test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
 
     test('mutating orchestrator.spawnFn propagates to processSupervisorService', () => {
         const orchestrator = createMinimalOrchestrator();
-        const newSpawn = () => 'mutated-spawn';
+        const newSpawn     = () => 'mutated-spawn';
         newSpawn.marker = 'mutated-spawnfn';
         orchestrator.spawnFn = newSpawn;
 
         expect(orchestrator.processSupervisorService.spawnFn?.marker).toBe('mutated-spawnfn');
     });
 
+    test('mutating orchestrator.processSupervisorService propagates to recoveryActuatorService', () => {
+        const orchestrator = createMinimalOrchestrator();
+        orchestrator.processSupervisorService = {
+            taskDefinitions: {
+                customTask: {label: 'Custom Task'}
+            }
+        };
+
+        expect(orchestrator.recoveryActuatorService.processSupervisorService.taskDefinitions.customTask.label).toBe('Custom Task');
+    });
+
     test('mutating orchestrator.heavyMaintenanceLeasePath propagates to maintenanceBackpressureService', () => {
         const orchestrator = createMinimalOrchestrator();
-        const newPath = '/tmp/orchestrator-test/heavy-maintenance-lease-mutated.json';
+        const newPath      = '/tmp/orchestrator-test/heavy-maintenance-lease-mutated.json';
         orchestrator.heavyMaintenanceLeasePath = newPath;
 
         expect(orchestrator.maintenanceBackpressureService.heavyMaintenanceLeasePath).toBe(newPath);
@@ -476,22 +489,22 @@ test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
 
 test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
     test('Orchestrator.mjs has no `configure()` shadow-resolver method', async () => {
-        const source = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
+        const source  = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
         const matches = source.match(/^\s*configure\s*\(/gm) || [];
 
         expect(matches, 'Orchestrator.mjs must NOT define a `configure()` method (Sub-1 anti-pattern; lazy getters supersede it).').toHaveLength(0);
     });
 
     test('taskDefinitions.mjs has no `DEFAULT_*_INTERVAL_MS` exports', async () => {
-        const source = await fs.readFile(TASK_DEFINITIONS_MJS_PATH, 'utf8');
+        const source  = await fs.readFile(TASK_DEFINITIONS_MJS_PATH, 'utf8');
         const matches = source.match(/export\s+(?:const|let)\s+DEFAULT_\w*INTERVAL_MS/g) || [];
 
         expect(matches, 'taskDefinitions.mjs must NOT export `DEFAULT_*_INTERVAL_MS` constants (Sub-1 anti-pattern; AiConfig.orchestrator.intervals owns these values).').toHaveLength(0);
     });
 
     test('Orchestrator.mjs has no `parseInterval` / `parseEnabledFlag` call sites', async () => {
-        const source = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
-        const codeLines = stripCommentsAndStrings(source);
+        const source             = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
+        const codeLines          = stripCommentsAndStrings(source);
         const parseIntervalCalls = codeLines.match(/\bparseInterval\s*\(/g) || [];
         const parseEnabledCalls  = codeLines.match(/\bparseEnabledFlag\s*\(/g) || [];
 
@@ -500,15 +513,15 @@ test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
     });
 
     test('Orchestrator.mjs has no `processSupervisorService.set({...this...})` context-replay block', async () => {
-        const source = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
+        const source    = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
         const codeLines = stripCommentsAndStrings(source);
-        const matches = codeLines.match(/processSupervisorService\.set\s*\(\s*\{\s*\.\.\.this/g) || [];
+        const matches   = codeLines.match(/processSupervisorService\.set\s*\(\s*\{\s*\.\.\.this/g) || [];
 
         expect(matches, 'Orchestrator.mjs must NOT spread `this` into `processSupervisorService.set({...})` (Sub-1 anti-pattern; `afterSetX` parent-prop propagation hooks supersede the start()-time context replay).').toHaveLength(0);
     });
 
     test('orchestrator config reads are fail-loud direct reads on declared subtrees (#12515 / #13875)', async () => {
-        const orchestratorSource = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8'));
+        const orchestratorSource              = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8'));
         const configuredTaskDefinitionsSource = stripCommentsAndStrings(
             await fs.readFile(CONFIGURED_TASK_DEFINITIONS_SERVICE_PATH, 'utf8')
         );
@@ -559,7 +572,7 @@ test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
     });
 
     test('Orchestrator.mjs has no `_`-suffix reactive config slot without a corresponding `beforeSet*` or `afterSet*` hook', async () => {
-        const source = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
+        const source    = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
         const codeLines = stripCommentsAndStrings(source);
 
         // Find `_`-suffix slot declarations inside `static config = { ... }` — pattern: `<name>_: <default>`
@@ -595,12 +608,12 @@ test.describe('Sibling daemon source-level invariants (#11836)', () => {
  * line structure for line-aware regex anchors.
  */
 function stripCommentsAndStrings(source) {
-    let out = '';
-    let i = 0;
+    let   out = '';
+    let   i   = 0;
     const len = source.length;
 
     while (i < len) {
-        const c = source[i];
+        const c    = source[i];
         const next = source[i + 1];
 
         // Block comment
@@ -617,7 +630,7 @@ function stripCommentsAndStrings(source) {
 
         // Line comment
         if (c === '/' && next === '/') {
-            const end = source.indexOf('\n', i);
+            const end  = source.indexOf('\n', i);
             const stop = end === -1 ? len : end;
             for (let j = i; j < stop; j++) out += ' ';
             i = stop;

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -1,0 +1,283 @@
+import {test, expect}            from '@playwright/test';
+import {mkdtemp, rm}             from 'fs/promises';
+import os                        from 'os';
+import path                      from 'path';
+import Neo                       from '../../../../../../../src/Neo.mjs';
+import * as core                 from '../../../../../../../src/core/_export.mjs';
+import {RecoveryActuatorService} from '../../../../../../../ai/daemons/orchestrator/services/RecoveryActuatorService.mjs';
+import {
+    appendRecoveryRunState,
+    createRecoveryDiagnosisEvent,
+    createRecoveryRunStateEntry,
+    createRecoveryTargetIdentity,
+    readRecentRecoveryRunStates
+} from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
+
+function createDiagnosis(overrides = {}) {
+    return createRecoveryDiagnosisEvent({
+        diagnosisId   : 'diagnosis-ollama-crash',
+        recoveryClass : 'crash',
+        confidence    : 0.94,
+        targetIdentity: createRecoveryTargetIdentity({kind: 'supervised-task', id: 'ollama'}),
+        evidenceFacts : [{kind: 'process-exit', value: 1}],
+        observedAt    : 9000,
+        ...overrides
+    });
+}
+
+async function seedAttempt({dir, diagnosisId, attempt, updatedAt}) {
+    const diagnosisEvent = createDiagnosis({diagnosisId});
+
+    await appendRecoveryRunState(createRecoveryRunStateEntry({
+        recoveryRunId: `recovery:supervised-task:ollama:${diagnosisId}`,
+        diagnosisEvent,
+        rung       : 'rung-2',
+        attempt,
+        status     : 'reobserve-requested',
+        startedAt  : updatedAt - 100,
+        updatedAt,
+        completedAt: updatedAt,
+        details    : {
+            action  : 'restart-supervised-process',
+            taskName: 'ollama',
+            tier    : 'B0'
+        }
+    }), {dir});
+}
+
+test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
+    let tmpDir;
+
+    test.beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), 'neo-recovery-actuator-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(tmpDir, {recursive: true, force: true});
+    });
+
+    function createService(config = {}) {
+        const calls      = [],
+              logEntries = [],
+              outcomes   = [];
+
+        const processSupervisorService = {
+            taskDefinitions: {
+                ollama: {label: 'ollama server'}
+            },
+            superviseTask(taskName, now, cooldownMs) {
+                calls.push({cooldownMs, now, taskName});
+            }
+        };
+
+        const service = Neo.create(RecoveryActuatorService, {
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({details, status, taskName});
+                }
+            },
+            processSupervisorService,
+            recoveryRunStateDir      : tmpDir,
+            recoveryRunRetentionLimit: 20,
+            nowFn                    : () => 10000,
+            writeLog                 : (level, message) => logEntries.push({level, message}),
+            ...config
+        });
+
+        return {calls, logEntries, outcomes, processSupervisorService, service};
+    }
+
+    test('routes supervised crash diagnoses through ProcessSupervisorService and records reobserve state', async () => {
+        const {calls, outcomes, service} = createService();
+
+        const result = await service.applyDiagnosis(createDiagnosis(), {cooldownMs: 15000});
+
+        expect(calls).toEqual([{taskName: 'ollama', now: 10000, cooldownMs: 15000}]);
+        expect(result).toMatchObject({
+            action  : 'restart-supervised-process',
+            attempt : 1,
+            rung    : 'rung-2',
+            status  : 'reobserve-requested',
+            taskName: 'ollama'
+        });
+        expect(result.reobserveRequest).toMatchObject({
+            cooldownMs           : 15000,
+            earliestObservationAt: 25000,
+            targetIdentity       : {kind: 'supervised-task', id: 'ollama'}
+        });
+
+        const recent = await readRecentRecoveryRunStates({dir: tmpDir, limit: 1});
+        expect(recent[0]).toMatchObject({
+            recoveryRunId : 'recovery:supervised-task:ollama:diagnosis-ollama-crash',
+            recoveryClass : 'crash',
+            targetIdentity: {kind: 'supervised-task', id: 'ollama'},
+            rung          : 'rung-2',
+            attempt       : 1,
+            status        : 'reobserve-requested',
+            details       : {
+                action    : 'restart-supervised-process',
+                cooldownMs: 15000,
+                taskName  : 'ollama',
+                tier      : 'B0'
+            }
+        });
+        expect(outcomes).toEqual([{
+            taskName: 'recovery-actuator',
+            status  : 'completed',
+            details : expect.objectContaining({
+                action        : 'restart-supervised-process',
+                cooldownMs    : 15000,
+                recoveryRunId : 'recovery:supervised-task:ollama:diagnosis-ollama-crash',
+                status        : 'reobserve-requested',
+                targetIdentity: {kind: 'supervised-task', id: 'ollama'},
+                taskName      : 'ollama',
+                tier          : 'B0'
+            })
+        }]);
+    });
+
+    test('routes supervised exhaustion diagnoses to the same restart half of the B0 ladder', async () => {
+        const {calls, service} = createService();
+
+        const result = await service.applyDiagnosis(createDiagnosis({
+            diagnosisId  : 'diagnosis-ollama-exhaustion',
+            recoveryClass: 'exhaustion'
+        }));
+
+        expect(calls).toEqual([{taskName: 'ollama', now: 10000, cooldownMs: 15000}]);
+        expect(result.status).toBe('reobserve-requested');
+        expect(result.attempt).toBe(1);
+    });
+
+    test('does not apply B0 to external targets', async () => {
+        const {calls, outcomes, service} = createService();
+
+        const result = await service.applyDiagnosis(createDiagnosis({
+            diagnosisId   : 'diagnosis-memory-core-crash',
+            targetIdentity: createRecoveryTargetIdentity({kind: 'compose-service', id: 'memory-core'})
+        }));
+
+        expect(calls).toEqual([]);
+        expect(result).toMatchObject({
+            action: 'none',
+            rung  : 'rung-2',
+            status: 'no-action'
+        });
+
+        const recent = await readRecentRecoveryRunStates({dir: tmpDir, limit: 1});
+        expect(recent[0].details).toMatchObject({
+            action    : 'none',
+            reason    : 'unsupported-target-kind',
+            targetKind: 'compose-service'
+        });
+        expect(outcomes).toEqual([{
+            taskName: 'recovery-actuator',
+            status  : 'skipped',
+            details : expect.objectContaining({
+                action        : 'none',
+                reason        : 'unsupported-target-kind',
+                recoveryRunId : 'recovery:compose-service:memory-core:diagnosis-memory-core-crash',
+                status        : 'no-action',
+                targetIdentity: {kind: 'compose-service', id: 'memory-core'}
+            })
+        }]);
+    });
+
+    test('escalates instead of restarting after the supervised attempt cap', async () => {
+        await seedAttempt({dir: tmpDir, diagnosisId: 'diagnosis-old-1', attempt: 1, updatedAt: 8000});
+        await seedAttempt({dir: tmpDir, diagnosisId: 'diagnosis-old-2', attempt: 2, updatedAt: 9000});
+
+        const {calls, outcomes, service} = createService({maxSupervisedAttempts: 2});
+
+        const result = await service.applyDiagnosis(createDiagnosis({
+            diagnosisId: 'diagnosis-ollama-crash-3'
+        }));
+
+        expect(calls).toEqual([]);
+        expect(result).toMatchObject({
+            action : 'escalate-supervised-process',
+            attempt: 3,
+            rung   : 'rung-3',
+            status : 'escalated'
+        });
+
+        const recent = await readRecentRecoveryRunStates({dir: tmpDir, limit: 1});
+        expect(recent[0]).toMatchObject({
+            recoveryRunId: 'recovery:supervised-task:ollama:diagnosis-ollama-crash-3',
+            rung         : 'rung-3',
+            attempt      : 3,
+            status       : 'escalated',
+            details      : {
+                action     : 'escalate-supervised-process',
+                reason     : 'max-supervised-attempts-exceeded',
+                maxAttempts: 2,
+                taskName   : 'ollama'
+            }
+        });
+        expect(outcomes).toEqual([{
+            taskName: 'recovery-actuator',
+            status  : 'failed',
+            details : expect.objectContaining({
+                action     : 'escalate-supervised-process',
+                attempt    : 3,
+                maxAttempts: 2,
+                reason     : 'max-supervised-attempts-exceeded',
+                rung       : 'rung-3',
+                status     : 'escalated',
+                taskName   : 'ollama'
+            })
+        }]);
+    });
+
+    test('fails loud when the supervised task id is not in the task table', async () => {
+        const {calls, outcomes, service} = createService();
+
+        const result = await service.applyDiagnosis(createDiagnosis({
+            diagnosisId   : 'diagnosis-unknown-task',
+            targetIdentity: createRecoveryTargetIdentity({kind: 'supervised-task', id: 'unknown'})
+        }));
+
+        expect(calls).toEqual([]);
+        expect(result).toMatchObject({
+            action: 'restart-supervised-process',
+            rung  : 'rung-2',
+            status: 'failed'
+        });
+
+        const recent = await readRecentRecoveryRunStates({dir: tmpDir, limit: 1});
+        expect(recent[0].details).toMatchObject({
+            reason  : 'unknown-supervised-task',
+            taskName: 'unknown'
+        });
+        expect(outcomes).toEqual([{
+            taskName: 'recovery-actuator',
+            status  : 'failed',
+            details : expect.objectContaining({
+                action        : 'restart-supervised-process',
+                reason        : 'unknown-supervised-task',
+                status        : 'failed',
+                targetIdentity: {kind: 'supervised-task', id: 'unknown'},
+                taskName      : 'unknown'
+            })
+        }]);
+    });
+
+    test('keeps recovery non-fatal when HealthService outcome recording fails', async () => {
+        const {calls, logEntries, service} = createService({
+            healthService: {
+                recordTaskOutcome() {
+                    throw new Error('health sink down');
+                }
+            }
+        });
+
+        const result = await service.applyDiagnosis(createDiagnosis());
+
+        expect(result.status).toBe('reobserve-requested');
+        expect(calls).toEqual([{taskName: 'ollama', now: 10000, cooldownMs: 15000}]);
+        expect(logEntries).toEqual([{
+            level  : 'ERROR',
+            message: '[RecoveryActuator] Failed to record recovery outcome: health sink down'
+        }]);
+    });
+});


### PR DESCRIPTION
Resolves #13883
Refs #13874

Adds the B0 supervised-process recovery actuator without moving policy into the orchestrator poll loop. `RecoveryActuatorService` consumes typed `recovery-diagnosis` events, selects B0 only from `targetIdentity.kind === 'supervised-task'`, writes the recovery-run ledger before action, delegates the restart to `ProcessSupervisorService.superviseTask()`, emits a cooldown-to-reobserve request, and records a guarded `recovery-actuator` HealthService outcome. `Orchestrator` now owns only the composition slot so the actuator receives the live supervisor, health sink, logger, and `.neo-ai-data/orchestrator-daemon/recovery-runs` state path; B1/docker/deploy targets remain out of this leaf.

Evidence: L2 (unit/invariant tests with real JSONL recovery-run state writes and mocked supervisor dispatch) -> L2 required (B0 actuator binding, deterministic target routing, persisted anti-thrash cap, HealthService observability). No residuals for #13883; live deployment behavior remains ordinary post-merge smoke validation.

## Deltas from ticket

- The B0 binding is a dedicated service plus a composition-root slot, not another branch in `Orchestrator.poll()`.
- External targets (`compose-service` / `deploy-target`) are recorded as `no-action` here and remain sequenced behind #13884.
- The persisted anti-thrash cap escalates to `rung-3` after the configured supervised-attempt limit instead of calling the supervisor again.

## Signal Ledger

- `[GRADUATION_APPROVED by @neo-gpt @ #13871 body 2026-06-22T14:51:10Z]` — GPT family, non-author signal for the parent recovery-daemon graduation.
- `[AUTHOR_SIGNAL by @neo-opus-grace @ #13871 body 2026-06-22T14:51:10Z]` — Opus author-family coverage.
- Parent epic #13874 carries the full discussion criteria mapping and was reviewed by @neo-gpt at #13874.

## Unresolved Dissent

None known for this B0 leaf.

## Unresolved Liveness

@neo-opus-vega's explicit graduation approval remains non-blocking liveness on the parent discussion record; the parent quorum was already met without it. #13884 remains open for the privileged B1/Rung-3 actuator.

## Test Evidence

- `node --check ai/daemons/orchestrator/Orchestrator.mjs && node --check ai/daemons/orchestrator/services/RecoveryActuatorService.mjs && node --check test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs && node --check test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs && git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs` -> 6 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs` -> 24 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs` -> 33 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs` -> 9 passed
- `npm run agent-preflight -- ai/daemons/orchestrator/Orchestrator.mjs ai/daemons/orchestrator/services/RecoveryActuatorService.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs` -> passed

## Post-Merge Validation

- [ ] Feed a supervised-task `crash` or `exhaustion` diagnosis to the recovery actuator on a live orchestrator and verify the ledger entry, HealthService `recovery-actuator` outcome, and supervisor restart/reobserve path are visible under `.neo-ai-data/orchestrator-daemon/recovery-runs`.

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef100-77a2-7781-a83f-4f064a3c1aca.
