### PR TITLE
feat(ai): expose KB ingestion progress (#14028)

### DIFF
--- a/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
+++ b/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
@@ -6,7 +6,7 @@ import Base                          from '../../../src/core/Base.mjs';
 import {Memory_Config as aiConfig}   from '../../services.mjs';
 import ChromaManager                 from '../../services/knowledge-base/ChromaManager.mjs';
 import KBRecorderService             from '../../services/knowledge-base/KBRecorderService.mjs';
-import KnowledgeBaseIngestionService from '../../services/knowledge-base/KnowledgeBaseIngestionService.mjs';
+import IngestionService              from '../../services/knowledge-base/IngestionService.mjs';
 import logger                        from '../../mcp/server/knowledge-base/logger.mjs';
 import {
     diffTenantChunks,
@@ -292,7 +292,7 @@ class KbReconciliationService extends Base {
      * @protected
      */
     async fetchTenantConfigVersion(tenantId) {
-        const config = await KnowledgeBaseIngestionService.getTenantConfig({tenantId});
+        const config = await IngestionService.getTenantConfig({tenantId});
 
         return config?.version ?? 0
     }
@@ -304,7 +304,7 @@ class KbReconciliationService extends Base {
      * @protected
      */
     async fetchTenantManifests(tenantId) {
-        return KnowledgeBaseIngestionService.getTenantManifests({tenantId})
+        return IngestionService.getTenantManifests({tenantId})
     }
 
     /**
@@ -340,7 +340,7 @@ class KbReconciliationService extends Base {
      * @summary Test-stubbable seam — fetches all of a tenant's Chroma rows, batched.
      *
      * Mirrors the batched `collection.get({where: {tenantId}})` idiom of
-     * `KnowledgeBaseIngestionService.getTenantRows`; kept local rather than calling that
+     * `IngestionService.getTenantRows`; kept local rather than calling that
      * `@protected` method so reconciliation remains additive to ingestion internals.
      *
      * @param {Object} collection The Chroma `knowledge-base` collection.

--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -73,7 +73,7 @@ class Server extends BaseServer {
      * @returns {Array<String>}
      */
     getHealthExemptTools() {
-        return ['healthcheck', 'list_agent_faqs', 'manage_knowledge_base'];
+        return ['healthcheck', 'get_ingestion_progress', 'list_agent_faqs', 'manage_knowledge_base'];
     }
 
     /**

--- a/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
+++ b/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
@@ -1,5 +1,5 @@
-import aiConfig                      from './config.mjs';
-import KnowledgeBaseIngestionService from '../../../services/knowledge-base/KnowledgeBaseIngestionService.mjs';
+import aiConfig         from './config.mjs';
+import IngestionService from '../../../services/knowledge-base/IngestionService.mjs';
 
 const ingestToolName = 'ingest_source_files';
 
@@ -43,7 +43,7 @@ const assertToolTransportAllowed = toolName => {
 };
 
 /**
- * @summary MCP facade for `KnowledgeBaseIngestionService.ingestSourceFiles`.
+ * @summary MCP facade for `IngestionService.ingestSourceFiles`.
  *
  * An agent-initiated `ingest_source_files` push embeds synchronously; an oversized batch
  * would freeze the calling agent. This facade counts the batch volume up-front and, when
@@ -62,7 +62,7 @@ const assertToolTransportAllowed = toolName => {
  * @param {Object}    args            The `ingest_source_files` tool envelope.
  * @param {String}   [args.tenantId]  Authenticated tenant id.
  * @param {Object[]} [args.files]     Raw file payloads or client-side parsed records.
- * @returns {Promise<Object>} The `KnowledgeBaseIngestionService.ingestSourceFiles` summary,
+ * @returns {Promise<Object>} The `IngestionService.ingestSourceFiles` summary,
  *     OR a `{error, message, code: 'KB_INGEST_VOLUME_EXCEEDED', bulkPath, batchSize, threshold}`
  *     refusal when the work-volume gate fires.
  * @see https://github.com/neomjs/neo/issues/11634
@@ -87,7 +87,7 @@ const ingestSourceFilesViaMcp = async args => {
         };
     }
 
-    return KnowledgeBaseIngestionService.ingestSourceFiles(args);
+    return IngestionService.ingestSourceFiles(args);
 };
 
 export {

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -56,6 +56,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /ingestion/progress:
+    get:
+      summary: Get Ingestion Progress
+      operationId: get_ingestion_progress
+      x-annotations:
+        readOnlyHint: true
+      x-neo-tool-summary: Inspect active or last ingestion progress.
+      description: |
+        Returns a read-only snapshot for the active ingestion run, or an idle state with the last
+        completed run summary. This diagnostics tool stays separate from `healthcheck` so liveness
+        payloads remain compact.
+      tags: [Health]
+      parameters:
+        - in: query
+          name: staleAfterMs
+          schema:
+            type: integer
+            minimum: 0
+            default: 60000
+          description: Mark an active run stalled when no progress has occurred for this many milliseconds.
+      responses:
+        '200':
+          description: Ingestion progress snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IngestionProgressResponse'
+
   /tool/handbook:
     post:
       summary: Tool Handbook
@@ -1034,7 +1062,7 @@ components:
 
     IngestSourceFilesResponse:
       type: object
-      description: Structured ingestion summary returned by KnowledgeBaseIngestionService.
+      description: Structured ingestion summary returned by IngestionService.
       properties:
         ingested:
           type: integer
@@ -1060,6 +1088,80 @@ components:
         durationMs:
           type: integer
           description: Wall-clock duration of the ingestion in milliseconds.
+
+    IngestionProgressResponse:
+      type: object
+      description: Read-only active/idle ingestion progress snapshot.
+      additionalProperties: true
+      properties:
+        status:
+          type: string
+          enum: [idle, running, completed, completed_with_errors, failed]
+          description: Current progress state.
+        active:
+          type: boolean
+          description: True when an ingestion run is currently executing.
+        phase:
+          type: string
+          description: Current phase for an active run, or idle when no ingestion is running.
+        startedAt:
+          type: string
+          nullable: true
+          description: ISO timestamp for the active or last run start.
+        updatedAt:
+          type: string
+          nullable: true
+          description: ISO timestamp for the last progress ledger update.
+        lastProgressAt:
+          type: string
+          nullable: true
+          description: ISO timestamp for the last active progress event.
+        completedAt:
+          type: string
+          nullable: true
+          description: ISO timestamp for the last run completion.
+        durationMs:
+          type: integer
+          description: Elapsed wall-clock duration in milliseconds.
+        staleAfterMs:
+          type: integer
+          description: Staleness threshold used to compute stalled.
+        stalled:
+          type: boolean
+          description: True when an active run has not advanced within staleAfterMs.
+        tenantId:
+          type: string
+        repoSlug:
+          type: string
+        totalSources:
+          type: integer
+        seenSources:
+          type: integer
+        totalChunks:
+          type: integer
+        embeddedChunks:
+          type: integer
+        skippedChunks:
+          type: integer
+        remaining:
+          type: integer
+        deletedRows:
+          type: integer
+        errorCount:
+          type: integer
+        etaMs:
+          type: integer
+          nullable: true
+        rate:
+          type: object
+          additionalProperties: true
+          properties:
+            chunksPerSecond:
+              type: number
+        lastRunSummary:
+          type: object
+          nullable: true
+          additionalProperties: true
 
     KbIngestVolumeExceededResponse:
       type: object

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -3,6 +3,7 @@ import {fileURLToPath}               from 'url';
 import DatabaseService               from '../../../services/knowledge-base/DatabaseService.mjs';
 import DocumentService               from '../../../services/knowledge-base/DocumentService.mjs';
 import HealthService                 from '../../../services/knowledge-base/HealthService.mjs';
+import IngestionService              from '../../../services/knowledge-base/IngestionService.mjs';
 import KBRecorderService             from '../../../services/knowledge-base/KBRecorderService.mjs';
 import QueryService                  from '../../../services/knowledge-base/QueryService.mjs';
 import SearchService                 from '../../../services/knowledge-base/SearchService.mjs';
@@ -66,6 +67,7 @@ const serviceMapping = {
     healthcheck                  : HealthService           .healthcheck        .bind(HealthService),
     get_deployment_state_snapshot: readDeploymentInspection,
     inspect_deployment           : readDeploymentInspection,
+    get_ingestion_progress       : IngestionService        .getIngestionProgress.bind(IngestionService),
     list_documents               : DocumentService         .listDocuments      .bind(DocumentService),
     list_agent_faqs              : KBRecorderService       .listAgentFaqs      .bind(KBRecorderService),
     // MCP dispatch marks `viaMcp: true` so VectorService.embed can apply the synchronous

--- a/ai/scripts/maintenance/ingestTenant.mjs
+++ b/ai/scripts/maintenance/ingestTenant.mjs
@@ -9,7 +9,7 @@ import readline                     from 'readline';
 import {pathToFileURL}              from 'url';
 import KB_Config                    from '../../mcp/server/knowledge-base/config.mjs';
 import KB_ChromaManager             from '../../services/knowledge-base/ChromaManager.mjs';
-import KB_IngestionService          from '../../services/knowledge-base/KnowledgeBaseIngestionService.mjs';
+import KB_IngestionService          from '../../services/knowledge-base/IngestionService.mjs';
 import KB_LifecycleService          from '../../services/knowledge-base/DatabaseLifecycleService.mjs';
 import {withHeavyMaintenanceLease}  from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
 
@@ -19,7 +19,7 @@ import {withHeavyMaintenanceLease}  from '../../daemons/orchestrator/services/He
  * @summary Bulk-facade CLI (`npm run ai:ingest-tenant`) for Cloud-Native KB Ingestion.
  *
  * Streams `parsed-chunk-v1` JSONL records (one record per line) from a file or stdin into the
- * Knowledge Base via {@link Neo.ai.services.knowledge-base.KnowledgeBaseIngestionService}. This is
+ * Knowledge Base via {@link Neo.ai.services.knowledge-base.IngestionService}. This is
  * the bulk data-plane counterpart to the `ingest_source_files` MCP small-batch facade:
  * initial tenant onboarding (5k–50k chunks) and large `git push` hook bursts exceed the
  * MCP work-volume gate (`aiConfig.mcpSyncMaxChunks`), so the CLI calls `ingestSourceFiles` with

--- a/ai/services.mjs
+++ b/ai/services.mjs
@@ -33,7 +33,7 @@ import _KB_DatabaseService from './services/knowledge-base/DatabaseService.mjs';
 import _KB_LifecycleService from './services/knowledge-base/DatabaseLifecycleService.mjs';
 import _KB_DocumentService from './services/knowledge-base/DocumentService.mjs';
 import _KB_HealthService from './services/knowledge-base/HealthService.mjs';
-import _KB_IngestionService from './services/knowledge-base/KnowledgeBaseIngestionService.mjs';
+import _KB_IngestionService from './services/knowledge-base/IngestionService.mjs';
 import _KB_RecorderService from './services/knowledge-base/KBRecorderService.mjs';
 import _KB_QueryService from './services/knowledge-base/QueryService.mjs';
 import _KB_SearchService from './services/knowledge-base/SearchService.mjs';

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -9,19 +9,19 @@ import {
 }                            from '../memory-core/helpers/consumerFrictionHelper.mjs';
 import RequestContextService,
        {normalizeUserId}    from '../../mcp/server/shared/services/RequestContextService.mjs';
-import SourceRegistry        from './source/_export.mjs';
+import SourceRegistry       from './source/_export.mjs';
 import {normalizeTenantRepoConfig}
-                             from './helpers/tenantRepoAccessContract.mjs';
-import VectorService   from './VectorService.mjs';
-import aiConfig        from '../../mcp/server/knowledge-base/config.mjs';
-import crypto          from 'crypto';
-import fs              from 'fs-extra';
-import logger          from '../../mcp/server/knowledge-base/logger.mjs';
-import mcConfig        from '../../mcp/server/memory-core/config.mjs';
-import os              from 'os';
-import path            from 'path';
-import yaml            from 'js-yaml';
-import {fileURLToPath} from 'url';
+                            from './helpers/tenantRepoAccessContract.mjs';
+import VectorService        from './VectorService.mjs';
+import aiConfig             from '../../mcp/server/knowledge-base/config.mjs';
+import crypto               from 'crypto';
+import fs                   from 'fs-extra';
+import logger               from '../../mcp/server/knowledge-base/logger.mjs';
+import mcConfig             from '../../mcp/server/memory-core/config.mjs';
+import os                   from 'os';
+import path                 from 'path';
+import yaml                 from 'js-yaml';
+import {fileURLToPath}      from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -32,7 +32,7 @@ const PARSED_CHUNK_SCHEMA_PATH  = path.join(__dirname, 'parser/parsed-chunk-v1.s
 /**
  * @summary Orchestrates tenant-aware Knowledge Base ingestion pushes.
  *
- * `KnowledgeBaseIngestionService` is the service-layer substrate consumed by the
+ * `IngestionService` is the service-layer substrate consumed by the
  * MCP and bulk ingestion facades. It validates the caller tenant boundary, accepts
  * client-side parsed `parsed-chunk-v1` records or server-side raw file payloads,
  * rejects restore-only embedding records, applies deletion signaling, and delegates
@@ -43,17 +43,17 @@ const PARSED_CHUNK_SCHEMA_PATH  = path.join(__dirname, 'parser/parsed-chunk-v1.s
  * successful portion of a push, and fully failed pushes still return the contract
  * summary instead of throwing out of the facade boundary.
  *
- * @class Neo.ai.services.knowledge-base.KnowledgeBaseIngestionService
+ * @class Neo.ai.services.knowledge-base.IngestionService
  * @extends Neo.core.Base
  * @singleton
  */
-class KnowledgeBaseIngestionService extends Base {
+class IngestionService extends Base {
     static config = {
         /**
-         * @member {String} className='Neo.ai.services.knowledge-base.KnowledgeBaseIngestionService'
+         * @member {String} className='Neo.ai.services.knowledge-base.IngestionService'
          * @protected
          */
-        className: 'Neo.ai.services.knowledge-base.KnowledgeBaseIngestionService',
+        className: 'Neo.ai.services.knowledge-base.IngestionService',
         /**
          * @member {Boolean} singleton=true
          * @protected
@@ -103,6 +103,18 @@ class KnowledgeBaseIngestionService extends Base {
     parsedChunkValidator = null
 
     /**
+     * @member {Object|null} activeIngestionProgress=null
+     * @summary In-memory progress ledger for the currently executing ingestion request.
+     */
+    activeIngestionProgress = null
+
+    /**
+     * @member {Object|null} lastIngestionProgress=null
+     * @summary Last completed ingestion snapshot surfaced while the service is idle.
+     */
+    lastIngestionProgress = null
+
+    /**
      * @summary Ingests raw or client-parsed source files into the Knowledge Base.
      *
      * @param {Object}  payload
@@ -143,10 +155,29 @@ class KnowledgeBaseIngestionService extends Base {
                 }));
             }
 
-            const files            = Array.isArray(payload.files) ? payload.files : [];
-            const chunks           = await this.collectParsedChunks({files, tenantContext, summary});
-            const embeddableChunks = this.filterEmbeddingInputBudget({chunks, tenantContext, summary});
+            const files = Array.isArray(payload.files) ? payload.files : [];
 
+            this.startIngestionProgress({
+                startedAt,
+                tenantContext,
+                totalSources: files.length
+            });
+
+            const chunks = await this.collectParsedChunks({files, tenantContext, summary});
+            this.updateIngestionProgress({
+                errorCount : summary.errors.length,
+                phase      : 'filtering',
+                totalChunks: chunks.length
+            });
+
+            const embeddableChunks = this.filterEmbeddingInputBudget({chunks, tenantContext, summary});
+            this.updateIngestionProgress({
+                embeddableChunks: embeddableChunks.length,
+                errorCount      : summary.errors.length,
+                skippedChunks   : summary.skippedOversized
+            });
+
+            this.updateIngestionProgress({phase: 'deleting'});
             summary.deleted = await this.applyDeletionSignals({
                 deleted         : payload.deleted,
                 manifestSnapshot: payload.manifestSnapshot,
@@ -155,8 +186,10 @@ class KnowledgeBaseIngestionService extends Base {
                 tenantContext,
                 summary
             });
+            this.updateIngestionProgress({deletedRows: summary.deleted});
 
             if (embeddableChunks.length > 0) {
+                this.updateIngestionProgress({phase: 'embedding'});
                 await this.embedChunkGroups({
                     chunks: embeddableChunks,
                     tenantContext,
@@ -168,6 +201,7 @@ class KnowledgeBaseIngestionService extends Base {
             summary.ingested   = embeddableChunks.length;
             summary.durationMs = Date.now() - startedAt;
 
+            this.updateIngestionProgress({phase: 'manifest'});
             await this.persistManifestSnapshot({
                 manifestSnapshot: payload.manifestSnapshot,
                 tenantContext,
@@ -175,14 +209,22 @@ class KnowledgeBaseIngestionService extends Base {
             });
 
             this.recordMetric(summary, tenantContext);
+            this.finishIngestionProgress({
+                summary,
+                status: summary.errors.length > 0 ? 'completed_with_errors' : 'completed'
+            });
             return summary;
         } catch (error) {
-            summary.errors.push(this.createError({code: error.code || 'KB_INGEST_FAILED', message: error.message}));
+            summary.errors.push(this.createError({
+                code   : error.code || 'KB_INGEST_FAILED',
+                message: error.message
+            }));
             summary.durationMs = Date.now() - startedAt;
             this.recordMetric(summary, {
                 tenantId: summary.tenantId || aiConfig.defaultTenantId,
                 repoSlug: aiConfig.defaultRepoSlug
             });
+            this.finishIngestionProgress({summary, status: 'failed'});
             return summary;
         }
     }
@@ -290,16 +332,28 @@ class KnowledgeBaseIngestionService extends Base {
                         message: result.message || result.error,
                         details: result
                     }));
+                    this.updateIngestionProgress({
+                        embeddedChunks: summary.embeddingsGenerated,
+                        errorCount    : summary.errors.length
+                    });
                     continue;
                 }
 
                 summary.embeddingsGenerated += result?.embedded ?? group.length;
+                this.updateIngestionProgress({
+                    embeddedChunks: summary.embeddingsGenerated,
+                    errorCount    : summary.errors.length
+                });
             } catch (error) {
                 summary.errors.push(this.createError({
                     code   : error.code || 'KB_VECTOR_EMBED_FAILED',
                     message: error.message,
                     details: {repoSlug}
                 }));
+                this.updateIngestionProgress({
+                    embeddedChunks: summary.embeddingsGenerated,
+                    errorCount    : summary.errors.length
+                });
             } finally {
                 await fs.remove(tempFile);
             }
@@ -342,6 +396,12 @@ class KnowledgeBaseIngestionService extends Base {
                     details: {fileIndex, sourcePath: file?.sourcePath}
                 }));
             }
+
+            this.updateIngestionProgress({
+                errorCount : summary.errors.length,
+                seenSources: fileIndex + 1,
+                totalChunks: chunks.length
+            });
         }
 
         return chunks;
@@ -377,6 +437,196 @@ class KnowledgeBaseIngestionService extends Base {
             tenantId           : aiConfig.defaultTenantId,
             durationMs         : Date.now() - startedAt
         };
+    }
+
+    /**
+     * @summary Returns the current ingestion progress snapshot.
+     *
+     * This is a diagnostics surface, deliberately separate from `healthcheck`: liveness stays
+     * compact while operators can still inspect whether a long ingestion is healthy, idle, or stale.
+     *
+     * @param {Object} [options]
+     * @param {Number} [options.staleAfterMs=60000] Age after which the active run is marked stalled.
+     * @returns {Object} Read-only ingestion progress snapshot.
+     */
+    getIngestionProgress({staleAfterMs = 60000} = {}) {
+        const now = Date.now();
+
+        if (this.activeIngestionProgress) {
+            return this.createIngestionProgressSnapshot({
+                progress: this.activeIngestionProgress,
+                active  : true,
+                now,
+                staleAfterMs
+            });
+        }
+
+        const lastRunSummary = this.lastIngestionProgress
+            ? this.createIngestionProgressSnapshot({
+                progress: this.lastIngestionProgress,
+                active  : false,
+                now,
+                staleAfterMs
+            })
+            : null;
+
+        return {
+            status        : 'idle',
+            active        : false,
+            phase         : 'idle',
+            startedAt     : null,
+            updatedAt     : lastRunSummary?.updatedAt ?? null,
+            lastProgressAt: null,
+            completedAt   : lastRunSummary?.completedAt ?? null,
+            durationMs    : 0,
+            staleAfterMs,
+            stalled       : false,
+            totalSources  : 0,
+            seenSources   : 0,
+            totalChunks   : 0,
+            embeddedChunks: 0,
+            skippedChunks : 0,
+            remaining     : 0,
+            deletedRows   : 0,
+            errorCount    : 0,
+            lastRunSummary
+        };
+    }
+
+    /**
+     * @summary Starts the active ingestion progress ledger.
+     * @param {Object} options
+     * @returns {void}
+     * @protected
+     */
+    startIngestionProgress({startedAt, tenantContext, totalSources}) {
+        this.activeIngestionProgress = {
+            status          : 'running',
+            phase           : 'collecting',
+            startedAt,
+            updatedAt       : startedAt,
+            lastProgressAt  : startedAt,
+            completedAt     : null,
+            tenantId        : tenantContext.tenantId,
+            repoSlug        : tenantContext.repoSlug,
+            totalSources,
+            seenSources     : 0,
+            totalChunks     : 0,
+            embeddableChunks: 0,
+            embeddedChunks  : 0,
+            skippedChunks   : 0,
+            deletedRows     : 0,
+            errorCount      : 0
+        };
+    }
+
+    /**
+     * @summary Mutates the active progress ledger with a fresh progress timestamp.
+     * @param {Object} updates
+     * @returns {void}
+     * @protected
+     */
+    updateIngestionProgress(updates = {}) {
+        if (!this.activeIngestionProgress) return;
+
+        const now = Date.now();
+        Object.assign(this.activeIngestionProgress, updates, {
+            updatedAt     : now,
+            lastProgressAt: now
+        });
+    }
+
+    /**
+     * @summary Completes the active progress ledger and stores the idle last-run summary.
+     * @param {Object} options
+     * @returns {void}
+     * @protected
+     */
+    finishIngestionProgress({summary, status}) {
+        const active = this.activeIngestionProgress;
+        const now    = Date.now();
+
+        this.lastIngestionProgress = {
+            ...(active || {
+                startedAt       : now - (summary.durationMs || 0),
+                tenantId        : summary.tenantId,
+                repoSlug        : aiConfig.defaultRepoSlug,
+                totalSources    : 0,
+                seenSources     : 0,
+                totalChunks     : summary.ingested + summary.skippedOversized,
+                embeddableChunks: summary.ingested,
+                skippedChunks   : summary.skippedOversized
+            }),
+            status,
+            phase         : 'completed',
+            updatedAt     : now,
+            lastProgressAt: now,
+            completedAt   : now,
+            embeddedChunks: summary.embeddingsGenerated,
+            skippedChunks : summary.skippedOversized,
+            deletedRows   : summary.deleted,
+            errorCount    : summary.errors.length
+        };
+
+        this.activeIngestionProgress = null;
+    }
+
+    /**
+     * @summary Normalizes a progress ledger into the public diagnostics shape.
+     * @param {Object} options
+     * @returns {Object}
+     * @protected
+     */
+    createIngestionProgressSnapshot({progress, active, now, staleAfterMs}) {
+        const startedAt        = progress.startedAt;
+        const completedAt      = progress.completedAt;
+        const durationMs       = completedAt ? Math.max(0, completedAt - startedAt) : Math.max(0, now - startedAt);
+        const totalChunks      = progress.totalChunks || 0;
+        const embeddableChunks = progress.embeddableChunks || 0;
+        const embeddedChunks   = progress.embeddedChunks || 0;
+        const skippedChunks    = progress.skippedChunks || 0;
+        const targetChunks     = embeddableChunks > 0 || skippedChunks > 0 ? embeddableChunks : totalChunks;
+        const remaining        = Math.max(0, targetChunks - embeddedChunks);
+        const stalled          = active && staleAfterMs > 0 && now - progress.lastProgressAt > staleAfterMs;
+        const chunksPerSecond  = durationMs > 0 ? embeddedChunks / (durationMs / 1000) : 0;
+        const etaMs            = active && chunksPerSecond > 0 ? Math.ceil((remaining / chunksPerSecond) * 1000) : null;
+
+        return {
+            status        : progress.status,
+            active,
+            phase         : active ? progress.phase : 'idle',
+            startedAt     : this.formatProgressTimestamp(startedAt),
+            updatedAt     : this.formatProgressTimestamp(progress.updatedAt),
+            lastProgressAt: active ? this.formatProgressTimestamp(progress.lastProgressAt) : null,
+            completedAt   : this.formatProgressTimestamp(completedAt),
+            durationMs,
+            staleAfterMs,
+            stalled,
+            tenantId      : progress.tenantId,
+            repoSlug      : progress.repoSlug,
+            totalSources  : progress.totalSources || 0,
+            seenSources   : progress.seenSources || 0,
+            totalChunks,
+            embeddedChunks,
+            skippedChunks,
+            remaining,
+            deletedRows   : progress.deletedRows || 0,
+            errorCount    : progress.errorCount || 0,
+            rate          : {
+                chunksPerSecond
+            },
+            etaMs
+        };
+    }
+
+    /**
+     * @summary Formats an epoch millisecond timestamp for the public progress snapshot.
+     * @param {Number|null|undefined} timestamp
+     * @returns {String|null}
+     * @protected
+     */
+    formatProgressTimestamp(timestamp) {
+        return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
     }
 
     /**
@@ -808,7 +1058,7 @@ class KnowledgeBaseIngestionService extends Base {
 
         emitConsumerFriction({
             assetRef                 : `${details.tenantId}:${details.repoSlug}:${details.sourcePath}`,
-            consumer                 : 'KnowledgeBaseIngestionService.ingestSourceFiles',
+            consumer                 : 'IngestionService.ingestSourceFiles',
             model                    : guardrail.model,
             symptom                  : 'size-precheck-skip',
             emissionPoint            : 'pre-invocation',
@@ -821,7 +1071,7 @@ class KnowledgeBaseIngestionService extends Base {
             note                     : 'KB ingestion chunk exceeds local embedding safe-processing band; add parser chunking or skip this source file.'
         });
 
-        logger.warn('[KnowledgeBaseIngestionService] Skipping oversized ingestion chunk before embedding.', details);
+        logger.warn('[IngestionService] Skipping oversized ingestion chunk before embedding.', details);
     }
 
     /**
@@ -1313,4 +1563,4 @@ class KnowledgeBaseIngestionService extends Base {
     }
 }
 
-export default Neo.setupClass(KnowledgeBaseIngestionService);
+export default Neo.setupClass(IngestionService);

--- a/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
@@ -468,7 +468,7 @@ function ingestSourceFilesViaMcpTool({collectionName, repoSlug, tenantId}) {
  * Drives the `ai:ingest-tenant` Phase 2C bulk-facade CLI end-to-end inside the deployed KB
  * container. Streams a 1k+-record `parsed-chunk-v1` JSONL fixture through the CLI's exported
  * orchestration units (`readJsonlRecords` -> `runIngest`) wired to the real ingestion `ingestFn`
- * (`KnowledgeBaseIngestionService.ingestSourceFiles` with `viaMcp:false` — the bulk gate-bypass),
+ * (`IngestionService.ingestSourceFiles` with `viaMcp:false` — the bulk gate-bypass),
  * then verifies the isolated temp collection holds every embedded chunk. The ingestion service
  * is imported directly (not via `ai/services.mjs`) so the closure-injected `viaMcp:false` flag
  * survives the makeSafe Zod wrapper and reaches `VectorService.embed` as the explicit #10572
@@ -496,7 +496,7 @@ function ingestTenantViaCli({collectionName, recordCount, repoSlug, tenantId}) {
         // Direct import (not ai/services.mjs): the makeSafe Zod wrapper strips the
         // closure-injected viaMcp flag, and the bulk CLI relies on viaMcp:false reaching
         // VectorService.embed as the explicit #10572 work-volume-gate bypass.
-        const {default: KB_IngestionService} = await import('./ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs');
+        const {default: KB_IngestionService} = await import('./ai/services/knowledge-base/IngestionService.mjs');
         const {readJsonlRecords, runIngest}  = await import('./ai/scripts/maintenance/ingestTenant.mjs');
 
         await KB_LifecycleService.ready();
@@ -583,7 +583,7 @@ function ingestTenantViaCli({collectionName, recordCount, repoSlug, tenantId}) {
  * container. Writes a tenant's config as a `KnowledgeBaseTenantConfig` graph node via
  * `setTenantConfig`, reads it back, then simulates a KB-server restart by dropping the
  * in-memory Native Edge Graph cache — forcing the next `getTenantConfig` to reload the node
- * from the on-disk `memory-core-graph.sqlite`. `KnowledgeBaseIngestionService` is imported
+ * from the on-disk `memory-core-graph.sqlite`. `IngestionService` is imported
  * directly (not via `ai/services.mjs`) so the makeSafe Zod wrapper does not strip the
  * structured config payload; all calls run under the tenant's request context so the
  * `setTenantConfig` RLS gate and the `getNodeRecord` RLS re-check resolve as the owner.
@@ -596,7 +596,7 @@ function tenantConfigPersistsAcrossRestart({tenantId}) {
         ${NEO_BOOTSTRAP}
 
         const {KB_LifecycleService}            = await import('./ai/services.mjs');
-        const {default: KB_IngestionService}   = await import('./ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs');
+        const {default: KB_IngestionService}   = await import('./ai/services/knowledge-base/IngestionService.mjs');
         const {default: GraphService}          = await import('./ai/services/memory-core/GraphService.mjs');
         const {default: RequestContextService} = await import('./ai/mcp/server/shared/services/RequestContextService.mjs');
 

--- a/test/playwright/integration/ai/kb-ingestion/multi-tenant.spec.mjs
+++ b/test/playwright/integration/ai/kb-ingestion/multi-tenant.spec.mjs
@@ -112,7 +112,7 @@ function runMultiTenantMatrix(collectionName) {
         } = await import('./ai/services.mjs');
         const {callTool} = await import('./ai/mcp/server/knowledge-base/toolService.mjs');
         const {default: KbReconciliationService} = await import('./ai/daemons/kb-reconciliation/KbReconciliationService.mjs');
-        const {default: KnowledgeBaseIngestionService} = await import('./ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs');
+        const {default: IngestionService} = await import('./ai/services/knowledge-base/IngestionService.mjs');
         const {default: QueryService} = await import('./ai/services/knowledge-base/QueryService.mjs');
         const {default: SearchService} = await import('./ai/services/knowledge-base/SearchService.mjs');
         const {default: SourceRegistry} = await import('./ai/services/knowledge-base/source/_export.mjs');
@@ -226,7 +226,7 @@ function runMultiTenantMatrix(collectionName) {
             spoofRejectionMode: KB_Config.data.spoofRejectionMode,
             embedText        : Memory_TextEmbeddingService.embedText.bind(Memory_TextEmbeddingService),
             embedTexts       : Memory_TextEmbeddingService.embedTexts.bind(Memory_TextEmbeddingService),
-            revisionResolver : KnowledgeBaseIngestionService.revisionResolver
+            revisionResolver : IngestionService.revisionResolver
         };
 
         KB_Config.data.collectionName     = process.env.NEO_TEST_KB_COLLECTION;
@@ -446,7 +446,7 @@ function runMultiTenantMatrix(collectionName) {
             await waitForRows({tenantId: 'tenant-alpha'}, rows => rows.some(row => (
                 row.metadata.repoSlug === forcePushRepoSlug && row.metadata.sourcePath === forcePushSourcePath
             )));
-            KnowledgeBaseIngestionService.revisionResolver = {
+            IngestionService.revisionResolver = {
                 resolveDeletedPaths: async () => [{repoSlug: forcePushRepoSlug, sourcePath: forcePushSourcePath}]
             };
             const forcePush = await asTenant('tenant-alpha', () => callTool('ingest_source_files', {
@@ -469,7 +469,7 @@ function runMultiTenantMatrix(collectionName) {
                 newPresent: forceRows.some(row => row.metadata.repoSlug === forcePushRepoSlug && row.metadata.sourcePath === 'src/new.js')
             };
 
-            await asTenant('tenant-alpha', () => KnowledgeBaseIngestionService.setTenantManifest({
+            await asTenant('tenant-alpha', () => IngestionService.setTenantManifest({
                 tenantId      : 'tenant-alpha',
                 repoSlug      : forcePushRepoSlug,
                 pathsAfterPush: ['src/new.js']
@@ -517,7 +517,7 @@ function runMultiTenantMatrix(collectionName) {
         } finally {
             Memory_TextEmbeddingService.embedText  = originals.embedText;
             Memory_TextEmbeddingService.embedTexts = originals.embedTexts;
-            KnowledgeBaseIngestionService.revisionResolver = originals.revisionResolver;
+            IngestionService.revisionResolver = originals.revisionResolver;
             delete KbReconciliationService.recordReconcileMetric;
             KB_Config.data.collectionName      = originals.collectionName;
             KB_Config.data.defaultRepoSlug     = originals.defaultRepoSlug;

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
@@ -22,7 +22,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 /**
  * Coverage for the `ingest_source_files` MCP facade (#11634, Phase 2B).
  *
- * `ingestSourceFilesViaMcp` wraps `KnowledgeBaseIngestionService.ingestSourceFiles`
+ * `ingestSourceFilesViaMcp` wraps `IngestionService.ingestSourceFiles`
  * with the #10572 work-volume gate: an oversized agent-initiated push is refused
  * up-front with a structured `KB_INGEST_VOLUME_EXCEEDED` payload instead of being
  * dispatched (which would embed synchronously and freeze the calling agent).
@@ -32,12 +32,12 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
  * wrapper; `listTools()` separately confirms the openapi operation registers.
  *
  * Serial mode: specs mutate the `aiConfig.mcpSyncMaxChunks` threshold and the
- * `KnowledgeBaseIngestionService.ingestSourceFiles` singleton method.
+ * `IngestionService.ingestSourceFiles` singleton method.
  */
 test.describe.configure({mode: 'serial'});
 
 test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', () => {
-    let callTool, ingestSourceFilesViaMcp, listTools, KnowledgeBaseIngestionService, aiConfig;
+    let callTool, ingestSourceFilesViaMcp, listTools, IngestionService, aiConfig;
     let originalIngest, originalThreshold, originalTransport;
 
     test.beforeAll(async () => {
@@ -47,17 +47,17 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
         ingestSourceFilesViaMcp = ingestTool.ingestSourceFilesViaMcp;
         listTools               = toolService.listTools;
 
-        KnowledgeBaseIngestionService = (await import('../../../../../../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs')).default;
+        IngestionService = (await import('../../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
         aiConfig                      = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
 
-        originalIngest    = KnowledgeBaseIngestionService.ingestSourceFiles;
+        originalIngest    = IngestionService.ingestSourceFiles;
         originalThreshold = aiConfig.mcpSyncMaxChunks;
         originalTransport = aiConfig.transport;
     });
 
     test.afterAll(() => {
-        if (KnowledgeBaseIngestionService) {
-            KnowledgeBaseIngestionService.ingestSourceFiles = originalIngest;
+        if (IngestionService) {
+            IngestionService.ingestSourceFiles = originalIngest;
         }
         if (aiConfig) {
             aiConfig.mcpSyncMaxChunks = originalThreshold;
@@ -69,12 +69,12 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
         // Tight, predictable threshold; restore the real service method before each spec.
         aiConfig.mcpSyncMaxChunks                       = 5;
         aiConfig.transport                              = 'sse';
-        KnowledgeBaseIngestionService.ingestSourceFiles = originalIngest;
+        IngestionService.ingestSourceFiles = originalIngest;
     });
 
     test('gate fires above threshold — returns KB_INGEST_VOLUME_EXCEEDED, service not dispatched', async () => {
         let dispatched = false;
-        KnowledgeBaseIngestionService.ingestSourceFiles = async () => {
+        IngestionService.ingestSourceFiles = async () => {
             dispatched = true;
             return {};
         };
@@ -95,7 +95,7 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
         let dispatchedArgs = null;
         const summary      = {ingested: 5, deleted: 0, embeddingsGenerated: 5, errors: [], tenantId: 'neo-shared', durationMs: 1};
 
-        KnowledgeBaseIngestionService.ingestSourceFiles = async args => {
+        IngestionService.ingestSourceFiles = async args => {
             dispatchedArgs = args;
             return summary;
         };
@@ -111,7 +111,7 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
 
     test('batch volume sums parsedChunks lengths and counts each raw file as 1', async () => {
         let dispatched = false;
-        KnowledgeBaseIngestionService.ingestSourceFiles = async () => {
+        IngestionService.ingestSourceFiles = async () => {
             dispatched = true;
             return {};
         };
@@ -131,7 +131,7 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
 
     test('missing files field dispatches with a zero batch volume', async () => {
         let dispatchedArgs = 'unset';
-        KnowledgeBaseIngestionService.ingestSourceFiles = async args => {
+        IngestionService.ingestSourceFiles = async args => {
             dispatchedArgs = args;
             return {ingested: 0, deleted: 0, embeddingsGenerated: 0, errors: [], tenantId: 'neo-shared', durationMs: 0};
         };

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
@@ -31,7 +31,7 @@ test.describe('Neo.ai.mcp.server.knowledge-base.Server', () => {
         try {
             const exemptTools = serverInstance.getHealthExemptTools();
 
-            expect(exemptTools).toEqual(['healthcheck', 'list_agent_faqs', 'manage_knowledge_base']);
+            expect(exemptTools).toEqual(['healthcheck', 'get_ingestion_progress', 'list_agent_faqs', 'manage_knowledge_base']);
             expect(exemptTools).not.toContain('start_database');
             expect(exemptTools).not.toContain('stop_database');
         } finally {

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -1,6 +1,6 @@
 import {setup} from '../../../../setup.mjs';
 
-const appName = 'KBIngestionServiceTest';
+const appName = 'IngestionServiceTest';
 
 setup({
     neoConfig: {
@@ -22,7 +22,7 @@ import fs             from 'fs-extra';
 import aiConfig       from '../../../../../../ai/mcp/server/knowledge-base/config.mjs';
 
 /**
- * Contract coverage for KnowledgeBaseIngestionService (#11633).
+ * Contract coverage for IngestionService (#11633).
  *
  * The suite uses mock VectorService / Chroma / telemetry dependencies so it verifies the
  * Phase 2A orchestration contract without touching the real ChromaDB collection or external
@@ -101,7 +101,7 @@ function createEmbeddingGuardrail(overrides = {}) {
     };
 }
 
-test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
+test.describe('IngestionService.ingestSourceFiles', () => {
     let Service;
     let originals;
     let vectorCalls;
@@ -109,7 +109,7 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
     let collection;
 
     test.beforeAll(async () => {
-        Service = (await import('../../../../../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs')).default;
+        Service = (await import('../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
     });
 
     test.beforeEach(() => {
@@ -119,8 +119,10 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
 
         originals = {
             chromaManager                 : Service.chromaManager,
+            activeIngestionProgress       : Service.activeIngestionProgress,
             graphService                  : Service.graphService,
             getTenantConfig               : Service.getTenantConfig,
+            lastIngestionProgress         : Service.lastIngestionProgress,
             recorderService               : Service.recorderService,
             requestContextService         : Service.requestContextService,
             resolveEmbeddingInputGuardrail: Service.resolveEmbeddingInputGuardrail,
@@ -156,6 +158,8 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
                 return {message: 'Embedding complete. Collection now contains 1 items.', embedded: lines.length, deleted: 0};
             }
         };
+        Service.activeIngestionProgress = null;
+        Service.lastIngestionProgress   = null;
     });
 
     test.afterEach(() => {
@@ -193,6 +197,112 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
             eventType     : 'ingest',
             chunksTotal   : 1,
             chunksEmbedded: 1
+        });
+    });
+
+    test('reports idle ingestion progress before any observed run (#14028)', () => {
+        expect(Service.getIngestionProgress()).toMatchObject({
+            status        : 'idle',
+            active        : false,
+            phase         : 'idle',
+            stalled       : false,
+            totalSources  : 0,
+            seenSources   : 0,
+            totalChunks   : 0,
+            embeddedChunks: 0,
+            skippedChunks : 0,
+            remaining     : 0,
+            lastRunSummary: null
+        });
+    });
+
+    test('reports active ingestion progress and preserves the last-run summary (#14028)', async () => {
+        let activeSnapshot;
+        let releaseEmbed;
+        const embedGate = new Promise(resolve => { releaseEmbed = resolve; });
+
+        Service.vectorService.embed = async (filePath, options) => {
+            const lines = (await fs.readFile(filePath, 'utf8')).trim().split('\n').filter(Boolean);
+            vectorCalls.push({filePath, options, records: lines.map(line => JSON.parse(line))});
+            activeSnapshot = Service.getIngestionProgress({staleAfterMs: 60000});
+            await embedGate;
+            return {message: 'Embedding complete.', embedded: lines.length, deleted: 0};
+        };
+
+        const ingestPromise = Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk()]}]
+        });
+
+        while (!activeSnapshot) {
+            await new Promise(resolve => setTimeout(resolve, 0));
+        }
+
+        expect(activeSnapshot).toMatchObject({
+            status        : 'running',
+            active        : true,
+            phase         : 'embedding',
+            stalled       : false,
+            totalSources  : 1,
+            seenSources   : 1,
+            totalChunks   : 1,
+            embeddedChunks: 0,
+            skippedChunks : 0,
+            remaining     : 1
+        });
+
+        releaseEmbed();
+
+        const summary = await ingestPromise;
+        expect(summary.embeddingsGenerated).toBe(1);
+
+        const idle = Service.getIngestionProgress();
+        expect(idle).toMatchObject({
+            status: 'idle',
+            active: false,
+            phase : 'idle'
+        });
+        expect(idle.lastRunSummary).toMatchObject({
+            status        : 'completed',
+            active        : false,
+            totalSources  : 1,
+            seenSources   : 1,
+            totalChunks   : 1,
+            embeddedChunks: 1,
+            remaining     : 0
+        });
+    });
+
+    test('marks active progress stalled when the last progress timestamp exceeds the threshold (#14028)', () => {
+        const now = Date.now();
+
+        Service.activeIngestionProgress = {
+            status          : 'running',
+            phase           : 'embedding',
+            startedAt       : now - 1000,
+            updatedAt       : now - 1000,
+            lastProgressAt  : now - 1000,
+            completedAt     : null,
+            tenantId        : 'tenant-a',
+            repoSlug        : 'repo-a',
+            totalSources    : 1,
+            seenSources     : 1,
+            totalChunks     : 2,
+            embeddableChunks: 2,
+            embeddedChunks  : 1,
+            skippedChunks   : 0,
+            deletedRows     : 0,
+            errorCount      : 0
+        };
+
+        const snapshot = Service.getIngestionProgress({staleAfterMs: 1});
+
+        expect(snapshot).toMatchObject({
+            status   : 'running',
+            active   : true,
+            phase    : 'embedding',
+            stalled  : true,
+            remaining: 1
         });
     });
 
@@ -500,6 +610,16 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
         });
         expect(summary.errors[0].details).not.toHaveProperty('content');
         expect(vectorCalls).toHaveLength(0);
+
+        const idle = Service.getIngestionProgress();
+
+        expect(idle.lastRunSummary).toMatchObject({
+            status        : 'completed_with_errors',
+            totalChunks   : 1,
+            embeddedChunks: 0,
+            skippedChunks : 1,
+            remaining     : 0
+        });
     });
 
     test('does not apply local embedding caps to non-local ingestion providers', async () => {
@@ -608,13 +728,13 @@ test.describe('KnowledgeBaseIngestionService.ingestSourceFiles', () => {
     });
 });
 
-test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
+test.describe('IngestionService.tenantConfig (#11637)', () => {
     let Service;
     let originals;
     let graphStub;
 
     test.beforeAll(async () => {
-        Service = (await import('../../../../../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs')).default;
+        Service = (await import('../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
     });
 
     test.beforeEach(() => {
@@ -809,14 +929,14 @@ test.describe('KnowledgeBaseIngestionService.tenantConfig (#11637)', () => {
     });
 });
 
-test.describe('KnowledgeBaseIngestionService.listConfiguredTenantRepos (#12145)', () => {
+test.describe('IngestionService.listConfiguredTenantRepos (#12145)', () => {
     let Service;
     let originals;
     let graphStub;
     let originalAiConfigRepos;
 
     test.beforeAll(async () => {
-        Service = (await import('../../../../../../ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs')).default;
+        Service = (await import('../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
     });
 
     test.beforeEach(() => {


### PR DESCRIPTION
Resolves #14028

Adds a read-only Knowledge Base ingestion progress surface so operators can inspect active and last ingestion runs without expanding `healthcheck`. `IngestionService` tracks phase, counters, staleness, and last-run summary in memory; the KB MCP server exposes that snapshot through `get_ingestion_progress` as a health-gate-exempt diagnostics tool.

Evidence: L2 focused unit/API-shape coverage passed for the close-target behavior; residual L4 validation is limited to watching the live tool during a long post-merge ingestion.

## Deltas from ticket

Implemented the separate `get_ingestion_progress` tool rather than adding fields to `healthcheck`.

The surface reports current-process active/last-run state. Persistent historical rollups stay with the existing KB telemetry path.

Consistency update: the KB-local service is renamed from `KnowledgeBaseIngestionService` to `IngestionService` so the service file/class naming matches the rest of `ai/services/knowledge-base/`.

This head was rebuilt on current `origin/dev` to remove unrelated merged-file churn. Current GitHub diff is 13 files: the ingestion-progress tool surface, the `IngestionService` service/spec rename, and the actual import sites required by that rename.

## Test Evidence

- `node --check ai/services/knowledge-base/IngestionService.mjs` -> passed
- `node --check ai/mcp/server/knowledge-base/toolService.mjs` -> passed
- `node --check ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs` -> passed
- `node --check ai/daemons/kb-reconciliation/KbReconciliationService.mjs` -> passed
- `node --check ai/scripts/maintenance/ingestTenant.mjs` -> passed
- `node --check ai/services.mjs` -> passed
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs` -> 47 passed
- `git diff --check origin/dev...HEAD` -> passed

## Post-Merge Validation

- [ ] During a long KB ingestion, call `get_ingestion_progress` and verify phase/counters advance while `healthcheck` stays compact.

## Commit

- `1bab595800` - `fix(ai): rebuild KB ingestion progress diff (#14028)`

Authored by Euclid (GPT-5, Codex Desktop). Session 35f83031-f1a6-41a7-9c3b-089b87307db9.