### PR TITLE
fix(ai): promote recoverable memory repair rows (#14062)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -719,6 +719,7 @@ export async function rewriteCollectionViaShadowPromotion({
  * @param {Object} options.embeddingFunction Chroma embedding function.
  * @param {String} options.statePath Durable state marker path.
  * @param {Object} [options.stateBase] Stable fields written into every phase marker.
+ * @param {Boolean} [options.deleteParking=true] Delete parked source collection after validation.
  * @param {Number} [options.timestamp=Date.now()] Stable run timestamp.
  * @param {Function} [options.uuidFactory=crypto.randomUUID] Unique id factory.
  * @param {Function} [options.writeStateFn=writeDefragState] State writer seam.
@@ -734,6 +735,7 @@ export async function promoteLoadedShadowCollection({
     embeddingFunction,
     statePath,
     stateBase   = {},
+    deleteParking = true,
     timestamp   = Date.now(),
     uuidFactory = crypto.randomUUID,
     writeStateFn = writeDefragState,
@@ -778,12 +780,16 @@ export async function promoteLoadedShadowCollection({
         await validateLoadedCollectionByIds({collection: canonicalCollection, ids: sourceIds, collectionName});
         await writeStateFn({statePath, state: {...baseState, phase: 'canonical-validated'}});
 
-        try {
-            await client.deleteCollection({name: parkingName});
-            parkingDeleted = true;
-            await writeStateFn({statePath, state: {...baseState, phase: 'parking-deleted'}});
-        } catch (error) {
-            warn(`   ⚠️  Could not delete parked pre-defrag collection '${parkingName}': ${error.message}`);
+        if (deleteParking) {
+            try {
+                await client.deleteCollection({name: parkingName});
+                parkingDeleted = true;
+                await writeStateFn({statePath, state: {...baseState, phase: 'parking-deleted'}});
+            } catch (error) {
+                warn(`   ⚠️  Could not delete parked pre-defrag collection '${parkingName}': ${error.message}`);
+            }
+        } else {
+            await writeStateFn({statePath, state: {...baseState, phase: 'parking-retained'}});
         }
 
         return {
@@ -968,6 +974,53 @@ export async function repairMemoryCoreCollectionViaResumableShadow({
     });
 
     if (unrecoverable.length > 0) {
+        const recoveredIds = await listIdsFn({collection: shadowCollection});
+
+        if (recoveredIds.length > 0) {
+            await writeStateFn({
+                statePath,
+                state: {
+                    ...baseState,
+                    phase               : 'memory-core-repair-shadow-loaded',
+                    partial             : true,
+                    shadowName,
+                    loadedCount,
+                    recoveredCount      : recoveredIds.length,
+                    unrecoverableCount  : unrecoverable.length,
+                    unrecoverablePreview: unrecoverable.slice(0, 20),
+                    unrecoverable,
+                    counts
+                }
+            });
+
+            log(`   🚚 '${collectionName}': partial shadow promotion starting for ${recoveredIds.length}/${sourceCount} recovered row(s); ${unrecoverable.length} unrecoverable row(s) stay in parked source...`);
+            const promotion = await promoteLoadedFn({
+                client,
+                collectionName,
+                shadowCollection,
+                shadowName,
+                sourceIds    : recoveredIds,
+                embeddingFunction,
+                statePath,
+                stateBase,
+                deleteParking: false,
+                writeStateFn
+            });
+            log(`   ⚠️  '${collectionName}': partial shadow promotion complete; parked source retained as '${promotion.parkingName}'.`);
+
+            return {
+                collectionName,
+                partialPromoted: true,
+                promotion,
+                unrecoverable,
+                counts,
+                shadowName,
+                loadedCount,
+                recoveredCount : recoveredIds.length,
+                sourceCount
+            }
+        }
+
         await writeStateFn({
             statePath,
             state: {
@@ -1039,14 +1092,16 @@ export async function repairMemoryCoreCollectionViaResumableShadow({
  *      still-materializing documents (`extractMemoryCoreCollectionData`);
  *   3. streams recovered batches into a resumable shadow collection, then promotes that loaded shadow.
  *
- * Fail-loud: a collection with ANY unrecoverable row (document-less / metadata-absent) aborts its
- * own promotion with counts — never a silent partial promote. The seams (`auditFn` / `extractFn` /
+ * Fail-loud: a collection with unrecoverable rows promotes recovered rows only when the shadow already
+ * contains recoverable data, retains the parked source, and returns a non-clean partial result. It aborts
+ * only when there is no recoverable shadow to promote. The seams (`auditFn` / `extractFn` /
  * `repairCollectionFn` / `clearStateFn` / `writeStateFn`) are injectable for unit isolation.
  *
  * State-marker lifecycle: the mutating repair writes durable per-phase markers, so a fully successful repair
  * CLEARS the marker (`clearStateFn`) before returning — else the next run aborts as DEFRAG_INCOMPLETE_STATE.
- * An aborted/partial repair instead rewrites an explicit `memory-core-repair-aborted` marker (`writeStateFn`)
- * with the active shadow name so the next run can retry only the unrecovered rows.
+ * An aborted repair rewrites an explicit `memory-core-repair-aborted` marker (`writeStateFn`) with the active
+ * shadow name. A partial-promoted repair rewrites `memory-core-repair-partial-promoted` with the retained
+ * parking collection and full unrecoverable manifest.
  *
  * This function is INERT until wired behind the explicit `--allow-memory-core` opt-in; the default
  * `assertDefragTargetSupported` fail-closed stands until then.
@@ -1066,11 +1121,13 @@ export async function repairMemoryCoreCollectionViaResumableShadow({
  * @param {Function} [options.repairCollectionFn=repairMemoryCoreCollectionViaResumableShadow] Mutating repair seam.
  * @param {Object|null} [options.resumeState=null] Resumable defrag state returned by `assertNoIncompleteDefragState`.
  * @param {Function} [options.clearStateFn=clearDefragState] Clears the durable marker on a fully successful repair.
- * @param {Function} [options.writeStateFn=writeDefragState] Rewrites the explicit aborted marker on a partial repair.
+ * @param {Function} [options.writeStateFn=writeDefragState] Rewrites explicit non-clean repair markers.
  * @param {Function} [options.log=console.log] Log sink.
  * @returns {Promise<{results: Object[]}>} Per collection: `{collectionName, promotion, counts}` on success,
- *   `{collectionName, dryRun: true, counts}` on clean dry-run, or
- *   `{collectionName, aborted: true, unrecoverable, counts}` when fail-loud aborts the promotion/report.
+ *   `{collectionName, dryRun: true, counts}` on clean dry-run,
+ *   `{collectionName, partialPromoted: true, unrecoverable, counts}` when recovered rows were promoted but
+ *   unrecoverable rows remain, or `{collectionName, aborted: true, unrecoverable, counts}` when fail-loud
+ *   aborts the promotion/report.
  */
 export async function repairMemoryCoreCollectionsViaFullEnumeration({
     client,
@@ -1178,27 +1235,41 @@ export async function repairMemoryCoreCollectionsViaFullEnumeration({
             break;
         }
 
+        if (result.partialPromoted) {
+            log(`   ⚠️  '${collectionName}': partial repair promoted ${result.recoveredCount}/${result.sourceCount} recovered row(s); ${result.unrecoverable.length} unrecoverable row(s) remain in retained parking '${result.promotion?.parkingName}'. Counts: ${JSON.stringify(result.counts)}`);
+        }
+
         results.push(result);
     }
 
     // State-marker lifecycle (mirrors the KB path's end-of-run clearDefragState): rewriteCollectionViaShadowPromotion
     // wrote durable per-phase markers, so a fully successful repair MUST clear the marker — else the next run aborts
-    // as DEFRAG_INCOMPLETE_STATE. An aborted/partial repair instead rewrites an explicit aborted marker with
-    // the active shadow name, so the next run can resume without discarding already loaded batches.
+    // as DEFRAG_INCOMPLETE_STATE. Aborted/partial repairs instead rewrite explicit non-clean markers, preserving
+    // either the active shadow resume handle or the retained parking collection + unrecoverable manifest.
     if (statePath && !dryRun) {
-        if (anyRepairAborted(results)) {
-            const activeAbort = results.find(result => result.aborted);
+        if (anyRepairNonClean(results)) {
+            const activeNonClean            = results.find(result => result.aborted || result.partialPromoted),
+                  unrecoverableByCollection = Object.fromEntries(
+                      results
+                          .filter(result => result.aborted || result.partialPromoted)
+                          .map(result => [result.collectionName, result.unrecoverable || []])
+                  );
 
             await writeStateFn({statePath, state: {
                 ...stateBase,
-                phase               : 'memory-core-repair-aborted',
-                collectionName      : activeAbort?.collectionName,
-                shadowName          : activeAbort?.shadowName,
-                sourceCount         : activeAbort?.sourceCount,
-                loadedCount         : activeAbort?.loadedCount,
-                unrecoverableCount  : activeAbort?.unrecoverable?.length,
-                unrecoverablePreview: createUnrecoverablePreview(activeAbort?.unrecoverable),
+                phase               : activeNonClean?.partialPromoted ? 'memory-core-repair-partial-promoted' : 'memory-core-repair-aborted',
+                collectionName      : activeNonClean?.collectionName,
+                shadowName          : activeNonClean?.shadowName,
+                parkingName         : activeNonClean?.promotion?.parkingName,
+                sourceCount         : activeNonClean?.sourceCount,
+                loadedCount         : activeNonClean?.loadedCount,
+                recoveredCount      : activeNonClean?.recoveredCount,
+                unrecoverableCount  : activeNonClean?.unrecoverable?.length,
+                unrecoverablePreview: createUnrecoverablePreview(activeNonClean?.unrecoverable),
+                unrecoverable       : activeNonClean?.unrecoverable || [],
+                unrecoverableByCollection,
                 aborted             : results.filter(result => result.aborted).map(result => result.collectionName),
+                partialPromoted     : results.filter(result => result.partialPromoted).map(result => result.collectionName),
                 promoted            : results.filter(result => result.promotion).map(result => result.collectionName)
             }});
         } else {
@@ -1307,6 +1378,19 @@ export function formatUnrecoverablePreview(entries = [], {limit = 5} = {}) {
  */
 export function anyRepairAborted(results = []) {
     return results.some(result => result?.aborted === true);
+}
+
+/**
+ * @summary True when any repair result is non-clean (aborted or partial-promoted).
+ *
+ * The CLI must exit non-zero for both classes: aborted means no promotion happened; partial-promoted means
+ * recovered rows were promoted durably, but unrecoverable rows remain in a retained parked source.
+ *
+ * @param {Object[]} [results=[]] Per-collection results from `repairMemoryCoreCollectionsViaFullEnumeration`.
+ * @returns {Boolean}
+ */
+export function anyRepairNonClean(results = []) {
+    return results.some(result => result?.aborted === true || result?.partialPromoted === true);
 }
 
 /**
@@ -1431,21 +1515,25 @@ async function defragChromaDB() {
             for (const result of results) {
                 console.log(result.aborted
                     ? `   ⚠️  ${result.collectionName}: ${dryRun ? 'DRY-RUN WOULD ABORT' : 'ABORTED'} — ${result.unrecoverable.length} unrecoverable row(s); counts ${JSON.stringify(result.counts)}`
-                    : dryRun
-                        ? `   🧪 ${result.collectionName}: dry-run report clean; no promotion; counts ${JSON.stringify(result.counts)}`
-                        : `   ✅ ${result.collectionName}: repaired + promoted; counts ${JSON.stringify(result.counts)}`);
+                    : result.partialPromoted
+                        ? `   ⚠️  ${result.collectionName}: PARTIAL PROMOTED — ${result.recoveredCount}/${result.sourceCount} recovered row(s), ${result.unrecoverable.length} unrecoverable row(s), parked source retained at ${result.promotion?.parkingName}; counts ${JSON.stringify(result.counts)}`
+                        : dryRun
+                            ? `   🧪 ${result.collectionName}: dry-run report clean; no promotion; counts ${JSON.stringify(result.counts)}`
+                            : `   ✅ ${result.collectionName}: repaired + promoted; counts ${JSON.stringify(result.counts)}`);
             }
 
             const finalSize = await getDirSize(DB_PATH);
             console.log(`   📊 Final Size: ${(finalSize / 1024 / 1024).toFixed(2)} MB`);
 
-            // Fail loud at the operator boundary: an aborted collection is NOT a successful repair
+            // Fail loud at the operator boundary: non-clean repair work is NOT a successful repair
             // (mirrors the KB extractionErrors / hasRestoreErrors -> process.exit(1) discipline below).
-            if (anyRepairAborted(results)) {
-                const abortedNames = results.filter(result => result.aborted).map(result => result.collectionName);
+            if (anyRepairNonClean(results)) {
+                const abortedNames  = results.filter(result => result.aborted).map(result => result.collectionName),
+                      partialNames  = results.filter(result => result.partialPromoted).map(result => result.collectionName),
+                      nonCleanNames = [...abortedNames, ...partialNames];
                 console.error(dryRun
                     ? `❌ Memory Core repair dry-run found unrecoverable rows for ${abortedNames.join(', ')} — no promotion was attempted; resolve the unrecoverable rows before running the mutating repair. Counts and reasons logged above.`
-                    : `❌ Memory Core repair aborted for ${abortedNames.join(', ')} (unrecoverable rows) — NOT a successful repair; resolve the unrecoverable rows and re-run. Counts and reasons logged above.`);
+                    : `❌ Memory Core repair non-clean for ${nonCleanNames.join(', ')} (aborted: ${abortedNames.join(', ') || 'none'}; partial-promoted: ${partialNames.join(', ') || 'none'}) — recovered rows are durable where partial-promoted, but this is NOT a successful repair. Resolve unrecoverable rows using the retained parking/source state. Counts and reasons logged above.`);
                 process.exit(1);
             }
             return;

--- a/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect} from '@playwright/test';
 import {
     anyRepairAborted,
+    anyRepairNonClean,
     assertDefragTargetSupported,
     createUnrecoverablePreview,
     formatMemoryCoreRepairProgress,
@@ -147,6 +148,51 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#14020)', () => {
         expect(calls.writeState[0].state.unrecoverablePreview).toEqual(unrecoverable);
         expect(calls.writeState[0].state.aborted).toEqual(['mc-memory']);
         expect(logs.some(message => message.includes('Reasons: b (document-empty: document field was empty)'))).toBe(true);
+    });
+
+    test('partial-promoted repair keeps recovered rows durable while retaining parked source', async () => {
+        const coverage = {collections: [
+                  {name: 'mc-memory', allIds: ['a', 'b'], missingVectorIds: ['b']},
+                  {name: 'mc-graph',  allIds: ['g'],      missingVectorIds: []}
+              ]},
+              repairResults = {
+                  'mc-memory': {
+                      collectionName : 'mc-memory',
+                      partialPromoted: true,
+                      promotion      : {parkingName: 'mc-memory-parking', parkingDeleted: false},
+                      shadowName     : 'mc-memory-shadow-resume',
+                      loadedCount    : 1,
+                      recoveredCount : 1,
+                      sourceCount    : 2,
+                      unrecoverable  : ['b'],
+                      counts         : {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}
+                  },
+                  'mc-graph': {
+                      collectionName: 'mc-graph',
+                      promotion     : {promoted: 'mc-graph'},
+                      counts        : {total: 1, intact: 1, reEmbedded: 0, unrecoverable: 0}
+                  }
+              },
+              {calls, client, auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn} = makeSeams({coverage, repairResults});
+
+        const {results} = await repairMemoryCoreCollectionsViaFullEnumeration({
+            client, collections: ['mc-memory', 'mc-graph'], snapshotPath: '/snap', persistDir: '/persist',
+            embedFn, embeddingFunction, statePath: '/state', stateBase: {targetName: 'memory-core'},
+            auditFn, extractFn, repairCollectionFn, clearStateFn, writeStateFn, log: () => {}
+        });
+
+        expect(calls.repair.map(call => call.collectionName)).toEqual(['mc-memory', 'mc-graph']);
+        expect(results[0].partialPromoted).toBe(true);
+        expect(results[1].promotion).toEqual({promoted: 'mc-graph'});
+        expect(calls.clearState).toHaveLength(0);
+        expect(calls.writeState).toHaveLength(1);
+        expect(calls.writeState[0].state.phase).toBe('memory-core-repair-partial-promoted');
+        expect(calls.writeState[0].state.parkingName).toBe('mc-memory-parking');
+        expect(calls.writeState[0].state.unrecoverable).toEqual(['b']);
+        expect(calls.writeState[0].state.unrecoverableByCollection).toEqual({'mc-memory': ['b']});
+        expect(calls.writeState[0].state.partialPromoted).toEqual(['mc-memory']);
+        expect(calls.writeState[0].state.promoted).toEqual(['mc-memory', 'mc-graph']);
+        expect(anyRepairNonClean(results)).toBe(true);
     });
 
     test('resume state skips earlier collections and resumes the matching collection repair', async () => {
@@ -442,6 +488,51 @@ test.describe('repairMemoryCoreCollectionViaResumableShadow (#14020)', () => {
         expect(states.filter(state => state.phase === 'memory-core-repair-shadow-loading').map(state => state.loadedCount))
             .toEqual([1, 2]);
     });
+
+    test('partially promotes recovered shadow rows and retains parked source on unrecoverable rows', async () => {
+        const states       = [];
+        const promoteCalls = [];
+        const client       = createClient();
+        const live         = createCollection({name: 'mc-memory'});
+
+        const result = await repairMemoryCoreCollectionViaResumableShadow({
+            client,
+            collectionName  : 'mc-memory',
+            collection      : live,
+            allIds          : ['a', 'b'],
+            missingVectorIds: ['b'],
+            embedFn,
+            embeddingFunction,
+            statePath       : '/state',
+            stateBase       : {targetName: 'memory-core'},
+            extractFn       : async args => {
+                await args.onDataBatch({ids: ['a'], embeddings: [[1]], documents: ['doc-a'], metadatas: [{}]});
+                return {unrecoverable: ['b'], counts: {total: 2, intact: 1, reEmbedded: 0, unrecoverable: 1}};
+            },
+            promoteLoadedFn: async args => {
+                promoteCalls.push(args);
+                return {shadowName: args.shadowName, parkingName: 'mc-memory-parking', parkingDeleted: false};
+            },
+            writeStateFn: async args => states.push(args.state),
+            timestamp   : 123,
+            uuidFactory : () => 'uuid-1',
+            log         : () => {}
+        });
+
+        expect(promoteCalls).toHaveLength(1);
+        expect(promoteCalls[0].sourceIds).toEqual(['a']);
+        expect(promoteCalls[0].deleteParking).toBe(false);
+        expect(result.partialPromoted).toBe(true);
+        expect(result.recoveredCount).toBe(1);
+        expect(result.unrecoverable).toEqual(['b']);
+        expect(states.some(state => state.phase === 'memory-core-repair-aborted')).toBe(false);
+        expect(states.find(state => state.partial === true)).toMatchObject({
+            phase             : 'memory-core-repair-shadow-loaded',
+            recoveredCount    : 1,
+            unrecoverableCount: 1,
+            unrecoverable     : ['b']
+        });
+    });
 });
 
 test.describe('runDefragChromaDBCli (#14020)', () => {
@@ -559,6 +650,28 @@ test.describe('unrecoverable reason previews (#14023)', () => {
         expect(formatUnrecoverablePreview(entries, {limit: 2}))
             .toBe('a (document-empty: document field was empty); b (embedding-provider-error: context overflow); +1 more');
         expect(formatUnrecoverablePreview(['legacy-id'])).toBe('legacy-id (unknown)');
+    });
+});
+
+test.describe('anyRepairNonClean — operator fail-loud predicate (#14062)', () => {
+    test('true when any collection partial-promoted', () => {
+        expect(anyRepairNonClean([
+            {collectionName: 'mc-memory', partialPromoted: true, promotion: {}, unrecoverable: ['x']},
+            {collectionName: 'mc-graph',  promotion: {}}
+        ])).toBe(true);
+    });
+
+    test('true when any collection aborted', () => {
+        expect(anyRepairNonClean([
+            {collectionName: 'mc-memory', aborted: true, unrecoverable: ['x']}
+        ])).toBe(true);
+    });
+
+    test('false when every collection promoted cleanly', () => {
+        expect(anyRepairNonClean([
+            {collectionName: 'mc-memory', promotion: {}},
+            {collectionName: 'mc-graph',  promotion: {}}
+        ])).toBe(false);
     });
 });
 


### PR DESCRIPTION
Authored by Euclid (GPT-5.5, Codex Desktop). Session 019efe4c-5d55-76c0-aba5-665f86d9cbdc.

Resolves #14062
Related: #14039
Refs #14027
Refs #14021
Refs #13999

This makes Memory Core repair-defrag preserve recovered work when unrecoverable rows remain. A repair that has already streamed recoverable rows into a shadow collection now promotes those recovered rows, retains the parked source collection, records a `memory-core-repair-partial-promoted` state with the unrecoverable manifest, and still exits non-clean instead of pretending the repair succeeded.

Evidence: L2 (focused unit seams + static/preflight checks; no live Chroma mutation) -> L2 required (repair promotion/state contracts are unit-seamed and live defrag is intentionally not exercised from tests). Residual: post-merge operator validation of the real defrag CLI on the affected Memory Core store remains outside CI.

## Deltas from ticket

The ticket asked for a distinct partial-repair contract. This PR keeps the existing hard abort when there are zero recovered rows to promote, and uses partial promotion only once the shadow contains recoverable data. Partial promotion is intentionally still non-clean: the CLI uses `anyRepairNonClean()` so operators get a non-zero exit while recovered vectors are durable.

## Contract Ledger

| Surface | Contract |
| --- | --- |
| `repairMemoryCoreCollectionViaResumableShadow()` | Unrecoverable rows plus recovered shadow rows return `partialPromoted: true`, promote only recovered IDs, and pass `deleteParking: false`. |
| `promoteLoadedShadowCollection()` | `deleteParking: false` validates/promotes the shadow but writes `parking-retained` and keeps the parked source collection. |
| `repairMemoryCoreCollectionsViaFullEnumeration()` | Partial-promoted results continue repairing later collections, then write `memory-core-repair-partial-promoted` with `parkingName`, `unrecoverable`, and `unrecoverableByCollection`. |
| CLI status | `anyRepairNonClean()` treats aborted and partial-promoted repairs as non-clean so the operator boundary exits non-zero. |

## Test Evidence

- `node --check ai/scripts/maintenance/defragChromaDB.mjs`
- `npm run agent-preflight -- ai/scripts/maintenance/defragChromaDB.mjs test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs` -> 28 passed after rebasing onto latest `origin/dev` (`69f0bba5c8`)
- `git diff --check origin/dev..HEAD`

## Post-Merge Validation

- [ ] Run the operator Memory Core repair-defrag against the affected store and confirm partial-promoted collections retain a parked source while recovered vectors are available from the canonical collection.

## Commit

- `3d41baa449` — `fix(ai): promote recoverable memory repair rows (#14062)`
