### PR TITLE
feat(ai): add gated recovery actuator (#13884)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -650,6 +650,27 @@ class Config extends ConfigProvider {
                     tenantRepoSyncEnabled: leaf(null, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED', 'boolean')
                 },
                 /**
+                 * ADR-0026 B1 recovery actuator envelope. Disabled and empty by default: the
+                 * orchestrator may only restart compose services or page deploy targets that are
+                 * explicitly named here by the operator.
+                 * @type {Object}
+                 */
+                recoveryActuator: {
+                    enabled                    : leaf(false, 'NEO_RECOVERY_ACTUATOR_ENABLED', 'boolean'),
+                    allowedComposeServices     : leaf([], 'NEO_RECOVERY_ACTUATOR_COMPOSE_SERVICES', 'csv'),
+                    allowedDeployTargets       : leaf([], 'NEO_RECOVERY_ACTUATOR_DEPLOY_TARGETS', 'csv'),
+                    healAttemptsPath           : leaf(path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/heal-attempts.json'), 'NEO_RECOVERY_ACTUATOR_HEAL_ATTEMPTS_PATH', 'string'),
+                    recoveryRunStateDir        : leaf(path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/recovery-runs'), 'NEO_RECOVERY_ACTUATOR_RUN_STATE_DIR', 'string'),
+                    recoveryRunRetentionLimit  : leaf(100, 'NEO_RECOVERY_ACTUATOR_RUN_RETENTION_LIMIT', 'number'),
+                    maxAttemptsPerWindow       : leaf(3, 'NEO_RECOVERY_ACTUATOR_MAX_ATTEMPTS_PER_WINDOW', 'number'),
+                    maxAttemptsWindowMs        : leaf(HOUR_MS, 'NEO_RECOVERY_ACTUATOR_MAX_ATTEMPTS_WINDOW_MS', 'number'),
+                    baseBackoffMs              : leaf(5 * 60 * 1000, 'NEO_RECOVERY_ACTUATOR_BASE_BACKOFF_MS', 'number'),
+                    maxBackoffMs               : leaf(HOUR_MS, 'NEO_RECOVERY_ACTUATOR_MAX_BACKOFF_MS', 'number'),
+                    verifyCooldownMs           : leaf(60 * 1000, 'NEO_RECOVERY_ACTUATOR_VERIFY_COOLDOWN_MS', 'number'),
+                    healthyObservationThreshold: leaf(1, 'NEO_RECOVERY_ACTUATOR_HEALTHY_OBSERVATION_THRESHOLD', 'number'),
+                    operatorPageTarget         : leaf('AGENT:*', 'NEO_RECOVERY_ACTUATOR_OPERATOR_PAGE_TARGET', 'string')
+                },
+                /**
                  * Optional local Neo repo roots for the primary-dev-sync lane.
                  * Keep the template machine-neutral; set real absolute paths in gitignored
                  * `ai/config.mjs` or via `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`.

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -30,6 +30,7 @@ import {normalizeAgentIdentityNodeId}                                           
 import TaskStateService                                                         from './services/TaskStateService.mjs';
 import ProcessSupervisorService                                                 from './services/ProcessSupervisorService.mjs';
 import DeploymentRuntimeAccessService                                           from './services/DeploymentRuntimeAccessService.mjs';
+import RecoveryActuatorService                                                  from './services/RecoveryActuatorService.mjs';
 import DreamService                                                             from './services/DreamService.mjs';
 import SwarmHeartbeatService                                                    from './services/SwarmHeartbeatService.mjs';
 import GoldenPathSynthesizer                                                    from '../../services/graph/GoldenPathSynthesizer.mjs';
@@ -106,6 +107,7 @@ export class Orchestrator extends Base {
         singleton                      : true,
         processSupervisorService_      : null,
         deploymentRuntimeAccessService_: null,
+        recoveryActuatorService_       : null,
         maintenanceBackpressureService_: MaintenanceBackpressureService,
         dataDir_                       : DEFAULT_DATA_DIR,
         taskDefinitions_               : null,
@@ -301,9 +303,24 @@ export class Orchestrator extends Base {
         });
     }
 
+    /**
+     * @param {Neo.ai.daemons.services.RecoveryActuatorService|Object|null} value
+     * @returns {Neo.ai.daemons.services.RecoveryActuatorService}
+     */
+    beforeSetRecoveryActuatorService(value) {
+        return ClassSystemUtil.beforeSetInstance(value, RecoveryActuatorService, {
+            dataDir                        : this.dataDir,
+            deploymentRuntimeAccessService: this.deploymentRuntimeAccessService,
+            healthService                  : this.healthService,
+            writeLog                       : this.processSupervisorWriteLog,
+            actuatorConfig                 : AiConfig.orchestrator.recoveryActuator
+        });
+    }
+
     afterSetDataDir(value, oldValue) {
         if (oldValue === undefined) return;
         this.processSupervisorService.dataDir          = value;
+        this.recoveryActuatorService.dataDir           = value;
         this.maintenanceBackpressureService.dataDir    = value;
     }
     afterSetTaskDefinitions(value, oldValue) {
@@ -319,7 +336,12 @@ export class Orchestrator extends Base {
     afterSetHealthService(value, oldValue) {
         if (oldValue === undefined) return;
         this.processSupervisorService.healthService       = value;
+        this.recoveryActuatorService.healthService        = value;
         this.maintenanceBackpressureService.healthService = value;
+    }
+    afterSetDeploymentRuntimeAccessService(value, oldValue) {
+        if (oldValue === undefined || !this.recoveryActuatorService) return;
+        this.recoveryActuatorService.deploymentRuntimeAccessService = value;
     }
     afterSetSpawnFn(value, oldValue) {
         if (oldValue === undefined) return;
@@ -409,6 +431,7 @@ export class Orchestrator extends Base {
 
         this.processSupervisorService = {};
         this.deploymentRuntimeAccessService = {};
+        this.recoveryActuatorService = {};
         this.processSupervisorService.recoverTasks();
 
         this.db = await this.initializeDatabaseFn(this.dbPath);

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -309,11 +309,11 @@ export class Orchestrator extends Base {
      */
     beforeSetRecoveryActuatorService(value) {
         return ClassSystemUtil.beforeSetInstance(value, RecoveryActuatorService, {
-            dataDir                        : this.dataDir,
+            dataDir                       : this.dataDir,
             deploymentRuntimeAccessService: this.deploymentRuntimeAccessService,
-            healthService                  : this.healthService,
-            writeLog                       : this.processSupervisorWriteLog,
-            actuatorConfig                 : AiConfig.orchestrator.recoveryActuator
+            healthService                 : this.healthService,
+            writeLog                      : this.processSupervisorWriteLog,
+            actuatorConfig                : AiConfig.orchestrator.recoveryActuator
         });
     }
 

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -1,0 +1,694 @@
+import fs   from 'fs-extra';
+import path from 'path';
+
+import Base     from '../../../../src/core/Base.mjs';
+import AiConfig from '../../../config.mjs';
+import {
+    appendRecoveryRunState,
+    createRecoveryDiagnosisEvent,
+    createRecoveryReobserveRequest,
+    createRecoveryRunStateEntry,
+    createRecoveryTargetIdentity
+} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+import {DEFAULT_DATA_DIR} from '../taskDefinitions.mjs';
+
+const DEFAULT_ACTIONS = Object.freeze(['restart', 'redeploy', 'page']);
+
+/**
+ * @summary Normalizes string/object allowlist entries into stable recovery targets.
+ *
+ * String entries use the same value for `serviceKey` and `id`. Object entries may use an
+ * explicit `serviceKey` plus either `id`, `composeService`, or `deployTarget`. The actuator
+ * never accepts a runtime target that cannot be traced back to one of these normalized entries.
+ *
+ * @param {Array<String|Object>} entries Configured allowlist entries.
+ * @param {String} kind Recovery target kind.
+ * @returns {Object[]} Normalized target descriptors.
+ */
+export function normalizeRecoveryActuatorAllowlist(entries, kind) {
+    if (!Array.isArray(entries)) {
+        return [];
+    }
+
+    const targets = [];
+
+    for (const entry of entries) {
+        if (typeof entry === 'string') {
+            const id = entry.trim();
+            if (id) {
+                targets.push({kind, serviceKey: id, id});
+            }
+            continue;
+        }
+
+        if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+            continue;
+        }
+
+        const id         = String(entry.id || entry.composeService || entry.deployTarget || '').trim(),
+              serviceKey = String(entry.serviceKey || id).trim();
+
+        if (!serviceKey || !id) {
+            continue;
+        }
+
+        targets.push({
+            ...entry,
+            kind,
+            serviceKey,
+            id
+        });
+    }
+
+    return targets;
+}
+
+/**
+ * @class Neo.ai.daemons.services.RecoveryActuatorService
+ * @extends Neo.core.Base
+ *
+ * B1 privileged recovery actuator for ADR-0026. The service is controller-blind:
+ * callers pass an already-selected action, and this class only answers whether the
+ * actuator allowlist + persisted anti-thrash envelope admits it. Compose-service
+ * lifecycle writes are delegated to the shared L0 deployment-runtime access holder,
+ * keeping Docker socket access and container identity resolution out of this B1 class.
+ */
+export class RecoveryActuatorService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.RecoveryActuatorService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.RecoveryActuatorService',
+        /**
+         * @member {Object|null} actuatorConfig_=null
+         * @protected
+         * @reactive
+         */
+        actuatorConfig_: null,
+        /**
+         * @member {String} dataDir_='.neo-ai-data/orchestrator-daemon'
+         * @protected
+         * @reactive
+         */
+        dataDir_: DEFAULT_DATA_DIR,
+        /**
+         * @member {Object|null} healthService_=null
+         * @protected
+         * @reactive
+         */
+        healthService_: null,
+        /**
+         * @member {Object|null} deploymentRuntimeAccessService_=null
+         * @protected
+         * @reactive
+         */
+        deploymentRuntimeAccessService_: null,
+        /**
+         * @member {Function|null} pageDispatcher_=null
+         * @protected
+         * @reactive
+         */
+        pageDispatcher_: null,
+        /**
+         * @member {Function|null} writeLog_=null
+         * @protected
+         * @reactive
+         */
+        writeLog_: null
+    }
+
+    /** @summary Resolves the active actuator config from an injected test value or Tier-1 AiConfig. */
+    get cfg() {
+        return this.actuatorConfig || AiConfig.orchestrator?.recoveryActuator || {};
+    }
+
+    /** @summary Resolves the persisted anti-thrash attempt state path. */
+    get healAttemptsPath() {
+        return this.cfg.healAttemptsPath || path.join(this.dataDir, 'heal-attempts.json');
+    }
+
+    /** @summary Resolves the durable recovery-run ledger directory. */
+    get recoveryRunStateDir() {
+        return this.cfg.recoveryRunStateDir || path.join(this.dataDir, 'recovery-runs');
+    }
+
+    /** @summary Resolves the allowlisted compose-service actuator targets. */
+    get allowedComposeServices() {
+        return normalizeRecoveryActuatorAllowlist(this.cfg.allowedComposeServices, 'compose-service');
+    }
+
+    /** @summary Resolves the allowlisted deploy-target page/escalation targets. */
+    get allowedDeployTargets() {
+        return normalizeRecoveryActuatorAllowlist(this.cfg.allowedDeployTargets, 'deploy-target');
+    }
+
+    /**
+     * @summary Applies one bounded recovery action if the allowlist and anti-thrash envelope admit it.
+     *
+     * @param {String} serviceKey Stable allowlisted recovery target key.
+     * @param {String} action restart | redeploy | page.
+     * @param {Object} [options]
+     * @param {Object|null} [options.diagnosisEvent=null] Optional ADR-0025 diagnosis event.
+     * @param {Object|null} [options.targetIdentity=null] Optional typed target identity.
+     * @param {String|null} [options.recoveryRunId=null] Optional stable recovery run id.
+     * @param {Number} [options.now=Date.now()] Epoch milliseconds.
+     * @param {String|null} [options.reason=null] Operator/controller reason.
+     * @returns {Promise<Object>} Action outcome descriptor.
+     */
+    async apply(serviceKey, action, {
+        diagnosisEvent = null,
+        targetIdentity = null,
+        recoveryRunId = null,
+        now = Date.now(),
+        reason = null
+    } = {}) {
+        if (typeof serviceKey !== 'string' || serviceKey.length === 0) {
+            throw new TypeError('RecoveryActuatorService.apply: serviceKey is required');
+        }
+        if (!DEFAULT_ACTIONS.includes(action)) {
+            return this.rejectAction({serviceKey, action, now, reasonCode: 'unsupported-action', targetIdentity});
+        }
+        if (this.cfg.enabled !== true) {
+            return this.rejectAction({serviceKey, action, now, reasonCode: 'actuator-disabled', targetIdentity});
+        }
+
+        const target = this.resolveTarget({serviceKey, action, targetIdentity});
+
+        if (!target) {
+            return this.rejectAction({serviceKey, action, now, reasonCode: 'target-not-allowlisted', targetIdentity});
+        }
+
+        if (!this.isActionAllowedForTarget({action, target})) {
+            return this.rejectAction({serviceKey, action, now, reasonCode: 'action-not-allowed-for-target', target});
+        }
+
+        const attempts = await this.readHealAttempts(),
+              gate     = this.evaluateEnvelope({attempts, serviceKey, action, now});
+
+        if (!gate.admitted) {
+            return this.finishAction({
+                action,
+                attempts,
+                attempt       : gate.attempt,
+                backoffUntil  : gate.backoffUntil || null,
+                diagnosisEvent: this.resolveDiagnosisEvent({diagnosisEvent, action, target, now}),
+                outcome       : {
+                    status        : gate.status,
+                    reasonCode    : gate.reasonCode,
+                    serviceKey,
+                    action,
+                    targetIdentity: createRecoveryTargetIdentity({kind: target.kind, id: target.id})
+                },
+                recoveryRunId,
+                serviceKey,
+                startedAt : now,
+                target,
+                taskStatus: gate.status === 'escalated' ? 'failed' : 'skipped',
+                updatedAt : now
+            });
+        }
+
+        const startedAt = now;
+
+        try {
+            const result = target.kind === 'compose-service'
+                ? await this.restartComposeService({target, reason})
+                : await this.pageDeployTarget({target, action, reason});
+
+            const updatedAt     = Date.now(),
+                  diagnosis     = this.resolveDiagnosisEvent({diagnosisEvent, action, target, now: startedAt}),
+                  nextAttempt   = gate.attempt + 1,
+                  nextBackoffAt = this.computeBackoffUntil({attempt: nextAttempt, now: updatedAt});
+
+            this.persistAttempt({
+                attempts,
+                serviceKey,
+                action,
+                attempt     : nextAttempt,
+                backoffUntil: nextBackoffAt,
+                now         : updatedAt,
+                status      : target.kind === 'deploy-target' ? 'escalated' : 'actioned'
+            });
+            await this.writeHealAttempts(attempts);
+
+            return this.finishAction({
+                action,
+                attempts,
+                attempt       : nextAttempt,
+                backoffUntil  : nextBackoffAt,
+                diagnosisEvent: diagnosis,
+                outcome       : {
+                    status        : target.kind === 'deploy-target' ? 'escalated' : 'actioned',
+                    serviceKey,
+                    action,
+                    targetIdentity: createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
+                    runtimeAccess : result.runtimeAccess || null,
+                    page          : result.page || null
+                },
+                recoveryRunId,
+                serviceKey,
+                startedAt,
+                target,
+                taskStatus: 'completed',
+                updatedAt
+            });
+        } catch (error) {
+            const updatedAt     = Date.now(),
+                  diagnosis     = this.resolveDiagnosisEvent({diagnosisEvent, action, target, now: startedAt}),
+                  nextAttempt   = gate.attempt + 1,
+                  nextBackoffAt = this.computeBackoffUntil({attempt: nextAttempt, now: updatedAt});
+
+            this.persistAttempt({
+                attempts,
+                serviceKey,
+                action,
+                attempt     : nextAttempt,
+                backoffUntil: nextBackoffAt,
+                now         : updatedAt,
+                status      : 'failed'
+            });
+            await this.writeHealAttempts(attempts);
+
+            return this.finishAction({
+                action,
+                attempts,
+                attempt       : nextAttempt,
+                backoffUntil  : nextBackoffAt,
+                diagnosisEvent: diagnosis,
+                outcome       : {
+                    status        : 'failed',
+                    reasonCode    : 'executor-failed',
+                    serviceKey,
+                    action,
+                    targetIdentity: createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
+                    error         : error.message
+                },
+                recoveryRunId,
+                serviceKey,
+                startedAt,
+                target,
+                taskStatus: 'failed',
+                updatedAt
+            });
+        }
+    }
+
+    /**
+     * @summary Resolves the strict target allowlist entry for a service key and optional identity.
+     * @param {Object} options
+     * @returns {Object|null}
+     */
+    resolveTarget({serviceKey, targetIdentity}) {
+        const candidates = [
+            ...this.allowedComposeServices,
+            ...this.allowedDeployTargets
+        ].filter(target => target.serviceKey === serviceKey || target.id === serviceKey);
+
+        if (targetIdentity) {
+            return candidates.find(target => (
+                target.kind === targetIdentity.kind && target.id === targetIdentity.id
+            )) || null;
+        }
+
+        return candidates.length === 1 ? candidates[0] : null;
+    }
+
+    /**
+     * @summary Checks the closed action set against the target kind.
+     * @param {Object} options
+     * @returns {Boolean}
+     */
+    isActionAllowedForTarget({action, target}) {
+        if (target.kind === 'compose-service') {
+            return action === 'restart';
+        }
+
+        if (target.kind === 'deploy-target') {
+            return action === 'redeploy' || action === 'page';
+        }
+
+        return false;
+    }
+
+    /**
+     * @summary Restarts one allowlisted compose service through the L0 lifecycle-write envelope.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async restartComposeService({target, reason}) {
+        if (!this.deploymentRuntimeAccessService?.applyLifecycle) {
+            throw new Error('Deployment runtime access service is unavailable');
+        }
+
+        const result = await this.deploymentRuntimeAccessService.applyLifecycle({
+            serviceKey: target.id,
+            operation : 'restart',
+            reason    : reason || `recovery-actuator:${target.serviceKey}`
+        });
+
+        return {
+            runtimeAccess: result.proof || null
+        };
+    }
+
+    /**
+     * @summary Triggers the config-drift redeploy page without executing arbitrary deployment code.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async pageDeployTarget({target, action, reason}) {
+        const page = {
+            serviceKey        : target.serviceKey,
+            deployTarget      : target.id,
+            action,
+            reason            : reason || 'config-drift-redeploy-required',
+            operatorPageTarget: this.cfg.operatorPageTarget || 'AGENT:*'
+        };
+
+        if (typeof this.pageDispatcher === 'function') {
+            await this.pageDispatcher(page);
+        } else {
+            this.writeLog?.('WARN', `[RecoveryActuator] Redeploy required for ${target.id}; page target ${page.operatorPageTarget}.`);
+        }
+
+        return {page};
+    }
+
+    /**
+     * @summary Reads the persisted heal-attempt state file.
+     * @returns {Promise<Object>}
+     */
+    async readHealAttempts() {
+        try {
+            return await fs.readJson(this.healAttemptsPath);
+        } catch (error) {
+            if (error?.code === 'ENOENT') {
+                return {};
+            }
+            throw error;
+        }
+    }
+
+    /**
+     * @summary Writes the persisted heal-attempt state file.
+     * @param {Object} attempts Attempt state.
+     * @returns {Promise<void>}
+     */
+    async writeHealAttempts(attempts) {
+        await fs.ensureDir(path.dirname(this.healAttemptsPath));
+        await fs.writeJson(this.healAttemptsPath, attempts, {spaces: 2});
+    }
+
+    /**
+     * @summary Evaluates the persisted anti-thrash envelope for the next action.
+     * @param {Object} options
+     * @returns {Object}
+     */
+    evaluateEnvelope({attempts, serviceKey, action, now}) {
+        const key   = this.getAttemptKey({serviceKey, action}),
+              state = this.getCurrentAttemptState({attempts, key, now});
+
+        if (state.backoffUntil && now < state.backoffUntil) {
+            return {
+                admitted    : false,
+                attempt     : state.attemptCount,
+                backoffUntil: state.backoffUntil,
+                reasonCode  : 'backoff-active',
+                status      : 'deferred'
+            };
+        }
+
+        if (state.attemptCount >= this.getMaxAttemptsPerWindow()) {
+            state.alarmOnly = true;
+            attempts[key] = state;
+            return {
+                admitted  : false,
+                attempt   : state.attemptCount,
+                reasonCode: 'attempt-cap-reached',
+                status    : 'escalated'
+            };
+        }
+
+        attempts[key] = state;
+
+        return {
+            admitted: true,
+            attempt : state.attemptCount
+        };
+    }
+
+    /**
+     * @summary Resolves the active attempt state, resetting expired windows.
+     * @param {Object} options
+     * @returns {Object}
+     */
+    getCurrentAttemptState({attempts, key, now}) {
+        const existing = attempts[key],
+              windowMs = this.getAttemptWindowMs();
+
+        if (!existing || !Number.isFinite(existing.windowStartedAt) || now - existing.windowStartedAt >= windowMs) {
+            return {
+                windowStartedAt: now,
+                attemptCount   : 0,
+                backoffUntil   : null,
+                alarmOnly      : false
+            };
+        }
+
+        return existing;
+    }
+
+    /**
+     * @summary Persists a post-action attempt state.
+     * @param {Object} options
+     * @returns {void}
+     */
+    persistAttempt({attempts, serviceKey, action, attempt, backoffUntil, now, status}) {
+        const key   = this.getAttemptKey({serviceKey, action}),
+              state = this.getCurrentAttemptState({attempts, key, now});
+
+        attempts[key] = {
+            ...state,
+            attemptCount : attempt,
+            lastAction   : action,
+            lastAttemptAt: now,
+            lastStatus   : status,
+            backoffUntil,
+            alarmOnly    : attempt >= this.getMaxAttemptsPerWindow()
+        };
+    }
+
+    /**
+     * @summary Builds the recovery run id used by the durable ledger.
+     * @param {Object} options
+     * @returns {String}
+     */
+    getRecoveryRunId({recoveryRunId, serviceKey, action, startedAt}) {
+        return recoveryRunId || `recovery-actuator:${serviceKey}:${action}:${new Date(startedAt).toISOString()}`;
+    }
+
+    /**
+     * @summary Records health + durable recovery-run ledger traces for an action outcome.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async finishAction({
+        action,
+        attempt,
+        backoffUntil,
+        diagnosisEvent,
+        outcome,
+        recoveryRunId,
+        serviceKey,
+        startedAt,
+        target,
+        taskStatus,
+        updatedAt
+    }) {
+        const runId            = this.getRecoveryRunId({recoveryRunId, serviceKey, action, startedAt}),
+              reobserveRequest = outcome.status === 'actioned'
+                  ? createRecoveryReobserveRequest({
+                        recoveryRunId              : runId,
+                        diagnosisEvent,
+                        requestedAt                : updatedAt,
+                        cooldownMs                 : this.getVerifyCooldownMs(),
+                        healthyObservationThreshold: this.getHealthyObservationThreshold()
+                    })
+                  : null,
+              ledgerStatus = this.getLedgerStatus({outcome}),
+              entry = createRecoveryRunStateEntry({
+                  recoveryRunId: runId,
+                  diagnosisEvent,
+                  rung         : target?.kind === 'deploy-target' ? 'rung-3' : 'rung-2',
+                  attempt      : Math.max(1, Number(attempt || 1)),
+                  status       : ledgerStatus,
+                  startedAt,
+                  updatedAt,
+                  completedAt  : updatedAt,
+                  backoffUntil,
+                  reobserveRequest,
+                  details      : outcome
+              });
+
+        await appendRecoveryRunState(entry, {
+            dir           : this.recoveryRunStateDir,
+            retentionLimit: this.cfg.recoveryRunRetentionLimit ?? 100
+        });
+
+        this.recordTaskOutcome(serviceKey, taskStatus, {
+            ...outcome,
+            recoveryRunId: runId,
+            backoffUntil,
+            ledgerStatus
+        });
+
+        return {
+            ...outcome,
+            recoveryRunId: runId,
+            backoffUntil,
+            reobserveRequest
+        };
+    }
+
+    /**
+     * @summary Records a rejected action without reaching a privileged executor.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async rejectAction({serviceKey, action, now, reasonCode, target = null, targetIdentity = null}) {
+        const diagnosisEvent = createRecoveryDiagnosisEvent({
+            diagnosisId   : `recovery-actuator:${serviceKey}:${action || 'unknown'}:${now}`,
+            recoveryClass : target?.kind === 'deploy-target' ? 'config-drift' : 'ambiguous',
+            confidence    : 1,
+            targetIdentity: targetIdentity || createRecoveryTargetIdentity({
+                kind: target?.kind || 'compose-service',
+                id  : target?.id || serviceKey
+            }),
+            evidenceFacts: [],
+            observedAt   : now,
+            source       : 'recovery-actuator',
+            details      : {action, reasonCode}
+        });
+
+        return this.finishAction({
+            action,
+            attempt     : 1,
+            backoffUntil: null,
+            diagnosisEvent,
+            outcome     : {
+                status        : 'rejected',
+                reasonCode,
+                serviceKey,
+                action,
+                targetIdentity: targetIdentity || (target
+                    ? createRecoveryTargetIdentity({kind: target.kind, id: target.id})
+                    : null)
+            },
+            recoveryRunId: null,
+            serviceKey,
+            startedAt    : now,
+            target       : target || {kind: targetIdentity?.kind || 'compose-service', id: targetIdentity?.id || serviceKey},
+            taskStatus   : 'skipped',
+            updatedAt    : now
+        });
+    }
+
+    /**
+     * @summary Records an actuator health trace without letting observability failures break action flow.
+     * @param {String} serviceKey Stable target key.
+     * @param {String} status Health status.
+     * @param {Object} details Outcome details.
+     * @returns {void}
+     */
+    recordTaskOutcome(serviceKey, status, details) {
+        try {
+            this.healthService?.recordTaskOutcome?.(`recovery-actuator:${serviceKey}`, status, details);
+        } catch (error) {
+            this.writeLog?.('ERROR', `[RecoveryActuator] Failed to record ${serviceKey} outcome: ${error.message}`);
+        }
+    }
+
+    /**
+     * @summary Resolves or synthesizes the diagnosis event consumed by the actuator.
+     * @param {Object} options
+     * @returns {Object}
+     */
+    resolveDiagnosisEvent({diagnosisEvent, action, target, now}) {
+        if (diagnosisEvent) {
+            return createRecoveryDiagnosisEvent(diagnosisEvent);
+        }
+
+        return createRecoveryDiagnosisEvent({
+            diagnosisId   : `recovery-actuator:${target.serviceKey}:${action}:${now}`,
+            recoveryClass : target.kind === 'deploy-target' ? 'config-drift' : 'crash',
+            confidence    : 1,
+            targetIdentity: createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
+            evidenceFacts : [],
+            observedAt    : now,
+            source        : 'recovery-actuator',
+            details       : {action}
+        });
+    }
+
+    /** @summary Builds the durable anti-thrash key for one service/action pair. */
+    getAttemptKey({serviceKey, action}) {
+        return `${serviceKey}:${action}`;
+    }
+
+    /** @summary Resolves the rolling attempt-window size. */
+    getAttemptWindowMs() {
+        return Math.max(1, Number(this.cfg.maxAttemptsWindowMs ?? 60 * 60 * 1000));
+    }
+
+    /** @summary Resolves the maximum admitted attempts within one rolling window. */
+    getMaxAttemptsPerWindow() {
+        return Math.max(1, Number(this.cfg.maxAttemptsPerWindow ?? 3));
+    }
+
+    /** @summary Resolves the cooldown before the controller should re-observe after action. */
+    getVerifyCooldownMs() {
+        return Math.max(0, Number(this.cfg.verifyCooldownMs ?? 60 * 1000));
+    }
+
+    /** @summary Resolves the required healthy-observation count for verify-loop completion. */
+    getHealthyObservationThreshold() {
+        return Math.max(1, Number(this.cfg.healthyObservationThreshold ?? 1));
+    }
+
+    /**
+     * @summary Computes the exponential backoff ceiling for a completed attempt.
+     * @param {Object} options
+     * @returns {Number|null}
+     */
+    computeBackoffUntil({attempt, now}) {
+        const base = Math.max(0, Number(this.cfg.baseBackoffMs ?? 5 * 60 * 1000)),
+              max  = Math.max(base, Number(this.cfg.maxBackoffMs ?? 60 * 60 * 1000));
+
+        if (base === 0) {
+            return null;
+        }
+
+        return now + Math.min(max, base * Math.pow(2, Math.max(0, attempt - 1)));
+    }
+
+    /**
+     * @summary Maps the actuator outcome state to the recovery-run ledger status enum.
+     * @param {Object} options
+     * @returns {String}
+     */
+    getLedgerStatus({outcome}) {
+        if (outcome.status === 'actioned') {
+            return 'reobserve-requested';
+        }
+        if (outcome.status === 'escalated') {
+            return 'escalated';
+        }
+        if (outcome.status === 'failed') {
+            return 'failed';
+        }
+        return 'no-action';
+    }
+}
+
+export default Neo.setupClass(RecoveryActuatorService);

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -120,17 +120,17 @@ export class RecoveryActuatorService extends Base {
 
     /** @summary Resolves the active actuator config from an injected test value or Tier-1 AiConfig. */
     get cfg() {
-        return this.actuatorConfig || AiConfig.orchestrator?.recoveryActuator || {};
+        return this.actuatorConfig || AiConfig.orchestrator.recoveryActuator;
     }
 
     /** @summary Resolves the persisted anti-thrash attempt state path. */
     get healAttemptsPath() {
-        return this.cfg.healAttemptsPath || path.join(this.dataDir, 'heal-attempts.json');
+        return this.cfg.healAttemptsPath;
     }
 
     /** @summary Resolves the durable recovery-run ledger directory. */
     get recoveryRunStateDir() {
-        return this.cfg.recoveryRunStateDir || path.join(this.dataDir, 'recovery-runs');
+        return this.cfg.recoveryRunStateDir;
     }
 
     /** @summary Resolves the allowlisted compose-service actuator targets. */
@@ -363,7 +363,7 @@ export class RecoveryActuatorService extends Base {
             deployTarget      : target.id,
             action,
             reason            : reason || 'config-drift-redeploy-required',
-            operatorPageTarget: this.cfg.operatorPageTarget || 'AGENT:*'
+            operatorPageTarget: this.cfg.operatorPageTarget
         };
 
         if (typeof this.pageDispatcher === 'function') {
@@ -533,7 +533,7 @@ export class RecoveryActuatorService extends Base {
 
         await appendRecoveryRunState(entry, {
             dir           : this.recoveryRunStateDir,
-            retentionLimit: this.cfg.recoveryRunRetentionLimit ?? 100
+            retentionLimit: this.cfg.recoveryRunRetentionLimit
         });
 
         this.recordTaskOutcome(serviceKey, taskStatus, {
@@ -638,22 +638,22 @@ export class RecoveryActuatorService extends Base {
 
     /** @summary Resolves the rolling attempt-window size. */
     getAttemptWindowMs() {
-        return Math.max(1, Number(this.cfg.maxAttemptsWindowMs ?? 60 * 60 * 1000));
+        return Math.max(1, Number(this.cfg.maxAttemptsWindowMs));
     }
 
     /** @summary Resolves the maximum admitted attempts within one rolling window. */
     getMaxAttemptsPerWindow() {
-        return Math.max(1, Number(this.cfg.maxAttemptsPerWindow ?? 3));
+        return Math.max(1, Number(this.cfg.maxAttemptsPerWindow));
     }
 
     /** @summary Resolves the cooldown before the controller should re-observe after action. */
     getVerifyCooldownMs() {
-        return Math.max(0, Number(this.cfg.verifyCooldownMs ?? 60 * 1000));
+        return Math.max(0, Number(this.cfg.verifyCooldownMs));
     }
 
     /** @summary Resolves the required healthy-observation count for verify-loop completion. */
     getHealthyObservationThreshold() {
-        return Math.max(1, Number(this.cfg.healthyObservationThreshold ?? 1));
+        return Math.max(1, Number(this.cfg.healthyObservationThreshold));
     }
 
     /**
@@ -662,8 +662,8 @@ export class RecoveryActuatorService extends Base {
      * @returns {Number|null}
      */
     computeBackoffUntil({attempt, now}) {
-        const base = Math.max(0, Number(this.cfg.baseBackoffMs ?? 5 * 60 * 1000)),
-              max  = Math.max(base, Number(this.cfg.maxBackoffMs ?? 60 * 60 * 1000));
+        const base = Math.max(0, Number(this.cfg.baseBackoffMs)),
+              max  = Math.max(base, Number(this.cfg.maxBackoffMs));
 
         if (base === 0) {
             return null;

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -2,11 +2,11 @@ import path            from 'path';
 import {fileURLToPath} from 'url';
 import Neo             from '../../../src/Neo.mjs';
 
-const HOUR_MS     = 60 * 60 * 1000;
-const DAY_MS      = 24 * HOUR_MS;
-const __filename  = fileURLToPath(import.meta.url);
-const __dirname   = path.dirname(__filename);
-const neoRootDir  = path.resolve(__dirname, '../../..');
+const HOUR_MS    = 60 * 60 * 1000;
+const DAY_MS     = 24 * HOUR_MS;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const neoRootDir = path.resolve(__dirname, '../../..');
 
 /**
  * @module test/playwright/fixtures/aiConfigDefaults
@@ -109,7 +109,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     },
     openAiCompatible: {
         host                   : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-        model                  : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+        model                  : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'google/gemma-4-26b-a4b',
         embeddingModel         : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
         apiKey                 : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
         unloadRetryCount       : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -2,11 +2,11 @@ import path            from 'path';
 import {fileURLToPath} from 'url';
 import Neo             from '../../../src/Neo.mjs';
 
-const HOUR_MS    = 60 * 60 * 1000;
-const DAY_MS     = 24 * HOUR_MS;
-const __filename = fileURLToPath(import.meta.url);
-const __dirname  = path.dirname(__filename);
-const neoRootDir = path.resolve(__dirname, '../../..');
+const HOUR_MS     = 60 * 60 * 1000;
+const DAY_MS      = 24 * HOUR_MS;
+const __filename  = fileURLToPath(import.meta.url);
+const __dirname   = path.dirname(__filename);
+const neoRootDir  = path.resolve(__dirname, '../../..');
 
 /**
  * @module test/playwright/fixtures/aiConfigDefaults
@@ -109,7 +109,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     },
     openAiCompatible: {
         host                   : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-        model                  : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'google/gemma-4-26b-a4b',
+        model                  : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
         embeddingModel         : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
         apiKey                 : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
         unloadRetryCount       : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
@@ -159,6 +159,21 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
             goldenPathMs                     : HOUR_MS,
             swarmHeartbeatMs                 : 20 * 60 * 1000,
             embedDrainLivenessWatchdogCheckMs: HOUR_MS
+        },
+        recoveryActuator: {
+            enabled                    : false,
+            allowedComposeServices     : [],
+            allowedDeployTargets       : [],
+            healAttemptsPath           : path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/heal-attempts.json'),
+            recoveryRunStateDir        : path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/recovery-runs'),
+            recoveryRunRetentionLimit  : 100,
+            maxAttemptsPerWindow       : 3,
+            maxAttemptsWindowMs        : HOUR_MS,
+            baseBackoffMs              : 5 * 60 * 1000,
+            maxBackoffMs               : HOUR_MS,
+            verifyCooldownMs           : 60 * 1000,
+            healthyObservationThreshold: 1,
+            operatorPageTarget         : 'AGENT:*'
         }
     }
 }, true, true));

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -1,0 +1,242 @@
+import {test, expect}          from '@playwright/test';
+import {mkdtemp, rm, readFile} from 'fs/promises';
+import os                      from 'os';
+import path                    from 'path';
+
+import Neo       from '../../../../../../../src/Neo.mjs';
+import * as core from '../../../../../../../src/core/_export.mjs';
+import {
+    RecoveryActuatorService,
+    normalizeRecoveryActuatorAllowlist
+} from '../../../../../../../ai/daemons/orchestrator/services/RecoveryActuatorService.mjs';
+
+test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
+    let tmpDir;
+
+    test.beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), 'neo-recovery-actuator-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(tmpDir, {recursive: true, force: true});
+    });
+
+    function createService(overrides = {}) {
+        const runtimeCalls   = [],
+              pageCalls      = [],
+              taskOutcomes   = [],
+              actuatorConfig = {
+                  enabled               : true,
+                  allowedComposeServices: ['memory-core'],
+                  allowedDeployTargets  : ['cloud-deploy'],
+                  healAttemptsPath      : path.join(tmpDir, 'heal-attempts.json'),
+                  recoveryRunStateDir   : path.join(tmpDir, 'recovery-runs'),
+                  baseBackoffMs         : 0,
+                  maxBackoffMs          : 0,
+                  maxAttemptsPerWindow  : 2,
+                  maxAttemptsWindowMs   : 60_000,
+                  verifyCooldownMs      : 5_000,
+                  ...overrides.actuatorConfig
+              },
+              service = Neo.create(RecoveryActuatorService, {
+                  actuatorConfig,
+                  dataDir      : tmpDir,
+                  healthService: {
+                      recordTaskOutcome(taskName, status, details) {
+                          taskOutcomes.push({taskName, status, details});
+                  }
+                  },
+                  deploymentRuntimeAccessService: {
+                      async applyLifecycle(options) {
+                          runtimeCalls.push(options);
+
+                          return {
+                              ok        : true,
+                              statusCode: 204,
+                              proof     : {
+                                  capabilityEnvelope: 'lifecycle-write',
+                                  operation         : options.operation,
+                                  serviceKey        : options.serviceKey,
+                                  targetIdentity    : {kind: 'compose-service', id: options.serviceKey}
+                              }
+                          };
+                      },
+                      ...overrides.deploymentRuntimeAccessService
+                  },
+                  pageDispatcher(page) {
+                      pageCalls.push(page);
+                  },
+                  writeLog: () => {},
+                  ...overrides.serviceConfig
+              });
+
+        return {service, runtimeCalls, pageCalls, taskOutcomes, actuatorConfig};
+    }
+
+    async function readAttempts() {
+        return JSON.parse(await readFile(path.join(tmpDir, 'heal-attempts.json'), 'utf8'));
+    }
+
+    test('normalizes string and object allowlist entries', () => {
+        expect(normalizeRecoveryActuatorAllowlist([
+            'memory-core',
+            {serviceKey: 'kb', composeService: 'knowledge-base'},
+            {id: 'local-model'}
+        ], 'compose-service')).toEqual([
+            {kind: 'compose-service', serviceKey: 'memory-core', id: 'memory-core'},
+            {kind: 'compose-service', serviceKey: 'kb', id: 'knowledge-base', composeService: 'knowledge-base'},
+            {kind: 'compose-service', serviceKey: 'local-model', id: 'local-model'}
+        ]);
+    });
+
+    test('restart applies only to an allowlisted compose service and writes health plus recovery ledger traces', async () => {
+        const {service, runtimeCalls, taskOutcomes} = createService();
+
+        const result = await service.apply('memory-core', 'restart', {now: 10_000});
+
+        expect(result.status).toBe('actioned');
+        expect(result.reobserveRequest).toMatchObject({
+            recoveryClass : 'crash',
+            targetIdentity: {kind: 'compose-service', id: 'memory-core'},
+            cooldownMs    : 5_000
+        });
+        expect(runtimeCalls).toEqual([expect.objectContaining({
+            serviceKey: 'memory-core',
+            operation : 'restart',
+            reason    : 'recovery-actuator:memory-core'
+        })]);
+        expect(result.runtimeAccess).toMatchObject({
+            capabilityEnvelope: 'lifecycle-write',
+            operation         : 'restart',
+            serviceKey        : 'memory-core'
+        });
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            taskName: 'recovery-actuator:memory-core',
+            status  : 'completed',
+            details : expect.objectContaining({
+                status      : 'actioned',
+                ledgerStatus: 'reobserve-requested'
+            })
+        }));
+
+        const attempts = await readAttempts();
+        expect(attempts['memory-core:restart']).toMatchObject({
+            attemptCount: 1,
+            lastAction  : 'restart',
+            lastStatus  : 'actioned'
+        });
+    });
+
+    test('non-allowlisted compose services are rejected before any executor call', async () => {
+        const {service, runtimeCalls, taskOutcomes} = createService();
+
+        const result = await service.apply('not-allowed', 'restart', {now: 20_000});
+
+        expect(result).toMatchObject({
+            status    : 'rejected',
+            reasonCode: 'target-not-allowlisted'
+        });
+        expect(runtimeCalls).toEqual([]);
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            taskName: 'recovery-actuator:not-allowed',
+            status  : 'skipped'
+        }));
+    });
+
+    test('disabled actuator refuses allowlisted targets before any executor call', async () => {
+        const {service, runtimeCalls} = createService({
+            actuatorConfig: {
+                enabled: false
+            }
+        });
+
+        const result = await service.apply('memory-core', 'restart', {now: 25_000});
+
+        expect(result).toMatchObject({
+            status    : 'rejected',
+            reasonCode: 'actuator-disabled'
+        });
+        expect(runtimeCalls).toEqual([]);
+    });
+
+    test('persisted backoff defers a repeated restart without touching docker', async () => {
+        const {service, runtimeCalls} = createService({
+            actuatorConfig: {
+                baseBackoffMs: 30_000,
+                maxBackoffMs : 30_000
+            }
+        });
+
+        const first  = await service.apply('memory-core', 'restart', {now: 100_000});
+        const second = await service.apply('memory-core', 'restart', {now: 101_000});
+
+        expect(first.status).toBe('actioned');
+        expect(second).toMatchObject({
+            status    : 'deferred',
+            reasonCode: 'backoff-active'
+        });
+        expect(runtimeCalls).toHaveLength(1);
+    });
+
+    test('attempt cap escalates to alarm-only and never loops the privileged action', async () => {
+        const {service, runtimeCalls} = createService({
+            actuatorConfig: {
+                maxAttemptsPerWindow: 1,
+                baseBackoffMs       : 0
+            }
+        });
+
+        const first  = await service.apply('memory-core', 'restart', {now: 200_000});
+        const second = await service.apply('memory-core', 'restart', {now: 201_000});
+
+        expect(first.status).toBe('actioned');
+        expect(second).toMatchObject({
+            status    : 'escalated',
+            reasonCode: 'attempt-cap-reached'
+        });
+        expect(runtimeCalls).toHaveLength(1);
+
+        const attempts = await readAttempts();
+        expect(attempts['memory-core:restart'].alarmOnly).toBe(true);
+    });
+
+    test('deploy-target redeploy pages without executing arbitrary deployment code', async () => {
+        const {service, runtimeCalls, pageCalls, taskOutcomes} = createService();
+
+        const result = await service.apply('cloud-deploy', 'redeploy', {
+            now   : 300_000,
+            reason: 'config-drift'
+        });
+
+        expect(result).toMatchObject({
+            status        : 'escalated',
+            targetIdentity: {kind: 'deploy-target', id: 'cloud-deploy'}
+        });
+        expect(runtimeCalls).toEqual([]);
+        expect(pageCalls).toEqual([expect.objectContaining({
+            deployTarget      : 'cloud-deploy',
+            reason            : 'config-drift',
+            operatorPageTarget: 'AGENT:*'
+        })]);
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            taskName: 'recovery-actuator:cloud-deploy',
+            status  : 'completed',
+            details : expect.objectContaining({
+                status      : 'escalated',
+                ledgerStatus: 'escalated'
+            })
+        }));
+    });
+
+    test('arbitrary actions are rejected before allowlist or executor access', async () => {
+        const {service, runtimeCalls} = createService();
+
+        const result = await service.apply('memory-core', 'exec', {now: 400_000});
+
+        expect(result).toMatchObject({
+            status    : 'rejected',
+            reasonCode: 'unsupported-action'
+        });
+        expect(runtimeCalls).toEqual([]);
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -9,6 +9,9 @@ import {
     RecoveryActuatorService,
     normalizeRecoveryActuatorAllowlist
 } from '../../../../../../../ai/daemons/orchestrator/services/RecoveryActuatorService.mjs';
+import {TIER1_DEFAULTS} from '../../../../../fixtures/aiConfigDefaults.mjs';
+
+const DEFAULT_ACTUATOR_CONFIG = TIER1_DEFAULTS.orchestrator.recoveryActuator;
 
 test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
     let tmpDir;
@@ -26,6 +29,7 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
               pageCalls      = [],
               taskOutcomes   = [],
               actuatorConfig = {
+                  ...DEFAULT_ACTUATOR_CONFIG,
                   enabled               : true,
                   allowedComposeServices: ['memory-core'],
                   allowedDeployTargets  : ['cloud-deploy'],
@@ -44,7 +48,7 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                   healthService: {
                       recordTaskOutcome(taskName, status, details) {
                           taskOutcomes.push({taskName, status, details});
-                  }
+                      }
                   },
                   deploymentRuntimeAccessService: {
                       async applyLifecycle(options) {

--- a/test/playwright/unit/test/fixtures/aiConfigDefaults.spec.mjs
+++ b/test/playwright/unit/test/fixtures/aiConfigDefaults.spec.mjs
@@ -85,6 +85,7 @@ test.describe('aiConfigDefaults fixture contract (#11977 cycle-2)', () => {
         expect(Object.isFrozen(TIER1_DEFAULTS.engines.chroma)).toBe(true);
         expect(Object.isFrozen(TIER1_DEFAULTS.orchestrator)).toBe(true);
         expect(Object.isFrozen(TIER1_DEFAULTS.orchestrator.intervals)).toBe(true);
+        expect(Object.isFrozen(TIER1_DEFAULTS.orchestrator.recoveryActuator)).toBe(true);
     });
 
     test('nested groups are independent references from live AiConfig.data', () => {
@@ -97,10 +98,11 @@ test.describe('aiConfigDefaults fixture contract (#11977 cycle-2)', () => {
         expect(TIER1_DEFAULTS.engines).not.toBe(AiConfig.data.engines);
         expect(TIER1_DEFAULTS.engines.chroma).not.toBe(AiConfig.data.engines.chroma);
         expect(TIER1_DEFAULTS.orchestrator.intervals).not.toBe(AiConfig.data.orchestrator.intervals);
+        expect(TIER1_DEFAULTS.orchestrator.recoveryActuator).not.toBe(AiConfig.data.orchestrator.recoveryActuator);
     });
 
     test('mutating live AiConfig.data does NOT leak into TIER1_DEFAULTS snapshot', () => {
-        const originalRealm    = TIER1_DEFAULTS.auth.realm;
+        const originalRealm     = TIER1_DEFAULTS.auth.realm;
         const liveOriginalRealm = AiConfig.data.auth.realm;
 
         try {


### PR DESCRIPTION
Resolves #13884

Related: #13874
Related: #13925

Adds the gated recovery actuator surface for ADR-0026's privileged B1/Rung-3 slice: the orchestrator now owns a disabled-by-default `RecoveryActuatorService` that can restart allowlisted compose services through the merged L0 deployment-runtime lifecycle holder, page for configured deploy targets, persist anti-thrash state, write recovery-run ledger entries, and emit `recordTaskOutcome` traces for each attempted privileged action.

Evidence: L2 (mocked L0 deployment-runtime lifecycle holder + actuator envelope coverage for allowlist, anti-thrash, ledger, and config-default alignment) -> L3 required for the external-container restart AC. Residual: live operator-owned deployment smoke in Post-Merge Validation.

## Deltas from ticket

- The compose-service restart path no longer owns a docker/compose CLI executor. It delegates to `DeploymentRuntimeAccessService.applyLifecycle({operation: 'restart'})`, so socket access, Docker label identity resolution, and runtime proof metadata stay in the shared L0 holder from #13925.
- The deploy-target path pages/escalates and records the recovery trace; it deliberately does not execute arbitrary deployment commands.
- The actuator stays disabled by default and requires explicit actuator allowlists for compose services and deploy targets. The runtime holder also keeps its own allowlist, so privileged restart requires both envelopes to admit the target.

## Test Evidence

- `node --check ai/config.template.mjs`
- `node --check ai/daemons/orchestrator/Orchestrator.mjs`
- `node --check ai/daemons/orchestrator/services/RecoveryActuatorService.mjs`
- `node --check test/playwright/fixtures/aiConfigDefaults.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs`
- `node --check test/playwright/unit/test/fixtures/aiConfigDefaults.spec.mjs`
- `git diff --check origin/dev..HEAD`
- Freshness: `merge-base HEAD origin/dev == origin/dev`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs test/playwright/unit/test/fixtures/aiConfigDefaults.spec.mjs` -> 89 passed
- `npm run agent-preflight -- ai/config.template.mjs ai/daemons/orchestrator/Orchestrator.mjs ai/daemons/orchestrator/services/RecoveryActuatorService.mjs test/playwright/fixtures/aiConfigDefaults.mjs test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs test/playwright/unit/test/fixtures/aiConfigDefaults.spec.mjs` -> passed

## Post-Merge Validation

- [ ] In an operator-owned deployment, enable both `orchestrator.deploymentRuntimeAccess.enabled` and `orchestrator.recoveryActuator.enabled`, configure matching runtime + actuator allowlists, trigger a controlled compose-service restart, and verify the recovery-run ledger plus reobserve request.
- [ ] Configure an allowlisted deploy target, trigger the config-drift path, and verify the page/escalation target receives the bounded recovery trace.

## Commits

- `7348d11ba4` - `feat(ai): add gated recovery actuator (#13884)`
- `051e572c87` - `fix(ai): address recovery actuator review cleanup (#13884)`
- `742c563c13` - `fix(ai): preserve recovery actuator fixture default (#13884)`

Authored by Euclid (GPT-5, Codex Desktop). Session 1be84a2d-a911-424a-bfb0-10a51fff6303.
