### PR TITLE
fix(ai): bound LMS REM graph output (#13981)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -247,6 +247,15 @@ class Config extends ConfigProvider {
                     // and embedding models stay loaded regardless of this value.
                     parallel                 : leaf(1, 'NEO_LOCAL_MODELS_CHAT_PARALLEL', 'number'),
                     /**
+                     * @summary Output-token budget for REM graph structured-output calls.
+                     *
+                     * Input chunking protects the prompt side; this caps the provider's JSON response
+                     * side so an LMS/OpenAI-compatible schema request cannot consume the remaining
+                     * context window while the backlog waits for a response.
+                     * @type {Number}
+                     */
+                    graphOutputLimitTokens   : leaf(8192, 'NEO_LOCAL_MODELS_CHAT_GRAPH_OUTPUT_LIMIT_TOKENS', 'number'),
+                    /**
                      * @summary Per-task reasoning-effort for the chat model's two structured-output
                      * consumers — passed straight through as the OpenAI / LM-Studio `reasoning_effort`
                      * request param. Default `'none'` disables the gemma MoE's hidden "thinking" pass

--- a/ai/provider/OpenAiCompatible.mjs
+++ b/ai/provider/OpenAiCompatible.mjs
@@ -9,6 +9,8 @@ import {createTimeoutError} from './createTimeoutError.mjs';
  * @extends Neo.ai.provider.Base
  */
 class OpenAiCompatibleProvider extends Base {
+    #lastCompletionMetadata = null;
+
     static config = {
         /**
          * @member {String} className='Neo.ai.provider.OpenAiCompatible'
@@ -162,11 +164,23 @@ class OpenAiCompatibleProvider extends Base {
                 fullContent += chunk;
             }
 
-            return {
-                content: fullContent,
-                // Simulate the raw message expected by upstream callers
-                raw: { message: { content: fullContent } }
-            };
+            const finishReason = this.#lastCompletionMetadata?.finish_reason || '',
+                  result       = {
+                      content: fullContent,
+                      // Simulate the raw message expected by upstream callers.
+                      raw: { message: { content: fullContent } }
+                  };
+
+            if (finishReason) {
+                result.finish_reason     = finishReason;
+                result.raw.finish_reason = finishReason;
+                result.raw.choices       = [{
+                    finish_reason: finishReason,
+                    message      : { content: fullContent }
+                }];
+            }
+
+            return result;
         } catch (error) {
             throw error;
         }
@@ -184,9 +198,14 @@ class OpenAiCompatibleProvider extends Base {
      * @private
      */
     #getChoiceContent(data) {
-        const choice = data?.choices?.[0],
-              deltaContent = choice?.delta?.content,
-              messageContent = choice?.message?.content;
+        const choice         = data?.choices?.[0],
+              deltaContent   = choice?.delta?.content,
+              messageContent = choice?.message?.content,
+              finishReason   = choice?.finish_reason ?? choice?.finishReason ?? data?.finish_reason ?? data?.finishReason;
+
+        if (typeof finishReason === 'string' && finishReason) {
+            this.#lastCompletionMetadata = {finish_reason: finishReason};
+        }
 
         if (typeof deltaContent === 'string') {
             return deltaContent;
@@ -252,7 +271,7 @@ class OpenAiCompatibleProvider extends Base {
      */
     async *stream(input, options = {}) {
         const cleanOptions = { ...options };
-        const rawTimeoutMs  = Number(cleanOptions.timeoutMs),
+        const rawTimeoutMs = Number(cleanOptions.timeoutMs),
               timeoutMs     = Number.isFinite(rawTimeoutMs) && rawTimeoutMs > 0 ? rawTimeoutMs : null,
               operationLabel = cleanOptions.operationLabel || 'OpenAI-compatible chat completion',
               upstreamSignal = cleanOptions.signal;
@@ -262,7 +281,9 @@ class OpenAiCompatibleProvider extends Base {
         delete cleanOptions.signal;
         delete cleanOptions.timeoutMs;
 
-        const payload = this.preparePayload(input, cleanOptions, true);
+        this.#lastCompletionMetadata = null;
+
+        const payload    = this.preparePayload(input, cleanOptions, true);
         const controller = timeoutMs || upstreamSignal ? new AbortController() : null;
         let timeoutId, upstreamAbortListener, timedOut = false;
 
@@ -304,9 +325,9 @@ class OpenAiCompatibleProvider extends Base {
                 throw new Error(`OpenAI-Compatible API error: ${response.status} - ${text}`);
             }
 
-            const reader = response.body.getReader();
+            const reader  = response.body.getReader();
             const decoder = new TextDecoder('utf-8');
-            let buffer = '',
+            let   buffer  = '',
                 bodyText = '',
                 yieldedContent = false;
 

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -122,6 +122,25 @@ class SemanticGraphExtractor extends Base {
     }
 
     /**
+     * Reads the AiConfig graph output budget at the use site.
+     *
+     * @summary Anchor & Echo: Complements input chunking with an explicit response-token cap.
+     * The config leaf owns defaults/env decoding; this method only fails loud if the SSOT is invalid.
+     *
+     * @returns {Number}
+     * @protected
+     */
+    getGraphOutputLimitTokens() {
+        const value = AiConfig.localModels.chat.graphOutputLimitTokens;
+
+        if (!Number.isFinite(value) || value <= 0) {
+            throw new Error(`[SemanticGraphExtractor] Required AiConfig leaf "localModels.chat.graphOutputLimitTokens" must be a positive number.`);
+        }
+
+        return value;
+    }
+
+    /**
      * Builds the graph-generation provider from resolved AiConfig leaves.
      *
      * @summary Anchor & Echo: Keeps ADR-19 ownership local to this consumer: the
@@ -493,7 +512,12 @@ class SemanticGraphExtractor extends Base {
             const inputPayload     = this.estimateChatMessagesPayload(messages);
             const inputPayloadText = inputPayload.text;
             const guardrailed      = await invokeWithGuardrail({
-                invocationFn             : () => provider.generate(messages, {reasoning_effort: graphReasoningEffort || undefined, responseSchema: triVectorSchema, responseSchemaName: 'triVector'}),
+                invocationFn             : () => provider.generate(messages, {
+                    reasoning_effort  : graphReasoningEffort || undefined,
+                    responseSchema    : triVectorSchema,
+                    responseSchemaName: 'triVector',
+                    max_tokens        : this.getGraphOutputLimitTokens()
+                }),
                 inputPayload             : inputPayloadText,
                 model                    : consumerModel,
                 assetRef,
@@ -936,8 +960,12 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 const chunkPayloads = [];
 
                 for (let index = 0; index < chunkPlan.chunks.length; index++) {
-                    const chunk  = chunkPlan.chunks[index],
-                          result = await this.extractTriVectorPayload({
+                    const chunk             = chunkPlan.chunks[index],
+                          outputLimitTokens = this.getGraphOutputLimitTokens();
+
+                    logger.info(`[SemanticGraphExtractor] Tri-Vector extracting chunk ${index + 1}/${chunkPlan.chunks.length} for session ${session.meta.sessionId} (${chunk.chunkId}); estimated ${chunk.estimatedTokens} tokens; output cap ${outputLimitTokens} tokens.`);
+
+                    const result = await this.extractTriVectorPayload({
                               session,
                               document: chunk.text,
                               assetRef: chunk.chunkId,

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -51,6 +51,16 @@ function readRequiredChatNumberLeaf(leafName) {
     return value;
 }
 
+function readRequiredChatPositiveNumberLeaf(leafName) {
+    const value = readRequiredChatNumberLeaf(leafName);
+
+    if (value <= 0) {
+        throw new Error(`[TopologyInferenceEngine] Required AiConfig leaf "localModels.chat.${leafName}" must be a positive number.`);
+    }
+
+    return value;
+}
+
 function readRequiredChatStringLeaf(leafName) {
     const value = aiConfig.localModels.chat[leafName];
 
@@ -222,7 +232,8 @@ ${contextText}
             reasoning_effort    : readRequiredChatStringLeaf('graphReasoningEffort'),
             responseSchema      : topologyConflictSchema,
             responseSchemaName  : 'topologyConflicts',
-            responseSchemaStrict: true
+            responseSchemaStrict: true,
+            max_tokens          : readRequiredChatPositiveNumberLeaf('graphOutputLimitTokens')
         }
     }
 

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -93,7 +93,8 @@ test.describe('Tier 1 Config Immutability', () => {
             chat: {
                 contextLimitTokens       : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072,
                 safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 100000,
-                parallel                 : Number(process.env.NEO_LOCAL_MODELS_CHAT_PARALLEL) || 1
+                parallel                 : Number(process.env.NEO_LOCAL_MODELS_CHAT_PARALLEL) || 1,
+                graphOutputLimitTokens   : Number(process.env.NEO_LOCAL_MODELS_CHAT_GRAPH_OUTPUT_LIMIT_TOKENS) || 8192
             },
             embedding: {
                 contextLimitTokens       : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -834,6 +834,29 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
         });
     });
 
+    test('OpenAiCompatible.generate() preserves streaming finish_reason metadata (#13981)', async () => {
+        globalThis.fetch = async () => ({
+            ok  : true,
+            body: createReadableStream([
+                'data: {"choices":[{"delta":{"content":"{\\"status\\""},"finish_reason":null}]}\n\n',
+                'data: {"choices":[{"delta":{"content":":\\"ok\\"}"},"finish_reason":"length"}]}\n\n',
+                'data: [DONE]\n\n'
+            ])
+        });
+
+        const provider = Neo.create(OpenAiCompatibleProvider, {
+            host     : 'http://openai-compatible.test',
+            modelName: 'gemma4-test'
+        });
+
+        const result = await provider.generate('hello', {max_tokens: 8});
+
+        expect(result.content).toBe('{"status":"ok"}');
+        expect(result.finish_reason).toBe('length');
+        expect(result.raw.finish_reason).toBe('length');
+        expect(result.raw.choices[0].finish_reason).toBe('length');
+    });
+
     test('OpenAiCompatible.generate() aggregates non-SSE JSON message content', async () => {
         let capturedPayload;
 

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -547,15 +547,17 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         const originalGraphProvider             = aiConfig.graphProvider;
         const originalContextLimitTokens        = aiConfig.localModels.chat.contextLimitTokens;
         const originalSafeProcessingLimitTokens = aiConfig.localModels.chat.safeProcessingLimitTokens;
+        const originalGraphOutputLimitTokens    = aiConfig.localModels.chat.graphOutputLimitTokens;
         const providerCalls                     = [];
 
         try {
             aiConfig.graphProvider                              = 'openAiCompatible';
             aiConfig.localModels.chat.contextLimitTokens        = 100000;
             aiConfig.localModels.chat.safeProcessingLimitTokens = 50000;
+            aiConfig.localModels.chat.graphOutputLimitTokens    = 2048;
 
-            OpenAiCompatible.prototype.generate = async function(messages) {
-                providerCalls.push(messages);
+            OpenAiCompatible.prototype.generate = async function(messages, options) {
+                providerCalls.push({messages, options});
 
                 return {
                     content: JSON.stringify({
@@ -578,7 +580,9 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
             });
 
             expect(providerCalls.length).toBe(1);
-            expect(providerCalls[0][1].content).toContain('turn-a\n\n---\n\nturn-b');
+            expect(providerCalls[0].messages[1].content).toContain('turn-a\n\n---\n\nturn-b');
+            expect(providerCalls[0].options.max_tokens).toBe(2048);
+            expect(providerCalls[0].options.responseSchemaName).toBe('triVector');
             expect(result.session_artifact.chunking).toBeUndefined();
             expect(result.session_artifact.human_readable_summary).toBe('Small session used the original single-pass path.');
         } finally {
@@ -586,6 +590,7 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
             aiConfig.graphProvider                              = originalGraphProvider;
             aiConfig.localModels.chat.contextLimitTokens        = originalContextLimitTokens;
             aiConfig.localModels.chat.safeProcessingLimitTokens = originalSafeProcessingLimitTokens;
+            aiConfig.localModels.chat.graphOutputLimitTokens    = originalGraphOutputLimitTokens;
         }
     });
 


### PR DESCRIPTION
Resolves #13981

Bounds REM graph structured-output generation for LMS/OpenAI-compatible chat calls so turn-boundary input chunking is not undermined by unbounded JSON output. The patch adds an ADR-19 `AiConfig.localModels.chat.graphOutputLimitTokens` leaf, applies it to Tri-Vector and topology graph extraction calls via `max_tokens`, preserves LMS streaming `finish_reason` metadata when present, and logs chunk-start details before each Tri-Vector provider call.

Evidence: L2 unit/static validation covers #13981 AC1-AC5. Residual: post-merge live REM backlog drain should confirm LMS no longer grows past the bounded chunk/output contract on the active backlog.

## Deltas from ticket

- Used `max_tokens` only for LMS/OpenAI-compatible payload compatibility; no wall-clock timeout was added.
- Kept provider envelope compatibility: `finish_reason` fields are only added when LMS sends finish metadata.
- Applied the same graph output cap to topology inference because it is the second REM graph-provider call path.

## Test Evidence

- `node --check ai/config.template.mjs`
- `node --check ai/provider/OpenAiCompatible.mjs`
- `node --check ai/services/graph/TopologyInferenceEngine.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs` — 22 passed, 1 skipped
- `npm run test-unit -- test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs` — 12 passed
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs` — 8 passed
- `npm run agent-preflight -- ai/config.template.mjs ai/provider/OpenAiCompatible.mjs ai/services/graph/SemanticGraphExtractor.mjs ai/services/graph/TopologyInferenceEngine.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/provider/KeepAlive.spec.mjs test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs`

## Post-Merge Validation

- [ ] Pull `dev`, run the config overlay update script, restart the orchestrator, and confirm the pending REM backlog resumes with LMS chunk logs and without over-cap growth.

## Commit

- `079858ee28` — `fix(ai): bound LMS REM graph output (#13981)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.