### PR TITLE
fix(ai): augment PATH for the lms readiness probe to fix embedding false-negative (#14072)

### DIFF
--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -1,5 +1,7 @@
 import http       from 'http';
 import {execFile} from 'child_process';
+import os         from 'os';
+import path       from 'path';
 import aiConfig   from '../../mcp/server/memory-core/config.mjs';
 import logger     from '../../mcp/server/memory-core/logger.mjs';
 import {
@@ -22,6 +24,35 @@ const
     providerDiscoveryForceInflight = new Map(),
     PROVIDER_DISCOVERY_FORCE       = 'force',
     PROVIDER_DISCOVERY_ROUTINE     = 'routine';
+
+/**
+ * Default LM Studio CLI bin directory. `lms bootstrap` installs the CLI here; an interactive shell
+ * has it on PATH, but a daemon / MCP-server launch env often does not — so a bare `execFile('lms', …)`
+ * ENOENTs and false-negatives the provider as unavailable while it is actually healthy (blocking
+ * KB + Memory Core embedding ops).
+ * @type {String}
+ */
+const LMS_DEFAULT_BIN_DIR = path.join(os.homedir(), '.lmstudio', 'bin');
+
+/**
+ * @summary Builds execFile options for the `lms` CLI with its bin dir guaranteed on PATH.
+ *
+ * Augmenting PATH here makes every `lms` readiness/management probe robust to the launch env,
+ * fixing `spawn lms ENOENT` false-negatives. Idempotent — never duplicates an already-present
+ * bin dir. The caller's extra options (e.g. `{timeout}`) are merged.
+ *
+ * @param {Object} [extra={}] Extra execFile options merged into the result.
+ * @returns {Object} execFile options carrying an augmented `PATH` env.
+ */
+export function lmsExecOptions(extra = {}) {
+    const sep  = process.platform === 'win32' ? ';' : ':',
+          curr = process.env.PATH || '',
+          PATH = curr.split(sep).includes(LMS_DEFAULT_BIN_DIR)
+              ? curr
+              : (curr ? `${curr}${sep}${LMS_DEFAULT_BIN_DIR}` : LMS_DEFAULT_BIN_DIR);
+
+    return {...extra, env: {...process.env, PATH}};
+}
 
 /**
  * @module ai/services/graph/ProviderReadinessHelper
@@ -357,7 +388,7 @@ export function fetchLmsLoadedModels({
         caller: 'fetchLmsLoadedModels',
         runProbe() {
             return new Promise((resolve, reject) => {
-                execFileFn('lms', ['ps', '--json'], {timeout: timeoutMs}, (error, stdout = '', stderr = '') => {
+                execFileFn('lms', ['ps', '--json'], lmsExecOptions({timeout: timeoutMs}), (error, stdout = '', stderr = '') => {
                     if (error) {
                         reject(new Error(`lms ps --json failed: ${error.message}${stderr ? `; stderr=${stderr.trim()}` : ''}`));
                         return;

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -37,21 +37,26 @@ const LMS_DEFAULT_BIN_DIR = path.join(os.homedir(), '.lmstudio', 'bin');
 /**
  * @summary Builds execFile options for the `lms` CLI with its bin dir guaranteed on PATH.
  *
- * Augmenting PATH here makes every `lms` readiness/management probe robust to the launch env,
- * fixing `spawn lms ENOENT` false-negatives. Idempotent — never duplicates an already-present
- * bin dir. The caller's extra options (e.g. `{timeout}`) are merged.
+ * Augmenting PATH here makes the `lms` readiness probe (`fetchLmsLoadedModels`) robust to the launch
+ * env, fixing `spawn lms ENOENT` false-negatives. Idempotent — never duplicates an already-present bin
+ * dir. The caller's extra options are preserved, INCLUDING a caller-supplied `extra.env` (merged, not
+ * clobbered). (The `lms` load/unload spawns carry the same fragility — a noted follow-up — but their
+ * tests assert a 3-arg execFile signature, so they stay out of this slice.)
  *
- * @param {Object} [extra={}] Extra execFile options merged into the result.
- * @returns {Object} execFile options carrying an augmented `PATH` env.
+ * @param {Object} [extra={}] Extra execFile options (e.g. `{timeout}`, `{env}`) merged into the result.
+ * @returns {Object} execFile options carrying an augmented `PATH` env (caller `extra.env` preserved).
  */
 export function lmsExecOptions(extra = {}) {
-    const sep  = process.platform === 'win32' ? ';' : ':',
-          curr = process.env.PATH || '',
-          PATH = curr.split(sep).includes(LMS_DEFAULT_BIN_DIR)
+    // Merge the caller's env (if any) over process.env, then derive + augment PATH from THAT merged env,
+    // so a caller-supplied `extra.env` (and its own PATH) is preserved rather than clobbered.
+    const baseEnv = {...process.env, ...(extra.env || {})},
+          sep     = process.platform === 'win32' ? ';' : ':',
+          curr    = baseEnv.PATH || '',
+          PATH    = curr.split(sep).includes(LMS_DEFAULT_BIN_DIR)
               ? curr
               : (curr ? `${curr}${sep}${LMS_DEFAULT_BIN_DIR}` : LMS_DEFAULT_BIN_DIR);
 
-    return {...extra, env: {...process.env, PATH}};
+    return {...extra, env: {...baseEnv, PATH}};
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -941,11 +941,12 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             }
         });
 
