### PR TITLE
fix(ai): stop REM repair retry overflow (#13918)

### DIFF
--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -1,8 +1,12 @@
-import fs                                              from 'fs';
-import path                                            from 'path';
-import aiConfig                                        from '../../mcp/server/memory-core/config.mjs';
-import Base                                            from '../../../src/core/Base.mjs';
-import {emitConsumerFriction, invokeWithGuardrail}     from '../../services/memory-core/helpers/consumerFrictionHelper.mjs';
+import fs       from 'fs';
+import path     from 'path';
+import aiConfig from '../../mcp/server/memory-core/config.mjs';
+import Base     from '../../../src/core/Base.mjs';
+import {
+    bytesToTokens,
+    emitConsumerFriction,
+    invokeWithGuardrail
+} from '../../services/memory-core/helpers/consumerFrictionHelper.mjs';
 import GraphService                                    from '../../services/memory-core/GraphService.mjs';
 import Json                                            from '../../../src/util/Json.mjs';
 import logger                                          from '../../mcp/server/memory-core/logger.mjs';
@@ -55,6 +59,105 @@ class SemanticGraphExtractor extends Base {
      */
     normalizeMemorySessionGraphNodeId(id) {
         return this.isMemorySessionGraphNodeId(id) ? GraphService.normalizeGraphNodeId(id) : id;
+    }
+
+    /**
+     * Estimates chat-message payload size using the shared consumer-friction token heuristic.
+     *
+     * @summary Anchor & Echo: Keeps post-invocation retry sizing on the same estimator as the
+     * pre-invocation guardrail, so calibration fixes land in one place.
+     *
+     * @param {Object[]} messages Provider chat messages
+     * @returns {Object} `{text, bytes, tokens}` estimate for the composed provider payload
+     * @protected
+     */
+    estimateChatMessagesPayload(messages) {
+        const text  = messages.map(m => m.content).join('\n'),
+              bytes = Buffer.byteLength(text, 'utf8');
+
+        return {
+            text,
+            bytes,
+            tokens: bytesToTokens(bytes)
+        };
+    }
+
+    /**
+     * Resolves provider completion finish reasons across supported raw envelopes.
+     *
+     * @summary Anchor & Echo: Normalizes OpenAI-compatible `finish_reason`, Ollama
+     * `done_reason`, and Gemini `finishReason` shapes into one retry-loop predicate.
+     *
+     * @param {Object} result Provider generation result
+     * @returns {String} Completion finish reason, or an empty string when unavailable
+     * @protected
+     */
+    getCompletionFinishReason(result) {
+        const reason = result?.finish_reason ??
+                       result?.finishReason ??
+                       result?.raw?.finish_reason ??
+                       result?.raw?.finishReason ??
+                       result?.raw?.done_reason ??
+                       result?.raw?.doneReason ??
+                       result?.raw?.choices?.[0]?.finish_reason ??
+                       result?.raw?.choices?.[0]?.finishReason ??
+                       result?.raw?.candidates?.[0]?.finishReason;
+
+        return typeof reason === 'string' ? reason : '';
+    }
+
+    /**
+     * Tests whether a provider finish reason means the response hit an output/token cap.
+     *
+     * @summary Anchor & Echo: Length-capped non-empty responses are treated as overflow
+     * evidence because schema-repair retries would append the truncated body and grow the prompt.
+     *
+     * @param {String} finishReason Provider finish reason
+     * @returns {Boolean} `true` when the reason indicates token-length truncation
+     * @protected
+     */
+    isLengthTruncatedCompletion(finishReason) {
+        return /^(length|max_tokens|token_limit)$/i.test(String(finishReason || '').trim());
+    }
+
+    /**
+     * Emits deterministic context-overflow friction for post-invocation retry aborts.
+     *
+     * @summary Anchor & Echo: Reuses the established ConsumerFriction channel for retry-loop
+     * overflow evidence instead of introducing a parallel symptom path.
+     *
+     * @param {Object} options
+     * @param {String} options.sessionId Session identifier
+     * @param {String} options.consumerModel Provider model identifier
+     * @param {Number} options.consumerContextTokens Context window in tokens
+     * @param {Number} options.consumerSafeTokens Safe processing band in tokens
+     * @param {Number} options.inputBytes Estimated prompt bytes
+     * @param {Number} options.inputTokensEstimate Estimated prompt tokens
+     * @param {String} options.note Diagnostic note
+     * @protected
+     */
+    emitRetryLoopContextOverflow({
+        sessionId,
+        consumerModel,
+        consumerContextTokens,
+        consumerSafeTokens,
+        inputBytes,
+        inputTokensEstimate,
+        note
+    }) {
+        emitConsumerFriction({
+            symptom                  : 'context-overflow',
+            consumer                 : 'SemanticGraphExtractor',
+            model                    : consumerModel,
+            assetRef                 : sessionId,
+            serviceDomain            : 'dream-pipeline',
+            emissionPoint            : 'post-invocation-failure',
+            inputBytes,
+            inputTokensEstimate,
+            contextLimitTokens       : consumerContextTokens,
+            safeProcessingLimitTokens: consumerSafeTokens,
+            note
+        });
     }
 
     /**
@@ -128,7 +231,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 
         try {
             const graphProvider = resolveGraphModelProvider(aiConfig);
-            const provider = buildGraphProvider({
+            const provider      = buildGraphProvider({
                 modelProvider         : graphProvider,
                 ollamaConfig          : aiConfig.ollama,
                 openAiCompatibleConfig: aiConfig.openAiCompatible
@@ -141,9 +244,9 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             ];
 
             let maxRetries = 3;
-            let attempt = 0;
-            let payload = null;
-            let result = null;
+            let attempt    = 0;
+            let payload    = null;
+            let result     = null;
 
             // Wrap each LLM invocation with the Consumer-Friction guardrail. The upstream
             // pre-check skips invocation when the composed messages' estimated token count
@@ -157,9 +260,12 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             // threshold (model-role axis, not provider-namespace — remote providers like
             // Gemini are API-bound and don't expose these knobs; local providers
             // share the same caps because the limit comes from the loaded model).
-            const consumerModel          = aiConfig[graphProvider].model;
-            const consumerContextTokens  = aiConfig.localModels.chat.contextLimitTokens;
-            const consumerSafeTokens     = aiConfig.localModels.chat.safeProcessingLimitTokens;
+            const consumerModel         = aiConfig[graphProvider].model;
+            const consumerContextTokens = aiConfig.localModels.chat.contextLimitTokens;
+            const configuredSafeTokens  = aiConfig.localModels.chat.safeProcessingLimitTokens;
+            const consumerSafeTokens    = Number.isFinite(configuredSafeTokens)
+                ? configuredSafeTokens
+                : Math.floor(consumerContextTokens * 0.75);
 
             // Per-task no-think + grammar-constrained tri-vector output. `graphReasoningEffort`
             // (default 'none') disables the gemma MoE's hidden thinking pass; `triVectorSchema` enforces
@@ -167,7 +273,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             // repair-retry loop below a safety net rather than the happy path. Schema mirrors the strict
             // shape declared in the systemInstruction above.
             const graphReasoningEffort = aiConfig.localModels.chat.graphReasoningEffort;
-            const triVectorSchema = {
+            const triVectorSchema      = {
                 type      : 'object',
                 properties: {
                     a2a_version     : {type: 'string'},
@@ -217,11 +323,13 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 },
                 required: ['a2a_version', 'session_artifact']
             };
+            const repairFeedback = `Your previous response failed internal schema validation. You are missing required keys (e.g., session_artifact) or you provided malformed JSON. Please correct your output and provide ONLY the exact JSON shape requested in the instructions.`;
 
             while (attempt < maxRetries && !payload) {
                 attempt++;
 
-                const inputPayloadText = messages.map(m => m.content).join('\n');
+                const inputPayload     = this.estimateChatMessagesPayload(messages);
+                const inputPayloadText = inputPayload.text;
                 const guardrailed      = await invokeWithGuardrail({
                     invocationFn             : () => provider.generate(messages, {reasoning_effort: graphReasoningEffort || undefined, responseSchema: triVectorSchema, responseSchemaName: 'triVector'}),
                     inputPayload             : inputPayloadText,
@@ -240,6 +348,23 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 }
 
                 result = guardrailed.result;
+                const finishReason = this.getCompletionFinishReason(result);
+
+                if (this.isLengthTruncatedCompletion(finishReason)) {
+                    logger.warn(`[SemanticGraphExtractor] Attempt ${attempt}: Provider reported '${finishReason}' for session ${session.meta.sessionId}; classifying as context-overflow and aborting JSON repair loop.`);
+
+                    this.emitRetryLoopContextOverflow({
+                        sessionId          : session.meta.sessionId,
+                        consumerModel,
+                        consumerContextTokens,
+                        consumerSafeTokens,
+                        inputBytes         : inputPayload.bytes,
+                        inputTokensEstimate: inputPayload.tokens,
+                        note                    : `Provider finish_reason='${finishReason}' before schema validation. Aborting repair loop to avoid appending a truncated response. Attempt ${attempt}/${maxRetries}.`
+                    });
+
+                    return null;
+                }
 
                 // Silent context-overflow detection: provider can stream-close immediately
                 // with an empty body when its loaded-model context window is smaller than
@@ -276,12 +401,32 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                     logger.warn(`[SemanticGraphExtractor] Attempt ${attempt}: Failed to validate extracted Tri-Vector A2A payload for session: ${session.meta.sessionId}`);
 
                     if (attempt < maxRetries) {
+                        const repairMessages = [
+                            ...messages,
+                            { role: 'assistant', content: result.content },
+                            { role: 'user', content: repairFeedback }
+                        ];
+                        const repairPayload = this.estimateChatMessagesPayload(repairMessages);
+
+                        if (repairPayload.tokens > consumerSafeTokens) {
+                            logger.warn(`[SemanticGraphExtractor] Attempt ${attempt}: JSON repair prompt would exceed safe processing band for session ${session.meta.sessionId}; classifying as context-overflow and aborting retry loop.`);
+
+                            this.emitRetryLoopContextOverflow({
+                                sessionId          : session.meta.sessionId,
+                                consumerModel,
+                                consumerContextTokens,
+                                consumerSafeTokens,
+                                inputBytes         : repairPayload.bytes,
+                                inputTokensEstimate: repairPayload.tokens,
+                                note                    : `Repair retry prompt estimate ${repairPayload.tokens} tokens exceeds safe band ${consumerSafeTokens}. Aborting instead of appending assistant output and repair feedback. Attempt ${attempt}/${maxRetries}.`
+                            });
+
+                            return null;
+                        }
+
                         logger.warn(`[SemanticGraphExtractor] Attempt ${attempt}: Injecting autonomous JSON repair feedback loop.`);
-                        messages.push({ role: 'assistant', content: result.content });
-                        messages.push({
-                            role: 'user',
-                            content: `Your previous response failed internal schema validation. You are missing required keys (e.g., session_artifact) or you provided malformed JSON. Please correct your output and provide ONLY the exact JSON shape requested in the instructions.`
-                        });
+                        messages.push(repairMessages[repairMessages.length - 2]);
+                        messages.push(repairMessages[repairMessages.length - 1]);
                         payload = null; // Ensure loop continues
                     } else {
                         logger.warn(`[SemanticGraphExtractor] --- FINAL EXHAUSTED RAW LLM DUMP ---\n${result.content}\n-----------------------------`);
@@ -326,7 +471,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 if (node.id === 'frontier') continue;
 
                 let nodeType = node.type && VALID_TYPES.includes(node.type.toUpperCase()) ? node.type.toUpperCase() : 'CONCEPT';
-                let nodeId = node.id;
+                let nodeId   = node.id;
 
                 // Enforce Neo native Graph ID specification (Type:Name) if hallucinated
                 if (!nodeId.includes(':')) {
@@ -376,7 +521,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 const targetExists = validNodeRefs.has(resolvedTarget) || GraphService.db.nodes.has(resolvedTarget);
 
                 if (!sourceExists || !targetExists) {
-                    const isProvenance = ['MENTIONED_IN', 'DISCUSSED_IN', 'REFERENCED_BY'].includes(edge.relationship);
+                    const isProvenance           = ['MENTIONED_IN', 'DISCUSSED_IN', 'REFERENCED_BY'].includes(edge.relationship);
                     const targetsSessionOrMemory = this.isMemorySessionGraphNodeId(resolvedTarget) || this.isMemorySessionGraphNodeId(resolvedSource);
 
                     if (isProvenance && targetsSessionOrMemory) {
@@ -389,7 +534,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                          */
                         logger.info(`[SemanticGraphExtractor] Queuing unresolved provenance edge for lazy back-fill: ${resolvedSource} -> ${resolvedTarget}`);
                         const lazyQueueFile = aiConfig.lazyEdgesQueuePath;
-                        const edgeData = JSON.stringify({ ...edge, source: resolvedSource, target: resolvedTarget, timestamp: new Date().toISOString() }) + '\n';
+                        const edgeData      = JSON.stringify({ ...edge, source: resolvedSource, target: resolvedTarget, timestamp: new Date().toISOString() }) + '\n';
                         try {
                             // Ensure the directory exists before appending
                             await fs.promises.mkdir(path.dirname(lazyQueueFile), { recursive: true });
@@ -478,7 +623,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 
         try {
             const graphProvider = resolveGraphModelProvider(aiConfig);
-            const provider = buildGraphProvider({
+            const provider      = buildGraphProvider({
                 modelProvider         : graphProvider,
                 ollamaConfig          : aiConfig.ollama,
                 openAiCompatibleConfig: aiConfig.openAiCompatible
@@ -490,8 +635,8 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             ];
 
             let maxRetries = 2;
-            let attempt = 0;
-            let payload = null;
+            let attempt    = 0;
+            let payload    = null;
 
             while (attempt < maxRetries && !payload) {
                 attempt++;

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -13,11 +13,11 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import fs             from 'fs';
-import path           from 'path';
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
+import fs                    from 'fs';
+import path                  from 'path';
 import {TestLifecycleHelper} from '../../services/memory-core/util.mjs';
 import {
     clearAggregatedFrictions,
@@ -112,36 +112,36 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
             OpenAiCompatible.prototype.generate = async function(messages) {
                 return {
                     content: JSON.stringify({
-                        a2a_version: "1.0",
-                        agent_id: "Antigravity",
+                        a2a_version     : "1.0",
+                        agent_id        : "Antigravity",
                         session_artifact: {
                             graph: {
                                 nodes: [
                                     {
-                                        id: "CONCEPT:TestConcept",
-                                        type: "CONCEPT",
-                                        name: "TestConcept",
+                                        id         : "CONCEPT:TestConcept",
+                                        type       : "CONCEPT",
+                                        name       : "TestConcept",
                                         description: "Test concept for provenance edges"
                                     }
                                 ],
                                 edges: [
                                     {
-                                        source: "CONCEPT:TestConcept",
-                                        target: "MEMORY:non-existent-memory",
-                                        relationship: "MENTIONED_IN",
-                                        weight: 1.0,
+                                        source       : "CONCEPT:TestConcept",
+                                        target       : "MEMORY:non-existent-memory",
+                                        relationship : "MENTIONED_IN",
+                                        weight       : 1.0,
                                         justification: "Uppercase compatibility provenance test"
                                     },
                                     {
-                                        source: "CONCEPT:TestConcept",
-                                        target: "session:non-existent-session",
-                                        relationship: "DISCUSSED_IN",
-                                        weight: 1.0,
+                                        source       : "CONCEPT:TestConcept",
+                                        target       : "session:non-existent-session",
+                                        relationship : "DISCUSSED_IN",
+                                        weight       : 1.0,
                                         justification: "Canonical lowercase provenance test"
                                     },
                                     {
-                                        source: "CONCEPT:TestConcept",
-                                        target: "frontier",
+                                        source      : "CONCEPT:TestConcept",
+                                        target      : "frontier",
                                         relationship: "RELATES_TO"
                                     }
                                 ]
@@ -152,8 +152,8 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
             };
 
             const session = {
-                id: 'mock-semantic-vector-id',
-                meta: { sessionId: 'playwright-provenance-test' },
+                id      : 'mock-semantic-vector-id',
+                meta    : { sessionId: 'playwright-provenance-test' },
                 document: "Mock episodic history for provenance"
             };
 
@@ -251,8 +251,8 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
             OpenAiCompatible.prototype.generate = async function(messages) {
                 return {
                     content: JSON.stringify({
-                        a2a_version: "1.0",
-                        agent_id: "Antigravity",
+                        a2a_version     : "1.0",
+                        agent_id        : "Antigravity",
                         session_artifact: {
                             graph: {}
                         }
@@ -268,8 +268,8 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
             OpenAiCompatible.prototype.generate = async function(messages) {
                 return {
                     content: JSON.stringify({
-                        a2a_version: "1.0",
-                        agent_id: "Antigravity",
+                        a2a_version     : "1.0",
+                        agent_id        : "Antigravity",
                         session_artifact: {
                             graph: {
                                 nodes: { someObject: true },
@@ -290,8 +290,8 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
     });
 
     test('Sub 9 hypotheses 9 and 11: empty-response overflow records friction and aborts retry amplification (#12617, #12091)', async () => {
-        const baseGenerate = OpenAiCompatible.prototype.generate;
-        let invocationCount = 0;
+        const baseGenerate    = OpenAiCompatible.prototype.generate;
+        let   invocationCount = 0;
 
         try {
             clearAggregatedFrictions();
@@ -339,11 +339,154 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         }
     });
 
+    test('truncated non-empty tri-vector output records friction and aborts repair amplification (#13918)', async () => {
+        const baseGenerate                      = OpenAiCompatible.prototype.generate;
+        const originalContextLimitTokens        = aiConfig.localModels.chat.contextLimitTokens;
+        const originalSafeProcessingLimitTokens = aiConfig.localModels.chat.safeProcessingLimitTokens;
+        let   invocationCount                   = 0;
+
+        try {
+            clearAggregatedFrictions();
+
+            aiConfig.localModels.chat.contextLimitTokens        = 100000;
+            aiConfig.localModels.chat.safeProcessingLimitTokens = 50000;
+
+            OpenAiCompatible.prototype.generate = async function(messages) {
+                invocationCount++;
+
+                return {
+                    content      : '{"a2a_version":"1.0","session_artifact":',
+                    finish_reason: 'length'
+                };
+            };
+
+            const result = await SemanticGraphExtractor.executeTriVectorExtraction({
+                id      : 'mock-truncated-response-vector-id',
+                meta    : {sessionId: 'truncated-response-overflow-session'},
+                document: 'Mock episodic history for truncated non-empty response detection.'
+            });
+
+            expect(result).toBeNull();
+            expect(invocationCount).toBe(1);
+
+            const frictions = getAggregatedFrictions();
+            const friction  = frictions.find(item => item.assetRef === 'truncated-response-overflow-session');
+
+            expect(friction).toBeDefined();
+            expect(friction.symptom).toBe('context-overflow');
+            expect(friction.note).toContain("finish_reason='length'");
+            expect(friction.note).toContain('Aborting repair loop');
+        } finally {
+            OpenAiCompatible.prototype.generate                 = baseGenerate;
+            aiConfig.localModels.chat.contextLimitTokens        = originalContextLimitTokens;
+            aiConfig.localModels.chat.safeProcessingLimitTokens = originalSafeProcessingLimitTokens;
+            clearAggregatedFrictions();
+        }
+    });
+
+    test('over-band tri-vector repair prompt records friction instead of appending feedback (#13918)', async () => {
+        const baseGenerate                      = OpenAiCompatible.prototype.generate;
+        const originalContextLimitTokens        = aiConfig.localModels.chat.contextLimitTokens;
+        const originalSafeProcessingLimitTokens = aiConfig.localModels.chat.safeProcessingLimitTokens;
+        let   invocationCount                   = 0;
+
+        try {
+            clearAggregatedFrictions();
+
+            aiConfig.localModels.chat.contextLimitTokens        = 100000;
+            aiConfig.localModels.chat.safeProcessingLimitTokens = 50000;
+
+            OpenAiCompatible.prototype.generate = async function(messages) {
+                invocationCount++;
+
+                return {
+                    content: 'malformed-json'.repeat(20000)
+                };
+            };
+
+            const result = await SemanticGraphExtractor.executeTriVectorExtraction({
+                id      : 'mock-over-band-repair-vector-id',
+                meta    : {sessionId: 'over-band-repair-session'},
+                document: 'Mock episodic history for over-band repair retry detection.'
+            });
+
+            expect(result).toBeNull();
+            expect(invocationCount).toBe(1);
+
+            const frictions = getAggregatedFrictions();
+            const friction  = frictions.find(item => item.assetRef === 'over-band-repair-session');
+
+            expect(friction).toBeDefined();
+            expect(friction.symptom).toBe('context-overflow');
+            expect(friction.inputTokensEstimate).toBeGreaterThan(50000);
+            expect(friction.note).toContain('Repair retry prompt estimate');
+            expect(friction.note).toContain('Aborting instead of appending');
+        } finally {
+            OpenAiCompatible.prototype.generate                 = baseGenerate;
+            aiConfig.localModels.chat.contextLimitTokens        = originalContextLimitTokens;
+            aiConfig.localModels.chat.safeProcessingLimitTokens = originalSafeProcessingLimitTokens;
+            clearAggregatedFrictions();
+        }
+    });
+
+    test('under-band malformed tri-vector output still uses one JSON repair retry (#13918)', async () => {
+        const baseGenerate                      = OpenAiCompatible.prototype.generate;
+        const originalContextLimitTokens        = aiConfig.localModels.chat.contextLimitTokens;
+        const originalSafeProcessingLimitTokens = aiConfig.localModels.chat.safeProcessingLimitTokens;
+        let   invocationCount                   = 0;
+
+        try {
+            clearAggregatedFrictions();
+
+            aiConfig.localModels.chat.contextLimitTokens        = 100000;
+            aiConfig.localModels.chat.safeProcessingLimitTokens = 50000;
+
+            OpenAiCompatible.prototype.generate = async function(messages) {
+                invocationCount++;
+
+                if (invocationCount === 1) {
+                    return {content: 'not-json'};
+                }
+
+                return {
+                    content: JSON.stringify({
+                        a2a_version     : '1.0',
+                        agent_id        : 'Antigravity',
+                        session_artifact: {
+                            feature_namespace     : null,
+                            human_readable_summary: 'Recovered after a bounded JSON repair retry.',
+                            graph                 : {
+                                nodes: [],
+                                edges: []
+                            }
+                        }
+                    })
+                };
+            };
+
+            const result = await SemanticGraphExtractor.executeTriVectorExtraction({
+                id      : 'mock-under-band-repair-vector-id',
+                meta    : {sessionId: 'under-band-repair-session'},
+                document: 'Mock episodic history for bounded repair retry detection.'
+            });
+
+            expect(result).not.toBeNull();
+            expect(result.session_artifact.human_readable_summary).toBe('Recovered after a bounded JSON repair retry.');
+            expect(invocationCount).toBe(2);
+            expect(getAggregatedFrictions().find(item => item.assetRef === 'under-band-repair-session')).toBeUndefined();
+        } finally {
+            OpenAiCompatible.prototype.generate                 = baseGenerate;
+            aiConfig.localModels.chat.contextLimitTokens        = originalContextLimitTokens;
+            aiConfig.localModels.chat.safeProcessingLimitTokens = originalSafeProcessingLimitTokens;
+            clearAggregatedFrictions();
+        }
+    });
+
     test('Sub 9 hypotheses 2, 8, 9: guardrail telemetry uses configured graph-provider model (#12617, #12059)', async () => {
-        const originalGraphProvider                  = aiConfig.graphProvider;
-        const originalOllamaModel                    = aiConfig.ollama?.model;
-        const originalContextLimitTokens             = aiConfig.localModels.chat.contextLimitTokens;
-        const originalSafeProcessingLimitTokens      = aiConfig.localModels.chat.safeProcessingLimitTokens;
+        const originalGraphProvider             = aiConfig.graphProvider;
+        const originalOllamaModel               = aiConfig.ollama?.model;
+        const originalContextLimitTokens        = aiConfig.localModels.chat.contextLimitTokens;
+        const originalSafeProcessingLimitTokens = aiConfig.localModels.chat.safeProcessingLimitTokens;
 
         try {
             clearAggregatedFrictions();


### PR DESCRIPTION
Resolves #13918

Stops `SemanticGraphExtractor` from turning a malformed near-limit REM response into a larger retry prompt. The extractor now treats provider length-truncation as deterministic `context-overflow` evidence, estimates any repair retry envelope with the shared `bytesToTokens()` guardrail primitive, and aborts before appending assistant output plus repair feedback when the retry would cross the configured safe band.

Evidence: L2 (focused unit specs for truncation abort, over-band repair abort, normal bounded repair, shared guardrail behavior, and DreamService handoff) -> L2 required (retry loop must not append-grow past the safe band; truncated/length responses abort before repair). No residuals.

## Deltas from ticket

- Reuses the shared consumer-friction token estimator so the #13919 density calibration applies to both the pre-invocation and post-invocation guardrails.
- Normalizes OpenAI-compatible, Ollama, and Gemini finish-reason shapes into one length-truncation predicate.
- Emits through the existing `context-overflow` `ConsumerFriction` channel instead of adding a new symptom path.
- Keeps the normal under-band JSON repair behavior intact.

## Test Evidence

- `node --check ai/services/graph/SemanticGraphExtractor.mjs`
- `node --check test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs`
- `git diff --check origin/dev..HEAD`
- `npm run test-unit -- test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/consumerFrictionHelper.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs --workers=1` -> 61 passed
- `npm run agent-preflight -- ai/services/graph/SemanticGraphExtractor.mjs test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs` -> passed

## Post-Merge Validation

- [ ] Observe the next live REM/orchestrator cycle against a near-band or truncated tri-vector response and confirm it aborts without repair prompt amplification.

## Commits

- `4e49ae1e6b` — `fix(ai): stop REM repair retry overflow (#13918)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
