### PR TITLE
fix(ai): replace stale lms resident models (#13700)

### DIFF
--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -82,6 +82,68 @@ function readNumericField(row, keys) {
 }
 
 /**
+ * @summary Checks whether an LM Studio loaded-model identifier belongs to a configured model.
+ *
+ * LM Studio appends numeric suffixes (`:2`, `:3`, etc.) when the same model is
+ * loaded more than once. Matching only numeric suffixes avoids conflating
+ * legitimate colon-bearing model keys with unrelated model identifiers.
+ *
+ * @param {String} id Loaded-model identifier reported by `lms ps`.
+ * @param {String} model Configured model id.
+ * @returns {Boolean}
+ */
+function matchesLmsLoadedModelId(id, model) {
+    if (!id || !model) {
+        return false;
+    }
+
+    if (id === model) {
+        return true;
+    }
+
+    if (!id.startsWith(`${model}:`)) {
+        return false;
+    }
+
+    return /^[1-9]\d*$/.test(id.slice(model.length + 1));
+}
+
+/**
+ * @summary Checks whether an exact LM Studio resident model satisfies the configured shape.
+ * @param {Object} options
+ * @param {Object} options.loadedModel Parsed `lms ps --json` row for the exact model id.
+ * @param {String} options.model Configured model id.
+ * @param {Object} [options.contextLengths] Per-model required context lengths.
+ * @param {Object} [options.parallels] Per-model required parallel slots.
+ * @returns {Boolean}
+ */
+function isLmsLoadedModelSufficient({
+    loadedModel,
+    model,
+    contextLengths = {},
+    parallels      = {}
+} = {}) {
+    if (!loadedModel) {
+        return false;
+    }
+
+    const requiredContext  = contextLengths?.[model],
+          requiredParallel = parallels?.[model],
+          hasContextGate   = Neo.isNumber(requiredContext),
+          hasParallelGate  = Neo.isNumber(requiredParallel);
+
+    if (hasContextGate && (!Neo.isNumber(loadedModel.contextLength) || loadedModel.contextLength < requiredContext)) {
+        return false;
+    }
+
+    if (hasParallelGate && loadedModel.parallel !== requiredParallel) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
  * @summary Extracts loaded LM Studio model metadata from `lms ps --json`.
  *
  * LM Studio CLI output has evolved across versions, so this normalizer accepts
@@ -163,6 +225,53 @@ export function fetchLmsLoadedModels({timeoutMs, execFileFn = execFile} = {}) {
             }
         });
     });
+}
+
+/**
+ * @summary Finds loaded LM Studio siblings superseded by a verified exact model id.
+ *
+ * The configured model id must stay resident because downstream OpenAI-compatible
+ * calls target that id. Once that exact id has the desired context/parallel shape,
+ * suffixed duplicate siblings are stale resident memory and should be unloaded.
+ *
+ * @param {Object} options
+ * @param {Object[]} options.loadedModels Parsed `lms ps --json` models.
+ * @param {String[]} options.requiredModels Required configured model ids.
+ * @param {Object} [options.contextLengths] Per-model required context lengths.
+ * @param {Object} [options.parallels] Per-model required parallel slots.
+ * @returns {Object[]}
+ */
+export function getSupersededLmsLoadedModels({
+    loadedModels,
+    requiredModels,
+    contextLengths = {},
+    parallels      = {}
+} = {}) {
+    const models     = Array.isArray(loadedModels) ? loadedModels : [],
+          byId       = new Map(models.map(item => [item.id, item])),
+          superseded = [];
+
+    for (const model of requiredModels || []) {
+        if (!isLmsLoadedModelSufficient({
+            loadedModel: byId.get(model),
+            model,
+            contextLengths,
+            parallels
+        })) {
+            continue;
+        }
+
+        for (const item of models) {
+            if (item.id !== model && matchesLmsLoadedModelId(item.id, model)) {
+                superseded.push({
+                    ...item,
+                    model
+                });
+            }
+        }
+    }
+
+    return superseded;
 }
 
 /**
@@ -399,9 +508,10 @@ export async function warmOllamaRoleModel({
  * slot holds an independent KV cache at the loaded context window, so the slot count multiplies the
  * model's resident RAM. Omit to inherit the lms default; set low for a lease-serialized role whose
  * concurrent demand is 1 (the chat model) to reclaim the idle KV-cache multiplier.
+ * @param {String} [options.identifier] Stable LM Studio loaded-model identifier.
  * @returns {Promise<{stdout: String, stderr: String}>}
  */
