### PR TITLE
fix(ai): surface defrag unrecoverable reasons (#14023)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -976,7 +976,7 @@ export async function repairMemoryCoreCollectionViaResumableShadow({
                 shadowName,
                 loadedCount,
                 unrecoverableCount  : unrecoverable.length,
-                unrecoverablePreview: unrecoverable.slice(0, 20),
+                unrecoverablePreview: createUnrecoverablePreview(unrecoverable),
                 counts
             }
         });
@@ -1146,7 +1146,7 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
             });
 
             if (unrecoverable.length > 0) {
-                log(`   ⚠️  '${collectionName}': DRY-RUN found ${unrecoverable.length} unrecoverable row(s) (document-less / metadata-absent) — no promotion attempted. Counts: ${JSON.stringify(counts)}`);
+                log(`   ⚠️  '${collectionName}': DRY-RUN found ${unrecoverable.length} unrecoverable row(s) — no promotion attempted. Reasons: ${formatUnrecoverablePreview(unrecoverable)}. Counts: ${JSON.stringify(counts)}`);
                 results.push({collectionName, dryRun: true, aborted: true, unrecoverable, counts});
                 continue;
             }
@@ -1173,7 +1173,7 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
         });
 
         if (result.aborted) {
-            log(`   ⚠️  '${collectionName}': ${result.unrecoverable.length} unrecoverable row(s) (document-less / metadata-absent / provider-overcap) — aborting before promotion, but keeping resumable shadow '${result.shadowName}'. Counts: ${JSON.stringify(result.counts)}`);
+            log(`   ⚠️  '${collectionName}': ${result.unrecoverable.length} unrecoverable row(s) — aborting before promotion, but keeping resumable shadow '${result.shadowName}'. Reasons: ${formatUnrecoverablePreview(result.unrecoverable)}. Counts: ${JSON.stringify(result.counts)}`);
             results.push(result);
             break;
         }
@@ -1197,7 +1197,7 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
                 sourceCount         : activeAbort?.sourceCount,
                 loadedCount         : activeAbort?.loadedCount,
                 unrecoverableCount  : activeAbort?.unrecoverable?.length,
-                unrecoverablePreview: activeAbort?.unrecoverable?.slice?.(0, 20) || [],
+                unrecoverablePreview: createUnrecoverablePreview(activeAbort?.unrecoverable),
                 aborted             : results.filter(result => result.aborted).map(result => result.collectionName),
                 promoted            : results.filter(result => result.promotion).map(result => result.collectionName)
             }});
