### PR TITLE
fix(ai): mark terminal REM digests undigestible (#13835)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -64,6 +64,15 @@ function getTriVectorFailureMessage(failure) {
            `tri-vector extraction failed (${getTriVectorFailureKind(failure)})`;
 }
 
+/**
+ * @summary Returns true for digest states excluded from the steady REM cadence.
+ * @param {String} state
+ * @returns {Boolean}
+ */
+function isSteadyCadenceExcludedDigestState(state) {
+    return state === 'deferred' || state === 'undigestible';
+}
+
 function toErrorMessage(error) {
     return error && error.message !== undefined ? String(error.message) : String(error);
 }
@@ -142,10 +151,9 @@ function addUndigestedRowsFromBatch(batch, byId) {
     for (let i = 0; i < batch.ids.length; i++) {
         const meta = batch.metadatas?.[i];
 
-        // Exclude both digested sessions (graphDigested) AND sessions bounded out as `deferred` after
-        // `maxDigestAttempts` failures — the latter is the load-reduction lever: stop re-serving (and
-        // re-paying the per-cycle pre-check on) un-digestible sessions in the steady cadence.
-        if (meta && meta.graphDigested !== true && meta.graphDigested !== 'true' && meta.digestState !== 'deferred') {
+        // Exclude digested sessions plus terminal/legacy states that were already bounded out.
+        // `deferred` is kept as a back-compat alias for rows written by the first stop-re-serve kernel.
+        if (meta && meta.graphDigested !== true && meta.graphDigested !== 'true' && !isSteadyCadenceExcludedDigestState(meta.digestState)) {
             byId.set(batch.ids[i], {
                 id      : batch.ids[i],
                 document: batch.documents?.[i],
@@ -589,7 +597,7 @@ class DreamService extends Base {
                             ? 'ingestion-failure'
                             : (extractionFailure?.deferReason || 'schema-failure');
                         const digestState = terminalForCadence && digestAttempts >= maxDigestAttempts
-                            ? 'deferred'
+                            ? 'undigestible'
                             : 'undigested';
 
                         await this.sessionsCollection.update({
@@ -601,8 +609,8 @@ class DreamService extends Base {
                         sessionState.digestAttempts     = digestAttempts;
                         sessionState.terminalForCadence = terminalForCadence;
 
-                        if (digestState === 'deferred') {
-                            logger.warn(`[DreamService] Session ${session.meta.sessionId} marked 'deferred' after ${digestAttempts} failed digest attempt(s) (reason: ${deferReason}); excluded from the steady REM cadence to stop the re-serve bleed.`);
+                        if (digestState === 'undigestible') {
+                            logger.warn(`[DreamService] Session ${session.meta.sessionId} marked 'undigestible' after ${digestAttempts} failed digest attempt(s) (reason: ${deferReason}); excluded from the steady REM cadence to stop the re-serve bleed.`);
                         } else {
                             logger.info(`[DreamService] Session ${session.meta.sessionId} digest failed (reason: ${deferReason}); attempt ${digestAttempts}/${maxDigestAttempts}, will retry next cycle.`);
                         }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -1443,7 +1443,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         }
     });
 
-    test('findUndigestedSessions excludes `deferred` sessions and re-serves back-compat undigested rows (#13835)', async () => {
+    test('findUndigestedSessions excludes bounded-out sessions and re-serves back-compat undigested rows (#13835)', async () => {
         const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         const original = {
             summarizationBatchLimit: aiConfig.summarizationBatchLimit,
@@ -1451,14 +1451,15 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             sessionsCollection     : DreamService.sessionsCollection
         };
 
-        // Mix: a fresh undigested row, a `deferred` row (bounded out after MAX failed attempts), a
-        // digested row, and a back-compat row that predates digestState (no flag at all — must still
-        // be served). `deferred` is the load-reduction lever: excluded from the steady cadence.
+        // Mix: a fresh undigested row, a legacy `deferred` row, a terminal `undigestible` row,
+        // a digested row, and a back-compat row that predates digestState (no flag at all — must still
+        // be served). The bounded-out states are excluded from the steady cadence.
         const rows = [
-            {id: 'undigested-new', document: 'a', meta: {sessionId: 'undigested-new', timestamp: 4000}},
-            {id: 'deferred-x',     document: 'b', meta: {sessionId: 'deferred-x', timestamp: 3000, digestState: 'deferred', deferReason: 'skip-over-band', digestAttempts: 3}},
-            {id: 'digested-x',     document: 'c', meta: {sessionId: 'digested-x', timestamp: 2000, graphDigested: true, digestState: 'digested'}},
-            {id: 'undigested-old', document: 'd', meta: {sessionId: 'undigested-old', timestamp: 1000}}
+            {id: 'undigested-new', document: 'a', meta: {sessionId: 'undigested-new', timestamp: 5000}},
+            {id: 'deferred-x',     document: 'b', meta: {sessionId: 'deferred-x', timestamp: 4000, digestState: 'deferred', deferReason: 'skip-over-band', digestAttempts: 3}},
+            {id: 'undigestible-x', document: 'c', meta: {sessionId: 'undigestible-x', timestamp: 3000, digestState: 'undigestible', deferReason: 'under-band-choke', digestAttempts: 3}},
+            {id: 'digested-x',     document: 'd', meta: {sessionId: 'digested-x', timestamp: 2000, graphDigested: true, digestState: 'digested'}},
+            {id: 'undigested-old', document: 'e', meta: {sessionId: 'undigested-old', timestamp: 1000}}
         ];
 
         aiConfig.summarizationBatchLimit = 10;
@@ -1477,8 +1478,9 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
 
         try {
             const ids = (await DreamService.findUndigestedSessions()).map(row => row.id);
-            // Load-reduction: `deferred` is excluded from the steady cadence (stops the re-serve bleed).
+            // Load-reduction: bounded-out rows are excluded from the steady cadence.
             expect(ids).not.toContain('deferred-x');
+            expect(ids).not.toContain('undigestible-x');
             // Digested stays excluded; back-compat undigested rows (no digestState) are still served.
             expect(ids).not.toContain('digested-x');
             expect(ids).toContain('undigested-new');
@@ -1490,7 +1492,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         }
     });
 
-    test('processUndigestedSessions bounds the re-serve — marks a session `deferred` once a skip-over-band failure reaches MAX (#13835)', async () => {
+    test('processUndigestedSessions bounds the re-serve — marks a session `undigestible` once a skip-over-band failure reaches MAX (#13835)', async () => {
         const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         const AdrIngestor             = (await import('../../../../../../../ai/services/ingestion/AdrIngestor.mjs')).default;
         const ConceptIngestor         = (await import('../../../../../../../ai/services/ingestion/ConceptIngestor.mjs')).default;
@@ -1560,7 +1562,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             expect(sessionUpdatePayloads.length).toBe(1);
             const meta = sessionUpdatePayloads[0].metadatas[0];
             expect(meta.graphDigested).toBeUndefined();   // never falsely-digested
-            expect(meta.digestState).toBe('deferred');     // 3rd failure reaches MAX → bounded out (deterministic)
+            expect(meta.digestState).toBe('undigestible'); // 3rd failure reaches MAX → bounded out (deterministic)
             expect(meta.digestAttempts).toBe(3);
             expect(meta.deferReason).toBe('skip-over-band');
         } finally {
@@ -1651,7 +1653,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             expect(meta.graphDigested).toBeUndefined();    // never falsely-digested
             expect(meta.deferReason).toBe('under-band-choke');
             expect(meta.digestAttempts).toBe(6);            // 5 prior + this one
-            expect(meta.digestState).toBe('deferred');      // typed terminal descriptor → bounded out
+            expect(meta.digestState).toBe('undigestible');  // typed terminal descriptor → bounded out
         } finally {
             aiConfig.modelProvider                            = orig.provider;
             DreamService.findUndigestedSessions               = orig.findUndigested;


### PR DESCRIPTION
Resolves #13835

This finalizes the REM digest-state closeout by writing terminal extraction failures as `digestState: 'undigestible'` instead of overloading the legacy `deferred` state, while keeping legacy `deferred` rows excluded from the steady cadence. `findUndigestedSessions()` now filters both bounded-out states, so old rows remain compatible and new terminal rows stop re-serving without pretending they were graph-digested.

Evidence: L2 unit/static covered the state-machine ACs; L3 live load-reduction remains post-merge because it requires the orchestrator processing the real REM backlog.

## Deltas from ticket

Earlier merged work delivered the extraction terminality and under-band classification pieces. This PR is the final state-machine delta: terminal max-attempt rows become `undigestible`, legacy `deferred` remains a supported excluded state, and the tests cover both the candidate filter and max-attempt terminal writes.

## Test Evidence

- `node --check ai/daemons/orchestrator/services/DreamService.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs`
- `npm run agent-preflight -- ai/daemons/orchestrator/services/DreamService.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs` - 34 passed
- `git diff --check`
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `fc18b3aeb9 fix(ai): mark terminal REM digests undigestible (#13835)`

## Post-Merge Validation

- [ ] Restart the orchestrator on the merged SHA and confirm bounded-out rows no longer appear in the steady REM candidate set.
- [ ] Confirm extraction attempts per cycle drop by the size of the bounded-out pile once the live backlog reaches those rows.

## Commit

- `fc18b3aeb9` - `fix(ai): mark terminal REM digests undigestible (#13835)`

Authored by Euclid (GPT-5, Codex Desktop). Session 2cfc471c-c571-4caf-b0c4-77499f43a0ea.
