### PR TITLE
feat(ai): DiscussionSource per-element chunking — #14033 Discussion vertical (#14070)

### DIFF
--- a/ai/services/knowledge-base/source/DiscussionSource.mjs
+++ b/ai/services/knowledge-base/source/DiscussionSource.mjs
@@ -1,7 +1,8 @@
-import Base from './Base.mjs';
-import fs   from 'fs-extra';
-import path from 'path';
-import aiConfig from '../../../mcp/server/knowledge-base/config.mjs';
+import Base                             from './Base.mjs';
+import fs                               from 'fs-extra';
+import path                             from 'path';
+import aiConfig                         from '../../../mcp/server/knowledge-base/config.mjs';
+import {splitDiscussionArchiveMarkdown} from './discussionArchiveElementSplitter.mjs';
 
 /**
  * @summary Extracts knowledge chunks from the active and archived GitHub Discussions.
@@ -61,9 +62,9 @@ class DiscussionSource extends Base {
         // Per-source paths (array) from the `sourcePaths` config (SSOT). Each entry is resolved
         // against `neoRootDir`.
         const discussionPaths = aiConfig.sourcePaths.DiscussionSource;
-        const targetPaths = discussionPaths.map(p => path.resolve(aiConfig.neoRootDir, p));
+        const targetPaths     = discussionPaths.map(p => path.resolve(aiConfig.neoRootDir, p));
 
-        const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'discussions');
+        const indexMap    = await loadIndexMap(aiConfig.neoRootDir, 'discussions');
         const contentRoot = path.resolve(aiConfig.neoRootDir, 'resources/content');
 
         for (const targetPath of targetPaths) {
@@ -73,7 +74,7 @@ class DiscussionSource extends Base {
 
                 for (const file of discussionFiles) {
                     if (typeof file === 'string' && file.endsWith('.md')) {
-                        const filePath   = path.join(targetPath, file);
+                        const filePath          = path.join(targetPath, file);
                         const relativeToContent = path.relative(contentRoot, filePath);
 
                         let id = indexMap.get(relativeToContent);
@@ -81,19 +82,28 @@ class DiscussionSource extends Base {
                             id = path.basename(file).replace('.md', '').replace(/^discussion-/, '');
                         }
 
-                        const content    = await fs.readFile(filePath, 'utf-8');
-                        const chunk      = {
-                            type   : 'discussion',
-                            kind   : 'discussion',
-                            name   : `discussion-${id}`,
-                            content,
-                            // Relative path keeps the distributed Chroma zip portable.
-                            source : path.relative(aiConfig.neoRootDir, filePath)
-                        };
+                        const content = await fs.readFile(filePath, 'utf-8');
+                        // Relative path keeps the distributed Chroma zip portable.
+                        const source = path.relative(aiConfig.neoRootDir, filePath);
+                        // Per-element chunks (body + each comment) keep a large converged Discussion
+                        // under the embedding cap; a no-comment discussion yields one body chunk whose
+                        // content equals the whole file.
+                        const elements = splitDiscussionArchiveMarkdown(content);
 
-                        chunk.hash = createHashFn(chunk);
-                        writeStream.write(JSON.stringify(chunk) + '\n');
-                        count++;
+                        for (const element of elements) {
+                            const suffix = element.kind === 'body' ? 'body' : `comment-${element.ordinal}`;
+                            const chunk = {
+                                type: 'discussion',
+                                kind: 'discussion',
+                                name   : `discussion-${id}#${suffix}`,
+                                content: element.content,
+                                source
+                            };
+
+                            chunk.hash = createHashFn(chunk);
+                            writeStream.write(JSON.stringify(chunk) + '\n');
+                            count++;
+                        }
                     }
                 }
             }

--- a/ai/services/knowledge-base/source/discussionArchiveElementSplitter.mjs
+++ b/ai/services/knowledge-base/source/discussionArchiveElementSplitter.mjs
@@ -1,0 +1,90 @@
+/**
+ * @module ai/services/knowledge-base/source/discussionArchiveElementSplitter
+ * @summary Pure splitter that breaks a discussion-archive markdown file into per-element pieces — the
+ * converged-model body and each maintainer comment as separate units — so the Knowledge Base can chunk
+ * a large converged Discussion at element granularity instead of one growing whole-file blob. Sibling of
+ * the ticket / PR splitters; discussions reuse the PR comment delimiter.
+ *
+ * A whole-artifact chunk that crosses the embedding cap is dropped (unindexed) or blind-byte-split
+ * (incoherent); on a path without a hard skip it fails to embed and leaves metadata without a vector
+ * (the corruption class). The big converged Discussions (the most-referenced architectural docs)
+ * accumulate a rich body + many maintainer comments; per-element chunks keep each small and make each
+ * maintainer's reasoning separately retrievable.
+ *
+ * Boundary format (verified across the archive — 84/176 files carry comments): the body (frontmatter +
+ * the converged-model doc, which carries its OWN `## Converged Model` / `## Decision Record` /
+ * `## Signal Ledger` / … sections) runs until the FIRST comment delimiter; each comment is delimited by a
+ * backtick-author line ``### `@<author>` commented on <ISO>`` (the same delimiter as PR comments). Comment
+ * bodies may contain their own `##`/`###` headings, so the split keys ONLY on the delimiter — never on
+ * arbitrary headings. A discussion with no comment delimiter yields a single body element equal to the
+ * whole file, so the converged-model body + any section content is CONSERVED, never dropped.
+ */
+
+/**
+ * A discussion comment delimiter, e.g. ``### `@neo-gpt` commented on 2026-06-20T05:13:58Z``.
+ * @type {RegExp}
+ */
+const COMMENT_DELIMITER = /^### `@[A-Za-z0-9_-]+` commented on \d{4}-\d{2}-\d{2}T[0-9:.Z+-]+\s*$/;
+
+/**
+ * Splits discussion-archive markdown into ordered per-element pieces.
+ *
+ * Pure — no I/O. Returns the body as element `ordinal: 0` followed by each comment as `ordinal: 1..N` in
+ * document order. A discussion with no comment delimiter returns a single body element whose content equals
+ * the whole file — so the whole-file chunk is preserved and the converged-model body is never dropped.
+ *
+ * @param {String} content Raw `discussion-*.md` file content (frontmatter + converged-model body + comments).
+ * @returns {Array<{kind: ('body'|'comment'), ordinal: Number, content: String}>}
+ *          `kind` — `'body'` for the single body element, `'comment'` for each maintainer comment.
+ *          `ordinal` — `0` for the body, `1..N` for comments in document order.
+ *          `content` — the element text (trailing whitespace trimmed).
+ * @throws {TypeError} when `content` is not a string.
+ */
+export function splitDiscussionArchiveMarkdown(content) {
+    if (typeof content !== 'string') {
+        throw new TypeError(`splitDiscussionArchiveMarkdown: content must be a string, got ${typeof content}`);
+    }
+
+    const lines           = content.split('\n');
+    let   firstCommentIdx = -1;
+
+    for (let i = 0; i < lines.length; i++) {
+        if (COMMENT_DELIMITER.test(lines[i])) {
+            firstCommentIdx = i;
+            break;
+        }
+    }
+
+    // No comment delimiter → the whole file is a single body element. This CONSERVES the converged-model
+    // body + any `## Comments`/section content (there are no entries to split out).
+    if (firstCommentIdx === -1) {
+        return [{kind: 'body', ordinal: 0, content: content.trimEnd()}];
+    }
+
+    // Body = everything before the first comment (frontmatter + the converged-model doc + the `## Comments`
+    // heading + any pre-comment content — no content dropped). Comments split out after it.
+    const elements      = [{kind: 'body', ordinal: 0, content: lines.slice(0, firstCommentIdx).join('\n').trimEnd()}],
+          commentBlocks = [];
+
+    let current = null;
+
+    // From the first comment onward: a backtick-author delimiter opens a comment block that runs until the
+    // next delimiter or EOF. Comment bodies may carry their own `##`/`###` headings, so we split ONLY on the
+    // author delimiter.
+    for (let i = firstCommentIdx; i < lines.length; i++) {
+        const line = lines[i];
+
+        if (COMMENT_DELIMITER.test(line)) {
+            current = [line];
+            commentBlocks.push(current);
+        } else if (current) {
+            current.push(line);
+        }
+    }
+
+    commentBlocks.forEach((blockLines, index) => {
+        elements.push({kind: 'comment', ordinal: index + 1, content: blockLines.join('\n').trimEnd()});
+    });
+
+    return elements;
+}