@@ -1233,6 +1233,67 @@ export function formatMemoryCoreRepairProgress({collectionName, event, now = new
         default:
             return `   [${timestamp}] ⏳ '${collectionName}': ${event.phase || 'progress'} ${event.percent ?? '?'}% (${event.processed ?? '?'}/${event.total ?? '?'})`;
     }
+}
+
+/**
+ * @summary Normalizes structured and legacy unrecoverable entries for state/log consumers.
+ * @param {String|Object} entry Unrecoverable row entry.
+ * @returns {Object} Structured unrecoverable row entry.
+ */
+export function normalizeUnrecoverableEntry(entry) {
+    if (entry && typeof entry === 'object') {
+        const normalized = {
+            id    : String(entry.id ?? ''),
+            reason: entry.reason || 'unknown'
+        };
+
+        if (entry.message) {
+            normalized.message = String(entry.message);
+        }
+
+        return normalized
+    }
+
+    return {
+        id    : String(entry),
+        reason: 'unknown'
+    }
+}
+
+/**
+ * @summary Creates the bounded structured preview stored in defrag abort state markers.
+ * @param {Array<String|Object>} [entries=[]] Unrecoverable rows.
+ * @param {Number} [limit=20] Maximum preview entries.
+ * @returns {Object[]} Structured unrecoverable row entries.
+ */
+export function createUnrecoverablePreview(entries = [], limit = 20) {
+    return entries.slice(0, limit).map(entry => normalizeUnrecoverableEntry(entry))
+}
+
+/**
+ * @summary Formats a bounded operator-facing unrecoverable reason preview for terminal logs.
+ * @param {Array<String|Object>} [entries=[]] Unrecoverable rows.
+ * @param {Object} [options]
+ * @param {Number} [options.limit=5] Maximum entries to include inline.
+ * @returns {String}
+ */
+export function formatUnrecoverablePreview(entries = [], {limit = 5} = {}) {
+    const preview = createUnrecoverablePreview(entries, limit);
+
+    if (preview.length === 0) {
+        return 'none'
+    }
+
+    const formatted = preview.map(entry => {
+        const message = entry.message ? `: ${entry.message}` : '';
+        return `${entry.id} (${entry.reason}${message})`
+    });
+
+    if (entries.length > preview.length) {
+        formatted.push(`+${entries.length - preview.length} more`);
+    }
+
+    return formatted.join('; ')
 }
 
 /**
@@ -1383,8 +1444,8 @@ async function defragChromaDB() {
             if (anyRepairAborted(results)) {
                 const abortedNames = results.filter(result => result.aborted).map(result => result.collectionName);
                 console.error(dryRun
-                    ? `❌ Memory Core repair dry-run found unrecoverable rows for ${abortedNames.join(', ')} — no promotion was attempted; resolve the unrecoverable rows before running the mutating repair. Counts logged above.`
-                    : `❌ Memory Core repair aborted for ${abortedNames.join(', ')} (unrecoverable rows) — NOT a successful repair; resolve the unrecoverable rows and re-run. Counts logged above.`);
+                    ? `❌ Memory Core repair dry-run found unrecoverable rows for ${abortedNames.join(', ')} — no promotion was attempted; resolve the unrecoverable rows before running the mutating repair. Counts and reasons logged above.`
+                    : `❌ Memory Core repair aborted for ${abortedNames.join(', ')} (unrecoverable rows) — NOT a successful repair; resolve the unrecoverable rows and re-run. Counts and reasons logged above.`);
                 process.exit(1);
             }
             return;

--- a/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
+++ b/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
@@ -12,7 +12,8 @@
  * rows from their DOCUMENTS (which still materialize — only the embedding fetch fails). Recovered batches
  * can either be retained in a merged `{ids, embeddings, documents, metadatas}` buffer or streamed into a
  * resumable shadow collection. A missing-vector row with no recoverable document/embedding is reported as
- * `unrecoverable` (counts surfaced, never silently dropped — the fail-loud discipline).
+ * a structured `unrecoverable` entry (`{id, reason, message?}`; counts surfaced, never silently dropped —
+ * the fail-loud discipline).
  *
  * The live shadow run + canonical promotion is operator/env-gated (out of scope without
  * explicit authorization); this module is the pure extraction logic, unit-tested against mocked Chroma.
@@ -26,7 +27,7 @@
  *
  * Intact-vector rows keep their stored embeddings. Missing-vector rows are re-embedded from their
  * documents via `embedFn`. A missing-vector row that returns no document (or is absent from the
- * metadata read) is `unrecoverable` — surfaced with counts, not dropped.
+ * metadata read) is `unrecoverable` — surfaced with reason metadata and counts, not dropped.
  *
  * @param {Object}     options
  * @param {Object}     options.collection       Chroma collection handle (`.get({ids, include})`).
@@ -40,9 +41,8 @@
  * @param {Function}   [options.onDataBatch] Optional async sink for each recovered batch.
  * @param {Function}   [options.onProgress] Optional callback receiving 10%-bucket progress events:
  *                                           `{phase, percent, processed, total, counts}`.
- * @returns {Promise<{data: {ids: String[], embeddings: Number[][], documents: String[], metadatas: Object[]},
- *                    unrecoverable: String[],
- *                    counts: {total: Number, intact: Number, reEmbedded: Number, unrecoverable: Number}}>}
+ * @returns {Promise<Object>} Extraction result with data buffers, structured unrecoverable entries,
+ *   an ids-only `unrecoverableIds` projection, and repair counts.
  */
 export async function extractMemoryCoreCollectionData({
     collection,
@@ -122,18 +122,30 @@ export async function extractMemoryCoreCollectionData({
         // An id that did not even come back from the metadata read is unrecoverable.
         for (const id of batchIds) {
             if (!returned.has(id)) {
-                unrecoverable.push(id);
-                counts.unrecoverable++;
+                recordUnrecoverable({
+                    unrecoverable,
+                    counts,
+                    id,
+                    reason : 'metadata-row-missing',
+                    message: 'id was absent from the Chroma documents/metadatas read'
+                });
             }
         }
 
         const reEmbedIds = [], reEmbedDocs = [], reEmbedMetas = [];
 
         for (let j = 0; j < (got.ids?.length || 0); j++) {
-            const doc = got.documents?.[j];
-            if (!doc) {
-                unrecoverable.push(got.ids[j]);
-                counts.unrecoverable++;
+            const doc             = got.documents?.[j],
+                  documentProblem = getDocumentProblem(doc);
+
+            if (documentProblem) {
+                recordUnrecoverable({
+                    unrecoverable,
+                    counts,
+                    id     : got.ids[j],
+                    reason : documentProblem.reason,
+                    message: documentProblem.message
+                });
                 continue;
             }
             reEmbedIds.push(got.ids[j]);
@@ -142,12 +154,17 @@ export async function extractMemoryCoreCollectionData({
         }
 
         if (reEmbedDocs.length > 0) {
-            const {embeddings, failedIndexes} = await embedRecoverableDocuments({embedFn, ids: reEmbedIds, documents: reEmbedDocs});
-            const batchData                   = {ids: [], embeddings: [], documents: [], metadatas: []};
+            const {embeddings, failedIndexes, failures} = await embedRecoverableDocuments({embedFn, ids: reEmbedIds, documents: reEmbedDocs});
+            const batchData                             = {ids: [], embeddings: [], documents: [], metadatas: []};
 
-            for (const failedIndex of failedIndexes) {
-                unrecoverable.push(reEmbedIds[failedIndex]);
-                counts.unrecoverable++;
+            for (const failure of failures) {
+                recordUnrecoverable({
+                    unrecoverable,
+                    counts,
+                    id     : reEmbedIds[failure.index],
+                    reason : failure.reason,
+                    message: failure.message
+                });
             }
 
             for (let j = 0; j < reEmbedIds.length; j++) {
@@ -173,8 +190,72 @@ export async function extractMemoryCoreCollectionData({
     return {
         data,
         unrecoverable,
+        unrecoverableIds: unrecoverable.map(entry => entry.id),
         counts
     };
+}
+
+/**
+ * @summary Records one unrecoverable row while keeping the fail-loud counter in sync.
+ * @param {Object} options
+ * @param {Array} options.unrecoverable Mutable structured unrecoverable entry buffer.
+ * @param {Object} options.counts Mutable extraction counters.
+ * @param {String} options.id Row id.
+ * @param {String} options.reason Stable reason code.
+ * @param {String} [options.message] Operator-readable reason detail.
+ * @returns {void}
+ */
+function recordUnrecoverable({unrecoverable, counts, id, reason, message} = {}) {
+    unrecoverable.push(createUnrecoverableEntry({id, reason, message}));
+    counts.unrecoverable++;
+}
+
+/**
+ * @summary Creates the structured unrecoverable row shape consumed by defrag diagnostics.
+ * @param {Object} options
+ * @param {String} options.id Row id.
+ * @param {String} options.reason Stable reason code.
+ * @param {String} [options.message] Operator-readable reason detail.
+ * @returns {Object} Structured unrecoverable row entry.
+ */
+function createUnrecoverableEntry({id, reason, message} = {}) {
+    const entry = {id, reason};
+
+    if (message) {
+        entry.message = message;
+    }
+
+    return entry
+}
+
+/**
+ * @summary Classifies missing-vector rows whose documents cannot be re-embedded.
+ * @param {*} document Document value returned by Chroma.
+ * @returns {{reason: String, message: String}|null}
+ */
+function getDocumentProblem(document) {
+    if (document === null || document === undefined) {
+        return {
+            reason : 'document-missing',
+            message: 'document field was missing from the Chroma metadata read'
+        }
+    }
+
+    if (typeof document !== 'string') {
+        return {
+            reason : 'document-invalid',
+            message: `document field was ${typeof document}, expected string`
+        }
+    }
+
+    if (document.trim().length === 0) {
+        return {
+            reason : 'document-empty',
+            message: 'document field was empty'
+        }
+    }
+
+    return null
 }
 
 /**
@@ -183,37 +264,64 @@ export async function extractMemoryCoreCollectionData({
  * @param {Function} options.embedFn Embedding function.
  * @param {String[]} options.ids Row ids paired with `documents`.
  * @param {String[]} options.documents Documents to embed.
- * @returns {Promise<{embeddings: Number[][], failedIndexes: Set<Number>}>}
+ * @returns {Promise<{embeddings: Number[][], failedIndexes: Set<Number>,
+ *                    failures: Array<{index: Number, reason: String, message: String}>}>}
  */
 async function embedRecoverableDocuments({embedFn, ids, documents} = {}) {
     try {
         const embeddings = await embedFn(documents);
 
         if (!Array.isArray(embeddings) || embeddings.length !== documents.length) {
-            throw new Error(`embedFn returned ${Array.isArray(embeddings) ? embeddings.length : 'non-array'} embeddings for ${documents.length} documents`);
+            throw createEmbeddingResultError(`embedFn returned ${Array.isArray(embeddings) ? embeddings.length : 'non-array'} embeddings for ${documents.length} documents`);
         }
 
-        return {embeddings, failedIndexes: new Set()}
+        return {embeddings, failedIndexes: new Set(), failures: []}
     } catch {
-        const embeddings    = new Array(documents.length);
-        const failedIndexes = new Set();
+        const embeddings = new Array(documents.length);
+        const failures   = [];
 
         for (let i = 0; i < documents.length; i++) {
             try {
                 const single = await embedFn([documents[i]]);
 
                 if (!Array.isArray(single) || single.length !== 1) {
-                    throw new Error(`single embed returned ${Array.isArray(single) ? single.length : 'non-array'} embeddings`);
+                    throw createEmbeddingResultError(`single embed returned ${Array.isArray(single) ? single.length : 'non-array'} embeddings`);
                 }
 
                 embeddings[i] = single[0];
             } catch (error) {
-                failedIndexes.add(i);
+                failures.push({
+                    index  : i,
+                    reason : getEmbeddingFailureReason(error),
+                    message: error?.message || String(error)
+                });
             }
         }
 
-        return {embeddings, failedIndexes}
+        return {embeddings, failedIndexes: new Set(failures.map(failure => failure.index)), failures}
     }
+}
+
+/**
+ * @summary Creates a provider-result shape error that can survive batch-to-single isolation.
+ * @param {String} message Error message.
+ * @returns {Error}
+ */
+function createEmbeddingResultError(message) {
+    const error = new Error(message);
+
+    error.unrecoverableReason = 'embedding-result-malformed';
+
+    return error
+}
+
+/**
+ * @summary Maps a per-document embedding failure to a stable unrecoverable reason code.
+ * @param {Error} error Provider or shape error.
+ * @returns {String}
+ */
+function getEmbeddingFailureReason(error) {
+    return error?.unrecoverableReason || 'embedding-provider-error'
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
@@ -2,7 +2,9 @@ import {test, expect} from '@playwright/test';
 import {
     anyRepairAborted,
     assertDefragTargetSupported,
+    createUnrecoverablePreview,
     formatMemoryCoreRepairProgress,
+    formatUnrecoverablePreview,
     repairMemoryCoreCollectionViaResumableShadow,
     repairMemoryCoreCollectionsViaFullEnumeration,
     runDefragChromaDBCli
@@ -114,21 +116,23 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#14020)', () => {
     });
 
     test('fail-loud: unrecoverable rows abort that collection promotion (no silent drop)', async () => {
+        const unrecoverable = [{id: 'b', reason: 'document-empty', message: 'document field was empty'}],
+              logs          = [];
         const coverage      = {collections: [{name: 'mc-memory', allIds: ['a', 'b'], missingVectorIds: ['b']}]},
               repairResults = {
-                  'mc-memory': {collectionName: 'mc-memory', aborted: true, shadowName: 'mc-memory-shadow-resume', loadedCount: 1, sourceCount: 2, unrecoverable: ['b'], counts: {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}}
+                  'mc-memory': {collectionName: 'mc-memory', aborted: true, shadowName: 'mc-memory-shadow-resume', loadedCount: 1, sourceCount: 2, unrecoverable, counts: {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}}
               },
               {calls, client, auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn} = makeSeams({coverage, repairResults});
 
         const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
             embedFn, embeddingFunction, statePath: '/state', stateBase: {targetName: 'memory-core'},
-            auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn, log: () => {}
+            auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn, log: message => logs.push(message)
         });
 
         expect(calls.repair).toHaveLength(1);
         expect(results[0].aborted).toBe(true);
-        expect(results[0].unrecoverable).toEqual(['b']);
+        expect(results[0].unrecoverable).toEqual(unrecoverable);
         expect(results[0].counts.unrecoverable).toBe(1);
 
         // an aborted repair NEVER clears the marker; it rewrites an explicit aborted marker so the next run
@@ -140,7 +144,9 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#14020)', () => {
         expect(calls.writeState[0].state.targetName).toBe('memory-core');
         expect(calls.writeState[0].state.shadowName).toBe('mc-memory-shadow-resume');
         expect(calls.writeState[0].state.loadedCount).toBe(1);
+        expect(calls.writeState[0].state.unrecoverablePreview).toEqual(unrecoverable);
         expect(calls.writeState[0].state.aborted).toEqual(['mc-memory']);
+        expect(logs.some(message => message.includes('Reasons: b (document-empty: document field was empty)'))).toBe(true);
     });
 
     test('resume state skips earlier collections and resumes the matching collection repair', async () => {
@@ -232,16 +238,18 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#14020)', () => {
     });
 
     test('dry-run reports unrecoverable rows without writing an aborted state marker', async () => {
+        const unrecoverable = [{id: 'b', reason: 'metadata-row-missing', message: 'id was absent from the Chroma documents/metadatas read'}],
+              logs          = [];
         const coverage       = {collections: [{name: 'mc-memory', allIds: ['a', 'b'], missingVectorIds: ['b']}]},
               extractResults = {
-                  'mc-memory': {data: {ids: ['a'], embeddings: [[1]], documents: [''], metadatas: [{}]}, unrecoverable: ['b'], counts: {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}}
+                  'mc-memory': {data: {ids: ['a'], embeddings: [[1]], documents: [''], metadatas: [{}]}, unrecoverable, counts: {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}}
               },
               {calls, client, auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn} = makeSeams({coverage, extractResults});
 
         const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
             client, collections: ['mc-memory'], snapshotPath: '/snap', persistDir: '/persist',
             embedFn, embeddingFunction, statePath: '/state', dryRun: true,
-            auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn, log: () => {}
+            auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn, log: message => logs.push(message)
         });
 
         expect(calls.repair).toHaveLength(0);
@@ -251,9 +259,12 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#14020)', () => {
             collectionName: 'mc-memory',
             dryRun        : true,
             aborted       : true,
-            unrecoverable : ['b'],
+            unrecoverable,
             counts        : {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}
         });
+        expect(logs.some(message => message.includes(
+            'Reasons: b (metadata-row-missing: id was absent from the Chroma documents/metadatas read)'
+        ))).toBe(true);
         expect(anyRepairAborted(results)).toBe(true);
     });
 
@@ -530,6 +541,24 @@ test.describe('anyRepairAborted — operator fail-loud predicate (#14020)', () =
 
     test('false for an empty result set', () => {
         expect(anyRepairAborted([])).toBe(false);
+    });
+});
+
+test.describe('unrecoverable reason previews (#14023)', () => {
+    test('keeps structured state previews and formats bounded operator logs', () => {
+        const entries = [
+            {id: 'a', reason: 'document-empty', message: 'document field was empty'},
+            {id: 'b', reason: 'embedding-provider-error', message: 'context overflow'},
+            'legacy-id'
+        ];
+
+        expect(createUnrecoverablePreview(entries, 2)).toEqual([
+            {id: 'a', reason: 'document-empty', message: 'document field was empty'},
+            {id: 'b', reason: 'embedding-provider-error', message: 'context overflow'}
+        ]);
+        expect(formatUnrecoverablePreview(entries, {limit: 2}))
+            .toBe('a (document-empty: document field was empty); b (embedding-provider-error: context overflow); +1 more');
+        expect(formatUnrecoverablePreview(['legacy-id'])).toBe('legacy-id (unknown)');
     });
 });
 

--- a/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
@@ -103,16 +103,27 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         expect(embedCalls).toBe(1);
     });
 
-    test('a missing-vector row with no document is unrecoverable, not silently dropped', async () => {
-        const rows    = {m: {document: '', metadata: {}}, n: {document: 'dn', metadata: {}}};
+    test('missing-vector rows with empty or missing documents are unrecoverable with distinct reasons', async () => {
+        const rows = {
+            empty  : {document: '', metadata: {}},
+            missing: {metadata: {}},
+            n      : {document: 'dn', metadata: {}}
+        };
         const embedFn = async docs => docs.map(() => [5]);
 
         const result = await extractMemoryCoreCollectionData({
-            collection: makeCollection(rows), allIds: ['m', 'n'], missingVectorIds: ['m', 'n'], embedFn
+            collection      : makeCollection(rows),
+            allIds          : ['empty', 'missing', 'n'],
+            missingVectorIds: ['empty', 'missing', 'n'],
+            embedFn
         });
 
-        expect(result.unrecoverable).toEqual(['m']);
-        expect(result.counts).toEqual({total: 2, intact: 0, reEmbedded: 1, unrecoverable: 1});
+        expect(result.unrecoverable).toEqual([
+            {id: 'empty', reason: 'document-empty', message: 'document field was empty'},
+            {id: 'missing', reason: 'document-missing', message: 'document field was missing from the Chroma metadata read'}
+        ]);
+        expect(result.unrecoverableIds).toEqual(['empty', 'missing']);
+        expect(result.counts).toEqual({total: 3, intact: 0, reEmbedded: 1, unrecoverable: 2});
     });
 
     test('a missing id absent from the metadata read is unrecoverable', async () => {
@@ -123,7 +134,12 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
             collection: makeCollection(rows), allIds: ['n', 'gone'], missingVectorIds: ['n', 'gone'], embedFn
         });
 
-        expect(result.unrecoverable).toEqual(['gone']);
+        expect(result.unrecoverable).toEqual([{
+            id     : 'gone',
+            reason : 'metadata-row-missing',
+            message: 'id was absent from the Chroma documents/metadatas read'
+        }]);
+        expect(result.unrecoverableIds).toEqual(['gone']);
         expect(result.counts.reEmbedded).toBe(1);
     });
 
@@ -156,7 +172,12 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
             ['too-large'],
             ['small-2']
         ]);
