### PR TITLE
fix(hooks): clarify operator-dialogue stop exits (#14034)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -49,7 +49,8 @@ import {buildDeferenceStopHookDirective,
         isOperatorInLoop,
         LANE_STATE_SCHEMA_HINT,
         parseOutcomeToVerdict,
-        scanHoldLexicon}           from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
+        scanHoldLexicon,
+        STOP_HOOK_TURN_OPTIONS_HINT} from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
 export {isOperatorInLoop, parseOutcomeToVerdict};
@@ -132,7 +133,7 @@ Declaring a lane is NOT driving it. Do the next concrete action NOW:
 Teeth-test: does this advance a NAMED lane right now? If you can't name the lane, it isn't driving.
 Collaboration (review · ideation · A2A) counts ONLY when it advances a named lane AND ends with a return to your own lane or an explicit lane-swap — it is an interruption, not a replacement for your own PRs.
 Passive waiting (a merge · a review · CI) is parked, not driven — take another lane.
-The only stop is a hard external limit: context-sunset, an operator halt, or a live operator reply.
+${STOP_HOOK_TURN_OPTIONS_HINT}
 
 ${LANE_STATE_SCHEMA_HINT}`;
 

--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -19,7 +19,8 @@ import {decideDeferenceStopHookAction,
         decideStopHookAction,
         isOperatorInLoop,
         LANE_STATE_SCHEMA_HINT,
-        parseOutcomeToVerdict}     from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
+        parseOutcomeToVerdict,
+        STOP_HOOK_TURN_OPTIONS_HINT} from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
 export const CODEX_STOP_BLOCK_INJECTION_SUPPORTED = true;
@@ -280,8 +281,15 @@ export function extractPromptingText(input = {}) {
  * @param {String} verdictReason
  * @returns {String}
  */
-export function buildNoHoldReminder(verdictReason) {
+export function buildNoHoldReminder(verdictReason, {promptSource = '', operatorInLoop = false} = {}) {
+    const promptDiagnostic = !operatorInLoop && promptSource === 'none'
+        ? '\nOperator prompt was not visible to this hook (promptSource=none), so live operator dialogue could not be confirmed.'
+        : '';
+
     return `No-hold reminder: ${verdictReason}. There is no hold state: continue concrete work on the active lane, perform an assigned review that advances a named lane, or pick a fresh claimable lane. Passive waiting is not a terminal.
+${promptDiagnostic}
+
+${STOP_HOOK_TURN_OPTIONS_HINT}
 
 ${LANE_STATE_SCHEMA_HINT}`;
 }
@@ -300,7 +308,8 @@ ${LANE_STATE_SCHEMA_HINT}`;
 export function decideCodexHookAction(verdict, {
     enforcing               = false,
     blockInjectionSupported = CODEX_STOP_BLOCK_INJECTION_SUPPORTED,
-    operatorInLoop          = false
+    operatorInLoop          = false,
+    promptSource            = ''
 } = {}) {
     const decision = decideStopHookAction(verdict, {
         enforcing,
@@ -310,9 +319,15 @@ export function decideCodexHookAction(verdict, {
     });
 
     if (decision.action === 'allow') return decision;
-    if (decision.action === 'block') return {action: 'block', reason: buildNoHoldReminder(decision.reason)};
+    if (decision.action === 'block') return {
+        action: 'block',
+        reason: buildNoHoldReminder(decision.reason, {operatorInLoop, promptSource})
+    };
 
-    return {action: 'would-block', reason: buildNoHoldReminder(decision.reason)};
+    return {
+        action: 'would-block',
+        reason: buildNoHoldReminder(decision.reason, {operatorInLoop, promptSource})
+    };
 }
 
 /**
@@ -338,10 +353,10 @@ export function summarizePayloadShape(payload = {}) {
  * @returns {{action: ('allow'|'block'|'would-block'), reason: String, source: String, promptSource: String, verdict: Object, phrase: (String|undefined)}}
  */
 export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
-    const stopHookActive                            = !!(input.stop_hook_active || input.stopHookActive),
-          {text, source}                            = extractFinalAssistantText(input),
+    const stopHookActive                              = !!(input.stop_hook_active || input.stopHookActive),
+          {text, source}                              = extractFinalAssistantText(input),
           {text: promptingText, source: promptSource} = extractPromptingText(input),
-          operatorInLoop                            = isOperatorInLoop({stopHookActive, promptingText});
+          operatorInLoop                              = isOperatorInLoop({stopHookActive, promptingText});
 
     // Deference-register check: shared decision, adapter-owned payload/source metadata.
     const deferenceDecision = decideDeferenceStopHookAction(text, {operatorInLoop, enforcing});
@@ -350,6 +365,7 @@ export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
             ...deferenceDecision,
             source,
             promptSource,
+            operatorInLoop,
             verdict: null
         };
     }
