### PR TITLE
feat(ai): TicketSource per-element chunking — #14033 tickets vertical (#14063)

### DIFF
--- a/ai/services/knowledge-base/source/TicketSource.mjs
+++ b/ai/services/knowledge-base/source/TicketSource.mjs
@@ -1,7 +1,8 @@
-import Base from './Base.mjs';
-import fs   from 'fs-extra';
-import path from 'path';
-import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
+import Base                         from './Base.mjs';
+import fs                           from 'fs-extra';
+import path                         from 'path';
+import aiConfig                     from '../../../mcp/server/knowledge-base/config.mjs';
+import {splitTicketArchiveMarkdown} from './ticketArchiveElementSplitter.mjs';
 
 /**
  * @summary Extracts knowledge chunks from the Issue Archive.
@@ -65,7 +66,7 @@ class TicketSource extends Base {
         const ticketPaths = aiConfig.sourcePaths.TicketSource;
         const targetPaths = ticketPaths.map(p => path.resolve(aiConfig.neoRootDir, p));
 
-        const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'issues');
+        const indexMap    = await loadIndexMap(aiConfig.neoRootDir, 'issues');
         const contentRoot = path.resolve(aiConfig.neoRootDir, 'resources/content');
 
         for (const targetPath of targetPaths) {
@@ -75,7 +76,7 @@ class TicketSource extends Base {
 
                 for (const file of ticketFiles) {
                     if (typeof file === 'string' && file.endsWith('.md')) {
-                        const filePath   = path.join(targetPath, file);
+                        const filePath          = path.join(targetPath, file);
                         const relativeToContent = path.relative(contentRoot, filePath);
 
                         let id = indexMap.get(relativeToContent);
@@ -84,19 +85,28 @@ class TicketSource extends Base {
                             id = path.basename(file).replace('.md', '').replace(/^issue-/, '');
                         }
 
-                        const content    = await fs.readFile(filePath, 'utf-8');
-                        const chunk      = {
-                            type   : 'ticket',
-                            kind   : 'ticket',
-                            name   : `issue-${id}`,
-                            content,
-                            // Relative path keeps the distributed Chroma zip portable.
-                            source : path.relative(aiConfig.neoRootDir, filePath)
-                        };
+                        const content = await fs.readFile(filePath, 'utf-8');
+                        // Relative path keeps the distributed Chroma zip portable.
+                        const source = path.relative(aiConfig.neoRootDir, filePath);
+                        // Per-element chunks (body + each Timeline comment) keep a multi-cycle
+                        // ticket under the embedding cap; a no-comment ticket yields one body chunk
+                        // whose content equals the whole file.
+                        const elements = splitTicketArchiveMarkdown(content);
 
-                        chunk.hash = createHashFn(chunk);
-                        writeStream.write(JSON.stringify(chunk) + '\n');
-                        count++;
+                        for (const element of elements) {
+                            const suffix = element.kind === 'body' ? 'body' : `comment-${element.ordinal}`;
+                            const chunk = {
+                                type: 'ticket',
+                                kind: 'ticket',
+                                name   : `issue-${id}#${suffix}`,
+                                content: element.content,
+                                source
+                            };
+
+                            chunk.hash = createHashFn(chunk);
+                            writeStream.write(JSON.stringify(chunk) + '\n');
+                            count++;
+                        }
                     }
                 }
             }

--- a/ai/services/knowledge-base/source/ticketArchiveElementSplitter.mjs
+++ b/ai/services/knowledge-base/source/ticketArchiveElementSplitter.mjs
@@ -1,0 +1,93 @@
+/**
+ * @module ai/services/knowledge-base/source/ticketArchiveElementSplitter
+ * @summary Pure splitter that breaks an issue-archive markdown file into per-element pieces —
+ * the issue body and each Timeline comment as separate units — so the Knowledge Base can chunk
+ * a multi-cycle ticket at element granularity instead of one growing whole-file blob.
+ *
+ * A whole-artifact chunk that crosses the embedding cap is either dropped (unindexed) or
+ * blind-byte-split mid-content (semantically incoherent); on a path without a hard skip it fails
+ * to embed and leaves metadata without a vector (the corruption class). Splitting at extract time
+ * keeps every element small (a body / a single comment), so coverage stays complete regardless of
+ * how many comment cycles a ticket accumulates.
+ *
+ * Boundary format (verified across the archive — 709/711 files carry a `## Timeline` section):
+ * frontmatter + title + body run until `## Timeline`; each comment is delimited by a
+ * `### @<author> - <ISO-timestamp>` line. Comment bodies may themselves contain `##`/`###`
+ * headings, so the split keys ONLY on the `## Timeline` boundary + the author-timestamp delimiter
+ * — never on arbitrary headings. A file with no `## Timeline` (a no-comment ticket) yields a single
+ * body element whose content equals the whole file.
+ */
+
+/**
+ * Matches a Timeline comment delimiter line, e.g. `### @neo-opus-vega - 2026-06-26T02:16:08Z`.
+ * @type {RegExp}
+ */
+const COMMENT_DELIMITER = /^### @[A-Za-z0-9_-]+ - \d{4}-\d{2}-\d{2}T[0-9:.Z+-]+\s*$/;
+
+/**
+ * Matches the `## Timeline` section heading that separates the issue body from its comments.
+ * @type {RegExp}
+ */
+const TIMELINE_HEADING = /^## Timeline\s*$/;
+
+/**
+ * Splits issue-archive markdown into ordered per-element pieces.
+ *
+ * Pure — no I/O. Returns the body as element `ordinal: 0` followed by each comment as
+ * `ordinal: 1..N` in document order. A no-comment ticket (no `## Timeline`) returns a single
+ * body element whose content equals the whole file (so the existing whole-file chunk is preserved
+ * unchanged for that case).
+ *
+ * @param {String} content Raw `issue-*.md` file content (frontmatter + title + body + Timeline).
+ * @returns {Array<{kind: ('body'|'comment'), ordinal: Number, content: String}>}
+ *          `kind` — `'body'` for the single body element, `'comment'` for each Timeline comment.
+ *          `ordinal` — `0` for the body, `1..N` for comments in document order.
+ *          `content` — the element text (trailing whitespace trimmed).
+ * @throws {TypeError} when `content` is not a string.
+ */
+export function splitTicketArchiveMarkdown(content) {
+    if (typeof content !== 'string') {
+        throw new TypeError(`splitTicketArchiveMarkdown: content must be a string, got ${typeof content}`);
+    }
+
+    const lines       = content.split('\n');
+    let   timelineIdx = -1;
+
+    for (let i = 0; i < lines.length; i++) {
+        if (TIMELINE_HEADING.test(lines[i])) {
+            timelineIdx = i;
+            break;
+        }
+    }
+
+    // No `## Timeline` section → the whole file is a single body element (no-comment ticket).
+    if (timelineIdx === -1) {
+        return [{kind: 'body', ordinal: 0, content: content.trimEnd()}];
+    }
+
+    const elements      = [{kind: 'body', ordinal: 0, content: lines.slice(0, timelineIdx).join('\n').trimEnd()}],
+          commentBlocks = [];
+
+    let current = null;
+
+    // Everything after `## Timeline`: a `### @author - <ISO>` line opens a comment block that runs
+    // until the next delimiter or EOF. Comment bodies may carry their own `##`/`###` headings, so we
+    // split ONLY on the author-timestamp delimiter. Lines before the first delimiter (the Timeline
+    // preamble / bare heading) belong to no comment and are skipped.
+    for (let i = timelineIdx + 1; i < lines.length; i++) {
+        const line = lines[i];
+
+        if (COMMENT_DELIMITER.test(line)) {
+            current = [line];
+            commentBlocks.push(current);
+        } else if (current) {
+            current.push(line);
+        }
+    }
+
+    commentBlocks.forEach((blockLines, index) => {
+        elements.push({kind: 'comment', ordinal: index + 1, content: blockLines.join('\n').trimEnd()});
+    });
+
+    return elements;
+}

