### PR TITLE
fix(ai): fail loud on stale handoff PR state (#13985)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -557,24 +557,36 @@ async function runGoldenPathTask({taskName, reason, services, repoEnrichmentEnab
     try {
         const outcome = await services.goldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled});
 
-        if (outcome?.status === 'failed') {
+        if (outcome?.status === 'failed' || outcome?.wroteHandoff !== true) {
+            const writeProofMissing = outcome?.wroteHandoff !== true,
+                  reasonCode        = writeProofMissing ? 'golden-path-handoff-write-unverified' : outcome.reasonCode,
+                  error             = writeProofMissing ? 'Golden Path synthesizer did not report wroteHandoff=true.' : outcome.error;
             const state = services.taskStateService.getTaskState(taskName);
-            if (state) state.lastReason = outcome.reasonCode || outcome.error || 'golden-path-failed';
+            if (state) state.lastReason = reasonCode || error || 'golden-path-failed';
             services.taskStateService.markFailed(taskName, 1);
             services.healthService?.recordTaskOutcome?.(taskName, 'failed', {
                 reason,
-                reasonCode  : outcome.reasonCode,
-                error       : outcome.error,
+                reasonCode,
+                error,
                 failedAt    : new Date().toISOString(),
-                wroteHandoff: outcome.wroteHandoff === true
+                wroteHandoff: outcome?.wroteHandoff === true
             });
             return;
         }
 
-        services.taskStateService.markCompleted(taskName);
+        const completedAt = new Date().toISOString();
+        services.taskStateService.markCompleted(taskName, {
+            completedAt,
+            prunedGuideEdges: outcome.prunedGuideEdges,
+            selectedTopNodes: outcome.selectedTopNodes,
+            wroteHandoff    : true
+        });
         services.healthService?.recordTaskOutcome?.(taskName, 'completed', {
             reason,
-            completedAt: new Date().toISOString()
+            completedAt,
+            prunedGuideEdges: outcome.prunedGuideEdges,
+            selectedTopNodes: outcome.selectedTopNodes,
+            wroteHandoff    : true
         });
     } catch (e) {
         const state = services.taskStateService.getTaskState(taskName);

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -537,6 +537,12 @@ class Config extends ConfigProvider {
              */
             goldenPathRecentOpenPrRenderLimit: leaf(10, 'NEO_GOLDEN_PATH_RECENT_OPEN_PR_RENDER_LIMIT', 'number'),
             /**
+             * Freshness SLA for generated `Active PR Cycle State` data. Older PR-cycle snapshots
+             * are rendered as stale instead of implied-current.
+             * @type {number}
+             */
+            goldenPathActivePrStateFreshnessMs: leaf(60 * 60 * 1000, 'NEO_GOLDEN_PATH_ACTIVE_PR_STATE_FRESHNESS_MS', 'number'),
+            /**
              * Maximum Golden Path priority nodes rendered into the Sandman handoff. The
              * Golden Path is the one section that earns more depth than the 5-row
              * convention applied to every other category; defaults to 10.

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -751,6 +751,68 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Resolves whether an Active PR Cycle snapshot is still within its freshness SLA.
+     *
+     * @param {Object} options
+     * @param {Date|String} options.capturedAt Snapshot timestamp.
+     * @param {Date|String} options.now Freshness comparison timestamp.
+     * @param {Number} options.freshnessMs Freshness SLA in milliseconds.
+     * @returns {String}
+     */
+    static getActivePrCycleStatus({capturedAt, now, freshnessMs}) {
+        const capturedMs = capturedAt instanceof Date ? capturedAt.getTime() : new Date(capturedAt).getTime(),
+              nowMs      = now        instanceof Date ? now.getTime()        : new Date(now).getTime();
+
+        if (!Number.isFinite(capturedMs) || !Number.isFinite(nowMs)) return 'unknown';
+
+        return nowMs - capturedMs > freshnessMs ? 'stale' : 'current'
+    }
+
+    /**
+     * @summary Renders the complete Active PR Cycle State section.
+     *
+     * @param {Object} options
+     * @param {Object[]} [options.prs=[]] GitHub PR payloads.
+     * @param {Date|String} [options.capturedAt=new Date()] Snapshot timestamp.
+     * @param {Date|String} [options.now=options.capturedAt] Freshness comparison timestamp.
+     * @param {Error} [options.error=null] Fetch failure that makes the section degraded.
+     * @param {Number} [options.freshnessMs=aiConfig.goldenPathActivePrStateFreshnessMs] Freshness SLA.
+     * @param {Number} [options.limit=aiConfig.goldenPathRecentOpenPrRenderLimit] Maximum PR rows.
+     * @returns {String}
+     */
+    static renderActivePrCycleState({
+        prs         = [],
+        capturedAt  = new Date(),
+        now         = capturedAt,
+        error       = null,
+        freshnessMs = aiConfig.goldenPathActivePrStateFreshnessMs,
+        limit       = aiConfig.goldenPathRecentOpenPrRenderLimit
+    } = {}) {
+        const capturedDate = capturedAt instanceof Date ? capturedAt : new Date(capturedAt),
+              freshUntil   = new Date(capturedDate.getTime() + freshnessMs),
+              status       = error ? 'degraded' : this.getActivePrCycleStatus({capturedAt: capturedDate, now, freshnessMs});
+
+        let section = `\n## Active PR Cycle State\n\n`;
+        section += `*Captured at: ${capturedDate.toISOString()} (Source: GitHub Live; Status at generation: ${status}; Fresh until: ${freshUntil.toISOString()})*\n\n`;
+
+        if (error) {
+            section += `### Recent Open PRs (degraded)\n`;
+            section += `Live PR fetch failed; stale PR data was intentionally not reused.\n`;
+            section += `- Error: ${String(error.message || error).replace(/\s+/g, ' ').slice(0, 240)}\n\n`;
+            return section
+        }
+
+        const summary = this.renderRecentOpenPrSummary(prs, {limit});
+
+        if (summary) return section + summary;
+
+        section += `### Recent Open PRs (\`0\` of \`0\` items)\n`;
+        section += `No open PRs reported by GitHub at capture time.\n\n`;
+
+        return section
+    }
+
+    /**
      * @summary Renders a compact deterministic Strategic Interpretation fallback.
      *
      * The preferred path is still the model-generated brief. This fallback keeps the
@@ -1377,16 +1439,22 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         let prStateAppend = '';
         if (repoEnrichmentEnabled) {
             try {
-                const Synthesizer = this.constructor;
-                const prs         = await this.fetchOpenPRs();
+                const Synthesizer = this.constructor,
+                      prs         = await this.fetchOpenPRs(),
+                      capturedAt  = now instanceof Date ? now : new Date(now);
 
-                if (prs.length > 0) {
-                    prStateAppend += `\n## Active PR Cycle State\n\n`;
-                    prStateAppend += `*Captured at: ${new Date().toISOString()} (Source: GitHub Live)*\n\n`;
-                    prStateAppend += Synthesizer.renderRecentOpenPrSummary(prs);
+                if (!Array.isArray(prs)) {
+                    throw new Error('fetchOpenPRs did not return an array');
                 }
+
+                prStateAppend = Synthesizer.renderActivePrCycleState({prs, capturedAt, now: capturedAt});
             } catch (e) {
                 logger.warn('[GoldenPathSynthesizer] Failed to generate Active PR Cycle State', e);
+                prStateAppend = this.constructor.renderActivePrCycleState({
+                    capturedAt: now instanceof Date ? now : new Date(now),
+                    error     : e,
+                    now       : now instanceof Date ? now : new Date(now)
+                });
             }
         }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -155,7 +155,10 @@ function createTestOrchestrator(config = {}) {
     orchestrator.tenantRepoSyncGetDueTask = config.tenantRepoSyncGetDueTask || (() => null);
     orchestrator.dreamGetDueTask          = config.dreamGetDueTask          || orchestrator.dreamGetDueTask;
     orchestrator.dreamService             = config.dreamService             || {processUndigestedSessions: () => Promise.resolve()};
-    orchestrator.goldenPathSynthesizer    = config.goldenPathSynthesizer    || {synthesizeGoldenPath: () => Promise.resolve()};
+    orchestrator.goldenPathSynthesizer    = config.goldenPathSynthesizer    || {synthesizeGoldenPath: () => Promise.resolve({
+        status      : 'completed',
+        wroteHandoff: true
+    })};
     orchestrator.swarmHeartbeatService    = config.swarmHeartbeatService    || {initAsync: () => Promise.resolve(), pulse: () => Promise.resolve()};
 
     orchestrator.writeLog  = () => {};
@@ -469,7 +472,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             goldenPathSynthesizer: {
                 synthesizeGoldenPath() {
                     calls.push('golden-path');
-                    return Promise.resolve();
+                    return Promise.resolve({
+                        status      : 'completed',
+                        wroteHandoff: true
+                    });
                 }
             }
         });
@@ -496,7 +502,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             goldenPathSynthesizer: {
                 synthesizeGoldenPath() {
                     calls.push('golden-path');
-                    return Promise.resolve();
+                    return Promise.resolve({
+                        status      : 'completed',
+                        wroteHandoff: true
+                    });
                 }
             }
         });
@@ -519,7 +528,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             goldenPathSynthesizer          : {
                 synthesizeGoldenPath(options) {
                     calls.push(options);
-                    return Promise.resolve();
+                    return Promise.resolve({
+                        status      : 'completed',
+                        wroteHandoff: true
+                    });
                 }
             }
         });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -41,7 +41,10 @@ function makeServices(overrides = {}) {
             executeRemCycle: () => Promise.resolve({status: 'completed'})
         },
         goldenPathSynthesizer: {
-            synthesizeGoldenPath: () => Promise.resolve()
+            synthesizeGoldenPath: () => Promise.resolve({
+                status      : 'completed',
+                wroteHandoff: true
+            })
         },
         healthService: {
             recordTaskOutcome() {}
@@ -598,6 +601,67 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
                     error       : 'Error executing plan: Internal error: Error finding id',
                     failedAt    : expect.any(String),
                     wroteHandoff: true
+                }
+            }
+        ]);
+    });
+
+    test('records Golden Path missing handoff write proof as failure (#13985)', async () => {
+        const calls    = [];
+        const outcomes = [];
+        const state    = {};
+
+        runSchedulingPipeline({
+            registry: [
+                makeCandidateDescriptor({
+                    taskName        : 'golden-path',
+                    executionKind   : 'in-process-async',
+                    maintenanceClass: 'graph-dependent'
+                })
+            ],
+            context : makeContext(),
+            services: makeServices({
+                goldenPathSynthesizer: {
+                    synthesizeGoldenPath: () => Promise.resolve({status: 'completed'})
+                },
+                healthService: {
+                    recordTaskOutcome(taskName, status, details) {
+                        outcomes.push({taskName, status, details});
+                    }
+                },
+                taskStateService: {
+                    getTaskState: () => state,
+                    markCompleted(taskName) { calls.push(['markCompleted', taskName]); },
+                    markFailed(taskName, exitCode) { calls.push(['markFailed', taskName, exitCode]); },
+                    markSkipped(taskName) { calls.push(['markSkipped', taskName]); },
+                    markStarted(taskName, reason) { calls.push(['markStarted', taskName, reason]); }
+                }
+            }),
+            runtime: makeRuntime()
+        });
+
+        await Promise.resolve();
+
+        expect(calls).toEqual([
+            ['markStarted', 'golden-path', 'golden-path-reason'],
+            ['markFailed', 'golden-path', 1]
+        ]);
+        expect(state.lastReason).toBe('golden-path-handoff-write-unverified');
+        expect(outcomes).toEqual([
+            {
+                taskName: 'golden-path',
+                status  : 'running',
+                details : {reason: 'golden-path-reason', startedAt: expect.any(String)}
+            },
+            {
+                taskName: 'golden-path',
+                status  : 'failed',
+                details : {
+                    reason      : 'golden-path-reason',
+                    reasonCode  : 'golden-path-handoff-write-unverified',
+                    error       : 'Golden Path synthesizer did not report wroteHandoff=true.',
+                    failedAt    : expect.any(String),
+                    wroteHandoff: false
                 }
             }
         ]);

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -267,6 +267,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
 
         expect(handoffContent).toContain('## Active PR Cycle State');
+        expect(handoffContent).toContain('(Source: GitHub Live; Status at generation: current; Fresh until:');
         expect(handoffContent).toContain('### Recent Open PRs (`1` of `1` items)');
         expect(handoffContent).toContain('cross-family reviewed: yes');
         expect(handoffContent).toContain('- **PR #11178**: feat(ai): Automate PR Cycle State Extraction');
@@ -342,6 +343,73 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).not.toContain('### @neo-gpt');
         expect(handoffContent).not.toContain('### @neo-opus-grace');
         expect(handoffContent).not.toContain('stale author-grouped PR entry');
+    });
+
+    test('synthesizeGoldenPath renders degraded Active PR Cycle State when GitHub PR fetch fails (#13985)', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
+        const issuesDir                    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-degraded-pr-issues-'));
+        const now                          = new Date('2026-06-25T02:00:00.000Z');
+        aiConfig.vectorDimension = 2;
+
+        fs.mkdirSync(path.dirname(tmpHandoffFile), {recursive: true});
+        fs.writeFileSync(tmpHandoffFile, [
+            '# Autonomous Handoff (Dream Pipeline & Golden Path)',
+            '',
+            '## Active PR Cycle State',
+            '',
+            '*Captured at: 2026-06-22T12:48:16.738Z (Source: GitHub Live)*',
+            '',
+            '### Recent Open PRs',
+            '',
+            '- **PR #13864**: stale lifecycle data',
+            '',
+            '### @neo-gpt',
+            '',
+            '- stale author-grouped PR entry'
+        ].join('\n'));
+
+        StorageRouter.getGraphCollection = async () => ({ query: async () => ({ ids: [[]], distances: [[]] }) });
+        StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => {
+            throw new Error('gh pr list unavailable');
+        };
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({issuesDir, now});
+        } finally {
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+
+        expect(handoffContent).toContain('## Active PR Cycle State');
+        expect(handoffContent).toContain('*Captured at: 2026-06-25T02:00:00.000Z (Source: GitHub Live; Status at generation: degraded; Fresh until: 2026-06-25T03:00:00.000Z)*');
+        expect(handoffContent).toContain('### Recent Open PRs (degraded)');
+        expect(handoffContent).toContain('Live PR fetch failed; stale PR data was intentionally not reused.');
+        expect(handoffContent).toContain('- Error: gh pr list unavailable');
+        expect(handoffContent).not.toContain('PR #13864');
+        expect(handoffContent).not.toContain('### @neo-gpt');
+        expect(handoffContent).not.toContain('stale author-grouped PR entry');
+    });
+
+    test('renderActivePrCycleState marks snapshots older than the configured SLA as stale (#13985)', () => {
+        const section = GoldenPathSynthesizer.constructor.renderActivePrCycleState({
+            capturedAt : new Date('2026-06-25T00:00:00.000Z'),
+            freshnessMs: 60 * 60 * 1000,
+            now        : new Date('2026-06-25T02:00:00.000Z'),
+            prs        : []
+        });
+
+        expect(section).toContain('*Captured at: 2026-06-25T00:00:00.000Z (Source: GitHub Live; Status at generation: stale; Fresh until: 2026-06-25T01:00:00.000Z)*');
+        expect(section).toContain('### Recent Open PRs (`0` of `0` items)');
     });
 
     test('synthesizeGoldenPath skips Neo repo enrichment sections when deployment config disables them', async () => {


### PR DESCRIPTION
Resolves #13985

Golden Path now fails loud when the synthesizer does not prove a handoff write: `golden-path` records a failed task outcome with `reasonCode: golden-path-handoff-write-unverified` unless `wroteHandoff: true` is returned. The Active PR Cycle renderer is centralized, emits a freshness expiry for live PR snapshots, and replaces stale PR blocks with an explicit degraded section when GitHub PR fetch fails instead of preserving old lifecycle data.

Evidence: L2 focused unit/static/config lint is complete. Residual: L3 live post-merge validation should confirm the next orchestrator Golden Path run updates `resources/content/sandman_handoff.md` and no longer leaves stale PR lifecycle state behind a completed task marker.

## Deltas from ticket

- Added `goldenPathActivePrStateFreshnessMs` / `NEO_GOLDEN_PATH_ACTIVE_PR_STATE_FRESHNESS_MS` with a 60 minute default for `Active PR Cycle State` freshness.
- Kept repo-enrichment failure local to the handoff output: fetch failures render degraded PR state but do not block the rest of the Golden Path write.
- Added scheduler-level write-proof enforcement so a silent/undefined synthesizer return can no longer mark `golden-path` complete.

## Config Template Change

Changed key:
- `goldenPathActivePrStateFreshnessMs` / `NEO_GOLDEN_PATH_ACTIVE_PR_STATE_FRESHNESS_MS`

Local config follow-up:
- No manual value is required; the default is active.
- After merge, run the config overlay update script so gitignored local `config.mjs` files understand the new shape.
- Restart the orchestrator after pulling `dev`; running daemons need the new code and config leaf loaded.

## Test Evidence

- `node --check ai/services/graph/GoldenPathSynthesizer.mjs`
- `node --check ai/daemons/orchestrator/scheduling/pipeline.mjs`
- `node --check test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs` -> 17 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` -> 56 passed
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` -> 36 passed
- Exact-head self-review spot checks: pipeline missing-handoff proof 1/1, Active PR Cycle State 2/2, full `Orchestrator.spec.mjs` 56/56.
- `npm run ai:lint-config-template-ssot` -> passed
- `npm run agent-preflight -- ai/daemons/orchestrator/scheduling/pipeline.mjs ai/mcp/server/memory-core/config.template.mjs ai/services/graph/GoldenPathSynthesizer.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` -> passed
- `git diff --check` -> passed

## Post-Merge Validation

- [ ] Pull `dev`, run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config`, then restart the orchestrator.
- [ ] Confirm the next Golden Path run writes `resources/content/sandman_handoff.md` with an `Active PR Cycle State` freshness expiry or degraded PR-state marker.
- [ ] Confirm `golden-path` task state is not marked completed unless the synthesizer reports `wroteHandoff: true`.

## Commits

- `816d146f0d` - `fix(ai): fail loud on stale handoff PR state (#13985)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ef378-527d-7393-bc74-ec3a1d3f2ddf.