### PR TITLE
fix(ai): prevent embedding context truncation (#13944)

### DIFF
--- a/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
+++ b/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
@@ -121,7 +121,7 @@ function applyConfiguredLmsTask(tasks) {
             try {
                 await fetchOpenAiCompatibleModelIds({
                     host     : AiConfig.openAiCompatible.host,
-                    timeoutMs: AiConfig.orchestrator.providerReadiness.timeoutMs ?? 2000
+                    timeoutMs: AiConfig.orchestrator.providerReadiness.timeoutMs
                 });
                 return true;
             } catch {
@@ -230,10 +230,10 @@ function applyConfiguredOllamaTask(tasks) {
             // probes still pass). Only a real inference canary, failing SUSTAINED (N consecutive
             // cooldown-gated probes), distinguishes stuck from busy and recycles the child; a single
             // failure stays healthy so a legitimately-long request is never killed.
-            const stuckCfg  = AiConfig.orchestrator?.providerReadiness?.stuckRunner;
+            const stuckCfg  = AiConfig.orchestrator.providerReadiness.stuckRunner;
             const chatModel = roles.find(role => role.role === 'chat')?.model;
 
-            if (!(stuckCfg?.enabled ?? false) || !chatModel) {
+            if (!stuckCfg.enabled || !chatModel) {
                 return true;
             }
 
@@ -242,12 +242,12 @@ function applyConfiguredOllamaTask(tasks) {
             const served = await probeOllamaServing({
                 host     : readinessConfig.host,
                 model    : chatModel,
-                timeoutMs: stuckCfg.canaryTimeoutMs ?? 10000
+                timeoutMs: stuckCfg.canaryTimeoutMs
             });
             const verdict = classifyStuckRunner({
                 served,
                 consecutiveFailures: consecutiveStuckFailures,
-                threshold          : stuckCfg.consecutiveFailures ?? 3
+                threshold          : stuckCfg.consecutiveFailures
             });
 
             consecutiveStuckFailures = verdict.consecutiveFailures;

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -323,6 +323,64 @@ export class ProcessSupervisorService extends Base {
     }
 
     /**
+     * Runs the task readiness hook after an out-of-band service passes liveness.
+     *
+     * Fire-and-exit launchers such as `lms server start` can leave the HTTP endpoint healthy
+     * while their model-residency contract is stale. Reusing the task-owned readiness hook here
+     * lets the LM Studio task enforce configured model context even when no child spawn happens.
+     *
+     * @param {String} taskName Task key.
+     * @param {Object} task Task definition.
+     * @param {String} reason Scheduling reason.
+     * @param {Function} [onFailure] Callback for readiness-hook failures.
+     * @returns {Promise|null}
+     */
+    runLivenessReadinessHook(taskName, task, reason, onFailure) {
+        if (typeof task.postSpawn !== 'function') {
+            return null;
+        }
+
+        return Promise.resolve()
+            .then(() => task.postSpawn({
+                taskName,
+                task,
+                reason,
+                pid     : null,
+                writeLog: this.writeLog
+            }))
+            .then(result => {
+                if (result?.ready === false || result?.degraded === true) {
+                    this.writeLog?.('WARN', `[ProcessSupervisor] ${task.label} readiness hook completed with degraded readiness after liveness confirmation.`);
+                    this.recordTaskOutcome(taskName, 'degraded', {
+                        reason,
+                        pid      : null,
+                        readyAt  : new Date().toISOString(),
+                        readiness: result || null
+                    });
+                    return;
+                }
+
+                this.taskStateService.markReady?.(taskName);
+                this.writeLog?.('INFO', `[ProcessSupervisor] ${task.label} readiness hook completed successfully after liveness confirmation.`);
+                this.recordTaskOutcome(taskName, 'ready', {
+                    reason,
+                    pid      : null,
+                    readyAt  : new Date().toISOString(),
+                    readiness: result || null
+                });
+            })
+            .catch(error => {
+                this.writeLog?.('ERROR', `[ProcessSupervisor] ${task.label} readiness hook failed after liveness confirmation: ${error.message}`);
+                this.recordTaskOutcome(taskName, 'failed', {
+                    reason,
+                    phase: 'liveness-readiness',
+                    error: error.message
+                });
+                onFailure?.();
+            });
+    }
+
+    /**
      * Starts a child task and wires completion status back into task state and HealthService.
      * @param {String} taskName Task key.
      * @param {String} reason Scheduling reason.
@@ -758,6 +816,7 @@ export class ProcessSupervisorService extends Base {
             .then(up => {
                 if (up) {
                     this._livenessConfirmedAt[taskName] = Date.now();
+                    this.runLivenessReadinessHook(taskName, task, 'liveness-confirmed', () => this.runTask(taskName, 'supervisor-restart'));
                 } else {
                     this.runTask(taskName, 'supervisor-restart');
                 }

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -3,6 +3,10 @@ import aiConfig             from '../../mcp/server/memory-core/config.mjs';
 import Base                 from '../../../src/core/Base.mjs';
 import logger               from '../../mcp/server/memory-core/logger.mjs';
 import OllamaProvider       from '../../provider/Ollama.mjs';
+import {
+    bytesToTokens,
+    emitConsumerFriction
+}                           from './helpers/consumerFrictionHelper.mjs';
 
 const DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS = 60 * 60 * 1000;
 const OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE   = /openAiCompatible embedding error HTTP (408|429|503|504):/;
@@ -98,7 +102,13 @@ class TextEmbeddingService extends Base {
          * @protected
          * @reactive
          */
-        ollamaProvider_: null
+        ollamaProvider_: null,
+        /**
+         * Optional test seam for LM Studio loaded-model context probes.
+         * @member {Function|null} openAiCompatibleLoadedModelsProbe=null
+         * @protected
+         */
+        openAiCompatibleLoadedModelsProbe: null
     }
 
     #openAiCompatiblePostQueue       = [];
@@ -192,6 +202,167 @@ class TextEmbeddingService extends Base {
         }
 
         return bestIndex;
+    }
+
+    /**
+     * @summary Estimates the largest text input in an OpenAI-compatible embedding request.
+     *
+     * LM Studio truncates each input string independently. Batch safety therefore uses the
+     * largest member, not the aggregate byte length of the whole batch envelope.
+     *
+     * @param {String|String[]} inputData The text or array of texts to embed.
+     * @returns {{inputBytes: Number, inputTokensEstimate: Number}}
+     * @private
+     */
+    #getOpenAiCompatibleInputEstimate(inputData) {
+        const texts = Array.isArray(inputData) ? inputData : [inputData];
+
+        let inputBytes = 0;
+
+        for (const text of texts) {
+            inputBytes = Math.max(inputBytes, Buffer.byteLength(typeof text === 'string' ? text : '', 'utf8'));
+        }
+
+        return {
+            inputBytes,
+            inputTokensEstimate: bytesToTokens(inputBytes)
+        };
+    }
+
+    /**
+     * @summary Reads currently resident LM Studio models for embedding-context enforcement.
+     *
+     * Runtime uses the canonical readiness helper. The optional plain test seam avoids spawning
+     * the LM Studio CLI from unit tests while preserving the same normalized model shape.
+     *
+     * @param {Number} timeoutMs LM Studio CLI timeout.
+     * @returns {Promise<Object[]>}
+     * @private
+     */
+    async #getOpenAiCompatibleLoadedModels(timeoutMs) {
+        if (this.openAiCompatibleLoadedModelsProbe) {
+            return this.openAiCompatibleLoadedModelsProbe({timeoutMs});
+        }
+
+        const {fetchLmsLoadedModels} = await import('../graph/providerReadinessHelper.mjs');
+        return fetchLmsLoadedModels({timeoutMs});
+    }
+
+    /**
+     * @summary Determines whether the active OpenAI-compatible endpoint is the orchestrator-owned LM Studio lane.
+     *
+     * OpenAI-compatible covers LM Studio, Ollama's compatibility surface, llama.cpp, vLLM, and
+     * CI fixture servers. The `lms ps` loaded-context probe is valid only for the LM Studio CLI
+     * lane, identified by the configured `orchestrator.lms.port` owning the provider host.
+     *
+     * @returns {Boolean}
+     * @private
+     */
+    #shouldAssertOpenAiCompatibleEmbeddingContext() {
+        if (this.openAiCompatibleLoadedModelsProbe) {
+            return true;
+        }
+        if (Neo.config.unitTestMode) {
+            return false;
+        }
+        if (aiConfig.orchestrator.lms.enabled !== true) {
+            return false;
+        }
+
+        const
+            host    = aiConfig.openAiCompatible.host,
+            lmsPort = aiConfig.orchestrator.lms.port;
+
+        let endpointUrl;
+
+        try {
+            endpointUrl = new URL(host);
+        } catch (error) {
+            throw new TypeError(`TextEmbeddingService: openAiCompatible.host must be a valid URL for embedding context enforcement, got '${host}': ${error.message}`);
+        }
+
+        return endpointUrl.port === lmsPort;
+    }
+
+    /**
+     * @summary Fails before OpenAI-compatible embeddings can be silently provider-truncated.
+     *
+     * LM Studio can answer `/v1/embeddings` while the embedding model is resident at a smaller
+     * loaded context than Neo's `localModels.embedding.contextLimitTokens` leaf. The provider then
+     * logs a truncation warning and still returns an embedding. This guard checks the resident model
+     * shape before the request so KB / Memory Core callers never accept that corrupted vector.
+     *
+     * @param {String|String[]} inputData The text or array of texts to embed.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #assertOpenAiCompatibleEmbeddingContext(inputData) {
+        if (!this.#shouldAssertOpenAiCompatibleEmbeddingContext()) {
+            return;
+        }
+
+        const
+            configuredContextLength = aiConfig.localModels.embedding.contextLimitTokens,
+            timeoutMs               = aiConfig.orchestrator.providerReadiness.timeoutMs,
+            model                   = aiConfig.openAiCompatible.embeddingModel;
+
+        if (!Neo.isNumber(configuredContextLength) || configuredContextLength <= 0) {
+            throw new TypeError(`TextEmbeddingService: localModels.embedding.contextLimitTokens must be a positive number, got ${configuredContextLength}`);
+        }
+        if (!Neo.isNumber(timeoutMs) || timeoutMs <= 0) {
+            throw new TypeError(`TextEmbeddingService: orchestrator.providerReadiness.timeoutMs must be a positive number, got ${timeoutMs}`);
+        }
+        if (!model) {
+            throw new TypeError('TextEmbeddingService: openAiCompatible.embeddingModel is required for embedding context enforcement');
+        }
+
+        let loadedModels;
+
+        try {
+            loadedModels = await this.#getOpenAiCompatibleLoadedModels(timeoutMs);
+        } catch (error) {
+            throw new Error(`TextEmbeddingService: unable to verify LM Studio embedding context for '${model}': ${error.message}`);
+        }
+
+        const
+            loadedModel = loadedModels.find(item => item.id === model),
+            estimate    = this.#getOpenAiCompatibleInputEstimate(inputData);
+
+        if (!loadedModel) {
+            const observedIds = loadedModels.map(item => item.id).filter(Boolean).slice(0, 5).join(', ') || 'none';
+            throw new Error(`TextEmbeddingService: LM Studio embedding model '${model}' is not resident under its configured identifier; observed=${observedIds}`);
+        }
+        if (!Neo.isNumber(loadedModel.contextLength)) {
+            throw new Error(`TextEmbeddingService: LM Studio embedding model '${model}' has unknown loaded context; configured>=${configuredContextLength}`);
+        }
+
+        if (loadedModel.contextLength < configuredContextLength || estimate.inputTokensEstimate > loadedModel.contextLength) {
+            if (estimate.inputTokensEstimate > loadedModel.contextLength) {
+                emitConsumerFriction({
+                    assetRef                 : `openAiCompatible:${model}`,
+                    consumer                 : 'TextEmbeddingService.openAiCompatible',
+                    model,
+                    symptom                  : 'context-overflow',
+                    emissionPoint            : 'pre-invocation',
+                    suggestionKind           : 'split-document',
+                    inputBytes               : estimate.inputBytes,
+                    inputTokensEstimate      : estimate.inputTokensEstimate,
+                    contextLimitTokens       : configuredContextLength,
+                    safeProcessingLimitTokens: loadedModel.contextLength,
+                    serviceDomain            : 'memory-core',
+                    note                     : 'OpenAI-compatible embedding request would exceed the observed loaded LM Studio embedding context.'
+                });
+            }
+
+            logger.warn('[TextEmbeddingService] Refusing OpenAI-compatible embedding before provider-side truncation.', {
+                model,
+                loadedContextLength: loadedModel.contextLength,
+                configuredContextLength,
+                inputTokensEstimate: estimate.inputTokensEstimate
+            });
+
+            throw new Error(`TextEmbeddingService: LM Studio embedding context too small for '${model}' (loaded=${loadedModel.contextLength}, configured>=${configuredContextLength}, inputEstimate=${estimate.inputTokensEstimate})`);
+        }
     }
 
     /**
@@ -318,7 +489,7 @@ class TextEmbeddingService extends Base {
     #getOllamaProvider() {
         if (this.ollamaProvider) return this.ollamaProvider;
 
-        const config = aiConfig.ollama;
+        const config   = aiConfig.ollama;
         const provider = Neo.create(OllamaProvider, {
             host          : config.host,
             modelName     : config.model,
@@ -350,7 +521,7 @@ class TextEmbeddingService extends Base {
               data      = [];
 
         for (let offset = 0; offset < texts.length; offset += chunkSize) {
-            const chunk = texts.slice(offset, offset + chunkSize),
+            const chunk  = texts.slice(offset, offset + chunkSize),
                   result = await this.#enqueueOpenAiCompatiblePost(chunk, {
                       unloadRetriesLeft: unloadRetryCount
                   }, 'batch');
@@ -388,6 +559,7 @@ class TextEmbeddingService extends Base {
                 contentionRetryCount      = 2,
                 contentionTimeoutMs       = 15000
             } = aiConfig.openAiCompatible;
+            await this.#assertOpenAiCompatibleEmbeddingContext(text);
             const result = await this.#enqueueOpenAiCompatiblePost(text, {
                 unloadRetriesLeft    : unloadRetryCount,
                 contentionRetriesLeft: contentionRetryCount,
@@ -431,6 +603,7 @@ class TextEmbeddingService extends Base {
         if (!explicitProvider) throw new Error('TextEmbeddingService.embedTexts requires an explicit provider argument');
 
         if (explicitProvider === 'openAiCompatible') {
+            await this.#assertOpenAiCompatibleEmbeddingContext(texts);
             return this.#embedOpenAiCompatibleBatch(texts);
         } else if (explicitProvider === 'ollama') {
             // Ollama's `/api/embed` accepts array-of-strings natively + returns
@@ -448,7 +621,7 @@ class TextEmbeddingService extends Base {
             }
 
             const requests = texts.map(text => ({model: aiConfig.embeddingModel, content: {parts: [{text}]}}));
-            const result = await this.embeddingModel.batchEmbedContents({ requests });
+            const result   = await this.embeddingModel.batchEmbedContents({ requests });
             return result.embeddings.map(e => e.values);
         } else {
             // Unknown provider names fail loudly (matches `embedText`).

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -667,6 +667,44 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         expect(service._livenessConfirmedAt.probeTask).toBeTruthy();
     });
 
+    test('superviseTask runs readiness hook when fire-and-exit liveness is already UP (#13944)', async () => {
+        const {service, taskOutcomes} = createTestService();
+        const calls          = [];
+        let   readyMarked    = false;
+        let   readinessCalls = 0;
+
+        service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
+        service.taskStateService.getTaskState = () => ({running: false, lastRunAt: 0});
+        service.taskStateService.markReady = taskName => {
+            readyMarked = taskName === 'probeTask';
+        };
+        service.taskDefinitions = {
+            probeTask: {
+                label        : 'Probe Task',
+                livenessProbe: async () => true,
+                postSpawn    : async () => {
+                    readinessCalls++;
+                    return {ready: true, loadedModels: ['embedding-model']};
+                }
+            }
+        };
+
+        service.superviseTask('probeTask', 1_000_000, 15000);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(calls).toEqual([]);
+        expect(readinessCalls).toBe(1);
+        expect(readyMarked).toBe(true);
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status  : 'ready',
+            taskName: 'probeTask',
+            details : expect.objectContaining({
+                readiness: {ready: true, loadedModels: ['embedding-model']}
+            })
+        }));
+    });
+
     test('superviseTask gates a fire-and-exit lane on its liveness probe — DOWN triggers a restart', async () => {
         const {service} = createTestService();
         const calls = [];

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -32,7 +32,7 @@ async function waitForCondition(condition, message, timeoutMs = 250) {
 
 test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openAiCompatible retry, QoS, and lms server start support', () => {
     let SDK, TextEmbeddingService, server;
-    let requestCount = 0;
+    let requestCount   = 0;
     let serverBehavior = 'succeed';
     let lastRequest;
     let allRequests;
@@ -42,6 +42,8 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
     let originalHost, originalRetryCount, originalRetryDelay;
     let originalContentionRetryCount, originalContentionRetryDelay, originalContentionTimeout;
     let originalBatchEmbeddingChunkSize, originalBatchEmbeddingYieldMs;
+    let originalLmsPort;
+    let originalLoadedModelsProbe;
 
     test.beforeAll(async () => {
         SDK = await import('../../../../../../ai/services.mjs');
@@ -188,6 +190,8 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         originalContentionTimeout = aiConfig.openAiCompatible.contentionTimeoutMs;
         originalBatchEmbeddingChunkSize = aiConfig.openAiCompatible.batchEmbeddingChunkSize;
         originalBatchEmbeddingYieldMs = aiConfig.openAiCompatible.batchEmbeddingYieldMs;
+        originalLmsPort = aiConfig.orchestrator.lms.port;
+        originalLoadedModelsProbe = TextEmbeddingService.openAiCompatibleLoadedModelsProbe;
 
         aiConfig.openAiCompatible.host = `http://127.0.0.1:${testPort}`;
         aiConfig.openAiCompatible.unloadRetryCount = 3;
@@ -197,6 +201,10 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         aiConfig.openAiCompatible.contentionTimeoutMs = 25;
         aiConfig.openAiCompatible.batchEmbeddingChunkSize = 5;
         aiConfig.openAiCompatible.batchEmbeddingYieldMs = 0;
+        TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{
+            id           : aiConfig.openAiCompatible.embeddingModel,
+            contextLength: aiConfig.localModels.embedding.contextLimitTokens
+        }];
     });
 
     test.afterEach(() => {
@@ -208,6 +216,8 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         aiConfig.openAiCompatible.contentionTimeoutMs = originalContentionTimeout;
         aiConfig.openAiCompatible.batchEmbeddingChunkSize = originalBatchEmbeddingChunkSize;
         aiConfig.openAiCompatible.batchEmbeddingYieldMs = originalBatchEmbeddingYieldMs;
+        aiConfig.orchestrator.lms.port = originalLmsPort;
+        TextEmbeddingService.openAiCompatibleLoadedModelsProbe = originalLoadedModelsProbe;
     });
 
     test('first-call-succeeds-no-retry path', async () => {
@@ -252,6 +262,60 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
                 input: ['first', 'second']
             }
         });
+    });
+
+    test('openAiCompatible refuses single embeddings when LM Studio loaded context is below the configured embedding context (#13944)', async () => {
+        serverBehavior = 'succeed';
+        TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{
+            id           : aiConfig.openAiCompatible.embeddingModel,
+            contextLength: 8192
+        }];
+
+        const providerTruncatedInput = 'x'.repeat(12746 * 3);
+
+        await expect(TextEmbeddingService.embedText(providerTruncatedInput, 'openAiCompatible'))
+            .rejects.toThrow(/loaded=8192, configured>=32768, inputEstimate=12746/);
+
+        expect(requestCount).toBe(0);
+    });
+
+    test('openAiCompatible refuses batch embeddings before any provider-truncated request is posted (#13944)', async () => {
+        serverBehavior = 'chunked-batch-succeed';
+        let probeCount = 0;
+        TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => {
+            probeCount++;
+            return [{
+                id           : aiConfig.openAiCompatible.embeddingModel,
+                contextLength: 8192
+            }];
+        };
+
+        const providerTruncatedInput = 'x'.repeat(12746 * 3);
+
+        await expect(TextEmbeddingService.embedTexts(['short', providerTruncatedInput], 'openAiCompatible'))
+            .rejects.toThrow(/LM Studio embedding context too small/);
+
+        expect(probeCount).toBe(1);
+        expect(requestCount).toBe(0);
+    });
+
+    test('openAiCompatible skips LM Studio context probe for non-LMS endpoints (#13944)', async () => {
+        serverBehavior = 'succeed';
+
+        const originalUnitTestMode = Neo.config.unitTestMode;
+
+        try {
+            Neo.config.unitTestMode = false;
+            aiConfig.orchestrator.lms.port = '1234';
+            TextEmbeddingService.openAiCompatibleLoadedModelsProbe = null;
+
+            const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
+
+            expect(result).toEqual([0.1, 0.2, 0.3]);
+            expect(requestCount).toBe(1);
+        } finally {
+            Neo.config.unitTestMode = originalUnitTestMode;
+        }
     });
 
     test('first-call-fails-second-call-succeeds path with mock client', async () => {


### PR DESCRIPTION
Resolves #13944

This prevents local OpenAI-compatible embedding calls from accepting vectors after LM Studio silently truncates input. `TextEmbeddingService` now verifies the resident LM Studio embedding model context before posting to `/v1/embeddings`, refuses below-config or over-loaded-context requests with bounded diagnostics, and emits consumer friction when an input would overflow the observed loaded context. The guard is scoped to the configured LM Studio endpoint, so CI/cloud/generic OpenAI-compatible endpoints do not require an `lms` CLI. The orchestrator supervisor now reruns a task-owned readiness hook even when a fire-and-exit service is already live, so the existing LMS preload/replacement path runs after an "endpoint is up" liveness result instead of only after a child spawn.

Evidence: L2 (focused unit coverage for stale loaded context, no provider request posted, and liveness-up readiness execution) -> L2 required for #13944 code gate. Residual: L3 local LMS smoke after merge/restart.

## Deltas from ticket

- Added the provider-boundary guard in `TextEmbeddingService`, so Memory Core and KB callers share the same truncation stop.
- Reused the existing LMS preload/readiness hook from the supervisor liveness-up path, covering the restart race where `lms server` is already healthy.
- Removed hidden fallback defaults in the touched LMS/stuck-runner task config path and read typed AiConfig leaves directly.

## Test Evidence

- `node --check ai/services/memory-core/TextEmbeddingService.mjs`
- `node --check ai/daemons/orchestrator/services/ProcessSupervisorService.mjs`
- `node --check ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` — 17 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs` — 34 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` — 55 passed
- `npm run test-integration-unified -- test/playwright/integration/healthcheck.spec.mjs` — 2 skipped locally by fixture gate
- `git diff --cached --check`

## Post-Merge Validation

- [ ] Restart the harness/orchestrator with LM Studio models ejected; confirm the embedding model is resident at `localModels.embedding.contextLimitTokens` or higher before KB sync accepts embeddings.
- [ ] Confirm the KB sync log no longer shows provider-side truncation warnings for embedding requests.

Authored by Euclid (GPT-5, Codex Desktop). Session cd2b88d7-8134-4ef8-a10f-0b1e80c03db4.
