### PR TITLE
fix(ai): preserve Memory Core partial-export collection identity (#14001)

### DIFF
--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -45,18 +45,19 @@ class DatabaseService extends Base {
      * @param {Object} collection The ChromaDB collection to export.
      * @param {String} backupPath The directory to save the backup file.
      * @param {String} filePrefix The prefix for the backup filename.
+     * @param {String} collectionName Stable collection label for logs, stats, and fail-loud errors.
      * @returns {Promise<{collection: String, backupFile: String|null, expected: Number, exported: Number, skipped: Number, skippedIds: String[]}>} Export statistics.
      * @private
      */
-    async #exportCollection(collection, backupPath, filePrefix) {
-        logger.log(`Fetching all documents from "${collection.name}"...`);
+    async #exportCollection(collection, backupPath, filePrefix, collectionName = collection.name || filePrefix) {
+        logger.log(`Fetching all documents from "${collectionName}"...`);
 
         // 1. Get total count first
         const count = await collection.count();
         if (count === 0) {
-            logger.log(`No documents found in ${collection.name} to export.`);
+            logger.log(`No documents found in ${collectionName} to export.`);
             return {
-                collection: collection.name,
+                collection: collectionName,
                 backupFile: null,
                 expected  : 0,
                 exported  : 0,
@@ -65,14 +66,14 @@ class DatabaseService extends Base {
             }
         }
 
-        logger.log(`Found ${count} documents in ${collection.name} to export.`);
+        logger.log(`Found ${count} documents in ${collectionName} to export.`);
 
         await fs.ensureDir(backupPath);
-        const timestamp   = new Date().toISOString().replace(/:/g, '-');
+        const timestamp = new Date().toISOString().replace(/:/g, '-');
         const backupFile  = path.join(backupPath, `${filePrefix}-${timestamp}.jsonl`);
         const writeStream = fs.createWriteStream(backupFile);
-        const stats = {
-            collection: collection.name,
+        const stats       = {
+            collection: collectionName,
             backupFile,
             expected  : count,
             exported  : 0,
@@ -81,8 +82,8 @@ class DatabaseService extends Base {
         };
 
         // 2. Paginated Fetch
-        const limit = 2000; // Safe batch size
-        let offset  = 0;
+        const limit  = 2000; // Safe batch size
+        let   offset = 0;
 
         while (offset < count) {
             logger.log(`Fetching batch: ${offset} to ${Math.min(offset + limit, count)} of ${count}`);
@@ -146,7 +147,7 @@ class DatabaseService extends Base {
         await new Promise(resolve => writeStream.end(resolve));
         if (stats.exported !== stats.expected) {
             const error = new Error(
-                `PARTIAL_COLLECTION_EXPORT: ${collection.name} exported ${stats.exported}/${stats.expected} ` +
+                `PARTIAL_COLLECTION_EXPORT: ${collectionName} exported ${stats.exported}/${stats.expected} ` +
                 `records to ${backupFile}; skipped ${stats.skipped} corrupted vector id(s).`
             );
             error.code    = 'PARTIAL_COLLECTION_EXPORT';
@@ -154,7 +155,7 @@ class DatabaseService extends Base {
             throw error
         }
 
-        logger.log(`Successfully exported ${stats.exported}/${stats.expected} documents to: ${backupFile}`);
+        logger.log(`Successfully exported ${stats.exported}/${stats.expected} documents from ${collectionName} to: ${backupFile}`);
         return stats
     }
 
@@ -197,11 +198,11 @@ class DatabaseService extends Base {
 
         logger.log(`Found ${nodesCount} nodes and ${edgesCount} edges to export.`);
 
-        const fs        = (await import('fs-extra')).default;
-        const path      = (await import('path')).default;
+        const fs   = (await import('fs-extra')).default;
+        const path = (await import('path')).default;
         await fs.ensureDir(backupPath);
 
-        const timestamp   = new Date().toISOString().replace(/:/g, '-');
+        const timestamp = new Date().toISOString().replace(/:/g, '-');
         const backupFile  = path.join(backupPath, `${filePrefix}-${timestamp}.jsonl`);
         const writeStream = fs.createWriteStream(backupFile);
 
@@ -211,7 +212,7 @@ class DatabaseService extends Base {
         const nodesStmt = db.prepare('SELECT data FROM Nodes');
         for (const row of nodesStmt.iterate()) {
              try {
-                 const node = JSON.parse(row.data);
+                 const node   = JSON.parse(row.data);
                  const record = { type: 'node', data: node };
                  writeStream.write(JSON.stringify(record) + '\n');
                  exported++;
@@ -224,7 +225,7 @@ class DatabaseService extends Base {
         const edgesStmt = db.prepare('SELECT data FROM Edges');
         for (const row of edgesStmt.iterate()) {
              try {
-                 const edge = JSON.parse(row.data);
+                 const edge   = JSON.parse(row.data);
                  const record = { type: 'edge', data: edge };
                  writeStream.write(JSON.stringify(record) + '\n');
                  exported++;
@@ -269,11 +270,11 @@ class DatabaseService extends Base {
             db.prepare('DELETE FROM Edges').run();
         }
 
-        const fs = (await import('fs-extra')).default;
+        const fs       = (await import('fs-extra')).default;
         const readline = (await import('readline')).default;
 
         const fileStream = fs.createReadStream(filePath);
-        const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+        const rl         = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
 
         let imported = 0;
 
@@ -384,12 +385,12 @@ class DatabaseService extends Base {
 
             if (include.includes('memories')) {
                 const collection = await StorageRouter.getMemoryCollection();
-                memoryStats      = await this.#exportCollection(collection, backupPath, 'memory-backup');
+                memoryStats      = await this.#exportCollection(collection, backupPath, 'memory-backup', aiConfig.collections.memory);
             }
 
             if (include.includes('summaries')) {
                 const collection = await StorageRouter.getSummaryCollection();
-                summaryStats     = await this.#exportCollection(collection, backupPath, 'summaries-backup');
+                summaryStats     = await this.#exportCollection(collection, backupPath, 'summaries-backup', aiConfig.collections.session);
             }
 
             if (include.includes('graph')) {
@@ -397,7 +398,7 @@ class DatabaseService extends Base {
                 graphStats       = {expected: graphCount, exported: graphCount};
             }
 
-            const memoryCount = memoryStats?.exported || 0,
+            const memoryCount  = memoryStats?.exported || 0,
                   summaryCount = summaryStats?.exported || 0,
                   graphCount   = graphStats?.exported || 0,
                   result       = {
@@ -519,7 +520,7 @@ class DatabaseService extends Base {
 
                 // Determine which collection to import into based on filename heuristics
                 const isMemoryBackup = path.basename(filePath).startsWith('memory-backup');
-                let collection       = isMemoryBackup
+                let   collection     = isMemoryBackup
                     ? await StorageRouter.getMemoryCollection()
                     : await StorageRouter.getSummaryCollection();
 
@@ -574,7 +575,7 @@ class DatabaseService extends Base {
                         existence.ids.forEach(id => existingIds.add(id));
                     }
 
-                    const missing       = records.filter(r => !existingIds.has(r.id));
+                    const missing = records.filter(r => !existingIds.has(r.id));
                     fileSkippedExisting = existingIds.size;
 
                     if (existingIds.size > 0) {

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs
@@ -27,18 +27,20 @@ import path            from 'path';
 test.describe.configure({mode: 'serial'});
 
 test.describe('Memory_DatabaseService — backupPath routing (#10129 Phase 2 prerequisite)', () => {
-    let SDK, Memory_DatabaseService, Memory_StorageRouter;
-    let originalGetMemory, originalGetSummary, tmpDir;
+    let SDK, aiConfig, Memory_DatabaseService, Memory_StorageRouter;
+    let memoryCollectionName, originalGetMemory, originalGetSummary, tmpDir;
 
     test.beforeAll(async () => {
-        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         if (!aiConfig.collections) aiConfig.collections = {};
-        aiConfig.collections.memory = `test-memory-${process.pid}-${Date.now()}`;
+        memoryCollectionName       = `test-memory-${process.pid}-${Date.now()}`;
+        aiConfig.collections.memory = memoryCollectionName;
         aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
 
         SDK                    = await import('../../../../../../ai/services.mjs');
         Memory_DatabaseService = SDK.Memory_DatabaseService;
         Memory_StorageRouter   = SDK.Memory_StorageRouter;
+        memoryCollectionName   = aiConfig.collections.memory;
 
         tmpDir = path.resolve(process.cwd(), 'tmp', `mc-backuppath-test-${process.pid}-${Date.now()}`);
         fs.mkdirSync(tmpDir, {recursive: true});
@@ -104,7 +106,7 @@ test.describe('Memory_DatabaseService — backupPath routing (#10129 Phase 2 pre
         expect(produced.some(f => f.startsWith('summaries-backup-'))).toBe(true);
     });
 
-    test('fails loudly when corrupt vector ids make a collection export partial (#13496)', async () => {
+    test('fails loudly when corrupt vector ids make a collection export partial without collection.name (#13496, #13999)', async () => {
         const partialDir = path.join(tmpDir, `partial-${Date.now()}`);
         fs.mkdirSync(partialDir, {recursive: true});
 
@@ -114,7 +116,6 @@ test.describe('Memory_DatabaseService — backupPath routing (#10129 Phase 2 pre
         ];
 
         const partialCollection = {
-            name : 'fake-memories-partial',
             count: async () => rows.length,
             get  : async ({ids, include = [], limit, offset = 0} = {}) => {
                 if (ids) {
@@ -137,11 +138,23 @@ test.describe('Memory_DatabaseService — backupPath routing (#10129 Phase 2 pre
 
         Memory_StorageRouter.getMemoryCollection = async () => partialCollection;
 
-        await expect(Memory_DatabaseService.manageDatabaseBackup({
-            action    : 'export',
-            include   : ['memories'],
-            backupPath: partialDir
-        })).rejects.toThrow(/DATABASE_EXPORT_ERROR: PARTIAL_COLLECTION_EXPORT: fake-memories-partial exported 1\/2/);
+        let error;
+        try {
+            await Memory_DatabaseService.manageDatabaseBackup({
+                action    : 'export',
+                include   : ['memories'],
+                backupPath: partialDir
+            });
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBeDefined();
+        expect(error.message).toContain(
+            `DATABASE_EXPORT_ERROR: PARTIAL_COLLECTION_EXPORT: ${memoryCollectionName} exported 1/2`
+        );
+        expect(error.message).not.toContain('undefined exported');
+        expect(error.details.collection).toBe(memoryCollectionName);
 
         const produced = fs.readdirSync(partialDir).filter(f => f.startsWith('memory-backup-'));
         expect(produced.length).toBe(1);


### PR DESCRIPTION
Resolves #14001

Threads a stable Memory Core collection label into the partial-export path so `PARTIAL_COLLECTION_EXPORT` logs, stats, and thrown error details no longer collapse to `collection: undefined` when a Chroma collection handle lacks `.name`. The export still fails loudly on partial output; this PR only repairs operator-triage fidelity for the `#13999` backup incident.

Evidence: L2 (unit-level Memory Core export-path regression with a fake collection omitting `.name`) -> L2 required (error/log detail contract). No residuals.

Related: #13999
Related: #13583
Related: #13584

## Deltas from ticket

None. The parent `#13999` remains open for the live exportability diagnostic, production repair path, and canonical backup parity proof.

## Test Evidence

- `npm run agent-preflight -- ai/services/memory-core/DatabaseService.mjs test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs` passed: 2/2.
- `git diff --check` passed.
- Rebased onto current `origin/dev` before publish; outgoing range is exactly `e978c9f3b2`.

## Post-Merge Validation

- [ ] Re-run the Memory Core backup/exportability diagnostic from #13999 and verify any partial-export failure names the affected Memory Core collection instead of `undefined`.

## Commits

- `e978c9f3b2` - `fix(ai): preserve Memory Core partial-export collection identity (#14001)`

## Evolution

This was split out of `#13999` because the implementation is a narrow, reviewable diagnostic-contract repair. It improves the incident evidence surface without pretending the broader live Memory Core collection repair is complete.

Authored by Euclid (GPT-5, Codex Desktop). Session f4d00667-a65a-4285-83f5-6761f3aea394.
