### PR TITLE
fix(ai): restore provider role-set residency (#13948)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -273,13 +273,20 @@ class Config extends ConfigProvider {
                  * 4K-token margin below the advertised model maximum.
                  *
                  * Env overrides: `NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS`,
-                 * `NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS`.
+                 * `NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS`,
+                 * `NEO_LOCAL_MODELS_EMBEDDING_PARALLEL`.
                  *
                  * @type {Object}
                  */
                 embedding: {
                     contextLimitTokens       : leaf(32768, 'NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', 'number'),
-                    safeProcessingLimitTokens: leaf(28672, 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
+                    safeProcessingLimitTokens: leaf(28672, 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 'number'),
+                    // lms `--parallel` request-slot count for the embedding model. Same primitive as
+                    // `localModels.chat.parallel`: each slot carries its own KV cache, so slot count
+                    // multiplies resident RAM. Default 1 keeps the embedding role resident without
+                    // letting the LM Studio default silently spend memory that can force chat/embedding
+                    // role-set churn. Distinct from requireParallelModels (distinct model residency).
+                    parallel                 : leaf(1, 'NEO_LOCAL_MODELS_EMBEDDING_PARALLEL', 'number')
                 }
             },
             /**

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -20,7 +20,8 @@ export const CONTAINER_HEALTH_FACT_TYPES = Object.freeze({
 export const CONTAINER_HEALTH_ACTION_CLASSES = Object.freeze({
     escalate    : 'escalate',
     restart     : 'restart',
-    throttleShed: 'throttle-shed'
+    throttleShed: 'throttle-shed',
+    warmProvider: 'warm-provider'
 });
 
 export const DEFAULT_CONTAINER_HEALTH_DIAGNOSIS_CONFIG = Object.freeze({
@@ -448,6 +449,18 @@ export class ContainerHealthDiagnosisService extends Base {
      * @returns {Object|null}
      */
     classifyFacts({facts}) {
+        const providerRoleResidencyFacts = facts.filter(fact => this.isProviderRoleResidencyRecoverable(fact));
+        if (providerRoleResidencyFacts.length > 0) {
+            return {
+                recoveryClass : 'provider-role-residency',
+                actionClass   : CONTAINER_HEALTH_ACTION_CLASSES.warmProvider,
+                confidence    : 0.85,
+                evidenceFacts : providerRoleResidencyFacts,
+                reason        : 'provider-role-residency-warm',
+                targetIdentity: this.resolveProviderFactTargetIdentity(providerRoleResidencyFacts[0])
+            };
+        }
+
         const configDriftFacts = facts.filter(fact =>
             fact.type === CONTAINER_HEALTH_FACT_TYPES.configDrift ||
             this.isProviderResidencyConfigDrift(fact)
@@ -682,11 +695,20 @@ export class ContainerHealthDiagnosisService extends Base {
     isProviderResidencyConfigDrift(fact) {
         return fact.type === CONTAINER_HEALTH_FACT_TYPES.providerResidency && [
             'insufficient-context',
-            'missing-required-model',
             'provider-not-ready',
             'provider-warmup-failed',
             'unsupported-provider'
         ].includes(fact.details?.reasonCode);
+    }
+
+    /**
+     * Checks whether a provider-residency fact should first restore the active role set.
+     * @param {Object} fact Diagnosis fact.
+     * @returns {Boolean}
+     */
+    isProviderRoleResidencyRecoverable(fact) {
+        return fact.type === CONTAINER_HEALTH_FACT_TYPES.providerResidency &&
+            fact.details?.reasonCode === 'missing-required-model';
     }
 
     /**

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -1,8 +1,9 @@
 import fs   from 'fs-extra';
 import path from 'path';
 
-import Base     from '../../../../src/core/Base.mjs';
-import AiConfig from '../../../config.mjs';
+import Base                             from '../../../../src/core/Base.mjs';
+import AiConfig                         from '../../../config.mjs';
+import {repairProviderRoleSetResidency} from '../../../services/graph/providerReadinessHelper.mjs';
 import {
     appendRecoveryRunState,
     createRecoveryDiagnosisEvent,
@@ -12,7 +13,7 @@ import {
 } from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {DEFAULT_DATA_DIR} from '../taskDefinitions.mjs';
 
-const DEFAULT_ACTIONS = Object.freeze(['restart', 'redeploy', 'page']);
+const DEFAULT_ACTIONS = Object.freeze(['restart', 'redeploy', 'page', 'warm-provider']);
 
 /**
  * @summary Normalizes string/object allowlist entries into stable recovery targets.
@@ -121,7 +122,12 @@ export class RecoveryActuatorService extends Base {
          * @protected
          * @reactive
          */
-        writeLog_: null
+        writeLog_: null,
+        /**
+         * @member {Function|null} providerResidencyRepair=null
+         * @protected
+         */
+        providerResidencyRepair: null
     }
 
     /** @summary Resolves the active actuator config from an injected test value or Tier-1 AiConfig. */
@@ -158,7 +164,7 @@ export class RecoveryActuatorService extends Base {
      * @summary Applies one bounded recovery action if the allowlist and anti-thrash envelope admit it.
      *
      * @param {String} serviceKey Stable allowlisted recovery target key.
-     * @param {String} action restart | redeploy | page.
+     * @param {String} action restart | redeploy | page | warm-provider.
      * @param {Object} [options]
      * @param {Object|null} [options.diagnosisEvent=null] Optional ADR-0025 diagnosis event.
      * @param {Object|null} [options.targetIdentity=null] Optional typed target identity.
@@ -248,13 +254,14 @@ export class RecoveryActuatorService extends Base {
                 backoffUntil  : nextBackoffAt,
                 diagnosisEvent: diagnosis,
                 outcome       : {
-                    status        : target.kind === 'deploy-target' ? 'escalated' : 'actioned',
+                    status           : target.kind === 'deploy-target' ? 'escalated' : 'actioned',
                     serviceKey,
                     action,
-                    targetIdentity: createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
-                    runtimeAccess : result.runtimeAccess || null,
-                    supervisor    : result.supervisor || null,
-                    page          : result.page || null
+                    targetIdentity   : createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
+                    runtimeAccess    : result.runtimeAccess || null,
+                    supervisor       : result.supervisor || null,
+                    page             : result.page || null,
+                    providerResidency: result.providerResidency || null
                 },
                 recoveryRunId,
                 serviceKey,
@@ -332,11 +339,11 @@ export class RecoveryActuatorService extends Base {
      */
     isActionAllowedForTarget({action, target}) {
         if (target.kind === 'compose-service') {
-            return action === 'restart';
+            return action === 'restart' || action === 'warm-provider';
         }
 
         if (target.kind === 'supervised-task') {
-            return action === 'restart';
+            return action === 'restart' || action === 'warm-provider';
         }
 
         if (target.kind === 'deploy-target') {
@@ -352,6 +359,10 @@ export class RecoveryActuatorService extends Base {
      * @returns {Promise<Object>}
      */
     async executeTargetAction({target, action, reason}) {
+        if (action === 'warm-provider') {
+            return this.warmProviderResidency({target, reason});
+        }
+
         if (target.kind === 'compose-service') {
             return this.restartComposeService({target, reason});
         }
@@ -406,6 +417,39 @@ export class RecoveryActuatorService extends Base {
 
         return {
             runtimeAccess: result.proof || null
+        };
+    }
+
+    /**
+     * @summary Warms the configured chat + embedding provider role set without restarting a service.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async warmProviderResidency({target, reason}) {
+        const repair = this.providerResidencyRepair || repairProviderRoleSetResidency,
+              result = await repair({
+                  attempts : AiConfig.orchestrator.providerReadiness.attempts,
+                  delayMs  : AiConfig.orchestrator.providerReadiness.delayMs,
+                  timeoutMs: AiConfig.orchestrator.providerReadiness.timeoutMs,
+                  log      : {
+                      info: message => this.writeLog?.('INFO', message),
+                      warn: message => this.writeLog?.('WARN', message)
+                  }
+              });
+
+        if (result.ready !== true) {
+            throw new Error(result.warning || `Provider role-set repair did not converge for ${target.serviceKey}`);
+        }
+
+        return {
+            providerResidency: {
+                capabilityEnvelope: 'provider-role-set-warm',
+                operation         : 'warm-provider',
+                serviceKey        : target.serviceKey,
+                reason            : reason || `recovery-actuator:${target.serviceKey}`,
+                targetIdentity    : createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
+                result
+            }
         };
     }
 
@@ -678,7 +722,7 @@ export class RecoveryActuatorService extends Base {
 
         return createRecoveryDiagnosisEvent({
             diagnosisId   : `recovery-actuator:${target.serviceKey}:${action}:${now}`,
-            recoveryClass : target.kind === 'deploy-target' ? 'config-drift' : 'crash',
+            recoveryClass : this.getRecoveryClassForAction({action, target}),
             confidence    : 1,
             targetIdentity: createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
             evidenceFacts : [],
@@ -686,6 +730,18 @@ export class RecoveryActuatorService extends Base {
             source        : 'recovery-actuator',
             details       : {action}
         });
+    }
+
+    /**
+     * @summary Resolves the synthetic diagnosis class for direct actuator calls.
+     * @param {Object} options
+     * @returns {String}
+     */
+    getRecoveryClassForAction({action, target}) {
+        if (action === 'warm-provider') {
+            return 'provider-role-residency';
+        }
+        return target.kind === 'deploy-target' ? 'config-drift' : 'crash';
     }
 
     /** @summary Builds the durable anti-thrash key for one service/action pair. */

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -630,6 +630,7 @@ export function buildLmsPreloadConfig(config = aiConfig) {
           chatContextLength      = config.localModels?.chat?.contextLimitTokens,
           embeddingContextLength = config.localModels?.embedding?.contextLimitTokens,
           chatParallel           = config.localModels?.chat?.parallel,
+          embeddingParallel      = config.localModels?.embedding?.parallel,
           roles                  = [{
               provider     : config.modelProvider,
               model        : chatModel,
@@ -658,12 +659,24 @@ export function buildLmsPreloadConfig(config = aiConfig) {
 
     // `--parallel` is a per-model request-slot count (each slot = an independent KV cache = a RAM
     // multiplier), distinct from `requireParallelModels` (how many DISTINCT models stay co-resident).
-    // Only the chat role carries a configured slot count; the embedding role keeps the lms default.
-    // Keyed by model id so it force-includes through the same path as contextLengths; the embedding
-    // model is intentionally absent (no per-model parallel override).
-    const parallels = selectedContextRole('chat') && chatModel && Neo.isNumber(chatParallel)
-        ? {[chatModel]: chatParallel}
-        : {};
+    // Keyed by model id so it force-includes through the same path as contextLengths. When an operator
+    // points chat + embedding at one LM Studio id, keep the larger requested slot count.
+    const parallels   = {};
+    const setParallel = (model, value) => {
+        if (!model || !Neo.isNumber(value)) {
+            return;
+        }
+        if (parallels[model] === undefined || value > parallels[model]) {
+            parallels[model] = value;
+        }
+    };
+
+    if (selectedContextRole('chat')) {
+        setParallel(chatModel, chatParallel);
+    }
+    if (selectedContextRole('embedding')) {
+        setParallel(embeddingModel, embeddingParallel);
+    }
 
     return {models, contextLengths, parallels}
 }
@@ -1478,6 +1491,126 @@ export async function ensureOllamaModelsReady({
     throw new Error(
         `Ollama model readiness failed: ${warning}`
     );
+}
+
+/**
+ * @summary Restores the active provider role-set residency before higher-cost recovery actions.
+ *
+ * This is the bounded recovery companion to the read-only parallel-capacity probe:
+ * LM Studio is repaired through the orchestrator-owned `lms load` path, while
+ * native Ollama is warmed through its role-specific HTTP endpoints. Remote or
+ * disabled OpenAI-compatible deployments remain observe-only and return a
+ * degraded envelope instead of attempting a local CLI mutation.
+ *
+ * @param {Object} options
+ * @param {Object} [options.config=aiConfig] Provider-source config.
+ * @param {Number} options.attempts Probe attempts after warm-up.
+ * @param {Number} options.delayMs Delay between probes.
+ * @param {Number} options.timeoutMs HTTP/CLI probe timeout.
+ * @param {Object} [options.log=logger] Logger seam.
+ * @param {Function} [options.lmsRepairFn=ensureLmsModelsLoaded] Test seam for LM Studio repair.
+ * @param {Function} [options.ollamaRepairFn=ensureOllamaModelsReady] Test seam for native Ollama repair.
+ * @returns {Promise<Object>} Provider readiness repair result.
+ */
+export async function repairProviderRoleSetResidency({
+    config = aiConfig,
+    attempts,
+    delayMs,
+    timeoutMs,
+    log = logger,
+    lmsRepairFn = ensureLmsModelsLoaded,
+    ollamaRepairFn = ensureOllamaModelsReady
+} = {}) {
+    if (!config || typeof config !== 'object') {
+        throw new TypeError('repairProviderRoleSetResidency: config is required');
+    }
+    if (typeof attempts !== 'number' || typeof delayMs !== 'number' || typeof timeoutMs !== 'number') {
+        throw new TypeError('repairProviderRoleSetResidency: attempts, delayMs, and timeoutMs are required');
+    }
+
+    const provider = resolveGraphModelProvider(config);
+
+    if (provider === 'ollama') {
+        const readinessConfig = buildOllamaReadinessConfig(config);
+
+        if (readinessConfig.roles.length === 0) {
+            return {
+                ready  : true,
+                skipped: true,
+                provider,
+                reason : 'no-active-ollama-roles'
+            };
+        }
+
+        const result = await ollamaRepairFn({
+            host                 : readinessConfig.host,
+            roles                : readinessConfig.roles,
+            keepAlive            : readinessConfig.keepAlive,
+            requireParallelModels: readinessConfig.requireParallelModels,
+            allowPartial         : true,
+            attempts,
+            delayMs,
+            timeoutMs,
+            log
+        });
+
+        return {
+            ...result,
+            provider,
+            action: 'warm-provider'
+        };
+    }
+
+    if (isOpenAiCompatibleProvider(provider)) {
+        if (config.orchestrator.lms.enabled !== true) {
+            return {
+                ready   : false,
+                degraded: true,
+                skipped : true,
+                provider,
+                reason  : 'lms-disabled',
+                warning : '[provider/openAiCompatible] provider role-set repair requires orchestrator.lms.enabled=true; non-LM-Studio OpenAI-compatible endpoints remain observe-only.'
+            };
+        }
+
+        const preloadConfig = buildLmsPreloadConfig(config);
+
+        if (preloadConfig.models.length === 0) {
+            return {
+                ready  : true,
+                skipped: true,
+                provider,
+                reason : 'no-active-openai-compatible-roles'
+            };
+        }
+
+        const result = await lmsRepairFn({
+            host          : getOpenAiCompatibleHost(config),
+            models        : preloadConfig.models,
+            contextLengths: preloadConfig.contextLengths,
+            parallels     : preloadConfig.parallels,
+            allowPartial  : true,
+            attempts,
+            delayMs,
+            timeoutMs,
+            log
+        });
+
+        return {
+            ...result,
+            provider,
+            host  : getOpenAiCompatibleHost(config),
+            action: 'warm-provider'
+        };
+    }
+
+    return {
+        ready    : true,
+        skipped  : true,
+        provider,
+        supported: false,
+        reason   : 'unsupported-provider'
+    };
 }
 
 /**

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -624,13 +624,13 @@ export function buildLmsContextLengthsMap({
  * @returns {{models: String[], contextLengths: Object, parallels: Object}} Role-aware LMS preload config.
  */
 export function buildLmsPreloadConfig(config = aiConfig) {
-    const openAiCompatibleConfig = config.openAiCompatible ?? {},
+    const openAiCompatibleConfig = config.openAiCompatible,
           chatModel              = openAiCompatibleConfig.model,
           embeddingModel         = openAiCompatibleConfig.embeddingModel,
-          chatContextLength      = config.localModels?.chat?.contextLimitTokens,
-          embeddingContextLength = config.localModels?.embedding?.contextLimitTokens,
-          chatParallel           = config.localModels?.chat?.parallel,
-          embeddingParallel      = config.localModels?.embedding?.parallel,
+          chatContextLength      = config.localModels.chat.contextLimitTokens,
+          embeddingContextLength = config.localModels.embedding.contextLimitTokens,
+          chatParallel           = config.localModels.chat.parallel,
+          embeddingParallel      = config.localModels.embedding.parallel,
           roles                  = [{
               provider     : config.modelProvider,
               model        : chatModel,
@@ -693,11 +693,11 @@ export function buildLmsPreloadConfig(config = aiConfig) {
  * @returns {{provider: String, host: String, keepAlive: *, requireParallelModels: Number, model: String, embeddingModel: String, roles: Object[], models: String[], contextLengths: Object}}
  */
 export function buildOllamaReadinessConfig(config = aiConfig) {
-    const ollamaConfig           = config.ollama ?? {},
+    const ollamaConfig           = config.ollama,
           chatModel              = ollamaConfig.model,
           embeddingModel         = ollamaConfig.embeddingModel,
-          chatContextLength      = config.localModels?.chat?.contextLimitTokens,
-          embeddingContextLength = config.localModels?.embedding?.contextLimitTokens,
+          chatContextLength      = config.localModels.chat.contextLimitTokens,
+          embeddingContextLength = config.localModels.embedding.contextLimitTokens,
           roles                  = [{
               provider     : config.modelProvider,
               providerRole : 'modelProvider',

--- a/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
@@ -9,7 +9,8 @@ export const RECOVERY_CLASSES = Object.freeze([
     'contention',
     'crash',
     'exhaustion',
-    'external-load'
+    'external-load',
+    'provider-role-residency'
 ]);
 
 export const RECOVERY_RUN_RUNG_IDS = Object.freeze([

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -125,11 +125,13 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     localModels: {
         chat: {
             contextLimitTokens       : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072,
-            safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 100000
+            safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 100000,
+            parallel                 : Number(process.env.NEO_LOCAL_MODELS_CHAT_PARALLEL) || 1
         },
         embedding: {
             contextLimitTokens       : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
-            safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 28672
+            safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 28672,
+            parallel                 : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_PARALLEL) || 1
         }
     },
     vectorDimension: Number(process.env.NEO_VECTOR_DIMENSION) || 4096,

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -92,11 +92,13 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(Config.localModels).toMatchObject({
             chat: {
                 contextLimitTokens       : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072,
-                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 100000
+                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 100000,
+                parallel                 : Number(process.env.NEO_LOCAL_MODELS_CHAT_PARALLEL) || 1
             },
             embedding: {
                 contextLimitTokens       : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
-                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 28672
+                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 28672,
+                parallel                 : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_PARALLEL) || 1
             }
         });
         expect(Config.engines.chroma).toEqual({
@@ -110,20 +112,24 @@ test.describe('Tier 1 Config Immutability', () => {
     });
 
     test('keeps local embedding context env overrides role-scoped (#12286)', () => {
-        const originalContext = Config.localModels.embedding.contextLimitTokens,
-              originalSafe    = Config.localModels.embedding.safeProcessingLimitTokens;
+        const originalContext  = Config.localModels.embedding.contextLimitTokens,
+              originalSafe     = Config.localModels.embedding.safeProcessingLimitTokens,
+              originalParallel = Config.localModels.embedding.parallel;
 
         Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', 12345);
         Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 11111);
+        Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_PARALLEL', 2);
 
         expect(Config.localModels.embedding).toMatchObject({
             contextLimitTokens       : 12345,
-            safeProcessingLimitTokens: 11111
+            safeProcessingLimitTokens: 11111,
+            parallel                 : 2
         });
         expect(Config.localModels.chat.contextLimitTokens).toBe(Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072);
 
         Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', originalContext);
         Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', originalSafe);
+        Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_PARALLEL', originalParallel);
     });
 
     test('ships top-level deployment and maintenance policy defaults', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -20,9 +20,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const REPO_ROOT  = path.resolve(__dirname, '../../../../../..');
 
-const ORCHESTRATOR_MJS_PATH    = path.join(REPO_ROOT, 'ai/daemons/orchestrator/Orchestrator.mjs');
-const ORCHESTRATOR_DAEMON_PATH = path.join(REPO_ROOT, 'ai/daemons/orchestrator/daemon.mjs');
-const TASK_DEFINITIONS_MJS_PATH = path.join(REPO_ROOT, 'ai/daemons/orchestrator/taskDefinitions.mjs');
+const ORCHESTRATOR_MJS_PATH                    = path.join(REPO_ROOT, 'ai/daemons/orchestrator/Orchestrator.mjs');
+const ORCHESTRATOR_DAEMON_PATH                 = path.join(REPO_ROOT, 'ai/daemons/orchestrator/daemon.mjs');
+const TASK_DEFINITIONS_MJS_PATH                = path.join(REPO_ROOT, 'ai/daemons/orchestrator/taskDefinitions.mjs');
 const CONFIGURED_TASK_DEFINITIONS_SERVICE_PATH = path.join(
     REPO_ROOT,
     'ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs'
@@ -34,32 +34,32 @@ const SIBLING_DAEMON_CONFIG_PATHS = {
     'KbGarbageCollectionService.mjs': path.join(REPO_ROOT, 'ai/daemons/kb-gc/KbGarbageCollectionService.mjs')
 };
 
-let invariantSeq         = 0;
-let savedIntervals       = null;
-let savedLocalOnly       = null;
-let savedCloudOnly       = null;
-let savedDeploymentMode  = null;
-let savedMlxConfig                   = undefined;
-let savedLmsConfig                   = undefined;
-let savedOrchestratorOllamaConfig    = undefined;
-let savedProviderOllamaConfig        = undefined;
-let savedOpenAiCompatibleConfig      = undefined;
-let savedChatProvider                = undefined;
-let savedModelProvider               = undefined;
-let savedGraphProvider               = undefined;
-let savedEmbeddingProvider           = undefined;
-let savedEnvKbSyncEnabled            = undefined;
-let savedEnvKbSyncInterval           = undefined;
-let savedEnvTenantRepoSyncEnabled    = undefined;
-let savedEnvTenantRepoSyncInterval   = undefined;
-let savedEnvChromaDaemonEnabled      = undefined;
-let savedEnvMlxEnabled               = undefined;
-let savedEnvMlxModel                 = undefined;
-let savedEnvMlxPort                  = undefined;
-let savedEnvLmsEnabled               = undefined;
-let savedEnvLmsModel                 = undefined;
-let savedEnvLmsPort                  = undefined;
-let savedEnvOllamaEnabled            = undefined;
+let invariantSeq                   = 0;
+let savedIntervals                 = null;
+let savedLocalOnly                 = null;
+let savedCloudOnly                 = null;
+let savedDeploymentMode            = null;
+let savedMlxConfig                 = undefined;
+let savedLmsConfig                 = undefined;
+let savedOrchestratorOllamaConfig  = undefined;
+let savedProviderOllamaConfig      = undefined;
+let savedOpenAiCompatibleConfig    = undefined;
+let savedChatProvider              = undefined;
+let savedModelProvider             = undefined;
+let savedGraphProvider             = undefined;
+let savedEmbeddingProvider         = undefined;
+let savedEnvKbSyncEnabled          = undefined;
+let savedEnvKbSyncInterval         = undefined;
+let savedEnvTenantRepoSyncEnabled  = undefined;
+let savedEnvTenantRepoSyncInterval = undefined;
+let savedEnvChromaDaemonEnabled    = undefined;
+let savedEnvMlxEnabled             = undefined;
+let savedEnvMlxModel               = undefined;
+let savedEnvMlxPort                = undefined;
+let savedEnvLmsEnabled             = undefined;
+let savedEnvLmsModel               = undefined;
+let savedEnvLmsPort                = undefined;
+let savedEnvOllamaEnabled          = undefined;
 
 function createMinimalOrchestrator() {
     const taskDefinitions = buildTaskDefinitions({
@@ -358,12 +358,12 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
             },
             localModels: {
                 chat     : {contextLimitTokens: 262144},
-                embedding: {contextLimitTokens: 8192}
+                embedding: {contextLimitTokens: 8192, parallel: 1}
             }
         })).toEqual({
             models        : ['shared-model'],
             contextLengths: {'shared-model': 8192},
-            parallels     : {}
+            parallels     : {'shared-model': 1}
         });
 
         expect(buildLmsPreloadConfig({
@@ -385,7 +385,7 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
         })
     });
 
-    test('buildLmsPreloadConfig threads localModels.chat.parallel into a chat-only parallels map (#13700)', () => {
+    test('buildLmsPreloadConfig threads role parallel values into the parallels map (#13700, #13948)', () => {
         const result = buildLmsPreloadConfig({
             modelProvider    : 'openAiCompatible',
             graphProvider    : 'openAiCompatible',
@@ -396,12 +396,15 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
             },
             localModels: {
                 chat     : {contextLimitTokens: 131072, parallel: 1},
-                embedding: {contextLimitTokens: 32768}
+                embedding: {contextLimitTokens: 32768, parallel: 1}
             }
         });
-        // Chat-only: the configured slot count is keyed by the chat model id; the embedding model is
-        // intentionally absent (it keeps the lms default). Distinct from requireParallelModels.
-        expect(result.parallels).toEqual({'gemma-4-31b-it': 1});
+        // Per-model slot counts are distinct from requireParallelModels, which governs how many
+        // distinct configured models stay co-resident.
+        expect(result.parallels).toEqual({
+            'gemma-4-31b-it' : 1,
+            'qwen3-embedding': 1
+        });
     });
 
 });
@@ -414,7 +417,7 @@ test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
 
     test('mutating orchestrator.taskDefinitions propagates to processSupervisorService via afterSetTaskDefinitions hook', () => {
         const orchestrator = createMinimalOrchestrator();
-        const newDefs = buildTaskDefinitions({
+        const newDefs      = buildTaskDefinitions({
             scriptDir: '/repo/ai/scripts/mutated',
             nodeBin  : '/node'
         });
@@ -436,7 +439,7 @@ test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
 
     test('mutating orchestrator.healthService propagates to processSupervisorService + maintenanceBackpressureService', () => {
         const orchestrator = createMinimalOrchestrator();
-        const newHealth = {recordTaskOutcome() {}, marker: 'mutated-healthservice'};
+        const newHealth    = {recordTaskOutcome() {}, marker: 'mutated-healthservice'};
         orchestrator.healthService = newHealth;
 
         expect(orchestrator.processSupervisorService.healthService?.marker).toBe('mutated-healthservice');
@@ -445,7 +448,7 @@ test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
 
     test('mutating orchestrator.taskStateService propagates to processSupervisorService + maintenanceBackpressureService', () => {
         const orchestrator = createMinimalOrchestrator();
-        const newTss = {
+        const newTss       = {
             marker: 'mutated-taskstateservice',
             getState() {return {};},
             getTaskState() {return null;}
@@ -458,7 +461,7 @@ test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
 
     test('mutating orchestrator.spawnFn propagates to processSupervisorService', () => {
         const orchestrator = createMinimalOrchestrator();
-        const newSpawn = () => 'mutated-spawn';
+        const newSpawn     = () => 'mutated-spawn';
         newSpawn.marker = 'mutated-spawnfn';
         orchestrator.spawnFn = newSpawn;
 
@@ -467,7 +470,7 @@ test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
 
     test('mutating orchestrator.heavyMaintenanceLeasePath propagates to maintenanceBackpressureService', () => {
         const orchestrator = createMinimalOrchestrator();
-        const newPath = '/tmp/orchestrator-test/heavy-maintenance-lease-mutated.json';
+        const newPath      = '/tmp/orchestrator-test/heavy-maintenance-lease-mutated.json';
         orchestrator.heavyMaintenanceLeasePath = newPath;
 
         expect(orchestrator.maintenanceBackpressureService.heavyMaintenanceLeasePath).toBe(newPath);
@@ -476,22 +479,22 @@ test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
 
 test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
     test('Orchestrator.mjs has no `configure()` shadow-resolver method', async () => {
-        const source = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
+        const source  = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
         const matches = source.match(/^\s*configure\s*\(/gm) || [];
 
         expect(matches, 'Orchestrator.mjs must NOT define a `configure()` method (Sub-1 anti-pattern; lazy getters supersede it).').toHaveLength(0);
     });
 
     test('taskDefinitions.mjs has no `DEFAULT_*_INTERVAL_MS` exports', async () => {
-        const source = await fs.readFile(TASK_DEFINITIONS_MJS_PATH, 'utf8');
+        const source  = await fs.readFile(TASK_DEFINITIONS_MJS_PATH, 'utf8');
         const matches = source.match(/export\s+(?:const|let)\s+DEFAULT_\w*INTERVAL_MS/g) || [];
 
         expect(matches, 'taskDefinitions.mjs must NOT export `DEFAULT_*_INTERVAL_MS` constants (Sub-1 anti-pattern; AiConfig.orchestrator.intervals owns these values).').toHaveLength(0);
     });
 
     test('Orchestrator.mjs has no `parseInterval` / `parseEnabledFlag` call sites', async () => {
-        const source = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
-        const codeLines = stripCommentsAndStrings(source);
+        const source             = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
+        const codeLines          = stripCommentsAndStrings(source);
         const parseIntervalCalls = codeLines.match(/\bparseInterval\s*\(/g) || [];
         const parseEnabledCalls  = codeLines.match(/\bparseEnabledFlag\s*\(/g) || [];
 
@@ -500,15 +503,15 @@ test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
     });
 
     test('Orchestrator.mjs has no `processSupervisorService.set({...this...})` context-replay block', async () => {
-        const source = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
+        const source    = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
         const codeLines = stripCommentsAndStrings(source);
-        const matches = codeLines.match(/processSupervisorService\.set\s*\(\s*\{\s*\.\.\.this/g) || [];
+        const matches   = codeLines.match(/processSupervisorService\.set\s*\(\s*\{\s*\.\.\.this/g) || [];
 
         expect(matches, 'Orchestrator.mjs must NOT spread `this` into `processSupervisorService.set({...})` (Sub-1 anti-pattern; `afterSetX` parent-prop propagation hooks supersede the start()-time context replay).').toHaveLength(0);
     });
 
     test('orchestrator config reads are fail-loud direct reads on declared subtrees (#12515 / #13875)', async () => {
-        const orchestratorSource = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8'));
+        const orchestratorSource              = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8'));
         const configuredTaskDefinitionsSource = stripCommentsAndStrings(
             await fs.readFile(CONFIGURED_TASK_DEFINITIONS_SERVICE_PATH, 'utf8')
         );
@@ -559,7 +562,7 @@ test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
     });
 
     test('Orchestrator.mjs has no `_`-suffix reactive config slot without a corresponding `beforeSet*` or `afterSet*` hook', async () => {
-        const source = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
+        const source    = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
         const codeLines = stripCommentsAndStrings(source);
 
         // Find `_`-suffix slot declarations inside `static config = { ... }` — pattern: `<name>_: <default>`
@@ -595,12 +598,12 @@ test.describe('Sibling daemon source-level invariants (#11836)', () => {
  * line structure for line-aware regex anchors.
  */
 function stripCommentsAndStrings(source) {
-    let out = '';
-    let i = 0;
+    let   out = '';
+    let   i   = 0;
     const len = source.length;
 
     while (i < len) {
-        const c = source[i];
+        const c    = source[i];
         const next = source[i + 1];
 
         // Block comment
@@ -617,7 +620,7 @@ function stripCommentsAndStrings(source) {
 
         // Line comment
         if (c === '/' && next === '/') {
-            const end = source.indexOf('\n', i);
+            const end  = source.indexOf('\n', i);
             const stop = end === -1 ? len : end;
             for (let j = i; j < stop; j++) out += ' ';
             i = stop;

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -219,7 +219,7 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         ]);
     });
 
-    test('escalates native Ollama missing required models as provider config drift', () => {
+    test('routes missing provider role models to warm-provider before config-drift escalation', () => {
         const service = createService();
 
         const decision = service.diagnose({
@@ -238,13 +238,13 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         });
 
         expect(decision.status).toBe('diagnosed');
-        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.escalate);
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.warmProvider);
         expect(decision.targetIdentity).toEqual({kind: 'compose-service', id: 'model'});
         expect(decision.diagnosis).toMatchObject({
-            recoveryClass : 'config-drift',
+            recoveryClass : 'provider-role-residency',
             targetIdentity: {kind: 'compose-service', id: 'model'},
             details       : {
-                classificationReason: 'config-drift-escalate'
+                classificationReason: 'provider-role-residency-warm'
             }
         });
         expect(decision.diagnosis.evidenceFacts).toHaveLength(1);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -25,11 +25,12 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
     });
 
     function createService(overrides = {}) {
-        const runtimeCalls    = [],
-              supervisorCalls = [],
-              pageCalls       = [],
-              taskOutcomes    = [],
-              actuatorConfig  = {
+        const runtimeCalls                 = [],
+              supervisorCalls              = [],
+              pageCalls                    = [],
+              providerResidencyRepairCalls = [],
+              taskOutcomes                 = [],
+              actuatorConfig               = {
                   ...DEFAULT_ACTUATOR_CONFIG,
                   enabled               : true,
                   allowedSupervisedTasks: [{serviceKey: 'model', taskName: 'ollama'}],
@@ -78,11 +79,19 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                   pageDispatcher(page) {
                       pageCalls.push(page);
                   },
+                  async providerResidencyRepair(options) {
+                      providerResidencyRepairCalls.push(options);
+                      return {
+                          ready       : true,
+                          provider    : 'ollama',
+                          warmedModels: [{model: 'gemma4:26b', role: 'chat'}]
+                      };
+                  },
                   writeLog: () => {},
                   ...overrides.serviceConfig
               });
 
-        return {service, runtimeCalls, supervisorCalls, pageCalls, taskOutcomes, actuatorConfig};
+        return {service, runtimeCalls, supervisorCalls, pageCalls, providerResidencyRepairCalls, taskOutcomes, actuatorConfig};
     }
 
     async function readAttempts() {
@@ -174,6 +183,111 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
             lastAction  : 'restart',
             lastStatus  : 'actioned'
         });
+    });
+
+    test('warm-provider restores provider role-set residency through the bounded actuator envelope', async () => {
+        const {service, runtimeCalls, providerResidencyRepairCalls, taskOutcomes} = createService({
+            actuatorConfig: {
+                allowedComposeServices: ['model']
+            }
+        });
+
+        const result = await service.apply('model', 'warm-provider', {
+            now           : 30_000,
+            reason        : 'missing-required-model',
+            targetIdentity: {kind: 'compose-service', id: 'model'}
+        });
+
+        expect(result.status).toBe('actioned');
+        expect(runtimeCalls).toEqual([]);
+        expect(providerResidencyRepairCalls).toHaveLength(1);
+        expect(result.targetIdentity).toEqual({kind: 'compose-service', id: 'model'});
+        expect(result.reobserveRequest).toMatchObject({
+            recoveryClass : 'provider-role-residency',
+            targetIdentity: {kind: 'compose-service', id: 'model'},
+            cooldownMs    : 5_000
+        });
+        expect(result.providerResidency).toMatchObject({
+            capabilityEnvelope: 'provider-role-set-warm',
+            operation         : 'warm-provider',
+            serviceKey        : 'model',
+            reason            : 'missing-required-model',
+            result            : {
+                ready   : true,
+                provider: 'ollama'
+            }
+        });
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            taskName: 'recovery-actuator:model',
+            status  : 'completed',
+            details : expect.objectContaining({
+                status      : 'actioned',
+                ledgerStatus: 'reobserve-requested'
+            })
+        }));
+
+        const attempts = await readAttempts();
+        expect(attempts['model:warm-provider']).toMatchObject({
+            attemptCount: 1,
+            lastAction  : 'warm-provider',
+            lastStatus  : 'actioned'
+        });
+    });
+
+    test('warm-provider honors persisted backoff and does not loop warm attempts', async () => {
+        const {service, providerResidencyRepairCalls} = createService({
+            actuatorConfig: {
+                allowedComposeServices: ['model'],
+                baseBackoffMs         : 30_000,
+                maxBackoffMs          : 30_000
+            }
+        });
+
+        const first = await service.apply('model', 'warm-provider', {
+            now           : 40_000,
+            targetIdentity: {kind: 'compose-service', id: 'model'}
+        });
+        const second = await service.apply('model', 'warm-provider', {
+            now           : 41_000,
+            targetIdentity: {kind: 'compose-service', id: 'model'}
+        });
+
+        expect(first.status).toBe('actioned');
+        expect(second).toMatchObject({
+            status    : 'deferred',
+            reasonCode: 'backoff-active'
+        });
+        expect(providerResidencyRepairCalls).toHaveLength(1);
+    });
+
+    test('warm-provider reports failed provider repair without restarting the target', async () => {
+        const {service, runtimeCalls, providerResidencyRepairCalls} = createService({
+            actuatorConfig: {
+                allowedComposeServices: ['model']
+            },
+            serviceConfig: {
+                async providerResidencyRepair() {
+                    providerResidencyRepairCalls.push({});
+                    return {
+                        ready  : false,
+                        warning: 'provider cannot hold chat and embedding together'
+                    };
+                }
+            }
+        });
+
+        const result = await service.apply('model', 'warm-provider', {
+            now           : 50_000,
+            targetIdentity: {kind: 'compose-service', id: 'model'}
+        });
+
+        expect(result).toMatchObject({
+            status    : 'failed',
+            reasonCode: 'executor-failed',
+            error     : 'provider cannot hold chat and embedding together'
+        });
+        expect(runtimeCalls).toEqual([]);
+        expect(providerResidencyRepairCalls).toHaveLength(1);
     });
 
     test('non-allowlisted compose services are rejected before any executor call', async () => {

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -600,6 +600,28 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         }]);
     });
 
+    test('provider role-set builders fail loud on missing AiConfig localModels leaves (#13948)', () => {
+        expect(() => providerReadinessHelper.buildLmsPreloadConfig({
+            modelProvider    : 'openAiCompatible',
+            graphProvider    : 'openAiCompatible',
+            embeddingProvider: 'openAiCompatible',
+            openAiCompatible : {
+                model         : 'chat-model',
+                embeddingModel: 'embedding-model'
+            }
+        })).toThrow(TypeError);
+
+        expect(() => providerReadinessHelper.buildOllamaReadinessConfig({
+            modelProvider    : 'ollama',
+            graphProvider    : 'ollama',
+            embeddingProvider: 'ollama',
+            ollama           : {
+                model         : 'chat-model',
+                embeddingModel: 'embedding-model'
+            }
+        })).toThrow(TypeError);
+    });
+
     test('ensureLmsModelsLoaded skips lms load when both models are already resident AND no contextLengths configured', async () => {
         const loads = [];
 
@@ -1561,6 +1583,14 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 model                : 'gemma4:31b',
                 embeddingModel       : 'qwen3-embedding',
                 requireParallelModels: 2
+            },
+            localModels: {
+                chat: {
+                    contextLimitTokens: 131072
+                },
+                embedding: {
+                    contextLimitTokens: 32768
+                }
             }
         }).roles).toEqual([]);
     });

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -481,6 +481,125 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         });
     });
 
+    test('repairProviderRoleSetResidency warms the LM Studio chat and embedding role set (#13948)', async () => {
+        let repairOptions;
+
+        const result = await providerReadinessHelper.repairProviderRoleSetResidency({
+            config: {
+                modelProvider    : 'openAiCompatible',
+                graphProvider    : 'openAiCompatible',
+                embeddingProvider: 'openAiCompatible',
+                openAiCompatible : {
+                    host          : 'http://127.0.0.1:1234',
+                    model         : 'chat-model',
+                    embeddingModel: 'embedding-model'
+                },
+                localModels: {
+                    chat     : {contextLimitTokens: 131072, parallel: 1},
+                    embedding: {contextLimitTokens: 32768, parallel: 1}
+                },
+                orchestrator: {
+                    lms: {enabled: true}
+                }
+            },
+            attempts   : 2,
+            delayMs    : 0,
+            timeoutMs  : 50,
+            lmsRepairFn: async options => {
+                repairOptions = options;
+                return {
+                    ready          : true,
+                    requiredModels : options.models,
+                    availableModels: options.models
+                };
+            }
+        });
+
+        expect(result).toMatchObject({
+            ready   : true,
+            provider: 'openAiCompatible',
+            host    : 'http://127.0.0.1:1234',
+            action  : 'warm-provider'
+        });
+        expect(repairOptions).toMatchObject({
+            host          : 'http://127.0.0.1:1234',
+            models        : ['chat-model', 'embedding-model'],
+            contextLengths: {
+                'chat-model'     : 131072,
+                'embedding-model': 32768
+            },
+            parallels: {
+                'chat-model'     : 1,
+                'embedding-model': 1
+            },
+            allowPartial: true,
+            attempts    : 2,
+            delayMs     : 0,
+            timeoutMs   : 50
+        });
+    });
+
+    test('repairProviderRoleSetResidency warms native Ollama chat and embedding roles (#13948)', async () => {
+        let repairOptions;
+
+        const result = await providerReadinessHelper.repairProviderRoleSetResidency({
+            config: {
+                modelProvider    : 'ollama',
+                graphProvider    : 'ollama',
+                embeddingProvider: 'ollama',
+                ollama           : {
+                    host                 : 'http://127.0.0.1:11434',
+                    model                : 'gemma4:26b',
+                    embeddingModel       : 'qwen3-embedding:latest',
+                    keep_alive           : -1,
+                    requireParallelModels: 2
+                },
+                localModels: {
+                    chat     : {contextLimitTokens: 131072},
+                    embedding: {contextLimitTokens: 32768}
+                }
+            },
+            attempts      : 2,
+            delayMs       : 0,
+            timeoutMs     : 50,
+            ollamaRepairFn: async options => {
+                repairOptions = options;
+                return {
+                    ready       : true,
+                    warmedModels: options.roles.map(role => ({model: role.model, role: role.role}))
+                };
+            }
+        });
+
+        expect(result).toMatchObject({
+            ready   : true,
+            provider: 'ollama',
+            action  : 'warm-provider'
+        });
+        expect(repairOptions).toMatchObject({
+            host                 : 'http://127.0.0.1:11434',
+            keepAlive            : -1,
+            requireParallelModels: 2,
+            allowPartial         : true,
+            attempts             : 2,
+            delayMs              : 0,
+            timeoutMs            : 50
+        });
+        expect(repairOptions.roles).toEqual([{
+            provider     : 'ollama',
+            providerRole : 'modelProvider',
+            role         : 'chat',
+            model        : 'gemma4:26b',
+            contextLength: 131072
+        }, {
+            provider     : 'ollama',
+            providerRole : 'embeddingProvider',
+            role         : 'embedding',
+            model        : 'qwen3-embedding:latest',
+            contextLength: 32768
+        }]);
+    });
+
     test('ensureLmsModelsLoaded skips lms load when both models are already resident AND no contextLengths configured', async () => {
         const loads = [];
 


### PR DESCRIPTION
Resolves #13948

## Summary
- Restores provider role-set residency through a bounded `warm-provider` recovery action before restart/redeploy escalation.
- Covers both active local provider surfaces: LM Studio/OpenAI-compatible via `lms load`, and native Ollama via role-specific warm-up endpoints.
- Adds an embedding `localModels.embedding.parallel` leaf so LM Studio can keep chat and embedding resident with explicit per-role slot counts instead of inheriting an opaque default.

## Deltas
- `missing-required-model` provider residency facts now route to `provider-role-residency` + `warm-provider`; context/warm-up failures still fail loud into config-drift.
- Recovery actuator allows `warm-provider` only for typed compose-service/supervised-task targets and preserves the existing anti-thrash ledger/backoff envelope.
- Provider readiness repair remains local-provider scoped: LM Studio requires `orchestrator.lms.enabled=true`; unsupported/remote providers return observe-only degraded/skipped envelopes.

Evidence: L2 focused unit coverage plus pre-commit gate coverage for the new recovery class, actuator path, and provider helper paths.

## Test Evidence
- `node --check ai/config.template.mjs`
- `node --check ai/services/graph/providerReadinessHelper.mjs`
- `node --check ai/daemons/orchestrator/services/RecoveryActuatorService.mjs`
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs`
- pre-commit hook passed on commit `088b2265ef`

## Post-Merge Validation
- [ ] Restart orchestrator and trigger a KB sync with LM Studio active; verify chat + embedding role models stay resident with the configured per-role `parallel` values.
- [ ] Verify an Ollama deployment warms both chat and embedding roles before escalating missing-provider-role residency.

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