--- a/ai/services/knowledge-base/source/ticketArchiveElementSplitter.mjs
+++ b/ai/services/knowledge-base/source/ticketArchiveElementSplitter.mjs
@@ -10,12 +10,12 @@
  * keeps every element small (a body / a single comment), so coverage stays complete regardless of
  * how many comment cycles a ticket accumulates.
  *
- * Boundary format (verified across the archive — 709/711 files carry a `## Timeline` section):
- * frontmatter + title + body run until `## Timeline`; each comment is delimited by a
- * `### @<author> - <ISO-timestamp>` line. Comment bodies may themselves contain `##`/`###`
- * headings, so the split keys ONLY on the `## Timeline` boundary + the author-timestamp delimiter
- * — never on arbitrary headings. A file with no `## Timeline` (a no-comment ticket) yields a single
- * body element whose content equals the whole file.
+ * Boundary format (verified across the archive): the body runs until the FIRST
+ * `### @<author> - <ISO-timestamp>` comment delimiter; each comment is delimited by that line.
+ * Comment bodies may themselves contain `##`/`###` headings, so the split keys ONLY on the
+ * author-timestamp delimiter — never on arbitrary headings. A file with no comment delimiter
+ * (including a `## Timeline` carrying only event rows — the majority of the corpus) yields a single
+ * body element equal to the whole file, so non-comment Timeline events are CONSERVED, never dropped.
  */
 
 /**
@@ -25,18 +25,12 @@
 const COMMENT_DELIMITER = /^### @[A-Za-z0-9_-]+ - \d{4}-\d{2}-\d{2}T[0-9:.Z+-]+\s*$/;
 
 /**
- * Matches the `## Timeline` section heading that separates the issue body from its comments.
- * @type {RegExp}
- */
-const TIMELINE_HEADING = /^## Timeline\s*$/;
-
-/**
  * Splits issue-archive markdown into ordered per-element pieces.
  *
  * Pure — no I/O. Returns the body as element `ordinal: 0` followed by each comment as
- * `ordinal: 1..N` in document order. A no-comment ticket (no `## Timeline`) returns a single
- * body element whose content equals the whole file (so the existing whole-file chunk is preserved
- * unchanged for that case).
+ * `ordinal: 1..N` in document order. A ticket with no comment delimiter (including a `## Timeline`
+ * carrying only event rows) returns a single body element whose content equals the whole file — so
+ * the whole-file chunk is preserved and non-comment Timeline content is never dropped.
  *
  * @param {String} content Raw `issue-*.md` file content (frontmatter + title + body + Timeline).
  * @returns {Array<{kind: ('body'|'comment'), ordinal: Number, content: String}>}
@@ -50,31 +44,34 @@ export function splitTicketArchiveMarkdown(content) {
         throw new TypeError(`splitTicketArchiveMarkdown: content must be a string, got ${typeof content}`);
     }
 
-    const lines       = content.split('\n');
-    let   timelineIdx = -1;
+    const lines           = content.split('\n');
+    let   firstCommentIdx = -1;
 
     for (let i = 0; i < lines.length; i++) {
-        if (TIMELINE_HEADING.test(lines[i])) {
-            timelineIdx = i;
+        if (COMMENT_DELIMITER.test(lines[i])) {
+            firstCommentIdx = i;
             break;
         }
     }
 
-    // No `## Timeline` section → the whole file is a single body element (no-comment ticket).
-    if (timelineIdx === -1) {
+    // No `### @author - <ISO>` comment delimiter → the whole file is a single body element. This
+    // CONSERVES a `## Timeline` section that carries only event rows (no comments): its content stays
+    // in the body rather than being dropped.
+    if (firstCommentIdx === -1) {
         return [{kind: 'body', ordinal: 0, content: content.trimEnd()}];
     }
 
-    const elements      = [{kind: 'body', ordinal: 0, content: lines.slice(0, timelineIdx).join('\n').trimEnd()}],
+    // Body = everything before the first comment (frontmatter + title + issue body + the `## Timeline`
+    // heading + any pre-comment event rows — no content dropped). Comments split out after it.
+    const elements      = [{kind: 'body', ordinal: 0, content: lines.slice(0, firstCommentIdx).join('\n').trimEnd()}],
           commentBlocks = [];
 
     let current = null;
 
-    // Everything after `## Timeline`: a `### @author - <ISO>` line opens a comment block that runs
-    // until the next delimiter or EOF. Comment bodies may carry their own `##`/`###` headings, so we
-    // split ONLY on the author-timestamp delimiter. Lines before the first delimiter (the Timeline
-    // preamble / bare heading) belong to no comment and are skipped.
-    for (let i = timelineIdx + 1; i < lines.length; i++) {
+    // From the first comment onward: a `### @author - <ISO>` line opens a comment block that runs until
+    // the next delimiter or EOF. Comment bodies may carry their own `##`/`###` headings + trailing event
+    // rows, so we split ONLY on the author-timestamp delimiter.
+    for (let i = firstCommentIdx; i < lines.length; i++) {
         const line = lines[i];
 
         if (COMMENT_DELIMITER.test(line)) {

--- a/test/playwright/unit/ai/services/knowledge-base/source/TicketSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/TicketSource.spec.mjs
@@ -138,7 +138,7 @@ test.describe('Neo.ai.services.knowledge-base.source.TicketSource', () => {
         const comment2 = written.find(c => c.name === 'issue-1004#comment-2');
 
         expect(body.content).toContain('## Context');
-        expect(body.content).not.toContain('## Timeline');
+        expect(body.content).toContain('## Timeline');
         expect(body.content).not.toContain('First comment.');
         expect(comment1.content).toContain('@neo-opus-vega');
         expect(comment1.content).toContain('First comment.');

--- a/test/playwright/unit/ai/services/knowledge-base/source/TicketSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/TicketSource.spec.mjs
@@ -37,7 +37,7 @@ test.describe('Neo.ai.services.knowledge-base.source.TicketSource', () => {
         fs.ensureDirSync(tmpDir);
         mockRoot = path.join(tmpDir, 'ticketsource-mock-' + process.pid + '-' + Date.now());
 
-        const activeDir = path.join(mockRoot, 'resources/content/issues/chunk-1');
+        const activeDir  = path.join(mockRoot, 'resources/content/issues/chunk-1');
         const archiveDir = path.join(mockRoot, 'resources/content/archive/issues/v1.0.0/chunk-2');
 
         fs.ensureDirSync(activeDir);
@@ -56,11 +56,33 @@ test.describe('Neo.ai.services.knowledge-base.source.TicketSource', () => {
             `External source was defanged as ${QUARANTINED_URL}.`
         ].join('\n'));
         fs.writeFileSync(path.join(archiveDir, 'issue-1002.md'), '# Second');
+        fs.writeFileSync(path.join(activeDir, 'issue-1004.md'), [
+            '---',
+            'id: 1004',
+            'title: Multi-comment issue',
+            'state: CLOSED',
+            '---',
+            '# Multi-comment issue',
+            '',
+            '## Context',
+            'Body of the issue.',
+            '',
+            '## Timeline',
+            '',
+            '### @neo-opus-vega - 2026-06-26T02:16:08Z',
+            '',
+            'First comment.',
+            '',
+            '### @neo-gpt - 2026-06-26T02:20:08Z',
+            '',
+            'Second comment.'
+        ].join('\n'));
 
         const indexMap = [
             { type: 'issues', id: 1001, path: 'issues/chunk-1/issue-1001.md' },
             { type: 'issues', id: 1003, path: 'issues/chunk-1/issue-1003.md' },
-            { type: 'issues', id: 1002, path: 'archive/issues/v1.0.0/chunk-2/issue-1002.md' }
+            { type: 'issues', id: 1002, path: 'archive/issues/v1.0.0/chunk-2/issue-1002.md' },
+            { type: 'issues', id: 1004, path: 'issues/chunk-1/issue-1004.md' }
         ];
 
         fs.writeFileSync(path.join(mockRoot, 'resources/content/issues/_index.json'), JSON.stringify(indexMap));
@@ -74,26 +96,59 @@ test.describe('Neo.ai.services.knowledge-base.source.TicketSource', () => {
     });
 
     test('extract() uses _index.json to resolve ID and reads both active and archive', async () => {
-        const written = [];
+        const written     = [];
         const writeStream = { write(str) { written.push(JSON.parse(str.trim())); return true; } };
 
         const count = await TicketSource.extract(writeStream, chunk => 'hash');
 
-        expect(count).toBe(3);
+        // 3 no-comment tickets (one body chunk each) + issue-1004 (body + 2 comments) = 6.
+        expect(count).toBe(6);
 
         const ids = written.map(w => w.name).sort();
-        expect(ids).toEqual(['issue-1001', 'issue-1002', 'issue-1003']);
+        expect(ids).toEqual([
+            'issue-1001#body',
+            'issue-1002#body',
+            'issue-1003#body',
+            'issue-1004#body',
+            'issue-1004#comment-1',
+            'issue-1004#comment-2'
+        ]);
     });
 
     test('extract() emits persisted contentTrust-sanitized issue content without raw external URLs (#13703)', async () => {
-        const written = [];
+        const written     = [];
         const writeStream = { write(str) { written.push(JSON.parse(str.trim())); return true; } };
 
         await TicketSource.extract(writeStream, chunk => 'hash');
 
-        const sanitized = written.find(chunk => chunk.name === 'issue-1003');
+        const sanitized = written.find(chunk => chunk.name === 'issue-1003#body');
 
         expect(sanitized.content).toContain(QUARANTINED_URL);
         expect(sanitized.content).not.toContain(RAW_EXTERNAL_URL);
+    });
+
+    test('extract() splits a multi-comment ticket into body + per-comment elements (#14063)', async () => {
+        const written     = [];
+        const writeStream = { write(str) { written.push(JSON.parse(str.trim())); return true; } };
+
+        await TicketSource.extract(writeStream, chunk => 'hash');
+
+        const body     = written.find(c => c.name === 'issue-1004#body');
+        const comment1 = written.find(c => c.name === 'issue-1004#comment-1');
+        const comment2 = written.find(c => c.name === 'issue-1004#comment-2');
+
+        expect(body.content).toContain('## Context');
+        expect(body.content).not.toContain('## Timeline');
+        expect(body.content).not.toContain('First comment.');
+        expect(comment1.content).toContain('@neo-opus-vega');
+        expect(comment1.content).toContain('First comment.');
+        expect(comment1.content).not.toContain('Second comment.');
+        expect(comment2.content).toContain('@neo-gpt');
+        expect(comment2.content).toContain('Second comment.');
+
+        for (const c of [body, comment1, comment2]) {
+            expect(c.type).toBe('ticket');
+            expect(c.source).toContain('issue-1004.md');
+        }
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/source/ticketArchiveElementSplitter.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/ticketArchiveElementSplitter.spec.mjs
@@ -36,7 +36,7 @@ First comment body.`;
         expect(els).toHaveLength(2);
         expect(els[0]).toMatchObject({kind: 'body', ordinal: 0});
         expect(els[0].content).toContain('## Context');
-        expect(els[0].content).not.toContain('## Timeline');
+        expect(els[0].content).toContain('## Timeline');
         expect(els[0].content).not.toContain('First comment body');
         expect(els[1]).toMatchObject({kind: 'comment', ordinal: 1});
         expect(els[1].content).toContain('### @neo-gpt - 2026-06-26T02:20:08Z');
@@ -89,15 +89,22 @@ Second comment.`;
         expect(els[2].content).toContain('Second comment.');
     });
 
-    test('## Timeline with no comments -> single body element', () => {
+    test('event-only Timeline (no comment delimiter) -> single body element conserving the event rows (#14065 RC)', () => {
         const content = `${BODY}
 
 ## Timeline
-`;
+
+- referenced in commit abc1234 on 2026-06-26T02:00:00Z
+- @tobiu added the bug label`;
         const els = splitTicketArchiveMarkdown(content);
         expect(els).toHaveLength(1);
         expect(els[0].kind).toBe('body');
-        expect(els[0].content).not.toContain('## Timeline');
+        // Conservation: a Timeline with only event rows (no ### @author comment) is NOT dropped —
+        // the heading + event rows stay in the body.
+        expect(els[0].content).toContain('## Timeline');
+        expect(els[0].content).toContain('referenced in commit abc1234');
+        expect(els[0].content).toContain('@tobiu added the bug label');
+        expect(els[0].content).toBe(content.trimEnd());
     });
 
     test('throws on non-string content', () => {

--- a/test/playwright/unit/ai/services/knowledge-base/source/ticketArchiveElementSplitter.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/ticketArchiveElementSplitter.spec.mjs
@@ -1,0 +1,108 @@
+import {test, expect}               from '@playwright/test';
+import {splitTicketArchiveMarkdown} from '../../../../../../../ai/services/knowledge-base/source/ticketArchiveElementSplitter.mjs';
+
+// Pure splitter (no I/O) — direct import, mirrors parseAgentEnvelope.spec / detectionRetentionSla.spec.
+// Boundary format V-B-A'd across the issue archive: `## Timeline` body->comments boundary +
+// `### @author - <ISO>` comment delimiter (709/711 files carry Timeline; 2 are body-only).
+
+const BODY = `---
+id: 14063
+title: Sample
+---
+# Sample Issue
+
+## Context
+Some body text.
+
+## Related
+- #14039`;
+
+test.describe('splitTicketArchiveMarkdown', () => {
+    test('no-comment ticket (no ## Timeline) -> single body element equal to the whole content', () => {
+        const els = splitTicketArchiveMarkdown(BODY);
+        expect(els).toHaveLength(1);
+        expect(els[0]).toEqual({kind: 'body', ordinal: 0, content: BODY});
+    });
+
+    test('body + single comment -> body element + one comment element', () => {
+        const content = `${BODY}
+
+## Timeline
+
+### @neo-gpt - 2026-06-26T02:20:08Z
+
+First comment body.`;
+        const els = splitTicketArchiveMarkdown(content);
+        expect(els).toHaveLength(2);
+        expect(els[0]).toMatchObject({kind: 'body', ordinal: 0});
+        expect(els[0].content).toContain('## Context');
+        expect(els[0].content).not.toContain('## Timeline');
+        expect(els[0].content).not.toContain('First comment body');
+        expect(els[1]).toMatchObject({kind: 'comment', ordinal: 1});
+        expect(els[1].content).toContain('### @neo-gpt - 2026-06-26T02:20:08Z');
+        expect(els[1].content).toContain('First comment body.');
+    });
+
+    test('multiple comments -> body + N comments in document order', () => {
+        const content = `${BODY}
+
+## Timeline
+
+### @neo-opus-vega - 2026-06-26T02:16:08Z
+
+Comment one.
+
+### @neo-gpt - 2026-06-26T02:20:08Z
+
+Comment two.`;
+        const els = splitTicketArchiveMarkdown(content);
+        expect(els.map(e => e.kind)).toEqual(['body', 'comment', 'comment']);
+        expect(els.map(e => e.ordinal)).toEqual([0, 1, 2]);
+        expect(els[1].content).toContain('Comment one.');
+        expect(els[1].content).not.toContain('Comment two.');
+        expect(els[2].content).toContain('@neo-gpt');
+        expect(els[2].content).toContain('Comment two.');
+    });
+
+    test('comment containing its own ##/### headings stays ONE comment (split only on the author-timestamp delimiter)', () => {
+        const content = `${BODY}
+
+## Timeline
+
+### @neo-gpt - 2026-06-26T02:20:08Z
+
+## Intake classification
+Some structured comment.
+
+### Sub-heading inside the comment
+More text.
+
+### @neo-opus-vega - 2026-06-26T03:00:00Z
+
+Second comment.`;
+        const els = splitTicketArchiveMarkdown(content);
+        expect(els.map(e => e.kind)).toEqual(['body', 'comment', 'comment']);
+        expect(els[1].content).toContain('## Intake classification');
+        expect(els[1].content).toContain('### Sub-heading inside the comment');
+        expect(els[1].content).toContain('More text.');
+        expect(els[1].content).not.toContain('Second comment.');
+        expect(els[2].content).toContain('Second comment.');
+    });
+
+    test('## Timeline with no comments -> single body element', () => {
+        const content = `${BODY}
+
+## Timeline
+`;
+        const els = splitTicketArchiveMarkdown(content);
+        expect(els).toHaveLength(1);
+        expect(els[0].kind).toBe('body');
+        expect(els[0].content).not.toContain('## Timeline');
+    });
+
+    test('throws on non-string content', () => {
+        for (const bad of [undefined, null, 42, {}, []]) {
+            expect(() => splitTicketArchiveMarkdown(bad)).toThrow('content must be a string');
+        }
+    });
+});


### PR DESCRIPTION
Resolves #14063

#14033's tickets vertical — `TicketSource.extract()` now emits per-element KB chunks (the issue body + each Timeline comment as separate chunks) instead of one growing whole-file chunk, closing the multi-cycle-ticket over-cap ingestion hazard (the #13999 metadata-without-vector class) for tickets.

- **Pure splitter** `splitTicketArchiveMarkdown(content)` (new `ai/services/knowledge-base/source/ticketArchiveElementSplitter.mjs`) -> `[{kind:'body'|'comment', ordinal, content}]`. The body runs until the FIRST `### @author - <ISO>` comment delimiter; comments split on that delimiter. Comment bodies may carry their own `##`/`###` headings, so it splits ONLY on the delimiter, never on arbitrary headings. **Conservation (per @neo-gpt's #14065 RC): a `## Timeline` carrying only event rows with no comment delimiter — the majority of the corpus — keeps its events in the body, never dropped.**
- **Wiring**: `extract()` emits `issue-<id>#body` + `issue-<id>#comment-<n>` chunks (stable names -> idempotent re-ingestion), preserving `type`/`kind`/`source` + a per-element hash.

Contract: the chunk `name` gains a `#body`/`#comment-n` suffix. V-B-A'd that `name` is descriptive metadata + the embedding-input prefix — NOT a lookup/join key (`DatabaseService`/`VectorService` store it; nothing queries by it) — so retrieval granularity improves with no name-keyed breakage.

Evidence: L2 unit — splitter (body-only / single / multi-comment / comment-with-internal-headings / event-only-Timeline conservation / non-string) + `extract()` (per-element emission, names, no-regression for no-comment tickets, content-trust sanitization preserved).

## Test Evidence

- `node --check` on both source files -> passed
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/ticketArchiveElementSplitter.spec.mjs` -> **6 passed** (incl. the event-only-Timeline conservation test)
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/TicketSource.spec.mjs` -> **3 passed** (multi-comment split + no-regression name assertions)
- Commits: 0587fb769 (splitter), 317916615 (wiring), 153bab0c7 (#14065 RC fix: conserve non-comment Timeline event rows)

## Deltas From Ticket

None — implements the #14063 tickets vertical as filed. `PullRequestSource` (review-cycles) + `DiscussionSource` (threads) remain the explicitly out-of-scope #14033 follow-up slices.

## Post-Merge Validation

- [ ] After the next KB re-ingestion, a multi-comment ticket appears as N per-element chunks (one body + per-comment) in `neo-knowledge-base`; the old whole-file chunk's hash is replaced.

## Contract Ledger

Per #14063 — the `TicketSource.extract()` chunk `name` (`issue-<id>` -> `issue-<id>#body`/`#comment-n`) + per-element `hash`. Matrix on the ticket; the diff matches it.

Authored by Vega (Claude Opus 4.8, Claude Code). Session ef66cbd0-3770-466c-9df1-f93c141eb1d3.
