### PR TITLE
fix(ai): make lms embedding readiness load-aware (#13950)

### DIFF
--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -12,6 +12,8 @@ import {
     resolveGraphModelProvider
 } from './providerDispatch.mjs';
 
+let openAiCompatibleEmbeddingServingProbeQueue = Promise.resolve();
+
 /**
  * @module ai/services/graph/ProviderReadinessHelper
  */
@@ -82,6 +84,24 @@ function readNumericField(row, keys) {
 }
 
 /**
+ * @summary Checks an observed LM Studio parallel value only when the CLI exposes it.
+ *
+ * `lms ps --json` can report `parallel: null` for embedding rows even when the
+ * desktop UI shows a configured value. Unknown telemetry is diagnostic, not an
+ * unsatisfiable repair loop. Numeric mismatches still fail loud for roles whose
+ * parallel value is observable, such as chat rows.
+ *
+ * @param {*} observedParallel Loaded-model parallel value.
+ * @param {*} requiredParallel Configured required parallel value.
+ * @returns {Boolean}
+ */
+function isObservedLmsParallelSufficient(observedParallel, requiredParallel) {
+    return !Neo.isNumber(requiredParallel) ||
+        !Neo.isNumber(observedParallel) ||
+        observedParallel === requiredParallel;
+}
+
+/**
  * @summary Checks whether an LM Studio loaded-model identifier belongs to a configured model.
  *
  * LM Studio appends numeric suffixes (`:2`, `:3`, etc.) when the same model is
@@ -136,7 +156,7 @@ function isLmsLoadedModelSufficient({
         return false;
     }
 
-    if (hasParallelGate && loadedModel.parallel !== requiredParallel) {
+    if (hasParallelGate && !isObservedLmsParallelSufficient(loadedModel.parallel, requiredParallel)) {
         return false;
     }
 
@@ -351,6 +371,139 @@ export async function fetchOpenAiCompatibleModelIds({host, timeoutMs, fetchFn = 
     }
 
     return getOpenAiCompatibleModelIds(await response.json());
+}
+
+/**
+ * @summary Runs one tiny OpenAI-compatible embedding-serving canary.
+ *
+ * This probe verifies `/v1/embeddings` can serve the configured embedding model
+ * without returning or logging vector bodies. The caller owns load gating through
+ * `shouldRun`; a skipped decision returns an explicit degraded envelope instead
+ * of issuing a provider request during heavy maintenance or known contention.
+ *
+ * @param {Object} options
+ * @param {String} options.host Provider host.
+ * @param {String} options.model Embedding model identifier.
+ * @param {String} options.input Tiny canary text. Required and capped at 256 UTF-8 bytes.
+ * @param {Number} options.timeoutMs HTTP timeout. Required; no module-level default.
+ * @param {String} [options.apiKey] Optional OpenAI-compatible bearer token.
+ * @param {Function} [options.fetchFn=fetch] Fetch seam for tests.
+ * @param {Function} [options.shouldRun] Optional load/backpressure gate.
+ * @returns {Promise<Object>}
+ */
+export async function checkOpenAiCompatibleEmbeddingServing({
+    host,
+    model,
+    input,
+    timeoutMs,
+    apiKey,
+    fetchFn = fetch,
+    shouldRun
+} = {}) {
+    if (!host) {
+        throw new TypeError('checkOpenAiCompatibleEmbeddingServing: host is required');
+    }
+    if (!model) {
+        throw new TypeError('checkOpenAiCompatibleEmbeddingServing: model is required');
+    }
+    if (typeof timeoutMs !== 'number') {
+        throw new TypeError('checkOpenAiCompatibleEmbeddingServing: timeoutMs is required');
+    }
+    if (!Neo.isString(input) || input.length === 0) {
+        throw new TypeError('checkOpenAiCompatibleEmbeddingServing: non-empty input is required');
+    }
+    if (Buffer.byteLength(input, 'utf8') > 256) {
+        throw new TypeError('checkOpenAiCompatibleEmbeddingServing: input must be <= 256 UTF-8 bytes');
+    }
+
+    const gate = shouldRun ? await shouldRun({host, model, timeoutMs}) : true;
+
+    if (gate === false || gate?.run === false || gate?.skipped === true) {
+        return {
+            ready   : false,
+            degraded: true,
+            skipped : true,
+            provider: 'openAiCompatible',
+            host,
+            model,
+            reason  : gate?.reason || 'embedding-serving-canary-skipped',
+            warning : gate?.warning || `[provider/openAiCompatible] embedding-serving canary skipped for '${model}': ${gate?.reason || 'load gate returned false'}`
+        };
+    }
+
+    const headers = {'content-type': 'application/json'};
+    if (apiKey) {
+        headers.authorization = `Bearer ${apiKey}`;
+    }
+
+    const runProbe = async () => {
+        const response = await fetchFn(new URL('/v1/embeddings', host).toString(), {
+            method: 'POST',
+            headers,
+            body  : JSON.stringify({model, input}),
+            signal: AbortSignal.timeout(timeoutMs)
+        });
+
+        if (!response.ok) {
+            const text = typeof response.text === 'function' ? await response.text() : '',
+                  message = `HTTP ${response.status}${text ? ` - ${text.slice(0, 256)}` : ''}`;
+
+            return {
+                ready   : false,
+                degraded: true,
+                provider: 'openAiCompatible',
+                host,
+                model,
+                status  : response.status,
+                error   : {message},
+                warning : `[provider/openAiCompatible] embedding-serving canary failed for '${model}': ${message}`
+            };
+        }
+
+        const payload = await response.json(),
+              vector  = payload?.data?.[0]?.embedding;
+
+        if (!Array.isArray(vector)) {
+            return {
+                ready   : false,
+                degraded: true,
+                provider: 'openAiCompatible',
+                host,
+                model,
+                error   : {message: 'response did not contain data[0].embedding[]'},
+                warning : `[provider/openAiCompatible] embedding-serving canary failed for '${model}': response did not contain data[0].embedding[]`
+            };
+        }
+
+        return {
+            ready       : true,
+            degraded    : false,
+            provider    : 'openAiCompatible',
+            host,
+            model,
+            vectorLength: vector.length
+        };
+    };
+
+    const queuedProbe = openAiCompatibleEmbeddingServingProbeQueue
+        .catch(() => {})
+        .then(runProbe)
+        .catch(error => ({
+            ready   : false,
+            degraded: true,
+            provider: 'openAiCompatible',
+            host,
+            model,
+            error   : {
+                message: error?.message || String(error),
+                code   : error?.code
+            },
+            warning : `[provider/openAiCompatible] embedding-serving canary failed for '${model}': ${error?.message || error}`
+        }));
+
+    openAiCompatibleEmbeddingServingProbeQueue = queuedProbe.catch(() => {});
+
+    return queuedProbe;
 }
 
 /**
@@ -777,7 +930,7 @@ export function getInsufficientLmsLoadedModels({
 
         const observed    = byId.get(model),
               contextGap  = hasContextGate && (!Neo.isNumber(observed?.contextLength) || observed.contextLength < requiredContext),
-              parallelGap = hasParallelGate && observed?.parallel !== requiredParallel;
+              parallelGap = hasParallelGate && !isObservedLmsParallelSufficient(observed?.parallel, requiredParallel);
 
         if (contextGap || parallelGap) {
             insufficient.push({
@@ -824,6 +977,7 @@ export function getInsufficientLmsLoadedModels({
  * @param {Function} [options.fetchLoadedModels] Injectable loaded-model metadata probe.
  * @param {Function} [options.loadModel] Injectable model-load function.
  * @param {Function} [options.unloadModel] Injectable model-unload function.
+ * @param {Function} [options.embeddingServingProbe] Optional bounded embedding-serving canary seam.
  * @param {Object} [options.log=logger] Logger seam.
  * @returns {Promise<Object>}
  */
@@ -840,6 +994,7 @@ export async function ensureLmsModelsLoaded({
     fetchLoadedModels = opts => fetchLmsLoadedModels(opts),
     loadModel         = (model, options) => loadLmsModel(model, options),
     unloadModel       = (identifier, options) => unloadLmsModel(identifier, options),
+    embeddingServingProbe,
     log               = logger
 } = {}) {
     if (!Array.isArray(models) || models.length === 0) {
@@ -854,7 +1009,52 @@ export async function ensureLmsModelsLoaded({
         throw new TypeError('ensureLmsModelsLoaded: models must contain at least one configured model');
     }
 
-    const getMissing                = available => requiredModels.filter(model => !available.includes(model));
+    const getMissing          = available => requiredModels.filter(model => !available.includes(model));
+    const completeReadyResult = async result => {
+        if (result.ready !== true || typeof embeddingServingProbe !== 'function') {
+            return result;
+        }
+
+        let embeddingServing;
+
+        try {
+            embeddingServing = await embeddingServingProbe({
+                host,
+                timeoutMs,
+                requiredModels,
+                availableModels     : result.availableModels,
+                lmsLoadedModels     : result.lmsLoadedModels || [],
+                loadedContexts      : result.loadedContexts || {},
+                loadedParallels     : result.loadedParallels || {},
+                loadedParallelsKnown: Object.fromEntries((result.lmsLoadedModels || []).map(item => [item.id, Neo.isNumber(item.parallel)]))
+            });
+        } catch (error) {
+            embeddingServing = {
+                ready   : false,
+                degraded: true,
+                error   : {message: error?.message || String(error)},
+                warning : `[provider/openAiCompatible] embedding-serving canary failed: ${error?.message || error}`
+            };
+        }
+
+        if (embeddingServing?.ready === true) {
+            return {
+                ...result,
+                embeddingServing
+            };
+        }
+
+        if (embeddingServing?.warning) {
+            log.warn?.(`[ProviderReadinessHelper] ${embeddingServing.warning}`);
+        }
+
+        return {
+            ...result,
+            ready   : false,
+            degraded: true,
+            embeddingServing
+        };
+    };
     const requiresObservedLoadCheck = requiredModels.some(model =>
         Neo.isNumber(contextLengths?.[model]) || Neo.isNumber(parallels?.[model])
     );
@@ -955,7 +1155,7 @@ export async function ensureLmsModelsLoaded({
             await cleanupSupersededModels(initialLoadedModels);
         }
 
-        return {
+        return completeReadyResult({
             ready          : cleanupFailedModels.length === 0,
             degraded       : cleanupFailedModels.length > 0,
             loadedModels   : [],
@@ -969,7 +1169,7 @@ export async function ensureLmsModelsLoaded({
             loadedContexts : Object.fromEntries(initialLoadedModels.map(item => [item.id, item.contextLength])),
             loadedParallels: Object.fromEntries(initialLoadedModels.map(item => [item.id, item.parallel])),
             attempts       : 1
-        };
+        });
     }
 
     for (const model of modelsToLoad) {
@@ -1126,7 +1326,7 @@ export async function ensureLmsModelsLoaded({
             }
 
             const ready = missingModels.length === 0 && failedModels.length === 0 && cleanupFailedModels.length === 0;
-            return {
+            return completeReadyResult({
                 ready,
                 degraded       : !ready,
                 loadedModels,
@@ -1142,7 +1342,7 @@ export async function ensureLmsModelsLoaded({
                 loadedParallels: Object.fromEntries(lmsLoadedModels.map(item => [item.id, item.parallel])),
                 attempts       : attempt,
                 elapsedMs      : Date.now() - startedAt
-            };
+            });
         }
 
         if (allowPartial && serviceableMissing.length === 0) {

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -670,6 +670,87 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(result.loadedModels).toEqual([]);
     });
 
+    test('ensureLmsModelsLoaded treats unknown embedding parallel as unobservable telemetry (#13950)', async () => {
+        const loadCalls = [];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host             : 'http://127.0.0.1:1234',
+            models           : ['chat-model', 'embedding-model'],
+            contextLengths   : {'chat-model': 131072, 'embedding-model': 32768},
+            parallels        : {'chat-model': 1, 'embedding-model': 1},
+            attempts         : 1,
+            delayMs          : 0,
+            timeoutMs        : 50,
+            fetchModelIds    : async () => ['chat-model', 'embedding-model'],
+            loadModel        : async (model, options) => loadCalls.push({model, options}),
+            fetchLoadedModels: async () => [{
+                id           : 'chat-model',
+                contextLength: 131072,
+                parallel     : 1
+            }, {
+                id           : 'embedding-model',
+                contextLength: 32768
+            }],
+            log: {info: () => {}}
+        });
+
+        expect(loadCalls).toEqual([]);
+        expect(result.ready).toBe(true);
+        expect(result.loadedModels).toEqual([]);
+        expect(result.loadedParallels).toEqual({
+            'chat-model'     : 1,
+            'embedding-model': undefined
+        });
+    });
+
+    test('ensureLmsModelsLoaded still repairs numeric chat parallel mismatches (#13950)', async () => {
+        const loadCalls       = [],
+              unloadCalls     = [],
+              loadedSnapshots = [
+                  [{
+                      id           : 'chat-model',
+                      contextLength: 131072,
+                      parallel     : 4
+                  }],
+                  [{
+                      id           : 'chat-model',
+                      contextLength: 131072,
+                      parallel     : 1
+                  }]
+              ];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host             : 'http://127.0.0.1:1234',
+            models           : ['chat-model'],
+            contextLengths   : {'chat-model': 131072},
+            parallels        : {'chat-model': 1},
+            attempts         : 1,
+            delayMs          : 0,
+            timeoutMs        : 50,
+            fetchModelIds    : async () => ['chat-model'],
+            unloadModel      : async identifier => unloadCalls.push(identifier),
+            loadModel        : async (model, options) => loadCalls.push({model, options}),
+            fetchLoadedModels: async () => loadedSnapshots.shift() || [{
+                id           : 'chat-model',
+                contextLength: 131072,
+                parallel     : 1
+            }],
+            log: {info: () => {}}
+        });
+
+        expect(unloadCalls).toEqual(['chat-model']);
+        expect(loadCalls).toEqual([{
+            model  : 'chat-model',
+            options: {
+                contextLength: 131072,
+                parallel     : 1,
+                identifier   : 'chat-model'
+            }
+        }]);
+        expect(result.ready).toBe(true);
+        expect(result.loadedModels).toEqual(['chat-model']);
+    });
+
     test('ensureLmsModelsLoaded replaces stale exact lms load and unloads suffixed siblings (#13700)', async () => {
         const loadCalls      = [],
               unloadCalls    = [],
@@ -1066,6 +1147,175 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         }]);
         expect(result.missingModels).toEqual(['chat-model']);
         expect(warnings[0]).toContain('preload failed');
+    });
+
+    test('checkOpenAiCompatibleEmbeddingServing reports success without returning vector bodies (#13950)', async () => {
+        let request;
+
+        const result = await providerReadinessHelper.checkOpenAiCompatibleEmbeddingServing({
+            host     : 'http://127.0.0.1:1234',
+            model    : 'embedding-model',
+            input    : 'neo embedding canary',
+            timeoutMs: 50,
+            fetchFn  : async (url, options) => {
+                request = {
+                    url,
+                    method: options.method,
+                    body  : JSON.parse(options.body)
+                };
+
+                return {
+                    ok  : true,
+                    json: async () => ({data: [{embedding: [0.1, 0.2, 0.3]}]})
+                };
+            }
+        });
+
+        expect(request).toEqual({
+            url   : 'http://127.0.0.1:1234/v1/embeddings',
+            method: 'POST',
+            body  : {
+                model: 'embedding-model',
+                input: 'neo embedding canary'
+            }
+        });
+        expect(result).toEqual({
+            ready       : true,
+            degraded    : false,
+            provider    : 'openAiCompatible',
+            host        : 'http://127.0.0.1:1234',
+            model       : 'embedding-model',
+            vectorLength: 3
+        });
+        expect(result.embedding).toBeUndefined();
+    });
+
+    test('checkOpenAiCompatibleEmbeddingServing serializes concurrent canaries (#13950)', async () => {
+        const events = [];
+        let releaseFirst;
+
+        const firstCanaryDone = new Promise(resolve => {
+            releaseFirst = resolve;
+        });
+        const fetchFn = async (url, options) => {
+            const {input} = JSON.parse(options.body);
+
+            events.push(`start:${input}`);
+
+            if (input === 'first') {
+                await firstCanaryDone;
+            }
+
+            events.push(`finish:${input}`);
+
+            return {
+                ok  : true,
+                json: async () => ({data: [{embedding: [1]}]})
+            };
+        };
+
+        const first = providerReadinessHelper.checkOpenAiCompatibleEmbeddingServing({
+            host     : 'http://127.0.0.1:1234',
+            model    : 'embedding-model',
+            input    : 'first',
+            timeoutMs: 50,
+            fetchFn
+        });
+        const second = providerReadinessHelper.checkOpenAiCompatibleEmbeddingServing({
+            host     : 'http://127.0.0.1:1234',
+            model    : 'embedding-model',
+            input    : 'second',
+            timeoutMs: 50,
+            fetchFn
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(events).toEqual(['start:first']);
+
+        releaseFirst();
+        await Promise.all([first, second]);
+
+        expect(events).toEqual([
+            'start:first',
+            'finish:first',
+            'start:second',
+            'finish:second'
+        ]);
+    });
+
+    test('checkOpenAiCompatibleEmbeddingServing skips under load without issuing a request (#13950)', async () => {
+        let fetchCalled = false;
+
+        const result = await providerReadinessHelper.checkOpenAiCompatibleEmbeddingServing({
+            host     : 'http://127.0.0.1:1234',
+            model    : 'embedding-model',
+            input    : 'neo embedding canary',
+            timeoutMs: 50,
+            fetchFn  : async () => {
+                fetchCalled = true;
+            },
+            shouldRun: async () => ({
+                run   : false,
+                reason: 'heavy-maintenance-active'
+            })
+        });
+
+        expect(fetchCalled).toBe(false);
+        expect(result).toMatchObject({
+            ready   : false,
+            degraded: true,
+            skipped : true,
+            provider: 'openAiCompatible',
+            model   : 'embedding-model',
+            reason  : 'heavy-maintenance-active'
+        });
+    });
+
+    test('ensureLmsModelsLoaded surfaces degraded embedding-serving canary diagnostics (#13950)', async () => {
+        const warnings = [];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host             : 'http://127.0.0.1:1234',
+            models           : ['embedding-model'],
+            contextLengths   : {'embedding-model': 32768},
+            parallels        : {'embedding-model': 1},
+            attempts         : 1,
+            delayMs          : 0,
+            timeoutMs        : 50,
+            fetchModelIds    : async () => ['embedding-model'],
+            fetchLoadedModels: async () => [{
+                id           : 'embedding-model',
+                contextLength: 32768
+            }],
+            embeddingServingProbe: async () => ({
+                ready   : false,
+                degraded: true,
+                error   : {message: 'HTTP 400 - Model unloaded while request was queued'},
+                warning : '[provider/openAiCompatible] embedding-serving canary failed for embedding-model: HTTP 400 - Model unloaded while request was queued'
+            }),
+            log: {
+                info: () => {},
+                warn: message => warnings.push(message)
+            }
+        });
+
+        expect(result.ready).toBe(false);
+        expect(result.degraded).toBe(true);
+        expect(result.embeddingServing).toMatchObject({
+            ready   : false,
+            degraded: true,
+            error   : {message: 'HTTP 400 - Model unloaded while request was queued'}
+        });
+        expect(warnings[0]).toContain('embedding-serving canary failed');
+    });
+
+    test('checkOpenAiCompatibleEmbeddingServing rejects large canary bodies (#13950)', async () => {
+        await expect(providerReadinessHelper.checkOpenAiCompatibleEmbeddingServing({
+            host     : 'http://127.0.0.1:1234',
+            model    : 'embedding-model',
+            input    : 'x'.repeat(257),
+            timeoutMs: 50
+        })).rejects.toThrow(/<= 256 UTF-8 bytes/);
     });
 
     test('ensureOllamaModelsReady warms missing chat and embedding models through native roles (#12285)', async () => {


### PR DESCRIPTION
Resolves #13950

LM Studio loaded-model readiness now treats non-numeric `parallel` telemetry as unobservable instead of an unsatisfiable gate, while still repairing numeric chat parallel mismatches. The readiness helper also exposes a serialized, size-capped OpenAI-compatible embedding-serving canary that reports only diagnostics and vector length, never vector bodies.

Evidence: L2 (focused unit fixtures plus static diff/syntax checks) -> L2 required (the close target explicitly forbids live large-input stress probes). Residual: operator-gated local orchestrator restart smoke after merge.

## Deltas from ticket

The embedding canary is implemented as an opt-in readiness seam, not an automatic orchestrator startup request. That is intentional: the incident evidence showed direct provider probes can contend with KB sync or maintenance work. Callers must pass the canary and can skip/degrade it through the load gate.

Existing `TextEmbeddingService` loaded-context enforcement remains the hard stop for provider-side embedding truncation. This PR does not change embedding context defaults or add any env/config fallback.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs` -> 62 passed.
- `git diff --check` -> passed.
- `node --check ai/services/graph/providerReadinessHelper.mjs` -> passed.
- Commit hook passed: whitespace, shorthand, AiConfig test-mutation, JSDoc types, ticket archaeology, and block-alignment checks.

## Post-Merge Validation

- [ ] Pull `dev`, run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config`, then restart the harness/orchestrator.
- [ ] With models idle, confirm LM Studio keeps chat + embedding resident and no reload loop is caused by embedding `parallel` being unreported.
- [ ] Run any embedding-serving canary only when no KB sync/heavy maintenance is active.

## Commits

- `a0f0810556` - `fix(ai): make lms embedding readiness load-aware (#13950)`

Authored by Euclid (GPT-5, Codex Desktop). Session cd2b88d7-8134-4ef8-a10f-0b1e80c03db4.