--- a/ai/services/knowledge-base/source/discussionArchiveElementSplitter.mjs
+++ b/ai/services/knowledge-base/source/discussionArchiveElementSplitter.mjs
@@ -11,7 +11,8 @@
  * accumulate a rich body + many maintainer comments; per-element chunks keep each small and make each
  * maintainer's reasoning separately retrievable.
  *
- * Boundary format (verified across the archive — 84/176 files carry comments): the body (frontmatter +
+ * Boundary format (verified active+archive — 155/176 files carry the comment delimiter, 84 active + 71
+ * archive; a corpus scan found zero files with content unowned by an element): the body (frontmatter +
  * the converged-model doc, which carries its OWN `## Converged Model` / `## Decision Record` /
  * `## Signal Ledger` / … sections) runs until the FIRST comment delimiter; each comment is delimited by a
  * backtick-author line ``### `@<author>` commented on <ISO>`` (the same delimiter as PR comments). Comment

--- a/test/playwright/unit/ai/services/knowledge-base/source/DiscussionSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/DiscussionSource.spec.mjs
@@ -34,7 +34,7 @@ test.describe('Neo.ai.services.knowledge-base.source.DiscussionSource', () => {
         fs.ensureDirSync(tmpDir);
         mockRoot = path.join(tmpDir, 'discussionsource-mock-' + process.pid + '-' + Date.now());
 
-        const activeDir = path.join(mockRoot, 'resources/content/discussions/chunk-1');
+        const activeDir  = path.join(mockRoot, 'resources/content/discussions/chunk-1');
         const archiveDir = path.join(mockRoot, 'resources/content/archive/discussions/v1.0.0/chunk-2');
 
         fs.ensureDirSync(activeDir);
@@ -42,10 +42,31 @@ test.describe('Neo.ai.services.knowledge-base.source.DiscussionSource', () => {
 
         fs.writeFileSync(path.join(activeDir, 'discussion-1001.md'), '# First');
         fs.writeFileSync(path.join(archiveDir, 'discussion-1002.md'), '# Second');
+        fs.writeFileSync(path.join(activeDir, 'discussion-1003.md'), [
+            '---',
+            'id: 1003',
+            'title: Converged discussion',
+            '---',
+            '# Converged discussion',
+            '',
+            '## Converged Model',
+            'The agreed shape.',
+            '',
+            '## Comments',
+            '',
+            '### `@neo-gpt` commented on 2026-06-20T05:13:58Z',
+            '',
+            'First reply.',
+            '',
+            '### `@neo-opus-ada` commented on 2026-06-20T05:22:13Z',
+            '',
+            'Second reply.'
+        ].join('\n'));
 
         const indexMap = [
             { type: 'discussions', id: 1001, path: 'discussions/chunk-1/discussion-1001.md' },
-            { type: 'discussions', id: 1002, path: 'archive/discussions/v1.0.0/chunk-2/discussion-1002.md' }
+            { type: 'discussions', id: 1002, path: 'archive/discussions/v1.0.0/chunk-2/discussion-1002.md' },
+            { type: 'discussions', id: 1003, path: 'discussions/chunk-1/discussion-1003.md' }
         ];
 
         fs.writeFileSync(path.join(mockRoot, 'resources/content/discussions/_index.json'), JSON.stringify(indexMap));
@@ -59,14 +80,45 @@ test.describe('Neo.ai.services.knowledge-base.source.DiscussionSource', () => {
     });
 
     test('extract() uses _index.json to resolve ID and reads both active and archive', async () => {
-        const written = [];
+        const written     = [];
         const writeStream = { write(str) { written.push(JSON.parse(str.trim())); return true; } };
 
         const count = await DiscussionSource.extract(writeStream, chunk => 'hash');
 
-        expect(count).toBe(2);
+        // 2 no-comment discussions (one body chunk each) + discussion-1003 (body + 2 comments) = 5.
+        expect(count).toBe(5);
 
         const ids = written.map(w => w.name).sort();
-        expect(ids).toEqual(['discussion-1001', 'discussion-1002']);
+        expect(ids).toEqual([
+            'discussion-1001#body',
+            'discussion-1002#body',
+            'discussion-1003#body',
+            'discussion-1003#comment-1',
+            'discussion-1003#comment-2'
+        ]);
+    });
+
+    test('extract() splits a converged discussion into body + per-comment elements (#14070)', async () => {
+        const written     = [];
+        const writeStream = { write(str) { written.push(JSON.parse(str.trim())); return true; } };
+
+        await DiscussionSource.extract(writeStream, chunk => 'hash');
+
+        const body     = written.find(c => c.name === 'discussion-1003#body');
+        const comment1 = written.find(c => c.name === 'discussion-1003#comment-1');
+        const comment2 = written.find(c => c.name === 'discussion-1003#comment-2');
+
+        expect(body.content).toContain('## Converged Model');
+        expect(body.content).not.toContain('First reply.');
+        expect(comment1.content).toContain('@neo-gpt');
+        expect(comment1.content).toContain('First reply.');
+        expect(comment1.content).not.toContain('Second reply.');
+        expect(comment2.content).toContain('@neo-opus-ada');
+        expect(comment2.content).toContain('Second reply.');
+
+        for (const c of [body, comment1, comment2]) {
+            expect(c.type).toBe('discussion');
+            expect(c.source).toContain('discussion-1003.md');
+        }
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/source/discussionArchiveElementSplitter.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/discussionArchiveElementSplitter.spec.mjs
@@ -1,0 +1,95 @@
+import {test, expect}                   from '@playwright/test';
+import {splitDiscussionArchiveMarkdown} from '../../../../../../../ai/services/knowledge-base/source/discussionArchiveElementSplitter.mjs';
+
+// Pure splitter (no I/O) — direct import, mirrors ticket/PR splitter specs.
+// Discussion format V-B-A'd: converged-model body until the first backtick-author "commented on <ISO>"
+// delimiter (same as PR comments); conservation = split only on the delimiter, nothing dropped.
+
+const BODY = `---
+id: 13594
+title: Sample discussion
+---
+# Sample discussion
+
+## Converged Model
+The agreed shape.
+
+## Decision Record
+- decided X`;
+
+test.describe('splitDiscussionArchiveMarkdown', () => {
+    test('no-comment discussion -> single body element equal to the whole content', () => {
+        const els = splitDiscussionArchiveMarkdown(BODY);
+        expect(els).toHaveLength(1);
+        expect(els[0]).toEqual({kind: 'body', ordinal: 0, content: BODY});
+    });
+
+    test('body + comments -> body + per-comment elements; body keeps its converged-model sections', () => {
+        const content = `${BODY}
+
+## Comments
+
+### \`@neo-gpt\` commented on 2026-06-20T05:13:58Z
+
+First reply.
+
+### \`@neo-opus-ada\` commented on 2026-06-20T05:22:13Z
+
+Second reply.`;
+        const els = splitDiscussionArchiveMarkdown(content);
+        expect(els.map(e => `${e.kind}-${e.ordinal}`)).toEqual(['body-0', 'comment-1', 'comment-2']);
+        expect(els[0].content).toContain('## Converged Model');
+        expect(els[0].content).toContain('## Comments');
+        expect(els[0].content).not.toContain('First reply');
+        expect(els[1].content).toContain('@neo-gpt');
+        expect(els[1].content).toContain('First reply.');
+        expect(els[1].content).not.toContain('Second reply.');
+        expect(els[2].content).toContain('@neo-opus-ada');
+        expect(els[2].content).toContain('Second reply.');
+    });
+
+    test('a comment containing its own ##/### headings stays ONE comment', () => {
+        const content = `${BODY}
+
+## Comments
+
+### \`@neo-gpt\` commented on 2026-06-20T05:13:58Z
+
+## A heading inside the comment
+Detail.
+
+### Another sub-heading
+More.
+
+### \`@neo-opus-vega\` commented on 2026-06-20T06:00:00Z
+
+Next reply.`;
+        const els = splitDiscussionArchiveMarkdown(content);
+        expect(els.map(e => e.kind)).toEqual(['body', 'comment', 'comment']);
+        expect(els[1].content).toContain('## A heading inside the comment');
+        expect(els[1].content).toContain('### Another sub-heading');
+        expect(els[1].content).toContain('More.');
+        expect(els[1].content).not.toContain('Next reply.');
+        expect(els[2].content).toContain('Next reply.');
+    });
+
+    test('section content with no comment delimiter -> single body element conserving everything', () => {
+        const content = `${BODY}
+
+## Unresolved Dissent
+- @x disagrees on Y`;
+        const els = splitDiscussionArchiveMarkdown(content);
+        expect(els).toHaveLength(1);
+        expect(els[0].kind).toBe('body');
+        // Conservation: section content with no backtick-author delimiter is NOT dropped.
+        expect(els[0].content).toContain('## Unresolved Dissent');
+        expect(els[0].content).toContain('@x disagrees on Y');
+        expect(els[0].content).toBe(content.trimEnd());
+    });
+
+    test('throws on non-string content', () => {
+        for (const bad of [undefined, null, 42, {}, []]) {
+            expect(() => splitDiscussionArchiveMarkdown(bad)).toThrow('content must be a string');
+        }
+    });
+});


### PR DESCRIPTION
Resolves #14070

#14033's 3rd + final slice (after tickets #14065, PRs #14069) — **completes the trilogy**. `DiscussionSource.extract()` now emits per-element KB chunks (the converged-model body + each maintainer comment) instead of one whole-file chunk, closing the multi-comment-Discussion over-cap ingestion hazard (the #13999 metadata-without-vector class) for discussions AND making each maintainer's architectural reasoning separately retrievable.

- **Pure splitter** `splitDiscussionArchiveMarkdown(content)` (new `ai/services/knowledge-base/source/discussionArchiveElementSplitter.mjs`) -> `[{kind:'body'|'comment', ordinal, content}]`. Body runs until the FIRST `` ### `@<author>` commented on <ISO> `` delimiter (the SAME delimiter as PR comments); comments split on it. Conservation invariant (per the #14065 RC): split ONLY on the delimiter, body = before the first one, so non-delimiter content (converged-model `## Converged Model`/`## Decision Record`/etc. sections + the `## Comments` heading) is never dropped. V-B-A'd active+archive (sampled `discussion-13594.md`; 155/176 files carry the comment delimiter — 84 active + 71 archive).
- **Wiring**: `extract()` emits `discussion-<id>#body` + `discussion-<id>#comment-<n>` (stable names -> idempotent re-ingestion), preserving `type`/`kind`/`source` + a per-element hash.

Contract: the chunk `name` gains a `#body`/`#comment-n` suffix — same shape as the sibling verticals. V-B-A'd `name` is metadata + the embedding-prefix, NOT a lookup/join key (identical KB consumers), so retrieval granularity improves with no name-keyed breakage.

Evidence: L2 unit — splitter (no-comment / with-comments / internal-headings / no-delimiter conservation / non-string) + `extract()` (per-element emission, names, no-regression for no-comment discussions).

## Test Evidence

- `node --check` both source files -> passed
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/discussionArchiveElementSplitter.spec.mjs` -> **5 passed**
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/source/DiscussionSource.spec.mjs` -> **2 passed** (converged-discussion split + no-regression names)
- Commits: a32214a97 (splitter), adc6169cc (wiring), d4847fbd4 (count-scope correction to active+archive)
- Corpus conservation + under-cap (per @neo-gpt's active+archive scan): `totalElements=1231`, `contentMismatches=0`, `emptyElements=0`. **5 whole-file discussions exceed the safe-byte estimate (max 101770 bytes ≈ 34k tok, over the 32k cap) while ZERO emitted elements do** (max element 50799 bytes ≈ 17k tok) — the per-element split brings the over-cap discussions under, which is the whole point.

## Deltas From Ticket

Count-scope correction (per @neo-gpt's #14071 RC): the original "84/176" was active-only; corrected to the full active+archive scope (155/176 carry the comment delimiter, 84 active + 71 archive) in the source JSDoc + above; #14070's ticket carries the same correction comment. Implementation unaffected. Otherwise: completes #14033's three sources — with #14065 (tickets) + #14069 (PRs), all per-entity KB Sources now chunk at element granularity with the conservation invariant (split only on author delimiters; never drop non-delimiter content).

## Post-Merge Validation

- [ ] After the next KB re-ingestion, a converged discussion appears as N per-element chunks (body + per-comment) in `neo-knowledge-base`; the old whole-file chunk's hash is replaced.

## Contract Ledger

Per #14070 — the `DiscussionSource.extract()` chunk `name` (`discussion-<id>` -> `discussion-<id>#body`/`#comment-n`) + per-element `hash`. Matrix on the ticket; the diff matches it.

Authored by Vega (Claude Opus 4.8, Claude Code). Session ef66cbd0-3770-466c-9df1-f93c141eb1d3.
