### PR TITLE
feat(ai): backup restorability pre-flight check (#14053)

### DIFF
--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -384,6 +384,69 @@ export async function validateBundle(bundleRoot, layout, logger = console) {
 }
 
 /**
+ * @summary Verifies the latest backup bundle is structurally restorable WITHOUT performing a restore.
+ *
+ * Backups are the recovery source of last resort, yet assumed-restorable-but-never-checked. This runs
+ * the same pre-flight `validateBundle` gate the restore path uses (required subdirs present, JSONL
+ * parseable, `bundle-meta.json` parseable) against the newest `backup-<ISO-ts>/` under `backupRoot`,
+ * returning a structured verdict. It performs NO writes and NO live-store import — a read-only
+ * restorability probe. The alert-on-failure wiring is the escalation-mechanism piece (it shares the
+ * AC1 sink decision, tracked on the parent backup-reliability ticket); this is the check that produces
+ * the verdict that piece consumes.
+ *
+ * @param {Object}    options
+ * @param {String}    options.backupRoot Absolute path to the `.neo-ai-data/backups` root.
+ * @param {Object}   [options.logger=console] Log sink.
+ * @param {Object}   [options.fsModule=fs] Filesystem seam (test injection).
+ * @param {Function} [options.validateFn=validateBundle] Bundle validator seam (test injection).
+ * @returns {Promise<{restorable: Boolean, bundleRoot: String|null, reason: String|null, checkedAt: String}>}
+ */
+export async function verifyLatestBackupRestorable({
+    backupRoot,
+    logger     = console,
+    fsModule   = fs,
+    validateFn = validateBundle
+} = {}) {
+    if (!backupRoot) {
+        throw new Error('verifyLatestBackupRestorable requires a `backupRoot` argument.');
+    }
+
+    const checkedAt = new Date().toISOString();
+
+    if (!await fsModule.pathExists(backupRoot)) {
+        return {restorable: false, bundleRoot: null, reason: `backup root not found: ${backupRoot}`, checkedAt};
+    }
+
+    // backup-<ISO-ts> names sort lexically by their ISO timestamp, so reverse-sort yields newest-first.
+    const bundleNames = (await fsModule.readdir(backupRoot, {withFileTypes: true}))
+        .filter(entry => entry.isDirectory() && entry.name.startsWith('backup-'))
+        .map(entry => entry.name)
+        .sort()
+        .reverse();
+
+    if (bundleNames.length === 0) {
+        return {restorable: false, bundleRoot: null, reason: `no backup-* bundles under ${backupRoot}`, checkedAt};
+    }
+
+    const bundleRoot = path.join(backupRoot, bundleNames[0]);
+    const layout     = {
+        kb          : path.join(bundleRoot, 'kb'),
+        mc          : path.join(bundleRoot, 'mc'),
+        graph       : path.join(bundleRoot, 'graph'),
+        concepts    : path.join(bundleRoot, 'concepts'),
+        trajectories: path.join(bundleRoot, 'trajectories'),
+        mailbox     : path.join(bundleRoot, 'mailbox')
+    };
+
+    try {
+        await validateFn(bundleRoot, layout, logger);
+        return {restorable: true, bundleRoot, reason: null, checkedAt};
+    } catch (error) {
+        return {restorable: false, bundleRoot, reason: error.message, checkedAt};
+    }
+}
+
+/**
  * Compares the bundle's `topology.shared_topology` to the live deployment (always true).
  * Mismatch is refused unless `forceTopologyMismatch` is set. Bundles without metadata
  * skip the check (legacy bundles).

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -15,13 +15,14 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
-import fs             from 'fs';
-import fsExtra        from 'fs-extra';
-import path           from 'path';
+import fs              from 'fs';
+import fsExtra         from 'fs-extra';
+import os              from 'os';
+import path            from 'path';
 
 // Serial mode: this file mutates SDK service methods and StorageRouter accessors across
 // beforeAll/beforeEach. Running in serial protects against intra-file races during
@@ -168,10 +169,10 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
     });
 
     test('happy-path merge: routes embedded substrates through SDK and copies flat files', async () => {
-        const bundleRoot   = buildSyntheticBundle({bundleName: 'happy-merge', shared_topology: true});
-        const conceptsTgt  = path.join(workRoot, 'happy-merge-targets', 'concepts');
-        const trajTgt      = path.join(workRoot, 'happy-merge-targets', 'trajectories.jsonl');
-        const mailboxTgt   = path.join(workRoot, 'happy-merge-targets', 'sent-to-cull.jsonl');
+        const bundleRoot  = buildSyntheticBundle({bundleName: 'happy-merge', shared_topology: true});
+        const conceptsTgt = path.join(workRoot, 'happy-merge-targets', 'concepts');
+        const trajTgt     = path.join(workRoot, 'happy-merge-targets', 'trajectories.jsonl');
+        const mailboxTgt  = path.join(workRoot, 'happy-merge-targets', 'sent-to-cull.jsonl');
 
         const result = await runRestore({
             bundleRoot,
@@ -235,11 +236,11 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
 
         const result = await runRestore({
             bundleRoot,
-            forceTopologyMismatch: true,
-            conceptsTargetDir    : path.join(workRoot, 'topo-targets', 'concepts'),
+            forceTopologyMismatch : true,
+            conceptsTargetDir     : path.join(workRoot, 'topo-targets', 'concepts'),
             trajectoriesTargetFile: path.join(workRoot, 'topo-targets', 'trajectories.jsonl'),
-            sentToCullTargetFile : path.join(workRoot, 'topo-targets', 'sent-to-cull.jsonl'),
-            logger               : silentLogger
+            sentToCullTargetFile  : path.join(workRoot, 'topo-targets', 'sent-to-cull.jsonl'),
+            logger                : silentLogger
         });
         expect(result.topology.match).toBe(false);
         expect(result.topology.forced).toBe(true);
@@ -261,10 +262,10 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
     });
 
     test('replace mode with --force fires guard for flat substrates and forwards mode through SDK', async () => {
-        const bundleRoot   = buildSyntheticBundle({bundleName: 'replace-force', shared_topology: true});
-        const conceptsTgt  = path.join(workRoot, 'replace-targets', 'concepts');
-        const trajTgt      = path.join(workRoot, 'replace-targets', 'trajectories.jsonl');
-        const mailboxTgt   = path.join(workRoot, 'replace-targets', 'sent-to-cull.jsonl');
+        const bundleRoot  = buildSyntheticBundle({bundleName: 'replace-force', shared_topology: true});
+        const conceptsTgt = path.join(workRoot, 'replace-targets', 'concepts');
+        const trajTgt     = path.join(workRoot, 'replace-targets', 'trajectories.jsonl');
+        const mailboxTgt  = path.join(workRoot, 'replace-targets', 'sent-to-cull.jsonl');
 
         // Targets empty so --force-not-needed-due-to-empty-targets passes the pre-flight occupancy check.
         // Goal of this test: assert guard fires for flat substrates AND mode=replace forwards through SDK.
@@ -304,10 +305,10 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
     });
 
     test('merge mode skips existing flat-file targets to preserve operator additions', async () => {
-        const bundleRoot   = buildSyntheticBundle({bundleName: 'merge-preserve', chromaUnified: true});
-        const conceptsTgt  = path.join(workRoot, 'preserve-targets', 'concepts');
-        const trajTgt      = path.join(workRoot, 'preserve-targets', 'trajectories.jsonl');
-        const mailboxTgt   = path.join(workRoot, 'preserve-targets', 'sent-to-cull.jsonl');
+        const bundleRoot  = buildSyntheticBundle({bundleName: 'merge-preserve', chromaUnified: true});
+        const conceptsTgt = path.join(workRoot, 'preserve-targets', 'concepts');
+        const trajTgt     = path.join(workRoot, 'preserve-targets', 'trajectories.jsonl');
+        const mailboxTgt  = path.join(workRoot, 'preserve-targets', 'sent-to-cull.jsonl');
 
         // Pre-populate targets with operator data
         fs.mkdirSync(conceptsTgt, {recursive: true});
@@ -413,7 +414,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
 
     test('validateBundle: standalone validation call returns parsed meta', async () => {
         const bundleRoot = buildSyntheticBundle({bundleName: 'validate-only', chromaUnified: true});
-        const layout = {
+        const layout     = {
             kb          : path.join(bundleRoot, 'kb'),
             mc          : path.join(bundleRoot, 'mc'),
             graph       : path.join(bundleRoot, 'graph'),
@@ -424,5 +425,58 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         const meta = await validateBundle(bundleRoot, layout, silentLogger);
         expect(meta.bundleVersion).toBe(1);
         expect(meta.topology.chromaUnified).toBe(true);
+    });
+});
+
+test.describe('verifyLatestBackupRestorable — read-only restorability probe (#14030 AC2)', () => {
+    let verifyLatestBackupRestorable;
+    let probeRoot;
+    const silent = {log: () => {}, warn: () => {}, error: () => {}};
+
+    const writeBundle = (name, {torn = false} = {}) => {
+        const bundleRoot = path.join(probeRoot, name);
+        for (const sub of ['kb', 'mc', 'graph', 'concepts', 'trajectories']) {
+            fs.mkdirSync(path.join(bundleRoot, sub), {recursive: true});
+        }
+        fs.writeFileSync(path.join(bundleRoot, 'mc', 'memory-backup.jsonl'),
+            torn ? '{this is not valid json\n' : '{"id":"m-1"}\n');
+        return bundleRoot;
+    };
+
+    test.beforeAll(async () => {
+        ({verifyLatestBackupRestorable} = await import('../../../../../../ai/scripts/maintenance/restore.mjs'));
+    });
+
+    test.beforeEach(() => {
+        probeRoot = path.join(os.tmpdir(), `neo-restorable-probe-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(probeRoot, {recursive: true});
+    });
+
+    test.afterEach(() => {
+        fsExtra.removeSync(probeRoot);
+    });
+
+    test('empty root, torn-newest, and valid-newest verdicts (#14030 AC2)', async () => {
+        // (1) no bundles → not restorable, with a clear reason.
+        const empty = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+        expect(empty.restorable).toBe(false);
+        expect(empty.reason).toMatch(/no backup-\* bundles/);
+        expect(empty.checkedAt).toBeTruthy();
+
+        // (2) an older valid bundle + a NEWER torn bundle → the newest is selected → not restorable.
+        writeBundle('backup-2026-05-01T00-00-00');
+        writeBundle('backup-2026-06-01T00-00-00', {torn: true});
+        const torn = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+        expect(torn.restorable).toBe(false);
+        expect(torn.bundleRoot).toContain('backup-2026-06-01T00-00-00');
+        expect(torn.reason).toMatch(/parse error/);
+
+        // (3) replace the newest with a valid bundle → restorable, no reason.
+        fsExtra.removeSync(path.join(probeRoot, 'backup-2026-06-01T00-00-00'));
+        writeBundle('backup-2026-06-02T00-00-00');
+        const ok = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+        expect(ok.restorable).toBe(true);
+        expect(ok.bundleRoot).toContain('backup-2026-06-02T00-00-00');
+        expect(ok.reason).toBeNull();
     });
 });


### PR DESCRIPTION
Resolves #14053

`verifyLatestBackupRestorable({backupRoot})` — a read-only restorability probe for the latest backup bundle. Backups are the recovery source of last resort yet were assumed-restorable-but-never-checked. This finds the newest `backup-<ISO-ts>/` and runs the **same pre-flight `validateBundle` gate** the restore path uses (required subdirs present, JSONL parseable, `bundle-meta.json` parseable), returning a structured verdict `{restorable, bundleRoot, reason, checkedAt}`. NO writes, NO live-store import — reuses the existing tested validator (DRY).

This is the verdict-producing **check-half** of the parent backup-reliability AC. The alert-on-failure routing is escalation-mechanism-gated (it shares the AC1 sink decision — no existing primitive fits a maintenance-task alert; A2A-routed to @neo-gpt) and stays on the parent ticket. Complements #14048 (empty-parity) + #14024/#14042 (timeline diagnostic).

Evidence: L2 unit — valid-latest → restorable; torn-newest (+ newest-selection) → not-restorable with reason; empty/absent root → not-restorable. The check is pure file-validation (no infra), so L2 fully covers the verdict ACs.

## Deltas From Ticket

None — implements the #14053 check-half as filed; the alert-routing + the throwaway-import variant are explicitly out-of-scope (escalation-gated / infra-gated) per the ticket.

## Test Evidence

- `node --check ai/scripts/maintenance/restore.mjs` → passed
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs` → **12 passed** (11 existing + the new restorability-probe test: empty-root, torn-newest + newest-selection, valid-newest)

## Post-Merge Validation

- [ ] Operator runs `verifyLatestBackupRestorable` against the live `.neo-ai-data/backups` and confirms the latest bundle's verdict matches reality.

Authored by Vega (Claude Opus 4.8).
