### PR TITLE
fix(ai): harden REM token guardrail (#13918)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -36,9 +36,10 @@ import {
     createRemPhaseState,
     createRemRunStateEntry
 } from '../../../services/memory-core/helpers/remRunStateStore.mjs';
+import {bytesToTokens} from '../../../services/memory-core/helpers/consumerFrictionHelper.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname  = path.dirname(__filename);
 
 // Bounds the re-serve ONLY for the DETERMINISTICALLY-terminal failure: `skip-over-band` (payload over the
 // model's safe band) is a reliable size check — that session genuinely cannot be processed at this cadence
@@ -52,7 +53,7 @@ const PERMANENT_DEFER_REASONS = new Set(['skip-over-band']);
 
 function estimatePayloadTokens(payload) {
     const text = payload === undefined || payload === null ? '' : String(payload);
-    return Math.ceil(Buffer.byteLength(text, 'utf8') / 4);
+    return bytesToTokens(Buffer.byteLength(text, 'utf8'));
 }
 
 function toErrorMessage(error) {
@@ -151,10 +152,10 @@ function splitFreshAndAgedUndigested(rows, maxToProcess) {
         return [];
     }
 
-    const reserve = maxToProcess > 1 ? Math.min(readRequiredNumberLeaf('undigestedSessionFreshReserve'), maxToProcess - 1) : maxToProcess;
-    const fresh   = [...rows].sort(compareSessionRows('DESC')).slice(0, reserve);
+    const reserve  = maxToProcess > 1 ? Math.min(readRequiredNumberLeaf('undigestedSessionFreshReserve'), maxToProcess - 1) : maxToProcess;
+    const fresh    = [...rows].sort(compareSessionRows('DESC')).slice(0, reserve);
     const freshIds = new Set(fresh.map(row => row.id));
-    const aged = [...rows]
+    const aged     = [...rows]
         .filter(row => !freshIds.has(row.id))
         .sort(compareSessionRows('ASC'))
         .slice(0, maxToProcess - fresh.length);
@@ -241,7 +242,7 @@ class DreamService extends Base {
         }
 
         try {
-            const byId = new Map();
+            const byId      = new Map();
             const readBatch = offset => this.sessionsCollection.get({
                 include: ['metadatas', 'documents'],
                 limit,
@@ -301,7 +302,7 @@ class DreamService extends Base {
         if (aiConfig.modelProvider === 'openAiCompatible') {
             const providerStart = Date.now();
             try {
-                const url = new URL('/v1/models', aiConfig.openAiCompatible.host);
+                const url  = new URL('/v1/models', aiConfig.openAiCompatible.host);
                 const ping = await fetch(url.toString(), { method: 'GET', signal: AbortSignal.timeout(5000) });
                 if (!ping.ok) throw new Error('API provider not running');
                 perPhaseStates.push(finishPhase('legacyProviderProbe', providerStart, 'completed', {
@@ -428,7 +429,7 @@ class DreamService extends Base {
                     }
                     const rawIngestErrors = Array.isArray(ingestStats.errors) ? ingestStats.errors : [];
                     const ingestErrors    = rawIngestErrors.length;
-                    const ingestTime = ((Date.now() - ingestStart) / 1000).toFixed(1);
+                    const ingestTime      = ((Date.now() - ingestStart) / 1000).toFixed(1);
                     logger.info(`[DreamService]   -> Memory/Session graph ingestion took: ${ingestTime}s (${ingestStats.memoriesUpserted} upserted, ${ingestStats.memoriesSkipped} skipped, ${ingestErrors} errors)`);
 
                     const ingestErrorReasons = rawIngestErrors.map(item => toErrorMessage(item));
@@ -675,8 +676,8 @@ class DreamService extends Base {
         const startedAtMs = Date.now();
         const startedAt   = new Date(startedAtMs);
         const runId       = `rem-${crypto.randomUUID()}`;
-        const perPhaseStates = [];
-        let perSessionStates = [];
+        const perPhaseStates   = [];
+        let   perSessionStates = [];
 
         const baseOutcome = {
             runId,
@@ -785,7 +786,7 @@ class DreamService extends Base {
         // work-completed `completed` path without requiring a return-value refactor on
         // processUndigestedSessions. A pre-call query is cheaper than the alternative
         // of inspecting graph state after the fact.
-        let sessionCount = 0;
+        let   sessionCount      = 0;
         const sessionQueryStart = Date.now();
         try {
             const undigested = await this.findUndigestedSessions();
@@ -830,7 +831,7 @@ class DreamService extends Base {
         // Work path: process sessions, then run decay as the cycle-finalization step
         // under the same lease window the caller already holds.
         try {
-            const processStart = Date.now();
+            const processStart  = Date.now();
             const processResult = await this.processUndigestedSessions();
             if (Array.isArray(processResult?.perPhaseStates)) {
                 perPhaseStates.push(...processResult.perPhaseStates);
@@ -917,7 +918,7 @@ class DreamService extends Base {
         }
 
         const ollamaReadinessConfig = buildOllamaReadinessConfig(AiConfig);
-        const capacity = ollamaReadinessConfig.roles.length > 0
+        const capacity              = ollamaReadinessConfig.roles.length > 0
             ? await ensureOllamaModelsReady({
                 ...ollamaReadinessConfig,
                 attempts    : readinessConfig.attempts,

--- a/ai/services/graph/sessionChunker.mjs
+++ b/ai/services/graph/sessionChunker.mjs
@@ -8,18 +8,18 @@
  * wraps: it splits a session into bounded, turn-aligned chunks so each chunk stays under the safe band.
  *
  * Pure by design — no I/O, no LLM round-trip, no graph mutation — so chunk boundaries are deterministic and
- * fully unit-testable. The estimator is a coarse char-based heuristic (no model call), which keeps boundaries
- * reproducible across runs; the integration MAY inject the guardrail's own estimator for parity.
+ * fully unit-testable. The estimator is a conservative char-based heuristic (no model call), which keeps
+ * boundaries reproducible across runs; the integration MAY inject the guardrail's own estimator for parity.
  *
  * @module ai/services/graph/sessionChunker
  */
 
 /**
- * ~4 characters per token — the standard coarse heuristic. Deterministic by construction (no model round-trip),
- * which is what makes chunk boundaries reproducible.
+ * ~3 characters per token — the conservative dense REM / Agent OS heuristic. Deterministic by construction
+ * (no model round-trip), which is what makes chunk boundaries reproducible.
  * @type {Number}
  */
-const DEFAULT_TOKENS_PER_CHAR = 0.25;
+const DEFAULT_TOKENS_PER_CHAR = 1 / 3;
 
 /**
  * @summary Coarse, deterministic token estimate (`ceil(chars × ratio)`).
@@ -28,7 +28,7 @@ const DEFAULT_TOKENS_PER_CHAR = 0.25;
  * session produce identical chunk boundaries (the determinism AC). Non-string input estimates to `0`.
  *
  * @param {String} text
- * @param {Number} [tokensPerChar=0.25]
+ * @param {Number} [tokensPerChar=1/3]
  * @returns {Number} Estimated token count.
  */
 export function estimateTokens(text, tokensPerChar = DEFAULT_TOKENS_PER_CHAR) {

--- a/ai/services/memory-core/helpers/consumerFrictionHelper.mjs
+++ b/ai/services/memory-core/helpers/consumerFrictionHelper.mjs
@@ -29,8 +29,9 @@
  *   once `count >= PROBABILISTIC_EMIT_THRESHOLD` to avoid burying single transient errors
  *   in the handoff feed.
  *
- * Token estimation: V1 uses a 4-chars/token heuristic (`Math.ceil(Buffer.byteLength(payload) / 4)`)
- * because the codebase has no canonical provider-specific tokenizer. Bytes are retained on
+ * Token estimation: V1 uses a conservative 3-bytes/token heuristic
+ * (`Math.ceil(Buffer.byteLength(payload) / 3)`) because the codebase has no canonical
+ * provider-specific tokenizer and REM payloads are code/JSON/log dense. Bytes are retained on
  * the record as evidence; tokens are the durable LLM-relevant contract.
  * Future V2 may integrate with Model-Stats registry (ADR 0012) for per-provider tokenization. ticket-ref-ok: load-bearing ADR design-pointer (mirrors the @see below).
  *
@@ -51,7 +52,7 @@ import {PROVIDER_TIMEOUT_CODE} from '../../../provider/createTimeoutError.mjs';
  * @property {'pre-invocation' | 'post-invocation-failure'} emissionPoint When the friction was detected.
  * @property {'split-document' | 'compress-payload' | 'extract-anchor' | 'reduce-review-cycle' | 'schema-repair' | 'unknown'} suggestionKind Enum-backed structured suggestion for substrate-evolution action.
  * @property {Number} inputBytes Raw byte size of the payload that triggered the friction — evidence.
- * @property {Number} inputTokensEstimate Estimated token count of the input payload (Math.ceil(inputBytes / 4) heuristic) — durable LLM-relevant metric.
+ * @property {Number} inputTokensEstimate Estimated token count of the input payload (Math.ceil(inputBytes / 3) heuristic) — durable LLM-relevant metric.
  * @property {Number} contextLimitTokens Configured context window of the consumer model (tokens) — durable contract.
  * @property {Number} [safeProcessingLimitTokens] Optional safer threshold in tokens (default = Math.floor(contextLimitTokens * 0.75)).
  * @property {String} firstSeenAt ISO 8601 timestamp of the first emission for this aggregation-tuple.
@@ -111,12 +112,14 @@ const AGGREGATOR_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_SAFE_FRACTION = 0.75;
 
 /**
- * @summary Bytes-per-token heuristic for English-prevalent text.
- * Conservative estimate; provider-specific tokenizers may yield slightly different counts.
+ * @summary Bytes-per-token heuristic for dense REM / Agent OS text.
+ * Conservative estimate; code, JSON, and logs tokenize denser than the old English-prevalent
+ * 4-bytes/token heuristic, which let incident-shaped payloads pass the safe band and overflow
+ * local Gemma contexts before the guardrail could skip them.
  * V2 may delegate to Model-Stats registry per-provider.
  * @type {Number}
  */
-const BYTES_PER_TOKEN_HEURISTIC = 4;
+const BYTES_PER_TOKEN_HEURISTIC = 3;
 
 /**
  * Module-singleton aggregator. Keys are `${assetRef}|${consumer}|${symptom}` tuple-hashes;
@@ -130,7 +133,7 @@ function tupleKey(assetRef, consumer, symptom) {
 }
 
 /**
- * @summary Estimates token count from raw bytes via the 4-chars/token English heuristic.
+ * @summary Estimates token count from raw bytes via the conservative dense-text heuristic.
  * Exported for test verification + caller-side cross-references; not provider-specific.
  *
  * @param {Number} bytes Raw byte count.
@@ -228,11 +231,11 @@ export function emitConsumerFriction(input) {
     const existing = _aggregator.get(key);
 
     const entry = existing || {
-        count          : 0,
-        firstSeenAt    : nowIso,
-        lastSeenAt     : nowIso,
-        latestFriction : null,
-        surfaced       : false
+        count         : 0,
+        firstSeenAt   : nowIso,
+        lastSeenAt    : nowIso,
+        latestFriction: null,
+        surfaced      : false
     };
 
     entry.count += 1;
@@ -347,22 +350,22 @@ export async function invokeWithGuardrail({
         throw new TypeError(`invokeWithGuardrail: contextLimitTokens must be a positive finite number, got ${contextLimitTokens}`);
     }
 
-    const inputBytes              = Buffer.byteLength(inputPayload || '', 'utf8');
-    const inputTokensEstimate     = bytesToTokens(inputBytes);
-    const effectiveSafeTokens     = Number.isFinite(safeProcessingLimitTokens)
+    const inputBytes          = Buffer.byteLength(inputPayload || '', 'utf8');
+    const inputTokensEstimate = bytesToTokens(inputBytes);
+    const effectiveSafeTokens = Number.isFinite(safeProcessingLimitTokens)
         ? safeProcessingLimitTokens
         : Math.floor(contextLimitTokens * DEFAULT_SAFE_FRACTION);
-    const consumerKey             = consumer || model;
+    const consumerKey = consumer || model;
 
     if (inputTokensEstimate > effectiveSafeTokens) {
         const symptom = 'size-precheck-skip';
         const entry   = emitConsumerFriction({
             assetRef,
-            consumer                : consumerKey,
+            consumer                 : consumerKey,
             model,
             symptom,
-            emissionPoint           : 'pre-invocation',
-            suggestionKind          : suggestionKind || deriveSuggestionKind(symptom, assetRef),
+            emissionPoint            : 'pre-invocation',
+            suggestionKind           : suggestionKind || deriveSuggestionKind(symptom, assetRef),
             inputBytes,
             inputTokensEstimate,
             contextLimitTokens,
@@ -382,17 +385,17 @@ export async function invokeWithGuardrail({
         const errTail = String(err?.message || err || '').substring(0, 200);
         const entry   = emitConsumerFriction({
             assetRef,
-            consumer                : consumerKey,
+            consumer                 : consumerKey,
             model,
             symptom,
-            emissionPoint           : 'post-invocation-failure',
-            suggestionKind          : suggestionKind || deriveSuggestionKind(symptom, assetRef),
+            emissionPoint            : 'post-invocation-failure',
+            suggestionKind           : suggestionKind || deriveSuggestionKind(symptom, assetRef),
             inputBytes,
             inputTokensEstimate,
             contextLimitTokens,
             safeProcessingLimitTokens: effectiveSafeTokens,
             serviceDomain,
-            note                    : note || errTail
+            note                     : note || errTail
         });
 
         return {result: null, friction: entry.latestFriction};

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -38,8 +38,8 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
 
     let originalGenerate;
     let originalAppendFile;
-    let appendedContent = [];
-    let providerPrompt = '';
+    let   appendedContent = [];
+    let   providerPrompt  = '';
     const freshVerifiedAt = new Date().toISOString();
 
     function createNlActionLogTable() {
@@ -212,7 +212,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             KBRecorderService.db.exec('DELETE FROM kb_query_log; DELETE FROM kb_query_faqs;');
         }
 
-        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        const tmpDir      = path.resolve(process.cwd(), 'tmp');
         const mockHandoff = path.join(tmpDir, 'mock_sandman_handoff.md');
         if (fs.existsSync(mockHandoff)) {
             try { fs.unlinkSync(mockHandoff); } catch (e) {}
@@ -301,7 +301,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         await DreamService.inferTestGapsFromSession(payload);
 
         const coveredNode = GraphService.db.nodes.get('covered-class');
-        const edge = GraphService.db.edges.items.find(e =>
+        const edge        = GraphService.db.edges.items.find(e =>
             e.source === 'test-file-button-feature' &&
             e.target === 'covered-class' &&
             e.type === 'VALIDATES'
@@ -599,7 +599,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             }
         });
 
-        const result = await DreamService.executeNLActionDigest();
+        const result    = await DreamService.executeNLActionDigest();
         const classNode = GraphService.db.nodes.get('class-stale-nl-evidence');
 
         expect(result.resetWeakEvidenceAnnotations).toBe(1);
@@ -610,7 +610,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     });
 
     test('findUndigestedSessions fails loud when remSleepBatchLimit is malformed in the imported config', async () => {
-        const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
+        const aiConfig                   = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
               originalRemSleepBatchLimit = aiConfig.remSleepBatchLimit;
 
         aiConfig.remSleepBatchLimit = Number.NaN;
@@ -740,7 +740,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         // Concept-graph pass is session-independent and hoisted to cycle-scope.
         await DreamService.inferConceptGraphGaps();
 
-        const covered     = GraphService.db.nodes.get('concept-covered');
+        const covered      = GraphService.db.nodes.get('concept-covered');
         const missingGuide = GraphService.db.nodes.get('concept-missing-guide');
 
         expect(covered.properties.capabilityGap).toBeUndefined();
@@ -1174,12 +1174,12 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             meta    : {sessionId: 'agent-session-partial', title: 'Partial ingest session'}
         };
 
-        let testGapCalls     = 0;
-        let conceptGapCalls  = 0;
-        let sessionUpdates          = 0;
+        let   testGapCalls          = 0;
+        let   conceptGapCalls       = 0;
+        let   sessionUpdates        = 0;
         const sessionUpdatePayloads = [];
         const infoMessages          = [];
-        const warnMessages   = [];
+        const warnMessages          = [];
 
         const orig = {
             provider          : aiConfig.modelProvider,
@@ -1322,19 +1322,20 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         const FileSystemIngestor      = (await import('../../../../../../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
         const TopologyInferenceEngine = (await import('../../../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
 
-        // The session has already failed MAX-1 (2) times; this cycle's failure is the 3rd. Payload OVER the
-        // model's safe band → deferReason resolves to the DETERMINISTICALLY-terminal `skip-over-band` (the
-        // only reason that bounds the re-serve — a genuine size check, not a guess). It must be bounded out
-        // as `deferred` so the steady cadence stops re-serving a session the model demonstrably cannot fit.
+        // The session has already failed MAX-1 (2) times; this cycle's failure is the 3rd. 400k dense bytes
+        // estimate to 133,334 tokens through the shared guardrail helper (bytes/3) but only 100,000 tokens
+        // through the old split-brain bytes/4 classifier. This must classify as `skip-over-band`, not
+        // `under-band-choke`, so the steady cadence stops re-serving a session the model demonstrably cannot fit.
         const mockSession = {
             id      : 'chroma-summary-overband',
-            document: 'x'.repeat(2_000_000),
+            document: 'x'.repeat(400_000),
             meta    : {sessionId: 'agent-session-overband', title: 'Over-band session', digestAttempts: 2}
         };
 
         const sessionUpdatePayloads = [];
-        const orig = {
+        const orig                  = {
             provider          : aiConfig.modelProvider,
+            safeProcessing    : aiConfig.localModels.chat.safeProcessingLimitTokens,
             findUndigested    : DreamService.findUndigestedSessions,
             sessionsCollection: DreamService.sessionsCollection,
             inferTest         : DreamService.inferTestGapsFromSession,
@@ -1352,7 +1353,8 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         };
 
         try {
-            aiConfig.modelProvider    = 'mock-provider';
+            aiConfig.modelProvider                                  = 'mock-provider';
+            aiConfig.localModels.chat.safeProcessingLimitTokens      = 100_000;
             DreamService.isProcessing = false;
 
             DreamService.findUndigestedSessions = async () => [mockSession];
@@ -1381,7 +1383,8 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             expect(meta.digestAttempts).toBe(3);
             expect(meta.deferReason).toBe('skip-over-band');
         } finally {
-            aiConfig.modelProvider                            = orig.provider;
+            aiConfig.modelProvider                                  = orig.provider;
+            aiConfig.localModels.chat.safeProcessingLimitTokens      = orig.safeProcessing;
             DreamService.findUndigestedSessions               = orig.findUndigested;
             DreamService.sessionsCollection                   = orig.sessionsCollection;
             DreamService.inferTestGapsFromSession             = orig.inferTest;
@@ -1418,7 +1421,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         };
 
         const sessionUpdatePayloads = [];
-        const orig = {
+        const orig                  = {
             provider          : aiConfig.modelProvider,
             findUndigested    : DreamService.findUndigestedSessions,
             sessionsCollection: DreamService.sessionsCollection,
@@ -1503,7 +1506,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         };
 
         const sessionUpdatePayloads = [];
-        const orig = {
+        const orig                  = {
             provider          : aiConfig.modelProvider,
             findUndigested    : DreamService.findUndigestedSessions,
             sessionsCollection: DreamService.sessionsCollection,
@@ -1833,8 +1836,8 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     test('synthesizeGoldenPath should mathematically select and inject Golden Path while rejecting BLOCKS', async () => {
         // Mock StorageRouter to return deterministic ChromaDB metric formats
         const originalGetSummary = StorageRouter.getSummaryCollection;
-        const originalGetGraph = StorageRouter.getGraphCollection;
-        const originalPrepare = GraphService.db.storage.db.prepare;
+        const originalGetGraph   = StorageRouter.getGraphCollection;
+        const originalPrepare    = GraphService.db.storage.db.prepare;
 
         StorageRouter.getSummaryCollection = async () => {
              return {
@@ -1925,7 +1928,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         TextEmbeddingService.embedText = async () => new Array(4096).fill(0.1);
 
         // Setup markdown with a conflicting gap to verify dynamic stripping / injection sequence
-        const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const aiConfig    = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         const handoffFile = aiConfig.handoffFilePath,
               originalModelProvider = aiConfig.modelProvider;
 
@@ -1965,7 +1968,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             const twiceContent = fs.readFileSync(handoffFile, 'utf8');
 
             // Count capabilities gaps to ensure idempotence
-            const firstCount = finalContent.split('[Codebase Gap]').length;
+            const firstCount  = finalContent.split('[Codebase Gap]').length;
             const secondCount = twiceContent.split('[Codebase Gap]').length;
             expect(secondCount).toBe(firstCount);
         } finally {
@@ -1987,8 +1990,8 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     });
 
     test('should retry extraction on malformed JSON payload up to 3 times to fix #9913', async () => {
-        let executionCount = 0;
-        const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
+        let   executionCount = 0;
+        const aiConfig       = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
               baseGenerate = OpenAiCompatible.prototype.generate,
               originalModelProvider = aiConfig.modelProvider;
 

--- a/test/playwright/unit/ai/services/graph/sessionChunker.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/sessionChunker.spec.mjs
@@ -1,4 +1,4 @@
-import {test, expect}              from '@playwright/test';
+import {test, expect}                 from '@playwright/test';
 import {chunkSession, estimateTokens} from '../../../../../../ai/services/graph/sessionChunker.mjs';
 
 /**
@@ -6,21 +6,25 @@ import {chunkSession, estimateTokens} from '../../../../../../ai/services/graph/
  * No Neo bootstrap — the module is a pure helper, mirroring the queries.mjs / consumerFrictionHelper pattern.
  */
 test.describe('ai/services/graph/sessionChunker', () => {
-    // A 400-char turn estimates to 100 tokens at the 0.25 ratio; a 40-token limit forces chunking.
+    // A 300-char turn estimates to 100 tokens at the conservative 1/3 ratio; a 40-token limit forces chunking.
     const turn  = (label, chars) => `${label}:` + 'x'.repeat(Math.max(0, chars - label.length - 1));
-    const TOKENS_PER_CHAR = 0.25;
 
     test.describe('estimateTokens', () => {
-        test('is a deterministic char-based estimate (ceil of chars × 0.25)', () => {
+        test('is a deterministic conservative char-based estimate (ceil of chars / 3)', () => {
             expect(estimateTokens('')).toBe(0);
-            expect(estimateTokens('x'.repeat(400))).toBe(100);
-            expect(estimateTokens('x'.repeat(401))).toBe(101); // ceil(100.25)
+            expect(estimateTokens('x'.repeat(300))).toBe(100);
+            expect(estimateTokens('x'.repeat(301))).toBe(101); // ceil(100.333...)
         });
 
         test('treats non-string input as zero tokens', () => {
             expect(estimateTokens(null)).toBe(0);
             expect(estimateTokens(undefined)).toBe(0);
             expect(estimateTokens(42)).toBe(0);
+        });
+
+        test('estimates incident-shaped dense payloads above the 100k safe band (#13918)', () => {
+            expect(estimateTokens('x'.repeat(400000))).toBe(133334);
+            expect(estimateTokens('x'.repeat(400000))).toBeGreaterThan(100000);
         });
     });
 
@@ -44,8 +48,8 @@ test.describe('ai/services/graph/sessionChunker', () => {
     });
 
     test.describe('chunkSession — chunk activation (AC1) + boundaries (AC2)', () => {
-        // Four 400-char turns = 100 tokens each; limit 250 → packs 2 turns/chunk (200 ≤ 250, +100 would be 300 > 250).
-        const turns = [turn('t0', 400), turn('t1', 400), turn('t2', 400), turn('t3', 400)];
+        // Four 300-char turns = 100 tokens each; limit 250 → packs 2 turns/chunk (~201 ≤ 250, +100 would be > 250).
+        const turns = [turn('t0', 300), turn('t1', 300), turn('t2', 300), turn('t3', 300)];
 
         test('activates chunking above threshold and keeps every chunk within the limit', () => {
             const {chunked, chunks} = chunkSession(turns, {sessionId: 'session:big', safeProcessingLimitTokens: 250});
@@ -64,7 +68,7 @@ test.describe('ai/services/graph/sessionChunker', () => {
 
         test('boundaries are turn-aligned — turnIndices are contiguous and cover every turn exactly once (AC3 traceability)', () => {
             const {chunks} = chunkSession(turns, {sessionId: 'session:big', safeProcessingLimitTokens: 250});
-            const covered  = chunks.flatMap(c => c.turnIndices);
+            const covered = chunks.flatMap(c => c.turnIndices);
 
             expect(covered).toEqual([0, 1, 2, 3]); // full coverage, in order, no duplicates, no mid-turn split
             expect(chunks[0].turnIndices).toEqual([0, 1]);
@@ -80,7 +84,7 @@ test.describe('ai/services/graph/sessionChunker', () => {
 
     test.describe('chunkSession — oversized single turn (Contract Ledger edge: keep intact, do not split)', () => {
         test('a turn larger than the limit becomes its own chunk flagged oversizedTurn', () => {
-            const turns  = [turn('t0', 400), turn('huge', 4000), turn('t2', 400)]; // 100, 1000, 100 tokens; limit 250
+            const turns = [turn('t0', 300), turn('huge', 3000), turn('t2', 300)]; // 100, 1000, 100 tokens; limit 250
             const {chunks} = chunkSession(turns, {sessionId: 'session:x', safeProcessingLimitTokens: 250});
 
             const oversized = chunks.find(c => c.oversizedTurn);
@@ -120,7 +124,7 @@ test.describe('ai/services/graph/sessionChunker', () => {
         });
 
         test('every chunk reports estimatedTokens === estimate(text); non-oversized chunks stay within the limit', () => {
-            const turns = Array.from({length: 7}, (_, i) => `turn${i}:` + 'y'.repeat(300)); // ~77 tokens each
+            const turns = Array.from({length: 7}, (_, i) => `turn${i}:` + 'y'.repeat(300)); // ~102 tokens each
             const limit = 200;
             const {chunks} = chunkSession(turns, {sessionId: 'inv', safeProcessingLimitTokens: limit});
 

--- a/test/playwright/unit/ai/services/memory-core/helpers/consumerFrictionHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/consumerFrictionHelper.spec.mjs
@@ -42,13 +42,13 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         helper.clearAggregatedFrictions();
     });
 
-    test('bytesToTokens applies the 4-chars/token heuristic', () => {
+    test('bytesToTokens applies the conservative dense-text heuristic', () => {
         const {bytesToTokens} = helper;
         expect(bytesToTokens(0)).toBe(0);
-        expect(bytesToTokens(4)).toBe(1);
-        expect(bytesToTokens(5)).toBe(2);
-        expect(bytesToTokens(40)).toBe(10);
-        expect(bytesToTokens(131072)).toBe(32768);
+        expect(bytesToTokens(3)).toBe(1);
+        expect(bytesToTokens(4)).toBe(2);
+        expect(bytesToTokens(40)).toBe(14);
+        expect(bytesToTokens(131072)).toBe(43691);
         // Edge: negative / non-finite → 0
         expect(bytesToTokens(-1)).toBe(0);
         expect(bytesToTokens(NaN)).toBe(0);
@@ -85,16 +85,16 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         expect(() => emitConsumerFriction({})).toThrow(/invalid symptom/);
         expect(() => emitConsumerFriction({symptom: 'bogus'})).toThrow(/invalid symptom/);
         expect(() => emitConsumerFriction({
-            symptom        : 'parse-failure',
-            suggestionKind : 'invented-kind'
+            symptom       : 'parse-failure',
+            suggestionKind: 'invented-kind'
         })).toThrow(/invalid suggestionKind/);
         expect(() => emitConsumerFriction({
-            symptom       : 'parse-failure',
-            serviceDomain : 'fake-domain'
+            symptom      : 'parse-failure',
+            serviceDomain: 'fake-domain'
         })).toThrow(/invalid serviceDomain/);
         expect(() => emitConsumerFriction({
-            symptom       : 'parse-failure',
-            emissionPoint : 'wrong-point'
+            symptom      : 'parse-failure',
+            emissionPoint: 'wrong-point'
         })).toThrow(/invalid emissionPoint/);
     });
 
@@ -116,17 +116,17 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
 
         expect(surfaced).toHaveLength(1);
         expect(surfaced[0]).toMatchObject({
-            assetRef            : 'session:abc',
-            consumer            : 'SemanticGraphExtractor',
-            model               : 'gemma4-31b',
-            symptom             : 'size-precheck-skip',
-            emissionPoint       : 'pre-invocation',
-            suggestionKind      : 'compress-payload',
-            inputBytes          : 100000,
-            inputTokensEstimate : 25000,
-            contextLimitTokens  : 8192,
-            count               : 1,
-            serviceDomain       : 'dream-pipeline'
+            assetRef           : 'session:abc',
+            consumer           : 'SemanticGraphExtractor',
+            model              : 'gemma4-31b',
+            symptom            : 'size-precheck-skip',
+            emissionPoint      : 'pre-invocation',
+            suggestionKind     : 'compress-payload',
+            inputBytes         : 100000,
+            inputTokensEstimate: 33334,
+            contextLimitTokens : 8192,
+            count              : 1,
+            serviceDomain      : 'dream-pipeline'
         });
         // Required durable-aggregation fields present
         expect(typeof surfaced[0].firstSeenAt).toBe('string');
@@ -232,10 +232,10 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
     test('invokeWithGuardrail Angle 2 — pre-check skips invocation when input tokens exceed safeProcessingLimitTokens', async () => {
         const {invokeWithGuardrail, getAggregatedFrictions} = helper;
 
-        let invoked = false;
-        const result = await invokeWithGuardrail({
+        let   invoked = false;
+        const result  = await invokeWithGuardrail({
             invocationFn             : async () => { invoked = true; return 'should not run'; },
-            inputPayload             : 'x'.repeat(50000), // 50000 bytes = 12500 tokens estimate
+            inputPayload             : 'x'.repeat(50000), // 50000 bytes = 16667 tokens estimate
             model                    : 'gemma4-31b',
             assetRef                 : 'session:precheck',
             consumer                 : 'SemanticGraphExtractor',
@@ -251,7 +251,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
             symptom                  : 'size-precheck-skip',
             emissionPoint            : 'pre-invocation',
             inputBytes               : 50000,
-            inputTokensEstimate      : 12500,
+            inputTokensEstimate      : 16667,
             contextLimitTokens       : 10000,
             safeProcessingLimitTokens: 7500,
             suggestionKind           : 'compress-payload',
@@ -261,11 +261,62 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         expect(getAggregatedFrictions()).toHaveLength(1);
     });
 
+    test('invokeWithGuardrail skips incident-shaped dense REM payload before provider invocation (#13918)', async () => {
+        const {invokeWithGuardrail} = helper;
+
+        let   invoked = false;
+        const result  = await invokeWithGuardrail({
+            invocationFn             : async () => { invoked = true; return 'should not run'; },
+            inputPayload             : 'x'.repeat(400000),
+            model                    : 'google/gemma-4-26b-a4b',
+            assetRef                 : 'session:incident-13918',
+            consumer                 : 'SemanticGraphExtractor',
+            contextLimitTokens       : 131072,
+            safeProcessingLimitTokens: 100000,
+            serviceDomain            : 'dream-pipeline'
+        });
+
+        expect(invoked).toBe(false);
+        expect(result.result).toBeNull();
+        expect(result.friction).toMatchObject({
+            assetRef                 : 'session:incident-13918',
+            symptom                  : 'size-precheck-skip',
+            emissionPoint            : 'pre-invocation',
+            inputBytes               : 400000,
+            inputTokensEstimate      : 133334,
+            contextLimitTokens       : 131072,
+            safeProcessingLimitTokens: 100000
+        });
+    });
+
+    test('invokeWithGuardrail still invokes payloads that remain inside the safe band (#13918)', async () => {
+        const {invokeWithGuardrail} = helper;
+
+        let   invoked = false;
+        const result  = await invokeWithGuardrail({
+            invocationFn             : async () => {
+                invoked = true;
+                return {content: 'ok'};
+            },
+            inputPayload             : 'x'.repeat(21000), // 21000 bytes = 7000 tokens estimate
+            model                    : 'gemma4-31b',
+            assetRef                 : 'session:under-band',
+            consumer                 : 'SemanticGraphExtractor',
+            contextLimitTokens       : 10000,
+            safeProcessingLimitTokens: 7500,
+            serviceDomain            : 'dream-pipeline'
+        });
+
+        expect(invoked).toBe(true);
+        expect(result.result).toEqual({content: 'ok'});
+        expect(result.friction).toBeNull();
+    });
+
     test('invokeWithGuardrail Angle 2 — safeProcessingLimitTokens defaults to 75% of contextLimitTokens', async () => {
         const {invokeWithGuardrail} = helper;
 
         let invoked = false;
-        // 33000 bytes ≈ 8250 tokens; contextLimitTokens 10000; default safe = 7500; input EXCEEDS safe
+        // 33000 bytes ≈ 11000 tokens; contextLimitTokens 10000; default safe = 7500; input EXCEEDS safe
         const result = await invokeWithGuardrail({
             invocationFn      : async () => { invoked = true; return 'should not run'; },
             inputPayload      : 'x'.repeat(33000),
@@ -280,7 +331,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         expect(invoked).toBe(false);
         expect(result.friction.symptom).toBe('size-precheck-skip');
         expect(result.friction.safeProcessingLimitTokens).toBe(7500);
-        expect(result.friction.inputTokensEstimate).toBe(8250);
+        expect(result.friction.inputTokensEstimate).toBe(11000);
     });
 
     test('invokeWithGuardrail Angle 1 — success path returns result without friction', async () => {
@@ -436,15 +487,15 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         const {emitConsumerFriction, renderConsumerFrictionSection} = helper;
 
         emitConsumerFriction({
-            assetRef          : 'session:render',
-            consumer          : 'SemanticGraphExtractor',
-            model             : 'gemma4-31b',
-            symptom           : 'size-precheck-skip',
-            emissionPoint     : 'pre-invocation',
-            inputBytes        : 100000,
-            contextLimitTokens: 8192,
+            assetRef                 : 'session:render',
+            consumer                 : 'SemanticGraphExtractor',
+            model                    : 'gemma4-31b',
+            symptom                  : 'size-precheck-skip',
+            emissionPoint            : 'pre-invocation',
+            inputBytes               : 100000,
+            contextLimitTokens       : 8192,
             safeProcessingLimitTokens: 6144,
-            serviceDomain     : 'dream-pipeline'
+            serviceDomain            : 'dream-pipeline'
         });
 
         const section = renderConsumerFrictionSection();
@@ -455,7 +506,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         expect(section).toContain('`session:render`');
         expect(section).toContain('`gemma4-31b`');
         expect(section).toContain('`dream-pipeline`');
-        expect(section).toContain('25000 tokens');
+        expect(section).toContain('33334 tokens');
         expect(section).toContain('safe 6144');
         expect(section).toContain('context 8192');
         expect(section).toContain('(`compress-payload`)');


### PR DESCRIPTION
Refs #13918

Switches the REM guardrail token estimate from 4 bytes/token to a conservative 3 bytes/token and applies the same ratio to deterministic `sessionChunker` bounds. The follow-up commit also removes the DreamService split-brain estimator by routing its REM defer classifier through the shared `bytesToTokens()` helper.

An incident-shaped 400KB payload now estimates to 133,334 tokens and trips the 100k safe band before provider invocation; the same shape is now terminally classified as `skip-over-band` in DreamService instead of cycling as `under-band-choke`. Payloads still inside the band continue to invoke.

Evidence: L2 unit/static -> L2 required. This PR covers the burn-stop estimator, deterministic chunk-bound estimate, and DreamService re-serve termination pieces. Residual: SemanticGraphExtractor retry-append/headroom amplification remains open on #13918; full chunk-map/reduce remains #12073; loaded-context verification remains #13851.

## Deltas from ticket
- Kept the fix deterministic and dependency-free instead of introducing a provider tokenizer in the hot guardrail path.
- Preserved small/under-band behavior with explicit unit coverage.
- Changed this PR from `Resolves #13918` to `Refs #13918` because the retry-append/headroom residual is still open.

## Test Evidence
- `node --check ai/daemons/orchestrator/services/DreamService.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs` -> 30 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/consumerFrictionHelper.spec.mjs test/playwright/unit/ai/services/graph/sessionChunker.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs` -> 66 passed after rebase
- `npm run agent-preflight -- ai/daemons/orchestrator/services/DreamService.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs ai/services/memory-core/helpers/consumerFrictionHelper.mjs ai/services/graph/sessionChunker.mjs test/playwright/unit/ai/services/memory-core/helpers/consumerFrictionHelper.spec.mjs test/playwright/unit/ai/services/graph/sessionChunker.spec.mjs` -> passed after rebase
- `git diff --check` -> passed
- Freshness after rebase: `merge-base HEAD origin/dev == origin/dev`

## Post-Merge Validation
- [ ] Restart the local orchestrator so the updated estimator is loaded before the next REM cycle.
- [ ] Verify incident-shaped sessions emit `size-precheck-skip` instead of reaching LM Studio at over-context size.
- [ ] Verify the incident-shaped DreamService path marks over-band MAX-attempt sessions `deferred` with `deferReason: skip-over-band`.

## Commit
- `0ade263b31` - `fix(ai): harden REM token guardrail (#13918)`
- `af32d32752` - `fix(ai): align REM defer token estimate (#13918)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
