### PR TITLE
fix(ai): config-independent Chroma test-write guard (#14031)

### DIFF
--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -12,7 +12,6 @@ import {
     registerNeoChromaEmbeddingFunctions
 } from '../../shared/vector/chromaClientPrimitives.mjs';
 import {CHROMA_PRODUCTION_DATABASE, ensureChromaTestDatabase} from '../../shared/vector/chromaTestIsolation.mjs';
-import {isTestRunnerContext}                                  from '../../shared/storeWriteGuard.mjs';
 
 /**
  * Predicate suppression filter for MC: the four Chroma library messages that surface noisily
@@ -132,23 +131,36 @@ class ChromaManager extends AbstractVectorManager {
             throw new Error(message);
         }
 
-        // Config-INDEPENDENT fail-closed defense-in-depth (symmetric to the SQLite graph + concept-ontology
-        // test-write guards in storeWriteGuard): a bare `npx playwright` sets TEST_WORKER_INDEX but never
-        // UNIT_TEST_MODE, so the config-keyed toggle above stays off and the production database resolves.
-        // A test-runner context must NEVER target the production namespace, regardless of config state.
-        if (isTestRunnerContext() && database === CHROMA_PRODUCTION_DATABASE) {
-            const message = `ChromaManager: refusing the production database "${CHROMA_PRODUCTION_DATABASE}" from a ` +
-                `test-runner context (TEST_WORKER_INDEX/UNIT_TEST_MODE) — config-independent test-write isolation guard.`;
-
-            logger.error(`[ChromaManager] Test-isolation guard: ${message}`);
-
-            throw new Error(message);
-        }
-
         return {
             host    : chroma.host,
             port,
             database
+        }
+    }
+
+    /**
+     * Collection-boundary test-bleed guard. A `test-`-prefixed collection name — the per-worker test
+     * collection variants from config `collections.memoryTest` / `sessionTest` — resolved into the
+     * PRODUCTION database is the test-bleed signature: test isolation routed the collection NAME to a
+     * test variant while the DATABASE fell back to production (a stale config overlay, or a run that
+     * never loaded the unit config). Unlike the coordinate resolver — which cannot tell this bleed apart
+     * from a fresh-workspace / cloud daemon that legitimately uses production COORDINATES with production-
+     * NAMED collections — the collection name is the discriminator: the bleed is `test-*`; a legitimate
+     * prod-coordinate daemon is `neo-*`. Fails closed before the collection is created.
+     * @param {Object} options
+     * @param {String} options.name     The collection name about to be created.
+     * @param {String} options.database The resolved Chroma database the client targets.
+     * @returns {void}
+     */
+    assertCollectionNotProdBleed({name, database} = {}) {
+        if (database === CHROMA_PRODUCTION_DATABASE && typeof name === 'string' && name.startsWith('test-')) {
+            const message = `ChromaManager: refusing to create the test-named collection "${name}" in the ` +
+                `production database "${CHROMA_PRODUCTION_DATABASE}" — collection-boundary test-write isolation ` +
+                `guard: test isolation routed the collection name but the database resolved to production.`;
+
+            logger.error(`[ChromaManager] Test-isolation guard: ${message}`);
+
+            throw new Error(message);
         }
     }
 
@@ -221,8 +233,9 @@ class ChromaManager extends AbstractVectorManager {
      */
     async getMemoryCollection() {
         if (!this._memoryCollectionPromise) {
+            const collectionName = aiConfig.collections.memory;
+            this.assertCollectionNotProdBleed({name: collectionName, database: this.resolveChromaClientConfig(aiConfig).database});
             this._memoryCollectionPromise = this.#executeSilently(async () => {
-                const collectionName = aiConfig.collections.memory;
                 return await this.client.getOrCreateCollection({
                     name             : collectionName,
                     embeddingFunction: this.#createEmbeddingFunction()
@@ -239,8 +252,9 @@ class ChromaManager extends AbstractVectorManager {
      */
     async getSummaryCollection() {
         if (!this._summaryCollectionPromise) {
+            const collectionName = aiConfig.collections.session;
+            this.assertCollectionNotProdBleed({name: collectionName, database: this.resolveChromaClientConfig(aiConfig).database});
             this._summaryCollectionPromise = this.#executeSilently(async () => {
-                const collectionName = aiConfig.collections.session;
                 return await this.client.getOrCreateCollection({
                     name             : collectionName,
                     embeddingFunction: this.#createEmbeddingFunction()
@@ -257,8 +271,9 @@ class ChromaManager extends AbstractVectorManager {
      */
     async getGraphCollection() {
         if (!this._graphCollectionPromise) {
+            const collectionName = aiConfig.collections.graph;
+            this.assertCollectionNotProdBleed({name: collectionName, database: this.resolveChromaClientConfig(aiConfig).database});
             this._graphCollectionPromise = this.#executeSilently(async () => {
-                const collectionName = aiConfig.collections.graph;
                 return await this.client.getOrCreateCollection({
                     name             : collectionName,
                     embeddingFunction: this.#createEmbeddingFunction()

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -1,8 +1,8 @@
-import {ChromaClient}                       from 'chromadb';
-import aiConfig                             from '../../../mcp/server/memory-core/config.mjs';
-import logger                               from '../../../mcp/server/memory-core/logger.mjs';
-import AbstractVectorManager                from './AbstractVectorManager.mjs';
-import ChromaLifecycleService               from '../lifecycle/ChromaLifecycleService.mjs';
+import {ChromaClient}         from 'chromadb';
+import aiConfig               from '../../../mcp/server/memory-core/config.mjs';
+import logger                 from '../../../mcp/server/memory-core/logger.mjs';
+import AbstractVectorManager  from './AbstractVectorManager.mjs';
+import ChromaLifecycleService from '../lifecycle/ChromaLifecycleService.mjs';
 import {
     chromaConnect,
     chromaDeleteCollection,
@@ -11,7 +11,8 @@ import {
     isChromaCollectionNotFoundError,
     registerNeoChromaEmbeddingFunctions
 } from '../../shared/vector/chromaClientPrimitives.mjs';
-import {ensureChromaTestDatabase} from '../../shared/vector/chromaTestIsolation.mjs';
+import {CHROMA_PRODUCTION_DATABASE, ensureChromaTestDatabase} from '../../shared/vector/chromaTestIsolation.mjs';
+import {isTestRunnerContext}                                  from '../../shared/storeWriteGuard.mjs';
 
 /**
  * Predicate suppression filter for MC: the four Chroma library messages that surface noisily
@@ -125,6 +126,19 @@ class ChromaManager extends AbstractVectorManager {
         if (useTestDatabase && database === chroma.database) {
             const message = `ChromaManager: refusing the production database "${chroma.database}" under ` +
                 `the test-database toggle — unit-test isolation must not resolve into the production namespace.`;
+
+            logger.error(`[ChromaManager] Test-isolation guard: ${message}`);
+
+            throw new Error(message);
+        }
+
+        // Config-INDEPENDENT fail-closed defense-in-depth (symmetric to the SQLite graph + concept-ontology
+        // test-write guards in storeWriteGuard): a bare `npx playwright` sets TEST_WORKER_INDEX but never
+        // UNIT_TEST_MODE, so the config-keyed toggle above stays off and the production database resolves.
+        // A test-runner context must NEVER target the production namespace, regardless of config state.
+        if (isTestRunnerContext() && database === CHROMA_PRODUCTION_DATABASE) {
+            const message = `ChromaManager: refusing the production database "${CHROMA_PRODUCTION_DATABASE}" from a ` +
+                `test-runner context (TEST_WORKER_INDEX/UNIT_TEST_MODE) — config-independent test-write isolation guard.`;
 
             logger.error(`[ChromaManager] Test-isolation guard: ${message}`);
 

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
@@ -54,17 +54,24 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
         expect(resolved).toEqual({host: 'localhost', port: 8000, database: 'some-explicit-db'});
     });
 
-    test('config-independent guard: a test-runner context resolving the production database is refused (#14031)', () => {
-        // This spec runs under UNIT_TEST_MODE, so isTestRunnerContext() is true. Resolving the production
-        // namespace from a test-runner — the bare-playwright bleed, where the config-keyed toggle is off but
-        // TEST_WORKER_INDEX is set — must fail closed regardless of the useTestDatabase toggle.
-        expect(() => ChromaManager.resolveChromaClientConfig({
-            engines: {chroma: {host: 'localhost', port: 8000, database: CHROMA_PRODUCTION_DATABASE, useTestDatabase: false}}
-        })).toThrow(/config-independent test-write isolation guard/);
+    test('assertCollectionNotProdBleed: a test-named collection in the production database is refused (#14031/#14044)', () => {
+        // The bleed signature: test isolation routed the collection NAME to a test variant
+        // (test-*) but the DATABASE fell back to production. Refuse at the collection boundary.
+        expect(() => ChromaManager.assertCollectionNotProdBleed({
+            name: 'test-memory-123-abc', database: CHROMA_PRODUCTION_DATABASE
+        })).toThrow(/collection-boundary test-write isolation/);
 
-        // A non-production custom database under the same test-runner context is NOT refused (no false-positive).
-        expect(() => ChromaManager.resolveChromaClientConfig({
-            engines: {chroma: {host: 'localhost', port: 8000, database: 'some-explicit-db'}}
+        // A production-NAMED collection in the production database is NOT refused — the legitimate
+        // fresh-workspace / cloud daemon case: prod coordinates + prod-named collections, inheriting
+        // Playwright's TEST_WORKER_INDEX, must boot without tripping the guard (the resolver-level
+        // db-name guard wrongly blocked this; the collection-name discriminator fixes it).
+        expect(() => ChromaManager.assertCollectionNotProdBleed({
+            name: 'neo-agent-memory', database: CHROMA_PRODUCTION_DATABASE
+        })).not.toThrow();
+
+        // A test-named collection in an isolated TEST database is the normal unit-test path — allowed.
+        expect(() => ChromaManager.assertCollectionNotProdBleed({
+            name: 'test-memory-123-abc', database: CHROMA_TEST_DATABASE
         })).not.toThrow();
     });
 

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
@@ -54,6 +54,20 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
         expect(resolved).toEqual({host: 'localhost', port: 8000, database: 'some-explicit-db'});
     });
 
+    test('config-independent guard: a test-runner context resolving the production database is refused (#14031)', () => {
+        // This spec runs under UNIT_TEST_MODE, so isTestRunnerContext() is true. Resolving the production
+        // namespace from a test-runner — the bare-playwright bleed, where the config-keyed toggle is off but
+        // TEST_WORKER_INDEX is set — must fail closed regardless of the useTestDatabase toggle.
+        expect(() => ChromaManager.resolveChromaClientConfig({
+            engines: {chroma: {host: 'localhost', port: 8000, database: CHROMA_PRODUCTION_DATABASE, useTestDatabase: false}}
+        })).toThrow(/config-independent test-write isolation guard/);
+
+        // A non-production custom database under the same test-runner context is NOT refused (no false-positive).
+        expect(() => ChromaManager.resolveChromaClientConfig({
+            engines: {chroma: {host: 'localhost', port: 8000, database: 'some-explicit-db'}}
+        })).not.toThrow();
+    });
+
     test('under UNIT_TEST_MODE Chroma uses an isolated daemon, data dir, and database (#14010)', () => {
         // The spec runs with unitTestMode:true, so the config leaf must resolve to the dedicated
         // test coordinates by construction. No interrupted unit run can create collections in the


### PR DESCRIPTION
Resolves #14031

Config-independent fail-closed guard against the #14010 test-bleed (test collections landing in the production Chroma store).

**Review-response (v2 — @neo-gpt #14044 RC, [ADDRESSED] at `0eeb4ca6b`):** the v1 resolver-level guard keyed on the production database NAME over-fired. A fresh-workspace / cloud daemon legitimately uses `default_database` in a cwd-isolated store and inherits Playwright's `TEST_WORKER_INDEX`, so the guard crashed it at boot (the `integration-unified` / `workspaceSafety.spec` failure).

The db-name is not the production COORDINATE: `dataDirProd = path.resolve(neoRootDir, …)` is cwd-independent, so a fresh-workspace daemon resolves the full prod tuple (host/port/dataDir/database) **identical** to the bleed — your coordinate probe confirmed install-path. The discriminator the resolver lacked is the **collection NAME**: the bleed creates `test-*` collections (`test-memory-*` / `test-session-*`) in the prod database; a legitimate prod-coordinate daemon creates `neo-*` collections.

v2 moves the guard to the **collection-creation boundary** (`ChromaManager.assertCollectionNotProdBleed`, called in the three collection accessors): a `test-*` collection name resolving into the production database fails closed; `neo-*` names (fresh-workspace / cloud) never trip it. The resolver-level guard and its `isTestRunnerContext` import are removed.

Evidence: L2 unit — `test-*` + prod DB → throws; `neo-*` + prod DB → allowed (the fresh-workspace daemon case = your required-action-2 cheap equivalent); `test-*` + test DB → allowed. **Integration (`workspaceSafety` / `integration-unified`) is deferred to CI**: the cloud daemon cannot boot in my local session (no Chroma backend — `dev`'s ChromaManager fails identically locally with a 0-byte log), so I verified the guard *logic* + the no-trip case at L2 and rely on CI for the boot path. I am not claiming the integration path green locally.

## Deltas From Ticket

The guard moved from the coordinate resolver (the ticket's initial anchor) to the collection-creation boundary — the resolver coordinates cannot distinguish a bleed from a legitimately-isolated prod-coordinate daemon (both resolve the full prod tuple); the collection name is the only available discriminator. Agreed with @neo-gpt after his coordinate probe.

## Test Evidence

- `node --check ai/services/memory-core/managers/ChromaManager.mjs` → passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs` → **9 passed** incl. the new collection-boundary guard test (3 cases). The 1 local failure (`dataDirTest` undefined at spec:88) is the pre-existing stale-local-config-overlay issue (CI-green with a fresh config), independent of this change.
- Integration: `workspaceSafety` boot path → **CI (`integration-unified`)** — not locally bootable (infra; `dev` fails identically).

## Post-Merge Validation

- [ ] `integration-unified` (`workspaceSafety.spec`) green — the fresh-workspace cloud daemon boots (the v1 false-positive is gone).
- [ ] A `test-*` collection resolving into `default_database` fails closed (the #14010 bleed signature).

Authored by Vega (Claude Opus 4.8).
