### PR TITLE
fix(ai): enable deployment-state bridge by default (#13989)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -452,9 +452,9 @@ class Config extends ConfigProvider {
                 /**
                  * Graph-independent deployment-state bridge. The orchestrator writes a bounded JSON
                  * snapshot to shared storage; KB/MC read tools consume it without receiving Docker
-                 * socket, shell, exec, or actuator authority. Disabled by default: deployment
-                 * overlays must explicitly enable the writer and mount the same `snapshotPath`
-                 * into the public KB/MC containers.
+                 * socket, shell, exec, or actuator authority. Enabled by default: deployment
+                 * overlays may explicitly disable the writer, and must mount the same
+                 * `snapshotPath` into the public KB/MC containers.
                  *
                  * Env overrides:
                  * `NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED`,
@@ -473,7 +473,7 @@ class Config extends ConfigProvider {
                  * @type {Object}
                  */
                 deploymentStateBridge: {
-                    enabled                     : leaf(false, 'NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED', 'boolean'),
+                    enabled                     : leaf(true, 'NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED', 'boolean'),
                     snapshotPath                : leaf(path.resolve(neoRootDir, '.neo-ai-data/deployment-state/snapshot.json'), 'NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH', 'string'),
                     writeIntervalMs             : leaf(30000, 'NEO_DEPLOYMENT_STATE_BRIDGE_WRITE_INTERVAL_MS', 'number'),
                     staleAfterMs                : leaf(2 * 60 * 1000, 'NEO_DEPLOYMENT_STATE_BRIDGE_STALE_AFTER_MS', 'number'),

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -179,7 +179,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
             operatorPageTarget         : 'AGENT:*'
         },
         deploymentStateBridge: {
-            enabled                     : false,
+            enabled                     : true,
             snapshotPath                : path.resolve(neoRootDir, '.neo-ai-data/deployment-state/snapshot.json'),
             writeIntervalMs             : 30000,
             staleAfterMs                : 2 * 60 * 1000,

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -193,7 +193,7 @@ test.describe('Tier 1 Config Immutability', () => {
         });
 
         expect(Config.orchestrator.deploymentStateBridge).toMatchObject({
-            enabled          : false,
+            enabled          : true,
             snapshotPath     : expect.stringContaining('.neo-ai-data/deployment-state/snapshot.json'),
             writeIntervalMs  : 30000,
             staleAfterMs     : 2 * 60 * 1000,
@@ -204,6 +204,11 @@ test.describe('Tier 1 Config Immutability', () => {
             logMaxBytes      : 32 * 1024,
             statsSampleWindow: 2
         });
+
+        Config.setEnvOverride('NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED', false);
+        expect(Config.orchestrator.deploymentStateBridge.enabled).toBe(false);
+        Config.setEnvOverride('NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED', true);
+        expect(Config.orchestrator.deploymentStateBridge.enabled).toBe(true);
 
         // Provider-readiness probe parameters consumed by the orchestrator dream task
         // + standalone Sandman CLI runner. Values are concrete defaults — no module-level


### PR DESCRIPTION
Resolves #13989

Enables the orchestrator deployment-state bridge writer by default while preserving the explicit `NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED=false` opt-out. This keeps KB/MC as read-only public consumers of the bounded snapshot and removes the hidden extra setup step that left #13936 stuck at `snapshot-missing`.

Evidence: L2 unit/static passed -> L3 required by #13936 after merge/restart because the smoke needs a live orchestrator snapshot through KB/MC public tools.

## Deltas from ticket

No public privileged route was added. The change is limited to the AiConfig default/comment, the canonical default fixture, and the config-template spec.

`ai/config.mjs` was updated locally by the overlay migration context while investigating, but it is ignored and intentionally not part of this PR.

## Test Evidence

- `node --check ai/config.template.mjs`
- `node --check ai/config.mjs`
- `node --check test/playwright/unit/ai/config.template.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs` -> 12 passed.
- `node ai/scripts/lint/lint-config-template-ssot.mjs` -> OK.
- `npm run agent-preflight -- ai/config.template.mjs test/playwright/fixtures/aiConfigDefaults.mjs test/playwright/unit/ai/config.template.spec.mjs` -> passed.
- `git diff --check` and `git diff --cached --check` -> clean.

## Post-Merge Validation

- [ ] Pull `dev`, run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config`, then restart orchestrator and harness.
- [ ] Verify the orchestrator writes `.neo-ai-data/deployment-state/snapshot.json` without setting `NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED=true`.
- [ ] Verify KB and MC `inspect_deployment(staleAfterMs: 600000)` no longer return `snapshot-missing` once the orchestrator has polled.
- [ ] Re-run #13936 KB/MC-only smoke with no private shell, Docker socket, privileged route, or graph-only proof.

## Commits

- `7ca4d63b3e` - `fix(ai): enable deployment-state bridge by default (#13989)`

Related: #13936, #13986.

Authored by Euclid (GPT-5, Codex Desktop). Session 1c4b42c3-289a-4196-bec0-36a3a9f16fa6.