### PR TITLE
feat(ai): add Chroma test-collection catalog diagnostics (#14010)

### DIFF
--- a/ai/scripts/maintenance/purgeTestCollections.mjs
+++ b/ai/scripts/maintenance/purgeTestCollections.mjs
@@ -1,10 +1,12 @@
-import {program}                       from 'commander';
-import {ChromaClient}                  from 'chromadb';
-import fs                              from 'fs-extra';
-import path                            from 'path';
-import {fileURLToPath, pathToFileURL}  from 'url';
-import Neo                             from '../../../src/Neo.mjs'; // side-effect: defines globalThis.Neo so the memory-core config module evaluates
+import {program}                      from 'commander';
+import Database                       from 'better-sqlite3';
+import {ChromaClient}                 from 'chromadb';
+import fs                             from 'fs-extra';
+import path                           from 'path';
+import {fileURLToPath, pathToFileURL} from 'url';
+import Neo                            from '../../../src/Neo.mjs'; // side-effect: defines globalThis.Neo so the memory-core config module evaluates
 import {
+    CHROMA_PRODUCTION_DATABASE,
     CHROMA_TEST_DATABASE,
     dropChromaTestDatabase
 }                                     from '../../services/shared/vector/chromaTestIsolation.mjs';
@@ -23,6 +25,8 @@ import {
  * daemon dir (now routed to `os.tmpdir()`, but earlier residue can remain).
  *
  * This is the on-demand reclaimer for that backlog. It is **dry-run by default** — pass `--apply` to delete.
+ * It also reads the Chroma SQLite catalog to distinguish isolated `neo-unit-test` residue from real
+ * `default_database` bleed before any destructive action is considered.
  *
  * ## Safety model
  *
@@ -34,6 +38,7 @@ import {
  *   node ai/scripts/maintenance/purgeTestCollections.mjs            # dry-run report
  *   node ai/scripts/maintenance/purgeTestCollections.mjs --apply    # actually delete
  *   node ai/scripts/maintenance/purgeTestCollections.mjs --apply --host 127.0.0.1 --port 8000
+ *   node ai/scripts/maintenance/purgeTestCollections.mjs --fail-on-production-test-collections
  *
  * @module ai.scripts.maintenance.purgeTestCollections
  * @see ai/scripts/maintenance/defragChromaDB.mjs   Peer maintenance script (HNSW defrag, not orphan purge)
@@ -45,6 +50,7 @@ const PROJECT_ROOT = path.resolve(__dirname, '../../..');
 
 export const MEMORY_CORE_CONFIG = path.resolve(__dirname, '../../mcp/server/memory-core/config.mjs');
 export const DATA_DIR           = path.resolve(PROJECT_ROOT, '.neo-ai-data');
+export const CHROMA_SQLITE_FILE = 'chroma.sqlite3';
 
 /**
  * Production collections that must NEVER be deleted, regardless of any pattern match
@@ -84,6 +90,232 @@ export function partitionCollections(names) {
     }
 
     return {purge, keep};
+}
+
+/**
+ * @summary Resolves the Chroma catalog SQLite path from the memory-core config.
+ *
+ * This is read-only diagnostic plumbing. The live Chroma API can list only the selected database;
+ * the SQLite catalog is the source of truth for tenant/database placement across the unified store.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.sqlitePath] Explicit sqlite override.
+ * @param {String} [options.configPath=MEMORY_CORE_CONFIG] Memory-core config module path.
+ * @returns {Promise<String>}
+ */
+export async function resolveChromaSqlitePath({sqlitePath, configPath = MEMORY_CORE_CONFIG} = {}) {
+    if (sqlitePath) {
+        return path.resolve(sqlitePath)
+    }
+
+    const module  = await import(pathToFileURL(path.resolve(configPath)).href),
+          dataDir = module.default?.engines?.chroma?.dataDir;
+
+    if (!dataDir) {
+        throw new Error('resolveChromaSqlitePath: memory-core config has no engines.chroma.dataDir')
+    }
+
+    return path.join(dataDir, CHROMA_SQLITE_FILE)
+}
+
+const TEST_COLLECTION_CATALOG_SQL = `
+WITH segment_rollup AS (
+    SELECT
+        collection,
+        MAX(CASE WHEN scope = 'METADATA' THEN id END) AS metadataSegmentId,
+        MAX(CASE WHEN scope = 'VECTOR' THEN id END) AS vectorSegmentId
+    FROM segments
+    GROUP BY collection
+),
+embedding_rollup AS (
+    SELECT
+        s.collection,
+        s.scope,
+        COUNT(e.id) AS embeddingRows,
+        MAX(e.created_at) AS latestEmbeddingCreatedAt
+    FROM segments s
+    LEFT JOIN embeddings e ON e.segment_id = s.id
+    GROUP BY s.collection, s.scope
+)
+SELECT
+    c.id AS collectionId,
+    c.name AS collectionName,
+    d.name AS databaseName,
+    t.id AS tenantId,
+    sr.metadataSegmentId,
+    sr.vectorSegmentId,
+    COALESCE(meta.embeddingRows, 0) AS metadataRows,
+    COALESCE(vector.embeddingRows, 0) AS vectorRows,
+    meta.latestEmbeddingCreatedAt AS latestMetadataTimestamp,
+    vector.latestEmbeddingCreatedAt AS latestVectorTimestamp,
+    COUNT(q.seq_id) AS queueRows,
+    MAX(q.created_at) AS latestQueueTimestamp
+FROM collections c
+JOIN databases d ON d.id = c.database_id
+JOIN tenants t ON t.id = d.tenant_id
+LEFT JOIN segment_rollup sr ON sr.collection = c.id
+LEFT JOIN embedding_rollup meta ON meta.collection = c.id AND meta.scope = 'METADATA'
+LEFT JOIN embedding_rollup vector ON vector.collection = c.id AND vector.scope = 'VECTOR'
+LEFT JOIN embeddings_queue q ON q.topic LIKE '%' || c.id
+WHERE c.name LIKE 'test-%'
+GROUP BY c.id, c.name, d.name, t.id, sr.metadataSegmentId, sr.vectorSegmentId,
+    meta.embeddingRows, vector.embeddingRows, meta.latestEmbeddingCreatedAt, vector.latestEmbeddingCreatedAt
+ORDER BY d.name, t.id, c.name
+`;
+
+/**
+ * @summary Returns the lexically newest timestamp from Chroma's SQLite timestamp strings.
+ * @param  {...String|null|undefined} values Candidate timestamps.
+ * @returns {String}
+ */
+export function latestChromaTimestamp(...values) {
+    return values.filter(Boolean).sort().at(-1) || ''
+}
+
+/**
+ * @summary Decorates raw Chroma catalog rows with vector segment path evidence.
+ * @param {Object} options
+ * @param {Object[]} options.rows Raw rows from the Chroma SQLite catalog.
+ * @param {String} options.dataDir Chroma persist directory containing segment UUID dirs.
+ * @param {Object} [options.fsModule=fs]
+ * @returns {Object[]}
+ */
+export function decorateChromaTestCollectionRows({rows, dataDir, fsModule = fs} = {}) {
+    return (rows || []).map(row => {
+        const
+            vectorSegmentPath = row.vectorSegmentId ? path.join(dataDir, row.vectorSegmentId) : '',
+            pathExists        = vectorSegmentPath ? fsModule.pathExistsSync(vectorSegmentPath) : false;
+
+        return {
+            collectionId           : row.collectionId,
+            collectionName         : row.collectionName,
+            databaseName           : row.databaseName,
+            tenantId               : row.tenantId,
+            metadataSegmentId      : row.metadataSegmentId || '',
+            vectorSegmentId        : row.vectorSegmentId || '',
+            vectorSegmentPath,
+            vectorSegmentPathExists: pathExists,
+            metadataRows           : Number(row.metadataRows || 0),
+            vectorRows             : Number(row.vectorRows || 0),
+            queueRows              : Number(row.queueRows || 0),
+            latestRelevantTimestamp: latestChromaTimestamp(
+                row.latestMetadataTimestamp,
+                row.latestVectorTimestamp,
+                row.latestQueueTimestamp
+            )
+        }
+    })
+}
+
+/**
+ * @summary Reads Chroma catalog evidence for `test-*` collections across all tenant databases.
+ * @param {Object} options
+ * @param {String} options.sqlitePath Path to `chroma.sqlite3`.
+ * @param {String} [options.dataDir=path.dirname(sqlitePath)] Chroma persist directory.
+ * @param {Function} [options.DatabaseClass=Database] better-sqlite3-compatible constructor.
+ * @param {Object} [options.fsModule=fs]
+ * @returns {Object[]}
+ */
+export function readChromaTestCollectionDiagnostics({
+    sqlitePath,
+    dataDir       = sqlitePath ? path.dirname(sqlitePath) : '',
+    DatabaseClass = Database,
+    fsModule      = fs
+} = {}) {
+    if (!sqlitePath) {
+        throw new Error('readChromaTestCollectionDiagnostics: sqlitePath is required')
+    }
+
+    const db = new DatabaseClass(sqlitePath, {readonly: true, fileMustExist: true});
+
+    try {
+        return decorateChromaTestCollectionRows({
+            rows: db.prepare(TEST_COLLECTION_CATALOG_SQL).all(),
+            dataDir,
+            fsModule
+        })
+    } finally {
+        db.close?.()
+    }
+}
+
+/**
+ * @summary Summarizes catalog placement for `test-*` Chroma collections.
+ * @param {Object[]} rows Diagnostic rows.
+ * @param {Object} [options]
+ * @param {String} [options.productionDatabase=CHROMA_PRODUCTION_DATABASE]
+ * @param {String} [options.testDatabase=CHROMA_TEST_DATABASE]
+ * @returns {Object}
+ */
+export function summarizeChromaTestCollectionDiagnostics(rows = [], {
+    productionDatabase = CHROMA_PRODUCTION_DATABASE,
+    testDatabase       = CHROMA_TEST_DATABASE
+} = {}) {
+    const summary = {
+        totalCollections             : rows.length,
+        productionDatabaseCollections: 0,
+        isolatedTestDatabaseRows     : 0,
+        nonEmptyCollections          : 0,
+        missingVectorSegmentPaths    : 0,
+        latestRelevantTimestamp      : ''
+    };
+
+    for (const row of rows) {
+        if (row.databaseName === productionDatabase) {
+            summary.productionDatabaseCollections++
+        }
+        if (row.databaseName === testDatabase) {
+            summary.isolatedTestDatabaseRows++
+        }
+        if (row.metadataRows > 0 || row.vectorRows > 0 || row.queueRows > 0) {
+            summary.nonEmptyCollections++
+        }
+        if (row.vectorSegmentId && !row.vectorSegmentPathExists) {
+            summary.missingVectorSegmentPaths++
+        }
+
+        summary.latestRelevantTimestamp = latestChromaTimestamp(
+            summary.latestRelevantTimestamp,
+            row.latestRelevantTimestamp
+        )
+    }
+
+    return summary
+}
+
+/**
+ * @summary Formats one catalog diagnostic row for operator-facing logs.
+ * @param {Object} row Diagnostic row.
+ * @returns {String}
+ */
+export function formatChromaTestCollectionDiagnosticRow(row) {
+    return `   - ${row.collectionName} (${row.collectionId}) tenant=${row.tenantId} ` +
+        `database=${row.databaseName} metadataRows=${row.metadataRows} vectorRows=${row.vectorRows} ` +
+        `queueRows=${row.queueRows} vectorSegment=${row.vectorSegmentId || 'none'} ` +
+        `vectorPath=${row.vectorSegmentPathExists ? 'present' : 'missing'} ` +
+        `latest=${row.latestRelevantTimestamp || 'none'}`
+}
+
+/**
+ * @summary Logs Chroma test-collection diagnostics and returns the summary.
+ * @param {Object} options
+ * @param {Object[]} options.rows Diagnostic rows.
+ * @param {Function} [options.log=console.log]
+ * @returns {Object}
+ */
+export function logChromaTestCollectionDiagnostics({rows, log = console.log} = {}) {
+    const summary = summarizeChromaTestCollectionDiagnostics(rows);
+
+    log('\n🔎 Chroma catalog test-collection diagnostic:');
+    log(`   total=${summary.totalCollections}, productionDatabase=${summary.productionDatabaseCollections}, ` +
+        `isolatedTestDatabase=${summary.isolatedTestDatabaseRows}, nonEmpty=${summary.nonEmptyCollections}, ` +
+        `missingVectorPaths=${summary.missingVectorSegmentPaths}, latest=${summary.latestRelevantTimestamp || 'none'}`);
+
+    for (const row of rows || []) {
+        log(formatChromaTestCollectionDiagnosticRow(row))
+    }
+
+    return summary
 }
 
 /**
@@ -128,7 +360,7 @@ export async function listAllCollectionNames({client, limit = 1000}) {
         origWarn(...args)
     };
 
-    const names = [];
+    const names  = [];
     let   offset = 0;
 
     try {
@@ -226,6 +458,9 @@ async function purgeTestCollections() {
         .option('--apply', 'Actually delete. Without this flag the script is a dry-run report.', false)
         .option('--host <host>', 'Chroma host override (defaults to memory-core config).')
         .option('--port <port>', 'Chroma port override (defaults to memory-core config).')
+        .option('--sqlite <path>', 'Chroma sqlite catalog path for tenant/database diagnostics.')
+        .option('--skip-catalog-diagnostic', 'Skip read-only sqlite catalog diagnostics.', false)
+        .option('--fail-on-production-test-collections', `Exit non-zero if any test-* collection is in ${CHROMA_PRODUCTION_DATABASE}.`, false)
         .option('--drop-test-db', `Also drop the isolated unit-test database "${CHROMA_TEST_DATABASE}" wholesale (prevention-era cleanup).`, false)
         .parse(process.argv);
 
@@ -236,6 +471,30 @@ async function purgeTestCollections() {
 
     const {host, port} = await resolveChromaEndpoint(options);
     console.log(`   🔌 Chroma: ${host}:${port}`);
+
+    if (!options.skipCatalogDiagnostic) {
+        try {
+            const sqlitePath = await resolveChromaSqlitePath({sqlitePath: options.sqlite});
+            console.log(`   🗄️  Catalog: ${sqlitePath}`);
+
+            const rows    = readChromaTestCollectionDiagnostics({sqlitePath}),
+                  summary = logChromaTestCollectionDiagnostics({rows});
+
+            if (options.failOnProductionTestCollections && summary.productionDatabaseCollections > 0) {
+                console.error(`❌ ${summary.productionDatabaseCollections} test-* collection(s) are in ${CHROMA_PRODUCTION_DATABASE}.`);
+                process.exit(1);
+            }
+        } catch (e) {
+            const message = `   ⚠️  Chroma catalog diagnostic unavailable: ${e.message}`;
+
+            if (options.failOnProductionTestCollections) {
+                console.error(message);
+                process.exit(1);
+            }
+
+            console.warn(message);
+        }
+    }
 
     const client = new ChromaClient({host, port, ssl: false});
 
@@ -285,7 +544,7 @@ async function purgeTestCollections() {
     }
 
     // Verify: re-list and report what remains.
-    const after            = await listAllCollectionNames({client});
+    const after             = await listAllCollectionNames({client});
     const {purge: leftover} = partitionCollections(after);
 
     console.log(`\n🎉 Purge complete: deleted ${deleted} collections (${failed} failed); ${after.length} remain (${leftover.length} test orphans left).`);

--- a/test/playwright/unit/ai/scripts/maintenance/purgeTestCollections.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/purgeTestCollections.spec.mjs
@@ -1,8 +1,20 @@
 import {test, expect} from '@playwright/test';
 import {
-    isPurgeableTestCollection, partitionCollections, listAllCollectionNames, cleanDaemonSqliteResidue, dropTestDatabase
+    isPurgeableTestCollection,
+    partitionCollections,
+    listAllCollectionNames,
+    cleanDaemonSqliteResidue,
+    dropTestDatabase,
+    decorateChromaTestCollectionRows,
+    formatChromaTestCollectionDiagnosticRow,
+    latestChromaTimestamp,
+    readChromaTestCollectionDiagnostics,
+    summarizeChromaTestCollectionDiagnostics
 } from '../../../../../../ai/scripts/maintenance/purgeTestCollections.mjs';
-import {CHROMA_TEST_DATABASE} from '../../../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
+import {
+    CHROMA_PRODUCTION_DATABASE,
+    CHROMA_TEST_DATABASE
+} from '../../../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
 
 /**
  * Self-test for the test-collection purge: the on-demand reclaimer for leaked unit-test Chroma
@@ -39,7 +51,7 @@ test.describe('purgeTestCollections guard', () => {
     });
 
     test('listAllCollectionNames paginates until a short page', async () => {
-        const calls  = [];
+        const calls = [];
         const page   = (n, count) => Array.from({length: count}, (_, i) => ({name: `c-${n}-${i}`}));
         const client = {
             listCollections: async ({limit, offset}) => {
@@ -117,5 +129,132 @@ test.describe('purgeTestCollections guard', () => {
         const result = await dropTestDatabase({host: 'h', port: 1, apply: true, dropFn, log: () => {}});
 
         expect(result).toBe(false)
+    })
+});
+
+test.describe('purgeTestCollections catalog diagnostics (#14010)', () => {
+    const rawRows = [{
+        collectionId           : 'collection-prod',
+        collectionName         : 'test-memory-prod',
+        databaseName           : CHROMA_PRODUCTION_DATABASE,
+        tenantId               : 'default_tenant',
+        metadataSegmentId      : 'metadata-prod',
+        vectorSegmentId        : 'vector-prod',
+        metadataRows           : 2,
+        vectorRows             : 2,
+        queueRows              : 1,
+        latestMetadataTimestamp: '2026-06-05 10:00:00',
+        latestVectorTimestamp  : '2026-06-05 10:01:00',
+        latestQueueTimestamp   : '2026-06-05 10:02:00'
+    }, {
+        collectionId           : 'collection-test',
+        collectionName         : 'test-session-isolated',
+        databaseName           : CHROMA_TEST_DATABASE,
+        tenantId               : 'default_tenant',
+        metadataSegmentId      : '',
+        vectorSegmentId        : 'vector-test',
+        metadataRows           : 0,
+        vectorRows             : 0,
+        queueRows              : 0,
+        latestMetadataTimestamp: '',
+        latestVectorTimestamp  : '',
+        latestQueueTimestamp   : ''
+    }];
+
+    test('latestChromaTimestamp returns the newest present Chroma timestamp', () => {
+        expect(latestChromaTimestamp('', '2026-06-05 10:01:00', '2026-06-05 10:02:00'))
+            .toBe('2026-06-05 10:02:00');
+        expect(latestChromaTimestamp('', null, undefined)).toBe('')
+    });
+
+    test('decorates catalog rows with vector segment path evidence', () => {
+        const rows = decorateChromaTestCollectionRows({
+            rows    : rawRows,
+            dataDir : '/fake/chroma',
+            fsModule: {
+                pathExistsSync: path => path.endsWith('vector-prod')
+            }
+        });
+
+        expect(rows[0]).toMatchObject({
+            collectionName         : 'test-memory-prod',
+            vectorSegmentPath      : '/fake/chroma/vector-prod',
+            vectorSegmentPathExists: true,
+            latestRelevantTimestamp: '2026-06-05 10:02:00'
+        });
+        expect(rows[1]).toMatchObject({
+            collectionName         : 'test-session-isolated',
+            vectorSegmentPathExists: false,
+            latestRelevantTimestamp: ''
+        })
+    });
+
+    test('summarizes production bleed separately from isolated test database residue', () => {
+        const rows = decorateChromaTestCollectionRows({
+            rows    : rawRows,
+            dataDir : '/fake/chroma',
+            fsModule: {
+                pathExistsSync: () => false
+            }
+        });
+
+        expect(summarizeChromaTestCollectionDiagnostics(rows)).toEqual({
+            totalCollections             : 2,
+            productionDatabaseCollections: 1,
+            isolatedTestDatabaseRows     : 1,
+            nonEmptyCollections          : 1,
+            missingVectorSegmentPaths    : 2,
+            latestRelevantTimestamp      : '2026-06-05 10:02:00'
+        })
+    });
+
+    test('formats an operator-readable diagnostic row with tenant/database evidence', () => {
+        const [row] = decorateChromaTestCollectionRows({
+            rows    : rawRows,
+            dataDir : '/fake/chroma',
+            fsModule: {
+                pathExistsSync: () => true
+            }
+        });
+
+        expect(formatChromaTestCollectionDiagnosticRow(row))
+            .toContain('tenant=default_tenant database=default_database metadataRows=2 vectorRows=2 queueRows=1')
+    });
+
+    test('readChromaTestCollectionDiagnostics opens sqlite read-only and closes the handle', () => {
+        const calls = [];
+
+        class FakeDatabase {
+            constructor(sqlitePath, options) {
+                calls.push({sqlitePath, options});
+            }
+
+            prepare(sql) {
+                calls.push({sqlIncludesCollections: sql.includes('FROM collections c')});
+
+                return {
+                    all: () => rawRows
+                }
+            }
+
+            close() {
+                calls.push({closed: true})
+            }
+        }
+
+        const rows = readChromaTestCollectionDiagnostics({
+            sqlitePath   : '/fake/chroma/chroma.sqlite3',
+            DatabaseClass: FakeDatabase,
+            fsModule     : {
+                pathExistsSync: () => true
+            }
+        });
+
+        expect(rows).toHaveLength(2);
+        expect(calls).toEqual([
+            {sqlitePath: '/fake/chroma/chroma.sqlite3', options: {readonly: true, fileMustExist: true}},
+            {sqlIncludesCollections: true},
+            {closed: true}
+        ])
     })
 });


### PR DESCRIPTION
Resolves #14010

Adds read-only Chroma SQLite catalog diagnostics to the existing `purgeTestCollections` maintenance tool. The tool now distinguishes production `default_database` test-row bleed from isolated `neo-unit-test` residue, reports each `test-*` collection with tenant/database, collection id, metadata/vector/queue counts, vector segment path presence, and latest relevant timestamp, and exposes a `--fail-on-production-test-collections` guard for post-run checks.

Evidence: L3 (focused unit coverage plus live read-only unified-store catalog probe) -> L3 required (the incident is a live Chroma catalog recurrence where tenant/database placement determines whether this is production bleed or isolated test residue). Residual: post-merge operator validation can run the full CLI report during a quiet window.

## Deltas from ticket

Live catalog evidence corrected the initial premise: the current 448 `test-*` collection rows are not in `default_database`. They are all in the isolated `neo-unit-test` database; only one is non-empty, and the latest relevant timestamp is `2026-06-06 01:14:46`. The implementation therefore keeps the production guard and diagnostic, but does not treat the rows as active production namespace bleeding.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/purgeTestCollections.spec.mjs` -> 14 passed.
- `node --input-type=module -e '...'` live read-only diagnostic probe -> `totalCollections=448`, `productionDatabaseCollections=0`, `isolatedTestDatabaseRows=448`, `nonEmptyCollections=1`, `latestRelevantTimestamp=2026-06-06 01:14:46`.
- `git diff --check` passed.
- `npm run agent-preflight -- ai/scripts/maintenance/purgeTestCollections.mjs test/playwright/unit/ai/scripts/maintenance/purgeTestCollections.spec.mjs` passed.

## Post-Merge Validation

- [ ] Run `npm run ai:purge-test-collections -- --fail-on-production-test-collections` against the live store and confirm `productionDatabase=0`.
- [ ] If cleanup is desired, run `npm run ai:purge-test-collections -- --drop-test-db --apply` in a separate operator window after the current defrag/backup work is quiescent.

Authored by Euclid (GPT-5, Codex Desktop). Session 9280140f-8b54-4462-9342-49cca7e226f4.
