### PR TITLE
fix(ai): expose memory repair progress (#14011)

### DIFF
--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -69,10 +69,6 @@ If the proposed ticket involves modifying any agent skill (i.e., any file within
 
 For source anchors (`#11078` / `#11082` / `#11083` / `#11084`), Discussion `#11091` authority context, and substrate-decay review, read [`../../ideation-sandbox/audits/double-diamond-divergence-guard.md`](../../ideation-sandbox/audits/double-diamond-divergence-guard.md).
 
-### 1d. Project Attachment Pre-Flight (during release cycle)
-
-Before draft, make the §4 scope judgment — does this ticket **block or belong to** the release? If yes, confirm the target project number is current and cite it in your Pre-Flight statement (e.g., *"Release-blocking → Project 12 per §4."*); if no, it is **boardless** — state the `Release classification:` in the body instead. Prevents both stale-project-number drift and board over-attachment.
-
 ## 2. Six-Stage Challenge Chain
 
 Apply at creation time — not just at intake. Every stage must pass before the ticket is drafted.
@@ -109,12 +105,6 @@ Keep titles under ~70 characters. PR titles derive from ticket titles; length di
 - **Primary — exactly one:** `epic`, `enhancement`, or `bug`.
 - **Secondary — as applicable:** `architecture`, `performance`, `regression`, `refactoring`, `documentation`, `testing`, plus domain labels (`core`, `grid`, `build`, etc.).
 - Before filing: call `list_labels` to confirm the labels exist. Do not invent label names.
-- **Project attachment is a SCOPE JUDGMENT, not an unconditional mandate.** Attach a new ticket to Project 12 ([Neo v13 Release board](https://github.com/orgs/neomjs/projects/12)) **IFF it blocks or belongs to the release** — bugs in release-scoped subsystems, ship-hardening, release-process work. Everything else defaults **boardless**. ProjectV2 memberships supersede the deprecated `release:v*` label family per [ProjectV2 migration ticket](https://github.com/neomjs/neo/issues/11233).
-  - **Why a judgment, not attach-everything:** "created during the v13 cycle" ≠ "required for v13". Unconditional attachment composes with `pr-review` §9 `Approve+Follow-Up` into a **release asymptote** — every merge that spawns a board-attached follow-up grows the release, so the faster the swarm merges the further the release recedes. Resolving invariant: **a follow-up that must land before release contradicts the `Approve+Follow-Up` verdict that spawned it** (the verdict certifies "shippable without it"), so its follow-ups are post-release by construction; a release-blocking gap means the verdict should have been `Request Changes`.
-  - **Default boardless + classify:** `Approve+Follow-Up`-born tickets, hypothesis validations, and post-release hardening skip the board and state a one-line **`Release classification:`** in the body (greppable, reviewable, operator-reversible) — e.g. `Release classification: post-release (Approve+Follow-Up follow-up — non-blocking)` or `Release classification: ON the board — <why it blocks the release>`.
-  - **`create_issue` MCP tool path:** release-blocking → pass `projects: [{projectNumber: 12}]` atomically with the create; boardless → `projects: []` (the default).
-  - **`gh issue create` CLI bypass path:** release-blocking only → follow with `gh project item-add 12 --owner neomjs --url <new-issue-url>` (inseparable two-step); skip it for boardless tickets.
-  - **Project anchor** is currently `12` (v13). When v14 release work begins, update the project number here AND any hard-coded `create_issue` call-sites naming the release project. Sunset condition: once v13 ships, this rule needs disposition review (`keep` with updated project number, OR `compress-to-trigger`).
 
 ## 5. Fat Ticket Body Structure
 
@@ -160,7 +150,6 @@ When drafting ticket bodies, read [`learn/agentos/process/reference-hygiene.md`]
 | Inventing label names | Breaks label taxonomy; causes silent GitHub API rejections |
 | Precedent-following without skill check | Propagates anti-patterns from prior sessions (e.g., `[enhancement]` prefix spread this way) |
 | Cross-scope bundling | `epic` label on a single-commit ticket; hurts granularity |
-| Boarding a non-release-blocking ticket, OR the `gh issue create` → `gh project item-add` bypass on a release-blocking one | §4 is a scope judgment (board IFF release-blocking, else boardless + `Release classification:`); over-attaching inflates the release surface (the asymptote `#12865` fixes), and the CLI two-step stays inseparable for release-blocking tickets |
 
 ## 9. When to Escalate to Discussion Instead
 
@@ -172,12 +161,11 @@ The `create_issue` tool returns the new issue number. Typical immediate follow-u
 
 - **`manage_issue_assignees(action: 'add', issue_number: N, assignees: ['@me'])`** — **MANDATORY** if you intend to start working immediately (AGENTS.md §0 Invariant 7). Do this *before* editing any tracked files. (Note: once `#11308` is resolved, atomic assignee injection at creation will replace this post-hoc call).
 - **`manage_issue_labels(action: 'add', ...)`** — only if the label set needs adjustment post-creation (e.g., label list was incomplete at `create_issue` time). Prefer getting labels right in the initial call.
-- **`manage_issue_projects(action: 'add', issue_number, projectNumbers: [12])`** — only if project membership needs adjustment post-creation. Prefer the `projects` parameter on `create_issue` for atomic attach. Use `action: 'update_field'` to set Status/Priority on the project board after creation.
 - **`update_issue_relationship(parent_id: N, child_id: M, type: 'SUB_ISSUE')`** — required when filing sub-issues under an Epic. Native graph linkage only; do NOT rely on inline `- [ ] #N` markdown checkboxes (see §6).
 - **Ticket body edits:** Edit the local `.md` file and use the `sync_all` tool to push the local version back to GitHub. The local `.md` file is canonical after `sync_all`.
 - **Picking up the ticket:** If you intend to start working on this newly created ticket immediately, you MUST run the `ticket-intake` skill next (your assignee claim fulfills the primary gate).
 
-Minimize chained calls where possible — a well-formed `create_issue` call with complete `title`, `body`, `labels`, and `projects` at creation time avoids all of the above except `update_issue_relationship` (which can only run after the issue exists).
+Minimize chained calls where possible — a well-formed `create_issue` call with complete `title`, `body`, and `labels` at creation time avoids all of the above except `update_issue_relationship` (which can only run after the issue exists).
 
 ## 11. Authorship Respect
 

--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -637,6 +637,43 @@ export async function rewriteCollectionViaShadowPromotion({
 }
 
 /**
+ * @summary Selects the coverage row that belongs to the live Chroma collection.
+ *
+ * Chroma snapshots can contain stale duplicate collection-name rows even when `listCollections()`
+ * exposes only one active collection. Name-only pairing can then feed ids from a stale row into
+ * the active collection repair. Single rows remain the normal path; duplicate names must match
+ * the live collection id or fail before any shadow promotion is attempted.
+ *
+ * @param {Object} options
+ * @param {String} options.collectionName Collection name being repaired.
+ * @param {Object[]} [options.coverageRows=[]] Audit rows with matching collection names.
+ * @param {String} [options.liveCollectionId] Collection id returned by `client.getCollection`.
+ * @returns {Object}
+ */
+function selectMemoryCoreRepairCoverageRow({
+    collectionName,
+    coverageRows = [],
+    liveCollectionId
+} = {}) {
+    if (coverageRows.length === 1) {
+        return coverageRows[0];
+    }
+
+    if (!liveCollectionId) {
+        throw new Error(`repairMemoryCoreCollectionsViaFullEnumeration: '${collectionName}' has ${coverageRows.length} coverage rows, but the live collection id is unavailable — refusing name-only repair.`);
+    }
+
+    const match = coverageRows.find(row => row.collectionId === liveCollectionId);
+
+    if (!match) {
+        const ids = coverageRows.map(row => row.collectionId || '(missing-id)').join(', ');
+        throw new Error(`repairMemoryCoreCollectionsViaFullEnumeration: '${collectionName}' has duplicate coverage rows, but none match live collection id '${liveCollectionId}' (coverage ids: ${ids}) — refusing ambiguous repair.`);
+    }
+
+    return match
+}
+
+/**
  * @summary Repairs Memory Core collections' missing stored-embeddings via FULL (uncapped) enumeration,
  * then promotes the recovered data through the existing shadow-promotion path.
  *
@@ -697,23 +734,41 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
     writeStateFn = writeDefragState,
     log          = console.log
 } = {}) {
+    log(`   🔎 Enumerating Memory Core metadata/vector coverage for ${collections.length} collection(s)...`);
     const coverage = await auditFn({
         snapshotPath,
         persistDir,
         collectionNames: collections,
         includeFullIds : true
     });
+    log(`   ✅ Coverage enumeration complete (${coverage.collections.length} coverage row(s)).`);
     const results = [];
 
     for (const collectionName of collections) {
-        const cov = coverage.collections.find(entry => entry.name === collectionName);
-        if (!cov) {
+        const
+            coverageRows = coverage.collections.filter(entry => entry.name === collectionName),
+            collection   = await client.getCollection({name: collectionName, embeddingFunction});
+
+        if (coverageRows.length === 0) {
             throw new Error(`repairMemoryCoreCollectionsViaFullEnumeration: no coverage row for '${collectionName}' — refusing to promote a collection the enumeration never saw.`);
         }
 
+        const cov = selectMemoryCoreRepairCoverageRow({
+            collectionName,
+            coverageRows,
+            liveCollectionId: collection.id
+        });
+
+        log(`   📦 '${collectionName}': metadata=${cov.metadataRowCount ?? cov.allIds?.length ?? 0}, vector=${cov.vectorIndexIdCount ?? cov.vectorIds?.length ?? 0}, missing=${cov.missingFromVectorCount ?? cov.missingVectorIds?.length ?? 0}, extra=${cov.extraInVectorCount ?? cov.extraVectorIds?.length ?? 0}`);
+
         const {allIds, missingVectorIds}    = cov,
-              collection                    = await client.getCollection({name: collectionName, embeddingFunction}),
-              {data, unrecoverable, counts} = await extractFn({collection, allIds, missingVectorIds, embedFn});
+              {data, unrecoverable, counts} = await extractFn({
+                  collection,
+                  allIds,
+                  missingVectorIds,
+                  embedFn,
+                  onProgress: event => log(formatMemoryCoreRepairProgress({collectionName, event}))
+              });
 
         if (dryRun) {
             if (unrecoverable.length > 0) {
@@ -734,7 +789,9 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
             continue;
         }
 
+        log(`   🚚 '${collectionName}': shadow promotion starting for ${data.ids.length} recovered row(s)...`);
         const promotion = await promoteFn({client, collectionName, data, embeddingFunction, statePath, stateBase});
+        log(`   ✅ '${collectionName}': shadow promotion complete.`);
         results.push({collectionName, promotion, counts});
     }
 
@@ -756,6 +813,30 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
     }
 
     return {results};
+}
+
+/**
+ * @summary Formats progress events from Memory Core repair extraction for operator terminals.
+ * @param {Object} options
+ * @param {String} options.collectionName Collection currently being repaired.
+ * @param {Object} options.event Progress event emitted by `extractMemoryCoreCollectionData`.
+ * @returns {String}
+ */
+function formatMemoryCoreRepairProgress({collectionName, event} = {}) {
+    const counts = event.counts || {};
+
+    switch (event.phase) {
+        case 'start':
+            return `   ⏳ '${collectionName}': extraction starting (total=${event.total}, intact=${counts.intact || 0}, reEmbedded=${counts.reEmbedded || 0}, unrecoverable=${counts.unrecoverable || 0})`;
+        case 'intact-extract':
+            return `   ⏳ '${collectionName}': intact-vector extraction ${event.percent}% (${event.processed}/${event.total}; intact=${counts.intact || 0})`;
+        case 'missing-reembed':
+            return `   ⏳ '${collectionName}': missing-vector re-embed ${event.percent}% (${event.processed}/${event.total}; reEmbedded=${counts.reEmbedded || 0}, unrecoverable=${counts.unrecoverable || 0})`;
+        case 'complete':
+            return `   ✅ '${collectionName}': extraction complete; counts ${JSON.stringify(counts)}`;
+        default:
+            return `   ⏳ '${collectionName}': ${event.phase || 'progress'} ${event.percent ?? '?'}% (${event.processed ?? '?'}/${event.total ?? '?'})`;
+    }
 }
 
 /**

--- a/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
+++ b/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
@@ -35,11 +35,20 @@
  * @param {Function}   options.embedFn          `(documents: String[]) => Promise<Number[][]>` — re-embed a batch
  *                                               (e.g. `TextEmbeddingService.embedTexts` bound to the MC provider).
  * @param {Number}     [options.batchSize=1000] Chroma `.get` / embed batch size.
+ * @param {Function}   [options.onProgress] Optional callback receiving 10%-bucket progress events:
+ *                                           `{phase, percent, processed, total, counts}`.
  * @returns {Promise<{data: {ids: String[], embeddings: Number[][], documents: String[], metadatas: Object[]},
  *                    unrecoverable: String[],
  *                    counts: {total: Number, intact: Number, reEmbedded: Number, unrecoverable: Number}}>}
  */
-export async function extractMemoryCoreCollectionData({collection, allIds = [], missingVectorIds = [], embedFn, batchSize = 1000} = {}) {
+export async function extractMemoryCoreCollectionData({
+    collection,
+    allIds = [],
+    missingVectorIds = [],
+    embedFn,
+    batchSize = 1000,
+    onProgress
+} = {}) {
     if (typeof embedFn !== 'function') {
         throw new Error('extractMemoryCoreCollectionData: embedFn (documents -> embeddings) is required');
     }
@@ -47,8 +56,12 @@ export async function extractMemoryCoreCollectionData({collection, allIds = [], 
     const missingSet = new Set(missingVectorIds);
     const intactIds  = allIds.filter(id => !missingSet.has(id));
     const data       = {ids: [], embeddings: [], documents: [], metadatas: []};
+    const counts     = {total: allIds.length, intact: 0, reEmbedded: 0, unrecoverable: 0};
 
-    let intactCount = 0;
+    const reportIntactProgress  = createTenPercentProgressReporter({phase: 'intact-extract', total: intactIds.length, onProgress});
+    const reportMissingProgress = createTenPercentProgressReporter({phase: 'missing-reembed', total: missingVectorIds.length, onProgress});
+
+    onProgress?.({phase: 'start', percent: 0, processed: 0, total: allIds.length, counts: {...counts}});
 
     // 1. Intact rows — extract with their stored embeddings (these vectors exist in the HNSW index).
     for (let i = 0; i < intactIds.length; i += batchSize) {
@@ -60,13 +73,14 @@ export async function extractMemoryCoreCollectionData({collection, allIds = [], 
             data.embeddings.push(got.embeddings[j]);
             data.documents.push(got.documents?.[j] ?? '');
             data.metadatas.push(got.metadatas?.[j] ?? {});
-            intactCount++;
+            counts.intact++;
         }
+
+        reportIntactProgress({processed: Math.min(i + batchIds.length, intactIds.length), counts});
     }
 
     // 2. Missing-vector rows — re-embed from documents (their stored embeddings cannot be fetched).
     const unrecoverable = [];
-    let   reEmbedded    = 0;
 
     for (let i = 0; i < missingVectorIds.length; i += batchSize) {
         const batchIds = missingVectorIds.slice(i, i + batchSize);
@@ -76,14 +90,21 @@ export async function extractMemoryCoreCollectionData({collection, allIds = [], 
 
         // An id that did not even come back from the metadata read is unrecoverable.
         for (const id of batchIds) {
-            if (!returned.has(id)) unrecoverable.push(id);
+            if (!returned.has(id)) {
+                unrecoverable.push(id);
+                counts.unrecoverable++;
+            }
         }
 
         const reEmbedIds = [], reEmbedDocs = [], reEmbedMetas = [];
 
         for (let j = 0; j < (got.ids?.length || 0); j++) {
             const doc = got.documents?.[j];
-            if (!doc) { unrecoverable.push(got.ids[j]); continue; }
+            if (!doc) {
+                unrecoverable.push(got.ids[j]);
+                counts.unrecoverable++;
+                continue;
+            }
             reEmbedIds.push(got.ids[j]);
             reEmbedDocs.push(doc);
             reEmbedMetas.push(got.metadatas?.[j] ?? {});
@@ -101,16 +122,48 @@ export async function extractMemoryCoreCollectionData({collection, allIds = [], 
                 data.embeddings.push(embeddings[j]);
                 data.documents.push(reEmbedDocs[j]);
                 data.metadatas.push(reEmbedMetas[j]);
-                reEmbedded++;
+                counts.reEmbedded++;
             }
         }
+
+        reportMissingProgress({processed: Math.min(i + batchIds.length, missingVectorIds.length), counts});
     }
+
+    onProgress?.({phase: 'complete', percent: 100, processed: allIds.length, total: allIds.length, counts: {...counts}});
 
     return {
         data,
         unrecoverable,
-        counts: {total: allIds.length, intact: intactCount, reEmbedded, unrecoverable: unrecoverable.length}
+        counts
     };
+}
+
+/**
+ * @summary Creates a 10%-bucket progress callback wrapper for long repair phases.
+ * @param {Object} options
+ * @param {String} options.phase Progress phase label.
+ * @param {Number} options.total Total rows in the phase.
+ * @param {Function} [options.onProgress] Progress sink.
+ * @returns {Function}
+ */
+function createTenPercentProgressReporter({phase, total, onProgress} = {}) {
+    let nextPercent = 10;
+
+    return ({processed, counts} = {}) => {
+        if (typeof onProgress !== 'function' || total <= 0) {
+            return
+        }
+
+        const percent = Math.min(100, Math.floor((processed / total) * 100)),
+              bucket  = Math.floor(percent / 10) * 10;
+
+        if (bucket < nextPercent) {
+            return
+        }
+
+        onProgress({phase, percent: bucket, processed, total, counts: {...counts}});
+        nextPercent = bucket + 10;
+    }
 }
 
 export default extractMemoryCoreCollectionData;

--- a/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
@@ -11,12 +11,12 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
     const embeddingFunction = {name: 'dummy'},
           embedFn           = async docs => docs.map(() => [0.1, 0.2]);
 
-    function makeSeams({coverage, extractResults}) {
+    function makeSeams({coverage, extractResults, client}) {
         const calls = {audit: [], extract: [], promote: [], clearState: [], writeState: []};
 
         return {
             calls,
-            client      : {getCollection: async ({name}) => ({_name: name})},
+            client      : client || {getCollection: async ({name}) => ({_name: name})},
             auditFn     : async args => { calls.audit.push(args);   return coverage; },
             extractFn   : async args => { calls.extract.push(args); return extractResults[args.collection._name]; },
             promoteFn   : async args => { calls.promote.push(args); return {promoted: args.collectionName}; },
@@ -59,6 +59,45 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
         // clean success CLEARS the durable marker (no rerun-poisoning); the aborted marker is never written
         expect(calls.clearState).toEqual([{statePath: '/state'}]);
         expect(calls.writeState).toHaveLength(0);
+    });
+
+    test('duplicate collection names select the coverage row matching the live collection id', async () => {
+        const coverage = {collections: [
+                  {name: 'mc-graph', collectionId: 'stale-id', allIds: ['stale'], missingVectorIds: ['stale']},
+                  {name: 'mc-graph', collectionId: 'live-id',  allIds: ['live'],  missingVectorIds: []}
+              ]},
+              extractResults = {
+                  'mc-graph': {data: {ids: ['live'], embeddings: [[9]], documents: [''], metadatas: [{}]}, unrecoverable: [], counts: {total: 1, intact: 1, reEmbedded: 0, unrecoverable: 0}}
+              },
+              client = {getCollection: async ({name}) => ({_name: name, id: 'live-id'})},
+              {calls, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults, client});
+
+        const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
+            client, collections: ['mc-graph'], snapshotPath: '/snap', persistDir: '/persist',
+            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, clearStateFn, writeStateFn, log: () => {}
+        });
+
+        expect(calls.extract).toHaveLength(1);
+        expect(calls.extract[0].allIds).toEqual(['live']);
+        expect(calls.extract[0].missingVectorIds).toEqual([]);
+        expect(results[0].promotion).toEqual({promoted: 'mc-graph'});
+    });
+
+    test('duplicate collection names fail before extraction when the live collection id cannot be matched', async () => {
+        const coverage = {collections: [
+                  {name: 'mc-graph', collectionId: 'stale-id', allIds: ['stale'], missingVectorIds: ['stale']},
+                  {name: 'mc-graph', collectionId: 'other-id', allIds: ['other'], missingVectorIds: []}
+              ]},
+              client = {getCollection: async ({name}) => ({_name: name, id: 'live-id'})},
+              {calls, auditFn, extractFn, promoteFn} = makeSeams({coverage, extractResults: {}, client});
+
+        await expect(repairMemoryCoreCollectionsViaFullEnumeration({
+            client, collections: ['mc-graph'], snapshotPath: '/snap', persistDir: '/persist',
+            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, log: () => {}
+        })).rejects.toThrow(/none match live collection id 'live-id'/);
+
+        expect(calls.extract).toHaveLength(0);
+        expect(calls.promote).toHaveLength(0);
     });
 
     test('fail-loud: unrecoverable rows abort that collection promotion (no silent drop)', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
@@ -88,6 +88,43 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         expect(result.counts.reEmbedded).toBe(1);
     });
 
+    test('reports 10%-bucket progress for intact extraction and missing-vector re-embed', async () => {
+        const intactIds = Array.from({length: 10}, (_, i) => `i${i}`),
+              missingIds = Array.from({length: 10}, (_, i) => `m${i}`),
+              rows       = {};
+
+        for (const id of intactIds) {
+            rows[id] = {embedding: [1], document: `doc-${id}`, metadata: {}};
+        }
+
+        for (const id of missingIds) {
+            rows[id] = {document: `doc-${id}`, metadata: {}};
+        }
+
+        const events = [];
+
+        const result = await extractMemoryCoreCollectionData({
+            collection      : makeCollection(rows),
+            allIds          : [...intactIds, ...missingIds],
+            missingVectorIds: missingIds,
+            batchSize       : 1,
+            embedFn         : async docs => docs.map(() => [7]),
+            onProgress      : event => events.push(event)
+        });
+
+        expect(result.counts).toEqual({total: 20, intact: 10, reEmbedded: 10, unrecoverable: 0});
+        expect(events.filter(event => event.phase === 'intact-extract').map(event => event.percent))
+            .toEqual([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
+        expect(events.filter(event => event.phase === 'missing-reembed').map(event => event.percent))
+            .toEqual([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
+        expect(events.at(0)).toMatchObject({phase: 'start', percent: 0, processed: 0, total: 20});
+        expect(events.at(-1)).toMatchObject({
+            phase  : 'complete',
+            percent: 100,
+            counts : {total: 20, intact: 10, reEmbedded: 10, unrecoverable: 0}
+        });
+    });
+
     test('embedFn returning a wrong-length result throws (fail loud)', async () => {
         const rows = {m: {document: 'dm', metadata: {}}};
 


### PR DESCRIPTION
Resolves #14011
Resolves #14012

Related: #13999
Related: #14010

Evidence: L2 unit/preflight evidence for the repair-progress and duplicate-coverage guard changes. The broader #13999 incident remains open until the live Memory Core repair completes and canonical backup/export parity is proven.

## Summary

- Adds operator-visible Memory Core repair-defrag progress: coverage enumeration start/finish, per-collection coverage counts, 10%-bucket intact extraction, 10%-bucket missing-vector re-embed, and shadow-promotion start/finish.
- Guards Memory Core repair coverage selection against duplicate stale Chroma collection-name rows by requiring the coverage row to match the live collection id.
- Removes roadmap-placement guidance from `ticket-create` instead of replacing stale Project 12 wording with another planning rule.

## Deltas from ticket

- #14011 also includes the duplicate collection-name coverage guard because the repair path can otherwise log or repair against a stale backing row.
- #14012 was narrowed after operator correction: `ticket-create` now removes roadmap-placement guidance entirely; planning placement is out of scope for this skill.

## `/turn-memory-pre-flight` Load-Effect Audit

- `ticket-create` router unchanged: `.agents/skills/ticket-create/SKILL.md` has zero delta.
- Conditional payload net-reduced: `.agents/skills/ticket-create/references/ticket-create-workflow.md` is 13 lines smaller.
- Source-ticket Contract Ledger posted on #14012: https://github.com/neomjs/neo/issues/14012#issuecomment-4801078937

## Test Evidence

- `npm run agent-preflight -- ai/scripts/maintenance/defragChromaDB.mjs ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs .agents/skills/ticket-create/references/ticket-create-workflow.md`
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev`
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs` — 21 passed
- `git diff --check origin/dev..HEAD`
- `rg -n "Project|project|board|Release classification|release:v|project item|projects|Boarding" .agents/skills/ticket-create/references/ticket-create-workflow.md` — no matches

## Post-Merge Validation

- Run `npm run ai:defrag-memory -- --allow-memory-core` from a visible operator terminal and verify repair logs show coverage enumeration, per-collection counts, and 10%-bucket extraction/re-embed progress before shadow promotion.
- Keep #13999 open until live repair and canonical backup/export parity are proven.

## Commits

- `ed3b00c5d3` — `fix(ai): log memory repair progress and guard coverage (#14011)`
- `123ad36c50` — `docs(agentos): remove ticket roadmap placement rule (#14012)`

Authored by Euclid (@neo-gpt, Codex Desktop). Session 9280140f-8b54-4462-9342-49cca7e226f4.
