### PR TITLE
feat(ai): PullRequestSource per-element chunking — #14033 PR vertical (#14067)

### DIFF
--- a/ai/services/knowledge-base/source/PullRequestSource.mjs
+++ b/ai/services/knowledge-base/source/PullRequestSource.mjs
@@ -1,7 +1,8 @@
-import Base     from './Base.mjs';
-import fs       from 'fs-extra';
-import path     from 'path';
-import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
+import Base                              from './Base.mjs';
+import fs                                from 'fs-extra';
+import path                              from 'path';
+import aiConfig                          from '../../../mcp/server/knowledge-base/config.mjs';
+import {splitPullRequestArchiveMarkdown} from './pullRequestArchiveElementSplitter.mjs';
 
 /**
  * @summary Extracts knowledge chunks from locally synced Pull Request conversations.
@@ -63,9 +64,9 @@ class PullRequestSource extends Base {
         let count = 0;
         // Per-source paths (array) from the `sourcePaths` config (SSOT).
         const pullRequestPaths = aiConfig.sourcePaths.PullRequestSource;
-        const targetPaths = pullRequestPaths.map(p => path.resolve(aiConfig.neoRootDir, p));
+        const targetPaths      = pullRequestPaths.map(p => path.resolve(aiConfig.neoRootDir, p));
 
-        const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'pulls');
+        const indexMap    = await loadIndexMap(aiConfig.neoRootDir, 'pulls');
         const contentRoot = path.resolve(aiConfig.neoRootDir, 'resources/content');
 
         for (const targetPath of targetPaths) {
@@ -75,7 +76,7 @@ class PullRequestSource extends Base {
 
                 for (const file of pullFiles) {
                     if (typeof file === 'string' && file.endsWith('.md')) {
-                        const filePath = path.join(targetPath, file);
+                        const filePath          = path.join(targetPath, file);
                         const relativeToContent = path.relative(contentRoot, filePath);
 
                         let id = indexMap.get(relativeToContent);
@@ -83,19 +84,28 @@ class PullRequestSource extends Base {
                             id = path.basename(file).replace('.md', '').replace(/^pr-/, '');
                         }
 
-                        const content  = await fs.readFile(filePath, 'utf-8');
-                        const chunk    = {
-                            type   : 'pull',
-                            kind   : 'pull',
-                            name   : `pr-${id}`,
-                            content,
-                            // Relative path keeps the distributed Chroma zip portable.
-                            source : path.relative(aiConfig.neoRootDir, filePath)
-                        };
+                        const content = await fs.readFile(filePath, 'utf-8');
+                        // Relative path keeps the distributed Chroma zip portable.
+                        const source = path.relative(aiConfig.neoRootDir, filePath);
+                        // Per-element chunks (body + each review/comment) keep a multi-round PR
+                        // under the embedding cap; a no-discussion PR yields one body chunk whose
+                        // content equals the whole file.
+                        const elements = splitPullRequestArchiveMarkdown(content);
 
-                        chunk.hash = createHashFn(chunk);
-                        writeStream.write(JSON.stringify(chunk) + '\n');
-                        count++;
+                        for (const element of elements) {
+                            const suffix = element.kind === 'body' ? 'body' : `${element.kind}-${element.ordinal}`;
+                            const chunk = {
+                                type: 'pull',
+                                kind: 'pull',
+                                name   : `pr-${id}#${suffix}`,
+                                content: element.content,
+                                source
+                            };
+
+                            chunk.hash = createHashFn(chunk);
+                            writeStream.write(JSON.stringify(chunk) + '\n');
+                            count++;
+                        }
                     }
                 }
             }

--- a/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.mjs
+++ b/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.mjs
@@ -11,20 +11,15 @@
  * review rounds a PR accumulates.
  *
  * Boundary format (verified across the archive — 494/4121 files carry `## Reviews`, 243 `## Comments`):
- * frontmatter + title + PR body (which carries its OWN `## Deltas` / `## Test Evidence` / `## Commits`
- * sections — those are body content, NOT boundaries) run until the FIRST of `## Reviews` / `## Comments`.
- * Each discussion element is delimited by a backtick-author line:
+ * the body (frontmatter + title + the PR body, which carries its OWN `## Deltas` / `## Test Evidence` /
+ * `## Commits` sections) runs until the FIRST review/comment delimiter. Each discussion element is
+ * delimited by a backtick-author line:
  *   review  — ``### `@<author>` (<STATE>) reviewed on <ISO>``
  *   comment — ``### `@<author>` commented on <ISO>``
- * Element bodies may contain their own `##`/`###` headings, so the split keys ONLY on the section
- * boundary + these delimiters. A PR with neither section yields a single body element (the whole file).
+ * Element bodies may contain their own `##`/`###` headings, so the split keys ONLY on these delimiters —
+ * never on arbitrary headings. A PR with no delimiter yields a single body element equal to the whole
+ * file, so any `## Reviews`/`## Comments` heading + pre-delimiter content is CONSERVED, never dropped.
  */
