### PR TITLE
feat(ai): replay message WAL into mailbox graph (#13892)

### DIFF
--- a/ai/daemons/message/daemon.mjs
+++ b/ai/daemons/message/daemon.mjs
@@ -15,9 +15,13 @@ import fs         from 'fs-extra';
 import path       from 'path';
 import {execSync} from 'child_process';
 
-import {startMessageDrainLoop}      from './drainCycle.mjs';
+import {
+    createMessageGraphProjectionProcessor,
+    startMessageDrainLoop
+} from './drainCycle.mjs';
 import {acquireMessageDrainLock}    from './drainLock.mjs';
 import {getMissingMessageWalLeaves} from '../../services/memory-core/helpers/messageWalStore.mjs';
+import MailboxService               from '../../services/memory-core/MailboxService.mjs';
 
 const missingLeaves = getMissingMessageWalLeaves(memoryCoreConfig.messageWal,
     ['dir', 'daemonDataDir', 'pollIntervalMs', 'batchSize', 'maxRetries', 'backoffBaseMs']);
@@ -192,8 +196,9 @@ async function main() {
     writeLog('INFO', `[Message Daemon] Started. Observing message WAL dir: ${memoryCoreConfig.messageWal.dir} (poll: ${memoryCoreConfig.messageWal.pollIntervalMs}ms, batch: ${memoryCoreConfig.messageWal.batchSize})`);
 
     startMessageDrainLoop({
-        getConfig: () => memoryCoreConfig.messageWal,
-        log      : writeLog
+        getConfig   : () => memoryCoreConfig.messageWal,
+        getProcessor: () => createMessageGraphProjectionProcessor(MailboxService),
+        log         : writeLog
     });
 }
 

--- a/ai/daemons/message/drainCycle.mjs
+++ b/ai/daemons/message/drainCycle.mjs
@@ -1,17 +1,13 @@
-import {readWalMessages} from '../../services/memory-core/helpers/messageWalStore.mjs';
+import {readPendingMessageWalRecords} from '../../services/memory-core/helpers/messageWalStore.mjs';
 
 /**
  * @module ai/daemons/message/drainCycle
  * @summary Host-agnostic message WAL drain loop topology.
  *
- * This module intentionally owns only the drain-host mechanics: read the accepted message WAL
- * from the configured directory, batch it, retry the injected replay processor, and expose a loop
- * host that both the local daemon and in-process Memory Core mode can share.
- *
- * Full graph replay/idempotency is a separate projection concern. Until that processor is wired,
- * cycles stay inactive and skip WAL reads entirely, preserving the WAL as the authority without
- * adding a growing no-op scan to live deployments. A2A-message vector/search population is likewise
- * outside this topology layer.
+ * This module intentionally owns only the drain-host mechanics: read graph-pending accepted
+ * message WAL records from the configured directory, batch them, retry the injected replay
+ * processor, and expose a loop host that both the local daemon and in-process Memory Core mode can
+ * share. A2A-message vector/search population is outside this topology layer.
  */
 
 /**
@@ -30,6 +26,27 @@ function normalizeProcessResult(records, result = {}) {
           deferred = Number.isFinite(result.deferred) ? result.deferred : 0;
 
     return {drained, failed, deferred};
+}
+
+/**
+ * @summary Adapts MailboxService's graph-projection drain into the generic loop processor shape.
+ * @param {Object} mailboxService Service exposing `drainPendingMessageGraphProjections`.
+ * @returns {Function} Processor compatible with {@link processMessageBatch}.
+ */
+export function createMessageGraphProjectionProcessor(mailboxService) {
+    return async records => {
+        const ids     = records.map(record => record.id).filter(Boolean);
+        const summary = await mailboxService.drainPendingMessageGraphProjections({
+            ids,
+            limit: records.length
+        });
+
+        return {
+            drained : summary.projected,
+            failed  : summary.failed,
+            deferred: Math.max(summary.pending - summary.projected - summary.failed, 0)
+        };
+    };
 }
 
 /**
@@ -90,7 +107,7 @@ export async function processMessageBatch({
  * @param {Function|null} [options.processRecords] Optional replay processor.
  * @param {Function} [options.log] Log sink.
  * @param {Function} [options.sleep] Delay primitive.
- * @param {Function} [options.readMessages] WAL reader injection for tests.
+ * @param {Function} [options.readMessages] Pending WAL reader injection for tests.
  * @returns {Promise<{observed: Number, drained: Number, failed: Number, deferred: Number, inactive: Boolean}>}
  */
 export async function drainMessageWalOnce({
@@ -101,7 +118,7 @@ export async function drainMessageWalOnce({
     processRecords,
     log,
     sleep,
-    readMessages = readWalMessages
+    readMessages = readPendingMessageWalRecords
 } = {}) {
     if (!processRecords) {
         return {observed: 0, drained: 0, failed: 0, deferred: 0, inactive: true};
@@ -128,8 +145,8 @@ export async function drainMessageWalOnce({
  * @returns {{stop: Function}}
  */
 export function startMessageDrainLoop({getConfig, getProcessor = () => null, log = () => {}}) {
-    let stopped = false,
-        timer   = null,
+    let stopped        = false,
+        timer          = null,
         inactiveLogged = false;
 
     const tick = async () => {

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -18,12 +18,16 @@ import {
     Memory_InferenceLifecycleService  as InferenceLifecycleService,
     Memory_RecorderService            as RecorderService,
     Memory_StorageRouter              as StorageRouter,
+    Memory_MailboxService             as MailboxService,
     Memory_WakeSubscriptionService    as WakeSubscriptionService,
     Memory_CoalescingEngineService    as CoalescingEngineService
 } from '../../../services.mjs';
-import {startDrainLoop}             from '../../../daemons/embed/drainCycle.mjs';
-import {acquireDrainLock}           from '../../../daemons/embed/drainLock.mjs';
-import {startMessageDrainLoop}      from '../../../daemons/message/drainCycle.mjs';
+import {startDrainLoop}   from '../../../daemons/embed/drainCycle.mjs';
+import {acquireDrainLock} from '../../../daemons/embed/drainLock.mjs';
+import {
+    createMessageGraphProjectionProcessor,
+    startMessageDrainLoop
+} from '../../../daemons/message/drainCycle.mjs';
 import {acquireMessageDrainLock}    from '../../../daemons/message/drainLock.mjs';
 import {getMissingMessageWalLeaves} from '../../../services/memory-core/helpers/messageWalStore.mjs';
 
@@ -304,8 +308,9 @@ class Server extends BaseServer {
 
                 if (this.messageWalDrainLock) {
                     this.messageWalDrainLoop = startMessageDrainLoop({
-                        getConfig: () => aiConfig.messageWal,
-                        log      : messageDrainLog
+                        getConfig   : () => aiConfig.messageWal,
+                        getProcessor: () => createMessageGraphProjectionProcessor(MailboxService),
+                        log         : messageDrainLog
                     });
                     process.on('exit', () => this.messageWalDrainLock?.release());
                     logger.info('[neo-memory-core MCP] In-process message WAL drain loop active (messageWal.inProcessDrain)');

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1,15 +1,21 @@
-import Base                                           from '../../../src/core/Base.mjs';
-import aiConfig                                       from '../../mcp/server/memory-core/config.mjs';
-import logger                                         from '../../mcp/server/memory-core/logger.mjs';
-import RequestContextService, {normalizeUserId}       from '../../mcp/server/shared/services/RequestContextService.mjs';
-import GraphService                                   from './GraphService.mjs';
-import PermissionService                              from './PermissionService.mjs';
-import WakeSubscriptionService                        from './WakeSubscriptionService.mjs';
-import {appendWalMessage, getMissingMessageWalLeaves} from './helpers/messageWalStore.mjs';
-import {getMissingMemoryWalLeaves}                    from './helpers/memoryWalStore.mjs';
-import {execFile}                                     from 'child_process';
-import {promisify}                                    from 'util';
-import crypto                                         from 'crypto';
+import Base                                     from '../../../src/core/Base.mjs';
+import aiConfig                                 from '../../mcp/server/memory-core/config.mjs';
+import logger                                   from '../../mcp/server/memory-core/logger.mjs';
+import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
+import GraphService                             from './GraphService.mjs';
+import PermissionService                        from './PermissionService.mjs';
+import WakeSubscriptionService                  from './WakeSubscriptionService.mjs';
+import {
+    appendMessageWalGraphProjectionMarker,
+    appendWalMessage,
+    getMessageWalSegmentKey,
+    getMissingMessageWalLeaves,
+    readPendingMessageWalRecords
+} from './helpers/messageWalStore.mjs';
+import {getMissingMemoryWalLeaves} from './helpers/memoryWalStore.mjs';
+import {execFile}                  from 'child_process';
+import {promisify}                 from 'util';
+import crypto                      from 'crypto';
 
 const
     execFileAsync                     = promisify(execFile),
@@ -246,6 +252,8 @@ function buildMessageWalRecord({
     messageId,
     messageProperties,
     originSessionId,
+    preNormalizeTo,
+    postNormalizeTo,
     relatedSessions,
     relatedTickets,
     sentBy,
@@ -267,6 +275,8 @@ function buildMessageWalRecord({
         routing: {
             sentBy,
             to,
+            preNormalizeTo,
+            postNormalizeTo,
             senderUserId,
             broadcastRecipients: to === 'AGENT:*' ? getBroadcastAudience(sentBy) : []
         },
@@ -279,6 +289,19 @@ function buildMessageWalRecord({
             taggedConcepts : [...messageProperties.taggedConcepts]
         }
     }
+}
+
+function getMessageWalTimestamp(record, properties = {}) {
+    if (properties.sentAt) return properties.sentAt;
+    if (record?.sentAt) return record.sentAt;
+
+    const timestampMs = Number(record?.timestamp);
+
+    return Number.isFinite(timestampMs) ? new Date(timestampMs).toISOString() : new Date().toISOString();
+}
+
+function getMessageWalArray(value) {
+    return Array.isArray(value) ? value : [];
 }
 
 /**
@@ -443,6 +466,14 @@ async function setDeliveryEdgeArchivedAt(edge, archivedAt) {
     if (db?.autoSave && db.storage) {
         await db.storage.addEdges([edge]);
         db.acknowledgeLocalMutations?.();
+    }
+}
+
+function linkOptionalMailboxEdge(source, target, type, weight, properties) {
+    try {
+        GraphService.linkNodes(source, target, type, weight, properties);
+    } catch (e) {
+        logger.warn(`[MailboxService] optional message graph edge skipped: ${source} -[${type}]-> ${target}: ${e.message}`);
     }
 }
 
@@ -694,69 +725,26 @@ class MailboxService extends Base {
             throw new Error(`message WAL config leaves missing: ${missingLeaves.join(', ')} — sync the memoryWal/messageWal blocks from config.template.mjs into the local config.mjs (node ai/scripts/setup/initServerConfigs.mjs --migrate-config) and restart memory-core.`);
         }
 
-        await appendWalMessage(
-            buildMessageWalRecord({
-                messageId,
-                messageProperties,
-                originSessionId,
-                relatedSessions,
-                relatedTickets,
-                sentBy,
-                senderUserId,
-                timestamp,
-                to
-            }),
-            {dir: aiConfig.messageWal.dir}
-        );
+        const walRecord = buildMessageWalRecord({
+            messageId,
+            messageProperties,
+            originSessionId,
+            preNormalizeTo,
+            postNormalizeTo,
+            relatedSessions,
+            relatedTickets,
+            sentBy,
+            senderUserId,
+            timestamp,
+            to
+        });
+
+        await appendWalMessage(walRecord, {dir: aiConfig.messageWal.dir});
 
         let projectionStatus = 'projected';
 
         try {
-            // 2. Project the accepted Message intent to the graph. This is derived work after the
-            // durable WAL append; if projection fails, the accepted `MESSAGE:*` id stays replayable.
-            GraphService.upsertNode({
-                id        : messageId,
-                type      : 'MESSAGE',
-                name      : subject,
-                properties: messageProperties
-            });
-
-            // 3. Map the delivery-critical routing edges. These still fail loudly inside projection
-            // so a replay/drain can retry the complete delivery-critical graph state.
-            const routingDiagnostics = {preNormalizeTo, postNormalizeTo};
-            linkRequiredMailboxEdgeOrThrow(messageId, sentBy, 'SENT_BY', 1.0, { timestamp, userId: senderUserId, sharedEntity: true }, routingDiagnostics);
-            linkRequiredMailboxEdgeOrThrow(messageId, to, 'SENT_TO', 1.0, { timestamp, userId: senderUserId, sharedEntity: true }, routingDiagnostics);
-            if (to === 'AGENT:*') {
-                for (const recipient of getBroadcastAudience(sentBy)) {
-                    linkRequiredMailboxEdgeOrThrow(messageId, recipient, 'DELIVERED_TO', 1.0, {
-                        deliveredAt : timestamp,
-                        readAt      : null,
-                        deliveryKind: 'broadcast',
-                        userId      : senderUserId,
-                        sharedEntity: true
-                    }, routingDiagnostics);
-                }
-            }
-
-            // 4. Map additional graph semantic edges. These remain cull-tolerant:
-            // mailbox delivery does not depend on optional provenance/thread/concept links.
-            if (originSessionId) GraphService.linkNodes(messageId, originSessionId, 'ORIGINATES_IN', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
-            if (inReplyTo) GraphService.linkNodes(messageId, inReplyTo, 'IN_REPLY_TO', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
-            if (partOfThread) GraphService.linkNodes(messageId, partOfThread, 'PART_OF_THREAD', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
-
-            for (const s of relatedSessions) GraphService.linkNodes(messageId, s, 'RELATED_SESSION', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
-            for (const t of relatedTickets) GraphService.linkNodes(messageId, t, 'REFERENCES_TICKET', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
-            for (const c of taggedConcepts) GraphService.linkNodes(messageId, c, 'TAGGED_CONCEPT', 1.0, { timestamp, userId: senderUserId, sharedEntity: true });
-
-            // Per-message auto concept-extraction is intentionally NOT run inline: it fired a chat-model
-            // call (up to 2 attempts) on EVERY message, in parallel with the orchestrator's exclusive-heavy
-            // tasks — starving the model of an idle window. The curated `taggedConcepts` edges (weight 1.0)
-            // are already linked above; the low-confidence auto-extracted concepts (weight 0.8) were the
-            // bulk of the non-curated graph population and are dropped here as redundant noise. Concept
-            // mining stays orchestrator-driven (scheduled, lease-gated), keeping model inference off the
-            // message hot path.
-
-            WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
+            await this._projectMessageWalRecord(walRecord);
         } catch (e) {
             projectionStatus = 'pending';
             logger.error('[MailboxService.addMessage] graph projection failed after message WAL append', {
@@ -772,6 +760,128 @@ class MailboxService extends Base {
             status: 'sent',
             ...(projectionStatus === 'pending' ? {projectionStatus} : {})
         };
+    }
+
+    /**
+     * @summary Projects one accepted message WAL record into the Native Edge Graph.
+     *
+     * The WAL record is the authority: replay uses its canonical recipient, send-time broadcast
+     * audience snapshot, sender identity, and optional semantic edges. Delivery-critical edges
+     * fail loudly so the record remains pending until a later drain succeeds; optional semantic
+     * edges are cull/throw tolerant and never block mailbox delivery completion.
+     *
+     * @param {Object} record Accepted message WAL record.
+     * @param {Object} [options]
+     * @param {Boolean} [options.pumpWake=true] Whether to pump wake subscriptions after projection.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async _projectMessageWalRecord(record, {pumpWake = true} = {}) {
+        const messageId = record?.id || record?.message?.id;
+        if (typeof messageId !== 'string' || !messageId.startsWith('MESSAGE:')) {
+            throw new Error('[MailboxService] message WAL projection requires a MESSAGE:* id');
+        }
+
+        const message            = record.message || {};
+        const messageProperties  = message.properties || {};
+        const routing            = record.routing || {};
+        const optionalEdges      = record.optionalEdges || {};
+        const sentBy             = routing.sentBy || messageProperties.from;
+        const to                 = routing.to || messageProperties.to;
+        const senderUserId       = routing.senderUserId || normalizeUserId(sentBy);
+        const timestamp          = getMessageWalTimestamp(record, messageProperties);
+        const edgeProperties     = {timestamp, userId: senderUserId, sharedEntity: true};
+        const routingDiagnostics = {
+            preNormalizeTo : routing.preNormalizeTo ?? to,
+            postNormalizeTo: routing.postNormalizeTo ?? to
+        };
+
+        if (!sentBy || !to) {
+            throw new Error(`[MailboxService] message WAL projection requires routing.sentBy and routing.to for ${messageId}`);
+        }
+
+        GraphService.upsertNode({
+            id        : messageId,
+            type      : message.type || 'MESSAGE',
+            name      : message.name || messageProperties.subject || messageId,
+            properties: messageProperties
+        });
+
+        linkRequiredMailboxEdgeOrThrow(messageId, sentBy, 'SENT_BY', 1.0, edgeProperties, routingDiagnostics);
+        linkRequiredMailboxEdgeOrThrow(messageId, to, 'SENT_TO', 1.0, edgeProperties, routingDiagnostics);
+
+        if (to === 'AGENT:*') {
+            for (const recipient of getMessageWalArray(routing.broadcastRecipients)) {
+                linkRequiredMailboxEdgeOrThrow(messageId, recipient, 'DELIVERED_TO', 1.0, {
+                    deliveredAt : timestamp,
+                    readAt      : null,
+                    deliveryKind: 'broadcast',
+                    userId      : senderUserId,
+                    sharedEntity: true
+                }, routingDiagnostics);
+            }
+        }
+
+        if (optionalEdges.originSessionId) {
+            linkOptionalMailboxEdge(messageId, optionalEdges.originSessionId, 'ORIGINATES_IN', 1.0, edgeProperties);
+        }
+        if (optionalEdges.inReplyTo) {
+            linkOptionalMailboxEdge(messageId, optionalEdges.inReplyTo, 'IN_REPLY_TO', 1.0, edgeProperties);
+        }
+        if (optionalEdges.partOfThread) {
+            linkOptionalMailboxEdge(messageId, optionalEdges.partOfThread, 'PART_OF_THREAD', 1.0, edgeProperties);
+        }
+
+        for (const s of getMessageWalArray(optionalEdges.relatedSessions)) {
+            linkOptionalMailboxEdge(messageId, s, 'RELATED_SESSION', 1.0, edgeProperties);
+        }
+        for (const t of getMessageWalArray(optionalEdges.relatedTickets)) {
+            linkOptionalMailboxEdge(messageId, t, 'REFERENCES_TICKET', 1.0, edgeProperties);
+        }
+        for (const c of getMessageWalArray(optionalEdges.taggedConcepts)) {
+            linkOptionalMailboxEdge(messageId, c, 'TAGGED_CONCEPT', 1.0, edgeProperties);
+        }
+
+        // Per-message auto concept-extraction remains intentionally outside projection: curated
+        // taggedConcepts are replayed above, while low-confidence model-derived concepts stay out
+        // of the message hot path.
+
+        await appendMessageWalGraphProjectionMarker({
+            id        : messageId,
+            segmentKey: record.segmentKey || getMessageWalSegmentKey(record.timestamp ?? Date.now())
+        }, {dir: aiConfig.messageWal.dir});
+
+        if (pumpWake) {
+            WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
+        }
+    }
+
+    /**
+     * @summary Reconciles graph-pending accepted message WAL records into the mailbox graph.
+     * @param {Object} [options]
+     * @param {String[]} [options.ids] Optional targeted message ids.
+     * @param {Number} [options.limit] Maximum pending records to process.
+     * @returns {Promise<{pending: Number, projected: Number, failed: Number}>}
+     */
+    async drainPendingMessageGraphProjections({ids, limit = aiConfig.messageWal.batchSize} = {}) {
+        const records = await readPendingMessageWalRecords({
+            dir: aiConfig.messageWal.dir,
+            ids,
+            limit
+        });
+        const summary = {pending: records.length, projected: 0, failed: 0};
+
+        for (const record of records) {
+            try {
+                await this._projectMessageWalRecord(record);
+                summary.projected++;
+            } catch (error) {
+                summary.failed++;
+                logger.warn(`[MailboxService] message graph projection drain failed for ${record.id}: ${error.message}`);
+            }
+        }
+
+        return summary;
     }
 
     /**

--- a/ai/services/memory-core/helpers/messageWalStore.mjs
+++ b/ai/services/memory-core/helpers/messageWalStore.mjs
@@ -56,6 +56,15 @@ export function getMessageWalRecordsFileName(segmentKey) {
 }
 
 /**
+ * @summary Builds the graph-projection markers file name for a message WAL segment key.
+ * @param {String} segmentKey `YYYY-MM-DD` day key.
+ * @returns {String} JSONL graph-projection markers file name.
+ */
+export function getMessageWalGraphMarkersFileName(segmentKey) {
+    return `message-wal-${segmentKey}.graph.jsonl`;
+}
+
+/**
  * @summary Appends one accepted A2A message intent to its UTC-day WAL segment.
  * @param {Object} record
  * @param {String} record.id Stable `MESSAGE:*` id.
@@ -86,6 +95,91 @@ export async function appendWalMessage(record, {dir, now, lockOptions} = {}) {
 }
 
 /**
+ * @summary Appends a graph-projection success marker for one accepted message WAL record.
+ *
+ * The accepted message JSONL remains the authority. This marker records only that the derived
+ * Native Edge Graph projection completed, so drain hosts can retry crash/pending rows
+ * idempotently without reprocessing already-converged messages.
+ *
+ * @param {Object} marker
+ * @param {String} marker.id Stable `MESSAGE:*` id.
+ * @param {String} marker.segmentKey WAL segment key containing the accepted record.
+ * @param {Number} [marker.projectedAt] Epoch-ms projection completion time.
+ * @param {Object} options
+ * @param {String} options.dir Message WAL directory.
+ * @returns {Promise<String>} Written markers file path.
+ */
+export async function appendMessageWalGraphProjectionMarker({id, segmentKey, projectedAt}, {dir} = {}) {
+    if (!dir) {
+        throw new TypeError('appendMessageWalGraphProjectionMarker: dir is required');
+    }
+    if (typeof id !== 'string' || !id.startsWith('MESSAGE:') || typeof segmentKey !== 'string' || segmentKey.length === 0) {
+        throw new TypeError('appendMessageWalGraphProjectionMarker: id and segmentKey are required');
+    }
+
+    await fs.mkdir(dir, {recursive: true});
+
+    const filePath = path.join(dir, getMessageWalGraphMarkersFileName(segmentKey));
+
+    await fs.appendFile(filePath, `${JSON.stringify({id, projectedAt: projectedAt ?? Date.now()})}\n`, 'utf8');
+
+    return filePath;
+}
+
+/**
+ * @summary Parses one JSONL file into entries, skipping corrupt/torn lines.
+ * @param {String} filePath JSONL file path.
+ * @returns {Promise<Object[]>}
+ * @private
+ */
+async function readJsonlEntries(filePath) {
+    let text;
+
+    try {
+        text = await fs.readFile(filePath, 'utf8');
+    } catch (e) {
+        if (e?.code === 'ENOENT') return [];
+        throw e;
+    }
+
+    const entries = [];
+
+    for (const line of text.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+            entries.push(JSON.parse(line));
+        } catch (e) {
+            // Torn/corrupt line: skip. A partial append must not make other accepted
+            // message records unreadable.
+        }
+    }
+
+    return entries;
+}
+
+/**
+ * @summary Lists message WAL segment keys newest first.
+ * @param {String} dir Message WAL directory.
+ * @returns {Promise<String[]>}
+ * @private
+ */
+async function listMessageWalSegmentKeys(dir) {
+    let names;
+
+    try {
+        names = await fs.readdir(dir);
+    } catch (e) {
+        if (e?.code === 'ENOENT') return [];
+        throw e;
+    }
+
+    return names
+        .map(name => name.match(MESSAGE_WAL_SEGMENT_RE)?.[1])
+        .filter(Boolean)
+        .sort((a, b) => b.localeCompare(a));
+}
+
+/**
  * @summary Reads message WAL records from newest segment to oldest, skipping corrupt lines.
  * @param {Object} options
  * @param {String} options.dir Message WAL directory.
@@ -96,42 +190,48 @@ export async function readWalMessages({dir} = {}) {
         throw new TypeError('readWalMessages: dir is required');
     }
 
-    let names;
-    try {
-        names = await fs.readdir(dir);
-    } catch (e) {
-        if (e?.code === 'ENOENT') return [];
-        throw e;
-    }
-
-    const segmentNames = names
-        .filter(name => MESSAGE_WAL_SEGMENT_RE.test(name))
-        .sort()
-        .reverse();
-
     const records = [];
 
-    for (const name of segmentNames) {
-        const filePath = path.join(dir, name);
-        let text;
-
-        try {
-            text = await fs.readFile(filePath, 'utf8');
-        } catch (e) {
-            if (e?.code === 'ENOENT') continue;
-            throw e;
-        }
-
-        for (const line of text.split('\n')) {
-            if (!line.trim()) continue;
-            try {
-                records.push(JSON.parse(line));
-            } catch (e) {
-                // Torn/corrupt line: skip. A partial append must not make other accepted
-                // message records unreadable.
-            }
-        }
+    for (const segmentKey of await listMessageWalSegmentKeys(dir)) {
+        records.push(...await readJsonlEntries(path.join(dir, getMessageWalRecordsFileName(segmentKey))));
     }
 
     return records;
+}
+
+/**
+ * @summary Reads accepted message WAL records whose graph-projection marker is still absent.
+ * @param {Object} options
+ * @param {String} options.dir Message WAL directory.
+ * @param {String[]} [options.ids] Optional targeted record ids.
+ * @param {Number} [options.limit] Maximum pending records to return.
+ * @returns {Promise<Object[]>} Pending records newest segment first.
+ */
+export async function readPendingMessageWalRecords({dir, ids, limit} = {}) {
+    if (!dir) return [];
+
+    const idFilter = Array.isArray(ids) ? new Set(ids) : null;
+    const bounded  = Number.isFinite(limit) && limit > 0 ? limit : Infinity;
+    const pending  = [];
+
+    for (const segmentKey of await listMessageWalSegmentKeys(dir)) {
+        if (pending.length >= bounded) break;
+
+        const records = await readJsonlEntries(path.join(dir, getMessageWalRecordsFileName(segmentKey)));
+        if (records.length === 0) continue;
+
+        const markedIds = new Set(
+            (await readJsonlEntries(path.join(dir, getMessageWalGraphMarkersFileName(segmentKey)))).map(entry => entry.id)
+        );
+
+        for (const record of records) {
+            if (pending.length >= bounded) break;
+            if (!record?.id || markedIds.has(record.id)) continue;
+            if (record.graphProjectionVersion !== 1) continue;
+            if (idFilter && !idFilter.has(record.id)) continue;
+            pending.push(record);
+        }
+    }
+
+    return pending;
 }

--- a/test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs
@@ -7,6 +7,7 @@ import path           from 'path';
 
 import {appendWalMessage} from '../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs';
 import {
+    createMessageGraphProjectionProcessor,
     drainMessageWalOnce,
     getMessageDrainBackoffDelayMs,
     processMessageBatch
@@ -29,8 +30,9 @@ test.describe('Neo.ai.daemons.message.drainCycle', () => {
 
     const record = id => ({
         id,
-        timestamp: Date.now(),
-        message  : {
+        timestamp             : Date.now(),
+        graphProjectionVersion: 1,
+        message               : {
             id,
             type      : 'MESSAGE',
             name      : `subject ${id}`,
@@ -45,8 +47,8 @@ test.describe('Neo.ai.daemons.message.drainCycle', () => {
     test('without a replay processor, the cycle skips WAL reads instead of doing active no-op work', async () => {
         await seed('MESSAGE:deferred');
 
-        let readCalled = false;
-        const summary = await drainMessageWalOnce({
+        let   readCalled = false;
+        const summary    = await drainMessageWalOnce({
             dir          : tmpDir,
             batchSize    : 20,
             maxRetries   : 1,
@@ -121,5 +123,20 @@ test.describe('Neo.ai.daemons.message.drainCycle', () => {
         });
 
         expect(summary).toEqual({drained: 0, failed: 1, deferred: 0});
+    });
+
+    test('projection processor adapts mailbox drain summaries to cycle counters', async () => {
+        const processRecords = createMessageGraphProjectionProcessor({
+            async drainPendingMessageGraphProjections({ids, limit}) {
+                expect(ids).toEqual(['MESSAGE:a', 'MESSAGE:b']);
+                expect(limit).toBe(2);
+
+                return {pending: 2, projected: 1, failed: 1};
+            }
+        });
+
+        const summary = await processRecords([record('MESSAGE:a'), record('MESSAGE:b')]);
+
+        expect(summary).toEqual({drained: 1, failed: 1, deferred: 0});
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -23,7 +23,7 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
 
 test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     test.describe.configure({ mode: 'serial' });
-    let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, originalAutoSave, mailboxAiConfig, originalMailboxPolicy, readWalMessages;
+    let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, originalAutoSave, mailboxAiConfig, originalMailboxPolicy, readWalMessages, readPendingMessageWalRecords;
     let dbPath, messageWalDir;
 
     test.beforeAll(async () => {
@@ -49,8 +49,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         SwarmHeartbeatService = (await import('../../../../../../ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs')).default;
         buildMailboxDelta = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).buildMailboxDelta;
         const messageWalStore = await import('../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs');
-        readWalMessages = messageWalStore.readWalMessages;
-        messageWalDir   = mailboxAiConfig.messageWal.dir;
+        readWalMessages              = messageWalStore.readWalMessages;
+        readPendingMessageWalRecords = messageWalStore.readPendingMessageWalRecords;
+        messageWalDir                = mailboxAiConfig.messageWal.dir;
 
         // Pin this suite to strict-isolation mode. These tests predate the
         // config-gated default and assert `'blocked'`-mode behavior (Unauthorized
@@ -149,6 +150,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(records[0].id).toBe(res.messageId);
         expect(records[0].message.properties.subject).toBe('Hello');
         expect(records[0].routing).toMatchObject({sentBy: '@alice', to: '@bob', senderUserId: 'alice'});
+
+        const pending = await readPendingMessageWalRecords({dir: messageWalDir});
+        expect(pending).toHaveLength(0);
     });
 
     test('addMessage stamps the normalized canonical user_id, keeping @-form only as the sender label (#13578)', async () => {
@@ -203,6 +207,90 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             expect(records[0].id).toBe(res.messageId);
             expect(records[0].message.properties.subject).toBe('culled route');
             expect(records[0].routing.to).toBe('@bob');
+
+            const pending = await readPendingMessageWalRecords({dir: messageWalDir});
+            expect(pending.map(record => record.id)).toEqual([res.messageId]);
+        } finally {
+            GraphService.linkNodes = originalLinkNodes;
+        }
+    });
+
+    test('drainPendingMessageGraphProjections replays pending direct MESSAGE rows idempotently (#13892)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        const originalLinkNodes = GraphService.linkNodes;
+        let   res;
+
+        try {
+            GraphService.linkNodes = function(source, target, relationship, weight, properties) {
+                if (relationship === 'SENT_TO') {
+                    return;
+                }
+
+                return originalLinkNodes.call(GraphService, source, target, relationship, weight, properties);
+            };
+
+            res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+                return await MailboxService.addMessage({
+                    to     : '@bob',
+                    subject: 'replay me',
+                    body   : 'body'
+                });
+            });
+        } finally {
+            GraphService.linkNodes = originalLinkNodes;
+        }
+
+        expect(res.projectionStatus).toBe('pending');
+        expect((await readPendingMessageWalRecords({dir: messageWalDir, ids: [res.messageId]})).map(record => record.id)).toEqual([res.messageId]);
+
+        const firstDrain = await MailboxService.drainPendingMessageGraphProjections({ids: [res.messageId]});
+        expect(firstDrain).toEqual({pending: 1, projected: 1, failed: 0});
+
+        const secondDrain = await MailboxService.drainPendingMessageGraphProjections({ids: [res.messageId]});
+        expect(secondDrain).toEqual({pending: 0, projected: 0, failed: 0});
+
+        const sentTo = GraphService.db.edges.items.find(edge =>
+            edge.source === res.messageId &&
+            edge.type === 'SENT_TO' &&
+            edge.target === '@bob'
+        );
+
+        expect(sentTo).toBeDefined();
+        expect(await readPendingMessageWalRecords({dir: messageWalDir, ids: [res.messageId]})).toHaveLength(0);
+    });
+
+    test('drainPendingMessageGraphProjections leaves failed required-edge replay pending (#13892)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        const originalLinkNodes = GraphService.linkNodes;
+
+        try {
+            GraphService.linkNodes = function(source, target, relationship, weight, properties) {
+                if (relationship === 'SENT_TO') {
+                    return;
+                }
+
+                return originalLinkNodes.call(GraphService, source, target, relationship, weight, properties);
+            };
+
+            const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+                return await MailboxService.addMessage({
+                    to     : '@bob',
+                    subject: 'still pending',
+                    body   : 'body'
+                });
+            });
+
+            expect(res.projectionStatus).toBe('pending');
+
+            const summary = await MailboxService.drainPendingMessageGraphProjections({ids: [res.messageId]});
+            expect(summary).toEqual({pending: 1, projected: 0, failed: 1});
+            expect((await readPendingMessageWalRecords({dir: messageWalDir, ids: [res.messageId]})).map(record => record.id)).toEqual([res.messageId]);
         } finally {
             GraphService.linkNodes = originalLinkNodes;
         }
@@ -237,6 +325,82 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             expect(records[0].id).toBe(res.messageId);
             expect(records[0].routing.to).toBe('AGENT:*');
             expect(records[0].routing.broadcastRecipients).toEqual(expect.arrayContaining(['@bob']));
+        } finally {
+            GraphService.linkNodes = originalLinkNodes;
+        }
+    });
+
+    test('broadcast replay uses WAL send-time audience snapshot, not the current graph audience (#13892)', async () => {
+        GraphService.upsertNode({ id: '@charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+
+        const originalLinkNodes = GraphService.linkNodes;
+        let   res;
+
+        try {
+            GraphService.linkNodes = function(source, target, relationship, weight, properties) {
+                if (relationship === 'DELIVERED_TO') {
+                    return;
+                }
+
+                return originalLinkNodes.call(GraphService, source, target, relationship, weight, properties);
+            };
+
+            res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+                return await MailboxService.addMessage({
+                    to     : 'AGENT:*',
+                    subject: 'snapshot broadcast',
+                    body   : 'body'
+                });
+            });
+        } finally {
+            GraphService.linkNodes = originalLinkNodes;
+        }
+
+        expect(res.projectionStatus).toBe('pending');
+
+        GraphService.upsertNode({ id: '@dana', type: 'AGENT', name: 'Dana', properties: {} });
+
+        const summary = await MailboxService.drainPendingMessageGraphProjections({ids: [res.messageId]});
+        expect(summary).toEqual({pending: 1, projected: 1, failed: 0});
+
+        const deliveryTargets = GraphService.db.edges.items
+            .filter(edge => edge.source === res.messageId && edge.type === 'DELIVERED_TO')
+            .map(edge => edge.target)
+            .sort();
+
+        expect(deliveryTargets).toEqual(['@bob', '@charlie']);
+        expect(deliveryTargets).not.toContain('@dana');
+    });
+
+    test('optional semantic edge failures do not block message graph completion (#13892)', async () => {
+        GraphService.upsertNode({ id: 'CONCEPT:ok', type: 'CONCEPT', name: 'Concept', properties: {} });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        const originalLinkNodes = GraphService.linkNodes;
+
+        try {
+            GraphService.linkNodes = function(source, target, relationship, weight, properties) {
+                if (relationship === 'TAGGED_CONCEPT') {
+                    throw new Error('optional concept target temporarily unavailable');
+                }
+
+                return originalLinkNodes.call(GraphService, source, target, relationship, weight, properties);
+            };
+
+            const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+                return await MailboxService.addMessage({
+                    to            : '@bob',
+                    subject       : 'optional edge',
+                    body          : 'body',
+                    taggedConcepts: ['CONCEPT:ok']
+                });
+            });
+
+            expect(res.projectionStatus).toBeUndefined();
+            expect(await readPendingMessageWalRecords({dir: messageWalDir, ids: [res.messageId]})).toHaveLength(0);
         } finally {
             GraphService.linkNodes = originalLinkNodes;
         }


### PR DESCRIPTION
Resolves #13892
Related: #13889

Projects accepted A2A message WAL records into the mailbox graph idempotently. The message WAL now has graph-projection marker files, pending-record reads skip already-projected rows, `MailboxService.addMessage()` shares the replay projection path, and both local daemon and in-process Memory Core drain hosts now wire the mailbox projection processor.

Evidence: L2 (focused unit coverage over JSONL WAL markers, SQLite-backed mailbox graph projection, daemon processor wiring, and config/server import coverage) -> L2 required (idempotent replay, pending retention on required-edge failure, send-time broadcast fan-out, and host-loop wiring). Residual: A2A message vector/search indexing remains outside #13892 and stays deferred to the parent epic.

## Deltas from ticket

- Reused the memory-WAL marker pattern for message graph projection instead of inventing a second reconciliation model.
- Made optional semantic edge failures non-blocking during projection; delivery-critical `SENT_BY`, `SENT_TO`, and broadcast `DELIVERED_TO` still fail loudly and leave the WAL row pending.
- Replay uses the WAL's send-time broadcast recipient snapshot, not the current AgentIdentity graph audience.

## Test Evidence

- `node --check ai/services/memory-core/helpers/messageWalStore.mjs`
- `node --check ai/services/memory-core/MailboxService.mjs`
- `node --check ai/daemons/message/drainCycle.mjs`
- `node --check ai/daemons/message/daemon.mjs`
- `node --check ai/mcp/server/memory-core/Server.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs`
- `node --check test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs`
- `git diff --check`
- `npm run agent-preflight -- ai/services/memory-core/helpers/messageWalStore.mjs ai/services/memory-core/MailboxService.mjs ai/daemons/message/drainCycle.mjs ai/daemons/message/daemon.mjs ai/mcp/server/memory-core/Server.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/daemons/message/drainLock.spec.mjs` (107 passed)

## Post-Merge Validation

- [ ] Confirm a deployed message drain host projects a seeded pending message WAL row, writes the graph marker, and leaves no pending row for that message.

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
