### PR TITLE
fix(ai): fail loud on ollama embedding truncation (#13946)

### DIFF
--- a/ai/provider/Ollama.mjs
+++ b/ai/provider/Ollama.mjs
@@ -476,14 +476,34 @@ class OllamaProvider extends Base {
      * @param {String|String[]} input Single text or array of texts to embed.
      * @param {Object} [options]
      * @param {String} [options.model] Override the configured `embeddingModel` / `modelName`.
+     * @param {Boolean} [options.truncate=false] Whether Ollama may truncate inputs over context.
+     * @param {Number} [options.num_ctx] Native Ollama context window for this embedding request.
      * @returns {Promise<{embeddings: Number[][], raw: Object, evalSample: Object}>}
      */
     async embed(input, options = {}) {
-        const model   = options.model || this.embeddingModel || this.modelName;
+        const {
+            dimensions,
+            keep_alive,
+            model: modelOverride,
+            truncate = false,
+            ...ollamaOptions
+        } = options;
+        const model   = modelOverride || this.embeddingModel || this.modelName;
         const payload = {
             model,
-            input
+            input,
+            truncate
         };
+
+        if (keep_alive !== undefined) {
+            payload.keep_alive = keep_alive;
+        }
+        if (dimensions !== undefined) {
+            payload.dimensions = dimensions;
+        }
+        if (Object.keys(ollamaOptions).length > 0) {
+            payload.options = ollamaOptions;
+        }
 
         try {
             const parsedUrl  = new URL(`${this.host}/api/embed`);

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -570,7 +570,10 @@ class TextEmbeddingService extends Base {
             // Native Ollama returns `{embeddings: [[...]]}` even for single-input;
             // project the single inner array since this method is the per-text variant.
             const provider = this.#getOllamaProvider();
-            const result   = await provider.embed(text);
+            const result   = await provider.embed(text, {
+                num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
+                truncate: false
+            });
             return result.embeddings?.[0];
         } else if (explicitProvider === 'gemini') {
             const geminiKey = process.env.GEMINI_API_KEY;
@@ -609,7 +612,10 @@ class TextEmbeddingService extends Base {
             // Ollama's `/api/embed` accepts array-of-strings natively + returns
             // a parallel embeddings array — no per-text fan-out needed.
             const provider = this.#getOllamaProvider();
-            const result   = await provider.embed(texts);
+            const result   = await provider.embed(texts, {
+                num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
+                truncate: false
+            });
             return result.embeddings || [];
         } else if (explicitProvider === 'gemini') {
             const geminiKey = process.env.GEMINI_API_KEY;

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -217,7 +217,7 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
             });
 
             const chatResult      = await provider.generate('hello');
-            const embeddingResult = await provider.embed('hello');
+            const embeddingResult = await provider.embed('hello', {num_ctx: 32768});
             const attribution     = buildOllamaEvalAttribution([
                 chatResult.evalSample,
                 embeddingResult.evalSample
@@ -258,6 +258,14 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
         }
 
         expect(payloads.map(item => item.url)).toEqual(['/api/chat', '/api/embed']);
+        expect(payloads[1].body).toMatchObject({
+            model   : 'qwen3-embedding',
+            input   : 'hello',
+            truncate: false,
+            options : {
+                num_ctx: 32768
+            }
+        });
     });
 
     test('Ollama.generate() defaults and overrides keep_alive at the top-level payload', async () => {

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -51,10 +51,12 @@ test.describe('TextEmbeddingService #10804 — shouldInitializeGeminiEmbeddingCl
 
 test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', () => {
     let TextEmbeddingService;
+    let aiConfig;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs');
         TextEmbeddingService = mod.default;
+        aiConfig             = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
     });
 
     test.afterEach(() => {
@@ -63,10 +65,10 @@ test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', ()
     });
 
     test('embedText dispatches to native Ollama provider when explicitProvider=ollama', async () => {
-        const captured  = [];
+        const captured   = [];
         const fakeOllama = {
-            async embed(input) {
-                captured.push({input});
+            async embed(input, options) {
+                captured.push({input, options});
                 return {embeddings: [[0.1, 0.2, 0.3]], raw: {model: 'fake-model'}};
             }
         };
@@ -75,14 +77,20 @@ test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', ()
         const result = await TextEmbeddingService.embedText('hello world', 'ollama');
 
         expect(result).toEqual([0.1, 0.2, 0.3]);
-        expect(captured).toEqual([{input: 'hello world'}]);
+        expect(captured).toEqual([{
+            input  : 'hello world',
+            options: {
+                num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
+                truncate: false
+            }
+        }]);
     });
 
     test('embedTexts dispatches batch to native Ollama provider when explicitProvider=ollama', async () => {
-        const captured  = [];
+        const captured   = [];
         const fakeOllama = {
-            async embed(input) {
-                captured.push({input});
+            async embed(input, options) {
+                captured.push({input, options});
                 return {
                     embeddings: [
                         [0.1, 0.2],
@@ -98,7 +106,13 @@ test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', ()
         const result = await TextEmbeddingService.embedTexts(['a', 'b', 'c'], 'ollama');
 
         expect(result).toEqual([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]);
-        expect(captured).toEqual([{input: ['a', 'b', 'c']}]);
+        expect(captured).toEqual([{
+            input  : ['a', 'b', 'c'],
+            options: {
+                num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
+                truncate: false
+            }
+        }]);
     });
 
     test('embedText with explicitProvider=ollama returns empty when provider returns no embeddings', async () => {


### PR DESCRIPTION
Resolves #13946

Native Ollama embedding now uses a fail-loud request shape: `/api/embed` sends `truncate:false`, and TextEmbeddingService passes `AiConfig.localModels.embedding.contextLimitTokens` as native `options.num_ctx` for both single and batch Ollama embeddings. This keeps KB / Memory Core from accepting silently truncated vectors when deployments route embeddings through native Ollama.

Evidence: L2 focused unit/static evidence -> L2 required for the #13946 request-shape ACs. Residual: none for the close target.

## Deltas from ticket

The provider now defaults native embedding truncation to false at `OllamaProvider.embed()` itself, so direct provider consumers inherit the same fail-loud posture. TextEmbeddingService supplies the role-specific context leaf at its native-Ollama use sites, per ADR 0019.

## Test Evidence

- `npm run agent-preflight -- ai/provider/Ollama.mjs ai/services/memory-core/TextEmbeddingService.mjs test/playwright/unit/ai/provider/KeepAlive.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs` passed: 30 passed, 1 skipped.
- `git diff --check` passed.

## Post-Merge Validation

- [ ] Native-Ollama deployment smoke can embed an over-context fixture and observe provider rejection instead of silent truncation.

## Commits

- `feb2b2c9cd` — fail loud on native Ollama embedding truncation

Authored by Euclid (GPT-5, Codex Desktop). Session cd2b88d7-8134-4ef8-a10f-0b1e80c03db4.