### PR TITLE
fix(ai): isolate unit Chroma daemon and data dir (#14010)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,3 +1,4 @@
+import os                                        from 'os';
 import path                                      from 'path';
 import {fileURLToPath}                           from 'url';
 import ConfigProvider, {createConfigProxy, leaf} from './ConfigProvider.mjs';
@@ -6,7 +7,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../');
 // Fallback to neoRootDir if cwd is root (e.g., container/daemon edge cases)
-const projectRoot = process.cwd() === '/' ? neoRootDir : process.cwd();
+const projectRoot           = process.cwd() === '/' ? neoRootDir : process.cwd();
+const chromaUnitTestDataDir = path.join(os.tmpdir(), 'neo-chroma-unit-test');
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS  = 24 * HOUR_MS;
@@ -333,20 +335,21 @@ class Config extends ConfigProvider {
             /**
              * @summary Deployment-wide storage engine coordinates.
              *
-             * `engines.chroma` is the unified Chroma topology: ONE daemon, ONE persist dir,
-             * shared by Knowledge Base + Memory Core. `dataDir` is the fixed canonical persist dir
-             * read by both server configs + the `defragChromaDB` maintenance script; the local
-             * orchestrator launches the daemon against the same fixed path. The leaf is named `unified`
-             * (identical local + cloud) — it holds every realm (KB + MC + graph + sessions), so a
-             * realm-specific name would misrepresent the store. Collection NAMES remain server-local;
-             * the persist DIR is unified.
+             * `engines.chroma` is the unified production topology: ONE daemon, ONE persist dir,
+             * shared by Knowledge Base + Memory Core. The active `host` / `port` / `dataDir` values are
+             * formulas (below) that resolve production vs unit-test coordinates from the existing
+             * `UNIT_TEST_MODE` toggle. Unit tests therefore connect to a separate daemon and separate
+             * persist directory by construction; a database-name swap alone is not isolation.
              * @type {Object}
              */
             engines: {
                 chroma: {
-                    dataDir: leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/unified')),
-                    host   : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
-                    port   : leaf(8000, 'NEO_CHROMA_PORT', 'port'),
+                    dataDirProd: leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/unified')),
+                    dataDirTest: leaf(chromaUnitTestDataDir, 'NEO_CHROMA_DATA_DIR_TEST', 'string'),
+                    hostProd   : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
+                    hostTest   : leaf('localhost', 'NEO_CHROMA_HOST_TEST', 'string'),
+                    portProd   : leaf(8000, 'NEO_CHROMA_PORT', 'port'),
+                    portTest   : leaf(18180, 'NEO_CHROMA_PORT_TEST', 'port'),
                     /**
                      * Chroma database selection — three declarative leaves, all SSOT-inline (config.template
                      * imports no config values):
@@ -982,6 +985,14 @@ class Config extends ConfigProvider {
                     })
                 }
             })
+        },
+        /**
+         * Reactive computed config values (`Neo.state.Provider` formulas).
+         */
+        formulas: {
+            'engines.chroma.dataDir': data => data.engines.chroma.useTestDatabase ? data.engines.chroma.dataDirTest : data.engines.chroma.dataDirProd,
+            'engines.chroma.host'   : data => data.engines.chroma.useTestDatabase ? data.engines.chroma.hostTest    : data.engines.chroma.hostProd,
+            'engines.chroma.port'   : data => data.engines.chroma.useTestDatabase ? data.engines.chroma.portTest    : data.engines.chroma.portProd
         }
     }
 }

--- a/ai/services/shared/vector/chromaTestIsolation.mjs
+++ b/ai/services/shared/vector/chromaTestIsolation.mjs
@@ -63,6 +63,19 @@ async function createAdminClient({host, port, ssl = false}) {
 }
 
 /**
+ * @summary Detects Chroma's "already exists" response for concurrent createDatabase calls.
+ *
+ * Fully parallel unit workers can all race through `getDatabase` before any one creates the
+ * stable test database. The first create wins; the rest receive `ChromaUniqueError`. That is a
+ * successful ensure outcome, not a boot failure.
+ * @param {Error} error
+ * @returns {Boolean}
+ */
+export function isChromaAlreadyExistsError(error) {
+    return error?.name === 'ChromaUniqueError' || /resource already exists|already exists/i.test(error?.message || '')
+}
+
+/**
  * @summary Ensures the unit-test Chroma database exists before the first collection op. chromadb
  * 3.x has no `getOrCreateDatabase`, so this is `getDatabase` → catch → `createDatabase`. Idempotent;
  * safe to call on every connect.
@@ -86,7 +99,13 @@ export async function ensureChromaTestDatabase({host, port, ssl = false, databas
     try {
         await admin.getDatabase({name: database, tenant})
     } catch {
-        await admin.createDatabase({name: database, tenant})
+        try {
+            await admin.createDatabase({name: database, tenant})
+        } catch (error) {
+            if (!isChromaAlreadyExistsError(error)) {
+                throw error
+            }
+        }
     }
 
     return database

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -1,12 +1,14 @@
 import path            from 'path';
 import {fileURLToPath} from 'url';
+import os              from 'os';
 import Neo             from '../../../src/Neo.mjs';
 
-const HOUR_MS    = 60 * 60 * 1000;
-const DAY_MS     = 24 * HOUR_MS;
-const __filename = fileURLToPath(import.meta.url);
-const __dirname  = path.dirname(__filename);
-const neoRootDir = path.resolve(__dirname, '../../..');
+const HOUR_MS               = 60 * 60 * 1000;
+const DAY_MS                = 24 * HOUR_MS;
+const __filename            = fileURLToPath(import.meta.url);
+const __dirname             = path.dirname(__filename);
+const neoRootDir            = path.resolve(__dirname, '../../..');
+const chromaUnitTestDataDir = path.join(os.tmpdir(), 'neo-chroma-unit-test');
 
 /**
  * @module test/playwright/fixtures/aiConfigDefaults
@@ -139,9 +141,12 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     embeddingModel : 'gemini-embedding-001',
     engines        : {
         chroma: {
-            dataDir: path.resolve(neoRootDir, '.neo-ai-data/chroma/unified'),
-            host   : process.env.NEO_CHROMA_HOST || 'localhost',
-            port   : Number(process.env.NEO_CHROMA_PORT) || 8000
+            dataDirProd: path.resolve(neoRootDir, '.neo-ai-data/chroma/unified'),
+            dataDirTest: process.env.NEO_CHROMA_DATA_DIR_TEST || chromaUnitTestDataDir,
+            hostProd   : process.env.NEO_CHROMA_HOST || 'localhost',
+            hostTest   : process.env.NEO_CHROMA_HOST_TEST || 'localhost',
+            portProd   : Number(process.env.NEO_CHROMA_PORT) || 8000,
+            portTest   : Number(process.env.NEO_CHROMA_PORT_TEST) || 18180
         }
     },
     orchestrator: {

--- a/test/playwright/playwright.config.unit.mjs
+++ b/test/playwright/playwright.config.unit.mjs
@@ -1,4 +1,5 @@
 import {defineConfig}  from '@playwright/test';
+import os              from 'os';
 import path            from 'path';
 import {fileURLToPath} from 'url';
 
@@ -6,6 +7,15 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 process.env.UNIT_TEST_MODE = 'true';
+
+const chromaTestHost    = process.env.NEO_CHROMA_HOST_TEST || '127.0.0.1';
+const chromaTestPort    = Number(process.env.NEO_CHROMA_PORT_TEST) || 18180;
+const chromaTestDataDir = process.env.NEO_CHROMA_DATA_DIR_TEST ||
+    path.join(os.tmpdir(), `neo-chroma-unit-test-${process.pid}`);
+
+process.env.NEO_CHROMA_HOST_TEST     = chromaTestHost;
+process.env.NEO_CHROMA_PORT_TEST     = String(chromaTestPort);
+process.env.NEO_CHROMA_DATA_DIR_TEST = chromaTestDataDir;
 
 export default defineConfig({
     testDir      : path.join(__dirname, 'unit'),
@@ -15,5 +25,17 @@ export default defineConfig({
     retries      : process.env.CI ? 2 : 0,
     workers      : process.env.CI ? 1 : undefined,
     reporter     : [['json', {outputFile: path.join(__dirname, 'test-results/unit/test-results.json')}]],
-    use          : {trace: 'on-first-retry'}
+    use          : {trace: 'on-first-retry'},
+    webServer    : {
+        command            : `chroma run --path "${chromaTestDataDir}" --host ${chromaTestHost} --port ${chromaTestPort}`,
+        url                : `http://${chromaTestHost}:${chromaTestPort}/api/v2/heartbeat`,
+        timeout            : 120000,
+        reuseExistingServer: false,
+        stdout             : 'pipe',
+        stderr             : 'pipe',
+        gracefulShutdown   : {
+            signal : 'SIGTERM',
+            timeout: 30000
+        }
+    }
 });

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 import fs               from 'fs/promises';
+import os               from 'os';
+import path             from 'path';
 import Neo              from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
 import ConfigProvider         from '../../../../ai/ConfigProvider.mjs';
@@ -102,9 +104,15 @@ test.describe('Tier 1 Config Immutability', () => {
             }
         });
         expect(Config.engines.chroma).toEqual({
-            dataDir        : expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]unified$/),
-            host           : process.env.NEO_CHROMA_HOST || 'localhost',
-            port           : Number(process.env.NEO_CHROMA_PORT) || 8000,
+            dataDir        : process.env.NEO_CHROMA_DATA_DIR_TEST || expect.stringMatching(/neo-chroma-unit-test/),
+            dataDirProd    : expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]unified$/),
+            dataDirTest    : process.env.NEO_CHROMA_DATA_DIR_TEST || path.join(os.tmpdir(), 'neo-chroma-unit-test'),
+            host           : process.env.NEO_CHROMA_HOST_TEST || 'localhost',
+            hostProd       : process.env.NEO_CHROMA_HOST || 'localhost',
+            hostTest       : process.env.NEO_CHROMA_HOST_TEST || 'localhost',
+            port           : Number(process.env.NEO_CHROMA_PORT_TEST) || 18180,
+            portProd       : Number(process.env.NEO_CHROMA_PORT) || 8000,
+            portTest       : Number(process.env.NEO_CHROMA_PORT_TEST) || 18180,
             database       : process.env.NEO_CHROMA_DATABASE || 'default_database',
             databaseTest   : process.env.NEO_CHROMA_DATABASE_TEST || CHROMA_TEST_DATABASE,
             useTestDatabase: true

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -1,7 +1,7 @@
-import {test, expect}  from '@playwright/test';
-import Neo             from '../../../../../../../src/Neo.mjs';
+import {test, expect}                      from '@playwright/test';
+import Neo                                 from '../../../../../../../src/Neo.mjs';
 import ConfigProvider, {createConfigProxy} from '../../../../../../../ai/ConfigProvider.mjs';
-import {TIER1_DEFAULTS} from '../../../../../fixtures/aiConfigDefaults.mjs';
+import {TIER1_DEFAULTS}                    from '../../../../../fixtures/aiConfigDefaults.mjs';
 
 test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
     let originalEnv;
@@ -93,12 +93,13 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         expect(config.auth.trustProxyIdentity).toBe(TIER1_DEFAULTS.auth.trustProxyIdentity);
         expect(config.backupPath).toBe(TIER1_DEFAULTS.backupPath);
 
-        // KB-local leaves: Chroma host/port stay local top-level aliases (pending the S3/S4
-        // consumer codemod to engines.chroma.*); collection + path are genuinely KB-owned.
-        expect(config.host).toBe(TIER1_DEFAULTS.engines.chroma.host);
-        expect(config.port).toBe(TIER1_DEFAULTS.engines.chroma.port);
+        // KB-local leaves snapshot the active Tier-1 Chroma endpoint as top-level aliases
+        // (pending the S3/S4 consumer codemod to engines.chroma.*). Under UNIT_TEST_MODE that
+        // active endpoint is the isolated unit-test daemon; collection + path are genuinely KB-owned.
+        expect(config.host).toBe(TIER1_DEFAULTS.engines.chroma.hostTest);
+        expect(config.port).toBe(TIER1_DEFAULTS.engines.chroma.portTest);
         expect(config.collectionName).toBe('neo-knowledge-base');
-        expect(config.path).toContain('.neo-ai-data/chroma/unified');
+        expect(config.path).toBe(TIER1_DEFAULTS.engines.chroma.dataDirTest);
     });
 
     test('env overrides win — KB-local leaves at the child, Tier-1-owned leaves at the owner (inherited)', () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -11,6 +11,8 @@ test.describe('Memory Core Config (#10010)', () => {
     let originalTier1ClassHierarchy;
     let originalConfig;
     let originalClassHierarchy;
+    let tier1TemplateData;
+    let tier1TemplateFormulas;
 
     test.beforeAll(async () => {
         originalEnv = { ...process.env };
@@ -43,8 +45,14 @@ test.describe('Memory Core Config (#10010)', () => {
         // (cached module) that's a no-op — so install a fresh Tier-1 root built from the canonical
         // template tree, making inheritance deterministic across workers.
         const tier1Template = (await import('../../../../../../../ai/config.template.mjs')).default;
+        tier1TemplateData     = tier1Template._data;
+        tier1TemplateFormulas = tier1Template._formulas;
         Neo.ai = Neo.ai || {};
-        Neo.ai.Config = Neo.create(ConfigProvider, {data: tier1Template._data});
+        delete Neo.ai.Config;
+        Neo.ai.Config = Neo.create(ConfigProvider, {
+            data    : tier1TemplateData,
+            formulas: tier1TemplateFormulas
+        });
     });
 
     test.afterAll(() => {
@@ -114,12 +122,13 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.openAiCompatible.model).toBe(TIER1_DEFAULTS.openAiCompatible.model);
         expect(config.openAiCompatible.embeddingModel).toBe(TIER1_DEFAULTS.openAiCompatible.embeddingModel);
 
-        expect(config.engines.chroma.host).toBe(TIER1_DEFAULTS.engines.chroma.host);
-        expect(config.engines.chroma.port).toBe(TIER1_DEFAULTS.engines.chroma.port);
-        // MC reads the unified persist-dir SSOT, not a server-local dir.
-        // Was the stale `.neo-ai-data/chroma/memory-core` — the bug.
-        expect(config.engines.chroma.dataDir).toBe(TIER1_DEFAULTS.engines.chroma.dataDir);
-        expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/unified');
+        expect(config.engines.chroma.host).toBe(TIER1_DEFAULTS.engines.chroma.hostTest);
+        expect(config.engines.chroma.port).toBe(TIER1_DEFAULTS.engines.chroma.portTest);
+        // MC reads the Tier-1 Chroma SSOT. Under UNIT_TEST_MODE the active endpoint is the
+        // isolated unit-test daemon/data dir, while the production leaf stays the unified store.
+        expect(config.engines.chroma.dataDir).toBe(TIER1_DEFAULTS.engines.chroma.dataDirTest);
+        expect(config.engines.chroma.dataDirProd).toContain('.neo-ai-data/chroma/unified');
+        expect(config.engines.chroma.dataDir).toContain('neo-chroma-unit-test');
     });
 
     test('inherits the Tier-1 active-session idle threshold (#9959)', () => {
@@ -160,15 +169,20 @@ test.describe('Memory Core Config (#10010)', () => {
         process.env.NEO_OLLAMA_REQUIRE_PARALLEL_MODELS = '3';
         process.env.NEO_OPENAI_COMPATIBLE_KEEP_ALIVE = '10m';
         process.env.NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS = '4';
+        process.env.UNIT_TEST_MODE = 'false';
         process.env.NEO_CHROMA_HOST = 'chroma';
         process.env.NEO_CHROMA_PORT = '8010';
 
         // Post-split, MC declares none of these locally — they are Tier-1-owned, so env
         // precedence lives at the OWNER. Build a fresh realm root WITH the env set, register it, and
         // a fresh MC child inherits the overrides up the getParent() chain. (config._data is the raw
-        // MC meta-leaf tree; Neo.ai.Config._data is the Tier-1 realm tree, loaded via MC's import.)
-        const prevRoot  = Neo.ai?.Config;
-        const freshRoot = Neo.create(ConfigProvider, {data: Neo.ai.Config._data});
+        // MC meta-leaf tree; tier1TemplateData is the raw Tier-1 meta-leaf tree.)
+        const prevRoot = Neo.ai?.Config;
+        delete Neo.ai.Config;
+        const freshRoot = Neo.create(ConfigProvider, {
+            data    : tier1TemplateData,
+            formulas: tier1TemplateFormulas
+        });
         Neo.ai.Config   = freshRoot;
         const freshMC = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 

--- a/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
@@ -23,11 +23,12 @@ import DestructiveOperationGuard, {
     DESTRUCTIVE_PRODUCTION_BYPASS_ENV,
     DESTRUCTIVE_PRODUCTION_CONFIRMATION
 } from '../../../../../../../../ai/mcp/server/shared/services/DestructiveOperationGuard.mjs';
-import CollectionProxy from '../../../../../../../../ai/services/memory-core/managers/CollectionProxy.mjs';
+import CollectionProxy       from '../../../../../../../../ai/services/memory-core/managers/CollectionProxy.mjs';
 import MemoryDatabaseService from '../../../../../../../../ai/services/memory-core/DatabaseService.mjs';
-import KbChromaManager from '../../../../../../../../ai/services/knowledge-base/ChromaManager.mjs';
-import KbVectorService from '../../../../../../../../ai/services/knowledge-base/VectorService.mjs';
-import aiConfig from '../../../../../../../../ai/mcp/server/memory-core/config.mjs';
+import KbChromaManager       from '../../../../../../../../ai/services/knowledge-base/ChromaManager.mjs';
+import KbVectorService       from '../../../../../../../../ai/services/knowledge-base/VectorService.mjs';
+import kbConfig              from '../../../../../../../../ai/mcp/server/knowledge-base/config.mjs';
+import aiConfig              from '../../../../../../../../ai/mcp/server/memory-core/config.mjs';
 
 const repoRoot = process.cwd();
 
@@ -153,7 +154,7 @@ test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard (#108
             subsystem: 'memory-core',
             mode     : 'drop',
             target,
-            env: {
+            env      : {
                 [DESTRUCTIVE_PRODUCTION_BYPASS_ENV]: 'true'
             }
         })).rejects.toMatchObject({
@@ -161,9 +162,9 @@ test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard (#108
         });
 
         const result = await DestructiveOperationGuard.assertDestructiveTargetAllowed({
-            operation: 'memory-core.memory.drop',
-            subsystem: 'memory-core',
-            mode     : 'drop',
+            operation   : 'memory-core.memory.drop',
+            subsystem   : 'memory-core',
+            mode        : 'drop',
             target,
             confirmation: DESTRUCTIVE_PRODUCTION_CONFIRMATION,
             env         : {
@@ -195,34 +196,40 @@ test.describe('DestructiveOperationGuard call-site wiring (#10845)', () => {
     const skipCiSubstrateData = !!process.env.NEO_TEST_SKIP_CI;
 
     test('Memory Core CollectionProxy stops before deleting a production Chroma collection', async () => {
-        const proxy = Neo.create(CollectionProxy, {
-            collectionType: 'memory'
-        });
+        const
+            originalUseTestDatabase = aiConfig.engines.chroma.useTestDatabase,
+            proxy                   = Neo.create(CollectionProxy, {
+                collectionType: 'memory'
+            });
         let deleteCalls = 0;
 
-        proxy.getManagers = async () => [{
-            getMemoryCollection: async () => ({
-                name: 'neo-agent-memory'
-            }),
-            client: {
+        aiConfig.engines.chroma.useTestDatabase = false;
+
+        try {
+            proxy.getManagers = async () => [{
+                getMemoryCollection: async () => ({
+                    name: 'neo-agent-memory'
+                }),
                 deleteCollection: async () => {
                     deleteCalls++;
                 }
-            }
-        }];
+            }];
 
-        await expect(proxy.drop()).rejects.toMatchObject({
-            code: 'DESTRUCTIVE_TARGET_BLOCKED'
-        });
-        expect(deleteCalls).toBe(0);
+            await expect(proxy.drop()).rejects.toMatchObject({
+                code: 'DESTRUCTIVE_TARGET_BLOCKED'
+            });
+            expect(deleteCalls).toBe(0);
+        } finally {
+            aiConfig.engines.chroma.useTestDatabase = originalUseTestDatabase;
+        }
     });
 
     test('Memory Core graph truncate stops before SQLite deletion on the production graph path', async () => {
         test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
-        const originalGraphPath = aiConfig.storagePaths.graph;
+        const originalUseTestDatabase = aiConfig.storagePaths.useTestDatabase;
         try {
-            aiConfig.storagePaths.graph = path.join(repoRoot, '.neo-ai-data/sqlite/memory-core-graph.sqlite');
+            aiConfig.storagePaths.useTestDatabase = false;
 
             await expect(MemoryDatabaseService.truncateDatabase({
                 include: ['graph']
@@ -231,14 +238,17 @@ test.describe('DestructiveOperationGuard call-site wiring (#10845)', () => {
                 message: expect.stringContaining('DESTRUCTIVE_TARGET_BLOCKED')
             });
         } finally {
-            aiConfig.storagePaths.graph = originalGraphPath;
+            aiConfig.storagePaths.useTestDatabase = originalUseTestDatabase;
         }
     });
 
     test('Knowledge Base VectorService stops before deleting the production collection', async () => {
-        const originalClient = KbChromaManager.client;
-        let deleteCalls      = 0;
+        const
+            originalClient = KbChromaManager.client,
+            originalPath   = kbConfig.path;
+        let deleteCalls = 0;
 
+        kbConfig.path          = path.join(repoRoot, '.neo-ai-data/chroma/unified');
         KbChromaManager.client = {
             deleteCollection: async () => {
                 deleteCalls++;
@@ -252,6 +262,7 @@ test.describe('DestructiveOperationGuard call-site wiring (#10845)', () => {
             expect(deleteCalls).toBe(0);
         } finally {
             KbChromaManager.client = originalClient;
+            kbConfig.path          = originalPath;
         }
     });
 

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs
@@ -35,12 +35,12 @@ test.describe('Neo.ai.services.knowledge-base.SearchService model guard', () => 
         QueryService.queryDocuments    = originalQueryDocuments;
     });
 
-    test('ask returns the no-documents response before requiring a Gemini model', async () => {
+    test('ask returns the empty-collection response before requiring a Gemini model', async () => {
         SearchService.model         = null;
         QueryService.queryDocuments = async () => ({message: 'No results found for your query and type.'});
 
         await expect(SearchService.ask({query: 'How does KB work?'})).resolves.toEqual({
-            answer    : 'No relevant documents found in the knowledge base.',
+            answer    : "The knowledge base collection is empty. Populate it with the release artifact via 'npm run ai:download-kb' (or build locally with 'npm run ai:sync-kb').",
             references: []
         });
     });
@@ -52,11 +52,11 @@ test.describe('Neo.ai.services.knowledge-base.SearchService model guard', () => 
         });
 
         await expect(SearchService.ask({query: 'How does KB work?'})).resolves.toEqual({
-            answer    : 'Knowledge-base retrieval succeeded, but answer synthesis is currently unavailable (GEMINI_API_KEY is required for RAG features.). Use the references directly while the synthesis provider recovers.',
-            degraded  : true,
+            answer      : 'Knowledge-base retrieval succeeded, but answer synthesis is currently unavailable (GEMINI_API_KEY is required for RAG features.). Use the references directly while the synthesis provider recovers.',
+            degraded    : true,
             degradedCode: 'no_provider',
-            reason    : 'GEMINI_API_KEY is required for RAG features.',
-            references: [{
+            reason      : 'GEMINI_API_KEY is required for RAG features.',
+            references  : [{
                 name  : 'KnowledgeBase.md',
                 score : 100,
                 source: 'learn/agentos/KnowledgeBase.md'

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
@@ -7,23 +7,23 @@ setup({
         unitTestMode: true
     },
     appConfig: {
-        name: appName,
-        isMounted: () => true,
+        name             : appName,
+        isMounted        : () => true,
         vnodeInitialising: false
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
-import aiConfig       from '../../../../../../../ai/mcp/server/memory-core/config.mjs';
-import ChromaManager  from '../../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
+import {test, expect}                                     from '@playwright/test';
+import Neo                                                from '../../../../../../../src/Neo.mjs';
+import * as core                                          from '../../../../../../../src/core/_export.mjs';
+import InstanceManager                                    from '../../../../../../../src/manager/Instance.mjs';
+import aiConfig                                           from '../../../../../../../ai/mcp/server/memory-core/config.mjs';
+import ChromaManager                                      from '../../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
 import {CHROMA_PRODUCTION_DATABASE, CHROMA_TEST_DATABASE} from '../../../../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
-import logger         from '../../../../../../../ai/mcp/server/memory-core/logger.mjs';
-import StorageRouter  from '../../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
-import SystemLifecycleService from '../../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs';
-import {resetMemoryCoreLifecycle} from '../util.mjs';
+import logger                                             from '../../../../../../../ai/mcp/server/memory-core/logger.mjs';
+import StorageRouter                                      from '../../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
+import SystemLifecycleService                             from '../../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs';
+import {resetMemoryCoreLifecycle}                         from '../util.mjs';
 
 // Unit test mode resolves storagePaths.graph to ':memory:' by construction.
 
@@ -54,21 +54,26 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
         expect(resolved).toEqual({host: 'localhost', port: 8000, database: 'some-explicit-db'});
     });
 
-    test('under UNIT_TEST_MODE the Chroma database is isolated from production (#12335 AC1/AC2)', () => {
+    test('under UNIT_TEST_MODE Chroma uses an isolated daemon, data dir, and database (#14010)', () => {
         // The spec runs with unitTestMode:true, so the config leaf must resolve to the dedicated
-        // test database — never default_database — by construction. No crashed/npx-bypassed run can
-        // create collections in the production namespace because the client never points there.
+        // test coordinates by construction. No interrupted unit run can create collections in the
+        // live Chroma daemon because the client never points at its endpoint or persist dir.
         // The test-database toggle is ON (declaratively resolved from UNIT_TEST_MODE), so the resolver
         // selects the dedicated test database — never default_database — by construction. Both NAMES are
         // config literals; the toggle (not an env var the runner must remember to set) drives selection.
         expect(aiConfig.engines.chroma.useTestDatabase).toBe(true);
         expect(aiConfig.engines.chroma.databaseTest).toBe(CHROMA_TEST_DATABASE);
         expect(aiConfig.engines.chroma.database).toBe(CHROMA_PRODUCTION_DATABASE);
+        expect(aiConfig.engines.chroma.dataDir).toBe(aiConfig.engines.chroma.dataDirTest);
+        expect(aiConfig.engines.chroma.dataDir).not.toBe(aiConfig.engines.chroma.dataDirProd);
+        expect(aiConfig.engines.chroma.port).toBe(aiConfig.engines.chroma.portTest);
+        expect(aiConfig.engines.chroma.port).not.toBe(aiConfig.engines.chroma.portProd);
 
         // …and the resolver carries the isolated namespace (databaseTest) through to the client coordinates.
-        const {database} = ChromaManager.resolveChromaClientConfig(aiConfig);
+        const {database, port} = ChromaManager.resolveChromaClientConfig(aiConfig);
         expect(database).toBe(CHROMA_TEST_DATABASE);
         expect(database).not.toBe(CHROMA_PRODUCTION_DATABASE);
+        expect(port).toBe(aiConfig.engines.chroma.portTest);
     });
 
     test('the constructed ChromaClient targets the isolated test database', () => {
@@ -155,7 +160,7 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
 
     test('should prevent console.warn global state theft during concurrent collection fetching', async () => {
         // Set up a custom warn logger to inspect leaks
-        const warningLogs = [];
+        const warningLogs  = [];
         const originalWarn = console.warn;
         let originalClient;
 

--- a/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
@@ -3,7 +3,8 @@ import {
     CHROMA_PRODUCTION_DATABASE,
     CHROMA_TEST_DATABASE,
     dropChromaTestDatabase,
-    ensureChromaTestDatabase
+    ensureChromaTestDatabase,
+    isChromaAlreadyExistsError
 } from '../../../../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
 
 /**
@@ -20,7 +21,7 @@ test.describe('chromaTestIsolation helpers', () => {
     });
 
     test('ensureChromaTestDatabase is a no-op create when the database already exists', async () => {
-        const calls = [];
+        const calls       = [];
         const adminClient = {
             getDatabase   : async args => { calls.push(['get',    args]) },
             createDatabase: async args => { calls.push(['create', args]) }
@@ -33,7 +34,7 @@ test.describe('chromaTestIsolation helpers', () => {
     });
 
     test('ensureChromaTestDatabase creates the database when getDatabase rejects (not-found)', async () => {
-        const created = [];
+        const created     = [];
         const adminClient = {
             getDatabase   : async () => { throw new Error('database not found') },
             createDatabase: async args => { created.push(args) }
@@ -47,12 +48,41 @@ test.describe('chromaTestIsolation helpers', () => {
         expect(result).toBe(CHROMA_TEST_DATABASE);
     });
 
+    test('ensureChromaTestDatabase treats a concurrent already-exists create as success', async () => {
+        const calls       = [];
+        const adminClient = {
+            getDatabase   : async args => { calls.push(['get', args]); throw new Error('database not found') },
+            createDatabase: async args => {
+                calls.push(['create', args]);
+                const error = new Error('The resource already exists');
+                error.name = 'ChromaUniqueError';
+                throw error
+            }
+        };
+
+        const result = await ensureChromaTestDatabase({
+            database: CHROMA_TEST_DATABASE, tenant: 'default_tenant', adminClient
+        });
+
+        expect(calls.map(c => c[0])).toEqual(['get', 'create']);
+        expect(result).toBe(CHROMA_TEST_DATABASE);
+    });
+
+    test('isChromaAlreadyExistsError detects Chroma duplicate-create signatures', () => {
+        const named = new Error('The resource already exists');
+        named.name = 'ChromaUniqueError';
+
+        expect(isChromaAlreadyExistsError(named)).toBe(true);
+        expect(isChromaAlreadyExistsError(new Error('already exists'))).toBe(true);
+        expect(isChromaAlreadyExistsError(new Error('connection refused'))).toBe(false);
+    });
+
     test('ensureChromaTestDatabase rejects when database is missing', async () => {
         await expect(ensureChromaTestDatabase({adminClient: {}})).rejects.toThrow(/`database` is required/);
     });
 
     test('dropChromaTestDatabase drops the named test database', async () => {
-        const deleted = [];
+        const deleted     = [];
         const adminClient = {deleteDatabase: async args => { deleted.push(args) }};
 
         const result = await dropChromaTestDatabase({
@@ -64,7 +94,7 @@ test.describe('chromaTestIsolation helpers', () => {
     });
 
     test('dropChromaTestDatabase REFUSES to drop the production database', async () => {
-        const deleted = [];
+        const deleted     = [];
         const adminClient = {deleteDatabase: async args => { deleted.push(args) }};
 
         await expect(dropChromaTestDatabase({database: CHROMA_PRODUCTION_DATABASE, adminClient}))


### PR DESCRIPTION
Resolves #14010

Unit test Chroma traffic now routes to a Playwright-managed Chroma daemon with a temp data directory and test endpoint leaves, instead of the live unified daemon/store. Tier-1 Chroma config keeps production and unit-test coordinates as separate leaves and exposes active host/port/dataDir through formulas driven by `UNIT_TEST_MODE`. The Memory Core test database ensure path is also race-safe when parallel workers create the shared `neo-unit-test` database concurrently.

Evidence: L3 (real local `chroma run` daemon launched by Playwright unit webServer; Memory Core/KB/MCP boot slices connect through it) -> L3 required (unit tests must not touch the live Chroma daemon/store). No residuals.

## Deltas from ticket
The fix goes beyond database-name isolation: unit tests now get a separate Chroma process and separate persist directory. I also refreshed the local ignored `knowledge-base/config.mjs` overlay with `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` after the template grew new Chroma leaves; that migration is local/gitignored and not part of the commit.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs` -> 16 passed
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs` -> 40 passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs test/playwright/unit/ai/scripts/maintenance/purgeTestCollections.spec.mjs` -> 13 passed
- `npm run test-unit -- test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs` -> 9 passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/client/McpServersHealth.spec.mjs test/playwright/unit/ai/mcp/client/McpServersIsolation.spec.mjs test/playwright/unit/ai/mcp/Authorization.spec.mjs` -> 13 passed
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs test/playwright/unit/ai/scripts/maintenance/purgeTestCollections.spec.mjs` -> 55 passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs` -> 17 passed
- `git diff --check` -> passed
- `node --check ai/config.template.mjs` -> passed
- `node --check ai/services/shared/vector/chromaTestIsolation.mjs` -> passed
- `node --check test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs` -> passed
- `node --check test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs` -> passed
- `npm run agent-preflight -- --no-fix test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs` -> passed
- Pre-commit hook suite passed for commit `b54fb2d457`

Full suite note: `npm run test-unit` was attempted and interrupted after 4,731 passed. It exposed a stale local ignored `knowledge-base/config.mjs` overlay and a duplicate Chroma `createDatabase` race; both were fixed or migrated locally and revalidated with the focused MCP/config slices above. The interrupted full-suite output also contained unrelated/pre-existing failures, so I am not claiming full-suite green in this PR.

## Post-Merge Validation
- [ ] Run a fresh unit suite from a clean checkout after `npm prepare`/config migration and confirm Chroma writes land only in the Playwright-managed temp data dir, not the live unified store.
- [ ] After CI, inspect the Chroma unit webServer startup log for the temp `neo-chroma-unit-test-*` data path.

## Commit
- `b54fb2d457` - `fix(ai): isolate unit chroma daemon and data dir (#14010)`

Authored by Euclid (GPT-5, Codex Desktop). Session 9280140f-8b54-4462-9342-49cca7e226f4.
