### PR TITLE
fix(ai): surface oversized kb ingest skips (#13930)

### DIFF
--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -981,6 +981,9 @@ components:
         embeddingsGenerated:
           type: integer
           description: Count of embeddings generated for this push.
+        skippedOversized:
+          type: integer
+          description: Count of local-provider over-budget chunks skipped before embedding.
         errors:
           type: array
           description: Accumulated per-file caller errors; a non-empty array does not imply total failure.

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -6,19 +6,19 @@ import VectorService             from './VectorService.mjs';
 // SourceRegistry owns KB source discovery. Importing `./source/_export.mjs` triggers
 // auto-registration of Neo's default Source classes when `aiConfig.useDefaultSources !== false`,
 // plus declarative `aiConfig.customSources` entries.
-import SourceRegistry            from './source/_export.mjs';
-import crypto                    from 'crypto';
-import dotenv                    from 'dotenv';
-import fs                        from 'fs-extra';
-import logger                    from '../../mcp/server/knowledge-base/logger.mjs';
-import path                      from 'path';
-import readline                  from 'readline';
+import SourceRegistry from './source/_export.mjs';
+import crypto         from 'crypto';
+import dotenv         from 'dotenv';
+import fs             from 'fs-extra';
+import logger         from '../../mcp/server/knowledge-base/logger.mjs';
+import path           from 'path';
+import readline       from 'readline';
 
 const cwd       = aiConfig.neoRootDir;
 const insideNeo = process.env.npm_package_name?.includes('neo.mjs') ?? false;
 
 dotenv.config({
-    path: insideNeo ? path.resolve(cwd, '.env') : path.resolve(cwd, '../../.env'),
+    path : insideNeo ? path.resolve(cwd, '.env') : path.resolve(cwd, '../../.env'),
     quiet: true
 });
 
@@ -87,8 +87,8 @@ class DatabaseService extends Base {
             nestedKb.defaultVisibility !== undefined
         )) ? nestedKb : aiConfig;
         const contentString = JSON.stringify({
-            tenantId   : chunk.tenantId ?? kbConfig.defaultTenantId ?? 'neo-shared',
-            repoSlug   : chunk.repoSlug ?? kbConfig.defaultRepoSlug ?? 'neo',
+            tenantId   : chunk.tenantId ?? kbConfig.defaultTenantId,
+            repoSlug   : chunk.repoSlug ?? kbConfig.defaultRepoSlug,
             type       : chunk.type,
             name       : chunk.name,
             description: chunk.description,
@@ -153,12 +153,12 @@ class DatabaseService extends Base {
         logger.log(`Found ${count} documents in ${collection.name} to export.`);
 
         await fs.ensureDir(backupPath);
-        const timestamp   = new Date().toISOString().replace(/:/g, '-');
+        const timestamp = new Date().toISOString().replace(/:/g, '-');
         const backupFile  = path.join(backupPath, `${filePrefix}-${timestamp}.jsonl`);
         const writeStream = fs.createWriteStream(backupFile);
 
-        const limit = 2000;
-        let offset  = 0;
+        const limit  = 2000;
+        let   offset = 0;
 
         while (offset < count) {
             logger.log(`Fetching batch: ${offset} to ${Math.min(offset + limit, count)} of ${count}`);
@@ -307,7 +307,7 @@ class DatabaseService extends Base {
             logger.log(`Starting Knowledge Base import. Discovered ${sourceFiles.length} backup file(s) (mode: ${mode})...`);
 
             const collection = await ChromaManager.getKnowledgeBaseCollection();
-            let imported     = 0;
+            let   imported   = 0;
 
             for (const filePath of sourceFiles) {
                 logger.log(`Importing: ${filePath}`);
@@ -473,7 +473,7 @@ class DatabaseService extends Base {
         const outputPath = aiConfig.dataPath;
         await fs.ensureDir(path.dirname(outputPath));
         const writeStream = fs.createWriteStream(outputPath);
-        let totalChunks   = 0;
+        let   totalChunks = 0;
 
         // Sources are discovered via SourceRegistry instead of a hardcoded array. Default
         // Neo sources auto-register at import-time via `./source/_export.mjs` unless

--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -1,26 +1,33 @@
-import Ajv2020               from 'ajv/dist/2020.js';
-import Base                  from '../../../src/core/Base.mjs';
-import ChromaManager         from './ChromaManager.mjs';
-import GraphService          from '../memory-core/GraphService.mjs';
-import KBRecorderService     from './KBRecorderService.mjs';
+import Ajv2020           from 'ajv/dist/2020.js';
+import Base              from '../../../src/core/Base.mjs';
+import ChromaManager     from './ChromaManager.mjs';
+import GraphService      from '../memory-core/GraphService.mjs';
+import KBRecorderService from './KBRecorderService.mjs';
+import {
+    bytesToTokens,
+    emitConsumerFriction
+}                            from '../memory-core/helpers/consumerFrictionHelper.mjs';
 import RequestContextService,
        {normalizeUserId}    from '../../mcp/server/shared/services/RequestContextService.mjs';
 import SourceRegistry        from './source/_export.mjs';
 import {normalizeTenantRepoConfig}
                              from './helpers/tenantRepoAccessContract.mjs';
-import VectorService         from './VectorService.mjs';
-import aiConfig              from '../../mcp/server/knowledge-base/config.mjs';
-import crypto                from 'crypto';
-import fs                    from 'fs-extra';
-import os                    from 'os';
-import path                  from 'path';
-import yaml                  from 'js-yaml';
-import {fileURLToPath}       from 'url';
+import VectorService   from './VectorService.mjs';
+import aiConfig        from '../../mcp/server/knowledge-base/config.mjs';
+import crypto          from 'crypto';
+import fs              from 'fs-extra';
+import logger          from '../../mcp/server/knowledge-base/logger.mjs';
+import mcConfig        from '../../mcp/server/memory-core/config.mjs';
+import os              from 'os';
+import path            from 'path';
+import yaml            from 'js-yaml';
+import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
-const PARSED_CHUNK_SCHEMA_PATH = path.join(__dirname, 'parser/parsed-chunk-v1.schema.json');
+const LOCAL_EMBEDDING_PROVIDERS = new Set(['openAiCompatible', 'ollama']);
+const PARSED_CHUNK_SCHEMA_PATH  = path.join(__dirname, 'parser/parsed-chunk-v1.schema.json');
 
 /**
  * @summary Orchestrates tenant-aware Knowledge Base ingestion pushes.
@@ -136,8 +143,9 @@ class KnowledgeBaseIngestionService extends Base {
                 }));
             }
 
-            const files  = Array.isArray(payload.files) ? payload.files : [];
-            const chunks = await this.collectParsedChunks({files, tenantContext, summary});
+            const files            = Array.isArray(payload.files) ? payload.files : [];
+            const chunks           = await this.collectParsedChunks({files, tenantContext, summary});
+            const embeddableChunks = this.filterEmbeddingInputBudget({chunks, tenantContext, summary});
 
             summary.deleted = await this.applyDeletionSignals({
                 deleted         : payload.deleted,
@@ -148,11 +156,16 @@ class KnowledgeBaseIngestionService extends Base {
                 summary
             });
 
-            if (chunks.length > 0) {
-                await this.embedChunkGroups({chunks, tenantContext, summary, viaMcp: payload.viaMcp !== false});
+            if (embeddableChunks.length > 0) {
+                await this.embedChunkGroups({
+                    chunks: embeddableChunks,
+                    tenantContext,
+                    summary,
+                    viaMcp: payload.viaMcp !== false
+                });
             }
 
-            summary.ingested   = chunks.length;
+            summary.ingested   = embeddableChunks.length;
             summary.durationMs = Date.now() - startedAt;
 
             await this.persistManifestSnapshot({
@@ -228,7 +241,7 @@ class KnowledgeBaseIngestionService extends Base {
 
         if (normalizedManifest) {
             const livePaths = new Set(normalizedManifest.pathsAfterPush);
-            const rows = await this.getTenantRows(collection, tenantContext.tenantId);
+            const rows      = await this.getTenantRows(collection, tenantContext.tenantId);
 
             rows
                 .filter(row => row.metadata.repoSlug === normalizedManifest.repoSlug && !livePaths.has(row.metadata.sourcePath))
@@ -309,7 +322,7 @@ class KnowledgeBaseIngestionService extends Base {
                 const parsed = await this.resolveFileChunks({file, fileIndex, tenantContext});
 
                 for (let chunkIndex = 0; chunkIndex < parsed.length; chunkIndex++) {
-                    const record = parsed[chunkIndex];
+                    const record     = parsed[chunkIndex];
                     const normalized = await this.validateAndNormalizeParsedChunk({
                         record,
                         fileIndex,
@@ -359,6 +372,7 @@ class KnowledgeBaseIngestionService extends Base {
             ingested           : 0,
             deleted            : 0,
             embeddingsGenerated: 0,
+            skippedOversized   : 0,
             errors             : [],
             tenantId           : aiConfig.defaultTenantId,
             durationMs         : Date.now() - startedAt
@@ -393,9 +407,9 @@ class KnowledgeBaseIngestionService extends Base {
      * @protected
      */
     async getTenantRows(collection, tenantId) {
-        const rows = [];
-        const limit = 2000;
-        let offset  = 0;
+        const rows   = [];
+        const limit  = 2000;
+        let   offset = 0;
         let batch;
 
         do {
@@ -403,7 +417,7 @@ class KnowledgeBaseIngestionService extends Base {
                 include: ['metadatas'],
                 limit,
                 offset,
-                where: {tenantId}
+                where  : {tenantId}
             });
 
             for (let i = 0; i < (batch.ids?.length || 0); i++) {
@@ -509,8 +523,8 @@ class KnowledgeBaseIngestionService extends Base {
                   updatedAt = Date.now();
 
             manifests[tenantContext.repoSlug] = {
-                repoSlug       : tenantContext.repoSlug,
-                pathsAfterPush : paths,
+                repoSlug      : tenantContext.repoSlug,
+                pathsAfterPush: paths,
                 updatedAt
             };
 
@@ -549,9 +563,9 @@ class KnowledgeBaseIngestionService extends Base {
         }
 
         const result = await this.setTenantManifest({
-            tenantId       : tenantContext.tenantId,
-            repoSlug       : normalized.repoSlug,
-            pathsAfterPush : normalized.pathsAfterPush
+            tenantId      : tenantContext.tenantId,
+            repoSlug      : normalized.repoSlug,
+            pathsAfterPush: normalized.pathsAfterPush
         });
 
         if (result?.error) {
@@ -632,13 +646,138 @@ class KnowledgeBaseIngestionService extends Base {
             repoSlug           : tenantContext.repoSlug,
             originAgentIdentity: tenantContext.originAgentIdentity,
             eventType          : this.resolveMetricEventType(summary),
-            chunksTotal        : summary.ingested,
+            chunksTotal        : summary.ingested + summary.skippedOversized,
             chunksEmbedded     : summary.embeddingsGenerated,
             chunksDeleted      : summary.deleted,
             durationMs         : summary.durationMs,
             errorCode          : summary.errors[0]?.code,
             detail             : summary.errors.length > 0 ? {errors: summary.errors} : undefined
         });
+    }
+
+    /**
+     * @summary Resolves the local embedding input-budget guardrail for ingestion diagnostics.
+     * @returns {{enabled: Boolean, embeddingProvider: String, contextLimitTokens: Number, safeProcessingLimitTokens: Number, model: String}}
+     * @protected
+     */
+    resolveEmbeddingInputGuardrail() {
+        const embeddingProvider         = mcConfig.embeddingProvider;
+        const contextLimitTokens        = Number(aiConfig.localModels.embedding.contextLimitTokens);
+        const safeProcessingLimitTokens = Number(aiConfig.localModels.embedding.safeProcessingLimitTokens);
+        const model                     = embeddingProvider === 'ollama'
+            ? aiConfig.ollama.embeddingModel
+            : embeddingProvider === 'openAiCompatible'
+                ? aiConfig.openAiCompatible.embeddingModel
+                : embeddingProvider;
+
+        return {
+            enabled: LOCAL_EMBEDDING_PROVIDERS.has(embeddingProvider),
+            embeddingProvider,
+            contextLimitTokens,
+            safeProcessingLimitTokens,
+            model
+        };
+    }
+
+    /**
+     * @summary Builds the provider input string using the same shape as `VectorService.embedChunks`.
+     * @param {Object} chunk Normalized parsed chunk.
+     * @returns {String}
+     * @protected
+     */
+    buildEmbeddingInputText(chunk) {
+        return `${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n${chunk.description || chunk.content || ''}`;
+    }
+
+    /**
+     * @summary Drops local-provider oversized chunks before writing the VectorService temp JSONL.
+     *
+     * `VectorService` remains the final safety net, but doing the same bounded check here
+     * gives ingestion callers and daemon diagnostics a durable skip signal even when no
+     * graph row can be written for the offending source file.
+     *
+     * @param {Object} options
+     * @param {Array<Object>} options.chunks Normalized parsed chunks.
+     * @param {Object} options.tenantContext Server-resolved tenant context.
+     * @param {Object} options.summary Mutable ingestion summary.
+     * @returns {Array<Object>} Chunks safe to send to VectorService.
+     * @protected
+     */
+    filterEmbeddingInputBudget({chunks, tenantContext, summary}) {
+        const guardrail = this.resolveEmbeddingInputGuardrail();
+
+        if (!guardrail.enabled) {
+            return chunks;
+        }
+
+        return chunks.filter(chunk => {
+            const
+                text                = this.buildEmbeddingInputText(chunk),
+                inputBytes          = Buffer.byteLength(text, 'utf8'),
+                inputTokensEstimate = bytesToTokens(inputBytes);
+
+            if (inputTokensEstimate <= guardrail.safeProcessingLimitTokens) {
+                return true;
+            }
+
+            this.recordOversizedEmbeddingSkip({
+                chunk,
+                guardrail,
+                inputBytes,
+                inputTokensEstimate,
+                summary,
+                tenantContext
+            });
+
+            return false;
+        });
+    }
+
+    /**
+     * @summary Records a bounded oversized-ingestion diagnostic without exposing raw content.
+     * @param {Object} options
+     * @returns {void}
+     * @protected
+     */
+    recordOversizedEmbeddingSkip({chunk, guardrail, inputBytes, inputTokensEstimate, summary, tenantContext}) {
+        const details = {
+            tenantId                 : tenantContext.tenantId,
+            repoSlug                 : chunk.repoSlug || tenantContext.repoSlug,
+            sourcePath               : chunk.sourcePath || chunk.source || chunk.name,
+            parserId                 : chunk.parserId,
+            parserVersion            : chunk.parserVersion,
+            kind                     : chunk.kind || chunk.type,
+            inputBytes,
+            inputTokensEstimate,
+            contextLimitTokens       : guardrail.contextLimitTokens,
+            safeProcessingLimitTokens: guardrail.safeProcessingLimitTokens,
+            embeddingProvider        : guardrail.embeddingProvider,
+            model                    : guardrail.model
+        };
+
+        summary.skippedOversized++;
+        summary.errors.push(this.createError({
+            code   : 'KB_INGEST_INPUT_SIZE_EXCEEDED',
+            message: `KB ingestion chunk '${details.sourcePath}' exceeds the local embedding safe-processing band and was skipped before provider invocation.`,
+            details
+        }));
+
+        emitConsumerFriction({
+            assetRef                 : `${details.tenantId}:${details.repoSlug}:${details.sourcePath}`,
+            consumer                 : 'KnowledgeBaseIngestionService.ingestSourceFiles',
+            model                    : guardrail.model,
+            symptom                  : 'size-precheck-skip',
+            emissionPoint            : 'pre-invocation',
+            suggestionKind           : 'split-document',
+            inputBytes,
+            inputTokensEstimate,
+            contextLimitTokens       : guardrail.contextLimitTokens,
+            safeProcessingLimitTokens: guardrail.safeProcessingLimitTokens,
+            serviceDomain            : 'other',
+            note                     : 'KB ingestion chunk exceeds local embedding safe-processing band; add parser chunking or skip this source file.'
+        });
+
+        logger.warn('[KnowledgeBaseIngestionService] Skipping oversized ingestion chunk before embedding.', details);
     }
 
     /**
@@ -750,7 +889,7 @@ class KnowledgeBaseIngestionService extends Base {
      * @protected
      */
     resolveTenantContext(payload = {}) {
-        const activeTenant = normalizeUserId(this.requestContextService.getUserId?.());
+        const activeTenant    = normalizeUserId(this.requestContextService.getUserId?.());
         const requestedTenant = normalizeUserId(payload.tenantId);
 
         if (activeTenant && requestedTenant && activeTenant !== requestedTenant) {
@@ -763,8 +902,8 @@ class KnowledgeBaseIngestionService extends Base {
 
         return {
             tenantId,
-            repoSlug: payload.repoSlug || this.resolvePayloadRepoSlug(payload) || aiConfig.defaultRepoSlug,
-            visibility: payload.visibility || aiConfig.defaultVisibility,
+            repoSlug           : payload.repoSlug || this.resolvePayloadRepoSlug(payload) || aiConfig.defaultRepoSlug,
+            visibility         : payload.visibility || aiConfig.defaultVisibility,
             originAgentIdentity: this.requestContextService.getAgentIdentityNodeId?.() || payload.originAgentIdentity
         };
     }
@@ -1120,7 +1259,7 @@ class KnowledgeBaseIngestionService extends Base {
      * @protected
      */
     async writeTempJsonl(chunks) {
-        const dir  = path.join(os.tmpdir(), 'neo-kb-ingestion');
+        const dir = path.join(os.tmpdir(), 'neo-kb-ingestion');
         const file = path.join(dir, `ingest-${process.pid}-${Date.now()}-${crypto.randomUUID()}.jsonl`);
 
         await fs.ensureDir(dir);

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -147,10 +147,10 @@ class VectorService extends Base {
      */
     resolveTenantStamp(tenantContext = {}) {
         const config = this.getTenantIsolationConfig();
-        const stamp = {
-            tenantId           : tenantContext.tenantId ?? config.defaultTenantId ?? 'neo-shared',
-            repoSlug           : tenantContext.repoSlug ?? config.defaultRepoSlug ?? 'neo',
-            visibility         : tenantContext.visibility ?? config.defaultVisibility ?? 'team',
+        const stamp  = {
+            tenantId           : tenantContext.tenantId ?? config.defaultTenantId,
+            repoSlug           : tenantContext.repoSlug ?? config.defaultRepoSlug,
+            visibility         : tenantContext.visibility ?? config.defaultVisibility,
             tenantConfigVersion: tenantContext.configVersion ?? 0,
             ingestedAt         : Date.now()
         };
@@ -211,9 +211,9 @@ class VectorService extends Base {
                 field,
                 chunkId,
                 clientValue,
-                serverValue: serverValue ?? null,
-                tenantId: stamp.tenantId,
-                repoSlug: stamp.repoSlug,
+                serverValue        : serverValue ?? null,
+                tenantId           : stamp.tenantId,
+                repoSlug           : stamp.repoSlug,
                 originAgentIdentity: stamp.originAgentIdentity ?? null
             };
 
@@ -498,16 +498,16 @@ class VectorService extends Base {
         knowledgeBase.forEach(chunk => {
             if (chunk.kind === 'module-context' && chunk.className) {
                 classNameToDataMap[chunk.className] = {
-                    source : chunk.source,
-                    parent : chunk.extends || null
+                    source: chunk.source,
+                    parent: chunk.extends || null
                 };
             }
         });
 
         knowledgeBase.forEach(chunk => {
-            let currentClass = chunk.className; // Metadata is now on every chunk
+            let   currentClass     = chunk.className; // Metadata is now on every chunk
             const inheritanceChain = [];
-            const visited = new Set();
+            const visited          = new Set();
 
             // If no className metadata (e.g. non-class files), skip
             if (!currentClass) return;
@@ -529,8 +529,8 @@ class VectorService extends Base {
 
         logger.log('Fetching existing documents from ChromaDB...');
         const existingIds = new Set();
-        let offset = 0;
-        const limit = 2000;
+        let   offset      = 0;
+        const limit       = 2000;
         let batch;
 
         // ChromaDB has a default limit (usually 10) if not specified.
@@ -539,7 +539,7 @@ class VectorService extends Base {
             batch = await collection.get({
                 include: [],
                 limit,
-                offset: offset
+                offset : offset
             });
 
             batch.ids.forEach(id => existingIds.add(id));
@@ -593,7 +593,7 @@ class VectorService extends Base {
         if (viaMcp && workVolume > mcpThreshold) {
             // `logPath` is a Provider-owned leaf; read it directly so malformed config
             // shape fails loud instead of silently re-deriving a local default.
-            const logDir = aiConfig.logPath;
+            const logDir       = aiConfig.logPath;
             const errorPayload = {
                 error  : `KB sync work volume exceeds MCP-callable threshold`,
                 message: `${workVolume} chunks need re-embedding (threshold: ${mcpThreshold}). ` +
@@ -610,7 +610,7 @@ class VectorService extends Base {
 
         if (shouldShadowSwap) {
             return await this.embedViaShadowSwap({
-                liveCollection: collection,
+                liveCollection  : collection,
                 knowledgeBase,
                 idsToDeleteCount: idsToDelete.length
             });
@@ -623,7 +623,7 @@ class VectorService extends Base {
 
         await this.embedChunks({collection, chunksToProcess});
 
-        const count   = await collection.count();
+        const count = await collection.count();
         const message = `Embedding complete. Collection now contains ${count} items.`;
         logger.log(message);
         return {message, embedded: chunksToProcess.length, deleted: idsToDelete.length};

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -20,6 +20,7 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs-extra';
 import aiConfig       from '../../../../../../ai/mcp/server/knowledge-base/config.mjs';
+import memoryConfig   from '../../../../../../ai/mcp/server/memory-core/config.mjs';
 
 /**
  * Contract coverage for KnowledgeBaseIngestionService (#11633).
@@ -93,6 +94,7 @@ function createGraphStub() {
 test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
     let Service;
     let originals;
+    let originalEmbeddingConfig;
     let vectorCalls;
     let metrics;
     let collection;
@@ -115,6 +117,11 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
             revisionResolver     : Service.revisionResolver,
             sourceRegistry       : Service.sourceRegistry,
             vectorService        : Service.vectorService
+        };
+        originalEmbeddingConfig = {
+            embeddingProvider        : memoryConfig.data.embeddingProvider,
+            contextLimitTokens       : Number(aiConfig.data.localModels.embedding.contextLimitTokens),
+            safeProcessingLimitTokens: Number(aiConfig.data.localModels.embedding.safeProcessingLimitTokens)
         };
 
         Service.chromaManager = {
@@ -147,6 +154,9 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
 
     test.afterEach(() => {
         Object.assign(Service, originals);
+        memoryConfig.data.embeddingProvider = originalEmbeddingConfig.embeddingProvider;
+        aiConfig.data.localModels.embedding.contextLimitTokens        = originalEmbeddingConfig.contextLimitTokens;
+        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = originalEmbeddingConfig.safeProcessingLimitTokens;
     });
 
     test('validates parsed-chunk-v1 records, routes them to VectorService, and records telemetry', async () => {
@@ -342,9 +352,9 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         expect(summary.ingested).toBe(1);
         expect(summary.deleted).toBe(1);
         expect(metrics[0]).toMatchObject({
-            eventType      : 'reconcile',
-            chunksEmbedded : 1,
-            chunksDeleted  : 1
+            eventType     : 'reconcile',
+            chunksEmbedded: 1,
+            chunksDeleted : 1
         });
     });
 
@@ -385,6 +395,98 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
             sourcePath   : 'docs/readme.md',
             type         : 'doc-section'
         });
+    });
+
+    test('skips over-budget client parsed chunks while embedding safe chunks', async () => {
+        memoryConfig.data.embeddingProvider                            = 'openAiCompatible';
+        aiConfig.data.localModels.embedding.contextLimitTokens        = 50;
+        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = 40;
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [
+                validParsedChunk({sourcePath: 'src/safe.js', content: 'short payload'}),
+                validParsedChunk({sourcePath: 'src/monster.js', content: 'x'.repeat(300)})
+            ]}]
+        });
+
+        expect(summary.ingested).toBe(1);
+        expect(summary.embeddingsGenerated).toBe(1);
+        expect(summary.skippedOversized).toBe(1);
+        expect(summary.errors[0]).toMatchObject({
+            code   : 'KB_INGEST_INPUT_SIZE_EXCEEDED',
+            details: {
+                tenantId         : 'tenant-a',
+                repoSlug         : 'repo-a',
+                sourcePath       : 'src/monster.js',
+                parserId         : 'client-parser',
+                embeddingProvider: 'openAiCompatible'
+            }
+        });
+        expect(summary.errors[0].details).not.toHaveProperty('content');
+        expect(vectorCalls).toHaveLength(1);
+        expect(vectorCalls[0].records).toHaveLength(1);
+        expect(vectorCalls[0].records[0].sourcePath).toBe('src/safe.js');
+        expect(metrics[0]).toMatchObject({
+            eventType     : 'error',
+            chunksTotal   : 2,
+            chunksEmbedded: 1
+        });
+        expect(metrics[0].detail.errors[0].code).toBe('KB_INGEST_INPUT_SIZE_EXCEEDED');
+    });
+
+    test('skips over-budget raw fallback files before VectorService receives a temp JSONL', async () => {
+        memoryConfig.data.embeddingProvider                            = 'openAiCompatible';
+        aiConfig.data.localModels.embedding.contextLimitTokens        = 50;
+        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = 40;
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            repoSlug: 'repo-a',
+            files   : [{
+                content   : 'x'.repeat(300),
+                sourcePath: 'docs/monster.md'
+            }]
+        });
+
+        expect(summary.ingested).toBe(0);
+        expect(summary.embeddingsGenerated).toBe(0);
+        expect(summary.skippedOversized).toBe(1);
+        expect(summary.errors[0]).toMatchObject({
+            code   : 'KB_INGEST_INPUT_SIZE_EXCEEDED',
+            details: {
+                sourcePath   : 'docs/monster.md',
+                parserId     : 'raw-text',
+                parserVersion: '1.0.0'
+            }
+        });
+        expect(vectorCalls).toHaveLength(0);
+        expect(metrics[0]).toMatchObject({
+            eventType     : 'error',
+            chunksTotal   : 1,
+            chunksEmbedded: 0
+        });
+    });
+
+    test('does not apply local embedding caps to non-local ingestion providers', async () => {
+        memoryConfig.data.embeddingProvider                            = 'gemini';
+        aiConfig.data.localModels.embedding.contextLimitTokens        = 50;
+        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = 1;
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk({
+                sourcePath: 'src/remote-large.js',
+                content   : 'x'.repeat(300)
+            })]}]
+        });
+
+        expect(summary.ingested).toBe(1);
+        expect(summary.embeddingsGenerated).toBe(1);
+        expect(summary.skippedOversized).toBe(0);
+        expect(summary.errors).toEqual([]);
+        expect(vectorCalls).toHaveLength(1);
+        expect(vectorCalls[0].records[0].sourcePath).toBe('src/remote-large.js');
     });
 
     test('captures VectorService refusal as a summary error without losing the summary', async () => {


### PR DESCRIPTION
Resolves #13930

Adds a Knowledge Base ingestion guardrail for local embedding providers so over-budget source-file inputs are skipped before temp JSONL/vector handoff. Safe chunks still embed normally; oversized raw fallback and client-parser chunks now surface `skippedOversized`, a bounded `KB_INGEST_INPUT_SIZE_EXCEEDED` error, `ConsumerFriction`, and KB logger diagnostics without exposing raw source content. The update also removes the ADR-0019-violating hard-coded tenant default fallbacks from the KB tenant-stamp/hash use sites; those paths now read the resolved AiConfig leaves only.

Evidence: L2 (unit + static validator coverage of local-provider oversized skip behavior before vector handoff, plus tenant-stamping/hash regression coverage) -> L2 required (ingest-time diagnostic contract). No residuals.

Related: #13928
Related: #13914
Related: #13924
Related: #11735

## Deltas from ticket

No private deployment config changes, new public daemon surface, custom parser, or auto-splitting behavior is included here. Non-local embedding providers remain exempt because this guardrail is keyed to the local embedding context leaves.

The operator-surfaced ADR-0019 issue is included as a follow-up delta: no MCP response shape changes were needed for that cleanup, and the existing `IngestSourceFilesResponse` schema update remains limited to `skippedOversized`.

## Test Evidence

- `npm run agent-preflight -- ai/services/knowledge-base/DatabaseService.mjs ai/services/knowledge-base/VectorService.mjs ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs ai/mcp/server/knowledge-base/openapi.yaml test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs` — 57 passed
- `git diff --check`

## Post-Merge Validation

- [ ] Run a real tenant-repo ingestion with an intentionally over-budget file and verify the KB tool response includes `skippedOversized` plus a bounded `KB_INGEST_INPUT_SIZE_EXCEEDED` diagnostic.
- [ ] Confirm the daemon diagnostic work in #13914 / #13924 can consume the emitted KB log and friction surfaces without adding a new public connection path.

## Commits

- `b51a485a9d` — `fix(ai): surface oversized kb ingest skips (#13930)`
- `4b6b301046` — `fix(ai): read kb tenant defaults from aiconfig (#13930)`

Authored by Euclid (GPT-5, Codex Desktop). Session 1be84a2d-a911-424a-bfb0-10a51fff6303.
