### PR TITLE
feat(ai): add deployment runtime access holder (#13920)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -397,6 +397,52 @@ class Config extends ConfigProvider {
                     }
                 },
                 /**
+                 * L0 deployment-runtime access holder used by the self-healing stack.
+                 *
+                 * The mechanism decision is ADR-0026 OQ-1 as resolved by #13920:
+                 * docker-socket + deny-by-default wrapper is the MVP, while a privileged sidecar
+                 * remains the hardening fallback if the wrapper cannot prove strict service
+                 * identity and operation allowlisting. The holder exposes two separate
+                 * capability envelopes over the same runtime handle:
+                 *
+                 * - `readOperations`: logs / stats / inspect for #13914 observability.
+                 * - `lifecycleOperations`: restart for #13884/#13915 recovery.
+                 *
+                 * `allowedServices` names Docker Compose service labels, not arbitrary
+                 * container ids. `composeProject` is optional for single-stack deployments;
+                 * set it when a host runs multiple Neo compose projects on one Docker socket.
+                 *
+                 * Env overrides:
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED`,
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_MECHANISM`,
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_SOCKET_PATH`,
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT`,
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES`,
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_READ_OPERATIONS`,
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_LIFECYCLE_OPERATIONS`,
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_TIMEOUT_MS`,
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_RESPONSE_MAX_BYTES`,
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_LOG_TAIL`,
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_RESTART_TIMEOUT_SECONDS`,
+                 * `NEO_ORCHESTRATOR_RUNTIME_ACCESS_AUDIT_MODE`.
+                 *
+                 * @type {Object}
+                 */
+                deploymentRuntimeAccess: {
+                    enabled                     : leaf(false, 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED', 'boolean'),
+                    mechanism                   : leaf('docker-socket', 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_MECHANISM', 'string'),
+                    socketPath                  : leaf('/var/run/docker.sock', 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_SOCKET_PATH', 'string'),
+                    composeProject              : leaf(null, 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT', 'string'),
+                    allowedServices             : leaf(['chroma', 'kb-server', 'mc-server', 'local-model'], 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES', 'csv'),
+                    readOperations              : leaf(['inspect', 'logs', 'stats'], 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_READ_OPERATIONS', 'csv'),
+                    lifecycleOperations         : leaf(['restart'], 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_LIFECYCLE_OPERATIONS', 'csv'),
+                    timeoutMs                   : leaf(5000, 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_TIMEOUT_MS', 'number'),
+                    responseMaxBytes            : leaf(1024 * 1024, 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_RESPONSE_MAX_BYTES', 'number'),
+                    logTail                     : leaf(200, 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_LOG_TAIL', 'number'),
+                    defaultRestartTimeoutSeconds: leaf(10, 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_RESTART_TIMEOUT_SECONDS', 'number'),
+                    auditMode                   : leaf('metadata', 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_AUDIT_MODE', 'string')
+                },
+                /**
                  * Maintenance-loop intervals consumed by the orchestrator daemon.
                  * Env vars at the daemon boundary retain precedence over these defaults.
                  * @type {Object}

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -29,6 +29,7 @@ import RequestContextService                                                    
 import {normalizeAgentIdentityNodeId}                                           from '../../scripts/lifecycle/resumeHarness.mjs';
 import TaskStateService                                                         from './services/TaskStateService.mjs';
 import ProcessSupervisorService                                                 from './services/ProcessSupervisorService.mjs';
+import DeploymentRuntimeAccessService                                           from './services/DeploymentRuntimeAccessService.mjs';
 import DreamService                                                             from './services/DreamService.mjs';
 import SwarmHeartbeatService                                                    from './services/SwarmHeartbeatService.mjs';
 import GoldenPathSynthesizer                                                    from '../../services/graph/GoldenPathSynthesizer.mjs';
@@ -104,6 +105,7 @@ export class Orchestrator extends Base {
         className                      : 'Neo.ai.daemons.Orchestrator',
         singleton                      : true,
         processSupervisorService_      : null,
+        deploymentRuntimeAccessService_: null,
         maintenanceBackpressureService_: MaintenanceBackpressureService,
         dataDir_                       : DEFAULT_DATA_DIR,
         taskDefinitions_               : null,
@@ -141,6 +143,7 @@ export class Orchestrator extends Base {
     goldenPathDependencyTaskNames = DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
 
     processSupervisorWriteLog = (level, msg) => this.writeLog(level, msg)
+    deploymentRuntimeAccessWriteLog = (level, msg) => this.writeLog(level, msg)
     maintenanceBackpressureWriteLog = (level, msg) => this.writeLog(level, msg)
 
     /**
@@ -274,6 +277,17 @@ export class Orchestrator extends Base {
         });
     }
 
+    /**
+     * @param {Neo.ai.daemons.services.DeploymentRuntimeAccessService|Object|null} value
+     * @returns {Neo.ai.daemons.services.DeploymentRuntimeAccessService}
+     */
+    beforeSetDeploymentRuntimeAccessService(value) {
+        return ClassSystemUtil.beforeSetInstance(value, DeploymentRuntimeAccessService, {
+            runtimeAccessConfig: AiConfig.orchestrator.deploymentRuntimeAccess,
+            writeLog           : this.deploymentRuntimeAccessWriteLog
+        });
+    }
+
     beforeSetMaintenanceBackpressureService(value) {
         return ClassSystemUtil.beforeSetInstance(value, MaintenanceBackpressureService, {
             heavyMaintenanceTaskNames    : this.heavyMaintenanceTaskNames,
@@ -394,6 +408,7 @@ export class Orchestrator extends Base {
         });
 
         this.processSupervisorService = {};
+        this.deploymentRuntimeAccessService = {};
         this.processSupervisorService.recoverTasks();
 
         this.db = await this.initializeDatabaseFn(this.dbPath);

--- a/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
@@ -1,0 +1,494 @@
+import http from 'http';
+import Base from '../../../../src/core/Base.mjs';
+
+export const DEPLOYMENT_RUNTIME_MECHANISMS = Object.freeze([
+    'docker-socket',
+    'sidecar'
+]);
+
+export const DEPLOYMENT_RUNTIME_READ_OPERATIONS = Object.freeze([
+    'inspect',
+    'logs',
+    'stats'
+]);
+
+export const DEPLOYMENT_RUNTIME_LIFECYCLE_OPERATIONS = Object.freeze([
+    'restart'
+]);
+
+const DEFAULT_RESPONSE_MAX_BYTES = 1024 * 1024;
+
+/**
+ * @summary Performs one bounded HTTP request against the Docker Engine Unix socket.
+ *
+ * @param {Object} options
+ * @param {String} options.socketPath Docker socket path.
+ * @param {String} options.method HTTP method.
+ * @param {String} options.path Docker Engine API path.
+ * @param {String|null} [options.body=null] Optional request body.
+ * @param {Number} [options.timeoutMs=5000] Request timeout.
+ * @param {Number} [options.maxBytes=1048576] Response byte cap.
+ * @returns {Promise<{statusCode: Number, headers: Object, body: String}>}
+ */
+export function dockerSocketRequest({
+    socketPath,
+    method,
+    path,
+    body = null,
+    timeoutMs = 5000,
+    maxBytes = DEFAULT_RESPONSE_MAX_BYTES
+}) {
+    return new Promise((resolve, reject) => {
+        const req = http.request({
+            socketPath,
+            method,
+            path,
+            timeout: timeoutMs
+        }, res => {
+            const chunks = [];
+            let   bytes  = 0;
+
+            res.on('data', chunk => {
+                bytes += chunk.length;
+
+                if (bytes > maxBytes) {
+                    req.destroy(new Error(`Docker API response exceeded ${maxBytes} bytes`));
+                    return;
+                }
+
+                chunks.push(chunk);
+            });
+
+            res.on('end', () => {
+                const responseBody = Buffer.concat(chunks).toString('utf8');
+
+                if (res.statusCode >= 400) {
+                    reject(new Error(`Docker API ${method} ${path} failed with HTTP ${res.statusCode}: ${responseBody.slice(0, 512)}`));
+                    return;
+                }
+
+                resolve({
+                    statusCode: res.statusCode,
+                    headers   : res.headers,
+                    body      : responseBody
+                });
+            });
+        });
+
+        req.on('timeout', () => req.destroy(new Error(`Docker API ${method} ${path} timed out after ${timeoutMs}ms`)));
+        req.on('error', reject);
+
+        if (body !== null) {
+            req.write(body);
+        }
+
+        req.end();
+    });
+}
+
+/**
+ * @summary Orchestrator-owned L0 deployment-runtime holder with separate read and lifecycle envelopes.
+ *
+ * The service deliberately talks to the Docker socket through a deny-by-default wrapper instead
+ * of exposing docker/compose as a generic executor. Service identity resolves through Docker
+ * Compose labels (`com.docker.compose.service`, optionally project-scoped), so callers name an
+ * allowlisted service key and never pass an arbitrary container id or shell command.
+ *
+ * @class Neo.ai.daemons.services.DeploymentRuntimeAccessService
+ * @extends Neo.core.Base
+ */
+export class DeploymentRuntimeAccessService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.DeploymentRuntimeAccessService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.DeploymentRuntimeAccessService',
+        /**
+         * @member {Object|null} runtimeAccessConfig_=null
+         * @protected
+         * @reactive
+         */
+        runtimeAccessConfig_: null,
+        /**
+         * @member {Function|null} dockerRequestFn_=null
+         * @protected
+         * @reactive
+         */
+        dockerRequestFn_: null,
+        /**
+         * @member {Function|null} nowFn_=null
+         * @protected
+         * @reactive
+         */
+        nowFn_: null,
+        /**
+         * @member {Function|null} writeLog_=null
+         * @protected
+         * @reactive
+         */
+        writeLog_: null
+    }
+
+    /**
+     * Resolves the active runtime-access config.
+     * @returns {Object}
+     */
+    get configValues() {
+        return this.runtimeAccessConfig || {};
+    }
+
+    /**
+     * Resolves the configured runtime mechanism.
+     * @returns {String}
+     */
+    get mechanism() {
+        return this.configValues.mechanism || 'docker-socket';
+    }
+
+    /**
+     * Resolves the configured Docker socket path.
+     * @returns {String}
+     */
+    get socketPath() {
+        return this.configValues.socketPath || '/var/run/docker.sock';
+    }
+
+    /**
+     * Resolves the request timeout.
+     * @returns {Number}
+     */
+    get timeoutMs() {
+        return this.configValues.timeoutMs ?? 5000;
+    }
+
+    /**
+     * Resolves the bounded response cap.
+     * @returns {Number}
+     */
+    get responseMaxBytes() {
+        return this.configValues.responseMaxBytes ?? DEFAULT_RESPONSE_MAX_BYTES;
+    }
+
+    /**
+     * Executes a read-only deployment observation through the read-observe envelope.
+     *
+     * @param {Object} options
+     * @param {String} options.serviceKey Allowlisted compose service key.
+     * @param {'inspect'|'logs'|'stats'} options.operation Read operation.
+     * @param {Number} [options.tail] Log tail count for `logs`.
+     * @returns {Promise<Object>} Observation payload plus structured proof metadata.
+     */
+    async readObserve({serviceKey, operation = 'inspect', tail} = {}) {
+        this.assertEnabled();
+        this.assertMechanismSupported();
+        this.assertOperationAllowed('read-observe', operation);
+
+        const target = await this.resolveServiceTarget(serviceKey);
+
+        if (operation === 'inspect') {
+            return this.inspectTarget(target);
+        }
+
+        if (operation === 'logs') {
+            return this.readTargetLogs(target, {tail});
+        }
+
+        if (operation === 'stats') {
+            return this.readTargetStats(target);
+        }
+
+        throw new TypeError(`Unsupported read-observe operation '${operation}'`);
+    }
+
+    /**
+     * Executes a lifecycle operation through the lifecycle-write envelope.
+     *
+     * @param {Object} options
+     * @param {String} options.serviceKey Allowlisted compose service key.
+     * @param {'restart'} options.operation Lifecycle operation.
+     * @param {String} [options.reason='manual'] Audit reason.
+     * @param {Number} [options.restartTimeoutSeconds] Docker restart timeout.
+     * @returns {Promise<Object>} Lifecycle result plus structured proof metadata.
+     */
+    async applyLifecycle({serviceKey, operation = 'restart', reason = 'manual', restartTimeoutSeconds} = {}) {
+        this.assertEnabled();
+        this.assertMechanismSupported();
+        this.assertOperationAllowed('lifecycle-write', operation);
+
+        const target = await this.resolveServiceTarget(serviceKey);
+
+        if (operation === 'restart') {
+            return this.restartTarget(target, {reason, restartTimeoutSeconds});
+        }
+
+        throw new TypeError(`Unsupported lifecycle-write operation '${operation}'`);
+    }
+
+    /**
+     * Ensures deployment runtime access is explicitly enabled.
+     * @returns {void}
+     */
+    assertEnabled() {
+        if (!this.configValues.enabled) {
+            throw new Error('Deployment runtime access is disabled');
+        }
+    }
+
+    /**
+     * Ensures the configured runtime mechanism is supported by this holder.
+     * @returns {void}
+     */
+    assertMechanismSupported() {
+        if (!DEPLOYMENT_RUNTIME_MECHANISMS.includes(this.mechanism)) {
+            throw new Error(`Unsupported deployment runtime mechanism '${this.mechanism}'`);
+        }
+
+        if (this.mechanism === 'sidecar') {
+            throw new Error('Deployment runtime sidecar mechanism is documented fallback only; docker-socket is the MVP implementation');
+        }
+    }
+
+    /**
+     * Ensures the requested operation is allowlisted for the requested capability envelope.
+     * @param {'read-observe'|'lifecycle-write'} envelope Capability envelope.
+     * @param {String} operation Operation name.
+     * @returns {void}
+     */
+    assertOperationAllowed(envelope, operation) {
+        const allowed = envelope === 'read-observe'
+            ? this.configValues.readOperations
+            : this.configValues.lifecycleOperations;
+
+        if (!Array.isArray(allowed) || !allowed.includes(operation)) {
+            throw new Error(`Deployment runtime ${envelope} operation '${operation}' is not allowlisted`);
+        }
+    }
+
+    /**
+     * Resolves an allowlisted compose service key to exactly one Docker container.
+     * @param {String} serviceKey Allowlisted compose service key.
+     * @returns {Promise<Object>} Resolved target.
+     */
+    async resolveServiceTarget(serviceKey) {
+        this.assertServiceKeyAllowed(serviceKey);
+
+        const composeProject = this.configValues.composeProject || null,
+              filters        = {
+                  label: [`com.docker.compose.service=${serviceKey}`]
+              };
+
+        if (composeProject) {
+            filters.label.push(`com.docker.compose.project=${composeProject}`);
+        }
+
+        const response = await this.dockerRequest({
+            method: 'GET',
+            path  : `/containers/json?all=true&filters=${encodeURIComponent(JSON.stringify(filters))}`
+        });
+        const containers = this.parseJson(response.body, 'container list');
+
+        if (!Array.isArray(containers)) {
+            throw new Error('Docker API container list response is not an array');
+        }
+
+        if (containers.length === 0) {
+            throw new Error(`No Docker container found for compose service '${serviceKey}'`);
+        }
+
+        if (containers.length > 1) {
+            throw new Error(`Compose service '${serviceKey}' resolved to ${containers.length} containers; configure composeProject to disambiguate`);
+        }
+
+        const [container] = containers;
+
+        return {
+            serviceKey,
+            containerId   : container.Id,
+            names         : container.Names || [],
+            image         : container.Image || null,
+            state         : container.State || null,
+            status        : container.Status || null,
+            composeProject: container.Labels?.['com.docker.compose.project'] || composeProject,
+            labels        : {
+                composeService: container.Labels?.['com.docker.compose.service'] || serviceKey,
+                composeProject: container.Labels?.['com.docker.compose.project'] || composeProject
+            }
+        };
+    }
+
+    /**
+     * Ensures the caller cannot address arbitrary services.
+     * @param {String} serviceKey Compose service key.
+     * @returns {void}
+     */
+    assertServiceKeyAllowed(serviceKey) {
+        if (typeof serviceKey !== 'string' || serviceKey.length === 0) {
+            throw new TypeError('Deployment runtime serviceKey is required');
+        }
+
+        if (!/^[a-zA-Z0-9_.-]+$/.test(serviceKey)) {
+            throw new TypeError(`Deployment runtime serviceKey '${serviceKey}' contains unsupported characters`);
+        }
+
+        const allowedServices = this.configValues.allowedServices;
+
+        if (!Array.isArray(allowedServices) || !allowedServices.includes(serviceKey)) {
+            throw new Error(`Deployment runtime service '${serviceKey}' is not allowlisted`);
+        }
+    }
+
+    /**
+     * Reads Docker inspect data for a resolved target.
+     * @param {Object} target Resolved target.
+     * @returns {Promise<Object>}
+     */
+    async inspectTarget(target) {
+        const response = await this.dockerRequest({
+            method: 'GET',
+            path  : `/containers/${encodeURIComponent(target.containerId)}/json`
+        });
+
+        return {
+            ok        : true,
+            data      : this.parseJson(response.body, 'container inspect'),
+            proof     : this.createProofMetadata({envelope: 'read-observe', operation: 'inspect', target}),
+            statusCode: response.statusCode
+        };
+    }
+
+    /**
+     * Reads bounded Docker logs for a resolved target.
+     * @param {Object} target Resolved target.
+     * @param {Object} options
+     * @param {Number} [options.tail] Log tail count.
+     * @returns {Promise<Object>}
+     */
+    async readTargetLogs(target, {tail} = {}) {
+        const tailCount = tail ?? this.configValues.logTail ?? 200,
+              response  = await this.dockerRequest({
+                  method: 'GET',
+                  path  : `/containers/${encodeURIComponent(target.containerId)}/logs?stdout=1&stderr=1&tail=${encodeURIComponent(String(tailCount))}`
+              });
+
+        return {
+            ok        : true,
+            data      : {logs: response.body, tail: tailCount},
+            proof     : this.createProofMetadata({envelope: 'read-observe', operation: 'logs', target}),
+            statusCode: response.statusCode
+        };
+    }
+
+    /**
+     * Reads one non-streaming Docker stats sample for a resolved target.
+     * @param {Object} target Resolved target.
+     * @returns {Promise<Object>}
+     */
+    async readTargetStats(target) {
+        const response = await this.dockerRequest({
+            method: 'GET',
+            path  : `/containers/${encodeURIComponent(target.containerId)}/stats?stream=false`
+        });
+
+        return {
+            ok        : true,
+            data      : this.parseJson(response.body, 'container stats'),
+            proof     : this.createProofMetadata({envelope: 'read-observe', operation: 'stats', target}),
+            statusCode: response.statusCode
+        };
+    }
+
+    /**
+     * Restarts a resolved Docker target through the lifecycle-write envelope.
+     * @param {Object} target Resolved target.
+     * @param {Object} options
+     * @param {String} options.reason Audit reason.
+     * @param {Number} [options.restartTimeoutSeconds] Docker restart timeout.
+     * @returns {Promise<Object>}
+     */
+    async restartTarget(target, {reason, restartTimeoutSeconds} = {}) {
+        const timeoutSeconds = restartTimeoutSeconds ?? this.configValues.defaultRestartTimeoutSeconds ?? 10,
+              response       = await this.dockerRequest({
+                  method: 'POST',
+                  path  : `/containers/${encodeURIComponent(target.containerId)}/restart?t=${encodeURIComponent(String(timeoutSeconds))}`
+              });
+
+        return {
+            ok        : true,
+            data      : {restarted: true, reason, restartTimeoutSeconds: timeoutSeconds},
+            proof     : this.createProofMetadata({envelope: 'lifecycle-write', operation: 'restart', target, reason}),
+            statusCode: response.statusCode
+        };
+    }
+
+    /**
+     * Performs a runtime request through the injected seam or Docker socket implementation.
+     * @param {Object} request Request descriptor.
+     * @returns {Promise<{statusCode: Number, headers: Object, body: String}>}
+     */
+    async dockerRequest(request) {
+        const fn = this.dockerRequestFn || dockerSocketRequest;
+
+        return fn({
+            socketPath: this.socketPath,
+            timeoutMs : this.timeoutMs,
+            maxBytes  : this.responseMaxBytes,
+            ...request
+        });
+    }
+
+    /**
+     * Parses Docker JSON response bodies with operation context.
+     * @param {String} body Response body.
+     * @param {String} label Response label.
+     * @returns {*}
+     */
+    parseJson(body, label) {
+        try {
+            return JSON.parse(body);
+        } catch (e) {
+            throw new Error(`Invalid Docker ${label} JSON: ${e.message}`);
+        }
+    }
+
+    /**
+     * Creates structured proof metadata for graph/MCP consumers.
+     * @param {Object} options
+     * @param {'read-observe'|'lifecycle-write'} options.envelope Capability envelope.
+     * @param {String} options.operation Operation name.
+     * @param {Object} options.target Resolved target.
+     * @param {String} [options.reason] Optional lifecycle reason.
+     * @returns {Object}
+     */
+    createProofMetadata({envelope, operation, target, reason} = {}) {
+        const observedAt = this.nowFn ? this.nowFn() : Date.now();
+
+        return {
+            schemaVersion     : 1,
+            recordType        : 'deployment-runtime-access',
+            runtimeMechanism  : this.mechanism,
+            capabilityEnvelope: envelope,
+            operation,
+            auditLabel       : `${envelope}:${operation}`,
+            auditMode     : this.configValues.auditMode || 'metadata',
+            serviceKey    : target.serviceKey,
+            targetIdentity: {
+                kind: 'compose-service',
+                id  : target.serviceKey
+            },
+            target: {
+                containerId   : target.containerId,
+                names         : target.names,
+                image         : target.image,
+                state         : target.state,
+                status        : target.status,
+                composeProject: target.composeProject,
+                labels        : target.labels
+            },
+            observedAt,
+            reason: reason || null
+        };
+    }
+}
+
+export default Neo.setupClass(DeploymentRuntimeAccessService);

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -198,6 +198,13 @@ services:
       - NEO_CHROMA_HOST=chroma
       - NEO_CHROMA_PORT=8000
       - NEO_MEMORY_DB_PATH=/app/.neo-ai-data/sqlite/memory-core-graph.sqlite
+      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED=true
+      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_MECHANISM=docker-socket
+      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_SOCKET_PATH=/var/run/docker.sock
+      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT=${NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT:-}
+      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES=chroma,kb-server,mc-server,local-model
+      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_READ_OPERATIONS=inspect,logs,stats
+      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_LIFECYCLE_OPERATIONS=restart
     volumes:
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
       - tenant-repo-mirrors:/app/.neo-ai-data/tenant-repos
@@ -213,6 +220,10 @@ services:
       # query time; without the mount the orchestrator silently falls back to the
       # aiConfig.tenantRepos[] default tier only. Example:
       #   - ./kb-config.yaml:/app/kb-config.yaml:ro
+      # Deployment-runtime access (#13920): the orchestrator owns one constrained Docker
+      # socket holder. `DeploymentRuntimeAccessService` resolves allowlisted compose
+      # service labels and exposes separate read-observe / lifecycle-write envelopes.
+      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       chroma:
         condition: service_healthy

--- a/learn/agentos/decisions/0026-recovery-actuator.md
+++ b/learn/agentos/decisions/0026-recovery-actuator.md
@@ -4,13 +4,13 @@
 
 | Attribute | Value |
 |---|---|
-| **Status** | Proposed — 2026-06-23 (design-gate sub of Epic #13874; graduated from Discussion #13871; pending cross-family §6.2 family-keyed quorum + human merge gate per ADR-0005 lifecycle). |
+| **Status** | Proposed — 2026-06-23 (design-gate sub of Epic #13874; graduated from Discussion #13871; OQ-1 resolved by #13920 toward the socket-wrapper MVP; pending human merge gate per ADR-0005 lifecycle). |
 | **Author** | @neo-opus-grace (Grace, Claude Opus 4.8) — shaped #13871 / #13874 / ADR-0025 (deepest context). The actuator matrix, persisted anti-thrash state, and detect≠actuator separation are inherited from ADR-0025's cross-family convergence with @neo-gpt (Euclid, GPT family); this ADR carries them forward via the §2.1 successor-risk audit. |
 | **Resolves** | #13880 — *"ADR pair — recovery-actuator ADR + ADR-0025 → diagnostics rescope"* (this is the new-ADR half; the 0025 rescope lands in the **same PR** to avoid a dangling cross-reference). |
 | **Parent epic** | #13874 — *"Orchestrator recovery daemon — reactive heal/act half of self-healing (phase-1)."* |
 | **Depends on** | **ADR-0025** (the diagnostics half — the diagnosis this actuator consumes, and the heal-safety properties this ADR inherits), ADR-0019 (config SSOT — every tuning leaf extends an existing `leaf()`, never a parallel reader), ADR-0009 (cross-daemon lease — the persisted anti-thrash state reuses the same durable harness-state layer), ADR-0020 (agent-harness — the actuator's orchestrator home), the **two-worlds safety model** (cloud-tier = config + lifecycle ONLY, never code-exec / dynamic-import). |
 | **Connects to** | **#13882 / PR #13900** (the B0 actuator's first live instance — the stuck-runner recovery: `ProcessSupervisorService` recycles a resident-but-not-serving local-model child within the existing cooldown, gated on a sustained-failure health probe, zero new privilege — the live proof the B0 recycle works; the durable anti-thrash ledger is scoped to B1, §2.5), **#13884** (the B1 privileged-actuator sub this ADR gates), **Discussion #13873** (phase-2 homeostatic controller — plugs into this ADR's controller-agnostic interface, AC-9), #13852 (config-side prevention — the complementary *prevention* layer, distinct from this *response* layer). |
-| **Implemented by** | **[B0 — shipped]** the supervised-process recovery (`ProcessSupervisorService` restart/recycle; #13882 / PR #13900). **[B1 — gated on this ADR]** the docker-socket actuator for the external-container-crash class (#13884). |
+| **Implemented by** | **[B0 — shipped]** the supervised-process recovery (`ProcessSupervisorService` restart/recycle; #13882 / PR #13900). **[L0 runtime-access holder — #13920]** `DeploymentRuntimeAccessService`, one orchestrator-resident holder with separate read-observe and lifecycle-write envelopes. **[B1 — gated on this ADR]** the recovery actuator consumer for the external-container-crash class (#13884/#13915). |
 | **Anti-anchor for** | `diagnosis == action` (a diagnosis is *consumed by a controller*; the actuator is privilege-bounded and class-keyed); an **unbounded** docker-socket grant (the socket addresses exactly one allowlisted service+action set, never arbitrary containers or exec); **in-memory** anti-thrash state (an orchestrator restart erases the cap → the forbidden loop); a **controller-specific** actuator (phase-2's homeostatic loop must plug in without an actuator rewrite); reaching for B1 privilege where B0 already covers the class. |
 
 ---
@@ -69,7 +69,7 @@ B1 is the *only* tier that introduces privilege, so the actuator-divergence matr
 | **(b) Minimal privileged sidecar** | A tiny separate container owns the runtime handle; exposes a **lifecycle-only** internal API the orchestrator calls; the orchestrator never holds the socket | The sidecar API grows **beyond lifecycle** (exec / arbitrary), **or** its auth is **weaker** than the socket option → reject |
 | **(c) Runtime-native restart** | The container runtime restarts an unhealthy sibling **without** granting the orchestrator any runtime access | The current compose/runtime only *reports* unhealthy or gates *startup* — it does not restart an unhealthy-but-running sibling. Until proven otherwise, **(c) is detection / startup-gating only, not an actuator** |
 
-**Recommendation (for the re-poll, not yet final):** **(a) for the B1 MVP** — fewest moving parts, the safety living in auditable allowlist-wrapper code — **with (b) as the documented hardening path** if socket-in-orchestrator privilege proves too broad. **(c) is rejected as an actuator** on its falsifier (it remains a valuable *detect* input for 0025). Falsifier-gated: if (a)'s wrapper cannot be *proven* strictly-allowlisted + identity-distinguishing, it drops to (b). This is **OQ-1**.
+**Decision (#13920):** **(a) is the B1/L0 MVP** — Docker socket API through `DeploymentRuntimeAccessService`, an auditable allowlist wrapper that resolves Docker Compose service identity by labels and exposes separate read-observe / lifecycle-write envelopes. **(b) remains the documented hardening fallback** if socket-in-orchestrator privilege proves too broad or the wrapper cannot prove strict service identity + operation allowlisting. **(c) remains rejected as an actuator** on its falsifier (it is still a valuable *detect* input for ADR-0025). This resolves **OQ-1** without granting arbitrary container ids, shell access, exec, or non-lifecycle mutation.
 
 ### 2.4 The controller-agnostic actuator interface (AC-9)
 
@@ -97,7 +97,7 @@ The bounded, non-looping state machine and its **persisted** anti-thrash state a
 - **AC-2 — two-worlds safety, inherited.** Every action is config + lifecycle only, reversible, N-capped; never code-exec / dynamic-import. (Inherit-audit §2.1.)
 - **AC-3 — persisted anti-thrash, inherited (tier-scoped).** The §2.5 envelope is binding; the process-memory-external `heal_attempts` store binds **B1 / the daemon-core actuator** (where a heal can churn the orchestrator or must cap across restarts). The **B0 supervised-child slice is narrowed** to the supervisor's in-process cooldown — loop-safe because a child recycle does not restart the orchestrator (§2.5). #13900 ships B0 under that narrowed envelope; it is **not** pending durable-ledger wiring.
 - **AC-4 — privilege tiering.** B0 (no new privilege) covers the supervised-process class; B1 (one allowlisted socket grant) covers exactly the external-container-crash class; reaching for B1 where B0 suffices is rejected (§2.2).
-- **AC-5 — B1 matrix with falsifiers.** The §2.3 matrix stands; runtime-native (c) is rejected as an actuator unless its falsifier is disproven; (a)→(b) is falsifier-gated.
+- **AC-5 — B1 matrix with falsifiers.** The §2.3 matrix stands; socket-wrapper (a) is the MVP selected by #13920; runtime-native (c) is rejected as an actuator unless its falsifier is disproven; (a)→(b) remains falsifier-gated if the wrapper cannot prove strict allowlisting + service identity.
 - **AC-6 — escalate-with-diagnosis, inherited.** A `config-drift` / un-healable class pages with the diagnosis; it never loops an action.
 - **AC-7 — controller-agnostic interface.** The §2.4 `apply` interface + envelope are fixed; phase-2's homeostatic controller (#13873) plugs in without widening the action set, bypassing the envelope, or rewriting the actuator.
 - **AC-8 — orchestrator-SPOF, inherited + accepted.** The actuator is orchestrator-resident (ADR-0025 AC-7); if the orchestrator dies there is no heal. Recorded so a future agent does not grant the actuator a second independent home without re-opening the privilege decision.
@@ -110,11 +110,11 @@ The bounded, non-looping state machine and its **persisted** anti-thrash state a
 - **A second, non-orchestrator home for the actuator** (to dodge the SPOF). Rejected here: it re-opens the privilege decision (a second process holding the socket) without the cross-family review that governs it. Recorded as AC-8, not silently "fixed."
 - **In-memory anti-thrash for B1** (because B0's cooldown is in-process). Rejected (§2.5): the orchestrator-restart-erases-the-cap loop ADR-0025 forbids; B1 reuses the durable store.
 
-## 4. Open questions (for the cross-family re-poll)
+## 4. Resolved and open questions
 
-- **OQ-1 — B1 privilege:** (a) socket+wrapper MVP vs (b) sidecar — the §2.3 falsifier-gated decision. (Unchanged from ADR-0025 OQ-1, now scoped to B1 only.)
+- **OQ-1 — B1 privilege: RESOLVED by #13920.** Docker socket API + constrained wrapper is the MVP; sidecar remains the documented hardening fallback; runtime-native remains rejected as an actuator.
 - **OQ-2 — persisted-state binding:** the exact `heal_attempts` table/file in the durable harness-state store (confirmed in #13884; the survives-restart invariant is fixed).
-- **OQ-3 — controller/actuator seam location:** whether the §2.4 `apply` interface lives on `ProcessSupervisorService` (extended for B1) or a new `RecoveryActuatorService` that delegates to it for B0 and to the B1 wrapper for external containers.
+- **OQ-3 — controller/actuator seam location: narrowed by #13920.** The L0 runtime handle lives in `DeploymentRuntimeAccessService`; the B1 recovery consumer still decides how its `apply` interface delegates to that holder and to B0 `ProcessSupervisorService`.
 
 ## 5. Consequences
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
@@ -1,0 +1,208 @@
+import {test, expect}                   from '@playwright/test';
+import Neo                              from '../../../../../../../src/Neo.mjs';
+import * as core                        from '../../../../../../../src/core/_export.mjs';
+import {DeploymentRuntimeAccessService} from '../../../../../../../ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs';
+
+const BASE_CONFIG = {
+    enabled                     : true,
+    mechanism                   : 'docker-socket',
+    socketPath                  : '/var/run/docker.sock',
+    composeProject              : null,
+    allowedServices             : ['chroma', 'kb-server', 'mc-server', 'local-model'],
+    readOperations              : ['inspect', 'logs', 'stats'],
+    lifecycleOperations         : ['restart'],
+    timeoutMs                   : 5000,
+    responseMaxBytes            : 1024 * 1024,
+    logTail                     : 200,
+    defaultRestartTimeoutSeconds: 10,
+    auditMode                   : 'metadata'
+};
+
+function makeContainer(overrides = {}) {
+    return {
+        Id    : 'container-abc',
+        Names : ['/neo-mc-server-1'],
+        Image : 'neo-mc-server:test',
+        State : 'running',
+        Status: 'Up 10 minutes',
+        Labels: {
+            'com.docker.compose.service': 'mc-server',
+            'com.docker.compose.project': 'neo'
+        },
+        ...overrides
+    };
+}
+
+function createService({config = {}, containers = [makeContainer()], inspectData = {Name: '/neo-mc-server-1'}, statsData = {cpu_stats: {}}, logText = 'ready'} = {}) {
+    const calls = [];
+
+    const dockerRequestFn = async request => {
+        calls.push(request);
+
+        if (request.path.startsWith('/containers/json')) {
+            return {statusCode: 200, headers: {}, body: JSON.stringify(containers)};
+        }
+
+        if (request.path.endsWith('/json')) {
+            return {statusCode: 200, headers: {}, body: JSON.stringify(inspectData)};
+        }
+
+        if (request.path.includes('/logs?')) {
+            return {statusCode: 200, headers: {}, body: logText};
+        }
+
+        if (request.path.includes('/stats?')) {
+            return {statusCode: 200, headers: {}, body: JSON.stringify(statsData)};
+        }
+
+        if (request.path.includes('/restart?')) {
+            return {statusCode: 204, headers: {}, body: ''};
+        }
+
+        throw new Error(`Unexpected Docker request: ${request.method} ${request.path}`);
+    };
+
+    const service = Neo.create(DeploymentRuntimeAccessService, {
+        runtimeAccessConfig: {...BASE_CONFIG, ...config},
+        dockerRequestFn,
+        nowFn              : () => 1710000000000
+    });
+
+    return {calls, service};
+}
+
+test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
+    test('readObserve inspect resolves an allowlisted compose service by Docker labels', async () => {
+        const {service, calls} = createService();
+
+        const result = await service.readObserve({serviceKey: 'mc-server', operation: 'inspect'});
+
+        expect(result.ok).toBe(true);
+        expect(result.data).toEqual({Name: '/neo-mc-server-1'});
+        expect(result.proof).toMatchObject({
+            recordType        : 'deployment-runtime-access',
+            runtimeMechanism  : 'docker-socket',
+            capabilityEnvelope: 'read-observe',
+            operation         : 'inspect',
+            auditLabel        : 'read-observe:inspect',
+            serviceKey        : 'mc-server',
+            targetIdentity    : {kind: 'compose-service', id: 'mc-server'},
+            observedAt        : 1710000000000
+        });
+
+        expect(calls[0]).toMatchObject({method: 'GET'});
+        const filters = JSON.parse(decodeURIComponent(calls[0].path.split('filters=')[1]));
+        expect(filters).toEqual({
+            label: ['com.docker.compose.service=mc-server']
+        });
+        expect(calls[1]).toMatchObject({
+            method: 'GET',
+            path  : '/containers/container-abc/json'
+        });
+    });
+
+    test('readObserve includes composeProject in the Docker label filter when configured', async () => {
+        const {service, calls} = createService({config: {composeProject: 'prod'}});
+
+        await service.readObserve({serviceKey: 'mc-server', operation: 'inspect'});
+
+        const filters = JSON.parse(decodeURIComponent(calls[0].path.split('filters=')[1]));
+        expect(filters).toEqual({
+            label: [
+                'com.docker.compose.service=mc-server',
+                'com.docker.compose.project=prod'
+            ]
+        });
+    });
+
+    test('readObserve logs and stats stay on the read-observe envelope', async () => {
+        const {service, calls} = createService({
+            statsData: {memory_stats: {usage: 42}},
+            logText  : 'service booted'
+        });
+
+        const logs  = await service.readObserve({serviceKey: 'mc-server', operation: 'logs', tail: 25});
+        const stats = await service.readObserve({serviceKey: 'mc-server', operation: 'stats'});
+
+        expect(logs.data).toEqual({logs: 'service booted', tail: 25});
+        expect(logs.proof.auditLabel).toBe('read-observe:logs');
+        expect(stats.data).toEqual({memory_stats: {usage: 42}});
+        expect(stats.proof.auditLabel).toBe('read-observe:stats');
+        expect(calls.some(call => call.path === '/containers/container-abc/logs?stdout=1&stderr=1&tail=25')).toBe(true);
+        expect(calls.some(call => call.path === '/containers/container-abc/stats?stream=false')).toBe(true);
+    });
+
+    test('applyLifecycle restart uses the lifecycle-write envelope and POSTs to Docker restart', async () => {
+        const {service, calls} = createService();
+
+        const result = await service.applyLifecycle({
+            serviceKey           : 'mc-server',
+            operation            : 'restart',
+            reason               : 'diagnosis:crash',
+            restartTimeoutSeconds: 4
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.statusCode).toBe(204);
+        expect(result.data).toEqual({
+            restarted            : true,
+            reason               : 'diagnosis:crash',
+            restartTimeoutSeconds: 4
+        });
+        expect(result.proof).toMatchObject({
+            capabilityEnvelope: 'lifecycle-write',
+            operation         : 'restart',
+            auditLabel        : 'lifecycle-write:restart',
+            reason            : 'diagnosis:crash'
+        });
+        expect(calls[1]).toMatchObject({
+            method: 'POST',
+            path  : '/containers/container-abc/restart?t=4'
+        });
+    });
+
+    test('denies cross-envelope and non-allowlisted operations before Docker access', async () => {
+        const {service, calls} = createService();
+
+        await expect(service.readObserve({serviceKey: 'mc-server', operation: 'restart'}))
+            .rejects.toThrow(/read-observe operation 'restart' is not allowlisted/);
+        await expect(service.applyLifecycle({serviceKey: 'mc-server', operation: 'inspect'}))
+            .rejects.toThrow(/lifecycle-write operation 'inspect' is not allowlisted/);
+
+        expect(calls).toHaveLength(0);
+    });
+
+    test('denies arbitrary service keys before Docker access', async () => {
+        const {service, calls} = createService();
+
+        await expect(service.readObserve({serviceKey: 'arbitrary-container', operation: 'inspect'}))
+            .rejects.toThrow(/service 'arbitrary-container' is not allowlisted/);
+
+        expect(calls).toHaveLength(0);
+    });
+
+    test('fails closed when runtime access is disabled or sidecar fallback is selected', async () => {
+        const disabled = createService({config: {enabled: false}});
+        const sidecar  = createService({config: {mechanism: 'sidecar'}});
+
+        await expect(disabled.service.readObserve({serviceKey: 'mc-server', operation: 'inspect'}))
+            .rejects.toThrow(/disabled/);
+        await expect(sidecar.service.readObserve({serviceKey: 'mc-server', operation: 'inspect'}))
+            .rejects.toThrow(/sidecar mechanism is documented fallback only/);
+
+        expect(disabled.calls).toHaveLength(0);
+        expect(sidecar.calls).toHaveLength(0);
+    });
+
+    test('requires composeProject when a service label resolves ambiguously', async () => {
+        const {service} = createService({
+            containers: [
+                makeContainer({Id: 'container-a'}),
+                makeContainer({Id: 'container-b'})
+            ]
+        });
+
+        await expect(service.readObserve({serviceKey: 'mc-server', operation: 'inspect'}))
+            .rejects.toThrow(/resolved to 2 containers/);
+    });
+});


### PR DESCRIPTION
Resolves #13920

Adds the L0 deployment-runtime access holder needed by the self-healing stack. `DeploymentRuntimeAccessService` uses the Docker socket API directly through a deny-by-default wrapper, resolves Docker Compose service identity by labels, and exposes separate read-observe (`inspect`, `logs`, `stats`) and lifecycle-write (`restart`) envelopes over one orchestrator-owned holder.

Evidence: L2 (service + orchestrator unit coverage, compose config validation, syntax/preflight checks) -> L3 residual required after merge/redeploy because the real cloud Docker socket and compose project label set are host-owned deployment state.

## Deltas from ticket

- Resolves ADR-0026 OQ-1 toward the socket-wrapper MVP, with sidecar preserved as the documented hardening fallback and runtime-native still rejected as an actuator.
- Keeps service identity allowlist-backed via Compose labels instead of accepting arbitrary container ids or shell commands.
- Adds AiConfig template leaves/env overrides for enablement, mechanism, socket path, compose project, allowed services, read/lifecycle operations, timeouts, response caps, log tail, restart timeout, and audit mode.
- Wires the production cloud compose profile to enable the holder and mount `/var/run/docker.sock`.
- Adds structured proof metadata on every runtime observation/action for #13914/#13916 consumers.

## Test Evidence

- `node --check ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs`
- `node --check ai/daemons/orchestrator/Orchestrator.mjs`
- `node --check ai/config.template.mjs`
- `git diff --check`
- `npm run agent-preflight -- ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs ai/daemons/orchestrator/Orchestrator.mjs ai/config.template.mjs ai/deploy/docker-compose.yml learn/agentos/decisions/0026-recovery-actuator.md test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs` -> passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs --workers=1` -> 31 passed
- `docker compose -f ai/deploy/docker-compose.yml config --quiet` -> passed

## Post-Merge Validation

- [ ] Redeploy the cloud profile at the merged SHA and verify the orchestrator container can resolve exactly one compose container for `mc-server`, `kb-server`, and `chroma` via Docker labels.
- [ ] Run read-envelope smoke: `inspect`, `logs`, and `stats` against at least `mc-server`; confirm proof metadata exposes `recordType=deployment-runtime-access` and `capabilityEnvelope=read-observe`.
- [ ] Run one controlled lifecycle-write smoke only under operator-approved conditions: restart an allowlisted non-critical target or a disposable local compose stack; confirm non-allowlisted services and cross-envelope operations are denied before Docker access.

## Commits

- `e5ba927d86` — `feat(ai): add deployment runtime access holder (#13920)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.