### PR TITLE
feat(ai): supervised-task failure/overdue diagnosis producer-core (#14055)

### DIFF
--- a/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.mjs
@@ -1,0 +1,78 @@
+import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/taskOutcomeDiagnosis
+ * @summary Producer-core for supervised-maintenance-task failure/overdue diagnosis (parent backup-reliability AC1).
+ *
+ * A sibling to the container-health diagnosis path — NOT bolted into `ContainerHealthDiagnosisService`
+ * (which is container CPU/memory/config-drift-scoped) and NOT modeling a maintenance task as a pageable
+ * recovery-actuator target. These are pure functions: they detect a failed/overdue supervised task and
+ * build a `recovery-diagnosis` event (`targetIdentity.kind: 'supervised-task'`, `details.actionClass:
+ * 'escalate'`) for a diagnosis-escalation sink to route. They never restart or retry the task — the
+ * recovery boundary (e.g. `escalateDiagnosis` in the actuator) owns dispatch; this owns detection.
+ *
+ * Consumed by (next slice): the `ProcessSupervisorService.recordTaskOutcome('<task>', 'failed', …)` hook
+ * and a scheduling-loop overdue check, both for the configured alert-on-failure task set (e.g. `backup`).
+ */
+
+// A supervised task that exited non-zero / crashed maps to the `crash` recovery class; a scheduled run
+// that never started (overdue) maps to `ambiguous` — the cause is not yet known at detection time.
+const TASK_FAILURE_RECOVERY_CLASS = 'crash';
+const TASK_OVERDUE_RECOVERY_CLASS = 'ambiguous';
+
+/**
+ * @summary Pure overdue detector for a periodically-scheduled supervised task.
+ *
+ * A task is overdue when `now` is past `lastRunAt + intervalMs + graceMs`. A non-positive `intervalMs`
+ * means periodic scheduling is disabled, so the task is never overdue by construction.
+ *
+ * @param {Object}  options
+ * @param {Number} [options.lastRunAt=0] Epoch ms of the last run start (0/absent = never run).
+ * @param {Number}  options.intervalMs Periodic interval; `<= 0` disables overdue detection.
+ * @param {Number} [options.graceMs=0] Extra slack before declaring overdue.
+ * @param {Number}  options.now Current epoch ms.
+ * @returns {{overdue: Boolean, overdueByMs: Number}}
+ */
+export function detectTaskOverdue({lastRunAt, intervalMs, graceMs = 0, now} = {}) {
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+        return {overdue: false, overdueByMs: 0};
+    }
+
+    const dueAt       = (Number.isFinite(lastRunAt) ? lastRunAt : 0) + intervalMs + Math.max(0, graceMs || 0),
+          overdueByMs = (Number.isFinite(now) ? now : 0) - dueAt;
+
+    return {overdue: overdueByMs > 0, overdueByMs: Math.max(0, overdueByMs)};
+}
+
+/**
+ * @summary Builds the recovery-diagnosis event for a failed or overdue supervised maintenance task.
+ *
+ * Producer half of the parent backup-reliability AC1 — does NOT restart/retry the task; the event routes to the escalation sink.
+ *
+ * @param {Object}  options
+ * @param {String}  options.taskName Supervised task id (e.g. `backup`).
+ * @param {'failed'|'overdue'} options.outcome The detected fault.
+ * @param {Number}  options.observedAt Epoch ms when the fault was observed.
+ * @param {Object} [options.details={}] Diagnostics-owned details; merged with `actionClass: 'escalate'`.
+ * @returns {Object} A `recovery-diagnosis` event (see `createRecoveryDiagnosisEvent`).
+ */
+export function buildSupervisedTaskDiagnosis({taskName, outcome, observedAt, details = {}} = {}) {
+    if (typeof taskName !== 'string' || taskName.length === 0) {
+        throw new TypeError('buildSupervisedTaskDiagnosis: taskName is required');
+    }
+    if (outcome !== 'failed' && outcome !== 'overdue') {
+        throw new TypeError(`buildSupervisedTaskDiagnosis: outcome must be 'failed' or 'overdue', got ${outcome}`);
+    }
+
+    const recoveryClass = outcome === 'failed' ? TASK_FAILURE_RECOVERY_CLASS : TASK_OVERDUE_RECOVERY_CLASS;
+
+    return createRecoveryDiagnosisEvent({
+        diagnosisId   : `supervised-task:${taskName}:${outcome}:${observedAt}`,
+        recoveryClass,
+        confidence    : 1,
+        targetIdentity: {kind: 'supervised-task', id: taskName},
+        observedAt,
+        source        : 'task-outcome-diagnostics',
+        details       : {...details, actionClass: 'escalate', outcome}
+    });
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.spec.mjs
@@ -1,0 +1,65 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'TaskOutcomeDiagnosisTest';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: appName, isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
+import {
+    buildSupervisedTaskDiagnosis,
+    detectTaskOverdue
+} from '../../../../../../../ai/daemons/orchestrator/services/taskOutcomeDiagnosis.mjs';
+
+test.describe('taskOutcomeDiagnosis — supervised-task failure/overdue producer (#14030 AC1)', () => {
+    test('detectTaskOverdue: overdue past interval+grace, not within, disabled when interval<=0', () => {
+        const base = 1_000_000;
+
+        // within interval+grace (due at base+1500) → not overdue
+        expect(detectTaskOverdue({lastRunAt: base, intervalMs: 1000, graceMs: 500, now: base + 1400}))
+            .toEqual({overdue: false, overdueByMs: 0});
+
+        // past due (base+1500) by 500ms → overdue
+        expect(detectTaskOverdue({lastRunAt: base, intervalMs: 1000, graceMs: 500, now: base + 2000}))
+            .toEqual({overdue: true, overdueByMs: 500});
+
+        // periodic disabled (interval <= 0) → never overdue
+        expect(detectTaskOverdue({lastRunAt: base, intervalMs: 0, now: base + 1_000_000}))
+            .toEqual({overdue: false, overdueByMs: 0});
+
+        // never-run (lastRunAt absent → 0) past interval → overdue
+        expect(detectTaskOverdue({intervalMs: 1000, now: 2000}).overdue).toBe(true);
+    });
+
+    test('buildSupervisedTaskDiagnosis: failed→crash, overdue→ambiguous, supervised-task identity + escalate (#14030 AC1)', () => {
+        const failed = buildSupervisedTaskDiagnosis({
+            taskName: 'backup', outcome: 'failed', observedAt: 1_700_000_000_000, details: {code: 1}
+        });
+
+        expect(failed.type).toBe('recovery-diagnosis');
+        expect(failed.recoveryClass).toBe('crash');
+        expect(failed.targetIdentity).toEqual({kind: 'supervised-task', id: 'backup'});
+        expect(failed.details.actionClass).toBe('escalate');
+        expect(failed.details.outcome).toBe('failed');
+        expect(failed.details.code).toBe(1);
+        expect(failed.confidence).toBe(1);
+
+        const overdue = buildSupervisedTaskDiagnosis({
+            taskName: 'backup', outcome: 'overdue', observedAt: 1_700_000_000_000
+        });
+
+        expect(overdue.recoveryClass).toBe('ambiguous');
+        expect(overdue.details.actionClass).toBe('escalate');
+        expect(overdue.targetIdentity.kind).toBe('supervised-task');
+
+        expect(() => buildSupervisedTaskDiagnosis({taskName: 'backup', outcome: 'bogus', observedAt: 1}))
+            .toThrow(/outcome must be/);
+        expect(() => buildSupervisedTaskDiagnosis({outcome: 'failed', observedAt: 1}))
+            .toThrow(/taskName is required/);
+    });
+});


### PR DESCRIPTION
Resolves #14055

The **producer-core** for backup-reliability AC1, per the escalation-mechanism convergence with @neo-gpt on #14030: a sibling task-diagnostics producer — NOT bolted into `ContainerHealthDiagnosisService` (container CPU/memory/config-drift-scoped), NOT a pageable recovery-actuator target.

Pure functions in `ai/daemons/orchestrator/services/taskOutcomeDiagnosis.mjs`:
- `detectTaskOverdue({lastRunAt, intervalMs, graceMs, now})` → `{overdue, overdueByMs}`; a non-positive interval disables overdue detection by construction.
- `buildSupervisedTaskDiagnosis({taskName, outcome, observedAt, details})` → a contract-valid `recovery-diagnosis` event (via the existing `createRecoveryDiagnosisEvent`): `failed`→`crash`, `overdue`→`ambiguous` recovery class; `targetIdentity {kind:'supervised-task', id}`; `details.actionClass:'escalate'`. Detection only — never restarts/retries.

Evidence: L2 unit — `detectTaskOverdue` verdicts (overdue past interval+grace / within / disabled / never-run) and `buildSupervisedTaskDiagnosis` event shapes (failed→crash, overdue→ambiguous, supervised-task identity, escalate actionClass) + invalid-outcome/missing-taskName rejection. Pure functions, so L2 fully covers the ACs.

## Deltas From Ticket

None — implements the #14055 producer-core as filed. The live wiring (the `ProcessSupervisorService.recordTaskOutcome('<task>','failed')` hook + the scheduling-loop overdue check + the narrow `escalateDiagnosis` sink in `RecoveryActuatorService` — not `apply('backup','page')`, which is `deploy-target`-only) is the explicitly out-of-scope next AC1 slice per the converged design.

## Test Evidence

- `node --check ai/daemons/orchestrator/services/taskOutcomeDiagnosis.mjs` → passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.spec.mjs` → **2 passed**

## Post-Merge Validation

- [ ] The next AC1 slice wires `recordTaskOutcome('backup','failed')` + the overdue check into these helpers → `escalateDiagnosis`, with an integration assertion that a failed/overdue backup escalates without restart/retry.

Authored by Vega (Claude Opus 4.8).
