### PR TITLE
fix(ai): emit Claude turn-presence beacons (#13498)

### DIFF
--- a/.claude/hooks/turnPresenceHook.mjs
+++ b/.claude/hooks/turnPresenceHook.mjs
@@ -1,0 +1,87 @@
+import {fileURLToPath, pathToFileURL} from 'node:url';
+import {
+    readHookPayload,
+    recordTurnPresenceFromHook
+} from '../../ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs';
+
+function parseHookPayload(raw) {
+    if (!raw) return null;
+
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return raw;
+    }
+}
+
+function normalizeHookEventName(hookPayload) {
+    return typeof hookPayload?.hook_event_name === 'string' ? hookPayload.hook_event_name : null;
+}
+
+function resolveAction({actionArg, hookPayload} = {}) {
+    if (actionArg) return actionArg;
+
+    const eventName = normalizeHookEventName(hookPayload);
+    return eventName === 'PostToolUse' ? 'progress' : 'start';
+}
+
+function resolveSource({action, hookPayload} = {}) {
+    const eventName = normalizeHookEventName(hookPayload);
+    if (eventName === 'UserPromptSubmit') return 'claude-user-prompt-submit';
+    if (eventName === 'PostToolUse')      return 'claude-post-tool-use';
+    return `claude-${action}`;
+}
+
+function resolveNote({action, hookPayload} = {}) {
+    const eventName = normalizeHookEventName(hookPayload);
+    if (eventName === 'PostToolUse' && typeof hookPayload?.tool_name === 'string') {
+        return `claude PostToolUse ${hookPayload.tool_name}`;
+    }
+    if (eventName) {
+        return `claude ${eventName}`;
+    }
+    return `claude ${action}`;
+}
+
+/**
+ * @summary Records fail-soft Claude Code turn-presence from hook input.
+ * @param {Object} options
+ * @param {'start'|'progress'|'terminal'} [options.actionArg] Optional action override.
+ * @param {Object} [options.env=process.env] Environment source.
+ * @param {*} [options.hookPayload] Parsed Claude Code hook payload.
+ * @param {String|Date|Number} [options.now=new Date()] Clock override for tests.
+ * @param {String} [options.rootDir] Repository root.
+ * @returns {Promise<Object>|undefined}
+ */
+export async function recordClaudeTurnPresence({
+    actionArg,
+    env = process.env,
+    hookPayload,
+    now = new Date(),
+    rootDir = fileURLToPath(new URL('../../', import.meta.url))
+} = {}) {
+    const action = resolveAction({actionArg, hookPayload});
+
+    return recordTurnPresenceFromHook({
+        action,
+        env,
+        hookPayload,
+        note  : resolveNote({action, hookPayload}),
+        now,
+        rootDir,
+        source: resolveSource({action, hookPayload})
+    });
+}
+
+async function main() {
+    const hookPayload = parseHookPayload(await readHookPayload());
+
+    await recordClaudeTurnPresence({
+        actionArg: process.argv[2],
+        hookPayload
+    }).catch(() => {});
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    await main();
+}

--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -36,6 +36,28 @@
     ]
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/env node \"$(git rev-parse --show-toplevel)/.claude/hooks/turnPresenceHook.mjs\" start",
+            "timeout": 2
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/env node \"$(git rev-parse --show-toplevel)/.claude/hooks/turnPresenceHook.mjs\" progress",
+            "timeout": 2
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.codex/hooks/codex-context.mjs
+++ b/.codex/hooks/codex-context.mjs
@@ -1,26 +1,10 @@
 import {readFileSync}                 from 'node:fs';
-import {randomUUID}                   from 'node:crypto';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import {
-    resolveMemoryCoreGraphPath,
-    resolveTurnPresenceRuntimeConfig
-} from '../../ai/mcp/server/memory-core/helpers/TurnPresenceConfig.mjs';
-
-const WAKE_SUBMIT_NONCE_PATTERN = /NEO_WAKE_SUBMIT_NONCE:([0-9a-fA-F-]{36})/;
-
-function normalizeAgentIdentity(value) {
-    if (!value || typeof value !== 'string') return null;
-    const trimmed = value.trim();
-    if (!trimmed) return null;
-    return trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
-}
-
-function normalizeWakeSubmitNonce(value) {
-    if (!value || typeof value !== 'string') return null;
-
-    const trimmed = value.trim();
-    return /^[0-9a-fA-F-]{36}$/.test(trimmed) ? trimmed.toLowerCase() : null;
-}
+    extractWakeSubmitNonce,
+    readHookPayload,
+    recordTurnPresenceFromHook
+} from '../../ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs';
 
 /**
  * @summary Extracts a wake-submit nonce from a Codex hook payload or raw prompt text.
@@ -28,65 +12,7 @@ function normalizeWakeSubmitNonce(value) {
  * @param {Number} [depth=0] Recursion guard for nested payloads.
  * @returns {String|null}
  */
