### PR TITLE
fix(ai): bound embedding batch requests (#14036)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -191,6 +191,9 @@ class Config extends ConfigProvider {
                 contentionRetryDelayMs : leaf(1000, 'NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS', 'number'),
                 contentionTimeoutMs    : leaf(15000, 'NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS', 'number'),
                 batchEmbeddingChunkSize: leaf(5, 'NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE', 'number'),
+                // Upper bound for one batch embedding HTTP request. Batch chunks can legitimately take
+                // longer than interactive single embeddings, but must not hold the provider queue forever.
+                batchEmbeddingTimeoutMs: leaf(300000, 'NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_TIMEOUT_MS', 'number'),
                 batchEmbeddingYieldMs  : leaf(0, 'NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS', 'number'),
                 keep_alive             : leaf(-1, 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', 'keepAlive'),
                 requireParallelModels  : leaf(2, 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', 'number')

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -68,6 +68,20 @@ function waitForOpenAiCompatibleBatchYield(delayMs) {
 }
 
 /**
+ * @summary Fails loudly when a resolved embedding request timeout leaf is invalid.
+ * @param {Number} value Resolved timeout value in milliseconds.
+ * @param {String} label Config label for the error message.
+ * @returns {Number}
+ */
+function assertPositiveTimeoutMs(value, label) {
+    if (!Number.isFinite(value) || value <= 0) {
+        throw new TypeError(`TextEmbeddingService: ${label} must be a positive number, got ${value}`);
+    }
+
+    return value
+}
+
+/**
  * @summary Service for creating embedding vectors for text.
  *
  * This wrapper service interfaces with the Google Generative AI API (Gemini) to generate vector embeddings
@@ -504,8 +518,44 @@ class TextEmbeddingService extends Base {
                     requestTimeoutMs
                 });
             }
+            if (isOpenAiCompatibleContentionTimeoutError(err)) {
+                this.#emitOpenAiCompatibleTimeoutFriction(inputData, requestTimeoutMs, err);
+            }
             logger.error(`[TextEmbeddingService] Failed to generate embedding from openAiCompatible:`, err.message);
             throw err;
+        }
+    }
+
+    /**
+     * @summary Emits a structured ConsumerFriction timeout signal for bounded embedding requests.
+     * @param {String|String[]} inputData Text input that timed out.
+     * @param {Number} requestTimeoutMs Request timeout in milliseconds.
+     * @param {Error} err Timeout error.
+     * @returns {void}
+     * @private
+     */
+    #emitOpenAiCompatibleTimeoutFriction(inputData, requestTimeoutMs, err) {
+        const
+            {embeddingModel} = aiConfig.openAiCompatible,
+            estimate         = this.#getOpenAiCompatibleInputEstimate(inputData);
+
+        try {
+            emitConsumerFriction({
+                assetRef                 : `openAiCompatible:${embeddingModel}`,
+                consumer                 : 'TextEmbeddingService.openAiCompatible',
+                model                    : embeddingModel,
+                symptom                  : 'timeout',
+                emissionPoint            : 'post-invocation-failure',
+                suggestionKind           : 'unknown',
+                inputBytes               : estimate.inputBytes,
+                inputTokensEstimate      : estimate.inputTokensEstimate,
+                contextLimitTokens       : aiConfig.localModels.embedding.contextLimitTokens,
+                safeProcessingLimitTokens: aiConfig.localModels.embedding.safeProcessingLimitTokens,
+                serviceDomain            : 'memory-core',
+                note                     : `OpenAI-compatible embedding request timed out after ${describeOpenAiCompatibleTimeout(requestTimeoutMs)}: ${String(err?.message || err).substring(0, 160)}`
+            });
+        } catch (frictionError) {
+            logger.warn('[TextEmbeddingService] Failed to emit embedding timeout friction.', frictionError.message);
         }
     }
 
@@ -549,15 +599,18 @@ class TextEmbeddingService extends Base {
         const {
             unloadRetryCount        = 3,
             batchEmbeddingChunkSize = 5,
+            batchEmbeddingTimeoutMs = DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS,
             batchEmbeddingYieldMs   = 0
         } = aiConfig.openAiCompatible;
-        const chunkSize = Math.max(1, Math.floor(batchEmbeddingChunkSize || texts.length)),
-              data      = [];
+        const chunkSize        = Math.max(1, Math.floor(batchEmbeddingChunkSize || texts.length)),
+              requestTimeoutMs = assertPositiveTimeoutMs(batchEmbeddingTimeoutMs, 'openAiCompatible.batchEmbeddingTimeoutMs'),
+              data             = [];
 
         for (let offset = 0; offset < texts.length; offset += chunkSize) {
             const chunk  = texts.slice(offset, offset + chunkSize),
                   result = await this.#enqueueOpenAiCompatiblePost(chunk, {
-                      unloadRetriesLeft: unloadRetryCount
+                      unloadRetriesLeft: unloadRetryCount,
+                      requestTimeoutMs
                   }, 'batch');
 
             data.push(...(result.data || []).map(item => ({

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -27,6 +27,10 @@ import {
     resolveLmsEmbeddingInputSuffix,
     withLmsEmbeddingInputSuffix
 } from '../../../../../../ai/services/shared/vector/lmsEmbeddingInputSuffix.mjs';
+import {
+    clearAggregatedFrictions,
+    getAggregatedFrictions
+} from '../../../../../../ai/services/memory-core/helpers/consumerFrictionHelper.mjs';
 
 async function waitForCondition(condition, message, timeoutMs = 250) {
     const start = Date.now();
@@ -96,7 +100,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
     let testPort;
     let originalHost, originalRetryCount, originalRetryDelay;
     let originalContentionRetryCount, originalContentionRetryDelay, originalContentionTimeout;
-    let originalBatchEmbeddingChunkSize, originalBatchEmbeddingYieldMs;
+    let originalBatchEmbeddingChunkSize, originalBatchEmbeddingTimeoutMs, originalBatchEmbeddingYieldMs;
     let originalLmsPort;
     let originalLoadedModelsProbe;
 
@@ -244,6 +248,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         originalContentionRetryDelay = aiConfig.openAiCompatible.contentionRetryDelayMs;
         originalContentionTimeout = aiConfig.openAiCompatible.contentionTimeoutMs;
         originalBatchEmbeddingChunkSize = aiConfig.openAiCompatible.batchEmbeddingChunkSize;
+        originalBatchEmbeddingTimeoutMs = aiConfig.openAiCompatible.batchEmbeddingTimeoutMs;
         originalBatchEmbeddingYieldMs = aiConfig.openAiCompatible.batchEmbeddingYieldMs;
         originalLmsPort = aiConfig.orchestrator.lms.port;
         originalLoadedModelsProbe = TextEmbeddingService.openAiCompatibleLoadedModelsProbe;
@@ -255,6 +260,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         aiConfig.openAiCompatible.contentionRetryDelayMs = 10;
         aiConfig.openAiCompatible.contentionTimeoutMs = 25;
         aiConfig.openAiCompatible.batchEmbeddingChunkSize = 5;
+        aiConfig.openAiCompatible.batchEmbeddingTimeoutMs = 1000;
         aiConfig.openAiCompatible.batchEmbeddingYieldMs = 0;
         TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{
             id           : aiConfig.openAiCompatible.embeddingModel,
@@ -270,9 +276,11 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         aiConfig.openAiCompatible.contentionRetryDelayMs = originalContentionRetryDelay;
         aiConfig.openAiCompatible.contentionTimeoutMs = originalContentionTimeout;
         aiConfig.openAiCompatible.batchEmbeddingChunkSize = originalBatchEmbeddingChunkSize;
+        aiConfig.openAiCompatible.batchEmbeddingTimeoutMs = originalBatchEmbeddingTimeoutMs;
         aiConfig.openAiCompatible.batchEmbeddingYieldMs = originalBatchEmbeddingYieldMs;
         aiConfig.orchestrator.lms.port = originalLmsPort;
         TextEmbeddingService.openAiCompatibleLoadedModelsProbe = originalLoadedModelsProbe;
+        clearAggregatedFrictions();
     });
 
     test('first-call-succeeds-no-retry path', async () => {
@@ -515,9 +523,10 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         expect(requestCount).toBe(2);
     });
 
-    test('batch embeddings preserve the long batch timeout instead of using the interactive contention timeout', async () => {
+    test('batch embeddings use the batch timeout instead of the interactive contention timeout', async () => {
         serverBehavior = 'delayed-batch-succeed';
         aiConfig.openAiCompatible.contentionTimeoutMs = 1;
+        aiConfig.openAiCompatible.batchEmbeddingTimeoutMs = 100;
 
         const result = await TextEmbeddingService.embedTexts(['first', 'second'], 'openAiCompatible');
 
@@ -526,6 +535,31 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
             [4.1, 4.2, 4.3]
         ]);
         expect(requestCount).toBe(1);
+    });
+
+    test('batch embeddings time out through the batch timeout and surface ConsumerFriction (#14036)', async () => {
+        serverBehavior = 'timeout-all';
+        aiConfig.openAiCompatible.batchEmbeddingTimeoutMs = 25;
+        clearAggregatedFrictions();
+
+        for (let i = 0; i < 3; i++) {
+            await expect(TextEmbeddingService.embedTexts([`stuck batch ${i}`], 'openAiCompatible'))
+                .rejects.toThrow(/openAiCompatible request timed out after 25ms/);
+        }
+
+        expect(requestCount).toBe(3);
+        expect(getAggregatedFrictions()).toEqual([
+            expect.objectContaining({
+                assetRef      : `openAiCompatible:${aiConfig.openAiCompatible.embeddingModel}`,
+                consumer      : 'TextEmbeddingService.openAiCompatible',
+                model         : aiConfig.openAiCompatible.embeddingModel,
+                symptom       : 'timeout',
+                emissionPoint : 'post-invocation-failure',
+                suggestionKind: 'unknown',
+                serviceDomain : 'memory-core',
+                count         : 3
+            })
+        ]);
     });
 
     test('batch embeddings split large requests into yieldable chunks and preserve global ordering', async () => {


### PR DESCRIPTION
Resolves #14036

Bounds OpenAI-compatible batch embedding requests so a wedged provider call cannot hold the shared embedding queue indefinitely. Batch chunks now read a dedicated `openAiCompatible.batchEmbeddingTimeoutMs` leaf at the use site, throw the existing timeout error shape when exceeded, and emit a structured `ConsumerFriction` timeout signal before the caller falls into its existing fail-loud path.

Evidence: L2 focused unit coverage passed for the provider timeout/signal path and the Memory Core repair fallback path; L2 preflight passed for the touched files. Residual: provider CPU-saturation-with-no-throughput remains optional scope in #14036 and is not implemented here.

## Deltas from ticket

- Added `NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_TIMEOUT_MS` with a 300000ms default instead of reusing the 15000ms interactive contention timeout; batch work still has a larger budget, but no one-hour indefinite queue hold.
- Used the existing `ConsumerFriction` visibility channel as the current diagnosis surface. ADR-0025's broader container-health diagnosis daemon is still a separate substrate and was not reimplemented here.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` -> 20 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs` -> 30 passed.
- `npm run agent-preflight -- ai/config.template.mjs ai/services/memory-core/TextEmbeddingService.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` -> passed.
- `git diff --check` -> passed.

## Post-Merge Validation

- [ ] Run or observe the active Memory Core defrag after a provider timeout; it should fail loud and continue via row-level fallback instead of leaving the shadow-load state stale behind one hung batch request.

## Commits

- `75a72f3ded` - `fix(ai): bound embedding batch requests (#14036)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019efe4c-5d55-76c0-aba5-665f86d9cbdc.
