### PR TITLE
fix(ai): avoid message-harvest test AiConfig mutation (#13969)

### DIFF
--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -61,6 +61,12 @@ function createTestOrchestrator(config = {}) {
             TaskStateService.taskState[name].running = true;
         }
     });
+    if (TaskStateService.taskState['message-concept-harvest']) {
+        TaskStateService.taskState['message-concept-harvest'].lastRunAt =
+            Object.hasOwn(config, 'messageConceptHarvestLastRunAt') ?
+                config.messageConceptHarvestLastRunAt :
+                Date.now();
+    }
 
     // Save canonical AiConfig once per test; afterEach restores.
     savedIntervals = savedIntervals || {...AiConfig.orchestrator.intervals};
@@ -90,7 +96,6 @@ function createTestOrchestrator(config = {}) {
     AiConfig.orchestrator.intervals.primaryDevSyncMs = config.primaryDevSyncIntervalMs ?? 600000;
     AiConfig.orchestrator.intervals.tenantRepoSyncMs = config.tenantRepoSyncIntervalMs ?? Number.MAX_SAFE_INTEGER;
     AiConfig.orchestrator.intervals.dreamMs          = config.dreamIntervalMs          ?? Number.MAX_SAFE_INTEGER;
-    AiConfig.orchestrator.intervals.messageConceptHarvestMs = config.messageConceptHarvestIntervalMs ?? Number.MAX_SAFE_INTEGER;
     AiConfig.orchestrator.intervals.dreamOverflowThreshold = config.dreamOverflowThreshold ?? 0.8;
     AiConfig.orchestrator.intervals.goldenPathMs     = config.goldenPathIntervalMs     ?? Number.MAX_SAFE_INTEGER;
     AiConfig.orchestrator.intervals.swarmHeartbeatMs = config.swarmHeartbeatIntervalMs ?? Number.MAX_SAFE_INTEGER;
@@ -387,6 +392,29 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         orchestrator.poll();
 
         expect(started).toEqual([]);
+    });
+
+    test('keeps message-concept-harvest scoped out of default helper polls without AiConfig mutation (#13969)', () => {
+        const originalCadence = AiConfig.orchestrator.intervals.messageConceptHarvestMs;
+        const started         = [];
+
+        const orchestrator = createTestOrchestrator({
+            kbSyncEnabled: false
+        });
+
+        expect(AiConfig.orchestrator.intervals.messageConceptHarvestMs).toBe(originalCadence);
+        expect(TaskStateService.taskState['message-concept-harvest'].lastRunAt).toBeGreaterThan(0);
+
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(started.find(entry => entry.taskName === 'message-concept-harvest')).toBeUndefined();
     });
 
     test('does not restart bridge-daemon when deployment config disables local wake delivery', () => {


### PR DESCRIPTION
Resolves #13969

Removes the #13968-added `AiConfig.orchestrator.intervals.messageConceptHarvestMs` write from the Orchestrator unit-test helper. The helper now keeps `message-concept-harvest` scoped out of unrelated default polls by seeding only the isolated test task state as fresh, while the existing registry/pipeline tests continue to cover the cadence behavior.

Evidence: L2 (focused unit tests + static no-hit grep) -> L2 required (test-helper ADR 0019 regression). Residual: none for #13969.

## Deltas from ticket
No production behavior changed. The older historical AiConfig interval mutations in the helper remain explicitly out of scope for this narrow follow-up.

## Test Evidence
- `rg -n "messageConceptHarvestIntervalMs|AiConfig\\.orchestrator\\.intervals\\.messageConceptHarvestMs\\s*=" test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` returned no hits.
- `git diff --check` passed.
- `npm run agent-preflight -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs` passed: 86 tests.

## Post-Merge Validation
- [ ] Normal CI remains green.

## Commits
- `e28fdb1f69` — remove the message-harvest AiConfig mutation from the Orchestrator spec helper

Authored by Euclid (GPT-5, Codex Desktop). Session 30ba1931-9d59-48bb-afdf-af8904070af9.
