### PR TITLE
fix(ai): chunk REM topology inference by turn (#13965)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -374,7 +374,8 @@ class DreamService extends Base {
                 for (const session of sessions) {
                     logger.info(`[DreamService] Preparing session ${session.meta.sessionId} ("${session.meta.title}") for REM extraction.`);
 
-                    let rawEpisodicMemory = session.document;
+                    let rawEpisodicMemory = session.document,
+                        turnDocuments     = [session.document];
                     try {
                         const memoryCollection = await StorageRouter.getMemoryCollection();
                         if (memoryCollection) {
@@ -385,14 +386,16 @@ class DreamService extends Base {
                             if (rawMemories?.documents?.length > 0) {
                                 // Send the full raw memory to the LLM. Lossless context tracking is required.
                                 // If local APIs crash, it is a configuration issue with n_ctx, not a client logic error.
-                                rawEpisodicMemory = rawMemories.documents.join('\n\n---\n\n');
+                                turnDocuments     = rawMemories.documents;
+                                rawEpisodicMemory = turnDocuments.join('\n\n---\n\n');
                             }
                         }
                     } catch (e) {
                         logger.warn(`[DreamService] Could not fetch raw memories for ${session.meta.sessionId}`, e);
                     }
 
-                    session.document = rawEpisodicMemory;
+                    session.document      = rawEpisodicMemory;
+                    session.turnDocuments = turnDocuments;
                     logger.info(`[DreamService]   -> Payload size (chars): ${session.document.length}`);
 
                     const sessionState = {
@@ -486,10 +489,19 @@ class DreamService extends Base {
                     }));
 
                     const topoStart     = Date.now();
-                    let   conflictCount = 0;
+                    let   conflictCount = 0,
+                          topologyDetails = {};
                     try {
-                        await TopologyInferenceEngine.extractTopology(session.document, session.meta.sessionId);
+                        const topologyResult = await TopologyInferenceEngine.extractTopology(session.document, session.meta.sessionId, {
+                            turnDocuments: session.turnDocuments
+                        });
                         conflictCount = await TopologyInferenceEngine.getTopologyConflictCount();
+                        if (topologyResult?.chunks) {
+                            topologyDetails = {
+                                chunks : topologyResult.chunks,
+                                chunked: topologyResult.chunked
+                            };
+                        }
                     } catch (e) {
                         sessionState.topology = {
                             status       : 'failed',
@@ -507,11 +519,13 @@ class DreamService extends Base {
                     logger.info(`[DreamService]   -> Topological Conflicts took: ${topoTime}s`);
                     sessionState.topology = {
                         status: 'completed',
-                        conflictCount
+                        conflictCount,
+                        ...topologyDetails
                     };
                     perPhaseStates.push(finishPhase('topology', topoStart, 'completed', {
                         sessionId: session.meta.sessionId,
-                        conflictCount
+                        conflictCount,
+                        ...topologyDetails
                     }));
 
                     const capStart = Date.now();

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -1,15 +1,65 @@
-import fs                                              from 'fs';
-import path                                            from 'path';
-import { Memory_Config as aiConfig }                   from '../../services.mjs';
-import Base                                            from '../../../src/core/Base.mjs';
-import Json                                            from '../../../src/util/Json.mjs';
-import logger                                          from '../../mcp/server/memory-core/logger.mjs';
-import {emitConsumerFriction}                          from '../memory-core/helpers/consumerFrictionHelper.mjs';
+import fs                            from 'fs';
+import path                          from 'path';
+import { Memory_Config as aiConfig } from '../../services.mjs';
+import Base                          from '../../../src/core/Base.mjs';
+import Json                          from '../../../src/util/Json.mjs';
+import logger                        from '../../mcp/server/memory-core/logger.mjs';
+import {
+    bytesToTokens,
+    emitConsumerFriction,
+    invokeWithGuardrail
+}                                                       from '../memory-core/helpers/consumerFrictionHelper.mjs';
 import {buildGraphProvider, resolveGraphModelProvider} from './providerDispatch.mjs';
+import {chunkSession}                                  from './sessionChunker.mjs';
 
 const
     conflictEntryRegex          = /^- \*\*\[(SUPERSEDES|OBSOLETES|DUPLICATE)\]\*\* `([^`]+)`: (.*?) \(Source Session: ([^)]+)\)$/gm,
-    topologyConflictRenderLimit = 5;
+    topologyConflictRenderLimit = 5,
+    topologyConflictSchema      = {
+        type      : 'object',
+        properties: {
+            conflicts: {
+                type    : 'array',
+                maxItems: topologyConflictRenderLimit,
+                items   : {
+                    type      : 'object',
+                    properties: {
+                        issueId    : {type: 'string', maxLength: 64},
+                        type       : {type: 'string', enum: ['SUPERSEDES', 'OBSOLETES', 'DUPLICATE']},
+                        description: {type: 'string', maxLength: 240}
+                    },
+                    required            : ['issueId', 'type', 'description'],
+                    additionalProperties: false
+                }
+            }
+        },
+        required            : ['conflicts'],
+        additionalProperties: false
+    };
+
+function estimateTopologyTokens(text) {
+    return bytesToTokens(Buffer.byteLength(text === undefined || text === null ? '' : String(text), 'utf8'));
+}
+
+function readRequiredChatNumberLeaf(leafName) {
+    const value = aiConfig.localModels.chat[leafName];
+
+    if (!Number.isFinite(value)) {
+        throw new Error(`[TopologyInferenceEngine] Required AiConfig leaf "localModels.chat.${leafName}" is missing or invalid. Update ai/mcp/server/memory-core/config.mjs from config.template.mjs.`);
+    }
+
+    return value;
+}
+
+function readRequiredChatStringLeaf(leafName) {
+    const value = aiConfig.localModels.chat[leafName];
+
+    if (typeof value !== 'string') {
+        throw new Error(`[TopologyInferenceEngine] Required AiConfig leaf "localModels.chat.${leafName}" is missing or invalid. Update ai/mcp/server/memory-core/config.mjs from config.template.mjs.`);
+    }
+
+    return value;
+}
 
 /**
  * @class Neo.ai.daemons.services.TopologyInferenceEngine
@@ -106,17 +156,22 @@ class TopologyInferenceEngine extends Base {
     }
 
     /**
-     * Dedicated inference pass to scan episodic memory explicitly for topological conflicts
-     * (e.g. tracking when an OPEN issue is superseded or rendered obsolete by recent session decisions).
-     * @param {String} contextText The raw session episodic document.
-     * @param {String} sessionId The ID of the session being processed.
+     * @summary Builds the bounded topology-conflict prompt for one turn-aligned chunk.
+     * @param {String} contextText Turn-aligned chunk text.
+     * @param {Object} chunkInfo Chunk provenance.
+     * @returns {String}
      */
-    async extractTopology(contextText, sessionId) {
-        logger.info(`[TopologyInferenceEngine] Extracting Topological Conflicts for session ID: ${sessionId}`);
+    buildTopologyPrompt(contextText, chunkInfo = {}) {
+        const chunkLine = chunkInfo.chunked
+            ? `Chunk ${chunkInfo.index + 1}/${chunkInfo.chunkCount}; source turn indices: ${chunkInfo.turnIndices.join(', ')}.`
+            : 'Single-pass session payload.';
 
-        const prompt = `
-You are the Neo.mjs REM Sandman. Analyze the following session history for strict topological conflicts.
-A topological conflict occurs primarily when the user and agent realize an OPEN GitHub ticket/issue has been rendered obsolete, superseded, or is a duplicate.
+        return `
+You are the Neo.mjs REM Sandman. Analyze the following session history chunk for strict topological conflicts.
+A topological conflict occurs only when the session explicitly establishes that an OPEN GitHub ticket/issue has been rendered obsolete, superseded, or is a duplicate.
+
+Return at most ${topologyConflictRenderLimit} highest-confidence conflicts for this chunk. Keep descriptions concise.
+Do not infer conflicts from missing earlier or later chunks.
 
 Enforce this STRICT JSON schema:
 {
@@ -131,46 +186,149 @@ Enforce this STRICT JSON schema:
 
 DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide purely the JSON object. If there are no conflicts, output {"conflicts": []}.
 
---- Session Episodic Memory ---
+--- Session Episodic Memory (${chunkLine}) ---
 ${contextText}
 `;
+    }
+
+    /**
+     * @summary Creates deterministic turn chunks after subtracting topology prompt overhead.
+     * @param {String[]} turnDocuments Complete raw memory turn documents.
+     * @param {String} sessionId Source session id.
+     * @returns {{chunked: Boolean, totalEstimatedTokens: Number, chunks: Object[]}}
+     */
+    createTopologyChunks(turnDocuments, sessionId) {
+        const envelopeTokens = estimateTopologyTokens(this.buildTopologyPrompt('', {
+                  chunked    : true,
+                  index      : 0,
+                  chunkCount : 1,
+                  turnIndices: []
+              })),
+              chunkBudget    = Math.max(1, readRequiredChatNumberLeaf('safeProcessingLimitTokens') - envelopeTokens);
+
+        return chunkSession(turnDocuments, {
+            sessionId,
+            safeProcessingLimitTokens: chunkBudget,
+            estimate                 : estimateTopologyTokens
+        });
+    }
+
+    /**
+     * @summary Returns provider options that bound topology output across graph providers.
+     * @returns {Object} Provider generation options.
+     */
+    getTopologyProviderOptions() {
+        return {
+            reasoning_effort    : readRequiredChatStringLeaf('graphReasoningEffort'),
+            responseSchema      : topologyConflictSchema,
+            responseSchemaName  : 'topologyConflicts',
+            responseSchemaStrict: true
+        }
+    }
+
+    /**
+     * Dedicated inference pass to scan episodic memory explicitly for topological conflicts
+     * (e.g. tracking when an OPEN issue is superseded or rendered obsolete by recent session decisions).
+     * @param {String} contextText The raw session episodic document.
+     * @param {String} sessionId The ID of the session being processed.
+     * @param {Object} [options]
+     * @param {String[]} [options.turnDocuments] Complete raw memory turn documents, preserving turn boundaries.
+     * @returns {Promise<Object|undefined>} Topology extraction summary.
+     */
+    async extractTopology(contextText, sessionId, options = {}) {
+        logger.info(`[TopologyInferenceEngine] Extracting Topological Conflicts for session ID: ${sessionId}`);
+
         try {
-            const graphProvider = resolveGraphModelProvider(aiConfig);
-            const provider      = buildGraphProvider({
+            const turnDocuments = Array.isArray(options.turnDocuments) && options.turnDocuments.length > 0
+                ? options.turnDocuments
+                : [contextText];
+            const chunkPlan = this.createTopologyChunks(turnDocuments, sessionId);
+
+            const graphProvider = resolveGraphModelProvider(aiConfig),
+                  provider      = buildGraphProvider({
                 modelProvider         : graphProvider,
                 ollamaConfig          : aiConfig.ollama,
                 openAiCompatibleConfig: aiConfig.openAiCompatible
-            });
+            }),
+                  consumerModel         = aiConfig[graphProvider].model,
+                  consumerContextTokens = readRequiredChatNumberLeaf('contextLimitTokens'),
+                  consumerSafeTokens    = readRequiredChatNumberLeaf('safeProcessingLimitTokens'),
+                  providerOptions       = this.getTopologyProviderOptions(),
+                  conflicts             = [];
 
-            const result = await provider.generate(prompt);
+            let skippedChunks = 0;
 
-            // Silent context-overflow detection (parallel single-attempt path): empty
-            // result.content with no thrown error is the LM Studio loaded-context-cap
-            // signature (ttftMs===ttltMs, outputChars===0). Emit the deterministic
-            // `'context-overflow'` symptom (auto-surfaces) and return early to avoid
-            // downstream null-payload handling on empty input.
-            if (!result?.content || result.content.trim() === '') {
-                logger.warn(`[TopologyInferenceEngine] Empty response from provider for session ${sessionId}; classifying as context-overflow (silent: no thrown error, no body).`);
+            for (let index = 0; index < chunkPlan.chunks.length; index++) {
+                const chunk  = chunkPlan.chunks[index],
+                      prompt = this.buildTopologyPrompt(chunk.text, {
+                          chunked    : chunkPlan.chunked,
+                          index,
+                          chunkCount : chunkPlan.chunks.length,
+                          turnIndices: chunk.turnIndices
+                      });
 
-                emitConsumerFriction({
-                    symptom                  : 'context-overflow',
+                const guardrailed = await invokeWithGuardrail({
+                    invocationFn             : () => provider.generate(prompt, providerOptions),
+                    inputPayload             : prompt,
+                    model                    : consumerModel,
+                    assetRef                 : chunk.chunkId,
                     consumer                 : 'TopologyInferenceEngine',
-                    model                    : aiConfig[graphProvider].model,
-                    assetRef                 : sessionId,
+                    contextLimitTokens       : consumerContextTokens,
+                    safeProcessingLimitTokens: consumerSafeTokens,
                     serviceDomain            : 'dream-pipeline',
-                    emissionPoint            : 'post-invocation-failure',
-                    inputBytes               : Buffer.byteLength(prompt),
-                    contextLimitTokens       : aiConfig.localModels.chat.contextLimitTokens,
-                    safeProcessingLimitTokens: aiConfig.localModels.chat.safeProcessingLimitTokens,
-                    note                     : `Silent empty-response from provider (no thrown error, no body). Prompt chars: ${prompt.length}.`
+                    note                     : `Topological conflict chunk ${index + 1}/${chunkPlan.chunks.length}`
                 });
 
-                return;
+                if (!guardrailed.result) {
+                    skippedChunks++;
+                    logger.warn(`[TopologyInferenceEngine] Chunk ${index + 1}/${chunkPlan.chunks.length} for session ${sessionId} skipped by ${guardrailed.friction?.symptom || 'guardrail'}.`);
+                    continue;
+                }
+
+                const result = guardrailed.result;
+
+                // Silent context-overflow detection (parallel single-attempt path): empty
+                // result.content with no thrown error is the LM Studio loaded-context-cap
+                // signature (ttftMs===ttltMs, outputChars===0). Emit the deterministic
+                // `'context-overflow'` symptom (auto-surfaces) and continue with the next
+                // turn-aligned chunk instead of retry-amplifying the same prompt.
+                if (!result?.content || result.content.trim() === '') {
+                    logger.warn(`[TopologyInferenceEngine] Empty response from provider for session ${sessionId} chunk ${index + 1}/${chunkPlan.chunks.length}; classifying as context-overflow (silent: no thrown error, no body).`);
+
+                    emitConsumerFriction({
+                        symptom                  : 'context-overflow',
+                        consumer                 : 'TopologyInferenceEngine',
+                        model                    : consumerModel,
+                        assetRef                 : chunk.chunkId,
+                        serviceDomain            : 'dream-pipeline',
+                        emissionPoint            : 'post-invocation-failure',
+                        inputBytes               : Buffer.byteLength(prompt, 'utf8'),
+                        inputTokensEstimate      : estimateTopologyTokens(prompt),
+                        contextLimitTokens       : consumerContextTokens,
+                        safeProcessingLimitTokens: consumerSafeTokens,
+                        note                     : `Silent empty-response from provider (no thrown error, no body). Chunk ${index + 1}/${chunkPlan.chunks.length}; prompt chars: ${prompt.length}.`
+                    });
+
+                    skippedChunks++;
+                    continue;
+                }
+
+                const payload = Json.extract(result.content);
+                if (payload && Array.isArray(payload.conflicts) && payload.conflicts.length > 0) {
+                    conflicts.push(...payload.conflicts.slice(0, topologyConflictRenderLimit));
+                }
             }
 
-            const payload = Json.extract(result.content);
-            if (!payload || !Array.isArray(payload.conflicts) || payload.conflicts.length === 0) {
-                return;
+            if (conflicts.length === 0) {
+                return {
+                    chunked: chunkPlan.chunked,
+                    chunks : {
+                        total    : chunkPlan.chunks.length,
+                        skipped  : skippedChunks,
+                        processed: chunkPlan.chunks.length - skippedChunks
+                    },
+                    conflictCount: 0
+                }
             }
 
             // Write to sandman_handoff.md
@@ -184,13 +342,23 @@ ${contextText}
                 handoffContent = '# Sandman Handoff Alerts\n\nThis file tracks topological conflict alerts generated during overnight REM sleep cycles. Agents MUST reconcile these conflicts structurally upon startup.\n\n## Active Conflicts\n\n';
             }
 
-            const {content, changed} = this.mergeConflictAlerts(handoffContent, payload.conflicts, sessionId);
+            const {content, changed} = this.mergeConflictAlerts(handoffContent, conflicts, sessionId);
 
             if (changed) {
                 await fs.promises.mkdir(path.dirname(handoffFile), {recursive: true});
                 await fs.promises.writeFile(tmpFile, content, 'utf8');
                 await fs.promises.rename(tmpFile, handoffFile);
                 logger.info(`[TopologyInferenceEngine] Registered new topological conflicts to sandman_handoff.md for session ${sessionId}.`);
+            }
+
+            return {
+                chunked: chunkPlan.chunked,
+                chunks : {
+                    total    : chunkPlan.chunks.length,
+                    skipped  : skippedChunks,
+                    processed: chunkPlan.chunks.length - skippedChunks
+                },
+                conflictCount: conflicts.length
             }
 
         } catch (error) {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -1156,6 +1156,155 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         }
     });
 
+    test('processUndigestedSessions threads complete raw memory turns into topology inference (#12073)', async () => {
+        const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const AdrIngestor             = (await import('../../../../../../../ai/services/ingestion/AdrIngestor.mjs')).default;
+        const ConceptIngestor         = (await import('../../../../../../../ai/services/ingestion/ConceptIngestor.mjs')).default;
+        const FileSystemIngestor      = (await import('../../../../../../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
+        const TopologyInferenceEngine = (await import('../../../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
+
+        const rawTurns    = ['prompt turn body', 'response turn body'];
+        const mockSession = {
+            id      : 'chroma-summary-raw-turns',
+            document: 'summary fallback should not reach topology',
+            meta    : {sessionId: 'agent-session-raw-turns', title: 'Raw turn session'}
+        };
+
+        let triVectorDocument;
+        let topologyArgs;
+
+        const orig = {
+            provider          : aiConfig.modelProvider,
+            findUndigested    : DreamService.findUndigestedSessions,
+            sessionsCollection: DreamService.sessionsCollection,
+            inferTest         : DreamService.inferTestGapsFromSession,
+            executeNlDigest   : DreamService.executeNLActionDigest,
+            inferConcept      : DreamService.inferConceptGraphGaps,
+            runGarbageCol     : DreamService.runGarbageCollection,
+            synthesizeGolden  : DreamService.synthesizeGoldenPath,
+            triVector         : SemanticGraphExtractor.executeTriVectorExtraction,
+            syncSession       : MemorySessionIngestor.syncSessionToGraph,
+            syncAdrs          : AdrIngestor.syncAdrsToGraph,
+            syncConcepts      : ConceptIngestor.syncConceptsToGraph,
+            syncFs            : FileSystemIngestor.syncWorkspaceToGraph,
+            extractTopo       : TopologyInferenceEngine.extractTopology,
+            conflictCount     : TopologyInferenceEngine.getTopologyConflictCount,
+            getMemory         : StorageRouter.getMemoryCollection,
+            isProcessing      : DreamService.isProcessing
+        };
+
+        try {
+            aiConfig.modelProvider    = 'mock-provider';
+            DreamService.isProcessing = false;
+
+            DreamService.findUndigestedSessions = async () => [mockSession];
+            DreamService.sessionsCollection     = {update: async () => {}};
+            StorageRouter.getMemoryCollection   = async () => ({
+                get: async () => ({documents: rawTurns})
+            });
+            DreamService.inferTestGapsFromSession = async () => {};
+            DreamService.executeNLActionDigest    = async () => ({status: 'completed'});
+            DreamService.inferConceptGraphGaps    = async () => {};
+            DreamService.runGarbageCollection     = async () => {};
+            DreamService.synthesizeGoldenPath     = async () => {};
+            MemorySessionIngestor.syncSessionToGraph = async () => ({errors: [], memoriesSkipped: 0, memoriesUpserted: rawTurns.length});
+            AdrIngestor.syncAdrsToGraph              = async () => ({});
+            ConceptIngestor.syncConceptsToGraph     = async () => ({});
+            FileSystemIngestor.syncWorkspaceToGraph = async () => {};
+            SemanticGraphExtractor.executeTriVectorExtraction = async session => {
+                triVectorDocument = session.document;
+                return {session_artifact: {graph: {nodes: [], edges: []}}};
+            };
+            TopologyInferenceEngine.extractTopology = async (contextText, sessionId, options) => {
+                topologyArgs = {contextText, sessionId, options};
+                return {chunked: true, chunks: {total: 2, skipped: 0, processed: 2}, conflictCount: 0};
+            };
+            TopologyInferenceEngine.getTopologyConflictCount = async () => 0;
+
+            await DreamService.processUndigestedSessions();
+
+            expect(triVectorDocument).toBe(rawTurns.join('\n\n---\n\n'));
+            expect(topologyArgs).toMatchObject({
+                contextText: rawTurns.join('\n\n---\n\n'),
+                sessionId  : 'agent-session-raw-turns',
+                options    : {turnDocuments: rawTurns}
+            });
+        } finally {
+            aiConfig.modelProvider                            = orig.provider;
+            DreamService.findUndigestedSessions               = orig.findUndigested;
+            DreamService.sessionsCollection                   = orig.sessionsCollection;
+            DreamService.inferTestGapsFromSession             = orig.inferTest;
+            DreamService.executeNLActionDigest                = orig.executeNlDigest;
+            DreamService.inferConceptGraphGaps                = orig.inferConcept;
+            DreamService.runGarbageCollection                 = orig.runGarbageCol;
+            DreamService.synthesizeGoldenPath                 = orig.synthesizeGolden;
+            SemanticGraphExtractor.executeTriVectorExtraction = orig.triVector;
+            MemorySessionIngestor.syncSessionToGraph          = orig.syncSession;
+            AdrIngestor.syncAdrsToGraph                       = orig.syncAdrs;
+            ConceptIngestor.syncConceptsToGraph               = orig.syncConcepts;
+            FileSystemIngestor.syncWorkspaceToGraph           = orig.syncFs;
+            TopologyInferenceEngine.extractTopology           = orig.extractTopo;
+            TopologyInferenceEngine.getTopologyConflictCount  = orig.conflictCount;
+            StorageRouter.getMemoryCollection                 = orig.getMemory;
+            DreamService.isProcessing                         = orig.isProcessing;
+        }
+    });
+
+    test('TopologyInferenceEngine chunks complete memory turns and bounds topology output (#12073)', async () => {
+        const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const TopologyInferenceEngine = (await import('../../../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
+
+        const turnDocuments = Array.from({length: 15}, (_, index) => `turn-${index}\n${'x'.repeat(1200)}`);
+        const providerCalls = [];
+
+        const orig = {
+            graphProvider : aiConfig.graphProvider,
+            chatContext   : aiConfig.localModels.chat.contextLimitTokens,
+            chatSafe      : aiConfig.localModels.chat.safeProcessingLimitTokens,
+            graphReasoning: aiConfig.localModels.chat.graphReasoningEffort,
+            openAiModel   : aiConfig.openAiCompatible.model,
+            generate      : OpenAiCompatible.prototype.generate
+        };
+
+        try {
+            aiConfig.graphProvider                                = 'openAiCompatible';
+            aiConfig.openAiCompatible.model                       = 'topology-test-model';
+            aiConfig.localModels.chat.contextLimitTokens          = 8192;
+            aiConfig.localModels.chat.safeProcessingLimitTokens   = 5000;
+            aiConfig.localModels.chat.graphReasoningEffort        = 'none';
+            OpenAiCompatible.prototype.generate = async (prompt, providerOptions) => {
+                providerCalls.push({prompt, providerOptions});
+                return {content: '{"conflicts":[]}'};
+            };
+
+            const result = await TopologyInferenceEngine.extractTopology(
+                turnDocuments.join('\n\n---\n\n'),
+                'topology-turns-test',
+                {turnDocuments}
+            );
+
+            expect(result.chunked).toBe(true);
+            expect(providerCalls.length).toBeGreaterThan(1);
+            expect(result.chunks.total).toBe(providerCalls.length);
+            expect(providerCalls[0].prompt).toContain('source turn indices');
+            expect(providerCalls[0].prompt).toContain('turn-0');
+            expect(providerCalls[0].prompt).not.toContain('turn-14');
+            expect(providerCalls[0].providerOptions).toMatchObject({
+                reasoning_effort    : 'none',
+                responseSchemaName  : 'topologyConflicts',
+                responseSchemaStrict: true
+            });
+            expect(providerCalls[0].providerOptions.responseSchema.properties.conflicts.maxItems).toBe(5);
+        } finally {
+            aiConfig.graphProvider                              = orig.graphProvider;
+            aiConfig.localModels.chat.contextLimitTokens        = orig.chatContext;
+            aiConfig.localModels.chat.safeProcessingLimitTokens = orig.chatSafe;
+            aiConfig.localModels.chat.graphReasoningEffort      = orig.graphReasoning;
+            aiConfig.openAiCompatible.model                     = orig.openAiModel;
+            OpenAiCompatible.prototype.generate                 = orig.generate;
+        }
+    });
+
     test('processUndigestedSessions does not set graphDigested when memory ingestion reports errors (#10460)', async () => {
         // Regression guard: the Tri-Vector extractor can succeed from
         // `session.document` even when MemorySessionIngestor partially failed to upsert MEMORY


### PR DESCRIPTION
Resolves #13965

Related: #12073

Threads complete raw memory-turn documents from `DreamService` into topology inference, then makes `TopologyInferenceEngine` chunk by memory-turn boundary before each graph-provider call. Each topology chunk now goes through the ConsumerFriction guardrail, uses graph-provider structured output/no-think options, and reports chunk totals into REM state. This keeps the broader #12073 Tri-Vector map/reduce lane open while removing the proven topology-side over-cap burn.

Evidence: L2 focused unit/static evidence landed; L3 live REM validation remains required after merge/restart because the over-cap symptom only appears during real local-model REM runs. Residual: full Tri-Vector map/reduce remains #12073.

## Deltas from ticket

The implementation uses the existing `sessionChunker` primitive and subtracts the topology prompt envelope before chunking so “safe” chunks do not become unsafe after instructions are added. It adds no new deployment config leaf; required `AiConfig.localModels.chat.*` leaves are read at the topology use site and fail loud when stale or malformed.

## Test Evidence

- `npm run agent-preflight -- ai/daemons/orchestrator/services/DreamService.mjs ai/services/graph/TopologyInferenceEngine.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs` → 33/33 passed
- `git diff --check`

## Post-Merge Validation

- [ ] Restart orchestrator and confirm the next REM topology phase reports chunk totals in run state.
- [ ] Confirm live local-model token growth stays within expected topology chunk bounds on a large memory-mining session.
- [ ] Confirm #12073 remains open for full Tri-Vector map/reduce work.

## Commit

- `51116b608a` — `fix(ai): chunk REM topology inference by turn (#12073)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
