### PR TITLE
feat(ai): backup-corruption timeline diagnostic (#14024)

### DIFF
--- a/ai/scripts/maintenance/backupCorruptionTimeline.mjs
+++ b/ai/scripts/maintenance/backupCorruptionTimeline.mjs
@@ -5,20 +5,27 @@ import {fileURLToPath, pathToFileURL} from 'url';
 import Neo                            from '../../../src/Neo.mjs';
 
 /**
- * @summary Read-only backup-corruption timeline diagnostic.
+ * @summary Read-only backup-corruption timeline diagnostic — artifact-verified, not manifest-trusted.
  *
- * Walks `.neo-ai-data/backups/backup-*&#47;bundle-meta.json`, extracts each backup's fail-loud
- * per-collection export counts, and reports a chronological coverage timeline plus the
- * corruption-onset window — the transition from the last clean export to the first failed export
- * (a failed/partial export leaves no `bundle-meta.json`), and any monotonicity regression (an
- * append-mostly collection's count dropping between consecutive clean backups = data loss).
+ * Walks `.neo-ai-data/backups/backup-*&#47;`, and for each backup compares the `bundle-meta.json`
+ * CLAIM (per-subsystem export counts) against the actual exported JSONL ARTIFACT (its byte size).
+ * A manifest is treated as ONE signal, never as proof of a recoverable backup: a backup whose
+ * manifest claims `N > 0` records while the matching artifact is 0 bytes / missing is classified
+ * `manifest-false-green`, NOT `clean`. The output exposes both the manifest count and the artifact
+ * byte size so the operator sees any disagreement. It NEVER contacts the live Chroma daemon or
+ * mutates anything — backups only.
  *
- * This is a HISTORICAL/forensic complement to `checkChromaIntegrity.mjs` (the live-store probe):
- * it dates *when* a corruption first appeared from the backup series, instead of only reporting
- * current coverage. It NEVER contacts the live Chroma daemon or mutates anything — backups only.
+ * Why byte-size, not row-count: artifacts reach multiple GB (the KB JSONL is ~1.6GB), so reading
+ * them to count rows is infeasible; and the JSONL is not reliably one-record-per-line (a summaries
+ * artifact had 103 newlines for 5.6MB). `stat` byte-size is O(1), scalable, and unambiguous for the
+ * empty-artifact false-green this incident produced. A non-empty artifact is reported as
+ * artifact-present (`clean`); strict per-record parity is out of scope here.
  *
- * Empirically: this walk pinned the Memory Core vector-loss incident to 2026-06-18→06-20 (the last
- * clean MC export was 18,835 memories on 06-18; the 06-20 backup was the first failed export).
+ * Empirically: every retained Memory Core MEMORY artifact (`mc/memory-backup-*.jsonl`) is 0 bytes
+ * from 2026-05-27 through 2026-06-18 despite manifests claiming 14,520→18,835 memories — i.e. there
+ * is NO artifact-verified-clean MC-memory backup in the retained series; the manifests are
+ * false-green. The first manifest-absent backup (06-20) marks when fail-loud export landed, NOT the
+ * corruption onset.
  *
  * Usage:
  *   node ai/scripts/maintenance/backupCorruptionTimeline.mjs
@@ -28,7 +35,6 @@ import Neo                            from '../../../src/Neo.mjs';
  * @module ai.scripts.maintenance.backupCorruptionTimeline
  * @see ai/scripts/maintenance/checkChromaIntegrity.mjs
  * @see learn/agentos/tooling/RestorationRunbook.md
- * @see https://github.com/neomjs/neo/issues/14024
  */
 void Neo;
 
@@ -42,13 +48,26 @@ const neoRootDir = path.resolve(__dirname, '../../../');
 export const DEFAULT_BACKUPS_DIR = path.resolve(neoRootDir, '.neo-ai-data/backups');
 
 /**
- * @summary Parses a backup `bundle-meta.json` into per-collection export counts.
+ * @summary Per-subsystem artifact specs: which backup subdir + filename prefix holds the JSONL whose
+ * presence verifies the manifest claim. `manifestCount` maps the spec to its `extractBackupCounts` value.
+ * @type {Array<{key: String, subdir: String, prefix: String, manifestCount: Function, label: String}>}
+ */
+export const ARTIFACT_SPECS = [
+    {key: 'mcMemory',    subdir: 'mc',    prefix: 'memory-backup-',         label: 'MC memories',  manifestCount: c => c?.mc?.memories},
+    {key: 'mcSummaries', subdir: 'mc',    prefix: 'summaries-backup-',      label: 'MC summaries', manifestCount: c => c?.mc?.summaries},
+    {key: 'kb',          subdir: 'kb',    prefix: 'knowledge-base-backup-', label: 'KB chunks',    manifestCount: c => c?.kb?.chunks},
+    {key: 'graph',       subdir: 'graph', prefix: 'graph-backup-',          label: 'graph',        manifestCount: c => c?.graph?.elements}
+];
+
+/**
+ * @summary Parses a backup `bundle-meta.json` into per-collection export counts (the CLAIM only).
  *
- * A successful backup carries a fail-loud export message per subsystem; an absent/partial manifest
- * (a failed export never completes the bundle) yields `null` — itself the corruption signal.
+ * The manifest is one signal; its count is NOT proof of a recoverable artifact (pre-fail-loud
+ * exports logged success by source count while writing a 0-byte artifact). Verification happens in
+ * {@link classifyBackup} against the artifact byte size.
  *
  * @param {Object|null} meta Parsed `bundle-meta.json`, or null when the manifest is missing.
- * @returns {Object|null} `{mc, kb, graph, completedAt, gitSha}` (each collection `null` when unparsable), or `null` when `meta` is absent/shapeless.
+ * @returns {Object|null} `{mc, kb, graph, completedAt, gitSha}`, or `null` when `meta` is absent/shapeless.
  */
 export function extractBackupCounts(meta) {
     if (!meta || typeof meta !== 'object' || !meta.subsystems) {
@@ -70,68 +89,145 @@ export function extractBackupCounts(meta) {
 }
 
 /**
- * @summary Builds a chronologically-sorted coverage timeline from backup entries.
+ * @summary Stats the exported artifact byte sizes for one backup dir (one per {@link ARTIFACT_SPECS}).
  *
- * @param {Array<{timestamp: String, meta: (Object|null)}>} entries One per backup dir.
- * @returns {Array<{timestamp: String, status: ('clean'|'export-failed'), counts: (Object|null)}>}
+ * @param {Object} options
+ * @param {String} options.backupDir   Absolute path to the `backup-<ISO>` dir.
+ * @param {Object} [options.fsModule=fs] Filesystem seam (test injection: `readdir`, `stat`, `pathExists`).
+ * @returns {Promise<Object>} `{[key]: (Number|null)}` — artifact byte size, or `null` when missing.
+ */
+export async function readArtifactSizes({backupDir, fsModule = fs} = {}) {
+    const sizes = {};
+
+    for (const spec of ARTIFACT_SPECS) {
+        const subdir = path.join(backupDir, spec.subdir);
+        let   bytes  = null;
+
+        if (await fsModule.pathExists(subdir)) {
+            const file = (await fsModule.readdir(subdir)).find(name => name.startsWith(spec.prefix) && name.endsWith('.jsonl'));
+
+            if (file) {
+                bytes = (await fsModule.stat(path.join(subdir, file))).size
+            }
+        }
+
+        sizes[spec.key] = bytes
+    }
+
+    return sizes
+}
+
+/**
+ * @summary Classifies one backup by comparing each subsystem's manifest claim to its artifact bytes.
+ *
+ * Per subsystem: `verified` (claim > 0 AND artifact bytes > 0), `false-green` (claim > 0 AND artifact
+ * 0-bytes/missing), `no-claim` (manifest present, no count), `no-manifest` (no manifest at all). The
+ * overall row status is the headline MC-memory verdict, since the recoverability question is
+ * MC-memory-centric (the live incident's axis); per-subsystem detail is preserved.
+ *
+ * @param {Object}      options
+ * @param {Object|null} options.counts    From {@link extractBackupCounts}.
+ * @param {Object}      options.artifacts From {@link readArtifactSizes}.
+ * @returns {{status: String, subsystems: Object}}
+ */
+export function classifyBackup({counts, artifacts = {}} = {}) {
+    const subsystems = {};
+
+    for (const spec of ARTIFACT_SPECS) {
+        const claim = counts ? spec.manifestCount(counts) : null,
+              bytes = artifacts[spec.key] ?? null;
+        let   verdict;
+
+        if (!counts) {
+            verdict = 'no-manifest'
+        } else if (claim == null) {
+            verdict = 'no-claim'
+        } else if (claim > 0 && (bytes == null || bytes === 0)) {
+            verdict = 'false-green'
+        } else if (claim > 0 && bytes > 0) {
+            verdict = 'verified'
+        } else {
+            verdict = 'empty-claim' // claim === 0
+        }
+
+        subsystems[spec.key] = {claim, bytes, verdict}
+    }
+
+    const mc     = subsystems.mcMemory.verdict;
+    const status = !counts ? 'export-failed'
+        : mc === 'false-green' ? 'manifest-false-green'
+        : mc === 'verified'    ? 'clean'
+        : 'no-mc-claim';
+
+    return {status, subsystems}
+}
+
+/**
+ * @summary Builds a chronologically-sorted, artifact-verified coverage timeline.
+ *
+ * @param {Array<{timestamp: String, meta: (Object|null), artifacts: Object}>} entries One per backup dir.
+ * @returns {Array<{timestamp: String, status: String, counts: (Object|null), subsystems: Object}>}
  */
 export function buildCoverageTimeline(entries = []) {
     return [...entries]
         .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
         .map(entry => {
-            const counts = extractBackupCounts(entry.meta);
+            const counts               = extractBackupCounts(entry.meta),
+                  {status, subsystems} = classifyBackup({counts, artifacts: entry.artifacts || {}});
 
-            return {
-                timestamp: entry.timestamp,
-                status   : counts ? 'clean' : 'export-failed',
-                counts
-            }
+            return {timestamp: entry.timestamp, status, counts, subsystems}
         })
 }
 
 /**
- * @summary Detects the corruption-onset window for one collection's count series.
+ * @summary Per-subsystem analysis over the verified timeline.
  *
- * Two independent signals: (1) the first `clean → export-failed` transition (the export stopped
- * completing); (2) a count DROP between consecutive clean backups — append-mostly collections
- * (Memory Core memories/sessions) should be monotonic, so a decrease is itself data loss.
+ * Reports verified-clean vs false-green counts, the last artifact-verified-clean backup, the
+ * false-green span (first→last manifest-claimed-but-empty), and the first manifest-absent backup.
+ * A subsystem with zero verified-clean backups has NO recoverable retained backup.
  *
- * @param {Array<Object>} timeline Rows from {@link buildCoverageTimeline}.
- * @param {Function}      countOf  `(row) => Number|null|undefined` — the collection's count from a row.
- * @returns {{onsetWindow: ({lastClean: String, firstDegraded: String}|null), drop: ({from: Number, to: Number, fromAt: String, at: String}|null)}}
+ * @param {Array<Object>} timeline From {@link buildCoverageTimeline}.
+ * @param {String}        specKey  An {@link ARTIFACT_SPECS} `key`.
+ * @returns {Object}
  */
-export function detectCorruptionOnset(timeline = [], countOf) {
-    let lastClean = null, onsetWindow = null, drop = null, prevCount = null, prevTs = null;
+export function analyzeSubsystem(timeline = [], specKey) {
+    let verifiedClean     = 0, falseGreen = 0, manifestAbsent = 0,
+        lastVerifiedClean = null, firstFalseGreen = null, lastFalseGreen = null, firstManifestAbsent = null;
 
     for (const row of timeline) {
-        const count = row.status === 'clean' ? countOf(row) : null;
+        const v = row.subsystems?.[specKey]?.verdict;
 
-        if (count == null) {
-            if (lastClean && !onsetWindow) {
-                onsetWindow = {lastClean, firstDegraded: row.timestamp}
-            }
-            continue
+        if (v === 'verified') {
+            verifiedClean++;
+            lastVerifiedClean = row.timestamp
+        } else if (v === 'false-green') {
+            falseGreen++;
+            firstFalseGreen ??= row.timestamp;
+            lastFalseGreen = row.timestamp
+        } else if (v === 'no-manifest') {
+            manifestAbsent++;
+            firstManifestAbsent ??= row.timestamp
         }
-
-        if (prevCount != null && count < prevCount && !drop) {
-            drop = {from: prevCount, to: count, fromAt: prevTs, at: row.timestamp}
-        }
-
-        lastClean = row.timestamp;
-        prevCount = count;
-        prevTs    = row.timestamp
     }
 
-    return {onsetWindow, drop}
+    return {
+        verifiedClean,
+        falseGreen,
+        manifestAbsent,
+        lastVerifiedClean,
+        falseGreenSpan     : firstFalseGreen ? {from: firstFalseGreen, to: lastFalseGreen} : null,
+        firstManifestAbsent,
+        noRecoverableBackup: verifiedClean === 0
+    }
 }
 
 /**
- * @summary Reads every `backup-*&#47;bundle-meta.json` under the backups dir into timeline entries.
+ * @summary Reads each backup dir's manifest + artifact sizes into timeline entries.
  *
  * @param {Object}   options
  * @param {String}   options.backupsDir   Directory holding `backup-<ISO>` snapshot dirs.
  * @param {Object}   [options.fsModule=fs] Filesystem seam (test injection).
- * @returns {Promise<Array<{timestamp: String, meta: (Object|null)}>>}
+ * @returns {Promise<Array<{timestamp: String, meta: (Object|null), artifacts: Object}>>}
  */
 export async function readBackupEntries({backupsDir, fsModule = fs} = {}) {
     if (!backupsDir || !await fsModule.pathExists(backupsDir)) {
@@ -142,8 +238,9 @@ export async function readBackupEntries({backupsDir, fsModule = fs} = {}) {
           entries = [];
 
     for (const dir of dirs) {
-        const metaPath = path.join(backupsDir, dir, 'bundle-meta.json');
-        let   meta     = null;
+        const backupDir = path.join(backupsDir, dir),
+              metaPath  = path.join(backupDir, 'bundle-meta.json');
+        let meta = null;
 
         if (await fsModule.pathExists(metaPath)) {
             try {
@@ -153,7 +250,9 @@ export async function readBackupEntries({backupsDir, fsModule = fs} = {}) {
             }
         }
 
-        entries.push({timestamp: dir.replace(/^backup-/, ''), meta})
+        const artifacts = await readArtifactSizes({backupDir, fsModule});
+
+        entries.push({timestamp: dir.replace(/^backup-/, ''), meta, artifacts})
     }
 
     return entries
@@ -161,57 +260,67 @@ export async function readBackupEntries({backupsDir, fsModule = fs} = {}) {
 
 /**
  * @summary Assembles the full report object (pure; the CLI renders or JSON-prints it).
- * @param {Array<Object>} timeline Rows from {@link buildCoverageTimeline}.
+ * @param {Array<Object>} timeline From {@link buildCoverageTimeline}.
  * @param {String}        backupsDir
  * @returns {Object}
  */
 export function buildReport(timeline, backupsDir) {
+    const perSubsystem = {};
+
+    for (const spec of ARTIFACT_SPECS) {
+        perSubsystem[spec.key] = analyzeSubsystem(timeline, spec.key)
+    }
+
     return {
         backupsDir,
-        totalBackups: timeline.length,
-        cleanBackups: timeline.filter(r => r.status === 'clean').length,
-        onset       : {
-            mc   : detectCorruptionOnset(timeline, r => r.counts?.mc?.memories),
-            kb   : detectCorruptionOnset(timeline, r => r.counts?.kb?.chunks),
-            graph: detectCorruptionOnset(timeline, r => r.counts?.graph?.elements)
-        },
+        totalBackups         : timeline.length,
+        artifactVerifiedClean: timeline.filter(r => r.status === 'clean').length,
+        manifestFalseGreen   : timeline.filter(r => r.status === 'manifest-false-green').length,
+        exportFailed         : timeline.filter(r => r.status === 'export-failed').length,
+        perSubsystem,
         timeline
     }
 }
 
 /**
- * @summary Renders the report as a human-readable table + onset summary.
+ * @summary Renders the report as a human table (manifest claim vs artifact bytes) + per-subsystem verdict.
  * @param {Object} report From {@link buildReport}.
  * @returns {String}
  */
 export function formatReport(report) {
     const lines = [
-        `Backup-corruption timeline — ${report.backupsDir}`,
-        `${report.totalBackups} backups (${report.cleanBackups} clean, ${report.totalBackups - report.cleanBackups} export-failed)`,
+        `Backup-corruption timeline (artifact-verified) — ${report.backupsDir}`,
+        `${report.totalBackups} backups: ${report.artifactVerifiedClean} artifact-verified-clean, ${report.manifestFalseGreen} manifest-false-green, ${report.exportFailed} export-failed`,
         '',
-        'DATE                     | STATUS        | MC mem | KB chunks | graph',
-        '-------------------------|---------------|--------|-----------|------'
+        'DATE                     | STATUS               | MC mem claim → bytes',
+        '-------------------------|----------------------|---------------------'
     ];
 
     for (const row of report.timeline) {
-        const mc    = row.counts?.mc?.memories ?? '—',
-              kb    = row.counts?.kb?.chunks   ?? '—',
-              graph = row.counts?.graph?.elements ?? '—';
+        const mc    = row.subsystems?.mcMemory,
+              claim = mc?.claim ?? '—',
+              bytes = mc?.bytes == null ? '—' : mc.bytes;
 
-        lines.push(`${row.timestamp.padEnd(24)} | ${row.status.padEnd(13)} | ${String(mc).padStart(6)} | ${String(kb).padStart(9)} | ${graph}`)
+        lines.push(`${row.timestamp.padEnd(24)} | ${row.status.padEnd(20)} | ${String(claim).padStart(7)} → ${bytes}`)
     }
 
     lines.push('');
 
-    for (const [name, {onsetWindow, drop}] of Object.entries(report.onset)) {
-        if (onsetWindow) {
-            lines.push(`⚠️  ${name}: corruption onset window ${onsetWindow.lastClean} (last clean) → ${onsetWindow.firstDegraded} (first export-failed)`)
+    for (const spec of ARTIFACT_SPECS) {
+        const a = report.perSubsystem[spec.key];
+
+        if (a.noRecoverableBackup && a.falseGreen > 0) {
+            lines.push(`⛔ ${spec.label}: NO artifact-verified-clean backup retained — ${a.falseGreen} manifest-false-green (claim>0, 0-byte artifact)${a.falseGreenSpan ? ` spanning ${a.falseGreenSpan.from} → ${a.falseGreenSpan.to}` : ''}. Backup-based recovery is NOT possible from the retained series.`)
+        } else if (a.falseGreen > 0) {
+            lines.push(`⚠️  ${spec.label}: ${a.verifiedClean} verified-clean, ${a.falseGreen} false-green; last verified-clean ${a.lastVerifiedClean || 'none'}.`)
+        } else if (a.verifiedClean > 0) {
+            lines.push(`✅ ${spec.label}: ${a.verifiedClean} artifact-verified-clean; last ${a.lastVerifiedClean}.`)
+        } else {
+            lines.push(`• ${spec.label}: no manifest claims in the retained series.`)
         }
-        if (drop) {
-            lines.push(`⚠️  ${name}: count regression ${drop.from} → ${drop.to} between ${drop.fromAt} and ${drop.at} (append-mostly collection should not shrink)`)
-        }
-        if (!onsetWindow && !drop) {
-            lines.push(`✅ ${name}: no onset window or regression detected across the backup series`)
+
+        if (a.firstManifestAbsent) {
+            lines.push(`   (first manifest-absent backup ${a.firstManifestAbsent} = when fail-loud export landed, not necessarily the corruption onset.)`)
         }
     }
 

--- a/ai/scripts/maintenance/backupCorruptionTimeline.mjs
+++ b/ai/scripts/maintenance/backupCorruptionTimeline.mjs
@@ -1,0 +1,237 @@
+import {program}                      from 'commander';
+import fs                             from 'fs-extra';
+import path                           from 'path';
+import {fileURLToPath, pathToFileURL} from 'url';
+import Neo                            from '../../../src/Neo.mjs';
+
+/**
+ * @summary Read-only backup-corruption timeline diagnostic.
+ *
+ * Walks `.neo-ai-data/backups/backup-*&#47;bundle-meta.json`, extracts each backup's fail-loud
+ * per-collection export counts, and reports a chronological coverage timeline plus the
+ * corruption-onset window — the transition from the last clean export to the first failed export
+ * (a failed/partial export leaves no `bundle-meta.json`), and any monotonicity regression (an
+ * append-mostly collection's count dropping between consecutive clean backups = data loss).
+ *
+ * This is a HISTORICAL/forensic complement to `checkChromaIntegrity.mjs` (the live-store probe):
+ * it dates *when* a corruption first appeared from the backup series, instead of only reporting
+ * current coverage. It NEVER contacts the live Chroma daemon or mutates anything — backups only.
+ *
+ * Empirically: this walk pinned the Memory Core vector-loss incident to 2026-06-18→06-20 (the last
+ * clean MC export was 18,835 memories on 06-18; the 06-20 backup was the first failed export).
+ *
+ * Usage:
+ *   node ai/scripts/maintenance/backupCorruptionTimeline.mjs
+ *   node ai/scripts/maintenance/backupCorruptionTimeline.mjs --json
+ *   node ai/scripts/maintenance/backupCorruptionTimeline.mjs --backups /path/to/backups
+ *
+ * @module ai.scripts.maintenance.backupCorruptionTimeline
+ * @see ai/scripts/maintenance/checkChromaIntegrity.mjs
+ * @see learn/agentos/tooling/RestorationRunbook.md
+ * @see https://github.com/neomjs/neo/issues/14024
+ */
+void Neo;
+
+const __dirname  = path.dirname(fileURLToPath(import.meta.url));
+const neoRootDir = path.resolve(__dirname, '../../../');
+
+/**
+ * @summary Default backups directory (the layout `backup.mjs` writes; verified during live-store triage).
+ * @type {String}
+ */
+export const DEFAULT_BACKUPS_DIR = path.resolve(neoRootDir, '.neo-ai-data/backups');
+
+/**
+ * @summary Parses a backup `bundle-meta.json` into per-collection export counts.
+ *
+ * A successful backup carries a fail-loud export message per subsystem; an absent/partial manifest
+ * (a failed export never completes the bundle) yields `null` — itself the corruption signal.
+ *
+ * @param {Object|null} meta Parsed `bundle-meta.json`, or null when the manifest is missing.
+ * @returns {Object|null} `{mc, kb, graph, completedAt, gitSha}` (each collection `null` when unparsable), or `null` when `meta` is absent/shapeless.
+ */
+export function extractBackupCounts(meta) {
+    if (!meta || typeof meta !== 'object' || !meta.subsystems) {
+        return null
+    }
+
+    const s          = meta.subsystems,
+          mcMatch    = /Exported\s+(\d+)\s+memories(?:,\s+(\d+)\s+summaries)?/.exec(s.mc?.message || ''),
+          kbMatch    = /Exported\s+(\d+)\s+knowledge base chunks/.exec(s.kb?.message || ''),
+          graphMatch = /(\d+)\s+graph elements/.exec(s.graph?.message || '');
+
+    return {
+        mc         : mcMatch    ? {memories: Number(mcMatch[1]), summaries: mcMatch[2] ? Number(mcMatch[2]) : null} : null,
+        kb         : kbMatch     ? {chunks: Number(kbMatch[1])} : null,
+        graph      : graphMatch  ? {elements: Number(graphMatch[1])} : null,
+        completedAt: meta.completedAt || null,
+        gitSha     : meta.gitSha     || null
+    }
+}
+
+/**
+ * @summary Builds a chronologically-sorted coverage timeline from backup entries.
+ *
+ * @param {Array<{timestamp: String, meta: (Object|null)}>} entries One per backup dir.
+ * @returns {Array<{timestamp: String, status: ('clean'|'export-failed'), counts: (Object|null)}>}
+ */
+export function buildCoverageTimeline(entries = []) {
+    return [...entries]
+        .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+        .map(entry => {
+            const counts = extractBackupCounts(entry.meta);
+
+            return {
+                timestamp: entry.timestamp,
+                status   : counts ? 'clean' : 'export-failed',
+                counts
+            }
+        })
+}
+
+/**
+ * @summary Detects the corruption-onset window for one collection's count series.
+ *
+ * Two independent signals: (1) the first `clean → export-failed` transition (the export stopped
+ * completing); (2) a count DROP between consecutive clean backups — append-mostly collections
+ * (Memory Core memories/sessions) should be monotonic, so a decrease is itself data loss.
+ *
+ * @param {Array<Object>} timeline Rows from {@link buildCoverageTimeline}.
+ * @param {Function}      countOf  `(row) => Number|null|undefined` — the collection's count from a row.
+ * @returns {{onsetWindow: ({lastClean: String, firstDegraded: String}|null), drop: ({from: Number, to: Number, fromAt: String, at: String}|null)}}
+ */
+export function detectCorruptionOnset(timeline = [], countOf) {
+    let lastClean = null, onsetWindow = null, drop = null, prevCount = null, prevTs = null;
+
+    for (const row of timeline) {
+        const count = row.status === 'clean' ? countOf(row) : null;
+
+        if (count == null) {
+            if (lastClean && !onsetWindow) {
+                onsetWindow = {lastClean, firstDegraded: row.timestamp}
+            }
+            continue
+        }
+
+        if (prevCount != null && count < prevCount && !drop) {
+            drop = {from: prevCount, to: count, fromAt: prevTs, at: row.timestamp}
+        }
+
+        lastClean = row.timestamp;
+        prevCount = count;
+        prevTs    = row.timestamp
+    }
+
+    return {onsetWindow, drop}
+}
+
+/**
+ * @summary Reads every `backup-*&#47;bundle-meta.json` under the backups dir into timeline entries.
+ *
+ * @param {Object}   options
+ * @param {String}   options.backupsDir   Directory holding `backup-<ISO>` snapshot dirs.
+ * @param {Object}   [options.fsModule=fs] Filesystem seam (test injection).
+ * @returns {Promise<Array<{timestamp: String, meta: (Object|null)}>>}
+ */
+export async function readBackupEntries({backupsDir, fsModule = fs} = {}) {
+    if (!backupsDir || !await fsModule.pathExists(backupsDir)) {
+        return []
+    }
+
+    const dirs    = (await fsModule.readdir(backupsDir)).filter(name => name.startsWith('backup-')),
+          entries = [];
+
+    for (const dir of dirs) {
+        const metaPath = path.join(backupsDir, dir, 'bundle-meta.json');
+        let   meta     = null;
+
+        if (await fsModule.pathExists(metaPath)) {
+            try {
+                meta = await fsModule.readJson(metaPath)
+            } catch {
+                meta = null // unreadable/corrupt manifest reads as a failed export
+            }
+        }
+
+        entries.push({timestamp: dir.replace(/^backup-/, ''), meta})
+    }
+
+    return entries
+}
+
+/**
+ * @summary Assembles the full report object (pure; the CLI renders or JSON-prints it).
+ * @param {Array<Object>} timeline Rows from {@link buildCoverageTimeline}.
+ * @param {String}        backupsDir
+ * @returns {Object}
+ */
+export function buildReport(timeline, backupsDir) {
+    return {
+        backupsDir,
+        totalBackups: timeline.length,
+        cleanBackups: timeline.filter(r => r.status === 'clean').length,
+        onset       : {
+            mc   : detectCorruptionOnset(timeline, r => r.counts?.mc?.memories),
+            kb   : detectCorruptionOnset(timeline, r => r.counts?.kb?.chunks),
+            graph: detectCorruptionOnset(timeline, r => r.counts?.graph?.elements)
+        },
+        timeline
+    }
+}
+
+/**
+ * @summary Renders the report as a human-readable table + onset summary.
+ * @param {Object} report From {@link buildReport}.
+ * @returns {String}
+ */
+export function formatReport(report) {
+    const lines = [
+        `Backup-corruption timeline — ${report.backupsDir}`,
+        `${report.totalBackups} backups (${report.cleanBackups} clean, ${report.totalBackups - report.cleanBackups} export-failed)`,
+        '',
+        'DATE                     | STATUS        | MC mem | KB chunks | graph',
+        '-------------------------|---------------|--------|-----------|------'
+    ];
+
+    for (const row of report.timeline) {
+        const mc    = row.counts?.mc?.memories ?? '—',
+              kb    = row.counts?.kb?.chunks   ?? '—',
+              graph = row.counts?.graph?.elements ?? '—';
+
+        lines.push(`${row.timestamp.padEnd(24)} | ${row.status.padEnd(13)} | ${String(mc).padStart(6)} | ${String(kb).padStart(9)} | ${graph}`)
+    }
+
+    lines.push('');
+
+    for (const [name, {onsetWindow, drop}] of Object.entries(report.onset)) {
+        if (onsetWindow) {
+            lines.push(`⚠️  ${name}: corruption onset window ${onsetWindow.lastClean} (last clean) → ${onsetWindow.firstDegraded} (first export-failed)`)
+        }
+        if (drop) {
+            lines.push(`⚠️  ${name}: count regression ${drop.from} → ${drop.to} between ${drop.fromAt} and ${drop.at} (append-mostly collection should not shrink)`)
+        }
+        if (!onsetWindow && !drop) {
+            lines.push(`✅ ${name}: no onset window or regression detected across the backup series`)
+        }
+    }
+
+    return lines.join('\n')
+}
+
+async function main() {
+    program
+        .option('--backups <dir>', 'Backups directory to scan', DEFAULT_BACKUPS_DIR)
+        .option('--json', 'Emit JSON instead of the human table', false)
+        .parse();
+
+    const opts     = program.opts(),
+          entries  = await readBackupEntries({backupsDir: opts.backups}),
+          timeline = buildCoverageTimeline(entries),
+          report   = buildReport(timeline, opts.backups);
+
+    process.stdout.write((opts.json ? JSON.stringify(report, null, 2) : formatReport(report)) + '\n')
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main()
+}

--- a/test/playwright/unit/ai/scripts/maintenance/backupCorruptionTimeline.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backupCorruptionTimeline.spec.mjs
@@ -1,0 +1,128 @@
+import {test, expect} from '@playwright/test';
+import {
+    buildCoverageTimeline,
+    buildReport,
+    detectCorruptionOnset,
+    extractBackupCounts,
+    readBackupEntries
+} from '../../../../../../ai/scripts/maintenance/backupCorruptionTimeline.mjs';
+
+/**
+ * @summary Unit coverage for the read-only backup-corruption timeline diagnostic.
+ * Fixture-based — never touches a real backup dir or the live store.
+ * @see ai/scripts/maintenance/backupCorruptionTimeline.mjs
+ */
+
+const cleanMeta = (memories, chunks = 30000, graph = 100000) => ({
+    completedAt: '2026-06-18T07:42:41Z',
+    gitSha     : 'abc123',
+    subsystems : {
+        mc   : {message: `Export complete. Exported ${memories} memories, 1000 summaries, and 0 graph elements.`},
+        kb   : {message: `Export complete. Exported ${chunks} knowledge base chunks.`},
+        graph: {message: `Export complete. Exported 0 memories, 0 summaries, and ${graph} graph elements.`}
+    }
+});
+
+test.describe('backupCorruptionTimeline — extractBackupCounts', () => {
+    test('parses mc / kb / graph counts from a clean bundle-meta', () => {
+        const counts = extractBackupCounts(cleanMeta(18835));
+
+        expect(counts.mc).toEqual({memories: 18835, summaries: 1000});
+        expect(counts.kb).toEqual({chunks: 30000});
+        expect(counts.graph).toEqual({elements: 100000});
+        expect(counts.completedAt).toBe('2026-06-18T07:42:41Z');
+    });
+
+    test('returns null for an absent or shapeless manifest (a failed export)', () => {
+        expect(extractBackupCounts(null)).toBeNull();
+        expect(extractBackupCounts({})).toBeNull();
+        expect(extractBackupCounts({subsystems: {}})).toEqual({
+            mc: null, kb: null, graph: null, completedAt: null, gitSha: null
+        });
+    });
+});
+
+test.describe('backupCorruptionTimeline — buildCoverageTimeline', () => {
+    test('sorts chronologically and marks clean vs export-failed', () => {
+        const timeline = buildCoverageTimeline([
+            {timestamp: '2026-06-20T05-23Z', meta: null},
+            {timestamp: '2026-06-18T07-42Z', meta: cleanMeta(18835)}
+        ]);
+
+        expect(timeline.map(r => r.timestamp)).toEqual(['2026-06-18T07-42Z', '2026-06-20T05-23Z']);
+        expect(timeline[0].status).toBe('clean');
+        expect(timeline[1].status).toBe('export-failed');
+    });
+});
+
+test.describe('backupCorruptionTimeline — detectCorruptionOnset', () => {
+    test('detects the clean → export-failed onset window (the live incident shape)', () => {
+        const timeline = buildCoverageTimeline([
+            {timestamp: '2026-06-17', meta: cleanMeta(18822)},
+            {timestamp: '2026-06-18', meta: cleanMeta(18835)},
+            {timestamp: '2026-06-20', meta: null}
+        ]);
+
+        const {onsetWindow} = detectCorruptionOnset(timeline, r => r.counts?.mc?.memories);
+
+        expect(onsetWindow).toEqual({lastClean: '2026-06-18', firstDegraded: '2026-06-20'});
+    });
+
+    test('detects a count regression between consecutive clean backups (append-mostly loss)', () => {
+        const timeline = buildCoverageTimeline([
+            {timestamp: '2026-06-01', meta: cleanMeta(15000)},
+            {timestamp: '2026-06-02', meta: cleanMeta(12000)}
+        ]);
+
+        const {drop} = detectCorruptionOnset(timeline, r => r.counts?.mc?.memories);
+
+        expect(drop).toEqual({from: 15000, to: 12000, fromAt: '2026-06-01', at: '2026-06-02'});
+    });
+
+    test('a clean monotonic series yields no onset window and no drop', () => {
+        const timeline = buildCoverageTimeline([
+            {timestamp: '2026-06-01', meta: cleanMeta(15000)},
+            {timestamp: '2026-06-02', meta: cleanMeta(15400)}
+        ]);
+
+        expect(detectCorruptionOnset(timeline, r => r.counts?.mc?.memories)).toEqual({onsetWindow: null, drop: null});
+    });
+});
+
+test.describe('backupCorruptionTimeline — readBackupEntries (injected fs)', () => {
+    test('reads backup-* dirs + their bundle-meta; null for a missing manifest; filters non-backups', async () => {
+        const meta     = cleanMeta(18835),
+              fsModule = {
+                  pathExists: async p => !p.endsWith('backup-2026-06-20Z/bundle-meta.json'),
+                  readdir   : async () => ['backup-2026-06-18Z', 'backup-2026-06-20Z', 'not-a-backup'],
+                  readJson  : async () => meta
+              };
+
+        const entries = await readBackupEntries({backupsDir: '/x', fsModule});
+
+        expect(entries.map(e => e.timestamp)).toEqual(['2026-06-18Z', '2026-06-20Z']);
+        expect(entries[0].meta).toEqual(meta);
+        expect(entries[1].meta).toBeNull();
+    });
+
+    test('returns [] when the backups dir does not exist', async () => {
+        const entries = await readBackupEntries({backupsDir: '/nope', fsModule: {pathExists: async () => false}});
+
+        expect(entries).toEqual([]);
+    });
+});
+
+test.describe('backupCorruptionTimeline — buildReport', () => {
+    test('aggregates totals + per-collection onset', () => {
+        const timeline = buildCoverageTimeline([
+            {timestamp: '2026-06-18', meta: cleanMeta(18835)},
+            {timestamp: '2026-06-20', meta: null}
+        ]);
+
+        const report = buildReport(timeline, '/backups');
+
+        expect(report.totalBackups).toBe(2);
+        expect(report.cleanBackups).toBe(1);
+        expect(report.onset.mc.onsetWindow).toEqual({lastClean: '2026-06-18', firstDegraded: '2026-06-20'});
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/backupCorruptionTimeline.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backupCorruptionTimeline.spec.mjs
@@ -1,108 +1,146 @@
 import {test, expect} from '@playwright/test';
 import {
+    analyzeSubsystem,
     buildCoverageTimeline,
     buildReport,
-    detectCorruptionOnset,
+    classifyBackup,
     extractBackupCounts,
+    readArtifactSizes,
     readBackupEntries
 } from '../../../../../../ai/scripts/maintenance/backupCorruptionTimeline.mjs';
 
 /**
- * @summary Unit coverage for the read-only backup-corruption timeline diagnostic.
- * Fixture-based — never touches a real backup dir or the live store.
+ * @summary Unit coverage for the artifact-verified backup-corruption timeline diagnostic.
+ * Fixture-based — never touches a real backup dir or the live store. Covers the live incident shape:
+ * a manifest claiming N memories while the actual memory JSONL artifact is empty (false-green).
  * @see ai/scripts/maintenance/backupCorruptionTimeline.mjs
  */
 
-const cleanMeta = (memories, chunks = 30000, graph = 100000) => ({
+const claimMeta = (memories, chunks = 30000, graph = 100000) => ({
     completedAt: '2026-06-18T07:42:41Z',
     gitSha     : 'abc123',
     subsystems : {
-        mc   : {message: `Export complete. Exported ${memories} memories, 1000 summaries, and 0 graph elements.`},
+        mc   : {message: `Export complete. Exported ${memories} memories, 1023 summaries, and 0 graph elements.`},
         kb   : {message: `Export complete. Exported ${chunks} knowledge base chunks.`},
         graph: {message: `Export complete. Exported 0 memories, 0 summaries, and ${graph} graph elements.`}
     }
 });
 
-test.describe('backupCorruptionTimeline — extractBackupCounts', () => {
-    test('parses mc / kb / graph counts from a clean bundle-meta', () => {
-        const counts = extractBackupCounts(cleanMeta(18835));
+// artifacts: bytes per ARTIFACT_SPECS key. The incident shape = mcMemory 0 bytes despite a positive claim.
+const falseGreenArtifacts = {mcMemory: 0,      mcSummaries: 5622247, kb: 1688668103, graph: 72821271};
+const verifiedArtifacts   = {mcMemory: 500000, mcSummaries: 5622247, kb: 1688668103, graph: 72821271};
 
-        expect(counts.mc).toEqual({memories: 18835, summaries: 1000});
+test.describe('backupCorruptionTimeline — extractBackupCounts (manifest claim only)', () => {
+    test('parses mc / kb / graph counts from a manifest', () => {
+        const counts = extractBackupCounts(claimMeta(18835));
+
+        expect(counts.mc).toEqual({memories: 18835, summaries: 1023});
         expect(counts.kb).toEqual({chunks: 30000});
         expect(counts.graph).toEqual({elements: 100000});
-        expect(counts.completedAt).toBe('2026-06-18T07:42:41Z');
     });
 
-    test('returns null for an absent or shapeless manifest (a failed export)', () => {
+    test('returns null for an absent or shapeless manifest', () => {
         expect(extractBackupCounts(null)).toBeNull();
-        expect(extractBackupCounts({})).toBeNull();
-        expect(extractBackupCounts({subsystems: {}})).toEqual({
-            mc: null, kb: null, graph: null, completedAt: null, gitSha: null
-        });
+        expect(extractBackupCounts({subsystems: {}})).toMatchObject({mc: null, kb: null, graph: null});
     });
 });
 
-test.describe('backupCorruptionTimeline — buildCoverageTimeline', () => {
-    test('sorts chronologically and marks clean vs export-failed', () => {
-        const timeline = buildCoverageTimeline([
-            {timestamp: '2026-06-20T05-23Z', meta: null},
-            {timestamp: '2026-06-18T07-42Z', meta: cleanMeta(18835)}
-        ]);
+test.describe('backupCorruptionTimeline — classifyBackup (artifact verification)', () => {
+    test('THE incident shape: manifest claims 18835 memories but the artifact is 0 bytes → manifest-false-green, NOT clean', () => {
+        const {status, subsystems} = classifyBackup({counts: extractBackupCounts(claimMeta(18835)), artifacts: falseGreenArtifacts});
 
-        expect(timeline.map(r => r.timestamp)).toEqual(['2026-06-18T07-42Z', '2026-06-20T05-23Z']);
-        expect(timeline[0].status).toBe('clean');
-        expect(timeline[1].status).toBe('export-failed');
+        expect(subsystems.mcMemory).toMatchObject({claim: 18835, bytes: 0, verdict: 'false-green'});
+        expect(status).toBe('manifest-false-green');
+        expect(status).not.toBe('clean');
+    });
+
+    test('manifest claim + non-empty artifact → verified / clean', () => {
+        const {status, subsystems} = classifyBackup({counts: extractBackupCounts(claimMeta(18835)), artifacts: verifiedArtifacts});
+
+        expect(subsystems.mcMemory).toMatchObject({claim: 18835, bytes: 500000, verdict: 'verified'});
+        expect(status).toBe('clean');
+    });
+
+    test('no manifest at all → export-failed (every subsystem no-manifest)', () => {
+        const {status, subsystems} = classifyBackup({counts: null, artifacts: {}});
+
+        expect(status).toBe('export-failed');
+        expect(subsystems.mcMemory.verdict).toBe('no-manifest');
     });
 });
 
-test.describe('backupCorruptionTimeline — detectCorruptionOnset', () => {
-    test('detects the clean → export-failed onset window (the live incident shape)', () => {
+test.describe('backupCorruptionTimeline — buildCoverageTimeline + analyzeSubsystem', () => {
+    test('a series of manifest-false-green MC backups has zero verified-clean and no recoverable backup', () => {
         const timeline = buildCoverageTimeline([
-            {timestamp: '2026-06-17', meta: cleanMeta(18822)},
-            {timestamp: '2026-06-18', meta: cleanMeta(18835)},
-            {timestamp: '2026-06-20', meta: null}
+            {timestamp: '2026-06-18', meta: claimMeta(18835), artifacts: falseGreenArtifacts},
+            {timestamp: '2026-05-27', meta: claimMeta(14520), artifacts: falseGreenArtifacts},
+            {timestamp: '2026-06-20', meta: null,             artifacts: {}}
         ]);
 
-        const {onsetWindow} = detectCorruptionOnset(timeline, r => r.counts?.mc?.memories);
+        // sorted chronologically
+        expect(timeline.map(r => r.timestamp)).toEqual(['2026-05-27', '2026-06-18', '2026-06-20']);
+        expect(timeline[0].status).toBe('manifest-false-green');
+        expect(timeline[2].status).toBe('export-failed');
 
-        expect(onsetWindow).toEqual({lastClean: '2026-06-18', firstDegraded: '2026-06-20'});
+        const mc = analyzeSubsystem(timeline, 'mcMemory');
+
+        expect(mc.verifiedClean).toBe(0);
+        expect(mc.falseGreen).toBe(2);
+        expect(mc.noRecoverableBackup).toBe(true);
+        expect(mc.falseGreenSpan).toEqual({from: '2026-05-27', to: '2026-06-18'});
+        expect(mc.firstManifestAbsent).toBe('2026-06-20');
     });
 
-    test('detects a count regression between consecutive clean backups (append-mostly loss)', () => {
+    test('a verified-clean MC backup makes the series recoverable', () => {
         const timeline = buildCoverageTimeline([
-            {timestamp: '2026-06-01', meta: cleanMeta(15000)},
-            {timestamp: '2026-06-02', meta: cleanMeta(12000)}
+            {timestamp: '2026-06-18', meta: claimMeta(18835), artifacts: verifiedArtifacts}
         ]);
 
-        const {drop} = detectCorruptionOnset(timeline, r => r.counts?.mc?.memories);
+        const mc = analyzeSubsystem(timeline, 'mcMemory');
 
-        expect(drop).toEqual({from: 15000, to: 12000, fromAt: '2026-06-01', at: '2026-06-02'});
+        expect(mc.verifiedClean).toBe(1);
+        expect(mc.noRecoverableBackup).toBe(false);
+        expect(mc.lastVerifiedClean).toBe('2026-06-18');
     });
+});
 
-    test('a clean monotonic series yields no onset window and no drop', () => {
-        const timeline = buildCoverageTimeline([
-            {timestamp: '2026-06-01', meta: cleanMeta(15000)},
-            {timestamp: '2026-06-02', meta: cleanMeta(15400)}
-        ]);
+test.describe('backupCorruptionTimeline — readArtifactSizes (injected fs)', () => {
+    test('stats the per-subsystem artifact byte sizes; missing file → null', async () => {
+        const fsModule = {
+            pathExists: async dir => !dir.endsWith('/graph'),         // graph subdir missing
+            readdir   : async dir => dir.endsWith('/mc') ? ['memory-backup-x.jsonl', 'summaries-backup-x.jsonl']
+                                   : dir.endsWith('/kb') ? ['knowledge-base-backup-x.jsonl']
+                                   : [],
+            stat      : async p => ({size: p.includes('memory-backup') ? 0 : 4242})
+        };
 
-        expect(detectCorruptionOnset(timeline, r => r.counts?.mc?.memories)).toEqual({onsetWindow: null, drop: null});
+        const sizes = await readArtifactSizes({backupDir: '/b', fsModule});
+
+        expect(sizes).toEqual({mcMemory: 0, mcSummaries: 4242, kb: 4242, graph: null});
     });
 });
 
 test.describe('backupCorruptionTimeline — readBackupEntries (injected fs)', () => {
-    test('reads backup-* dirs + their bundle-meta; null for a missing manifest; filters non-backups', async () => {
-        const meta     = cleanMeta(18835),
+    test('reads manifest + artifact sizes per backup; non-backup dirs filtered', async () => {
+        const meta     = claimMeta(18835),
               fsModule = {
-                  pathExists: async p => !p.endsWith('backup-2026-06-20Z/bundle-meta.json'),
-                  readdir   : async () => ['backup-2026-06-18Z', 'backup-2026-06-20Z', 'not-a-backup'],
-                  readJson  : async () => meta
+                  pathExists: async p => !p.endsWith('graph'),
+                  readdir   : async dir => {
+                      if (dir.endsWith('backups')) return ['backup-2026-06-18Z', 'not-a-backup'];
+                      if (dir.endsWith('/mc'))     return ['memory-backup-x.jsonl'];
+                      if (dir.endsWith('/kb'))     return ['knowledge-base-backup-x.jsonl'];
+                      return []
+                  },
+                  readJson: async () => meta,
+                  stat    : async p => ({size: p.includes('memory-backup') ? 0 : 999})
               };
 
-        const entries = await readBackupEntries({backupsDir: '/x', fsModule});
+        const entries = await readBackupEntries({backupsDir: '/x/backups', fsModule});
 
-        expect(entries.map(e => e.timestamp)).toEqual(['2026-06-18Z', '2026-06-20Z']);
+        expect(entries.map(e => e.timestamp)).toEqual(['2026-06-18Z']);
         expect(entries[0].meta).toEqual(meta);
-        expect(entries[1].meta).toBeNull();
+        expect(entries[0].artifacts.mcMemory).toBe(0);
+        expect(entries[0].artifacts.kb).toBe(999);
     });
 
     test('returns [] when the backups dir does not exist', async () => {
@@ -113,16 +151,18 @@ test.describe('backupCorruptionTimeline — readBackupEntries (injected fs)', ()
 });
 
 test.describe('backupCorruptionTimeline — buildReport', () => {
-    test('aggregates totals + per-collection onset', () => {
+    test('aggregates artifact-verified / false-green / export-failed totals + per-subsystem analysis', () => {
         const timeline = buildCoverageTimeline([
-            {timestamp: '2026-06-18', meta: cleanMeta(18835)},
-            {timestamp: '2026-06-20', meta: null}
+            {timestamp: '2026-06-18', meta: claimMeta(18835), artifacts: falseGreenArtifacts},
+            {timestamp: '2026-06-20', meta: null,             artifacts: {}}
         ]);
 
         const report = buildReport(timeline, '/backups');
 
         expect(report.totalBackups).toBe(2);
-        expect(report.cleanBackups).toBe(1);
-        expect(report.onset.mc.onsetWindow).toEqual({lastClean: '2026-06-18', firstDegraded: '2026-06-20'});
+        expect(report.artifactVerifiedClean).toBe(0);
+        expect(report.manifestFalseGreen).toBe(1);
+        expect(report.exportFailed).toBe(1);
+        expect(report.perSubsystem.mcMemory.noRecoverableBackup).toBe(true);
     });
 });


### PR DESCRIPTION
Resolves #14024

Read-only, **artifact-verified** backup-corruption timeline diagnostic. Walks `.neo-ai-data/backups/backup-*/`, and for each backup compares the `bundle-meta.json` CLAIM against the actual exported JSONL ARTIFACT byte size. A manifest is one signal, never proof of recoverability: a positive claim with a 0-byte/missing artifact is classified `manifest-false-green`, not `clean`. Output exposes both manifest claim and artifact bytes. Read-only; never contacts the live store.

Why byte-size, not row-count: artifacts reach ~1.6GB (the KB JSONL), so reading-to-count-rows is infeasible, and the JSONL is not reliably one-record-per-line (a summaries artifact: 103 newlines for 5.6MB). `stat` byte-size is O(1), scalable, and unambiguous for the empty-artifact false-green this incident produced.

**Finding (artifact-grounded):** every retained MC-memory artifact (`mc/memory-backup-*.jsonl`) is **0 bytes from 2026-05-27 → 06-18** despite manifests claiming 14,520→18,835 memories — so there is **no artifact-verified-clean MC-memory backup in the retained series; backup-based MC recovery is not possible from it.** (MC summaries / KB / graph artifacts are present.) The 06-20 first-manifest-absent backup marks when fail-loud export landed, not the corruption onset.

Refs #14039 (sub of the v13.1 "Agent OS Stability & Self-Healing" epic).

## Review Response (#14042 cycle-1 — @neo-gpt REQUEST_CHANGES, [ADDRESSED])

[ADDRESSED] The cycle-1 blocker: the diagnostic trusted `bundle-meta` counts as `clean`, but every retained MC backup is false-green (positive count + 0-byte artifact). Fixed at head `f6403e101`: artifact byte-verification (`classifyBackup` / `readArtifactSizes`), a `manifest-false-green` status, both counts exposed, and the finding reframed from a false "06-18 clean / 06-20 onset" to "no recoverable MC backup retained." Added the required incident fixture (claim 18835 + 0-byte artifact → `manifest-false-green`, never `clean`/`lastVerifiedClean`). JSDoc + this body corrected. Thanks for the V-B-A — I'd trusted the manifest; you read the artifact.

Evidence: L2 unit (11 specs incl. the false-green incident fixture) + a live read-only run reproducing the artifact-grounded finding. Residual: strict per-record parity is out of scope (byte-presence verification; rationale above).

## Deltas From Ticket

None to the ticket scope; the implementation's trust boundary was corrected from manifest-count to artifact-byte verification per the review.

## Test Evidence

- `node --check ai/scripts/maintenance/backupCorruptionTimeline.mjs` → passed
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/backupCorruptionTimeline.spec.mjs` → **11 passed** (incl. the false-green incident fixture)
- Live read-only run `node ai/scripts/maintenance/backupCorruptionTimeline.mjs` → 19 manifest-false-green MC-memory backups (05-27→06-18), 0 artifact-verified-clean; MC summaries / KB / graph artifact-present

## Post-Merge Validation

- [ ] Operator runs the diagnostic (or `--json`) and confirms the manifest-vs-artifact disagreement + the no-recoverable-MC-backup finding match the live backup series.

## Commits

- `d698606b2` — initial read-only diagnostic
- `f6403e101` — `fix(ai): artifact-verify backups vs false-green manifests (#14024)` (the review-response)

Authored by Vega (Claude Opus 4.8).
