### PR TITLE
fix(ai): dedupe liveness readiness success logs (#13954)

### DIFF
--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -223,6 +223,40 @@ export class ProcessSupervisorService extends Base {
     }
 
     /**
+     * @summary Resets stable-success logging when readiness leaves the healthy state.
+     *
+     * Clears a readiness-success log guard after degraded/failed/down states.
+     * @param {String} taskName Task key.
+     * @param {String} phase Readiness phase key.
+     * @returns {void}
+     */
+    clearReadinessSuccessLogState(taskName, phase) {
+        this.readinessSuccessLogKeys?.delete(`${taskName}:${phase}`);
+    }
+
+    /**
+     * @summary Allows only the first stable readiness success log for a task phase.
+     *
+     * Determines whether a stable readiness success transition should be logged.
+     * @param {String} taskName Task key.
+     * @param {String} phase Readiness phase key.
+     * @returns {Boolean}
+     */
+    shouldLogReadinessSuccess(taskName, phase) {
+        this.readinessSuccessLogKeys ??= new Set();
+
+        const key = `${taskName}:${phase}`;
+
+        if (this.readinessSuccessLogKeys.has(key)) {
+            return false;
+        }
+
+        this.readinessSuccessLogKeys.add(key);
+
+        return true;
+    }
+
+    /**
      * Maps child-process stderr log prefixes to daemon log severities.
      * @param {String} line Child stderr line.
      * @returns {String}
@@ -350,6 +384,7 @@ export class ProcessSupervisorService extends Base {
             }))
             .then(result => {
                 if (result?.ready === false || result?.degraded === true) {
+                    this.clearReadinessSuccessLogState(taskName, 'liveness');
                     this.writeLog?.('WARN', `[ProcessSupervisor] ${task.label} readiness hook completed with degraded readiness after liveness confirmation.`);
                     this.recordTaskOutcome(taskName, 'degraded', {
                         reason,
@@ -361,7 +396,9 @@ export class ProcessSupervisorService extends Base {
                 }
 
                 this.taskStateService.markReady?.(taskName);
-                this.writeLog?.('INFO', `[ProcessSupervisor] ${task.label} readiness hook completed successfully after liveness confirmation.`);
+                if (this.shouldLogReadinessSuccess(taskName, 'liveness')) {
+                    this.writeLog?.('INFO', `[ProcessSupervisor] ${task.label} readiness hook completed successfully after liveness confirmation.`);
+                }
                 this.recordTaskOutcome(taskName, 'ready', {
                     reason,
                     pid      : null,
@@ -370,6 +407,7 @@ export class ProcessSupervisorService extends Base {
                 });
             })
             .catch(error => {
+                this.clearReadinessSuccessLogState(taskName, 'liveness');
                 this.writeLog?.('ERROR', `[ProcessSupervisor] ${task.label} readiness hook failed after liveness confirmation: ${error.message}`);
                 this.recordTaskOutcome(taskName, 'failed', {
                     reason,
@@ -403,6 +441,7 @@ export class ProcessSupervisorService extends Base {
         }
 
         this.clearRunningSkipLogState(taskName);
+        this.clearReadinessSuccessLogState(taskName, 'liveness');
         this.taskStateService.markStarted(taskName, reason);
 
         this.writeLog?.('INFO', `[ProcessSupervisor] Starting ${task.label} (${reason}).`);
@@ -818,10 +857,14 @@ export class ProcessSupervisorService extends Base {
                     this._livenessConfirmedAt[taskName] = Date.now();
                     this.runLivenessReadinessHook(taskName, task, 'liveness-confirmed', () => this.runTask(taskName, 'supervisor-restart'));
                 } else {
+                    this.clearReadinessSuccessLogState(taskName, 'liveness');
                     this.runTask(taskName, 'supervisor-restart');
                 }
             })
-            .catch(() => this.runTask(taskName, 'supervisor-restart'))
+            .catch(() => {
+                this.clearReadinessSuccessLogState(taskName, 'liveness');
+                this.runTask(taskName, 'supervisor-restart');
+            })
             .finally(() => { this._livenessProbeInFlight[taskName] = false; });
     }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -504,6 +504,51 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         }));
     });
 
+    test('#13954: liveness-readiness hook dedupes repeated success logs but records each outcome', async () => {
+        const { service, logEntries, taskOutcomes } = createTestService();
+        let readyMarks = 0;
+
+        service.taskDefinitions.mockTask.postSpawn = async () => ({ready: true, loadedModels: ['embedding-model']});
+        service.taskStateService.markReady = taskName => {
+            if (taskName === 'mockTask') {
+                readyMarks++;
+            }
+        };
+
+        await service.runLivenessReadinessHook('mockTask', service.taskDefinitions.mockTask, 'liveness-confirmed');
+        await service.runLivenessReadinessHook('mockTask', service.taskDefinitions.mockTask, 'liveness-confirmed');
+
+        const successLogs   = logEntries.filter(entry => entry.message.includes('completed successfully after liveness confirmation'));
+        const readyOutcomes = taskOutcomes.filter(entry => entry.status === 'ready' && entry.taskName === 'mockTask');
+
+        expect(successLogs.length).toBe(1);
+        expect(readyMarks).toBe(2);
+        expect(readyOutcomes.length).toBe(2);
+    });
+
+    test('#13954: liveness-readiness success logs again after degraded readiness recovers', async () => {
+        const { service, logEntries } = createTestService();
+        const readinessResults = [
+            {ready: true},
+            {ready: true},
+            {ready: false, degraded: true, missingModels: ['chat-model']},
+            {ready: true}
+        ];
+
+        service.taskDefinitions.mockTask.postSpawn = async () => readinessResults.shift();
+
+        await service.runLivenessReadinessHook('mockTask', service.taskDefinitions.mockTask, 'liveness-confirmed');
+        await service.runLivenessReadinessHook('mockTask', service.taskDefinitions.mockTask, 'liveness-confirmed');
+        await service.runLivenessReadinessHook('mockTask', service.taskDefinitions.mockTask, 'liveness-confirmed');
+        await service.runLivenessReadinessHook('mockTask', service.taskDefinitions.mockTask, 'liveness-confirmed');
+
+        const successLogs  = logEntries.filter(entry => entry.message.includes('completed successfully after liveness confirmation'));
+        const degradedLogs = logEntries.filter(entry => entry.message.includes('degraded readiness after liveness confirmation'));
+
+        expect(successLogs.length).toBe(2);
+        expect(degradedLogs.length).toBe(1);
+    });
+
     test('reapDuplicateListeners SIGKILLs extra listeners but keeps the canonical pid', () => {
         const { service, taskOutcomes } = createTestService();
         const killed = [];


### PR DESCRIPTION
Resolves #13954

Suppresses duplicate parent `ProcessSupervisor` INFO logs for repeated successful liveness-confirmed readiness checks. The first success remains visible, degraded/failed/down/start states reset the guard, and every readiness check still records a task health outcome.

Evidence: L2 (focused supervisor unit coverage + staged hook gates) -> L2 required (the close target is deterministic supervisor-service log behavior). Residual: none.

## Deltas from ticket

- Kept the fix inside `ProcessSupervisorService`; the orchestrator scheduler remains untouched.
- Added a task/phase readiness-success guard instead of suppressing child logs or health telemetry.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs` -> 36 passed
- `node ./buildScripts/util/check-block-alignment.mjs --staged` -> passed
- `git diff --check --cached` -> passed
- Pre-commit hook passed: whitespace, shorthand, AiConfig test-mutation, JSDoc types, ticket archaeology, block alignment

## Post-Merge Validation

- [ ] Restart the orchestrator and confirm repeated healthy LM Studio liveness-readiness polls no longer flood the parent supervisor log.

## Commit

- `8fc88eaeed` — `fix(ai): dedupe liveness readiness success logs (#13954)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
