### PR TITLE
fix(ai): cover full kb sync oversized splitting (#14007)

### DIFF
--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -720,7 +720,11 @@ class KnowledgeBaseIngestionService extends Base {
                 continue;
             }
 
-            const splitChunks = this.splitOversizedEmbeddingChunk({chunk, guardrail, tenantContext});
+            const splitChunks = this.vectorService.splitOversizedEmbeddingChunk({
+                chunk,
+                guardrail,
+                createHash: splitChunk => this.createChunkHash(splitChunk, tenantContext)
+            });
 
             if (splitChunks.length <= 1) {
                 this.recordOversizedEmbeddingSkip({
@@ -771,129 +775,6 @@ class KnowledgeBaseIngestionService extends Base {
             inputBytes,
             inputTokensEstimate
         };
-    }
-
-    /**
-     * @summary Splits a recoverable oversized text chunk into deterministic embedding-safe sub-chunks.
-     * @param {Object} options
-     * @returns {Object[]} Either multiple sub-chunks or the original chunk when no safe split is possible.
-     * @protected
-     */
-    splitOversizedEmbeddingChunk({chunk, guardrail, tenantContext}) {
-        const content = chunk.content || chunk.description;
-
-        if (typeof content !== 'string' || content.length === 0) {
-            return [chunk];
-        }
-
-        const maxInputBytes = Math.max(1, guardrail.safeProcessingLimitTokens * 3),
-              prefixBytes   = Buffer.byteLength(`${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n`, 'utf8'),
-              maxContentBytes = Math.max(1, maxInputBytes - prefixBytes - 128),
-              parts = this.splitTextByByteBudget(content, maxContentBytes);
-
-        if (parts.length <= 1) {
-            return [chunk];
-        }
-
-        let charStart = 0;
-
-        return parts.map((part, index) => {
-            const charEnd = charStart + part.length,
-                  child   = {
-                      ...chunk,
-                      content    : part,
-                      description: part,
-                      name         : `${chunk.name} [part ${index + 1}/${parts.length}]`,
-                      hashInputs   : Array.from(new Set([
-                          ...(chunk.hashInputs || []),
-                          'oversizedSplitIndex',
-                          'oversizedSplitTotal',
-                          'oversizedSplitCharStart',
-                          'oversizedSplitCharEnd'
-                      ])),
-                      oversizedSplit         : true,
-                      oversizedSplitIndex    : index,
-                      oversizedSplitTotal    : parts.length,
-                      oversizedSplitCharStart: charStart,
-                      oversizedSplitCharEnd  : charEnd
-                  };
-
-            charStart = charEnd;
-
-            const hash = this.createChunkHash(child, tenantContext);
-
-            child.hash = hash;
-            child.id   = hash;
-
-            return child;
-        });
-    }
-
-    /**
-     * @summary Splits text on stable line boundaries, falling back to character slices for single huge lines.
-     * @param {String} text Source text.
-     * @param {Number} maxBytes Maximum byte size per returned part.
-     * @returns {String[]}
-     * @protected
-     */
-    splitTextByByteBudget(text, maxBytes) {
-        if (Buffer.byteLength(text, 'utf8') <= maxBytes) {
-            return [text];
-        }
-
-        const parts   = [];
-        let   current = '';
-
-        for (const line of text.match(/[^\n]*\n?|[^\n]+$/g).filter(Boolean)) {
-            if (Buffer.byteLength(line, 'utf8') > maxBytes) {
-                if (current) {
-                    parts.push(current);
-                    current = '';
-                }
-                parts.push(...this.splitLongStringByByteBudget(line, maxBytes));
-                continue;
-            }
-
-            if (current && Buffer.byteLength(current + line, 'utf8') > maxBytes) {
-                parts.push(current);
-                current = line;
-            } else {
-                current += line;
-            }
-        }
-
-        if (current) {
-            parts.push(current);
-        }
-
-        return parts.filter(part => part.length > 0);
-    }
-
-    /**
-     * @summary Splits one oversized line without breaking JavaScript surrogate pairs.
-     * @param {String} value Source string.
-     * @param {Number} maxBytes Maximum byte size per part.
-     * @returns {String[]}
-     * @protected
-     */
-    splitLongStringByByteBudget(value, maxBytes) {
-        const parts   = [];
-        let   current = '';
-
-        for (const char of value) {
-            if (current && Buffer.byteLength(current + char, 'utf8') > maxBytes) {
-                parts.push(current);
-                current = char;
-            } else {
-                current += char;
-            }
-        }
-
-        if (current) {
-            parts.push(current);
-        }
-
-        return parts;
     }
 
     /**

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -304,6 +304,237 @@ class VectorService extends Base {
     }
 
     /**
+     * Builds the provider input string used by the embedding guardrail and provider call.
+     *
+     * @param {Object} chunk Parsed knowledge chunk.
+     * @returns {String} Provider input text.
+     */
+    buildEmbeddingInputText(chunk) {
+        return `${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n${chunk.description || chunk.content || ''}`;
+    }
+
+    /**
+     * Expands recoverable over-budget text chunks before tenant stamping and diffing.
+     *
+     * The final `embedChunks()` guardrail still refuses any chunk that remains too large;
+     * this pass only prevents the full-corpus sync route from losing split-safe source
+     * files before they ever become Chroma rows.
+     *
+     * @param {Object[]} chunks Raw parsed knowledge chunks read from JSONL.
+     * @returns {Object[]} Original chunks plus deterministic split children.
+     */
+    expandOversizedEmbeddingChunks(chunks) {
+        const guardrail = this.resolveEmbeddingGuardrail();
+
+        if (!guardrail.enabled) {
+            return chunks;
+        }
+
+        const expanded = [];
+
+        for (const chunk of chunks) {
+            const inputText  = this.buildEmbeddingInputText(chunk),
+                  evaluation = this.measureEmbeddingInput({text: inputText, guardrail});
+
+            if (!evaluation.skip) {
+                expanded.push(chunk);
+                continue;
+            }
+
+            const splitChunks = this.splitOversizedEmbeddingChunk({chunk, guardrail});
+
+            expanded.push(...splitChunks);
+        }
+
+        return expanded;
+    }
+
+    /**
+     * Creates a deterministic pre-tenant split hash for a full-sync child chunk.
+     *
+     * @param {Object} options
+     * @param {Object} options.chunk     Source chunk before splitting.
+     * @param {String} options.content   Split content slice.
+     * @param {Number} options.index     Zero-based split index.
+     * @param {Number} options.total     Total split count.
+     * @param {Number} options.charStart Character offset where the split starts.
+     * @param {Number} options.charEnd   Character offset where the split ends.
+     * @returns {String} Stable SHA-256 hash.
+     */
+    createSplitChunkHash({chunk, content, index, total, charStart, charEnd}) {
+        const identityString = JSON.stringify({
+            parentHash             : chunk.hash,
+            type                   : chunk.type,
+            kind                   : chunk.kind,
+            name                   : chunk.name,
+            source                 : chunk.source,
+            content,
+            oversizedSplitIndex    : index,
+            oversizedSplitTotal    : total,
+            oversizedSplitCharStart: charStart,
+            oversizedSplitCharEnd  : charEnd
+        });
+
+        return crypto.createHash('sha256').update(identityString).digest('hex');
+    }
+
+    /**
+     * Splits a recoverable over-budget text chunk into deterministic sub-chunks.
+     *
+     * @param {Object} options
+     * @param {Object} options.chunk     Source chunk before tenant stamping.
+     * @param {Object} options.guardrail Resolved embedding guardrail.
+     * @param {Function} [options.createHash] Optional caller-specific split hash function.
+     * @returns {Object[]} Either split children or the original chunk.
+     */
+    splitOversizedEmbeddingChunk({chunk, guardrail, createHash}) {
+        const content = chunk.content || chunk.description;
+
+        if (typeof content !== 'string' || content.length === 0) {
+            return [chunk];
+        }
+
+        const maxInputBytes = Math.max(1, guardrail.safeProcessingLimitTokens * 3),
+              prefixBytes     = Buffer.byteLength(`${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n`, 'utf8'),
+              maxContentBytes = Math.max(1, maxInputBytes - prefixBytes - 128),
+              parts           = this.splitTextByByteBudget(content, maxContentBytes);
+
+        if (parts.length <= 1) {
+            return [chunk];
+        }
+
+        let charStart = 0;
+
+        return parts.map((part, index) => {
+            const charEnd = charStart + part.length,
+                  child   = {
+                      ...chunk,
+                      content    : part,
+                      description: part,
+                      name       : `${chunk.name} [part ${index + 1}/${parts.length}]`,
+                      hashInputs : Array.from(new Set([
+                          ...(chunk.hashInputs || []),
+                          'oversizedSplitIndex',
+                          'oversizedSplitTotal',
+                          'oversizedSplitCharStart',
+                          'oversizedSplitCharEnd'
+                      ])),
+                      oversizedSplit         : true,
+                      oversizedSplitIndex    : index,
+                      oversizedSplitTotal    : parts.length,
+                      oversizedSplitCharStart: charStart,
+                      oversizedSplitCharEnd  : charEnd
+                  };
+
+            const hash = createHash
+                ? createHash(child)
+                : this.createSplitChunkHash({
+                    chunk,
+                    content: part,
+                    index,
+                    total  : parts.length,
+                    charStart,
+                    charEnd
+                });
+
+            child.hash = hash;
+            child.id   = hash;
+            charStart = charEnd;
+            return child;
+        });
+    }
+
+    /**
+     * Splits text on stable line boundaries, falling back to character slices for huge lines.
+     *
+     * @param {String} text Source text.
+     * @param {Number} maxBytes Maximum byte size per returned part.
+     * @returns {String[]} Split text parts.
+     */
+    splitTextByByteBudget(text, maxBytes) {
+        if (Buffer.byteLength(text, 'utf8') <= maxBytes) {
+            return [text];
+        }
+
+        const parts   = [];
+        let   current = '';
+
+        for (const line of text.match(/[^\n]*\n?|[^\n]+$/g).filter(Boolean)) {
+            if (Buffer.byteLength(line, 'utf8') > maxBytes) {
+                if (current) {
+                    parts.push(current);
+                    current = '';
+                }
+                parts.push(...this.splitLongStringByByteBudget(line, maxBytes));
+                continue;
+            }
+
+            if (current && Buffer.byteLength(current + line, 'utf8') > maxBytes) {
+                parts.push(current);
+                current = line;
+            } else {
+                current += line;
+            }
+        }
+
+        if (current) {
+            parts.push(current);
+        }
+
+        return parts.filter(part => part.length > 0);
+    }
+
+    /**
+     * Splits one oversized line without breaking JavaScript surrogate pairs.
+     *
+     * @param {String} value Source string.
+     * @param {Number} maxBytes Maximum byte size per part.
+     * @returns {String[]} Split text parts.
+     */
+    splitLongStringByByteBudget(value, maxBytes) {
+        const parts   = [];
+        let   current = '';
+
+        for (const char of value) {
+            if (current && Buffer.byteLength(current + char, 'utf8') > maxBytes) {
+                parts.push(current);
+                current = char;
+            } else {
+                current += char;
+            }
+        }
+
+        if (current) {
+            parts.push(current);
+        }
+
+        return parts;
+    }
+
+    /**
+     * Measures provider input size without recording a final refusal diagnostic.
+     *
+     * @param {Object} options
+     * @param {String} options.text Provider input text.
+     * @param {Object} options.guardrail Resolved embedding guardrail.
+     * @returns {{skip: Boolean, inputBytes: Number, inputTokensEstimate: Number}}
+     */
+    measureEmbeddingInput({text, guardrail}) {
+        if (!guardrail.enabled) {
+            return {skip: false, inputBytes: 0, inputTokensEstimate: 0};
+        }
+
+        const inputBytes          = Buffer.byteLength(text || '', 'utf8');
+        const inputTokensEstimate = bytesToTokens(inputBytes);
+
+        return {
+            skip: inputTokensEstimate > guardrail.safeProcessingLimitTokens,
+            inputBytes,
+            inputTokensEstimate
+        };
+    }
+
+    /**
      * Emits a bounded, non-secret friction record for an over-budget embedding input.
      *
      * @param {Object} options
@@ -313,14 +544,9 @@ class VectorService extends Base {
      * @returns {{skip: Boolean, inputBytes: Number, inputTokensEstimate: Number}}
      */
     evaluateEmbeddingInput({chunk, text, guardrail}) {
-        if (!guardrail.enabled) {
-            return {skip: false, inputBytes: 0, inputTokensEstimate: 0};
-        }
+        const {skip, inputBytes, inputTokensEstimate} = this.measureEmbeddingInput({text, guardrail});
 
-        const inputBytes          = Buffer.byteLength(text || '', 'utf8');
-        const inputTokensEstimate = bytesToTokens(inputBytes);
-
-        if (inputTokensEstimate <= guardrail.safeProcessingLimitTokens) {
+        if (!skip) {
             return {skip: false, inputBytes, inputTokensEstimate};
         }
 
@@ -370,9 +596,9 @@ class VectorService extends Base {
         logger.log('Embedding chunks...');
 
         const {batchSize, batchDelay, maxRetries} = aiConfig;
-        const guardrail     = this.resolveEmbeddingGuardrail();
-        let   embeddedCount = 0;
-        let   skippedCount  = 0;
+        const guardrail                           = this.resolveEmbeddingGuardrail();
+        let   embeddedCount                       = 0;
+        let   skippedCount                        = 0;
 
         for (let i = 0; i < chunksToProcess.length; i += batchSize) {
             if (i > 0 && batchDelay) {
@@ -382,7 +608,7 @@ class VectorService extends Base {
             const batch       = chunksToProcess.slice(i, i + batchSize);
             const batchInputs = batch.map(chunk => ({
                 chunk,
-                text: `${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n${chunk.description || chunk.content || ''}`
+                text: this.buildEmbeddingInputText(chunk)
             }));
             const embeddable = [];
 
@@ -601,15 +827,16 @@ class VectorService extends Base {
         }
         logger.log(`Loaded ${knowledgeBase.length} knowledge chunks from file.`);
 
-        const tenantStamp = this.resolveTenantStamp(tenantContext);
+        const tenantStamp           = this.resolveTenantStamp(tenantContext);
+        const expandedKnowledgeBase = this.expandOversizedEmbeddingChunks(knowledgeBase);
 
-        for (let i = 0; i < knowledgeBase.length; i++) {
-            knowledgeBase[i] = this.applyTenantStamp(knowledgeBase[i], tenantStamp);
+        for (let i = 0; i < expandedKnowledgeBase.length; i++) {
+            expandedKnowledgeBase[i] = this.applyTenantStamp(expandedKnowledgeBase[i], tenantStamp);
         }
 
         // Enrich with inheritance chains
         const classNameToDataMap = {};
-        knowledgeBase.forEach(chunk => {
+        expandedKnowledgeBase.forEach(chunk => {
             if (chunk.kind === 'module-context' && chunk.className) {
                 classNameToDataMap[chunk.className] = {
                     source: chunk.source,
@@ -618,7 +845,7 @@ class VectorService extends Base {
             }
         });
 
-        knowledgeBase.forEach(chunk => {
+        expandedKnowledgeBase.forEach(chunk => {
             let   currentClass     = chunk.className; // Metadata is now on every chunk
             const inheritanceChain = [];
             const visited          = new Set();
@@ -667,7 +894,7 @@ class VectorService extends Base {
         const allIds          = new Set();
         const processedIds    = new Set();
 
-        knowledgeBase.forEach(chunk => {
+        expandedKnowledgeBase.forEach(chunk => {
             const chunkId = chunk.id;
             allIds.add(chunkId);
 
@@ -681,7 +908,7 @@ class VectorService extends Base {
         const existingIdsArray = Array.from(existingIds);
         const idsToDelete      = resolvedStaleStrategy === STALE_STRATEGY_SKIP ? [] : existingIdsArray.filter(id => !allIds.has(id));
         const shouldShadowSwap = resolvedStaleStrategy === 'shadow-swap' && (chunksToProcess.length > 0 || idsToDelete.length > 0);
-        const workVolume       = shouldShadowSwap ? knowledgeBase.length : chunksToProcess.length;
+        const workVolume       = shouldShadowSwap ? expandedKnowledgeBase.length : chunksToProcess.length;
 
         logger.log(`${workVolume} chunks to add or update.`);
         logger.log(`${idsToDelete.length} chunks to delete.`);
@@ -725,7 +952,7 @@ class VectorService extends Base {
         if (shouldShadowSwap) {
             return await this.embedViaShadowSwap({
                 liveCollection  : collection,
-                knowledgeBase,
+                knowledgeBase   : expandedKnowledgeBase,
                 idsToDeleteCount: idsToDelete.length
             });
         }

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs
@@ -149,7 +149,8 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
             getParsers  : () => []
         };
         Service.vectorService = {
-            embed: async (filePath, options) => {
+            splitOversizedEmbeddingChunk: originals.vectorService.splitOversizedEmbeddingChunk.bind(originals.vectorService),
+            embed                       : async (filePath, options) => {
                 const lines = (await fs.readFile(filePath, 'utf8')).trim().split('\n').filter(Boolean);
                 vectorCalls.push({filePath, options, records: lines.map(line => JSON.parse(line))});
                 return {message: 'Embedding complete. Collection now contains 1 items.', embedded: lines.length, deleted: 0};

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -271,48 +271,74 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         expect(spy.calls.upsert).toBeGreaterThan(0); // embedding actually happened
     });
 
-    test('skips over-budget chunks before provider invocation while embedding the safe remainder', async () => {
-        KB_Config.data.localModels.embedding.contextLimitTokens        = 50;
-        KB_Config.data.localModels.embedding.safeProcessingLimitTokens = 40;
+    test('splits over-budget full-sync chunks before provider invocation while embedding the safe remainder', async () => {
+        const originalResolveEmbeddingGuardrail = KB_VectorService.resolveEmbeddingGuardrail.bind(KB_VectorService);
 
-        const embeddedTexts = [];
-        TextEmbeddingService.embedTexts = async texts => {
-            embeddedTexts.push(...texts);
-            return texts.map(() => new Array(384).fill(0));
-        };
+        KB_VectorService.resolveEmbeddingGuardrail = () => ({
+            enabled                  : true,
+            contextLimitTokens       : 100,
+            safeProcessingLimitTokens: 80,
+            model                    : 'unit-test-embedding-model'
+        });
 
-        const spy = createSpyCollection({existingIds: []});
-        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+        try {
+            const embeddedTexts = [];
+            TextEmbeddingService.embedTexts = async texts => {
+                embeddedTexts.push(...texts);
+                return texts.map(() => new Array(384).fill(0));
+            };
 
-        fs.writeFileSync(fixturePath, [
-            JSON.stringify({
-                hash       : 'small-chunk',
-                type       : 'method',
-                name       : 'small',
-                className  : '',
-                description: 'small body',
-                content    : 'small body'
-            }),
-            JSON.stringify({
-                hash       : 'large-chunk',
-                type       : 'method',
-                name       : 'large',
-                className  : '',
-                description: 'x'.repeat(300),
-                content    : 'x'.repeat(300)
-            })
-        ].join('\n'), 'utf8');
+            const spy = createSpyCollection({existingIds: []});
+            KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
 
-        const result = await KB_VectorService.embed(fixturePath);
+            fs.writeFileSync(fixturePath, [
+                JSON.stringify({
+                    hash       : 'small-chunk',
+                    type       : 'method',
+                    name       : 'small',
+                    className  : '',
+                    description: 'small body',
+                    content    : 'small body'
+                }),
+                JSON.stringify({
+                    hash     : 'large-chunk',
+                    type     : 'ticket',
+                    kind     : 'ticket',
+                    name     : 'issue-12065',
+                    className: '',
+                    description: Array.from({length: 12}, (_, index) => `section-${index} ${'x'.repeat(24)}`).join('\n'),
+                    content    : Array.from({length: 12}, (_, index) => `section-${index} ${'x'.repeat(24)}`).join('\n'),
+                    source     : 'resources/content/issues/chunk-2/issue-12065.md'
+                })
+            ].join('\n'), 'utf8');
 
-        expect(result.embedded).toBe(1);
-        expect('skipped' in result).toBe(false);
-        expect(result.message).toContain('Embedding complete');
-        expect(spy.calls.upsert).toBe(1);
-        expect(spy.rows.size).toBe(1);
-        expect(embeddedTexts).toHaveLength(1);
-        expect(embeddedTexts[0]).toContain('small body');
-        expect(embeddedTexts[0]).not.toContain('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+            const result = await KB_VectorService.embed(fixturePath);
+
+            expect(result.embedded).toBeGreaterThan(1);
+            expect('skipped' in result).toBe(false);
+            expect(result.message).toContain('Embedding complete');
+            expect(spy.calls.upsert).toBe(1);
+            expect(spy.rows.size).toBe(result.embedded);
+            expect(embeddedTexts).toHaveLength(result.embedded);
+            expect(embeddedTexts[0]).toContain('small body');
+
+            const splitRows = Array.from(spy.rows.values())
+                .filter(row => row.metadata.source === 'resources/content/issues/chunk-2/issue-12065.md');
+
+            expect(splitRows.length).toBeGreaterThan(1);
+            expect(splitRows.every(row => row.metadata.oversizedSplit === true)).toBe(true);
+            expect(splitRows.map(row => row.metadata.oversizedSplitIndex)).toEqual(splitRows.map((_, index) => index));
+            expect(new Set(splitRows.map(row => row.id)).size).toBe(splitRows.length);
+
+            const upsertCountAfterFirstRun = spy.calls.upsert;
+            const secondResult             = await KB_VectorService.embed(fixturePath);
+
+            expect(secondResult.embedded).toBe(0);
+            expect(secondResult.message).toContain('No changes detected');
+            expect(spy.calls.upsert).toBe(upsertCountAfterFirstRun);
+        } finally {
+            KB_VectorService.resolveEmbeddingGuardrail = originalResolveEmbeddingGuardrail;
+        }
     });
 
     test('does not apply local-model input caps to non-local embedding providers', async () => {
@@ -422,10 +448,10 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
             JSON.stringify({
                 hash       : 'large-chunk',
                 type       : 'method',
-                name       : 'large',
+                name       : 'x'.repeat(300),
                 className  : '',
-                description: 'x'.repeat(300),
-                content    : 'x'.repeat(300)
+                description: '',
+                content    : ''
             })
         ].join('\n'), 'utf8');
 


### PR DESCRIPTION
Resolves #14007

Full KB sync now expands recoverable over-budget text chunks inside `VectorService.embed()` before tenant stamping and diffing, so the orchestrator sync path no longer reaches the final skip for `issue-12065.md`-class sources. `VectorService` keeps the final pre-provider refusal guardrail for unsplittable or still-over-budget inputs, and split rows keep deterministic `oversizedSplit*` metadata plus stable IDs.

Evidence: L2 (unit-level full `VectorService.embed()` route with mocked Chroma/provider plus ingestion regression suite) -> L2 required (full-sync route ACs). No residuals.

Related: #14000
Related: #13999

## Deltas from ticket

- Moved common oversized text-splitting mechanics into `VectorService` so the full-sync route and `KnowledgeBaseIngestionService` share the same splitter.
- `KnowledgeBaseIngestionService` now supplies only its ingestion hash function when delegating split construction; it no longer carries duplicate line/byte splitting helpers.
- The full-sync pre-split size check is silent. Skip/friction diagnostics remain reserved for final refusal after splitting is attempted.

## Test Evidence

- `npm run agent-preflight -- ai/services/knowledge-base/VectorService.mjs ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs` passed: 50/50.
- `git diff --check` passed.
- Pre-commit hooks passed, including `check-aiconfig-test-mutation`.
- Freshness check passed after rebase: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `be819ff5b2 fix(ai): cover full kb sync oversized splitting (#14007)`.

## Post-Merge Validation

- [ ] Run or let the orchestrator run Knowledge Base sync including `resources/content/issues/chunk-2/issue-12065.md` and verify the old `[VectorService] Skipping over-budget embedding chunk before provider invocation` log is absent for that source.
- [ ] Verify rows exist for `resources/content/issues/chunk-2/issue-12065.md` with `oversizedSplit` metadata in `neo-knowledge-base`.

## Commits

- `be819ff5b2` - `fix(ai): cover full kb sync oversized splitting (#14007)`

## Evolution

The live restart validated that PR `#14003` closed the tenant-ingestion path but not the orchestrator full-corpus sync path. This PR keeps #14000 closed and implements the fresh #14007 residual without raising provider limits or weakening the final guardrail.

Authored by Euclid (GPT-5, Codex Desktop). Session 9280140f-8b54-4462-9342-49cca7e226f4.
