### PR TITLE
feat(ai): add deployment-state bridge snapshot (#13926)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -443,6 +443,39 @@ class Config extends ConfigProvider {
                     auditMode                   : leaf('metadata', 'NEO_ORCHESTRATOR_RUNTIME_ACCESS_AUDIT_MODE', 'string')
                 },
                 /**
+                 * Graph-independent deployment-state bridge. The orchestrator writes a bounded JSON
+                 * snapshot to shared storage; KB/MC read tools consume it without receiving Docker
+                 * socket, shell, exec, or actuator authority. Disabled by default: deployment
+                 * overlays must explicitly enable the writer and mount the same `snapshotPath`
+                 * into the public KB/MC containers.
+                 *
+                 * Env overrides:
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED`,
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH`,
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_WRITE_INTERVAL_MS`,
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_STALE_AFTER_MS`,
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_MAX_BYTES`,
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES`,
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_INCLUDE_LOGS`,
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_LOG_TAIL`,
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_LOG_MAX_BYTES`,
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_STATS_SAMPLE_WINDOW`.
+                 *
+                 * @type {Object}
+                 */
+                deploymentStateBridge: {
+                    enabled          : leaf(false, 'NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED', 'boolean'),
+                    snapshotPath     : leaf(path.resolve(neoRootDir, '.neo-ai-data/deployment-state/snapshot.json'), 'NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH', 'string'),
+                    writeIntervalMs  : leaf(30000, 'NEO_DEPLOYMENT_STATE_BRIDGE_WRITE_INTERVAL_MS', 'number'),
+                    staleAfterMs     : leaf(2 * 60 * 1000, 'NEO_DEPLOYMENT_STATE_BRIDGE_STALE_AFTER_MS', 'number'),
+                    maxSnapshotBytes : leaf(256 * 1024, 'NEO_DEPLOYMENT_STATE_BRIDGE_MAX_BYTES', 'number'),
+                    allowedServices  : leaf([], 'NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES', 'csv'),
+                    includeLogs      : leaf(true, 'NEO_DEPLOYMENT_STATE_BRIDGE_INCLUDE_LOGS', 'boolean'),
+                    logTail          : leaf(120, 'NEO_DEPLOYMENT_STATE_BRIDGE_LOG_TAIL', 'number'),
+                    logMaxBytes      : leaf(32 * 1024, 'NEO_DEPLOYMENT_STATE_BRIDGE_LOG_MAX_BYTES', 'number'),
+                    statsSampleWindow: leaf(2, 'NEO_DEPLOYMENT_STATE_BRIDGE_STATS_SAMPLE_WINDOW', 'number')
+                },
+                /**
                  * Maintenance-loop intervals consumed by the orchestrator daemon.
                  * Env vars at the daemon boundary retain precedence over these defaults.
                  * @type {Object}

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -30,6 +30,7 @@ import {normalizeAgentIdentityNodeId}                                           
 import TaskStateService                                                         from './services/TaskStateService.mjs';
 import ProcessSupervisorService                                                 from './services/ProcessSupervisorService.mjs';
 import DeploymentRuntimeAccessService                                           from './services/DeploymentRuntimeAccessService.mjs';
+import DeploymentStateBridgeService                                             from './services/DeploymentStateBridgeService.mjs';
 import RecoveryActuatorService                                                  from './services/RecoveryActuatorService.mjs';
 import ContainerHealthDiagnosisService                                          from './services/ContainerHealthDiagnosisService.mjs';
 import DreamService                                                             from './services/DreamService.mjs';
@@ -108,6 +109,7 @@ export class Orchestrator extends Base {
         singleton                       : true,
         processSupervisorService_       : null,
         deploymentRuntimeAccessService_ : null,
+        deploymentStateBridgeService_   : null,
         recoveryActuatorService_        : null,
         containerHealthDiagnosisService_: null,
         maintenanceBackpressureService_ : MaintenanceBackpressureService,
@@ -148,6 +150,7 @@ export class Orchestrator extends Base {
 
     processSupervisorWriteLog = (level, msg) => this.writeLog(level, msg)
     deploymentRuntimeAccessWriteLog = (level, msg) => this.writeLog(level, msg)
+    deploymentStateBridgeWriteLog   = (level, msg) => this.writeLog(level, msg)
     maintenanceBackpressureWriteLog = (level, msg) => this.writeLog(level, msg)
 
     /**
@@ -300,6 +303,19 @@ export class Orchestrator extends Base {
         return ClassSystemUtil.beforeSetInstance(value, ContainerHealthDiagnosisService);
     }
 
+    /**
+     * @param {Neo.ai.daemons.services.DeploymentStateBridgeService|Object|null} value
+     * @returns {Neo.ai.daemons.services.DeploymentStateBridgeService}
+     */
+    beforeSetDeploymentStateBridgeService(value) {
+        return ClassSystemUtil.beforeSetInstance(value, DeploymentStateBridgeService, {
+            bridgeConfig        : AiConfig.orchestrator.deploymentStateBridge,
+            runtimeAccessService: this.deploymentRuntimeAccessService,
+            diagnosisService    : this.containerHealthDiagnosisService,
+            writeLog            : this.deploymentStateBridgeWriteLog
+        });
+    }
+
     beforeSetMaintenanceBackpressureService(value) {
         return ClassSystemUtil.beforeSetInstance(value, MaintenanceBackpressureService, {
             heavyMaintenanceTaskNames    : this.heavyMaintenanceTaskNames,
@@ -350,8 +366,17 @@ export class Orchestrator extends Base {
         this.maintenanceBackpressureService.healthService = value;
     }
     afterSetDeploymentRuntimeAccessService(value, oldValue) {
-        if (oldValue === undefined || !this.recoveryActuatorService) return;
-        this.recoveryActuatorService.deploymentRuntimeAccessService = value;
+        if (oldValue === undefined) return;
+        if (this.recoveryActuatorService) {
+            this.recoveryActuatorService.deploymentRuntimeAccessService = value;
+        }
+        if (this.deploymentStateBridgeService) {
+            this.deploymentStateBridgeService.runtimeAccessService = value;
+        }
+    }
+    afterSetContainerHealthDiagnosisService(value, oldValue) {
+        if (oldValue === undefined || !this.deploymentStateBridgeService) return;
+        this.deploymentStateBridgeService.diagnosisService = value;
     }
     afterSetSpawnFn(value, oldValue) {
         if (oldValue === undefined) return;
@@ -441,6 +466,7 @@ export class Orchestrator extends Base {
 
         this.processSupervisorService = {};
         this.deploymentRuntimeAccessService = {};
+        this.deploymentStateBridgeService = {};
         this.recoveryActuatorService = {};
         this.containerHealthDiagnosisService = {};
         this.processSupervisorService.recoverTasks();
@@ -570,6 +596,9 @@ export class Orchestrator extends Base {
         runSchedulingPipeline({
             ...buildOrchestratorSchedulingOptions({orchestrator: this, config: AiConfig, now, registry: TASK_REGISTRY})
         });
+
+        this.deploymentStateBridgeService?.writeSnapshotIfDue()
+            .catch(error => this.writeLog('ERROR', `[Orchestrator] Deployment state bridge failed: ${error.message}`));
 
         if (this.isPolling) {
             this.pollHandle = setTimeout(() => this.poll(), AiConfig.orchestrator.intervals.pollMs);

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -309,7 +309,6 @@ export class Orchestrator extends Base {
      */
     beforeSetDeploymentStateBridgeService(value) {
         return ClassSystemUtil.beforeSetInstance(value, DeploymentStateBridgeService, {
-            bridgeConfig        : AiConfig.orchestrator.deploymentStateBridge,
             runtimeAccessService: this.deploymentRuntimeAccessService,
             diagnosisService    : this.containerHealthDiagnosisService,
             writeLog            : this.deploymentStateBridgeWriteLog
@@ -366,7 +365,6 @@ export class Orchestrator extends Base {
         this.maintenanceBackpressureService.healthService = value;
     }
     afterSetDeploymentRuntimeAccessService(value, oldValue) {
-        if (oldValue === undefined) return;
         if (this.recoveryActuatorService) {
             this.recoveryActuatorService.deploymentRuntimeAccessService = value;
         }
@@ -375,8 +373,9 @@ export class Orchestrator extends Base {
         }
     }
     afterSetContainerHealthDiagnosisService(value, oldValue) {
-        if (oldValue === undefined || !this.deploymentStateBridgeService) return;
-        this.deploymentStateBridgeService.diagnosisService = value;
+        if (this.deploymentStateBridgeService) {
+            this.deploymentStateBridgeService.diagnosisService = value;
+        }
     }
     afterSetSpawnFn(value, oldValue) {
         if (oldValue === undefined) return;
@@ -466,9 +465,9 @@ export class Orchestrator extends Base {
 
         this.processSupervisorService = {};
         this.deploymentRuntimeAccessService = {};
+        this.containerHealthDiagnosisService = {};
         this.deploymentStateBridgeService = {};
         this.recoveryActuatorService = {};
-        this.containerHealthDiagnosisService = {};
         this.processSupervisorService.recoverTasks();
 
         this.db = await this.initializeDatabaseFn(this.dbPath);

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -43,12 +43,6 @@ export class DeploymentStateBridgeService extends Base {
          */
         diagnosisService_: null,
         /**
-         * @member {Object|null} bridgeConfig_=null
-         * @protected
-         * @reactive
-         */
-        bridgeConfig_: null,
-        /**
          * @member {Function|null} nowFn_=null
          * @protected
          * @reactive
@@ -66,11 +60,6 @@ export class DeploymentStateBridgeService extends Base {
     writeInFlight         = false
     statsSamplesByService = new Map()
 
-    /** @summary Resolves the active bridge config from an injected test value or Tier-1 AiConfig. */
-    get cfg() {
-        return this.bridgeConfig || AiConfig.orchestrator.deploymentStateBridge;
-    }
-
     /**
      * Writes a snapshot when enabled and due.
      * @param {Object} [options]
@@ -78,9 +67,11 @@ export class DeploymentStateBridgeService extends Base {
      * @returns {Promise<Object>}
      */
     async writeSnapshotIfDue({force = false} = {}) {
-        const now = this.now();
+        const
+            bridgeConfig = AiConfig.orchestrator.deploymentStateBridge,
+            now          = this.now();
 
-        if (!this.cfg.enabled) {
+        if (!bridgeConfig.enabled) {
             return {ok: true, status: 'disabled'};
         }
 
@@ -88,7 +79,7 @@ export class DeploymentStateBridgeService extends Base {
             return {ok: true, status: 'in-flight'};
         }
 
-        if (!force && this.lastWriteAt > 0 && now - this.lastWriteAt < this.cfg.writeIntervalMs) {
+        if (!force && this.lastWriteAt > 0 && now - this.lastWriteAt < bridgeConfig.writeIntervalMs) {
             return {ok: true, status: 'skipped'};
         }
 
@@ -97,13 +88,13 @@ export class DeploymentStateBridgeService extends Base {
         try {
             const snapshot = await this.collectSnapshot({generatedAt: now}),
                   result   = await writeDeploymentStateSnapshot({
-                      filePath: this.cfg.snapshotPath,
+                      filePath: bridgeConfig.snapshotPath,
                       snapshot,
-                      maxBytes: this.cfg.maxSnapshotBytes
+                      maxBytes: bridgeConfig.maxSnapshotBytes
                   });
 
             this.lastWriteAt = now;
-            this.writeLog?.('INFO', `[DeploymentStateBridge] wrote ${snapshot.services.length} service snapshots to ${this.cfg.snapshotPath}`);
+            this.writeLog?.('INFO', `[DeploymentStateBridge] wrote ${snapshot.services.length} service snapshots to ${bridgeConfig.snapshotPath}`);
 
             return {ok: true, status: 'written', snapshot, ...result};
         } catch (error) {
@@ -163,8 +154,10 @@ export class DeploymentStateBridgeService extends Base {
         inspect = await read('inspect');
         stats   = await read('stats');
 
-        if (this.cfg.includeLogs) {
-            logs = await read('logs', {tail: this.cfg.logTail});
+        const bridgeConfig = AiConfig.orchestrator.deploymentStateBridge;
+
+        if (bridgeConfig.includeLogs) {
+            logs = await read('logs', {tail: bridgeConfig.logTail});
         }
 
         if (stats) {
@@ -190,7 +183,7 @@ export class DeploymentStateBridgeService extends Base {
             status        : errors.length > 0 ? 'degraded' : 'available',
             inspect       : summarizeInspect(inspect),
             stats         : summarizeStats(stats),
-            logs          : summarizeLogs(logs, this.cfg.logMaxBytes),
+            logs          : summarizeLogs(logs, bridgeConfig.logMaxBytes),
             diagnosis,
             proofs,
             errors
@@ -202,7 +195,7 @@ export class DeploymentStateBridgeService extends Base {
      * @returns {String[]}
      */
     getServiceKeys() {
-        const {allowedServices} = this.cfg;
+        const {allowedServices} = AiConfig.orchestrator.deploymentStateBridge;
 
         if (Array.isArray(allowedServices) && allowedServices.length > 0) {
             return allowedServices.filter(isSafeServiceKey);
@@ -223,7 +216,7 @@ export class DeploymentStateBridgeService extends Base {
 
         samples.push(stats);
 
-        const max = Math.max(1, Number(this.cfg.statsSampleWindow) || 1);
+        const max = Math.max(1, Number(AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow) || 1);
         this.statsSamplesByService.set(serviceKey, samples.slice(-max));
     }
 

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -43,6 +43,12 @@ export class DeploymentStateBridgeService extends Base {
          */
         diagnosisService_: null,
         /**
+         * @member {Object|null} bridgeConfig_=null
+         * @protected
+         * @reactive
+         */
+        bridgeConfig_: null,
+        /**
          * @member {Function|null} nowFn_=null
          * @protected
          * @reactive
@@ -60,18 +66,21 @@ export class DeploymentStateBridgeService extends Base {
     writeInFlight         = false
     statsSamplesByService = new Map()
 
+    /** @summary Resolves the active bridge config from an injected test value or Tier-1 AiConfig. */
+    get cfg() {
+        return this.bridgeConfig || AiConfig.orchestrator.deploymentStateBridge;
+    }
+
     /**
      * Writes a snapshot when enabled and due.
      * @param {Object} [options]
      * @param {Boolean} [options.force=false] Bypass interval gate.
-     * @param {Object} [options.bridgeOptions] Test seam for call-local bridge options.
      * @returns {Promise<Object>}
      */
-    async writeSnapshotIfDue({force = false, bridgeOptions} = {}) {
-        const options = this.resolveBridgeOptions(bridgeOptions),
-              now     = this.now();
+    async writeSnapshotIfDue({force = false} = {}) {
+        const now = this.now();
 
-        if (!options.enabled) {
+        if (!this.cfg.enabled) {
             return {ok: true, status: 'disabled'};
         }
 
@@ -79,22 +88,22 @@ export class DeploymentStateBridgeService extends Base {
             return {ok: true, status: 'in-flight'};
         }
 
-        if (!force && this.lastWriteAt > 0 && now - this.lastWriteAt < options.writeIntervalMs) {
+        if (!force && this.lastWriteAt > 0 && now - this.lastWriteAt < this.cfg.writeIntervalMs) {
             return {ok: true, status: 'skipped'};
         }
 
         this.writeInFlight = true;
 
         try {
-            const snapshot = await this.collectSnapshot({generatedAt: now, bridgeOptions: options}),
+            const snapshot = await this.collectSnapshot({generatedAt: now}),
                   result   = await writeDeploymentStateSnapshot({
-                      filePath: options.snapshotPath,
+                      filePath: this.cfg.snapshotPath,
                       snapshot,
-                      maxBytes: options.maxSnapshotBytes
+                      maxBytes: this.cfg.maxSnapshotBytes
                   });
 
             this.lastWriteAt = now;
-            this.writeLog?.('INFO', `[DeploymentStateBridge] wrote ${snapshot.services.length} service snapshots to ${options.snapshotPath}`);
+            this.writeLog?.('INFO', `[DeploymentStateBridge] wrote ${snapshot.services.length} service snapshots to ${this.cfg.snapshotPath}`);
 
             return {ok: true, status: 'written', snapshot, ...result};
         } catch (error) {
@@ -109,15 +118,13 @@ export class DeploymentStateBridgeService extends Base {
      * Collects one bounded deployment-state snapshot.
      * @param {Object} [options]
      * @param {Number} [options.generatedAt]
-     * @param {Object} [options.bridgeOptions] Test seam for call-local bridge options.
      * @returns {Promise<Object>}
      */
-    async collectSnapshot({generatedAt = this.now(), bridgeOptions} = {}) {
-        const options  = this.resolveBridgeOptions(bridgeOptions),
-              services = [];
+    async collectSnapshot({generatedAt = this.now()} = {}) {
+        const services = [];
 
-        for (const serviceKey of this.getServiceKeys({allowedServices: options.allowedServices})) {
-            services.push(await this.collectServiceSnapshot({serviceKey, observedAt: generatedAt, bridgeOptions: options}));
+        for (const serviceKey of this.getServiceKeys()) {
+            services.push(await this.collectServiceSnapshot({serviceKey, observedAt: generatedAt}));
         }
 
         return createDeploymentStateSnapshot({
@@ -131,12 +138,9 @@ export class DeploymentStateBridgeService extends Base {
      * @param {Object} options
      * @param {String} options.serviceKey Allowlisted service key.
      * @param {Number} options.observedAt Epoch ms.
-     * @param {Object} [options.bridgeOptions] Test seam for call-local bridge options.
      * @returns {Promise<Object>}
      */
-    async collectServiceSnapshot({serviceKey, observedAt, bridgeOptions}) {
-        const options = this.resolveBridgeOptions(bridgeOptions);
-
+    async collectServiceSnapshot({serviceKey, observedAt}) {
         const
             errors = [],
             proofs = [];
@@ -159,12 +163,12 @@ export class DeploymentStateBridgeService extends Base {
         inspect = await read('inspect');
         stats   = await read('stats');
 
-        if (options.includeLogs) {
-            logs = await read('logs', {tail: options.logTail});
+        if (this.cfg.includeLogs) {
+            logs = await read('logs', {tail: this.cfg.logTail});
         }
 
         if (stats) {
-            this.rememberStatsSample(serviceKey, stats, {statsSampleWindow: options.statsSampleWindow});
+            this.rememberStatsSample(serviceKey, stats);
         }
 
         const diagnosis = this.diagnosisService?.diagnose
@@ -186,7 +190,7 @@ export class DeploymentStateBridgeService extends Base {
             status        : errors.length > 0 ? 'degraded' : 'available',
             inspect       : summarizeInspect(inspect),
             stats         : summarizeStats(stats),
-            logs          : summarizeLogs(logs, options.logMaxBytes),
+            logs          : summarizeLogs(logs, this.cfg.logMaxBytes),
             diagnosis,
             proofs,
             errors
@@ -195,11 +199,11 @@ export class DeploymentStateBridgeService extends Base {
 
     /**
      * Resolves allowlisted service keys for snapshot collection.
-     * @param {Object} [options]
-     * @param {String[]} [options.allowedServices] Call-local service allowlist.
      * @returns {String[]}
      */
-    getServiceKeys({allowedServices = AiConfig.orchestrator.deploymentStateBridge.allowedServices} = {}) {
+    getServiceKeys() {
+        const {allowedServices} = this.cfg;
+
         if (Array.isArray(allowedServices) && allowedServices.length > 0) {
             return allowedServices.filter(isSafeServiceKey);
         }
@@ -212,37 +216,15 @@ export class DeploymentStateBridgeService extends Base {
      * Stores a bounded stats sample window per service.
      * @param {String} serviceKey Service key.
      * @param {Object} stats Docker stats sample.
-     * @param {Object} [options]
-     * @param {Number} [options.statsSampleWindow] Bounded sample count.
      * @returns {void}
      */
-    rememberStatsSample(serviceKey, stats, {statsSampleWindow = AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow} = {}) {
+    rememberStatsSample(serviceKey, stats) {
         const samples = this.statsSamplesByService.get(serviceKey) || [];
 
         samples.push(stats);
 
-        const max = Math.max(1, Number(statsSampleWindow) || 1);
+        const max = Math.max(1, Number(this.cfg.statsSampleWindow) || 1);
         this.statsSamplesByService.set(serviceKey, samples.slice(-max));
-    }
-
-    /**
-     * Reads Tier-1 bridge leaves at the use site, with call-local overrides for tests.
-     * @param {Object} [overrides]
-     * @returns {Object}
-     */
-    resolveBridgeOptions(overrides = {}) {
-        return {
-            enabled          : overrides.enabled           ?? AiConfig.orchestrator.deploymentStateBridge.enabled,
-            snapshotPath     : overrides.snapshotPath      ?? AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
-            writeIntervalMs  : overrides.writeIntervalMs   ?? AiConfig.orchestrator.deploymentStateBridge.writeIntervalMs,
-            staleAfterMs     : overrides.staleAfterMs      ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
-            maxSnapshotBytes : overrides.maxSnapshotBytes  ?? AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes,
-            allowedServices  : overrides.allowedServices   ?? AiConfig.orchestrator.deploymentStateBridge.allowedServices,
-            includeLogs      : overrides.includeLogs       ?? AiConfig.orchestrator.deploymentStateBridge.includeLogs,
-            logTail          : overrides.logTail           ?? AiConfig.orchestrator.deploymentStateBridge.logTail,
-            logMaxBytes      : overrides.logMaxBytes       ?? AiConfig.orchestrator.deploymentStateBridge.logMaxBytes,
-            statsSampleWindow: overrides.statsSampleWindow ?? AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow
-        };
     }
 
     /**

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -1,4 +1,5 @@
-import Base from '../../../../src/core/Base.mjs';
+import Base     from '../../../../src/core/Base.mjs';
+import AiConfig from '../../../config.mjs';
 
 import {
     boundUtf8Tail,
@@ -9,19 +10,6 @@ import {
     calculateDockerCpuPercent,
     calculateDockerMemoryPercent
 } from './ContainerHealthDiagnosisService.mjs';
-
-export const DEFAULT_DEPLOYMENT_STATE_BRIDGE_CONFIG = Object.freeze({
-    enabled          : false,
-    snapshotPath     : null,
-    writeIntervalMs  : 30000,
-    staleAfterMs     : 2 * 60 * 1000,
-    maxSnapshotBytes : 256 * 1024,
-    allowedServices  : null,
-    includeLogs      : true,
-    logTail          : 120,
-    logMaxBytes      : 32 * 1024,
-    statsSampleWindow: 2
-});
 
 /**
  * @summary Writes a bounded, graph-independent deployment-state snapshot for KB/MC tools.
@@ -42,12 +30,6 @@ export class DeploymentStateBridgeService extends Base {
          * @protected
          */
         className: 'Neo.ai.daemons.services.DeploymentStateBridgeService',
-        /**
-         * @member {Object|null} bridgeConfig_=null
-         * @protected
-         * @reactive
-         */
-        bridgeConfig_: null,
         /**
          * @member {Object|null} runtimeAccessService_=null
          * @protected
@@ -79,27 +61,17 @@ export class DeploymentStateBridgeService extends Base {
     statsSamplesByService = new Map()
 
     /**
-     * Resolves active bridge config.
-     * @returns {Object}
-     */
-    get configValues() {
-        return {
-            ...DEFAULT_DEPLOYMENT_STATE_BRIDGE_CONFIG,
-            ...(this.bridgeConfig || {})
-        };
-    }
-
-    /**
      * Writes a snapshot when enabled and due.
      * @param {Object} [options]
      * @param {Boolean} [options.force=false] Bypass interval gate.
+     * @param {Object} [options.bridgeOptions] Test seam for call-local bridge options.
      * @returns {Promise<Object>}
      */
-    async writeSnapshotIfDue({force = false} = {}) {
-        const config = this.configValues,
-              now    = this.now();
+    async writeSnapshotIfDue({force = false, bridgeOptions} = {}) {
+        const options = this.resolveBridgeOptions(bridgeOptions),
+              now     = this.now();
 
-        if (!config.enabled) {
+        if (!options.enabled) {
             return {ok: true, status: 'disabled'};
         }
 
@@ -107,22 +79,22 @@ export class DeploymentStateBridgeService extends Base {
             return {ok: true, status: 'in-flight'};
         }
 
-        if (!force && this.lastWriteAt > 0 && now - this.lastWriteAt < config.writeIntervalMs) {
+        if (!force && this.lastWriteAt > 0 && now - this.lastWriteAt < options.writeIntervalMs) {
             return {ok: true, status: 'skipped'};
         }
 
         this.writeInFlight = true;
 
         try {
-            const snapshot = await this.collectSnapshot({generatedAt: now}),
+            const snapshot = await this.collectSnapshot({generatedAt: now, bridgeOptions: options}),
                   result   = await writeDeploymentStateSnapshot({
-                      filePath: config.snapshotPath,
+                      filePath: options.snapshotPath,
                       snapshot,
-                      maxBytes: config.maxSnapshotBytes
+                      maxBytes: options.maxSnapshotBytes
                   });
 
             this.lastWriteAt = now;
-            this.writeLog?.('INFO', `[DeploymentStateBridge] wrote ${snapshot.services.length} service snapshots to ${config.snapshotPath}`);
+            this.writeLog?.('INFO', `[DeploymentStateBridge] wrote ${snapshot.services.length} service snapshots to ${options.snapshotPath}`);
 
             return {ok: true, status: 'written', snapshot, ...result};
         } catch (error) {
@@ -137,13 +109,15 @@ export class DeploymentStateBridgeService extends Base {
      * Collects one bounded deployment-state snapshot.
      * @param {Object} [options]
      * @param {Number} [options.generatedAt]
+     * @param {Object} [options.bridgeOptions] Test seam for call-local bridge options.
      * @returns {Promise<Object>}
      */
-    async collectSnapshot({generatedAt = this.now()} = {}) {
-        const services = [];
+    async collectSnapshot({generatedAt = this.now(), bridgeOptions} = {}) {
+        const options  = this.resolveBridgeOptions(bridgeOptions),
+              services = [];
 
-        for (const serviceKey of this.getServiceKeys()) {
-            services.push(await this.collectServiceSnapshot({serviceKey, observedAt: generatedAt}));
+        for (const serviceKey of this.getServiceKeys({allowedServices: options.allowedServices})) {
+            services.push(await this.collectServiceSnapshot({serviceKey, observedAt: generatedAt, bridgeOptions: options}));
         }
 
         return createDeploymentStateSnapshot({
@@ -157,9 +131,12 @@ export class DeploymentStateBridgeService extends Base {
      * @param {Object} options
      * @param {String} options.serviceKey Allowlisted service key.
      * @param {Number} options.observedAt Epoch ms.
+     * @param {Object} [options.bridgeOptions] Test seam for call-local bridge options.
      * @returns {Promise<Object>}
      */
-    async collectServiceSnapshot({serviceKey, observedAt}) {
+    async collectServiceSnapshot({serviceKey, observedAt, bridgeOptions}) {
+        const options = this.resolveBridgeOptions(bridgeOptions);
+
         const
             errors = [],
             proofs = [];
@@ -182,12 +159,12 @@ export class DeploymentStateBridgeService extends Base {
         inspect = await read('inspect');
         stats   = await read('stats');
 
-        if (this.configValues.includeLogs) {
-            logs = await read('logs', {tail: this.configValues.logTail});
+        if (options.includeLogs) {
+            logs = await read('logs', {tail: options.logTail});
         }
 
         if (stats) {
-            this.rememberStatsSample(serviceKey, stats);
+            this.rememberStatsSample(serviceKey, stats, {statsSampleWindow: options.statsSampleWindow});
         }
 
         const diagnosis = this.diagnosisService?.diagnose
@@ -209,7 +186,7 @@ export class DeploymentStateBridgeService extends Base {
             status        : errors.length > 0 ? 'degraded' : 'available',
             inspect       : summarizeInspect(inspect),
             stats         : summarizeStats(stats),
-            logs          : summarizeLogs(logs, this.configValues.logMaxBytes),
+            logs          : summarizeLogs(logs, options.logMaxBytes),
             diagnosis,
             proofs,
             errors
@@ -218,16 +195,16 @@ export class DeploymentStateBridgeService extends Base {
 
     /**
      * Resolves allowlisted service keys for snapshot collection.
+     * @param {Object} [options]
+     * @param {String[]} [options.allowedServices] Call-local service allowlist.
      * @returns {String[]}
      */
-    getServiceKeys() {
-        const configured = this.configValues.allowedServices;
-
-        if (Array.isArray(configured) && configured.length > 0) {
-            return configured.filter(isSafeServiceKey);
+    getServiceKeys({allowedServices = AiConfig.orchestrator.deploymentStateBridge.allowedServices} = {}) {
+        if (Array.isArray(allowedServices) && allowedServices.length > 0) {
+            return allowedServices.filter(isSafeServiceKey);
         }
 
-        const runtimeAllowed = this.runtimeAccessService?.configValues?.allowedServices;
+        const runtimeAllowed = this.runtimeAccessService.configValues.allowedServices;
         return Array.isArray(runtimeAllowed) ? runtimeAllowed.filter(isSafeServiceKey) : [];
     }
 
@@ -235,15 +212,37 @@ export class DeploymentStateBridgeService extends Base {
      * Stores a bounded stats sample window per service.
      * @param {String} serviceKey Service key.
      * @param {Object} stats Docker stats sample.
+     * @param {Object} [options]
+     * @param {Number} [options.statsSampleWindow] Bounded sample count.
      * @returns {void}
      */
-    rememberStatsSample(serviceKey, stats) {
+    rememberStatsSample(serviceKey, stats, {statsSampleWindow = AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow} = {}) {
         const samples = this.statsSamplesByService.get(serviceKey) || [];
 
         samples.push(stats);
 
-        const max = Math.max(1, Number(this.configValues.statsSampleWindow) || 1);
+        const max = Math.max(1, Number(statsSampleWindow) || 1);
         this.statsSamplesByService.set(serviceKey, samples.slice(-max));
+    }
+
+    /**
+     * Reads Tier-1 bridge leaves at the use site, with call-local overrides for tests.
+     * @param {Object} [overrides]
+     * @returns {Object}
+     */
+    resolveBridgeOptions(overrides = {}) {
+        return {
+            enabled          : overrides.enabled           ?? AiConfig.orchestrator.deploymentStateBridge.enabled,
+            snapshotPath     : overrides.snapshotPath      ?? AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+            writeIntervalMs  : overrides.writeIntervalMs   ?? AiConfig.orchestrator.deploymentStateBridge.writeIntervalMs,
+            staleAfterMs     : overrides.staleAfterMs      ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
+            maxSnapshotBytes : overrides.maxSnapshotBytes  ?? AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes,
+            allowedServices  : overrides.allowedServices   ?? AiConfig.orchestrator.deploymentStateBridge.allowedServices,
+            includeLogs      : overrides.includeLogs       ?? AiConfig.orchestrator.deploymentStateBridge.includeLogs,
+            logTail          : overrides.logTail           ?? AiConfig.orchestrator.deploymentStateBridge.logTail,
+            logMaxBytes      : overrides.logMaxBytes       ?? AiConfig.orchestrator.deploymentStateBridge.logMaxBytes,
+            statsSampleWindow: overrides.statsSampleWindow ?? AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow
+        };
     }
 
     /**

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -31,29 +31,25 @@ export class DeploymentStateBridgeService extends Base {
          */
         className: 'Neo.ai.daemons.services.DeploymentStateBridgeService',
         /**
-         * @member {Object|null} runtimeAccessService_=null
+         * @member {Object|null} runtimeAccessService=null
          * @protected
-         * @reactive
          */
-        runtimeAccessService_: null,
+        runtimeAccessService: null,
         /**
-         * @member {Object|null} diagnosisService_=null
+         * @member {Object|null} diagnosisService=null
          * @protected
-         * @reactive
          */
-        diagnosisService_: null,
+        diagnosisService: null,
         /**
-         * @member {Function|null} nowFn_=null
+         * @member {Function|null} nowFn=null
          * @protected
-         * @reactive
          */
-        nowFn_: null,
+        nowFn: null,
         /**
-         * @member {Function|null} writeLog_=null
+         * @member {Function|null} writeLog=null
          * @protected
-         * @reactive
          */
-        writeLog_: null
+        writeLog: null
     }
 
     lastWriteAt           = 0

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -1,0 +1,321 @@
+import Base from '../../../../src/core/Base.mjs';
+
+import {
+    boundUtf8Tail,
+    createDeploymentStateSnapshot,
+    writeDeploymentStateSnapshot
+} from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
+import {
+    calculateDockerCpuPercent,
+    calculateDockerMemoryPercent
+} from './ContainerHealthDiagnosisService.mjs';
+
+export const DEFAULT_DEPLOYMENT_STATE_BRIDGE_CONFIG = Object.freeze({
+    enabled          : false,
+    snapshotPath     : null,
+    writeIntervalMs  : 30000,
+    staleAfterMs     : 2 * 60 * 1000,
+    maxSnapshotBytes : 256 * 1024,
+    allowedServices  : null,
+    includeLogs      : true,
+    logTail          : 120,
+    logMaxBytes      : 32 * 1024,
+    statsSampleWindow: 2
+});
+
+/**
+ * @summary Writes a bounded, graph-independent deployment-state snapshot for KB/MC tools.
+ *
+ * The bridge is internal-only: it reads through the orchestrator-owned deployment runtime holder,
+ * summarizes allowlisted service state, and writes a JSON snapshot to shared storage. KB/MC read
+ * tools consume that file. No public route, socket mount, shell, or write actuator is introduced.
+ *
+ * @class Neo.ai.daemons.services.DeploymentStateBridgeService
+ * @extends Neo.core.Base
+ * @see ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
+ * @see ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+ */
+export class DeploymentStateBridgeService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.DeploymentStateBridgeService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.DeploymentStateBridgeService',
+        /**
+         * @member {Object|null} bridgeConfig_=null
+         * @protected
+         * @reactive
+         */
+        bridgeConfig_: null,
+        /**
+         * @member {Object|null} runtimeAccessService_=null
+         * @protected
+         * @reactive
+         */
+        runtimeAccessService_: null,
+        /**
+         * @member {Object|null} diagnosisService_=null
+         * @protected
+         * @reactive
+         */
+        diagnosisService_: null,
+        /**
+         * @member {Function|null} nowFn_=null
+         * @protected
+         * @reactive
+         */
+        nowFn_: null,
+        /**
+         * @member {Function|null} writeLog_=null
+         * @protected
+         * @reactive
+         */
+        writeLog_: null
+    }
+
+    lastWriteAt           = 0
+    writeInFlight         = false
+    statsSamplesByService = new Map()
+
+    /**
+     * Resolves active bridge config.
+     * @returns {Object}
+     */
+    get configValues() {
+        return {
+            ...DEFAULT_DEPLOYMENT_STATE_BRIDGE_CONFIG,
+            ...(this.bridgeConfig || {})
+        };
+    }
+
+    /**
+     * Writes a snapshot when enabled and due.
+     * @param {Object} [options]
+     * @param {Boolean} [options.force=false] Bypass interval gate.
+     * @returns {Promise<Object>}
+     */
+    async writeSnapshotIfDue({force = false} = {}) {
+        const config = this.configValues,
+              now    = this.now();
+
+        if (!config.enabled) {
+            return {ok: true, status: 'disabled'};
+        }
+
+        if (this.writeInFlight) {
+            return {ok: true, status: 'in-flight'};
+        }
+
+        if (!force && this.lastWriteAt > 0 && now - this.lastWriteAt < config.writeIntervalMs) {
+            return {ok: true, status: 'skipped'};
+        }
+
+        this.writeInFlight = true;
+
+        try {
+            const snapshot = await this.collectSnapshot({generatedAt: now}),
+                  result   = await writeDeploymentStateSnapshot({
+                      filePath: config.snapshotPath,
+                      snapshot,
+                      maxBytes: config.maxSnapshotBytes
+                  });
+
+            this.lastWriteAt = now;
+            this.writeLog?.('INFO', `[DeploymentStateBridge] wrote ${snapshot.services.length} service snapshots to ${config.snapshotPath}`);
+
+            return {ok: true, status: 'written', snapshot, ...result};
+        } catch (error) {
+            this.writeLog?.('ERROR', `[DeploymentStateBridge] snapshot write failed: ${error.message}`);
+            throw error;
+        } finally {
+            this.writeInFlight = false;
+        }
+    }
+
+    /**
+     * Collects one bounded deployment-state snapshot.
+     * @param {Object} [options]
+     * @param {Number} [options.generatedAt]
+     * @returns {Promise<Object>}
+     */
+    async collectSnapshot({generatedAt = this.now()} = {}) {
+        const services = [];
+
+        for (const serviceKey of this.getServiceKeys()) {
+            services.push(await this.collectServiceSnapshot({serviceKey, observedAt: generatedAt}));
+        }
+
+        return createDeploymentStateSnapshot({
+            generatedAt,
+            services
+        });
+    }
+
+    /**
+     * Collects one bounded per-service state envelope.
+     * @param {Object} options
+     * @param {String} options.serviceKey Allowlisted service key.
+     * @param {Number} options.observedAt Epoch ms.
+     * @returns {Promise<Object>}
+     */
+    async collectServiceSnapshot({serviceKey, observedAt}) {
+        const
+            errors = [],
+            proofs = [];
+
+        let inspect = null,
+            stats   = null,
+            logs    = null;
+
+        const read = async (operation, args = {}) => {
+            try {
+                const result = await this.runtimeAccessService.readObserve({serviceKey, operation, ...args});
+                proofs.push(result.proof);
+                return result.data;
+            } catch (error) {
+                errors.push({operation, message: error.message});
+                return null;
+            }
+        };
+
+        inspect = await read('inspect');
+        stats   = await read('stats');
+
+        if (this.configValues.includeLogs) {
+            logs = await read('logs', {tail: this.configValues.logTail});
+        }
+
+        if (stats) {
+            this.rememberStatsSample(serviceKey, stats);
+        }
+
+        const diagnosis = this.diagnosisService?.diagnose
+            ? this.diagnosisService.diagnose({
+                serviceKey,
+                inspect,
+                stats,
+                statsSamples: this.getStatsSamples(serviceKey),
+                observedAt
+            })
+            : null;
+
+        return {
+            schemaVersion : 1,
+            recordType    : 'deployment-service-state',
+            serviceKey,
+            targetIdentity: {kind: 'compose-service', id: serviceKey},
+            observedAt,
+            status        : errors.length > 0 ? 'degraded' : 'available',
+            inspect       : summarizeInspect(inspect),
+            stats         : summarizeStats(stats),
+            logs          : summarizeLogs(logs, this.configValues.logMaxBytes),
+            diagnosis,
+            proofs,
+            errors
+        };
+    }
+
+    /**
+     * Resolves allowlisted service keys for snapshot collection.
+     * @returns {String[]}
+     */
+    getServiceKeys() {
+        const configured = this.configValues.allowedServices;
+
+        if (Array.isArray(configured) && configured.length > 0) {
+            return configured.filter(isSafeServiceKey);
+        }
+
+        const runtimeAllowed = this.runtimeAccessService?.configValues?.allowedServices;
+        return Array.isArray(runtimeAllowed) ? runtimeAllowed.filter(isSafeServiceKey) : [];
+    }
+
+    /**
+     * Stores a bounded stats sample window per service.
+     * @param {String} serviceKey Service key.
+     * @param {Object} stats Docker stats sample.
+     * @returns {void}
+     */
+    rememberStatsSample(serviceKey, stats) {
+        const samples = this.statsSamplesByService.get(serviceKey) || [];
+
+        samples.push(stats);
+
+        const max = Math.max(1, Number(this.configValues.statsSampleWindow) || 1);
+        this.statsSamplesByService.set(serviceKey, samples.slice(-max));
+    }
+
+    /**
+     * Reads the bounded stats sample window for a service.
+     * @param {String} serviceKey Service key.
+     * @returns {Object[]}
+     */
+    getStatsSamples(serviceKey) {
+        return this.statsSamplesByService.get(serviceKey) || [];
+    }
+
+    /**
+     * Returns current time in epoch ms.
+     * @returns {Number}
+     */
+    now() {
+        return this.nowFn ? this.nowFn() : Date.now();
+    }
+}
+
+function summarizeInspect(inspect) {
+    if (!inspect || typeof inspect !== 'object') return null;
+
+    const state = inspect.State || {};
+
+    return {
+        name        : inspect.Name || null,
+        image       : inspect.Config?.Image || inspect.Image || null,
+        restartCount: Number.isFinite(inspect.RestartCount) ? inspect.RestartCount : null,
+        state       : {
+            status    : state.Status || null,
+            health    : state.Health?.Status || null,
+            startedAt : state.StartedAt || null,
+            finishedAt: state.FinishedAt || null,
+            exitCode  : Number.isFinite(state.ExitCode) ? state.ExitCode : null,
+            oomKilled : typeof state.OOMKilled === 'boolean' ? state.OOMKilled : null,
+            error     : state.Error || null
+        }
+    };
+}
+
+function summarizeStats(stats) {
+    if (!stats || typeof stats !== 'object') return null;
+
+    const
+        memoryUsage = Number(stats.memory_stats?.usage),
+        memoryLimit = Number(stats.memory_stats?.limit);
+
+    return {
+        cpuPercent      : calculateDockerCpuPercent(stats),
+        memoryPercent   : calculateDockerMemoryPercent(stats),
+        memoryUsageBytes: Number.isFinite(memoryUsage) ? memoryUsage : null,
+        memoryLimitBytes: Number.isFinite(memoryLimit) ? memoryLimit : null,
+        pidsCurrent     : Number.isFinite(Number(stats.pids_stats?.current)) ? Number(stats.pids_stats.current) : null
+    };
+}
+
+function summarizeLogs(logs, maxBytes) {
+    if (!logs || typeof logs !== 'object') return null;
+
+    const bounded = boundUtf8Tail(logs.logs, maxBytes);
+
+    return {
+        tail     : Number.isFinite(logs.tail) ? logs.tail : null,
+        text     : bounded.text,
+        truncated: bounded.truncated,
+        maxBytes : bounded.maxBytes
+    };
+}
+
+function isSafeServiceKey(value) {
+    return typeof value === 'string' && /^[a-zA-Z0-9_.-]+$/.test(value);
+}
+
+export default Neo.setupClass(DeploymentStateBridgeService);

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -100,6 +100,41 @@ paths:
                   message:
                     type: string
 
+  /deployment/state/snapshot:
+    post:
+      summary: Deployment State Snapshot
+      operationId: get_deployment_state_snapshot
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      x-neo-tool-summary: Read the graph-independent deployment-state bridge snapshot.
+      description: |
+        Reads the bounded deployment-state bridge snapshot written by the internal orchestrator.
+        This is a read-only public KB surface: it does not expose Docker, shell, exec, restart,
+        or any public daemon/orchestrator route. It exists so MC-unhealthy / graph-unavailable
+        incidents still have a KB-hosted current-state path when KB is healthy.
+      tags: [Health]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                staleAfterMs:
+                  type: number
+                  description: Optional freshness window override in milliseconds.
+                snapshotPath:
+                  type: string
+                  description: Test/operator override for the snapshot path; production uses the Tier-1 bridge path.
+      responses:
+        '200':
+          description: Snapshot status and payload when available.
+          content:
+            application/json:
+              schema:
+                type: object
+
   /db/data/manage:
     post:
       summary: Manage Knowledge Base Data

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -124,9 +124,6 @@ paths:
                 staleAfterMs:
                   type: number
                   description: Optional freshness window override in milliseconds.
-                snapshotPath:
-                  type: string
-                  description: Test/operator override for the snapshot path; production uses the Tier-1 bridge path.
       responses:
         '200':
           description: Snapshot status and payload when available.

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -59,11 +59,15 @@ const serviceMapping = {
     get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
     healthcheck          : HealthService           .healthcheck        .bind(HealthService),
     get_deployment_state_snapshot:
-                         args => readDeploymentStateSnapshot({
-                             filePath    : args?.snapshotPath || AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
-                             staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
-                             maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
-                         }),
+                         args => {
+                             const bridgeConfig = AiConfig.orchestrator?.deploymentStateBridge || {};
+
+                             return readDeploymentStateSnapshot({
+                                 filePath    : args?.snapshotPath || bridgeConfig.snapshotPath,
+                                 staleAfterMs: args?.staleAfterMs ?? bridgeConfig.staleAfterMs,
+                                 maxBytes    : bridgeConfig.maxSnapshotBytes
+                             });
+                         },
     list_documents : DocumentService         .listDocuments      .bind(DocumentService),
     list_agent_faqs: KBRecorderService       .listAgentFaqs      .bind(KBRecorderService),
     // MCP dispatch marks `viaMcp: true` so VectorService.embed can apply the synchronous

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -59,15 +59,11 @@ const serviceMapping = {
     get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
     healthcheck          : HealthService           .healthcheck        .bind(HealthService),
     get_deployment_state_snapshot:
-                         args => {
-                             const bridgeConfig = AiConfig.orchestrator?.deploymentStateBridge || {};
-
-                             return readDeploymentStateSnapshot({
-                                 filePath    : args?.snapshotPath || bridgeConfig.snapshotPath,
-                                 staleAfterMs: args?.staleAfterMs ?? bridgeConfig.staleAfterMs,
-                                 maxBytes    : bridgeConfig.maxSnapshotBytes
-                             });
-                         },
+                         args => readDeploymentStateSnapshot({
+                             filePath    : args?.snapshotPath || AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+                             staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
+                             maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
+                         }),
     list_documents : DocumentService         .listDocuments      .bind(DocumentService),
     list_agent_faqs: KBRecorderService       .listAgentFaqs      .bind(KBRecorderService),
     // MCP dispatch marks `viaMcp: true` so VectorService.embed can apply the synchronous

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -1,12 +1,14 @@
-import path              from 'path';
-import {fileURLToPath}   from 'url';
-import DatabaseService   from '../../../services/knowledge-base/DatabaseService.mjs';
-import DocumentService   from '../../../services/knowledge-base/DocumentService.mjs';
-import HealthService     from '../../../services/knowledge-base/HealthService.mjs';
-import KBRecorderService from '../../../services/knowledge-base/KBRecorderService.mjs';
-import QueryService      from '../../../services/knowledge-base/QueryService.mjs';
-import SearchService     from '../../../services/knowledge-base/SearchService.mjs';
-import ToolService       from '../../ToolService.mjs';
+import path                          from 'path';
+import {fileURLToPath}               from 'url';
+import DatabaseService               from '../../../services/knowledge-base/DatabaseService.mjs';
+import DocumentService               from '../../../services/knowledge-base/DocumentService.mjs';
+import HealthService                 from '../../../services/knowledge-base/HealthService.mjs';
+import KBRecorderService             from '../../../services/knowledge-base/KBRecorderService.mjs';
+import QueryService                  from '../../../services/knowledge-base/QueryService.mjs';
+import SearchService                 from '../../../services/knowledge-base/SearchService.mjs';
+import ToolService                   from '../../ToolService.mjs';
+import AiConfig                      from '../../../config.mjs';
+import {readDeploymentStateSnapshot} from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
 import {
     assertToolTransportAllowed,
     ingestSourceFilesViaMcp,
@@ -14,8 +16,8 @@ import {
     isIngestSourceFilesToolVisible
 } from './ingestSourceFilesTool.mjs';
 
-const __filename      = fileURLToPath(import.meta.url);
-const __dirname       = path.dirname(__filename);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
 /** @anchor test-isolation - ENV override to prevent parallel test mutations from corrupting the canonical file. Easily extensible to other servers via NEO_AI_MCP_<SERVER>_OPENAPI_PATH. */
 const openApiFilePath = process.env.NEO_AI_MCP_KB_OPENAPI_PATH || path.join(__dirname, 'openapi.yaml');
 
@@ -56,19 +58,25 @@ const serviceMapping = {
     get_document_by_id   : DocumentService         .getDocumentById    .bind(DocumentService),
     get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
     healthcheck          : HealthService           .healthcheck        .bind(HealthService),
-    list_documents       : DocumentService         .listDocuments      .bind(DocumentService),
-    list_agent_faqs      : KBRecorderService       .listAgentFaqs      .bind(KBRecorderService),
+    get_deployment_state_snapshot:
+                         args => readDeploymentStateSnapshot({
+                             filePath    : args?.snapshotPath || AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+                             staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
+                             maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
+                         }),
+    list_documents : DocumentService         .listDocuments      .bind(DocumentService),
+    list_agent_faqs: KBRecorderService       .listAgentFaqs      .bind(KBRecorderService),
     // MCP dispatch marks `viaMcp: true` so VectorService.embed can apply the synchronous
     // work-volume gate. CLI invocations call DatabaseService.syncDatabase directly without
     // `viaMcp`, preserving explicit operator opt-in to long-running work.
     manage_knowledge_base: args => DatabaseService.manageKnowledgeBase({...args, viaMcp: true}),
     // Remote tenant ingestion applies the MCP work-volume gate before service dispatch.
-    ingest_source_files  : ingestSourceFilesViaMcp,
-    query_documents      : QueryService            .queryDocuments     .bind(QueryService)
+    ingest_source_files: ingestSourceFilesViaMcp,
+    query_documents    : QueryService            .queryDocuments     .bind(QueryService)
 };
 
 const toolService = Neo.create(ToolService, {
-    compactToolDescriptions    : true,
+    compactToolDescriptions     : true,
     openApiFilePath,
     serviceMapping,
     toolListDescriptionMaxLength: 120

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -60,7 +60,7 @@ const serviceMapping = {
     healthcheck          : HealthService           .healthcheck        .bind(HealthService),
     get_deployment_state_snapshot:
                          args => readDeploymentStateSnapshot({
-                             filePath    : args?.snapshotPath || AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+                             filePath    : AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
                              staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
                              maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
                          }),

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -173,6 +173,41 @@ paths:
               schema:
                 $ref: '#/components/schemas/MemoryCoreToolMetricsResponse'
 
+  /deployment/state/snapshot:
+    post:
+      summary: Deployment State Snapshot
+      operationId: get_deployment_state_snapshot
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      x-neo-tool-summary: Read the graph-independent deployment-state bridge snapshot.
+      description: |
+        Reads the bounded deployment-state bridge snapshot written by the internal orchestrator.
+        This is a read-only public MC surface: it does not expose Docker, shell, exec, restart,
+        or any public daemon/orchestrator route. If the bridge is missing or stale, the response
+        reports that explicitly instead of falling back to graph-only proof.
+      tags: [Diagnostics]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                staleAfterMs:
+                  type: number
+                  description: Optional freshness window override in milliseconds.
+                snapshotPath:
+                  type: string
+                  description: Test/operator override for the snapshot path; production uses the Tier-1 bridge path.
+      responses:
+        '200':
+          description: Snapshot status and payload when available.
+          content:
+            application/json:
+              schema:
+                type: object
+
   /rem/pipeline-state:
     post:
       summary: Get REM Pipeline State

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -197,9 +197,6 @@ paths:
                 staleAfterMs:
                   type: number
                   description: Optional freshness window override in milliseconds.
-                snapshotPath:
-                  type: string
-                  description: Test/operator override for the snapshot path; production uses the Tier-1 bridge path.
       responses:
         '200':
           description: Snapshot status and payload when available.

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -49,7 +49,7 @@ const serviceMapping = {
                               HealthService          .getSqliteHolderDiagnostics.bind(HealthService),
     get_deployment_state_snapshot:
                               args => readDeploymentStateSnapshot({
-                                  filePath    : args?.snapshotPath || AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+                                  filePath    : AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
                                   staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
                                   maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
                               }),

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -48,15 +48,11 @@ const serviceMapping = {
     get_sqlite_holder_diagnostics:
                               HealthService          .getSqliteHolderDiagnostics.bind(HealthService),
     get_deployment_state_snapshot:
-                              args => {
-                                  const bridgeConfig = AiConfig.orchestrator?.deploymentStateBridge || {};
-
-                                  return readDeploymentStateSnapshot({
-                                      filePath    : args?.snapshotPath || bridgeConfig.snapshotPath,
-                                      staleAfterMs: args?.staleAfterMs ?? bridgeConfig.staleAfterMs,
-                                      maxBytes    : bridgeConfig.maxSnapshotBytes
-                                  });
-                              },
+                              args => readDeploymentStateSnapshot({
+                                  filePath    : args?.snapshotPath || AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+                                  staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
+                                  maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
+                              }),
     mark_read               : MailboxService         .markRead                .bind(MailboxService),
     archive_message         : MailboxService         .archiveMessage          .bind(MailboxService),
     delete_message          : MailboxService         .deleteMessage           .bind(MailboxService),

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -48,11 +48,15 @@ const serviceMapping = {
     get_sqlite_holder_diagnostics:
                               HealthService          .getSqliteHolderDiagnostics.bind(HealthService),
     get_deployment_state_snapshot:
-                              args => readDeploymentStateSnapshot({
-                                  filePath    : args?.snapshotPath || AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
-                                  staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
-                                  maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
-                              }),
+                              args => {
+                                  const bridgeConfig = AiConfig.orchestrator?.deploymentStateBridge || {};
+
+                                  return readDeploymentStateSnapshot({
+                                      filePath    : args?.snapshotPath || bridgeConfig.snapshotPath,
+                                      staleAfterMs: args?.staleAfterMs ?? bridgeConfig.staleAfterMs,
+                                      maxBytes    : bridgeConfig.maxSnapshotBytes
+                                  });
+                              },
     mark_read               : MailboxService         .markRead                .bind(MailboxService),
     archive_message         : MailboxService         .archiveMessage          .bind(MailboxService),
     delete_message          : MailboxService         .deleteMessage           .bind(MailboxService),

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -1,50 +1,58 @@
-import path                    from 'path';
-import {fileURLToPath}         from 'url';
-import ToolService               from '../../ToolService.mjs';
-import GraphService              from '../../../services/memory-core/GraphService.mjs';
-import HealthService             from '../../../services/memory-core/HealthService.mjs';
-import MemoryService             from '../../../services/memory-core/MemoryService.mjs';
-import SessionService            from '../../../services/memory-core/SessionService.mjs';
-import SummaryService            from '../../../services/memory-core/SummaryService.mjs';
-import MailboxService            from '../../../services/memory-core/MailboxService.mjs';
-import PermissionService         from '../../../services/memory-core/PermissionService.mjs';
-import WakeSubscriptionService   from '../../../services/memory-core/WakeSubscriptionService.mjs';
-import TurnPresenceService       from '../../../services/memory-core/TurnPresenceService.mjs';
-import MemoryCoreRecorderService from '../../../services/memory-core/MemoryCoreRecorderService.mjs';
+import path                          from 'path';
+import {fileURLToPath}               from 'url';
+import AiConfig                      from '../../../config.mjs';
+import ToolService                   from '../../ToolService.mjs';
+import GraphService                  from '../../../services/memory-core/GraphService.mjs';
+import HealthService                 from '../../../services/memory-core/HealthService.mjs';
+import MemoryService                 from '../../../services/memory-core/MemoryService.mjs';
+import SessionService                from '../../../services/memory-core/SessionService.mjs';
+import SummaryService                from '../../../services/memory-core/SummaryService.mjs';
+import MailboxService                from '../../../services/memory-core/MailboxService.mjs';
+import PermissionService             from '../../../services/memory-core/PermissionService.mjs';
+import WakeSubscriptionService       from '../../../services/memory-core/WakeSubscriptionService.mjs';
+import TurnPresenceService           from '../../../services/memory-core/TurnPresenceService.mjs';
+import MemoryCoreRecorderService     from '../../../services/memory-core/MemoryCoreRecorderService.mjs';
+import {readDeploymentStateSnapshot} from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
 const openApiFilePath = path.join(__dirname, 'openapi.yaml');
 
 const serviceMapping = {
-    add_memory              : MemoryService          .addMemory               .bind(MemoryService),
-    get_mcp_tool_handbook   : toolId => toolService.getToolHandbook(toolId),
+    add_memory           : MemoryService          .addMemory               .bind(MemoryService),
+    get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
     // `SummaryService.deleteAllSummaries` stays as the tenant-safe internal primitive (the
     // multi-tenant scoped-delete guard + future gated cleanups reuse it) but is deliberately
     // NOT agent-callable: a mass-destructive op does not belong on the MCP surface, and any
     // confirmation an agent can supply is not a guard. An operator path, if ever needed,
     // routes through DestructiveOperationGuard — never through tool re-exposure.
-    get_all_summaries       : SummaryService         .listSummaries           .bind(SummaryService),
-    get_context_frontier    : MemoryService          .getContextFrontier      .bind(MemoryService),
-    get_neighbors           : GraphService           .getNeighbors            .bind(GraphService),
-    get_node                : GraphService           .getNode                 .bind(GraphService),
-    get_session_memories    : MemoryService          .listMemories            .bind(MemoryService),
-    healthcheck             : HealthService          .healthcheck             .bind(HealthService),
-    mutate_frontier         : MemoryService          .mutateFrontier          .bind(MemoryService),
-    pre_brief_session       : MemoryService          .preBriefSession         .bind(MemoryService),
-    query_hybrid_graph      : GraphService           .queryNodeTopology       .bind(GraphService),
-    query_raw_memories      : MemoryService          .queryMemories           .bind(MemoryService),
-    query_recent_turns      : MemoryService          .queryRecentTurns        .bind(MemoryService),
-    query_summaries         : SummaryService         .querySummaries          .bind(SummaryService),
-    search_nodes            : GraphService           .searchNodes             .bind(GraphService),
+    get_all_summaries   : SummaryService         .listSummaries           .bind(SummaryService),
+    get_context_frontier: MemoryService          .getContextFrontier      .bind(MemoryService),
+    get_neighbors       : GraphService           .getNeighbors            .bind(GraphService),
+    get_node            : GraphService           .getNode                 .bind(GraphService),
+    get_session_memories: MemoryService          .listMemories            .bind(MemoryService),
+    healthcheck         : HealthService          .healthcheck             .bind(HealthService),
+    mutate_frontier     : MemoryService          .mutateFrontier          .bind(MemoryService),
+    pre_brief_session   : MemoryService          .preBriefSession         .bind(MemoryService),
+    query_hybrid_graph  : GraphService           .queryNodeTopology       .bind(GraphService),
+    query_raw_memories  : MemoryService          .queryMemories           .bind(MemoryService),
+    query_recent_turns  : MemoryService          .queryRecentTurns        .bind(MemoryService),
+    query_summaries     : SummaryService         .querySummaries          .bind(SummaryService),
+    search_nodes        : GraphService           .searchNodes             .bind(GraphService),
     get_memory_core_tool_metrics:
                               MemoryCoreRecorderService.getMemoryCoreToolMetrics.bind(MemoryCoreRecorderService),
-    add_message             : MailboxService         .addMessage              .bind(MailboxService),
-    list_messages           : MailboxService         .listMessages            .bind(MailboxService),
-    get_message             : MailboxService         .getMessage              .bind(MailboxService),
-    get_rem_pipeline_state  : HealthService          .getRemPipelineState     .bind(HealthService),
+    add_message           : MailboxService         .addMessage              .bind(MailboxService),
+    list_messages         : MailboxService         .listMessages            .bind(MailboxService),
+    get_message           : MailboxService         .getMessage              .bind(MailboxService),
+    get_rem_pipeline_state: HealthService          .getRemPipelineState     .bind(HealthService),
     get_sqlite_holder_diagnostics:
                               HealthService          .getSqliteHolderDiagnostics.bind(HealthService),
+    get_deployment_state_snapshot:
+                              args => readDeploymentStateSnapshot({
+                                  filePath    : args?.snapshotPath || AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+                                  staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
+                                  maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
+                              }),
     mark_read               : MailboxService         .markRead                .bind(MailboxService),
     archive_message         : MailboxService         .archiveMessage          .bind(MailboxService),
     delete_message          : MailboxService         .deleteMessage           .bind(MailboxService),
@@ -61,7 +69,7 @@ const serviceMapping = {
 };
 
 const toolService = Neo.create(ToolService, {
-    compactToolDescriptions    : true,
+    compactToolDescriptions     : true,
     openApiFilePath,
     serviceMapping,
     toolListDescriptionMaxLength: 120

--- a/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
@@ -1,0 +1,164 @@
+import fs   from 'fs-extra';
+import path from 'path';
+
+export const DEPLOYMENT_STATE_BRIDGE_SCHEMA_VERSION = 1;
+
+const DEFAULT_MAX_SNAPSHOT_BYTES = 256 * 1024;
+const DEFAULT_STALE_AFTER_MS     = 2 * 60 * 1000;
+
+/**
+ * @summary Builds a bounded deployment-state snapshot envelope for KB/MC read tools.
+ *
+ * The bridge snapshot is a model-free file handoff. It deliberately contains only bounded,
+ * allowlisted service state already collected by the internal orchestrator holder; KB/MC read
+ * tools consume this file without receiving Docker/socket/shell authority.
+ *
+ * @param {Object} options
+ * @param {Number} [options.generatedAt=Date.now()] Snapshot timestamp in epoch ms.
+ * @param {String} [options.source='orchestrator-deployment-state-bridge'] Producer label.
+ * @param {Object[]} [options.services=[]] Bounded per-service snapshots.
+ * @returns {Object}
+ */
+export function createDeploymentStateSnapshot({
+    generatedAt = Date.now(),
+    source = 'orchestrator-deployment-state-bridge',
+    services = []
+} = {}) {
+    if (!Number.isFinite(generatedAt)) {
+        throw new TypeError('createDeploymentStateSnapshot: generatedAt must be finite');
+    }
+
+    if (!Array.isArray(services)) {
+        throw new TypeError('createDeploymentStateSnapshot: services must be an array');
+    }
+
+    return {
+        schemaVersion: DEPLOYMENT_STATE_BRIDGE_SCHEMA_VERSION,
+        recordType   : 'deployment-state-snapshot',
+        generatedAt,
+        source,
+        services
+    };
+}
+
+/**
+ * @summary Writes a deployment-state snapshot atomically.
+ * @param {Object} options
+ * @param {String} options.filePath Destination JSON file.
+ * @param {Object} options.snapshot Snapshot payload.
+ * @param {Number} [options.maxBytes=262144] Hard serialized-size cap.
+ * @returns {Promise<{ok: Boolean, filePath: String, bytes: Number}>}
+ */
+export async function writeDeploymentStateSnapshot({
+    filePath,
+    snapshot,
+    maxBytes = DEFAULT_MAX_SNAPSHOT_BYTES
+} = {}) {
+    assertFilePath(filePath, 'writeDeploymentStateSnapshot');
+
+    const json  = `${JSON.stringify(snapshot, null, 2)}\n`,
+          bytes = Buffer.byteLength(json, 'utf8');
+
+    if (bytes > maxBytes) {
+        throw new Error(`Deployment state snapshot exceeds ${maxBytes} bytes`);
+    }
+
+    await fs.ensureDir(path.dirname(filePath));
+
+    const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    await fs.writeFile(tempPath, json, 'utf8');
+    await fs.rename(tempPath, filePath);
+
+    return {ok: true, filePath, bytes};
+}
+
+/**
+ * @summary Reads the latest deployment-state bridge snapshot.
+ * @param {Object} options
+ * @param {String} options.filePath Snapshot JSON file.
+ * @param {Number} [options.now=Date.now()] Current time in epoch ms.
+ * @param {Number} [options.staleAfterMs=120000] Freshness window; <=0 disables stale classification.
+ * @param {Number} [options.maxBytes=262144] Hard read-size cap.
+ * @returns {Promise<Object>}
+ */
+export async function readDeploymentStateSnapshot({
+    filePath,
+    now = Date.now(),
+    staleAfterMs = DEFAULT_STALE_AFTER_MS,
+    maxBytes = DEFAULT_MAX_SNAPSHOT_BYTES
+} = {}) {
+    if (!filePath) {
+        return unavailable({reason: 'snapshot-path-unconfigured'});
+    }
+
+    try {
+        const stat = await fs.stat(filePath);
+
+        if (stat.size > maxBytes) {
+            return unavailable({filePath, reason: 'snapshot-too-large', details: {size: stat.size, maxBytes}});
+        }
+
+        const snapshot = JSON.parse(await fs.readFile(filePath, 'utf8')),
+              ageMs    = Number.isFinite(snapshot.generatedAt) ? Math.max(0, now - snapshot.generatedAt) : null,
+              stale    = Number.isFinite(ageMs) && staleAfterMs > 0 && ageMs > staleAfterMs;
+
+        return {
+            ok    : !stale,
+            status: stale ? 'stale' : 'available',
+            filePath,
+            ageMs,
+            staleAfterMs,
+            snapshot,
+            reason: stale ? 'snapshot-stale' : null
+        };
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return unavailable({filePath, reason: 'snapshot-missing'});
+        }
+
+        return unavailable({filePath, reason: 'snapshot-read-failed', details: {message: error.message}});
+    }
+}
+
+/**
+ * @summary Bounds a UTF-8 string to the last `maxBytes` bytes.
+ * @param {String|null|undefined} value Text to bound.
+ * @param {Number} maxBytes Byte cap.
+ * @returns {{text: String, truncated: Boolean, maxBytes: Number}}
+ */
+export function boundUtf8Tail(value, maxBytes) {
+    const text = value == null ? '' : String(value);
+
+    if (!Number.isFinite(maxBytes) || maxBytes <= 0) {
+        return {text: '', truncated: text.length > 0, maxBytes};
+    }
+
+    const buffer = Buffer.from(text, 'utf8');
+    if (buffer.length <= maxBytes) {
+        return {text, truncated: false, maxBytes};
+    }
+
+    return {
+        text     : buffer.subarray(buffer.length - maxBytes).toString('utf8'),
+        truncated: true,
+        maxBytes
+    };
+}
+
+function unavailable({filePath = null, reason, details = null}) {
+    return {
+        ok      : false,
+        status  : 'unavailable',
+        filePath,
+        ageMs   : null,
+        snapshot: null,
+        reason,
+        details
+    };
+}
+
+function assertFilePath(filePath, callerName) {
+    if (typeof filePath !== 'string' || filePath.length === 0) {
+        throw new TypeError(`${callerName}: filePath is required`);
+    }
+}

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -174,6 +174,18 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
             verifyCooldownMs           : 60 * 1000,
             healthyObservationThreshold: 1,
             operatorPageTarget         : 'AGENT:*'
+        },
+        deploymentStateBridge: {
+            enabled          : false,
+            snapshotPath     : path.resolve(neoRootDir, '.neo-ai-data/deployment-state/snapshot.json'),
+            writeIntervalMs  : 30000,
+            staleAfterMs     : 2 * 60 * 1000,
+            maxSnapshotBytes : 256 * 1024,
+            allowedServices  : [],
+            includeLogs      : true,
+            logTail          : 120,
+            logMaxBytes      : 32 * 1024,
+            statsSampleWindow: 2
         }
     }
 }, true, true));

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -185,6 +185,19 @@ test.describe('Tier 1 Config Immutability', () => {
             vacuum : graphLogCompactionVacuum
         });
 
+        expect(Config.orchestrator.deploymentStateBridge).toMatchObject({
+            enabled          : false,
+            snapshotPath     : expect.stringContaining('.neo-ai-data/deployment-state/snapshot.json'),
+            writeIntervalMs  : 30000,
+            staleAfterMs     : 2 * 60 * 1000,
+            maxSnapshotBytes : 256 * 1024,
+            allowedServices  : [],
+            includeLogs      : true,
+            logTail          : 120,
+            logMaxBytes      : 32 * 1024,
+            statsSampleWindow: 2
+        });
+
         // Provider-readiness probe parameters consumed by the orchestrator dream task
         // + standalone Sandman CLI runner. Values are concrete defaults — no module-level
         // constants substitute when callers omit them.

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -411,6 +411,21 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(started).toEqual([]);
     });
 
+    test('wires deployment-state bridge dependencies through initial reactive service setup', () => {
+        const orchestrator = createTestOrchestrator({
+            kbSyncEnabled: false
+        });
+
+        orchestrator.deploymentRuntimeAccessService = {};
+        orchestrator.deploymentStateBridgeService = {};
+        orchestrator.containerHealthDiagnosisService = {};
+
+        expect(orchestrator.deploymentStateBridgeService.runtimeAccessService)
+            .toBe(orchestrator.deploymentRuntimeAccessService);
+        expect(orchestrator.deploymentStateBridgeService.diagnosisService)
+            .toBe(orchestrator.containerHealthDiagnosisService);
+    });
+
     test('refreshes golden path while dream graph mutation is active — decoupled for hourly freshness', async () => {
         const outcomes = [];
         const calls    = [];

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -30,18 +30,21 @@ function statsSample({cpuPercent = 0, memoryPercent = 0} = {}) {
     };
 }
 
-function createService({runtimeAccessService, diagnosisService, config = {}} = {}) {
+const BRIDGE_OPTIONS = Object.freeze({
+    enabled          : true,
+    snapshotPath     : '/tmp/unused-snapshot.json',
+    writeIntervalMs  : 30000,
+    staleAfterMs     : 120000,
+    maxSnapshotBytes : 256 * 1024,
+    allowedServices  : ['model'],
+    includeLogs      : true,
+    logTail          : 2,
+    logMaxBytes      : 8,
+    statsSampleWindow: 2
+});
+
+function createService({runtimeAccessService, diagnosisService} = {}) {
     return Neo.create(DeploymentStateBridgeService, {
-        bridgeConfig: {
-            enabled          : true,
-            snapshotPath     : '/tmp/unused-snapshot.json',
-            allowedServices  : ['model'],
-            includeLogs      : true,
-            logTail          : 2,
-            logMaxBytes      : 8,
-            statsSampleWindow: 2,
-            ...config
-        },
         runtimeAccessService,
         diagnosisService,
         nowFn: () => OBSERVED_AT
@@ -83,7 +86,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         };
 
         const service  = createService({runtimeAccessService, diagnosisService});
-        const snapshot = await service.collectSnapshot();
+        const snapshot = await service.collectSnapshot({bridgeOptions: BRIDGE_OPTIONS});
 
         expect(calls.map(call => call.operation)).toEqual(['inspect', 'stats', 'logs']);
         expect(snapshot.services).toHaveLength(1);
@@ -120,8 +123,8 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             }
         };
 
-        const service  = createService({runtimeAccessService, diagnosisService: null, config: {allowedServices: []}});
-        const snapshot = await service.collectSnapshot();
+        const service  = createService({runtimeAccessService, diagnosisService: null});
+        const snapshot = await service.collectSnapshot({bridgeOptions: {...BRIDGE_OPTIONS, allowedServices: []}});
 
         expect(snapshot.services).toHaveLength(1);
         expect(snapshot.services[0]).toMatchObject({

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -47,7 +47,8 @@ function createService({runtimeAccessService, diagnosisService} = {}) {
     return Neo.create(DeploymentStateBridgeService, {
         runtimeAccessService,
         diagnosisService,
-        nowFn: () => OBSERVED_AT
+        bridgeConfig: BRIDGE_OPTIONS,
+        nowFn       : () => OBSERVED_AT
     });
 }
 
@@ -86,7 +87,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         };
 
         const service  = createService({runtimeAccessService, diagnosisService});
-        const snapshot = await service.collectSnapshot({bridgeOptions: BRIDGE_OPTIONS});
+        const snapshot = await service.collectSnapshot();
 
         expect(calls.map(call => call.operation)).toEqual(['inspect', 'stats', 'logs']);
         expect(snapshot.services).toHaveLength(1);
@@ -123,8 +124,10 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             }
         };
 
-        const service  = createService({runtimeAccessService, diagnosisService: null});
-        const snapshot = await service.collectSnapshot({bridgeOptions: {...BRIDGE_OPTIONS, allowedServices: []}});
+        const service = createService({runtimeAccessService, diagnosisService: null});
+        service.bridgeConfig = {...BRIDGE_OPTIONS, allowedServices: []};
+
+        const snapshot = await service.collectSnapshot();
 
         expect(snapshot.services).toHaveLength(1);
         expect(snapshot.services[0]).toMatchObject({

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -30,25 +30,11 @@ function statsSample({cpuPercent = 0, memoryPercent = 0} = {}) {
     };
 }
 
-const BRIDGE_OPTIONS = Object.freeze({
-    enabled          : true,
-    snapshotPath     : '/tmp/unused-snapshot.json',
-    writeIntervalMs  : 30000,
-    staleAfterMs     : 120000,
-    maxSnapshotBytes : 256 * 1024,
-    allowedServices  : ['model'],
-    includeLogs      : true,
-    logTail          : 2,
-    logMaxBytes      : 8,
-    statsSampleWindow: 2
-});
-
 function createService({runtimeAccessService, diagnosisService} = {}) {
     return Neo.create(DeploymentStateBridgeService, {
         runtimeAccessService,
         diagnosisService,
-        bridgeConfig: BRIDGE_OPTIONS,
-        nowFn       : () => OBSERVED_AT
+        nowFn: () => OBSERVED_AT
     });
 }
 
@@ -103,9 +89,9 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                 memoryPercent: 75
             },
             logs: {
-                text     : '89abcdef',
-                truncated: true,
-                tail     : 2
+                text     : '0123456789abcdef',
+                truncated: false,
+                tail     : 120
             },
             diagnosis: {
                 serviceKey : 'model',
@@ -124,9 +110,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             }
         };
 
-        const service = createService({runtimeAccessService, diagnosisService: null});
-        service.bridgeConfig = {...BRIDGE_OPTIONS, allowedServices: []};
-
+        const service  = createService({runtimeAccessService, diagnosisService: null});
         const snapshot = await service.collectSnapshot();
 
         expect(snapshot.services).toHaveLength(1);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1,0 +1,137 @@
+import {test, expect}                 from '@playwright/test';
+import Neo                            from '../../../../../../../src/Neo.mjs';
+import * as core                      from '../../../../../../../src/core/_export.mjs';
+import {DeploymentStateBridgeService} from '../../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs';
+
+const OBSERVED_AT = 1710000000000;
+
+function statsSample({cpuPercent = 0, memoryPercent = 0} = {}) {
+    const systemDelta = 1_000_000_000,
+          cpuDelta    = (cpuPercent / 100) * systemDelta / 4,
+          memoryLimit = 1000;
+
+    return {
+        cpu_stats: {
+            online_cpus     : 4,
+            system_cpu_usage: systemDelta,
+            cpu_usage       : {
+                total_usage : cpuDelta,
+                percpu_usage: [cpuDelta / 4, cpuDelta / 4, cpuDelta / 4, cpuDelta / 4]
+            }
+        },
+        precpu_stats: {
+            system_cpu_usage: 0,
+            cpu_usage       : {total_usage: 0}
+        },
+        memory_stats: {
+            usage: memoryLimit * memoryPercent / 100,
+            limit: memoryLimit
+        }
+    };
+}
+
+function createService({runtimeAccessService, diagnosisService, config = {}} = {}) {
+    return Neo.create(DeploymentStateBridgeService, {
+        bridgeConfig: {
+            enabled          : true,
+            snapshotPath     : '/tmp/unused-snapshot.json',
+            allowedServices  : ['model'],
+            includeLogs      : true,
+            logTail          : 2,
+            logMaxBytes      : 8,
+            statsSampleWindow: 2,
+            ...config
+        },
+        runtimeAccessService,
+        diagnosisService,
+        nowFn: () => OBSERVED_AT
+    });
+}
+
+test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
+    test('collects bounded read-observe state and diagnosis for allowlisted services', async () => {
+        const calls                = [];
+        const runtimeAccessService = {
+            configValues: {allowedServices: ['model']},
+            async readObserve(request) {
+                calls.push(request);
+
+                if (request.operation === 'inspect') {
+                    return {
+                        data : {Name: '/model', State: {Status: 'running', Health: {Status: 'unhealthy'}}, Config: {Image: 'ollama'}},
+                        proof: {operation: 'inspect'}
+                    };
+                }
+
+                if (request.operation === 'stats') {
+                    return {
+                        data : statsSample({cpuPercent: 390, memoryPercent: 75}),
+                        proof: {operation: 'stats'}
+                    };
+                }
+
+                return {
+                    data : {logs: '0123456789abcdef', tail: request.tail},
+                    proof: {operation: 'logs'}
+                };
+            }
+        };
+        const diagnosisService = {
+            diagnose({serviceKey, inspect, statsSamples}) {
+                return {serviceKey, status: inspect.State.Health.Status, sampleCount: statsSamples.length};
+            }
+        };
+
+        const service  = createService({runtimeAccessService, diagnosisService});
+        const snapshot = await service.collectSnapshot();
+
+        expect(calls.map(call => call.operation)).toEqual(['inspect', 'stats', 'logs']);
+        expect(snapshot.services).toHaveLength(1);
+        expect(snapshot.services[0]).toMatchObject({
+            serviceKey: 'model',
+            status    : 'available',
+            inspect   : {
+                image: 'ollama',
+                state: {status: 'running', health: 'unhealthy'}
+            },
+            stats: {
+                cpuPercent   : 390,
+                memoryPercent: 75
+            },
+            logs: {
+                text     : '89abcdef',
+                truncated: true,
+                tail     : 2
+            },
+            diagnosis: {
+                serviceKey : 'model',
+                status     : 'unhealthy',
+                sampleCount: 1
+            },
+            proofs: [{operation: 'inspect'}, {operation: 'stats'}, {operation: 'logs'}]
+        });
+    });
+
+    test('falls back to runtime allowed services and records read errors as degraded state', async () => {
+        const runtimeAccessService = {
+            configValues: {allowedServices: ['memory']},
+            async readObserve() {
+                throw new Error('runtime unavailable');
+            }
+        };
+
+        const service  = createService({runtimeAccessService, diagnosisService: null, config: {allowedServices: []}});
+        const snapshot = await service.collectSnapshot();
+
+        expect(snapshot.services).toHaveLength(1);
+        expect(snapshot.services[0]).toMatchObject({
+            serviceKey: 'memory',
+            status    : 'degraded',
+            errors    : [
+                {operation: 'inspect', message: 'runtime unavailable'},
+                {operation: 'stats', message: 'runtime unavailable'},
+                {operation: 'logs', message: 'runtime unavailable'}
+            ]
+        });
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -23,6 +23,7 @@ import {fileURLToPath,
 import yaml        from 'js-yaml';
 import Neo         from '../../../../../../src/Neo.mjs';
 import * as core   from '../../../../../../src/core/_export.mjs';
+import AiConfig    from '../../../../../../ai/config.mjs';
 import ToolService from '../../../../../../ai/mcp/ToolService.mjs';
 import {
     createDeploymentStateSnapshot,
@@ -411,33 +412,41 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
 
         await writeDeploymentStateSnapshot({filePath: snapshotPath, snapshot});
 
-        const
-            args             = {snapshotPath, staleAfterMs: 60_000},
-            knowledgeBaseApi = await import(pathToFileURL(path.join(repoRoot, 'ai/mcp/server/knowledge-base/toolService.mjs')).href),
-            memoryCoreApi    = await import(pathToFileURL(path.join(repoRoot, 'ai/mcp/server/memory-core/toolService.mjs')).href),
-            kbSnapshot       = await knowledgeBaseApi.callTool('get_deployment_state_snapshot', args),
-            mcSnapshot       = await memoryCoreApi.callTool('get_deployment_state_snapshot', args);
+        const originalSnapshotPath = AiConfig.orchestrator.deploymentStateBridge.snapshotPath;
 
-        for (const result of [kbSnapshot, mcSnapshot]) {
-            expect(result).toMatchObject({
-                ok      : true,
-                status  : 'available',
-                snapshot: {
-                    recordType: 'deployment-state-snapshot',
-                    services  : [
-                        {
-                            serviceKey: 'model',
-                            status    : 'degraded',
-                            diagnosis : {status: 'critical', reasons: ['cpu-saturation']}
-                        },
-                        {
-                            serviceKey: 'memory',
-                            status    : 'degraded',
-                            diagnosis : {status: 'critical', reasons: ['unhealthy-container']}
-                        }
-                    ]
-                }
-            });
+        try {
+            AiConfig.setEnvOverride('NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH', snapshotPath);
+
+            const
+                args             = {staleAfterMs: 60_000},
+                knowledgeBaseApi = await import(pathToFileURL(path.join(repoRoot, 'ai/mcp/server/knowledge-base/toolService.mjs')).href),
+                memoryCoreApi    = await import(pathToFileURL(path.join(repoRoot, 'ai/mcp/server/memory-core/toolService.mjs')).href),
+                kbSnapshot       = await knowledgeBaseApi.callTool('get_deployment_state_snapshot', args),
+                mcSnapshot       = await memoryCoreApi.callTool('get_deployment_state_snapshot', args);
+
+            for (const result of [kbSnapshot, mcSnapshot]) {
+                expect(result).toMatchObject({
+                    ok      : true,
+                    status  : 'available',
+                    snapshot: {
+                        recordType: 'deployment-state-snapshot',
+                        services  : [
+                            {
+                                serviceKey: 'model',
+                                status    : 'degraded',
+                                diagnosis : {status: 'critical', reasons: ['cpu-saturation']}
+                            },
+                            {
+                                serviceKey: 'memory',
+                                status    : 'degraded',
+                                diagnosis : {status: 'critical', reasons: ['unhealthy-container']}
+                            }
+                        ]
+                    }
+                });
+            }
+        } finally {
+            AiConfig.setEnvOverride('NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH', originalSnapshotPath);
         }
     });
 

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -16,6 +16,7 @@ setup({
 import {test, expect} from '@playwright/test';
 import {parse}        from 'acorn';
 import fs             from 'fs';
+import os             from 'os';
 import path           from 'path';
 import {fileURLToPath,
         pathToFileURL}   from 'url';
@@ -23,6 +24,10 @@ import yaml        from 'js-yaml';
 import Neo         from '../../../../../../src/Neo.mjs';
 import * as core   from '../../../../../../src/core/_export.mjs';
 import ToolService from '../../../../../../ai/mcp/ToolService.mjs';
+import {
+    createDeploymentStateSnapshot,
+    writeDeploymentStateSnapshot
+} from '../../../../../../ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs';
 
 const
     __filename = fileURLToPath(import.meta.url),
@@ -384,6 +389,58 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         });
     });
 
+    test('knowledge-base and memory-core read deployment-state snapshots through public tools (#13926)', async () => {
+        const
+            dir          = fs.mkdtempSync(path.join(os.tmpdir(), 'deployment-state-tool-')),
+            snapshotPath = path.join(dir, 'snapshot.json'),
+            snapshot     = createDeploymentStateSnapshot({
+                generatedAt: Date.now(),
+                services   : [
+                    {
+                        serviceKey: 'model',
+                        status    : 'degraded',
+                        diagnosis : {status: 'critical', reasons: ['cpu-saturation']}
+                    },
+                    {
+                        serviceKey: 'memory',
+                        status    : 'degraded',
+                        diagnosis : {status: 'critical', reasons: ['unhealthy-container']}
+                    }
+                ]
+            });
+
+        await writeDeploymentStateSnapshot({filePath: snapshotPath, snapshot});
+
+        const
+            args             = {snapshotPath, staleAfterMs: 60_000},
+            knowledgeBaseApi = await import(pathToFileURL(path.join(repoRoot, 'ai/mcp/server/knowledge-base/toolService.mjs')).href),
+            memoryCoreApi    = await import(pathToFileURL(path.join(repoRoot, 'ai/mcp/server/memory-core/toolService.mjs')).href),
+            kbSnapshot       = await knowledgeBaseApi.callTool('get_deployment_state_snapshot', args),
+            mcSnapshot       = await memoryCoreApi.callTool('get_deployment_state_snapshot', args);
+
+        for (const result of [kbSnapshot, mcSnapshot]) {
+            expect(result).toMatchObject({
+                ok      : true,
+                status  : 'available',
+                snapshot: {
+                    recordType: 'deployment-state-snapshot',
+                    services  : [
+                        {
+                            serviceKey: 'model',
+                            status    : 'degraded',
+                            diagnosis : {status: 'critical', reasons: ['cpu-saturation']}
+                        },
+                        {
+                            serviceKey: 'memory',
+                            status    : 'degraded',
+                            diagnosis : {status: 'critical', reasons: ['unhealthy-container']}
+                        }
+                    ]
+                }
+            });
+        }
+    });
+
     test('gitlab-workflow exposes compact list descriptions plus lazy-loaded handbook detail (#9953)', async () => {
         const
             server       = servers.find(item => item.name === 'gitlab-workflow'),
@@ -529,7 +586,7 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
 
     test('ToolService refuses embedded-harness calls outside the projected tier (#13084)', async () => {
         const
-            server        = servers.find(item => item.name === 'neural-link'),
+            server = servers.find(item => item.name === 'neural-link'),
             toolService   = Neo.create(ToolService, {
                 openApiFilePath: path.join(repoRoot, server.openApiPath),
                 serviceMapping : {

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -16,7 +16,6 @@ setup({
 import {test, expect} from '@playwright/test';
 import {parse}        from 'acorn';
 import fs             from 'fs';
-import os             from 'os';
 import path           from 'path';
 import {fileURLToPath,
         pathToFileURL}   from 'url';
@@ -391,31 +390,29 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
     });
 
     test('knowledge-base and memory-core read deployment-state snapshots through public tools (#13926)', async () => {
+        const snapshot = createDeploymentStateSnapshot({
+            generatedAt: Date.now(),
+            services   : [
+                {
+                    serviceKey: 'model',
+                    status    : 'degraded',
+                    diagnosis : {status: 'critical', reasons: ['cpu-saturation']}
+                },
+                {
+                    serviceKey: 'memory',
+                    status    : 'degraded',
+                    diagnosis : {status: 'critical', reasons: ['unhealthy-container']}
+                }
+            ]
+        });
+
         const
-            dir          = fs.mkdtempSync(path.join(os.tmpdir(), 'deployment-state-tool-')),
-            snapshotPath = path.join(dir, 'snapshot.json'),
-            snapshot     = createDeploymentStateSnapshot({
-                generatedAt: Date.now(),
-                services   : [
-                    {
-                        serviceKey: 'model',
-                        status    : 'degraded',
-                        diagnosis : {status: 'critical', reasons: ['cpu-saturation']}
-                    },
-                    {
-                        serviceKey: 'memory',
-                        status    : 'degraded',
-                        diagnosis : {status: 'critical', reasons: ['unhealthy-container']}
-                    }
-                ]
-            });
-
-        await writeDeploymentStateSnapshot({filePath: snapshotPath, snapshot});
-
-        const originalSnapshotPath = AiConfig.orchestrator.deploymentStateBridge.snapshotPath;
+            snapshotPathConfig = AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+            snapshotExists     = fs.existsSync(snapshotPathConfig),
+            originalSnapshot   = snapshotExists ? fs.readFileSync(snapshotPathConfig) : null;
 
         try {
-            AiConfig.setEnvOverride('NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH', snapshotPath);
+            await writeDeploymentStateSnapshot({filePath: snapshotPathConfig, snapshot});
 
             const
                 args             = {staleAfterMs: 60_000},
@@ -446,7 +443,11 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
                 });
             }
         } finally {
-            AiConfig.setEnvOverride('NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH', originalSnapshotPath);
+            if (snapshotExists) {
+                fs.writeFileSync(snapshotPathConfig, originalSnapshot);
+            } else {
+                fs.rmSync(snapshotPathConfig, {force: true});
+            }
         }
     });
 

--- a/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
@@ -1,0 +1,65 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+
+import {
+    boundUtf8Tail,
+    createDeploymentStateSnapshot,
+    readDeploymentStateSnapshot,
+    writeDeploymentStateSnapshot
+} from '../../../../../../../ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs';
+
+test.describe('deploymentStateBridgeStore', () => {
+    test('writes and reads a fresh deployment-state snapshot', async () => {
+        const dir      = await fs.mkdtemp(path.join(os.tmpdir(), 'deployment-state-bridge-')),
+              filePath = path.join(dir, 'snapshot.json'),
+              snapshot = createDeploymentStateSnapshot({
+                  generatedAt: 1710000000000,
+                  services   : [{serviceKey: 'model', status: 'available'}]
+              });
+
+        const written = await writeDeploymentStateSnapshot({filePath, snapshot});
+        const read    = await readDeploymentStateSnapshot({filePath, now: 1710000000100});
+
+        expect(written.ok).toBe(true);
+        expect(read).toMatchObject({
+            ok    : true,
+            status: 'available',
+            ageMs : 100,
+            snapshot
+        });
+    });
+
+    test('reports missing and stale snapshots explicitly', async () => {
+        const dir      = await fs.mkdtemp(path.join(os.tmpdir(), 'deployment-state-bridge-')),
+              filePath = path.join(dir, 'snapshot.json');
+
+        await expect(readDeploymentStateSnapshot({filePath})).resolves.toMatchObject({
+            ok    : false,
+            status: 'unavailable',
+            reason: 'snapshot-missing'
+        });
+
+        await writeDeploymentStateSnapshot({
+            filePath,
+            snapshot: createDeploymentStateSnapshot({generatedAt: 1000})
+        });
+
+        await expect(readDeploymentStateSnapshot({filePath, now: 10000, staleAfterMs: 1000})).resolves.toMatchObject({
+            ok    : false,
+            status: 'stale',
+            reason: 'snapshot-stale'
+        });
+    });
+
+    test('bounds log tails by UTF-8 bytes', () => {
+        const bounded = boundUtf8Tail('0123456789', 4);
+
+        expect(bounded).toEqual({
+            text     : '6789',
+            truncated: true,
+            maxBytes : 4
+        });
+    });
+});


### PR DESCRIPTION
Resolves #13926

Related: #13860, #13914, #13920, #13924

Adds a graph-independent deployment-state bridge: the internal orchestrator can write a bounded, allowlisted snapshot through the existing deployment runtime holder, while public KB and MC MCP surfaces only get read-only snapshot tools. The public tools do not receive Docker socket, shell, exec, restart, daemon-route, write-actuator authority, or caller-selected file paths; they read only the Tier-1 `AiConfig.orchestrator.deploymentStateBridge.snapshotPath` leaf.

Evidence: L2 (unit coverage plus real KB/MC toolService dispatch against a wedged-model/unhealthy-memory snapshot fixture) -> L3 required (post-merge deployment smoke against the private overlay and shared snapshot mount). Residual: live deployment smoke [#13926].

## Deltas from ticket

- Added public KB/MC read dispatch coverage over the deployment-state snapshot fixture.
- Corrected the bridge config shape after ADR 0019 + Base/Neo review: `DeploymentStateBridgeService` no longer has a `bridgeConfig_` / `bridgeConfig` pass-through, and deployment-state tests no longer mutate the shared `AiConfig` singleton.
- Preserved the Base/Neo initial reactive service wiring fix: the bridge receives `containerHealthDiagnosisService` during startup via the generated getter/setter path, with regression coverage in `Orchestrator.spec.mjs`.

## Test Evidence

- `node --check ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs`
- `node --check ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs`
- `node --check ai/daemons/orchestrator/Orchestrator.mjs`
- `node --check ai/mcp/server/knowledge-base/toolService.mjs`
- `node --check ai/mcp/server/memory-core/toolService.mjs`
- `node --check test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs` -> 5 passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 29 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 42 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs` -> 77 passed
- `npm run ai:lint-config-template-ssot`
- `npm run agent-preflight -- ai/config.template.mjs ai/daemons/orchestrator/Orchestrator.mjs ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs ai/mcp/server/knowledge-base/openapi.yaml ai/mcp/server/knowledge-base/toolService.mjs ai/mcp/server/memory-core/openapi.yaml ai/mcp/server/memory-core/toolService.mjs ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs test/playwright/fixtures/aiConfigDefaults.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs`
- `npm run agent-preflight -- ai/mcp/server/knowledge-base/toolService.mjs ai/mcp/server/memory-core/toolService.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs`
- `npm run agent-preflight -- ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs ai/mcp/server/knowledge-base/openapi.yaml ai/mcp/server/knowledge-base/toolService.mjs ai/mcp/server/memory-core/openapi.yaml ai/mcp/server/memory-core/toolService.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 31 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs` -> 78 passed
- `npm run agent-preflight -- ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs`
- `git diff --check`

## Post-Merge Validation

- [ ] Private deployment overlay enables `NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED`, gives orchestrator a writer path, and mounts the same `NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH` read-only into KB and MC.
- [ ] Private deployment overlay sets `NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES` to the intended deployment service keys.
- [ ] Live deployment smoke reads KB and MC `get_deployment_state_snapshot` while the model runner is wedged and Memory Core is unhealthy or graph-unavailable, proving KB remains a current-state path when healthy.

## Commits

- `113be5c900` - `feat(ai): add deployment-state bridge snapshot (#13926)`
- `0ba1ecf999` - `test(ai): cover deployment-state MCP read path (#13926)`
- `16a0bd2ff1` - `fix(ai): align deployment bridge with reactive config (#13926)`
- `6ae9203474` - `fix(ai): align deployment-state bridge config shape (#13926)`
- `b768ca26cb` - `fix(ai): remove deployment bridge config seam (#13926)`

Authored by Euclid (GPT-5, Codex Desktop). Session f5e75eee-e7a1-4bf2-b8bf-4ab58d9ec932.
