### PR TITLE
feat(rem): fingerprint tri-vector request diagnostics (#13994)

### DIFF
--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -1,3 +1,4 @@
+import crypto   from 'crypto';
 import fs       from 'fs';
 import path     from 'path';
 import AiConfig from '../../mcp/server/memory-core/config.mjs';
@@ -85,6 +86,31 @@ class SemanticGraphExtractor extends Base {
             bytes,
             tokens: bytesToTokens(bytes)
         };
+    }
+
+    /**
+     * Builds bounded per-message fingerprints for REM provider request diagnostics.
+     *
+     * @summary Anchor & Echo: Lets operators correlate one provider-visible counter with
+     * one Neo request without logging full session payloads or repair-loop output.
+     *
+     * @param {Object[]} messages Provider chat messages
+     * @returns {Object[]} Bounded message-slot diagnostics
+     * @protected
+     */
+    buildTriVectorRequestFingerprints(messages = []) {
+        return messages.map((message, index) => {
+            const content = String(message?.content ?? ''),
+                  bytes   = Buffer.byteLength(content, 'utf8');
+
+            return {
+                index,
+                role               : typeof message?.role === 'string' ? message.role : 'unknown',
+                bytes,
+                tokensEstimate     : bytesToTokens(bytes),
+                contentSha256Prefix: crypto.createHash('sha256').update(content).digest('hex').slice(0, 16)
+            };
+        });
     }
 
     /**
@@ -512,8 +538,8 @@ class SemanticGraphExtractor extends Base {
             const inputPayloadText = inputPayload.text;
             const startedAt        = new Date().toISOString();
             const callDiagnostics  = {
-                phase                    : 'triVector',
-                sessionId                : session.meta.sessionId,
+                phase                     : 'triVector',
+                sessionId                 : session.meta.sessionId,
                 assetRef,
                 chunkIndex,
                 chunkCount,
@@ -521,14 +547,16 @@ class SemanticGraphExtractor extends Base {
                 chunkTokens,
                 attempt,
                 maxRetries,
-                provider                 : consumerProvider,
-                model                    : consumerModel,
-                promptBytes              : inputPayload.bytes,
-                promptTokensEstimate     : inputPayload.tokens,
-                outputLimitTokens        : graphOutputLimitTokens,
-                contextLimitTokens       : consumerContextTokens,
-                safeProcessingLimitTokens: consumerSafeTokens,
-                promptPlusOutputTokens   : inputPayload.tokens + graphOutputLimitTokens,
+                provider                  : consumerProvider,
+                model                     : consumerModel,
+                promptBytes               : inputPayload.bytes,
+                promptTokensEstimate      : inputPayload.tokens,
+                outputLimitTokens         : graphOutputLimitTokens,
+                contextLimitTokens        : consumerContextTokens,
+                safeProcessingLimitTokens : consumerSafeTokens,
+                promptPlusOutputTokens    : inputPayload.tokens + graphOutputLimitTokens,
+                requestMessageCount       : messages.length,
+                requestMessageFingerprints: this.buildTriVectorRequestFingerprints(messages),
                 startedAt
             };
             lastCallDiagnostics = callDiagnostics;

--- a/learn/agentos/rem-state-model.md
+++ b/learn/agentos/rem-state-model.md
@@ -79,6 +79,32 @@ Use `perSession.entityCount` to inspect extraction yield for a single session. A
 digested session with zero inbound entity/provenance edges is suspicious when the
 payload clearly contained entities.
 
+## Active Tri-Vector Call Diagnostics
+
+While a REM Tri-Vector provider call is in flight, `SemanticGraphExtractor`
+writes a gitignored active-call snapshot under `NEO_REM_RUN_STATE_DIR`. This is
+the operator correlation surface for provider-visible counters such as LM Studio's
+token meter. The snapshot includes the session id, asset/chunk id, chunk index,
+provider/model, prompt estimate, output cap, context cap, and bounded request
+message fingerprints.
+
+`requestMessageFingerprints[]` deliberately avoids payload logging. Each entry is
+limited to:
+
+```js
+{
+    index              : Number,
+    role               : String,
+    bytes              : Number,
+    tokensEstimate     : Number,
+    contentSha256Prefix: String // first 16 hex chars only
+}
+```
+
+Use these fields to correlate one Neo request with one provider counter without
+leaking full session content. A second REM call should show new fingerprints for
+its own message slots, not the prior session's payload.
+
 ## Durable Cycle State
 
 `DreamService.executeRemCycle()` writes one append-only JSONL artifact per run

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -531,6 +531,79 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         expect(activeOnDiskAfterCall).toBeNull();
     });
 
+    test('REM provider diagnostics fingerprint each request without cross-session payload bleed (#13994)', async () => {
+        const originalOverrides = {
+                  [ENV.GRAPH_PROVIDER]: aiConfig.graphProvider
+              },
+              baseGenerate      = OpenAiCompatible.prototype.generate,
+              firstNeedle       = 'FIRST_SESSION_13994_UNIQUE_PAYLOAD_NEEDLE',
+              secondNeedle      = 'SECOND_SESSION_13994_UNIQUE_PAYLOAD_NEEDLE',
+              providerCalls     = [];
+
+        try {
+            setConfigOverrides({[ENV.GRAPH_PROVIDER]: 'openAiCompatible'});
+
+            OpenAiCompatible.prototype.generate = async function(messages) {
+                providerCalls.push({
+                    messages: messages.map(message => ({...message})),
+                    active  : {...SemanticGraphExtractor.activeTriVectorCall}
+                });
+
+                return {
+                    content: JSON.stringify({
+                        a2a_version     : '1.0',
+                        agent_id        : 'Antigravity',
+                        session_artifact: {
+                            feature_namespace     : 'Neo.ai.REM',
+                            human_readable_summary: `fingerprinted request ${providerCalls.length}`,
+                            graph                 : {nodes: [], edges: []}
+                        }
+                    })
+                };
+            };
+
+            await SemanticGraphExtractor.executeTriVectorExtraction({
+                id  : 'mock-first-fingerprint-vector-id',
+                meta: {sessionId: 'first-fingerprint-session'},
+                document: `First session content ${firstNeedle}`
+            });
+            await SemanticGraphExtractor.executeTriVectorExtraction({
+                id  : 'mock-second-fingerprint-vector-id',
+                meta: {sessionId: 'second-fingerprint-session'},
+                document: `Second session content ${secondNeedle}`
+            });
+        } finally {
+            OpenAiCompatible.prototype.generate = baseGenerate;
+            setConfigOverrides(originalOverrides);
+        }
+
+        expect(providerCalls.length).toBe(2);
+
+        const firstCall  = providerCalls[0],
+              secondCall = providerCalls[1];
+
+        expect(firstCall.messages[1].content).toContain(firstNeedle);
+        expect(secondCall.messages[1].content).toContain(secondNeedle);
+        expect(secondCall.messages[1].content).not.toContain(firstNeedle);
+        expect(secondCall.active).toMatchObject({
+            phase              : 'triVector',
+            sessionId          : 'second-fingerprint-session',
+            requestMessageCount: 2
+        });
+        expect(secondCall.active.requestMessageFingerprints).toHaveLength(2);
+        expect(secondCall.active.requestMessageFingerprints[1]).toMatchObject({
+            index              : 1,
+            role               : 'user',
+            bytes              : Buffer.byteLength(secondCall.messages[1].content, 'utf8'),
+            tokensEstimate     : expect.any(Number),
+            contentSha256Prefix: expect.stringMatching(/^[a-f0-9]{16}$/)
+        });
+
+        const fingerprintPayload = JSON.stringify(secondCall.active.requestMessageFingerprints);
+        expect(fingerprintPayload).not.toContain(firstNeedle);
+        expect(fingerprintPayload).not.toContain(secondNeedle);
+    });
+
     test('REM parser fails before dispatch when prompt plus output reserve exceeds context (#13984)', async () => {
         let providerCalled = false;
 


### PR DESCRIPTION
Resolves #13994

Adds bounded per-message fingerprints to the active REM Tri-Vector provider diagnostics so an operator can correlate one Neo request with one provider-visible counter without logging raw session payloads. The diagnostic snapshot now records message count plus index/role/byte/token/hash-prefix slots, and the unit coverage proves sequential REM calls do not carry the previous session payload into the next provider request.

Evidence: L2 (targeted unit coverage for provider-call diagnostics and cross-session payload isolation) -> L2 required (diagnostic instrumentation and mocked-path characterization for #13994). Residual: live 400k-counter correlation remains an explicit post-merge validation item for #13994 before the operator symptom is treated as root-caused.

## Deltas from ticket

This PR intentionally ships the first diagnostic actuator rather than claiming root-cause closure for the 400k provider counter. It gives the next live REM run a bounded correlation surface without storing prompt text.

## Contract Ledger

| Target Surface | Source of Authority | Proposed Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `activeTriVectorCall.requestMessageCount` | #13994 + existing active-call diagnostics | Record provider message count for the in-flight Tri-Vector request | Omit field when no active call exists | `learn/agentos/rem-state-model.md` | Unit spec asserts count on the second provider call |
| `activeTriVectorCall.requestMessageFingerprints[]` | #13994 privacy-safe correlation need | Record bounded index/role/bytes/token-estimate/hash-prefix slots without payload text | Operators correlate by other active-call fields if fingerprints are absent | `learn/agentos/rem-state-model.md` | Unit spec asserts 16-hex hash prefix and absence of raw session needles |

## Test Evidence

- `node --check ai/services/graph/SemanticGraphExtractor.mjs`
- `git diff --check`
- `npm run agent-preflight -- ai/services/graph/SemanticGraphExtractor.mjs test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs learn/agentos/rem-state-model.md`
- `npm run agent-preflight -- ai/services/graph/SemanticGraphExtractor.mjs test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs learn/agentos/rem-state-model.md --pr-body /private/tmp/neo-pr-body-13994.md`
- `npm run test-unit -- test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs` -> `16 passed`

## Post-Merge Validation

- [ ] Run the next live REM reproduction and compare the provider token counter against `activeTriVectorCall.requestMessageFingerprints[]`.
- [ ] If the live 400k counter reproduces, file or update the narrow follow-up with the fingerprint/counter evidence instead of treating this PR as root-cause closure.

Authored by Euclid (GPT-5, Codex Desktop). Session 35f83031-f1a6-41a7-9c3b-089b87307db9.