-export function extractWakeSubmitNonce(value, depth = 0) {
-    if (depth > 8 || value == null) return null;
-
-    if (typeof value === 'string') {
-        const match = value.match(WAKE_SUBMIT_NONCE_PATTERN);
-        return normalizeWakeSubmitNonce(match?.[1]);
-    }
-
-    if (Array.isArray(value)) {
-        for (const item of value) {
-            const nonce = extractWakeSubmitNonce(item, depth + 1);
-            if (nonce) return nonce;
-        }
-        return null;
-    }
-
-    if (typeof value === 'object') {
-        for (const item of Object.values(value)) {
-            const nonce = extractWakeSubmitNonce(item, depth + 1);
-            if (nonce) return nonce;
-        }
-    }
-
-    return null;
-}
-
-/**
- * @summary Reads the Codex hook event payload from stdin when Codex provides one.
- * @param {Object} [options]
- * @param {NodeJS.ReadStream} [options.stdin=process.stdin]
- * @returns {Promise<String>}
- */
-export function readHookPayload({stdin = process.stdin} = {}) {
-    if (stdin.isTTY) return Promise.resolve('');
-
-    return new Promise((resolve, reject) => {
-        let data = '';
-
-        stdin.setEncoding('utf8');
-        stdin.on('data',  chunk => data += chunk);
-        stdin.on('end',   ()    => resolve(data));
-        stdin.on('error', reject);
-    });
-}
-
-async function withTimeout(promise, timeoutMs) {
-    let timer;
-    try {
-        return await Promise.race([
-            promise,
-            new Promise((_, reject) => {
-                timer = setTimeout(() => reject(new Error('turn presence hook timed out')), timeoutMs);
-                timer.unref?.();
-            })
-        ]);
-    } finally {
-        if (timer) clearTimeout(timer);
-    }
-}
+export {extractWakeSubmitNonce, readHookPayload};
 
 /**
  * @summary Emits a fail-soft Codex turn-start beacon without importing Neo singletons.
@@ -101,68 +27,13 @@ export async function recordTurnStarted({
     rootDir = fileURLToPath(new URL('../../', import.meta.url)),
     hookPayload
 } = {}) {
-    const agentIdentity = normalizeAgentIdentity(env.NEO_AGENT_IDENTITY);
-    if (!agentIdentity) return;
-
-    const {freshMs, ttlMs, noteMaxChars, hookWriteTimeoutMs: timeoutMs} = resolveTurnPresenceRuntimeConfig({env});
-    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return;
-
-    return withTimeout(writeTurnStarted({
-        agentIdentity,
-        dbPath         : resolveMemoryCoreGraphPath({env, rootDir}),
-        freshMs,
-        noteMaxChars,
-        ttlMs,
-        wakeSubmitNonce: extractWakeSubmitNonce(hookPayload)
-    }), timeoutMs);
-}
-
-async function writeTurnStarted({agentIdentity, dbPath, freshMs, noteMaxChars, ttlMs, wakeSubmitNonce}) {
-    const {default: Database} = await import('better-sqlite3');
-    const db = new Database(dbPath, {fileMustExist: true});
-
-    try {
-        const hasNodesTable = db.prepare(`
-            SELECT name FROM sqlite_master
-            WHERE type = 'table' AND name = 'Nodes'
-            LIMIT 1
-        `).get();
-        if (!hasNodesTable) return;
-
-        const nowDate = new Date(),
-              nowIso  = nowDate.toISOString(),
-              turnId  = randomUUID(),
-              nodeId  = `AGENT_TURN_PRESENCE:${agentIdentity}:${turnId}`,
-              note    = 'codex UserPromptSubmit'.slice(0, noteMaxChars),
-              node    = {
-                  id        : nodeId,
-                  label     : 'AGENT_TURN_PRESENCE',
-                  properties: {
-                      agentIdentity,
-                      turnId,
-                      startedAt     : nowIso,
-                      lastProgressAt: nowIso,
-                      freshUntil    : new Date(nowDate.getTime() + freshMs).toISOString(),
-                      expiresAt     : new Date(nowDate.getTime() + ttlMs).toISOString(),
-                      terminalState : null,
-                      status        : 'active',
-                      source        : 'codex-user-prompt-submit',
-                      note,
-                      updatedAt     : nowIso,
-                      userId        : agentIdentity,
-                      sharedEntity  : false,
-                      ...(wakeSubmitNonce ? {wakeSubmitNonce} : {})
-                  }
-              };
-
-        db.prepare(`
-            INSERT INTO Nodes (id, user_id, data)
-            VALUES (?, ?, ?)
-            ON CONFLICT(id) DO UPDATE SET data = excluded.data, user_id = excluded.user_id
-        `).run(nodeId, agentIdentity, JSON.stringify(node));
-    } finally {
-        db.close();
-    }
+    return recordTurnPresenceFromHook({
+        env,
+        hookPayload,
+        note  : 'codex UserPromptSubmit',
+        rootDir,
+        source: 'codex-user-prompt-submit'
+    });
 }
 
 /**

--- a/ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs
+++ b/ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs
@@ -1,0 +1,271 @@
+import {randomUUID}    from 'node:crypto';
+import {fileURLToPath} from 'node:url';
+import {
+    resolveMemoryCoreGraphPath,
+    resolveTurnPresenceRuntimeConfig
+} from './TurnPresenceConfig.mjs';
+
+const WAKE_SUBMIT_NONCE_PATTERN = /NEO_WAKE_SUBMIT_NONCE:([0-9a-fA-F-]{36})/;
+
+function coerceDate(value) {
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        throw new Error(`Invalid turn presence timestamp: ${value}`);
+    }
+    return date;
+}
+
+function normalizeWakeSubmitNonce(value) {
+    if (!value || typeof value !== 'string') return null;
+
+    const trimmed = value.trim();
+    return /^[0-9a-fA-F-]{36}$/.test(trimmed) ? trimmed.toLowerCase() : null;
+}
+
+function buildTurnPresenceId(agentIdentity, turnId) {
+    return `AGENT_TURN_PRESENCE:${agentIdentity}:${turnId}`;
+}
+
+function getTurnPresenceProperties(db, nodeId) {
+    const row = db.prepare('SELECT data FROM Nodes WHERE id = ?').get(nodeId);
+    if (!row?.data) return null;
+
+    try {
+        return JSON.parse(row.data).properties || null;
+    } catch {
+        return null;
+    }
+}
+
+function findNewestActiveTurnId(db, agentIdentity, nowIso) {
+    const row = db.prepare(`
+        SELECT data FROM Nodes
+        WHERE (
+            json_extract(data, '$.label') = 'AGENT_TURN_PRESENCE'
+            OR json_extract(data, '$.type') = 'AGENT_TURN_PRESENCE'
+        )
+          AND json_extract(data, '$.properties.agentIdentity') = ?
+          AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
+          AND (
+            json_extract(data, '$.properties.expiresAt') IS NULL
+            OR json_extract(data, '$.properties.expiresAt') > ?
+          )
+        ORDER BY json_extract(data, '$.properties.lastProgressAt') DESC
+        LIMIT 1
+    `).get(agentIdentity, nowIso);
+
+    if (!row?.data) return null;
+
+    try {
+        return JSON.parse(row.data).properties?.turnId || null;
+    } catch {
+        return null;
+    }
+}
+
+async function withTimeout(promise, timeoutMs) {
+    let timer;
+    try {
+        return await Promise.race([
+            promise,
+            new Promise((_, reject) => {
+                timer = setTimeout(() => reject(new Error('turn presence hook timed out')), timeoutMs);
+                timer.unref?.();
+            })
+        ]);
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+}
+
+async function writeTurnPresenceEvent({
+    action,
+    agentIdentity,
+    dbPath,
+    freshMs,
+    note,
+    noteMaxChars,
+    now,
+    source,
+    terminalState,
+    ttlMs,
+    turnId,
+    wakeSubmitNonce
+}) {
+    const {default: Database} = await import('better-sqlite3');
+    const db                  = new Database(dbPath, {fileMustExist: true});
+
+    try {
+        const hasNodesTable = db.prepare(`
+            SELECT name FROM sqlite_master
+            WHERE type = 'table' AND name = 'Nodes'
+            LIMIT 1
+        `).get();
+        if (!hasNodesTable) return {status: 'noop', reason: 'missing-nodes-table', action, agentIdentity};
+
+        const nowDate      = coerceDate(now),
+              nowIso       = nowDate.toISOString(),
+              targetTurnId = turnId || (action === 'start'
+                  ? randomUUID()
+                  : findNewestActiveTurnId(db, agentIdentity, nowIso));
+
+        if (!targetTurnId) {
+            return {status: 'noop', reason: 'no-active-turn', action, agentIdentity};
+        }
+
+        const nodeId     = buildTurnPresenceId(agentIdentity, targetTurnId),
+              current    = getTurnPresenceProperties(db, nodeId) || {},
+              startedAt  = current.startedAt || nowIso,
+              properties = {
+                  ...current,
+                  agentIdentity,
+                  turnId        : targetTurnId,
+                  startedAt,
+                  lastProgressAt: nowIso,
+                  freshUntil    : new Date(nowDate.getTime() + freshMs).toISOString(),
+                  expiresAt     : new Date(nowDate.getTime() + ttlMs).toISOString(),
+                  terminalState : action === 'terminal' ? terminalState : null,
+                  status        : action === 'terminal' ? 'terminal' : 'active',
+                  source,
+                  note          : typeof note === 'string' ? note.slice(0, noteMaxChars) : null,
+                  updatedAt     : nowIso,
+                  userId        : agentIdentity,
+                  sharedEntity  : false,
+                  ...(wakeSubmitNonce ? {wakeSubmitNonce} : {})
+              },
+              node       = {
+                  id   : nodeId,
+                  label: 'AGENT_TURN_PRESENCE',
+                  type : 'AGENT_TURN_PRESENCE',
+                  name : `TurnPresence ${agentIdentity}`,
+                  properties
+              };
+
+        db.prepare(`
+            INSERT INTO Nodes (id, user_id, data)
+            VALUES (?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET data = excluded.data, user_id = excluded.user_id
+        `).run(nodeId, agentIdentity, JSON.stringify(node));
+
+        return {
+            ...properties,
+            status: 'recorded',
+            action,
+            id    : nodeId
+        };
+    } finally {
+        db.close();
+    }
+}
+
+export function normalizeAgentIdentity(value) {
+    if (!value || typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    return trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
+}
+
+/**
+ * @summary Extracts a wake-submit nonce from hook payload text.
+ * @param {*} value Hook payload value.
+ * @param {Number} [depth=0] Recursion guard for nested payloads.
+ * @returns {String|null}
+ */
+export function extractWakeSubmitNonce(value, depth = 0) {
+    if (depth > 8 || value == null) return null;
+
+    if (typeof value === 'string') {
+        const match = value.match(WAKE_SUBMIT_NONCE_PATTERN);
+        return normalizeWakeSubmitNonce(match?.[1]);
+    }
+
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            const nonce = extractWakeSubmitNonce(item, depth + 1);
+            if (nonce) return nonce;
+        }
+        return null;
+    }
+
+    if (typeof value === 'object') {
+        for (const item of Object.values(value)) {
+            const nonce = extractWakeSubmitNonce(item, depth + 1);
+            if (nonce) return nonce;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * @summary Reads a hook event payload from stdin.
+ * @param {Object} [options]
+ * @param {NodeJS.ReadStream} [options.stdin=process.stdin]
+ * @returns {Promise<String>}
+ */
+export function readHookPayload({stdin = process.stdin} = {}) {
+    if (stdin.isTTY) return Promise.resolve('');
+
+    return new Promise((resolve, reject) => {
+        let data = '';
+
+        stdin.setEncoding('utf8');
+        stdin.on('data',  chunk => data += chunk);
+        stdin.on('end',   ()    => resolve(data));
+        stdin.on('error', reject);
+    });
+}
+
+/**
+ * @summary Emits a fail-soft turn-presence hook write without importing Neo singletons.
+ * @param {Object} options
+ * @param {'start'|'progress'|'terminal'} [options.action='start'] Event kind.
+ * @param {Object} [options.env=process.env] Environment source.
+ * @param {*} [options.hookPayload] Raw hook payload, used for optional wake nonce extraction.
+ * @param {String} [options.note] Bounded diagnostic note.
+ * @param {String|Date|Number} [options.now=new Date()] Clock override for tests.
+ * @param {String} [options.rootDir] Repository root.
+ * @param {String} [options.source='harness-hook'] Hook source identifier.
+ * @param {'completed'|'blocked'|'aborted'|'stale'} [options.terminalState='completed'] Terminal state.
+ * @param {String} [options.turnId] Stable active-turn identifier.
+ * @param {String} [options.wakeSubmitNonce] Optional explicit wake-submit nonce.
+ * @returns {Promise<Object>|undefined}
+ */
+export async function recordTurnPresenceFromHook({
+    action = 'start',
+    env = process.env,
+    hookPayload,
+    note,
+    now = new Date(),
+    rootDir = fileURLToPath(new URL('../../../../../', import.meta.url)),
+    source = 'harness-hook',
+    terminalState = 'completed',
+    turnId,
+    wakeSubmitNonce = extractWakeSubmitNonce(hookPayload)
+} = {}) {
+    const agentIdentity = normalizeAgentIdentity(env.NEO_AGENT_IDENTITY);
+    if (!agentIdentity) return;
+
+    const validActions = ['start', 'progress', 'terminal'];
+    if (!validActions.includes(action)) {
+        throw new Error(`Invalid turn presence action '${action}'. Must be one of: ${validActions.join(', ')}.`);
+    }
+
+    const {freshMs, ttlMs, noteMaxChars, hookWriteTimeoutMs: timeoutMs} = resolveTurnPresenceRuntimeConfig({env});
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return;
+
+    return withTimeout(writeTurnPresenceEvent({
+        action,
+        agentIdentity,
+        dbPath: resolveMemoryCoreGraphPath({env, rootDir}),
+        freshMs,
+        note,
+        noteMaxChars,
+        now,
+        source,
+        terminalState,
+        ttlMs,
+        turnId,
+        wakeSubmitNonce
+    }), timeoutMs);
+}

--- a/test/playwright/unit/hooks/codexContextHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexContextHook.spec.mjs
@@ -8,6 +8,7 @@ import {
     extractWakeSubmitNonce,
     recordTurnStarted
 } from '../../../../.codex/hooks/codex-context.mjs';
+import {recordClaudeTurnPresence} from '../../../../.claude/hooks/turnPresenceHook.mjs';
 
 test.describe('codex-context hook - wake submit nonce', () => {
     test('extracts a wake-submit nonce from nested hook payload text', () => {
@@ -54,6 +55,99 @@ test.describe('codex-context hook - wake submit nonce', () => {
             expect(node.properties.agentIdentity).toBe('@test-codex');
             expect(node.properties.source).toBe('codex-user-prompt-submit');
             expect(node.properties.wakeSubmitNonce).toBe(nonce);
+        } finally {
+            db.close();
+            fs.rmSync(dir, {recursive: true, force: true});
+        }
+    });
+});
+
+test.describe('turn-presence hook writer', () => {
+    test('Claude UserPromptSubmit starts and PostToolUse refreshes the active turn', async () => {
+        const dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-turn-presence-hook-')),
+              dbPath  = path.join(dir, 'graph.sqlite'),
+              db      = new Database(dbPath),
+              rootDir = path.resolve(new URL('../../../..', import.meta.url).pathname),
+              env     = {
+                  NEO_AGENT_IDENTITY        : '@test-claude',
+                  NEO_MEMORY_DB_PATH        : dbPath,
+                  NEO_AI_DAEMON_DIR         : dir,
+                  NEO_TURN_PRESENCE_FRESH_MS: '60000',
+                  NEO_TURN_PRESENCE_TTL_MS  : '600000'
+              },
+              startedAt = '2026-06-25T00:00:00.000Z',
+              progressAt = '2026-06-25T00:05:00.000Z';
+
+        db.exec(`
+            CREATE TABLE Nodes (
+                id TEXT PRIMARY KEY,
+                user_id TEXT,
+                data TEXT
+            )
+        `);
+
+        try {
+            await recordClaudeTurnPresence({
+                env,
+                hookPayload: {hook_event_name: 'UserPromptSubmit'},
+                now        : startedAt,
+                rootDir
+            });
+
+            await recordClaudeTurnPresence({
+                env,
+                hookPayload: {hook_event_name: 'PostToolUse', tool_name: 'Bash'},
+                now        : progressAt,
+                rootDir
+            });
+
+            const rows = db.prepare('SELECT data FROM Nodes WHERE id LIKE ?').all('AGENT_TURN_PRESENCE:%');
+            expect(rows).toHaveLength(1);
+
+            const node = JSON.parse(rows[0].data);
+            expect(node.properties.agentIdentity).toBe('@test-claude');
+            expect(node.properties.source).toBe('claude-post-tool-use');
+            expect(node.properties.note).toBe('claude PostToolUse Bash');
+            expect(node.properties.startedAt).toBe(startedAt);
+            expect(node.properties.lastProgressAt).toBe(progressAt);
+            expect(node.properties.freshUntil).toBe('2026-06-25T00:06:00.000Z');
+            expect(node.properties.status).toBe('active');
+        } finally {
+            db.close();
+            fs.rmSync(dir, {recursive: true, force: true});
+        }
+    });
+
+    test('Claude PostToolUse progress is a no-op without an active turn', async () => {
+        const dir    = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-turn-presence-hook-')),
+              dbPath = path.join(dir, 'graph.sqlite'),
+              db     = new Database(dbPath);
+
+        db.exec(`
+            CREATE TABLE Nodes (
+                id TEXT PRIMARY KEY,
+                user_id TEXT,
+                data TEXT
+            )
+        `);
+
+        try {
+            const result = await recordClaudeTurnPresence({
+                env: {
+                    NEO_AGENT_IDENTITY: '@test-claude',
+                    NEO_MEMORY_DB_PATH: dbPath,
+                    NEO_AI_DAEMON_DIR : dir
+                },
+                hookPayload: {hook_event_name: 'PostToolUse', tool_name: 'Bash'},
+                rootDir    : path.resolve(new URL('../../../..', import.meta.url).pathname)
+            });
+
+            expect(result).toMatchObject({
+                action: 'progress',
+                reason: 'no-active-turn',
+                status: 'noop'
+            });
+            expect(db.prepare('SELECT COUNT(*) AS count FROM Nodes').get().count).toBe(0);
         } finally {
             db.close();
             fs.rmSync(dir, {recursive: true, force: true});


### PR DESCRIPTION
Resolves #13498

Adds the remaining narrow emission slice for `who_is_online` local mid-turn rescue: Claude Code now writes `AGENT_TURN_PRESENCE` on `UserPromptSubmit` and refreshes the active interval on `PostToolUse`, matching the documented Claude Code hook cadences: https://code.claude.com/docs/en/hooks. The Codex hook now reuses the same fail-soft SQLite writer and keeps its existing wake-submit nonce behavior. `add_memory` recency remains the primary liveness signal; this PR only supplies local corroboration data where a harness can emit it.

Evidence: L2 (static checks + temp-SQLite hook unit tests + Memory Core liveness consumer specs) -> L3 required for live harness rollout. Residual: post-merge, refresh the active Claude project settings from `.claude/settings.template.json` and verify a real Claude turn creates and refreshes an `AGENT_TURN_PRESENCE` row.

## Deltas from ticket

The ticket title is broad, but prior work already shipped add-memory-recency primary, the `who_is_online` rescue read, and the health-gate exemption. This PR intentionally limits itself to the narrowed AC4 emission gap and does not alter liveness precedence or tenant scoping.

## Test Evidence

- `node --check ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs`
- `node --check .claude/hooks/turnPresenceHook.mjs`
- `node --check .codex/hooks/codex-context.mjs`
- `node buildScripts/util/check-block-alignment.mjs .codex/hooks/codex-context.mjs .claude/hooks/turnPresenceHook.mjs ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs test/playwright/unit/hooks/codexContextHook.spec.mjs`
- `npm run test-unit -- test/playwright/unit/hooks/codexContextHook.spec.mjs` — 4 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs` — 77 passed
- `npm run agent-preflight -- .claude/hooks/turnPresenceHook.mjs .claude/settings.template.json .codex/hooks/codex-context.mjs ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs test/playwright/unit/hooks/codexContextHook.spec.mjs`

## Post-Merge Validation

- [ ] Refresh active Claude project settings from `.claude/settings.template.json`; start a real Claude turn, run at least one tool, and verify one active `AGENT_TURN_PRESENCE` row has `source=claude-post-tool-use` with `lastProgressAt > startedAt`.

## Commits

- `7d0d9cf807` — `fix(ai): emit claude turn presence beacons (#13498)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.