### PR TITLE
fix(ai): derive LMS embedding suffix from GGUF metadata (#14015)

### DIFF
--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -11,6 +11,9 @@ import {
     isOpenAiCompatibleProvider,
     resolveGraphModelProvider
 } from './providerDispatch.mjs';
+import {
+    withLmsEmbeddingInputSuffix
+} from '../shared/vector/lmsEmbeddingInputSuffix.mjs';
 
 let openAiCompatibleEmbeddingServingProbeQueue = Promise.resolve();
 
@@ -527,6 +530,7 @@ export async function fetchOpenAiCompatibleModelIds({
  * @param {String} options.input Tiny canary text. Required and capped at 256 UTF-8 bytes.
  * @param {Number} options.timeoutMs HTTP timeout. Required; no module-level default.
  * @param {String} [options.apiKey] Optional OpenAI-compatible bearer token.
+ * @param {Object[]} [options.lmsLoadedModels] Optional LMS metadata rows for suffix parity with TextEmbeddingService.
  * @param {Function} [options.fetchFn=fetch] Fetch seam for tests.
  * @param {Function} [options.shouldRun] Optional load/backpressure gate.
  * @returns {Promise<Object>}
@@ -537,6 +541,7 @@ export async function checkOpenAiCompatibleEmbeddingServing({
     input,
     timeoutMs,
     apiKey,
+    lmsLoadedModels = [],
     fetchFn = fetch,
     shouldRun
 } = {}) {
@@ -576,11 +581,15 @@ export async function checkOpenAiCompatibleEmbeddingServing({
         headers.authorization = `Bearer ${apiKey}`;
     }
 
+    const
+        loadedModel  = Array.isArray(lmsLoadedModels) ? lmsLoadedModels.find(item => item?.id === model) : null,
+        requestInput = withLmsEmbeddingInputSuffix(input, loadedModel);
+
     const runProbe = async () => {
         const response = await fetchFn(new URL('/v1/embeddings', host).toString(), {
             method: 'POST',
             headers,
-            body  : JSON.stringify({model, input}),
+            body  : JSON.stringify({model, input: requestInput}),
             signal: AbortSignal.timeout(timeoutMs)
         });
 

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -4,15 +4,15 @@ import Base                 from '../../../src/core/Base.mjs';
 import logger               from '../../mcp/server/memory-core/logger.mjs';
 import OllamaProvider       from '../../provider/Ollama.mjs';
 import {
+    withLmsEmbeddingInputSuffix
+}                           from '../shared/vector/lmsEmbeddingInputSuffix.mjs';
+import {
     bytesToTokens,
     emitConsumerFriction
 }                           from './helpers/consumerFrictionHelper.mjs';
 
 const DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS = 60 * 60 * 1000;
 const OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE   = /openAiCompatible embedding error HTTP (408|429|503|504):/;
-const LMS_EMBEDDING_INPUT_SUFFIX_BY_ARCHITECTURE   = {
-    qwen3: '<|im_end|>'
-};
 
 /**
  * Determines whether TextEmbeddingService needs a Gemini embedding client for the active provider.
@@ -227,74 +227,6 @@ class TextEmbeddingService extends Base {
     }
 
     /**
-     * @summary Resolves the LMS-only embedding input suffix from loaded-model metadata.
-     *
-     * This deliberately does not use OpenAI-compatible config: Ollama, llama.cpp, vLLM, and
-     * managed compatibility endpoints share that provider surface but must not receive an
-     * LM Studio/Qwen-specific request suffix. `lms ps --json` exposes the resident model
-     * metadata; Qwen3 GGUF embeddings need `<|im_end|>` when their GGUF header does not auto-add
-     * EOS/SEP.
-     *
-     * @param {Object|null} loadedModel Normalized `lms ps --json` row.
-     * @returns {String}
-     * @private
-     */
-    #getLmsEmbeddingInputSuffix(loadedModel) {
-        const
-            format       = String(loadedModel?.format || '').toLowerCase(),
-            metadataText = [
-                loadedModel?.architecture,
-                loadedModel?.modelKey,
-                loadedModel?.path,
-                loadedModel?.indexedModelIdentifier
-            ].filter(value => typeof value === 'string').join(' ').toLowerCase();
-
-        if (format && format !== 'gguf') {
-            return '';
-        }
-
-        for (const [architecture, suffix] of Object.entries(LMS_EMBEDDING_INPUT_SUFFIX_BY_ARCHITECTURE)) {
-            if (metadataText.includes(architecture)) {
-                return suffix;
-            }
-        }
-
-        return '';
-    }
-
-    /**
-     * @summary Appends the LMS metadata-derived embedding input suffix when absent.
-     * @param {String} text The outbound embedding text.
-     * @param {Object|null} loadedModel Normalized `lms ps --json` row.
-     * @returns {String}
-     * @private
-     */
-    #appendLmsEmbeddingInputSuffix(text, loadedModel) {
-        const suffix = this.#getLmsEmbeddingInputSuffix(loadedModel);
-
-        if (!suffix || typeof text !== 'string' || text.endsWith(suffix)) {
-            return text;
-        }
-
-        return `${text}${suffix}`;
-    }
-
-    /**
-     * @summary Normalizes LMS embedding request input before context checks and POST.
-     * @param {String|String[]} inputData The text or array of texts to embed.
-     * @param {Object|null} loadedModel Normalized `lms ps --json` row.
-     * @returns {String|String[]}
-     * @private
-     */
-    #withLmsEmbeddingInputSuffix(inputData, loadedModel) {
-        if (Array.isArray(inputData)) {
-            return inputData.map(text => this.#appendLmsEmbeddingInputSuffix(text, loadedModel));
-        }
-
-        return this.#appendLmsEmbeddingInputSuffix(inputData, loadedModel);
-    }
-
-    /**
      * @summary Estimates the largest text input in an OpenAI-compatible embedding request.
      *
      * LM Studio truncates each input string independently. Batch safety therefore uses the
@@ -460,7 +392,7 @@ class TextEmbeddingService extends Base {
     async #prepareOpenAiCompatibleEmbeddingInput(inputData) {
         const
             runtime          = await this.#getOpenAiCompatibleEmbeddingRuntime(),
-            requestInputData = runtime ? this.#withLmsEmbeddingInputSuffix(inputData, runtime.loadedModel) : inputData;
+            requestInputData = runtime ? withLmsEmbeddingInputSuffix(inputData, runtime.loadedModel, {log: logger}) : inputData;
 
         this.#assertOpenAiCompatibleEmbeddingContext(requestInputData, runtime);
 

--- a/ai/services/shared/vector/lmsEmbeddingInputSuffix.mjs
+++ b/ai/services/shared/vector/lmsEmbeddingInputSuffix.mjs
@@ -1,0 +1,328 @@
+import fs   from 'fs';
+import os   from 'os';
+import path from 'path';
+
+const GGUF_VALUE_TYPE = Object.freeze({
+    UINT8  : 0,
+    INT8   : 1,
+    UINT16 : 2,
+    INT16  : 3,
+    UINT32 : 4,
+    INT32  : 5,
+    FLOAT32: 6,
+    BOOL   : 7,
+    STRING : 8,
+    ARRAY  : 9,
+    UINT64 : 10,
+    INT64  : 11,
+    FLOAT64: 12
+});
+
+const DEFAULT_LM_STUDIO_MODELS_DIR = path.join(os.homedir(), '.lmstudio', 'models');
+const eosSuffixCache               = new Map();
+
+/**
+ * @summary Clears cached GGUF suffix lookups for deterministic tests.
+ * @returns {void}
+ */
+export function clearLmsEmbeddingInputSuffixCache() {
+    eosSuffixCache.clear();
+}
+
+/**
+ * @summary Resolves an LM Studio GGUF model file path from loaded-model metadata.
+ * @param {Object|null} loadedModel Normalized `lms ps --json` row.
+ * @param {Object} [options]
+ * @param {String} [options.modelRoot] LM Studio model root.
+ * @returns {String}
+ */
+export function resolveLmsGgufModelPath(loadedModel, {modelRoot = DEFAULT_LM_STUDIO_MODELS_DIR} = {}) {
+    const candidates = [
+        loadedModel?.localPath,
+        loadedModel?.filePath,
+        loadedModel?.path,
+        loadedModel?.indexedModelIdentifier
+    ].filter(value => typeof value === 'string' && value.endsWith('.gguf'));
+
+    for (const candidate of candidates) {
+        if (path.isAbsolute(candidate)) {
+            return candidate;
+        }
+        if (modelRoot) {
+            return path.join(modelRoot, candidate);
+        }
+    }
+
+    return '';
+}
+
+/**
+ * @summary Reads tokenizer metadata needed to resolve a GGUF EOS token string.
+ * @param {String} filePath GGUF file path.
+ * @returns {{tokens: String[], eosTokenId: Number|null, eotTokenId: Number|null, addEosToken: Boolean|null}}
+ */
+export function readGgufTokenizerMetadata(filePath) {
+    const fd = fs.openSync(filePath, 'r');
+
+    let offset = 0;
+
+    const readBuffer = length => {
+        const buffer = Buffer.allocUnsafe(length),
+              bytes  = fs.readSync(fd, buffer, 0, length, offset);
+
+        if (bytes !== length) {
+            throw new Error(`readGgufTokenizerMetadata: short read ${bytes}/${length} at offset ${offset}`);
+        }
+
+        offset += length;
+        return buffer;
+    };
+
+    const skipBytes = length => {
+        offset += length;
+    };
+
+    const readU32    = () => readBuffer(4).readUInt32LE(0);
+    const readI32    = () => readBuffer(4).readInt32LE(0);
+    const readU64    = () => Number(readBuffer(8).readBigUInt64LE(0));
+    const readI64    = () => Number(readBuffer(8).readBigInt64LE(0));
+    const readString = () => {
+        const length = readU64();
+        return readBuffer(length).toString('utf8');
+    };
+    const skipString = () => {
+        skipBytes(readU64());
+    };
+
+    const readScalar = type => {
+        switch (type) {
+            case GGUF_VALUE_TYPE.UINT8:
+                return readBuffer(1).readUInt8(0);
+            case GGUF_VALUE_TYPE.INT8:
+                return readBuffer(1).readInt8(0);
+            case GGUF_VALUE_TYPE.UINT16:
+                return readBuffer(2).readUInt16LE(0);
+            case GGUF_VALUE_TYPE.INT16:
+                return readBuffer(2).readInt16LE(0);
+            case GGUF_VALUE_TYPE.UINT32:
+                return readU32();
+            case GGUF_VALUE_TYPE.INT32:
+                return readI32();
+            case GGUF_VALUE_TYPE.FLOAT32:
+                return readBuffer(4).readFloatLE(0);
+            case GGUF_VALUE_TYPE.BOOL:
+                return readBuffer(1).readUInt8(0) === 1;
+            case GGUF_VALUE_TYPE.STRING:
+                return readString();
+            case GGUF_VALUE_TYPE.UINT64:
+                return readU64();
+            case GGUF_VALUE_TYPE.INT64:
+                return readI64();
+            case GGUF_VALUE_TYPE.FLOAT64:
+                return readBuffer(8).readDoubleLE(0);
+            default:
+                throw new Error(`readGgufTokenizerMetadata: unsupported scalar type ${type}`);
+        }
+    };
+
+    const skipScalar = type => {
+        switch (type) {
+            case GGUF_VALUE_TYPE.UINT8:
+            case GGUF_VALUE_TYPE.INT8:
+            case GGUF_VALUE_TYPE.BOOL:
+                skipBytes(1);
+                break;
+            case GGUF_VALUE_TYPE.UINT16:
+            case GGUF_VALUE_TYPE.INT16:
+                skipBytes(2);
+                break;
+            case GGUF_VALUE_TYPE.UINT32:
+            case GGUF_VALUE_TYPE.INT32:
+            case GGUF_VALUE_TYPE.FLOAT32:
+                skipBytes(4);
+                break;
+            case GGUF_VALUE_TYPE.UINT64:
+            case GGUF_VALUE_TYPE.INT64:
+            case GGUF_VALUE_TYPE.FLOAT64:
+                skipBytes(8);
+                break;
+            case GGUF_VALUE_TYPE.STRING:
+                skipString();
+                break;
+            default:
+                throw new Error(`readGgufTokenizerMetadata: unsupported scalar type ${type}`);
+        }
+    };
+
+    const readArray = type => {
+        if (type !== GGUF_VALUE_TYPE.ARRAY) {
+            throw new Error(`readGgufTokenizerMetadata: expected array type, got ${type}`);
+        }
+
+        const
+            itemType = readU32(),
+            length   = readU64(),
+            values   = [];
+
+        for (let i = 0; i < length; i++) {
+            values.push(readScalar(itemType));
+        }
+
+        return values;
+    };
+
+    const skipValue = type => {
+        if (type === GGUF_VALUE_TYPE.ARRAY) {
+            const
+                itemType = readU32(),
+                length   = readU64();
+
+            for (let i = 0; i < length; i++) {
+                skipScalar(itemType);
+            }
+        } else {
+            skipScalar(type);
+        }
+    };
+
+    try {
+        const magic = readBuffer(4).toString('utf8');
+        if (magic !== 'GGUF') {
+            throw new Error(`readGgufTokenizerMetadata: expected GGUF magic, got '${magic}'`);
+        }
+
+        readU32(); // version
+        readU64(); // tensor count
+        const metadataCount = readU64();
+        const metadata      = {
+            addEosToken: null,
+            eosTokenId : null,
+            eotTokenId : null,
+            tokens     : []
+        };
+
+        for (let i = 0; i < metadataCount; i++) {
+            const
+                key  = readString(),
+                type = readU32();
+
+            switch (key) {
+                case 'tokenizer.ggml.tokens':
+                    metadata.tokens = readArray(type);
+                    break;
+                case 'tokenizer.ggml.eos_token_id':
+                    metadata.eosTokenId = readScalar(type);
+                    break;
+                case 'tokenizer.ggml.eot_token_id':
+                    metadata.eotTokenId = readScalar(type);
+                    break;
+                case 'tokenizer.ggml.add_eos_token':
+                    metadata.addEosToken = readScalar(type);
+                    break;
+                default:
+                    skipValue(type);
+            }
+        }
+
+        return metadata;
+    } finally {
+        fs.closeSync(fd);
+    }
+}
+
+/**
+ * @summary Returns the GGUF EOS token text from tokenizer metadata.
+ * @param {Object} metadata GGUF tokenizer metadata.
+ * @returns {String}
+ */
+export function getGgufEosTokenText(metadata = {}) {
+    const
+        tokens     = metadata.tokens || metadata['tokenizer.ggml.tokens'] || [],
+        eosTokenId = metadata.eosTokenId ?? metadata['tokenizer.ggml.eos_token_id'];
+
+    return Number.isInteger(eosTokenId) && typeof tokens[eosTokenId] === 'string'
+        ? tokens[eosTokenId]
+        : '';
+}
+
+/**
+ * @summary Resolves the LMS-only embedding input suffix from loaded GGUF metadata.
+ * @param {Object|null} loadedModel Normalized `lms ps --json` row.
+ * @param {Object} [options]
+ * @param {Function} [options.readGgufTokenizerMetadataFn] Test seam for GGUF metadata reads.
+ * @param {String} [options.modelRoot] LM Studio model root.
+ * @param {Object} [options.log] Optional logger.
+ * @returns {String}
+ */
+export function resolveLmsEmbeddingInputSuffix(loadedModel, {
+    readGgufTokenizerMetadataFn = readGgufTokenizerMetadata,
+    modelRoot,
+    log
+} = {}) {
+    if (!loadedModel) {
+        return '';
+    }
+
+    const format = String(loadedModel.format || '').toLowerCase();
+    if (format && format !== 'gguf') {
+        return '';
+    }
+
+    if (typeof loadedModel.eosTokenText === 'string' && loadedModel.eosTokenText) {
+        return loadedModel.eosTokenText;
+    }
+    if (loadedModel.ggufTokenizerMetadata) {
+        return getGgufEosTokenText(loadedModel.ggufTokenizerMetadata);
+    }
+
+    const ggufPath = resolveLmsGgufModelPath(loadedModel, {modelRoot});
+    if (!ggufPath) {
+        return '';
+    }
+
+    try {
+        const stat = fs.statSync(ggufPath),
+              cacheKey = `${ggufPath}:${stat.size}:${stat.mtimeMs}`;
+
+        if (!eosSuffixCache.has(cacheKey)) {
+            eosSuffixCache.set(cacheKey, getGgufEosTokenText(readGgufTokenizerMetadataFn(ggufPath)));
+        }
+
+        return eosSuffixCache.get(cacheKey);
+    } catch (error) {
+        log?.warn?.(`[lmsEmbeddingInputSuffix] Unable to read GGUF tokenizer metadata for '${ggufPath}': ${error.message}`);
+        return '';
+    }
+}
+
+/**
+ * @summary Appends the LMS metadata-derived embedding input suffix when absent.
+ * @param {String} text The outbound embedding text.
+ * @param {Object|null} loadedModel Normalized `lms ps --json` row.
+ * @param {Object} [options] Suffix resolver options.
+ * @returns {String}
+ */
+export function appendLmsEmbeddingInputSuffix(text, loadedModel, options = {}) {
+    const suffix = resolveLmsEmbeddingInputSuffix(loadedModel, options);
+
+    if (!suffix || typeof text !== 'string' || text.endsWith(suffix)) {
+        return text;
+    }
+
+    return `${text}${suffix}`;
+}
+
+/**
+ * @summary Normalizes LMS embedding request input before provider invocation.
+ * @param {String|String[]} inputData The text or array of texts to embed.
+ * @param {Object|null} loadedModel Normalized `lms ps --json` row.
+ * @param {Object} [options] Suffix resolver options.
+ * @returns {String|String[]}
+ */
+export function withLmsEmbeddingInputSuffix(inputData, loadedModel, options = {}) {
+    if (Array.isArray(inputData)) {
+        return inputData.map(text => appendLmsEmbeddingInputSuffix(text, loadedModel, options));
+    }
+
+    return appendLmsEmbeddingInputSuffix(inputData, loadedModel, options);
+}

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -1385,6 +1385,51 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(result.embedding).toBeUndefined();
     });
 
+    test('checkOpenAiCompatibleEmbeddingServing applies LMS GGUF EOS suffix when metadata is available (#14015)', async () => {
+        let request;
+
+        const result = await providerReadinessHelper.checkOpenAiCompatibleEmbeddingServing({
+            host           : 'http://127.0.0.1:1234',
+            model          : 'embedding-model',
+            input          : 'neo embedding canary',
+            timeoutMs      : 50,
+            lmsLoadedModels: [{
+                id          : 'embedding-model',
+                format      : 'gguf',
+                eosTokenText: '<|endoftext|>'
+            }],
+            fetchFn  : async (url, options) => {
+                request = {
+                    url,
+                    method: options.method,
+                    body  : JSON.parse(options.body)
+                };
+
+                return {
+                    ok  : true,
+                    json: async () => ({data: [{embedding: [0.1, 0.2, 0.3]}]})
+                };
+            }
+        });
+
+        expect(request).toEqual({
+            url   : 'http://127.0.0.1:1234/v1/embeddings',
+            method: 'POST',
+            body  : {
+                model: 'embedding-model',
+                input: 'neo embedding canary<|endoftext|>'
+            }
+        });
+        expect(result).toMatchObject({
+            ready       : true,
+            degraded    : false,
+            provider    : 'openAiCompatible',
+            host        : 'http://127.0.0.1:1234',
+            model       : 'embedding-model',
+            vectorLength: 3
+        });
+    });
+
     test('checkOpenAiCompatibleEmbeddingServing serializes concurrent canaries (#13950)', async () => {
         const events = [];
         let releaseFirst;

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -16,8 +16,17 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
 import http           from 'http';
+import os             from 'os';
+import path           from 'path';
 import aiConfig       from '../../../../../../ai/mcp/server/memory-core/config.mjs';
+import {
+    clearLmsEmbeddingInputSuffixCache,
+    readGgufTokenizerMetadata,
+    resolveLmsEmbeddingInputSuffix,
+    withLmsEmbeddingInputSuffix
+} from '../../../../../../ai/services/shared/vector/lmsEmbeddingInputSuffix.mjs';
 
 async function waitForCondition(condition, message, timeoutMs = 250) {
     const start = Date.now();
@@ -28,6 +37,52 @@ async function waitForCondition(condition, message, timeoutMs = 250) {
     }
 
     throw new Error(`Timed out waiting for ${message}`);
+}
+
+function u32(value) {
+    const buffer = Buffer.alloc(4);
+    buffer.writeUInt32LE(value);
+    return buffer;
+}
+
+function u64(value) {
+    const buffer = Buffer.alloc(8);
+    buffer.writeBigUInt64LE(BigInt(value));
+    return buffer;
+}
+
+function ggufString(value) {
+    const bytes = Buffer.from(value, 'utf8');
+    return Buffer.concat([u64(bytes.length), bytes]);
+}
+
+function ggufMetadataEntry(key, type, valueBuffer) {
+    return Buffer.concat([ggufString(key), u32(type), valueBuffer]);
+}
+
+function ggufStringArray(values) {
+    return Buffer.concat([
+        u32(8),
+        u64(values.length),
+        ...values.map(value => ggufString(value))
+    ]);
+}
+
+function buildMinimalGguf({tokens, eosTokenId, eotTokenId, addEosToken = true}) {
+    const entries = [
+        ggufMetadataEntry('tokenizer.ggml.tokens', 9, ggufStringArray(tokens)),
+        ggufMetadataEntry('tokenizer.ggml.eos_token_id', 4, u32(eosTokenId)),
+        ggufMetadataEntry('tokenizer.ggml.eot_token_id', 4, u32(eotTokenId)),
+        ggufMetadataEntry('tokenizer.ggml.add_eos_token', 7, Buffer.from([addEosToken ? 1 : 0]))
+    ];
+
+    return Buffer.concat([
+        Buffer.from('GGUF'),
+        u32(3),
+        u64(0),
+        u64(entries.length),
+        ...entries
+    ]);
 }
 
 test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openAiCompatible retry, QoS, and lms server start support', () => {
@@ -264,38 +319,68 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         });
     });
 