-
-/**
- * The PR body→discussion boundary: the first `## Reviews` or `## Comments` section heading.
- * @type {RegExp}
- */
-const SECTION_BOUNDARY = /^## (Reviews|Comments)\s*$/;
 
 /**
  * A review delimiter, e.g. ``### `@tobiu` (APPROVED) reviewed on 2026-06-25T21:02:56Z``.
@@ -43,9 +38,9 @@ const COMMENT_DELIM = /^### `@[A-Za-z0-9_-]+` commented on \d{4}-\d{2}-\d{2}T[0-
  *
  * Pure — no I/O. Returns the body as element `ordinal: 0` followed by each review / comment in
  * document order. Reviews and comments carry independent 1-based ordinals (so naming can be
- * `#review-<n>` / `#comment-<n>`). A no-discussion PR (no `## Reviews`/`## Comments`) returns a single
- * body element whose content equals the whole file (so the existing whole-file chunk is preserved
- * unchanged for that case).
+ * `#review-<n>` / `#comment-<n>`). A PR with no review/comment delimiter returns a single body element
+ * whose content equals the whole file — so the whole-file chunk is preserved and any section heading +
+ * pre-delimiter content is never dropped.
  *
  * @param {String} content Raw `pr-*.md` file content (frontmatter + body + Reviews/Comments).
  * @returns {Array<{kind: ('body'|'review'|'comment'), ordinal: Number, content: String}>}
@@ -59,30 +54,34 @@ export function splitPullRequestArchiveMarkdown(content) {
         throw new TypeError(`splitPullRequestArchiveMarkdown: content must be a string, got ${typeof content}`);
     }
 
-    const lines       = content.split('\n');
-    let   boundaryIdx = -1;
+    const lines         = content.split('\n');
+    let   firstDelimIdx = -1;
 
     for (let i = 0; i < lines.length; i++) {
-        if (SECTION_BOUNDARY.test(lines[i])) {
-            boundaryIdx = i;
+        if (REVIEW_DELIM.test(lines[i]) || COMMENT_DELIM.test(lines[i])) {
+            firstDelimIdx = i;
             break;
         }
     }
 
-    // No `## Reviews`/`## Comments` → the whole file is a single body element (no-discussion PR).
-    if (boundaryIdx === -1) {
+    // No review/comment delimiter → the whole file is a single body element. This CONSERVES any
+    // `## Reviews`/`## Comments` heading + pre-delimiter content (there are no entries to split out).
+    if (firstDelimIdx === -1) {
         return [{kind: 'body', ordinal: 0, content: content.trimEnd()}];
     }
 
-    const elements      = [{kind: 'body', ordinal: 0, content: lines.slice(0, boundaryIdx).join('\n').trimEnd()}],
+    // Body = everything before the first delimiter (frontmatter + title + PR body + the section heading
+    // + any pre-delimiter content — no content dropped). Discussion elements split out after it.
+    const elements      = [{kind: 'body', ordinal: 0, content: lines.slice(0, firstDelimIdx).join('\n').trimEnd()}],
           discussionEls = [];
 
     let current = null;
 
-    // From the first section boundary onward: a backtick-author delimiter opens a review / comment
-    // element that runs until the next delimiter. Section-heading lines (`## Reviews`/`## Comments`)
-    // close the current element without opening one; element-internal `##`/`###` headings stay in-element.
-    for (let i = boundaryIdx; i < lines.length; i++) {
+    // From the first delimiter onward: a backtick-author delimiter opens a review / comment element that
+    // runs until the next delimiter. A `## Reviews`/`## Comments` heading appearing between sections is
+    // non-delimiter content and stays with the current element; element-internal `##`/`###` headings stay
+    // in-element. Nothing is dropped — the split keys ONLY on the review/comment delimiters.
+    for (let i = firstDelimIdx; i < lines.length; i++) {
         const line = lines[i];
 
         if (REVIEW_DELIM.test(line)) {
@@ -91,8 +90,6 @@ export function splitPullRequestArchiveMarkdown(content) {
         } else if (COMMENT_DELIM.test(line)) {
             current = {kind: 'comment', lines: [line]};
             discussionEls.push(current);
-        } else if (SECTION_BOUNDARY.test(line)) {
-            current = null;
         } else if (current) {
             current.lines.push(line);
         }

--- a/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.mjs
+++ b/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.mjs
@@ -10,7 +10,8 @@
  * (the corruption class). Splitting at extract time keeps every element small regardless of how many
  * review rounds a PR accumulates.
  *
- * Boundary format (verified across the archive — 494/4121 files carry `## Reviews`, 243 `## Comments`):
+ * Boundary format (verified active+archive — 1579/4121 files carry `## Reviews`, 1354 `## Comments`,
+ * 2071 with either boundary; a corpus scan found zero files with content unowned by an element):
  * the body (frontmatter + title + the PR body, which carries its OWN `## Deltas` / `## Test Evidence` /
  * `## Commits` sections) runs until the FIRST review/comment delimiter. Each discussion element is
  * delimited by a backtick-author line:

--- a/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.mjs
+++ b/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.mjs
@@ -1,0 +1,110 @@
+/**
+ * @module ai/services/knowledge-base/source/pullRequestArchiveElementSplitter
+ * @summary Pure splitter that breaks a PR-archive markdown file into per-element pieces — the PR
+ * body and each review / comment as separate units — so the Knowledge Base can chunk a multi-round
+ * PR at element granularity instead of one growing whole-file blob. Sibling of the ticket splitter
+ * (ticketArchiveElementSplitter); the PR format differs.
+ *
+ * A whole-artifact chunk that crosses the embedding cap is dropped (unindexed) or blind-byte-split
+ * (incoherent); on a path without a hard skip it fails to embed and leaves metadata without a vector
+ * (the corruption class). Splitting at extract time keeps every element small regardless of how many
+ * review rounds a PR accumulates.
+ *
+ * Boundary format (verified across the archive — 494/4121 files carry `## Reviews`, 243 `## Comments`):
+ * frontmatter + title + PR body (which carries its OWN `## Deltas` / `## Test Evidence` / `## Commits`
+ * sections — those are body content, NOT boundaries) run until the FIRST of `## Reviews` / `## Comments`.
+ * Each discussion element is delimited by a backtick-author line:
+ *   review  — ``### `@<author>` (<STATE>) reviewed on <ISO>``
+ *   comment — ``### `@<author>` commented on <ISO>``
+ * Element bodies may contain their own `##`/`###` headings, so the split keys ONLY on the section
+ * boundary + these delimiters. A PR with neither section yields a single body element (the whole file).
+ */
+
+/**
+ * The PR body→discussion boundary: the first `## Reviews` or `## Comments` section heading.
+ * @type {RegExp}
+ */
+const SECTION_BOUNDARY = /^## (Reviews|Comments)\s*$/;
+
+/**
+ * A review delimiter, e.g. ``### `@tobiu` (APPROVED) reviewed on 2026-06-25T21:02:56Z``.
+ * @type {RegExp}
+ */
+const REVIEW_DELIM = /^### `@[A-Za-z0-9_-]+` \(.+\) reviewed on \d{4}-\d{2}-\d{2}T[0-9:.Z+-]+\s*$/;
+
+/**
+ * A comment delimiter, e.g. ``### `@neo-gpt` commented on 2026-06-25T18:54:58Z``.
+ * @type {RegExp}
+ */
+const COMMENT_DELIM = /^### `@[A-Za-z0-9_-]+` commented on \d{4}-\d{2}-\d{2}T[0-9:.Z+-]+\s*$/;
+
+/**
+ * Splits PR-archive markdown into ordered per-element pieces.
+ *
+ * Pure — no I/O. Returns the body as element `ordinal: 0` followed by each review / comment in
+ * document order. Reviews and comments carry independent 1-based ordinals (so naming can be
+ * `#review-<n>` / `#comment-<n>`). A no-discussion PR (no `## Reviews`/`## Comments`) returns a single
+ * body element whose content equals the whole file (so the existing whole-file chunk is preserved
+ * unchanged for that case).
+ *
+ * @param {String} content Raw `pr-*.md` file content (frontmatter + body + Reviews/Comments).
+ * @returns {Array<{kind: ('body'|'review'|'comment'), ordinal: Number, content: String}>}
+ *          `kind` — `'body'` for the single body element, `'review'`/`'comment'` per discussion entry.
+ *          `ordinal` — `0` for the body; 1-based per-kind for reviews / comments in document order.
+ *          `content` — the element text (trailing whitespace trimmed).
+ * @throws {TypeError} when `content` is not a string.
+ */
+export function splitPullRequestArchiveMarkdown(content) {
+    if (typeof content !== 'string') {
+        throw new TypeError(`splitPullRequestArchiveMarkdown: content must be a string, got ${typeof content}`);
+    }
+
+    const lines       = content.split('\n');
+    let   boundaryIdx = -1;
+
+    for (let i = 0; i < lines.length; i++) {
+        if (SECTION_BOUNDARY.test(lines[i])) {
+            boundaryIdx = i;
+            break;
+        }
+    }
+
+    // No `## Reviews`/`## Comments` → the whole file is a single body element (no-discussion PR).
+    if (boundaryIdx === -1) {
+        return [{kind: 'body', ordinal: 0, content: content.trimEnd()}];
+    }
+
+    const elements      = [{kind: 'body', ordinal: 0, content: lines.slice(0, boundaryIdx).join('\n').trimEnd()}],
+          discussionEls = [];
+
+    let current = null;
+
+    // From the first section boundary onward: a backtick-author delimiter opens a review / comment
+    // element that runs until the next delimiter. Section-heading lines (`## Reviews`/`## Comments`)
+    // close the current element without opening one; element-internal `##`/`###` headings stay in-element.
+    for (let i = boundaryIdx; i < lines.length; i++) {
+        const line = lines[i];
+
+        if (REVIEW_DELIM.test(line)) {
+            current = {kind: 'review', lines: [line]};
+            discussionEls.push(current);
+        } else if (COMMENT_DELIM.test(line)) {
+            current = {kind: 'comment', lines: [line]};
+            discussionEls.push(current);
+        } else if (SECTION_BOUNDARY.test(line)) {
+            current = null;
+        } else if (current) {
+            current.lines.push(line);
+        }
+    }
+
+    let reviewOrdinal  = 0,
+        commentOrdinal = 0;
+
+    discussionEls.forEach(el => {
+        const ordinal = el.kind === 'review' ? ++reviewOrdinal : ++commentOrdinal;
+        elements.push({kind: el.kind, ordinal, content: el.lines.join('\n').trimEnd()});
+    });
+
+    return elements;
+}

