### PR TITLE
fix(ai): fail loud on golden path query errors (#13978)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -555,7 +555,22 @@ async function runGoldenPathTask({taskName, reason, services, repoEnrichmentEnab
     services.taskStateService.markStarted(taskName, reason);
     services.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
     try {
-        await services.goldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled});
+        const outcome = await services.goldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled});
+
+        if (outcome?.status === 'failed') {
+            const state = services.taskStateService.getTaskState(taskName);
+            if (state) state.lastReason = outcome.reasonCode || outcome.error || 'golden-path-failed';
+            services.taskStateService.markFailed(taskName, 1);
+            services.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+                reason,
+                reasonCode  : outcome.reasonCode,
+                error       : outcome.error,
+                failedAt    : new Date().toISOString(),
+                wroteHandoff: outcome.wroteHandoff === true
+            });
+            return;
+        }
+
         services.taskStateService.markCompleted(taskName);
         services.healthService?.recordTaskOutcome?.(taskName, 'completed', {
             reason,

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -546,6 +546,64 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Normalizes a Golden Path failure into the task outcome shape consumed by the scheduler.
+     *
+     * The Golden Path task is freshness-critical steering substrate: a caught ChromaDB / graph-store
+     * failure must not resolve as a successful run and refresh `lastSuccessAt`.
+     *
+     * @param {String} reasonCode Stable machine-readable failure reason.
+     * @param {*} error Error object or message payload.
+     * @param {Object} [extra={}] Additional diagnostics for downstream task-state / health surfaces.
+     * @returns {{status: String, reasonCode: String, error: String}} Failure outcome.
+     */
+    static buildFailureOutcome(reasonCode, error, extra = {}) {
+        return {
+            status: 'failed',
+            reasonCode,
+            error : error instanceof Error ? error.message : String(error || reasonCode),
+            ...extra
+        }
+    }
+
+    /**
+     * @summary Renders a fail-loud Computed Golden Path section when the route cannot be trusted.
+     *
+     * No numbered recommendation entries are emitted, so downstream parsers cannot consume stale or
+     * partially-computed routing as an immediate lane.
+     *
+     * @param {Object} options
+     * @param {Object} options.failure Failure outcome from `buildFailureOutcome()`.
+     * @param {Object} [options.stats={}] Candidate-count diagnostics for the current pass.
+     * @returns {String} Markdown section.
+     */
+    static renderComputedGoldenPathFailureSection({
+        failure,
+        stats = {}
+    } = {}) {
+        const count      = value => Number.isFinite(Number(value)) ? Number(value) : 0;
+        const reasonCode = failure?.reasonCode || 'golden-path-failed';
+        const error      = failure?.error || 'unknown failure';
+
+        return [
+            '',
+            '## Computed Golden Path (Strategic Recommendation)',
+            '',
+            'Golden Path degraded: the semantic route could not be computed safely.',
+            '',
+            `- Reason: \`${reasonCode}\``,
+            `- Error: \`${error}\``,
+            `- Semantic candidates: ${count(stats.semanticCandidates)}`,
+            `- SQLite OPEN matches: ${count(stats.sqliteOpenMatches)}`,
+            `- Scored actionable candidates: ${count(stats.scoredCandidates)}`,
+            `- Selected routed nodes: ${count(stats.selectedTopNodes)}`,
+            `- Stale frontier GUIDES pruned: ${count(stats.prunedGuideEdges)}`,
+            '',
+            'No numbered immediate recommendation is rendered for this pass; do not claim a computed lane from stale handoff data until the next successful Golden Path run.',
+            ''
+        ].join('\n')
+    }
+
+    /**
      * @summary Scores one synced issue as a current release / incident focus candidate.
      *
      * This is deliberately a local-sync signal, not graph-centrality routing. It
@@ -850,12 +908,12 @@ class GoldenPathSynthesizer extends Base {
             summaryColl = await StorageRouter.getSummaryCollection();
         } catch (e) {
             logger.warn('[GoldenPathSynthesizer] StorageRouter unavailable. Skipping Golden Path extraction.');
-            return;
+            return this.constructor.buildFailureOutcome('storage-router-unavailable', e);
         }
 
         if (!graphColl || !summaryColl) {
             logger.warn('[GoldenPathSynthesizer] Collections missing. Skipping Golden Path extraction.');
-            return;
+            return this.constructor.buildFailureOutcome('collections-missing', 'graph or summary collection missing');
         }
 
         // Generate the Frontier Baseline Vector from the N MOST-RECENT session summaries.
@@ -876,7 +934,7 @@ class GoldenPathSynthesizer extends Base {
             frontierEmbedding = await TextEmbeddingService.embedText(frontierText, aiConfig.embeddingProvider);
         } catch (e) {
             logger.warn('[GoldenPathSynthesizer] Failed to generate Frontier Baseline Vector. Aborting Hybrid route.', e);
-            return;
+            return this.constructor.buildFailureOutcome('frontier-embedding-failed', e);
         }
 
         const actualDimension     = getEmbeddingVectorLength(frontierEmbedding);
@@ -889,13 +947,15 @@ class GoldenPathSynthesizer extends Base {
             const provider = aiConfig.embeddingProvider;
             const model    = getEmbeddingModelName(aiConfig, provider);
 
-            logger.warn(buildEmbeddingDimensionMismatchMessage({
+            const message = buildEmbeddingDimensionMismatchMessage({
                 provider,
                 model,
                 configuredDimension,
                 actualDimension
-            }));
-            return;
+            });
+
+            logger.warn(message);
+            return this.constructor.buildFailureOutcome('embedding-dimension-mismatch', message);
         }
 
         const scoredNodes  = [];
@@ -908,6 +968,7 @@ class GoldenPathSynthesizer extends Base {
             selectedTopNodes       : 0,
             prunedGuideEdges       : 0
         };
+        let routeFailure = null;
 
         // Pillar 1: Semantic Distance from ChromaDB
         let semanticIds       = [];
@@ -929,7 +990,7 @@ class GoldenPathSynthesizer extends Base {
             }
         } catch (e) {
             logger.warn('[GoldenPathSynthesizer] Failed to query semantic vectors from ChromaDB.', e);
-            return;
+            routeFailure = this.constructor.buildFailureOutcome('semantic-query-failed', e);
         }
 
         if (semanticIds.length === 0) {
@@ -941,7 +1002,7 @@ class GoldenPathSynthesizer extends Base {
         const SEMANTIC_WEIGHT   = 2.0;
         const STRUCTURAL_WEIGHT = 1.0;
 
-        if (semanticIds.length > 0) {
+        if (semanticIds.length > 0 && !routeFailure) {
             try {
                 const placeholders = semanticIds.map(() => '?').join(',');
                 const stmt         = GraphService.db.storage.db.prepare(`
@@ -1011,6 +1072,7 @@ class GoldenPathSynthesizer extends Base {
                 }
             } catch (e) {
                 logger.warn('[GoldenPathSynthesizer] Error executing hybrid mapping across local Graph Store.', e);
+                routeFailure = this.constructor.buildFailureOutcome('graph-store-mapping-failed', e);
             }
         }
 
@@ -1018,7 +1080,7 @@ class GoldenPathSynthesizer extends Base {
         scoredNodes.sort((a, b) => b.score - a.score);
 
         // Remove mathematically rejected targets (Negative ROI), then slice
-        const topNodes = scoredNodes.filter(n => n.score > -5000).slice(0, aiConfig.goldenPathTopNodeRenderLimit);
+        const topNodes = routeFailure ? [] : scoredNodes.filter(n => n.score > -5000).slice(0, aiConfig.goldenPathTopNodeRenderLimit);
 
         let currentFocusCandidates = [];
         if (repoEnrichmentEnabled) {
@@ -1048,7 +1110,13 @@ class GoldenPathSynthesizer extends Base {
 
         let markdownAppend = '';
 
-        if (routedTopNodes.length > 0) {
+        if (routeFailure) {
+            markdownAppend = this.constructor.renderComputedGoldenPathFailureSection({
+                failure: routeFailure,
+                stats  : scoringStats
+            });
+            logger.warn(`[GoldenPathSynthesizer] Golden Path route failed loud: ${routeFailure.reasonCode} — rendered degraded handoff section.`);
+        } else if (routedTopNodes.length > 0) {
             logger.info(`[GoldenPathSynthesizer] Top Issue 1 (${routedTopNodes[0].node.id}): Priority ${routedTopNodes[0].score.toFixed(2)} [Sem: ${routedTopNodes[0].semantic.toFixed(2)} / Struc: ${routedTopNodes[0].structural.toFixed(2)}]`);
 
             // Explicitly anchor this to the frontier context so the Agent NEVER loses sight of it
@@ -1369,6 +1437,18 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         logger.info(`[GoldenPathSynthesizer] sandman_handoff.md freshly generated via Centralized Pipeline. Golden Path integrated.`);
 
         logger.info(`[GoldenPathSynthesizer] Mathematical Golden Path established. Anchored ${topNodes.length} strategic nodes to frontier.`);
+
+        return routeFailure ? {
+            ...routeFailure,
+            wroteHandoff    : true,
+            selectedTopNodes: scoringStats.selectedTopNodes,
+            prunedGuideEdges: scoringStats.prunedGuideEdges
+        } : {
+            status          : 'completed',
+            wroteHandoff    : true,
+            selectedTopNodes: scoringStats.selectedTopNodes,
+            prunedGuideEdges: scoringStats.prunedGuideEdges
+        };
     }
 }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -537,6 +537,72 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
         ]);
     });
 
+    test('records Golden Path failed outcomes without marking success (#13978)', async () => {
+        const calls    = [];
+        const outcomes = [];
+        const state    = {};
+
+        runSchedulingPipeline({
+            registry: [
+                makeCandidateDescriptor({
+                    taskName        : 'golden-path',
+                    executionKind   : 'in-process-async',
+                    maintenanceClass: 'graph-dependent'
+                })
+            ],
+            context : makeContext(),
+            services: makeServices({
+                goldenPathSynthesizer: {
+                    synthesizeGoldenPath: () => Promise.resolve({
+                        status      : 'failed',
+                        reasonCode  : 'semantic-query-failed',
+                        error       : 'Error executing plan: Internal error: Error finding id',
+                        wroteHandoff: true
+                    })
+                },
+                healthService: {
+                    recordTaskOutcome(taskName, status, details) {
+                        outcomes.push({taskName, status, details});
+                    }
+                },
+                taskStateService: {
+                    getTaskState: () => state,
+                    markCompleted(taskName) { calls.push(['markCompleted', taskName]); },
+                    markFailed(taskName, exitCode) { calls.push(['markFailed', taskName, exitCode]); },
+                    markSkipped(taskName) { calls.push(['markSkipped', taskName]); },
+                    markStarted(taskName, reason) { calls.push(['markStarted', taskName, reason]); }
+                }
+            }),
+            runtime: makeRuntime()
+        });
+
+        await Promise.resolve();
+
+        expect(calls).toEqual([
+            ['markStarted', 'golden-path', 'golden-path-reason'],
+            ['markFailed', 'golden-path', 1]
+        ]);
+        expect(state.lastReason).toBe('semantic-query-failed');
+        expect(outcomes).toEqual([
+            {
+                taskName: 'golden-path',
+                status  : 'running',
+                details : {reason: 'golden-path-reason', startedAt: expect.any(String)}
+            },
+            {
+                taskName: 'golden-path',
+                status  : 'failed',
+                details : {
+                    reason      : 'golden-path-reason',
+                    reasonCode  : 'semantic-query-failed',
+                    error       : 'Error executing plan: Internal error: Error finding id',
+                    failedAt    : expect.any(String),
+                    wroteHandoff: true
+                }
+            }
+        ]);
+    });
+
     test('records skipped Dream outcomes without marking success (#13767)', async () => {
         const calls    = [];
         const outcomes = [];

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -877,6 +877,85 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(guideTargets).not.toContain(staleId);
     });
 
+    test('synthesizeGoldenPath renders degraded diagnostics when semantic vector query fails (#13978)', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const suffix     = `${process.pid}-${Date.now()}`;
+        const staleId    = `issue-stale-query-guide-${suffix}`;
+        const queryError = new Error('Error executing plan: Internal error: Error finding id');
+        aiConfig.vectorDimension = 2;
+
+        GraphService.upsertNode({
+            id        : 'frontier',
+            type      : 'SYSTEM_TENET',
+            properties: {name: 'Active Context Frontier'}
+        });
+        GraphService.upsertNode({
+            id        : staleId,
+            type      : 'ISSUE',
+            properties: {state: 'OPEN', title: 'Stale query guide'}
+        });
+        GoldenPathSynthesizer.constructor.pruneStaleFrontierGuideEdges();
+        GraphService.linkNodes('frontier', staleId, 'GUIDES', 3);
+        fs.writeFileSync(tmpHandoffFile, [
+            '# Stale Handoff',
+            '',
+            '### Recent Open PRs by Author',
+            '- stale solo PR bloat',
+            '',
+            '1. **issue-9890**: stale computed route'
+        ].join('\n'), 'utf-8');
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => { throw queryError; }
+        });
+        StorageRouter.getSummaryCollection = async () => ({
+            get: async config => {
+                if (Array.isArray(config?.ids)) {
+                    return {
+                        ids      : ['summary-1'],
+                        documents: ['Golden Path should fail loud when Chroma cannot resolve an id']
+                    };
+                }
+
+                return {
+                    ids      : ['summary-1'],
+                    metadatas: [{timestamp: '2026-06-24T23:00:00.000Z', graphDigested: true}]
+                };
+            }
+        });
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+
+        let outcome;
+        try {
+            outcome = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        const guideTargets   = GraphService.db.edges
+            .getByIndex('source', 'frontier')
+            .filter(edge => edge.type === 'GUIDES')
+            .map(edge => edge.target);
+
+        expect(outcome).toMatchObject({
+            status      : 'failed',
+            reasonCode  : 'semantic-query-failed',
+            wroteHandoff: true
+        });
+        expect(outcome.error).toContain('Error finding id');
+        expect(handoffContent).toContain('Golden Path degraded: the semantic route could not be computed safely.');
+        expect(handoffContent).toContain('- Reason: `semantic-query-failed`');
+        expect(handoffContent).toContain('No numbered immediate recommendation is rendered for this pass');
+        expect(handoffContent).not.toContain('### Recent Open PRs by Author');
+        expect(handoffContent).not.toContain('issue-9890');
+        expect(guideTargets).not.toContain(staleId);
+    });
+
     test('synthesizeGoldenPath prunes stale guides while preserving current computed guides (#13828)', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;


### PR DESCRIPTION
Resolves #13978
Related: #13755

Golden Path now treats semantic-route failures as failed task outcomes instead of successful empty runs. Chroma query failures render a fresh degraded Computed Golden Path section, prune stale frontier GUIDES, and return a structured failure outcome; the scheduler records that outcome via `markFailed` and health telemetry instead of refreshing `lastSuccessAt`.

Evidence: L2 focused unit coverage -> L2 required for the Golden Path scheduler and handoff-rendering close target. Residual: none for #13978.

## Deltas from ticket
The fix also covers local graph-store mapping failures with the same structured failure path, because those would otherwise create the same false-green class after semantic candidates are found.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` -> 34 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs` -> 16 passed
- `npm run agent-preflight -- ai/services/graph/GoldenPathSynthesizer.mjs ai/daemons/orchestrator/scheduling/pipeline.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs` -> passed
- `git diff --check` -> passed
- pre-commit hooks -> passed

## Post-Merge Validation
- [ ] Restart the orchestrator and verify a Golden Path route failure records `golden-path.lastErrorAt` / failed health outcome instead of `lastSuccessAt`.
- [ ] Confirm `resources/content/sandman_handoff.md` shows a degraded Computed Golden Path section rather than stale numbered recommendations after a route failure.

Authored by Euclid (GPT-5, Codex Desktop). Session unavailable in Codex Desktop harness.