-    test('LMS GGUF/Qwen3 embeddings append metadata-derived SEP/EOS suffix to request inputs (#14009)', async () => {
+    test('LMS suffix helper reads the GGUF EOS token instead of the chat EOT token (#14015)', async () => {
+        clearLmsEmbeddingInputSuffixCache();
+
+        const tmpDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-lms-gguf-suffix-')),
+              ggufPath = path.join(tmpDir, 'minimal-qwen3-embedding.gguf');
+
+        try {
+            fs.writeFileSync(ggufPath, buildMinimalGguf({
+                tokens    : ['<|pad|>', '<|endoftext|>', '<|im_end|>'],
+                eosTokenId: 1,
+                eotTokenId: 2
+            }));
+
+            const metadata = readGgufTokenizerMetadata(ggufPath),
+                  row      = {id: 'embedding-model', format: 'gguf', path: ggufPath};
+
+            expect(metadata).toMatchObject({
+                addEosToken: true,
+                eosTokenId : 1,
+                eotTokenId : 2
+            });
+            expect(resolveLmsEmbeddingInputSuffix(row)).toBe('<|endoftext|>');
+            expect(withLmsEmbeddingInputSuffix('hello<|im_end|>', row)).toBe('hello<|im_end|><|endoftext|>');
+        } finally {
+            fs.rmSync(tmpDir, {recursive: true, force: true});
+            clearLmsEmbeddingInputSuffixCache();
+        }
+    });
+
+    test('LMS GGUF embeddings append metadata-derived EOS suffix to request inputs (#14015)', async () => {
         serverBehavior = 'lms-server-start-succeed';
         TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{
             id           : aiConfig.openAiCompatible.embeddingModel,
             contextLength: aiConfig.localModels.embedding.contextLimitTokens,
             format       : 'gguf',
-            architecture : 'qwen3'
+            architecture : 'qwen3',
+            eosTokenText : '<|endoftext|>'
         }];
 
         const singleInput = 'last-token-is-semantic-content';
 
         await TextEmbeddingService.embedText(singleInput, 'openAiCompatible');
 
-        expect(lastRequest.body.input).toBe(`${singleInput}<|im_end|>`);
+        expect(lastRequest.body.input).toBe(`${singleInput}<|endoftext|>`);
         expect(singleInput).toBe('last-token-is-semantic-content');
 
         serverBehavior = 'lms-server-start-batch-succeed';
 
         const batchInput = [
             'batch-first-without-provider-separator',
-            'batch-second-with-provider-eos<|im_end|>'
+            'batch-second-with-provider-eos<|endoftext|>'
         ];
 
         await TextEmbeddingService.embedTexts(batchInput, 'openAiCompatible');
 
         expect(lastRequest.body.input).toEqual([
-            'batch-first-without-provider-separator<|im_end|>',
-            'batch-second-with-provider-eos<|im_end|>'
+            'batch-first-without-provider-separator<|endoftext|>',
+            'batch-second-with-provider-eos<|endoftext|>'
         ]);
         expect(batchInput).toEqual([
             'batch-first-without-provider-separator',
-            'batch-second-with-provider-eos<|im_end|>'
+            'batch-second-with-provider-eos<|endoftext|>'
         ]);
     });
 


### PR DESCRIPTION
Resolves #14015

Derives the LM Studio embedding request suffix from the loaded GGUF tokenizer metadata instead of mapping Qwen3 to the chat EOT token. `TextEmbeddingService` now appends the GGUF EOS token text (`<|endoftext|>` for the installed Qwen3 embedding GGUF), and the provider-readiness canary can apply the same metadata-derived suffix when LMS metadata is present. Generic OpenAI-compatible and unknown-metadata paths remain unchanged.

Evidence: L3 (live `lms ps --json` + local GGUF header probe showed `eos_token_id -> <|endoftext|>` and service-level fake-endpoint request capture sent that token) -> L3 required (runtime request-boundary correctness). Residual: post-merge operator log confirmation that LMS warnings stop during repair-defrag.

## Deltas from ticket

The first #14015 body focused on a canary bypass. Live logs then showed the real repair-defrag batch already ended with `<|im_end|>` and still warned, so the implementation pivoted to the stronger root cause: `<|im_end|>` is `eot_token_id`, not this GGUF's EOS/SEP token.

## Test Evidence

- `node --input-type=module -e '...'` live helper probe against `/Users/tobiasuhlig/.lmstudio/models/Qwen/Qwen3-Embedding-8B-GGUF/Qwen3-Embedding-8B-Q4_K_M.gguf` -> suffix `<|endoftext|>`.
- `node --input-type=module -e '...'` service-path probe with actual `lms ps` metadata + fake endpoint -> request input `hello<|endoftext|>` and `world<|im_end|><|endoftext|>`.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs` -> 87 passed.
- `git diff --check` and `git diff --cached --check` passed.

## Post-Merge Validation

- [ ] Restart the repair-defrag / embedding sender on merged `dev` and confirm LM Studio no longer emits the SEP warning for Memory Core re-embed batches.

Authored by Euclid (GPT-5, Codex Desktop). Session 9280140f-8b54-4462-9342-49cca7e226f4.
