### PR TITLE
docs(learn): add workspace-vs-repository guide (#6777)

### DIFF
--- a/.github/GETTING_STARTED.md
+++ b/.github/GETTING_STARTED.md
@@ -11,6 +11,10 @@ For most use cases, creating a dedicated workspace with `npx neo-app` is the bes
 
 A workspace provides the same structure as the main neo.mjs repository, but includes the framework as an NPM dependency, making it easier to manage.
 
+If you are deciding between a generated workspace and a repository fork, or if
+you need to move an app between the two layouts, read the deeper learning guide:
+**[Workspace or Repository Fork](../learn/gettingstarted/WorkspaceVsRepository.md)**.
+
 ### Create a Workspace
 1.  Open your terminal and navigate to the directory where you want to create your project.
 2.  Run the following command:

--- a/apps/portal/llms.txt
+++ b/apps/portal/llms.txt
@@ -388,6 +388,7 @@ Here you find the full history of Neo.mjs updates.
 ## Gettingstarted
 
 - [Setup](https://neomjs.com/raw/learn/gettingstarted/Setup.md)
+- [Workspace or Repository Fork](https://neomjs.com/raw/learn/gettingstarted/WorkspaceVsRepository.md)
 - [Workspaces and Applications](https://neomjs.com/raw/learn/gettingstarted/Workspaces.md)
 - [Describing a View](https://neomjs.com/raw/learn/gettingstarted/DescribingTheUI.md)
 - [Events](https://neomjs.com/raw/learn/gettingstarted/Events.md)

--- a/apps/portal/sitemap.xml
+++ b/apps/portal/sitemap.xml
@@ -131,8 +131,12 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/gettingstarted/Setup</loc>
-    <lastmod>2025-08-02T12:17:36+02:00</lastmod>
+    <lastmod>2026-06-25T07:27:49Z</lastmod>
     <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://neomjs.com/learn/gettingstarted/WorkspaceVsRepository</loc>
+    <lastmod>2026-06-25T07:27:49Z</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/gettingstarted/Workspaces</loc>

--- a/learn/gettingstarted/Setup.md
+++ b/learn/gettingstarted/Setup.md
@@ -28,6 +28,10 @@ This script automates the entire setup process:
 
 When you're finished, you will have a complete Neo.mjs workspace, as described in the _Workspaces and Applications_ topic, which follows.
 
+If you are not sure whether to use a generated workspace or a repository fork,
+read **[Workspace or Repository Fork](WorkspaceVsRepository.md)** before adding
+application code.
+
 ## Understanding the Four Environments
 
 A unique advantage of Neo.mjs is its support for four distinct environments, allowing you to switch between a rapid, zero-builds development workflow and highly optimized deployment builds. Understanding these environments is key to leveraging the full power of the framework.

--- a/learn/gettingstarted/WorkspaceVsRepository.md
+++ b/learn/gettingstarted/WorkspaceVsRepository.md
@@ -1,0 +1,176 @@
+# Workspace or Repository Fork
+
+Neo.mjs supports two common starting points for application work:
+
+1.  A generated workspace from `npx neo-app@latest`.
+2.  A fork of the `neomjs/neo` repository.
+
+Both can run Neo.mjs applications. The difference is ownership. A workspace is
+your application project with Neo.mjs installed as a dependency. A repository
+fork is a local copy of the framework source, examples, docs, and build
+tooling.
+
+## Choose a workspace for application development
+
+A workspace is the default choice when your goal is to build and ship your own
+app.
+
+Use a workspace when:
+
+-   Your application should live in its own Git repository.
+-   You want to upgrade Neo.mjs through npm instead of merging framework
+    development branches.
+-   Your app-specific code, resources, and themes should stay separate from the
+    framework source.
+-   You do not need to edit Neo.mjs internals or contribute framework patches.
+
+The tradeoff is that the framework source is not the thing you are editing. If
+you need to debug or patch Neo.mjs itself, reproduce the issue in a repository
+fork before opening a framework pull request.
+
+## Choose a repository fork for framework work
+
+A repository fork is the right choice when the framework itself is the target.
+
+Use a fork when:
+
+-   You are contributing to Neo.mjs core classes, build scripts, docs, examples,
+    or tests.
+-   You need the full in-repo example set.
+-   You are debugging behavior that may require framework-source changes.
+-   You want to validate a change against the same layout used by Neo.mjs pull
+    requests.
+
+The tradeoff is ownership pressure. App code placed in the framework repository
+is close to the engine and examples, but it is also living inside the framework
+project. For long-lived product work, move it into a workspace once it no
+longer needs framework-source proximity.
+
+## Build programs work the same way
+
+The build programs are intentionally available from both layouts. Run them from
+the root you are currently working in:
+
+```bash readonly
+npm run server-start
+npm run create-app
+npm run create-app-minimal
+npm run build-all
+npm run build-themes
+```
+
+The commands keep the same names and the same general responsibilities. The
+root changes:
+
+-   In a workspace, the root is your generated workspace directory.
+-   In a repository fork, the root is the `neo` checkout.
+
+This means the same app can move between layouts, but copied code must be
+checked for relative paths. In-repo apps commonly import framework classes from
+the local `src/` tree. Workspace apps commonly import the installed framework
+package under `node_modules/neo.mjs/`. After migration, inspect the app's import
+statements and its `neo-config.json` before assuming the app is portable.
+
+## Move an app from the repository to a workspace
+
+Use this direction when an app started as an in-repo experiment, demo, or
+prototype and is becoming a standalone product.
+
+1.  Create the target workspace:
+
+    ```bash readonly
+    npx neo-app@latest
+    ```
+
+2.  Copy the application folder from the repository into the workspace. For a
+    normal app, this means copying:
+
+    ```text readonly
+    neo/apps/your-app/
+    ```
+
+    to:
+
+    ```text readonly
+    your-workspace/apps/your-app/
+    ```
+
+3.  Copy any app-owned files outside the app folder, preserving their relative
+    paths. Common examples are app-specific assets under `resources/`, custom
+    theme files, local data files, or shared classes that the app owns.
+
+4.  Inspect framework imports. Imports that point into the repository's local
+    `src/` tree need to resolve through the workspace's installed Neo.mjs
+    package instead. Use a freshly generated workspace app as the reference
+    pattern for import roots.
+
+5.  Inspect `apps/your-app/neo-config.json`. Keep the app path and base paths
+    consistent with the new workspace location.
+
+6.  From the workspace root, reinstall and rebuild:
+
+    ```bash readonly
+    npm install
+    npm run build-all
+    ```
+
+7.  Start the workspace server and open the moved app:
+
+    ```bash readonly
+    npm run server-start
+    ```
+
+If the app only works in development mode, run the relevant dist build before
+calling the migration complete. Path issues often show up first in dist output.
+
+## Move an app from a workspace to the repository
+
+Use this direction when workspace app code has become framework documentation,
+an example, or a reproduction for a Neo.mjs pull request.
+
+1.  Fork and clone the repository, then create a branch for the migration.
+
+2.  Choose the destination deliberately:
+
+    -   Use `apps/` for a full application that belongs in the repository app
+        set.
+    -   Use `examples/` for a focused example that demonstrates one concept,
+        component, or behavior.
+
+3.  Copy the application folder into the chosen destination.
+
+4.  Copy app-owned resources and theme files into the matching repository
+    paths. Do not copy the generated workspace's installed dependency tree or
+    package lock as part of an app migration.
+
+5.  Inspect imports in the copied files. Workspace imports that point into
+    `node_modules/neo.mjs/src/` usually need to point at the repository's local
+    `src/` tree after the move.
+
+6.  Inspect `neo-config.json` for the app's new depth. A path that was correct
+    under `workspace/apps/your-app/` may be wrong under
+    `neo/examples/some/category/your-app/`.
+
+7.  From the repository root, install and build:
+
+    ```bash readonly
+    npm install
+    npm run build-all
+    ```
+
+8.  Run the local server and verify the app in development mode and the dist
+    environment that the pull request affects:
+
+    ```bash readonly
+    npm run server-start
+    ```
+
+For pull requests, include the exact app URL and build command you verified in
+the PR body. That gives reviewers a reproducible path through the migrated
+layout.
+
+## Practical rule
+
+Start in a workspace unless you know you are changing Neo.mjs itself. Move into
+a fork when the app becomes a framework contribution. Move back out when the app
+becomes product code again.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -22,6 +22,7 @@
         {"name": "Features and Benefits Summary",                      "parentId": "Benefits",                                            "id": "benefits/Features"},
     {"name": "Getting Started",                                        "parentId": null,                                 "isLeaf": false, "id": "GettingStarted"},
         {"name": "Setup",                                              "parentId": "GettingStarted",                                      "id": "gettingstarted/Setup"},
+        {"name": "Workspace or Repository Fork",                       "parentId": "GettingStarted",                                      "id": "gettingstarted/WorkspaceVsRepository"},
         {"name": "Workspaces and Applications",                        "parentId": "GettingStarted",                                      "id": "gettingstarted/Workspaces"},
         {"name": "Describing a View",                                  "parentId": "GettingStarted",                                      "id": "gettingstarted/DescribingTheUI"},
         {"name": "Events",                                             "parentId": "GettingStarted",                                      "id": "gettingstarted/Events"},


### PR DESCRIPTION
Resolves #6777

Adds a Getting Started learning guide that explains when to build in a generated `npx neo-app` workspace versus a `neomjs/neo` repository fork, documents that the build programs keep the same command surface in both layouts, and gives migration checklists for moving an app in both directions.

Evidence: L1 (static docs/tree lint) -> L1 required (docs-only close target). Residual: none.

## Deltas from ticket

The implementation places the deeper guide under `learn/gettingstarted/WorkspaceVsRepository.md`, registers it in `learn/tree.json`, links it from `.github/GETTING_STARTED.md` and `learn/gettingstarted/Setup.md`, and regenerates the checked-in Portal SEO outputs that mirror learn routes.

## Test Evidence

- `git diff --cached --check`
- `npm run ai:lint-tree-json`
- `rg -n "WorkspaceVsRepository|Workspace or Repository Fork" learn apps/portal/llms.txt apps/portal/sitemap.xml .github/GETTING_STARTED.md`

## Post-Merge Validation

- [ ] Open `/learn/gettingstarted/WorkspaceVsRepository` in the Portal app and verify it renders under Getting Started.

## Commit

- `a8b0101af6` - `docs(learn): add workspace-vs-repository guide (#6777)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019efd84-2ba3-7441-9ce6-04896f1c5cb9.
