### PR TITLE
fix(core): remove stale staticConfig mutator (#5619)

### DIFF
--- a/src/core/Base.mjs
+++ b/src/core/Base.mjs
@@ -571,8 +571,8 @@ class Base {
     }
 
     /**
-     * Returns the value of a static config key or the staticConfig object itself in case no value is set
-     * @param {String} key The key of a staticConfig defined inside static getStaticConfig
+     * Returns the value of a static constructor property.
+     * @param {String} key The key of a static property on the class constructor.
      * @returns {*}
      */
     getStaticConfig(key) {
@@ -1127,23 +1127,6 @@ class Base {
         });
 
         return config
-    }
-
-    /**
-     * Sets the value of a static config by a given key
-     * @param {String} key The key of a staticConfig defined inside static getStaticConfig
-     * @param {*} value
-     * @returns {Boolean} true in case the config exists and got changed
-     */
-    setStaticConfig(key, value) {
-        let staticConfig = this.constructor.staticConfig;
-
-        if (staticConfig.hasOwnProperty(key)) {
-            staticConfig[key] = value;
-            return true
-        }
-
-        return false
     }
 
     /**

--- a/test/playwright/unit/core/ClassConfigsAndFields.spec.mjs
+++ b/test/playwright/unit/core/ClassConfigsAndFields.spec.mjs
@@ -74,7 +74,7 @@ test.describe('ClassConfigsAndFields', () => {
 
             construct(config) {
                 super.construct(config);
-                let me = this;
+                let me        = this;
                 let extension = me.extension;
                 expect(me.fieldA).toBe(extension ? 3 : 1);
                 expect(me.fieldB).toBe(extension ? 4 : 2);
@@ -164,6 +164,24 @@ test.describe('ClassConfigsAndFields', () => {
         expect(instance.configB).toBe(6); // 2 + 4
         expect(instance.fieldA).toBe(1);
         expect(instance.fieldB).toBe(2);
+    });
+
+    test('Static constructor values remain readable without the retired staticConfig alias (#5619)', () => {
+        class StaticConstructorValueTest extends core.Base {
+            static dockPositions = ['top', 'right', 'bottom', 'left'];
+
+            static config = {
+                className: 'Test.Unit.Core.ClassConfigsAndFields.StaticConstructorValueTest'
+            }
+        }
+
+        StaticConstructorValueTest = Neo.setupClass(StaticConstructorValueTest);
+
+        const instance = Neo.create(StaticConstructorValueTest);
+
+        expect(instance.getStaticConfig('dockPositions')).toEqual(['top', 'right', 'bottom', 'left']);
+        expect(instance.constructor.staticConfig).toBeUndefined();
+        expect(instance.setStaticConfig).toBeUndefined();
     });
 
     test('Instance based class configs and fields', () => {


### PR DESCRIPTION
Resolves #5619

Removes the stale `Base#setStaticConfig()` alias that still expected `constructor.staticConfig`, while `Neo.setupClass()` has long exposed class metadata through `constructor.config` and direct static constructor fields. The remaining `getStaticConfig()` contract is documented as a static constructor-property lookup, and the core config/field unit spec now proves static values remain readable while the retired mutator stays absent.

Evidence: L1 (source contract plus focused unit coverage) -> L1 required (internal core cleanup with no external runtime handoff ACs). No residuals.

## Deltas from ticket
The ticket asked to evaluate whether the `staticConfig` path can be removed. Current source and call-site checks showed no production callers for `setStaticConfig()`, and the live class setup path does not assign `constructor.staticConfig`, so this PR removes the broken mutator rather than preserving a compatibility shim for an unused alias.

## Test Evidence
- `npm run agent-preflight -- src/core/Base.mjs test/playwright/unit/core/ClassConfigsAndFields.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/core/ClassConfigsAndFields.spec.mjs` passed: 8/8.
- `git diff --check` passed.

## Post-Merge Validation
- [ ] Confirm no downstream code relied on `Base#setStaticConfig()` after the method removal lands on `dev`.

## Commits
- `7daed691d9` - remove stale `staticConfig` mutator.

Authored by Euclid (GPT-5, Codex Desktop). Session 1c4b42c3-289a-4196-bec0-36a3a9f16fa6.