-        expect(calls).toEqual([{
-            cmd    : 'lms',
-            args   : ['ps', '--json'],
-            options: {timeout: 123}
-        }]);
+        expect(calls).toHaveLength(1);
+        expect(calls[0].cmd).toBe('lms');
+        expect(calls[0].args).toEqual(['ps', '--json']);
+        expect(calls[0].options.timeout).toBe(123);
+        // embedding-readiness fix: the LM Studio bin dir is augmented onto PATH so the probe resolves `lms` regardless of launch env
+        expect(calls[0].options.env.PATH).toContain('.lmstudio');
         expect(loadedModels).toEqual([{
             id           : 'chat-model',
             contextLength: 131072,

--- a/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
@@ -57,4 +57,13 @@ test.describe('lmsExecOptions — embedding-readiness PATH fix', () => {
             process.env.PATH = origPath;
         }
     });
+
+    test('preserves a caller-supplied extra.env (merges, does not clobber) + augments its PATH', () => {
+        const opts    = lmsExecOptions({timeout: 99, env: {FOO: 'bar', PATH: '/custom/bin'}});
+        const entries = opts.env.PATH.split(SEP);
+        expect(opts.timeout).toBe(99);   // extra options preserved
+        expect(opts.env.FOO).toBe('bar'); // caller env preserved (not clobbered)
+        expect(entries).toContain('/custom/bin'); // caller PATH preserved
+        expect(entries).toContain(LMS_BIN);       // lms bin dir augmented onto the caller PATH
+    });
 });

--- a/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
@@ -1,0 +1,60 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'ProviderReadinessHelperTest';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: appName, isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import os             from 'os';
+import path           from 'path';
+
+// Pure helper (no I/O) — imported dynamically after the Neo bootstrap (the module's import chain
+// references Neo at load). It guarantees LM Studio's CLI bin dir (~/.lmstudio/bin) is on the
+// execFile PATH, so the readiness probe no longer reports a healthy provider as unavailable when
+// the daemon/MCP-server launch env lacks that dir (the bare-`lms` spawn ENOENT false-negative).
+
+const LMS_BIN = path.join(os.homedir(), '.lmstudio', 'bin');
+const SEP     = process.platform === 'win32' ? ';' : ':';
+
+test.describe('lmsExecOptions — embedding-readiness PATH fix', () => {
+    let lmsExecOptions;
+
+    test.beforeAll(async () => {
+        lmsExecOptions = (await import('../../../../../../ai/services/graph/providerReadinessHelper.mjs')).lmsExecOptions;
+    });
+
+    test('augments PATH with the LM Studio bin dir', () => {
+        const opts = lmsExecOptions();
+        expect(opts.env.PATH.split(SEP)).toContain(LMS_BIN);
+    });
+
+    test('merges extra options (e.g. timeout) alongside the augmented env', () => {
+        const opts = lmsExecOptions({timeout: 5000});
+        expect(opts.timeout).toBe(5000);
+        expect(opts.env.PATH.split(SEP)).toContain(LMS_BIN);
+    });
+
+    test('preserves every pre-existing PATH entry', () => {
+        const opts = lmsExecOptions();
+        for (const entry of (process.env.PATH || '').split(SEP).filter(Boolean)) {
+            expect(opts.env.PATH.split(SEP)).toContain(entry);
+        }
+    });
+
+    test('is idempotent — does not duplicate the bin dir when already on PATH', () => {
+        const origPath = process.env.PATH;
+        try {
+            process.env.PATH  = `${LMS_BIN}${SEP}/usr/bin`;
+            const opts        = lmsExecOptions();
+            const occurrences = opts.env.PATH.split(SEP).filter(p => p === LMS_BIN).length;
+            expect(occurrences).toBe(1);
+        } finally {
+            process.env.PATH = origPath;
+        }
+    });
+});


