### PR TITLE
fix(ai): timestamp repair-defrag progress lines (#14017)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -820,22 +820,24 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
  * @param {Object} options
  * @param {String} options.collectionName Collection currently being repaired.
  * @param {Object} options.event Progress event emitted by `extractMemoryCoreCollectionData`.
+ * @param {Date|String|Number} [options.now=new Date()] Timestamp source for log correlation.
  * @returns {String}
  */
-function formatMemoryCoreRepairProgress({collectionName, event} = {}) {
-    const counts = event.counts || {};
+export function formatMemoryCoreRepairProgress({collectionName, event, now = new Date()} = {}) {
+    const counts    = event.counts || {},
+          timestamp = new Date(now).toISOString();
 
     switch (event.phase) {
         case 'start':
-            return `   ⏳ '${collectionName}': extraction starting (total=${event.total}, intact=${counts.intact || 0}, reEmbedded=${counts.reEmbedded || 0}, unrecoverable=${counts.unrecoverable || 0})`;
+            return `   [${timestamp}] ⏳ '${collectionName}': extraction starting (total=${event.total}, intact=${counts.intact || 0}, reEmbedded=${counts.reEmbedded || 0}, unrecoverable=${counts.unrecoverable || 0})`;
         case 'intact-extract':
-            return `   ⏳ '${collectionName}': intact-vector extraction ${event.percent}% (${event.processed}/${event.total}; intact=${counts.intact || 0})`;
+            return `   [${timestamp}] ⏳ '${collectionName}': intact-vector extraction ${event.percent}% (${event.processed}/${event.total}; intact=${counts.intact || 0})`;
         case 'missing-reembed':
-            return `   ⏳ '${collectionName}': missing-vector re-embed ${event.percent}% (${event.processed}/${event.total}; reEmbedded=${counts.reEmbedded || 0}, unrecoverable=${counts.unrecoverable || 0})`;
+            return `   [${timestamp}] ⏳ '${collectionName}': missing-vector re-embed ${event.percent}% (${event.processed}/${event.total}; reEmbedded=${counts.reEmbedded || 0}, unrecoverable=${counts.unrecoverable || 0})`;
         case 'complete':
-            return `   ✅ '${collectionName}': extraction complete; counts ${JSON.stringify(counts)}`;
+            return `   [${timestamp}] ✅ '${collectionName}': extraction complete; counts ${JSON.stringify(counts)}`;
         default:
-            return `   ⏳ '${collectionName}': ${event.phase || 'progress'} ${event.percent ?? '?'}% (${event.processed ?? '?'}/${event.total ?? '?'})`;
+            return `   [${timestamp}] ⏳ '${collectionName}': ${event.phase || 'progress'} ${event.percent ?? '?'}% (${event.processed ?? '?'}/${event.total ?? '?'})`;
     }
 }
 

--- a/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
@@ -1,5 +1,10 @@
 import {test, expect}                                                                                 from '@playwright/test';
-import {anyRepairAborted, assertDefragTargetSupported, repairMemoryCoreCollectionsViaFullEnumeration} from '../../../../../../ai/scripts/maintenance/defragChromaDB.mjs';
+import {
+    anyRepairAborted,
+    assertDefragTargetSupported,
+    formatMemoryCoreRepairProgress,
+    repairMemoryCoreCollectionsViaFullEnumeration
+} from '../../../../../../ai/scripts/maintenance/defragChromaDB.mjs';
 
 /**
  * AC4 — the Memory Core defrag-wiring orchestration: full (uncapped) enumeration ->
@@ -236,5 +241,68 @@ test.describe('anyRepairAborted — operator fail-loud predicate (#13634 AC4)', 
 
     test('false for an empty result set', () => {
         expect(anyRepairAborted([])).toBe(false);
+    });
+});
+
+test.describe('formatMemoryCoreRepairProgress — timestamped operator progress (#14017)', () => {
+    const now            = '2026-06-25T18:45:00.000Z',
+          collectionName = 'neo-agent-memory';
+
+    test('timestamps representative repair phases while preserving progress details', () => {
+        expect(formatMemoryCoreRepairProgress({
+            collectionName,
+            now,
+            event: {
+                phase : 'start',
+                total : 22545,
+                counts: {intact: 0, reEmbedded: 0, unrecoverable: 0}
+            }
+        })).toBe(`   [${now}] ⏳ 'neo-agent-memory': extraction starting (total=22545, intact=0, reEmbedded=0, unrecoverable=0)`);
+
+        expect(formatMemoryCoreRepairProgress({
+            collectionName,
+            now,
+            event: {
+                phase    : 'intact-extract',
+                percent  : 40,
+                processed: 4000,
+                total    : 8583,
+                counts   : {intact: 4000}
+            }
+        })).toBe(`   [${now}] ⏳ 'neo-agent-memory': intact-vector extraction 40% (4000/8583; intact=4000)`);
+
+        expect(formatMemoryCoreRepairProgress({
+            collectionName,
+            now,
+            event: {
+                phase    : 'missing-reembed',
+                percent  : 30,
+                processed: 5000,
+                total    : 13962,
+                counts   : {reEmbedded: 5000, unrecoverable: 0}
+            }
+        })).toBe(`   [${now}] ⏳ 'neo-agent-memory': missing-vector re-embed 30% (5000/13962; reEmbedded=5000, unrecoverable=0)`);
+
+        expect(formatMemoryCoreRepairProgress({
+            collectionName,
+            now,
+            event: {
+                phase : 'complete',
+                counts: {total: 22545, intact: 8583, reEmbedded: 13962, unrecoverable: 0}
+            }
+        })).toBe(`   [${now}] ✅ 'neo-agent-memory': extraction complete; counts {"total":22545,"intact":8583,"reEmbedded":13962,"unrecoverable":0}`);
+    });
+
+    test('timestamps fallback progress phases', () => {
+        expect(formatMemoryCoreRepairProgress({
+            collectionName,
+            now,
+            event: {
+                phase    : 'unexpected-phase',
+                percent  : 75,
+                processed: 3,
+                total    : 4
+            }
+        })).toBe(`   [${now}] ⏳ 'neo-agent-memory': unexpected-phase 75% (3/4)`);
     });
 });


### PR DESCRIPTION
Resolves #14017

Adds ISO wall-clock timestamps to Memory Core repair-defrag progress lines while preserving the existing collection/phase/percent/count content from #14011. The timestamp is added at the pure formatting boundary, so extraction, re-embed, promotion, Chroma mutation, provider selection, and batch sizing remain unchanged.

Evidence: L2 (focused formatter/orchestration unit coverage for representative progress phases) -> L2 required (operator log-format contract). No residuals.

## Deltas from ticket

None. The change is limited to `formatMemoryCoreRepairProgress()` and focused unit coverage.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs` -> 16 passed.
- `git diff --check` passed.
- `node ./buildScripts/util/check-block-alignment.mjs --staged ai/scripts/maintenance/defragChromaDB.mjs test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs` passed.

## Post-Merge Validation

- [ ] Next live repair-defrag run shows progress lines such as `[2026-06-25T18:45:00.000Z] ...` so they can be correlated with LM Studio logs.

Authored by Euclid (GPT-5, Codex Desktop). Session 9280140f-8b54-4462-9342-49cca7e226f4.
