### PR TITLE
fix(ai): coalesce LMS provider discovery (#13997)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -398,13 +398,16 @@ class Config extends ConfigProvider {
                  *
                  * Defaults are sized for a developer-laptop cold start (30 × 1s + 3s timeout
                  * per probe ≈ 2 min absolute ceiling). Cloud-deployment operators tune these
-                 * via gitignored `ai/config.mjs` or the env vars below.
+                 * via gitignored `ai/config.mjs` or the env vars below. Routine readiness
+                 * consumers share a short model-discovery cache to avoid flooding user-facing
+                 * provider logs; recovery and force-refresh diagnostics bypass it.
                  * @type {Object}
                  */
                 providerReadiness: {
-                    attempts : leaf(30, 'NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS', 'number'),
-                    delayMs  : leaf(1000, 'NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS', 'number'),
-                    timeoutMs: leaf(3000, 'NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS', 'number'),
+                    attempts         : leaf(30, 'NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS', 'number'),
+                    delayMs          : leaf(1000, 'NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS', 'number'),
+                    timeoutMs        : leaf(3000, 'NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS', 'number'),
+                    routineCacheTtlMs: leaf(1000, 'NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS', 'number'),
                     /**
                      * Stuck-runner detection. A resident model can be alive yet stuck —
                      * one pathological request (e.g. a too-large context prefill) grinding at

--- a/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
+++ b/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
@@ -120,8 +120,10 @@ function applyConfiguredLmsTask(tasks) {
 
             try {
                 await fetchOpenAiCompatibleModelIds({
-                    host     : AiConfig.openAiCompatible.host,
-                    timeoutMs: AiConfig.orchestrator.providerReadiness.timeoutMs
+                    host      : AiConfig.openAiCompatible.host,
+                    timeoutMs : AiConfig.orchestrator.providerReadiness.timeoutMs,
+                    freshness : 'routine',
+                    cacheTtlMs: AiConfig.orchestrator.providerReadiness.routineCacheTtlMs
                 });
                 return true;
             } catch {
@@ -144,14 +146,16 @@ function applyConfiguredLmsTask(tasks) {
             }
 
             return ensureLmsModelsLoaded({
-                host          : AiConfig.openAiCompatible.host,
-                models        : requiredModels,
-                contextLengths: preloadConfig.contextLengths,
-                parallels     : preloadConfig.parallels,
-                allowPartial  : true,
-                attempts      : AiConfig.orchestrator.providerReadiness.attempts,
-                delayMs       : AiConfig.orchestrator.providerReadiness.delayMs,
-                timeoutMs     : AiConfig.orchestrator.providerReadiness.timeoutMs
+                host                    : AiConfig.openAiCompatible.host,
+                models                  : requiredModels,
+                contextLengths          : preloadConfig.contextLengths,
+                parallels               : preloadConfig.parallels,
+                allowPartial            : true,
+                attempts                : AiConfig.orchestrator.providerReadiness.attempts,
+                delayMs                 : AiConfig.orchestrator.providerReadiness.delayMs,
+                timeoutMs               : AiConfig.orchestrator.providerReadiness.timeoutMs,
+                modelDiscoveryFreshness : 'routine',
+                modelDiscoveryCacheTtlMs: AiConfig.orchestrator.providerReadiness.routineCacheTtlMs
             });
         }
     };

--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -27,6 +27,7 @@ import {
     buildOllamaReadinessConfig,
     createProviderFailureDiagnostic,
     ensureOllamaModelsReady,
+    fetchOpenAiCompatibleModelIds,
     getGraphProviderReadinessTarget,
     waitForProvider,
     warnProviderParallelModelCapacity
@@ -334,9 +335,12 @@ class DreamService extends Base {
         if (aiConfig.modelProvider === 'openAiCompatible') {
             const providerStart = Date.now();
             try {
-                const url  = new URL('/v1/models', aiConfig.openAiCompatible.host);
-                const ping = await fetch(url.toString(), { method: 'GET', signal: AbortSignal.timeout(5000) });
-                if (!ping.ok) throw new Error('API provider not running');
+                await fetchOpenAiCompatibleModelIds({
+                    host      : aiConfig.openAiCompatible.host,
+                    timeoutMs : AiConfig.orchestrator.providerReadiness.timeoutMs,
+                    freshness : 'routine',
+                    cacheTtlMs: AiConfig.orchestrator.providerReadiness.routineCacheTtlMs
+                });
                 perPhaseStates.push(finishPhase('legacyProviderProbe', providerStart, 'completed', {
                     provider: aiConfig.modelProvider
                 }));
@@ -978,10 +982,12 @@ class DreamService extends Base {
         }
 
         const waitResult = await waitForProvider({
-            attempts : readinessConfig.attempts,
-            delayMs  : readinessConfig.delayMs,
-            timeoutMs: readinessConfig.timeoutMs,
-            output   : {write: () => {}}
+            attempts                : readinessConfig.attempts,
+            delayMs                 : readinessConfig.delayMs,
+            timeoutMs               : readinessConfig.timeoutMs,
+            modelDiscoveryFreshness : 'routine',
+            modelDiscoveryCacheTtlMs: readinessConfig.routineCacheTtlMs,
+            output                  : {write: () => {}}
         });
 
         if (!waitResult.running) {
@@ -1001,8 +1007,10 @@ class DreamService extends Base {
                 allowPartial: true
             })
             : await warnProviderParallelModelCapacity({
-                config   : AiConfig,
-                timeoutMs: readinessConfig.timeoutMs
+                config                  : AiConfig,
+                timeoutMs               : readinessConfig.timeoutMs,
+                modelDiscoveryFreshness : 'routine',
+                modelDiscoveryCacheTtlMs: readinessConfig.routineCacheTtlMs
             });
 
         if (capacity?.degraded) {

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -1,7 +1,7 @@
-import http                        from 'http';
-import {execFile}                  from 'child_process';
-import {Memory_Config as aiConfig} from '../../services.mjs';
-import logger                      from '../../mcp/server/memory-core/logger.mjs';
+import http       from 'http';
+import {execFile} from 'child_process';
+import aiConfig   from '../../mcp/server/memory-core/config.mjs';
+import logger     from '../../mcp/server/memory-core/logger.mjs';
 import {
     buildOllamaEvalAttribution,
     extractOllamaEvalSample

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -14,6 +14,12 @@ import {
 
 let openAiCompatibleEmbeddingServingProbeQueue = Promise.resolve();
 
+const
+    providerDiscoveryCache         = new Map(),
+    providerDiscoveryForceInflight = new Map(),
+    PROVIDER_DISCOVERY_FORCE       = 'force',
+    PROVIDER_DISCOVERY_ROUTINE     = 'routine';
+
 /**
  * @module ai/services/graph/ProviderReadinessHelper
  */
@@ -25,6 +31,101 @@ let openAiCompatibleEmbeddingServingProbeQueue = Promise.resolve();
  */
 export function getOpenAiCompatibleHost(config = aiConfig) {
     return config.openAiCompatible?.host;
+}
+
+/**
+ * @summary Clears provider-discovery caches for deterministic tests and explicit diagnostics.
+ * @returns {void}
+ */
+export function clearProviderDiscoveryProbeCache() {
+    providerDiscoveryCache.clear();
+    providerDiscoveryForceInflight.clear();
+}
+
+/**
+ * @summary Validates the requested provider-discovery freshness contract.
+ * @param {Object} options
+ * @param {String} options.freshness Either `force` or `routine`.
+ * @param {Number} [options.cacheTtlMs] Routine-cache freshness window.
+ * @param {String} options.caller Caller name for fail-loud errors.
+ * @returns {void}
+ */
+function assertProviderDiscoveryFreshness({freshness, cacheTtlMs, caller}) {
+    if (![PROVIDER_DISCOVERY_FORCE, PROVIDER_DISCOVERY_ROUTINE].includes(freshness)) {
+        throw new TypeError(`${caller}: freshness must be '${PROVIDER_DISCOVERY_FORCE}' or '${PROVIDER_DISCOVERY_ROUTINE}'`);
+    }
+
+    if (freshness === PROVIDER_DISCOVERY_ROUTINE && (!Neo.isNumber(cacheTtlMs) || cacheTtlMs < 0)) {
+        throw new TypeError(`${caller}: cacheTtlMs must be a non-negative number for routine provider discovery`);
+    }
+}
+
+/**
+ * @summary Runs one provider-discovery probe with routine TTL caching or force-fresh coalescing.
+ * @param {Object} options
+ * @param {String} options.key Stable probe identity.
+ * @param {String} options.freshness Either `force` or `routine`.
+ * @param {Number} [options.cacheTtlMs] Routine-cache freshness window.
+ * @param {String} options.caller Caller name for fail-loud errors.
+ * @param {Function} options.runProbe Probe executor.
+ * @returns {Promise<*>}
+ */
+async function runProviderDiscoveryProbe({
+    key,
+    freshness = PROVIDER_DISCOVERY_FORCE,
+    cacheTtlMs,
+    caller,
+    runProbe
+}) {
+    assertProviderDiscoveryFreshness({freshness, cacheTtlMs, caller});
+
+    if (freshness === PROVIDER_DISCOVERY_ROUTINE) {
+        const
+            cached = providerDiscoveryCache.get(key),
+            now    = Date.now();
+
+        if (cached?.promise) {
+            return cached.promise;
+        }
+
+        if (cached && now <= cached.expiresAt) {
+            return cached.value;
+        }
+
+        const promise = Promise.resolve()
+            .then(runProbe)
+            .then(value => {
+                providerDiscoveryCache.set(key, {
+                    value,
+                    expiresAt: Date.now() + cacheTtlMs
+                });
+
+                return value;
+            })
+            .catch(error => {
+                if (providerDiscoveryCache.get(key)?.promise === promise) {
+                    providerDiscoveryCache.delete(key);
+                }
+
+                throw error;
+            });
+
+        providerDiscoveryCache.set(key, {promise});
+        return promise;
+    }
+
+    const forceKey = `${PROVIDER_DISCOVERY_FORCE}:${key}`;
+
+    if (providerDiscoveryForceInflight.has(forceKey)) {
+        return providerDiscoveryForceInflight.get(forceKey);
+    }
+
+    const promise = Promise.resolve()
+        .then(runProbe)
+        .finally(() => providerDiscoveryForceInflight.delete(forceKey));
+
+    providerDiscoveryForceInflight.set(forceKey, promise);
+    return promise;
 }
 
 /**
@@ -224,26 +325,41 @@ export function getLmsLoadedModels(payload) {
  * @param {Object} options
  * @param {Number} options.timeoutMs CLI timeout. Required; no module-level default.
  * @param {Function} [options.execFileFn=execFile] Child-process seam for tests.
+ * @param {String} [options.freshness='force'] `routine` enables TTL caching; `force` bypasses completed cache.
+ * @param {Number} [options.cacheTtlMs] Required for routine caching.
  * @returns {Promise<Object[]>}
  */
-export function fetchLmsLoadedModels({timeoutMs, execFileFn = execFile} = {}) {
+export function fetchLmsLoadedModels({
+    timeoutMs,
+    execFileFn = execFile,
+    freshness  = PROVIDER_DISCOVERY_FORCE,
+    cacheTtlMs
+} = {}) {
     if (typeof timeoutMs !== 'number') {
         return Promise.reject(new TypeError('fetchLmsLoadedModels: timeoutMs is required'));
     }
 
-    return new Promise((resolve, reject) => {
-        execFileFn('lms', ['ps', '--json'], {timeout: timeoutMs}, (error, stdout = '', stderr = '') => {
-            if (error) {
-                reject(new Error(`lms ps --json failed: ${error.message}${stderr ? `; stderr=${stderr.trim()}` : ''}`));
-                return;
-            }
+    return runProviderDiscoveryProbe({
+        key   : `lms-loaded-models:${timeoutMs}`,
+        freshness,
+        cacheTtlMs,
+        caller: 'fetchLmsLoadedModels',
+        runProbe() {
+            return new Promise((resolve, reject) => {
+                execFileFn('lms', ['ps', '--json'], {timeout: timeoutMs}, (error, stdout = '', stderr = '') => {
+                    if (error) {
+                        reject(new Error(`lms ps --json failed: ${error.message}${stderr ? `; stderr=${stderr.trim()}` : ''}`));
+                        return;
+                    }
 
-            try {
-                resolve(getLmsLoadedModels(JSON.parse(stdout || '[]')));
-            } catch (parseError) {
-                reject(new Error(`lms ps --json returned invalid JSON: ${parseError.message}`));
-            }
-        });
+                    try {
+                        resolve(getLmsLoadedModels(JSON.parse(stdout || '[]')));
+                    } catch (parseError) {
+                        reject(new Error(`lms ps --json returned invalid JSON: ${parseError.message}`));
+                    }
+                });
+            });
+        }
     });
 }
 
@@ -349,9 +465,17 @@ export function getOllamaRunningModels(payload) {
  * @param {String} options.host Provider host.
  * @param {Number} options.timeoutMs HTTP timeout. Required; no module-level default.
  * @param {Function} [options.fetchFn=fetch] Fetch seam for tests.
+ * @param {String} [options.freshness='force'] `routine` enables TTL caching; `force` bypasses completed cache.
+ * @param {Number} [options.cacheTtlMs] Required for routine caching.
  * @returns {Promise<String[]>}
  */
-export async function fetchOpenAiCompatibleModelIds({host, timeoutMs, fetchFn = fetch} = {}) {
+export async function fetchOpenAiCompatibleModelIds({
+    host,
+    timeoutMs,
+    fetchFn    = fetch,
+    freshness  = PROVIDER_DISCOVERY_FORCE,
+    cacheTtlMs
+} = {}) {
     if (!host) {
         throw new TypeError('fetchOpenAiCompatibleModelIds: host is required');
     }
@@ -359,18 +483,26 @@ export async function fetchOpenAiCompatibleModelIds({host, timeoutMs, fetchFn = 
         throw new TypeError('fetchOpenAiCompatibleModelIds: timeoutMs is required');
     }
 
-    const url      = new URL('/v1/models', host).toString();
-    const response = await fetchFn(url, {
-        method: 'GET',
-        signal: AbortSignal.timeout(timeoutMs)
+    return runProviderDiscoveryProbe({
+        key   : `openai-compatible-models:${host}:${timeoutMs}`,
+        freshness,
+        cacheTtlMs,
+        caller: 'fetchOpenAiCompatibleModelIds',
+        async runProbe() {
+            const url      = new URL('/v1/models', host).toString();
+            const response = await fetchFn(url, {
+                method: 'GET',
+                signal: AbortSignal.timeout(timeoutMs)
+            });
+
+            if (!response.ok) {
+                const text = typeof response.text === 'function' ? await response.text() : '';
+                throw new Error(`OpenAI-compatible model enumeration failed: HTTP ${response.status}${text ? ` - ${text}` : ''}`);
+            }
+
+            return getOpenAiCompatibleModelIds(await response.json());
+        }
     });
-
-    if (!response.ok) {
-        const text = typeof response.text === 'function' ? await response.text() : '';
-        throw new Error(`OpenAI-compatible model enumeration failed: HTTP ${response.status}${text ? ` - ${text}` : ''}`);
-    }
-
-    return getOpenAiCompatibleModelIds(await response.json());
 }
 
 /**
@@ -978,6 +1110,8 @@ export function getInsufficientLmsLoadedModels({
  * @param {Function} [options.loadModel] Injectable model-load function.
  * @param {Function} [options.unloadModel] Injectable model-unload function.
  * @param {Function} [options.embeddingServingProbe] Optional bounded embedding-serving canary seam.
+ * @param {String} [options.modelDiscoveryFreshness='force'] Routine callers may use `routine`; post-mutation probes force-refresh.
+ * @param {Number} [options.modelDiscoveryCacheTtlMs] Required when `modelDiscoveryFreshness` is `routine`.
  * @param {Object} [options.log=logger] Logger seam.
  * @returns {Promise<Object>}
  */
@@ -995,6 +1129,8 @@ export async function ensureLmsModelsLoaded({
     loadModel         = (model, options) => loadLmsModel(model, options),
     unloadModel       = (identifier, options) => unloadLmsModel(identifier, options),
     embeddingServingProbe,
+    modelDiscoveryFreshness = PROVIDER_DISCOVERY_FORCE,
+    modelDiscoveryCacheTtlMs,
     log               = logger
 } = {}) {
     if (!Array.isArray(models) || models.length === 0) {
@@ -1058,14 +1194,19 @@ export async function ensureLmsModelsLoaded({
     const requiresObservedLoadCheck = requiredModels.some(model =>
         Neo.isNumber(contextLengths?.[model]) || Neo.isNumber(parallels?.[model])
     );
-    const probeModels = async phase => {
+    const probeModels = async (phase, freshness = modelDiscoveryFreshness) => {
         let lastError;
 
         for (let attempt = 1; attempt <= attempts; attempt++) {
             try {
                 return {
                     attempt,
-                    availableModels: await fetchModelIds({host, timeoutMs})
+                    availableModels: await fetchModelIds({
+                        host,
+                        timeoutMs,
+                        freshness,
+                        cacheTtlMs: freshness === PROVIDER_DISCOVERY_ROUTINE ? modelDiscoveryCacheTtlMs : undefined
+                    })
                 };
             } catch (error) {
                 lastError = error;
@@ -1078,8 +1219,8 @@ export async function ensureLmsModelsLoaded({
         throw new Error(`LM Studio model readiness failed during ${phase}: ${lastError?.message || lastError}`);
     };
 
-    let {availableModels} = await probeModels('initial /v1/models probe');
-    const initialMissing       = getMissing(availableModels),
+    let   {availableModels} = await probeModels('initial /v1/models probe');
+    const initialMissing    = getMissing(availableModels),
           initialLoadedModels  = [],
           failedModels         = [],
           cleanupFailedModels  = [],
@@ -1092,7 +1233,11 @@ export async function ensureLmsModelsLoaded({
 
     if (needsInitialLoadedProbe) {
         try {
-            initialLoadedModels.push(...await fetchLoadedModels({timeoutMs}));
+            initialLoadedModels.push(...await fetchLoadedModels({
+                timeoutMs,
+                freshness : modelDiscoveryFreshness,
+                cacheTtlMs: modelDiscoveryFreshness === PROVIDER_DISCOVERY_ROUTINE ? modelDiscoveryCacheTtlMs : undefined
+            }));
         } catch (error) {
             log.warn?.(`[ProviderReadinessHelper] Initial LM Studio loaded-model probe failed: ${error.message}; falling back to reload enforcement.`);
         }
@@ -1233,7 +1378,7 @@ export async function ensureLmsModelsLoaded({
 
     const startedAt = Date.now();
     for (let attempt = 1; attempt <= attempts; attempt++) {
-        ({availableModels} = await probeModels('post-load /v1/models probe'));
+        ({availableModels} = await probeModels('post-load /v1/models probe', PROVIDER_DISCOVERY_FORCE));
         missingModels = getMissing(availableModels);
 
         const knownUnavailable = new Set([
@@ -1246,7 +1391,10 @@ export async function ensureLmsModelsLoaded({
 
             if (requiresObservedLoadCheck) {
                 try {
-                    lmsLoadedModels = await fetchLoadedModels({timeoutMs});
+                    lmsLoadedModels = await fetchLoadedModels({
+                        timeoutMs,
+                        freshness: PROVIDER_DISCOVERY_FORCE
+                    });
                 } catch (error) {
                     const warning = `LM Studio loaded-model readiness failed: ${error.message}`;
 
@@ -1912,13 +2060,17 @@ export function createParallelModelCapacityWarning({
  * @param {Number} options.timeoutMs HTTP probe timeout. Required; no module-level default.
  * @param {Function} [options.fetchOpenAiCompatibleModels] Injectable OpenAI-compatible model-list probe.
  * @param {Function} [options.fetchOllamaModels] Injectable Ollama running-model probe.
+ * @param {String} [options.modelDiscoveryFreshness='force'] Routine callers may use `routine`; diagnostics/recovery keep `force`.
+ * @param {Number} [options.modelDiscoveryCacheTtlMs] Required when `modelDiscoveryFreshness` is `routine`.
  * @returns {Promise<Object>}
  */
 export async function probeProviderParallelModelCapacity({
     config = aiConfig,
     timeoutMs,
     fetchOpenAiCompatibleModels = opts => fetchOpenAiCompatibleModelIds(opts),
-    fetchOllamaModels           = opts => fetchOllamaRunningModelIds(opts)
+    fetchOllamaModels           = opts => fetchOllamaRunningModelIds(opts),
+    modelDiscoveryFreshness     = PROVIDER_DISCOVERY_FORCE,
+    modelDiscoveryCacheTtlMs
 } = {}) {
     if (!config || typeof config !== 'object') {
         throw new TypeError('probeProviderParallelModelCapacity: config is required');
@@ -1949,7 +2101,14 @@ export async function probeProviderParallelModelCapacity({
     const requiredModels  = getRequiredProviderModels(target);
     const availableModels = target.provider === 'ollama'
         ? await fetchOllamaModels({host: target.host, timeoutMs})
-        : await fetchOpenAiCompatibleModels({host: target.host, timeoutMs});
+        : await fetchOpenAiCompatibleModels({
+            host      : target.host,
+            timeoutMs,
+            freshness : modelDiscoveryFreshness,
+            cacheTtlMs: modelDiscoveryFreshness === PROVIDER_DISCOVERY_ROUTINE
+                ? modelDiscoveryCacheTtlMs
+                : undefined
+        });
     const uniqueAvailable        = [...new Set(availableModels)];
     const missingModels          = requiredModels.filter(model => !uniqueAvailable.includes(model));
     const requiredModelSet       = new Set(requiredModels);
@@ -2038,9 +2197,16 @@ export async function warnProviderParallelModelCapacity({
  * @param {Object} options
  * @param {Object} options.config Provider-source config (aiConfig-shaped).
  * @param {Number} options.timeoutMs HTTP probe abandon threshold. Required; no module-level default.
+ * @param {String} [options.modelDiscoveryFreshness='force'] Routine callers may use `routine`; diagnostics/recovery keep `force`.
+ * @param {Number} [options.modelDiscoveryCacheTtlMs] Required when `modelDiscoveryFreshness` is `routine`.
  * @returns {Promise<Boolean>}
  */
-export function checkProvider({config, timeoutMs} = {}) {
+export function checkProvider({
+    config,
+    timeoutMs,
+    modelDiscoveryFreshness = PROVIDER_DISCOVERY_FORCE,
+    modelDiscoveryCacheTtlMs
+} = {}) {
     if (typeof timeoutMs !== 'number') {
         throw new TypeError('checkProvider: timeoutMs is required (pass from config.orchestrator.providerReadiness.timeoutMs)');
     }
@@ -2048,6 +2214,17 @@ export function checkProvider({config, timeoutMs} = {}) {
 
     if (!target.supported || !target.url) {
         return Promise.resolve(false);
+    }
+
+    if (target.provider === 'openAiCompatible') {
+        return fetchOpenAiCompatibleModelIds({
+            host      : target.host,
+            timeoutMs,
+            freshness : modelDiscoveryFreshness,
+            cacheTtlMs: modelDiscoveryFreshness === PROVIDER_DISCOVERY_ROUTINE
+                ? modelDiscoveryCacheTtlMs
+                : undefined
+        }).then(() => true, () => false);
     }
 
     return new Promise(resolve => {
@@ -2084,6 +2261,8 @@ export function checkProvider({config, timeoutMs} = {}) {
  * @param {Number} options.attempts Retry cap.
  * @param {Number} options.delayMs Between-probe wait.
  * @param {Number} options.timeoutMs HTTP probe abandon threshold (also flows into the default `checkProvider` when no override is provided).
+ * @param {String} [options.modelDiscoveryFreshness='force'] Routine callers may use `routine`; diagnostics/recovery keep `force`.
+ * @param {Number} [options.modelDiscoveryCacheTtlMs] Required when `modelDiscoveryFreshness` is `routine`.
  * @param {Object} [options.output] Writable stream for dot-progress (defaults to `process.stdout`).
  * @returns {Promise<Object>}
  */
@@ -2092,13 +2271,19 @@ export async function waitForProvider({
     attempts,
     delayMs,
     timeoutMs,
+    modelDiscoveryFreshness = PROVIDER_DISCOVERY_FORCE,
+    modelDiscoveryCacheTtlMs,
     output = process.stdout
 } = {}) {
     if (typeof attempts !== 'number' || typeof delayMs !== 'number' || typeof timeoutMs !== 'number') {
         throw new TypeError('waitForProvider: attempts, delayMs, and timeoutMs are required (pass from config.orchestrator.providerReadiness)');
     }
 
-    const probe     = providerCheck ?? (() => checkProvider({timeoutMs}));
+    const probe = providerCheck ?? (() => checkProvider({
+        timeoutMs,
+        modelDiscoveryFreshness,
+        modelDiscoveryCacheTtlMs
+    }));
     const startedAt = Date.now();
 
     for (let i = 0; i < attempts; i++) {
@@ -2133,7 +2318,7 @@ export function assertProviderReadinessConfig(readinessConfig) {
         throw new TypeError('AiConfig.orchestrator.providerReadiness is required; copy the providerReadiness block from ai/config.template.mjs or set its env-backed values in ai/config.mjs');
     }
 
-    const missing = ['attempts', 'delayMs', 'timeoutMs'].filter(key => typeof readinessConfig[key] !== 'number');
+    const missing = ['attempts', 'delayMs', 'timeoutMs', 'routineCacheTtlMs'].filter(key => typeof readinessConfig[key] !== 'number');
     if (missing.length > 0) {
         throw new TypeError(`AiConfig.orchestrator.providerReadiness.${missing.join('|')} must be configured as number(s); no code-level fallback is applied`);
     }

--- a/ai/services/memory-core/lifecycle/InferenceLifecycleService.mjs
+++ b/ai/services/memory-core/lifecycle/InferenceLifecycleService.mjs
@@ -1,13 +1,14 @@
-import { spawn } from 'child_process';
-import aiConfig from '../../../mcp/server/memory-core/config.mjs';
-import logger from '../../../mcp/server/memory-core/logger.mjs';
-import Base from '../../../../src/core/Base.mjs';
-import path from 'path';
-import fs from 'fs';
-import { fileURLToPath } from 'url';
+import { spawn }                       from 'child_process';
+import aiConfig                        from '../../../mcp/server/memory-core/config.mjs';
+import logger                          from '../../../mcp/server/memory-core/logger.mjs';
+import Base                            from '../../../../src/core/Base.mjs';
+import path                            from 'path';
+import fs                              from 'fs';
+import { fileURLToPath }               from 'url';
+import {fetchOpenAiCompatibleModelIds} from '../../graph/providerReadinessHelper.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname  = path.dirname(__filename);
 const memCoreDir = path.resolve(__dirname, '../../../mcp/server/memory-core');
 
 /**
@@ -58,11 +59,13 @@ class InferenceLifecycleService extends Base {
      */
     async isInferenceRunning() {
         try {
-            const res = await fetch(aiConfig.openAiCompatible.host + '/v1/models', {
-                method: 'GET',
-                signal: AbortSignal.timeout(3000)
+            await fetchOpenAiCompatibleModelIds({
+                host      : aiConfig.openAiCompatible.host,
+                timeoutMs : aiConfig.orchestrator.providerReadiness.timeoutMs,
+                freshness : 'routine',
+                cacheTtlMs: aiConfig.orchestrator.providerReadiness.routineCacheTtlMs
             });
-            return res.ok;
+            return true;
         } catch (e) {
             return false;
         }

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -146,9 +146,10 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     },
     orchestrator: {
         providerReadiness: {
-            attempts : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS)   || 30,
-            delayMs  : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS)   || 1000,
-            timeoutMs: Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS) || 3000
+            attempts         : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS)             || 30,
+            delayMs          : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS)             || 1000,
+            timeoutMs        : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS)           || 3000,
+            routineCacheTtlMs: Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS) || 1000
         },
         intervals: {
             pollMs                           : 3000,

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -217,10 +217,11 @@ test.describe('Tier 1 Config Immutability', () => {
         const stuckRunnerDisabled   = ['false', 'no', 'off', '0'].includes(stuckRunnerEnabledEnv);
 
         expect(Config.orchestrator.providerReadiness).toEqual({
-            attempts   : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS)   || 30,
-            delayMs    : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS)   || 1000,
-            timeoutMs  : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS) || 3000,
-            stuckRunner: {
+            attempts         : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS)             || 30,
+            delayMs          : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS)             || 1000,
+            timeoutMs        : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS)           || 3000,
+            routineCacheTtlMs: Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS) || 1000,
+            stuckRunner      : {
                 enabled            : stuckRunnerEnabledEnv === undefined ? true : !stuckRunnerDisabled,
                 consecutiveFailures: Number(process.env.NEO_ORCHESTRATOR_STUCK_RUNNER_CONSECUTIVE_FAILURES) || 3,
                 canaryTimeoutMs    : Number(process.env.NEO_ORCHESTRATOR_STUCK_RUNNER_CANARY_TIMEOUT_MS)    || 10000

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -836,7 +836,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
                 model         : 'chat-model',
                 embeddingModel: 'embedding-model'
             };
-            AiConfig.orchestrator.providerReadiness = {attempts: 2, delayMs: 0, timeoutMs: 50};
+            AiConfig.orchestrator.providerReadiness = {attempts: 2, delayMs: 0, timeoutMs: 50, routineCacheTtlMs: 1000};
             AiConfig.modelProvider     = 'openAiCompatible';
             AiConfig.graphProvider     = 'openAiCompatible';
             AiConfig.embeddingProvider = 'openAiCompatible';
@@ -1171,7 +1171,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
                 model         : 'gemma4-31b',
                 embeddingModel: 'qwen3-8b'
             };
-            AiConfig.orchestrator.providerReadiness = {attempts: 2, delayMs: 0, timeoutMs: 50};
+            AiConfig.orchestrator.providerReadiness = {attempts: 2, delayMs: 0, timeoutMs: 50, routineCacheTtlMs: 1000};
             AiConfig.modelProvider     = 'openAiCompatible';
             AiConfig.graphProvider     = 'openAiCompatible';
             AiConfig.embeddingProvider = 'openAiCompatible';

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -76,7 +76,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         // Architectural contract: taskDefinitions.mjs has no embedded MLX defaults
         // and no env-var reads. The daemon entrypoint composes MLX after reading
         // AiConfig, so stale caller params and env-vars are ignored here.
-        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
+        const scriptDir          = path.resolve(process.cwd(), 'ai/scripts');
         const originalMlxModel   = process.env.NEO_ORCHESTRATOR_MLX_MODEL;
         const originalMlxEnabled = process.env.NEO_ORCHESTRATOR_MLX_ENABLED;
         const originalMlxPort    = process.env.NEO_ORCHESTRATOR_MLX_PORT;
@@ -140,7 +140,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         // Architectural contract: taskDefinitions.mjs has no embedded LM Studio
         // defaults and no env-var reads. The daemon entrypoint composes LMS after
         // reading AiConfig, so stale caller params and env-vars are ignored here.
-        const scriptDir = path.resolve(process.cwd(), 'ai/scripts');
+        const scriptDir          = path.resolve(process.cwd(), 'ai/scripts');
         const originalLmsModel   = process.env.NEO_ORCHESTRATOR_LMS_MODEL;
         const originalLmsEnabled = process.env.NEO_ORCHESTRATOR_LMS_ENABLED;
         const originalLmsPort    = process.env.NEO_ORCHESTRATOR_LMS_PORT;
@@ -160,7 +160,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
                 lmsModel         : 'explicit-model',
                 lmsModels        : ['chat-model', 'embedding-model'],
                 lmsHost          : 'http://127.0.0.1:4242',
-                providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50},
+                providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50, routineCacheTtlMs: 1000},
                 lmsPort          : 4242
             });
             expect(staleCallerParams.lms).toBeUndefined();
@@ -285,7 +285,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         const bridgeSource       = fs.readFileSync(path.resolve(process.cwd(), 'ai/daemons/wake/daemon.mjs'), 'utf8');
         const orchestratorSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/daemons/orchestrator/daemon.mjs'), 'utf8');
         const daemonSource       = fs.readFileSync(path.resolve(process.cwd(), 'ai/daemons/orchestrator/Orchestrator.mjs'), 'utf8');
-        const taskDefSource        = fs.readFileSync(path.resolve(process.cwd(), 'ai/daemons/orchestrator/taskDefinitions.mjs'), 'utf8');
+        const taskDefSource      = fs.readFileSync(path.resolve(process.cwd(), 'ai/daemons/orchestrator/taskDefinitions.mjs'), 'utf8');
 
         expect(bridgeSource).not.toContain('summarize-sessions.mjs');
         expect(bridgeSource).not.toContain('Piece C periodic summarization sweep');
@@ -328,7 +328,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
 
     test('loads gitignored top-level AI config only when present', async () => {
         const loadedPaths = [];
-        const aiConfig = {
+        const aiConfig    = {
             async load(configPath) {
                 loadedPaths.push(configPath);
             }

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -52,6 +52,10 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         providerReadinessHelper = await import('../../../../../../ai/services/graph/providerReadinessHelper.mjs');
     });
 
+    test.beforeEach(() => {
+        providerReadinessHelper?.clearProviderDiscoveryProbeCache();
+    });
+
     test.afterAll(() => {
         aiConfig.data.logPath = originalLogPath;
 
@@ -94,10 +98,17 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     test('assertProviderReadinessConfig fails loud when the SSOT config block is absent', () => {
         expect(() => runSandmanModule.assertProviderReadinessConfig()).toThrow(/providerReadiness is required/);
         expect(() => runSandmanModule.assertProviderReadinessConfig({attempts: 1, delayMs: 0})).toThrow(/timeoutMs.*configured/);
-        expect(runSandmanModule.assertProviderReadinessConfig({attempts: 1, delayMs: 0, timeoutMs: 10})).toEqual({
-            attempts : 1,
-            delayMs  : 0,
-            timeoutMs: 10
+        expect(() => runSandmanModule.assertProviderReadinessConfig({attempts: 1, delayMs: 0, timeoutMs: 10})).toThrow(/routineCacheTtlMs.*configured/);
+        expect(runSandmanModule.assertProviderReadinessConfig({
+            attempts         : 1,
+            delayMs          : 0,
+            timeoutMs        : 10,
+            routineCacheTtlMs: 1000
+        })).toEqual({
+            attempts         : 1,
+            delayMs          : 0,
+            timeoutMs        : 10,
+            routineCacheTtlMs: 1000
         });
     });
 
@@ -936,6 +947,186 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             contextLength: 131072,
             parallel     : 1
         }]);
+    });
+
+    test('fetchOpenAiCompatibleModelIds coalesces and caches routine probes (#13997)', async () => {
+        let fetchCalls = 0,
+            releaseFirst;
+
+        const firstProbe = new Promise(resolve => {
+            releaseFirst = resolve;
+        });
+        const fetchFn = async () => {
+            fetchCalls++;
+            await firstProbe;
+
+            return {
+                ok  : true,
+                json: async () => ({data: [{id: 'chat-model'}]})
+            };
+        };
+
+        const first = providerReadinessHelper.fetchOpenAiCompatibleModelIds({
+            host      : 'http://127.0.0.1:1234',
+            timeoutMs : 50,
+            freshness : 'routine',
+            cacheTtlMs: 1000,
+            fetchFn
+        });
+        const second = providerReadinessHelper.fetchOpenAiCompatibleModelIds({
+            host      : 'http://127.0.0.1:1234',
+            timeoutMs : 50,
+            freshness : 'routine',
+            cacheTtlMs: 1000,
+            fetchFn
+        });
+
+        await Promise.resolve();
+        expect(fetchCalls).toBe(1);
+
+        releaseFirst();
+        await expect(Promise.all([first, second])).resolves.toEqual([
+            ['chat-model'],
+            ['chat-model']
+        ]);
+
+        const cached = await providerReadinessHelper.fetchOpenAiCompatibleModelIds({
+            host      : 'http://127.0.0.1:1234',
+            timeoutMs : 50,
+            freshness : 'routine',
+            cacheTtlMs: 1000,
+            fetchFn
+        });
+
+        expect(cached).toEqual(['chat-model']);
+        expect(fetchCalls).toBe(1);
+    });
+
+    test('fetchOpenAiCompatibleModelIds force-refresh bypasses routine cache (#13997)', async () => {
+        let   fetchCalls = 0;
+        const fetchFn    = async () => {
+            fetchCalls++;
+
+            return {
+                ok  : true,
+                json: async () => ({data: [{id: fetchCalls === 1 ? 'cached-model' : 'fresh-model'}]})
+            };
+        };
+
+        await expect(providerReadinessHelper.fetchOpenAiCompatibleModelIds({
+            host      : 'http://127.0.0.1:1234',
+            timeoutMs : 50,
+            freshness : 'routine',
+            cacheTtlMs: 1000,
+            fetchFn
+        })).resolves.toEqual(['cached-model']);
+
+        await expect(providerReadinessHelper.fetchOpenAiCompatibleModelIds({
+            host     : 'http://127.0.0.1:1234',
+            timeoutMs: 50,
+            freshness: 'force',
+            fetchFn
+        })).resolves.toEqual(['fresh-model']);
+
+        expect(fetchCalls).toBe(2);
+    });
+
+    test('routine provider-discovery failures are not cached as healthy (#13997)', async () => {
+        let   fetchCalls = 0;
+        const fetchFn    = async () => {
+            fetchCalls++;
+
+            if (fetchCalls === 1) {
+                return {
+                    ok    : false,
+                    status: 503,
+                    text  : async () => 'starting'
+                };
+            }
+
+            return {
+                ok  : true,
+                json: async () => ({data: [{id: 'recovered-model'}]})
+            };
+        };
+
+        await expect(providerReadinessHelper.fetchOpenAiCompatibleModelIds({
+            host      : 'http://127.0.0.1:1234',
+            timeoutMs : 50,
+            freshness : 'routine',
+            cacheTtlMs: 1000,
+            fetchFn
+        })).rejects.toThrow(/HTTP 503/);
+
+        await expect(providerReadinessHelper.fetchOpenAiCompatibleModelIds({
+            host      : 'http://127.0.0.1:1234',
+            timeoutMs : 50,
+            freshness : 'routine',
+            cacheTtlMs: 1000,
+            fetchFn
+        })).resolves.toEqual(['recovered-model']);
+        expect(fetchCalls).toBe(2);
+    });
+
+    test('fetchLmsLoadedModels coalesces routine metadata probes and lets force-refresh bypass cache (#13997)', async () => {
+        let cliCalls = 0;
+
+        const execFileFn = (cmd, args, options, callback) => {
+            cliCalls++;
+            callback(null, JSON.stringify([{
+                id           : cliCalls === 1 ? 'cached-model' : 'fresh-model',
+                contextLength: 32768
+            }]), '');
+        };
+
+        const first = await providerReadinessHelper.fetchLmsLoadedModels({
+            timeoutMs : 123,
+            freshness : 'routine',
+            cacheTtlMs: 1000,
+            execFileFn
+        });
+        const cached = await providerReadinessHelper.fetchLmsLoadedModels({
+            timeoutMs : 123,
+            freshness : 'routine',
+            cacheTtlMs: 1000,
+            execFileFn
+        });
+        const fresh = await providerReadinessHelper.fetchLmsLoadedModels({
+            timeoutMs: 123,
+            freshness: 'force',
+            execFileFn
+        });
+
+        expect(first.map(item => item.id)).toEqual(['cached-model']);
+        expect(cached.map(item => item.id)).toEqual(['cached-model']);
+        expect(fresh.map(item => item.id)).toEqual(['fresh-model']);
+        expect(cliCalls).toBe(2);
+    });
+
+    test('ensureLmsModelsLoaded uses routine discovery before mutation and force-refresh after load (#13997)', async () => {
+        const
+            discoveryFreshness = [],
+            loadCalls          = [];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host                    : 'http://127.0.0.1:1234',
+            models                  : ['chat-model'],
+            attempts                : 1,
+            delayMs                 : 0,
+            timeoutMs               : 50,
+            modelDiscoveryFreshness : 'routine',
+            modelDiscoveryCacheTtlMs: 1000,
+            fetchModelIds           : async options => {
+                discoveryFreshness.push(options.freshness);
+                return discoveryFreshness.length === 1 ? [] : ['chat-model'];
+            },
+            loadModel: async model => loadCalls.push(model),
+            log      : {info: () => {}}
+        });
+
+        expect(discoveryFreshness).toEqual(['routine', 'force']);
+        expect(loadCalls).toEqual(['chat-model']);
+        expect(result.ready).toBe(true);
     });
 
     test('ensureLmsModelsLoaded degrades when lms ps reports insufficient context or parallel (#13851)', async () => {


### PR DESCRIPTION
Resolves #13997

Coalesces routine OpenAI-compatible/LMS model-discovery probes behind the existing provider-readiness helper while preserving force-fresh recovery and diagnostics. Normal orchestrator startup paths now opt into a short AiConfig-owned routine cache; recovery and deployment-state consumers remain force-fresh unless they explicitly request a routine contract.

Evidence: L2 unit/static evidence covers the coalescing, cache-hit, force-refresh, failed-probe, and post-load refresh contracts. L3 live LMS developer-console verification remains required post-merge because the sandbox cannot observe the operator's LM Studio console.

## Deltas from ticket

- Implemented this in `providerReadinessHelper.mjs` rather than adding a public MCP tool or new daemon surface.
- Added `orchestrator.providerReadiness.routineCacheTtlMs` as the AiConfig SSOT leaf for routine model-discovery cache cadence.
- Routed routine callers through `freshness: 'routine'`: LMS task liveness, LMS startup preload's pre-mutation discovery, DreamService's legacy provider probe, DreamService readiness/capacity checks, and Memory Core inference liveness.
- Preserved protected semantics by keeping helper defaults force-fresh. Recovery actuator warm-provider repair and deployment-state provider residency diagnostics do not opt into the routine cache.
- Post-load LM Studio verification force-refreshes after `lms load`/`lms unload`, so the cache cannot hide mutation results.

Decision Record impact: aligned with ADR 0019. The new cadence is a config leaf read at use sites; there are no hidden env reads, no local fallback constants, and no config pass-through object replacing AiConfig.

Related: #13995
Related: #13996
Related: #13950

## Test Evidence

- `npm run agent-preflight -- ai/config.template.mjs ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs ai/daemons/orchestrator/services/DreamService.mjs ai/services/graph/providerReadinessHelper.mjs ai/services/memory-core/lifecycle/InferenceLifecycleService.mjs test/playwright/fixtures/aiConfigDefaults.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs`
- `npm run ai:lint-config-template-ssot`
- `npm run test-unit -- test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` - 146 passed
- `git diff --check`
- Commit hook ran: whitespace, shorthand, AiConfig test-mutation lint, JSDoc type lint, ticket archaeology, and block alignment.

## Post-Merge Validation

- [ ] Run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` so local overlays inherit `orchestrator.providerReadiness.routineCacheTtlMs`.
- [ ] Restart the orchestrator and confirm normal startup no longer floods LMS developer logs with repeated `/v1/models` plus duplicate `LMSAuthenticator` metadata bursts.
- [ ] Exercise a cloud diagnostics/recovery path and confirm it still gets force-fresh provider evidence rather than stale routine-cache data.

## Commits

- `accb2cd187` - `fix(ai): coalesce LMS provider discovery (#13997)`

Authored by Euclid (GPT-5, Codex Desktop). Session 1583113d-4deb-455a-bee4-16521e9d1479.
