### PR TITLE
feat(ai): expose deployment inspection MCP surface (#13914)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -467,7 +467,8 @@ class Config extends ConfigProvider {
                  * `NEO_DEPLOYMENT_STATE_BRIDGE_LOG_TAIL`,
                  * `NEO_DEPLOYMENT_STATE_BRIDGE_LOG_MAX_BYTES`,
                  * `NEO_DEPLOYMENT_STATE_BRIDGE_STATS_SAMPLE_WINDOW`,
-                 * `NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_RESIDENCY_SERVICE_KEYS`.
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_RESIDENCY_SERVICE_KEYS`,
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_RECOVERY_RUN_LIMIT`.
                  *
                  * @type {Object}
                  */
@@ -482,7 +483,8 @@ class Config extends ConfigProvider {
                     logTail                     : leaf(120, 'NEO_DEPLOYMENT_STATE_BRIDGE_LOG_TAIL', 'number'),
                     logMaxBytes                 : leaf(32 * 1024, 'NEO_DEPLOYMENT_STATE_BRIDGE_LOG_MAX_BYTES', 'number'),
                     statsSampleWindow           : leaf(2, 'NEO_DEPLOYMENT_STATE_BRIDGE_STATS_SAMPLE_WINDOW', 'number'),
-                    providerResidencyServiceKeys: leaf(['local-model', 'model'], 'NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_RESIDENCY_SERVICE_KEYS', 'csv')
+                    providerResidencyServiceKeys: leaf(['local-model', 'model'], 'NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_RESIDENCY_SERVICE_KEYS', 'csv'),
+                    recoveryRunLimit            : leaf(10, 'NEO_DEPLOYMENT_STATE_BRIDGE_RECOVERY_RUN_LIMIT', 'number')
                 },
                 /**
                  * Maintenance-loop intervals consumed by the orchestrator daemon.

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -70,11 +70,9 @@ export class DeploymentStateBridgeService extends Base {
      * @returns {Promise<Object>}
      */
     async writeSnapshotIfDue({force = false} = {}) {
-        const
-            bridgeConfig = AiConfig.orchestrator.deploymentStateBridge,
-            now          = this.now();
+        const now = this.now();
 
-        if (!bridgeConfig.enabled) {
+        if (!AiConfig.orchestrator.deploymentStateBridge.enabled) {
             return {ok: true, status: 'disabled'};
         }
 
@@ -82,7 +80,7 @@ export class DeploymentStateBridgeService extends Base {
             return {ok: true, status: 'in-flight'};
         }
 
-        if (!force && this.lastWriteAt > 0 && now - this.lastWriteAt < bridgeConfig.writeIntervalMs) {
+        if (!force && this.lastWriteAt > 0 && now - this.lastWriteAt < AiConfig.orchestrator.deploymentStateBridge.writeIntervalMs) {
             return {ok: true, status: 'skipped'};
         }
 
@@ -91,13 +89,13 @@ export class DeploymentStateBridgeService extends Base {
         try {
             const snapshot = await this.collectSnapshot({generatedAt: now}),
                   result   = await writeDeploymentStateSnapshot({
-                      filePath: bridgeConfig.snapshotPath,
+                      filePath: AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
                       snapshot,
-                      maxBytes: bridgeConfig.maxSnapshotBytes
+                      maxBytes: AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
                   });
 
             this.lastWriteAt = now;
-            this.writeLog?.('INFO', `[DeploymentStateBridge] wrote ${snapshot.services.length} service snapshots to ${bridgeConfig.snapshotPath}`);
+            this.writeLog?.('INFO', `[DeploymentStateBridge] wrote ${snapshot.services.length} service snapshots to ${AiConfig.orchestrator.deploymentStateBridge.snapshotPath}`);
 
             return {ok: true, status: 'written', snapshot, ...result};
         } catch (error) {
@@ -248,7 +246,7 @@ export class DeploymentStateBridgeService extends Base {
      * @returns {String[]}
      */
     getServiceKeys() {
-        const {allowedServices} = AiConfig.orchestrator.deploymentStateBridge;
+        const allowedServices = AiConfig.orchestrator.deploymentStateBridge.allowedServices;
 
         if (allowedServices.length > 0) {
             return allowedServices.filter(isSafeServiceKey);

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -7,6 +7,7 @@ import {
     createDeploymentStateSnapshot,
     writeDeploymentStateSnapshot
 } from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
+import {readRecentRecoveryRunStates} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {
     calculateDockerCpuPercent,
     calculateDockerMemoryPercent
@@ -120,9 +121,12 @@ export class DeploymentStateBridgeService extends Base {
             services.push(await this.collectServiceSnapshot({serviceKey, observedAt: generatedAt}));
         }
 
+        const recoveryRuns = await this.collectRecoveryRunSnapshot();
+
         return createDeploymentStateSnapshot({
             generatedAt,
-            services
+            services,
+            recoveryRuns
         });
     }
 
@@ -274,6 +278,44 @@ export class DeploymentStateBridgeService extends Base {
      */
     getStatsSamples(serviceKey) {
         return this.statsSamplesByService.get(serviceKey) || [];
+    }
+
+    /**
+     * Reads the bounded recovery-run ledger for the public deployment inspection snapshot.
+     * @returns {Promise<Object>}
+     */
+    async collectRecoveryRunSnapshot() {
+        const
+            bridgeConfig = AiConfig.orchestrator.deploymentStateBridge,
+            limit        = bridgeConfig.recoveryRunLimit,
+            source       = 'orchestrator-recovery-run-ledger';
+
+        if (limit < 0) {
+            throw new RangeError(`DeploymentStateBridgeService: recoveryRunLimit must be >= 0, got ${limit}`);
+        }
+
+        if (limit === 0) {
+            return {status: 'disabled', source, limit, entries: [], errors: []};
+        }
+
+        try {
+            const entries = await readRecentRecoveryRunStates({
+                dir: AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir,
+                limit
+            });
+
+            return {status: 'available', source, limit, entries, errors: []};
+        } catch (error) {
+            this.writeLog?.('WARN', `[DeploymentStateBridge] recovery-run snapshot read failed: ${error.message}`);
+
+            return {
+                status : 'degraded',
+                source,
+                limit,
+                entries: [],
+                errors : [{reason: 'recovery-run-read-failed', code: error.code || null}]
+            };
+        }
     }
 
     /**

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -53,6 +53,11 @@ export class DeploymentStateBridgeService extends Base {
          */
         providerResidencyProbe: null,
         /**
+         * @member {Function|null} recoveryRunStateReader=null
+         * @protected
+         */
+        recoveryRunStateReader: null,
+        /**
          * @member {Function|null} writeLog=null
          * @protected
          */
@@ -288,6 +293,10 @@ export class DeploymentStateBridgeService extends Base {
             limit        = bridgeConfig.recoveryRunLimit,
             source       = 'orchestrator-recovery-run-ledger';
 
+        if (!Number.isFinite(limit)) {
+            throw new TypeError(`DeploymentStateBridgeService: recoveryRunLimit must be a finite number, got ${limit}`);
+        }
+
         if (limit < 0) {
             throw new RangeError(`DeploymentStateBridgeService: recoveryRunLimit must be >= 0, got ${limit}`);
         }
@@ -297,7 +306,8 @@ export class DeploymentStateBridgeService extends Base {
         }
 
         try {
-            const entries = await readRecentRecoveryRunStates({
+            const reader  = this.recoveryRunStateReader || readRecentRecoveryRunStates,
+                  entries = await reader({
                 dir: AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir,
                 limit
             });

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -132,6 +132,38 @@ paths:
               schema:
                 type: object
 
+  /deployment/inspect:
+    post:
+      summary: Inspect Deployment
+      operationId: inspect_deployment
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      x-neo-tool-summary: Inspect bounded cloud deployment state from the orchestrator bridge.
+      description: |
+        Reads the bounded deployment inspection snapshot written by the internal orchestrator.
+        This is a read-only public KB surface: it exposes allowlisted service state, bounded
+        log tails, current diagnoses, and recent recovery-run ledger entries without exposing
+        Docker, shell, exec, restart, or any public daemon/orchestrator route.
+      tags: [Health]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                staleAfterMs:
+                  type: number
+                  description: Optional freshness window override in milliseconds.
+      responses:
+        '200':
+          description: Inspection status and payload when available.
+          content:
+            application/json:
+              schema:
+                type: object
+
   /db/data/manage:
     post:
       summary: Manage Knowledge Base Data

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -21,6 +21,12 @@ const __dirname  = path.dirname(__filename);
 /** @anchor test-isolation - ENV override to prevent parallel test mutations from corrupting the canonical file. Easily extensible to other servers via NEO_AI_MCP_<SERVER>_OPENAPI_PATH. */
 const openApiFilePath = process.env.NEO_AI_MCP_KB_OPENAPI_PATH || path.join(__dirname, 'openapi.yaml');
 
+const readDeploymentInspection = args => readDeploymentStateSnapshot({
+    filePath    : AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+    staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
+    maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
+});
+
 /**
  * @summary Applies the KB transport visibility policy before returning MCP tools/list.
  * @param {Object} [options]
@@ -53,19 +59,15 @@ const listTransportVisibleTools = ({cursor=0, limit} = {}) => {
 };
 
 const serviceMapping = {
-    ask_knowledge_base   : SearchService           .ask                .bind(SearchService),
-    get_class_hierarchy  : QueryService            .getClassHierarchy  .bind(QueryService),
-    get_document_by_id   : DocumentService         .getDocumentById    .bind(DocumentService),
-    get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
-    healthcheck          : HealthService           .healthcheck        .bind(HealthService),
-    get_deployment_state_snapshot:
-                         args => readDeploymentStateSnapshot({
-                             filePath    : AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
-                             staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
-                             maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
-                         }),
-    list_documents : DocumentService         .listDocuments      .bind(DocumentService),
-    list_agent_faqs: KBRecorderService       .listAgentFaqs      .bind(KBRecorderService),
+    ask_knowledge_base           : SearchService           .ask                .bind(SearchService),
+    get_class_hierarchy          : QueryService            .getClassHierarchy  .bind(QueryService),
+    get_document_by_id           : DocumentService         .getDocumentById    .bind(DocumentService),
+    get_mcp_tool_handbook        : toolId => toolService.getToolHandbook(toolId),
+    healthcheck                  : HealthService           .healthcheck        .bind(HealthService),
+    get_deployment_state_snapshot: readDeploymentInspection,
+    inspect_deployment           : readDeploymentInspection,
+    list_documents               : DocumentService         .listDocuments      .bind(DocumentService),
+    list_agent_faqs              : KBRecorderService       .listAgentFaqs      .bind(KBRecorderService),
     // MCP dispatch marks `viaMcp: true` so VectorService.embed can apply the synchronous
     // work-volume gate. CLI invocations call DatabaseService.syncDatabase directly without
     // `viaMcp`, preserving explicit operator opt-in to long-running work.

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -205,6 +205,38 @@ paths:
               schema:
                 type: object
 
+  /deployment/inspect:
+    post:
+      summary: Inspect Deployment
+      operationId: inspect_deployment
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      x-neo-tool-summary: Inspect bounded cloud deployment state from the orchestrator bridge.
+      description: |
+        Reads the bounded deployment inspection snapshot written by the internal orchestrator.
+        This is a read-only public MC surface: it exposes allowlisted service state, bounded
+        log tails, current diagnoses, and recent recovery-run ledger entries without exposing
+        Docker, shell, exec, restart, or any public daemon/orchestrator route.
+      tags: [Diagnostics]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                staleAfterMs:
+                  type: number
+                  description: Optional freshness window override in milliseconds.
+      responses:
+        '200':
+          description: Inspection status and payload when available.
+          content:
+            application/json:
+              schema:
+                type: object
+
   /rem/pipeline-state:
     post:
       summary: Get REM Pipeline State

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -18,6 +18,12 @@ const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
 const openApiFilePath = path.join(__dirname, 'openapi.yaml');
 
+const readDeploymentInspection = args => readDeploymentStateSnapshot({
+    filePath    : AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+    staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
+    maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
+});
+
 const serviceMapping = {
     add_memory           : MemoryService          .addMemory               .bind(MemoryService),
     get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
@@ -47,25 +53,21 @@ const serviceMapping = {
     get_rem_pipeline_state: HealthService          .getRemPipelineState     .bind(HealthService),
     get_sqlite_holder_diagnostics:
                               HealthService          .getSqliteHolderDiagnostics.bind(HealthService),
-    get_deployment_state_snapshot:
-                              args => readDeploymentStateSnapshot({
-                                  filePath    : AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
-                                  staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
-                                  maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
-                              }),
-    mark_read               : MailboxService         .markRead                .bind(MailboxService),
-    archive_message         : MailboxService         .archiveMessage          .bind(MailboxService),
-    delete_message          : MailboxService         .deleteMessage           .bind(MailboxService),
-    transition_task         : MailboxService         .transitionTask          .bind(MailboxService),
-    grant_permission        : PermissionService      .grantPermission         .bind(PermissionService),
-    revoke_permission       : PermissionService      .revokePermission        .bind(PermissionService),
-    list_permissions        : PermissionService      .listPermissions         .bind(PermissionService),
-    manage_wake_subscription: WakeSubscriptionService.manage                  .bind(WakeSubscriptionService),
-    record_turn_presence    : TurnPresenceService    .recordTurnPresence      .bind(TurnPresenceService),
-    who_is_online           : WakeSubscriptionService.whoIsOnline             .bind(WakeSubscriptionService),
-    purge_session           : SessionService         .purgeSession            .bind(SessionService),
-    resume_session          : SessionService         .validateSessionForResume.bind(SessionService),
-    set_session_id          : SessionService         .setSessionId            .bind(SessionService)
+    get_deployment_state_snapshot: readDeploymentInspection,
+    inspect_deployment           : readDeploymentInspection,
+    mark_read                    : MailboxService         .markRead                .bind(MailboxService),
+    archive_message              : MailboxService         .archiveMessage          .bind(MailboxService),
+    delete_message               : MailboxService         .deleteMessage           .bind(MailboxService),
+    transition_task              : MailboxService         .transitionTask          .bind(MailboxService),
+    grant_permission             : PermissionService      .grantPermission         .bind(PermissionService),
+    revoke_permission            : PermissionService      .revokePermission        .bind(PermissionService),
+    list_permissions             : PermissionService      .listPermissions         .bind(PermissionService),
+    manage_wake_subscription     : WakeSubscriptionService.manage                  .bind(WakeSubscriptionService),
+    record_turn_presence         : TurnPresenceService    .recordTurnPresence      .bind(TurnPresenceService),
+    who_is_online                : WakeSubscriptionService.whoIsOnline             .bind(WakeSubscriptionService),
+    purge_session                : SessionService         .purgeSession            .bind(SessionService),
+    resume_session               : SessionService         .validateSessionForResume.bind(SessionService),
+    set_session_id               : SessionService         .setSessionId            .bind(SessionService)
 };
 
 const toolService = Neo.create(ToolService, {

--- a/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
@@ -17,12 +17,14 @@ const DEFAULT_STALE_AFTER_MS     = 2 * 60 * 1000;
  * @param {Number} [options.generatedAt=Date.now()] Snapshot timestamp in epoch ms.
  * @param {String} [options.source='orchestrator-deployment-state-bridge'] Producer label.
  * @param {Object[]} [options.services=[]] Bounded per-service snapshots.
+ * @param {Object|null} [options.recoveryRuns=null] Bounded recovery-run ledger snapshot.
  * @returns {Object}
  */
 export function createDeploymentStateSnapshot({
     generatedAt = Date.now(),
     source = 'orchestrator-deployment-state-bridge',
-    services = []
+    services = [],
+    recoveryRuns = null
 } = {}) {
     if (!Number.isFinite(generatedAt)) {
         throw new TypeError('createDeploymentStateSnapshot: generatedAt must be finite');
@@ -37,7 +39,8 @@ export function createDeploymentStateSnapshot({
         recordType   : 'deployment-state-snapshot',
         generatedAt,
         source,
-        services
+        services,
+        recoveryRuns
     };
 }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1,16 +1,8 @@
 import {test, expect}                 from '@playwright/test';
-import fs                             from 'fs-extra';
-import os                             from 'os';
-import path                           from 'path';
 import Neo                            from '../../../../../../../src/Neo.mjs';
 import * as core                      from '../../../../../../../src/core/_export.mjs';
 import AiConfig                       from '../../../../../../../ai/config.mjs';
 import {DeploymentStateBridgeService} from '../../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs';
-import {
-    appendRecoveryRunState,
-    createRecoveryDiagnosisEvent,
-    createRecoveryRunStateEntry
-} from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
 
 const OBSERVED_AT = 1710000000000;
 let originalDeploymentStateBridgeConfig,
@@ -41,11 +33,17 @@ function statsSample({cpuPercent = 0, memoryPercent = 0} = {}) {
     };
 }
 
-function createService({runtimeAccessService, diagnosisService, providerResidencyProbe = async () => null} = {}) {
+function createService({
+    runtimeAccessService,
+    diagnosisService,
+    providerResidencyProbe = async () => null,
+    recoveryRunStateReader = null
+} = {}) {
     return Neo.create(DeploymentStateBridgeService, {
         runtimeAccessService,
         diagnosisService,
         providerResidencyProbe,
+        recoveryRunStateReader,
         nowFn: () => OBSERVED_AT
     });
 }
@@ -144,73 +142,39 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
 
     test('includes bounded recent recovery-run ledger entries in the bridge snapshot', async () => {
         const
-            tmpDir                   = await fs.mkdtemp(path.join(os.tmpdir(), 'deployment-recovery-runs-')),
-            originalRecoveryRunDir   = AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir,
-            originalRecoveryRunLimit = AiConfig.orchestrator.deploymentStateBridge.recoveryRunLimit,
-            originalAllowedServices  = AiConfig.orchestrator.deploymentStateBridge.allowedServices,
-            originalIncludeLogs      = AiConfig.orchestrator.deploymentStateBridge.includeLogs;
+            readerCalls = [],
+            recoveryRunStateReader = async request => {
+                readerCalls.push(request);
 
-        try {
-            AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir = tmpDir;
-            AiConfig.orchestrator.deploymentStateBridge.recoveryRunLimit = 1;
-            AiConfig.orchestrator.deploymentStateBridge.allowedServices = [];
-            AiConfig.orchestrator.deploymentStateBridge.includeLogs = false;
+                return [{
+                    recoveryRunId : 'recovery-newer',
+                    diagnosisId   : 'diagnosis-1',
+                    recoveryClass : 'crash',
+                    targetIdentity: {kind: 'compose-service', id: 'memory'},
+                    status        : 'reobserve-requested'
+                }];
+            },
+            snapshot = await createService({recoveryRunStateReader}).collectSnapshot();
 
-            const diagnosisEvent = createRecoveryDiagnosisEvent({
-                diagnosisId    : 'diagnosis-1',
-                recoveryClass  : 'crash',
-                confidence     : 0.9,
-                targetIdentity : {kind: 'compose-service', id: 'memory'},
-                evidenceFacts  : [{type: 'container-unhealthy'}],
-                suggestedAction: 'restart',
-                observedAt     : OBSERVED_AT
-            });
-
-            await appendRecoveryRunState(createRecoveryRunStateEntry({
-                recoveryRunId: 'recovery-older',
-                diagnosisEvent,
-                rung         : 'rung-3',
-                attempt      : 1,
-                status       : 'recovered',
-                startedAt    : OBSERVED_AT - 2000,
-                updatedAt    : OBSERVED_AT - 1000,
-                completedAt  : OBSERVED_AT - 900
-            }), {dir: tmpDir});
-
-            await appendRecoveryRunState(createRecoveryRunStateEntry({
-                recoveryRunId: 'recovery-newer',
-                diagnosisEvent,
-                rung         : 'rung-3',
-                attempt      : 2,
-                status       : 'reobserve-requested',
-                startedAt    : OBSERVED_AT,
-                updatedAt    : OBSERVED_AT + 1000
-            }), {dir: tmpDir});
-
-            const snapshot = await createService().collectSnapshot();
-
-            expect(snapshot.recoveryRuns).toMatchObject({
-                status : 'available',
-                source : 'orchestrator-recovery-run-ledger',
-                limit  : 1,
-                entries: [
-                    {
-                        recoveryRunId : 'recovery-newer',
-                        diagnosisId   : 'diagnosis-1',
-                        recoveryClass : 'crash',
-                        targetIdentity: {kind: 'compose-service', id: 'memory'},
-                        status        : 'reobserve-requested'
-                    }
-                ],
-                errors: []
-            });
-        } finally {
-            AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir = originalRecoveryRunDir;
-            AiConfig.orchestrator.deploymentStateBridge.recoveryRunLimit = originalRecoveryRunLimit;
-            AiConfig.orchestrator.deploymentStateBridge.allowedServices = originalAllowedServices;
-            AiConfig.orchestrator.deploymentStateBridge.includeLogs = originalIncludeLogs;
-            await fs.remove(tmpDir);
-        }
+        expect(readerCalls).toEqual([{
+            dir  : AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir,
+            limit: AiConfig.orchestrator.deploymentStateBridge.recoveryRunLimit
+        }]);
+        expect(snapshot.recoveryRuns).toMatchObject({
+            status : 'available',
+            source : 'orchestrator-recovery-run-ledger',
+            limit  : AiConfig.orchestrator.deploymentStateBridge.recoveryRunLimit,
+            entries: [
+                {
+                    recoveryRunId : 'recovery-newer',
+                    diagnosisId   : 'diagnosis-1',
+                    recoveryClass : 'crash',
+                    targetIdentity: {kind: 'compose-service', id: 'memory'},
+                    status        : 'reobserve-requested'
+                }
+            ],
+            errors: []
+        });
     });
 
     test('falls back to runtime allowed services and records read errors as degraded state', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1,8 +1,16 @@
 import {test, expect}                 from '@playwright/test';
+import fs                             from 'fs-extra';
+import os                             from 'os';
+import path                           from 'path';
 import Neo                            from '../../../../../../../src/Neo.mjs';
 import * as core                      from '../../../../../../../src/core/_export.mjs';
 import AiConfig                       from '../../../../../../../ai/config.mjs';
 import {DeploymentStateBridgeService} from '../../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs';
+import {
+    appendRecoveryRunState,
+    createRecoveryDiagnosisEvent,
+    createRecoveryRunStateEntry
+} from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
 
 const OBSERVED_AT = 1710000000000;
 let originalDeploymentStateBridgeConfig,
@@ -53,7 +61,8 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             logTail                     : 120,
             logMaxBytes                 : 32 * 1024,
             statsSampleWindow           : 2,
-            providerResidencyServiceKeys: ['local-model', 'model']
+            providerResidencyServiceKeys: ['local-model', 'model'],
+            recoveryRunLimit            : 10
         });
         Object.assign(AiConfig.orchestrator.deploymentRuntimeAccess, {
             allowedServices: ['model']
@@ -125,6 +134,83 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             },
             proofs: [{operation: 'inspect'}, {operation: 'stats'}, {operation: 'logs'}]
         });
+        expect(snapshot.recoveryRuns).toMatchObject({
+            status : 'available',
+            source : 'orchestrator-recovery-run-ledger',
+            limit  : 10,
+            entries: []
+        });
+    });
+
+    test('includes bounded recent recovery-run ledger entries in the bridge snapshot', async () => {
+        const
+            tmpDir                   = await fs.mkdtemp(path.join(os.tmpdir(), 'deployment-recovery-runs-')),
+            originalRecoveryRunDir   = AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir,
+            originalRecoveryRunLimit = AiConfig.orchestrator.deploymentStateBridge.recoveryRunLimit,
+            originalAllowedServices  = AiConfig.orchestrator.deploymentStateBridge.allowedServices,
+            originalIncludeLogs      = AiConfig.orchestrator.deploymentStateBridge.includeLogs;
+
+        try {
+            AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir = tmpDir;
+            AiConfig.orchestrator.deploymentStateBridge.recoveryRunLimit = 1;
+            AiConfig.orchestrator.deploymentStateBridge.allowedServices = [];
+            AiConfig.orchestrator.deploymentStateBridge.includeLogs = false;
+
+            const diagnosisEvent = createRecoveryDiagnosisEvent({
+                diagnosisId    : 'diagnosis-1',
+                recoveryClass  : 'crash',
+                confidence     : 0.9,
+                targetIdentity : {kind: 'compose-service', id: 'memory'},
+                evidenceFacts  : [{type: 'container-unhealthy'}],
+                suggestedAction: 'restart',
+                observedAt     : OBSERVED_AT
+            });
+
+            await appendRecoveryRunState(createRecoveryRunStateEntry({
+                recoveryRunId: 'recovery-older',
+                diagnosisEvent,
+                rung         : 'rung-3',
+                attempt      : 1,
+                status       : 'recovered',
+                startedAt    : OBSERVED_AT - 2000,
+                updatedAt    : OBSERVED_AT - 1000,
+                completedAt  : OBSERVED_AT - 900
+            }), {dir: tmpDir});
+
+            await appendRecoveryRunState(createRecoveryRunStateEntry({
+                recoveryRunId: 'recovery-newer',
+                diagnosisEvent,
+                rung         : 'rung-3',
+                attempt      : 2,
+                status       : 'reobserve-requested',
+                startedAt    : OBSERVED_AT,
+                updatedAt    : OBSERVED_AT + 1000
+            }), {dir: tmpDir});
+
+            const snapshot = await createService().collectSnapshot();
+
+            expect(snapshot.recoveryRuns).toMatchObject({
+                status : 'available',
+                source : 'orchestrator-recovery-run-ledger',
+                limit  : 1,
+                entries: [
+                    {
+                        recoveryRunId : 'recovery-newer',
+                        diagnosisId   : 'diagnosis-1',
+                        recoveryClass : 'crash',
+                        targetIdentity: {kind: 'compose-service', id: 'memory'},
+                        status        : 'reobserve-requested'
+                    }
+                ],
+                errors: []
+            });
+        } finally {
+            AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir = originalRecoveryRunDir;
+            AiConfig.orchestrator.deploymentStateBridge.recoveryRunLimit = originalRecoveryRunLimit;
+            AiConfig.orchestrator.deploymentStateBridge.allowedServices = originalAllowedServices;
+            AiConfig.orchestrator.deploymentStateBridge.includeLogs = originalIncludeLogs;
+            await fs.remove(tmpDir);
+        }
     });
 
     test('falls back to runtime allowed services and records read errors as degraded state', async () => {

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -391,8 +391,15 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
 
     test('knowledge-base and memory-core read deployment-state snapshots through public tools (#13926)', async () => {
         const snapshot = createDeploymentStateSnapshot({
-            generatedAt: Date.now(),
-            services   : [
+            generatedAt : Date.now(),
+            recoveryRuns: {
+                status : 'available',
+                source : 'orchestrator-recovery-run-ledger',
+                limit  : 1,
+                entries: [{recoveryRunId: 'recovery-1', diagnosisId: 'diagnosis-1'}],
+                errors : []
+            },
+            services: [
                 {
                     serviceKey: 'model',
                     status    : 'degraded',
@@ -419,14 +426,20 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
                 knowledgeBaseApi = await import(pathToFileURL(path.join(repoRoot, 'ai/mcp/server/knowledge-base/toolService.mjs')).href),
                 memoryCoreApi    = await import(pathToFileURL(path.join(repoRoot, 'ai/mcp/server/memory-core/toolService.mjs')).href),
                 kbSnapshot       = await knowledgeBaseApi.callTool('get_deployment_state_snapshot', args),
-                mcSnapshot       = await memoryCoreApi.callTool('get_deployment_state_snapshot', args);
+                mcSnapshot       = await memoryCoreApi.callTool('get_deployment_state_snapshot', args),
+                kbInspection     = await knowledgeBaseApi.callTool('inspect_deployment', args),
+                mcInspection     = await memoryCoreApi.callTool('inspect_deployment', args);
 
-            for (const result of [kbSnapshot, mcSnapshot]) {
+            for (const result of [kbSnapshot, mcSnapshot, kbInspection, mcInspection]) {
                 expect(result).toMatchObject({
                     ok      : true,
                     status  : 'available',
                     snapshot: {
-                        recordType: 'deployment-state-snapshot',
+                        recordType  : 'deployment-state-snapshot',
+                        recoveryRuns: {
+                            status : 'available',
+                            entries: [{recoveryRunId: 'recovery-1', diagnosisId: 'diagnosis-1'}]
+                        },
                         services  : [
                             {
                                 serviceKey: 'model',


### PR DESCRIPTION
Resolves #13914

Related: #13860
Related: #13936

Adds the public `inspect_deployment` MCP operation on both KB and MC as a read-only alias over the deployment-state bridge snapshot. The internal orchestrator bridge now includes a bounded recent recovery-run ledger section, so public KB/MC inspection can show current allowlisted service state, bounded log tails, current diagnoses, provider-residency proof, and recent recovery-run proof without adding a public daemon route or putting Docker/socket authority on KB/MC.

Evidence: L2 (unit coverage for bridge recovery-run/provider-residency projection plus KB/MC OpenAPI/toolService drift checks) -> L3 required (live cloud smoke through the deployed public KB/MC tool path). Residual: live smoke tracked by #13936.

## Deltas from ticket

- Implements the corrected post-#13935 shape: public surfaces stay KB + MC only; orchestrator/runtime daemons remain internal.
- Adds `inspect_deployment` while preserving `get_deployment_state_snapshot` compatibility.
- Publishes bounded recovery-run history into the bridge snapshot via `readRecentRecoveryRunStates`, capped by `NEO_DEPLOYMENT_STATE_BRIDGE_RECOVERY_RUN_LIMIT` with default `10`.
- Keeps provider-residency visibility read-only and bounded through the existing provider readiness probe.
- Keeps the response read-only: no shell, exec, restart, socket, or public orchestrator/daemon route is exposed.
- Rebased onto current `dev` and kept ADR-19 shape: direct AiConfig leaf reads, no `runtimeAccessService.configValues`, no hidden defaults/type coercions for `recoveryRunLimit`.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 36 passed after rebasing onto current `origin/dev`.
- `npm run agent-preflight -- --no-fix ai/config.template.mjs ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs ai/mcp/server/knowledge-base/openapi.yaml ai/mcp/server/knowledge-base/toolService.mjs ai/mcp/server/memory-core/openapi.yaml ai/mcp/server/memory-core/toolService.mjs ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> passed.
- `git diff --check origin/dev..HEAD` -> passed.

## Post-Merge Validation

- [ ] Run the config overlay update script so the generated local/server config gets `NEO_DEPLOYMENT_STATE_BRIDGE_RECOVERY_RUN_LIMIT`.
- [ ] Restart/reconnect KB + MC MCP servers so their tool schemas include `inspect_deployment`.
- [ ] Run #13936 against the live cloud deployment through the public KB/MC MCP tool path.

## Commits

- `14e8121d4f` — `feat(ai): expose deployment inspection MCP surface (#13914)`
- `88f508300c` — `fix(ai): read deployment bridge config leaves directly (#13914)`

Authored by Euclid (GPT-5, Codex Desktop). Session 02b1972b-2925-4458-89c7-287df50c726e.