-        expect(result.unrecoverable).toEqual(['overcap']);
+        expect(result.unrecoverable).toEqual([{
+            id     : 'overcap',
+            reason : 'embedding-provider-error',
+            message: 'context overflow'
+        }]);
+        expect(result.unrecoverableIds).toEqual(['overcap']);
         expect(result.data.ids).toEqual(['ok', 'ok2']);
         expect(result.counts).toEqual({total: 3, intact: 0, reEmbedded: 2, unrecoverable: 1});
     });
@@ -205,7 +226,12 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
             collection: makeCollection(rows), allIds: ['m'], missingVectorIds: ['m'], embedFn: async () => []
         });
 
-        expect(result.unrecoverable).toEqual(['m']);
+        expect(result.unrecoverable).toEqual([{
+            id     : 'm',
+            reason : 'embedding-result-malformed',
+            message: 'single embed returned 0 embeddings'
+        }]);
+        expect(result.unrecoverableIds).toEqual(['m']);
         expect(result.counts).toEqual({total: 1, intact: 0, reEmbedded: 0, unrecoverable: 1});
     });
 


### PR DESCRIPTION
Resolves #14023

Memory Core repair-defrag now preserves unrecoverable row causes instead of only ids. `extractMemoryCoreCollectionData()` returns structured unrecoverable entries with stable reason codes and an ids-only compatibility projection, while the dry-run and mutating abort paths print bounded reason previews and store structured abort previews in defrag state markers. Promotion remains fail-loud.

Evidence: L2 unit/static fully covers the close-target ACs; live mutating defrag is intentionally out of scope. Residual: real operator runs can validate readability against production-scale logs after merge.

## Deltas from ticket

Added `unrecoverableIds` as a compatibility projection and kept preview formatting tolerant of legacy string entries so existing fail-loud predicates remain simple.

## Test Evidence

- `node --check ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs` -> passed
- `node --check ai/scripts/maintenance/defragChromaDB.mjs` -> passed
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs` -> 33 passed
- `npm run agent-preflight -- ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs ai/scripts/maintenance/defragChromaDB.mjs test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs` -> passed
- `git diff --check` -> passed

## Post-Merge Validation

- [ ] Next Memory Core repair-defrag dry-run/mutating abort, if unrecoverable rows remain, shows bounded reason previews without weakening fail-loud promotion blocking.

Authored by Euclid (GPT-5, Codex Desktop). Session 35f83031-f1a6-41a7-9c3b-089b87307db9.
