### PR TITLE
fix(ai): chunk oversized kb sources before embedding (#14000)

### DIFF
--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -474,8 +474,8 @@ class KnowledgeBaseIngestionService extends Base {
      */
     async getTenantManifest({tenantId, repoSlug} = {}) {
         const {tenantId: resolvedTenant, repoSlug: resolvedRepo} = this.resolveTenantContext({tenantId, repoSlug});
-        const manifests = await this.getTenantManifests({tenantId: resolvedTenant});
-        const manifest  = manifests[resolvedRepo];
+        const manifests                                          = await this.getTenantManifests({tenantId: resolvedTenant});
+        const manifest                                           = manifests[resolvedRepo];
 
         return {
             tenantId      : resolvedTenant,
@@ -710,27 +710,190 @@ class KnowledgeBaseIngestionService extends Base {
             return chunks;
         }
 
-        return chunks.filter(chunk => {
-            const
-                text                = this.buildEmbeddingInputText(chunk),
-                inputBytes          = Buffer.byteLength(text, 'utf8'),
-                inputTokensEstimate = bytesToTokens(inputBytes);
+        const embeddable = [];
 
-            if (inputTokensEstimate <= guardrail.safeProcessingLimitTokens) {
-                return true;
+        for (const chunk of chunks) {
+            const budget = this.evaluateEmbeddingInputBudget(chunk, guardrail);
+
+            if (!budget.skip) {
+                embeddable.push(chunk);
+                continue;
             }
 
-            this.recordOversizedEmbeddingSkip({
-                chunk,
-                guardrail,
-                inputBytes,
-                inputTokensEstimate,
-                summary,
-                tenantContext
-            });
+            const splitChunks = this.splitOversizedEmbeddingChunk({chunk, guardrail, tenantContext});
 
-            return false;
+            if (splitChunks.length <= 1) {
+                this.recordOversizedEmbeddingSkip({
+                    chunk,
+                    guardrail,
+                    summary,
+                    tenantContext,
+                    ...budget
+                });
+                continue;
+            }
+
+            for (const splitChunk of splitChunks) {
+                const splitBudget = this.evaluateEmbeddingInputBudget(splitChunk, guardrail);
+
+                if (!splitBudget.skip) {
+                    embeddable.push(splitChunk);
+                    continue;
+                }
+
+                this.recordOversizedEmbeddingSkip({
+                    chunk: splitChunk,
+                    guardrail,
+                    summary,
+                    tenantContext,
+                    ...splitBudget
+                });
+            }
+        }
+
+        return embeddable;
+    }
+
+    /**
+     * @summary Evaluates the final embedding input shape against the local provider budget.
+     * @param {Object} chunk Normalized parsed chunk.
+     * @param {Object} guardrail Local embedding guardrail.
+     * @returns {{skip: Boolean, inputBytes: Number, inputTokensEstimate: Number}}
+     * @protected
+     */
+    evaluateEmbeddingInputBudget(chunk, guardrail) {
+        const text                = this.buildEmbeddingInputText(chunk),
+              inputBytes          = Buffer.byteLength(text, 'utf8'),
+              inputTokensEstimate = bytesToTokens(inputBytes);
+
+        return {
+            skip: inputTokensEstimate > guardrail.safeProcessingLimitTokens,
+            inputBytes,
+            inputTokensEstimate
+        };
+    }
+
+    /**
+     * @summary Splits a recoverable oversized text chunk into deterministic embedding-safe sub-chunks.
+     * @param {Object} options
+     * @returns {Object[]} Either multiple sub-chunks or the original chunk when no safe split is possible.
+     * @protected
+     */
+    splitOversizedEmbeddingChunk({chunk, guardrail, tenantContext}) {
+        const content = chunk.content || chunk.description;
+
+        if (typeof content !== 'string' || content.length === 0) {
+            return [chunk];
+        }
+
+        const maxInputBytes = Math.max(1, guardrail.safeProcessingLimitTokens * 3),
+              prefixBytes   = Buffer.byteLength(`${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n`, 'utf8'),
+              maxContentBytes = Math.max(1, maxInputBytes - prefixBytes - 128),
+              parts = this.splitTextByByteBudget(content, maxContentBytes);
+
+        if (parts.length <= 1) {
+            return [chunk];
+        }
+
+        let charStart = 0;
+
+        return parts.map((part, index) => {
+            const charEnd = charStart + part.length,
+                  child   = {
+                      ...chunk,
+                      content    : part,
+                      description: part,
+                      name         : `${chunk.name} [part ${index + 1}/${parts.length}]`,
+                      hashInputs   : Array.from(new Set([
+                          ...(chunk.hashInputs || []),
+                          'oversizedSplitIndex',
+                          'oversizedSplitTotal',
+                          'oversizedSplitCharStart',
+                          'oversizedSplitCharEnd'
+                      ])),
+                      oversizedSplit         : true,
+                      oversizedSplitIndex    : index,
+                      oversizedSplitTotal    : parts.length,
+                      oversizedSplitCharStart: charStart,
+                      oversizedSplitCharEnd  : charEnd
+                  };
+
+            charStart = charEnd;
+
+            const hash = this.createChunkHash(child, tenantContext);
+
+            child.hash = hash;
+            child.id   = hash;
+
+            return child;
         });
+    }
+
+    /**
+     * @summary Splits text on stable line boundaries, falling back to character slices for single huge lines.
+     * @param {String} text Source text.
+     * @param {Number} maxBytes Maximum byte size per returned part.
+     * @returns {String[]}
+     * @protected
+     */
+    splitTextByByteBudget(text, maxBytes) {
+        if (Buffer.byteLength(text, 'utf8') <= maxBytes) {
+            return [text];
+        }
+
+        const parts   = [];
+        let   current = '';
+
+        for (const line of text.match(/[^\n]*\n?|[^\n]+$/g).filter(Boolean)) {
+            if (Buffer.byteLength(line, 'utf8') > maxBytes) {
+                if (current) {
+                    parts.push(current);
+                    current = '';
+                }
+                parts.push(...this.splitLongStringByByteBudget(line, maxBytes));
+                continue;
+            }
+
+            if (current && Buffer.byteLength(current + line, 'utf8') > maxBytes) {
+                parts.push(current);
+                current = line;
+            } else {
+                current += line;
+            }
+        }
+
+        if (current) {
+            parts.push(current);
+        }
+
+        return parts.filter(part => part.length > 0);
+    }
+
+    /**
+     * @summary Splits one oversized line without breaking JavaScript surrogate pairs.
+     * @param {String} value Source string.
+     * @param {Number} maxBytes Maximum byte size per part.
+     * @returns {String[]}
+     * @protected
+     */
+    splitLongStringByByteBudget(value, maxBytes) {
+        const parts   = [];
+        let   current = '';
+
+        for (const char of value) {
+            if (current && Buffer.byteLength(current + char, 'utf8') > maxBytes) {
+                parts.push(current);
+                current = char;
+            } else {
+                current += char;
+            }
+        }
+
+        if (current) {
+            parts.push(current);
+        }
+
+        return parts;
     }
 
     /**

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -20,7 +20,6 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs-extra';
 import aiConfig       from '../../../../../../ai/mcp/server/knowledge-base/config.mjs';
-import memoryConfig   from '../../../../../../ai/mcp/server/memory-core/config.mjs';
 
 /**
  * Contract coverage for KnowledgeBaseIngestionService (#11633).
@@ -91,10 +90,20 @@ function createGraphStub() {
     };
 }
 
+function createEmbeddingGuardrail(overrides = {}) {
+    return {
+        enabled                  : true,
+        embeddingProvider        : 'openAiCompatible',
+        contextLimitTokens       : 100,
+        safeProcessingLimitTokens: 80,
+        model                    : 'unit-test-embedding-model',
+        ...overrides
+    };
+}
+
 test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
     let Service;
     let originals;
-    let originalEmbeddingConfig;
     let vectorCalls;
     let metrics;
     let collection;
@@ -109,19 +118,15 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         collection  = createSpyCollection();
 
         originals = {
-            chromaManager        : Service.chromaManager,
-            graphService         : Service.graphService,
-            getTenantConfig      : Service.getTenantConfig,
-            recorderService      : Service.recorderService,
-            requestContextService: Service.requestContextService,
-            revisionResolver     : Service.revisionResolver,
-            sourceRegistry       : Service.sourceRegistry,
-            vectorService        : Service.vectorService
-        };
-        originalEmbeddingConfig = {
-            embeddingProvider        : memoryConfig.data.embeddingProvider,
-            contextLimitTokens       : Number(aiConfig.data.localModels.embedding.contextLimitTokens),
-            safeProcessingLimitTokens: Number(aiConfig.data.localModels.embedding.safeProcessingLimitTokens)
+            chromaManager                 : Service.chromaManager,
+            graphService                  : Service.graphService,
+            getTenantConfig               : Service.getTenantConfig,
+            recorderService               : Service.recorderService,
+            requestContextService         : Service.requestContextService,
+            resolveEmbeddingInputGuardrail: Service.resolveEmbeddingInputGuardrail,
+            revisionResolver              : Service.revisionResolver,
+            sourceRegistry                : Service.sourceRegistry,
+            vectorService                 : Service.vectorService
         };
 
         Service.chromaManager = {
@@ -154,9 +159,6 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
 
     test.afterEach(() => {
         Object.assign(Service, originals);
-        memoryConfig.data.embeddingProvider = originalEmbeddingConfig.embeddingProvider;
-        aiConfig.data.localModels.embedding.contextLimitTokens        = originalEmbeddingConfig.contextLimitTokens;
-        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = originalEmbeddingConfig.safeProcessingLimitTokens;
     });
 
     test('validates parsed-chunk-v1 records, routes them to VectorService, and records telemetry', async () => {
@@ -398,9 +400,7 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
     });
 
     test('splits over-budget client parsed chunks while embedding safe chunks', async () => {
-        memoryConfig.data.embeddingProvider                            = 'openAiCompatible';
-        aiConfig.data.localModels.embedding.contextLimitTokens        = 100;
-        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = 80;
+        Service.resolveEmbeddingInputGuardrail = () => createEmbeddingGuardrail();
         const monsterContent = Array.from({length: 12}, (_, index) => `line-${index} ${'x'.repeat(24)}`).join('\n');
 
         const summary = await Service.ingestSourceFiles({
@@ -444,9 +444,7 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
     });
 
     test('splits over-budget raw fallback files before VectorService receives a temp JSONL', async () => {
-        memoryConfig.data.embeddingProvider                            = 'openAiCompatible';
-        aiConfig.data.localModels.embedding.contextLimitTokens        = 100;
-        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = 80;
+        Service.resolveEmbeddingInputGuardrail = () => createEmbeddingGuardrail();
 
         const summary = await Service.ingestSourceFiles({
             tenantId: 'tenant-a',
@@ -474,9 +472,10 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
     });
 
     test('keeps skip diagnostics for over-budget chunks that cannot be split', async () => {
-        memoryConfig.data.embeddingProvider                            = 'openAiCompatible';
-        aiConfig.data.localModels.embedding.contextLimitTokens        = 50;
-        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = 40;
+        Service.resolveEmbeddingInputGuardrail = () => createEmbeddingGuardrail({
+            contextLimitTokens       : 50,
+            safeProcessingLimitTokens: 40
+        });
 
         const summary = await Service.ingestSourceFiles({
             tenantId: 'tenant-a',
@@ -503,9 +502,13 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
     });
 
     test('does not apply local embedding caps to non-local ingestion providers', async () => {
-        memoryConfig.data.embeddingProvider                            = 'gemini';
-        aiConfig.data.localModels.embedding.contextLimitTokens        = 50;
-        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = 1;
+        Service.resolveEmbeddingInputGuardrail = () => createEmbeddingGuardrail({
+            enabled                  : false,
+            embeddingProvider        : 'gemini',
+            contextLimitTokens       : 50,
+            safeProcessingLimitTokens: 1,
+            model                    : 'gemini'
+        });
 
         const summary = await Service.ingestSourceFiles({
             tenantId: 'tenant-a',

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -397,56 +397,94 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         });
     });
 
-    test('skips over-budget client parsed chunks while embedding safe chunks', async () => {
+    test('splits over-budget client parsed chunks while embedding safe chunks', async () => {
         memoryConfig.data.embeddingProvider                            = 'openAiCompatible';
-        aiConfig.data.localModels.embedding.contextLimitTokens        = 50;
-        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = 40;
+        aiConfig.data.localModels.embedding.contextLimitTokens        = 100;
+        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = 80;
+        const monsterContent = Array.from({length: 12}, (_, index) => `line-${index} ${'x'.repeat(24)}`).join('\n');
 
         const summary = await Service.ingestSourceFiles({
             tenantId: 'tenant-a',
             files   : [{parsedChunks: [
                 validParsedChunk({sourcePath: 'src/safe.js', content: 'short payload'}),
-                validParsedChunk({sourcePath: 'src/monster.js', content: 'x'.repeat(300)})
+                validParsedChunk({sourcePath: 'src/monster.js', content: monsterContent})
             ]}]
         });
 
-        expect(summary.ingested).toBe(1);
-        expect(summary.embeddingsGenerated).toBe(1);
-        expect(summary.skippedOversized).toBe(1);
-        expect(summary.errors[0]).toMatchObject({
-            code   : 'KB_INGEST_INPUT_SIZE_EXCEEDED',
-            details: {
-                tenantId         : 'tenant-a',
-                repoSlug         : 'repo-a',
-                sourcePath       : 'src/monster.js',
-                parserId         : 'client-parser',
-                embeddingProvider: 'openAiCompatible'
-            }
-        });
-        expect(summary.errors[0].details).not.toHaveProperty('content');
+        expect(summary.ingested).toBeGreaterThan(1);
+        expect(summary.embeddingsGenerated).toBe(summary.ingested);
+        expect(summary.skippedOversized).toBe(0);
+        expect(summary.errors).toEqual([]);
         expect(vectorCalls).toHaveLength(1);
-        expect(vectorCalls[0].records).toHaveLength(1);
         expect(vectorCalls[0].records[0].sourcePath).toBe('src/safe.js');
+
+        const splitRecords = vectorCalls[0].records.filter(record => record.sourcePath === 'src/monster.js');
+
+        expect(splitRecords.length).toBeGreaterThan(1);
+        expect(splitRecords.map(record => record.oversizedSplitIndex)).toEqual(splitRecords.map((_, index) => index));
+        expect(splitRecords.every(record => record.oversizedSplit === true)).toBe(true);
+        expect(splitRecords.every(record => record.oversizedSplitTotal === splitRecords.length)).toBe(true);
+        expect(new Set(splitRecords.map(record => record.id)).size).toBe(splitRecords.length);
         expect(metrics[0]).toMatchObject({
-            eventType     : 'error',
-            chunksTotal   : 2,
-            chunksEmbedded: 1
+            eventType     : 'ingest',
+            chunksTotal   : summary.ingested,
+            chunksEmbedded: summary.ingested
         });
-        expect(metrics[0].detail.errors[0].code).toBe('KB_INGEST_INPUT_SIZE_EXCEEDED');
+
+        const firstIds = splitRecords.map(record => record.id);
+        vectorCalls = [];
+        metrics     = [];
+
+        await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk({sourcePath: 'src/monster.js', content: monsterContent})]}]
+        });
+
+        expect(vectorCalls[0].records.map(record => record.id)).toEqual(firstIds);
     });
 
-    test('skips over-budget raw fallback files before VectorService receives a temp JSONL', async () => {
+    test('splits over-budget raw fallback files before VectorService receives a temp JSONL', async () => {
+        memoryConfig.data.embeddingProvider                            = 'openAiCompatible';
+        aiConfig.data.localModels.embedding.contextLimitTokens        = 100;
+        aiConfig.data.localModels.embedding.safeProcessingLimitTokens = 80;
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            repoSlug: 'repo-a',
+            files   : [{
+                content   : Array.from({length: 12}, (_, index) => `section-${index} ${'y'.repeat(24)}`).join('\n'),
+                sourcePath: 'docs/monster.md'
+            }]
+        });
+
+        expect(summary.ingested).toBeGreaterThan(1);
+        expect(summary.embeddingsGenerated).toBe(summary.ingested);
+        expect(summary.skippedOversized).toBe(0);
+        expect(summary.errors).toEqual([]);
+        expect(vectorCalls).toHaveLength(1);
+        expect(vectorCalls[0].records.length).toBe(summary.ingested);
+        expect(vectorCalls[0].records.every(record => record.sourcePath === 'docs/monster.md')).toBe(true);
+        expect(vectorCalls[0].records.every(record => record.parserId === 'raw-text')).toBe(true);
+        expect(vectorCalls[0].records.every(record => record.oversizedSplit === true)).toBe(true);
+        expect(metrics[0]).toMatchObject({
+            eventType     : 'ingest',
+            chunksTotal   : summary.ingested,
+            chunksEmbedded: summary.ingested
+        });
+    });
+
+    test('keeps skip diagnostics for over-budget chunks that cannot be split', async () => {
         memoryConfig.data.embeddingProvider                            = 'openAiCompatible';
         aiConfig.data.localModels.embedding.contextLimitTokens        = 50;
         aiConfig.data.localModels.embedding.safeProcessingLimitTokens = 40;
 
         const summary = await Service.ingestSourceFiles({
             tenantId: 'tenant-a',
-            repoSlug: 'repo-a',
-            files   : [{
-                content   : 'x'.repeat(300),
-                sourcePath: 'docs/monster.md'
-            }]
+            files   : [{parsedChunks: [validParsedChunk({
+                content   : '',
+                name      : 'x'.repeat(300),
+                sourcePath: 'src/metadata-only.js'
+            })]}]
         });
 
         expect(summary.ingested).toBe(0);
@@ -455,17 +493,13 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         expect(summary.errors[0]).toMatchObject({
             code   : 'KB_INGEST_INPUT_SIZE_EXCEEDED',
             details: {
-                sourcePath   : 'docs/monster.md',
-                parserId     : 'raw-text',
-                parserVersion: '1.0.0'
+                sourcePath       : 'src/metadata-only.js',
+                parserId         : 'client-parser',
+                embeddingProvider: 'openAiCompatible'
             }
         });
+        expect(summary.errors[0].details).not.toHaveProperty('content');
         expect(vectorCalls).toHaveLength(0);
-        expect(metrics[0]).toMatchObject({
-            eventType     : 'error',
-            chunksTotal   : 1,
-            chunksEmbedded: 0
-        });
     });
 
     test('does not apply local embedding caps to non-local ingestion providers', async () => {


### PR DESCRIPTION
Resolves #14000

Adds deterministic oversized-source chunking inside `KnowledgeBaseIngestionService` before the final embedding guardrail. Recoverable raw fallback and parser-produced text chunks are split into embedding-safe sub-chunks, keep trace metadata, and receive stable rehashed IDs; unsplittable chunks still use the existing bounded `KB_INGEST_INPUT_SIZE_EXCEEDED` diagnostic. `VectorService` remains the final refusal guardrail, and no provider limits are raised.

Evidence: L2 (unit-level ingestion path with mocked `VectorService` boundary and deterministic ID assertions) -> L2 required (pre-provider KB ingestion behavior). No residuals.

Related: #13999
Related: #13930
Related: #13929

## Deltas from ticket

No response schema change was needed: the existing summary fields already distinguish embedded chunks from final skipped chunks. Split metadata is stored on generated chunk records as `oversizedSplit`, `oversizedSplitIndex`, `oversizedSplitTotal`, `oversizedSplitCharStart`, and `oversizedSplitCharEnd`.

## Test Evidence

- `npm run agent-preflight -- ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs` passed: 37/37.
- `git diff --check` passed.
- Freshness check passed after rebase: `merge-base HEAD origin/dev == origin/dev` at `f97d1562a63272c86fb44e71e055111b19794ad2`.

## Post-Merge Validation

- [ ] Run a KB sync including `resources/content/issues/chunk-2/issue-12065.md` and verify rows exist for that `sourcePath` with `oversizedSplit` metadata instead of a zero-vector skip.

## Commits

- `2603f918cc` - `fix(ai): chunk oversized kb sources before embedding (#14000)`

## Evolution

This spun out of the `#13999` backup investigation after the operator's log sample proved a separate KB completeness gap: the KB store can remain exportable while an oversized source is missing entirely because the prior safety behavior skipped instead of splitting. This PR keeps the safety invariant and recovers vectors for split-safe sources.

Authored by Euclid (GPT-5, Codex Desktop). Session f4d00667-a65a-4285-83f5-6761f3aea394.
