### PR TITLE
feat(ai): expose Ollama eval attribution (#13923)

### DIFF
--- a/ai/provider/Ollama.mjs
+++ b/ai/provider/Ollama.mjs
@@ -1,6 +1,8 @@
 import Base                 from './Base.mjs';
 import {createTimeoutError} from './createTimeoutError.mjs';
 
+const OLLAMA_DURATION_NS_PER_SECOND = 1_000_000_000;
+
 /**
  * @summary Extracts native Ollama top-level request fields from generic
  * provider options while preserving caller-owned option objects.
@@ -54,6 +56,187 @@ function extractNativeOllamaFields(options) {
     delete options.reasoning_effort;
 
     return fields;
+}
+
+function finiteNumber(value) {
+    const parsed = typeof value === 'string' && value.trim() !== '' ? Number(value) : value;
+    return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * @summary Converts Ollama token-count and duration counters into tokens/second.
+ *
+ * Native Ollama responses report durations in nanoseconds. Returning `null` for
+ * zero/absent duration keeps callers from treating missing telemetry as zero
+ * throughput, which would collapse "unknown" into "stuck".
+ *
+ * @param {Number|String} count Ollama token counter (`eval_count`, `prompt_eval_count`).
+ * @param {Number|String} durationNs Ollama duration counter in nanoseconds.
+ * @returns {Number|null}
+ */
+export function calculateOllamaTokensPerSecond(count, durationNs) {
+    const tokenCount = finiteNumber(count),
+          duration   = finiteNumber(durationNs);
+
+    if (tokenCount === undefined || duration === undefined || duration <= 0) {
+        return null;
+    }
+
+    return tokenCount / (duration / OLLAMA_DURATION_NS_PER_SECOND);
+}
+
+/**
+ * @summary Normalizes one native Ollama raw response into a role/model eval sample.
+ *
+ * The diagnostics daemon needs chat-vs-embedding attribution without learning
+ * every caller's response envelope. This helper accepts the raw `/api/chat` or
+ * `/api/embed` payload (or a provider result carrying `.raw`) and preserves the
+ * counters that Ollama already emits: generated eval, prompt eval, total eval,
+ * and tokens/second. Missing counters remain `null` rather than implied zero.
+ *
+ * @param {Object} payload Native Ollama response payload or provider `{raw}` envelope.
+ * @param {Object} [options]
+ * @param {'chat'|'embedding'} [options.role] Provider role that produced the sample.
+ * @param {String} [options.model] Configured model id fallback when the raw payload omits it.
+ * @returns {Object}
+ */
+export function extractOllamaEvalSample(payload, {role, model} = {}) {
+    const raw                  = payload?.raw && typeof payload.raw === 'object' ? payload.raw : payload || {},
+          evalCount            = finiteNumber(raw.eval_count),
+          evalDurationNs       = finiteNumber(raw.eval_duration),
+          promptEvalCount      = finiteNumber(raw.prompt_eval_count),
+          promptEvalDurationNs = finiteNumber(raw.prompt_eval_duration),
+          totalEvalCount       = [evalCount, promptEvalCount].filter(Number.isFinite).reduce((sum, value) => sum + value, 0),
+          totalEvalDurationNs  = [evalDurationNs, promptEvalDurationNs].filter(Number.isFinite).reduce((sum, value) => sum + value, 0),
+          hasAnyEvalCounter    = evalCount !== undefined || promptEvalCount !== undefined,
+          hasAnyEvalDuration   = evalDurationNs !== undefined || promptEvalDurationNs !== undefined;
+
+    return {
+        model                    : model || raw.model || null,
+        role                     : role || (Array.isArray(raw.embeddings) ? 'embedding' : 'chat'),
+        evalCount                : evalCount ?? null,
+        evalDurationNs           : evalDurationNs ?? null,
+        evalTokensPerSecond      : calculateOllamaTokensPerSecond(evalCount, evalDurationNs),
+        promptEvalCount          : promptEvalCount ?? null,
+        promptEvalDurationNs     : promptEvalDurationNs ?? null,
+        promptEvalTokensPerSecond: calculateOllamaTokensPerSecond(promptEvalCount, promptEvalDurationNs),
+        totalEvalCount           : hasAnyEvalCounter ? totalEvalCount : null,
+        totalEvalDurationNs      : hasAnyEvalDuration ? totalEvalDurationNs : null,
+        totalTokensPerSecond     : hasAnyEvalCounter && hasAnyEvalDuration
+            ? calculateOllamaTokensPerSecond(totalEvalCount, totalEvalDurationNs)
+            : null
+    };
+}
+
+/**
+ * @summary Builds a per-model attribution summary from Ollama eval samples.
+ *
+ * This is the pure data contract for the deployment diagnostics probe: callers
+ * collect raw `/api/chat` and `/api/embed` results over their chosen window, then
+ * this helper identifies busy versus resident-but-not-progressing models without
+ * issuing provider calls itself.
+ *
+ * @param {Object[]} samples Raw Ollama payloads or normalized eval samples.
+ * @param {Object} [options]
+ * @param {Number} [options.stuckThresholdTokensPerSecond=0.001] Samples at or below this
+ *   observed throughput are classified as stuck when counters are present.
+ * @returns {{models: Object[], busyModels: Object[], stuckModels: Object[], primaryLoad: Object|null, roleLoad: Object, primaryRole: Object|null}}
+ */
+export function buildOllamaEvalAttribution(samples, {stuckThresholdTokensPerSecond = 0.001} = {}) {
+    const normalized = (Array.isArray(samples) ? samples : [])
+        .map(sample => sample?.totalTokensPerSecond !== undefined ? sample : extractOllamaEvalSample(sample))
+        .filter(Boolean);
+
+    const grouped = new Map();
+
+    for (const sample of normalized) {
+        const key = `${sample.role || 'unknown'}:${sample.model || 'unknown'}`;
+        let entry = grouped.get(key);
+
+        if (!entry) {
+            entry = {
+                model              : sample.model ?? null,
+                role               : sample.role ?? 'unknown',
+                sampleCount        : 0,
+                totalEvalCount     : 0,
+                totalEvalDurationNs: 0,
+                hasAnyEvalCounter  : false,
+                hasAnyEvalDuration : false
+            };
+            grouped.set(key, entry);
+        }
+
+        entry.sampleCount++;
+
+        if (Number.isFinite(sample.totalEvalCount)) {
+            entry.totalEvalCount    += sample.totalEvalCount;
+            entry.hasAnyEvalCounter  = true;
+        }
+        if (Number.isFinite(sample.totalEvalDurationNs)) {
+            entry.totalEvalDurationNs += sample.totalEvalDurationNs;
+            entry.hasAnyEvalDuration  = true;
+        }
+    }
+
+    const models = [...grouped.values()].map(entry => {
+        const tokensPerSecond = entry.hasAnyEvalCounter && entry.hasAnyEvalDuration
+            ? calculateOllamaTokensPerSecond(entry.totalEvalCount, entry.totalEvalDurationNs)
+            : null;
+        const state = !entry.hasAnyEvalCounter || tokensPerSecond === null
+            ? 'unknown'
+            : tokensPerSecond <= stuckThresholdTokensPerSecond
+                ? 'stuck'
+                : 'busy';
+
+        return {
+            model              : entry.model,
+            role               : entry.role,
+            sampleCount        : entry.sampleCount,
+            totalEvalCount     : entry.hasAnyEvalCounter ? entry.totalEvalCount : null,
+            totalEvalDurationNs: entry.hasAnyEvalDuration ? entry.totalEvalDurationNs : null,
+            tokensPerSecond,
+            state
+        };
+    });
+
+    const busyModels           = models.filter(sample => sample.state === 'busy'),
+          stuckModels          = models.filter(sample => sample.state === 'stuck'),
+          primaryLoad          = [...busyModels].sort((a, b) => b.tokensPerSecond - a.tokensPerSecond)[0] || null,
+          totalTokensPerSecond = models.reduce((sum, sample) => sum + (Number.isFinite(sample.tokensPerSecond) ? sample.tokensPerSecond : 0), 0),
+          roleLoad             = {};
+
+    for (const sample of models) {
+        const role = sample.role || 'unknown';
+
+        if (!roleLoad[role]) {
+            roleLoad[role] = {
+                role,
+                modelCount     : 0,
+                tokensPerSecond: 0,
+                throughputShare: 0
+            };
+        }
+
+        roleLoad[role].modelCount++;
+        if (Number.isFinite(sample.tokensPerSecond)) {
+            roleLoad[role].tokensPerSecond += sample.tokensPerSecond;
+        }
+    }
+
+    for (const role of Object.keys(roleLoad)) {
+        roleLoad[role].throughputShare = totalTokensPerSecond > 0
+            ? roleLoad[role].tokensPerSecond / totalTokensPerSecond
+            : 0;
+    }
+
+    return {
+        models,
+        busyModels,
+        stuckModels,
+        primaryLoad,
+        roleLoad,
+        primaryRole: Object.values(roleLoad).sort((a, b) => b.tokensPerSecond - a.tokensPerSecond)[0] || null
+    };
 }
 
 /**
@@ -184,7 +367,7 @@ class OllamaProvider extends Base {
      *     `ask` synthesis) fail fast and degrade rather than wait behind a long batch inference.
      * @param {String} [options.operationLabel] Safe diagnostic label surfaced in the timeout error.
      * @param {AbortSignal} [options.signal] Upstream cancellation signal; when it aborts, the in-flight request is destroyed (parity with OpenAiCompatible).
-     * @returns {Promise<{content: String, raw: Object}>}
+     * @returns {Promise<{content: String, raw: Object, evalSample: Object}>}
      */
     async generate(input, options = {}) {
         const payload          = this.preparePayload(input, options, false);
@@ -247,8 +430,12 @@ class OllamaProvider extends Base {
             const result = await responsePromise;
 
             const resultPayload = {
-                content: result.message?.content || '',
-                raw    : result
+                content   : result.message?.content || '',
+                raw       : result,
+                evalSample: extractOllamaEvalSample(result, {
+                    role : 'chat',
+                    model: this.modelName
+                })
             };
 
             if (result.message?.tool_calls && result.message.tool_calls.length > 0) {
@@ -289,10 +476,10 @@ class OllamaProvider extends Base {
      * @param {String|String[]} input Single text or array of texts to embed.
      * @param {Object} [options]
      * @param {String} [options.model] Override the configured `embeddingModel` / `modelName`.
-     * @returns {Promise<{embeddings: Number[][], raw: Object}>}
+     * @returns {Promise<{embeddings: Number[][], raw: Object, evalSample: Object}>}
      */
     async embed(input, options = {}) {
-        const model = options.model || this.embeddingModel || this.modelName;
+        const model   = options.model || this.embeddingModel || this.modelName;
         const payload = {
             model,
             input
@@ -342,7 +529,11 @@ class OllamaProvider extends Base {
             const result = await responsePromise;
             return {
                 embeddings: result.embeddings || [],
-                raw       : result
+                raw       : result,
+                evalSample: extractOllamaEvalSample(result, {
+                    role: 'embedding',
+                    model
+                })
             };
         } catch (error) {
             throw error;

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -3,6 +3,10 @@ import {execFile}                  from 'child_process';
 import {Memory_Config as aiConfig} from '../../services.mjs';
 import logger                      from '../../mcp/server/memory-core/logger.mjs';
 import {
+    buildOllamaEvalAttribution,
+    extractOllamaEvalSample
+} from '../../provider/Ollama.mjs';
+import {
     isGraphModelProviderSupported,
     isOpenAiCompatibleProvider,
     resolveGraphModelProvider
@@ -231,11 +235,32 @@ export async function warmOllamaRoleModel({
         throw new Error(`Ollama ${role} model warmup failed for '${model}': HTTP ${response.status}${text ? ` - ${text}` : ''}`);
     }
 
+    let raw = null;
+
     if (typeof response.text === 'function') {
-        await response.text();
+        const text = await response.text();
+
+        if (text.trim()) {
+            try {
+                raw = JSON.parse(text);
+            } catch (error) {
+                raw = null;
+            }
+        }
+    } else if (typeof response.json === 'function') {
+        try {
+            raw = await response.json();
+        } catch (error) {
+            raw = null;
+        }
     }
 
-    return {model, role, endpoint};
+    return {
+        model,
+        role,
+        endpoint,
+        evalSample: extractOllamaEvalSample(raw, {model, role})
+    };
 }
 
 /**
@@ -819,6 +844,8 @@ export async function ensureOllamaModelsReady({
     const warmedModels               = [];
     const failedModels               = [];
     const attemptedModels            = [];
+    const evalSamples                = [];
+    const getEvalAttribution         = () => evalSamples.length ? buildOllamaEvalAttribution(evalSamples) : null;
 
     for (const role of rolesToWarm) {
         const roleEnvelope = toRoleEnvelope(role);
@@ -833,8 +860,16 @@ export async function ensureOllamaModelsReady({
                 warmOptions.contextLength = role.contextLength;
             }
 
-            await warmModel(role, warmOptions);
-            warmedModels.push(roleEnvelope);
+            const warmResult = await warmModel(role, warmOptions);
+
+            if (warmResult?.evalSample) {
+                evalSamples.push(warmResult.evalSample);
+            }
+
+            warmedModels.push({
+                ...roleEnvelope,
+                ...(warmResult?.evalSample ? {evalSample: warmResult.evalSample} : {})
+            });
         } catch (error) {
             failedModels.push({
                 ...roleEnvelope,
@@ -875,7 +910,7 @@ export async function ensureOllamaModelsReady({
             return {
                 ready,
                 degraded,
-                provider       : 'ollama',
+                provider             : 'ollama',
                 host,
                 warmedModels,
                 attemptedModels,
@@ -883,16 +918,17 @@ export async function ensureOllamaModelsReady({
                 missingModels,
                 insufficientContextModels,
                 requiredModels,
-                availableModels: toIds(availableModels),
-                extraModels    : getExtraModels(availableModels),
-                loadedContexts : Object.fromEntries(availableModels.map(item => [item.id, item.contextLength])),
+                availableModels      : toIds(availableModels),
+                extraModels          : getExtraModels(availableModels),
+                loadedContexts       : Object.fromEntries(availableModels.map(item => [item.id, item.contextLength])),
                 observedCount,
                 observedRequiredCount,
                 requireParallelModels,
                 requiredResidentModels,
-                warning        : degraded ? (contextWarning || getWarning({availableModels, missingModels, observedRequiredCount})) : null,
-                attempts       : attempt,
-                elapsedMs      : Date.now() - startedAt
+                warning              : degraded ? (contextWarning || getWarning({availableModels, missingModels, observedRequiredCount})) : null,
+                ollamaEvalAttribution: getEvalAttribution(),
+                attempts             : attempt,
+                elapsedMs            : Date.now() - startedAt
             };
         }
 
@@ -908,9 +944,9 @@ export async function ensureOllamaModelsReady({
     const warning               = contextWarning || getWarning({availableModels, missingModels, observedRequiredCount});
     if (allowPartial) {
         return {
-            ready          : false,
-            degraded       : true,
-            provider       : 'ollama',
+            ready                : false,
+            degraded             : true,
+            provider             : 'ollama',
             host,
             warmedModels,
             attemptedModels,
@@ -918,16 +954,17 @@ export async function ensureOllamaModelsReady({
             missingModels,
             insufficientContextModels,
             requiredModels,
-            availableModels: toIds(availableModels),
-            extraModels    : getExtraModels(availableModels),
-            loadedContexts : Object.fromEntries(availableModels.map(item => [item.id, item.contextLength])),
-            observedCount  : availableModels.length,
+            availableModels      : toIds(availableModels),
+            extraModels          : getExtraModels(availableModels),
+            loadedContexts       : Object.fromEntries(availableModels.map(item => [item.id, item.contextLength])),
+            observedCount        : availableModels.length,
             observedRequiredCount,
             requireParallelModels,
             requiredResidentModels,
             warning,
+            ollamaEvalAttribution: getEvalAttribution(),
             attempts,
-            elapsedMs      : Date.now() - startedAt
+            elapsedMs            : Date.now() - startedAt
         };
     }
 

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -1,6 +1,6 @@
 import {setup} from '../../../setup.mjs';
 
-const appName = 'AiProviderKeepAliveTest';
+const appName      = 'AiProviderKeepAliveTest';
 const statusSchema = {
     type      : 'object',
     properties: {
@@ -50,7 +50,7 @@ function createReadableStream(chunks) {
     };
 }
 
-async function createOllamaChatServer(payloads) {
+async function createOllamaChatServer(payloads, responsePayload = {message: {content: 'ok'}}) {
     const server = http.createServer((req, res) => {
         let body = '';
 
@@ -58,7 +58,7 @@ async function createOllamaChatServer(payloads) {
         req.on('end', () => {
             payloads.push(JSON.parse(body));
             res.writeHead(200, {'Content-Type': 'application/json'});
-            res.end(JSON.stringify({message: {content: 'ok'}}));
+            res.end(JSON.stringify(responsePayload));
         });
     });
 
@@ -75,10 +75,17 @@ async function createOllamaChatServer(payloads) {
 test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
     let OllamaProvider;
     let OpenAiCompatibleProvider;
+    let buildOllamaEvalAttribution;
+    let calculateOllamaTokensPerSecond;
+    let extractOllamaEvalSample;
     let originalFetch;
 
     test.beforeAll(async () => {
-        OllamaProvider           = (await import('../../../../../ai/provider/Ollama.mjs')).default;
+        const ollamaModule = await import('../../../../../ai/provider/Ollama.mjs');
+        OllamaProvider           = ollamaModule.default;
+        buildOllamaEvalAttribution = ollamaModule.buildOllamaEvalAttribution;
+        calculateOllamaTokensPerSecond = ollamaModule.calculateOllamaTokensPerSecond;
+        extractOllamaEvalSample  = ollamaModule.extractOllamaEvalSample;
         OpenAiCompatibleProvider = (await import('../../../../../ai/provider/OpenAiCompatible.mjs')).default;
     });
 
@@ -90,9 +97,172 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
         globalThis.fetch = originalFetch;
     });
 
+    test('Ollama eval metrics normalize chat and embedding raw counters (#13923)', () => {
+        expect(calculateOllamaTokensPerSecond(40, 2_000_000_000)).toBe(20);
+        expect(calculateOllamaTokensPerSecond(40, 0)).toBeNull();
+
+        const chatSample = extractOllamaEvalSample({
+            model               : 'gemma4:26b',
+            eval_count          : 80,
+            eval_duration       : 4_000_000_000,
+            prompt_eval_count   : 20,
+            prompt_eval_duration: 1_000_000_000
+        }, {role: 'chat'});
+
+        const embeddingSample = extractOllamaEvalSample({
+            embeddings          : [[0.1, 0.2]],
+            prompt_eval_count   : '64',
+            prompt_eval_duration: '2000000000'
+        }, {
+            role : 'embedding',
+            model: 'qwen3-embedding'
+        });
+
+        expect(chatSample).toMatchObject({
+            model                    : 'gemma4:26b',
+            role                     : 'chat',
+            evalCount                : 80,
+            evalTokensPerSecond      : 20,
+            promptEvalCount          : 20,
+            promptEvalTokensPerSecond: 20,
+            totalEvalCount           : 100,
+            totalEvalDurationNs      : 5_000_000_000,
+            totalTokensPerSecond     : 20
+        });
+
+        expect(embeddingSample).toMatchObject({
+            model                    : 'qwen3-embedding',
+            role                     : 'embedding',
+            evalCount                : null,
+            promptEvalCount          : 64,
+            promptEvalTokensPerSecond: 32,
+            totalEvalCount           : 64,
+            totalTokensPerSecond     : 32
+        });
+    });
+
+    test('Ollama eval attribution separates busy, stuck, and unknown models (#13923)', () => {
+        const attribution = buildOllamaEvalAttribution([
+            extractOllamaEvalSample({
+                model        : 'gemma4:26b',
+                eval_count   : 120,
+                eval_duration: 3_000_000_000
+            }, {role: 'chat'}),
+            extractOllamaEvalSample({
+                model               : 'qwen3-embedding',
+                prompt_eval_count   : 0,
+                prompt_eval_duration: 2_000_000_000
+            }, {role: 'embedding'}),
+            extractOllamaEvalSample({model: 'resident-no-counters'}, {role: 'chat'})
+        ]);
+
+        expect(attribution.primaryLoad).toMatchObject({
+            model          : 'gemma4:26b',
+            role           : 'chat',
+            state          : 'busy',
+            tokensPerSecond: 40
+        });
+        expect(attribution.busyModels.map(item => item.model)).toEqual(['gemma4:26b']);
+        expect(attribution.stuckModels.map(item => item.model)).toEqual(['qwen3-embedding']);
+        expect(attribution.models.find(item => item.model === 'resident-no-counters')).toMatchObject({
+            state          : 'unknown',
+            tokensPerSecond: null
+        });
+        expect(attribution.roleLoad.chat).toMatchObject({
+            role           : 'chat',
+            modelCount     : 2,
+            tokensPerSecond: 40
+        });
+        expect(attribution.roleLoad.embedding).toMatchObject({
+            role           : 'embedding',
+            modelCount     : 1,
+            tokensPerSecond: 0
+        });
+        expect(attribution.primaryRole).toMatchObject({role: 'chat'});
+    });
+
+    test('Ollama provider returns normalized eval samples for chat and embedding (#13923)', async () => {
+        const payloads = [];
+        const server   = http.createServer((req, res) => {
+            let body = '';
+
+            req.on('data', chunk => body += chunk);
+            req.on('end', () => {
+                payloads.push({url: req.url, body: JSON.parse(body)});
+                res.writeHead(200, {'Content-Type': 'application/json'});
+
+                if (req.url === '/api/embed') {
+                    res.end(JSON.stringify({
+                        embeddings          : [[0.1, 0.2]],
+                        prompt_eval_count   : 30,
+                        prompt_eval_duration: 2_000_000_000
+                    }));
+                    return;
+                }
+
+                res.end(JSON.stringify({
+                    message      : {content: 'ok'},
+                    eval_count   : 20,
+                    eval_duration: 1_000_000_000
+                }));
+            });
+        });
+        await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+        try {
+            const provider = Neo.create(OllamaProvider, {
+                host          : `http://127.0.0.1:${server.address().port}`,
+                modelName     : 'gemma4-test',
+                embeddingModel: 'qwen3-embedding'
+            });
+
+            const chatResult      = await provider.generate('hello');
+            const embeddingResult = await provider.embed('hello');
+            const attribution     = buildOllamaEvalAttribution([
+                chatResult.evalSample,
+                embeddingResult.evalSample
+            ]);
+
+            expect(chatResult.evalSample).toMatchObject({
+                model               : 'gemma4-test',
+                role                : 'chat',
+                evalCount           : 20,
+                evalTokensPerSecond : 20,
+                totalTokensPerSecond: 20
+            });
+            expect(embeddingResult.evalSample).toMatchObject({
+                model                    : 'qwen3-embedding',
+                role                     : 'embedding',
+                promptEvalCount          : 30,
+                promptEvalTokensPerSecond: 15,
+                totalTokensPerSecond     : 15
+            });
+            expect(attribution.models).toEqual([
+                expect.objectContaining({
+                    model          : 'gemma4-test',
+                    role           : 'chat',
+                    state          : 'busy',
+                    tokensPerSecond: 20
+                }),
+                expect.objectContaining({
+                    model          : 'qwen3-embedding',
+                    role           : 'embedding',
+                    state          : 'busy',
+                    tokensPerSecond: 15
+                })
+            ]);
+            expect(attribution.roleLoad.chat.throughputShare).toBeCloseTo(20 / 35);
+            expect(attribution.roleLoad.embedding.throughputShare).toBeCloseTo(15 / 35);
+        } finally {
+            await new Promise(resolve => server.close(resolve));
+        }
+
+        expect(payloads.map(item => item.url)).toEqual(['/api/chat', '/api/embed']);
+    });
+
     test('Ollama.generate() defaults and overrides keep_alive at the top-level payload', async () => {
         const payloads = [];
-        const server = await createOllamaChatServer(payloads);
+        const server   = await createOllamaChatServer(payloads);
 
         try {
             const provider = Neo.create(OllamaProvider, {
@@ -100,7 +270,7 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
                 modelName: 'gemma4-test'
             });
 
-            const defaultResult = await provider.generate('hello', {temperature: 0.2});
+            const defaultResult  = await provider.generate('hello', {temperature: 0.2});
             const overrideResult = await provider.generate('hello', {keep_alive: 0, temperature: 0.2});
 
             expect(defaultResult.content).toBe('ok');

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -107,7 +107,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('Sub 9 hypothesis 7: manual CLI delegates to canonical REM cycle without autoDream coupling (#12617)', async () => {
-        const calls = [];
+        const calls  = [];
         const output = {
             log  : message => calls.push({type: 'log', message}),
             error: message => calls.push({type: 'error', message}),
@@ -203,7 +203,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('fetchOllamaRunningModelIds probes native Ollama /api/ps', async () => {
-        const calls = [];
+        const calls  = [];
         const result = await providerReadinessHelper.fetchOllamaRunningModelIds({
             host     : 'http://ollama.test',
             timeoutMs: 25,
@@ -226,7 +226,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('warmOllamaRoleModel uses native role endpoints and keep_alive', async () => {
-        const calls = [];
+        const calls   = [];
         const fetchFn = async (url, options) => {
             calls.push({
                 url,
@@ -236,11 +236,19 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             });
             return {
                 ok  : true,
-                text: async () => ''
+                text: async () => url.endsWith('/api/embed')
+                    ? JSON.stringify({
+                        prompt_eval_count   : 30,
+                        prompt_eval_duration: 2_000_000_000
+                    })
+                    : JSON.stringify({
+                        eval_count   : 20,
+                        eval_duration: 1_000_000_000
+                    })
             };
         };
 
-        await providerReadinessHelper.warmOllamaRoleModel({
+        const chatWarm = await providerReadinessHelper.warmOllamaRoleModel({
             host     : 'http://ollama.test',
             model    : 'gemma4:31b',
             role     : 'chat',
@@ -248,7 +256,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             timeoutMs: 25,
             fetchFn
         });
-        await providerReadinessHelper.warmOllamaRoleModel({
+        const embeddingWarm = await providerReadinessHelper.warmOllamaRoleModel({
             host     : 'http://ollama.test',
             model    : 'qwen3-embedding',
             role     : 'embedding',
@@ -277,10 +285,24 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 keep_alive: '-1'
             }
         }]);
+        expect(chatWarm.evalSample).toMatchObject({
+            model               : 'gemma4:31b',
+            role                : 'chat',
+            evalCount           : 20,
+            evalTokensPerSecond : 20,
+            totalTokensPerSecond: 20
+        });
+        expect(embeddingWarm.evalSample).toMatchObject({
+            model                    : 'qwen3-embedding',
+            role                     : 'embedding',
+            promptEvalCount          : 30,
+            promptEvalTokensPerSecond: 15,
+            totalTokensPerSecond     : 15
+        });
     });
 
     test('warmOllamaRoleModel threads native num_ctx for chat and embedding warm-ups (#13865)', async () => {
-        const calls = [];
+        const calls   = [];
         const fetchFn = async (url, options) => {
             calls.push({
                 url,
@@ -329,7 +351,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('warnProviderParallelModelCapacity warns for native Ollama missing the embedding model', async () => {
         const warnings = [];
-        const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+        const result   = await providerReadinessHelper.warnProviderParallelModelCapacity({
             config: {
                 graphProvider: 'ollama',
                 modelProvider: 'openAiCompatible',
@@ -357,7 +379,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('warnProviderParallelModelCapacity passes when OpenAI-compatible lists both models', async () => {
         const warnings = [];
-        const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+        const result   = await providerReadinessHelper.warnProviderParallelModelCapacity({
             config: {
                 graphProvider   : 'openAiCompatible',
                 modelProvider   : 'gemini',
@@ -384,7 +406,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('warnProviderParallelModelCapacity warns when requireParallelModels is missing', async () => {
         const warnings = [];
-        const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+        const result   = await providerReadinessHelper.warnProviderParallelModelCapacity({
             config: {
                 graphProvider   : 'openAiCompatible',
                 openAiCompatible: {
@@ -405,8 +427,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     test('warnProviderParallelModelCapacity rejects non-finite requireParallelModels values', async () => {
         for (const requireParallelModels of [NaN, Infinity, -Infinity]) {
             const warnings = [];
-            let fetched = false;
-            const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
+            let   fetched  = false;
+            const result   = await providerReadinessHelper.warnProviderParallelModelCapacity({
                 config: {
                     graphProvider   : 'openAiCompatible',
                     openAiCompatible: {
@@ -432,7 +454,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureLmsModelsLoaded invokes lms load for missing chat and embedding models', async () => {
-        const loads = [];
+        const loads          = [];
         const modelSnapshots = [
             [],
             ['chat-model'],
@@ -508,7 +530,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureLmsModelsLoaded mixes missing + context-configured force-reload paths correctly (#12117 RA1)', async () => {
-        const loadCalls = [];
+        const loadCalls      = [];
         const modelSnapshots = [
             ['chat-model'],                      // chat resident, embedding missing
             ['chat-model', 'embedding-model']    // post-load: both present
@@ -543,7 +565,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureLmsModelsLoaded threads per-model contextLengths into loadModel invocations (#12117)', async () => {
-        const loadCalls = [];
+        const loadCalls      = [];
         const modelSnapshots = [
             [],
             ['chat-model', 'embedding-model']
@@ -570,8 +592,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureLmsModelsLoaded does not pre-skip large local chat contexts (#12264)', async () => {
-        const loadCalls = [];
-        const warnings  = [];
+        const loadCalls      = [];
+        const warnings       = [];
         const modelSnapshots = [
             [],
             ['embedding-model']
@@ -615,8 +637,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureLmsModelsLoaded continues loading remaining models after a partial preload failure (#12264)', async () => {
-        const loadCalls = [];
-        const warnings  = [];
+        const loadCalls      = [];
+        const warnings       = [];
         const modelSnapshots = [
             [],
             ['embedding-model']
@@ -660,7 +682,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('ensureOllamaModelsReady warms missing chat and embedding models through native roles (#12285)', async () => {
-        const warmCalls = [];
+        const warmCalls      = [];
         const modelSnapshots = [
             [],
             [
@@ -691,7 +713,19 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 {id: 'gemma4:31b', contextLength: 131072},
                 {id: 'qwen3-embedding', contextLength: 32768}
             ],
-            warmModel: async (role, options) => warmCalls.push({role, options}),
+            warmModel: async (role, options) => {
+                warmCalls.push({role, options});
+
+                return {
+                    evalSample: {
+                        model               : role.model,
+                        role                : role.role,
+                        totalEvalCount      : role.role === 'chat' ? 20 : 30,
+                        totalEvalDurationNs : role.role === 'chat' ? 1_000_000_000 : 2_000_000_000,
+                        totalTokensPerSecond: role.role === 'chat' ? 20 : 15
+                    }
+                };
+            },
             log      : {info: () => {}}
         });
 
@@ -746,10 +780,25 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             observedRequiredCount: 2,
             requireParallelModels: 2
         });
+        expect(result.ollamaEvalAttribution).toMatchObject({
+            primaryLoad: {
+                model          : 'gemma4:31b',
+                role           : 'chat',
+                tokensPerSecond: 20
+            },
+            primaryRole: {
+                role           : 'chat',
+                tokensPerSecond: 20
+            }
+        });
+        expect(result.ollamaEvalAttribution.roleLoad.embedding).toMatchObject({
+            role           : 'embedding',
+            tokensPerSecond: 15
+        });
     });
 
     test('ensureOllamaModelsReady degrades resident models loaded below configured context (#13865)', async () => {
-        const warmCalls = [];
+        const warmCalls      = [];
         const modelSnapshots = [
             [{id: 'gemma4:31b', contextLength: 4096}],
             [{id: 'gemma4:31b', contextLength: 4096}]
@@ -805,7 +854,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('ensureOllamaModelsReady returns degraded when one native role cannot be warmed (#12285)', async () => {
         const warnings = [];
-        const result = await providerReadinessHelper.ensureOllamaModelsReady({
+        const result   = await providerReadinessHelper.ensureOllamaModelsReady({
             host : 'http://ollama.test',
             roles: [{
                 providerRole: 'modelProvider',
@@ -909,7 +958,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('loadLmsModel appends --context-length to execFile args when provided (#12117)', async () => {
-        const execCalls = [];
+        const execCalls    = [];
         const execFileStub = (cmd, args, callback) => {
             execCalls.push({cmd, args});
             callback(null, '', '');
@@ -926,7 +975,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('loadLmsModel omits --context-length when not provided (backward compat)', async () => {
-        const execCalls = [];
+        const execCalls    = [];
         const execFileStub = (cmd, args, callback) => {
             execCalls.push({cmd, args});
             callback(null, '', '');
@@ -1111,7 +1160,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     });
 
     test('loadLmsModel omits --context-length when contextLength is non-finite (defensive)', async () => {
-        const execCalls = [];
+        const execCalls    = [];
         const execFileStub = (cmd, args, callback) => {
             execCalls.push({cmd, args});
             callback(null, '', '');
@@ -1206,7 +1255,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         await logger.flush();
 
-        const today    = new Date().toISOString().slice(0, 10);
+        const today = new Date().toISOString().slice(0, 10);
         const logFile  = path.join(tmpLogDir, `mc-server-${today}.log`);
         const logLines = fs.readFileSync(logFile, 'utf8');
 
@@ -1321,7 +1370,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
     test('runSandman delegates exactly one canonical REM cycle inside the lease (#12070)', async () => {
         const calls     = [];
-        const logs = [];
+        const logs      = [];
         const exitCodes = [];
 
         const result = await runSandmanModule.runSandman({


### PR DESCRIPTION
Resolves #13923

Adds the missing native Ollama eval-metric contract for deployment diagnostics: `Ollama.generate()` and `Ollama.embed()` now return normalized `evalSample` payloads, `buildOllamaEvalAttribution()` groups samples by model and role, and the native Ollama readiness canary carries warm-up samples into an `ollamaEvalAttribution` block for daemon-side diagnostics.

Related: #13914
Related: #13924
Related: #13926
Related: #13860

Evidence: L2 (mocked native Ollama chat/embed responses through provider + readiness-helper contracts) -> L2 required (per-model eval attribution and internal diagnostics handoff). Residual: none for #13923; public `inspect_deployment` MCP read wiring remains #13914/#13926.

## Deltas from ticket

No public surface is added here. This PR keeps the signal inside provider/readiness diagnostics so #13924 can consume it as a producer fact and #13914/#13926 can expose bounded read-only state later through KB/MC, which remain the only public surfaces.

## Test Evidence

- `node --check ai/provider/Ollama.mjs`
- `node --check ai/services/graph/providerReadinessHelper.mjs`
- `npm run agent-preflight -- ai/provider/Ollama.mjs ai/services/graph/providerReadinessHelper.mjs test/playwright/unit/ai/provider/KeepAlive.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs`
- `npm run test-unit -- KeepAlive.spec.mjs runSandman.spec.mjs --workers=1` -> 65 passed, 1 skipped
- `git diff --check`

## Post-Merge Validation

- [ ] #13914/#13926 consume `ollamaEvalAttribution` without adding any public orchestrator/daemon/socket surface.

## Commit

- `7b12c2eac2` - `feat(ai): expose Ollama eval attribution (#13923)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
