### PR TITLE
feat(ai): detect-cadence-under-retention SLA verdict (#14059)

### DIFF
--- a/ai/scripts/maintenance/detectionRetentionSla.mjs
+++ b/ai/scripts/maintenance/detectionRetentionSla.mjs
@@ -1,0 +1,79 @@
+/**
+ * @module ai/scripts/maintenance/detectionRetentionSla
+ * @summary Pure verdict-half for the backup-reliability AC3: is the data-integrity detect
+ * cadence fast enough that a corruption is caught before the last good backup ages out of
+ * retention?
+ *
+ * The corruption incident exposed the structural risk: if corruption is not detected within the
+ * backup-retention window, the last *uncorrupted* backup is pruned before anyone knows
+ * recovery is needed — and recovery becomes impossible. The invariant that prevents this:
+ *
+ * ```
+ * detectCadenceMs  <=  backupRetentionMs / safetyFactor
+ * ```
+ *
+ * i.e. the worst-case time to *detect* a corruption must be a safe fraction of the window
+ * for which a good backup survives, leaving margin to actually run a recovery before the
+ * last good backup is pruned. `safetyFactor` defaults to 2 (detect within half the window).
+ *
+ * This module is the **verdict-half** (pure, no I/O) — it computes the SLA verdict from
+ * explicit inputs. The **wiring-half** (reading the detect-signal's live cadence config +
+ * the live backup-retention config and failing CI on a breach) is the gated next slice.
+ */
+
+/**
+ * Default safety factor: detection must fit within half the retention window, leaving the
+ * other half as margin to run an actual recovery before the last good backup is pruned.
+ * @type {Number}
+ */
+const DEFAULT_SAFETY_FACTOR = 2;
+
+/**
+ * Evaluate whether the data-integrity detect cadence beats backup retention with margin.
+ *
+ * Pure — no I/O, no clock, no config reads. The caller supplies the worst-case detect cadence
+ * and the retention window; this returns a structured verdict. The SLA holds iff
+ * `detectCadenceMs <= backupRetentionMs / safetyFactor`.
+ *
+ * @param {Object} options
+ * @param {Number} options.detectCadenceMs   Worst-case time (ms) for the data-integrity
+ *                                            detect-signal to flag a corruption. Must be > 0.
+ * @param {Number} options.backupRetentionMs Window (ms) for which the last good backup
+ *                                            survives before being pruned. Must be > 0.
+ * @param {Number} [options.safetyFactor=2]  Detection must fit within `retention/safetyFactor`
+ *                                            so recovery has margin. Must be >= 1.
+ * @returns {{withinSla: Boolean, marginMs: Number, requiredMaxDetectMs: Number, reason: (String|null)}}
+ *          `withinSla` — true iff the SLA holds.
+ *          `requiredMaxDetectMs` — the largest detect cadence that would still pass
+ *          (`backupRetentionMs / safetyFactor`).
+ *          `marginMs` — `requiredMaxDetectMs - detectCadenceMs` (negative when breached).
+ *          `reason` — null when within SLA; otherwise a human-readable breach explanation.
+ * @throws {TypeError} when `detectCadenceMs` or `backupRetentionMs` is missing or <= 0, or
+ *                     when `safetyFactor` < 1 — no silent pass on an unconfigured SLA.
+ */
+export function evaluateDetectionRetentionSla({detectCadenceMs, backupRetentionMs, safetyFactor = DEFAULT_SAFETY_FACTOR} = {}) {
+    if (!Number.isFinite(detectCadenceMs) || detectCadenceMs <= 0) {
+        throw new TypeError(`evaluateDetectionRetentionSla: detectCadenceMs must be a positive number, got ${detectCadenceMs}`);
+    }
+    if (!Number.isFinite(backupRetentionMs) || backupRetentionMs <= 0) {
+        throw new TypeError(`evaluateDetectionRetentionSla: backupRetentionMs must be a positive number, got ${backupRetentionMs}`);
+    }
+    if (!Number.isFinite(safetyFactor) || safetyFactor < 1) {
+        throw new TypeError(`evaluateDetectionRetentionSla: safetyFactor must be a number >= 1, got ${safetyFactor}`);
+    }
+
+    const requiredMaxDetectMs = backupRetentionMs / safetyFactor,
+          marginMs            = requiredMaxDetectMs - detectCadenceMs,
+          withinSla           = marginMs >= 0;
+
+    return {
+        withinSla,
+        marginMs,
+        requiredMaxDetectMs,
+        reason: withinSla
+            ? null
+            : `detect cadence ${detectCadenceMs}ms exceeds the SLA ceiling ${requiredMaxDetectMs}ms ` +
+              `(retention ${backupRetentionMs}ms / safetyFactor ${safetyFactor}); a corruption could age ` +
+              `out the last good backup before it is detected and recovered`
+    };
+}

--- a/test/playwright/unit/ai/scripts/maintenance/detectionRetentionSla.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/detectionRetentionSla.spec.mjs
@@ -1,0 +1,71 @@
+import {test, expect}                  from '@playwright/test';
+import {evaluateDetectionRetentionSla} from '../../../../../../ai/scripts/maintenance/detectionRetentionSla.mjs';
+
+// Pure verdict logic (no I/O / clock / config) — imported directly, mirrors parseAgentEnvelope.spec.
+// Backup-reliability AC3: the detect cadence must beat backup retention with margin so a corruption
+// is caught before the last good backup ages out of retention (the incident's failed backup sat
+// unalerted ~5 days).
+
+const DAY = 86400000;
+
+test.describe('evaluateDetectionRetentionSla (#14030 AC3 verdict-half)', () => {
+    test('within SLA — detect cadence well under retention/safetyFactor', () => {
+        // retention 30d, safetyFactor 2 → ceiling 15d; hourly detect → far within.
+        const r = evaluateDetectionRetentionSla({detectCadenceMs: 3600000, backupRetentionMs: 30 * DAY});
+        expect(r.withinSla).toBe(true);
+        expect(r.requiredMaxDetectMs).toBe(15 * DAY);
+        expect(r.marginMs).toBe(15 * DAY - 3600000);
+        expect(r.reason).toBe(null);
+    });
+
+    test('breached — detect cadence exceeds retention/safetyFactor', () => {
+        // retention 30d, safetyFactor 2 → ceiling 15d; detect every 20d → breach.
+        const r = evaluateDetectionRetentionSla({detectCadenceMs: 20 * DAY, backupRetentionMs: 30 * DAY});
+        expect(r.withinSla).toBe(false);
+        expect(r.requiredMaxDetectMs).toBe(15 * DAY);
+        expect(r.marginMs).toBeLessThan(0);
+        expect(r.reason).toContain('exceeds the SLA ceiling');
+    });
+
+    test('boundary — detect cadence exactly at the ceiling is within SLA (margin 0)', () => {
+        // retention 30d, safetyFactor 2 → ceiling 15d; detect every 15d → margin 0, still within.
+        const r = evaluateDetectionRetentionSla({detectCadenceMs: 15 * DAY, backupRetentionMs: 30 * DAY});
+        expect(r.withinSla).toBe(true);
+        expect(r.marginMs).toBe(0);
+        expect(r.reason).toBe(null);
+    });
+
+    test('explicit safetyFactor tightens the ceiling', () => {
+        // retention 30d, safetyFactor 3 → ceiling 10d; detect every 12d → breach.
+        const r = evaluateDetectionRetentionSla({detectCadenceMs: 12 * DAY, backupRetentionMs: 30 * DAY, safetyFactor: 3});
+        expect(r.requiredMaxDetectMs).toBe(10 * DAY);
+        expect(r.withinSla).toBe(false);
+    });
+
+    test('safetyFactor 1 — detection only needs to beat the full retention window', () => {
+        const r = evaluateDetectionRetentionSla({detectCadenceMs: 20 * DAY, backupRetentionMs: 30 * DAY, safetyFactor: 1});
+        expect(r.requiredMaxDetectMs).toBe(30 * DAY);
+        expect(r.withinSla).toBe(true);
+    });
+
+    test('rejects missing / non-positive / non-numeric detectCadenceMs — no silent pass', () => {
+        for (const bad of [undefined, 0, -1, NaN, Infinity, '1000']) {
+            expect(() => evaluateDetectionRetentionSla({detectCadenceMs: bad, backupRetentionMs: 30 * DAY}))
+                .toThrow('detectCadenceMs');
+        }
+    });
+
+    test('rejects missing / non-positive / non-numeric backupRetentionMs — no silent pass', () => {
+        for (const bad of [undefined, 0, -1, NaN, Infinity, '1000']) {
+            expect(() => evaluateDetectionRetentionSla({detectCadenceMs: 3600000, backupRetentionMs: bad}))
+                .toThrow('backupRetentionMs');
+        }
+    });
+
+    test('rejects safetyFactor < 1', () => {
+        for (const bad of [0, 0.5, -2, NaN]) {
+            expect(() => evaluateDetectionRetentionSla({detectCadenceMs: 3600000, backupRetentionMs: 30 * DAY, safetyFactor: bad}))
+                .toThrow('safetyFactor');
+        }
+    });
+});


### PR DESCRIPTION
Resolves #14059

The **verdict-half** of #14030 AC3 (detection-latency-under-retention SLA), per the same check-half / wiring-half split as AC2 (#14053): a pure `evaluateDetectionRetentionSla({detectCadenceMs, backupRetentionMs, safetyFactor})` in `ai/scripts/maintenance/detectionRetentionSla.mjs` returning `{withinSla, marginMs, requiredMaxDetectMs, reason}`. The SLA holds iff `detectCadenceMs <= backupRetentionMs / safetyFactor` — the worst-case detect latency must be a safe fraction of the window a good backup survives, leaving margin to run a recovery before the last good backup is pruned. `safetyFactor` defaults to 2.

Pure (no I/O / clock / config); fails loud (`TypeError`) on a non-positive/missing cadence or retention — no silent pass on an unconfigured SLA.

Evidence: 8/8 unit — within / breached / boundary (margin 0) / explicit-safetyFactor / safetyFactor-1 / invalid detectCadenceMs / invalid backupRetentionMs / invalid safetyFactor.

## Test Evidence

- `node --check ai/scripts/maintenance/detectionRetentionSla.mjs` -> passed
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/detectionRetentionSla.spec.mjs` -> **8 passed (31.1s)**
- Commit: 0e5a6f4d5

## Deltas From Ticket

None — implements the #14059 verdict-half as filed. The CI-guard wiring (reading the live detect-cadence config + the live backup-retention window — confirmed to exist at `aiConfig.maintenance.backup.retention.maxDays`, per `backup-retention.spec.mjs` — and failing CI on a breach) is the explicitly out-of-scope next slice, gated on #14026's detect-cadence being built.

## Post-Merge Validation

- [ ] The wiring slice consumes `evaluateDetectionRetentionSla()` with the live `maintenance.backup.retention.maxDays` window + #14026's configured detect-cadence, failing CI (or escalating) on a breach.

## Contract Ledger

`evaluateDetectionRetentionSla()` is a new exported function (additive); its return shape `{withinSla, marginMs, requiredMaxDetectMs, reason}` is documented in #14059's Contract Ledger Matrix + the function JSDoc. No existing export changed.

Authored by Vega (Claude Opus 4.8, Claude Code). Session ef66cbd0-3770-466c-9df1-f93c141eb1d3.