### PR DESCRIPTION
Resolves #14072

Fixes the embedding-readiness false-negative: `providerReadinessHelper.fetchLmsLoadedModels` shelled to a bare `execFile('lms', ['ps','--json'])`, which ENOENTs when the daemon/MCP-server launch env lacks `~/.lmstudio/bin` on PATH — reporting the embedding provider unavailable (blocking KB + Memory Core embedding ops) while LM Studio is healthy.

- New exported `lmsExecOptions(extra={})` helper: merges the caller's `extra.env` over `process.env`, then idempotently augments that merged env's `PATH` with LM Studio's default CLI bin dir (`~/.lmstudio/bin`), returning `{...extra, env: {...baseEnv, PATH}}` — so a caller-supplied `extra.env` (and its own PATH) is **preserved, never clobbered**. Applied to the `fetchLmsLoadedModels` readiness probe (the false-negative site). It builds a child-process spawn-env (standard `child_process` practice), not app-config — outside ADR-0019's AiConfig domain.
- The sibling `lms` load/unload spawns (`loadLmsModel`/`unloadLmsModel`) carry the same latent PATH fragility but their tests assert a 3-arg `execFile` signature; deferred to a focused follow-up to keep this PR scoped to the readiness false-negative.

V-B-A: `lms ps` runs fine with PATH (model IDLE/loaded, ctx 32768) and `:1234 /v1/models` serves the embedding model — the service is healthy; the bare-`lms` readiness probe was the bug.

Evidence: L2 unit — `lmsExecOptions` (augments PATH / **preserves + merges caller `extra.env` and its own PATH** / idempotent) + the existing #13851 `fetchLmsLoadedModels` test updated to assert the augmented options.

## Test Evidence

- `node --check ai/services/graph/providerReadinessHelper.mjs` -> passed
- `npm run test-unit -- test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs` -> **73 passed**
- Commit: b4ba20a47

## Deltas From Ticket

Scoped to the readiness probe (the #14072 false-negative). The load/unload sibling spawns (same latent fragility) are a noted follow-up (their tests need a 4-arg signature update) — flagged in #14072.

## Post-Merge Validation

- [ ] In an env whose launch PATH lacks `~/.lmstudio/bin`, `ask_knowledge_base` + Memory Core embedding ops succeed (no "spawn lms ENOENT") while LM Studio is up.

## Contract Ledger

New exported `lmsExecOptions(extra={})` (additive; no existing export changed). Shipped behavior:
- `baseEnv = {...process.env, ...(extra.env || {})}` — caller env merged over `process.env`.
- `PATH` derived from `baseEnv.PATH`, with the LM Studio bin dir appended idempotently (no double-append if already present; platform-correct separator).
- returns `{...extra, env: {...baseEnv, PATH}}` — caller-supplied `extra` options and `extra.env` (including its own PATH) are preserved; only PATH is augmented.

Documented in the function JSDoc.

Authored by Vega (Claude Opus 4.8, Claude Code). Session ef66cbd0-3770-466c-9df1-f93c141eb1d3.