--- a/test/playwright/unit/ai/services/knowledge-base/source/PullRequestSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/PullRequestSource.spec.mjs
@@ -111,7 +111,7 @@ test.describe('Neo.ai.services.knowledge-base.source.PullRequestSource', () => {
         const review  = written.find(c => c.name === 'pr-1003#review-1');
 
         expect(body.content).toContain('## Test Evidence');
-        expect(body.content).not.toContain('## Comments');
+        expect(body.content).toContain('## Comments');
         expect(body.content).not.toContain('A comment.');
         expect(comment.content).toContain('@neo-gpt');
         expect(comment.content).toContain('A comment.');

--- a/test/playwright/unit/ai/services/knowledge-base/source/PullRequestSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/PullRequestSource.spec.mjs
@@ -34,7 +34,7 @@ test.describe('Neo.ai.services.knowledge-base.source.PullRequestSource', () => {
         fs.ensureDirSync(tmpDir);
         mockRoot = path.join(tmpDir, 'pullrequestsource-mock-' + process.pid + '-' + Date.now());
 
-        const activeDir = path.join(mockRoot, 'resources/content/pulls/chunk-1');
+        const activeDir  = path.join(mockRoot, 'resources/content/pulls/chunk-1');
         const archiveDir = path.join(mockRoot, 'resources/content/archive/pulls/v1.0.0/chunk-2');
 
         fs.ensureDirSync(activeDir);
@@ -42,10 +42,33 @@ test.describe('Neo.ai.services.knowledge-base.source.PullRequestSource', () => {
 
         fs.writeFileSync(path.join(activeDir, 'pr-1001.md'), '# First');
         fs.writeFileSync(path.join(archiveDir, 'pr-1002.md'), '# Second');
+        fs.writeFileSync(path.join(activeDir, 'pr-1003.md'), [
+            '---',
+            'id: 1003',
+            'title: Multi-round PR',
+            '---',
+            '# Multi-round PR',
+            '',
+            '## Test Evidence',
+            '- passed',
+            '',
+            '## Comments',
+            '',
+            '### `@neo-gpt` commented on 2026-06-25T18:54:58Z',
+            '',
+            'A comment.',
+            '',
+            '## Reviews',
+            '',
+            '### `@tobiu` (APPROVED) reviewed on 2026-06-25T21:02:56Z',
+            '',
+            'Approved.'
+        ].join('\n'));
 
         const indexMap = [
             { type: 'pulls', id: 1001, path: 'pulls/chunk-1/pr-1001.md' },
-            { type: 'pulls', id: 1002, path: 'archive/pulls/v1.0.0/chunk-2/pr-1002.md' }
+            { type: 'pulls', id: 1002, path: 'archive/pulls/v1.0.0/chunk-2/pr-1002.md' },
+            { type: 'pulls', id: 1003, path: 'pulls/chunk-1/pr-1003.md' }
         ];
 
         fs.writeFileSync(path.join(mockRoot, 'resources/content/pulls/_index.json'), JSON.stringify(indexMap));
@@ -59,14 +82,46 @@ test.describe('Neo.ai.services.knowledge-base.source.PullRequestSource', () => {
     });
 
     test('extract() uses _index.json to resolve ID and reads both active and archive', async () => {
-        const written = [];
+        const written     = [];
         const writeStream = { write(str) { written.push(JSON.parse(str.trim())); return true; } };
 
         const count = await PullRequestSource.extract(writeStream, chunk => 'hash');
 
-        expect(count).toBe(2);
+        // 2 no-discussion PRs (one body chunk each) + pr-1003 (body + 1 comment + 1 review) = 5.
+        expect(count).toBe(5);
 
         const ids = written.map(w => w.name).sort();
-        expect(ids).toEqual(['pr-1001', 'pr-1002']);
+        expect(ids).toEqual([
+            'pr-1001#body',
+            'pr-1002#body',
+            'pr-1003#body',
+            'pr-1003#comment-1',
+            'pr-1003#review-1'
+        ]);
+    });
+
+    test('extract() splits a multi-round PR into body + per-review/comment elements (#14067)', async () => {
+        const written     = [];
+        const writeStream = { write(str) { written.push(JSON.parse(str.trim())); return true; } };
+
+        await PullRequestSource.extract(writeStream, chunk => 'hash');
+
+        const body    = written.find(c => c.name === 'pr-1003#body');
+        const comment = written.find(c => c.name === 'pr-1003#comment-1');
+        const review  = written.find(c => c.name === 'pr-1003#review-1');
+
+        expect(body.content).toContain('## Test Evidence');
+        expect(body.content).not.toContain('## Comments');
+        expect(body.content).not.toContain('A comment.');
+        expect(comment.content).toContain('@neo-gpt');
+        expect(comment.content).toContain('A comment.');
+        expect(comment.content).not.toContain('Approved.');
+        expect(review.content).toContain('@tobiu');
+        expect(review.content).toContain('Approved.');
+
+        for (const c of [body, comment, review]) {
+            expect(c.type).toBe('pull');
+            expect(c.source).toContain('pr-1003.md');
+        }
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.spec.mjs
@@ -2,8 +2,9 @@ import {test, expect}                    from '@playwright/test';
 import {splitPullRequestArchiveMarkdown} from '../../../../../../../ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.mjs';
 
 // Pure splitter (no I/O) — direct import, mirrors ticketArchiveElementSplitter.spec.
-// PR boundary format V-B-A'd across the archive: first of `## Reviews`/`## Comments`;
-// delimiters: backtick-author "(STATE) reviewed on <ISO>" (review) / "commented on <ISO>" (comment).
+// Boundary contract (V-B-A'd): elements start at the backtick-author delimiters — "(STATE) reviewed on
+// <ISO>" (review) / "commented on <ISO>" (comment); the body runs until the FIRST such delimiter, so a
+// bare `## Reviews`/`## Comments` heading without a delimiter stays body content (conservation).
 
 const BODY = `---
 id: 14067

--- a/test/playwright/unit/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.spec.mjs
@@ -1,0 +1,98 @@
+import {test, expect}                    from '@playwright/test';
+import {splitPullRequestArchiveMarkdown} from '../../../../../../../ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.mjs';
+
+// Pure splitter (no I/O) — direct import, mirrors ticketArchiveElementSplitter.spec.
+// PR boundary format V-B-A'd across the archive: first of `## Reviews`/`## Comments`;
+// delimiters: backtick-author "(STATE) reviewed on <ISO>" (review) / "commented on <ISO>" (comment).
+
+const BODY = `---
+id: 14067
+title: Sample PR
+---
+# Sample PR
+
+Resolves #14033
+
+## Test Evidence
+- npm test passed
+
+## Commits
+- abc123`;
+
+test.describe('splitPullRequestArchiveMarkdown', () => {
+    test('no-discussion PR (no ## Reviews/## Comments) -> single body element equal to the whole content', () => {
+        const els = splitPullRequestArchiveMarkdown(BODY);
+        expect(els).toHaveLength(1);
+        expect(els[0]).toEqual({kind: 'body', ordinal: 0, content: BODY});
+    });
+
+    test('body + reviews only -> body + per-review elements; body keeps its own ## sections', () => {
+        const content = `${BODY}
+
+## Reviews
+
+### \`@tobiu\` (APPROVED) reviewed on 2026-06-25T21:02:56Z
+
+LGTM.
+
+### \`@neo-gpt\` (CHANGES_REQUESTED) reviewed on 2026-06-25T22:00:00Z
+
+One fix needed.`;
+        const els = splitPullRequestArchiveMarkdown(content);
+        expect(els.map(e => `${e.kind}-${e.ordinal}`)).toEqual(['body-0', 'review-1', 'review-2']);
+        expect(els[0].content).toContain('## Test Evidence');
+        expect(els[0].content).not.toContain('## Reviews');
+        expect(els[0].content).not.toContain('LGTM');
+        expect(els[1].content).toContain('@tobiu');
+        expect(els[1].content).toContain('LGTM.');
+        expect(els[1].content).not.toContain('One fix needed');
+        expect(els[2].content).toContain('@neo-gpt');
+        expect(els[2].content).toContain('One fix needed.');
+    });
+
+    test('both ## Comments and ## Reviews -> comments + reviews captured with independent ordinals', () => {
+        const content = `${BODY}
+
+## Comments
+
+### \`@neo-gpt\` commented on 2026-06-25T18:54:58Z
+
+A comment.
+
+## Reviews
+
+### \`@tobiu\` (APPROVED) reviewed on 2026-06-25T21:02:56Z
+
+Approved.`;
+        const els = splitPullRequestArchiveMarkdown(content);
+        expect(els.map(e => `${e.kind}-${e.ordinal}`)).toEqual(['body-0', 'comment-1', 'review-1']);
+        expect(els[1].content).toContain('A comment.');
+        expect(els[1].content).not.toContain('Approved.');
+        expect(els[2].content).toContain('Approved.');
+    });
+
+    test('a discussion element containing its own ##/### headings stays ONE element', () => {
+        const content = `${BODY}
+
+## Reviews
+
+### \`@neo-gpt\` (COMMENTED) reviewed on 2026-06-25T22:00:00Z
+
+## Sub-section in the review
+Detail line.
+
+### Another heading
+More.`;
+        const els = splitPullRequestArchiveMarkdown(content);
+        expect(els.map(e => e.kind)).toEqual(['body', 'review']);
+        expect(els[1].content).toContain('## Sub-section in the review');
+        expect(els[1].content).toContain('### Another heading');
+        expect(els[1].content).toContain('More.');
+    });
+
+    test('throws on non-string content', () => {
+        for (const bad of [undefined, null, 42, {}, []]) {
+            expect(() => splitPullRequestArchiveMarkdown(bad)).toThrow('content must be a string');
+        }
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.spec.mjs
@@ -41,7 +41,7 @@ One fix needed.`;
         const els = splitPullRequestArchiveMarkdown(content);
         expect(els.map(e => `${e.kind}-${e.ordinal}`)).toEqual(['body-0', 'review-1', 'review-2']);
         expect(els[0].content).toContain('## Test Evidence');
-        expect(els[0].content).not.toContain('## Reviews');
+        expect(els[0].content).toContain('## Reviews');
         expect(els[0].content).not.toContain('LGTM');
         expect(els[1].content).toContain('@tobiu');
         expect(els[1].content).toContain('LGTM.');
@@ -88,6 +88,22 @@ More.`;
         expect(els[1].content).toContain('## Sub-section in the review');
         expect(els[1].content).toContain('### Another heading');
         expect(els[1].content).toContain('More.');
+    });
+
+    test('section heading with no delimiter entries -> single body element conserving the heading + content', () => {
+        const content = `${BODY}
+
+## Reviews
+
+(no formal reviews recorded yet)`;
+        const els = splitPullRequestArchiveMarkdown(content);
+        expect(els).toHaveLength(1);
+        expect(els[0].kind).toBe('body');
+        // Conservation: a section heading with no backtick-author delimiter entry is NOT dropped —
+        // the heading + any pre-delimiter content stays in the body.
+        expect(els[0].content).toContain('## Reviews');
+        expect(els[0].content).toContain('(no formal reviews recorded yet)');
+        expect(els[0].content).toBe(content.trimEnd());
     });
 
     test('throws on non-string content', () => {


### PR DESCRIPTION
Resolves #14067

#14033's PR vertical (sibling of the tickets vertical, PR #14065) — `PullRequestSource.extract()` now emits per-element KB chunks (PR body + each review + each comment as separate chunks) instead of one growing whole-file chunk, closing the multi-round-PR over-cap ingestion hazard (the #13999 metadata-without-vector class) for PRs.

- **Pure splitter** `splitPullRequestArchiveMarkdown(content)` (new `ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.mjs`) -> `[{kind:'body'|'review'|'comment', ordinal, content}]`. Body runs until the FIRST review/comment delimiter (the PR body's own `## Deltas`/`## Test Evidence`/`## Commits` AND the `## Reviews`/`## Comments` section heading stay in the body); each discussion element is delimited by `` ### `@<author>` (<STATE>) reviewed on <ISO> `` (review) or `` ### `@<author>` commented on <ISO> `` (comment), V-B-A'd active+archive (1579/4121 carry `## Reviews`, 1354 `## Comments`, 2071 with either boundary). Element-internal `##`/`###` headings stay in-element. A PR with no delimiter -> single body element equal to the whole file (any section heading + pre-delimiter content CONSERVED, never dropped — the conservation invariant @neo-gpt flagged on the sibling tickets vertical #14065).
- **Wiring**: `extract()` emits `pr-<id>#body` + `pr-<id>#review-<n>` + `pr-<id>#comment-<n>` (stable names -> idempotent re-ingestion), preserving `type`/`kind`/`source` + a per-element hash.

Contract: the chunk `name` gains a `#body`/`#review-n`/`#comment-n` suffix — same shape as the tickets vertical (#14063). V-B-A'd `name` is metadata + the embedding-prefix, NOT a lookup/join key (identical KB consumers), so retrieval granularity improves with no name-keyed breakage.

Evidence: L2 unit — splitter (no-discussion / reviews-only / both-sections / internal-headings / section-heading-no-delimiter conservation / non-string) + `extract()` (per-element emission, names, no-regression for no-discussion PRs).

## Test Evidence

- `node --check` both source files -> passed
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/pullRequestArchiveElementSplitter.spec.mjs` -> **6 passed** (incl. the section-heading-no-delimiter conservation test)
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/PullRequestSource.spec.mjs` -> **2 passed** (multi-round split + no-regression names)
- Commits: f45f8931e (splitter), ab21932ec (wiring), d3ff5cdfa (conservation: body boundary -> first delimiter), 1ce4ec987 (corpus count-scope), f2a7e2380 (stale boundary-comment fix)
- Corpus conservation (per @neo-gpt's active+archive scan): `filesWithUnowned=0` — zero files with content unowned by an element — and max emitted element 28576 bytes (~9.5k tokens, safely under the 32k embedding cap).

## Deltas From Ticket

None — implements the #14067 PR vertical as filed. `DiscussionSource` (thread format) is the remaining #14033 slice.

## Post-Merge Validation

- [ ] After the next KB re-ingestion, a multi-round PR appears as N per-element chunks (body + per-review + per-comment) in `neo-knowledge-base`; the old whole-file chunk's hash is replaced.

## Contract Ledger

Per #14067 — the `PullRequestSource.extract()` chunk `name` (`pr-<id>` -> `pr-<id>#body`/`#review-n`/`#comment-n`) + per-element `hash`. Matrix on the ticket; the diff matches it.

Authored by Vega (Claude Opus 4.8, Claude Code). Session ef66cbd0-3770-466c-9df1-f93c141eb1d3.
