### PR TITLE
fix(ai): isolate REM session failures (#13850)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -425,7 +425,8 @@ class DreamService extends Base {
                             sessionId: session.meta.sessionId,
                             error    : toErrorMessage(e)
                         }));
-                        throw e;
+                        logger.warn(`[DreamService] Session ${session.meta.sessionId} failed during memory/session graph ingestion; continuing REM batch.`, e);
+                        continue;
                     }
                     const rawIngestErrors = Array.isArray(ingestStats.errors) ? ingestStats.errors : [];
                     const ingestErrors    = rawIngestErrors.length;
@@ -467,7 +468,8 @@ class DreamService extends Base {
                             sessionId: session.meta.sessionId,
                             error    : toErrorMessage(e)
                         }));
-                        throw e;
+                        logger.warn(`[DreamService] Session ${session.meta.sessionId} failed during Tri-Vector extraction; continuing REM batch.`, e);
+                        continue;
                     }
                     const triVectorTime = ((Date.now() - startTime) / 1000).toFixed(1);
                     logger.info(`[DreamService]   -> Tri-Vector Synthesis took: ${triVectorTime}s`);
@@ -483,9 +485,11 @@ class DreamService extends Base {
                         sessionId: session.meta.sessionId
                     }));
 
-                    const topoStart = Date.now();
+                    const topoStart     = Date.now();
+                    let   conflictCount = 0;
                     try {
                         await TopologyInferenceEngine.extractTopology(session.document, session.meta.sessionId);
+                        conflictCount = await TopologyInferenceEngine.getTopologyConflictCount();
                     } catch (e) {
                         sessionState.topology = {
                             status       : 'failed',
@@ -496,11 +500,11 @@ class DreamService extends Base {
                             sessionId: session.meta.sessionId,
                             error    : toErrorMessage(e)
                         }));
-                        throw e;
+                        logger.warn(`[DreamService] Session ${session.meta.sessionId} failed during topology inference; continuing REM batch.`, e);
+                        continue;
                     }
                     const topoTime = ((Date.now() - topoStart) / 1000).toFixed(1);
                     logger.info(`[DreamService]   -> Topological Conflicts took: ${topoTime}s`);
-                    const conflictCount = await TopologyInferenceEngine.getTopologyConflictCount();
                     sessionState.topology = {
                         status: 'completed',
                         conflictCount
@@ -523,7 +527,8 @@ class DreamService extends Base {
                             sessionId: session.meta.sessionId,
                             error    : toErrorMessage(e)
                         }));
-                        throw e;
+                        logger.warn(`[DreamService] Session ${session.meta.sessionId} failed during TEST_GAP inference; continuing REM batch.`, e);
+                        continue;
                     }
                     const capTime = ((Date.now() - capStart) / 1000).toFixed(1);
                     logger.info(`[DreamService]   -> Session TEST_GAP Inference took: ${capTime}s`);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -1573,6 +1573,124 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         }
     });
 
