### PR TITLE
feat(ai): escalate backup task failure diagnoses (#14058)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -275,12 +275,13 @@ export class Orchestrator extends Base {
      */
     beforeSetProcessSupervisorService(value) {
         return ClassSystemUtil.beforeSetInstance(value, ProcessSupervisorService, {
-            dataDir         : this.dataDir,
-            taskDefinitions : this.taskDefinitions,
-            taskStateService: this.taskStateService,
-            healthService   : this.healthService,
-            writeLog        : this.processSupervisorWriteLog,
-            spawnFn         : this.spawnFn
+            dataDir                : this.dataDir,
+            taskDefinitions        : this.taskDefinitions,
+            taskStateService       : this.taskStateService,
+            healthService          : this.healthService,
+            recoveryActuatorService: this.recoveryActuatorService,
+            writeLog               : this.processSupervisorWriteLog,
+            spawnFn                : this.spawnFn
         });
     }
 
@@ -357,6 +358,14 @@ export class Orchestrator extends Base {
     afterSetProcessSupervisorService(value, oldValue) {
         if (this.recoveryActuatorService) {
             this.recoveryActuatorService.processSupervisorService = value;
+            if (value) {
+                value.recoveryActuatorService = this.recoveryActuatorService;
+            }
+        }
+    }
+    afterSetRecoveryActuatorService(value, oldValue) {
+        if (this.processSupervisorService) {
+            this.processSupervisorService.recoveryActuatorService = value;
         }
     }
     afterSetTaskStateService(value, oldValue) {

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -1,9 +1,11 @@
-import Base       from '../../../../src/core/Base.mjs';
-import fs         from 'fs-extra';
-import path       from 'path';
-import {execSync} from 'child_process';
+import Base                           from '../../../../src/core/Base.mjs';
+import fs                             from 'fs-extra';
+import path                           from 'path';
+import {execSync}                     from 'child_process';
+import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 
 const DEFAULT_STDOUT_JSON_MAX_BYTES = 65536;
+const ESCALATING_TASK_OUTCOMES      = Object.freeze(new Set(['backup']));
 
 /**
  * @class Neo.ai.daemons.services.ProcessSupervisorService
@@ -45,6 +47,12 @@ export class ProcessSupervisorService extends Base {
          * @reactive
          */
         healthService_: null,
+        /**
+         * @member {Object|null} recoveryActuatorService_=null
+         * @protected
+         * @reactive
+         */
+        recoveryActuatorService_: null,
         /**
          * @member {Function|null} writeLog_=null
          * @protected
@@ -168,7 +176,11 @@ export class ProcessSupervisorService extends Base {
     }
 
     /**
-     * Records task status into HealthService without letting observability failures break the loop.
+     * Records task status into HealthService and escalates critical task failures.
+     *
+     * Health recording is observability-only; escalation is alarm-only for allowlisted critical
+     * failed tasks, and never restarts the failed task from this sink.
+     *
      * @param {String} taskName Task key.
      * @param {String} status Outcome status.
      * @param {Object|null} [details=null] Outcome details.
@@ -180,6 +192,65 @@ export class ProcessSupervisorService extends Base {
         } catch (e) {
             this.writeLog?.('ERROR', `[ProcessSupervisor] Failed to record ${taskName} outcome: ${e.message}`);
         }
+
+        this.escalateFailedTaskOutcome({taskName, status, details});
+    }
+
+    /**
+     * @summary Escalates allowlisted failed task outcomes through the recovery diagnosis sink.
+     *
+     * This is alarm-only: it creates a `supervised-task` diagnosis and calls
+     * `RecoveryActuatorService.escalateDiagnosis()` without restarting the task.
+     *
+     * @param {Object} options
+     * @param {String} options.taskName Task key.
+     * @param {String} options.status Outcome status.
+     * @param {Object|null} [options.details=null] Outcome details.
+     * @returns {Boolean} True when an escalation was attempted.
+     */
+    escalateFailedTaskOutcome({taskName, status, details}) {
+        if (status !== 'failed' || !ESCALATING_TASK_OUTCOMES.has(taskName)) {
+            return false;
+        }
+
+        const actuator = this.recoveryActuatorService;
+
+        if (typeof actuator?.escalateDiagnosis !== 'function') {
+            return false;
+        }
+
+        const observedAt = Date.now(),
+              diagnosis  = createRecoveryDiagnosisEvent({
+                  diagnosisId   : `process-supervisor:${taskName}:failed:${observedAt}`,
+                  recoveryClass : 'ambiguous',
+                  confidence    : 1,
+                  targetIdentity: {kind: 'supervised-task', id: taskName},
+                  evidenceFacts : [{
+                      type   : 'task-failure',
+                      taskName,
+                      status,
+                      details: details || {},
+                      observedAt
+                  }],
+                  observedAt,
+                  source : 'process-supervisor-task-outcome',
+                  details: {
+                      actionClass   : 'escalate',
+                      reasonCode    : 'maintenance-task-failure',
+                      taskName,
+                      taskStatus    : status,
+                      outcomeDetails: details || {}
+                  }
+              });
+
+        Promise.resolve(actuator.escalateDiagnosis(diagnosis, {
+            now   : observedAt,
+            reason: 'maintenance-task-failure'
+        })).catch(error => {
+            this.writeLog?.('ERROR', `[ProcessSupervisor] Failed to escalate ${taskName} failure: ${error.message}`);
+        });
+
+        return true;
     }
 
     /**

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -357,6 +357,83 @@ export class RecoveryActuatorService extends Base {
     }
 
     /**
+     * @summary Escalates a diagnosis without executing a privileged recovery action.
+     *
+     * Backup/task-failure alerting needs the recovery-run ledger and operator page path, but
+     * must not coerce a supervised task into the deploy-target `page` action. This sink accepts
+     * only controller-produced alarm diagnoses and records them as escalated.
+     *
+     * @param {Object} diagnosisEvent Recovery diagnosis event with `details.actionClass = 'escalate'`.
+     * @param {Object} [options]
+     * @param {String|null} [options.recoveryRunId=null] Optional stable recovery run id.
+     * @param {Number} [options.now=Date.now()] Epoch milliseconds.
+     * @param {String|null} [options.reason=null] Operator/controller reason.
+     * @returns {Promise<Object>} Escalation outcome descriptor.
+     */
+    async escalateDiagnosis(diagnosisEvent, {
+        recoveryRunId = null,
+        now = Date.now(),
+        reason = null
+    } = {}) {
+        let diagnosis;
+
+        try {
+            diagnosis = createRecoveryDiagnosisEvent(diagnosisEvent);
+        } catch (error) {
+            return {
+                status    : 'rejected',
+                reasonCode: 'invalid-diagnosis',
+                error     : error.message
+            };
+        }
+
+        if (diagnosis.details?.actionClass !== 'escalate') {
+            return {
+                status        : 'rejected',
+                reasonCode    : 'diagnosis-not-escalatable',
+                targetIdentity: diagnosis.targetIdentity
+            };
+        }
+
+        const serviceKey = diagnosis.targetIdentity.id,
+              target     = {
+                  kind: diagnosis.targetIdentity.kind,
+                  serviceKey,
+                  id  : serviceKey
+              },
+              page       = this.createDiagnosisPage({diagnosisEvent: diagnosis, reason});
+
+        if (typeof this.pageDispatcher === 'function') {
+            await this.pageDispatcher(page);
+        } else {
+            this.writeLog?.('WARN', `[RecoveryActuator] Escalation required for ${serviceKey}; page target ${page.operatorPageTarget}.`);
+        }
+
+        const updatedAt = Date.now();
+
+        return this.finishAction({
+            action        : 'escalate',
+            attempt       : 1,
+            backoffUntil  : null,
+            diagnosisEvent: diagnosis,
+            outcome       : {
+                status        : 'escalated',
+                reasonCode    : diagnosis.details.reasonCode || 'diagnosis-escalation',
+                serviceKey,
+                action        : 'escalate',
+                targetIdentity: createRecoveryTargetIdentity(diagnosis.targetIdentity),
+                page
+            },
+            recoveryRunId,
+            serviceKey,
+            startedAt : now,
+            target,
+            taskStatus: 'failed',
+            updatedAt
+        });
+    }
+
+    /**
      * @summary Resolves the strict recovery target entry for a service key and optional identity.
      * @param {Object} options
      * @returns {Object|null}
@@ -519,6 +596,22 @@ export class RecoveryActuatorService extends Base {
         }
 
         return {page};
+    }
+
+    /**
+     * @summary Builds the operator page payload for an alarm-only diagnosis escalation.
+     * @param {Object} options
+     * @returns {Object}
+     */
+    createDiagnosisPage({diagnosisEvent, reason}) {
+        return {
+            serviceKey        : diagnosisEvent.targetIdentity.id,
+            targetIdentity    : createRecoveryTargetIdentity(diagnosisEvent.targetIdentity),
+            action            : 'escalate',
+            reason            : reason || diagnosisEvent.details?.reasonCode || 'diagnosis-escalation',
+            diagnosisEvent,
+            operatorPageTarget: this.cfg.operatorPageTarget
+        };
     }
 
     /**

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -101,7 +101,7 @@ function createManualChild() {
 test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
     test('getTaskPidFile returns correct path', () => {
         const { service, dataDir } = createTestService();
-        const pidFile = service.getTaskPidFile('mockTask');
+        const pidFile              = service.getTaskPidFile('mockTask');
 
         expect(pidFile).toBe(path.join(dataDir, 'mockTask.pid'));
     });
@@ -132,7 +132,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('runTask watchdog kills a child that exceeds maxRuntimeMs and finalizes it as failed', async () => {
         const { service, taskOutcomes } = createTestService();
-        let killed = false;
+        let   killed                    = false;
 
         service.taskDefinitions = {
             ...service.taskDefinitions,
@@ -162,7 +162,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('runTask does NOT arm a watchdog when maxRuntimeMs is unset (opt-in)', async () => {
         const { service } = createTestService();
-        let killed = false;
+        let   killed      = false;
 
         // mockTask has no maxRuntimeMs → no watchdog → a long-lived child is left alone.
         service.spawnFn = () => ({pid: 4243, on: () => {}, kill: () => { killed = true; }, stderr: {on: () => {}}});
@@ -223,7 +223,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('#13777: opted-in stdout JSON is recorded on successful child completion', () => {
         const { service, stateCalls, taskOutcomes } = createTestService();
-        const manualChild = createManualChild();
+        const manualChild                           = createManualChild();
 
         service.taskDefinitions.mockTask.captureStdoutJson = true;
         service.spawnFn = (command, args, options) => {
@@ -258,8 +258,8 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('#13777: memory-summary-backfill all-deferred stdout marks skipped, not completed', () => {
         const { service, stateCalls, taskOutcomes } = createTestService();
-        const manualChild  = createManualChild();
-        let   successHooks = 0;
+        const manualChild                           = createManualChild();
+        let   successHooks                          = 0;
 
         service.spawnFn = () => manualChild.child;
 
@@ -292,7 +292,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('#13777: memory-summary-backfill lease-held stdout marks skipped with child reason', () => {
         const { service, stateCalls, taskOutcomes } = createTestService();
-        const manualChild = createManualChild();
+        const manualChild                           = createManualChild();
 
         service.spawnFn = () => manualChild.child;
 
@@ -319,7 +319,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('#13777: malformed opted-in stdout fails soft and preserves success classification', () => {
         const { service, stateCalls, taskOutcomes } = createTestService();
-        const manualChild = createManualChild();
+        const manualChild                           = createManualChild();
 
         service.taskDefinitions.mockTask.captureStdoutJson = true;
         service.spawnFn = () => manualChild.child;
@@ -340,7 +340,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('#13784: kbSync lease-held stdout records skipped, not false-green completed', () => {
         const { service, stateCalls, taskOutcomes } = createTestService();
-        const manualChild = createManualChild();
+        const manualChild                           = createManualChild();
 
         service.spawnFn = () => manualChild.child;
 
@@ -367,7 +367,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('#13784: kbSync real sync (deferred:false) records completed with embed counts', () => {
         const { service, stateCalls, taskOutcomes } = createTestService();
-        const manualChild = createManualChild();
+        const manualChild                           = createManualChild();
 
         service.spawnFn = () => manualChild.child;
 
@@ -402,7 +402,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('runTask records ready state after a post-spawn hook succeeds', async () => {
         const { service, taskOutcomes } = createTestService();
-        let readyMarked = false;
+        let   readyMarked               = false;
 
         service.taskDefinitions.mockTask.postSpawn = async () => ({models: ['chat', 'embedding']});
         service.taskStateService.markReady = taskName => {
@@ -427,9 +427,69 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         }));
     });
 
+    test('recordTaskOutcome escalates failed backup outcomes without breaking HealthService', async () => {
+        const { service, taskOutcomes } = createTestService();
+        const escalations               = [];
+
+        service.recoveryActuatorService = {
+            async escalateDiagnosis(diagnosisEvent, options) {
+                escalations.push({diagnosisEvent, options});
+                return {status: 'escalated'};
+            }
+        };
+
+        service.recordTaskOutcome('backup', 'failed', {
+            reason: 'periodic-backup',
+            code  : 1
+        });
+        service.recordTaskOutcome('kbSync', 'failed', {reason: 'other-task'});
+
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            taskName: 'backup',
+            status  : 'failed',
+            details : expect.objectContaining({code: 1})
+        }));
+        expect(escalations).toHaveLength(1);
+        expect(escalations[0].options).toMatchObject({
+            now   : expect.any(Number),
+            reason: 'maintenance-task-failure'
+        });
+        expect(escalations[0].diagnosisEvent).toMatchObject({
+            type          : 'recovery-diagnosis',
+            recoveryClass : 'ambiguous',
+            targetIdentity: {kind: 'supervised-task', id: 'backup'},
+            source        : 'process-supervisor-task-outcome',
+            details       : expect.objectContaining({
+                actionClass   : 'escalate',
+                reasonCode    : 'maintenance-task-failure',
+                taskName      : 'backup',
+                taskStatus    : 'failed',
+                outcomeDetails: expect.objectContaining({code: 1})
+            })
+        });
+    });
+
+    test('recordTaskOutcome logs but swallows backup escalation failures', async () => {
+        const { service, logEntries } = createTestService();
+
+        service.recoveryActuatorService = {
+            async escalateDiagnosis() {
+                throw new Error('page unavailable');
+            }
+        };
+
+        service.recordTaskOutcome('backup', 'failed', {reason: 'periodic-backup'});
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(logEntries).toContainEqual(expect.objectContaining({
+            level  : 'ERROR',
+            message: expect.stringContaining('Failed to escalate backup failure: page unavailable')
+        }));
+    });
+
     test('runTask records degraded state when a post-spawn hook returns partial readiness (#12264)', async () => {
         const { service, logEntries, taskOutcomes } = createTestService();
-        let readyMarked = false;
+        let   readyMarked                           = false;
         let closeHandler;
 
         service.taskDefinitions.mockTask.postSpawn = async () => ({
@@ -474,8 +534,8 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('runTask fails and terminates the child when a post-spawn hook fails', async () => {
         const { service, taskOutcomes } = createTestService();
-        let killed = false;
-        let failed = false;
+        let   killed                    = false;
+        let   failed                    = false;
 
         service.taskDefinitions.mockTask.postSpawn = async () => {
             throw new Error('models missing');
@@ -506,7 +566,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('#13954: liveness-readiness hook dedupes repeated success logs but records each outcome', async () => {
         const { service, logEntries, taskOutcomes } = createTestService();
-        let readyMarks = 0;
+        let   readyMarks                            = 0;
 
         service.taskDefinitions.mockTask.postSpawn = async () => ({ready: true, loadedModels: ['embedding-model']});
         service.taskStateService.markReady = taskName => {
@@ -528,7 +588,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('#13954: liveness-readiness success logs again after degraded readiness recovers', async () => {
         const { service, logEntries } = createTestService();
-        const readinessResults = [
+        const readinessResults        = [
             {ready: true},
             {ready: true},
             {ready: false, degraded: true, missingModels: ['chat-model']},
@@ -551,7 +611,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('reapDuplicateListeners SIGKILLs extra listeners but keeps the canonical pid', () => {
         const { service, taskOutcomes } = createTestService();
-        const killed = [];
+        const killed                    = [];
 
         service.taskDefinitions.mockTask.singletonPort = 8000;
         service.taskStateService.getTaskState = () => ({running: true, pid: 100});
@@ -568,7 +628,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('reapDuplicateListeners leaves a process whose command is not the task command', () => {
         const { service } = createTestService();
-        const killed = [];
+        const killed      = [];
 
         service.taskDefinitions.mockTask.singletonPort = 8000;
         service.taskStateService.getTaskState = () => ({running: true, pid: 100});
@@ -582,7 +642,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('reapDuplicateListeners is a no-op for tasks without a singletonPort', () => {
         const { service } = createTestService();
-        let probed = false;
+        let   probed      = false;
 
         service.listPortListeners = () => { probed = true; return [200]; };
 
@@ -592,8 +652,8 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('reapDuplicateListeners defers shared local services without touching listeners', () => {
         const { service } = createTestService();
-        const killed = [];
-        let   probed = false;
+        const killed      = [];
+        let   probed      = false;
 
         service.taskDefinitions.mockTask.singletonPort = 8000;
         service.taskDefinitions.mockTask.duplicateListenerPolicy = 'defer';
@@ -607,7 +667,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('reapDuplicateListeners reaps every matching listener when no canonical pid is tracked', () => {
         const { service } = createTestService();
-        const killed = [];
+        const killed      = [];
 
         service.taskDefinitions.mockTask.singletonPort = 8000;
         service.taskStateService.getTaskState = () => ({running: false, pid: null});
@@ -621,8 +681,8 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('killTask SIGKILLs the tracked pid, marks the task recycled, and records the outcome (#12138)', () => {
         const {service, taskOutcomes} = createTestService();
-        const killed   = [];
-        const recycled = [];
+        const killed                  = [];
+        const recycled                = [];
 
         service.taskStateService.getTaskState = () => ({running: true, pid: 4242});
         service.taskStateService.markRecycled = name => recycled.push(name);
@@ -639,8 +699,8 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('killTask is safe when no pid is tracked: no kill attempted, still marks recycled (#12138)', () => {
         const {service, taskOutcomes} = createTestService();
-        const killed   = [];
-        const recycled = [];
+        const killed                  = [];
+        const recycled                = [];
 
         service.taskStateService.getTaskState = () => ({running: false, pid: null});
         service.taskStateService.markRecycled = name => recycled.push(name);
@@ -666,7 +726,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('superviseTask restarts a down process-match task once the cooldown elapses', () => {
         const {service} = createTestService();
-        const calls = [];
+        const calls     = [];
         service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
         service.taskStateService.getTaskState = () => ({running: false, lastRunAt: 0});
 
@@ -677,7 +737,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('superviseTask leaves a running task alone — no restart', () => {
         const {service} = createTestService();
-        const calls = [];
+        const calls     = [];
         service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
         service.taskStateService.getTaskState = () => ({running: true, lastRunAt: 0, pid: 1234});
 
@@ -688,7 +748,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('superviseTask holds off within the cooldown window', () => {
         const {service} = createTestService();
-        const calls = [];
+        const calls     = [];
         service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
         // lastRunAt only 5s before `now`: still inside the 15s cooldown.
         service.taskStateService.getTaskState = () => ({running: false, lastRunAt: 995_000});
@@ -700,7 +760,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('superviseTask gates a fire-and-exit lane on its liveness probe — UP yields a silent no-op', async () => {
         const {service} = createTestService();
-        const calls = [];
+        const calls     = [];
         service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
         service.taskStateService.getTaskState = () => ({running: false, lastRunAt: 0});
         service.taskDefinitions = {probeTask: {label: 'Probe Task', livenessProbe: async () => true}};
@@ -714,9 +774,9 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('superviseTask runs readiness hook when fire-and-exit liveness is already UP (#13944)', async () => {
         const {service, taskOutcomes} = createTestService();
-        const calls          = [];
-        let   readyMarked    = false;
-        let   readinessCalls = 0;
+        const calls                   = [];
+        let   readyMarked             = false;
+        let   readinessCalls          = 0;
 
         service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
         service.taskStateService.getTaskState = () => ({running: false, lastRunAt: 0});
@@ -752,7 +812,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('superviseTask gates a fire-and-exit lane on its liveness probe — DOWN triggers a restart', async () => {
         const {service} = createTestService();
-        const calls = [];
+        const calls     = [];
         service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
         service.taskStateService.getTaskState = () => ({running: false, lastRunAt: 0});
         service.taskDefinitions = {probeTask: {label: 'Probe Task', livenessProbe: async () => false}};
@@ -765,7 +825,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('superviseTask recycles a RUNNING task whose healthProbe reports sustained-stuck', async () => {
         const {service} = createTestService();
-        const killed = [];
+        const killed    = [];
         service.killProcess = pid => killed.push(pid);
         service.taskStateService.getTaskState = () => ({running: true, pid: 9999});
         service.taskStateService.markRecycled = () => {};
@@ -781,7 +841,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('superviseTask leaves a RUNNING task healthy per its healthProbe (no recycle)', async () => {
         const {service} = createTestService();
-        const killed = [];
+        const killed    = [];
         service.killProcess = pid => killed.push(pid);
         service.taskStateService.getTaskState = () => ({running: true, pid: 9999});
         service.taskStateService.markRecycled = () => {};
@@ -795,8 +855,8 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('superviseTask leaves a RUNNING task WITHOUT a healthProbe alone (no recycle, no respawn)', async () => {
         const {service} = createTestService();
-        const killed  = [];
-        let   spawned = false;
+        const killed    = [];
+        let   spawned   = false;
         service.killProcess = pid => killed.push(pid);
         service.runTask     = () => { spawned = true; return true; };
         service.taskStateService.getTaskState = () => ({running: true, pid: 9999});
@@ -811,7 +871,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
 
     test('a healthProbe fault never recycles a running child', async () => {
         const {service} = createTestService();
-        const killed = [];
+        const killed    = [];
         service.killProcess = pid => killed.push(pid);
         service.taskStateService.getTaskState = () => ({running: true, pid: 9999});
         service.taskStateService.markRecycled = () => {};

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -10,6 +10,10 @@ import {
     isRecoveryActuatorTargetBlocked,
     normalizeRecoveryActuatorTargets
 } from '../../../../../../../ai/daemons/orchestrator/services/RecoveryActuatorService.mjs';
+import {
+    createRecoveryDiagnosisEvent,
+    createRecoveryTargetIdentity
+} from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {TIER1_DEFAULTS} from '../../../../../fixtures/aiConfigDefaults.mjs';
 
 const DEFAULT_ACTUATOR_CONFIG       = TIER1_DEFAULTS.orchestrator.recoveryActuator;
@@ -101,6 +105,23 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
 
     async function readAttempts() {
         return JSON.parse(await readFile(path.join(tmpDir, 'heal-attempts.json'), 'utf8'));
+    }
+
+    function backupEscalationDiagnosis(overrides = {}) {
+        return createRecoveryDiagnosisEvent({
+            diagnosisId   : 'backup-failed-1',
+            recoveryClass : 'ambiguous',
+            confidence    : 1,
+            targetIdentity: createRecoveryTargetIdentity({kind: 'supervised-task', id: 'backup'}),
+            evidenceFacts : [{type: 'task-failure', taskName: 'backup'}],
+            observedAt    : 500_000,
+            source        : 'process-supervisor-task-outcome',
+            details       : {
+                actionClass: 'escalate',
+                reasonCode : 'maintenance-task-failure'
+            },
+            ...overrides
+        });
     }
 
     test('normalizes string and object recovery target entries', () => {
@@ -423,6 +444,68 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                 ledgerStatus: 'escalated'
             })
         }));
+    });
+
+    test('escalateDiagnosis pages a supervised-task diagnosis without executing target actions', async () => {
+        const {service, runtimeCalls, supervisorCalls, pageCalls, taskOutcomes} = createService();
+        let   executedTargetAction                                              = false;
+
+        service.executeTargetAction = async () => {
+            executedTargetAction = true;
+            throw new Error('should not execute');
+        };
+
+        const result = await service.escalateDiagnosis(backupEscalationDiagnosis(), {
+            now   : 500_000,
+            reason: 'backup-failed'
+        });
+
+        expect(result).toMatchObject({
+            status        : 'escalated',
+            reasonCode    : 'maintenance-task-failure',
+            targetIdentity: {kind: 'supervised-task', id: 'backup'}
+        });
+        expect(result.reobserveRequest).toBeNull();
+        expect(executedTargetAction).toBe(false);
+        expect(runtimeCalls).toEqual([]);
+        expect(supervisorCalls).toEqual([]);
+        expect(pageCalls).toEqual([expect.objectContaining({
+            serviceKey        : 'backup',
+            action            : 'escalate',
+            reason            : 'backup-failed',
+            targetIdentity    : {kind: 'supervised-task', id: 'backup'},
+            operatorPageTarget: 'AGENT:*'
+        })]);
+        expect(pageCalls[0].diagnosisEvent).toMatchObject({
+            type          : 'recovery-diagnosis',
+            targetIdentity: {kind: 'supervised-task', id: 'backup'},
+            details       : expect.objectContaining({actionClass: 'escalate'})
+        });
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            taskName: 'recovery-actuator:backup',
+            status  : 'failed',
+            details : expect.objectContaining({
+                status      : 'escalated',
+                ledgerStatus: 'escalated'
+            })
+        }));
+    });
+
+    test('escalateDiagnosis rejects non-escalate diagnoses without privileged actions', async () => {
+        const {service, runtimeCalls, supervisorCalls, pageCalls} = createService();
+
+        const result = await service.escalateDiagnosis(backupEscalationDiagnosis({
+            details: {actionClass: 'restart'}
+        }), {now: 510_000});
+
+        expect(result).toEqual({
+            status        : 'rejected',
+            reasonCode    : 'diagnosis-not-escalatable',
+            targetIdentity: {kind: 'supervised-task', id: 'backup'}
+        });
+        expect(runtimeCalls).toEqual([]);
+        expect(supervisorCalls).toEqual([]);
+        expect(pageCalls).toEqual([]);
     });
 
     test('arbitrary actions are rejected before target lookup or executor access', async () => {


### PR DESCRIPTION
Resolves #14058

Related: #14030

Adds the backup failure escalation half of `#14030` AC1: failed `backup` task outcomes now produce a `supervised-task:backup` recovery diagnosis escalation, and `RecoveryActuatorService.escalateDiagnosis()` pages/operators through the recovery ledger without executing restart, deploy-target, or `apply('backup', 'page')` machinery.

Evidence: L2 (focused unit coverage for the supervisor hook, actuator sink, rejection path, and no privileged action execution) -> L2 required (ticket ACs are unit-contract and service-boundary guarantees). No residual close-target ACs.

## Deltas from ticket

The implementation stayed intentionally independent of PR `#14056`: it uses the existing `createRecoveryDiagnosisEvent()` contract directly so this PR can target `dev` without stacking on Vega's producer-core branch. The scheduling-overdue producer remains out of scope.

## Contract Ledger

| Surface | Consumer | Contract | Evidence |
|---|---|---|---|
| `ProcessSupervisorService.recordTaskOutcome('backup', 'failed', details)` | Backup process-task failure path | Builds one `recovery-diagnosis` with `targetIdentity: {kind: 'supervised-task', id: 'backup'}` and `details.actionClass = 'escalate'`; HealthService recording remains best-effort | Unit test covers backup failure escalation and non-backup no-op |
| `RecoveryActuatorService.escalateDiagnosis(diagnosisEvent, options)` | ProcessSupervisor now; future diagnosis producers later | Accepts only escalation-class diagnoses, dispatches/logs an operator page, writes the recovery ledger as `escalated`, and never calls target action execution | Unit test spies prove no runtime/supervisor/deploy action is invoked |
| `Orchestrator` service wiring | Runtime composition | Keeps ProcessSupervisor wired to the current RecoveryActuator instance through constructor and reactive setter paths | Source preflight plus focused service tests |

## Test Evidence

- `npm run agent-preflight -- ai/daemons/orchestrator/Orchestrator.mjs ai/daemons/orchestrator/services/ProcessSupervisorService.mjs ai/daemons/orchestrator/services/RecoveryActuatorService.mjs test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs` -> passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs` -> 55 passed.
- `git diff --check` and `git diff --cached --check` -> passed.

## Post-Merge Validation

- [ ] Trigger or inspect a real orchestrator `backup` task failure and confirm an operator escalation page/health outcome is emitted without restarting backup.
- [ ] After the scheduling-overdue producer lands, verify it can route into the same `escalateDiagnosis()` sink without a deploy-target coercion.

## Commits

- `413b93eda0` — `feat(ai): escalate backup task failure diagnoses (#14058)`

Authored by Euclid (GPT-5, Codex Desktop). Session 35f83031-f1a6-41a7-9c3b-089b87307db9.
