### PR TITLE
fix(ai): add REM backlog catch-up scheduling (#13971)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -509,7 +509,13 @@ class Config extends ConfigProvider {
                      * cadence.
                      */
                     dreamOverflowThreshold: leaf(0.8, 'NEO_ORCHESTRATOR_DREAM_OVERFLOW_THRESHOLD', 'number'),
-                    goldenPathMs          : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS', 'number'),
+                    /**
+                     * Cooldown for REM backlog catch-up after a successful cycle saturates the configured
+                     * REM batch. This is shorter than `dreamMs`, but only activates for bounded
+                     * non-overflow cycles that prove backlog remains.
+                     */
+                    remBacklogCatchupCooldownMs: leaf(5 * 60 * 1000, 'NEO_ORCHESTRATOR_REM_BACKLOG_CATCHUP_COOLDOWN_MS', 'number'),
+                    goldenPathMs               : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS', 'number'),
                     /**
                      * Generic swarm-heartbeat / watchdog nudge cadence — the periodic pulse that fires a
                      * wake digest even with no new messages. Set to 20 min so the generic watchdog nudge

--- a/ai/daemons/orchestrator/scheduling/dream.mjs
+++ b/ai/daemons/orchestrator/scheduling/dream.mjs
@@ -17,6 +17,12 @@ function toTimestampMs(value) {
     return null;
 }
 
+function requireFiniteNumber(name, value) {
+    if (!Number.isFinite(value)) {
+        throw new Error(`[dream scheduling] Required numeric option "${name}" is missing or invalid.`);
+    }
+}
+
 /**
  * @summary Resolves the timestamp from which the next REM cadence should be
  * measured. Normal cycles retain start-time cadence; overflowed cycles cool down
@@ -40,6 +46,30 @@ export function getCadenceAnchor({state, dreamIntervalMs, dreamOverflowThreshold
 }
 
 /**
+ * @summary Determines whether the previous REM cycle proved a remaining backlog and was cheap enough
+ * for a catch-up cadence.
+ * @param {Object} options
+ * @param {Object} [options.state] Current task state for the dream lane.
+ * @param {Number} options.dreamIntervalMs Periodic REM interval.
+ * @param {Number} options.dreamOverflowThreshold Config-owned fraction of cadence that triggers
+ * completion-time cooldown for a completed cycle.
+ * @returns {Boolean} `true` when the previous REM run may schedule catch-up.
+ */
+export function isRemBacklogCatchupEligible({state, dreamIntervalMs, dreamOverflowThreshold}) {
+    const lastRunAt        = toTimestampMs(state?.lastRunAt) ?? 0;
+    const lastSuccessAt    = toTimestampMs(state?.lastSuccessAt);
+    const thresholdMs      = dreamIntervalMs * dreamOverflowThreshold;
+    const completedRuntime = lastSuccessAt !== null && lastSuccessAt > lastRunAt
+        ? lastSuccessAt - lastRunAt
+        : 0;
+
+    return state?.lastCompletion?.rem?.batchSaturated === true &&
+        lastSuccessAt !== null &&
+        completedRuntime > 0 &&
+        completedRuntime <= thresholdMs;
+}
+
+/**
  * @summary Dream-cycle due-trigger projection. Returns a trigger descriptor when
  * the configured interval has elapsed since the resolved cadence anchor; null
  * otherwise. Pure function.
@@ -49,17 +79,39 @@ export function getCadenceAnchor({state, dreamIntervalMs, dreamOverflowThreshold
  * @param {Number} options.dreamIntervalMs Periodic interval; `<= 0` disables.
  * @param {Number} options.dreamOverflowThreshold Config-owned fraction of cadence that makes
  * the completed prior cycle use completion-time cooldown.
+ * @param {Number} options.remBacklogCatchupCooldownMs Short cooldown for saturated REM batches.
  * @returns {Object|null} A dream task trigger or null when no work is due.
  */
-export function getDueTask({state, now, dreamIntervalMs, dreamOverflowThreshold}) {
+export function getDueTask({state, now, dreamIntervalMs, dreamOverflowThreshold, remBacklogCatchupCooldownMs}) {
+    requireFiniteNumber('dreamIntervalMs', dreamIntervalMs);
+    requireFiniteNumber('dreamOverflowThreshold', dreamOverflowThreshold);
+    requireFiniteNumber('remBacklogCatchupCooldownMs', remBacklogCatchupCooldownMs);
+
     const cadenceAnchor = getCadenceAnchor({state, dreamIntervalMs, dreamOverflowThreshold});
 
-    if (dreamIntervalMs > 0 && now - cadenceAnchor >= dreamIntervalMs) {
+    if (dreamIntervalMs <= 0) {
+        return null;
+    }
+
+    if (now - cadenceAnchor >= dreamIntervalMs) {
         return {
             taskName: 'dream',
             source  : 'periodic-dream',
             reason  : `periodic-dream:${dreamIntervalMs}`
         };
     }
+
+    const lastSuccessAt = toTimestampMs(state?.lastSuccessAt);
+    if (remBacklogCatchupCooldownMs > 0 &&
+        lastSuccessAt !== null &&
+        now - lastSuccessAt >= remBacklogCatchupCooldownMs &&
+        isRemBacklogCatchupEligible({state, dreamIntervalMs, dreamOverflowThreshold})) {
+        return {
+            taskName: 'dream',
+            source  : 'rem-backlog-catchup',
+            reason  : `rem-backlog-catchup:${remBacklogCatchupCooldownMs}`
+        };
+    }
+
     return null;
 }

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -97,6 +97,7 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
                 dream                          : config.orchestrator.intervals.dreamMs,
                 messageConceptHarvest          : config.orchestrator.intervals.messageConceptHarvestMs,
                 dreamOverflowThreshold         : config.orchestrator.intervals.dreamOverflowThreshold,
+                remBacklogCatchupCooldown      : config.orchestrator.intervals.remBacklogCatchupCooldownMs,
                 goldenPath                     : config.orchestrator.intervals.goldenPathMs,
                 swarmHeartbeat                 : config.orchestrator.intervals.swarmHeartbeatMs,
                 embedDrainLivenessWatchdogCheck: config.orchestrator.intervals.embedDrainLivenessWatchdogCheckMs,
@@ -481,10 +482,21 @@ async function runDreamTask({taskName, reason, services}) {
         sessionsProcessed: outcome.sessionsProcessed,
         runId            : outcome.runId
     };
+    if (outcome.remBatchLimit !== undefined) recordPayload.remBatchLimit = outcome.remBatchLimit;
+    if (outcome.remBatchSaturated !== undefined) recordPayload.remBatchSaturated = outcome.remBatchSaturated;
 
     switch (outcome.status) {
         case 'completed':
-            services.taskStateService.markCompleted(taskName);
+            services.taskStateService.markCompleted(taskName, {
+                completedAt: outcome.completedAt,
+                durationMs : outcome.durationMs,
+                runId      : outcome.runId,
+                rem        : {
+                    sessionsProcessed: outcome.sessionsProcessed,
+                    batchLimit       : outcome.remBatchLimit,
+                    batchSaturated   : outcome.remBatchSaturated === true
+                }
+            });
             services.healthService?.recordTaskOutcome?.(taskName, 'completed', recordPayload);
             break;
         case 'skipped':

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -189,10 +189,11 @@ export const TASK_REGISTRY = Object.freeze([
         dependencies    : [],
         getDueTask({state, now, intervals, hooks}) {
             return (hooks.dreamGetDueTask || getDreamDueTask)({
-                state                 : state.dream ?? {},
+                state                      : state.dream ?? {},
                 now,
-                dreamIntervalMs       : intervals.dream,
-                dreamOverflowThreshold: intervals.dreamOverflowThreshold
+                dreamIntervalMs            : intervals.dream,
+                dreamOverflowThreshold     : intervals.dreamOverflowThreshold,
+                remBacklogCatchupCooldownMs: intervals.remBacklogCatchupCooldown
             });
         }
     },

--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -706,6 +706,8 @@ class DreamService extends Base {
             completedAt      : null,
             durationMs       : null,
             sessionsProcessed: null,
+            remBatchLimit    : null,
+            remBatchSaturated: false,
             diagnostic       : null,
             skipReason       : null,
             error            : null
@@ -805,11 +807,13 @@ class DreamService extends Base {
         // work-completed `completed` path without requiring a return-value refactor on
         // processUndigestedSessions. A pre-call query is cheaper than the alternative
         // of inspecting graph state after the fact.
-        let   sessionCount      = 0;
+        let sessionCount  = 0,
+            remBatchLimit = null;
         const sessionQueryStart = Date.now();
         try {
             const undigested = await this.findUndigestedSessions();
             sessionCount = Array.isArray(undigested) ? undigested.length : 0;
+            remBatchLimit = Math.max(0, Math.floor(readRequiredNumberLeaf('remSleepBatchLimit')));
             perPhaseStates.push(finishPhase('sessionQuery', sessionQueryStart, 'completed', {sessionsFound: sessionCount}));
         } catch (e) {
             const message = toErrorMessage(e);
@@ -843,6 +847,8 @@ class DreamService extends Base {
             return await finalize('skipped', {
                 reasonCode       : 'no-undigested-sessions',
                 sessionsProcessed: 0,
+                remBatchLimit,
+                remBatchSaturated: false,
                 skipReason       : 'no undigested sessions'
             });
         }
@@ -873,7 +879,12 @@ class DreamService extends Base {
                 }
             }
 
-            return await finalize('completed', {reasonCode: 'ok', sessionsProcessed: sessionCount});
+            return await finalize('completed', {
+                reasonCode       : 'ok',
+                sessionsProcessed: sessionCount,
+                remBatchLimit,
+                remBatchSaturated: remBatchLimit > 0 && sessionCount >= remBatchLimit
+            });
         } catch (e) {
             if (e.remState) {
                 if (Array.isArray(e.remState.perPhaseStates)) {

--- a/ai/daemons/orchestrator/services/TaskStateService.mjs
+++ b/ai/daemons/orchestrator/services/TaskStateService.mjs
@@ -185,14 +185,16 @@ export class TaskStateService extends Base {
     /**
      * Marks a task as successfully completed.
      * @param {String} taskName
+     * @param {Object|null} [lastCompletion=null] Bounded task-specific completion metadata.
      * @returns {void}
      */
-    markCompleted(taskName) {
+    markCompleted(taskName, lastCompletion=null) {
         const state = this.taskState[taskName];
         state.running       = false;
         state.pid           = null;
         state.lastExitCode  = 0;
         state.lastSuccessAt = new Date().toISOString();
+        state.lastCompletion = lastCompletion;
         this.writeState();
     }
 
@@ -218,6 +220,7 @@ export class TaskStateService extends Base {
         state.running      = false;
         state.pid          = null;
         state.lastExitCode = null;
+        state.lastCompletion = null;
         this.writeState();
     }
 
@@ -248,6 +251,7 @@ export class TaskStateService extends Base {
         state.pid          = null;
         state.lastExitCode = code;
         state.lastErrorAt  = new Date().toISOString();
+        state.lastCompletion = null;
         this.writeState();
     }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs
@@ -1,16 +1,18 @@
 import {test, expect} from '@playwright/test';
 import {
     getCadenceAnchor,
-    getDueTask
+    getDueTask,
+    isRemBacklogCatchupEligible
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/dream.mjs';
 
 test.describe('orchestrator/scheduling/dream (#11858 / Epic #11831)', () => {
     test('returns a periodic-dream trigger when the interval has elapsed since lastRunAt', () => {
         expect(getDueTask({
-            state                 : {lastRunAt: 0},
-            now                   : 600000,
-            dreamIntervalMs       : 600000,
-            dreamOverflowThreshold: 0.8
+            state                      : {lastRunAt: 0},
+            now                        : 600000,
+            dreamIntervalMs            : 600000,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 0
         })).toEqual({
             taskName: 'dream',
             source  : 'periodic-dream',
@@ -20,40 +22,53 @@ test.describe('orchestrator/scheduling/dream (#11858 / Epic #11831)', () => {
 
     test('returns null when the interval has not yet elapsed', () => {
         expect(getDueTask({
-            state                 : {lastRunAt: 0},
-            now                   : 599999,
-            dreamIntervalMs       : 600000,
-            dreamOverflowThreshold: 0.8
+            state                      : {lastRunAt: 0},
+            now                        : 599999,
+            dreamIntervalMs            : 600000,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 0
         })).toBeNull();
     });
 
     test('treats intervalMs <= 0 as disabled (does not fire)', () => {
         expect(getDueTask({
-            state                 : {lastRunAt: 0},
-            now                   : 999999999,
-            dreamIntervalMs       : 0,
-            dreamOverflowThreshold: 0.8
+            state                      : {lastRunAt: 0},
+            now                        : 999999999,
+            dreamIntervalMs            : 0,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 0
         })).toBeNull();
 
         expect(getDueTask({
-            state                 : {lastRunAt: 0},
-            now                   : 999999999,
-            dreamIntervalMs       : -1,
-            dreamOverflowThreshold: 0.8
+            state                      : {lastRunAt: 0},
+            now                        : 999999999,
+            dreamIntervalMs            : -1,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 0
         })).toBeNull();
     });
 
     test('handles missing state gracefully (lastRunAt defaults to 0)', () => {
         expect(getDueTask({
-            state                 : undefined,
-            now                   : 600000,
-            dreamIntervalMs       : 600000,
-            dreamOverflowThreshold: 0.8
+            state                      : undefined,
+            now                        : 600000,
+            dreamIntervalMs            : 600000,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 0
         })).toEqual({
             taskName: 'dream',
             source  : 'periodic-dream',
             reason  : 'periodic-dream:600000'
         });
+    });
+
+    test('fails loud when the REM catch-up cooldown is not wired (#13971)', () => {
+        expect(() => getDueTask({
+            state                 : {lastRunAt: 0},
+            now                   : 600000,
+            dreamIntervalMs       : 600000,
+            dreamOverflowThreshold: 0.8
+        })).toThrow(/remBacklogCatchupCooldownMs/);
     });
 
     test('uses completion-time cooldown after a cadence-overflowing REM cycle (#12289)', () => {
@@ -73,16 +88,18 @@ test.describe('orchestrator/scheduling/dream (#11858 / Epic #11831)', () => {
 
         expect(getDueTask({
             state,
-            now                   : completedAt + 13000,
-            dreamIntervalMs       : intervalMs,
-            dreamOverflowThreshold: 0.8
+            now                        : completedAt + 13000,
+            dreamIntervalMs            : intervalMs,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 0
         })).toBeNull();
 
         expect(getDueTask({
             state,
-            now                   : completedAt + intervalMs,
-            dreamIntervalMs       : intervalMs,
-            dreamOverflowThreshold: 0.8
+            now                        : completedAt + intervalMs,
+            dreamIntervalMs            : intervalMs,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 0
         })).toEqual({
             taskName: 'dream',
             source  : 'periodic-dream',
@@ -104,13 +121,88 @@ test.describe('orchestrator/scheduling/dream (#11858 / Epic #11831)', () => {
 
         expect(getDueTask({
             state,
-            now                   : 3600000,
-            dreamIntervalMs       : 3600000,
-            dreamOverflowThreshold: 0.8
+            now                        : 3600000,
+            dreamIntervalMs            : 3600000,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 0
         })).toEqual({
             taskName: 'dream',
             source  : 'periodic-dream',
             reason  : 'periodic-dream:3600000'
         });
+    });
+
+    test('schedules short catch-up after a saturated non-overflowing REM cycle (#13971)', () => {
+        const state = {
+            lastRunAt     : 0,
+            lastSuccessAt : new Date(120000).toISOString(),
+            lastCompletion: {
+                rem: {
+                    batchSaturated: true
+                }
+            }
+        };
+
+        expect(isRemBacklogCatchupEligible({
+            state,
+            dreamIntervalMs       : 3600000,
+            dreamOverflowThreshold: 0.8
+        })).toBe(true);
+
+        expect(getDueTask({
+            state,
+            now                        : 420000,
+            dreamIntervalMs            : 3600000,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 300000
+        })).toEqual({
+            taskName: 'dream',
+            source  : 'rem-backlog-catchup',
+            reason  : 'rem-backlog-catchup:300000'
+        });
+    });
+
+    test('does not catch up after non-saturated, overflowed, or disabled REM cycles (#13971)', () => {
+        const baseState = {
+            lastRunAt     : 0,
+            lastSuccessAt : new Date(120000).toISOString(),
+            lastCompletion: {
+                rem: {
+                    batchSaturated: false
+                }
+            }
+        };
+
+        expect(getDueTask({
+            state                      : baseState,
+            now                        : 420000,
+            dreamIntervalMs            : 3600000,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 300000
+        })).toBeNull();
+
+        expect(getDueTask({
+            state: {
+                lastRunAt     : 0,
+                lastSuccessAt : new Date(3000000).toISOString(),
+                lastCompletion: {
+                    rem: {
+                        batchSaturated: true
+                    }
+                }
+            },
+            now                        : 3300000,
+            dreamIntervalMs            : 3600000,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 300000
+        })).toBeNull();
+
+        expect(getDueTask({
+            state                      : {...baseState, lastCompletion: {rem: {batchSaturated: true}}},
+            now                        : 420000,
+            dreamIntervalMs            : 3600000,
+            dreamOverflowThreshold     : 0.8,
+            remBacklogCatchupCooldownMs: 0
+        })).toBeNull();
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -130,7 +130,7 @@ function makeOrchestratorAdapterFixture(overrides = {}) {
     };
 }
 
-function makeAdapterConfig({dreamMs = 3_600_000} = {}) {
+function makeAdapterConfig({dreamMs = 3_600_000, remBacklogCatchupCooldownMs = 300_000} = {}) {
     return {
         orchestrator: {
             intervals: {
@@ -144,6 +144,7 @@ function makeAdapterConfig({dreamMs = 3_600_000} = {}) {
                 dreamMs,
                 messageConceptHarvestMs          : 1,
                 dreamOverflowThreshold           : 0.8,
+                remBacklogCatchupCooldownMs,
                 goldenPathMs                     : 1,
                 swarmHeartbeatMs                 : 1,
                 embedDrainLivenessWatchdogCheckMs: 1,
@@ -173,6 +174,7 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
 
         expect(enabledOptions.services.remConsolidationLivenessAlarmDispatcher).toBe(remDispatcher);
         expect(enabledOptions.runtime.remConsolidationWatchdogAlarmEnabled).toBe(true);
+        expect(enabledOptions.context.intervals.remBacklogCatchupCooldown).toBe(300_000);
 
         const disabledOptions = buildOrchestratorSchedulingOptions({
             orchestrator,
@@ -412,6 +414,8 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
                         completedAt      : '2026-06-21T12:00:00.000Z',
                         durationMs       : 42,
                         sessionsProcessed: 3,
+                        remBatchLimit    : 3,
+                        remBatchSaturated: true,
                         runId            : 'run-completed'
                     })
                 },
@@ -422,7 +426,7 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
                 },
                 taskStateService: {
                     getTaskState: () => null,
-                    markCompleted(taskName) { calls.push(['markCompleted', taskName]); },
+                    markCompleted(taskName, lastCompletion) { calls.push(['markCompleted', taskName, lastCompletion]); },
                     markFailed(taskName) { calls.push(['markFailed', taskName]); },
                     markSkipped(taskName) { calls.push(['markSkipped', taskName]); },
                     markStarted(taskName, reason) { calls.push(['markStarted', taskName, reason]); }
@@ -435,7 +439,16 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
 
         expect(calls).toEqual([
             ['markStarted', 'dream', 'dream-reason'],
-            ['markCompleted', 'dream']
+            ['markCompleted', 'dream', {
+                completedAt: '2026-06-21T12:00:00.000Z',
+                durationMs : 42,
+                runId      : 'run-completed',
+                rem        : {
+                    sessionsProcessed: 3,
+                    batchLimit       : 3,
+                    batchSaturated   : true
+                }
+            }]
         ]);
         expect(outcomes).toEqual([
             {
@@ -451,6 +464,8 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
                     completedAt      : '2026-06-21T12:00:00.000Z',
                     durationMs       : 42,
                     sessionsProcessed: 3,
+                    remBatchLimit    : 3,
+                    remBatchSaturated: true,
                     runId            : 'run-completed'
                 }
             }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs
@@ -1,13 +1,13 @@
-import {test, expect} from '@playwright/test';
-import Neo from '../../../../../../../src/Neo.mjs';
-import * as core from '../../../../../../../src/core/_export.mjs';
-import DreamService from '../../../../../../../ai/daemons/orchestrator/services/DreamService.mjs';
-import AiConfig from '../../../../../../../ai/config.mjs';
-import {Memory_Config as MemoryConfig} from '../../../../../../../ai/services.mjs';
-import logger from '../../../../../../../ai/mcp/server/memory-core/logger.mjs';
+import {test, expect}                   from '@playwright/test';
+import Neo                              from '../../../../../../../src/Neo.mjs';
+import * as core                        from '../../../../../../../src/core/_export.mjs';
+import DreamService                     from '../../../../../../../ai/daemons/orchestrator/services/DreamService.mjs';
+import AiConfig                         from '../../../../../../../ai/config.mjs';
+import {Memory_Config as MemoryConfig}  from '../../../../../../../ai/services.mjs';
+import logger                           from '../../../../../../../ai/mcp/server/memory-core/logger.mjs';
 import {mkdtemp, readdir, readFile, rm} from 'fs/promises';
-import os from 'os';
-import path from 'path';
+import os                               from 'os';
+import path                             from 'path';
 
 /**
  * @summary Focused coverage for the typed-outcome contract of `DreamService.executeRemCycle()`.
@@ -114,8 +114,8 @@ test.describe('DreamService.executeRemCycle typed outcome contract', () => {
         expect(entry.failureReason).toBe('PROVIDER_READINESS_TIMEOUT');
         expect(entry.cycleScopePhases).toEqual(['providerReady']);
         expect(entry.perPhaseStates[0]).toMatchObject({
-            phase : 'providerReady',
-            status: 'failed',
+            phase  : 'providerReady',
+            status : 'failed',
             details: {
                 diagnostic: {
                     provider     : 'openAiCompatible',
@@ -172,8 +172,8 @@ test.describe('DreamService.executeRemCycle typed outcome contract', () => {
         expect(entry.lastSuccessfulPhase).toBe('providerReady');
         expect(entry.cycleScopePhases).toEqual(['providerReady', 'concurrentGuard']);
         expect(entry.perPhaseStates[1]).toMatchObject({
-            phase : 'concurrentGuard',
-            status: 'skipped',
+            phase  : 'concurrentGuard',
+            status : 'skipped',
             details: {reasonCode: 'already-processing'}
         });
         expect(entry.perSessionStates).toEqual([]);
@@ -203,8 +203,24 @@ test.describe('DreamService.executeRemCycle typed outcome contract', () => {
 
         expect(outcome.status).toBe('completed');
         expect(outcome.sessionsProcessed).toBe(2);
+        expect(outcome.remBatchLimit).toBe(MemoryConfig.remSleepBatchLimit);
+        expect(outcome.remBatchSaturated).toBe(false);
         expect(outcome.error).toBeNull();
         expect(outcome.skipReason).toBeNull();
+    });
+
+    test('marks REM outcome as saturated when the processed count reaches the batch limit (#13971)', async () => {
+        const sessions = Array.from({length: MemoryConfig.remSleepBatchLimit}, (_, index) => ({id: `session-${index}`}));
+
+        DreamService.findUndigestedSessions    = async () => sessions;
+        DreamService.processUndigestedSessions = async () => {};
+
+        const outcome = await DreamService.executeRemCycle({reason: 'saturated-test', includeDecay: false});
+
+        expect(outcome.status).toBe('completed');
+        expect(outcome.sessionsProcessed).toBe(MemoryConfig.remSleepBatchLimit);
+        expect(outcome.remBatchLimit).toBe(MemoryConfig.remSleepBatchLimit);
+        expect(outcome.remBatchSaturated).toBe(true);
     });
 
     test('Sub 9 hypotheses 10 and 11: failed phase from processing is persisted into REM run state (#12617)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
@@ -1,18 +1,18 @@
-import {test, expect} from '@playwright/test';
-import fs from 'fs-extra';
-import path from 'path';
-import Neo from '../../../../../../../src/Neo.mjs';
-import * as core from '../../../../../../../src/core/_export.mjs';
+import {test, expect}                               from '@playwright/test';
+import fs                                           from 'fs-extra';
+import path                                         from 'path';
+import Neo                                          from '../../../../../../../src/Neo.mjs';
+import * as core                                    from '../../../../../../../src/core/_export.mjs';
 import { TaskStateService, createInitialTaskState } from '../../../../../../../ai/daemons/orchestrator/services/TaskStateService.mjs';
 
 function createTestService() {
     const dataDir = `/tmp/task-state-service-test-${Date.now()}-${Math.random()}`;
     fs.ensureDirSync(dataDir);
 
-    const stateFile = path.join(dataDir, 'state.json');
+    const stateFile       = path.join(dataDir, 'state.json');
     const taskDefinitions = {
         mockTask: {
-            name: 'mockTask',
+            name      : 'mockTask',
             scriptPath: '/mock/script.mjs'
         }
     };
@@ -35,7 +35,7 @@ function createTestService() {
 test.describe('Neo.ai.daemons.services.TaskStateService', () => {
     test('initializes with default state when no file exists', () => {
         const { service } = createTestService();
-        const state = service.getTaskState('mockTask');
+        const state       = service.getTaskState('mockTask');
 
         expect(state).toMatchObject({
             running      : false,
@@ -110,6 +110,30 @@ test.describe('Neo.ai.daemons.services.TaskStateService', () => {
         expect(stateData.mockTask.lastExitCode).toBe(null);
         expect(stateData.mockTask.lastReason).toBe('deferred-run');
         expect(stateData.mockTask.lastSuccessAt).toBe(previousSuccessAt);
+    });
+
+    test('completion metadata is persisted and cleared by non-completed endings (#13971)', () => {
+        const { service, stateFile } = createTestService();
+        const completion             = {
+            rem: {
+                sessionsProcessed: 10,
+                batchLimit       : 10,
+                batchSaturated   : true
+            }
+        };
+
+        service.markCompleted('mockTask', completion);
+        let stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        expect(stateData.mockTask.lastCompletion).toEqual(completion);
+
+        service.markSkipped('mockTask');
+        stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        expect(stateData.mockTask.lastCompletion).toBeNull();
+
+        service.markCompleted('mockTask', completion);
+        service.markFailed('mockTask', 1);
+        stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        expect(stateData.mockTask.lastCompletion).toBeNull();
     });
 
     test('adoptRunning sets state without immediately writing to disk', () => {


### PR DESCRIPTION
Resolves #13971

Related: #13755

Adds a backlog-aware REM catch-up path for saturated but non-overflowing Dream cycles. When a REM extraction run fills the configured batch limit, the scheduler can fire a bounded follow-up after the typed catch-up cooldown instead of waiting the full steady-state Dream cadence; non-saturated, overflowed, skipped, failed, or disabled-cooldown cycles keep the existing cadence.

Evidence: L2 (scheduler/service unit coverage for saturated REM cycles, cooldown gating, and completion-state metadata) -> L2 required (orchestrator scheduling contract). No residuals.

## Deltas from ticket

- Uses `AiConfig.orchestrator.intervals.remBacklogCatchupCooldownMs` as a typed leaf and fails loud when registry wiring omits it.
- Persists Dream completion metadata in `TaskStateService` so the scheduler can distinguish saturated REM work from ordinary successful Dream runs.
- Keeps the existing hourly Dream cadence for non-saturated cycles and for cycles that exceeded the runtime threshold.

## Test Evidence

- `git diff --check`
- `git diff --cached --check`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs` -> 62 passed.

## Post-Merge Validation

- [ ] Restart the orchestrator and confirm a saturated REM cycle schedules `rem-backlog-catchup` after `NEO_ORCHESTRATOR_REM_BACKLOG_CATCHUP_COOLDOWN_MS` instead of waiting `dreamMs`.

## Commits

- `2dd5e7c7e5` — `fix(ai): add REM backlog catch-up scheduling (#13971)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