+    test('processUndigestedSessions fault-isolates thrown per-session failures and digests remaining sessions (#13850)', async () => {
+        const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const AdrIngestor             = (await import('../../../../../../../ai/services/ingestion/AdrIngestor.mjs')).default;
+        const ConceptIngestor         = (await import('../../../../../../../ai/services/ingestion/ConceptIngestor.mjs')).default;
+        const FileSystemIngestor      = (await import('../../../../../../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
+        const TopologyInferenceEngine = (await import('../../../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
+
+        const mockSessions = [
+            {
+                id      : 'chroma-summary-poison',
+                document: 'poison session payload',
+                meta    : {sessionId: 'agent-session-poison', title: 'Poison Session'}
+            },
+            {
+                id      : 'chroma-summary-good',
+                document: 'good session payload',
+                meta    : {sessionId: 'agent-session-good', title: 'Good Session'}
+            }
+        ];
+
+        const sessionUpdatePayloads = [];
+        let   conceptGapCalls       = 0;
+        let   nlActionDigestCalls   = 0;
+        let   garbageCalls          = 0;
+
+        const orig = {
+            provider          : aiConfig.modelProvider,
+            findUndigested    : DreamService.findUndigestedSessions,
+            sessionsCollection: DreamService.sessionsCollection,
+            inferTest         : DreamService.inferTestGapsFromSession,
+            executeNlDigest   : DreamService.executeNLActionDigest,
+            inferConcept      : DreamService.inferConceptGraphGaps,
+            runGarbageCol     : DreamService.runGarbageCollection,
+            synthesizeGolden  : DreamService.synthesizeGoldenPath,
+            triVector         : SemanticGraphExtractor.executeTriVectorExtraction,
+            syncSession       : MemorySessionIngestor.syncSessionToGraph,
+            syncAdrs          : AdrIngestor.syncAdrsToGraph,
+            syncConcepts      : ConceptIngestor.syncConceptsToGraph,
+            syncFs            : FileSystemIngestor.syncWorkspaceToGraph,
+            extractTopo       : TopologyInferenceEngine.extractTopology,
+            conflictCount     : TopologyInferenceEngine.getTopologyConflictCount,
+            getMemory         : StorageRouter.getMemoryCollection,
+            isProcessing      : DreamService.isProcessing
+        };
+
+        try {
+            aiConfig.modelProvider    = 'mock-provider';
+            DreamService.isProcessing = false;
+
+            DreamService.findUndigestedSessions = async () => mockSessions;
+            DreamService.sessionsCollection     = {
+                update: async (payload) => { sessionUpdatePayloads.push(payload); }
+            };
+            StorageRouter.getMemoryCollection       = async () => null;
+            DreamService.inferTestGapsFromSession   = async () => {};
+            DreamService.executeNLActionDigest      = async () => { nlActionDigestCalls++; return {status: 'completed'}; };
+            DreamService.inferConceptGraphGaps      = async () => { conceptGapCalls++; };
+            DreamService.runGarbageCollection       = async () => { garbageCalls++; };
+            DreamService.synthesizeGoldenPath       = async () => {};
+            MemorySessionIngestor.syncSessionToGraph = async () => ({errors: [], memoriesSkipped: 0, memoriesUpserted: 1});
+            AdrIngestor.syncAdrsToGraph              = async () => ({});
+            ConceptIngestor.syncConceptsToGraph     = async () => ({});
+            FileSystemIngestor.syncWorkspaceToGraph = async () => {};
+            TopologyInferenceEngine.extractTopology = async () => {};
+            TopologyInferenceEngine.getTopologyConflictCount = async () => 0;
+
+            SemanticGraphExtractor.executeTriVectorExtraction = async session => {
+                if (session.meta.sessionId === 'agent-session-poison') {
+                    throw new Error('simulated extractor crash');
+                }
+
+                return {session_artifact: {graph: {nodes: [], edges: []}}};
+            };
+
+            const result = await DreamService.processUndigestedSessions();
+
+            const poisonState = result.perSessionStates.find(item => item.sessionId === 'agent-session-poison'),
+                  goodState   = result.perSessionStates.find(item => item.sessionId === 'agent-session-good');
+
+            expect(poisonState).toBeDefined();
+            expect(poisonState.triVector.status).toBe('failed');
+            expect(poisonState.triVector.errorKind).toBe('simulated extractor crash');
+            expect(poisonState.failureReasons).toContain('simulated extractor crash');
+            expect(poisonState.graphDigestedFlag).toBe(false);
+
+            expect(goodState).toBeDefined();
+            expect(goodState.triVector.status).toBe('completed');
+            expect(goodState.graphDigestedFlag).toBe(true);
+
+            expect(sessionUpdatePayloads).toHaveLength(1);
+            expect(sessionUpdatePayloads[0]).toMatchObject({
+                ids      : ['chroma-summary-good'],
+                metadatas: [{sessionId: 'agent-session-good', graphDigested: true, digestState: 'digested'}]
+            });
+            expect(nlActionDigestCalls).toBe(1);
+            expect(conceptGapCalls).toBe(1);
+            expect(garbageCalls).toBe(1);
+        } finally {
+            aiConfig.modelProvider                            = orig.provider;
+            DreamService.findUndigestedSessions               = orig.findUndigested;
+            DreamService.sessionsCollection                   = orig.sessionsCollection;
+            DreamService.inferTestGapsFromSession             = orig.inferTest;
+            DreamService.executeNLActionDigest                = orig.executeNlDigest;
+            DreamService.inferConceptGraphGaps                = orig.inferConcept;
+            DreamService.runGarbageCollection                 = orig.runGarbageCol;
+            DreamService.synthesizeGoldenPath                 = orig.synthesizeGolden;
+            SemanticGraphExtractor.executeTriVectorExtraction = orig.triVector;
+            MemorySessionIngestor.syncSessionToGraph          = orig.syncSession;
+            AdrIngestor.syncAdrsToGraph                       = orig.syncAdrs;
+            ConceptIngestor.syncConceptsToGraph               = orig.syncConcepts;
+            FileSystemIngestor.syncWorkspaceToGraph           = orig.syncFs;
+            TopologyInferenceEngine.extractTopology           = orig.extractTopo;
+            TopologyInferenceEngine.getTopologyConflictCount  = orig.conflictCount;
+            StorageRouter.getMemoryCollection                 = orig.getMemory;
+            DreamService.isProcessing                         = orig.isProcessing;
+        }
+    });
+
     test('Sub 9 hypothesis 9 (PRIMARY): real DreamService→SemanticGraphExtractor integration — empty-response overflow keeps the session undigested + surfaces friction, not silently completed (#12075)', async () => {
         // Integration complement to the Phase-A isolated extractor test
         // (SemanticGraphExtractor.spec `Sub 9 hypotheses 9 and 11`). Phase-A stubs the service


### PR DESCRIPTION
Resolves #13850
Related: #13624

`DreamService.processUndigestedSessions()` now fault-isolates thrown per-session REM phases: a poison session records failure metadata and the batch continues to digest later sessions. Cycle-scoped follow-up work stays fail-fast so daemon-level faults keep surfacing instead of being hidden.

Evidence: L2 (focused mocked unit regression plus full DreamService unit coverage) -> L2 required (per-session fault isolation is fully reachable in unit scope). No residuals.

## Deltas from ticket
- Changed per-session memory/graph extraction, Tri-Vector extraction, topology inference, and test-gap inference catch blocks from rethrow to logged continue after recording failure state.
- Kept post-loop NL action digest, concept-gap inference, and garbage collection outside the per-session isolation boundary.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs -g "#13850"` failed before the production change with `simulated extractor crash`; passed after the fix.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs -g "#11698"` -> 1 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs` -> 31 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs` -> 16 passed.
- `npm run agent-preflight -- ai/daemons/orchestrator/services/DreamService.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs` -> passed.
- `git diff --check` -> passed.

## Post-Merge Validation
- [ ] Confirm the next live REM batch logs failed poison-session phases while continuing later sessions.

## Commits
- `bea32147d2` — `fix(ai): isolate REM session failures (#13850)`

Authored by Euclid (GPT-5, Codex Desktop). Session 36d4ff02-3a3f-4a16-b4c4-2bbdcac67f48.