### PR TITLE
fix(ai): skip generated-only issue sync pushes (#13958)

### DIFF
--- a/ai/services/github-workflow/queries/mutations.mjs
+++ b/ai/services/github-workflow/queries/mutations.mjs
@@ -168,6 +168,31 @@ export const GET_ISSUE_ID = `
 `;
 
 /**
+ * Query to fetch the issue fields needed before deciding whether a local
+ * Markdown hash mismatch is a real pushable edit or generated-only drift.
+ *
+ * Variables required:
+ * - $owner: String!
+ * - $repo: String!
+ * - $number: Int!
+ */
+export const GET_ISSUE_FOR_PUSH = `
+  query GetIssueForPush(
+    $owner: String!
+    $repo: String!
+    $number: Int!
+  ) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        id
+        title
+        body
+      }
+    }
+  }
+`;
+
+/**
  * Mutation to remove a "blocked by" relationship from an issue.
  *
  * Variables required:

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -10,7 +10,7 @@ import semver                                                                 fr
 import GraphqlService                                                         from '../GraphqlService.mjs';
 import ReleaseNotesSyncer                                                     from './ReleaseNotesSyncer.mjs';
 import {FETCH_ISSUE_TIMELINE_PAGE, FETCH_ISSUES_FOR_SYNC, FETCH_SINGLE_ISSUE} from '../queries/issueQueries.mjs';
-import {GET_ISSUE_ID, UPDATE_ISSUE}                                           from '../queries/mutations.mjs';
+import {GET_ISSUE_FOR_PUSH, UPDATE_ISSUE}                                     from '../queries/mutations.mjs';
 import contentPath                                                            from '../shared/contentPath.mjs';
 import {createContentIndexEntry, updateContentIndex}                          from '../shared/contentIndex.mjs';
 import {createContentTrustSummary, projectAuthoredNodeTrust}                  from '../shared/conversationTrust.mjs';
@@ -65,6 +65,29 @@ class IssueSyncer extends Base {
      */
     #calculateContentHash(content) {
         return crypto.createHash('sha256').update(content).digest('hex');
+    }
+
+    /**
+     * @summary Extracts the only Markdown fields that can be pushed back to GitHub.
+     *
+     * The local issue file also contains generated frontmatter and a read-only timeline.
+     * Those sections are useful for pull-side rendering and metadata checks, but GitHub's
+     * updateIssue mutation only accepts title/body. Keeping this projection explicit prevents
+     * generated-only drift from masquerading as local edit intent.
+     *
+     * @param {object} parsed Gray-matter parsed issue Markdown.
+     * @returns {{title: string, body: string}} Pushable issue title/body.
+     * @private
+     */
+    #getPushPayloadFromMarkdown(parsed) {
+        const bodyContent = parsed.content.split('## Timeline')[0].trim(),
+            titleMatch    = bodyContent.match(/^#\s+(.+)$/m),
+            title         = titleMatch ? titleMatch[1] : parsed.data.title,
+            body          = bodyContent
+                .replace(/^#\s+.+$/m, '')
+                .trim();
+
+        return {title, body};
     }
 
     /**
@@ -199,7 +222,7 @@ class IssueSyncer extends Base {
      * @private
      */
     #formatIssueMarkdown(issue) {
-        const contentTrust = createContentTrustSummary();
+        const contentTrust   = createContentTrustSummary();
         const projectedIssue = this.#projectAuthoredNode(issue, contentTrust, 'body');
         // GitHub GraphQL may return null authors or relationship nodes after users, labels, or
         // linked issues are deleted. Each dereference site uses optional chaining plus stable
@@ -368,7 +391,7 @@ class IssueSyncer extends Base {
                 const absPath = path.resolve(aiConfig.projectRoot, issue.path);
                 if (absPath.startsWith(issueSyncConfig.archiveRoot)) {
                     const relativeToArchive = path.relative(issueSyncConfig.archiveRoot, absPath);
-                    const parts = relativeToArchive.split(path.sep);
+                    const parts             = relativeToArchive.split(path.sep);
                     if (parts.length >= 2 && parts[0] === 'issues') {
                         oldVersion = parts[1];
                     }
@@ -417,7 +440,7 @@ class IssueSyncer extends Base {
             }
         }
 
-        const buckets = new Map();
+        const buckets     = new Map();
         const activeItems = [];
 
         for (const issue of combined.values()) {
@@ -577,11 +600,11 @@ class IssueSyncer extends Base {
         // called later in the cycle reuse the same set, so each issue warns at most once per full sync.
         this.#warnedAnomalies.clear();
 
-        let allIssues   = [];
-        let hasNextPage = true;
-        let cursor      = null;
-        let totalCost   = 0;
-        const maxIssues = issueSyncConfig.maxIssues;
+        let   allIssues   = [];
+        let   hasNextPage = true;
+        let   cursor      = null;
+        let   totalCost   = 0;
+        const maxIssues   = issueSyncConfig.maxIssues;
 
         // Paginate through all issues
         while (hasNextPage && allIssues.length < maxIssues) {
@@ -635,17 +658,17 @@ class IssueSyncer extends Base {
             dropped: { count: 0, issues: [] }
         };
 
-        const indexMutations = {upsert: [], remove: []};
-        let shouldPruneEmptyDirs = false;
+        const indexMutations       = {upsert: [], remove: []};
+        let   shouldPruneEmptyDirs = false;
 
         const planBuckets = this.#planBuckets(metadata, allIssues);
 
         // Process each issue
         for (const issue of allIssues) {
             const issueNumber = issue.number;
-            let targetPath = this.#getIssuePath(issue, planBuckets);
+            let   targetPath  = this.#getIssuePath(issue, planBuckets);
 
-            const oldIssue = metadata.issues[issueNumber];
+            const oldIssue        = metadata.issues[issueNumber];
             const oldPathRelative = oldIssue?.path;
             const oldAbsolutePath = oldIssue ? this.#resolvePath(oldPathRelative) : null;
 
@@ -773,7 +796,7 @@ class IssueSyncer extends Base {
          */
         // Identify related issues that need force-updating
         const relatedIssuesToUpdate = new Set();
-        const lastSyncDate = metadata.lastSync ? new Date(metadata.lastSync) : new Date(0);
+        const lastSyncDate          = metadata.lastSync ? new Date(metadata.lastSync) : new Date(0);
 
         allIssues.forEach(issue => {
             // 1. Parent field check for relationships already present on the fetched node.
@@ -885,7 +908,7 @@ class IssueSyncer extends Base {
                 await this.#exhaustTimelineItems(issue);
 
                 const planBuckets = this.#planBuckets(metadata, [issue]);
-                const targetPath = this.#getIssuePath(issue, planBuckets);
+                const targetPath  = this.#getIssuePath(issue, planBuckets);
                 if (!targetPath) {
                     if (indexMutations) {
                         indexMutations.remove.push({ type: 'issues', id: issueNumber });
@@ -943,7 +966,12 @@ class IssueSyncer extends Base {
      */
     async pushToGitHub(metadata) {
         logger.info('📤 Checking for local changes to push via GraphQL...');
-        const stats = { count: 0, issues: [], failures: [] };
+        const stats = {
+            count        : 0,
+            issues       : [],
+            failures     : [],
+            generatedOnly: {count: 0, issues: []}
+        };
 
         if (!metadata.lastSync) {
             logger.info('✨ No previous sync found, skipping push.');
@@ -991,35 +1019,36 @@ class IssueSyncer extends Base {
 
                 logger.debug(`📝 Content changed for #${issueNumber}`);
 
-                // Step 1: Get the issue's GraphQL ID
-                const idData = await GraphqlService.query(GET_ISSUE_ID, {
+                const localPayload = this.#getPushPayloadFromMarkdown(parsed);
+
+                // Step 1: Get the issue's current pushable fields.
+                const issueData = await GraphqlService.query(GET_ISSUE_FOR_PUSH, {
                     owner : aiConfig.owner,
                     repo  : aiConfig.repo,
                     number: issueNumber
                 });
 
-                const issueId = idData.repository.issue.id;
+                const remoteIssue = issueData.repository.issue;
 
-                // Step 2: Prepare the updated content
-                // Remove Timeline section and everything after it
-                // This prevents the read-only timeline from being pushed back to the issue body
-                const bodyContent = parsed.content.split('## Timeline')[0].trim();
-
-                // Extract title from the markdown
-                const titleMatch = bodyContent.match(/^#\s+(.+)$/m);
-                const title      = titleMatch ? titleMatch[1] : parsed.data.title;
-
-                // Remove only the title from body
-                const cleanBody = bodyContent
-                    .replace(/^#\s+.+$/m, '') // Remove title
-                    .trim();
+                if (remoteIssue.title === localPayload.title &&
+                    (remoteIssue.body || '') === localPayload.body) {
+                    oldIssue.contentHash = currentHash;
+                    logger.debug(`🩹 Generated-only drift for #${issueNumber}; metadata hash healed without GitHub mutation`);
+                    stats.generatedOnly.count++;
+                    stats.generatedOnly.issues.push(issueNumber);
+                    continue;
+                }
 
                 // Step 3: Execute the mutation
-                await GraphqlService.query(UPDATE_ISSUE, {
-                    issueId,
-                    title,
-                    body: cleanBody
+                const updateData = await GraphqlService.query(UPDATE_ISSUE, {
+                    issueId: remoteIssue.id,
+                    title  : localPayload.title,
+                    body   : localPayload.body
                 });
+
+                oldIssue.contentHash = currentHash;
+                oldIssue.title       = localPayload.title;
+                oldIssue.updatedAt   = updateData.updateIssue?.issue?.updatedAt || oldIssue.updatedAt;
 
                 logger.debug(`✅ Updated GitHub issue #${issueNumber} via GraphQL`);
                 stats.count++;
@@ -1035,6 +1064,9 @@ class IssueSyncer extends Base {
 
         if (stats.count > 0) {
             logger.info(`📤 Pushed ${stats.count} local change(s) to GitHub`);
+        }
+        if (stats.generatedOnly.count > 0) {
+            logger.info(`🩹 Healed ${stats.generatedOnly.count} generated-only issue drift(s) without GitHub mutation`);
         }
         if (stats.failures.length > 0) {
             logger.warn(`⚠️ Encountered ${stats.failures.length} push failure(s).`);
@@ -1058,8 +1090,8 @@ class IssueSyncer extends Base {
     async reconcileClosedIssueLocations(metadata) {
         logger.info('🔄 Reconciling closed issue locations...');
 
-        const stats = { count: 0, issues: [] };
-        let shouldPruneEmptyDirs = false;
+        const stats                = { count: 0, issues: [] };
+        let   shouldPruneEmptyDirs = false;
 
         // Ensure releases are loaded
         if (!ReleaseNotesSyncer.sortedReleases || ReleaseNotesSyncer.sortedReleases.length === 0) {
@@ -1252,7 +1284,7 @@ class IssueSyncer extends Base {
      */
     async #scanLocalFiles() {
         const localFiles = [];
-        const scanDir = async (dir) => {
+        const scanDir    = async (dir) => {
             try {
                 const entries = await fs.readdir(dir, { withFileTypes: true });
                 for (const entry of entries) {

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -20,6 +20,7 @@ import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 import fs              from 'fs-extra';
 import matter          from 'gray-matter';
 import path            from 'path';
+import crypto          from 'crypto';
 
 /**
  * @summary Regression coverage for IssueSyncer's timeline-based comment accounting.
@@ -141,7 +142,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
 
         const chunkNumber = 1;
         const writtenPath = path.join(issueSyncConfig.issuesDir, `chunk-${chunkNumber}`, `issue-${mockIssue.number}.md`);
-        const written     = await fs.readFile(writtenPath, 'utf-8');
+        const written = await fs.readFile(writtenPath, 'utf-8');
 
         // Every comment body must appear — the bug being fixed is that second-page comments
         // were silently dropped.
@@ -199,7 +200,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         // Frontmatter commentsCount uses the same derivation — no dual-source divergence possible.
         const chunkNumber = 1;
         const writtenPath = path.join(issueSyncConfig.issuesDir, `chunk-${chunkNumber}`, `issue-${mockIssue.number}.md`);
-        const written     = await fs.readFile(writtenPath, 'utf-8');
+        const written = await fs.readFile(writtenPath, 'utf-8');
         expect(written).toContain(`commentsCount: ${COMMENT_COUNT}`);
     });
 
@@ -305,9 +306,9 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         // Assert via configured active root (issuesDir) rather than literal '/issues/' substring —
         // the test rewrites issuesDir to a tmp dir, so the literal substring no longer matches even
         // when behavior is correct.
-        const targetPath           = metadata.issues['50001'].path;
-        const absoluteTargetPath   = path.resolve(aiConfig.projectRoot, targetPath);
-        const relativeToIssuesDir  = path.relative(issueSyncConfig.issuesDir, absoluteTargetPath);
+        const targetPath          = metadata.issues['50001'].path;
+        const absoluteTargetPath  = path.resolve(aiConfig.projectRoot, targetPath);
+        const relativeToIssuesDir = path.relative(issueSyncConfig.issuesDir, absoluteTargetPath);
         expect(relativeToIssuesDir.startsWith('..')).toBe(false); // path is under issuesDir
         expect(targetPath).not.toContain('/archive/');
         expect(targetPath).not.toContain('unversioned');
@@ -382,8 +383,8 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         };
 
         try {
-            const metadata = {issues: {}};
-            const stats    = await IssueSyncer.refetchIssuesByNumber([mockIssue.number], metadata);
+            const metadata   = {issues: {}};
+            const stats      = await IssueSyncer.refetchIssuesByNumber([mockIssue.number], metadata);
             const targetPath = metadata.issues[mockIssue.number].path;
 
             expect(stats.refetched.count).toBe(1);
@@ -456,7 +457,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         const originalSorted = ReleaseNotesSyncer.sortedReleases;
         const issueNumber    = 6003;
         const oldAbs         = path.join(issueSyncConfig.issuesDir, 'chunk-77', `issue-${issueNumber}.md`);
-        const oldRel         = path.relative(aiConfig.projectRoot, oldAbs);
+        const oldRel = path.relative(aiConfig.projectRoot, oldAbs);
 
         await fs.ensureDir(path.dirname(oldAbs));
         await fs.writeFile(oldAbs, 'CLOSED ISSUE CONTENT', 'utf8');
@@ -479,7 +480,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         };
 
         try {
-            const stats     = await IssueSyncer.reconcileClosedIssueLocations(metadata);
+            const stats = await IssueSyncer.reconcileClosedIssueLocations(metadata);
             const targetAbs = path.join(issueSyncConfig.archiveRoot, 'issues', 'v13.0.0', 'chunk-1', `issue-${issueNumber}.md`);
 
             expect(stats.count).toBe(1);
@@ -677,7 +678,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
 
         const chunkNumber = 1;
         const writtenPath = path.join(issueSyncConfig.issuesDir, `chunk-${chunkNumber}`, `issue-${mockIssue.number}.md`);
-        const written     = await fs.readFile(writtenPath, 'utf-8');
+        const written = await fs.readFile(writtenPath, 'utf-8');
 
         // Fallback markers appear in rendered markdown.
         expect(written).toContain('assigned to @Ghost');
@@ -871,10 +872,10 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         await fs.writeFile(issueBOldAbsolutePath, 'mock content B', 'utf8');
 
         // Spy on logger.warn and logger.debug.
-        const warnCalls  = [];
-        const debugCalls = [];
-        const originalWarn  = logger.warn;
-        const originalDebug = logger.debug;
+        const warnCalls                = [];
+        const debugCalls               = [];
+        const originalWarn             = logger.warn;
+        const originalDebug            = logger.debug;
         const originalRouteByMilestone = issueSyncConfig.routeByMilestone;
         logger.warn  = (...args) => { warnCalls.push(args[0]); };
         logger.debug = (...args) => { debugCalls.push(args[0]); };
@@ -978,9 +979,9 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         await fs.ensureDir(path.dirname(issueAbsolutePath));
         await fs.writeFile(issueAbsolutePath, 'mock content unchanged', 'utf8');
 
-        const warnCalls = [];
-        const debugCalls = [];
-        const originalWarn = logger.warn;
+        const warnCalls     = [];
+        const debugCalls    = [];
+        const originalWarn  = logger.warn;
         const originalDebug = logger.debug;
         logger.warn  = (...args) => { warnCalls.push(args[0]); };
         logger.debug = (...args) => { debugCalls.push(args[0]); };
@@ -1052,7 +1053,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         // oldVersion-precedence keep it pinned during a normal sync; the migration ignores both and,
         // with the full release history, recomputes closedAt→release and moves it to v7.0.0.
         const originalSorted = ReleaseNotesSyncer.sortedReleases;
-        const N        = 6001;
+        const N              = 6001;
         const wrongAbs = path.join(issueSyncConfig.archiveRoot, 'issues', 'v8.1.0', 'chunk-1', `issue-${N}.md`);
         const wrongRel = path.relative(aiConfig.projectRoot, wrongAbs);
         await fs.ensureDir(path.dirname(wrongAbs));
@@ -1076,7 +1077,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         };
 
         try {
-            const result     = await IssueSyncer.migrateArchiveBuckets(metadata);
+            const result = await IssueSyncer.migrateArchiveBuckets(metadata);
             const correctAbs = path.join(issueSyncConfig.archiveRoot, 'issues', 'v7.0.0', 'chunk-1', `issue-${N}.md`);
 
             expect(result.moved).toBe(1);
@@ -1098,7 +1099,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
 
     test('migrateArchiveBuckets dryRun reports the plan without moving any file (#12194)', async () => {
         const originalSorted = ReleaseNotesSyncer.sortedReleases;
-        const N        = 6002;
+        const N              = 6002;
         const wrongAbs = path.join(issueSyncConfig.archiveRoot, 'issues', 'v8.1.0', 'chunk-1', `issue-${N}.md`);
         const wrongRel = path.relative(aiConfig.projectRoot, wrongAbs);
         await fs.ensureDir(path.dirname(wrongAbs));
@@ -1147,6 +1148,158 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         } finally {
             ReleaseNotesSyncer.sortedReleases = originalSorted;
         }
+    });
+
+    test('pushToGitHub heals generated-only drift without mutating GitHub (#13958)', async () => {
+        const issueNumber = 43058;
+        const filePath    = path.join(issueSyncConfig.issuesDir, 'chunk-1', `issue-${issueNumber}.md`);
+        const markdown = matter.stringify(
+            '# Generated-only drift\n\nRemote body already matches.\n\n## Timeline\n\n### @tobiu - 2026-06-24T12:00:00Z\n\nGenerated timeline changed.\n',
+            {
+                id       : issueNumber,
+                title    : 'Generated-only drift',
+                state    : 'OPEN',
+                updatedAt: '2026-06-24T12:00:00Z',
+                githubUrl    : `https://github.com/neomjs/neo/issues/${issueNumber}`,
+                author       : 'tobiu',
+                commentsCount: 1,
+                contentTrust : {projected: true, quarantined: 0, signals: []}
+            },
+            {lineWidth: -1}
+        );
+        const currentHash = hashContent(markdown);
+
+        await fs.ensureDir(path.dirname(filePath));
+        await fs.writeFile(filePath, markdown, 'utf8');
+
+        const metadata = {
+            lastSync: '2026-06-24T11:00:00Z',
+            issues  : {
+                [issueNumber]: {
+                    state        : 'OPEN',
+                    path         : path.relative(aiConfig.projectRoot, filePath),
+                    updatedAt    : '2026-06-24T12:00:00Z',
+                    closedAt     : null,
+                    milestone    : null,
+                    title        : 'Generated-only drift',
+                    contentHash  : 'stale-full-render-hash',
+                    commentsTotal: 1
+                }
+            }
+        };
+
+        const queries = [];
+        GraphqlService.query = async (query, variables) => {
+            queries.push({query, variables});
+
+            if (query.includes('GetIssueForPush')) {
+                return {
+                    repository: {
+                        issue: {
+                            id   : 'I_generated_only',
+                            title: 'Generated-only drift',
+                            body : 'Remote body already matches.'
+                        }
+                    }
+                };
+            }
+
+            if (query.includes('UpdateIssue')) {
+                throw new Error('generated-only drift must not call UPDATE_ISSUE');
+            }
+
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        const stats = await IssueSyncer.pushToGitHub(metadata);
+
+        expect(stats.count).toBe(0);
+        expect(stats.generatedOnly.count).toBe(1);
+        expect(stats.generatedOnly.issues).toEqual([issueNumber]);
+        expect(metadata.issues[issueNumber].contentHash).toBe(currentHash);
+        expect(queries.filter(item => item.query.includes('UpdateIssue'))).toHaveLength(0);
+    });
+
+    test('pushToGitHub still mutates GitHub for real title/body edits (#13958)', async () => {
+        const issueNumber = 43059;
+        const filePath    = path.join(issueSyncConfig.issuesDir, 'chunk-1', `issue-${issueNumber}.md`);
+        const markdown = matter.stringify(
+            '# Real body edit\n\nLocal body changed.\n\n## Timeline\n\n### @tobiu - 2026-06-24T12:00:00Z\n\nGenerated timeline.\n',
+            {
+                id       : issueNumber,
+                title    : 'Real body edit',
+                state    : 'OPEN',
+                updatedAt: '2026-06-24T12:00:00Z',
+                githubUrl    : `https://github.com/neomjs/neo/issues/${issueNumber}`,
+                author       : 'tobiu',
+                commentsCount: 1,
+                contentTrust : {projected: true, quarantined: 0, signals: []}
+            },
+            {lineWidth: -1}
+        );
+        const currentHash = hashContent(markdown);
+
+        await fs.ensureDir(path.dirname(filePath));
+        await fs.writeFile(filePath, markdown, 'utf8');
+
+        const metadata = {
+            lastSync: '2026-06-24T11:00:00Z',
+            issues  : {
+                [issueNumber]: {
+                    state        : 'OPEN',
+                    path         : path.relative(aiConfig.projectRoot, filePath),
+                    updatedAt    : '2026-06-24T12:00:00Z',
+                    closedAt     : null,
+                    milestone    : null,
+                    title        : 'Real body edit',
+                    contentHash  : 'stale-full-render-hash',
+                    commentsTotal: 1
+                }
+            }
+        };
+
+        const updates = [];
+        GraphqlService.query = async (query, variables) => {
+            if (query.includes('GetIssueForPush')) {
+                return {
+                    repository: {
+                        issue: {
+                            id   : 'I_real_edit',
+                            title: 'Real body edit',
+                            body : 'Remote body before local edit.'
+                        }
+                    }
+                };
+            }
+
+            if (query.includes('UpdateIssue')) {
+                updates.push(variables);
+                return {
+                    updateIssue: {
+                        issue: {
+                            number   : issueNumber,
+                            title    : variables.title,
+                            updatedAt: '2026-06-24T12:01:00Z'
+                        }
+                    }
+                };
+            }
+
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        const stats = await IssueSyncer.pushToGitHub(metadata);
+
+        expect(stats.count).toBe(1);
+        expect(stats.issues).toEqual([issueNumber]);
+        expect(stats.generatedOnly.count).toBe(0);
+        expect(updates).toEqual([{
+            issueId: 'I_real_edit',
+            title  : 'Real body edit',
+            body   : 'Local body changed.'
+        }]);
+        expect(metadata.issues[issueNumber].contentHash).toBe(currentHash);
+        expect(metadata.issues[issueNumber].updatedAt).toBe('2026-06-24T12:01:00Z');
     });
 });
 
@@ -1198,4 +1351,8 @@ function buildMockIssue({number, title, timelineFirst, hasNextPage, endCursor}) 
             nodes   : timelineFirst
         }
     };
+}
+
+function hashContent(content) {
+    return crypto.createHash('sha256').update(content).digest('hex');
 }


### PR DESCRIPTION
Resolves #13958

`IssueSyncer.pushToGitHub()` now separates full-render metadata drift from the actual title/body payload GitHub accepts. A new `GET_ISSUE_FOR_PUSH` query fetches the remote pushable fields; generated-only drift heals the metadata hash without `UPDATE_ISSUE`, and real title/body edits still push once.

Evidence: L2 (unit + read-only live diagnostic) -> L3 post-merge sync observation required. Residual: live orchestrator sync must confirm the repeated issue-push loop is gone on a normal run.

## Deltas from ticket

- Current read-only scan found 55 active full-render hash mismatches rather than the 54 from the reported log; all 55 already matched live GitHub title/body.
- Archived full-render metadata drift stays out of scope because `pushToGitHub()` only scans the active issue directory.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs` -> 20 passed.
- `npm run agent-preflight -- ai/services/github-workflow/queries/mutations.mjs ai/services/github-workflow/sync/IssueSyncer.mjs test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs` -> all requested gates passed.
- Read-only live payload scan: 55/55 active full-render mismatches already matched GitHub title/body; 0 payload differences.
- Patched no-mutation diagnostic against the current active mismatch set: `pushes: 0`, `generatedOnly: 55`, `updates: 0`.

## Post-Merge Validation

- [ ] Run the normal GitHub Workflow sync once; the summary should not report repeated local issue pushes for the generated-only drift set.
- [ ] Confirm metadata healing does not create an endless generated-content commit loop.

## Commit

- `8cd3c12daa` — payload-aware issue sync push gate.

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.