### PR TITLE
feat(ai): publish recovery proof to graph (#13916)

### DIFF
--- a/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
@@ -31,6 +31,13 @@ export const RECOVERY_RUN_STATUSES = Object.freeze([
     'reobserve-requested'
 ]);
 
+export const RECOVERY_RUN_GRAPH_NODE_TYPES = Object.freeze({
+    diagnosis       : 'RECOVERY_DIAGNOSIS',
+    recoveryRun     : 'RECOVERY_RUN',
+    recoveryRunState: 'RECOVERY_RUN_STATE',
+    reobserveRequest: 'RECOVERY_REOBSERVE_REQUEST'
+});
+
 export const RECOVERY_TARGET_IDENTITY_KINDS = Object.freeze([
     'compose-service',
     'deploy-target',
@@ -49,6 +56,58 @@ export function getRecoveryRunStateFileName(recoveryRunId) {
     }
 
     return `${recoveryRunId.replace(/[^a-zA-Z0-9_.-]/g, '_')}.jsonl`;
+}
+
+/**
+ * @summary Builds the stable graph id for the latest recovery-run proof node.
+ *
+ * @param {String} recoveryRunId Stable recovery run id.
+ * @returns {String} Graph node id.
+ */
+export function getRecoveryRunGraphNodeId(recoveryRunId) {
+    validateStringId(recoveryRunId, 'recoveryRunId', 'getRecoveryRunGraphNodeId');
+
+    return `recovery-run:${recoveryRunId}`;
+}
+
+/**
+ * @summary Builds the stable graph id for one recovery-run state update.
+ *
+ * @param {String} recoveryRunId Stable recovery run id.
+ * @param {Number} updatedAt Epoch milliseconds for the update.
+ * @returns {String} Graph node id.
+ */
+export function getRecoveryRunStateGraphNodeId(recoveryRunId, updatedAt) {
+    validateStringId(recoveryRunId, 'recoveryRunId', 'getRecoveryRunStateGraphNodeId');
+    validateTimestamp(updatedAt, 'updatedAt', 'getRecoveryRunStateGraphNodeId');
+
+    return `recovery-run-state:${recoveryRunId}:${updatedAt}`;
+}
+
+/**
+ * @summary Builds the stable graph id for a recovery diagnosis proof node.
+ *
+ * @param {String} diagnosisId Stable diagnosis event id.
+ * @returns {String} Graph node id.
+ */
+export function getRecoveryDiagnosisGraphNodeId(diagnosisId) {
+    validateStringId(diagnosisId, 'diagnosisId', 'getRecoveryDiagnosisGraphNodeId');
+
+    return `recovery-diagnosis:${diagnosisId}`;
+}
+
+/**
+ * @summary Builds the stable graph id for a recovery reobserve request proof node.
+ *
+ * @param {String} recoveryRunId Stable recovery run id.
+ * @param {Number} requestedAt Epoch milliseconds when the reobserve request was made.
+ * @returns {String} Graph node id.
+ */
+export function getRecoveryReobserveGraphNodeId(recoveryRunId, requestedAt) {
+    validateStringId(recoveryRunId, 'recoveryRunId', 'getRecoveryReobserveGraphNodeId');
+    validateTimestamp(requestedAt, 'requestedAt', 'getRecoveryReobserveGraphNodeId');
+
+    return `recovery-reobserve:${recoveryRunId}:${requestedAt}`;
 }
 
 /**
@@ -236,6 +295,150 @@ export function createRecoveryRunStateEntry({
 }
 
 /**
+ * @summary Projects one recovery-run ledger entry into deterministic Memory Core graph nodes.
+ *
+ * @param {Object} entry JSONL-ready recovery run state entry.
+ * @returns {Object[]} GraphService.upsertNode specs.
+ */
+export function createRecoveryRunGraphNodes(entry) {
+    validateRecoveryRunStateEntry(entry, 'createRecoveryRunGraphNodes');
+
+    const
+        runNodeId        = getRecoveryRunGraphNodeId(entry.recoveryRunId),
+        stateNodeId      = getRecoveryRunStateGraphNodeId(entry.recoveryRunId, entry.updatedAt),
+        diagnosisNodeId  = getRecoveryDiagnosisGraphNodeId(entry.diagnosisId),
+        commonProperties = createRecoveryRunGraphProperties(entry, {runNodeId, stateNodeId, diagnosisNodeId}),
+        nodes            = [{
+            id  : runNodeId,
+            type: RECOVERY_RUN_GRAPH_NODE_TYPES.recoveryRun,
+            name       : `Recovery run ${entry.recoveryRunId}`,
+            description: `Latest recovery state for ${entry.targetIdentity.kind}:${entry.targetIdentity.id}`,
+            state     : entry.status,
+            updatedAt : entry.updatedAt,
+            properties: {
+                ...commonProperties,
+                graphNodeType    : RECOVERY_RUN_GRAPH_NODE_TYPES.recoveryRun,
+                latestStateNodeId: stateNodeId,
+                recordType       : 'recovery-run'
+            }
+        }, {
+            id  : stateNodeId,
+            type: RECOVERY_RUN_GRAPH_NODE_TYPES.recoveryRunState,
+            name       : `Recovery run state ${entry.recoveryRunId}`,
+            description: `Recovery ${entry.rung} update for ${entry.targetIdentity.kind}:${entry.targetIdentity.id}`,
+            state     : entry.status,
+            updatedAt : entry.updatedAt,
+            properties: {
+                ...commonProperties,
+                graphNodeType: RECOVERY_RUN_GRAPH_NODE_TYPES.recoveryRunState,
+                recordType   : 'recovery-run-state'
+            }
+        }, {
+            id  : diagnosisNodeId,
+            type: RECOVERY_RUN_GRAPH_NODE_TYPES.diagnosis,
+            name       : `Recovery diagnosis ${entry.diagnosisId}`,
+            description: `${entry.recoveryClass} diagnosis for ${entry.targetIdentity.kind}:${entry.targetIdentity.id}`,
+            state     : entry.recoveryClass,
+            updatedAt : entry.updatedAt,
+            properties: {
+                graphNodeType         : RECOVERY_RUN_GRAPH_NODE_TYPES.diagnosis,
+                recordType            : 'recovery-diagnosis',
+                schemaVersion         : 1,
+                recoveryRunId         : entry.recoveryRunId,
+                recoveryRunNodeId     : runNodeId,
+                recoveryRunStateNodeId: stateNodeId,
+                diagnosisId           : entry.diagnosisId,
+                recoveryClass         : entry.recoveryClass,
+                targetIdentity        : entry.targetIdentity,
+                targetIdentityKind    : entry.targetIdentity.kind,
+                targetIdentityId      : entry.targetIdentity.id,
+                sourceEntryUpdatedAt  : entry.updatedAt
+            }
+        }];
+
+    if (entry.reobserveRequest) {
+        const
+            request       = entry.reobserveRequest,
+            reobserveNode = getRecoveryReobserveGraphNodeId(entry.recoveryRunId, request.requestedAt);
+
+        nodes.push({
+            id  : reobserveNode,
+            type: RECOVERY_RUN_GRAPH_NODE_TYPES.reobserveRequest,
+            name       : `Recovery reobserve ${entry.recoveryRunId}`,
+            description: `Reobserve request for ${entry.targetIdentity.kind}:${entry.targetIdentity.id}`,
+            state     : 'pending',
+            updatedAt : request.requestedAt,
+            properties: {
+                ...request,
+                graphNodeType         : RECOVERY_RUN_GRAPH_NODE_TYPES.reobserveRequest,
+                recordType            : 'recovery-reobserve-request',
+                recoveryRunNodeId     : runNodeId,
+                recoveryRunStateNodeId: stateNodeId,
+                diagnosisNodeId,
+                targetIdentityKind    : request.targetIdentity.kind,
+                targetIdentityId      : request.targetIdentity.id
+            }
+        });
+    }
+
+    return nodes;
+}
+
+/**
+ * @summary Publishes one recovery-run ledger entry into Memory Core graph proof nodes.
+ *
+ * @param {Object} entry JSONL-ready recovery run state entry.
+ * @param {Object} options
+ * @param {Object} options.graphService GraphService-like writer with upsertNode().
+ * @returns {Promise<Object>} Publication summary.
+ */
+export async function publishRecoveryRunStateToGraph(entry, {graphService} = {}) {
+    if (!graphService || typeof graphService.upsertNode !== 'function') {
+        throw new TypeError('publishRecoveryRunStateToGraph: graphService.upsertNode is required');
+    }
+
+    const nodes = createRecoveryRunGraphNodes(entry);
+
+    for (const node of nodes) {
+        await graphService.upsertNode(node);
+    }
+
+    return {
+        publishedCount: nodes.length,
+        nodeIds       : nodes.map(node => node.id)
+    };
+}
+
+/**
+ * @summary Selects remotely-readable recovery proof records from graph node records.
+ *
+ * @param {Object[]} records Graph node records or upsert specs.
+ * @param {Object} [filters={}]
+ * @param {Object} [filters.targetIdentity] Optional target identity filter.
+ * @param {String|String[]} [filters.recoveryClass] Optional recovery class filter.
+ * @param {String|String[]} [filters.status] Optional status filter.
+ * @param {Number} [filters.limit] Optional maximum count.
+ * @returns {Object[]} Recovery-run state proof records, newest first.
+ */
+export function selectRecoveryRunGraphRecords(records, {
+    targetIdentity = null,
+    recoveryClass  = null,
+    status         = null,
+    limit          = null
+} = {}) {
+    validateArray(records, 'records', 'selectRecoveryRunGraphRecords');
+
+    return records
+        .map(normalizeRecoveryRunGraphRecord)
+        .filter(record => record !== null)
+        .filter(record => matchesTargetIdentity(record, targetIdentity))
+        .filter(record => matchesFilter(record.recoveryClass, recoveryClass))
+        .filter(record => matchesFilter(record.status, status))
+        .sort((a, b) => getEntrySortTime(b) - getEntrySortTime(a))
+        .slice(0, Number.isFinite(limit) && limit > 0 ? limit : undefined);
+}
+
+/**
  * @summary Prunes the recovery-run state directory to the newest retained artifacts.
  *
  * @param {Object} options
@@ -283,9 +486,20 @@ export async function pruneRecoveryRunStates({dir, retentionLimit} = {}) {
  * @param {Object} options
  * @param {String} options.dir Directory for per-run state files.
  * @param {Number} [options.retentionLimit] Maximum artifacts to retain.
+ * @param {Object|null} [options.graphService=null] Optional GraphService-like writer for synchronous proof publication.
+ * @param {Object|null} [options.graphPublicationSummary=null] Mutable summary counters for publication attempts.
+ * @param {Function|null} [options.onGraphPublicationError=null] Optional callback invoked after graph publication fails.
+ * @param {Function|null} [options.writeLog=null] Optional logger for graph publication failures.
  * @returns {Promise<String>} Written file path.
  */
-export async function appendRecoveryRunState(entry, {dir, retentionLimit} = {}) {
+export async function appendRecoveryRunState(entry, {
+    dir,
+    graphPublicationSummary = null,
+    graphService            = null,
+    onGraphPublicationError = null,
+    retentionLimit,
+    writeLog                = null
+} = {}) {
     if (!dir) {
         throw new TypeError('appendRecoveryRunState: dir is required');
     }
@@ -297,6 +511,15 @@ export async function appendRecoveryRunState(entry, {dir, retentionLimit} = {}) 
 
     const filePath = path.join(dir, getRecoveryRunStateFileName(entry.recoveryRunId));
     await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, 'utf8');
+
+    if (graphService) {
+        await publishRecoveryRunStateToGraphWithSurface(entry, {
+            graphPublicationSummary,
+            graphService,
+            onGraphPublicationError,
+            writeLog
+        });
+    }
 
     if (Number.isFinite(retentionLimit) && retentionLimit > 0) {
         await pruneRecoveryRunStates({dir, retentionLimit});
@@ -363,6 +586,110 @@ function getEntrySortTime(entry) {
     return 0;
 }
 
+function createRecoveryRunGraphProperties(entry, {runNodeId, stateNodeId, diagnosisNodeId}) {
+    return {
+        schemaVersion         : 1,
+        graphProjectionVersion: 1,
+        graphNodeType         : RECOVERY_RUN_GRAPH_NODE_TYPES.recoveryRunState,
+        recordType            : entry.type,
+        proofSurface          : 'recovery-run-graph-ssot',
+        recoveryRunId         : entry.recoveryRunId,
+        recoveryRunNodeId     : runNodeId,
+        recoveryRunStateNodeId: stateNodeId,
+        diagnosisId           : entry.diagnosisId,
+        diagnosisNodeId,
+        recoveryClass         : entry.recoveryClass,
+        targetIdentity        : entry.targetIdentity,
+        targetIdentityKind    : entry.targetIdentity.kind,
+        targetIdentityId      : entry.targetIdentity.id,
+        rung                  : entry.rung,
+        attempt               : entry.attempt,
+        status                : entry.status,
+        startedAt             : entry.startedAt,
+        updatedAt             : entry.updatedAt,
+        completedAt           : entry.completedAt,
+        wallClockMs           : entry.wallClockMs,
+        backoffUntil          : entry.backoffUntil,
+        hasReobserveRequest   : entry.reobserveRequest !== null,
+        details               : entry.details
+    };
+}
+
+function matchesFilter(value, filter) {
+    if (filter === null || filter === undefined) {
+        return true;
+    }
+
+    return Array.isArray(filter) ? filter.includes(value) : value === filter;
+}
+
+function matchesTargetIdentity(record, targetIdentity) {
+    if (targetIdentity === null || targetIdentity === undefined) {
+        return true;
+    }
+
+    return record.targetIdentityKind === targetIdentity.kind && record.targetIdentityId === targetIdentity.id;
+}
+
+function normalizeRecoveryRunGraphRecord(record) {
+    if (!record || typeof record !== 'object') {
+        return null;
+    }
+
+    const
+        properties = record.properties && typeof record.properties === 'object' ? record.properties : record,
+        nodeType   = record.type || record.label || properties.graphNodeType;
+
+    if (nodeType !== RECOVERY_RUN_GRAPH_NODE_TYPES.recoveryRunState) {
+        return null;
+    }
+
+    return {
+        id: record.id || properties.recoveryRunStateNodeId,
+        ...properties
+    };
+}
+
+async function publishRecoveryRunStateToGraphWithSurface(entry, {
+    graphPublicationSummary,
+    graphService,
+    onGraphPublicationError,
+    writeLog
+}) {
+    incrementGraphPublicationSummary(graphPublicationSummary, 'attempted', 1);
+
+    try {
+        const publication = await publishRecoveryRunStateToGraph(entry, {graphService});
+        incrementGraphPublicationSummary(graphPublicationSummary, 'published', publication.publishedCount);
+    } catch (error) {
+        incrementGraphPublicationSummary(graphPublicationSummary, 'failed', 1);
+        recordGraphPublicationError(graphPublicationSummary, entry, error);
+
+        onGraphPublicationError?.({entry, error});
+        writeLog?.(`[RecoveryRunStateStore] Graph publication failed for ${entry.recoveryRunId}: ${error.message}`);
+    }
+}
+
+function incrementGraphPublicationSummary(summary, key, amount) {
+    if (!summary) {
+        return;
+    }
+
+    summary[key] = (summary[key] || 0) + amount;
+}
+
+function recordGraphPublicationError(summary, entry, error) {
+    if (!summary) {
+        return;
+    }
+
+    summary.errors ??= [];
+    summary.errors.push({
+        recoveryRunId: entry.recoveryRunId,
+        message      : error.message
+    });
+}
+
 function validateArray(value, name, callerName) {
     if (!Array.isArray(value)) {
         throw new TypeError(`${callerName}: ${name} must be an array`);
@@ -411,6 +738,46 @@ function validateReobserveRequest(value, recoveryRunId, callerName) {
     }
     if (value.recoveryRunId !== recoveryRunId) {
         throw new TypeError(`${callerName}: reobserveRequest.recoveryRunId must match recoveryRunId`);
+    }
+}
+
+function validateRecoveryRunStateEntry(value, callerName) {
+    validateObject(value, 'entry', callerName);
+
+    if (value.type !== 'recovery-run-state') {
+        throw new TypeError(`${callerName}: entry.type must be 'recovery-run-state'`);
+    }
+
+    validateStringId(value.recoveryRunId, 'recoveryRunId', callerName);
+    validateStringId(value.diagnosisId, 'diagnosisId', callerName);
+    validateEnum(value.recoveryClass, RECOVERY_CLASSES, 'recoveryClass', callerName);
+    createRecoveryTargetIdentity(value.targetIdentity);
+    validateEnum(value.rung, RECOVERY_RUN_RUNG_IDS, 'rung', callerName);
+    validateEnum(value.status, RECOVERY_RUN_STATUSES, 'status', callerName);
+    validateTimestamp(value.startedAt, 'startedAt', callerName);
+    validateTimestamp(value.updatedAt, 'updatedAt', callerName);
+    validateObject(value.details, 'details', callerName);
+
+    if (!Number.isInteger(value.attempt) || value.attempt < 1) {
+        throw new TypeError(`${callerName}: attempt must be a positive integer`);
+    }
+    if (value.completedAt !== null) {
+        validateTimestamp(value.completedAt, 'completedAt', callerName);
+    }
+    if (value.wallClockMs !== null && (!Number.isFinite(value.wallClockMs) || value.wallClockMs < 0)) {
+        throw new TypeError(`${callerName}: wallClockMs must be null or a non-negative number`);
+    }
+    if (value.backoffUntil !== null) {
+        validateTimestamp(value.backoffUntil, 'backoffUntil', callerName);
+    }
+    if (value.reobserveRequest !== null) {
+        validateReobserveRequest(value.reobserveRequest, value.recoveryRunId, callerName);
+    }
+}
+
+function validateStringId(value, name, callerName) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new TypeError(`${callerName}: ${name} is required`);
     }
 }
 

--- a/test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs
@@ -8,12 +8,20 @@ import path                                      from 'path';
 import {
     appendRecoveryRunState,
     createRecoveryDiagnosisEvent,
+    createRecoveryRunGraphNodes,
     createRecoveryReobserveRequest,
     createRecoveryRunStateEntry,
     createRecoveryTargetIdentity,
+    getRecoveryDiagnosisGraphNodeId,
+    getRecoveryReobserveGraphNodeId,
+    getRecoveryRunGraphNodeId,
+    getRecoveryRunStateGraphNodeId,
     getRecoveryRunStateFileName,
+    publishRecoveryRunStateToGraph,
     pruneRecoveryRunStates,
-    readRecentRecoveryRunStates
+    readRecentRecoveryRunStates,
+    RECOVERY_RUN_GRAPH_NODE_TYPES,
+    selectRecoveryRunGraphRecords
 } from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
 
 test.describe('RecoveryRunStateStore', () => {
@@ -155,6 +163,109 @@ test.describe('RecoveryRunStateStore', () => {
         expect(() => runEntry('bad-attempt', 2000, {attempt: 0})).toThrow(/attempt/);
     });
 
+    test('projects recovery run entries into deterministic graph proof nodes', () => {
+        const entry = runEntry('recovery-run-1', 2000, {
+            diagnosisEventOverrides: {
+                diagnosisId   : 'diagnosis-2',
+                targetIdentity: createRecoveryTargetIdentity({kind: 'compose-service', id: 'memory'})
+            }
+        });
+
+        const nodes = createRecoveryRunGraphNodes(entry);
+
+        expect(nodes.map(node => node.id)).toEqual([
+            getRecoveryRunGraphNodeId('recovery-run-1'),
+            getRecoveryRunStateGraphNodeId('recovery-run-1', 2000),
+            getRecoveryDiagnosisGraphNodeId('diagnosis-2'),
+            getRecoveryReobserveGraphNodeId('recovery-run-1', 2000)
+        ]);
+
+        const runNode = nodes.find(node => node.type === RECOVERY_RUN_GRAPH_NODE_TYPES.recoveryRun);
+        expect(runNode).toMatchObject({
+            state     : 'reobserve-requested',
+            properties: {
+                recordType        : 'recovery-run',
+                targetIdentityId  : 'memory',
+                targetIdentityKind: 'compose-service',
+                latestStateNodeId : getRecoveryRunStateGraphNodeId('recovery-run-1', 2000)
+            }
+        });
+
+        const stateNode = nodes.find(node => node.type === RECOVERY_RUN_GRAPH_NODE_TYPES.recoveryRunState);
+        expect(stateNode).toMatchObject({
+            properties: {
+                recordType        : 'recovery-run-state',
+                recoveryClass     : 'crash',
+                recoveryRunId     : 'recovery-run-1',
+                status            : 'reobserve-requested',
+                targetIdentityId  : 'memory',
+                targetIdentityKind: 'compose-service'
+            }
+        });
+
+        const diagnosisNode = nodes.find(node => node.type === RECOVERY_RUN_GRAPH_NODE_TYPES.diagnosis);
+        expect(diagnosisNode).toMatchObject({
+            properties: {
+                diagnosisId           : 'diagnosis-2',
+                recordType            : 'recovery-diagnosis',
+                recoveryRunStateNodeId: getRecoveryRunStateGraphNodeId('recovery-run-1', 2000)
+            }
+        });
+    });
+
+    test('publishes recovery graph nodes idempotently through GraphService upsertNode', async () => {
+        const entry   = runEntry('recovery-run-1', 2000);
+        const upserts = new Map();
+        const calls   = [];
+
+        const graphService = {
+            async upsertNode(node) {
+                calls.push(node.id);
+                upserts.set(node.id, node);
+            }
+        };
+
+        const first  = await publishRecoveryRunStateToGraph(entry, {graphService});
+        const second = await publishRecoveryRunStateToGraph(entry, {graphService});
+
+        expect(first).toEqual(second);
+        expect(first.publishedCount).toBe(4);
+        expect(upserts.size).toBe(4);
+        expect(calls).toHaveLength(8);
+    });
+
+    test('selectRecoveryRunGraphRecords filters graph state records for inspect-deployment providers', () => {
+        const records = [
+            ...createRecoveryRunGraphNodes(runEntry('recovery-memory', 2000, {
+                diagnosisEventOverrides: {
+                    recoveryClass : 'crash',
+                    targetIdentity: createRecoveryTargetIdentity({kind: 'compose-service', id: 'memory'})
+                }
+            })),
+            ...createRecoveryRunGraphNodes(runEntry('recovery-model', 3000, {
+                diagnosisEventOverrides: {
+                    recoveryClass : 'contention',
+                    targetIdentity: createRecoveryTargetIdentity({kind: 'compose-service', id: 'model'})
+                }
+            }))
+        ];
+
+        const proofRecords = selectRecoveryRunGraphRecords(records, {
+            limit         : 1,
+            recoveryClass : 'contention',
+            status        : 'reobserve-requested',
+            targetIdentity: {kind: 'compose-service', id: 'model'}
+        });
+
+        expect(proofRecords).toHaveLength(1);
+        expect(proofRecords[0]).toMatchObject({
+            recoveryRunId     : 'recovery-model',
+            targetIdentityId  : 'model',
+            targetIdentityKind: 'compose-service',
+            updatedAt         : 3000
+        });
+    });
+
     test('appends and reads recent recovery run entries newest first', async () => {
         await appendRecoveryRunState(runEntry('recovery-old', 1000), {dir: tmpDir});
         await appendRecoveryRunState(runEntry('recovery-new', 2000), {dir: tmpDir});
@@ -162,6 +273,64 @@ test.describe('RecoveryRunStateStore', () => {
         const recent = await readRecentRecoveryRunStates({dir: tmpDir, limit: 1});
 
         expect(recent.map(entry => entry.recoveryRunId)).toEqual(['recovery-new']);
+    });
+
+    test('appendRecoveryRunState publishes graph proof while preserving the JSONL return contract', async () => {
+        const
+            summary = {},
+            nodes   = [];
+
+        const filePath = await appendRecoveryRunState(runEntry('recovery-graph', 2000), {
+            dir                    : tmpDir,
+            graphPublicationSummary: summary,
+            graphService           : {
+                async upsertNode(node) {
+                    nodes.push(node);
+                }
+            }
+        });
+
+        expect(path.basename(filePath)).toBe(getRecoveryRunStateFileName('recovery-graph'));
+        expect(summary).toEqual({attempted: 1, published: 4});
+        expect(nodes).toHaveLength(4);
+
+        const recent = await readRecentRecoveryRunStates({dir: tmpDir, limit: 1});
+        expect(recent[0].recoveryRunId).toBe('recovery-graph');
+    });
+
+    test('appendRecoveryRunState surfaces graph publication failure without losing the local ledger', async () => {
+        const
+            errors  = [],
+            logs    = [],
+            summary = {};
+
+        const filePath = await appendRecoveryRunState(runEntry('recovery-local-first', 2000), {
+            dir                    : tmpDir,
+            graphPublicationSummary: summary,
+            graphService           : {
+                async upsertNode() {
+                    throw new Error('graph unavailable');
+                }
+            },
+            onGraphPublicationError(payload) {
+                errors.push(payload);
+            },
+            writeLog(message) {
+                logs.push(message);
+            }
+        });
+
+        expect(path.basename(filePath)).toBe(getRecoveryRunStateFileName('recovery-local-first'));
+        expect(summary).toEqual({
+            attempted: 1,
+            failed   : 1,
+            errors   : [{recoveryRunId: 'recovery-local-first', message: 'graph unavailable'}]
+        });
+        expect(errors).toHaveLength(1);
+        expect(logs[0]).toContain('Graph publication failed for recovery-local-first');
+
+        const recent = await readRecentRecoveryRunStates({dir: tmpDir, limit: 1});
+        expect(recent[0].recoveryRunId).toBe('recovery-local-first');
     });
 
     test('appendRecoveryRunState applies the write-side retention cap', async () => {


### PR DESCRIPTION
Resolves #13916

Adds the structured graph projection seam for recovery-run proof records. Recovery-run ledger entries now produce deterministic Memory Core graph node specs for the latest run, each state update, the diagnosis, and any reobserve request; `appendRecoveryRunState()` can synchronously publish those nodes through an injected `GraphService`-like writer after the JSONL append succeeds.

Evidence: L2 (focused Playwright unit tests with mocked graph upserts and graph-record filtering) -> L2 required (projection/idempotency/failure-surfacing/data-provider ACs). No residuals for #13916.

Related: #13860
Related: #13874
Related: #13889
Related: #13914

## Deltas from ticket

After the #13860 dependency-up resequence, this PR stays deliberately below the L0 docker-runtime primitive. It does not implement raw docker logs/stats, socket proxying, or the `inspect_deployment` MCP handler; those remain with #13914 and the L0 convergence thread.

The publication path is synchronous with the local ledger append when a `graphService` is supplied. The JSONL append remains the local durability boundary, and graph publication failure is surfaced through summary counters/callback/log while leaving the local ledger entry intact. This preserves proof projection without making graph writes the recovery durability gate.

The current `dev` branch has the recovery-run store and schemas but not the unmerged #13915 recovery service wiring. This PR provides the projection contract and append-time publication hook that recovery writers can call; it does not wire unmerged recovery-service code from another branch.

## Test Evidence

- `node --check ai/services/memory-core/helpers/recoveryRunStateStore.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs` - 14 passed
- `git diff --check`

## Post-Merge Validation

- [ ] When the recovery service lands on `dev`, verify its `appendRecoveryRunState()` call supplies the graph writer and that recent recovery proof appears through graph reads before #13914 consumes it.

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
