### PR TITLE
fix(ai): diagnose active provider residency (#13942)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -459,21 +459,23 @@ class Config extends ConfigProvider {
                  * `NEO_DEPLOYMENT_STATE_BRIDGE_INCLUDE_LOGS`,
                  * `NEO_DEPLOYMENT_STATE_BRIDGE_LOG_TAIL`,
                  * `NEO_DEPLOYMENT_STATE_BRIDGE_LOG_MAX_BYTES`,
-                 * `NEO_DEPLOYMENT_STATE_BRIDGE_STATS_SAMPLE_WINDOW`.
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_STATS_SAMPLE_WINDOW`,
+                 * `NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_RESIDENCY_SERVICE_KEYS`.
                  *
                  * @type {Object}
                  */
                 deploymentStateBridge: {
-                    enabled          : leaf(false, 'NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED', 'boolean'),
-                    snapshotPath     : leaf(path.resolve(neoRootDir, '.neo-ai-data/deployment-state/snapshot.json'), 'NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH', 'string'),
-                    writeIntervalMs  : leaf(30000, 'NEO_DEPLOYMENT_STATE_BRIDGE_WRITE_INTERVAL_MS', 'number'),
-                    staleAfterMs     : leaf(2 * 60 * 1000, 'NEO_DEPLOYMENT_STATE_BRIDGE_STALE_AFTER_MS', 'number'),
-                    maxSnapshotBytes : leaf(256 * 1024, 'NEO_DEPLOYMENT_STATE_BRIDGE_MAX_BYTES', 'number'),
-                    allowedServices  : leaf([], 'NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES', 'csv'),
-                    includeLogs      : leaf(true, 'NEO_DEPLOYMENT_STATE_BRIDGE_INCLUDE_LOGS', 'boolean'),
-                    logTail          : leaf(120, 'NEO_DEPLOYMENT_STATE_BRIDGE_LOG_TAIL', 'number'),
-                    logMaxBytes      : leaf(32 * 1024, 'NEO_DEPLOYMENT_STATE_BRIDGE_LOG_MAX_BYTES', 'number'),
-                    statsSampleWindow: leaf(2, 'NEO_DEPLOYMENT_STATE_BRIDGE_STATS_SAMPLE_WINDOW', 'number')
+                    enabled                     : leaf(false, 'NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED', 'boolean'),
+                    snapshotPath                : leaf(path.resolve(neoRootDir, '.neo-ai-data/deployment-state/snapshot.json'), 'NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH', 'string'),
+                    writeIntervalMs             : leaf(30000, 'NEO_DEPLOYMENT_STATE_BRIDGE_WRITE_INTERVAL_MS', 'number'),
+                    staleAfterMs                : leaf(2 * 60 * 1000, 'NEO_DEPLOYMENT_STATE_BRIDGE_STALE_AFTER_MS', 'number'),
+                    maxSnapshotBytes            : leaf(256 * 1024, 'NEO_DEPLOYMENT_STATE_BRIDGE_MAX_BYTES', 'number'),
+                    allowedServices             : leaf([], 'NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES', 'csv'),
+                    includeLogs                 : leaf(true, 'NEO_DEPLOYMENT_STATE_BRIDGE_INCLUDE_LOGS', 'boolean'),
+                    logTail                     : leaf(120, 'NEO_DEPLOYMENT_STATE_BRIDGE_LOG_TAIL', 'number'),
+                    logMaxBytes                 : leaf(32 * 1024, 'NEO_DEPLOYMENT_STATE_BRIDGE_LOG_MAX_BYTES', 'number'),
+                    statsSampleWindow           : leaf(2, 'NEO_DEPLOYMENT_STATE_BRIDGE_STATS_SAMPLE_WINDOW', 'number'),
+                    providerResidencyServiceKeys: leaf(['local-model', 'model'], 'NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_RESIDENCY_SERVICE_KEYS', 'csv')
                 },
                 /**
                  * Maintenance-loop intervals consumed by the orchestrator daemon.
@@ -683,13 +685,14 @@ class Config extends ConfigProvider {
                     tenantRepoSyncEnabled: leaf(null, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED', 'boolean')
                 },
                 /**
-                 * ADR-0026 B1 recovery actuator envelope. Disabled and empty by default: the
-                 * orchestrator may only restart compose services or page deploy targets that are
-                 * explicitly named here by the operator.
+                 * Recovery actuator envelope. Disabled and empty by default: the
+                 * orchestrator may only recycle supervised tasks, restart compose services, or
+                 * page deploy targets that are explicitly named here by the operator.
                  * @type {Object}
                  */
                 recoveryActuator: {
                     enabled                    : leaf(false, 'NEO_RECOVERY_ACTUATOR_ENABLED', 'boolean'),
+                    allowedSupervisedTasks     : leaf([], 'NEO_RECOVERY_ACTUATOR_SUPERVISED_TASKS', 'csv'),
                     allowedComposeServices     : leaf([], 'NEO_RECOVERY_ACTUATOR_COMPOSE_SERVICES', 'csv'),
                     allowedDeployTargets       : leaf([], 'NEO_RECOVERY_ACTUATOR_DEPLOY_TARGETS', 'csv'),
                     healAttemptsPath           : leaf(path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/heal-attempts.json'), 'NEO_RECOVERY_ACTUATOR_HEAL_ATTEMPTS_PATH', 'string'),

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -337,6 +337,7 @@ export class Orchestrator extends Base {
             dataDir                       : this.dataDir,
             deploymentRuntimeAccessService: this.deploymentRuntimeAccessService,
             healthService                 : this.healthService,
+            processSupervisorService      : this.processSupervisorService,
             writeLog                      : this.processSupervisorWriteLog,
             actuatorConfig                : AiConfig.orchestrator.recoveryActuator
         });
@@ -352,6 +353,11 @@ export class Orchestrator extends Base {
         if (oldValue === undefined) return;
         this.processSupervisorService.taskDefinitions       = value;
         this.maintenanceBackpressureService.taskDefinitions = value;
+    }
+    afterSetProcessSupervisorService(value, oldValue) {
+        if (this.recoveryActuatorService) {
+            this.recoveryActuatorService.processSupervisorService = value;
+        }
     }
     afterSetTaskStateService(value, oldValue) {
         if (oldValue === undefined) return;

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -1,6 +1,9 @@
 import Base from '../../../../src/core/Base.mjs';
 
-import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+import {
+    createRecoveryDiagnosisEvent,
+    createRecoveryTargetIdentity
+} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 
 export const CONTAINER_HEALTH_FACT_TYPES = Object.freeze({
     configDrift        : 'config-drift',
@@ -9,6 +12,7 @@ export const CONTAINER_HEALTH_FACT_TYPES = Object.freeze({
     endpointProbeFailed: 'endpoint-probe-failed',
     evalContention     : 'ollama-eval-contention',
     memorySaturation   : 'memory-saturation',
+    providerResidency  : 'provider-residency-degraded',
     resourceSaturation : 'resource-saturation',
     runtimeReadFailed  : 'runtime-read-failed'
 });
@@ -86,6 +90,7 @@ export class ContainerHealthDiagnosisService extends Base {
      * @param {Object|null} [options.endpointProbe=null] Direct service probe result.
      * @param {Object|null} [options.configCheck=null] Config correctness result.
      * @param {Object|null} [options.ollamaEvalAttribution=null] Native Ollama eval attribution.
+     * @param {Object|null} [options.providerResidency=null] Active-provider residency observation.
      * @param {Number} [options.observedAt] Epoch milliseconds for the observation.
      * @returns {Object} Diagnosis decision with advisory facts and optional diagnosis event.
      */
@@ -97,6 +102,7 @@ export class ContainerHealthDiagnosisService extends Base {
         endpointProbe = null,
         configCheck = null,
         ollamaEvalAttribution = null,
+        providerResidency = null,
         observedAt = this.now()
     } = {}) {
         this.validateServiceKey(serviceKey);
@@ -106,7 +112,8 @@ export class ContainerHealthDiagnosisService extends Base {
             ...this.collectStatsFacts({serviceKey, stats, statsSamples, observedAt}),
             ...this.collectEndpointProbeFacts({serviceKey, endpointProbe, observedAt}),
             ...this.collectConfigFacts({serviceKey, configCheck, observedAt}),
-            ...this.collectEvalAttributionFacts({serviceKey, ollamaEvalAttribution, observedAt})
+            ...this.collectEvalAttributionFacts({serviceKey, ollamaEvalAttribution, observedAt}),
+            ...this.collectProviderResidencyFacts({serviceKey, providerResidency, observedAt})
         ];
 
         const classification = this.classifyFacts({facts});
@@ -123,7 +130,7 @@ export class ContainerHealthDiagnosisService extends Base {
             diagnosisId   : this.createDiagnosisId({serviceKey, observedAt, recoveryClass: classification.recoveryClass}),
             recoveryClass : classification.recoveryClass,
             confidence    : classification.confidence,
-            targetIdentity: {kind: 'compose-service', id: serviceKey},
+            targetIdentity: this.resolveDiagnosisTargetIdentity({serviceKey, classification}),
             evidenceFacts : classification.evidenceFacts,
             observedAt,
             source        : 'container-health-diagnostics',
@@ -156,6 +163,7 @@ export class ContainerHealthDiagnosisService extends Base {
      * @param {Function|null} [options.endpointProbeFn=null] Optional direct probe callback.
      * @param {Function|null} [options.configCheckFn=null] Optional config-check callback.
      * @param {Object|null} [options.ollamaEvalAttribution=null] Optional eval attribution payload.
+     * @param {Object|null} [options.providerResidency=null] Optional active-provider residency observation.
      * @param {Object[]|null} [options.statsSamples=null] Optional stats samples spanning the window.
      * @param {Number} [options.observedAt] Epoch milliseconds for the observation.
      * @returns {Promise<Object>} Diagnosis decision.
@@ -166,6 +174,7 @@ export class ContainerHealthDiagnosisService extends Base {
         endpointProbeFn = null,
         configCheckFn = null,
         ollamaEvalAttribution = null,
+        providerResidency = null,
         statsSamples = null,
         observedAt = this.now()
     } = {}) {
@@ -203,6 +212,7 @@ export class ContainerHealthDiagnosisService extends Base {
                   endpointProbe,
                   configCheck,
                   ollamaEvalAttribution,
+                  providerResidency,
                   observedAt
               });
 
@@ -390,19 +400,83 @@ export class ContainerHealthDiagnosisService extends Base {
     }
 
     /**
+     * Collects active-provider residency facts from provider-specific probes.
+     *
+     * Diagnostics own normalization only: callers supply LMS, Ollama, or future-provider facts;
+     * recovery later routes by the typed target identity.
+     *
+     * @param {Object} options
+     * @returns {Object[]}
+     */
+    collectProviderResidencyFacts({serviceKey, providerResidency, observedAt}) {
+        if (!providerResidency || typeof providerResidency !== 'object') return [];
+
+        const reasonCode = this.getProviderResidencyReasonCode(providerResidency);
+        if (!reasonCode) return [];
+
+        return [this.createFact({
+            type         : CONTAINER_HEALTH_FACT_TYPES.providerResidency,
+            serviceKey,
+            observedAt,
+            severity     : ['extra-residents', 'provider-probe-failed'].includes(reasonCode) ? 'warning' : 'critical',
+            authoritative: !['extra-residents', 'provider-probe-failed'].includes(reasonCode),
+            details      : {
+                provider                 : typeof providerResidency.provider === 'string' ? providerResidency.provider : null,
+                host                     : typeof providerResidency.host === 'string' ? providerResidency.host : null,
+                message                  : typeof providerResidency.message === 'string' ? providerResidency.message : null,
+                reasonCode,
+                ready                    : typeof providerResidency.ready === 'boolean' ? providerResidency.ready : null,
+                degraded                 : typeof providerResidency.degraded === 'boolean' ? providerResidency.degraded : null,
+                targetIdentity           : this.readProviderTargetIdentity(providerResidency.targetIdentity),
+                requiredModels           : toSafeArray(providerResidency.requiredModels),
+                availableModels          : toSafeArray(providerResidency.availableModels),
+                missingModels            : toSafeArray(providerResidency.missingModels),
+                insufficientContextModels: toSafeArray(providerResidency.insufficientContextModels),
+                extraModels              : toSafeArray(providerResidency.extraModels),
+                failedModels             : toSafeArray(providerResidency.failedModels),
+                loadedContexts           : toSafeObject(providerResidency.loadedContexts),
+                observedRequiredCount    : toSafeNumber(providerResidency.observedRequiredCount),
+                requiredResidentModels   : toSafeNumber(providerResidency.requiredResidentModels),
+                residentButNotServing    : providerResidency.residentButNotServing === true
+            }
+        })];
+    }
+
+    /**
      * Classifies facts into the recovery diagnosis contract.
      * @param {Object} options
      * @returns {Object|null}
      */
     classifyFacts({facts}) {
-        if (facts.some(fact => fact.type === CONTAINER_HEALTH_FACT_TYPES.configDrift)) {
-            const evidenceFacts = facts.filter(fact => fact.type === CONTAINER_HEALTH_FACT_TYPES.configDrift);
+        const configDriftFacts = facts.filter(fact =>
+            fact.type === CONTAINER_HEALTH_FACT_TYPES.configDrift ||
+            this.isProviderResidencyConfigDrift(fact)
+        );
+
+        if (configDriftFacts.length > 0) {
+            const providerTargetIdentity = this.resolveProviderFactTargetIdentity(configDriftFacts.find(fact =>
+                fact.type === CONTAINER_HEALTH_FACT_TYPES.providerResidency
+            ));
+
             return {
-                recoveryClass: 'config-drift',
-                actionClass  : CONTAINER_HEALTH_ACTION_CLASSES.escalate,
-                confidence   : 0.95,
-                evidenceFacts,
-                reason       : 'config-drift-escalate'
+                recoveryClass : 'config-drift',
+                actionClass   : CONTAINER_HEALTH_ACTION_CLASSES.escalate,
+                confidence    : 0.95,
+                evidenceFacts : configDriftFacts,
+                reason        : 'config-drift-escalate',
+                targetIdentity: providerTargetIdentity
+            };
+        }
+
+        const providerCrashFacts = facts.filter(fact => this.isProviderResidentButNotServing(fact));
+        if (providerCrashFacts.length > 0) {
+            return {
+                recoveryClass : 'crash',
+                actionClass   : CONTAINER_HEALTH_ACTION_CLASSES.restart,
+                confidence    : 0.85,
+                evidenceFacts : this.selectEvidenceFacts(facts, providerCrashFacts),
+                reason        : 'provider-resident-not-serving',
+                targetIdentity: this.resolveProviderFactTargetIdentity(providerCrashFacts[0])
             };
         }
 
@@ -514,7 +588,7 @@ export class ContainerHealthDiagnosisService extends Base {
             schemaVersion : 1,
             recordType    : 'container-health-diagnosis-decision',
             serviceKey,
-            targetIdentity: {kind: 'compose-service', id: serviceKey},
+            targetIdentity: diagnosis?.targetIdentity || {kind: 'compose-service', id: serviceKey},
             observedAt,
             status,
             actionClass,
@@ -552,6 +626,103 @@ export class ContainerHealthDiagnosisService extends Base {
         if (!/^[a-zA-Z0-9_.-]+$/.test(serviceKey)) {
             throw new TypeError(`Container health diagnosis serviceKey '${serviceKey}' contains unsupported characters`);
         }
+    }
+
+    /**
+     * Resolves the diagnosis target without letting raw probe data bypass the target enum.
+     * @param {Object} options
+     * @returns {Object}
+     */
+    resolveDiagnosisTargetIdentity({serviceKey, classification}) {
+        return classification?.targetIdentity || createRecoveryTargetIdentity({
+            kind: 'compose-service',
+            id  : serviceKey
+        });
+    }
+
+    /**
+     * Determines the provider-residency reason code that diagnostics can classify.
+     * @param {Object} providerResidency Active-provider residency observation.
+     * @returns {String|null}
+     */
+    getProviderResidencyReasonCode(providerResidency) {
+        if (providerResidency.residentButNotServing === true) {
+            return 'resident-not-serving';
+        }
+        if (toSafeArray(providerResidency.missingModels).length > 0) {
+            return 'missing-required-model';
+        }
+        if (toSafeArray(providerResidency.insufficientContextModels).length > 0) {
+            return 'insufficient-context';
+        }
+        if (toSafeArray(providerResidency.failedModels).length > 0) {
+            return 'provider-warmup-failed';
+        }
+        if (providerResidency.supported === false) {
+            return 'unsupported-provider';
+        }
+        if (providerResidency.probeFailed === true) {
+            return 'provider-probe-failed';
+        }
+        if (providerResidency.ready === false) {
+            return 'provider-not-ready';
+        }
+        if (toSafeArray(providerResidency.extraModels).length > 0) {
+            return 'extra-residents';
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks whether a provider-residency fact should page instead of looping recovery.
+     * @param {Object} fact Diagnosis fact.
+     * @returns {Boolean}
+     */
+    isProviderResidencyConfigDrift(fact) {
+        return fact.type === CONTAINER_HEALTH_FACT_TYPES.providerResidency && [
+            'insufficient-context',
+            'missing-required-model',
+            'provider-not-ready',
+            'provider-warmup-failed',
+            'unsupported-provider'
+        ].includes(fact.details?.reasonCode);
+    }
+
+    /**
+     * Checks whether a provider-residency fact proves a resident-but-not-serving fault.
+     * @param {Object} fact Diagnosis fact.
+     * @returns {Boolean}
+     */
+    isProviderResidentButNotServing(fact) {
+        return fact.type === CONTAINER_HEALTH_FACT_TYPES.providerResidency &&
+            fact.details?.reasonCode === 'resident-not-serving';
+    }
+
+    /**
+     * Reads and validates a provider fact target identity.
+     * @param {Object|null} targetIdentity Target identity candidate.
+     * @returns {Object|null}
+     */
+    readProviderTargetIdentity(targetIdentity) {
+        if (!targetIdentity || typeof targetIdentity !== 'object') return null;
+
+        try {
+            return createRecoveryTargetIdentity(targetIdentity);
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * Resolves the first typed provider fact target identity.
+     * @param {Object} fact Diagnosis fact.
+     * @returns {Object|null}
+     */
+    resolveProviderFactTargetIdentity(fact) {
+        if (!fact) return null;
+
+        return this.readProviderTargetIdentity(fact.details?.targetIdentity);
     }
 }
 
@@ -623,6 +794,22 @@ function toSafeScalar(value) {
     if (['string', 'number', 'boolean'].includes(typeof value)) return value;
 
     return JSON.stringify(value).slice(0, 256);
+}
+
+function toSafeArray(value) {
+    return Array.isArray(value)
+        ? value.map(item => toSafeScalar(item)).filter(item => item !== null)
+        : [];
+}
+
+function toSafeObject(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, toSafeScalar(item)]));
+}
+
+function toSafeNumber(value) {
+    return Number.isFinite(value) ? value : null;
 }
 
 export default Neo.setupClass(ContainerHealthDiagnosisService);

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -264,12 +264,7 @@ export class DeploymentStateBridgeService extends Base {
 
         samples.push(stats);
 
-        const {statsSampleWindow} = AiConfig.orchestrator.deploymentStateBridge;
-        if (!Number.isInteger(statsSampleWindow) || statsSampleWindow < 1) {
-            throw new RangeError('DeploymentStateBridgeService requires a positive integer statsSampleWindow AiConfig leaf');
-        }
-
-        this.statsSamplesByService.set(serviceKey, samples.slice(-statsSampleWindow));
+        this.statsSamplesByService.set(serviceKey, samples.slice(-AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow));
     }
 
     /**

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -1,5 +1,6 @@
-import Base     from '../../../../src/core/Base.mjs';
-import AiConfig from '../../../config.mjs';
+import Base                                 from '../../../../src/core/Base.mjs';
+import AiConfig                             from '../../../config.mjs';
+import {probeProviderParallelModelCapacity} from '../../../services/graph/providerReadinessHelper.mjs';
 
 import {
     boundUtf8Tail,
@@ -45,6 +46,11 @@ export class DeploymentStateBridgeService extends Base {
          * @protected
          */
         nowFn: null,
+        /**
+         * @member {Function|null} providerResidencyProbe=null
+         * @protected
+         */
+        providerResidencyProbe: null,
         /**
          * @member {Function|null} writeLog=null
          * @protected
@@ -132,9 +138,10 @@ export class DeploymentStateBridgeService extends Base {
             errors = [],
             proofs = [];
 
-        let inspect = null,
-            stats   = null,
-            logs    = null;
+        let inspect           = null,
+            stats             = null,
+            logs              = null,
+            providerResidency = null;
 
         const read = async (operation, args = {}) => {
             try {
@@ -160,12 +167,15 @@ export class DeploymentStateBridgeService extends Base {
             this.rememberStatsSample(serviceKey, stats);
         }
 
+        providerResidency = await this.collectProviderResidency({serviceKey, observedAt});
+
         const diagnosis = this.diagnosisService?.diagnose
             ? this.diagnosisService.diagnose({
                 serviceKey,
                 inspect,
                 stats,
                 statsSamples: this.getStatsSamples(serviceKey),
+                providerResidency,
                 observedAt
             })
             : null;
@@ -180,10 +190,53 @@ export class DeploymentStateBridgeService extends Base {
             inspect       : summarizeInspect(inspect),
             stats         : summarizeStats(stats),
             logs          : summarizeLogs(logs, bridgeConfig.logMaxBytes),
+            providerResidency,
             diagnosis,
             proofs,
             errors
         };
+    }
+
+    /**
+     * Collects active graph-provider residency for the configured model service.
+     * @param {Object} options
+     * @param {String} options.serviceKey Allowlisted service key.
+     * @param {Number} options.observedAt Epoch ms.
+     * @returns {Promise<Object|null>}
+     */
+    async collectProviderResidency({serviceKey, observedAt}) {
+        if (!AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys.includes(serviceKey)) {
+            return null;
+        }
+
+        const targetIdentity = {kind: 'compose-service', id: serviceKey};
+
+        try {
+            const probe  = this.providerResidencyProbe || probeProviderParallelModelCapacity,
+                  result = await probe({
+                      timeoutMs: AiConfig.orchestrator.providerReadiness.timeoutMs,
+                      serviceKey,
+                      observedAt
+                  });
+
+            if (!result) {
+                return null;
+            }
+
+            return {
+                ...result,
+                targetIdentity
+            };
+        } catch (error) {
+            return {
+                ready      : null,
+                degraded   : true,
+                provider   : 'unknown',
+                probeFailed: true,
+                message    : error.message,
+                targetIdentity
+            };
+        }
     }
 
     /**
@@ -193,12 +246,11 @@ export class DeploymentStateBridgeService extends Base {
     getServiceKeys() {
         const {allowedServices} = AiConfig.orchestrator.deploymentStateBridge;
 
-        if (Array.isArray(allowedServices) && allowedServices.length > 0) {
+        if (allowedServices.length > 0) {
             return allowedServices.filter(isSafeServiceKey);
         }
 
-        const runtimeAllowed = this.runtimeAccessService.configValues.allowedServices;
-        return Array.isArray(runtimeAllowed) ? runtimeAllowed.filter(isSafeServiceKey) : [];
+        return AiConfig.orchestrator.deploymentRuntimeAccess.allowedServices.filter(isSafeServiceKey);
     }
 
     /**
@@ -212,8 +264,12 @@ export class DeploymentStateBridgeService extends Base {
 
         samples.push(stats);
 
-        const max = Math.max(1, Number(AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow) || 1);
-        this.statsSamplesByService.set(serviceKey, samples.slice(-max));
+        const {statsSampleWindow} = AiConfig.orchestrator.deploymentStateBridge;
+        if (!Number.isInteger(statsSampleWindow) || statsSampleWindow < 1) {
+            throw new RangeError('DeploymentStateBridgeService requires a positive integer statsSampleWindow AiConfig leaf');
+        }
+
+        this.statsSamplesByService.set(serviceKey, samples.slice(-statsSampleWindow));
     }
 
     /**

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -18,7 +18,7 @@ const DEFAULT_ACTIONS = Object.freeze(['restart', 'redeploy', 'page']);
  * @summary Normalizes string/object allowlist entries into stable recovery targets.
  *
  * String entries use the same value for `serviceKey` and `id`. Object entries may use an
- * explicit `serviceKey` plus either `id`, `composeService`, or `deployTarget`. The actuator
+ * explicit `serviceKey` plus either `id`, `taskName`, `composeService`, or `deployTarget`. The actuator
  * never accepts a runtime target that cannot be traced back to one of these normalized entries.
  *
  * @param {Array<String|Object>} entries Configured allowlist entries.
@@ -45,7 +45,7 @@ export function normalizeRecoveryActuatorAllowlist(entries, kind) {
             continue;
         }
 
-        const id         = String(entry.id || entry.composeService || entry.deployTarget || '').trim(),
+        const id         = String(entry.id || entry.taskName || entry.composeService || entry.deployTarget || '').trim(),
               serviceKey = String(entry.serviceKey || id).trim();
 
         if (!serviceKey || !id) {
@@ -105,6 +105,12 @@ export class RecoveryActuatorService extends Base {
          */
         deploymentRuntimeAccessService_: null,
         /**
+         * @member {Object|null} processSupervisorService_=null
+         * @protected
+         * @reactive
+         */
+        processSupervisorService_: null,
+        /**
          * @member {Function|null} pageDispatcher_=null
          * @protected
          * @reactive
@@ -136,6 +142,11 @@ export class RecoveryActuatorService extends Base {
     /** @summary Resolves the allowlisted compose-service actuator targets. */
     get allowedComposeServices() {
         return normalizeRecoveryActuatorAllowlist(this.cfg.allowedComposeServices, 'compose-service');
+    }
+
+    /** @summary Resolves the allowlisted supervised-task actuator targets. */
+    get allowedSupervisedTasks() {
+        return normalizeRecoveryActuatorAllowlist(this.cfg.allowedSupervisedTasks, 'supervised-task');
     }
 
     /** @summary Resolves the allowlisted deploy-target page/escalation targets. */
@@ -212,9 +223,7 @@ export class RecoveryActuatorService extends Base {
         const startedAt = now;
 
         try {
-            const result = target.kind === 'compose-service'
-                ? await this.restartComposeService({target, reason})
-                : await this.pageDeployTarget({target, action, reason});
+            const result = await this.executeTargetAction({target, action, reason});
 
             const updatedAt     = Date.now(),
                   diagnosis     = this.resolveDiagnosisEvent({diagnosisEvent, action, target, now: startedAt}),
@@ -244,6 +253,7 @@ export class RecoveryActuatorService extends Base {
                     action,
                     targetIdentity: createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
                     runtimeAccess : result.runtimeAccess || null,
+                    supervisor    : result.supervisor || null,
                     page          : result.page || null
                 },
                 recoveryRunId,
@@ -302,6 +312,7 @@ export class RecoveryActuatorService extends Base {
     resolveTarget({serviceKey, targetIdentity}) {
         const candidates = [
             ...this.allowedComposeServices,
+            ...this.allowedSupervisedTasks,
             ...this.allowedDeployTargets
         ].filter(target => target.serviceKey === serviceKey || target.id === serviceKey);
 
@@ -324,11 +335,57 @@ export class RecoveryActuatorService extends Base {
             return action === 'restart';
         }
 
+        if (target.kind === 'supervised-task') {
+            return action === 'restart';
+        }
+
         if (target.kind === 'deploy-target') {
             return action === 'redeploy' || action === 'page';
         }
 
         return false;
+    }
+
+    /**
+     * @summary Executes the typed target action through the matching privilege envelope.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async executeTargetAction({target, action, reason}) {
+        if (target.kind === 'compose-service') {
+            return this.restartComposeService({target, reason});
+        }
+
+        if (target.kind === 'supervised-task') {
+            return this.restartSupervisedTask({target, reason});
+        }
+
+        return this.pageDeployTarget({target, action, reason});
+    }
+
+    /**
+     * @summary Recycles one allowlisted supervised task through the B0 process supervisor.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async restartSupervisedTask({target, reason}) {
+        if (!this.processSupervisorService?.killTask) {
+            throw new Error('Process supervisor service is unavailable');
+        }
+
+        this.processSupervisorService.killTask(
+            target.id,
+            reason || `recovery-actuator:${target.serviceKey}`
+        );
+
+        return {
+            supervisor: {
+                capabilityEnvelope: 'supervised-task-recycle',
+                operation         : 'restart',
+                taskName          : target.id,
+                targetIdentity    : createRecoveryTargetIdentity({kind: target.kind, id: target.id})
+            }
+        };
     }
 
     /**
@@ -520,8 +577,8 @@ export class RecoveryActuatorService extends Base {
               entry = createRecoveryRunStateEntry({
                   recoveryRunId: runId,
                   diagnosisEvent,
-                  rung         : target?.kind === 'deploy-target' ? 'rung-3' : 'rung-2',
-                  attempt      : Math.max(1, Number(attempt || 1)),
+                  rung         : this.getRungForTarget(target),
+                  attempt      : this.requirePositiveNumber('attempt', attempt),
                   status       : ledgerStatus,
                   startedAt,
                   updatedAt,
@@ -638,22 +695,35 @@ export class RecoveryActuatorService extends Base {
 
     /** @summary Resolves the rolling attempt-window size. */
     getAttemptWindowMs() {
-        return Math.max(1, Number(this.cfg.maxAttemptsWindowMs));
+        return this.requirePositiveNumber('maxAttemptsWindowMs', this.cfg.maxAttemptsWindowMs);
     }
 
     /** @summary Resolves the maximum admitted attempts within one rolling window. */
     getMaxAttemptsPerWindow() {
-        return Math.max(1, Number(this.cfg.maxAttemptsPerWindow));
+        return this.requirePositiveNumber('maxAttemptsPerWindow', this.cfg.maxAttemptsPerWindow);
     }
 
     /** @summary Resolves the cooldown before the controller should re-observe after action. */
     getVerifyCooldownMs() {
-        return Math.max(0, Number(this.cfg.verifyCooldownMs));
+        return this.requireNonNegativeNumber('verifyCooldownMs', this.cfg.verifyCooldownMs);
     }
 
     /** @summary Resolves the required healthy-observation count for verify-loop completion. */
     getHealthyObservationThreshold() {
-        return Math.max(1, Number(this.cfg.healthyObservationThreshold));
+        return this.requirePositiveNumber('healthyObservationThreshold', this.cfg.healthyObservationThreshold);
+    }
+
+    /**
+     * @summary Resolves the recovery-run rung id for the typed actuator target.
+     * @param {Object} target Typed target descriptor.
+     * @returns {String}
+     */
+    getRungForTarget(target) {
+        if (target?.kind === 'supervised-task') return 'rung-1';
+        if (target?.kind === 'compose-service') return 'rung-2';
+        if (target?.kind === 'deploy-target') return 'rung-3';
+
+        return 'rung-0';
     }
 
     /**
@@ -662,14 +732,46 @@ export class RecoveryActuatorService extends Base {
      * @returns {Number|null}
      */
     computeBackoffUntil({attempt, now}) {
-        const base = Math.max(0, Number(this.cfg.baseBackoffMs)),
-              max  = Math.max(base, Number(this.cfg.maxBackoffMs));
+        const base = this.requireNonNegativeNumber('baseBackoffMs', this.cfg.baseBackoffMs),
+              max  = this.requireNonNegativeNumber('maxBackoffMs', this.cfg.maxBackoffMs);
+
+        if (max < base) {
+            throw new RangeError('RecoveryActuatorService requires maxBackoffMs to be greater than or equal to baseBackoffMs');
+        }
 
         if (base === 0) {
             return null;
         }
 
         return now + Math.min(max, base * Math.pow(2, Math.max(0, attempt - 1)));
+    }
+
+    /**
+     * @summary Reads a required non-negative numeric recovery-actuator config leaf.
+     * @param {String} name Config leaf name.
+     * @param {Number} value Config leaf value.
+     * @returns {Number}
+     */
+    requireNonNegativeNumber(name, value) {
+        if (!Number.isFinite(value) || value < 0) {
+            throw new TypeError(`RecoveryActuatorService requires numeric AiConfig leaf ${name} >= 0`);
+        }
+
+        return value;
+    }
+
+    /**
+     * @summary Reads a required positive numeric recovery-actuator config leaf.
+     * @param {String} name Config leaf name.
+     * @param {Number} value Config leaf value.
+     * @returns {Number}
+     */
+    requirePositiveNumber(name, value) {
+        if (!Number.isFinite(value) || value <= 0) {
+            throw new TypeError(`RecoveryActuatorService requires numeric AiConfig leaf ${name} > 0`);
+        }
+
+        return value;
     }
 
     /**

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -578,7 +578,7 @@ export class RecoveryActuatorService extends Base {
                   recoveryRunId: runId,
                   diagnosisEvent,
                   rung         : this.getRungForTarget(target),
-                  attempt      : this.requirePositiveNumber('attempt', attempt),
+                  attempt,
                   status       : ledgerStatus,
                   startedAt,
                   updatedAt,
@@ -695,22 +695,22 @@ export class RecoveryActuatorService extends Base {
 
     /** @summary Resolves the rolling attempt-window size. */
     getAttemptWindowMs() {
-        return this.requirePositiveNumber('maxAttemptsWindowMs', this.cfg.maxAttemptsWindowMs);
+        return this.cfg.maxAttemptsWindowMs;
     }
 
     /** @summary Resolves the maximum admitted attempts within one rolling window. */
     getMaxAttemptsPerWindow() {
-        return this.requirePositiveNumber('maxAttemptsPerWindow', this.cfg.maxAttemptsPerWindow);
+        return this.cfg.maxAttemptsPerWindow;
     }
 
     /** @summary Resolves the cooldown before the controller should re-observe after action. */
     getVerifyCooldownMs() {
-        return this.requireNonNegativeNumber('verifyCooldownMs', this.cfg.verifyCooldownMs);
+        return this.cfg.verifyCooldownMs;
     }
 
     /** @summary Resolves the required healthy-observation count for verify-loop completion. */
     getHealthyObservationThreshold() {
-        return this.requirePositiveNumber('healthyObservationThreshold', this.cfg.healthyObservationThreshold);
+        return this.cfg.healthyObservationThreshold;
     }
 
     /**
@@ -732,46 +732,13 @@ export class RecoveryActuatorService extends Base {
      * @returns {Number|null}
      */
     computeBackoffUntil({attempt, now}) {
-        const base = this.requireNonNegativeNumber('baseBackoffMs', this.cfg.baseBackoffMs),
-              max  = this.requireNonNegativeNumber('maxBackoffMs', this.cfg.maxBackoffMs);
+        const {baseBackoffMs, maxBackoffMs} = this.cfg;
 
-        if (max < base) {
-            throw new RangeError('RecoveryActuatorService requires maxBackoffMs to be greater than or equal to baseBackoffMs');
-        }
-
-        if (base === 0) {
+        if (baseBackoffMs === 0) {
             return null;
         }
 
-        return now + Math.min(max, base * Math.pow(2, Math.max(0, attempt - 1)));
-    }
-
-    /**
-     * @summary Reads a required non-negative numeric recovery-actuator config leaf.
-     * @param {String} name Config leaf name.
-     * @param {Number} value Config leaf value.
-     * @returns {Number}
-     */
-    requireNonNegativeNumber(name, value) {
-        if (!Number.isFinite(value) || value < 0) {
-            throw new TypeError(`RecoveryActuatorService requires numeric AiConfig leaf ${name} >= 0`);
-        }
-
-        return value;
-    }
-
-    /**
-     * @summary Reads a required positive numeric recovery-actuator config leaf.
-     * @param {String} name Config leaf name.
-     * @param {Number} value Config leaf value.
-     * @returns {Number}
-     */
-    requirePositiveNumber(name, value) {
-        if (!Number.isFinite(value) || value <= 0) {
-            throw new TypeError(`RecoveryActuatorService requires numeric AiConfig leaf ${name} > 0`);
-        }
-
-        return value;
+        return now + Math.min(maxBackoffMs, baseBackoffMs * Math.pow(2, Math.max(0, attempt - 1)));
     }
 
     /**

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -1332,14 +1332,14 @@ export function createParallelModelCapacityWarning({
  * or fail based on the returned envelope.
  *
  * @param {Object} options
- * @param {Object} options.config Provider-source config (aiConfig-shaped).
+ * @param {Object} [options.config=aiConfig] Provider-source config (aiConfig-shaped).
  * @param {Number} options.timeoutMs HTTP probe timeout. Required; no module-level default.
  * @param {Function} [options.fetchOpenAiCompatibleModels] Injectable OpenAI-compatible model-list probe.
  * @param {Function} [options.fetchOllamaModels] Injectable Ollama running-model probe.
  * @returns {Promise<Object>}
  */
 export async function probeProviderParallelModelCapacity({
-    config,
+    config = aiConfig,
     timeoutMs,
     fetchOpenAiCompatibleModels = opts => fetchOpenAiCompatibleModelIds(opts),
     fetchOllamaModels           = opts => fetchOllamaRunningModelIds(opts)
@@ -1420,13 +1420,13 @@ export async function probeProviderParallelModelCapacity({
  * owned by `waitForProvider()`.
  *
  * @param {Object} options
- * @param {Object} options.config Provider-source config (aiConfig-shaped).
+ * @param {Object} [options.config=aiConfig] Provider-source config (aiConfig-shaped).
  * @param {Number} options.timeoutMs HTTP probe timeout. Required; no module-level default.
  * @param {Object} [options.log=logger] Logger seam.
  * @returns {Promise<Object>}
  */
 export async function warnProviderParallelModelCapacity({
-    config,
+    config = aiConfig,
     timeoutMs,
     log = logger,
     ...probeOptions

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -162,6 +162,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
         },
         recoveryActuator: {
             enabled                    : false,
+            allowedSupervisedTasks     : [],
             allowedComposeServices     : [],
             allowedDeployTargets       : [],
             healAttemptsPath           : path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/heal-attempts.json'),
@@ -176,16 +177,17 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
             operatorPageTarget         : 'AGENT:*'
         },
         deploymentStateBridge: {
-            enabled          : false,
-            snapshotPath     : path.resolve(neoRootDir, '.neo-ai-data/deployment-state/snapshot.json'),
-            writeIntervalMs  : 30000,
-            staleAfterMs     : 2 * 60 * 1000,
-            maxSnapshotBytes : 256 * 1024,
-            allowedServices  : [],
-            includeLogs      : true,
-            logTail          : 120,
-            logMaxBytes      : 32 * 1024,
-            statsSampleWindow: 2
+            enabled                     : false,
+            snapshotPath                : path.resolve(neoRootDir, '.neo-ai-data/deployment-state/snapshot.json'),
+            writeIntervalMs             : 30000,
+            staleAfterMs                : 2 * 60 * 1000,
+            maxSnapshotBytes            : 256 * 1024,
+            allowedServices             : [],
+            includeLogs                 : true,
+            logTail                     : 120,
+            logMaxBytes                 : 32 * 1024,
+            statsSampleWindow           : 2,
+            providerResidencyServiceKeys: ['local-model', 'model']
         }
     }
 }, true, true));

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -219,6 +219,135 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         ]);
     });
 
+    test('escalates native Ollama missing required models as provider config drift', () => {
+        const service = createService();
+
+        const decision = service.diagnose({
+            serviceKey       : 'model',
+            providerResidency: {
+                provider              : 'ollama',
+                host                  : 'http://model:11434',
+                ready                 : false,
+                requiredModels        : ['gemma4:26b', 'qwen3-embedding:latest'],
+                availableModels       : ['qwen3-embedding:latest'],
+                missingModels         : ['gemma4:26b'],
+                observedRequiredCount : 1,
+                requiredResidentModels: 2,
+                targetIdentity        : {kind: 'compose-service', id: 'model'}
+            }
+        });
+
+        expect(decision.status).toBe('diagnosed');
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.escalate);
+        expect(decision.targetIdentity).toEqual({kind: 'compose-service', id: 'model'});
+        expect(decision.diagnosis).toMatchObject({
+            recoveryClass : 'config-drift',
+            targetIdentity: {kind: 'compose-service', id: 'model'},
+            details       : {
+                classificationReason: 'config-drift-escalate'
+            }
+        });
+        expect(decision.diagnosis.evidenceFacts).toHaveLength(1);
+        expect(decision.diagnosis.evidenceFacts[0]).toMatchObject({
+            type         : CONTAINER_HEALTH_FACT_TYPES.providerResidency,
+            authoritative: true,
+            details      : {
+                provider     : 'ollama',
+                reasonCode   : 'missing-required-model',
+                missingModels: ['gemma4:26b']
+            }
+        });
+    });
+
+    test('routes resident-but-not-serving provider faults to the supervised-task target', () => {
+        const service = createService();
+
+        const decision = service.diagnose({
+            serviceKey       : 'model',
+            providerResidency: {
+                provider             : 'ollama',
+                ready                : false,
+                residentButNotServing: true,
+                requiredModels       : ['gemma4:26b'],
+                availableModels      : ['gemma4:26b'],
+                targetIdentity       : {kind: 'supervised-task', id: 'ollama'}
+            }
+        });
+
+        expect(decision.status).toBe('diagnosed');
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.restart);
+        expect(decision.targetIdentity).toEqual({kind: 'supervised-task', id: 'ollama'});
+        expect(decision.diagnosis).toMatchObject({
+            recoveryClass : 'crash',
+            targetIdentity: {kind: 'supervised-task', id: 'ollama'},
+            details       : {
+                classificationReason: 'provider-resident-not-serving'
+            }
+        });
+        expect(decision.diagnosis.evidenceFacts[0]).toMatchObject({
+            type   : CONTAINER_HEALTH_FACT_TYPES.providerResidency,
+            details: {
+                reasonCode           : 'resident-not-serving',
+                residentButNotServing: true
+            }
+        });
+    });
+
+    test('keeps extra active-provider residents advisory without ownership proof', () => {
+        const service = createService();
+
+        const decision = service.diagnose({
+            serviceKey       : 'model',
+            providerResidency: {
+                provider       : 'ollama',
+                ready          : true,
+                requiredModels : ['gemma4:26b'],
+                availableModels: ['gemma4:26b', 'old-model:latest'],
+                extraModels    : ['old-model:latest'],
+                targetIdentity : {kind: 'compose-service', id: 'model'}
+            }
+        });
+
+        expect(decision.status).toBe('advisory');
+        expect(decision.diagnosis).toBeNull();
+        expect(decision.facts).toHaveLength(1);
+        expect(decision.facts[0]).toMatchObject({
+            type         : CONTAINER_HEALTH_FACT_TYPES.providerResidency,
+            authoritative: false,
+            severity     : 'warning',
+            details      : {
+                reasonCode : 'extra-residents',
+                extraModels: ['old-model:latest']
+            }
+        });
+    });
+
+    test('does not let provider probe transport failures override container restart evidence', () => {
+        const service = createService();
+
+        const decision = service.diagnose({
+            serviceKey       : 'model',
+            inspect          : runningInspect({Status: 'exited', ExitCode: 137}),
+            providerResidency: {
+                provider      : 'unknown',
+                degraded      : true,
+                probeFailed   : true,
+                message       : 'provider probe timed out',
+                targetIdentity: {kind: 'compose-service', id: 'model'}
+            }
+        });
+
+        expect(decision.status).toBe('diagnosed');
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.restart);
+        expect(decision.diagnosis).toMatchObject({
+            recoveryClass: 'crash',
+            details      : {
+                classificationReason: 'lifecycle-crash'
+            }
+        });
+        expect(decision.diagnosis.evidenceFacts.map(fact => fact.type)).toContain(CONTAINER_HEALTH_FACT_TYPES.containerDown);
+    });
+
     test('escalates config drift without selecting a lifecycle action', () => {
         const service = createService();
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1,9 +1,12 @@
 import {test, expect}                 from '@playwright/test';
 import Neo                            from '../../../../../../../src/Neo.mjs';
 import * as core                      from '../../../../../../../src/core/_export.mjs';
+import AiConfig                       from '../../../../../../../ai/config.mjs';
 import {DeploymentStateBridgeService} from '../../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs';
 
 const OBSERVED_AT = 1710000000000;
+let originalDeploymentStateBridgeConfig,
+    originalRuntimeAccessConfig;
 
 function statsSample({cpuPercent = 0, memoryPercent = 0} = {}) {
     const systemDelta = 1_000_000_000,
@@ -30,19 +33,41 @@ function statsSample({cpuPercent = 0, memoryPercent = 0} = {}) {
     };
 }
 
-function createService({runtimeAccessService, diagnosisService} = {}) {
+function createService({runtimeAccessService, diagnosisService, providerResidencyProbe = async () => null} = {}) {
     return Neo.create(DeploymentStateBridgeService, {
         runtimeAccessService,
         diagnosisService,
+        providerResidencyProbe,
         nowFn: () => OBSERVED_AT
     });
 }
 
 test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
+    test.beforeEach(() => {
+        originalDeploymentStateBridgeConfig = Neo.clone(AiConfig.orchestrator.deploymentStateBridge, true, true);
+        originalRuntimeAccessConfig         = Neo.clone(AiConfig.orchestrator.deploymentRuntimeAccess, true, true);
+
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
+            allowedServices             : [],
+            includeLogs                 : true,
+            logTail                     : 120,
+            logMaxBytes                 : 32 * 1024,
+            statsSampleWindow           : 2,
+            providerResidencyServiceKeys: ['local-model', 'model']
+        });
+        Object.assign(AiConfig.orchestrator.deploymentRuntimeAccess, {
+            allowedServices: ['model']
+        });
+    });
+
+    test.afterEach(() => {
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, originalDeploymentStateBridgeConfig);
+        Object.assign(AiConfig.orchestrator.deploymentRuntimeAccess, originalRuntimeAccessConfig);
+    });
+
     test('collects bounded read-observe state and diagnosis for allowlisted services', async () => {
         const calls                = [];
         const runtimeAccessService = {
-            configValues: {allowedServices: ['model']},
             async readObserve(request) {
                 calls.push(request);
 
@@ -103,8 +128,9 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
     });
 
     test('falls back to runtime allowed services and records read errors as degraded state', async () => {
+        AiConfig.orchestrator.deploymentRuntimeAccess.allowedServices = ['memory'];
+
         const runtimeAccessService = {
-            configValues: {allowedServices: ['memory']},
             async readObserve() {
                 throw new Error('runtime unavailable');
             }
@@ -122,6 +148,67 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                 {operation: 'stats', message: 'runtime unavailable'},
                 {operation: 'logs', message: 'runtime unavailable'}
             ]
+        });
+    });
+
+    test('passes active-provider residency into the diagnosis snapshot for model services', async () => {
+        const runtimeAccessService = {
+            async readObserve(request) {
+                if (request.operation === 'inspect') {
+                    return {
+                        data : {Name: '/model', State: {Status: 'running', Health: {Status: 'healthy'}}, Config: {Image: 'ollama'}},
+                        proof: {operation: 'inspect'}
+                    };
+                }
+
+                if (request.operation === 'stats') {
+                    return {
+                        data : statsSample({cpuPercent: 10, memoryPercent: 20}),
+                        proof: {operation: 'stats'}
+                    };
+                }
+
+                return {
+                    data : {logs: '', tail: request.tail},
+                    proof: {operation: 'logs'}
+                };
+            }
+        };
+        const providerResidencyProbe = async ({serviceKey, observedAt}) => ({
+            ready          : false,
+            provider       : 'ollama',
+            host           : 'http://model:11434',
+            requiredModels : ['gemma4:26b'],
+            availableModels: [],
+            missingModels  : ['gemma4:26b'],
+            serviceKey,
+            observedAt
+        });
+        const diagnosisService = {
+            diagnose({providerResidency}) {
+                return {
+                    provider     : providerResidency.provider,
+                    missingModels: providerResidency.missingModels,
+                    target       : providerResidency.targetIdentity
+                };
+            }
+        };
+
+        const service  = createService({runtimeAccessService, diagnosisService, providerResidencyProbe});
+        const snapshot = await service.collectSnapshot();
+
+        expect(snapshot.services[0]).toMatchObject({
+            serviceKey       : 'model',
+            providerResidency: {
+                provider      : 'ollama',
+                missingModels : ['gemma4:26b'],
+                targetIdentity: {kind: 'compose-service', id: 'model'}
+            },
+            diagnosis: {
+                provider     : 'ollama',
+                missingModels: ['gemma4:26b'],
+                target       : {kind: 'compose-service', id: 'model'}
+            }
         });
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -25,12 +25,14 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
     });
 
     function createService(overrides = {}) {
-        const runtimeCalls   = [],
-              pageCalls      = [],
-              taskOutcomes   = [],
-              actuatorConfig = {
+        const runtimeCalls    = [],
+              supervisorCalls = [],
+              pageCalls       = [],
+              taskOutcomes    = [],
+              actuatorConfig  = {
                   ...DEFAULT_ACTUATOR_CONFIG,
                   enabled               : true,
+                  allowedSupervisedTasks: [{serviceKey: 'model', taskName: 'ollama'}],
                   allowedComposeServices: ['memory-core'],
                   allowedDeployTargets  : ['cloud-deploy'],
                   healAttemptsPath      : path.join(tmpDir, 'heal-attempts.json'),
@@ -67,6 +69,12 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                       },
                       ...overrides.deploymentRuntimeAccessService
                   },
+                  processSupervisorService: {
+                      killTask(taskName, reason) {
+                          supervisorCalls.push({taskName, reason});
+                      },
+                      ...overrides.processSupervisorService
+                  },
                   pageDispatcher(page) {
                       pageCalls.push(page);
                   },
@@ -74,7 +82,7 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                   ...overrides.serviceConfig
               });
 
-        return {service, runtimeCalls, pageCalls, taskOutcomes, actuatorConfig};
+        return {service, runtimeCalls, supervisorCalls, pageCalls, taskOutcomes, actuatorConfig};
     }
 
     async function readAttempts() {
@@ -84,13 +92,50 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
     test('normalizes string and object allowlist entries', () => {
         expect(normalizeRecoveryActuatorAllowlist([
             'memory-core',
+            {serviceKey: 'model', taskName: 'ollama'},
             {serviceKey: 'kb', composeService: 'knowledge-base'},
             {id: 'local-model'}
         ], 'compose-service')).toEqual([
             {kind: 'compose-service', serviceKey: 'memory-core', id: 'memory-core'},
+            {kind: 'compose-service', serviceKey: 'model', id: 'ollama', taskName: 'ollama'},
             {kind: 'compose-service', serviceKey: 'kb', id: 'knowledge-base', composeService: 'knowledge-base'},
             {kind: 'compose-service', serviceKey: 'local-model', id: 'local-model'}
         ]);
+    });
+
+    test('restart recycles an allowlisted supervised task through the B0 supervisor envelope', async () => {
+        const {service, runtimeCalls, supervisorCalls, taskOutcomes} = createService();
+
+        const result = await service.apply('model', 'restart', {
+            now           : 15_000,
+            reason        : 'provider-resident-not-serving',
+            targetIdentity: {kind: 'supervised-task', id: 'ollama'}
+        });
+
+        expect(result.status).toBe('actioned');
+        expect(result.targetIdentity).toEqual({kind: 'supervised-task', id: 'ollama'});
+        expect(result.reobserveRequest).toMatchObject({
+            recoveryClass : 'crash',
+            targetIdentity: {kind: 'supervised-task', id: 'ollama'}
+        });
+        expect(result.supervisor).toMatchObject({
+            capabilityEnvelope: 'supervised-task-recycle',
+            operation         : 'restart',
+            taskName          : 'ollama'
+        });
+        expect(supervisorCalls).toEqual([{
+            taskName: 'ollama',
+            reason  : 'provider-resident-not-serving'
+        }]);
+        expect(runtimeCalls).toEqual([]);
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            taskName: 'recovery-actuator:model',
+            status  : 'completed',
+            details : expect.objectContaining({
+                status      : 'actioned',
+                ledgerStatus: 'reobserve-requested'
+            })
+        }));
     });
 
     test('restart applies only to an allowlisted compose service and writes health plus recovery ledger traces', async () => {


### PR DESCRIPTION
Resolves #13942

Related: #13874
Related: #13914
Related: #13936

Adds the active-provider residency diagnosis and recovery routing seam for the deployment immune system. The bridge now snapshots provider-residency observations for configured model services, diagnostics classify missing/wrong-context/resident-but-not-serving/provider-probe facts without relying on graph-only evidence, and the recovery actuator can route typed targets through B0 supervised-task recycle, B1 compose-service restart, or deploy-target escalation.

Evidence: L2 (unit coverage for provider observations, typed diagnosis, B0/B1/escalate actuator routing, anti-thrash, and helper behavior) -> L2 required (daemon decision/action seam). No residuals for #13942; L3 deployment smoke remains in #13914/#13936.

## Deltas from ticket

- Added `NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_RESIDENCY_SERVICE_KEYS` so deployments can choose which service snapshots collect provider-residency facts.
- Added `NEO_RECOVERY_ACTUATOR_SUPERVISED_TASKS` for B0 supervised-task recovery allowlisting.
- Kept stale extra residents advisory unless ownership is proven; config drift and unsupported/ambiguous facts escalate instead of looping recovery.
- Removed new ADR-0019 failure shapes in this path: no `config: AiConfig` pass-through from the bridge, no runtime `configValues` fallback, and no hidden numeric coercion for touched actuator/bridge config leaves.

## Test Evidence

- `npm run agent-preflight -- ai/config.template.mjs ai/daemons/orchestrator/Orchestrator.mjs ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs ai/daemons/orchestrator/services/RecoveryActuatorService.mjs ai/services/graph/providerReadinessHelper.mjs test/playwright/fixtures/aiConfigDefaults.mjs test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs` -> passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs` -> 72 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs` -> 23 passed.
- `git diff --check HEAD` -> passed.
- Commit hook passed: whitespace, shorthand, AiConfig test-mutation, JSDoc types, ticket archaeology, and staged block alignment.

## Post-Merge Validation

- [ ] Run the #13914/#13936 deployment smoke path and confirm provider-residency diagnosis/recovery-run evidence is visible through approved KB/MC proof surfaces.
- [ ] Configure actuator allowlists only for owned supervised tasks, compose services, or deploy targets before enabling recovery actions.

## Commits

- `fbbb879b57` — `fix(ai): diagnose active provider residency (#13942)`
- `636bc6593d` — `fix(ai): simplify recovery config leaf reads (#13942)`

Authored by Euclid (GPT-5, Codex Desktop). Session 2404e510-ad73-429d-bec8-5583ec83ba70.
