### PR TITLE
fix(ai): overwrite stale sandman handoff (#13962)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -732,7 +732,7 @@ class GoldenPathSynthesizer extends Base {
      */
     async fetchOpenPRs() {
         const { execSync } = await import('child_process');
-        const rawPrData = execSync('gh pr list --state open --json number,url,author,title,body,headRefOid,reviewRequests,reviews,comments,createdAt', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
+        const rawPrData    = execSync('gh pr list --state open --json number,url,author,title,body,headRefOid,reviewRequests,reviews,comments,createdAt', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
         return JSON.parse(rawPrData);
     }
 
@@ -898,6 +898,17 @@ class GoldenPathSynthesizer extends Base {
             return;
         }
 
+        const scoredNodes  = [];
+        const scoringStats = {
+            semanticCandidates     : 0,
+            sqliteOpenMatches      : 0,
+            blockedCandidates      : 0,
+            nonActionableCandidates: 0,
+            scoredCandidates       : 0,
+            selectedTopNodes       : 0,
+            prunedGuideEdges       : 0
+        };
+
         // Pillar 1: Semantic Distance from ChromaDB
         let semanticIds       = [];
         let semanticDistances = [];
@@ -923,92 +934,84 @@ class GoldenPathSynthesizer extends Base {
 
         if (semanticIds.length === 0) {
             logger.info('[GoldenPathSynthesizer] No semantic nodes found. Golden path empty.');
-            return;
         }
+        scoringStats.semanticCandidates = semanticIds.length;
 
         // Pillar 2: Structural Weight from SQLite Graph
-        const scoredNodes  = [];
-        const scoringStats = {
-            semanticCandidates     : semanticIds.length,
-            sqliteOpenMatches      : 0,
-            blockedCandidates      : 0,
-            nonActionableCandidates: 0,
-            scoredCandidates       : 0,
-            selectedTopNodes       : 0,
-            prunedGuideEdges       : 0
-        };
         const SEMANTIC_WEIGHT   = 2.0;
         const STRUCTURAL_WEIGHT = 1.0;
 
-        try {
-            const placeholders = semanticIds.map(() => '?').join(',');
-            const stmt         = GraphService.db.storage.db.prepare(`
-                SELECT
-                    n.id,
-                    n.data,
-                    COALESCE((
-                        SELECT SUM(json_extract(e.data, '$.properties.weight'))
-                        FROM Edges e
-                        WHERE e.target = n.id AND e.type != 'BLOCKS'
-                    ), 0.0) as struct_score
-                FROM Nodes n
-                WHERE (json_extract(n.data, '$.properties.state') = 'OPEN' OR json_extract(n.data, '$.state') = 'OPEN')
-                  AND n.id IN (${placeholders})
-            `);
+        if (semanticIds.length > 0) {
+            try {
+                const placeholders = semanticIds.map(() => '?').join(',');
+                const stmt         = GraphService.db.storage.db.prepare(`
+                    SELECT
+                        n.id,
+                        n.data,
+                        COALESCE((
+                            SELECT SUM(json_extract(e.data, '$.properties.weight'))
+                            FROM Edges e
+                            WHERE e.target = n.id AND e.type != 'BLOCKS'
+                        ), 0.0) as struct_score
+                    FROM Nodes n
+                    WHERE (json_extract(n.data, '$.properties.state') = 'OPEN' OR json_extract(n.data, '$.state') = 'OPEN')
+                      AND n.id IN (${placeholders})
+                `);
 
-            const results = stmt.all(...semanticIds);
-            scoringStats.sqliteOpenMatches = results.length;
+                const results = stmt.all(...semanticIds);
+                scoringStats.sqliteOpenMatches = results.length;
 
-            for (const row of results) {
-                const issueId = row.id;
+                for (const row of results) {
+                    const issueId = row.id;
 
-                // Guarantee graph topology is completely loaded into RAM BEFORE executing cold-cache resistant queries natively!
-                GraphService.db.getAdjacentNodes(issueId, 'both');
+                    // Guarantee graph topology is completely loaded into RAM BEFORE executing cold-cache resistant queries natively!
+                    GraphService.db.getAdjacentNodes(issueId, 'both');
 
-                // Re-verify blocker topology natively using GraphService API
-                const blockers  = GraphService.db.edges.getByIndex('target', issueId).filter(e => e.type === 'BLOCKS');
-                let   isBlocked = false;
+                    // Re-verify blocker topology natively using GraphService API
+                    const blockers  = GraphService.db.edges.getByIndex('target', issueId).filter(e => e.type === 'BLOCKS');
+                    let   isBlocked = false;
 
-                for (const bEdge of blockers) {
-                    const blockerNode = GraphService.db.nodes.get(bEdge.source);
-                    if (blockerNode && (blockerNode.properties?.state === 'OPEN' || blockerNode.state === 'OPEN')) {
-                        isBlocked = true;
-                        break;
+                    for (const bEdge of blockers) {
+                        const blockerNode = GraphService.db.nodes.get(bEdge.source);
+                        if (blockerNode && (blockerNode.properties?.state === 'OPEN' || blockerNode.state === 'OPEN')) {
+                            isBlocked = true;
+                            break;
+                        }
                     }
+
+                    if (isBlocked) {
+                        scoringStats.blockedCandidates++;
+                        continue; // Architecturally blocked issues cannot be Golden
+                    }
+
+                    const idx               = semanticIds.indexOf(issueId);
+                    const semantic_distance = parseFloat(semanticDistances[idx]) || 0.1;
+                    const struct_score      = parseFloat(row.struct_score) || 0;
+
+                    // Lower distance = Higher significance. (Add 0.1 to avoid div by 0 and curb massive asymptotes)
+                    const semanticScore = 1.0 / (semantic_distance + 0.1);
+
+                    let nodeData = null;
+                    try { nodeData = JSON.parse(row.data); } catch (e) { }
+
+                    let priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
+
+                    if (!this.constructor.isActionableComputedRecommendation(nodeData || {id: issueId})) {
+                        scoringStats.nonActionableCandidates++;
+                        logger.debug(`[GoldenPathSynthesizer] Skipping non-actionable computed recommendation: ${issueId}`);
+                        continue;
+                    }
+
+                    scoredNodes.push({
+                        node      : nodeData || { id: issueId },
+                        score     : priority,
+                        semantic  : semanticScore,
+                        structural: struct_score
+                    });
                 }
-
-                if (isBlocked) {
-                    scoringStats.blockedCandidates++;
-                    continue; // Architecturally blocked issues cannot be Golden
-                }
-
-                const idx               = semanticIds.indexOf(issueId);
-                const semantic_distance = parseFloat(semanticDistances[idx]) || 0.1;
-                const struct_score      = parseFloat(row.struct_score) || 0;
-
-                // Lower distance = Higher significance. (Add 0.1 to avoid div by 0 and curb massive asymptotes)
-                const semanticScore = 1.0 / (semantic_distance + 0.1);
-
-                let nodeData = null;
-                try { nodeData = JSON.parse(row.data); } catch (e) { }
-
-                let priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
-
-                if (!this.constructor.isActionableComputedRecommendation(nodeData || {id: issueId})) {
-                    scoringStats.nonActionableCandidates++;
-                    logger.debug(`[GoldenPathSynthesizer] Skipping non-actionable computed recommendation: ${issueId}`);
-                    continue;
-                }
-
-                scoredNodes.push({
-                    node      : nodeData || { id: issueId },
-                    score     : priority,
-                    semantic  : semanticScore,
-                    structural: struct_score
-                });
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Error executing hybrid mapping across local Graph Store.', e);
             }
-        } catch (e) {
-            logger.warn('[GoldenPathSynthesizer] Error executing hybrid mapping across local Graph Store.', e);
         }
 
         // Sort descending by calculated priority
@@ -1238,7 +1241,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         // larger-context consumer choice).
         try {
             const {renderConsumerFrictionSection} = await import('../../services/memory-core/helpers/consumerFrictionHelper.mjs');
-            const frictionSection = renderConsumerFrictionSection();
+            const frictionSection                 = renderConsumerFrictionSection();
 
             if (frictionSection) {
                 handoffContent += frictionSection + '\n';

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -279,6 +279,71 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).not.toContain('- **Head SHA**:');
     });
 
+    test('synthesizeGoldenPath overwrites stale author sections when semantic candidates are empty', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
+        const issuesDir                    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-zero-candidate-issues-'));
+        aiConfig.vectorDimension = 2;
+
+        fs.mkdirSync(path.dirname(tmpHandoffFile), {recursive: true});
+        fs.writeFileSync(tmpHandoffFile, [
+            '# Autonomous Handoff (Dream Pipeline & Golden Path)',
+            '',
+            '## Active PR Cycle State',
+            '',
+            '### Recent Open PRs',
+            '',
+            '### @neo-gpt',
+            '',
+            '- stale author-grouped PR entry',
+            '',
+            '### @neo-opus-grace',
+            '',
+            '- stale author-grouped PR entry'
+        ].join('\n'));
+
+        StorageRouter.getGraphCollection = async () => ({ query: async () => ({ ids: [[]], distances: [[]] }) });
+        StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [
+            {
+                number        : 13962,
+                url           : 'https://github.com/neomjs/neo/pull/13962',
+                author        : {login: 'neo-gpt'},
+                title         : 'fix(ai): overwrite stale Sandman handoff',
+                body          : '',
+                createdAt     : '2026-06-24T17:59:52Z',
+                headRefOid    : 'abcdef1234567890',
+                reviewRequests: [],
+                reviews       : [],
+                comments      : []
+            }
+        ];
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({issuesDir});
+        } finally {
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+
+        expect(handoffContent).toContain('## Active PR Cycle State');
+        expect(handoffContent).toContain('### Recent Open PRs (`1` of `1` items)');
+        expect(handoffContent).toContain('## Computed Golden Path (Strategic Recommendation)');
+        expect(handoffContent).toContain('No actionable computed recommendations survived the current Tri-Vector filter pass.');
+        expect(handoffContent).toContain('- Semantic candidates: 0');
+        expect(handoffContent).not.toContain('### @neo-gpt');
+        expect(handoffContent).not.toContain('### @neo-opus-grace');
+        expect(handoffContent).not.toContain('stale author-grouped PR entry');
+    });
+
     test('synthesizeGoldenPath skips Neo repo enrichment sections when deployment config disables them', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;


### PR DESCRIPTION
Resolves #13962

GoldenPathSynthesizer now treats an empty semantic candidate set as an empty Golden Path render, not as a pre-write return. That keeps Sandman handoff generation on the centralized overwrite path, so stale per-author PR sections from older generated content are purged and the current compact Recent Open PRs section is rendered.

Evidence: L2 focused unit/static evidence covers the close-target ACs; no live orchestrator restart is required for the implementation proof. Residual: post-merge validation should confirm the next scheduled Golden Path pass rewrites the root handoff.

## Deltas from ticket

The fix is narrower than a generic stale-output rewrite audit. It targets the verified zero-semantic-candidate branch and leaves storage, embedding, and Chroma failure returns unchanged.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` passed, 33/33.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Commit hook passed whitespace, shorthand, AiConfig test-mutation, JSDoc types, ticket archaeology, and staged block-alignment checks.

## Post-Merge Validation

- [ ] After the orchestrator picks up this SHA, run or wait for Golden Path synthesis and verify `resources/content/sandman_handoff.md` no longer contains stale `### @neo-*` PR author subsections.
- [ ] Verify the generated Active PR Cycle State shows `Recent Open PRs (x of y items)`.

Related: #13755

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
