### PR TITLE
fix(ai): make defrag resumable and lease-protected (#14020)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -7,6 +7,7 @@ import path                                  from 'path';
 import {fileURLToPath, pathToFileURL}        from 'url';
 import Neo                                   from '../../../src/Neo.mjs';
 import AiConfig                              from '../../config.mjs';
+import {withHeavyMaintenanceLease}           from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
 import {registerNeoChromaEmbeddingFunctions} from '../../services/shared/vector/chromaClientPrimitives.mjs';
 import {auditChromaVectorCoverage}           from './checkChromaIntegrity.mjs';
 import {extractMemoryCoreCollectionData}     from './repairMemoryCoreStoredEmbeddings.mjs';
@@ -219,19 +220,25 @@ export function resolveDefragStatePath({
 }
 
 /**
- * Refuses to run over an incomplete previous promotion.
+ * Refuses to run over an incomplete previous promotion unless its phase is explicitly resumable.
  *
  * @param {Object} options
  * @param {String} options.statePath State marker path.
+ * @param {String[]} [options.allowedPhases=[]] Incomplete phases the caller knows how to resume.
  * @param {Object} [options.fsModule=fs] Filesystem seam.
- * @returns {Promise<void>}
+ * @returns {Promise<Object|undefined>} Existing resumable state, when allowed.
  */
-export async function assertNoIncompleteDefragState({statePath, fsModule = fs} = {}) {
+export async function assertNoIncompleteDefragState({statePath, allowedPhases = [], fsModule = fs} = {}) {
     if (!await fsModule.pathExists(statePath)) {
         return
     }
 
     const state = await fsModule.readJson(statePath);
+
+    if (allowedPhases.includes(state.phase)) {
+        return state
+    }
+
     const error = new Error(
         `Incomplete Chroma defrag state found at ${statePath}. ` +
         `Phase '${state.phase}' for target '${state.targetName || 'unknown'}' must be recovered or cleared before rerun.`
@@ -503,6 +510,66 @@ export async function validateLoadedCollection({collection, data, collectionName
 }
 
 /**
+ * Lists all ids in a collection without requesting embeddings.
+ *
+ * @param {Object} options
+ * @param {Object} options.collection Chroma collection handle.
+ * @param {Number} [options.batchSize=2000] Chroma get page size.
+ * @returns {Promise<String[]>}
+ */
+export async function listCollectionIds({collection, batchSize = 2000} = {}) {
+    const ids    = [];
+    let   offset = 0;
+
+    while (true) {
+        const batch    = await collection.get({limit: batchSize, offset, include: []});
+        const batchIds = batch.ids || [];
+
+        if (batchIds.length === 0) {
+            break;
+        }
+
+        ids.push(...batchIds);
+        offset += batchSize;
+
+        if (batchIds.length < batchSize) {
+            break;
+        }
+    }
+
+    return ids
+}
+
+/**
+ * Validates a loaded replacement collection without holding full source vectors in memory.
+ *
+ * @param {Object} options
+ * @param {Object} options.collection Chroma collection handle.
+ * @param {String[]} options.ids Expected source ids.
+ * @param {String} options.collectionName Collection name for diagnostics.
+ * @returns {Promise<{count: Number}>}
+ */
+export async function validateLoadedCollectionByIds({collection, ids = [], collectionName} = {}) {
+    const expected = ids.length;
+    const count    = await collection.count();
+
+    if (count !== expected) {
+        throw new Error(`Collection '${collectionName}' validation failed: expected ${expected} rows, found ${count}.`)
+    }
+
+    if (expected > 0) {
+        const sampleId = ids[0];
+        const sample   = await collection.get({ids: [sampleId], include: []});
+
+        if (!sample.ids?.includes(sampleId)) {
+            throw new Error(`Collection '${collectionName}' validation failed: sample id '${sampleId}' was not readable.`)
+        }
+    }
+
+    return {count}
+}
+
+/**
  * Rewrites one canonical collection through a shadow/parking promotion. The
  * canonical name remains live while the shadow loads; the only absent-canonical
  * window is the bounded live->parking / shadow->canonical rename pair, where
@@ -637,6 +704,110 @@ export async function rewriteCollectionViaShadowPromotion({
 }
 
 /**
+ * Promotes an already loaded shadow collection to the canonical name.
+ *
+ * Memory Core repair uses this after streaming recovered batches durably into a resumable
+ * shadow collection. The shadow-loading phase is restartable; the bounded rename phase is
+ * deliberately not auto-resumed because the live canonical name may have been parked.
+ *
+ * @param {Object} options
+ * @param {Object} options.client Chroma client.
+ * @param {String} options.collectionName Canonical collection name.
+ * @param {Object} options.shadowCollection Loaded shadow collection handle.
+ * @param {String} options.shadowName Loaded shadow collection name.
+ * @param {String[]} options.sourceIds Expected source ids.
+ * @param {Object} options.embeddingFunction Chroma embedding function.
+ * @param {String} options.statePath Durable state marker path.
+ * @param {Object} [options.stateBase] Stable fields written into every phase marker.
+ * @param {Number} [options.timestamp=Date.now()] Stable run timestamp.
+ * @param {Function} [options.uuidFactory=crypto.randomUUID] Unique id factory.
+ * @param {Function} [options.writeStateFn=writeDefragState] State writer seam.
+ * @param {Function} [options.warn=console.warn] Warning sink.
+ * @returns {Promise<Object>}
+ */
+export async function promoteLoadedShadowCollection({
+    client,
+    collectionName,
+    shadowCollection,
+    shadowName,
+    sourceIds,
+    embeddingFunction,
+    statePath,
+    stateBase   = {},
+    timestamp   = Date.now(),
+    uuidFactory = crypto.randomUUID,
+    writeStateFn = writeDefragState,
+    warn        = console.warn
+} = {}) {
+    const parkingName = createSwapCollectionName(collectionName, 'parking', {timestamp, uuid: uuidFactory()});
+    const sourceCount = sourceIds.length;
+    const baseState   = {
+        ...stateBase,
+        collectionName,
+        sourceCount,
+        shadowName,
+        parkingName
+    };
+
+    let liveCollection;
+    let liveParked     = false;
+    let shadowPromoted = false;
+    let parkingDeleted = false;
+
+    await validateLoadedCollectionByIds({collection: shadowCollection, ids: sourceIds, collectionName: shadowName});
+    await writeStateFn({statePath, state: {...baseState, phase: 'memory-core-repair-shadow-loaded'}});
+
+    try {
+        liveCollection = await client.getCollection({
+            name             : collectionName,
+            embeddingFunction
+        });
+
+        await liveCollection.modify({name: parkingName});
+        liveParked = true;
+        await writeStateFn({statePath, state: {...baseState, phase: 'live-parked'}});
+
+        await shadowCollection.modify({name: collectionName});
+        shadowPromoted = true;
+        await writeStateFn({statePath, state: {...baseState, phase: 'shadow-promoted'}});
+
+        const canonicalCollection = await client.getCollection({
+            name             : collectionName,
+            embeddingFunction
+        });
+        await validateLoadedCollectionByIds({collection: canonicalCollection, ids: sourceIds, collectionName});
+        await writeStateFn({statePath, state: {...baseState, phase: 'canonical-validated'}});
+
+        try {
+            await client.deleteCollection({name: parkingName});
+            parkingDeleted = true;
+            await writeStateFn({statePath, state: {...baseState, phase: 'parking-deleted'}});
+        } catch (error) {
+            warn(`   ⚠️  Could not delete parked pre-defrag collection '${parkingName}': ${error.message}`);
+        }
+
+        return {
+            collectionName,
+            shadowName,
+            parkingName,
+            sourceCount,
+            parkingDeleted
+        }
+    } catch (error) {
+        if (liveParked && !shadowPromoted && liveCollection) {
+            try {
+                await liveCollection.modify({name: collectionName});
+                await writeStateFn({statePath, state: {...baseState, phase: 'live-rollback-complete'}});
+            } catch (rollbackError) {
+                warn(`   ⚠️  Failed to roll back parked collection '${parkingName}': ${rollbackError.message}`);
+            }
+        }
+
+        throw error
+    }
+}
+
+/**
  * @summary Selects the coverage row that belongs to the live Chroma collection.
  *
  * Chroma snapshots can contain stale duplicate collection-name rows even when `listCollections()`
@@ -674,6 +845,189 @@ function selectMemoryCoreRepairCoverageRow({
 }
 
 /**
+ * @summary Repairs one Memory Core collection through a resumable shadow-load phase.
+ *
+ * Recovered batches are added to the shadow collection immediately, then the state marker records
+ * the loaded count. If the process crashes, the next run lists the shadow ids and skips them during
+ * extraction/re-embedding instead of starting the provider work from zero.
+ *
+ * @param {Object} options
+ * @param {Object} options.client Chroma client.
+ * @param {String} options.collectionName Canonical collection name.
+ * @param {Object} options.collection Live canonical collection handle.
+ * @param {String[]} options.allIds Full source ids from metadata enumeration.
+ * @param {String[]} options.missingVectorIds Ids missing from the vector index.
+ * @param {Function} options.embedFn Re-embedder.
+ * @param {Object} options.embeddingFunction Chroma embedding function.
+ * @param {String} options.statePath Durable defrag state path.
+ * @param {Object} [options.stateBase={}] Stable state fields.
+ * @param {Object|null} [options.resumeState=null] Previously allowed resumable state.
+ * @param {Function} [options.extractFn=extractMemoryCoreCollectionData] Extraction seam.
+ * @param {Function} [options.addDataFn=addCollectionData] Shadow add seam.
+ * @param {Function} [options.listIdsFn=listCollectionIds] Collection id listing seam.
+ * @param {Function} [options.promoteLoadedFn=promoteLoadedShadowCollection] Promotion seam.
+ * @param {Function} [options.writeStateFn=writeDefragState] State writer seam.
+ * @param {Number} [options.timestamp=Date.now()] Stable run timestamp.
+ * @param {Function} [options.uuidFactory=crypto.randomUUID] Unique id factory.
+ * @param {Function} [options.log=console.log] Log sink.
+ * @returns {Promise<Object>} Repair result.
+ */
+export async function repairMemoryCoreCollectionViaResumableShadow({
+    client,
+    collectionName,
+    collection,
+    allIds = [],
+    missingVectorIds = [],
+    embedFn,
+    embeddingFunction,
+    statePath,
+    stateBase = {},
+    resumeState = null,
+    extractFn = extractMemoryCoreCollectionData,
+    addDataFn = addCollectionData,
+    listIdsFn = listCollectionIds,
+    promoteLoadedFn = promoteLoadedShadowCollection,
+    writeStateFn = writeDefragState,
+    timestamp = Date.now(),
+    uuidFactory = crypto.randomUUID,
+    log = console.log
+} = {}) {
+    const sourceCount = allIds.length;
+    const baseState   = {
+        ...stateBase,
+        collectionName,
+        sourceCount
+    };
+
+    let shadowName       = resumeState?.shadowName;
+    let shadowCollection = null;
+
+    if (shadowName) {
+        log(`   ♻️  '${collectionName}': resuming shadow load from '${shadowName}' (${resumeState.phase}).`);
+        shadowCollection = await client.getCollection({name: shadowName, embeddingFunction});
+    } else {
+        shadowName = createSwapCollectionName(collectionName, 'shadow', {timestamp, uuid: uuidFactory()});
+        await writeStateFn({statePath, state: {...baseState, phase: 'memory-core-repair-shadow-creating', shadowName}});
+        shadowCollection = await client.createCollection({
+            name    : shadowName,
+            embeddingFunction,
+            metadata: {"hnsw:space": "cosine"}
+        });
+    }
+
+    const shadowIds = await listIdsFn({collection: shadowCollection});
+    const sourceSet = new Set(allIds);
+    const extraIds  = shadowIds.filter(id => !sourceSet.has(id));
+
+    if (extraIds.length > 0) {
+        throw new Error(`repairMemoryCoreCollectionViaResumableShadow: shadow '${shadowName}' contains ${extraIds.length} id(s) not present in source '${collectionName}' (first: '${extraIds[0]}') — refusing ambiguous resume.`);
+    }
+
+    const skipIds     = shadowIds.filter(id => sourceSet.has(id));
+    let   loadedCount = skipIds.length;
+
+    await writeStateFn({
+        statePath,
+        state: {
+            ...baseState,
+            phase: 'memory-core-repair-shadow-loading',
+            shadowName,
+            loadedCount
+        }
+    });
+
+    const {unrecoverable, counts} = await extractFn({
+        collection,
+        allIds,
+        missingVectorIds,
+        embedFn,
+        skipIds,
+        collectData: false,
+        onDataBatch: async (batchData, event = {}) => {
+            await addDataFn({
+                collection   : shadowCollection,
+                data         : batchData,
+                writeProgress: () => {},
+                log          : () => {}
+            });
+
+            loadedCount += batchData.ids.length;
+
+            await writeStateFn({
+                statePath,
+                state: {
+                    ...baseState,
+                    phase : 'memory-core-repair-shadow-loading',
+                    shadowName,
+                    loadedCount,
+                    counts: event.counts
+                }
+            });
+        },
+        onProgress: event => log(formatMemoryCoreRepairProgress({collectionName, event}))
+    });
+
+    if (unrecoverable.length > 0) {
+        await writeStateFn({
+            statePath,
+            state: {
+                ...baseState,
+                phase               : 'memory-core-repair-aborted',
+                shadowName,
+                loadedCount,
+                unrecoverableCount  : unrecoverable.length,
+                unrecoverablePreview: unrecoverable.slice(0, 20),
+                counts
+            }
+        });
+
+        return {
+            collectionName,
+            aborted: true,
+            unrecoverable,
+            counts,
+            shadowName,
+            loadedCount,
+            sourceCount
+        }
+    }
+
+    await writeStateFn({
+        statePath,
+        state: {
+            ...baseState,
+            phase: 'memory-core-repair-shadow-loaded',
+            shadowName,
+            loadedCount,
+            counts
+        }
+    });
+
+    log(`   🚚 '${collectionName}': shadow promotion starting for ${loadedCount} recovered row(s)...`);
+    const promotion = await promoteLoadedFn({
+        client,
+        collectionName,
+        shadowCollection,
+        shadowName,
+        sourceIds: allIds,
+        embeddingFunction,
+        statePath,
+        stateBase,
+        writeStateFn
+    });
+    log(`   ✅ '${collectionName}': shadow promotion complete.`);
+
+    return {
+        collectionName,
+        promotion,
+        counts,
+        shadowName,
+        loadedCount,
+        sourceCount
+    }
+}
+
+/**
  * @summary Repairs Memory Core collections' missing stored-embeddings via FULL (uncapped) enumeration,
  * then promotes the recovered data through the existing shadow-promotion path.
  *
@@ -683,16 +1037,16 @@ function selectMemoryCoreRepairCoverageRow({
  *      with `includeFullIds`, NOT the sampled coverage audit);
  *   2. extracts intact rows with their stored vectors and RE-EMBEDS the missing-vector rows from their
  *      still-materializing documents (`extractMemoryCoreCollectionData`);
- *   3. promotes the recovered `{ids, embeddings, documents, metadatas}` through the shadow/parking promotion.
+ *   3. streams recovered batches into a resumable shadow collection, then promotes that loaded shadow.
  *
  * Fail-loud: a collection with ANY unrecoverable row (document-less / metadata-absent) aborts its
  * own promotion with counts — never a silent partial promote. The seams (`auditFn` / `extractFn` /
- * `promoteFn` / `clearStateFn` / `writeStateFn`) are injectable for unit isolation.
+ * `repairCollectionFn` / `clearStateFn` / `writeStateFn`) are injectable for unit isolation.
  *
- * State-marker lifecycle: `promoteFn` writes durable per-phase markers, so a fully successful repair
+ * State-marker lifecycle: the mutating repair writes durable per-phase markers, so a fully successful repair
  * CLEARS the marker (`clearStateFn`) before returning — else the next run aborts as DEFRAG_INCOMPLETE_STATE.
  * An aborted/partial repair instead rewrites an explicit `memory-core-repair-aborted` marker (`writeStateFn`)
- * so `assertNoIncompleteDefragState` blocks rerun with an accurate diagnostic, not a stale mid-phase marker.
+ * with the active shadow name so the next run can retry only the unrecovered rows.
  *
  * This function is INERT until wired behind the explicit `--allow-memory-core` opt-in; the default
  * `assertDefragTargetSupported` fail-closed stands until then.
@@ -709,7 +1063,8 @@ function selectMemoryCoreRepairCoverageRow({
  * @param {Boolean} [options.dryRun=false] True extracts/re-embeds and reports counts without shadow promotion or state-marker writes.
  * @param {Function} [options.auditFn=auditChromaVectorCoverage] Enumeration seam (test injection).
  * @param {Function} [options.extractFn=extractMemoryCoreCollectionData] Extract + re-embed seam.
- * @param {Function} [options.promoteFn=rewriteCollectionViaShadowPromotion] Shadow-promotion seam.
+ * @param {Function} [options.repairCollectionFn=repairMemoryCoreCollectionViaResumableShadow] Mutating repair seam.
+ * @param {Object|null} [options.resumeState=null] Resumable defrag state returned by `assertNoIncompleteDefragState`.
  * @param {Function} [options.clearStateFn=clearDefragState] Clears the durable marker on a fully successful repair.
  * @param {Function} [options.writeStateFn=writeDefragState] Rewrites the explicit aborted marker on a partial repair.
  * @param {Function} [options.log=console.log] Log sink.
@@ -729,7 +1084,8 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
     dryRun    = false,
     auditFn      = auditChromaVectorCoverage,
     extractFn    = extractMemoryCoreCollectionData,
-    promoteFn    = rewriteCollectionViaShadowPromotion,
+    repairCollectionFn = repairMemoryCoreCollectionViaResumableShadow,
+    resumeState  = null,
     clearStateFn = clearDefragState,
     writeStateFn = writeDefragState,
     log          = console.log
@@ -744,7 +1100,24 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
     log(`   ✅ Coverage enumeration complete (${coverage.collections.length} coverage row(s)).`);
     const results = [];
 
-    for (const collectionName of collections) {
+    if (!dryRun && resumeState && (!resumeState.collectionName || !resumeState.shadowName)) {
+        throw new Error(`repairMemoryCoreCollectionsViaFullEnumeration: resumable state phase '${resumeState.phase}' is missing collectionName or shadowName; manual recovery is required before rerun.`);
+    }
+
+    const resumeCollectionIndex = resumeState?.collectionName ? collections.indexOf(resumeState.collectionName) : -1;
+
+    if (resumeState?.collectionName && resumeCollectionIndex === -1) {
+        throw new Error(`repairMemoryCoreCollectionsViaFullEnumeration: resumable state targets '${resumeState.collectionName}', which is not in this run's collection list (${collections.join(', ')}).`);
+    }
+
+    for (let collectionIndex = 0; collectionIndex < collections.length; collectionIndex++) {
+        const collectionName = collections[collectionIndex];
+
+        if (!dryRun && resumeCollectionIndex > -1 && collectionIndex < resumeCollectionIndex) {
+            log(`   ♻️  '${collectionName}': skipping collection before resumable state target '${resumeState.collectionName}'.`);
+            continue;
+        }
+
         const
             coverageRows = coverage.collections.filter(entry => entry.name === collectionName),
             collection   = await client.getCollection({name: collectionName, embeddingFunction});
@@ -761,16 +1134,17 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
 
         log(`   📦 '${collectionName}': metadata=${cov.metadataRowCount ?? cov.allIds?.length ?? 0}, vector=${cov.vectorIndexIdCount ?? cov.vectorIds?.length ?? 0}, missing=${cov.missingFromVectorCount ?? cov.missingVectorIds?.length ?? 0}, extra=${cov.extraInVectorCount ?? cov.extraVectorIds?.length ?? 0}`);
 
-        const {allIds, missingVectorIds}    = cov,
-              {data, unrecoverable, counts} = await extractFn({
-                  collection,
-                  allIds,
-                  missingVectorIds,
-                  embedFn,
-                  onProgress: event => log(formatMemoryCoreRepairProgress({collectionName, event}))
-              });
+        const {allIds, missingVectorIds} = cov;
 
         if (dryRun) {
+            const {unrecoverable, counts} = await extractFn({
+                collection,
+                allIds,
+                missingVectorIds,
+                embedFn,
+                onProgress: event => log(formatMemoryCoreRepairProgress({collectionName, event}))
+            });
+
             if (unrecoverable.length > 0) {
                 log(`   ⚠️  '${collectionName}': DRY-RUN found ${unrecoverable.length} unrecoverable row(s) (document-less / metadata-absent) — no promotion attempted. Counts: ${JSON.stringify(counts)}`);
                 results.push({collectionName, dryRun: true, aborted: true, unrecoverable, counts});
@@ -782,30 +1156,50 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
             continue;
         }
 
-        // Fail-loud: never promote a collection that lost rows to unrecoverable extraction.
-        if (unrecoverable.length > 0) {
-            log(`   ⚠️  '${collectionName}': ${unrecoverable.length} unrecoverable row(s) (document-less / metadata-absent) — aborting its promotion, no silent drop. Counts: ${JSON.stringify(counts)}`);
-            results.push({collectionName, aborted: true, unrecoverable, counts});
-            continue;
+        const result = await repairCollectionFn({
+            client,
+            collectionName,
+            collection,
+            allIds,
+            missingVectorIds,
+            embedFn,
+            embeddingFunction,
+            statePath,
+            stateBase,
+            resumeState: resumeState?.collectionName === collectionName ? resumeState : null,
+            extractFn,
+            writeStateFn,
+            log
+        });
+
+        if (result.aborted) {
+            log(`   ⚠️  '${collectionName}': ${result.unrecoverable.length} unrecoverable row(s) (document-less / metadata-absent / provider-overcap) — aborting before promotion, but keeping resumable shadow '${result.shadowName}'. Counts: ${JSON.stringify(result.counts)}`);
+            results.push(result);
+            break;
         }
 
-        log(`   🚚 '${collectionName}': shadow promotion starting for ${data.ids.length} recovered row(s)...`);
-        const promotion = await promoteFn({client, collectionName, data, embeddingFunction, statePath, stateBase});
-        log(`   ✅ '${collectionName}': shadow promotion complete.`);
-        results.push({collectionName, promotion, counts});
+        results.push(result);
     }
 
     // State-marker lifecycle (mirrors the KB path's end-of-run clearDefragState): rewriteCollectionViaShadowPromotion
     // wrote durable per-phase markers, so a fully successful repair MUST clear the marker — else the next run aborts
-    // as DEFRAG_INCOMPLETE_STATE. An aborted/partial repair instead rewrites an explicit aborted marker so
-    // assertNoIncompleteDefragState blocks rerun with an accurate diagnostic, not a stale mid-phase marker.
+    // as DEFRAG_INCOMPLETE_STATE. An aborted/partial repair instead rewrites an explicit aborted marker with
+    // the active shadow name, so the next run can resume without discarding already loaded batches.
     if (statePath && !dryRun) {
         if (anyRepairAborted(results)) {
+            const activeAbort = results.find(result => result.aborted);
+
             await writeStateFn({statePath, state: {
                 ...stateBase,
-                phase   : 'memory-core-repair-aborted',
-                aborted : results.filter(result => result.aborted).map(result => result.collectionName),
-                promoted: results.filter(result => result.promotion).map(result => result.collectionName)
+                phase               : 'memory-core-repair-aborted',
+                collectionName      : activeAbort?.collectionName,
+                shadowName          : activeAbort?.shadowName,
+                sourceCount         : activeAbort?.sourceCount,
+                loadedCount         : activeAbort?.loadedCount,
+                unrecoverableCount  : activeAbort?.unrecoverable?.length,
+                unrecoverablePreview: activeAbort?.unrecoverable?.slice?.(0, 20) || [],
+                aborted             : results.filter(result => result.aborted).map(result => result.collectionName),
+                promoted            : results.filter(result => result.promotion).map(result => result.collectionName)
             }});
         } else {
             await clearStateFn({statePath});
@@ -890,7 +1284,14 @@ async function defragChromaDB() {
         const statePath = resolveDefragStatePath({targetName});
 
         assertDefragTargetSupported({targetName, allowMemoryCore: options.allowMemoryCore});
-        await assertNoIncompleteDefragState({statePath});
+        const resumeState = await assertNoIncompleteDefragState({
+            statePath,
+            allowedPhases: targetName === 'memory-core' && options.allowMemoryCore ? [
+                'memory-core-repair-shadow-loading',
+                'memory-core-repair-shadow-loaded',
+                'memory-core-repair-aborted'
+            ] : []
+        });
 
         const DB_PATH = config.path;
 
@@ -962,7 +1363,8 @@ async function defragChromaDB() {
                 embeddingFunction: dummyEf,
                 statePath,
                 stateBase        : {targetName},
-                dryRun
+                dryRun,
+                resumeState
             });
 
             for (const result of results) {
@@ -1153,8 +1555,48 @@ async function defragChromaDB() {
     }
 }
 
+/**
+ * Runs the standalone defrag CLI under the shared heavy-maintenance lease.
+ *
+ * The exported defrag implementation remains lease-free for tests and controlled
+ * module callers. Only direct CLI execution acquires the cross-process lease, so a
+ * manually started defrag is visible to the orchestrator before other heavy tasks run.
+ *
+ * @param {Object} options
+ * @param {Function} [options.runDefrag=defragChromaDB] Defrag implementation seam.
+ * @param {Function} [options.withLease=withHeavyMaintenanceLease] Lease wrapper seam.
+ * @param {Object} [options.output=console] Terminal sink.
+ * @param {Function} [options.exit=process.exit] Exit hook.
+ * @returns {Promise<*>}
+ */
+export async function runDefragChromaDBCli({
+    runDefrag = defragChromaDB,
+    withLease = withHeavyMaintenanceLease,
+    output    = console,
+    exit      = code => process.exit(code)
+} = {}) {
+    let outcome;
+
+    try {
+        outcome = await withLease(
+            () => runDefrag(),
+            {owner: 'defrag', reason: 'manual-cli', metadata: {script: 'ai/scripts/maintenance/defragChromaDB.mjs'}}
+        );
+    } catch (error) {
+        output.error('❌ Defrag lease acquisition failed:', error);
+        return exit(1)
+    }
+
+    if (outcome?.status === 'held') {
+        const held = outcome.lease;
+        output.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
+        output.log('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
+        return exit(0)
+    }
+
+    return exit(0)
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-    defragChromaDB().then(() => {
-        process.exit(0);
-    });
+    runDefragChromaDBCli();
 }

--- a/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
+++ b/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
@@ -9,10 +9,10 @@
  *
  * This module supplies the missing extraction half: partition each collection's ids into intact-vector
  * vs missing-vector, extract intact rows with their stored embeddings, and **re-embed** the missing-vector
- * rows from their DOCUMENTS (which still materialize — only the embedding fetch fails). The merged
- * `{ids, embeddings, documents, metadatas}` then feeds defrag's existing `addCollectionData` →
- * `validateLoadedCollection` → promote, unchanged. A missing-vector row with no recoverable document is
- * reported as `unrecoverable` (counts surfaced, never silently dropped — the fail-loud discipline).
+ * rows from their DOCUMENTS (which still materialize — only the embedding fetch fails). Recovered batches
+ * can either be retained in a merged `{ids, embeddings, documents, metadatas}` buffer or streamed into a
+ * resumable shadow collection. A missing-vector row with no recoverable document/embedding is reported as
+ * `unrecoverable` (counts surfaced, never silently dropped — the fail-loud discipline).
  *
  * The live shadow run + canonical promotion is operator/env-gated (out of scope without
  * explicit authorization); this module is the pure extraction logic, unit-tested against mocked Chroma.
@@ -35,6 +35,9 @@
  * @param {Function}   options.embedFn          `(documents: String[]) => Promise<Number[][]>` — re-embed a batch
  *                                               (e.g. `TextEmbeddingService.embedTexts` bound to the MC provider).
  * @param {Number}     [options.batchSize=1000] Chroma `.get` / embed batch size.
+ * @param {String[]}   [options.skipIds=[]] IDs already durably loaded into a resumable shadow collection.
+ * @param {Boolean}    [options.collectData=true] False streams batches through `onDataBatch` without retaining all vectors in memory.
+ * @param {Function}   [options.onDataBatch] Optional async sink for each recovered batch.
  * @param {Function}   [options.onProgress] Optional callback receiving 10%-bucket progress events:
  *                                           `{phase, percent, processed, total, counts}`.
  * @returns {Promise<{data: {ids: String[], embeddings: Number[][], documents: String[], metadatas: Object[]},
@@ -47,6 +50,9 @@ export async function extractMemoryCoreCollectionData({
     missingVectorIds = [],
     embedFn,
     batchSize = 1000,
+    skipIds = [],
+    collectData = true,
+    onDataBatch,
     onProgress
 } = {}) {
     if (typeof embedFn !== 'function') {
@@ -54,36 +60,61 @@ export async function extractMemoryCoreCollectionData({
     }
 
     const missingSet = new Set(missingVectorIds);
-    const intactIds  = allIds.filter(id => !missingSet.has(id));
+    const skipSet    = new Set(skipIds);
+    const intactIds  = allIds.filter(id => !missingSet.has(id) && !skipSet.has(id));
+    const missingIds = missingVectorIds.filter(id => !skipSet.has(id));
     const data       = {ids: [], embeddings: [], documents: [], metadatas: []};
     const counts     = {total: allIds.length, intact: 0, reEmbedded: 0, unrecoverable: 0};
 
+    if (skipSet.size > 0) {
+        counts.resumedExisting = skipSet.size;
+    }
+
     const reportIntactProgress  = createTenPercentProgressReporter({phase: 'intact-extract', total: intactIds.length, onProgress});
-    const reportMissingProgress = createTenPercentProgressReporter({phase: 'missing-reembed', total: missingVectorIds.length, onProgress});
+    const reportMissingProgress = createTenPercentProgressReporter({phase: 'missing-reembed', total: missingIds.length, onProgress});
 
     onProgress?.({phase: 'start', percent: 0, processed: 0, total: allIds.length, counts: {...counts}});
 
+    async function emitDataBatch(batchData) {
+        if (batchData.ids.length === 0) {
+            return
+        }
+
+        if (collectData) {
+            data.ids.push(...batchData.ids);
+            data.embeddings.push(...batchData.embeddings);
+            data.documents.push(...batchData.documents);
+            data.metadatas.push(...batchData.metadatas);
+        }
+
+        if (typeof onDataBatch === 'function') {
+            await onDataBatch(batchData, {counts: {...counts}});
+        }
+    }
+
     // 1. Intact rows — extract with their stored embeddings (these vectors exist in the HNSW index).
     for (let i = 0; i < intactIds.length; i += batchSize) {
-        const batchIds = intactIds.slice(i, i + batchSize);
-        const got      = await collection.get({ids: batchIds, include: ['embeddings', 'documents', 'metadatas']});
+        const batchIds  = intactIds.slice(i, i + batchSize);
+        const got       = await collection.get({ids: batchIds, include: ['embeddings', 'documents', 'metadatas']});
+        const batchData = {ids: [], embeddings: [], documents: [], metadatas: []};
 
         for (let j = 0; j < (got.ids?.length || 0); j++) {
-            data.ids.push(got.ids[j]);
-            data.embeddings.push(got.embeddings[j]);
-            data.documents.push(got.documents?.[j] ?? '');
-            data.metadatas.push(got.metadatas?.[j] ?? {});
+            batchData.ids.push(got.ids[j]);
+            batchData.embeddings.push(got.embeddings[j]);
+            batchData.documents.push(got.documents?.[j] ?? '');
+            batchData.metadatas.push(got.metadatas?.[j] ?? {});
             counts.intact++;
         }
 
+        await emitDataBatch(batchData);
         reportIntactProgress({processed: Math.min(i + batchIds.length, intactIds.length), counts});
     }
 
     // 2. Missing-vector rows — re-embed from documents (their stored embeddings cannot be fetched).
     const unrecoverable = [];
 
-    for (let i = 0; i < missingVectorIds.length; i += batchSize) {
-        const batchIds = missingVectorIds.slice(i, i + batchSize);
+    for (let i = 0; i < missingIds.length; i += batchSize) {
+        const batchIds = missingIds.slice(i, i + batchSize);
         // documents + metadatas DO materialize for missing-vector ids; only `embeddings` fails.
         const got      = await collection.get({ids: batchIds, include: ['documents', 'metadatas']});
         const returned = new Set(got.ids || []);
@@ -111,22 +142,30 @@ export async function extractMemoryCoreCollectionData({
         }
 
         if (reEmbedDocs.length > 0) {
-            const embeddings = await embedFn(reEmbedDocs);
+            const {embeddings, failedIndexes} = await embedRecoverableDocuments({embedFn, ids: reEmbedIds, documents: reEmbedDocs});
+            const batchData                   = {ids: [], embeddings: [], documents: [], metadatas: []};
 
-            if (!Array.isArray(embeddings) || embeddings.length !== reEmbedDocs.length) {
-                throw new Error(`extractMemoryCoreCollectionData: embedFn returned ${Array.isArray(embeddings) ? embeddings.length : 'non-array'} embeddings for ${reEmbedDocs.length} documents`);
+            for (const failedIndex of failedIndexes) {
+                unrecoverable.push(reEmbedIds[failedIndex]);
+                counts.unrecoverable++;
             }
 
             for (let j = 0; j < reEmbedIds.length; j++) {
-                data.ids.push(reEmbedIds[j]);
-                data.embeddings.push(embeddings[j]);
-                data.documents.push(reEmbedDocs[j]);
-                data.metadatas.push(reEmbedMetas[j]);
+                if (failedIndexes.has(j)) {
+                    continue;
+                }
+
+                batchData.ids.push(reEmbedIds[j]);
+                batchData.embeddings.push(embeddings[j]);
+                batchData.documents.push(reEmbedDocs[j]);
+                batchData.metadatas.push(reEmbedMetas[j]);
                 counts.reEmbedded++;
             }
+
+            await emitDataBatch(batchData);
         }
 
-        reportMissingProgress({processed: Math.min(i + batchIds.length, missingVectorIds.length), counts});
+        reportMissingProgress({processed: Math.min(i + batchIds.length, missingIds.length), counts});
     }
 
     onProgress?.({phase: 'complete', percent: 100, processed: allIds.length, total: allIds.length, counts: {...counts}});
@@ -136,6 +175,45 @@ export async function extractMemoryCoreCollectionData({
         unrecoverable,
         counts
     };
+}
+
+/**
+ * @summary Embeds a batch, falling back to per-document isolation when the batch fails.
+ * @param {Object} options
+ * @param {Function} options.embedFn Embedding function.
+ * @param {String[]} options.ids Row ids paired with `documents`.
+ * @param {String[]} options.documents Documents to embed.
+ * @returns {Promise<{embeddings: Number[][], failedIndexes: Set<Number>}>}
+ */
+async function embedRecoverableDocuments({embedFn, ids, documents} = {}) {
+    try {
+        const embeddings = await embedFn(documents);
+
+        if (!Array.isArray(embeddings) || embeddings.length !== documents.length) {
+            throw new Error(`embedFn returned ${Array.isArray(embeddings) ? embeddings.length : 'non-array'} embeddings for ${documents.length} documents`);
+        }
+
+        return {embeddings, failedIndexes: new Set()}
+    } catch {
+        const embeddings    = new Array(documents.length);
+        const failedIndexes = new Set();
+
+        for (let i = 0; i < documents.length; i++) {
+            try {
+                const single = await embedFn([documents[i]]);
+
+                if (!Array.isArray(single) || single.length !== 1) {
+                    throw new Error(`single embed returned ${Array.isArray(single) ? single.length : 'non-array'} embeddings`);
+                }
+
+                embeddings[i] = single[0];
+            } catch (error) {
+                failedIndexes.add(i);
+            }
+        }
+
+        return {embeddings, failedIndexes}
+    }
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs
@@ -15,12 +15,12 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import {execSync}     from 'child_process';
-import fs             from 'fs-extra';
-import path           from 'path';
+import {test, expect}                                  from '@playwright/test';
+import Neo                                             from '../../../../../../src/Neo.mjs';
+import * as core                                       from '../../../../../../src/core/_export.mjs';
+import {execSync}                                      from 'child_process';
+import fs                                              from 'fs-extra';
+import path                                            from 'path';
 import {getEmbeddingFunction, knownEmbeddingFunctions} from 'chromadb';
 
 /**
@@ -51,7 +51,7 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
     let cleanOrphanedSegmentDirs;
     let writeDefragState;
     let tmpRoot;
-    let nudge           = 0;
+    let nudge            = 0;
     let sqlite3Available = false;
 
     test.beforeAll(async () => {
@@ -96,7 +96,7 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
     }
 
     function createRegistryBackedCollection({name, registry, failModifyTo = null}) {
-        const rows = new Map();
+        const rows       = new Map();
         const collection = {
             name,
             calls: {
@@ -193,8 +193,8 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
         // Non-segment dirs that must survive the heuristic guard:
         //   - short name fails the 36-char branch
         //   - 36-char-no-hyphen fails the `includes('-')` branch
-        const shortDir       = 'system-cache';
-        const noHyphen36     = 'abcdefabcdefabcdefabcdefabcdef123456';
+        const shortDir   = 'system-cache';
+        const noHyphen36 = 'abcdefabcdefabcdefabcdefabcdef123456';
 
         await seedSegmentDir(thisTargetLive);
         await seedSegmentDir(siblingLive);
@@ -299,6 +299,32 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
         await expect(assertNoIncompleteDefragState({statePath})).resolves.toBeUndefined();
     });
 
+    test('durable phase marker can be returned when the caller owns resumability for that phase', async () => {
+        const statePath = path.join(tmpRoot, 'defrag-state-resumable.json');
+
+        await writeDefragState({
+            statePath,
+            state: {
+                targetName    : 'memory-core',
+                collectionName: 'neo-agent-memory',
+                phase         : 'memory-core-repair-shadow-loading',
+                shadowName    : 'neo-agent-memory-shadow-resume'
+            }
+        });
+
+        const state = await assertNoIncompleteDefragState({
+            statePath,
+            allowedPhases: ['memory-core-repair-shadow-loading']
+        });
+
+        expect(state).toMatchObject({
+            targetName    : 'memory-core',
+            collectionName: 'neo-agent-memory',
+            phase         : 'memory-core-repair-shadow-loading',
+            shadowName    : 'neo-agent-memory-shadow-resume'
+        });
+    });
+
     test('shadow promotion loads replacement before parking live and never deletes canonical', async () => {
         const registry       = new Map();
         const collectionName = 'neo-knowledge-base';
@@ -306,7 +332,7 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
         const client         = createRegistryBackedClient({registry});
         const data           = createCollectionData();
         const statePath      = path.join(tmpRoot, 'defrag-state.json');
-        let uuid             = 0;
+        let   uuid           = 0;
 
         const result = await rewriteCollectionViaShadowPromotion({
             client,
@@ -316,8 +342,8 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
             statePath,
             timestamp        : 123,
             uuidFactory      : () => `uuid-${++uuid}`,
-            log              : () => {},
-            writeProgress    : () => {}
+            log          : () => {},
+            writeProgress: () => {}
         });
 
         expect(result.shadowName).toBe('neo-knowledge-base-shadow-123-uuid-1');
@@ -347,12 +373,12 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
             timestamp: 456,
             uuid     : 'uuid-2'
         });
-        const failedName     = createSwapCollectionName(collectionName, 'failed-shadow', {
+        const failedName = createSwapCollectionName(collectionName, 'failed-shadow', {
             timestamp: 456,
             uuid     : 'uuid-3'
         });
-        const live           = createRegistryBackedCollection({name: collectionName, registry});
-        const client         = createRegistryBackedClient({
+        const live   = createRegistryBackedCollection({name: collectionName, registry});
+        const client = createRegistryBackedClient({
             registry,
             shadowFailModifyTo: collectionName
         });
@@ -366,9 +392,9 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
             statePath,
             timestamp        : 456,
             uuidFactory      : () => `uuid-${++uuid}`,
-            log              : () => {},
-            warn             : () => {},
-            writeProgress    : () => {}
+            log          : () => {},
+            warn         : () => {},
+            writeProgress: () => {}
         })).rejects.toThrow(`forced modify failure for ${collectionName}`);
 
         expect(registry.get(collectionName)).toBe(live);
@@ -386,8 +412,8 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
 
     test('registers Neo Chroma embedding functions before defrag collection hydration', async () => {
         const {default: AiConfig} = await import('../../../../../../ai/config.mjs');
-        const warnings     = [];
-        const originalWarn = console.warn;
+        const warnings            = [];
+        const originalWarn        = console.warn;
 
         console.warn = (...args) => warnings.push(args.join(' '));
 
@@ -416,7 +442,7 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
     });
 
     test('skips UUID-named entries that are files, not directories', async () => {
-        const liveSeg     = '66666666-6666-4666-8666-666666666666';
+        const liveSeg       = '66666666-6666-4666-8666-666666666666';
         const uuidNamedFile = '77777777-7777-4777-8777-777777777777';
 
         await seedSegmentDir(liveSeg);

--- a/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
@@ -1,49 +1,58 @@
-import {test, expect}                                                                                 from '@playwright/test';
+import {test, expect} from '@playwright/test';
 import {
     anyRepairAborted,
     assertDefragTargetSupported,
     formatMemoryCoreRepairProgress,
-    repairMemoryCoreCollectionsViaFullEnumeration
+    repairMemoryCoreCollectionViaResumableShadow,
+    repairMemoryCoreCollectionsViaFullEnumeration,
+    runDefragChromaDBCli
 } from '../../../../../../ai/scripts/maintenance/defragChromaDB.mjs';
 
 /**
  * AC4 — the Memory Core defrag-wiring orchestration: full (uncapped) enumeration ->
- * extract + re-embed -> shadow-promotion, with fail-loud on unrecoverable rows. The seams
- * (auditFn / extractFn / promoteFn) are injected so the orchestration is verified without a
+ * resumable shadow repair, with fail-loud on unrecoverable rows. The seams
+ * (auditFn / extractFn / repairCollectionFn) are injected so the orchestration is verified without a
  * live Chroma store.
  */
-test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () => {
+test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#14020)', () => {
     const embeddingFunction = {name: 'dummy'},
           embedFn           = async docs => docs.map(() => [0.1, 0.2]);
 
-    function makeSeams({coverage, extractResults, client}) {
-        const calls = {audit: [], extract: [], promote: [], clearState: [], writeState: []};
+    function makeSeams({coverage, extractResults = {}, repairResults = {}, client}) {
+        const calls = {audit: [], extract: [], repair: [], clearState: [], writeState: []};
 
         return {
             calls,
-            client      : client || {getCollection: async ({name}) => ({_name: name})},
-            auditFn     : async args => { calls.audit.push(args);   return coverage; },
-            extractFn   : async args => { calls.extract.push(args); return extractResults[args.collection._name]; },
-            promoteFn   : async args => { calls.promote.push(args); return {promoted: args.collectionName}; },
+            client            : client || {getCollection: async ({name}) => ({_name: name})},
+            auditFn           : async args => { calls.audit.push(args);   return coverage; },
+            extractFn         : async args => { calls.extract.push(args); return extractResults[args.collection._name]; },
+            repairCollectionFn: async args => {
+                calls.repair.push(args);
+                return repairResults[args.collectionName] || {
+                    collectionName: args.collectionName,
+                    promotion     : {promoted: args.collectionName},
+                    counts        : extractResults[args.collection._name]?.counts || {}
+                };
+            },
             clearStateFn: async args => { calls.clearState.push(args); },
             writeStateFn: async args => { calls.writeState.push(args); }
         };
     }
 
-    test('full-enumeration audit feeds extract + promote per collection (happy path)', async () => {
+    test('full-enumeration audit feeds resumable repair per collection (happy path)', async () => {
         const coverage = {collections: [
                   {name: 'mc-memory', allIds: ['a', 'b', 'c'], missingVectorIds: ['c']},
                   {name: 'mc-graph',  allIds: ['x'],           missingVectorIds: []}
               ]},
-              extractResults = {
-                  'mc-memory': {data: {ids: ['a', 'b', 'c'], embeddings: [[1], [2], [3]], documents: ['', '', ''], metadatas: [{}, {}, {}]}, unrecoverable: [], counts: {total: 3, intact: 2, reEmbedded: 1, unrecoverable: 0}},
-                  'mc-graph' : {data: {ids: ['x'], embeddings: [[9]], documents: [''], metadatas: [{}]},             unrecoverable: [], counts: {total: 1, intact: 1, reEmbedded: 0, unrecoverable: 0}}
+              repairResults = {
+                  'mc-memory': {collectionName: 'mc-memory', promotion: {promoted: 'mc-memory'}, counts: {total: 3, intact: 2, reEmbedded: 1, unrecoverable: 0}},
+                  'mc-graph' : {collectionName: 'mc-graph',  promotion: {promoted: 'mc-graph'},  counts: {total: 1, intact: 1, reEmbedded: 0, unrecoverable: 0}}
               },
-              {calls, client, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
+              {calls, client, auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn} = makeSeams({coverage, repairResults});
 
         const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-memory', 'mc-graph'], snapshotPath: '/snap', persistDir: '/persist',
-            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, clearStateFn, writeStateFn, log: () => {}
+            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn, log: () => {}
         });
 
         // exactly one enumeration call, uncapped (includeFullIds), over the requested collections
@@ -51,13 +60,12 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
         expect(calls.audit[0].includeFullIds).toBe(true);
         expect(calls.audit[0].collectionNames).toEqual(['mc-memory', 'mc-graph']);
 
-        // extract receives the FULL {allIds, missingVectorIds} from the coverage, per collection
-        expect(calls.extract.map(c => c.allIds)).toEqual([['a', 'b', 'c'], ['x']]);
-        expect(calls.extract.map(c => c.missingVectorIds)).toEqual([['c'], []]);
+        // mutating repair receives the FULL {allIds, missingVectorIds} from the coverage, per collection
+        expect(calls.repair.map(c => c.allIds)).toEqual([['a', 'b', 'c'], ['x']]);
+        expect(calls.repair.map(c => c.missingVectorIds)).toEqual([['c'], []]);
 
-        // both promoted with their recovered data
-        expect(calls.promote.map(c => c.collectionName)).toEqual(['mc-memory', 'mc-graph']);
-        expect(calls.promote[0].data.ids).toEqual(['a', 'b', 'c']);
+        // both repaired/promoted through the resumable seam
+        expect(calls.repair.map(c => c.collectionName)).toEqual(['mc-memory', 'mc-graph']);
         expect(results).toHaveLength(2);
         expect(results.every(r => r.promotion && !r.aborted)).toBe(true);
 
@@ -71,20 +79,20 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
                   {name: 'mc-graph', collectionId: 'stale-id', allIds: ['stale'], missingVectorIds: ['stale']},
                   {name: 'mc-graph', collectionId: 'live-id',  allIds: ['live'],  missingVectorIds: []}
               ]},
-              extractResults = {
-                  'mc-graph': {data: {ids: ['live'], embeddings: [[9]], documents: [''], metadatas: [{}]}, unrecoverable: [], counts: {total: 1, intact: 1, reEmbedded: 0, unrecoverable: 0}}
+              repairResults = {
+                  'mc-graph': {collectionName: 'mc-graph', promotion: {promoted: 'mc-graph'}, counts: {total: 1, intact: 1, reEmbedded: 0, unrecoverable: 0}}
               },
               client = {getCollection: async ({name}) => ({_name: name, id: 'live-id'})},
-              {calls, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults, client});
+              {calls, auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn} = makeSeams({coverage, repairResults, client});
 
         const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-graph'], snapshotPath: '/snap', persistDir: '/persist',
-            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, clearStateFn, writeStateFn, log: () => {}
+            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn, log: () => {}
         });
 
-        expect(calls.extract).toHaveLength(1);
-        expect(calls.extract[0].allIds).toEqual(['live']);
-        expect(calls.extract[0].missingVectorIds).toEqual([]);
+        expect(calls.repair).toHaveLength(1);
+        expect(calls.repair[0].allIds).toEqual(['live']);
+        expect(calls.repair[0].missingVectorIds).toEqual([]);
         expect(results[0].promotion).toEqual({promoted: 'mc-graph'});
     });
 
@@ -94,31 +102,31 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
                   {name: 'mc-graph', collectionId: 'other-id', allIds: ['other'], missingVectorIds: []}
               ]},
               client = {getCollection: async ({name}) => ({_name: name, id: 'live-id'})},
-              {calls, auditFn, extractFn, promoteFn} = makeSeams({coverage, extractResults: {}, client});
+              {calls, auditFn, extractFn, repairCollectionFn} = makeSeams({coverage, client});
 
         await expect(repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-graph'], snapshotPath: '/snap', persistDir: '/persist',
-            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, log: () => {}
+            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, repairCollectionFn, log: () => {}
         })).rejects.toThrow(/none match live collection id 'live-id'/);
 
         expect(calls.extract).toHaveLength(0);
-        expect(calls.promote).toHaveLength(0);
+        expect(calls.repair).toHaveLength(0);
     });
 
     test('fail-loud: unrecoverable rows abort that collection promotion (no silent drop)', async () => {
-        const coverage       = {collections: [{name: 'mc-memory', allIds: ['a', 'b'], missingVectorIds: ['b']}]},
-              extractResults = {
-                  'mc-memory': {data: {ids: ['a'], embeddings: [[1]], documents: [''], metadatas: [{}]}, unrecoverable: ['b'], counts: {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}}
+        const coverage      = {collections: [{name: 'mc-memory', allIds: ['a', 'b'], missingVectorIds: ['b']}]},
+              repairResults = {
+                  'mc-memory': {collectionName: 'mc-memory', aborted: true, shadowName: 'mc-memory-shadow-resume', loadedCount: 1, sourceCount: 2, unrecoverable: ['b'], counts: {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}}
               },
-              {calls, client, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
+              {calls, client, auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn} = makeSeams({coverage, repairResults});
 
         const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
             embedFn, embeddingFunction, statePath: '/state', stateBase: {targetName: 'memory-core'},
-            auditFn, extractFn, promoteFn, clearStateFn, writeStateFn, log: () => {}
+            auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn, log: () => {}
         });
 
-        expect(calls.promote).toHaveLength(0);              // never promoted
+        expect(calls.repair).toHaveLength(1);
         expect(results[0].aborted).toBe(true);
         expect(results[0].unrecoverable).toEqual(['b']);
         expect(results[0].counts.unrecoverable).toBe(1);
@@ -130,7 +138,72 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
         expect(calls.writeState[0].statePath).toBe('/state');
         expect(calls.writeState[0].state.phase).toBe('memory-core-repair-aborted');
         expect(calls.writeState[0].state.targetName).toBe('memory-core');
+        expect(calls.writeState[0].state.shadowName).toBe('mc-memory-shadow-resume');
+        expect(calls.writeState[0].state.loadedCount).toBe(1);
         expect(calls.writeState[0].state.aborted).toEqual(['mc-memory']);
+    });
+
+    test('resume state skips earlier collections and resumes the matching collection repair', async () => {
+        const coverage = {collections: [
+                  {name: 'mc-memory',   allIds: ['old'], missingVectorIds: []},
+                  {name: 'mc-sessions', allIds: ['a'],   missingVectorIds: ['a']}
+              ]},
+              repairResults = {
+                  'mc-sessions': {collectionName: 'mc-sessions', promotion: {promoted: 'mc-sessions'}, counts: {total: 1, intact: 0, reEmbedded: 1, unrecoverable: 0}}
+              },
+              resumeState = {
+                  phase         : 'memory-core-repair-shadow-loading',
+                  collectionName: 'mc-sessions',
+                  shadowName    : 'mc-sessions-shadow-resume'
+              },
+              {calls, client, auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn} = makeSeams({coverage, repairResults});
+
+        const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
+            client,
+            collections : ['mc-memory', 'mc-sessions'],
+            snapshotPath: '/snap',
+            persistDir  : '/persist',
+            embedFn,
+            embeddingFunction,
+            statePath   : '/state',
+            auditFn,
+            extractFn,
+            repairCollectionFn,
+            clearStateFn,
+            writeStateFn,
+            resumeState,
+            log         : () => {}
+        });
+
+        expect(calls.repair.map(call => call.collectionName)).toEqual(['mc-sessions']);
+        expect(calls.repair[0].resumeState).toBe(resumeState);
+        expect(results).toHaveLength(1);
+        expect(results[0].promotion).toEqual({promoted: 'mc-sessions'});
+        expect(calls.clearState).toEqual([{statePath: '/state'}]);
+    });
+
+    test('malformed resumable state fails closed instead of starting from zero', async () => {
+        const coverage = {collections: [
+                  {name: 'mc-memory', allIds: ['a'], missingVectorIds: ['a']}
+              ]},
+              {client, auditFn, extractFn, repairCollectionFn} = makeSeams({coverage});
+
+        await expect(repairMemoryCoreCollectionsViaFullEnumeration({
+            client,
+            collections : ['mc-memory'],
+            snapshotPath: '/snap',
+            persistDir  : '/persist',
+            embedFn,
+            embeddingFunction,
+            statePath   : '/state',
+            auditFn,
+            extractFn,
+            repairCollectionFn,
+            resumeState : {
+                phase: 'memory-core-repair-shadow-loading'
+            },
+            log: () => {}
+        })).rejects.toThrow(/missing collectionName or shadowName/);
     });
 
     test('dry-run reports clean extraction without promotion or state-marker writes', async () => {
@@ -138,17 +211,17 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
               extractResults = {
                   'mc-memory': {data: {ids: ['a', 'b'], embeddings: [[1], [2]], documents: ['', 'doc'], metadatas: [{}, {}]}, unrecoverable: [], counts: {total: 2, intact: 1, reEmbedded: 1, unrecoverable: 0}}
               },
-              {calls, client, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
+              {calls, client, auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
 
         const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
             embedFn, embeddingFunction, statePath: '/state', dryRun: true,
-            auditFn, extractFn, promoteFn, clearStateFn, writeStateFn, log: () => {}
+            auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn, log: () => {}
         });
 
         expect(calls.audit[0].includeFullIds).toBe(true);
         expect(calls.extract).toHaveLength(1);
-        expect(calls.promote).toHaveLength(0);
+        expect(calls.repair).toHaveLength(0);
         expect(calls.clearState).toHaveLength(0);
         expect(calls.writeState).toHaveLength(0);
         expect(results).toEqual([{
@@ -163,15 +236,15 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
               extractResults = {
                   'mc-memory': {data: {ids: ['a'], embeddings: [[1]], documents: [''], metadatas: [{}]}, unrecoverable: ['b'], counts: {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}}
               },
-              {calls, client, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
+              {calls, client, auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
 
         const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
             embedFn, embeddingFunction, statePath: '/state', dryRun: true,
-            auditFn, extractFn, promoteFn, clearStateFn, writeStateFn, log: () => {}
+            auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn, log: () => {}
         });
 
-        expect(calls.promote).toHaveLength(0);
+        expect(calls.repair).toHaveLength(0);
         expect(calls.clearState).toHaveLength(0);
         expect(calls.writeState).toHaveLength(0);
         expect(results[0]).toMatchObject({
@@ -185,11 +258,11 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
     });
 
     test('throws when the enumeration returns no coverage row for a requested collection', async () => {
-        const {client, auditFn, extractFn, promoteFn} = makeSeams({coverage: {collections: []}, extractResults: {}});
+        const {client, auditFn, extractFn, repairCollectionFn} = makeSeams({coverage: {collections: []}, extractResults: {}});
 
         await expect(repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
-            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, promoteFn, log: () => {}
+            embedFn, embeddingFunction, statePath: '/state', auditFn, extractFn, repairCollectionFn, log: () => {}
         })).rejects.toThrow(/no coverage row for 'mc-memory'/);
     });
 
@@ -198,11 +271,11 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
               extractResults = {
                   'mc-memory': {data: {ids: ['a'], embeddings: [[1]], documents: [''], metadatas: [{}]}, unrecoverable: [], counts: {total: 1, intact: 1, reEmbedded: 0, unrecoverable: 0}}
               },
-              {calls, client, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
+              {calls, client, auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
 
         await repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
-            embedFn, embeddingFunction, auditFn, extractFn, promoteFn, clearStateFn, writeStateFn, log: () => {}
+            embedFn, embeddingFunction, auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn, log: () => {}
         });
 
         expect(calls.clearState).toHaveLength(0);
@@ -210,7 +283,223 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#13634 AC4)', () =
     });
 });
 
-test.describe('assertDefragTargetSupported — Memory Core opt-in gate (#13634 AC4)', () => {
+test.describe('repairMemoryCoreCollectionViaResumableShadow (#14020)', () => {
+    const embeddingFunction = {name: 'dummy'},
+          embedFn           = async docs => docs.map(() => [0.1, 0.2]);
+
+    function createCollection({name, ids = []}) {
+        const rows = new Map(ids.map(id => [id, {
+            embedding: [1],
+            metadata : {},
+            document : `doc-${id}`
+        }]));
+
+        return {
+            name,
+            rows,
+            calls: {
+                add: [],
+                get: []
+            },
+            async add(payload) {
+                this.calls.add.push(payload);
+
+                for (let i = 0; i < payload.ids.length; i++) {
+                    rows.set(payload.ids[i], {
+                        embedding: payload.embeddings[i],
+                        metadata : payload.metadatas[i],
+                        document : payload.documents[i]
+                    });
+                }
+            },
+            async count() {
+                return rows.size;
+            },
+            async get({ids, limit, offset = 0, include = []} = {}) {
+                this.calls.get.push({ids, limit, offset, include});
+
+                if (ids) {
+                    return {ids: ids.filter(id => rows.has(id))};
+                }
+
+                return {ids: Array.from(rows.keys()).slice(offset, offset + limit)};
+            }
+        };
+    }
+
+    function createClient(collections = {}) {
+        const registry = new Map(Object.entries(collections));
+        const created  = [];
+
+        return {
+            created,
+            async createCollection({name}) {
+                const collection = createCollection({name});
+                registry.set(name, collection);
+                created.push(collection);
+                return collection;
+            },
+            async getCollection({name}) {
+                const collection = registry.get(name);
+
+                if (!collection) {
+                    throw new Error(`Collection ${name} not found`);
+                }
+
+                return collection;
+            }
+        };
+    }
+
+    test('streams recovered batches into a shadow collection and checkpoints loaded count', async () => {
+        const states       = [];
+        const promoteCalls = [];
+        const extractCalls = [];
+        const client       = createClient();
+        const live         = createCollection({name: 'mc-memory'});
+
+        const result = await repairMemoryCoreCollectionViaResumableShadow({
+            client,
+            collectionName  : 'mc-memory',
+            collection      : live,
+            allIds          : ['a', 'b'],
+            missingVectorIds: ['b'],
+            embedFn,
+            embeddingFunction,
+            statePath       : '/state',
+            stateBase       : {targetName: 'memory-core'},
+            extractFn       : async args => {
+                extractCalls.push(args);
+                await args.onDataBatch({ids: ['a'], embeddings: [[1]], documents: ['doc-a'], metadatas: [{}]});
+                await args.onDataBatch({ids: ['b'], embeddings: [[2]], documents: ['doc-b'], metadatas: [{}]});
+                return {unrecoverable: [], counts: {total: 2, intact: 1, reEmbedded: 1, unrecoverable: 0}};
+            },
+            promoteLoadedFn: async args => {
+                promoteCalls.push(args);
+                return {shadowName: args.shadowName, sourceCount: args.sourceIds.length, parkingDeleted: true};
+            },
+            writeStateFn: async args => states.push(args.state),
+            timestamp   : 123,
+            uuidFactory : () => 'uuid-1',
+            log         : () => {}
+        });
+
+        expect(client.created).toHaveLength(1);
+        expect(client.created[0].rows.size).toBe(2);
+        expect(extractCalls[0].collectData).toBe(false);
+        expect(extractCalls[0].skipIds).toEqual([]);
+        expect(states.filter(state => state.phase === 'memory-core-repair-shadow-loading').map(state => state.loadedCount))
+            .toEqual([0, 1, 2]);
+        expect(promoteCalls[0].sourceIds).toEqual(['a', 'b']);
+        expect(result.promotion).toEqual({shadowName: 'mc-memory-shadow-123-uuid-1', sourceCount: 2, parkingDeleted: true});
+    });
+
+    test('resumes from an existing shadow and skips already loaded ids', async () => {
+        const states       = [];
+        const extractCalls = [];
+        const shadow       = createCollection({name: 'mc-memory-shadow-resume', ids: ['a']});
+        const client       = createClient({'mc-memory-shadow-resume': shadow});
+        const live         = createCollection({name: 'mc-memory'});
+
+        await repairMemoryCoreCollectionViaResumableShadow({
+            client,
+            collectionName  : 'mc-memory',
+            collection      : live,
+            allIds          : ['a', 'b'],
+            missingVectorIds: ['b'],
+            embedFn,
+            embeddingFunction,
+            statePath       : '/state',
+            resumeState     : {
+                phase     : 'memory-core-repair-shadow-loading',
+                shadowName: 'mc-memory-shadow-resume'
+            },
+            extractFn: async args => {
+                extractCalls.push(args);
+                await args.onDataBatch({ids: ['b'], embeddings: [[2]], documents: ['doc-b'], metadatas: [{}]});
+                return {unrecoverable: [], counts: {total: 2, intact: 0, reEmbedded: 1, unrecoverable: 0, resumedExisting: 1}};
+            },
+            promoteLoadedFn: async () => ({promoted: true}),
+            writeStateFn   : async args => states.push(args.state),
+            log            : () => {}
+        });
+
+        expect(client.created).toHaveLength(0);
+        expect(extractCalls[0].skipIds).toEqual(['a']);
+        expect(shadow.rows.has('a')).toBe(true);
+        expect(shadow.rows.has('b')).toBe(true);
+        expect(states.filter(state => state.phase === 'memory-core-repair-shadow-loading').map(state => state.loadedCount))
+            .toEqual([1, 2]);
+    });
+});
+
+test.describe('runDefragChromaDBCli (#14020)', () => {
+    test('runs standalone defrag inside the shared heavy-maintenance lease', async () => {
+        const calls = {
+            lease: [],
+            run  : 0,
+            exit : []
+        };
+
+        await runDefragChromaDBCli({
+            runDefrag: async () => {
+                calls.run++;
+            },
+            withLease: async (task, options) => {
+                calls.lease.push(options);
+                await task();
+                return {status: 'acquired', result: undefined};
+            },
+            output: {
+                log  : () => {},
+                error: () => {}
+            },
+            exit: code => calls.exit.push(code)
+        });
+
+        expect(calls.run).toBe(1);
+        expect(calls.lease).toEqual([{
+            owner   : 'defrag',
+            reason  : 'manual-cli',
+            metadata: {script: 'ai/scripts/maintenance/defragChromaDB.mjs'}
+        }]);
+        expect(calls.exit).toEqual([0]);
+    });
+
+    test('defers without running defrag when another heavy task holds the lease', async () => {
+        const logs  = [];
+        const calls = {
+            run : 0,
+            exit: []
+        };
+
+        await runDefragChromaDBCli({
+            runDefrag: async () => {
+                calls.run++;
+            },
+            withLease: async () => ({
+                status: 'held',
+                lease : {
+                    owner     : 'sandman',
+                    reason    : 'manual-cli',
+                    pid       : 123,
+                    acquiredAt: '2026-06-25T21:00:00.000Z'
+                }
+            }),
+            output: {
+                log  : message => logs.push(message),
+                error: () => {}
+            },
+            exit: code => calls.exit.push(code)
+        });
+
+        expect(calls.run).toBe(0);
+        expect(calls.exit).toEqual([0]);
+        expect(logs.some(message => message.includes("Deferred: heavy-maintenance lease held by 'sandman'"))).toBe(true);
+    });
+});
+
+test.describe('assertDefragTargetSupported — Memory Core opt-in gate (#14020)', () => {
     test('fails closed for memory-core by default (no opt-in)', () => {
         expect(() => assertDefragTargetSupported({targetName: 'memory-core'})).toThrow(/Memory Core defrag is disabled/);
     });
@@ -224,7 +513,7 @@ test.describe('assertDefragTargetSupported — Memory Core opt-in gate (#13634 A
     });
 });
 
-test.describe('anyRepairAborted — operator fail-loud predicate (#13634 AC4)', () => {
+test.describe('anyRepairAborted — operator fail-loud predicate (#14020)', () => {
     test('true when any collection aborted — the CLI exits non-zero on this', () => {
         expect(anyRepairAborted([
             {collectionName: 'mc-memory', promotion: {}},

--- a/test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs
@@ -32,7 +32,7 @@ import * as core      from '../../../../../../src/core/_export.mjs';
  */
 test.describe('Manual heavy-maintenance script lease adoption', () => {
     const scriptsRoot = path.resolve(process.cwd(), 'ai/scripts');
-    const scriptPath = file => path.join(scriptsRoot, file === 'runSandman.mjs' ? 'runners' : 'maintenance', file);
+    const scriptPath  = file => path.join(scriptsRoot, file === 'runSandman.mjs' ? 'runners' : 'maintenance', file);
 
     /**
      * Maps each script to its expected lease `owner` string. Owner strings are stable
@@ -40,13 +40,14 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
      * task names — keep these in sync with `MaintenanceBackpressureService.mjs` DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES.
      */
     const SCRIPTS = [
-        {file: 'runSandman.mjs',           owner: 'sandman',            invocation: 'withLease('},
-        {file: 'syncKnowledgeBase.mjs',    owner: 'kbSync',             invocation: 'withHeavyMaintenanceLease('},
-        {file: 'backup.mjs',               owner: 'backup',             invocation: 'withHeavyMaintenanceLease('},
-        {file: 'syncGithubWorkflow.mjs',   owner: 'syncGithubWorkflow', invocation: 'withHeavyMaintenanceLease('}
+        {file: 'runSandman.mjs',           owner: 'sandman',            invocation: 'withLease(',                 heldExitPattern: /exit\(0\)/},
+        {file: 'syncKnowledgeBase.mjs',    owner: 'kbSync',             invocation: 'withHeavyMaintenanceLease(', heldExitPattern: /process\.exit\(0\)/},
+        {file: 'defragChromaDB.mjs',       owner: 'defrag',             invocation: 'withLease(',                 heldExitPattern: /exit\(0\)/},
+        {file: 'backup.mjs',               owner: 'backup',             invocation: 'withHeavyMaintenanceLease(', heldExitPattern: /process\.exit\(0\)/},
+        {file: 'syncGithubWorkflow.mjs',   owner: 'syncGithubWorkflow', invocation: 'withHeavyMaintenanceLease(', heldExitPattern: /process\.exit\(0\)/}
     ];
 
-    for (const {file, owner, invocation} of SCRIPTS) {
+    for (const {file, owner, invocation, heldExitPattern} of SCRIPTS) {
         test(`${file}: imports withHeavyMaintenanceLease`, async () => {
             const source = await fs.readFile(scriptPath(file), 'utf-8');
             expect(source).toMatch(/import\s*\{[^}]*withHeavyMaintenanceLease[^}]*\}\s*from\s*['"]\.\.\/\.\.\/daemons\/orchestrator\/services\/HeavyMaintenanceLeaseService\.mjs['"]/);
@@ -69,7 +70,7 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
             // Assert the deferred message names the active owner (so the user sees who holds the lease)
             expect(source).toMatch(/Deferred:.*lease held by/i);
             // Assert process.exit(0) is called on held — non-error semantics per AC2
-            expect(source).toMatch(file === 'runSandman.mjs' ? /exit\(0\)/ : /process\.exit\(0\)/);
+            expect(source).toMatch(heldExitPattern);
         });
     }
 
@@ -141,9 +142,9 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
         ).toBeLessThan(postWrapperMarkerMatch.index);
     });
 
-    test('all four scripts share the same lease-wrapper pattern (no per-script private locks)', async () => {
+    test('all heavy maintenance scripts share the same lease-wrapper pattern (no per-script private locks)', async () => {
         // Empirical anchor: #11503 explicitly named "per-script private locks" as an avoided
-        // trap. This test pins that none of the four scripts introduces an alternative
+        // trap. This test pins that none of the heavy-maintenance scripts introduces an alternative
         // lock-file or in-process mutex — they all consume the shared lease primitive.
         for (const {file} of SCRIPTS) {
             const source = await fs.readFile(scriptPath(file), 'utf-8');

--- a/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
@@ -64,6 +64,45 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         expect(result.data.embeddings[result.data.ids.indexOf('a')]).toEqual([1]);    // stored, untouched
     });
 
+    test('can stream recovered batches without retaining full collection data in memory', async () => {
+        const rows    = {a: {embedding: [1], document: 'da', metadata: {}}, m: {document: 'dm', metadata: {k: 1}}};
+        const batches = [];
+
+        const result = await extractMemoryCoreCollectionData({
+            collection      : makeCollection(rows),
+            allIds          : ['a', 'm'],
+            missingVectorIds: ['m'],
+            embedFn         : async docs => docs.map(() => [7]),
+            batchSize       : 1,
+            collectData     : false,
+            onDataBatch     : async batchData => batches.push(batchData)
+        });
+
+        expect(result.data).toEqual({ids: [], embeddings: [], documents: [], metadatas: []});
+        expect(result.counts).toEqual({total: 2, intact: 1, reEmbedded: 1, unrecoverable: 0});
+        expect(batches.map(batch => batch.ids)).toEqual([['a'], ['m']]);
+    });
+
+    test('skipIds prevents already shadow-loaded rows from being re-extracted or re-embedded', async () => {
+        const rows       = {a: {embedding: [1], document: 'da', metadata: {}}, m: {document: 'dm', metadata: {k: 1}}};
+        let   embedCalls = 0;
+
+        const result = await extractMemoryCoreCollectionData({
+            collection      : makeCollection(rows),
+            allIds          : ['a', 'm'],
+            missingVectorIds: ['m'],
+            skipIds         : ['a'],
+            embedFn         : async docs => {
+                embedCalls++;
+                return docs.map(() => [7]);
+            }
+        });
+
+        expect(result.data.ids).toEqual(['m']);
+        expect(result.counts).toEqual({total: 2, intact: 0, reEmbedded: 1, unrecoverable: 0, resumedExisting: 1});
+        expect(embedCalls).toBe(1);
+    });
+
     test('a missing-vector row with no document is unrecoverable, not silently dropped', async () => {
         const rows    = {m: {document: '', metadata: {}}, n: {document: 'dn', metadata: {}}};
         const embedFn = async docs => docs.map(() => [5]);
@@ -86,6 +125,40 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
 
         expect(result.unrecoverable).toEqual(['gone']);
         expect(result.counts.reEmbedded).toBe(1);
+    });
+
+    test('batch embed failure falls back to single-document isolation and marks only failed docs unrecoverable', async () => {
+        const rows = {
+            ok     : {document: 'small', metadata: {}},
+            overcap: {document: 'too-large', metadata: {}},
+            ok2    : {document: 'small-2', metadata: {}}
+        };
+        const calls = [];
+
+        const result = await extractMemoryCoreCollectionData({
+            collection      : makeCollection(rows),
+            allIds          : ['ok', 'overcap', 'ok2'],
+            missingVectorIds: ['ok', 'overcap', 'ok2'],
+            embedFn         : async docs => {
+                calls.push(docs);
+
+                if (docs.length > 1 || docs[0] === 'too-large') {
+                    throw new Error('context overflow');
+                }
+
+                return [[docs[0].length]];
+            }
+        });
+
+        expect(calls).toEqual([
+            ['small', 'too-large', 'small-2'],
+            ['small'],
+            ['too-large'],
+            ['small-2']
+        ]);
+        expect(result.unrecoverable).toEqual(['overcap']);
+        expect(result.data.ids).toEqual(['ok', 'ok2']);
+        expect(result.counts).toEqual({total: 3, intact: 0, reEmbedded: 2, unrecoverable: 1});
     });
 
     test('reports 10%-bucket progress for intact extraction and missing-vector re-embed', async () => {
@@ -125,12 +198,15 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         });
     });
 
-    test('embedFn returning a wrong-length result throws (fail loud)', async () => {
+    test('embedFn returning wrong-length results marks the row unrecoverable instead of crashing repair progress', async () => {
         const rows = {m: {document: 'dm', metadata: {}}};
 
-        await expect(extractMemoryCoreCollectionData({
+        const result = await extractMemoryCoreCollectionData({
             collection: makeCollection(rows), allIds: ['m'], missingVectorIds: ['m'], embedFn: async () => []
-        })).rejects.toThrow(/returned 0 embeddings for 1 documents/);
+        });
+
+        expect(result.unrecoverable).toEqual(['m']);
+        expect(result.counts).toEqual({total: 1, intact: 0, reEmbedded: 0, unrecoverable: 1});
     });
 
     test('a missing embedFn throws (required param)', async () => {


### PR DESCRIPTION
Resolves #14020

This PR turns the defrag incident from a one-shot repair into a resumable maintenance operation. Memory Core repair-defrag now streams recovered rows into a durable shadow collection, records resumable phase state, skips already-loaded shadow IDs on rerun, and isolates provider-overcap rows as unrecoverable instead of crashing away prior progress. Standalone defrag CLI execution also now acquires the shared heavy-maintenance lease, so a manually started defrag is visible to the orchestrator before it schedules other heavy work.

Evidence: L2 focused unit coverage achieved for all close-target ACs; no live defrag was run. Residual: none for #14020.

## Deltas From Ticket

The implementation keeps the exported defrag implementation lease-free and wraps only direct CLI execution with the heavy-maintenance lease, matching the existing `runSandman.mjs` testable wrapper shape.

## Test Evidence

- `node --check ai/scripts/maintenance/defragChromaDB.mjs`
- `node --check ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs`
- Result: 62 passed

## Post-Merge Validation

- [ ] Operator can start `npm run ai:defrag-memory -- --allow-memory-core`; a concurrent standalone Sandman/backup/KB-sync/defrag invocation defers on the heavy-maintenance lease.

## Commits

- `6c4c16ac44` — `fix(ai): make defrag resumable and lease-protected (#14020)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019efe4c-5d55-76c0-aba5-665f86d9cbdc.