@@ -364,7 +380,8 @@ export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
     const verdict = parseOutcomeToVerdict({descriptor, parseError}, validateLaneStateTerminal);
 
     return {
-        ...decideCodexHookAction(verdict, {enforcing, operatorInLoop}),
+        ...decideCodexHookAction(verdict, {enforcing, operatorInLoop, promptSource}),
+        operatorInLoop,
         source,
         promptSource,
         verdict
@@ -401,14 +418,14 @@ async function main() {
     const session = input.session_id || input.sessionId || '?';
 
     if (result.action === 'block') {
-        auditLog(`BLOCK (session=${session}, source=${result.source}): ${result.reason}`);
+        auditLog(`BLOCK (session=${session}, source=${result.source}, promptSource=${result.promptSource}, operatorInLoop=${result.operatorInLoop}): ${result.reason}`);
         process.stdout.write(JSON.stringify({decision: 'block', reason: result.reason}), () => process.exit(0));
         return;
     }
 
     const prefix = result.action === 'allow' ? 'ALLOW' : 'WOULD-BLOCK';
 
-    auditLog(`${prefix} (session=${session}, source=${result.source}): ${result.reason}`);
+    auditLog(`${prefix} (session=${session}, source=${result.source}, promptSource=${result.promptSource}, operatorInLoop=${result.operatorInLoop}): ${result.reason}`);
     process.exit(0);
 }
 

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -20,6 +20,12 @@ export const LANE_STATE_SCHEMA_HINT = `Machine lane-state block to emit with you
 Validator gotchas: if an own PR is only awaiting merge/review/CI, use laneContinuation "next-lane"; "active-lane" + awaitingOwnPrOnly:true is invalid. Every namedGates[] entry needs a same-turn checkedAt; mergeClaim must use field "mergedAt".`;
 
 /**
+ * @summary Compact cross-harness turn-end options hint for Stop-hook injections.
+ * @type {String}
+ */
+export const STOP_HOOK_TURN_OPTIONS_HINT = `Turn-end options: live operator dialogue/planning may stop only when the hook can confirm the operator prompt. Autonomous [WAKE]/stop-hook continuations must drive a named lane and emit lane-state. Before any stop, save one concise turn memory under 24KB. Missing prompt fails closed as autonomous.`;
+
+/**
  * @summary Pure mapping of a parse OUTCOME to a terminal verdict — the 3-bucket chain. A malformed
  * emission (parseLaneState threw) and an absent emission (null) are distinct idle-out failures from an
  * invalid descriptor, each with its own reason; a parsed descriptor is delegated to `validate`.

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -49,6 +49,19 @@ test.describe('codex-lane-state-stop - contract boundary', () => {
         expect(reason).toContain('No-hold reminder');
         expect(reason).toContain('pick a fresh claimable lane');
         expect(reason).toContain('Passive waiting is not a terminal');
+        expect(reason).toContain('operator dialogue/planning');
+        expect(reason).toContain('under 24KB');
+        expect(reason).toContain('Missing prompt fails closed');
+    });
+
+    test('the no-hold reminder explains when Codex cannot confirm operator dialogue', () => {
+        const reason = buildNoHoldReminder('no lane-state block emitted at turn-terminal', {
+            promptSource  : 'none',
+            operatorInLoop: false
+        });
+
+        expect(reason).toContain('promptSource=none');
+        expect(reason).toContain('live operator dialogue could not be confirmed');
     });
 
     test('the no-hold reminder shows the fenced lane-state JSON schema', () => {
@@ -143,8 +156,10 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
         expect(result.action).toBe('would-block');
         expect(result.reason).toContain('valid lane-state terminal');
         expect(result.reason).toContain('No-hold reminder');
+        expect(result.reason).toContain('promptSource=none');
         expect(result.source).toBe('last_assistant_message');
         expect(result.promptSource).toBe('none');
+        expect(result.operatorInLoop).toBe(false);
     });
 
     test('live operator prompt is the only valid voluntary allow', () => {
@@ -159,6 +174,7 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
         expect(result.reason).toContain('live operator dialogue');
         expect(result.source).toBe('messages');
         expect(result.promptSource).toBe('messages');
+        expect(result.operatorInLoop).toBe(true);
     });
 
     test('[WAKE] prompt is autonomous, so a valid terminal still would-blocks', () => {
@@ -172,6 +188,7 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
         expect(result.action).toBe('would-block');
         expect(result.reason).toContain('valid lane-state terminal');
         expect(result.promptSource).toBe('messages');
+        expect(result.operatorInLoop).toBe(false);
     });
 
     test('absent lane-state would-block with no-hold reminder', () => {
@@ -183,6 +200,7 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
         expect(result.action).toBe('would-block');
         expect(result.reason).toContain('no lane-state block emitted');
         expect(result.reason).toContain('No-hold reminder');
+        expect(result.reason).toContain('promptSource=none');
     });
 
     test('malformed lane-state is distinct from absent', () => {
@@ -208,6 +226,7 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
         expect(result.reason).toContain('valid lane-state terminal');
         expect(result.source).toBe('messages');
         expect(result.promptSource).toBe('messages');
+        expect(result.operatorInLoop).toBe(false);
     });
 });
 
@@ -295,6 +314,8 @@ test.describe('codex-lane-state-stop - spawned hook', () => {
         expect(stdout).toBe('');
         expect(log).toContain('WOULD-BLOCK');
         expect(log).toContain('source=last_assistant_message');
+        expect(log).toContain('promptSource=none');
+        expect(log).toContain('operatorInLoop=false');
         expect(log).toContain('valid lane-state terminal');
     });
 
@@ -310,6 +331,8 @@ test.describe('codex-lane-state-stop - spawned hook', () => {
         expect(stdout).toBe('');
         expect(log).toContain('ALLOW');
         expect(log).toContain('source=messages');
+        expect(log).toContain('promptSource=messages');
+        expect(log).toContain('operatorInLoop=true');
     });
 
     test('enforced invalid terminal logs BLOCK and writes the block decision to stdout', async () => {
@@ -320,6 +343,8 @@ test.describe('codex-lane-state-stop - spawned hook', () => {
 
         expect(JSON.parse(stdout).decision).toBe('block');
         expect(log).toContain('BLOCK');
+        expect(log).toContain('promptSource=none');
+        expect(log).toContain('operatorInLoop=false');
         expect(log).toContain('Unknown laneContinuation');
     });
 

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -98,6 +98,9 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
             expect(directive).toContain('there is no hold state');
             expect(directive).toContain('advance a NAMED lane');
             expect(directive).toContain('Passive waiting');
+            expect(directive).toContain('operator dialogue/planning');
+            expect(directive).toContain('under 24KB');
+            expect(directive).toContain('Missing prompt fails closed');
             expect(directive).toContain('no lane-state block emitted at turn-terminal');
         });
 
@@ -279,8 +282,8 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
 
             if (enforce) env.NEO_LANE_STATE_ENFORCE = '1';
 
-            const proc = spawn('node', ['.claude/hooks/laneStateStopHook.mjs'], {stdio: ['pipe', 'pipe', 'pipe'], env});
-            let stdout = '';
+            const proc   = spawn('node', ['.claude/hooks/laneStateStopHook.mjs'], {stdio: ['pipe', 'pipe', 'pipe'], env});
+            let   stdout = '';
 
             proc.stdout.on('data', chunk => stdout += chunk);
             proc.on('error', reject);

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -6,7 +6,8 @@ import {
     isOperatorInLoop,
     LANE_STATE_SCHEMA_HINT,
     parseOutcomeToVerdict,
-    scanHoldLexicon
+    scanHoldLexicon,
+    STOP_HOOK_TURN_OPTIONS_HINT
 }                        from '../../../../ai/scripts/lifecycle/stopHookDecision.mjs';
 
 /**
@@ -26,6 +27,14 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
         expect(LANE_STATE_SCHEMA_HINT).toContain('awaitingOwnPrOnly:true is invalid');
         expect(LANE_STATE_SCHEMA_HINT).toContain('same-turn checkedAt');
         expect(LANE_STATE_SCHEMA_HINT).toContain('field "mergedAt"');
+    });
+
+    test('STOP_HOOK_TURN_OPTIONS_HINT: compactly names operator dialogue, memory, and fail-closed behavior', () => {
+        expect(STOP_HOOK_TURN_OPTIONS_HINT).toContain('operator dialogue/planning');
+        expect(STOP_HOOK_TURN_OPTIONS_HINT).toContain('[WAKE]/stop-hook continuations');
+        expect(STOP_HOOK_TURN_OPTIONS_HINT).toContain('under 24KB');
+        expect(STOP_HOOK_TURN_OPTIONS_HINT).toContain('Missing prompt fails closed');
+        expect(STOP_HOOK_TURN_OPTIONS_HINT.length).toBeLessThanOrEqual(320);
     });
 
     // ── parseOutcomeToVerdict: the 3-bucket parse → verdict chain ──────────────────────────────


### PR DESCRIPTION
Resolves #14034

This clarifies the shared Stop-hook turn-end contract for Claude and Codex: live operator dialogue/planning is a valid voluntary stop only when the hook can externally confirm the prompting operator text; autonomous wakes and stop-hook continuations stay no-hold. The shared hint now tells peers to keep turn memory concise under 24KB, and Codex block/would-block logs now surface `promptSource` and `operatorInLoop` so a missing Codex prompt is diagnosable instead of looking like operator dialogue was ignored.

Evidence: L2 focused unit + spawned-hook coverage -> L2 required for hook contract changes. Residual: live Codex payload visibility remains harness-dependent; this PR adds diagnostics when the prompt source is absent.

## Deltas from ticket
Codex also now includes an explicit `promptSource=none` reminder when live operator dialogue cannot be confirmed, and the audit log records `promptSource`/`operatorInLoop` for BLOCK/ALLOW/WOULD-BLOCK.

## Test Evidence
- `npm run agent-preflight -- .codex/hooks/codex-lane-state-stop.mjs .claude/hooks/laneStateStopHook.mjs ai/scripts/lifecycle/stopHookDecision.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs test/playwright/unit/hooks/stopHookDecision.spec.mjs` passed after escalated rerun for `.codex` alignment.
- `npm run test-unit -- test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs` passed, 93 tests, before and after rebase.

## Post-Merge Validation
- [ ] Trigger a live Codex operator-dialogue stop and verify the audit log reports a confirmable prompt source plus `operatorInLoop=true`.
- [ ] Trigger an autonomous `[WAKE]` / missing-prompt stop and verify the injected reminder includes the compact options hint.

## Commit
- `e48955c6ab` — `fix(hooks): clarify operator-dialogue stop exits (#14034)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019efe4c-5d55-76c0-aba5-665f86d9cbdc.