-export function loadLmsModel(model, {execFileFn = execFile, contextLength, parallel} = {}) {
+export function loadLmsModel(model, {execFileFn = execFile, contextLength, parallel, identifier} = {}) {
     if (!model) {
         return Promise.reject(new TypeError('loadLmsModel: model is required'));
     }
@@ -413,11 +523,38 @@ export function loadLmsModel(model, {execFileFn = execFile, contextLength, paral
     if (Neo.isNumber(parallel)) {
         args.push('--parallel', String(parallel));
     }
+    if (Neo.isString(identifier) && identifier) {
+        args.push('--identifier', identifier);
+    }
 
     return new Promise((resolve, reject) => {
         execFileFn('lms', args, (error, stdout = '', stderr = '') => {
             if (error) {
                 reject(new Error(`lms load ${model} failed: ${error.message}${stderr ? `; stderr=${stderr.trim()}` : ''}`));
+                return;
+            }
+
+            resolve({stdout, stderr});
+        });
+    });
+}
+
+/**
+ * @summary Invokes `lms unload <identifier>` for one LM Studio resident model.
+ * @param {String} identifier LM Studio loaded-model identifier.
+ * @param {Object} [options]
+ * @param {Function} [options.execFileFn=execFile] Child-process seam for tests.
+ * @returns {Promise<{stdout: String, stderr: String}>}
+ */
+export function unloadLmsModel(identifier, {execFileFn = execFile} = {}) {
+    if (!identifier) {
+        return Promise.reject(new TypeError('unloadLmsModel: identifier is required'));
+    }
+
+    return new Promise((resolve, reject) => {
+        execFileFn('lms', ['unload', identifier], (error, stdout = '', stderr = '') => {
+            if (error) {
+                reject(new Error(`lms unload ${identifier} failed: ${error.message}${stderr ? `; stderr=${stderr.trim()}` : ''}`));
                 return;
             }
 
@@ -673,6 +810,7 @@ export function getInsufficientLmsLoadedModels({
  * @param {Function} [options.fetchModelIds] Injectable model-list probe.
  * @param {Function} [options.fetchLoadedModels] Injectable loaded-model metadata probe.
  * @param {Function} [options.loadModel] Injectable model-load function.
+ * @param {Function} [options.unloadModel] Injectable model-unload function.
  * @param {Object} [options.log=logger] Logger seam.
  * @returns {Promise<Object>}
  */
@@ -688,6 +826,7 @@ export async function ensureLmsModelsLoaded({
     fetchModelIds     = opts => fetchOpenAiCompatibleModelIds(opts),
     fetchLoadedModels = opts => fetchLmsLoadedModels(opts),
     loadModel         = (model, options) => loadLmsModel(model, options),
+    unloadModel       = (identifier, options) => unloadLmsModel(identifier, options),
     log               = logger
 } = {}) {
     if (!Array.isArray(models) || models.length === 0) {
@@ -727,32 +866,96 @@ export async function ensureLmsModelsLoaded({
     };
 
     let {availableModels} = await probeModels('initial /v1/models probe');
-    const initialMissing = getMissing(availableModels);
-    const failedModels   = [];
+    const initialMissing       = getMissing(availableModels),
+          initialLoadedModels  = [],
+          failedModels         = [],
+          cleanupFailedModels  = [],
+          unloadedModels       = [],
+          modelHasObservedGate = model => Neo.isNumber(contextLengths?.[model]) || Neo.isNumber(parallels?.[model]);
 
-    // Force-include context-configured models in the load set even when already
-    // resident in /v1/models. `/v1/models` reports presence only — it does NOT
-    // expose the loaded context window, so model-id presence is insufficient to
-    // confirm the loaded cap matches the operator-declared threshold. Without
-    // this re-load, the exact context-window-mismatch regression survives orchestrator restarts:
-    // a model loaded with the modelfile-default context window (~4K-8K) would
-    // be accepted as ready while every chat invocation silently overflows.
-    // Force-include each context-configured model in the load set even if resident,
-    // BUT preserve the declared requiredModels input order (filter rather than concat-dedupe).
+    const needsInitialLoadedProbe = requiresObservedLoadCheck && requiredModels.some(model =>
+        !initialMissing.includes(model) && modelHasObservedGate(model)
+    );
+
+    if (needsInitialLoadedProbe) {
+        try {
+            initialLoadedModels.push(...await fetchLoadedModels({timeoutMs}));
+        } catch (error) {
+            log.warn?.(`[ProviderReadinessHelper] Initial LM Studio loaded-model probe failed: ${error.message}; falling back to reload enforcement.`);
+        }
+    }
+
+    const initialLoadedById = new Map(initialLoadedModels.map(item => [item.id, item]));
+
+    // `/v1/models` reports presence only. For models with context/parallel gates, use
+    // `lms ps --json` metadata to avoid reloading an already-correct resident model,
+    // but still replace an exact resident model whose loaded shape is stale.
     const modelsToLoad = requiredModels.filter(model => {
         if (initialMissing.includes(model)) return true;
-        return Neo.isNumber(contextLengths?.[model]) || Neo.isNumber(parallels?.[model]);
+        if (!modelHasObservedGate(model)) return false;
+
+        return !isLmsLoadedModelSufficient({
+            loadedModel: initialLoadedById.get(model),
+            model,
+            contextLengths,
+            parallels
+        });
     });
     const attemptedModels = [...modelsToLoad];
     const loadedModels    = [];
 
+    const cleanupSupersededModels = async lmsLoadedModels => {
+        const superseded = getSupersededLmsLoadedModels({
+            loadedModels: lmsLoadedModels,
+            requiredModels,
+            contextLengths,
+            parallels
+        });
+
+        for (const item of superseded) {
+            log.info?.(`[ProviderReadinessHelper] Unloading superseded LM Studio model '${item.id}' after '${item.model}' reached the configured shape.`);
+
+            try {
+                await unloadModel(item.id);
+                unloadedModels.push(item.id);
+            } catch (error) {
+                const failure = {
+                    model: item.model,
+                    id   : item.id,
+                    error: error.message
+                };
+
+                cleanupFailedModels.push(failure);
+                log.warn?.(`[ProviderReadinessHelper] LM Studio model '${item.id}' unload failed: ${error.message}`);
+
+                if (!allowPartial) {
+                    throw error;
+                }
+            }
+        }
+
+        return cleanupFailedModels;
+    };
+
     if (modelsToLoad.length === 0) {
+        if (requiresObservedLoadCheck && initialLoadedModels.length) {
+            await cleanupSupersededModels(initialLoadedModels);
+        }
+
         return {
-            ready       : true,
-            loadedModels: [],
+            ready          : cleanupFailedModels.length === 0,
+            degraded       : cleanupFailedModels.length > 0,
+            loadedModels   : [],
+            attemptedModels,
+            failedModels,
+            cleanupFailedModels,
+            unloadedModels,
             requiredModels,
             availableModels,
-            attempts    : 1
+            lmsLoadedModels: initialLoadedModels,
+            loadedContexts : Object.fromEntries(initialLoadedModels.map(item => [item.id, item.contextLength])),
+            loadedParallels: Object.fromEntries(initialLoadedModels.map(item => [item.id, item.parallel])),
+            attempts       : 1
         };
     }
 
@@ -770,7 +973,33 @@ export async function ensureLmsModelsLoaded({
             : 'context-length / parallel enforcement on resident model';
         log.info?.(`[ProviderReadinessHelper] Loading LM Studio model '${model}' via lms load${contextSuffix}${parallelSuffix} (${reason}).`);
         try {
-            await loadModel(model, {contextLength, parallel});
+            const observed           = initialLoadedById.get(model),
+                  exactResident      = !initialMissing.includes(model),
+                  shouldReplaceExact = observed
+                      ? !isLmsLoadedModelSufficient({
+                          loadedModel: observed,
+                          model,
+                          contextLengths,
+                          parallels
+                      })
+                      : exactResident && modelHasObservedGate(model);
+
+            if (shouldReplaceExact) {
+                log.info?.(`[ProviderReadinessHelper] Unloading stale LM Studio model '${model}' before stable-identifier reload.`);
+                await unloadModel(model);
+                unloadedModels.push(model);
+            }
+
+            const loadOptions = {identifier: model};
+
+            if (Neo.isNumber(contextLength)) {
+                loadOptions.contextLength = contextLength;
+            }
+            if (Neo.isNumber(parallel)) {
+                loadOptions.parallel = parallel;
+            }
+
+            await loadModel(model, loadOptions);
             loadedModels.push(model);
         } catch (error) {
             failedModels.push({
@@ -820,6 +1049,8 @@ export async function ensureLmsModelsLoaded({
                         loadedModels,
                         attemptedModels,
                         failedModels,
+                        cleanupFailedModels,
+                        unloadedModels,
                         missingModels,
                         observedLoadError: error.message,
                         requiredModels,
@@ -863,6 +1094,8 @@ export async function ensureLmsModelsLoaded({
                     loadedModels,
                     attemptedModels,
                     failedModels,
+                    cleanupFailedModels,
+                    unloadedModels,
                     missingModels,
                     insufficientLoadedModels,
                     requiredModels,
@@ -875,13 +1108,19 @@ export async function ensureLmsModelsLoaded({
                 };
             }
 
-            const ready = missingModels.length === 0 && failedModels.length === 0;
+            if (requiresObservedLoadCheck && lmsLoadedModels.length) {
+                await cleanupSupersededModels(lmsLoadedModels);
+            }
+
+            const ready = missingModels.length === 0 && failedModels.length === 0 && cleanupFailedModels.length === 0;
             return {
                 ready,
                 degraded       : !ready,
                 loadedModels,
                 attemptedModels,
                 failedModels,
+                cleanupFailedModels,
+                unloadedModels,
                 missingModels,
                 requiredModels,
                 availableModels,
@@ -901,6 +1140,8 @@ export async function ensureLmsModelsLoaded({
                 loadedModels,
                 attemptedModels,
                 failedModels,
+                cleanupFailedModels,
+                unloadedModels,
                 missingModels,
                 requiredModels,
                 availableModels,
@@ -921,6 +1162,8 @@ export async function ensureLmsModelsLoaded({
             loadedModels,
             attemptedModels,
             failedModels,
+            cleanupFailedModels,
+            unloadedModels,
             missingModels,
             requiredModels,
             availableModels,

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -502,20 +502,16 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         });
     });
 
-    test('ensureLmsModelsLoaded force-reloads context-configured models even when already resident (#12117 RA1 — closes silent wrong-context regression)', async () => {
+    test('ensureLmsModelsLoaded skips reload when lms ps confirms resident context-configured models are sufficient (#13700)', async () => {
         const loadCalls = [];
 
         const result = await providerReadinessHelper.ensureLmsModelsLoaded({
-            host          : 'http://127.0.0.1:1234',
-            models        : ['chat-model', 'embedding-model'],
-            contextLengths: {'chat-model': 262144, 'embedding-model': 32768},
-            attempts      : 1,
-            delayMs       : 0,
-            timeoutMs     : 50,
-            // Both models ALREADY resident — without the RA1 fix, this scenario returned
-            // ready with zero loadModel calls, leaving any modelfile-default loaded
-            // context window in place. With the fix, context-configured models are
-            // force-included in the load set.
+            host             : 'http://127.0.0.1:1234',
+            models           : ['chat-model', 'embedding-model'],
+            contextLengths   : {'chat-model': 262144, 'embedding-model': 32768},
+            attempts         : 1,
+            delayMs          : 0,
+            timeoutMs        : 50,
             fetchModelIds    : async () => ['chat-model', 'embedding-model'],
             loadModel        : async (model, options) => loadCalls.push({model, contextLength: options?.contextLength}),
             fetchLoadedModels: async () => [{
@@ -528,12 +524,152 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             log          : {info: () => {}}
         });
 
-        expect(loadCalls).toEqual([
-            {model: 'chat-model',      contextLength: 262144},
-            {model: 'embedding-model', contextLength: 32768}
-        ]);
+        expect(loadCalls).toEqual([]);
         expect(result.ready).toBe(true);
-        expect(result.loadedModels).toEqual(['chat-model', 'embedding-model']);
+        expect(result.loadedModels).toEqual([]);
+    });
+
+    test('ensureLmsModelsLoaded replaces stale exact lms load and unloads suffixed siblings (#13700)', async () => {
+        const loadCalls      = [],
+              unloadCalls    = [],
+              modelSnapshots = [
+                  ['chat-model', 'chat-model:2', 'embedding-model'],
+                  ['chat-model', 'chat-model:2', 'embedding-model']
+              ],
+              loadedSnapshots = [
+                  [{
+                      id           : 'chat-model',
+                      contextLength: 4096,
+                      parallel     : 4
+                  }, {
+                      id           : 'chat-model:2',
+                      contextLength: 131072,
+                      parallel     : 1
+                  }, {
+                      id           : 'embedding-model',
+                      contextLength: 32768
+                  }],
+                  [{
+                      id           : 'chat-model',
+                      contextLength: 131072,
+                      parallel     : 1
+                  }, {
+                      id           : 'chat-model:2',
+                      contextLength: 4096,
+                      parallel     : 4
+                  }, {
+                      id           : 'embedding-model',
+                      contextLength: 32768
+                  }]
+              ];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host             : 'http://127.0.0.1:1234',
+            models           : ['chat-model', 'embedding-model'],
+            contextLengths   : {'chat-model': 131072, 'embedding-model': 32768},
+            parallels        : {'chat-model': 1},
+            attempts         : 1,
+            delayMs          : 0,
+            timeoutMs        : 50,
+            fetchModelIds    : async () => modelSnapshots.shift() || ['chat-model', 'embedding-model'],
+            loadModel        : async (model, options) => loadCalls.push({model, options}),
+            unloadModel      : async identifier => unloadCalls.push(identifier),
+            fetchLoadedModels: async () => loadedSnapshots.shift() || [{
+                id           : 'chat-model',
+                contextLength: 131072,
+                parallel     : 1
+            }, {
+                id           : 'embedding-model',
+                contextLength: 32768
+            }],
+            log: {info: () => {}}
+        });
+
+        expect(unloadCalls).toEqual(['chat-model', 'chat-model:2']);
+        expect(loadCalls).toEqual([{
+            model  : 'chat-model',
+            options: {
+                contextLength: 131072,
+                parallel     : 1,
+                identifier   : 'chat-model'
+            }
+        }]);
+        expect(result.ready).toBe(true);
+        expect(result.loadedModels).toEqual(['chat-model']);
+        expect(result.unloadedModels).toEqual(['chat-model', 'chat-model:2']);
+    });
+
+    test('ensureLmsModelsLoaded unloads an exact resident gated model when initial lms ps fails (#13700)', async () => {
+        const loadCalls   = [],
+              unloadCalls = [];
+        let loadedProbeRuns = 0;
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host             : 'http://127.0.0.1:1234',
+            models           : ['chat-model'],
+            contextLengths   : {'chat-model': 131072},
+            parallels        : {'chat-model': 1},
+            attempts         : 1,
+            delayMs          : 0,
+            timeoutMs        : 50,
+            fetchModelIds    : async () => ['chat-model'],
+            loadModel        : async (model, options) => loadCalls.push({model, options}),
+            unloadModel      : async identifier => unloadCalls.push(identifier),
+            fetchLoadedModels: async () => {
+                loadedProbeRuns++;
+
+                if (loadedProbeRuns === 1) {
+                    throw new Error('lms ps unavailable');
+                }
+
+                return [{
+                    id           : 'chat-model',
+                    contextLength: 131072,
+                    parallel     : 1
+                }];
+            },
+            log: {
+                info: () => {},
+                warn: () => {}
+            }
+        });
+
+        expect(unloadCalls).toEqual(['chat-model']);
+        expect(loadCalls).toEqual([{
+            model  : 'chat-model',
+            options: {
+                contextLength: 131072,
+                parallel     : 1,
+                identifier   : 'chat-model'
+            }
+        }]);
+        expect(result.ready).toBe(true);
+    });
+
+    test('getSupersededLmsLoadedModels only supersedes suffixed siblings after exact model is sufficient (#13700)', () => {
+        expect(providerReadinessHelper.getSupersededLmsLoadedModels({
+            requiredModels: ['chat-model'],
+            contextLengths: {'chat-model': 131072},
+            parallels     : {'chat-model': 1},
+            loadedModels  : [{
+                id           : 'chat-model',
+                contextLength: 131072,
+                parallel     : 1
+            }, {
+                id           : 'chat-model:2',
+                contextLength: 4096,
+                parallel     : 4
+            }, {
+                id           : 'chat-model:beta',
+                contextLength: 131072,
+                parallel     : 1
+            }]
+        })).toEqual([{
+            id           : 'chat-model:2',
+            contextLength: 4096,
+            parallel     : 4,
+            model        : 'chat-model'
+        }]);
     });
 
     test('getLmsLoadedModels normalizes lms ps json metadata (#13851)', () => {
@@ -594,6 +730,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             timeoutMs        : 50,
             fetchModelIds    : async () => ['chat-model', 'embedding-model'],
             loadModel        : async () => {},
+            unloadModel      : async () => {},
             fetchLoadedModels: async () => [{
                 id           : 'chat-model',
                 contextLength: 4096,
@@ -628,7 +765,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(warnings[0]).toContain('loaded-model readiness failed');
     });
 
-    test('ensureLmsModelsLoaded mixes missing + context-configured force-reload paths correctly (#12117 RA1)', async () => {
+    test('ensureLmsModelsLoaded mixes missing + context-configured verified-resident paths correctly (#13700)', async () => {
         const loadCalls      = [];
         const modelSnapshots = [
             ['chat-model'],                      // chat resident, embedding missing
@@ -652,9 +789,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             log           : {info: () => {}}
         });
 
-        // Both models should load: embedding because missing, chat because context-configured
+        // Only embedding loads: chat is resident and lms ps proves its configured context.
         expect(loadCalls).toEqual([
-            {model: 'chat-model',      contextLength: 262144},
             {model: 'embedding-model', contextLength: undefined}
         ]);
         expect(result.ready).toBe(true);
@@ -694,8 +830,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         });
 
         expect(loadCalls).toEqual([
-            {model: 'chat-model',      options: {contextLength: 262144}},
-            {model: 'embedding-model', options: {contextLength: 32768}}
+            {model: 'chat-model',      options: {contextLength: 262144, identifier: 'chat-model'}},
+            {model: 'embedding-model', options: {contextLength: 32768, identifier: 'embedding-model'}}
         ]);
         expect(result.ready).toBe(true);
         expect(result.loadedModels).toEqual(['chat-model', 'embedding-model']);
@@ -1081,6 +1217,47 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         expect(execCalls).toEqual([
             {cmd: 'lms', args: ['load', 'chat-model', '--context-length', '262144']}
+        ]);
+    });
+
+    test('loadLmsModel appends --parallel and --identifier when provided (#13700)', async () => {
+        const execCalls    = [];
+        const execFileStub = (cmd, args, callback) => {
+            execCalls.push({cmd, args});
+            callback(null, '', '');
+        };
+
+        await providerReadinessHelper.loadLmsModel('chat-model', {
+            execFileFn   : execFileStub,
+            contextLength: 131072,
+            parallel     : 1,
+            identifier   : 'chat-model'
+        });
+
+        expect(execCalls).toEqual([
+            {
+                cmd : 'lms',
+                args: [
+                    'load', 'chat-model',
+                    '--context-length', '131072',
+                    '--parallel', '1',
+                    '--identifier', 'chat-model'
+                ]
+            }
+        ]);
+    });
+
+    test('unloadLmsModel invokes lms unload for the requested identifier (#13700)', async () => {
+        const execCalls    = [];
+        const execFileStub = (cmd, args, callback) => {
+            execCalls.push({cmd, args});
+            callback(null, '', '');
+        };
+
+        await providerReadinessHelper.unloadLmsModel('chat-model:2', {execFileFn: execFileStub});
+
+        expect(execCalls).toEqual([
+            {cmd: 'lms', args: ['unload', 'chat-model:2']}
         ]);
     });
 


### PR DESCRIPTION
Resolves #13700
Related: #13942

Reworks LM Studio preload from blind resident reload to shape-aware replacement. `ensureLmsModelsLoaded` now uses `lms ps --json` metadata when a resident model has context/parallel gates, skips exact identifiers that already match the configured shape, unloads a stale exact identifier before reloading it with stable `--identifier <model>`, and unloads suffixed siblings only after the exact configured id is verified sufficient.

## Scope Boundary

This PR is the local LM Studio / OpenAI-compatible adapter fix for #13700. It does not claim to solve cloud/native Ollama deployment recovery. Active-provider residency recovery belongs to the diagnostics -> recovery daemon path under ADR-0025/ADR-0026 and is tracked in #13942.

Evidence: L2 (mocked `lms load` / `lms unload` dispatch plus focused provider-readiness unit coverage) -> L3 required (live LM Studio host shows only exact configured ids after orchestrator preload). Residual: live post-merge `lms ps` validation [#13700].

## Deltas from ticket

- Extends the original chat `--parallel` ticket into the unresolved load-order / already-loaded replacement path identified in the latest issue comment.
- Keeps phase-2 idle downscaling out of this PR; Discussion #13873 already owns that proactive homeostatic loop.
- Keeps cloud/native-provider recovery out of this PR; #13942 owns the active-provider daemon recovery lane.
- Does not add or change AiConfig leaves; callers still pass resolved context/parallel maps into the helper.

## Test Evidence

- `npm run agent-preflight -- ai/services/graph/providerReadinessHelper.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs` -> 52 passed
- `git diff --check`

## Post-Merge Validation

- [ ] Restart the orchestrator / LM Studio preload path on the local host.
- [ ] Run `lms ps` or `lms ps --json` and verify the configured chat and embedding models have the exact configured identifiers with the expected context/parallel shape.
- [ ] Verify stale suffixed resident siblings such as `<model>:2` / `<model>:3` are not left loaded after preload succeeds.

## Commit

- `7685fcd7f7` - `fix(ai): replace stale lms resident models (#13700)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
