### PR TITLE
fix(ai): verify lms loaded context readiness (#13851)

### DIFF
--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -43,6 +43,125 @@ export function getOpenAiCompatibleModelIds(payload) {
 }
 
 /**
+ * @summary Converts CLI/API numeric fields into finite numbers when possible.
+ * @param {*} value Candidate numeric value.
+ * @returns {Number|undefined}
+ */
+function toFiniteNumber(value) {
+    if (Neo.isNumber(value)) {
+        return value;
+    }
+
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number(value);
+
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+}
+
+/**
+ * @summary Reads the first finite numeric value from a row using tolerant field aliases.
+ * @param {Object} row Parsed LM Studio `lms ps --json` row.
+ * @param {String[]} keys Candidate field names.
+ * @returns {Number|undefined}
+ */
+function readNumericField(row, keys) {
+    for (const key of keys) {
+        const value = toFiniteNumber(row?.[key]);
+
+        if (value !== undefined) {
+            return value;
+        }
+    }
+}
+
+/**
+ * @summary Extracts loaded LM Studio model metadata from `lms ps --json`.
+ *
+ * LM Studio CLI output has evolved across versions, so this normalizer accepts
+ * common array/object envelopes and field aliases while preserving only the
+ * readiness facts Neo needs: model id, loaded context length, and parallel slots.
+ *
+ * @param {Object[]|Object} payload Parsed JSON payload from `lms ps --json`.
+ * @returns {Object[]}
+ */
+export function getLmsLoadedModels(payload) {
+    const rows = Array.isArray(payload)
+        ? payload
+        : Array.isArray(payload?.models)
+            ? payload.models
+            : Array.isArray(payload?.data)
+                ? payload.data
+                : Array.isArray(payload?.loadedModels)
+                    ? payload.loadedModels
+                    : [];
+
+    const models = [];
+    const seen   = new Set();
+
+    for (const row of rows) {
+        const id = row?.id || row?.identifier || row?.model || row?.name || row?.path || row?.modelKey;
+
+        if (!id || seen.has(id)) {
+            continue;
+        }
+
+        seen.add(id);
+        models.push({
+            id,
+            contextLength: readNumericField(row, [
+                'contextLength',
+                'context_length',
+                'context',
+                'contextWindow',
+                'context_window',
+                'n_ctx',
+                'num_ctx'
+            ]),
+            parallel: readNumericField(row, [
+                'parallel',
+                'parallelism',
+                'slots',
+                'numParallel',
+                'num_parallel'
+            ])
+        });
+    }
+
+    return models;
+}
+
+/**
+ * @summary Fetches loaded LM Studio model metadata using the CLI's JSON surface.
+ * @param {Object} options
+ * @param {Number} options.timeoutMs CLI timeout. Required; no module-level default.
+ * @param {Function} [options.execFileFn=execFile] Child-process seam for tests.
+ * @returns {Promise<Object[]>}
+ */
+export function fetchLmsLoadedModels({timeoutMs, execFileFn = execFile} = {}) {
+    if (typeof timeoutMs !== 'number') {
+        return Promise.reject(new TypeError('fetchLmsLoadedModels: timeoutMs is required'));
+    }
+
+    return new Promise((resolve, reject) => {
+        execFileFn('lms', ['ps', '--json'], {timeout: timeoutMs}, (error, stdout = '', stderr = '') => {
+            if (error) {
+                reject(new Error(`lms ps --json failed: ${error.message}${stderr ? `; stderr=${stderr.trim()}` : ''}`));
+                return;
+            }
+
+            try {
+                resolve(getLmsLoadedModels(JSON.parse(stdout || '[]')));
+            } catch (parseError) {
+                reject(new Error(`lms ps --json returned invalid JSON: ${parseError.message}`));
+            }
+        });
+    });
+}
+
+/**
  * @summary Extracts currently loaded model identifiers from an Ollama `/api/ps` payload.
  *
  * Native Ollama exposes currently resident models as `models: [{name, model}]`.
@@ -340,7 +459,7 @@ export function buildLmsContextLengthsMap({
  * - `embeddingProvider`: vector embedding role.
  *
  * @param {Object} config aiConfig-shaped provider config.
- * @returns {{models: String[], contextLengths: Object}} Role-aware LMS preload config.
+ * @returns {{models: String[], contextLengths: Object, parallels: Object}} Role-aware LMS preload config.
  */
 export function buildLmsPreloadConfig(config = aiConfig) {
     const openAiCompatibleConfig = config.openAiCompatible ?? {},
@@ -454,6 +573,52 @@ export function buildOllamaReadinessConfig(config = aiConfig) {
 }
 
 /**
+ * @summary Finds LM Studio models whose observed loaded context or parallel slots do not match config.
+ * @param {Object} options
+ * @param {Object[]} options.loadedModels Parsed `lms ps --json` models.
+ * @param {String[]} options.requiredModels Required model identifiers.
+ * @param {Object} [options.contextLengths] Per-model required context lengths.
+ * @param {Object} [options.parallels] Per-model required parallel slots.
+ * @returns {Object[]}
+ */
+export function getInsufficientLmsLoadedModels({
+    loadedModels,
+    requiredModels,
+    contextLengths = {},
+    parallels      = {}
+} = {}) {
+    const byId         = new Map((Array.isArray(loadedModels) ? loadedModels : []).map(item => [item.id, item]));
+    const insufficient = [];
+
+    for (const model of requiredModels || []) {
+        const requiredContext  = contextLengths?.[model],
+              requiredParallel = parallels?.[model],
+              hasContextGate   = Neo.isNumber(requiredContext),
+              hasParallelGate  = Neo.isNumber(requiredParallel);
+
+        if (!hasContextGate && !hasParallelGate) {
+            continue;
+        }
+
+        const observed    = byId.get(model),
+              contextGap  = hasContextGate && (!Neo.isNumber(observed?.contextLength) || observed.contextLength < requiredContext),
+              parallelGap = hasParallelGate && observed?.parallel !== requiredParallel;
+
+        if (contextGap || parallelGap) {
+            insufficient.push({
+                model,
+                contextLength        : observed?.contextLength,
+                requiredContextLength: hasContextGate ? requiredContext : undefined,
+                parallel             : observed?.parallel,
+                requiredParallel     : hasParallelGate ? requiredParallel : undefined
+            });
+        }
+    }
+
+    return insufficient;
+}
+
+/**
  * @summary Ensures LM Studio has all configured OpenAI-compatible models loaded.
  *
  * The orchestrator-owned `lms server start` task gets the server process running;
@@ -481,6 +646,7 @@ export function buildOllamaReadinessConfig(config = aiConfig) {
  * enforced on a resident model, not just a missing one.
  * @param {Boolean} [options.allowPartial=false] Return degraded readiness instead of throwing when one model cannot be loaded.
  * @param {Function} [options.fetchModelIds] Injectable model-list probe.
+ * @param {Function} [options.fetchLoadedModels] Injectable loaded-model metadata probe.
  * @param {Function} [options.loadModel] Injectable model-load function.
  * @param {Object} [options.log=logger] Logger seam.
  * @returns {Promise<Object>}
@@ -494,9 +660,10 @@ export async function ensureLmsModelsLoaded({
     contextLengths = {},
     parallels      = {},
     allowPartial   = false,
-    fetchModelIds = opts => fetchOpenAiCompatibleModelIds(opts),
-    loadModel     = (model, options) => loadLmsModel(model, options),
-    log           = logger
+    fetchModelIds     = opts => fetchOpenAiCompatibleModelIds(opts),
+    fetchLoadedModels = opts => fetchLmsLoadedModels(opts),
+    loadModel         = (model, options) => loadLmsModel(model, options),
+    log               = logger
 } = {}) {
     if (!Array.isArray(models) || models.length === 0) {
         throw new TypeError('ensureLmsModelsLoaded: models must contain at least one configured model');
@@ -510,7 +677,10 @@ export async function ensureLmsModelsLoaded({
         throw new TypeError('ensureLmsModelsLoaded: models must contain at least one configured model');
     }
 
-    const getMissing  = available => requiredModels.filter(model => !available.includes(model));
+    const getMissing                = available => requiredModels.filter(model => !available.includes(model));
+    const requiresObservedLoadCheck = requiredModels.some(model =>
+        Neo.isNumber(contextLengths?.[model]) || Neo.isNumber(parallels?.[model])
+    );
     const probeModels = async phase => {
         let lastError;
 
@@ -604,8 +774,102 @@ export async function ensureLmsModelsLoaded({
         ]);
         const serviceableMissing = missingModels.filter(model => !knownUnavailable.has(model));
 
-        if (missingModels.length === 0 || (allowPartial && serviceableMissing.length === 0)) {
+        if (missingModels.length === 0) {
+            let lmsLoadedModels = [];
+
+            if (requiresObservedLoadCheck) {
+                try {
+                    lmsLoadedModels = await fetchLoadedModels({timeoutMs});
+                } catch (error) {
+                    const warning = `LM Studio loaded-model readiness failed: ${error.message}`;
+
+                    log.warn?.(`[ProviderReadinessHelper] ${warning}`);
+
+                    if (!allowPartial) {
+                        throw new Error(warning);
+                    }
+
+                    return {
+                        ready            : false,
+                        degraded         : true,
+                        loadedModels,
+                        attemptedModels,
+                        failedModels,
+                        missingModels,
+                        observedLoadError: error.message,
+                        requiredModels,
+                        availableModels,
+                        attempts         : attempt,
+                        elapsedMs        : Date.now() - startedAt
+                    };
+                }
+            }
+
+            const insufficientLoadedModels = requiresObservedLoadCheck
+                ? getInsufficientLmsLoadedModels({
+                    loadedModels: lmsLoadedModels,
+                    requiredModels,
+                    contextLengths,
+                    parallels
+                })
+                : [];
+
+            if (insufficientLoadedModels.length) {
+                const warning = `LM Studio loaded-model readiness failed: ${insufficientLoadedModels.map(item => {
+                    const context = item.requiredContextLength !== undefined
+                        ? `context observed=${item.contextLength ?? 'unknown'} required>=${item.requiredContextLength}`
+                        : null;
+                    const parallel = item.requiredParallel !== undefined
+                        ? `parallel observed=${item.parallel ?? 'unknown'} required=${item.requiredParallel}`
+                        : null;
+
+                    return `${item.model} (${[context, parallel].filter(Boolean).join(', ')})`
+                }).join('; ')}`;
+
+                log.warn?.(`[ProviderReadinessHelper] ${warning}`);
+
+                if (!allowPartial) {
+                    throw new Error(warning);
+                }
+
+                return {
+                    ready          : false,
+                    degraded       : true,
+                    loadedModels,
+                    attemptedModels,
+                    failedModels,
+                    missingModels,
+                    insufficientLoadedModels,
+                    requiredModels,
+                    availableModels,
+                    lmsLoadedModels,
+                    loadedContexts : Object.fromEntries(lmsLoadedModels.map(item => [item.id, item.contextLength])),
+                    loadedParallels: Object.fromEntries(lmsLoadedModels.map(item => [item.id, item.parallel])),
+                    attempts       : attempt,
+                    elapsedMs      : Date.now() - startedAt
+                };
+            }
+
             const ready = missingModels.length === 0 && failedModels.length === 0;
+            return {
+                ready,
+                degraded       : !ready,
+                loadedModels,
+                attemptedModels,
+                failedModels,
+                missingModels,
+                requiredModels,
+                availableModels,
+                lmsLoadedModels,
+                loadedContexts : Object.fromEntries(lmsLoadedModels.map(item => [item.id, item.contextLength])),
+                loadedParallels: Object.fromEntries(lmsLoadedModels.map(item => [item.id, item.parallel])),
+                attempts       : attempt,
+                elapsedMs      : Date.now() - startedAt
+            };
+        }
+
+        if (allowPartial && serviceableMissing.length === 0) {
+            const ready = false;
             return {
                 ready,
                 degraded : !ready,

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -107,7 +107,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('Sub 9 hypothesis 7: manual CLI delegates to canonical REM cycle without autoDream coupling (#12617)', async () => {
-        const calls = [];
+        const calls  = [];
         const output = {
             log  : message => calls.push({type: 'log', message}),
             error: message => calls.push({type: 'error', message}),
@@ -203,7 +203,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('fetchOllamaRunningModelIds probes native Ollama /api/ps', async () => {
-        const calls = [];
+        const calls  = [];
         const result = await providerReadinessHelper.fetchOllamaRunningModelIds({
             host     : 'http://ollama.test',
             timeoutMs: 25,
@@ -226,7 +226,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('warmOllamaRoleModel uses native role endpoints and keep_alive', async () => {
-        const calls = [];
+        const calls   = [];
         const fetchFn = async (url, options) => {
             calls.push({
                 url,
@@ -280,7 +280,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('warmOllamaRoleModel threads native num_ctx for chat and embedding warm-ups (#13865)', async () => {
-        const calls = [];
+        const calls   = [];
         const fetchFn = async (url, options) => {
             calls.push({
                 url,
@@ -329,7 +329,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('warnProviderParallelModelCapacity warns for native Ollama missing the embedding model', async () => {
         const warnings = [];
-        const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+        const result   = await providerReadinessHelper.warnProviderParallelModelCapacity({
             config: {
                 graphProvider: 'ollama',
                 modelProvider: 'openAiCompatible',
@@ -357,7 +357,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('warnProviderParallelModelCapacity passes when OpenAI-compatible lists both models', async () => {
         const warnings = [];
-        const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+        const result   = await providerReadinessHelper.warnProviderParallelModelCapacity({
             config: {
                 graphProvider   : 'openAiCompatible',
                 modelProvider   : 'gemini',
@@ -384,7 +384,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('warnProviderParallelModelCapacity warns when requireParallelModels is missing', async () => {
         const warnings = [];
-        const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+        const result   = await providerReadinessHelper.warnProviderParallelModelCapacity({
             config: {
                 graphProvider   : 'openAiCompatible',
                 openAiCompatible: {
@@ -405,8 +405,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     test('warnProviderParallelModelCapacity rejects non-finite requireParallelModels values', async () => {
         for (const requireParallelModels of [NaN, Infinity, -Infinity]) {
             const warnings = [];
-            let fetched = false;
-            const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+            let   fetched  = false;
+            const result   = await providerReadinessHelper.warnProviderParallelModelCapacity({
                 config: {
                     graphProvider   : 'openAiCompatible',
                     openAiCompatible: {
@@ -432,7 +432,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureLmsModelsLoaded invokes lms load for missing chat and embedding models', async () => {
-        const loads = [];
+        const loads          = [];
         const modelSnapshots = [
             [],
             ['chat-model'],
@@ -494,8 +494,15 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             // ready with zero loadModel calls, leaving any modelfile-default loaded
             // context window in place. With the fix, context-configured models are
             // force-included in the load set.
-            fetchModelIds: async () => ['chat-model', 'embedding-model'],
-            loadModel    : async (model, options) => loadCalls.push({model, contextLength: options?.contextLength}),
+            fetchModelIds    : async () => ['chat-model', 'embedding-model'],
+            loadModel        : async (model, options) => loadCalls.push({model, contextLength: options?.contextLength}),
+            fetchLoadedModels: async () => [{
+                id           : 'chat-model',
+                contextLength: 262144
+            }, {
+                id           : 'embedding-model',
+                contextLength: 32768
+            }],
             log          : {info: () => {}}
         });
 
@@ -507,8 +514,100 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(result.loadedModels).toEqual(['chat-model', 'embedding-model']);
     });
 
+    test('getLmsLoadedModels normalizes lms ps json metadata (#13851)', () => {
+        expect(providerReadinessHelper.getLmsLoadedModels({
+            models: [{
+                identifier   : 'chat-model',
+                contextWindow: '131072',
+                parallel     : '1'
+            }, {
+                model         : 'embedding-model',
+                context_length: 32768,
+                num_parallel  : 2
+            }]
+        })).toEqual([{
+            id           : 'chat-model',
+            contextLength: 131072,
+            parallel     : 1
+        }, {
+            id           : 'embedding-model',
+            contextLength: 32768,
+            parallel     : 2
+        }]);
+    });
+
+    test('fetchLmsLoadedModels invokes lms ps --json (#13851)', async () => {
+        const calls        = [];
+        const loadedModels = await providerReadinessHelper.fetchLmsLoadedModels({
+            timeoutMs : 123,
+            execFileFn: (cmd, args, options, callback) => {
+                calls.push({cmd, args, options});
+                callback(null, JSON.stringify([{id: 'chat-model', contextLength: 131072, parallel: 1}]), '');
+            }
+        });
+
+        expect(calls).toEqual([{
+            cmd    : 'lms',
+            args   : ['ps', '--json'],
+            options: {timeout: 123}
+        }]);
+        expect(loadedModels).toEqual([{
+            id           : 'chat-model',
+            contextLength: 131072,
+            parallel     : 1
+        }]);
+    });
+
+    test('ensureLmsModelsLoaded degrades when lms ps reports insufficient context or parallel (#13851)', async () => {
+        const warnings = [];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host             : 'http://127.0.0.1:1234',
+            models           : ['chat-model', 'embedding-model'],
+            contextLengths   : {'chat-model': 131072, 'embedding-model': 32768},
+            parallels        : {'chat-model': 1},
+            allowPartial     : true,
+            attempts         : 1,
+            delayMs          : 0,
+            timeoutMs        : 50,
+            fetchModelIds    : async () => ['chat-model', 'embedding-model'],
+            loadModel        : async () => {},
+            fetchLoadedModels: async () => [{
+                id           : 'chat-model',
+                contextLength: 4096,
+                parallel     : 4
+            }, {
+                id           : 'embedding-model',
+                contextLength: 32768
+            }],
+            log: {
+                info: () => {},
+                warn: message => warnings.push(message)
+            }
+        });
+
+        expect(result.ready).toBe(false);
+        expect(result.degraded).toBe(true);
+        expect(result.insufficientLoadedModels).toEqual([{
+            model                : 'chat-model',
+            contextLength        : 4096,
+            requiredContextLength: 131072,
+            parallel             : 4,
+            requiredParallel     : 1
+        }]);
+        expect(result.loadedContexts).toEqual({
+            'chat-model'     : 4096,
+            'embedding-model': 32768
+        });
+        expect(result.loadedParallels).toEqual({
+            'chat-model'     : 4,
+            'embedding-model': undefined
+        });
+        expect(warnings[0]).toContain('loaded-model readiness failed');
+    });
+
     test('ensureLmsModelsLoaded mixes missing + context-configured force-reload paths correctly (#12117 RA1)', async () => {
-        const loadCalls = [];
+        const loadCalls      = [];
         const modelSnapshots = [
             ['chat-model'],                      // chat resident, embedding missing
             ['chat-model', 'embedding-model']    // post-load: both present
@@ -518,12 +617,16 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             host  : 'http://127.0.0.1:1234',
             models: ['chat-model', 'embedding-model'],
             // Only chat has a configured context-length; embedding must still load as missing
-            contextLengths: {'chat-model': 262144},
-            attempts      : 2,
-            delayMs       : 0,
-            timeoutMs     : 50,
-            fetchModelIds : async () => modelSnapshots.shift() || ['chat-model', 'embedding-model'],
-            loadModel     : async (model, options) => loadCalls.push({model, contextLength: options?.contextLength}),
+            contextLengths   : {'chat-model': 262144},
+            attempts         : 2,
+            delayMs          : 0,
+            timeoutMs        : 50,
+            fetchModelIds    : async () => modelSnapshots.shift() || ['chat-model', 'embedding-model'],
+            loadModel        : async (model, options) => loadCalls.push({model, contextLength: options?.contextLength}),
+            fetchLoadedModels: async () => [{
+                id           : 'chat-model',
+                contextLength: 262144
+            }],
             log           : {info: () => {}}
         });
 
@@ -543,21 +646,28 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureLmsModelsLoaded threads per-model contextLengths into loadModel invocations (#12117)', async () => {
-        const loadCalls = [];
+        const loadCalls      = [];
         const modelSnapshots = [
             [],
             ['chat-model', 'embedding-model']
         ];
 
         const result = await providerReadinessHelper.ensureLmsModelsLoaded({
-            host          : 'http://127.0.0.1:1234',
-            models        : ['chat-model', 'embedding-model'],
-            contextLengths: {'chat-model': 262144, 'embedding-model': 32768},
-            attempts      : 2,
-            delayMs       : 0,
-            timeoutMs     : 50,
-            fetchModelIds : async () => modelSnapshots.shift() || ['chat-model', 'embedding-model'],
-            loadModel     : async (model, options) => loadCalls.push({model, options}),
+            host             : 'http://127.0.0.1:1234',
+            models           : ['chat-model', 'embedding-model'],
+            contextLengths   : {'chat-model': 262144, 'embedding-model': 32768},
+            attempts         : 2,
+            delayMs          : 0,
+            timeoutMs        : 50,
+            fetchModelIds    : async () => modelSnapshots.shift() || ['chat-model', 'embedding-model'],
+            loadModel        : async (model, options) => loadCalls.push({model, options}),
+            fetchLoadedModels: async () => [{
+                id           : 'chat-model',
+                contextLength: 262144
+            }, {
+                id           : 'embedding-model',
+                contextLength: 32768
+            }],
             log           : {info: () => {}}
         });
 
@@ -570,8 +680,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureLmsModelsLoaded does not pre-skip large local chat contexts (#12264)', async () => {
-        const loadCalls = [];
-        const warnings  = [];
+        const loadCalls      = [];
+        const warnings       = [];
         const modelSnapshots = [
             [],
             ['embedding-model']
@@ -615,8 +725,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureLmsModelsLoaded continues loading remaining models after a partial preload failure (#12264)', async () => {
-        const loadCalls = [];
-        const warnings  = [];
+        const loadCalls      = [];
+        const warnings       = [];
         const modelSnapshots = [
             [],
             ['embedding-model']
@@ -660,7 +770,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureOllamaModelsReady warms missing chat and embedding models through native roles (#12285)', async () => {
-        const warmCalls = [];
+        const warmCalls      = [];
         const modelSnapshots = [
             [],
             [
@@ -749,7 +859,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureOllamaModelsReady degrades resident models loaded below configured context (#13865)', async () => {
-        const warmCalls = [];
+        const warmCalls      = [];
         const modelSnapshots = [
             [{id: 'gemma4:31b', contextLength: 4096}],
             [{id: 'gemma4:31b', contextLength: 4096}]
@@ -805,7 +915,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('ensureOllamaModelsReady returns degraded when one native role cannot be warmed (#12285)', async () => {
         const warnings = [];
-        const result = await providerReadinessHelper.ensureOllamaModelsReady({
+        const result   = await providerReadinessHelper.ensureOllamaModelsReady({
             host : 'http://ollama.test',
             roles: [{
                 providerRole: 'modelProvider',
@@ -909,7 +1019,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('loadLmsModel appends --context-length to execFile args when provided (#12117)', async () => {
-        const execCalls = [];
+        const execCalls    = [];
         const execFileStub = (cmd, args, callback) => {
             execCalls.push({cmd, args});
             callback(null, '', '');
@@ -926,7 +1036,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('loadLmsModel omits --context-length when not provided (backward compat)', async () => {
-        const execCalls = [];
+        const execCalls    = [];
         const execFileStub = (cmd, args, callback) => {
             execCalls.push({cmd, args});
             callback(null, '', '');
@@ -1111,7 +1221,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('loadLmsModel omits --context-length when contextLength is non-finite (defensive)', async () => {
-        const execCalls = [];
+        const execCalls    = [];
         const execFileStub = (cmd, args, callback) => {
             execCalls.push({cmd, args});
             callback(null, '', '');
@@ -1206,7 +1316,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         await logger.flush();
 
-        const today    = new Date().toISOString().slice(0, 10);
+        const today = new Date().toISOString().slice(0, 10);
         const logFile  = path.join(tmpLogDir, `mc-server-${today}.log`);
         const logLines = fs.readFileSync(logFile, 'utf8');
 
@@ -1321,7 +1431,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('runSandman delegates exactly one canonical REM cycle inside the lease (#12070)', async () => {
         const calls     = [];
-        const logs = [];
+        const logs      = [];
         const exitCodes = [];
 
         const result = await runSandmanModule.runSandman({


### PR DESCRIPTION
Resolves #13851

Related: #13874, #13923

Adds the missing post-load LM Studio readiness check: after `ensureLmsModelsLoaded()` reloads context-configured models, it now verifies observed `lms ps --json` metadata for loaded context length and configured chat parallel slots before declaring LMS ready. Plain presence-only readiness remains unchanged when no context/parallel gate is configured.

Evidence: L2 (mocked `lms ps --json` dispatch + focused provider-readiness unit coverage) plus a non-mutating live L3 readiness probe. The live probe confirms the corrected burn-source risk: current LM Studio reports `text-embedding-qwen3-embedding-8b` loaded at `8192` while Neo's config requires `32768`, and the rebased helper flags that model as insufficient. Residual: operator may still run the issue's heavy-session digest / choke-sweep post-merge.

## Deltas from ticket

- Uses the existing orchestrator task path through `buildLmsPreloadConfig()` and `ensureLmsModelsLoaded()` instead of adding another orchestrator layer.
- Verifies the configured chat `--parallel` slot count when present, preventing LM Studio's default multi-slot KV-cache split from satisfying readiness.
- Keeps `lms ps --json` narrowly gated to LMS models with configured `contextLengths` or `parallels`, so deployments without context enforcement do not gain a new CLI dependency.
- Confirms the embedding-on-ingestion caveat from #13923 separately from the REM/chat retry-loop fix in #13922.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Evidence |
|---|---|---|---|
| LM Studio model readiness | `ai/services/graph/providerReadinessHelper.mjs` | Required LMS models with configured context/parallel gates must report observed loaded metadata that satisfies those gates before readiness is true. | `npm run test-unit -- test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs --workers=1` |
| Orchestrator LMS task | `ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs` | Existing post-spawn path passes `contextLengths` and `parallels` into `ensureLmsModelsLoaded()`. | Source audit during implementation |

## Test Evidence

- `node --check ai/services/graph/providerReadinessHelper.mjs`
- `node --check test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs --workers=1` - 47 passed
- `node --input-type=module -e '<live lms ps comparator>'` - flagged `text-embedding-qwen3-embedding-8b` observed `8192` required `32768`
- `npm run agent-preflight -- ai/services/graph/providerReadinessHelper.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs`
- `node buildScripts/util/check-block-alignment.mjs ai/services/graph/providerReadinessHelper.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs`
- `git diff --check origin/dev..HEAD`

## Post-Merge Validation

- [ ] On a host with LM Studio running, rerun the issue's operator command sequence: `lms unload gemma-4-31b-it && lms load gemma-4-31b-it --context-length 131072 --parallel 1`, then verify the choke sweep stops failing at the former 4K boundary.
- [ ] Verify one real heavy session digests to a non-null tri-vector after the readiness gate is active.

Authored by Euclid (GPT-5, Codex Desktop).
