### PR TITLE
feat(ai): add scheduled MX concept harvester (#13840)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -492,15 +492,16 @@ class Config extends ConfigProvider {
                  * @type {Object}
                  */
                 intervals: {
-                    pollMs              : leaf(3000, 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS', 'number'),
-                    summarySweepMs      : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'number'),
-                    kbSyncMs            : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS', 'number'),
-                    githubWorkflowSyncMs: leaf(2 * HOUR_MS, 'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_INTERVAL_MS', 'number'),
-                    backupMs            : leaf(DAY_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS', 'number'),
-                    graphLogCompactionMs: leaf(DAY_MS, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_INTERVAL_MS', 'number'),
-                    primaryDevSyncMs    : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS', 'number'),
-                    tenantRepoSyncMs    : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS', 'number'),
-                    dreamMs             : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS', 'number'),
+                    pollMs                 : leaf(3000, 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS', 'number'),
+                    summarySweepMs         : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'number'),
+                    kbSyncMs               : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS', 'number'),
+                    githubWorkflowSyncMs   : leaf(2 * HOUR_MS, 'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_INTERVAL_MS', 'number'),
+                    backupMs               : leaf(DAY_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS', 'number'),
+                    graphLogCompactionMs   : leaf(DAY_MS, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_INTERVAL_MS', 'number'),
+                    primaryDevSyncMs       : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS', 'number'),
+                    tenantRepoSyncMs       : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS', 'number'),
+                    dreamMs                : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS', 'number'),
+                    messageConceptHarvestMs: leaf(6 * HOUR_MS, 'NEO_ORCHESTRATOR_MESSAGE_CONCEPT_HARVEST_INTERVAL_MS', 'number'),
                     /**
                      * Fraction of `dreamMs` runtime that triggers completion-time cooldown for the
                      * next dream cycle. This is intentionally below the cycle-overflow telemetry

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -32,6 +32,7 @@ export const TASK_STALENESS_CADENCE_KEY = Object.freeze({
     'graphlog-compaction'    : 'graphLogCompaction',
     'primary-dev-sync'       : 'primaryDevSync',
     dream                    : 'dream',
+    'message-concept-harvest': 'messageConceptHarvest',
     'golden-path'            : 'goldenPath'
 });
 
@@ -94,6 +95,7 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
                 primaryDevSync                 : config.orchestrator.intervals.primaryDevSyncMs,
                 tenantRepoSync                 : config.orchestrator.tenantRepoSync.sweepCadenceMs,
                 dream                          : config.orchestrator.intervals.dreamMs,
+                messageConceptHarvest          : config.orchestrator.intervals.messageConceptHarvestMs,
                 dreamOverflowThreshold         : config.orchestrator.intervals.dreamOverflowThreshold,
                 goldenPath                     : config.orchestrator.intervals.goldenPathMs,
                 swarmHeartbeat                 : config.orchestrator.intervals.swarmHeartbeatMs,
@@ -262,7 +264,7 @@ export function recordPickerDeferrals({
     runningHeavyTasks,
     maintenanceBackpressureService
 }) {
-    const runningSet        = new Set(runningTaskNames);
+    const runningSet = new Set(runningTaskNames);
 
     for (const candidate of candidates) {
         if (runningSet.has(candidate.taskName)) continue;
@@ -404,8 +406,9 @@ function executeServiceRunnerCandidate({candidate, activeHeavyTask, services, ru
 
 function executeInProcessCandidate({candidate, activeHeavyTask, services, runtime}) {
     const runners = {
-        dream        : (taskName, reason) => runDreamTask({taskName, reason, services}),
-        'golden-path': (taskName, reason) => runGoldenPathTask({
+        dream                    : (taskName, reason) => runDreamTask({taskName, reason, services}),
+        'message-concept-harvest': (taskName, reason) => runMessageConceptHarvestTask({taskName, reason, services}),
+        'golden-path'            : (taskName, reason) => runGoldenPathTask({
             taskName,
             reason,
             services,
@@ -506,6 +509,33 @@ async function runDreamTask({taskName, reason, services}) {
             });
             break;
         }
+    }
+}
+
+async function runMessageConceptHarvestTask({taskName, reason, services}) {
+    services.taskStateService.markStarted(taskName, reason);
+    services.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
+
+    try {
+        const outcome = await services.dreamService.runMessageConceptHarvest();
+        services.taskStateService.markCompleted(taskName);
+        services.healthService?.recordTaskOutcome?.(taskName, 'completed', {
+            reason,
+            completedAt      : new Date().toISOString(),
+            candidatesAdded  : outcome.candidatesAdded,
+            messagesProcessed: outcome.messagesProcessed,
+            messagesMarked   : outcome.messagesMarked,
+            termsConsidered  : outcome.termsConsidered
+        });
+    } catch (e) {
+        const state = services.taskStateService.getTaskState(taskName);
+        if (state) state.lastReason = e.message;
+        services.taskStateService.markFailed(taskName, 1);
+        services.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+            reason,
+            error   : e.message,
+            failedAt: new Date().toISOString()
+        });
     }
 }
 
@@ -616,7 +646,7 @@ async function runEmbedDrainLivenessWatchdogTask({taskName, reason, services, ru
         services.taskStateService.markStarted(taskName, reason);
         services.healthService?.recordTaskOutcome?.(taskName, 'running', {reason, startedAt: new Date().toISOString()});
 
-        const now = Date.now();
+        const now                                          = Date.now();
         const {oldestAgeMs, pendingCount, oldestTimestamp} = await getEmbedDrainPendingAge({
             walDir: runtime.embedDrainLivenessWatchdogWalDir,
             now
@@ -710,7 +740,7 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
         services.taskStateService.markStarted(taskName, reason);
         services.healthService?.recordTaskOutcome?.(taskName, 'running', {reason, startedAt: new Date().toISOString()});
 
-        const now = Date.now();
+        const now                                                 = Date.now();
         const {hasCycle, readFault, lastCompletedAt, stalenessMs} = await getRemCycleStaleness({
             remRunStateDir: runtime.remConsolidationWatchdogRunStateDir,
             now

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -1,13 +1,13 @@
-import {getDueTask as getSummaryDueTask}                    from './summary.mjs';
-import {getDueTask as getBackupDueTask}                     from './backup.mjs';
-import {getDueTask as getDreamDueTask}                      from './dream.mjs';
-import {getDueTask as getGraphLogCompactionDueTask}         from './graphLogCompaction.mjs';
-import {getDueTask as getGoldenPathDueTask}                 from './goldenPath.mjs';
-import {getDueTask as getMemorySummaryBackfillDueTask}      from './memorySummaryBackfill.mjs';
-import {getDueTask as getPrimaryDevSyncDueTask}             from './primaryDevSync.mjs';
-import {getDueTask as getSwarmHeartbeatDueTask}             from './swarmHeartbeat.mjs';
-import {getDueTask as getTenantRepoSyncDueTask}             from './tenantRepoSync.mjs';
-import {getDueTask as getEmbedDrainLivenessWatchdogDueTask} from './embedDrainLivenessWatchdog.mjs';
+import {getDueTask as getSummaryDueTask}                          from './summary.mjs';
+import {getDueTask as getBackupDueTask}                           from './backup.mjs';
+import {getDueTask as getDreamDueTask}                            from './dream.mjs';
+import {getDueTask as getGraphLogCompactionDueTask}               from './graphLogCompaction.mjs';
+import {getDueTask as getGoldenPathDueTask}                       from './goldenPath.mjs';
+import {getDueTask as getMemorySummaryBackfillDueTask}            from './memorySummaryBackfill.mjs';
+import {getDueTask as getPrimaryDevSyncDueTask}                   from './primaryDevSync.mjs';
+import {getDueTask as getSwarmHeartbeatDueTask}                   from './swarmHeartbeat.mjs';
+import {getDueTask as getTenantRepoSyncDueTask}                   from './tenantRepoSync.mjs';
+import {getDueTask as getEmbedDrainLivenessWatchdogDueTask}       from './embedDrainLivenessWatchdog.mjs';
 import {getDueTask as getRemConsolidationLivenessWatchdogDueTask} from './remConsolidationLivenessWatchdog.mjs';
 
 function toTimestampMs(value) {
@@ -194,6 +194,25 @@ export const TASK_REGISTRY = Object.freeze([
                 dreamIntervalMs       : intervals.dream,
                 dreamOverflowThreshold: intervals.dreamOverflowThreshold
             });
+        }
+    },
+    {
+        taskName        : 'message-concept-harvest',
+        executionKind   : 'in-process-async',
+        maintenanceClass: 'heavy',
+        backpressure    : 'exclusive-heavy',
+        dependencies    : [],
+        getDueTask({state, now, intervals}) {
+            const lastRunAt  = state['message-concept-harvest']?.lastRunAt ?? 0;
+            const intervalMs = intervals.messageConceptHarvest;
+            if (intervalMs > 0 && now - lastRunAt >= intervalMs) {
+                return {
+                    taskName: 'message-concept-harvest',
+                    source  : 'periodic-message-concept-harvest',
+                    reason  : `periodic-message-concept-harvest:${intervalMs}`
+                };
+            }
+            return null;
         }
     },
     {

--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -1026,6 +1026,17 @@ class DreamService extends Base {
     }
 
     /**
+     * Scheduled process/MX concept discovery entry point. Delegates to
+     * `ConceptDiscoveryService` so A2A-message vocabulary is drained outside the mailbox
+     * hot path: cheap frequency pre-filter first, then one bounded Teaching-Test prompt for
+     * top recurring terms, then `conceptHarvested` markers on processed MESSAGE nodes.
+     * @returns {Promise<Object>} Message-harvest stats.
+     */
+    async runMessageConceptHarvest() {
+        return ConceptDiscoveryService.runMessageConceptHarvest();
+    }
+
+    /**
      * @summary Parses the local file system for markdown files and explicitly syncs their state
      * into the Native Graph database. Re-asserts edge weights for OPEN issues, heavily discounting
      * any nodes structurally blocked via BLOCKED_BY relationships to prevent GraphRAG hallucinations.

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -23,7 +23,8 @@ export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
     'backup',
     'graphlog-compaction',
     'primary-dev-sync',
-    'dream'
+    'dream',
+    'message-concept-harvest'
 ]);
 
 /**
@@ -623,7 +624,7 @@ export class MaintenanceBackpressureService extends Base {
      * @returns {Boolean|*} `false` when deferred; otherwise whatever `executeFn` returns.
      */
     executeWithGoldenPathDependencyGate({taskName, executeFn, reason, activeHeavyTask}) {
-        const reasonText = reason || 'scheduled';
+        const reasonText       = reason || 'scheduled';
         const blockingTaskName = this.getActiveGoldenPathDependencyTask({
             activeTaskName: activeHeavyTask?.name
         });

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -302,6 +302,12 @@ export function buildTaskDefinitions({
             expectedCommand: 'DreamService',
             serviceTask    : true
         },
+        'message-concept-harvest': {
+            label          : 'message concept harvest',
+            pidFileName    : 'message-concept-harvest.pid',
+            expectedCommand: 'ConceptDiscoveryService',
+            serviceTask    : true
+        },
         'golden-path': {
             label          : 'golden path synthesis',
             pidFileName    : 'golden-path.pid',

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -597,14 +597,23 @@ class Config extends ConfigProvider {
              *   discourse) process first. Capping bounds per-cycle LLM cost against the ~300+ PR corpus.
              * - `minSourceLength`: minimum source text length (chars) to trigger an LLM extraction call.
              *   Short bodies aren't worth the provider round-trip; 200 ≈ 30 words of coherent prose.
+             * - `messageHarvestBatchLimit`: maximum unharvested A2A MESSAGE nodes scanned per scheduled
+             *   process/MX concept-harvest cycle.
+             * - `messageHarvestTopN`: maximum frequency-ranked message terms promoted to the LLM
+             *   Teaching-Test source for the cycle.
+             * - `messageHarvestMinFrequency`: minimum subject/tag frequency before a message term can
+             *   spend LLM budget.
              *
              * Expected to migrate to SDK-layer config once daemon/service ownership is split:
              * these are daemon concerns, not memory-core concerns.
              * @type {Object}
              */
             conceptDiscovery: {
-                prScanLimit    : leaf(20, 'NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT', 'number'),
-                minSourceLength: leaf(200, 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', 'number')
+                prScanLimit               : leaf(20, 'NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT', 'number'),
+                minSourceLength           : leaf(200, 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', 'number'),
+                messageHarvestBatchLimit  : leaf(500, 'NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_BATCH_LIMIT', 'number'),
+                messageHarvestTopN        : leaf(20, 'NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_TOP_N', 'number'),
+                messageHarvestMinFrequency: leaf(2, 'NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_MIN_FREQUENCY', 'number')
             },
             /**
              * Directory for the always-on Memory Core diagnostic log files. The MC server's

--- a/ai/services/graph/GapInferenceEngine.mjs
+++ b/ai/services/graph/GapInferenceEngine.mjs
@@ -12,7 +12,7 @@ import logger                                                           from '..
  * @private
  */
 const CONCEPT_REVERIFY_INTERVAL_MS = 90 * 24 * 60 * 60 * 1000;
-const NL_ACTION_WEAK_EVIDENCE_TAG = '[NL_ACTION_WEAK_EVIDENCE]';
+const NL_ACTION_WEAK_EVIDENCE_TAG  = '[NL_ACTION_WEAK_EVIDENCE]';
 
 /**
  * ISO freshness stamps accept either a date-only value (`YYYY-MM-DD`) or the canonical
@@ -120,7 +120,7 @@ class GapInferenceEngine extends Base {
 
         for (const node of structuralNodes) {
             const isInternalConfigHook = node.type === 'METHOD' && /^(beforeGet|beforeSet|afterSet)[A-Z]/.test(node.name);
-            const dbNode = GraphService.db.nodes.get(node.id) || GraphService.db.nodes.get(node._resolvedId);
+            const dbNode               = GraphService.db.nodes.get(node.id) || GraphService.db.nodes.get(node._resolvedId);
 
             if (!dbNode) continue;
 
@@ -304,6 +304,7 @@ class GapInferenceEngine extends Base {
                 exemplifiedByEdges = outboundEdges.filter(e => e.type === 'EXEMPLIFIED_BY'),
                 implementedByEdges = outboundEdges.filter(e => e.type === 'IMPLEMENTED_BY'),
                 weight             = concept.properties?.weight ?? 0,
+                codeGapEligible    = concept.properties?.codeGapEligible !== false && concept.properties?.ontologyLayer !== 'process-mx',
                 gaps               = [],
                 name               = concept.properties?.name || concept.name || concept.id;
 
@@ -316,7 +317,7 @@ class GapInferenceEngine extends Base {
                 ].join(' '));
             }
 
-            if (weight >= threshold) {
+            if (codeGapEligible && weight >= threshold) {
                 if (explainedByEdges.length === 0) {
                     gaps.push(`[GUIDE_GAP] The CONCEPT '${name}' lacks a corresponding architectural Guide (no EXPLAINED_BY edge in the concept ontology).`);
                 } else if (exemplifiedByEdges.length === 0) {
@@ -360,9 +361,9 @@ class GapInferenceEngine extends Base {
             return rows;
         }
 
-        const sequences = this.groupNlActionRowsBySequence(rows.rows);
+        const sequences                    = this.groupNlActionRowsBySequence(rows.rows);
         const resetWeakEvidenceAnnotations = this.resetNlActionWeakEvidenceAnnotations();
-        let qualifyingSequences = 0,
+        let   qualifyingSequences          = 0,
             linkedEdges         = 0,
             downgradedGaps      = 0,
             targetMatches       = 0;
@@ -418,7 +419,7 @@ class GapInferenceEngine extends Base {
                 return {status: 'skipped', reason: 'nl-action-log-missing'};
             }
 
-            const safeLimit = Math.max(1, Number(sequenceLimit) || aiConfig.nlActionDigestSequenceLimit);
+            const safeLimit    = Math.max(1, Number(sequenceLimit) || aiConfig.nlActionDigestSequenceLimit);
             const sequenceRows = sqlite.prepare(`
                 SELECT sequence_id, MAX(timestamp) AS latest_timestamp
                 FROM nl_action_log
@@ -434,7 +435,7 @@ class GapInferenceEngine extends Base {
             }
 
             const placeholders = sequenceIds.map(() => '?').join(',');
-            const rows = sqlite.prepare(`
+            const rows         = sqlite.prepare(`
                 SELECT sequence_id, session_id, timestamp, tool, args, result, success, duration_ms, app_name
                 FROM nl_action_log
                 WHERE sequence_id IN (${placeholders})
@@ -481,7 +482,7 @@ class GapInferenceEngine extends Base {
         if (!Array.isArray(rows) || rows.length === 0) return null;
 
         const successfulRows = rows.filter(row => Number(row.success) === 1);
-        const successRate = successfulRows.length / rows.length;
+        const successRate    = successfulRows.length / rows.length;
 
         if (successRate < minSuccessRate) {
             return null;
@@ -604,7 +605,7 @@ class GapInferenceEngine extends Base {
      */
     findNlActionTargetNodes(targets) {
         const targetNodes = [];
-        const seen = new Set();
+        const seen        = new Set();
 
         for (const node of GraphService.db.nodes.items) {
             const label = node.label || node.get?.('label');
@@ -775,10 +776,10 @@ class GapInferenceEngine extends Base {
      */
     annotateTestGapWithNlActionEvidence(dbNode, sequence) {
         const properties = dbNode.properties || dbNode.get?.('properties') || {};
-        const gaps = this.parseCapabilityGaps(properties.capabilityGap);
+        const gaps       = this.parseCapabilityGaps(properties.capabilityGap);
         if (gaps.length === 0) return false;
 
-        let changed = false;
+        let   changed     = false;
         const updatedGaps = gaps.map(gap => {
             if (!gap.includes('[TEST_GAP]') || gap.includes(NL_ACTION_WEAK_EVIDENCE_TAG)) {
                 return gap;
@@ -789,8 +790,8 @@ class GapInferenceEngine extends Base {
 
         if (!changed) return false;
 
-        const targetId = dbNode.id || dbNode.get?.('id');
-        const label    = dbNode.label || dbNode.get?.('label');
+        const targetId         = dbNode.id || dbNode.get?.('id');
+        const label            = dbNode.label || dbNode.get?.('label');
         const existingEvidence = Array.isArray(properties.nlActionEvidence) ? properties.nlActionEvidence : [];
 
         GraphService.upsertNode({

--- a/ai/services/ingestion/ConceptDiscoveryService.mjs
+++ b/ai/services/ingestion/ConceptDiscoveryService.mjs
@@ -1,14 +1,17 @@
-import fs                          from 'fs';
-import path                        from 'path';
-import yaml                        from 'js-yaml';
-import {fileURLToPath}             from 'url';
-import Base                        from '../../../src/core/Base.mjs';
-import ConceptService              from '../../services/ConceptService.mjs';
-import {Memory_Config as aiConfig} from '../../services.mjs';
-import Json                        from '../../../src/util/Json.mjs';
-import logger                      from '../../mcp/server/memory-core/logger.mjs';
-import OpenAiCompatible            from '../../provider/OpenAiCompatible.mjs';
-import {assertTestWriteIsolated}   from '../shared/storeWriteGuard.mjs';
+import fs              from 'fs';
+import path            from 'path';
+import yaml            from 'js-yaml';
+import {fileURLToPath} from 'url';
+import Base            from '../../../src/core/Base.mjs';
+import ConceptService  from '../../services/ConceptService.mjs';
+import {
+    Memory_Config as aiConfig,
+    Memory_GraphService as GraphService
+} from '../../services.mjs';
+import Json                      from '../../../src/util/Json.mjs';
+import logger                    from '../../mcp/server/memory-core/logger.mjs';
+import OpenAiCompatible          from '../../provider/OpenAiCompatible.mjs';
+import {assertTestWriteIsolated} from '../shared/storeWriteGuard.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -81,6 +84,62 @@ const CANDIDATE_DEFAULTS = {
     verifiedAt : null,
     tags       : ['mined-candidate']
 };
+
+const PROCESS_MX_ONTOLOGY_LAYER = 'process-mx';
+
+const PROCESS_MX_CANDIDATE_DEFAULTS = {
+    ...CANDIDATE_DEFAULTS,
+    tags           : ['mined-candidate', 'process-mx', 'message-concept-harvest'],
+    ontologyLayer  : PROCESS_MX_ONTOLOGY_LAYER,
+    codeGapEligible: false
+};
+
+function normalizeConceptNameForDedupe(value) {
+    if (typeof value !== 'string') return '';
+
+    return value
+        .replace(/^CONCEPT:/i, '')
+        .replace(/^The\s+/i, '')
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '');
+}
+
+function getConceptDedupeKeys(value) {
+    if (typeof value !== 'string') return [];
+
+    const keys       = new Set();
+    const normalized = normalizeConceptNameForDedupe(value);
+    if (normalized) keys.add(normalized);
+
+    const firstToken = value.trim().split(/[\s_-]+/)[0] || '';
+    if (/^[A-Z]{2,6}$/.test(firstToken)) {
+        keys.add(firstToken.toLowerCase());
+    }
+
+    if (/^(?:[A-Z][-_]){1,5}[A-Z](?:[_-]|$)/.test(value.trim())) {
+        keys.add(value.trim().split(/[\s_-]+/).slice(0, 6).join('').toLowerCase());
+    }
+
+    return [...keys];
+}
+
+function getNodeProperties(node) {
+    return node?.isRecord ? node.get('properties') : node?.properties;
+}
+
+function getNodeId(node) {
+    return node?.isRecord ? node.get('id') : node?.id;
+}
+
+function getNodeLabel(node) {
+    return node?.isRecord ? node.get('label') : node?.label;
+}
+
+function getMessageSortTimestamp(message) {
+    const parsed = Date.parse(message.sentAt || message.properties?.sentAt || '');
+    return Number.isFinite(parsed) ? parsed : 0;
+}
 
 /**
  * @summary Service for LLM-driven discovery of "unknown unknowns" in the concept ontology.
@@ -178,6 +237,102 @@ class ConceptDiscoveryService extends Base {
     }
 
     /**
+     * @summary Normalizes concept names for duplicate analysis and write-gate dedupe.
+     *
+     * The Concept Ontology's historical duplicates differ mostly by punctuation, casing,
+     * `CONCEPT:` / `The` prefixes, and acronym separators. This helper is deliberately
+     * deterministic and local: it does not ask the LLM whether two concepts are semantically
+     * identical; it only collapses spelling variants before a candidate can hit `nodes.jsonl`.
+     * @param {String} value Raw concept name, alias, or id.
+     * @returns {String} Compact lower-case key.
+     */
+    normalizeConceptNameForDedupe(value) {
+        return normalizeConceptNameForDedupe(value);
+    }
+
+    /**
+     * @summary Returns all deterministic duplicate keys for a concept-ish term.
+     * @param {String} value Raw concept name, alias, or id.
+     * @returns {String[]}
+     */
+    getConceptDedupeKeys(value) {
+        return getConceptDedupeKeys(value);
+    }
+
+    /**
+     * @summary Builds a dedupe index from the loaded ConceptService graph.
+     * @returns {Set<String>} Normalized concept-name keys.
+     */
+    getKnownConceptNameKeys() {
+        if (!ConceptService.loaded) {
+            try {
+                ConceptService.loadGraph();
+            } catch (e) {
+                logger.warn('[ConceptDiscoveryService] ConceptService.loadGraph() failed while building dedupe index — continuing with an empty index.', e.message);
+                return new Set();
+            }
+        }
+
+        const keys = new Set();
+
+        for (const node of ConceptService.nodes.values()) {
+            for (const value of [node.id, node.name, ...(Array.isArray(node.aliases) ? node.aliases : [])]) {
+                for (const key of this.getConceptDedupeKeys(value)) {
+                    keys.add(key);
+                }
+            }
+        }
+
+        return keys;
+    }
+
+    /**
+     * @summary Checks a raw LLM candidate against the deterministic concept-name index.
+     * @param {Object} raw Raw LLM candidate.
+     * @param {Set<String>} knownConceptNameKeys Existing concept-name keys.
+     * @returns {Boolean}
+     */
+    isKnownConceptCandidate(raw, knownConceptNameKeys) {
+        const values = [
+            raw?.id,
+            raw?.name,
+            ...(Array.isArray(raw?.aliases) ? raw.aliases : [])
+        ];
+
+        return values.some(value => this.getConceptDedupeKeys(value).some(key => knownConceptNameKeys.has(key)));
+    }
+
+    /**
+     * @summary Dedupes candidates by normalized name/id/alias keys before writing JSONL.
+     * @param {Object[]} candidates Candidate records.
+     * @returns {Object[]} First-seen candidates by normalized concept-name key.
+     */
+    dedupeCandidatesByNormalizedName(candidates) {
+        const seen   = new Set();
+        const unique = [];
+
+        for (const candidate of candidates) {
+            const keys = [
+                ...this.getConceptDedupeKeys(candidate.id),
+                ...this.getConceptDedupeKeys(candidate.name),
+                ...(Array.isArray(candidate.aliases) ? candidate.aliases.flatMap(alias => this.getConceptDedupeKeys(alias)) : [])
+            ].filter(Boolean);
+
+            if (keys.some(key => seen.has(key))) {
+                continue;
+            }
+
+            for (const key of keys) {
+                seen.add(key);
+            }
+
+            unique.push(candidate);
+        }
+
+        return unique;
+    }
+
+    /**
      * Invokes the configured LLM provider on a single source and parses the response as the
      * candidate schema. Returns `[]` on any failure (provider offline, malformed JSON, no
      * candidates) — failure to extract is never fatal to `runDiscoveryCycle`, just a skip.
@@ -188,10 +343,16 @@ class ConceptDiscoveryService extends Base {
      * never propose a concept that already exists.
      * @param {String} sourceRef Human-readable identifier for the source (e.g., `'epic-10030'`, `'pull-10084'`)
      * @param {String} text      The raw markdown body + comments for that source
+     * @param {Object} [options]
+     * @param {Object} [options.candidateDefaults=CANDIDATE_DEFAULTS] Metadata defaults for accepted candidates.
+     * @param {Boolean} [options.failOnError=false] Rethrow provider / parse failures for scheduled drainers.
      * @returns {Promise<Object[]>} Candidate records ready for `appendCandidates`
      * @protected
      */
-    async extractConceptsFromSource(sourceRef, text) {
+    async extractConceptsFromSource(sourceRef, text, {
+        candidateDefaults = CANDIDATE_DEFAULTS,
+        failOnError       = false
+    } = {}) {
         const minSourceLength = aiConfig.conceptDiscovery.minSourceLength;
         if (!text || text.trim().length < minSourceLength) return [];
 
@@ -204,6 +365,7 @@ class ConceptDiscoveryService extends Base {
             });
         } catch (e) {
             logger.warn(`[ConceptDiscoveryService] OpenAiCompatible provider could not be constructed; skipping ${sourceRef}:`, e.message);
+            if (failOnError) throw e;
             return [];
         }
 
@@ -214,27 +376,31 @@ class ConceptDiscoveryService extends Base {
             result = await provider.generate(prompt);
         } catch (e) {
             logger.warn(`[ConceptDiscoveryService] LLM call failed for ${sourceRef}; skipping:`, e.message);
+            if (failOnError) throw e;
             return [];
         }
 
         const payload = Json.extract(result?.content || '');
         if (!payload || !Array.isArray(payload.candidates)) {
             logger.debug(`[ConceptDiscoveryService] No usable candidates parsed from ${sourceRef}.`);
+            if (failOnError) throw new Error(`No usable candidates parsed from ${sourceRef}`);
             return [];
         }
 
         // Envelope-level extraction_metadata describes THIS extraction pass; it is denormalized
         // onto each candidate row below so nodes.jsonl stays the single store, and is null for
         // legacy candidates-only responses so the candidate-row schema stays additive.
-        const extractionMetadata = this.normalizeExtractionMetadata(payload.extraction_metadata);
+        const extractionMetadata   = this.normalizeExtractionMetadata(payload.extraction_metadata);
+        const knownConceptNameKeys = this.getKnownConceptNameKeys();
 
         const accepted = [];
         for (const raw of payload.candidates) {
             if (!raw || typeof raw !== 'object' || !raw.id || !raw.name) continue;
 
-            // Dedupe against existing concepts (alias index is case-insensitive; also check node id)
+            // Dedupe against existing concepts by alias/id and by normalized name variants.
             if (ConceptService.resolveAlias(raw.name)) continue;
             if (ConceptService.nodes.has(raw.id)) continue;
+            if (this.isKnownConceptCandidate(raw, knownConceptNameKeys)) continue;
 
             accepted.push({
                 id  : raw.id,
@@ -243,7 +409,7 @@ class ConceptDiscoveryService extends Base {
                 aliases  : Array.isArray(raw.aliases) ? raw.aliases : [],
                 source   : sourceRef,
                 reasoning: raw.reasoning || '',
-                ...CANDIDATE_DEFAULTS,
+                ...candidateDefaults,
                 ...(extractionMetadata ? {extraction_metadata: extractionMetadata} : {})
             });
         }
@@ -400,6 +566,251 @@ class ConceptDiscoveryService extends Base {
     }
 
     /**
+     * @summary Loads unharvested A2A MESSAGE nodes for scheduled process/MX concept mining.
+     *
+     * Reads SQLite directly when available so the orchestrator sees messages written by peer
+     * processes that are not hot in this process' graph cache. Unit tests can pass explicit
+     * messages to `runMessageConceptHarvest` and bypass the live graph read.
+     * @param {Object} [options]
+     * @param {Number} [options.limit=aiConfig.conceptDiscovery.messageHarvestBatchLimit] Max messages.
+     * @returns {Object[]} Message records `{id, subject, bodyText, taggedConcepts, properties}`.
+     */
+    loadUnharvestedMessages({limit = aiConfig.conceptDiscovery.messageHarvestBatchLimit} = {}) {
+        const db = GraphService.requireDb('ConceptDiscoveryService.loadUnharvestedMessages');
+
+        if (db.storage?.db?.prepare) {
+            const rows = db.storage.db.prepare(`
+                SELECT id, data
+                  FROM Nodes
+                 WHERE json_extract(data, '$.label') = 'MESSAGE'
+                   AND COALESCE(json_extract(data, '$.properties.conceptHarvested'), 0) != 1
+                 ORDER BY COALESCE(json_extract(data, '$.properties.sentAt'), '') DESC
+                 LIMIT ?
+            `).all(limit);
+
+            return rows.map(row => {
+                const data       = JSON.parse(row.data),
+                      properties = data.properties || {};
+
+                return {
+                    id            : row.id,
+                    subject       : properties.subject || data.name || row.id,
+                    bodyText      : properties.bodyText || '',
+                    taggedConcepts: Array.isArray(properties.taggedConcepts) ? properties.taggedConcepts : [],
+                    sentAt        : properties.sentAt,
+                    properties
+                };
+            });
+        }
+
+        return db.nodes.items
+            .filter(node => getNodeLabel(node) === 'MESSAGE')
+            .map(node => {
+                const properties = getNodeProperties(node) || {};
+                return {
+                    id            : getNodeId(node),
+                    subject       : properties.subject || properties.name || getNodeId(node),
+                    bodyText      : properties.bodyText || '',
+                    taggedConcepts: Array.isArray(properties.taggedConcepts) ? properties.taggedConcepts : [],
+                    sentAt        : properties.sentAt,
+                    properties
+                };
+            })
+            .filter(message => message.id && message.properties?.conceptHarvested !== true)
+            .sort((a, b) => getMessageSortTimestamp(b) - getMessageSortTimestamp(a))
+            .slice(0, limit);
+    }
+
+    /**
+     * @summary Extracts bracketed process markers from an A2A message subject.
+     * @param {String} subject Message subject.
+     * @returns {String[]}
+     */
+    extractSubjectConceptTerms(subject) {
+        if (typeof subject !== 'string') return [];
+
+        return [...subject.matchAll(/\[([^\]]+)]/g)]
+            .map(match => match[1].trim())
+            .filter(Boolean);
+    }
+
+    /**
+     * @summary Builds the cheap frequency pre-filter for message-derived process/MX concepts.
+     * @param {Object[]} messages Message records.
+     * @param {Object} [options]
+     * @param {Number} [options.topN=aiConfig.conceptDiscovery.messageHarvestTopN] Candidate cap.
+     * @param {Number} [options.minFrequency=aiConfig.conceptDiscovery.messageHarvestMinFrequency] Minimum count.
+     * @returns {Object} Frequency report.
+     */
+    buildMessageConceptFrequencyReport(messages, {
+        topN         = aiConfig.conceptDiscovery.messageHarvestTopN,
+        minFrequency = aiConfig.conceptDiscovery.messageHarvestMinFrequency
+    } = {}) {
+        const byKey = new Map();
+
+        const record = ({term, sourceKind, subject}) => {
+            const keys = this.getConceptDedupeKeys(term);
+            if (keys.length === 0) return;
+
+            const key = keys[0];
+            if (!byKey.has(key)) {
+                byKey.set(key, {
+                    term,
+                    normalizedName : key,
+                    count          : 0,
+                    subjectTagCount: 0,
+                    curatedTagCount: 0,
+                    sampleSubjects : []
+                });
+            }
+
+            const entry = byKey.get(key);
+            entry.count++;
+            if (sourceKind === 'subject-tag') {
+                entry.subjectTagCount++;
+            } else {
+                entry.curatedTagCount++;
+            }
+            if (subject && entry.sampleSubjects.length < 3 && !entry.sampleSubjects.includes(subject)) {
+                entry.sampleSubjects.push(subject);
+            }
+        };
+
+        for (const message of messages) {
+            const subject = message.subject || message.properties?.subject || '';
+
+            for (const term of this.extractSubjectConceptTerms(subject)) {
+                record({term, sourceKind: 'subject-tag', subject});
+            }
+            for (const term of message.taggedConcepts || message.properties?.taggedConcepts || []) {
+                record({term, sourceKind: 'curated-tag', subject});
+            }
+        }
+
+        const terms = [...byKey.values()]
+            .filter(entry => entry.count >= minFrequency)
+            .sort((a, b) => b.count - a.count || a.term.localeCompare(b.term))
+            .slice(0, topN);
+
+        return {
+            messagesConsidered: messages.length,
+            distinctTerms     : byKey.size,
+            terms
+        };
+    }
+
+    /**
+     * @summary Formats frequency-filtered message terms into one bounded Teaching-Test source.
+     * @param {Object} report Frequency report from `buildMessageConceptFrequencyReport`.
+     * @returns {String}
+     */
+    buildMessageConceptHarvestSource(report) {
+        const lines = [
+            'Scheduled A2A process/MX concept harvest.',
+            'Evaluate these recurring message-derived terms with the process Teaching Test: does a maintainer need to understand this concept to operate in the swarm productively?',
+            'Reject routine lifecycle labels unless the surrounding samples show an actual reusable process or MX concept.'
+        ];
+
+        for (const term of report.terms) {
+            lines.push([
+                `TERM: ${term.term}`,
+                `frequency: ${term.count}`,
+                `subject-tag-count: ${term.subjectTagCount}`,
+                `curated-tag-count: ${term.curatedTagCount}`,
+                `sample-subjects: ${term.sampleSubjects.join(' | ')}`
+            ].join('\n'));
+        }
+
+        return lines.join('\n\n');
+    }
+
+    /**
+     * @summary Marks messages as harvested so the scheduled drainer does not re-pay the same scan.
+     * @param {Object[]} messages Message records.
+     * @param {Object} [options]
+     * @param {String} [options.timestamp=new Date().toISOString()] Harvest timestamp.
+     * @param {Function} [options.upsertNode=GraphService.upsertNode.bind(GraphService)] Test seam.
+     * @returns {Number} Messages marked.
+     */
+    markMessagesConceptHarvested(messages, {
+        timestamp  = new Date().toISOString(),
+        upsertNode = GraphService.upsertNode.bind(GraphService)
+    } = {}) {
+        let marked = 0;
+
+        for (const message of messages) {
+            if (!message?.id) continue;
+
+            const properties = {
+                ...(message.properties || {}),
+                conceptHarvested  : true,
+                conceptHarvestedAt: timestamp
+            };
+
+            upsertNode({
+                id  : message.id,
+                type: 'MESSAGE',
+                name: properties.subject || message.subject || message.id,
+                properties
+            });
+
+            marked++;
+        }
+
+        return marked;
+    }
+
+    /**
+     * @summary Runs the scheduled process/MX message-concept drainer.
+     * @param {Object} [options]
+     * @param {Object[]} [options.messages] Optional message fixture/test seam.
+     * @param {Boolean} [options.markHarvested=true] Persist `conceptHarvested` markers.
+     * @returns {Promise<Object>} Harvest stats and candidates.
+     */
+    async runMessageConceptHarvest({messages, markHarvested = true} = {}) {
+        if (!ConceptService.loaded) {
+            try {
+                ConceptService.loadGraph();
+            } catch (e) {
+                logger.warn('[ConceptDiscoveryService] ConceptService.loadGraph() failed — message dedupe will be loose.', e.message);
+            }
+        }
+
+        const messageBatch = messages || this.loadUnharvestedMessages();
+        const report       = this.buildMessageConceptFrequencyReport(messageBatch);
+        let   candidates   = [];
+
+        if (report.terms.length > 0) {
+            const sourceText = this.buildMessageConceptHarvestSource(report);
+            candidates = await this.extractConceptsFromSource('message-concept-harvest', sourceText, {
+                candidateDefaults: PROCESS_MX_CANDIDATE_DEFAULTS,
+                failOnError      : true
+            });
+            candidates = this.dedupeCandidatesByNormalizedName(candidates);
+        }
+
+        if (candidates.length > 0) {
+            await this.appendCandidates(candidates);
+        }
+
+        let messagesMarked = 0;
+        if (markHarvested) {
+            messagesMarked = this.markMessagesConceptHarvested(messageBatch);
+        }
+
+        logger.info(`[ConceptDiscoveryService] Message concept harvest: ${messageBatch.length} message(s), ${report.terms.length} term(s), ${candidates.length} candidate(s).`);
+
+        return {
+            candidatesAdded  : candidates.length,
+            candidates,
+            messagesProcessed: messageBatch.length,
+            messagesMarked,
+            termsConsidered  : report.terms.length,
+            distinctTerms    : report.distinctTerms
+        };
+    }
+
+    /**
      * Runs both mining strategies sequentially (PRs typically produce more candidates; running
      * in parallel would hit the LLM provider with too many concurrent requests), merges and
      * dedupes by candidate ID, and appends new rows to `nodes.jsonl`. Idempotent across runs:
@@ -430,7 +841,7 @@ class ConceptDiscoveryService extends Base {
             if (!byId.has(c.id)) byId.set(c.id, c);
         }
 
-        const unique = [...byId.values()];
+        const unique = this.dedupeCandidatesByNormalizedName([...byId.values()]);
 
         if (unique.length === 0) {
             logger.info('[ConceptDiscoveryService] No new candidates discovered this cycle.');

--- a/ai/services/ingestion/ConceptIngestor.mjs
+++ b/ai/services/ingestion/ConceptIngestor.mjs
@@ -1,8 +1,8 @@
-import crypto                               from 'crypto';
-import Base                                 from '../../../src/core/Base.mjs';
-import ConceptService                       from '../../services/ConceptService.mjs';
+import crypto                                from 'crypto';
+import Base                                  from '../../../src/core/Base.mjs';
+import ConceptService                        from '../../services/ConceptService.mjs';
 import {Memory_GraphService as GraphService} from '../../services.mjs';
-import logger                               from '../../mcp/server/memory-core/logger.mjs';
+import logger                                from '../../mcp/server/memory-core/logger.mjs';
 
 /**
  * Canonical concept edge types. Enforced at ingestion time so downstream consumers
@@ -12,11 +12,11 @@ import logger                               from '../../mcp/server/memory-core/l
  * @private
  */
 const CONCEPT_EDGE_TYPES = {
-    ANALOGOUS_TO   : 'ANALOGOUS_TO',
-    EXEMPLIFIED_BY : 'EXEMPLIFIED_BY',
-    EXPLAINED_BY   : 'EXPLAINED_BY',
-    IMPLEMENTED_BY : 'IMPLEMENTED_BY',
-    PARENT_CONCEPT : 'PARENT_CONCEPT'
+    ANALOGOUS_TO  : 'ANALOGOUS_TO',
+    EXEMPLIFIED_BY: 'EXEMPLIFIED_BY',
+    EXPLAINED_BY  : 'EXPLAINED_BY',
+    IMPLEMENTED_BY: 'IMPLEMENTED_BY',
+    PARENT_CONCEPT: 'PARENT_CONCEPT'
 };
 
 /**
@@ -96,12 +96,14 @@ class ConceptIngestor extends Base {
      */
     computePayloadHash(conceptNode) {
         const payload = {
-            aliases    : conceptNode.aliases     ?? [],
-            description: conceptNode.description ?? '',
-            name       : conceptNode.name        ?? '',
-            tags       : conceptNode.tags        ?? [],
-            tier       : conceptNode.tier        ?? 0,
-            uniqueToNeo: !!conceptNode.uniqueToNeo,
+            aliases        : conceptNode.aliases     ?? [],
+            codeGapEligible: conceptNode.codeGapEligible !== false,
+            description    : conceptNode.description ?? '',
+            name           : conceptNode.name        ?? '',
+            ontologyLayer  : conceptNode.ontologyLayer ?? 'code',
+            tags           : conceptNode.tags        ?? [],
+            tier           : conceptNode.tier        ?? 0,
+            uniqueToNeo    : !!conceptNode.uniqueToNeo,
             // Unvalidated concepts are candidates from ConceptDiscoveryService awaiting human
             // curation. `undefined` from legacy rows is treated as validated.
             // Flipping `validated: false → true` during curator review must trigger re-upsert, so the
@@ -171,10 +173,10 @@ class ConceptIngestor extends Base {
      */
     replaceOutboundConceptEdges(sourceId, newEdges) {
         const
-            db                = GraphService.db,
-            existingOutbound  = db.edges.getByIndex('source', sourceId).slice(),
-            conceptEdgeTypes  = new Set(Object.values(CONCEPT_EDGE_TYPES)),
-            edgesToRemove     = existingOutbound.filter(e => conceptEdgeTypes.has(e.type));
+            db               = GraphService.db,
+            existingOutbound = db.edges.getByIndex('source', sourceId).slice(),
+            conceptEdgeTypes = new Set(Object.values(CONCEPT_EDGE_TYPES)),
+            edgesToRemove    = existingOutbound.filter(e => conceptEdgeTypes.has(e.type));
 
         if (edgesToRemove.length > 0) {
             db.edges.remove(edgesToRemove);
@@ -228,9 +230,9 @@ class ConceptIngestor extends Base {
 
                 try {
                     const
-                        payloadHash  = this.computePayloadHash(conceptNode),
-                        existingNode = db.nodes.get(conceptId),
-                        weight       = ConceptService.calculateWeight(conceptNode),
+                        payloadHash   = this.computePayloadHash(conceptNode),
+                        existingNode  = db.nodes.get(conceptId),
+                        weight        = ConceptService.calculateWeight(conceptNode),
                         outboundEdges = ConceptService.edgesBySource.get(conceptId) || [];
 
                     // Differential sync: skip upsert AND edge replacement if payload unchanged.
@@ -245,14 +247,16 @@ class ConceptIngestor extends Base {
                         type      : 'CONCEPT',
                         name      : conceptNode.name,
                         properties: {
-                            aliases    : conceptNode.aliases     ?? [],
-                            description: conceptNode.description ?? '',
+                            aliases        : conceptNode.aliases     ?? [],
+                            codeGapEligible: conceptNode.codeGapEligible !== false,
+                            description    : conceptNode.description ?? '',
+                            ontologyLayer  : conceptNode.ontologyLayer ?? 'code',
                             payloadHash,
-                            tags       : conceptNode.tags        ?? [],
-                            tier       : conceptNode.tier        ?? 0,
-                            uniqueToNeo: !!conceptNode.uniqueToNeo,
-                            validated  : conceptNode.validated !== false,
-                            verifiedAt : conceptNode.verifiedAt ?? null,
+                            tags           : conceptNode.tags        ?? [],
+                            tier           : conceptNode.tier        ?? 0,
+                            uniqueToNeo    : !!conceptNode.uniqueToNeo,
+                            validated      : conceptNode.validated !== false,
+                            verifiedAt     : conceptNode.verifiedAt ?? null,
                             weight
                         }
                     });

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -143,6 +143,7 @@ test.describe('Tier 1 Config Immutability', () => {
             graphLogCompactionMs             : 24 * 60 * 60 * 1000,
             primaryDevSyncMs                 : 10 * 60 * 1000,
             dreamMs                          : 60 * 60 * 1000,
+            messageConceptHarvestMs          : 6 * 60 * 60 * 1000,
             goldenPathMs                     : 60 * 60 * 1000,
             swarmHeartbeatMs                 : 20 * 60 * 1000,
             embedDrainLivenessWatchdogCheckMs: 60 * 60 * 1000

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -90,6 +90,7 @@ function createTestOrchestrator(config = {}) {
     AiConfig.orchestrator.intervals.primaryDevSyncMs = config.primaryDevSyncIntervalMs ?? 600000;
     AiConfig.orchestrator.intervals.tenantRepoSyncMs = config.tenantRepoSyncIntervalMs ?? Number.MAX_SAFE_INTEGER;
     AiConfig.orchestrator.intervals.dreamMs          = config.dreamIntervalMs          ?? Number.MAX_SAFE_INTEGER;
+    AiConfig.orchestrator.intervals.messageConceptHarvestMs = config.messageConceptHarvestIntervalMs ?? Number.MAX_SAFE_INTEGER;
     AiConfig.orchestrator.intervals.dreamOverflowThreshold = config.dreamOverflowThreshold ?? 0.8;
     AiConfig.orchestrator.intervals.goldenPathMs     = config.goldenPathIntervalMs     ?? Number.MAX_SAFE_INTEGER;
     AiConfig.orchestrator.intervals.swarmHeartbeatMs = config.swarmHeartbeatIntervalMs ?? Number.MAX_SAFE_INTEGER;
@@ -223,7 +224,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             neuralLinkBridgeLivenessTimeoutMs: 50
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'neuralLinkBridge', 'embedDaemon', 'messageDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'githubWorkflowSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat', 'embed-drain-liveness-watchdog', 'rem-consolidation-liveness-watchdog']);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'neuralLinkBridge', 'embedDaemon', 'messageDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'githubWorkflowSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'message-concept-harvest', 'golden-path', 'swarm-heartbeat', 'embed-drain-liveness-watchdog', 'rem-consolidation-liveness-watchdog']);
         expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
@@ -1294,6 +1295,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             'graphlog-compaction',
             'kbSync',
             'memory-summary-backfill',
+            'message-concept-harvest',
             'primary-dev-sync',
             'dream',
             'summary'

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -142,6 +142,7 @@ function makeAdapterConfig({dreamMs = 3_600_000} = {}) {
                 primaryDevSyncMs                 : 1,
                 tenantRepoSyncMs                 : 1,
                 dreamMs,
+                messageConceptHarvestMs          : 1,
                 dreamOverflowThreshold           : 0.8,
                 goldenPathMs                     : 1,
                 swarmHeartbeatMs                 : 1,
@@ -159,7 +160,7 @@ function makeAdapterConfig({dreamMs = 3_600_000} = {}) {
 test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
     test('buildOrchestratorSchedulingOptions wires the REM liveness active alarm and dream-ownership gate (#13839)', () => {
         const remDispatcher = () => {};
-        const orchestrator = makeOrchestratorAdapterFixture({
+        const orchestrator  = makeOrchestratorAdapterFixture({
             remConsolidationLivenessAlarmDispatcher: remDispatcher
         });
 
@@ -456,6 +457,71 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
         ]);
     });
 
+    test('records completed message-concept-harvest outcomes as successful runs (#13840)', async () => {
+        const calls    = [];
+        const outcomes = [];
+
+        const result = runSchedulingPipeline({
+            registry: [
+                makeCandidateDescriptor({
+                    taskName        : 'message-concept-harvest',
+                    executionKind   : 'in-process-async',
+                    maintenanceClass: 'heavy'
+                })
+            ],
+            context : makeContext(),
+            services: makeServices({
+                dreamService: {
+                    runMessageConceptHarvest: () => Promise.resolve({
+                        candidatesAdded  : 2,
+                        messagesProcessed: 7,
+                        messagesMarked   : 7,
+                        termsConsidered  : 3
+                    })
+                },
+                healthService: {
+                    recordTaskOutcome(taskName, status, details) {
+                        outcomes.push({taskName, status, details});
+                    }
+                },
+                taskStateService: {
+                    getTaskState: () => null,
+                    markCompleted(taskName) { calls.push(['markCompleted', taskName]); },
+                    markFailed(taskName) { calls.push(['markFailed', taskName]); },
+                    markSkipped(taskName) { calls.push(['markSkipped', taskName]); },
+                    markStarted(taskName, reason) { calls.push(['markStarted', taskName, reason]); }
+                }
+            }),
+            runtime: makeRuntime()
+        });
+
+        await result.executed;
+
+        expect(calls).toEqual([
+            ['markStarted', 'message-concept-harvest', 'message-concept-harvest-reason'],
+            ['markCompleted', 'message-concept-harvest']
+        ]);
+        expect(outcomes).toEqual([
+            {
+                taskName: 'message-concept-harvest',
+                status  : 'running',
+                details : {reason: 'message-concept-harvest-reason', startedAt: expect.any(String)}
+            },
+            {
+                taskName: 'message-concept-harvest',
+                status  : 'completed',
+                details : {
+                    reason           : 'message-concept-harvest-reason',
+                    completedAt      : expect.any(String),
+                    candidatesAdded  : 2,
+                    messagesProcessed: 7,
+                    messagesMarked   : 7,
+                    termsConsidered  : 3
+                }
+            }
+        ]);
+    });
+
     test('records skipped Dream outcomes without marking success (#13767)', async () => {
         const calls    = [];
         const outcomes = [];
@@ -601,20 +667,27 @@ test.describe('orchestrator/scheduling/pipeline staleness selector (#13586)', ()
         const candidates = [
             {taskName: 'summary'},
             {taskName: 'golden-path'},
+            {taskName: 'message-concept-harvest'},
             {taskName: 'swarm-heartbeat'},               // light → omitted
             {taskName: 'embed-drain-liveness-watchdog'}  // health → omitted
         ];
         const state = {
-            summary      : {lastRunAt: 5_000},
-            'golden-path': {lastRunAt: 1_000}
+            summary                  : {lastRunAt: 5_000},
+            'golden-path'            : {lastRunAt: 1_000},
+            'message-concept-harvest': {lastRunAt: 2_000}
         };
-        const intervals = {summarySweep: 600_000, goldenPath: 3_600_000};
+        const intervals = {
+            summarySweep         : 600_000,
+            goldenPath           : 3_600_000,
+            messageConceptHarvest: 21_600_000
+        };
 
         const meta = buildTaskStalenessMeta({candidates, state, intervals});
 
         expect(meta).toEqual({
-            summary      : {lastRunAt: 5_000, cadenceMs: 600_000},
-            'golden-path': {lastRunAt: 1_000, cadenceMs: 3_600_000}
+            summary                  : {lastRunAt: 5_000, cadenceMs: 600_000},
+            'golden-path'            : {lastRunAt: 1_000, cadenceMs: 3_600_000},
+            'message-concept-harvest': {lastRunAt: 2_000, cadenceMs: 21_600_000}
         });
         expect(meta['swarm-heartbeat']).toBeUndefined();
         expect(meta['embed-drain-liveness-watchdog']).toBeUndefined();
@@ -635,6 +708,7 @@ test.describe('orchestrator/scheduling/pipeline staleness selector (#13586)', ()
         expect(TASK_STALENESS_CADENCE_KEY['embed-drain-liveness-watchdog']).toBeUndefined();
         expect(TASK_STALENESS_CADENCE_KEY['rem-consolidation-liveness-watchdog']).toBeUndefined();
         expect(TASK_STALENESS_CADENCE_KEY['tenant-repo-sync']).toBeUndefined();
+        expect(TASK_STALENESS_CADENCE_KEY['message-concept-harvest']).toBe('messageConceptHarvest');
         expect(TASK_STALENESS_CADENCE_KEY['golden-path']).toBe('goldenPath');
         expect(TASK_STALENESS_CADENCE_KEY.summary).toBe('summarySweep');
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -2,9 +2,9 @@ import {test, expect}                         from '@playwright/test';
 import {TASK_REGISTRY}                        from '../../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
 import {DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES} from '../../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
 
-const VALID_EXECUTION_KINDS = ['supervised-child-process', 'service-runner', 'in-process-async', 'local-only-service', 'health-check'];
+const VALID_EXECUTION_KINDS     = ['supervised-child-process', 'service-runner', 'in-process-async', 'local-only-service', 'health-check'];
 const VALID_MAINTENANCE_CLASSES = ['continuous', 'heavy', 'graph-dependent', 'lightweight-signal', 'local-only', 'health-monitor'];
-const VALID_BACKPRESSURE = ['none', 'exclusive-heavy', 'after-heavy'];
+const VALID_BACKPRESSURE        = ['none', 'exclusive-heavy', 'after-heavy'];
 
 test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
     test('TASK_REGISTRY is a frozen array (immutability invariant)', () => {
@@ -43,8 +43,27 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
         expect(names).toEqual(expect.arrayContaining([
             'summary', 'memory-summary-backfill', 'kbSync', 'githubWorkflowSync', 'backup', 'graphlog-compaction',
             'primary-dev-sync', 'tenant-repo-sync', 'dream',
-            'golden-path', 'swarm-heartbeat'
+            'message-concept-harvest', 'golden-path', 'swarm-heartbeat'
         ]));
+    });
+
+    test('message-concept-harvest is registered as an exclusive-heavy scheduled graph-writing lane (#13840)', () => {
+        const descriptor = TASK_REGISTRY.find(d => d.taskName === 'message-concept-harvest');
+        expect(descriptor, 'message-concept-harvest is registered').toBeTruthy();
+        expect(descriptor.executionKind).toBe('in-process-async');
+        expect(descriptor.maintenanceClass).toBe('heavy');
+        expect(descriptor.backpressure).toBe('exclusive-heavy');
+        expect(descriptor.dependencies).toEqual([]);
+        expect(descriptor.getDueTask({
+            state    : {'message-concept-harvest': {lastRunAt: 0}},
+            now      : 6000,
+            intervals: {messageConceptHarvest: 5000}
+        })).toMatchObject({taskName: 'message-concept-harvest', source: 'periodic-message-concept-harvest'});
+        expect(descriptor.getDueTask({
+            state    : {'message-concept-harvest': {lastRunAt: 2000}},
+            now      : 6000,
+            intervals: {messageConceptHarvest: 5000}
+        })).toBeNull();
     });
 
     test('embed-drain-liveness-watchdog is registered as a read-only, no-backpressure health-check (#13551)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -973,6 +973,32 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         expect(node.properties.capabilityGap).toBeUndefined();
     });
 
+    test('process/MX concepts should be excluded from code-doc gap audit (#13840)', async () => {
+        GraphService.upsertNode({
+            id        : 'concept-process-mx',
+            type      : 'CONCEPT',
+            name      : 'Coordination Saturation Cycle',
+            properties: {
+                name           : 'Coordination Saturation Cycle',
+                tier           : 1,
+                uniqueToNeo    : true,
+                verifiedAt     : freshVerifiedAt,
+                weight         : 1.3,
+                validated      : true,
+                ontologyLayer  : 'process-mx',
+                codeGapEligible: false
+            }
+        });
+
+        await DreamService.inferConceptGraphGaps();
+
+        const node = GraphService.db.nodes.get('concept-process-mx');
+
+        // Weight 1.3 and no edges would normally emit GUIDE_GAP + ORPHAN_CONCEPT. Process/MX
+        // concepts are a separate operational vocabulary layer, not code ontology targets.
+        expect(node.properties.capabilityGap).toBeUndefined();
+    });
+
     test('should emit GUIDE_GAP and ORPHAN_CONCEPT together when concept lacks both EXPLAINED_BY and IMPLEMENTED_BY (#10087)', async () => {
         // Locks in the independence of ORPHAN_CONCEPT from the GUIDE_GAP / EXAMPLE_GAP branch.
         // GUIDE_GAP and EXAMPLE_GAP are mutually exclusive (one requires EXPLAINED_BY absent, the

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -73,6 +73,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
             'graphlog-compaction',
             'kbSync',
             'memory-summary-backfill',
+            'message-concept-harvest',
             'primary-dev-sync',
             'summary'
         ].sort());
@@ -373,7 +374,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         });
 
         const activeHeavyTask = {name: null};
-        const result = service.acquireLeaseAndExecute({
+        const result          = service.acquireLeaseAndExecute({
             taskName : NON_HEAVY_TASK_NAME,
             executeFn: (taskName, reason) => { executions.push({taskName, reason}); return true; },
             reason   : 'periodic-heartbeat',
@@ -396,7 +397,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         });
 
         const activeHeavyTask = {name: 'summary'};
-        const result = service.acquireLeaseAndExecute({
+        const result          = service.acquireLeaseAndExecute({
             taskName : 'kbSync',
             executeFn: () => { throw new Error('should not execute'); },
             reason   : 'periodic-sync',
@@ -421,7 +422,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         });
 
         const activeHeavyTask = {name: 'kbSync'};
-        const result = service.acquireLeaseAndExecute({
+        const result          = service.acquireLeaseAndExecute({
             taskName : 'memory-summary-backfill',
             executeFn: (taskName, reason, onSuccess, taskOptions) => {
                 executions.push({taskName, reason, env: taskOptions.env});
@@ -451,7 +452,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         });
 
         const activeHeavyTask = {name: null};
-        const result = service.acquireLeaseAndExecute({
+        const result          = service.acquireLeaseAndExecute({
             taskName : 'backup',
             executeFn: () => { throw new Error('should not execute'); },
             reason   : 'periodic-sweep',
@@ -476,7 +477,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         });
 
         const activeHeavyTask = {name: null};
-        const result = service.acquireLeaseAndExecute({
+        const result          = service.acquireLeaseAndExecute({
             taskName : 'memory-summary-backfill',
             executeFn: (taskName, reason, onSuccess, taskOptions) => {
                 executions.push({taskName, reason, env: taskOptions.env});
@@ -528,7 +529,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         });
 
         const activeHeavyTask = {name: null};
-        const result = service.acquireLeaseAndExecute({
+        const result          = service.acquireLeaseAndExecute({
             taskName : 'kbSync',
             executeFn: () => false, // task self-declined → still must release
             reason   : 'periodic-sync',
@@ -550,7 +551,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         });
 
         const activeHeavyTask = {name: null};
-        const result = service.acquireLeaseAndExecute({
+        const result          = service.acquireLeaseAndExecute({
             taskName : 'kbSync',
             executeFn: async () => 'work-done',
             reason   : 'periodic-sync',

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -260,6 +260,29 @@ test.describe('Memory Core Config (#10010)', () => {
         }
     });
 
+    test('conceptDiscovery message-harvest leaves parse numeric env overrides (#13840)', () => {
+        expect(config.conceptDiscovery.messageHarvestBatchLimit).toBe(500);
+        expect(config.conceptDiscovery.messageHarvestTopN).toBe(20);
+        expect(config.conceptDiscovery.messageHarvestMinFrequency).toBe(2);
+
+        process.env.NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_BATCH_LIMIT   = '77';
+        process.env.NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_TOP_N         = '9';
+        process.env.NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_MIN_FREQUENCY = '3';
+
+        const freshCfg = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(freshCfg.conceptDiscovery.messageHarvestBatchLimit).toBe(77);
+            expect(freshCfg.conceptDiscovery.messageHarvestTopN).toBe(9);
+            expect(freshCfg.conceptDiscovery.messageHarvestMinFrequency).toBe(3);
+        } finally {
+            delete process.env.NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_BATCH_LIMIT;
+            delete process.env.NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_TOP_N;
+            delete process.env.NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_MIN_FREQUENCY;
+            freshCfg.destroy();
+        }
+    });
+
     test('collections.memory/session resolve by construction to per-worker-unique test names under the toggle (#12499)', () => {
         // The reshape replaced the inline `process.env.UNIT_TEST_MODE ? test-... : prod` leaf ternaries
         // with *Prod/*Test leaves + formulas; the test names are per-worker-unique module consts. Under

--- a/test/playwright/unit/ai/services/ingestion/ConceptDiscoveryService.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/ConceptDiscoveryService.spec.mjs
@@ -210,12 +210,34 @@ test.describe('Neo.ai.daemons.services.ConceptDiscoveryService', () => {
             ]
         }];
 
-        const body = 'Enough content to exceed MIN_SOURCE_LENGTH. '.repeat(20);
+        const body     = 'Enough content to exceed MIN_SOURCE_LENGTH. '.repeat(20);
         const accepted = await ConceptDiscoveryService.extractConceptsFromSource('test-source', body);
 
         // Two dupes filtered (id match + alias match), only one survives
         expect(accepted.length).toBe(1);
         expect(accepted[0].name).toBe('Novel Concept');
+    });
+
+    test('extractConceptsFromSource should dedupe punctuation/case variants by normalized concept name (#13840)', async () => {
+        writeSeedConceptGraph([
+            {id: 'vba', name: 'VBA', tier: 2, description: '', uniqueToNeo: false, tags: [], aliases: ['Verify Before Assert']}
+        ]);
+        ConceptService.loadGraph();
+
+        llmResponses = [{
+            candidates: [
+                {id: 'v-b-a',             name: 'V-B-A',           description: 'dup', reasoning: 'y', aliases: []},
+                {id: 'review_response',   name: 'Review_Response', description: 'new', reasoning: 'y', aliases: []},
+                {id: 'review-response-2', name: 'Review-Response', description: 'dup-by-normalized-name', reasoning: 'y', aliases: []}
+            ]
+        }];
+
+        const body     = 'Enough content to exceed MIN_SOURCE_LENGTH. '.repeat(20);
+        const accepted = await ConceptDiscoveryService.extractConceptsFromSource('variant-source', body);
+        const unique   = ConceptDiscoveryService.dedupeCandidatesByNormalizedName(accepted);
+
+        expect(unique.length).toBe(1);
+        expect(unique[0].name).toBe('Review_Response');
     });
 
     test('extractConceptsFromSource should tolerate malformed LLM output without throwing', async () => {
@@ -224,7 +246,7 @@ test.describe('Neo.ai.daemons.services.ConceptDiscoveryService', () => {
 
         llmResponses = ['not valid json at all, certainly no candidates field'];
 
-        const body = 'Adequate source content. '.repeat(20);
+        const body     = 'Adequate source content. '.repeat(20);
         const accepted = await ConceptDiscoveryService.extractConceptsFromSource('broken-llm-source', body);
 
         expect(accepted).toEqual([]);
@@ -246,10 +268,10 @@ test.describe('Neo.ai.daemons.services.ConceptDiscoveryService', () => {
         writeEmptyConceptGraph();
         ConceptService.loadGraph();
 
-        const aiConfig  = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         aiConfig.data.conceptDiscovery ??= {};
-        const original  = aiConfig.data.conceptDiscovery?.minSourceLength;
-        const bodyText  = 'Moderate length source. '.repeat(15); // ~360 chars — above default 200, below an override of 10000
+        const original = aiConfig.data.conceptDiscovery?.minSourceLength;
+        const bodyText = 'Moderate length source. '.repeat(15); // ~360 chars — above default 200, below an override of 10000
 
         llmResponses = [{candidates: [{id: 'x', name: 'X', description: 'y', reasoning: 'z', aliases: []}]}];
 
@@ -304,6 +326,173 @@ test.describe('Neo.ai.daemons.services.ConceptDiscoveryService', () => {
         const sharedLine = nodesContent.split('\n').find(l => l.includes('"shared-concept"'));
         expect(sharedLine).toContain('from-epic');
         expect(sharedLine).not.toContain('from-pr');
+    });
+
+    test('runMessageConceptHarvest uses frequency pre-filter and appends process/MX candidates (#13840)', async () => {
+        writeEmptyConceptGraph();
+
+        const messages = [
+            {
+                id            : 'MESSAGE:one',
+                subject       : '[lane-claim] measure-cheap-first follow-up',
+                taggedConcepts: ['coordination-saturation-cycle'],
+                properties    : {subject: '[lane-claim] measure-cheap-first follow-up', taggedConcepts: ['coordination-saturation-cycle']}
+            },
+            {
+                id            : 'MESSAGE:two',
+                subject       : '[lane-claim] coordination saturation',
+                taggedConcepts: ['coordination-saturation-cycle'],
+                properties    : {subject: '[lane-claim] coordination saturation', taggedConcepts: ['coordination-saturation-cycle']}
+            },
+            {
+                id            : 'MESSAGE:three',
+                subject       : '[single-use] should not spend budget',
+                taggedConcepts: [],
+                properties    : {subject: '[single-use] should not spend budget', taggedConcepts: []}
+            }
+        ];
+
+        llmResponses = [{
+            candidates: [{
+                id         : 'coordination-saturation-cycle',
+                name       : 'Coordination Saturation Cycle',
+                description: 'A recurring swarm process loop surfaced from A2A messages.',
+                reasoning  : 'Maintainers need it to operate the swarm productively.',
+                aliases    : ['coordination saturation']
+            }]
+        }];
+
+        const result = await ConceptDiscoveryService.runMessageConceptHarvest({messages, markHarvested: false});
+
+        expect(llmCallCount).toBe(1);
+        expect(result.messagesProcessed).toBe(3);
+        expect(result.termsConsidered).toBe(2); // [lane-claim] + curated coordination tag; singleton filtered out
+        expect(result.candidatesAdded).toBe(1);
+        expect(result.candidates[0]).toMatchObject({
+            ontologyLayer  : 'process-mx',
+            codeGapEligible: false,
+            validated      : false
+        });
+        expect(result.candidates[0].tags).toEqual(expect.arrayContaining(['process-mx', 'message-concept-harvest']));
+
+        const nodesContent = fs.readFileSync(path.join(tmpConceptsDir, 'nodes.jsonl'), 'utf8');
+        const row          = JSON.parse(nodesContent.split('\n').find(l => l.includes('"coordination-saturation-cycle"')));
+        expect(row.ontologyLayer).toBe('process-mx');
+        expect(row.codeGapEligible).toBe(false);
+    });
+
+    test('markMessagesConceptHarvested stamps MESSAGE nodes through a narrow upsert seam (#13840)', () => {
+        const upserts = [];
+        const marked  = ConceptDiscoveryService.markMessagesConceptHarvested([
+            {
+                id        : 'MESSAGE:mark-me',
+                subject   : 'mark subject',
+                properties: {subject: 'mark subject', sentAt: '2026-06-24T00:00:00.000Z'}
+            }
+        ], {
+            timestamp : '2026-06-24T20:00:00.000Z',
+            upsertNode: spec => upserts.push(spec)
+        });
+
+        expect(marked).toBe(1);
+        expect(upserts).toEqual([{
+            id        : 'MESSAGE:mark-me',
+            type      : 'MESSAGE',
+            name      : 'mark subject',
+            properties: {
+                subject           : 'mark subject',
+                sentAt            : '2026-06-24T00:00:00.000Z',
+                conceptHarvested  : true,
+                conceptHarvestedAt: '2026-06-24T20:00:00.000Z'
+            }
+        }]);
+    });
+
+    test('runMessageConceptHarvest does not stamp messages when candidate append fails (#13840)', async () => {
+        writeEmptyConceptGraph();
+
+        const originalAppendCandidates = ConceptDiscoveryService.appendCandidates;
+        const originalMarkMessages     = ConceptDiscoveryService.markMessagesConceptHarvested;
+        let   marked                   = false;
+
+        ConceptDiscoveryService.appendCandidates = async () => {
+            throw new Error('append-failed');
+        };
+        ConceptDiscoveryService.markMessagesConceptHarvested = () => {
+            marked = true;
+            return 1;
+        };
+
+        llmResponses = [{
+            candidates: [{
+                id         : 'message-born-concept',
+                name       : 'Message Born Concept',
+                description: 'A process concept born in repeated A2A messages.',
+                reasoning  : 'Maintainers need it to operate the swarm productively.',
+                aliases    : []
+            }]
+        }];
+
+        try {
+            await expect(ConceptDiscoveryService.runMessageConceptHarvest({
+                messages: [
+                    {
+                        id            : 'MESSAGE:one',
+                        subject       : '[message-born-concept] one',
+                        taggedConcepts: [],
+                        properties    : {subject: '[message-born-concept] one'}
+                    },
+                    {
+                        id            : 'MESSAGE:two',
+                        subject       : '[message-born-concept] two',
+                        taggedConcepts: [],
+                        properties    : {subject: '[message-born-concept] two'}
+                    }
+                ]
+            })).rejects.toThrow('append-failed');
+
+            expect(marked).toBe(false);
+        } finally {
+            ConceptDiscoveryService.appendCandidates             = originalAppendCandidates;
+            ConceptDiscoveryService.markMessagesConceptHarvested = originalMarkMessages;
+        }
+    });
+
+    test('runMessageConceptHarvest does not stamp messages when provider output is unusable (#13840)', async () => {
+        writeEmptyConceptGraph();
+
+        const originalMarkMessages = ConceptDiscoveryService.markMessagesConceptHarvested;
+        let   marked               = false;
+
+        ConceptDiscoveryService.markMessagesConceptHarvested = () => {
+            marked = true;
+            return 1;
+        };
+
+        llmResponses = ['not-json'];
+
+        try {
+            await expect(ConceptDiscoveryService.runMessageConceptHarvest({
+                messages: [
+                    {
+                        id            : 'MESSAGE:one',
+                        subject       : '[unusable-provider-output] one',
+                        taggedConcepts: [],
+                        properties    : {subject: '[unusable-provider-output] one'}
+                    },
+                    {
+                        id            : 'MESSAGE:two',
+                        subject       : '[unusable-provider-output] two',
+                        taggedConcepts: [],
+                        properties    : {subject: '[unusable-provider-output] two'}
+                    }
+                ]
+            })).rejects.toThrow('No usable candidates parsed');
+
+            expect(marked).toBe(false);
+        } finally {
+            ConceptDiscoveryService.markMessagesConceptHarvested = originalMarkMessages;
+        }
     });
 
     test('runDiscoveryCycle captures envelope extraction_metadata, denormalizes onto each candidate, and persists it (#10106)', async () => {

--- a/test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs
@@ -13,12 +13,12 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import fs             from 'fs';
-import path           from 'path';
-import os             from 'os';
+import {test, expect}                          from '@playwright/test';
+import Neo                                     from '../../../../../../src/Neo.mjs';
+import * as core                               from '../../../../../../src/core/_export.mjs';
+import fs                                      from 'fs';
+import path                                    from 'path';
+import os                                      from 'os';
 import {snapshotAiConfig, TestLifecycleHelper} from '../../services/memory-core/util.mjs';
 
 test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
@@ -226,6 +226,30 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
         expect(node.properties.verifiedAt).toBe('2026-05-01T00:00:00.000Z');
     });
 
+    test('should persist process/MX ontology layer projection fields (#13840)', async () => {
+        writeFixture(
+            [{
+                id             : 'coordination-saturation-cycle',
+                name           : 'Coordination Saturation Cycle',
+                tier           : 3,
+                description    : 'Message-born swarm process vocabulary.',
+                uniqueToNeo    : false,
+                tags           : ['process-mx', 'message-concept-harvest'],
+                ontologyLayer  : 'process-mx',
+                codeGapEligible: false,
+                verifiedAt     : null
+            }],
+            []
+        );
+
+        await ConceptIngestor.syncConceptsToGraph();
+
+        const node = GraphService.db.nodes.get('coordination-saturation-cycle');
+        expect(node.properties.ontologyLayer).toBe('process-mx');
+        expect(node.properties.codeGapEligible).toBe(false);
+        expect(node.properties.tags).toEqual(expect.arrayContaining(['process-mx', 'message-concept-harvest']));
+    });
+
     test('should count orphan concepts in stats without emitting per-orphan logger.warn (#10087)', async () => {
         // Orphan surfacing moved from the ephemeral logger.warn channel to the
         // durable capabilityGap channel via GapInferenceEngine.inferConceptGraphGaps. ConceptIngestor
@@ -310,14 +334,14 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
             ]
         );
 
-        const first = await ConceptIngestor.syncConceptsToGraph();
+        const first           = await ConceptIngestor.syncConceptsToGraph();
         const nodesAfterFirst = new Set(GraphService.db.nodes.items.map(n => n.id));
         const edgesAfterFirst = GraphService.db.edges.items
             .map(e => `${e.source}|${e.target}|${e.type}`)
             .sort()
             .join('\n');
 
-        const second = await ConceptIngestor.syncConceptsToGraph();
+        const second           = await ConceptIngestor.syncConceptsToGraph();
         const nodesAfterSecond = new Set(GraphService.db.nodes.items.map(n => n.id));
         const edgesAfterSecond = GraphService.db.edges.items
             .map(e => `${e.source}|${e.target}|${e.type}`)


### PR DESCRIPTION
Resolves #13840

Adds a scheduled process/MX concept harvester for A2A MESSAGE nodes: it scans unharvested messages, builds a cheap subject/tag frequency pre-filter, sends only the bounded top terms through the existing Teaching-Test extractor, dedupes by normalized concept name, writes process/MX candidates, and marks source messages only after provider evaluation and candidate append succeed.

Evidence: L2 local unit/static checks -> L2 required (scheduled drainer, config leaves, graph projection, and scheduler behavior are unit-testable). Residual: none for #13840.

## Deltas from ticket

- Keeps process/MX terms in the existing concept ontology but tags them with `ontologyLayer: 'process-mx'` and `codeGapEligible: false`, so they can enrich MX/coordination knowledge without polluting code-doc gap inference.
- Adds strict drainer semantics: provider/parser failures and append failures fail the scheduled task and do not stamp messages as harvested.
- Adds deterministic normalized-name dedupe for mined candidates, covering punctuation/case/acronym variants before JSONL append.

## Config / Local Overlay Follow-Up

Changed committed config-template keys:

- `orchestrator.intervals.messageConceptHarvestMs` / `NEO_ORCHESTRATOR_MESSAGE_CONCEPT_HARVEST_INTERVAL_MS` (default: 6h)
- `conceptDiscovery.messageHarvestBatchLimit` / `NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_BATCH_LIMIT` (default: 500)
- `conceptDiscovery.messageHarvestTopN` / `NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_TOP_N` (default: 20)
- `conceptDiscovery.messageHarvestMinFrequency` / `NEO_CONCEPT_DISCOVERY_MESSAGE_HARVEST_MIN_FREQUENCY` (default: 2)

Matching local `config.mjs` overlays need the standard post-merge config overlay update script. Harness/orchestrator restart is recommended after that so the new scheduler and Memory Core leaves are loaded by live daemons.

## Test Evidence

- `npm run agent-preflight -- <touched files>` passed.
- `git diff --check origin/dev..HEAD` passed.
- `npm run test-unit -- test/playwright/unit/ai/services/ingestion/ConceptDiscoveryService.spec.mjs test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs` passed: 195 tests.

## Post-Merge Validation

- [ ] Run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config`.
- [ ] Restart orchestrator/harness and verify `message-concept-harvest` appears in task state after the first due poll.
- [ ] Confirm process/MX harvested candidates do not emit code-doc `GUIDE_GAP` / `EXAMPLE_GAP` / `ORPHAN_CONCEPT` findings.

## Commits

- `30aa395cac` — `feat(ai): add scheduled MX concept harvester (#13840)`

Authored by Euclid (GPT-5, Codex Desktop). Session 30ba1931-9d59-48bb-afdf-af8904070af9.
