### PR TITLE
fix(ai): bound topology REM logs (#13995)

### DIFF
--- a/ai/mcp/server/shared/logger.mjs
+++ b/ai/mcp/server/shared/logger.mjs
@@ -348,6 +348,7 @@ const getConfiguredLogLevel = (aiConfig, loggerConfig) => {
  * - workflow servers: priority-filtered stderr only (`stderrMode: "threshold"`)
  * - KB / Memory Core: always-on file sink plus debug-gated stderr
  * - Neural Link: always-on file sink plus tier-gated stderr
+ * - file-only diagnostics: `fileDebug()` writes durable debug entries without touching stderr
  *
  * The logger never writes to stdout. `error()` logs and never throws.
  *
@@ -426,6 +427,8 @@ export const createLogger = (aiConfig = {}, fallbackLoggerConfig = {}) => {
         const loggerConfig = getLoggerConfig(aiConfig, fallbackLoggerConfig);
 
         writeFile(level, args, loggerConfig);
+        if (options.fileOnly) return;
+
         writeStderr(level, args, options.forceStderr ? {
             ...loggerConfig,
             ...FATAL_STARTUP_LOGGER_CONFIG
@@ -436,6 +439,7 @@ export const createLogger = (aiConfig = {}, fallbackLoggerConfig = {}) => {
         debug       : createLogMethod('debug'),
         error       : createLogMethod('error'),
         fatalStartup: createLogMethod('error', {forceStderr: true}),
+        fileDebug   : createLogMethod('debug', {fileOnly: true}),
         info        : createLogMethod('info'),
         log         : createLogMethod('log'),
         warn        : createLogMethod('warn')

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -41,24 +41,37 @@ function estimateTopologyTokens(text) {
     return bytesToTokens(Buffer.byteLength(text === undefined || text === null ? '' : String(text), 'utf8'));
 }
 
-function readRequiredChatNumberLeaf(leafName) {
-    const value = aiConfig.localModels.chat[leafName];
-
-    if (!Number.isFinite(value)) {
-        throw new Error(`[TopologyInferenceEngine] Required AiConfig leaf "localModels.chat.${leafName}" is missing or invalid. Update ai/mcp/server/memory-core/config.mjs from config.template.mjs.`);
+function assertRequiredChatNumber(value, configPath) {
+    if (!Number.isFinite(value) || value <= 0) {
+        throw new Error(`[TopologyInferenceEngine] Required AiConfig leaf "${configPath}" is missing or invalid. Update ai/mcp/server/memory-core/config.mjs from config.template.mjs.`);
     }
 
     return value;
 }
 
-function readRequiredChatStringLeaf(leafName) {
-    const value = aiConfig.localModels.chat[leafName];
-
+function assertRequiredChatString(value, configPath) {
     if (typeof value !== 'string') {
-        throw new Error(`[TopologyInferenceEngine] Required AiConfig leaf "localModels.chat.${leafName}" is missing or invalid. Update ai/mcp/server/memory-core/config.mjs from config.template.mjs.`);
+        throw new Error(`[TopologyInferenceEngine] Required AiConfig leaf "${configPath}" is missing or invalid. Update ai/mcp/server/memory-core/config.mjs from config.template.mjs.`);
     }
 
     return value;
+}
+
+function getCompletionFinishReason(result) {
+    return result?.finish_reason ||
+        result?.finishReason ||
+        result?.raw?.finish_reason ||
+        result?.raw?.finishReason ||
+        result?.raw?.choices?.[0]?.finish_reason ||
+        result?.raw?.choices?.[0]?.finishReason ||
+        result?.raw?.done_reason ||
+        result?.raw?.doneReason ||
+        '';
+}
+
+function isLengthTruncatedCompletion(finishReason) {
+    return ['length', 'max_tokens', 'max_completion_tokens', 'num_predict', 'token_limit']
+        .includes(String(finishReason || '').toLowerCase());
 }
 
 /**
@@ -192,7 +205,7 @@ ${contextText}
     }
 
     /**
-     * @summary Creates deterministic turn chunks after subtracting topology prompt overhead.
+     * @summary Creates deterministic turn chunks after reserving topology output and prompt overhead.
      * @param {String[]} turnDocuments Complete raw memory turn documents.
      * @param {String} sessionId Source session id.
      * @returns {{chunked: Boolean, totalEstimatedTokens: Number, chunks: Object[]}}
@@ -204,7 +217,19 @@ ${contextText}
                   chunkCount : 1,
                   turnIndices: []
               })),
-              chunkBudget    = Math.max(1, readRequiredChatNumberLeaf('safeProcessingLimitTokens') - envelopeTokens);
+              {
+                  contextLimitTokens,
+                  safeProcessingLimitTokens,
+                  graphChunkLimitTokens,
+                  graphOutputLimitTokens
+              } = aiConfig.localModels.chat,
+              promptBudget   = Math.min(
+                  assertRequiredChatNumber(graphChunkLimitTokens, 'localModels.chat.graphChunkLimitTokens'),
+                  assertRequiredChatNumber(safeProcessingLimitTokens, 'localModels.chat.safeProcessingLimitTokens'),
+                  assertRequiredChatNumber(contextLimitTokens, 'localModels.chat.contextLimitTokens') -
+                      assertRequiredChatNumber(graphOutputLimitTokens, 'localModels.chat.graphOutputLimitTokens')
+              ),
+              chunkBudget    = Math.max(1, promptBudget - envelopeTokens);
 
         return chunkSession(turnDocuments, {
             sessionId,
@@ -219,10 +244,11 @@ ${contextText}
      */
     getTopologyProviderOptions() {
         return {
-            reasoning_effort    : readRequiredChatStringLeaf('graphReasoningEffort'),
+            reasoning_effort    : assertRequiredChatString(aiConfig.localModels.chat.graphReasoningEffort, 'localModels.chat.graphReasoningEffort'),
             responseSchema      : topologyConflictSchema,
             responseSchemaName  : 'topologyConflicts',
-            responseSchemaStrict: true
+            responseSchemaStrict: true,
+            maxCompletionTokens : assertRequiredChatNumber(aiConfig.localModels.chat.graphOutputLimitTokens, 'localModels.chat.graphOutputLimitTokens')
         }
     }
 
@@ -251,12 +277,14 @@ ${contextText}
                 openAiCompatibleConfig: aiConfig.openAiCompatible
             }),
                   consumerModel         = aiConfig[graphProvider].model,
-                  consumerContextTokens = readRequiredChatNumberLeaf('contextLimitTokens'),
-                  consumerSafeTokens    = readRequiredChatNumberLeaf('safeProcessingLimitTokens'),
+                  consumerContextTokens = assertRequiredChatNumber(aiConfig.localModels.chat.contextLimitTokens, 'localModels.chat.contextLimitTokens'),
+                  consumerSafeTokens    = assertRequiredChatNumber(aiConfig.localModels.chat.safeProcessingLimitTokens, 'localModels.chat.safeProcessingLimitTokens'),
+                  outputLimitTokens     = assertRequiredChatNumber(aiConfig.localModels.chat.graphOutputLimitTokens, 'localModels.chat.graphOutputLimitTokens'),
                   providerOptions       = this.getTopologyProviderOptions(),
                   conflicts             = [];
 
-            let skippedChunks = 0;
+            let parseFailedChunks = 0,
+                skippedChunks     = 0;
 
             for (let index = 0; index < chunkPlan.chunks.length; index++) {
                 const chunk  = chunkPlan.chunks[index],
@@ -265,10 +293,41 @@ ${contextText}
                           index,
                           chunkCount : chunkPlan.chunks.length,
                           turnIndices: chunk.turnIndices
-                      });
+                      }),
+                      promptBytes          = Buffer.byteLength(prompt, 'utf8'),
+                      promptTokensEstimate = estimateTopologyTokens(prompt),
+                      promptPlusOutput     = promptTokensEstimate + outputLimitTokens,
+                      chunkLabel           = `${index + 1}/${chunkPlan.chunks.length}`;
+
+                if (promptPlusOutput > consumerContextTokens) {
+                    logger.warn(
+                        `[TopologyInferenceEngine] Chunk ${chunkLabel} for session ${sessionId} exceeds context cap before dispatch: ` +
+                        `promptTokens=${promptTokensEstimate} outputLimitTokens=${outputLimitTokens} contextLimitTokens=${consumerContextTokens}.`
+                    );
+
+                    emitConsumerFriction({
+                        symptom                  : 'context-overflow',
+                        consumer                 : 'TopologyInferenceEngine',
+                        model                    : consumerModel,
+                        assetRef                 : chunk.chunkId,
+                        serviceDomain            : 'dream-pipeline',
+                        emissionPoint            : 'pre-invocation',
+                        inputBytes               : promptBytes,
+                        inputTokensEstimate      : promptPlusOutput,
+                        contextLimitTokens       : consumerContextTokens,
+                        safeProcessingLimitTokens: consumerSafeTokens,
+                        note                     : `Topology prompt estimate ${promptTokensEstimate} plus output reserve ${outputLimitTokens} exceeds context cap ${consumerContextTokens}. Chunk ${chunkLabel}.`
+                    });
+
+                    skippedChunks++;
+                    continue;
+                }
 
                 const guardrailed = await invokeWithGuardrail({
-                    invocationFn             : () => provider.generate(prompt, providerOptions),
+                    invocationFn             : () => provider.generate(prompt, {
+                        ...providerOptions,
+                        operationLabel: `REM topology ${sessionId} chunk ${chunkLabel}`
+                    }),
                     inputPayload             : prompt,
                     model                    : consumerModel,
                     assetRef                 : chunk.chunkId,
@@ -281,19 +340,16 @@ ${contextText}
 
                 if (!guardrailed.result) {
                     skippedChunks++;
-                    logger.warn(`[TopologyInferenceEngine] Chunk ${index + 1}/${chunkPlan.chunks.length} for session ${sessionId} skipped by ${guardrailed.friction?.symptom || 'guardrail'}.`);
+                    logger.warn(`[TopologyInferenceEngine] Chunk ${chunkLabel} for session ${sessionId} skipped by ${guardrailed.friction?.symptom || 'guardrail'}.`);
                     continue;
                 }
 
-                const result = guardrailed.result;
+                const result       = guardrailed.result;
+                const finishReason = getCompletionFinishReason(result),
+                      responseChars = String(result.content || '').length;
 
-                // Silent context-overflow detection (parallel single-attempt path): empty
-                // result.content with no thrown error is the LM Studio loaded-context-cap
-                // signature (ttftMs===ttltMs, outputChars===0). Emit the deterministic
-                // `'context-overflow'` symptom (auto-surfaces) and continue with the next
-                // turn-aligned chunk instead of retry-amplifying the same prompt.
-                if (!result?.content || result.content.trim() === '') {
-                    logger.warn(`[TopologyInferenceEngine] Empty response from provider for session ${sessionId} chunk ${index + 1}/${chunkPlan.chunks.length}; classifying as context-overflow (silent: no thrown error, no body).`);
+                if (isLengthTruncatedCompletion(finishReason)) {
+                    logger.warn(`[TopologyInferenceEngine] Provider reported finish_reason='${finishReason}' for session ${sessionId} chunk ${chunkLabel}; classifying as context-overflow before parsing.`);
 
                     emitConsumerFriction({
                         symptom                  : 'context-overflow',
@@ -302,11 +358,37 @@ ${contextText}
                         assetRef                 : chunk.chunkId,
                         serviceDomain            : 'dream-pipeline',
                         emissionPoint            : 'post-invocation-failure',
-                        inputBytes               : Buffer.byteLength(prompt, 'utf8'),
-                        inputTokensEstimate      : estimateTopologyTokens(prompt),
+                        inputBytes               : promptBytes,
+                        inputTokensEstimate      : promptTokensEstimate,
                         contextLimitTokens       : consumerContextTokens,
                         safeProcessingLimitTokens: consumerSafeTokens,
-                        note                     : `Silent empty-response from provider (no thrown error, no body). Chunk ${index + 1}/${chunkPlan.chunks.length}; prompt chars: ${prompt.length}.`
+                        note                     : `Topology provider finish_reason='${finishReason}' before schema validation. Chunk ${chunkLabel}; responseChars=${responseChars}; outputLimitTokens=${outputLimitTokens}.`
+                    });
+
+                    skippedChunks++;
+                    continue;
+                }
+
+                // Silent context-overflow detection (parallel single-attempt path): empty
+                // result.content with no thrown error is the LM Studio loaded-context-cap
+                // signature (ttftMs===ttltMs, outputChars===0). Emit the deterministic
+                // `'context-overflow'` symptom (auto-surfaces) and continue with the next
+                // turn-aligned chunk instead of retry-amplifying the same prompt.
+                if (!result?.content || result.content.trim() === '') {
+                    logger.warn(`[TopologyInferenceEngine] Empty response from provider for session ${sessionId} chunk ${chunkLabel}; classifying as context-overflow (silent: no thrown error, no body).`);
+
+                    emitConsumerFriction({
+                        symptom                  : 'context-overflow',
+                        consumer                 : 'TopologyInferenceEngine',
+                        model                    : consumerModel,
+                        assetRef                 : chunk.chunkId,
+                        serviceDomain            : 'dream-pipeline',
+                        emissionPoint            : 'post-invocation-failure',
+                        inputBytes               : promptBytes,
+                        inputTokensEstimate      : promptTokensEstimate,
+                        contextLimitTokens       : consumerContextTokens,
+                        safeProcessingLimitTokens: consumerSafeTokens,
+                        note                     : `Silent empty-response from provider (no thrown error, no body). Chunk ${chunkLabel}; prompt chars: ${prompt.length}; outputLimitTokens=${outputLimitTokens}.`
                     });
 
                     skippedChunks++;
@@ -314,18 +396,53 @@ ${contextText}
                 }
 
                 const payload = Json.extract(result.content);
-                if (payload && Array.isArray(payload.conflicts) && payload.conflicts.length > 0) {
+                if (!payload || !Array.isArray(payload.conflicts)) {
+                    parseFailedChunks++;
+                    logger.warn(`[TopologyInferenceEngine] Failed to parse topology-conflict payload for session ${sessionId} chunk ${chunkLabel}; responseChars=${responseChars}; finishReason=${finishReason || 'unknown'}.`);
+
+                    emitConsumerFriction({
+                        symptom                  : 'parse-failure',
+                        consumer                 : 'TopologyInferenceEngine',
+                        model                    : consumerModel,
+                        assetRef                 : chunk.chunkId,
+                        serviceDomain            : 'dream-pipeline',
+                        emissionPoint            : 'post-invocation-failure',
+                        suggestionKind           : 'schema-repair',
+                        inputBytes               : promptBytes,
+                        inputTokensEstimate      : promptTokensEstimate,
+                        contextLimitTokens       : consumerContextTokens,
+                        safeProcessingLimitTokens: consumerSafeTokens,
+                        note                     : `Topology response did not match {conflicts:Array}. Chunk ${chunkLabel}; responseChars=${responseChars}; finishReason=${finishReason || 'unknown'}; outputLimitTokens=${outputLimitTokens}.`
+                    });
+
+                    continue;
+                }
+
+                logger.info(
+                    `[TopologyInferenceEngine] Topology chunk ${chunkLabel} for session ${sessionId} completed: ` +
+                    `conflicts=${payload.conflicts.length} responseChars=${responseChars} ` +
+                    `finishReason=${finishReason || 'unknown'} outputLimitTokens=${outputLimitTokens}.`
+                );
+
+                if (payload.conflicts.length > 0) {
                     conflicts.push(...payload.conflicts.slice(0, topologyConflictRenderLimit));
                 }
             }
 
             if (conflicts.length === 0) {
+                logger.info(
+                    `[TopologyInferenceEngine] Topology extraction completed for session ${sessionId}: ` +
+                    `conflicts=0 processed=${chunkPlan.chunks.length - skippedChunks - parseFailedChunks}/${chunkPlan.chunks.length} ` +
+                    `skipped=${skippedChunks} parseFailed=${parseFailedChunks} outputLimitTokens=${outputLimitTokens}.`
+                );
+
                 return {
                     chunked: chunkPlan.chunked,
                     chunks : {
-                        total    : chunkPlan.chunks.length,
-                        skipped  : skippedChunks,
-                        processed: chunkPlan.chunks.length - skippedChunks
+                        total      : chunkPlan.chunks.length,
+                        skipped    : skippedChunks,
+                        parseFailed: parseFailedChunks,
+                        processed  : chunkPlan.chunks.length - skippedChunks - parseFailedChunks
                     },
                     conflictCount: 0
                 }
@@ -354,9 +471,10 @@ ${contextText}
             return {
                 chunked: chunkPlan.chunked,
                 chunks : {
-                    total    : chunkPlan.chunks.length,
-                    skipped  : skippedChunks,
-                    processed: chunkPlan.chunks.length - skippedChunks
+                    total      : chunkPlan.chunks.length,
+                    skipped    : skippedChunks,
+                    parseFailed: parseFailedChunks,
+                    processed  : chunkPlan.chunks.length - skippedChunks - parseFailedChunks
                 },
                 conflictCount: conflicts.length
             }

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1611,7 +1611,7 @@ class HealthService extends Base {
                 // If the cache is still fresh (< 5 minutes old), reuse it while keeping
                 // direct healthcheck observability request-fresh when requested.
                 if (age < this.#cacheDuration) {
-                    logger.debug(`[HealthService] Using cached health status (age: ${Math.round(age / 1000)}s)`);
+                    logger.fileDebug(`[HealthService] Using cached health status (age: ${Math.round(age / 1000)}s)`);
 
                     if (!freshObservability) {
                         return this.#cachedHealth;
@@ -1632,12 +1632,12 @@ class HealthService extends Base {
 
             // Check for in-flight request (deduplication)
             if (this.#healthCheckPromise) {
-                logger.debug('[HealthService] Joining in-flight health check...');
+                logger.fileDebug('[HealthService] Joining in-flight health check...');
                 return await this.#healthCheckPromise;
             }
 
             // Cache is stale, was unhealthy, or doesn't exist - perform a fresh check
-            logger.debug('[HealthService] Performing fresh health check');
+            logger.fileDebug('[HealthService] Performing fresh health check');
 
             // Create the promise and store it
             this.#healthCheckPromise = this.#performHealthCheck({
@@ -1825,13 +1825,15 @@ class HealthService extends Base {
      * Intent: This is primarily useful for testing and debugging scenarios where
      * you need to immediately verify a fix (e.g., after starting ChromaDB)
      * without waiting for the 5-minute cache to expire.
+     * The routine invalidation notice is durable-file-only so diagnostic churn
+     * does not flood developer-facing console streams.
      */
     clearCache() {
         this.#cachedHealth                = null;
         this.#lastCheckTime               = null;
         this.#embeddingWriteCanaryCache   = null;
         this.#runtimeFreshnessTracker.clearCache();
-        logger.debug('[HealthService] Cache cleared, next health check will be fresh');
+        logger.fileDebug('[HealthService] Cache cleared, next health check will be fresh');
     }
 }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -1286,21 +1286,28 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         const orig = {
             graphProvider : aiConfig.graphProvider,
             chatContext   : aiConfig.localModels.chat.contextLimitTokens,
+            chatGraphChunk: aiConfig.localModels.chat.graphChunkLimitTokens,
+            chatGraphOut  : aiConfig.localModels.chat.graphOutputLimitTokens,
             chatSafe      : aiConfig.localModels.chat.safeProcessingLimitTokens,
             graphReasoning: aiConfig.localModels.chat.graphReasoningEffort,
             openAiModel   : aiConfig.openAiCompatible.model,
-            generate      : OpenAiCompatible.prototype.generate
+            generate      : OpenAiCompatible.prototype.generate,
+            loggerInfo    : logger.info
         };
+        const infoCalls = [];
 
         try {
             aiConfig.graphProvider                                = 'openAiCompatible';
             aiConfig.openAiCompatible.model                       = 'topology-test-model';
             aiConfig.localModels.chat.contextLimitTokens          = 8192;
+            aiConfig.localModels.chat.graphChunkLimitTokens       = 4800;
+            aiConfig.localModels.chat.graphOutputLimitTokens      = 512;
             aiConfig.localModels.chat.safeProcessingLimitTokens   = 5000;
             aiConfig.localModels.chat.graphReasoningEffort        = 'none';
+            logger.info = (...args) => infoCalls.push(args.join(' '));
             OpenAiCompatible.prototype.generate = async (prompt, providerOptions) => {
                 providerCalls.push({prompt, providerOptions});
-                return {content: '{"conflicts":[]}'};
+                return {content: '{"conflicts":[]}', finish_reason: 'stop'};
             };
 
             const result = await TopologyInferenceEngine.extractTopology(
@@ -1318,16 +1325,90 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             expect(providerCalls[0].providerOptions).toMatchObject({
                 reasoning_effort    : 'none',
                 responseSchemaName  : 'topologyConflicts',
-                responseSchemaStrict: true
+                responseSchemaStrict: true,
+                maxCompletionTokens : 512
             });
             expect(providerCalls[0].providerOptions.responseSchema.properties.conflicts.maxItems).toBe(5);
+            expect(infoCalls.some(line => line.includes('conflicts=0') && line.includes('outputLimitTokens=512'))).toBe(true);
         } finally {
             aiConfig.graphProvider                              = orig.graphProvider;
             aiConfig.localModels.chat.contextLimitTokens        = orig.chatContext;
+            aiConfig.localModels.chat.graphChunkLimitTokens     = orig.chatGraphChunk;
+            aiConfig.localModels.chat.graphOutputLimitTokens    = orig.chatGraphOut;
             aiConfig.localModels.chat.safeProcessingLimitTokens = orig.chatSafe;
             aiConfig.localModels.chat.graphReasoningEffort      = orig.graphReasoning;
             aiConfig.openAiCompatible.model                     = orig.openAiModel;
             OpenAiCompatible.prototype.generate                 = orig.generate;
+            logger.info                                         = orig.loggerInfo;
+        }
+    });
+
+    test('TopologyInferenceEngine classifies non-empty invalid topology output as parse failure (#13995)', async () => {
+        const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const TopologyInferenceEngine = (await import('../../../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
+        const {
+            clearAggregatedFrictions,
+            getAggregatedFrictions
+        } = await import('../../../../../../../ai/services/memory-core/helpers/consumerFrictionHelper.mjs');
+
+        const orig = {
+            graphProvider : aiConfig.graphProvider,
+            chatContext   : aiConfig.localModels.chat.contextLimitTokens,
+            chatGraphChunk: aiConfig.localModels.chat.graphChunkLimitTokens,
+            chatGraphOut  : aiConfig.localModels.chat.graphOutputLimitTokens,
+            chatSafe      : aiConfig.localModels.chat.safeProcessingLimitTokens,
+            graphReasoning: aiConfig.localModels.chat.graphReasoningEffort,
+            openAiModel   : aiConfig.openAiCompatible.model,
+            generate      : OpenAiCompatible.prototype.generate,
+            loggerWarn    : logger.warn
+        };
+        const warnCalls = [];
+
+        try {
+            clearAggregatedFrictions();
+
+            aiConfig.graphProvider                              = 'openAiCompatible';
+            aiConfig.openAiCompatible.model                     = 'topology-parse-test-model';
+            aiConfig.localModels.chat.contextLimitTokens        = 8192;
+            aiConfig.localModels.chat.graphChunkLimitTokens     = 4800;
+            aiConfig.localModels.chat.graphOutputLimitTokens    = 512;
+            aiConfig.localModels.chat.safeProcessingLimitTokens = 5000;
+            aiConfig.localModels.chat.graphReasoningEffort      = 'none';
+            logger.warn = (...args) => warnCalls.push(args.join(' '));
+            OpenAiCompatible.prototype.generate = async () => ({
+                content      : 'this is not json',
+                finish_reason: 'stop'
+            });
+
+            for (let i = 0; i < 3; i++) {
+                const result = await TopologyInferenceEngine.extractTopology(
+                    'turn body',
+                    'topology-parse-failure-test',
+                    {turnDocuments: ['turn body']}
+                );
+
+                expect(result.conflictCount).toBe(0);
+                expect(result.chunks.parseFailed).toBe(1);
+                expect(result.chunks.processed).toBe(0);
+            }
+
+            expect(warnCalls.some(line => line.includes('Failed to parse topology-conflict payload'))).toBe(true);
+            expect(getAggregatedFrictions().some(friction =>
+                friction.consumer === 'TopologyInferenceEngine' &&
+                friction.symptom === 'parse-failure' &&
+                friction.model === 'topology-parse-test-model'
+            )).toBe(true);
+        } finally {
+            clearAggregatedFrictions();
+            aiConfig.graphProvider                              = orig.graphProvider;
+            aiConfig.localModels.chat.contextLimitTokens        = orig.chatContext;
+            aiConfig.localModels.chat.graphChunkLimitTokens     = orig.chatGraphChunk;
+            aiConfig.localModels.chat.graphOutputLimitTokens    = orig.chatGraphOut;
+            aiConfig.localModels.chat.safeProcessingLimitTokens = orig.chatSafe;
+            aiConfig.localModels.chat.graphReasoningEffort      = orig.graphReasoning;
+            aiConfig.openAiCompatible.model                     = orig.openAiModel;
+            OpenAiCompatible.prototype.generate                 = orig.generate;
+            logger.warn                                         = orig.loggerWarn;
         }
     });
 

--- a/test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs
@@ -177,7 +177,7 @@ test.describe('Neo.ai.mcp.server.shared.Logger', () => {
 
             expect(typeof logger.flush).toBe('function');
 
-            const today    = new Date().toISOString().slice(0, 10);
+            const today = new Date().toISOString().slice(0, 10);
             const expected = path.join(tmpLogDir, `shared-test-${today}.log`);
             const err      = new Error('shared logger failure');
             const circular = {};
@@ -200,12 +200,59 @@ test.describe('Neo.ai.mcp.server.shared.Logger', () => {
         }
     });
 
+    test('writes file-only diagnostics without touching console or stderr (#13995)', async () => {
+        const tmpLogDir    = path.resolve(os.tmpdir(), `shared-logger-file-debug-${process.pid}-${Date.now()}`);
+        const stderrCalls  = [];
+        const stderrWrites = [];
+        const stdoutCalls  = [];
+
+        console.error = (...args) => stderrCalls.push(args);
+        process.stderr.write = value => {
+            stderrWrites.push(String(value));
+            return true;
+        };
+        process.stdout.write = (...args) => {
+            stdoutCalls.push(args);
+            return true;
+        };
+
+        try {
+            const logger = createLogger({
+                debug  : true,
+                logPath: tmpLogDir,
+                logger : {
+                    filePrefix    : 'shared-test',
+                    fileSink      : true,
+                    flush         : true,
+                    stderrMode    : 'debug',
+                    timestampStyle: 'plain'
+                }
+            });
+
+            logger.fileDebug('file-only-diagnostic');
+            await logger.flush();
+
+            const today = new Date().toISOString().slice(0, 10);
+            const expected = path.join(tmpLogDir, `shared-test-${today}.log`);
+            const content = fs.readFileSync(expected, 'utf8');
+
+            expect(content).toContain('[DEBUG] file-only-diagnostic');
+            expect(stderrCalls).toHaveLength(0);
+            expect(stderrWrites).toHaveLength(0);
+            expect(stdoutCalls).toHaveLength(0);
+        } finally {
+            if (fs.existsSync(tmpLogDir)) {
+                fs.rmSync(tmpLogDir, {recursive: true, force: true});
+            }
+        }
+    });
+
     test('prunes old matching file logs while preserving active and unrelated files', async () => {
         const tmpLogDir = path.resolve(os.tmpdir(), `shared-logger-retention-${process.pid}-${Date.now()}`);
-        const today     = dayStamp(0);
-        const keepDay   = dayStamp(1);
-        const oldDay    = dayStamp(2);
-        const olderDay  = dayStamp(3);
+        const today    = dayStamp(0);
+        const keepDay  = dayStamp(1);
+        const oldDay   = dayStamp(2);
+        const olderDay = dayStamp(3);
 
         try {
             fs.ensureDirSync(tmpLogDir);
@@ -365,7 +412,7 @@ test.describe('Neo.ai.mcp.server.shared.Logger', () => {
 
     test('turns retention prune failures into bounded warnings', () => {
         const warnings = [];
-        const count = pruneLoggerRetention({
+        const count    = pruneLoggerRetention({
             logDir      : '/tmp',
             filePrefix  : 'shared-test',
             today       : '2026-06-18',

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -13,14 +13,15 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../../../src/manager/Instance.mjs';
-import AiConfig        from '../../../../../../ai/config.mjs';
-import ChromaManager   from '../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
-import StorageRouter   from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
+import {test, expect}         from '@playwright/test';
+import Neo                    from '../../../../../../src/Neo.mjs';
+import * as core              from '../../../../../../src/core/_export.mjs';
+import InstanceManager        from '../../../../../../src/manager/Instance.mjs';
+import AiConfig               from '../../../../../../ai/config.mjs';
+import ChromaManager          from '../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
+import StorageRouter          from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
 import ChromaLifecycleService from '../../../../../../ai/services/memory-core/lifecycle/ChromaLifecycleService.mjs';
+import logger                 from '../../../../../../ai/mcp/server/memory-core/logger.mjs';
 
 /**
  * @summary Coverage for the identity observability block in the healthcheck payload.
@@ -195,6 +196,27 @@ test.describe('HealthService #13312 — startup dependency observability', () =>
             expect(HealthService.getStartupDependencyState()[dependencyName].status).toBe('degraded');
         } finally {
             HealthService.clearStartupDependencyState();
+        }
+    });
+
+    test('clearCache writes file-only diagnostics without console debug spam (#13995)', () => {
+        const originalDebug     = logger.debug,
+              originalFileDebug = logger.fileDebug,
+              debugCalls        = [],
+              fileDebugCalls    = [];
+
+        logger.debug     = (...args) => debugCalls.push(args);
+        logger.fileDebug = (...args) => fileDebugCalls.push(args);
+
+        try {
+            HealthService.clearCache();
+
+            expect(debugCalls).toHaveLength(0);
+            expect(fileDebugCalls).toHaveLength(1);
+            expect(fileDebugCalls[0][0]).toContain('Cache cleared');
+        } finally {
+            logger.debug     = originalDebug;
+            logger.fileDebug = originalFileDebug;
         }
     });
 });
@@ -375,13 +397,13 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         const summaryCollection = makeCollection(() => summaryCount);
 
         originals = {
-            chromaConnected         : ChromaManager.connected,
-            chromaReady             : ChromaManager.ready,
-            chromaConnect           : ChromaManager.connect,
+            chromaConnected          : ChromaManager.connected,
+            chromaReady              : ChromaManager.ready,
+            chromaConnect            : ChromaManager.connect,
             invalidateCollectionCache: ChromaManager.invalidateCollectionCache,
-            getMemoryCollection     : StorageRouter.getMemoryCollection,
-            getSummaryCollection    : StorageRouter.getSummaryCollection,
-            getDatabaseStatus       : ChromaLifecycleService.getDatabaseStatus
+            getMemoryCollection      : StorageRouter.getMemoryCollection,
+            getSummaryCollection     : StorageRouter.getSummaryCollection,
+            getDatabaseStatus        : ChromaLifecycleService.getDatabaseStatus
         };
 
         ChromaManager.connected = true;
@@ -579,9 +601,9 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
 
         expect(result.status).toBe('degraded');
         expect(result.identity).toMatchObject({
-            source : 'env-var',
-            bound  : false,
-            nodeId : null
+            source: 'env-var',
+            bound : false,
+            nodeId: null
         });
         expect(result.identity.warning).toContain("NEO_AGENT_IDENTITY is pinned to 'neo-opus-grace'");
         expect(result.details).toContain(`WARN: ${result.identity.warning}`);
@@ -607,7 +629,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
     });
 
     test('#13466: memory count stale handle invalidates and retries once', async () => {
-        let memoryReads = 0;
+        let   memoryReads = 0;
         const invalidated = [];
 
         ChromaManager.invalidateCollectionCache = type => invalidated.push(type);
@@ -639,8 +661,8 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
     });
 
     test('#13466: summary count stale handle invalidates and retries once', async () => {
-        let summaryReads = 0;
-        const invalidated = [];
+        let   summaryReads = 0;
+        const invalidated  = [];
 
         ChromaManager.invalidateCollectionCache = type => invalidated.push(type);
         StorageRouter.getSummaryCollection = async () => {
@@ -883,7 +905,7 @@ test.describe('HealthService #10723/#10773/#10804 — buildEmbeddingProviderBloc
 
     test('dimensions fields always reflect vectorDimension regardless of provider', () => {
         for (const provider of ['gemini', 'openAiCompatible', 'ollama', 'unrecognized']) {
-            const cfg = {embeddingProvider: provider, vectorDimension: 768};
+            const cfg    = {embeddingProvider: provider, vectorDimension: 768};
             const result = buildEmbeddingProviderBlock(cfg);
             expect(result.dimensions).toBe(768);
         }
@@ -907,8 +929,8 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
     });
 
     test('reports healthy when the active provider returns a vector', async () => {
-        let nowCalls = 0;
-        const result = await buildEmbeddingWriteCanaryBlock({
+        let   nowCalls = 0;
+        const result   = await buildEmbeddingWriteCanaryBlock({
             cfg: {
                 embeddingProvider: 'openAiCompatible',
                 vectorDimension  : 3
@@ -959,7 +981,7 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
                 vectorDimension  : 4096
             },
             embedText: async () => new Promise(() => {}),
-            now: () => 100,
+            now      : () => 100,
             timeoutMs: 5
         });
 
@@ -980,7 +1002,7 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
                 vectorDimension  : 4096
             },
             embedText: async () => [],
-            now: () => 100
+            now      : () => 100
         });
 
         expect(result).toMatchObject({
@@ -999,7 +1021,7 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
                 vectorDimension  : 4096
             },
             embedText: async () => [0.1, 0.2, 0.3],
-            now: () => 100
+            now      : () => 100
         });
 
         expect(result).toMatchObject({
@@ -1053,7 +1075,7 @@ test.describe('HealthService #10724 — buildSummaryProviderBlock', () => {
 
     test('openAiCompatible config surfaces the lean local-route shape without leaking API key value', () => {
         const result = buildSummaryProviderBlock({
-            modelProvider: 'openAiCompatible',
+            modelProvider   : 'openAiCompatible',
             openAiCompatible: {
                 host  : 'http://127.0.0.1:11434',
                 model : 'qwen3-8b',
@@ -1185,7 +1207,7 @@ test.describe('HealthService #10844 — buildBackupStateBlock', () => {
     test('returns null if no backup directories exist', async () => {
         const mockFs = {
             pathExists: async () => true,
-            readdir: async () => [
+            readdir   : async () => [
                 { isDirectory: () => false, name: 'backup-2023' },
                 { isDirectory: () => true, name: 'other-dir' }
             ]


### PR DESCRIPTION
Resolves #13995

Bounds REM topology extraction so it reserves graph output tokens, passes `maxCompletionTokens` to the provider, fails loud on context overflow, length truncation, and parse failure, and records bounded per-chunk and zero-conflict outcomes. Adds a durable file-only diagnostic channel and routes routine `HealthService` cache churn into it so the LMS developer console is not spammed while diagnostic logs are still retained.

Evidence: L2 unit/static covers topology request bounds, parse-failure friction, zero-conflict outcome logging, and file-only diagnostic behavior. L3 post-merge live LMS observation remains required for console-noise verification. Residual: post-merge LMS developer-console smoke check.

## Deltas from ticket
#13984 remains closed; this PR targets the new #13995 only.

#13994 remains separate for the suspected 400k provider-context/counter contamination; this PR makes topology calls bounded and observable but does not claim to close that investigation.

Local ignored config overlays were refreshed with `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` after rebasing onto `origin/dev`; no tracked config overlay changes.

## Test Evidence
- `node --check ai/services/graph/TopologyInferenceEngine.mjs`
- `node --check ai/services/memory-core/HealthService.mjs`
- `node --check ai/mcp/server/shared/logger.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs`
- `node --check test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs`
- `git diff --check origin/dev...HEAD`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs` -> 106 passed

## Post-Merge Validation
- [ ] Run the live LMS developer console and diagnostic daemon path long enough to verify routine health cache churn no longer dominates user-facing logs while durable file logs still capture those diagnostics.

## Commits
- `81486c7124` — `fix(ai): bound topology REM logs (#13995)`

Authored by Euclid (GPT-5, Codex Desktop). Session 1583113d-4deb-455a-bee4-16521e9d1479.