### PR TITLE
fix(ai): append LMS embedding SEP from metadata (#14009)

### DIFF
--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -296,7 +296,7 @@ export function getLmsLoadedModels(payload) {
         }
 
         seen.add(id);
-        models.push({
+        const model = {
             id,
             contextLength: readNumericField(row, [
                 'contextLength',
@@ -314,7 +314,15 @@ export function getLmsLoadedModels(payload) {
                 'numParallel',
                 'num_parallel'
             ])
-        });
+        };
+
+        for (const key of ['type', 'modelKey', 'format', 'displayName', 'publisher', 'path', 'indexedModelIdentifier', 'architecture']) {
+            if (row?.[key] !== undefined) {
+                model[key] = row[key];
+            }
+        }
+
+        models.push(model);
     }
 
     return models;

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -10,6 +10,9 @@ import {
 
 const DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS = 60 * 60 * 1000;
 const OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE   = /openAiCompatible embedding error HTTP (408|429|503|504):/;
+const LMS_EMBEDDING_INPUT_SUFFIX_BY_ARCHITECTURE   = {
+    qwen3: '<|im_end|>'
+};
 
 /**
  * Determines whether TextEmbeddingService needs a Gemini embedding client for the active provider.
@@ -205,6 +208,93 @@ class TextEmbeddingService extends Base {
     }
 
     /**
+     * @summary Reads currently resident LM Studio models for embedding-context enforcement.
+     *
+     * Runtime uses the canonical readiness helper. The optional plain test seam avoids spawning
+     * the LM Studio CLI from unit tests while preserving the same normalized model shape.
+     *
+     * @param {Number} timeoutMs LM Studio CLI timeout.
+     * @returns {Promise<Object[]>}
+     * @private
+     */
+    async #getOpenAiCompatibleLoadedModels(timeoutMs) {
+        if (this.openAiCompatibleLoadedModelsProbe) {
+            return this.openAiCompatibleLoadedModelsProbe({timeoutMs});
+        }
+
+        const {fetchLmsLoadedModels} = await import('../graph/providerReadinessHelper.mjs');
+        return fetchLmsLoadedModels({timeoutMs});
+    }
+
+    /**
+     * @summary Resolves the LMS-only embedding input suffix from loaded-model metadata.
+     *
+     * This deliberately does not use OpenAI-compatible config: Ollama, llama.cpp, vLLM, and
+     * managed compatibility endpoints share that provider surface but must not receive an
+     * LM Studio/Qwen-specific request suffix. `lms ps --json` exposes the resident model
+     * metadata; Qwen3 GGUF embeddings need `<|im_end|>` when their GGUF header does not auto-add
+     * EOS/SEP.
+     *
+     * @param {Object|null} loadedModel Normalized `lms ps --json` row.
+     * @returns {String}
+     * @private
+     */
+    #getLmsEmbeddingInputSuffix(loadedModel) {
+        const
+            format       = String(loadedModel?.format || '').toLowerCase(),
+            metadataText = [
+                loadedModel?.architecture,
+                loadedModel?.modelKey,
+                loadedModel?.path,
+                loadedModel?.indexedModelIdentifier
+            ].filter(value => typeof value === 'string').join(' ').toLowerCase();
+
+        if (format && format !== 'gguf') {
+            return '';
+        }
+
+        for (const [architecture, suffix] of Object.entries(LMS_EMBEDDING_INPUT_SUFFIX_BY_ARCHITECTURE)) {
+            if (metadataText.includes(architecture)) {
+                return suffix;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @summary Appends the LMS metadata-derived embedding input suffix when absent.
+     * @param {String} text The outbound embedding text.
+     * @param {Object|null} loadedModel Normalized `lms ps --json` row.
+     * @returns {String}
+     * @private
+     */
+    #appendLmsEmbeddingInputSuffix(text, loadedModel) {
+        const suffix = this.#getLmsEmbeddingInputSuffix(loadedModel);
+
+        if (!suffix || typeof text !== 'string' || text.endsWith(suffix)) {
+            return text;
+        }
+
+        return `${text}${suffix}`;
+    }
+
+    /**
+     * @summary Normalizes LMS embedding request input before context checks and POST.
+     * @param {String|String[]} inputData The text or array of texts to embed.
+     * @param {Object|null} loadedModel Normalized `lms ps --json` row.
+     * @returns {String|String[]}
+     * @private
+     */
+    #withLmsEmbeddingInputSuffix(inputData, loadedModel) {
+        if (Array.isArray(inputData)) {
+            return inputData.map(text => this.#appendLmsEmbeddingInputSuffix(text, loadedModel));
+        }
+
+        return this.#appendLmsEmbeddingInputSuffix(inputData, loadedModel);
+    }
+
+    /**
      * @summary Estimates the largest text input in an OpenAI-compatible embedding request.
      *
      * LM Studio truncates each input string independently. Batch safety therefore uses the
@@ -227,25 +317,6 @@ class TextEmbeddingService extends Base {
             inputBytes,
             inputTokensEstimate: bytesToTokens(inputBytes)
         };
-    }
-
-    /**
-     * @summary Reads currently resident LM Studio models for embedding-context enforcement.
-     *
-     * Runtime uses the canonical readiness helper. The optional plain test seam avoids spawning
-     * the LM Studio CLI from unit tests while preserving the same normalized model shape.
-     *
-     * @param {Number} timeoutMs LM Studio CLI timeout.
-     * @returns {Promise<Object[]>}
-     * @private
-     */
-    async #getOpenAiCompatibleLoadedModels(timeoutMs) {
-        if (this.openAiCompatibleLoadedModelsProbe) {
-            return this.openAiCompatibleLoadedModelsProbe({timeoutMs});
-        }
-
-        const {fetchLmsLoadedModels} = await import('../graph/providerReadinessHelper.mjs');
-        return fetchLmsLoadedModels({timeoutMs});
     }
 
     /**
@@ -285,20 +356,18 @@ class TextEmbeddingService extends Base {
     }
 
     /**
-     * @summary Fails before OpenAI-compatible embeddings can be silently provider-truncated.
+     * @summary Reads and validates the active LM Studio embedding model metadata.
      *
      * LM Studio can answer `/v1/embeddings` while the embedding model is resident at a smaller
-     * loaded context than Neo's `localModels.embedding.contextLimitTokens` leaf. The provider then
-     * logs a truncation warning and still returns an embedding. This guard checks the resident model
-     * shape before the request so KB / Memory Core callers never accept that corrupted vector.
+     * loaded context than Neo's `localModels.embedding.contextLimitTokens` leaf. Fetching the
+     * resident row also exposes LMS model metadata used for request-boundary token handling.
      *
-     * @param {String|String[]} inputData The text or array of texts to embed.
-     * @returns {Promise<void>}
+     * @returns {Promise<{configuredContextLength: Number, loadedModel: Object, model: String}|null>}
      * @private
      */
-    async #assertOpenAiCompatibleEmbeddingContext(inputData) {
+    async #getOpenAiCompatibleEmbeddingRuntime() {
         if (!this.#shouldAssertOpenAiCompatibleEmbeddingContext()) {
-            return;
+            return null;
         }
 
         const
@@ -324,9 +393,7 @@ class TextEmbeddingService extends Base {
             throw new Error(`TextEmbeddingService: unable to verify LM Studio embedding context for '${model}': ${error.message}`);
         }
 
-        const
-            loadedModel = loadedModels.find(item => item.id === model),
-            estimate    = this.#getOpenAiCompatibleInputEstimate(inputData);
+        const loadedModel = loadedModels.find(item => item.id === model);
 
         if (!loadedModel) {
             const observedIds = loadedModels.map(item => item.id).filter(Boolean).slice(0, 5).join(', ') || 'none';
@@ -335,6 +402,25 @@ class TextEmbeddingService extends Base {
         if (!Neo.isNumber(loadedModel.contextLength)) {
             throw new Error(`TextEmbeddingService: LM Studio embedding model '${model}' has unknown loaded context; configured>=${configuredContextLength}`);
         }
+
+        return {configuredContextLength, loadedModel, model};
+    }
+
+    /**
+     * @summary Fails before OpenAI-compatible embeddings can be silently provider-truncated.
+     * @param {String|String[]} inputData The text or array of texts to embed.
+     * @param {{configuredContextLength: Number, loadedModel: Object, model: String}|null} runtime LMS runtime metadata.
+     * @returns {void}
+     * @private
+     */
+    #assertOpenAiCompatibleEmbeddingContext(inputData, runtime) {
+        if (!runtime) {
+            return;
+        }
+
+        const
+            {configuredContextLength, loadedModel, model} = runtime,
+            estimate                                      = this.#getOpenAiCompatibleInputEstimate(inputData);
 
         if (loadedModel.contextLength < configuredContextLength || estimate.inputTokensEstimate > loadedModel.contextLength) {
             if (estimate.inputTokensEstimate > loadedModel.contextLength) {
@@ -363,6 +449,22 @@ class TextEmbeddingService extends Base {
 
             throw new Error(`TextEmbeddingService: LM Studio embedding context too small for '${model}' (loaded=${loadedModel.contextLength}, configured>=${configuredContextLength}, inputEstimate=${estimate.inputTokensEstimate})`);
         }
+    }
+
+    /**
+     * @summary Prepares OpenAI-compatible embedding input at the provider request boundary.
+     * @param {String|String[]} inputData The caller's original text input.
+     * @returns {Promise<String|String[]>}
+     * @private
+     */
+    async #prepareOpenAiCompatibleEmbeddingInput(inputData) {
+        const
+            runtime          = await this.#getOpenAiCompatibleEmbeddingRuntime(),
+            requestInputData = runtime ? this.#withLmsEmbeddingInputSuffix(inputData, runtime.loadedModel) : inputData;
+
+        this.#assertOpenAiCompatibleEmbeddingContext(requestInputData, runtime);
+
+        return requestInputData;
     }
 
     /**
@@ -559,8 +661,8 @@ class TextEmbeddingService extends Base {
                 contentionRetryCount      = 2,
                 contentionTimeoutMs       = 15000
             } = aiConfig.openAiCompatible;
-            await this.#assertOpenAiCompatibleEmbeddingContext(text);
-            const result = await this.#enqueueOpenAiCompatiblePost(text, {
+            const requestText = await this.#prepareOpenAiCompatibleEmbeddingInput(text);
+            const result      = await this.#enqueueOpenAiCompatiblePost(requestText, {
                 unloadRetriesLeft    : unloadRetryCount,
                 contentionRetriesLeft: contentionRetryCount,
                 requestTimeoutMs     : contentionTimeoutMs
@@ -606,8 +708,8 @@ class TextEmbeddingService extends Base {
         if (!explicitProvider) throw new Error('TextEmbeddingService.embedTexts requires an explicit provider argument');
 
         if (explicitProvider === 'openAiCompatible') {
-            await this.#assertOpenAiCompatibleEmbeddingContext(texts);
-            return this.#embedOpenAiCompatibleBatch(texts);
+            const requestTexts = await this.#prepareOpenAiCompatibleEmbeddingInput(texts);
+            return this.#embedOpenAiCompatibleBatch(requestTexts);
         } else if (explicitProvider === 'ollama') {
             // Ollama's `/api/embed` accepts array-of-strings natively + returns
             // a parallel embeddings array — no per-text fan-out needed.

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -910,7 +910,9 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             models: [{
                 identifier   : 'chat-model',
                 contextWindow: '131072',
-                parallel     : '1'
+                parallel     : '1',
+                format       : 'gguf',
+                architecture : 'gemma3'
             }, {
                 model         : 'embedding-model',
                 context_length: 32768,
@@ -919,7 +921,9 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         })).toEqual([{
             id           : 'chat-model',
             contextLength: 131072,
-            parallel     : 1
+            parallel     : 1,
+            format       : 'gguf',
+            architecture : 'gemma3'
         }, {
             id           : 'embedding-model',
             contextLength: 32768,

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -264,6 +264,41 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         });
     });
 
+    test('LMS GGUF/Qwen3 embeddings append metadata-derived SEP/EOS suffix to request inputs (#14009)', async () => {
+        serverBehavior = 'lms-server-start-succeed';
+        TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{
+            id           : aiConfig.openAiCompatible.embeddingModel,
+            contextLength: aiConfig.localModels.embedding.contextLimitTokens,
+            format       : 'gguf',
+            architecture : 'qwen3'
+        }];
+
+        const singleInput = 'last-token-is-semantic-content';
+
+        await TextEmbeddingService.embedText(singleInput, 'openAiCompatible');
+
+        expect(lastRequest.body.input).toBe(`${singleInput}<|im_end|>`);
+        expect(singleInput).toBe('last-token-is-semantic-content');
+
+        serverBehavior = 'lms-server-start-batch-succeed';
+
+        const batchInput = [
+            'batch-first-without-provider-separator',
+            'batch-second-with-provider-eos<|im_end|>'
+        ];
+
+        await TextEmbeddingService.embedTexts(batchInput, 'openAiCompatible');
+
+        expect(lastRequest.body.input).toEqual([
+            'batch-first-without-provider-separator<|im_end|>',
+            'batch-second-with-provider-eos<|im_end|>'
+        ]);
+        expect(batchInput).toEqual([
+            'batch-first-without-provider-separator',
+            'batch-second-with-provider-eos<|im_end|>'
+        ]);
+    });
+
     test('openAiCompatible refuses single embeddings when LM Studio loaded context is below the configured embedding context (#13944)', async () => {
         serverBehavior = 'succeed';
         TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{
@@ -313,6 +348,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
 
             expect(result).toEqual([0.1, 0.2, 0.3]);
             expect(requestCount).toBe(1);
+            expect(lastRequest.body.input).toBe('hello');
         } finally {
             Neo.config.unitTestMode = originalUnitTestMode;
         }
@@ -438,7 +474,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
 
         await waitForCondition(() => allRequests.length === 1, 'first batch chunk request');
 
-        const interactivePromise = TextEmbeddingService.embedText('urgent', 'openAiCompatible');
+        const interactivePromise               = TextEmbeddingService.embedText('urgent', 'openAiCompatible');
         const [batchResult, interactiveResult] = await Promise.all([batchPromise, interactivePromise]);
 
         expect(maxInFlightRequests).toBe(1);


### PR DESCRIPTION
Resolves #14009

Related: #13999

Fixes the actual LM Studio warning path. `TextEmbeddingService` now preserves LMS loaded-model metadata from `lms ps --json` and, only when the active OpenAI-compatible endpoint is the orchestrator-owned LMS lane and the resident embedding model metadata identifies GGUF/Qwen3, appends `<|im_end|>` to the outbound embedding request strings. Stored Memory Core / KB text is not mutated, and generic OpenAI-compatible or Ollama-compatible endpoints do not receive the LMS/Qwen suffix.

Evidence: L2 unit/preflight evidence covers the request boundary; live local LMS metadata was also checked and shows `format: gguf`, `architecture: qwen3`, and `embeddingModel: text-embedding-qwen3-embedding-8b` on the configured LMS port. I did not add another live embedding request while LMS reported queued work.

## Deltas from ticket

The first version of this PR was wrong: it documented or tested around the warning instead of satisfying LMS. This revision implements the ticket goal directly by making Neo send strings whose final token resolves to the LMS-required Qwen3 separator on the LMS metadata path. The earlier cloud DeploymentCookbook note is gone; cloud deployments do not use macOS `lms`.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs` — 85 passed
- `npm run agent-preflight -- ai/services/graph/providerReadinessHelper.mjs ai/services/memory-core/TextEmbeddingService.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs`
- `git diff --check`
- Local LMS/config sanity: configured host `http://127.0.0.1:1234`, `orchestrator.lms.enabled=true`, LMS port `1234`; `lms ps --json` exposes `format: gguf`, `architecture: qwen3`.

## Post-Merge Validation

- [ ] Restart the affected local Agent OS process and confirm new LMS embedding requests no longer emit `tokenizer.ggml.add_eos_token should be set to true`.

## Commits

- `64274a27d2` — `fix(ai): append LMS embedding SEP from metadata (#14009)`

Authored by Euclid (GPT-5 Codex, Codex Desktop). Session 9280140f-8b54-4462-9342-49cca7e226f4.