### PR TITLE
fix(ai): expose REM extractor failure terminality (#13974)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -41,19 +41,27 @@ import {bytesToTokens} from '../../../services/memory-core/helpers/consumerFrict
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
-// Bounds the re-serve ONLY for the DETERMINISTICALLY-terminal failure: `skip-over-band` (payload over the
-// model's safe band) is a reliable size check — that session genuinely cannot be processed at this cadence
-// until a deep-digest lane exists, so deferring it after the `maxDigestAttempts` config leaf is a safe bleed-stop.
-// `under-band-choke` (a bare-null return UNDER the band) and a transient ingestion-failure are NOT proven
-// terminal — the extractor returns the same null for choke / schema-failure / timeout alike, so treating an
-// under-band null as un-digestible is a guess. They stay `undigested` (attempt-tracked, re-served) until
-// typed extractor failure semantics exist; deferring on a guessed-terminal null would risk silently
-// dropping a digestible session.
-const PERMANENT_DEFER_REASONS = new Set(['skip-over-band']);
-
 function estimatePayloadTokens(payload) {
     const text = payload === undefined || payload === null ? '' : String(payload);
     return bytesToTokens(Buffer.byteLength(text, 'utf8'));
+}
+
+function isTriVectorFailureDescriptor(value) {
+    return value?.ok === false;
+}
+
+function getTriVectorFailureAttempts(failure) {
+    return Number.isFinite(failure?.evidence?.attempts) ? failure.evidence.attempts : 1;
+}
+
+function getTriVectorFailureKind(failure) {
+    return failure?.deferReason || failure?.frictionSymptom || 'typed-failure';
+}
+
+function getTriVectorFailureMessage(failure) {
+    return failure?.evidence?.note ||
+           failure?.evidence?.errorMessage ||
+           `tri-vector extraction failed (${getTriVectorFailureKind(failure)})`;
 }
 
 function toErrorMessage(error) {
@@ -457,9 +465,9 @@ class DreamService extends Base {
                     }
 
                     const startTime = Date.now();
-                    let success;
+                    let extractionResult;
                     try {
-                        success = await SemanticGraphExtractor.executeTriVectorExtraction(session);
+                        extractionResult = await SemanticGraphExtractor.executeTriVectorExtraction(session);
                     } catch (e) {
                         sessionState.triVector = {
                             status   : 'failed',
@@ -476,16 +484,24 @@ class DreamService extends Base {
                     }
                     const triVectorTime = ((Date.now() - startTime) / 1000).toFixed(1);
                     logger.info(`[DreamService]   -> Tri-Vector Synthesis took: ${triVectorTime}s`);
+                    const extractionFailure = isTriVectorFailureDescriptor(extractionResult) ? extractionResult : null;
+                    const success           = extractionResult && !extractionFailure;
                     sessionState.triVector = {
                         status   : success ? 'completed' : 'failed',
-                        attempts : 1,
-                        errorKind: success ? undefined : 'null-result'
+                        attempts : extractionFailure ? getTriVectorFailureAttempts(extractionFailure) : 1,
+                        errorKind: success ? undefined : (extractionFailure ? getTriVectorFailureKind(extractionFailure) : 'null-result')
                     };
+                    if (extractionFailure) {
+                        sessionState.triVector.deferReason        = extractionFailure.deferReason;
+                        sessionState.triVector.frictionSymptom    = extractionFailure.frictionSymptom;
+                        sessionState.triVector.terminalForCadence = extractionFailure.terminalForCadence === true;
+                    }
                     if (!success) {
-                        sessionState.failureReasons.push('tri-vector extraction returned null');
+                        sessionState.failureReasons.push(extractionFailure ? getTriVectorFailureMessage(extractionFailure) : 'tri-vector extraction returned null');
                     }
                     perPhaseStates.push(finishPhase('triVector', startTime, success ? 'completed' : 'failed', {
-                        sessionId: session.meta.sessionId
+                        sessionId  : session.meta.sessionId,
+                        deferReason: extractionFailure?.deferReason
                     }));
 
                     const topoStart     = Date.now();
@@ -530,7 +546,7 @@ class DreamService extends Base {
 
                     const capStart = Date.now();
                     try {
-                        await this.inferTestGapsFromSession(success);
+                        await this.inferTestGapsFromSession(success ? extractionResult : null);
                     } catch (e) {
                         sessionState.gapSession = {
                             status      : 'failed',
@@ -561,23 +577,17 @@ class DreamService extends Base {
                         sessionState.graphDigestedFlag = true;
                         logger.info(`[DreamService] Session ${session.meta.sessionId} marked as graphDigested in Memory Core.`);
                     } else {
-                        // Digest failed (extractor returned null OR memory-ingestion errors). Bound the
-                        // re-serve: count the attempt, and once it reaches `maxDigestAttempts` mark the
-                        // session `deferred` so findUndigestedSessions stops re-serving it every cycle —
-                        // the chronic local-model load bleed. `deferReason` records WHY for the honest
-                        // consolidation-gap surface + a future deep-digest lane. Back-compat: graphDigested
-                        // stays unset, so a consumer that does not yet read digestState still sees an
-                        // un-digested (never a falsely-digested) session.
-                        const digestAttempts = (Number(session.meta.digestAttempts) || 0) + 1;
-                        const safeBandTokens = aiConfig.localModels?.chat?.safeProcessingLimitTokens;
-                        const deferReason    = ingestErrors > 0
+                        // Digest failed (typed extractor failure OR memory-ingestion errors). Bound the
+                        // re-serve only when the extractor supplies cadence-terminal evidence; ingestion
+                        // errors and legacy bare-null returns stay retryable so a storage/transient failure
+                        // never removes a digestible session from the steady cadence.
+                        const digestAttempts     = (Number(session.meta.digestAttempts) || 0) + 1;
+                        const maxDigestAttempts  = readRequiredNumberLeaf('maxDigestAttempts');
+                        const terminalForCadence = ingestErrors === 0 && extractionFailure?.terminalForCadence === true;
+                        const deferReason        = ingestErrors > 0
                             ? 'ingestion-failure'
-                            : (safeBandTokens > 0 && sessionState.payloadSizeTokens > safeBandTokens ? 'skip-over-band' : 'under-band-choke');
-                        // Bound the re-serve ONLY for the deterministically-terminal reason (skip-over-band);
-                        // under-band-choke + transient ingestion-failure keep retrying (attempt-tracked) so a
-                        // digestible session is never silently dropped on a guessed-terminal null.
-                        const maxDigestAttempts = readRequiredNumberLeaf('maxDigestAttempts');
-                        const digestState       = PERMANENT_DEFER_REASONS.has(deferReason) && digestAttempts >= maxDigestAttempts
+                            : (extractionFailure?.deferReason || 'schema-failure');
+                        const digestState = terminalForCadence && digestAttempts >= maxDigestAttempts
                             ? 'deferred'
                             : 'undigested';
 
@@ -585,9 +595,10 @@ class DreamService extends Base {
                             ids      : [session.id],
                             metadatas: [{ ...session.meta, digestState, digestAttempts, deferReason }]
                         });
-                        sessionState.digestState    = digestState;
-                        sessionState.deferReason    = deferReason;
-                        sessionState.digestAttempts = digestAttempts;
+                        sessionState.digestState        = digestState;
+                        sessionState.deferReason        = deferReason;
+                        sessionState.digestAttempts     = digestAttempts;
+                        sessionState.terminalForCadence = terminalForCadence;
 
                         if (digestState === 'deferred') {
                             logger.warn(`[DreamService] Session ${session.meta.sessionId} marked 'deferred' after ${digestAttempts} failed digest attempt(s) (reason: ${deferReason}); excluded from the steady REM cadence to stop the re-serve bleed.`);

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -1,6 +1,6 @@
 import fs       from 'fs';
 import path     from 'path';
-import aiConfig from '../../mcp/server/memory-core/config.mjs';
+import AiConfig from '../../mcp/server/memory-core/config.mjs';
 import Base     from '../../../src/core/Base.mjs';
 import {
     bytesToTokens,
@@ -161,6 +161,62 @@ class SemanticGraphExtractor extends Base {
     }
 
     /**
+     * Maps ConsumerFriction symptoms into REM digest-state `deferReason` values.
+     *
+     * @summary Anchor & Echo: Keeps the visibility taxonomy (`ConsumerFriction.symptom`)
+     * separate from the REM cadence taxonomy (`deferReason`). The extractor owns this
+     * bridge because it is the only layer with direct provider-failure evidence.
+     *
+     * @param {String} symptom ConsumerFriction symptom
+     * @returns {String} REM digest-state defer reason
+     * @protected
+     */
+    getDeferReasonForFrictionSymptom(symptom) {
+        switch (symptom) {
+            case 'size-precheck-skip':
+                return 'skip-over-band';
+            case 'timeout':
+                return 'wall-clock-timeout';
+            case 'parse-failure':
+                return 'schema-failure';
+            case 'context-overflow':
+            default:
+                return 'under-band-choke';
+        }
+    }
+
+    /**
+     * Creates the typed failure descriptor consumed by `DreamService`.
+     *
+     * @summary Anchor & Echo: Success still returns the Tri-Vector payload for compatibility.
+     * Failure returns this descriptor instead of bare `null`, so REM cadence can persist
+     * `deferReason` / `terminalForCadence` from provider-local evidence rather than guessing
+     * from payload size after the fact.
+     *
+     * @param {Object} options
+     * @param {String} options.deferReason REM digest-state reason
+     * @param {String} [options.frictionSymptom] ConsumerFriction symptom used as visibility evidence
+     * @param {Boolean} [options.terminalForCadence=true] Whether repeated failures may be deferred after max attempts
+     * @param {Object} [options.evidence] Bounded diagnostic evidence
+     * @returns {Object}
+     * @protected
+     */
+    createTriVectorFailureDescriptor({
+        deferReason,
+        frictionSymptom,
+        terminalForCadence = true,
+        evidence = {}
+    }) {
+        return {
+            ok: false,
+            deferReason,
+            frictionSymptom,
+            terminalForCadence,
+            evidence
+        };
+    }
+
+    /**
      * Executes the Tri-Vector Synthesis (Semantic Graph, Open Deltas, Roadmap Strategy)
      * from the session memory log via JSON schema extraction.
      *
@@ -169,7 +225,7 @@ class SemanticGraphExtractor extends Base {
      * failures. This graceful degradation prevents token-exhaustion crash-loops under peak payload sizes.
      *
      * @param {Object} session Wrapped session object containing id, document, and meta
-     * @returns {Promise<Object|null>} The extracted payload, or null on failure
+     * @returns {Promise<Object>} The extracted payload, or `{ok:false, ...}` on failure
      */
     async executeTriVectorExtraction(session) {
         logger.info(`[SemanticGraphExtractor] Extracting Tri-Vector Synthesis for session ID: ${session.meta.sessionId}`);
@@ -230,11 +286,11 @@ This does not recase semantic or identity prefixes such as CONCEPT:, CLASS:, or 
 DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide purely the JSON object.`;
 
         try {
-            const graphProvider = resolveGraphModelProvider(aiConfig);
+            const graphProvider = resolveGraphModelProvider(AiConfig);
             const provider      = buildGraphProvider({
                 modelProvider         : graphProvider,
-                ollamaConfig          : aiConfig.ollama,
-                openAiCompatibleConfig: aiConfig.openAiCompatible
+                ollamaConfig          : AiConfig.ollama,
+                openAiCompatibleConfig: AiConfig.openAiCompatible
             });
 
             // Format boundaries securely
@@ -260,19 +316,16 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             // threshold (model-role axis, not provider-namespace — remote providers like
             // Gemini are API-bound and don't expose these knobs; local providers
             // share the same caps because the limit comes from the loaded model).
-            const consumerModel         = aiConfig[graphProvider].model;
-            const consumerContextTokens = aiConfig.localModels.chat.contextLimitTokens;
-            const configuredSafeTokens  = aiConfig.localModels.chat.safeProcessingLimitTokens;
-            const consumerSafeTokens    = Number.isFinite(configuredSafeTokens)
-                ? configuredSafeTokens
-                : Math.floor(consumerContextTokens * 0.75);
+            const consumerModel         = AiConfig[graphProvider].model;
+            const consumerContextTokens = AiConfig.localModels.chat.contextLimitTokens;
+            const consumerSafeTokens    = AiConfig.localModels.chat.safeProcessingLimitTokens;
 
             // Per-task no-think + grammar-constrained tri-vector output. `graphReasoningEffort`
             // (default 'none') disables the gemma MoE's hidden thinking pass; `triVectorSchema` enforces
             // the A2A session_artifact/graph shape via the provider's json_schema path, which makes the
             // repair-retry loop below a safety net rather than the happy path. Schema mirrors the strict
             // shape declared in the systemInstruction above.
-            const graphReasoningEffort = aiConfig.localModels.chat.graphReasoningEffort;
+            const graphReasoningEffort = AiConfig.localModels.chat.graphReasoningEffort;
             const triVectorSchema      = {
                 type      : 'object',
                 properties: {
@@ -344,7 +397,21 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 
                 if (!guardrailed.result) {
                     logger.warn(`[SemanticGraphExtractor] Attempt ${attempt}: invocation guardrail emitted ${guardrailed.friction?.symptom} for session ${session.meta.sessionId}; aborting retry loop.`);
-                    return null;
+
+                    return this.createTriVectorFailureDescriptor({
+                        deferReason       : this.getDeferReasonForFrictionSymptom(guardrailed.friction?.symptom),
+                        frictionSymptom   : guardrailed.friction?.symptom,
+                        terminalForCadence: true,
+                        evidence          : {
+                            attempts                 : attempt,
+                            emissionPoint            : guardrailed.friction?.emissionPoint,
+                            inputBytes               : guardrailed.friction?.inputBytes,
+                            inputTokensEstimate      : guardrailed.friction?.inputTokensEstimate,
+                            contextLimitTokens       : guardrailed.friction?.contextLimitTokens,
+                            safeProcessingLimitTokens: guardrailed.friction?.safeProcessingLimitTokens,
+                            note                     : guardrailed.friction?.note
+                        }
+                    });
                 }
 
                 result = guardrailed.result;
@@ -363,7 +430,18 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                         note                    : `Provider finish_reason='${finishReason}' before schema validation. Aborting repair loop to avoid appending a truncated response. Attempt ${attempt}/${maxRetries}.`
                     });
 
-                    return null;
+                    return this.createTriVectorFailureDescriptor({
+                        deferReason       : 'under-band-choke',
+                        frictionSymptom   : 'context-overflow',
+                        terminalForCadence: true,
+                        evidence          : {
+                            attempts           : attempt,
+                            finishReason,
+                            inputBytes         : inputPayload.bytes,
+                            inputTokensEstimate: inputPayload.tokens,
+                            note               : `Provider finish_reason='${finishReason}' before schema validation.`
+                        }
+                    });
                 }
 
                 // Silent context-overflow detection: provider can stream-close immediately
@@ -390,7 +468,17 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                         note                     : `Silent empty-response from provider (no thrown error, no body). Prompt chars: ${inputPayloadText.length}. Attempt ${attempt}/${maxRetries}.`
                     });
 
-                    return null;
+                    return this.createTriVectorFailureDescriptor({
+                        deferReason       : 'under-band-choke',
+                        frictionSymptom   : 'context-overflow',
+                        terminalForCadence: true,
+                        evidence          : {
+                            attempts           : attempt,
+                            inputBytes         : Buffer.byteLength(inputPayloadText),
+                            inputTokensEstimate: inputPayload.tokens,
+                            note               : `Silent empty-response from provider (no thrown error, no body). Prompt chars: ${inputPayloadText.length}.`
+                        }
+                    });
                 }
 
                 // Extract using robust Json parser to catch malformed boundaries
@@ -421,7 +509,17 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                                 note                    : `Repair retry prompt estimate ${repairPayload.tokens} tokens exceeds safe band ${consumerSafeTokens}. Aborting instead of appending assistant output and repair feedback. Attempt ${attempt}/${maxRetries}.`
                             });
 
-                            return null;
+                            return this.createTriVectorFailureDescriptor({
+                                deferReason       : 'under-band-choke',
+                                frictionSymptom   : 'context-overflow',
+                                terminalForCadence: true,
+                                evidence          : {
+                                    attempts           : attempt,
+                                    inputBytes         : repairPayload.bytes,
+                                    inputTokensEstimate: repairPayload.tokens,
+                                    note               : `Repair retry prompt estimate ${repairPayload.tokens} tokens exceeds safe band ${consumerSafeTokens}.`
+                                }
+                            });
                         }
 
                         logger.warn(`[SemanticGraphExtractor] Attempt ${attempt}: Injecting autonomous JSON repair feedback loop.`);
@@ -445,7 +543,15 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             }
 
             if (!payload) {
-                return null;
+                return this.createTriVectorFailureDescriptor({
+                    deferReason       : 'schema-failure',
+                    frictionSymptom   : 'parse-failure',
+                    terminalForCadence: true,
+                    evidence          : {
+                        attempts: attempt,
+                        note: `Tri-Vector schema validation failed after ${attempt} attempt(s).`
+                    }
+                });
             }
 
             logger.debug(`[SemanticGraphExtractor] Successfully extracted Tri-Vector A2A schema for session ${session.meta.sessionId} after ${attempt} attempts.`);
@@ -533,7 +639,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                          * Consumer-side draining and retry logic is handled by LazyEdgeDrainer.
                          */
                         logger.info(`[SemanticGraphExtractor] Queuing unresolved provenance edge for lazy back-fill: ${resolvedSource} -> ${resolvedTarget}`);
-                        const lazyQueueFile = aiConfig.lazyEdgesQueuePath;
+                        const lazyQueueFile = AiConfig.lazyEdgesQueuePath;
                         const edgeData      = JSON.stringify({ ...edge, source: resolvedSource, target: resolvedTarget, timestamp: new Date().toISOString() }) + '\n';
                         try {
                             // Ensure the directory exists before appending
@@ -579,7 +685,14 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             } else {
                 logger.error('[SemanticGraphExtractor] Error during graph extraction run:', error);
             }
-            return null;
+            return this.createTriVectorFailureDescriptor({
+                deferReason       : 'schema-failure',
+                frictionSymptom   : 'parse-failure',
+                terminalForCadence: false,
+                evidence          : {
+                    errorMessage: error?.message ? String(error.message) : String(error)
+                }
+            });
         }
     }
 
@@ -622,11 +735,11 @@ Enforce this STRICT JSON schema:
 DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide purely the JSON object.`;
 
         try {
-            const graphProvider = resolveGraphModelProvider(aiConfig);
+            const graphProvider = resolveGraphModelProvider(AiConfig);
             const provider      = buildGraphProvider({
                 modelProvider         : graphProvider,
-                ollamaConfig          : aiConfig.ollama,
-                openAiCompatibleConfig: aiConfig.openAiCompatible
+                ollamaConfig          : AiConfig.ollama,
+                openAiCompatibleConfig: AiConfig.openAiCompatible
             });
 
             const messages = [

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -121,6 +121,35 @@ class SemanticGraphExtractor extends Base {
     }
 
     /**
+     * Builds the graph-generation provider from resolved AiConfig leaves.
+     *
+     * @summary Anchor & Echo: Keeps ADR-19 ownership local to this consumer: the
+     * Provider tree is read at the graph-extraction use site, while the dispatch
+     * helper receives only the plain constructor shape it needs for provider creation.
+     *
+     * @param {String} graphProvider Active graph-generation provider selector
+     * @returns {{generate: Function}} Chat-capable graph provider
+     * @protected
+     */
+    buildConfiguredGraphProvider(graphProvider) {
+        return buildGraphProvider({
+            modelProvider: graphProvider,
+            ollamaConfig : {
+                host          : AiConfig.ollama.host,
+                model         : AiConfig.ollama.model,
+                embeddingModel: AiConfig.ollama.embeddingModel,
+                keep_alive    : AiConfig.ollama.keep_alive
+            },
+            openAiCompatibleConfig: {
+                apiKey    : AiConfig.openAiCompatible.apiKey,
+                host      : AiConfig.openAiCompatible.host,
+                keep_alive: AiConfig.openAiCompatible.keep_alive,
+                model     : AiConfig.openAiCompatible.model
+            }
+        });
+    }
+
+    /**
      * Emits deterministic context-overflow friction for post-invocation retry aborts.
      *
      * @summary Anchor & Echo: Reuses the established ConsumerFriction channel for retry-loop
@@ -287,11 +316,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 
         try {
             const graphProvider = resolveGraphModelProvider(AiConfig);
-            const provider      = buildGraphProvider({
-                modelProvider         : graphProvider,
-                ollamaConfig          : AiConfig.ollama,
-                openAiCompatibleConfig: AiConfig.openAiCompatible
-            });
+            const provider      = this.buildConfiguredGraphProvider(graphProvider);
 
             // Format boundaries securely
             const messages = [
@@ -736,11 +761,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 
         try {
             const graphProvider = resolveGraphModelProvider(AiConfig);
-            const provider      = buildGraphProvider({
-                modelProvider         : graphProvider,
-                ollamaConfig          : AiConfig.ollama,
-                openAiCompatibleConfig: AiConfig.openAiCompatible
-            });
+            const provider      = this.buildConfiguredGraphProvider(graphProvider);
 
             const messages = [
                 { role: 'system', content: systemInstruction },

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -1541,7 +1541,13 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             DreamService.runGarbageCollection     = async () => {};
             DreamService.synthesizeGoldenPath     = async () => {};
 
-            SemanticGraphExtractor.executeTriVectorExtraction = async () => null;
+            SemanticGraphExtractor.executeTriVectorExtraction = async () => ({
+                ok                : false,
+                deferReason       : 'skip-over-band',
+                frictionSymptom   : 'size-precheck-skip',
+                terminalForCadence: true,
+                evidence          : {attempts: 1, note: 'unit over-band guardrail'}
+            });
             MemorySessionIngestor.syncSessionToGraph = async () => ({errors: [], memoriesSkipped: 0, memoriesUpserted: 1});
             AdrIngestor.syncAdrsToGraph              = async () => ({});
             ConceptIngestor.syncConceptsToGraph     = async () => ({});
@@ -1577,18 +1583,15 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         }
     });
 
-    test('processUndigestedSessions does NOT defer under-band-choke even at MAX — the heuristic null retries until typed failure semantics exist (#13835)', async () => {
+    test('processUndigestedSessions defers typed under-band-choke once it reaches MAX (#13974)', async () => {
         const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         const AdrIngestor             = (await import('../../../../../../../ai/services/ingestion/AdrIngestor.mjs')).default;
         const ConceptIngestor         = (await import('../../../../../../../ai/services/ingestion/ConceptIngestor.mjs')).default;
         const FileSystemIngestor      = (await import('../../../../../../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
         const TopologyInferenceEngine = (await import('../../../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
 
-        // Under-band payload + a bare-null extractor return = `under-band-choke`. The extractor returns the
-        // same null for choke / schema-failure / timeout alike, so terminality here is a GUESS — it must NOT
-        // be bounded out as `deferred` even past MAX. It stays `undigested` (attempt-tracked) and keeps
-        // retrying until typed extractor failure semantics can prove it terminal, so a digestible session
-        // that merely hit a transient/ambiguous null is never silently dropped.
+        // Typed extractor failure semantics remove the payload-size guess: when the extractor reports
+        // cadence-terminal under-band choke, DreamService may bound it out after maxDigestAttempts.
         const mockSession = {
             id      : 'chroma-summary-underband',
             document: 'tiny',
@@ -1627,7 +1630,13 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             DreamService.runGarbageCollection     = async () => {};
             DreamService.synthesizeGoldenPath     = async () => {};
 
-            SemanticGraphExtractor.executeTriVectorExtraction = async () => null;
+            SemanticGraphExtractor.executeTriVectorExtraction = async () => ({
+                ok                : false,
+                deferReason       : 'under-band-choke',
+                frictionSymptom   : 'context-overflow',
+                terminalForCadence: true,
+                evidence          : {attempts: 1, note: 'unit under-band choke'}
+            });
             MemorySessionIngestor.syncSessionToGraph = async () => ({errors: [], memoriesSkipped: 0, memoriesUpserted: 1});
             AdrIngestor.syncAdrsToGraph              = async () => ({});
             ConceptIngestor.syncConceptsToGraph     = async () => ({});
@@ -1642,7 +1651,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             expect(meta.graphDigested).toBeUndefined();    // never falsely-digested
             expect(meta.deferReason).toBe('under-band-choke');
             expect(meta.digestAttempts).toBe(6);            // 5 prior + this one
-            expect(meta.digestState).toBe('undigested');    // heuristic null → NOT deferred, keeps retrying
+            expect(meta.digestState).toBe('deferred');      // typed terminal descriptor → bounded out
         } finally {
             aiConfig.modelProvider                            = orig.provider;
             DreamService.findUndigestedSessions               = orig.findUndigested;
@@ -1871,7 +1880,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         // (SemanticGraphExtractor.spec `Sub 9 hypotheses 9 and 11`). Phase-A stubs the service
         // choreography; this drives the REAL processUndigestedSessions → SemanticGraphExtractor
         // handoff so a genuine empty-response overflow at the provider boundary flows through
-        // DreamService's actual null-result handling. Per the Sub-9 avoided-trap, only the
+        // DreamService's typed failure handling. Per the Sub-9 avoided-trap, only the
         // peripheral pipeline phases (ingestors / topology / gap inference / golden-path / GC),
         // the storage backend, and the LLM boundary are neutralized — the DreamService↔
         // SemanticGraphExtractor choreography under test runs real. Hypothesis 9 (PRIMARY),
@@ -1937,18 +1946,21 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             TopologyInferenceEngine.getTopologyConflictCount = async () => 0;
 
             // THE H9 TRIGGER: the provider boundary streams an empty body (LM Studio silent-overflow
-            // signature). SemanticGraphExtractor.executeTriVectorExtraction runs REAL and must
-            // classify this as context-overflow + return null (no retry amplification).
+            // signature). SemanticGraphExtractor.executeTriVectorExtraction runs REAL and must classify
+            // this as context-overflow + return a typed under-band-choke descriptor (no retry amplification).
             OpenAiCompatible.prototype.generate = async function() { return {content: ''}; };
 
             const result = await DreamService.processUndigestedSessions();
 
-            // The REAL extractor returned null; assert DreamService's integration handling propagated it.
+            // The REAL extractor returned a typed descriptor; assert DreamService propagated it.
             const sessionState = result.perSessionStates.find(s => s.sessionId === 'agent-session-empty-overflow');
             expect(sessionState).toBeDefined();
             expect(sessionState.triVector.status).toBe('failed');
-            expect(sessionState.triVector.errorKind).toBe('null-result');
-            expect(sessionState.failureReasons).toContain('tri-vector extraction returned null');
+            expect(sessionState.triVector.errorKind).toBe('under-band-choke');
+            expect(sessionState.triVector.deferReason).toBe('under-band-choke');
+            expect(sessionState.triVector.frictionSymptom).toBe('context-overflow');
+            expect(sessionState.triVector.terminalForCadence).toBe(true);
+            expect(sessionState.failureReasons.some(reason => reason.includes('Silent empty-response from provider'))).toBe(true);
 
             // graphDigested NOT set → session stays undigested for the next REM cycle, not silently masked.
             expect(sessionState.graphDigestedFlag).toBe(false);
@@ -1985,8 +1997,8 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         // Integration complement to the isolated JSON-repair retry test (which calls the extractor
         // directly and exercises success-after-retry). Here the provider returns malformed JSON
         // on every attempt, so the REAL extractor exhausts its retry budget through the REAL
-        // processUndigestedSessions choreography and returns null — and DreamService must record
-        // the failure + keep the session undigested rather than mask it behind graphDigested.
+        // processUndigestedSessions choreography and returns a typed schema-failure descriptor —
+        // and DreamService must record the failure + keep the session undigested rather than mask it behind graphDigested.
         // Only peripheral phases + storage + the LLM boundary are neutralized. Hypothesis 11,
         // Discussion silent-failure enumeration §2.4.
         const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
@@ -2047,7 +2059,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             TopologyInferenceEngine.getTopologyConflictCount = async () => 0;
 
             // THE H11 TRIGGER: provider returns unparseable JSON on every attempt. The REAL extractor
-            // runs its full retry budget (no valid payload ever) and returns null.
+            // runs its full retry budget (no valid payload ever) and returns a typed descriptor.
             OpenAiCompatible.prototype.generate = async function() {
                 invocationCount++;
                 return {content: '```json\n{ "a2a_version": "1.0", "agent_id": "Antigravity" '}; // truncated, never valid
@@ -2058,12 +2070,15 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             // The real retry loop ran to exhaustion through the real choreography.
             expect(invocationCount).toBeGreaterThan(1);
 
-            // The REAL extractor returned null; assert DreamService's integration handling propagated it.
+            // The REAL extractor returned a typed descriptor; assert DreamService propagated it.
             const sessionState = result.perSessionStates.find(s => s.sessionId === 'agent-session-json-exhaustion');
             expect(sessionState).toBeDefined();
             expect(sessionState.triVector.status).toBe('failed');
-            expect(sessionState.triVector.errorKind).toBe('null-result');
-            expect(sessionState.failureReasons).toContain('tri-vector extraction returned null');
+            expect(sessionState.triVector.errorKind).toBe('schema-failure');
+            expect(sessionState.triVector.deferReason).toBe('schema-failure');
+            expect(sessionState.triVector.frictionSymptom).toBe('parse-failure');
+            expect(sessionState.triVector.terminalForCadence).toBe(true);
+            expect(sessionState.failureReasons.some(reason => reason.includes('Tri-Vector schema validation failed'))).toBe(true);
 
             // graphDigested NOT set → session stays undigested for the next REM cycle, not silently masked.
             expect(sessionState.graphDigestedFlag).toBe(false);

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -309,8 +309,13 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
                 document: 'Mock episodic history for silent empty-response detection.'
             });
 
-            // AC4: returns null (no retry-loop amplification)
-            expect(result).toBeNull();
+            // AC4: returns a typed failure descriptor (no retry-loop amplification)
+            expect(result).toMatchObject({
+                ok                : false,
+                deferReason       : 'under-band-choke',
+                frictionSymptom   : 'context-overflow',
+                terminalForCadence: true
+            });
 
             // AC6 (e): retry loop did NOT fire — single invocation only
             expect(invocationCount).toBe(1);
@@ -366,7 +371,13 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
                 document: 'Mock episodic history for truncated non-empty response detection.'
             });
 
-            expect(result).toBeNull();
+            expect(result).toMatchObject({
+                ok                : false,
+                deferReason       : 'under-band-choke',
+                frictionSymptom   : 'context-overflow',
+                terminalForCadence: true,
+                evidence          : {finishReason: 'length'}
+            });
             expect(invocationCount).toBe(1);
 
             const frictions = getAggregatedFrictions();
@@ -410,7 +421,12 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
                 document: 'Mock episodic history for over-band repair retry detection.'
             });
 
-            expect(result).toBeNull();
+            expect(result).toMatchObject({
+                ok                : false,
+                deferReason       : 'under-band-choke',
+                frictionSymptom   : 'context-overflow',
+                terminalForCadence: true
+            });
             expect(invocationCount).toBe(1);
 
             const frictions = getAggregatedFrictions();
@@ -502,7 +518,12 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
                 document: 'Force guardrail pre-check so provider.generate is never invoked.'
             });
 
-            expect(result).toBeNull();
+            expect(result).toMatchObject({
+                ok                : false,
+                deferReason       : 'skip-over-band',
+                frictionSymptom   : 'size-precheck-skip',
+                terminalForCadence: true
+            });
 
             const frictions = getAggregatedFrictions();
             const friction  = frictions.find(item => item.assetRef === 'consumer-model-telemetry-session');


### PR DESCRIPTION
Resolves #13974
Related: #13835

`SemanticGraphExtractor.executeTriVectorExtraction()` now returns typed failure descriptors instead of bare `null` for REM failure paths, while successful extraction still returns the existing Tri-Vector payload. `DreamService.processUndigestedSessions()` consumes those descriptors for `deferReason` / `terminalForCadence`, removes the payload-size defer heuristic, and keeps ingestion failures retryable.

Evidence: L2 (focused unit coverage for extractor failure descriptors plus DreamService digest-state consumption) -> L2 required (internal REM state-machine contract). No residuals.

## Deltas from Ticket

- Kept `ConsumerFriction` V1 stable: no new symptom enum, cadence-specific `deferReason` remains separate.
- Preserved a legacy bare-null fallback in `DreamService` as retryable `schema-failure`, so old-style stubs or unexpected nulls do not silently defer sessions.
- Removed the ADR 0019-defensive `localModels?.chat?.safeProcessingLimitTokens` heuristic at the DreamService decision point.

## Test Evidence

- `npm run agent-preflight -- ai/services/graph/SemanticGraphExtractor.mjs ai/daemons/orchestrator/services/DreamService.mjs test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs`

## Post-Merge Validation

- [ ] Optional operator observation: next REM cycle surfaces typed `deferReason` values in per-session telemetry when provider failures occur.

## Commits

- `60f0f59431` - `fix(ai): expose REM extractor failure terminality (#13974)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.
