### PR TITLE
feat(ai): data-integrity coverage-drift detect-producer — #14026 first leaf (#14074)

### DIFF
--- a/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs
@@ -1,0 +1,68 @@
+import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis
+ * @summary Pure detect-producer for the data-integrity coverage-drift signal (the first leaf of the
+ * data-integrity detect-signal) — the DETECT half of the v13.1 corruption-recovery gate. Turns a Chroma
+ * vector-coverage audit (`auditChromaVectorCoverage`) into a `recovery-diagnosis` when a Memory Core
+ * collection is "up but data-gutted" (metadata rows present, vectors missing — the corruption-incident
+ * shape), so the immune system can ESCALATE rather than report a gutted store as healthy.
+ *
+ * Detect-only by construction: it consumes a coverage RESULT and emits a diagnosis — it performs no
+ * repair / re-embed / restore / Chroma mutation (those are the recovery actuator + defrag). It emits
+ * `recoveryClass: 'data-integrity'` + `details.actionClass: 'escalate'`, targeting the Memory Core
+ * `compose-service` (per-collection drift carried in `evidenceFacts`/`details` — no per-collection
+ * target kind, for blast-control). Mirrors the supervised-task producer-core pattern: pure, with the
+ * audit result injected so it is testable in isolation.
+ */
+
+/**
+ * @summary Builds a data-integrity `recovery-diagnosis` from a Chroma vector-coverage audit result.
+ *
+ * Pure — no I/O. Returns a diagnosis when ANY collection's coverage `ok === false` (drift); returns
+ * `null` when every collection is clean (never a false escalation). The caller (the diagnostics daemon)
+ * supplies the `auditChromaVectorCoverage()` result + the Memory Core service id.
+ *
+ * @param {Object} options
+ * @param {Object} options.coverageResult The `auditChromaVectorCoverage()` result — `{collections:[{name, ok, ...}]}`.
+ * @param {Number} options.observedAt Epoch milliseconds when the audit was observed.
+ * @param {String} options.serviceId The Memory Core compose-service identifier.
+ * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity` / `escalate`) when drift is present, else `null`.
+ * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
+ */
+export function buildDataIntegrityCoverageDiagnosis({coverageResult, observedAt, serviceId} = {}) {
+    if (typeof serviceId !== 'string' || serviceId.length === 0) {
+        throw new TypeError('buildDataIntegrityCoverageDiagnosis: serviceId is required');
+    }
+    if (!Number.isFinite(observedAt)) {
+        throw new TypeError('buildDataIntegrityCoverageDiagnosis: observedAt must be a finite number');
+    }
+
+    const collections = Array.isArray(coverageResult?.collections) ? coverageResult.collections : [],
+          drifted     = collections.filter(collection => collection?.ok === false);
+
+    // Clean coverage → no diagnosis (never a false escalation).
+    if (drifted.length === 0) {
+        return null;
+    }
+
+    return createRecoveryDiagnosisEvent({
+        diagnosisId   : `data-integrity:coverage-drift:${observedAt}`,
+        recoveryClass : 'data-integrity',
+        confidence    : 1,
+        targetIdentity: {kind: 'compose-service', id: serviceId},
+        evidenceFacts : drifted.map(collection => ({
+            type                  : 'vector-coverage-drift',
+            collection            : collection.name,
+            missingFromVectorCount: collection.missingFromVectorCount,
+            extraInVectorCount    : collection.extraInVectorCount
+        })),
+        observedAt,
+        source : 'data-integrity-coverage-monitor',
+        details: {
+            actionClass       : 'escalate',
+            reasonCode        : 'data-integrity-coverage-drift',
+            driftedCollections: drifted.map(collection => collection.name)
+        }
+    });
+}

--- a/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs
@@ -47,7 +47,7 @@ export function buildDataIntegrityCoverageDiagnosis({coverageResult, observedAt,
     }
 
     return createRecoveryDiagnosisEvent({
-        diagnosisId   : `data-integrity:coverage-drift:${observedAt}`,
+        diagnosisId   : `data-integrity:${serviceId}:coverage-drift:${observedAt}`,
         recoveryClass : 'data-integrity',
         confidence    : 1,
         targetIdentity: {kind: 'compose-service', id: serviceId},

--- a/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
@@ -8,6 +8,7 @@ export const RECOVERY_CLASSES = Object.freeze([
     'config-drift',
     'contention',
     'crash',
+    'data-integrity',
     'exhaustion',
     'external-load',
     'provider-role-residency'

--- a/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.spec.mjs
@@ -17,6 +17,7 @@ test.describe('buildDataIntegrityCoverageDiagnosis — data-integrity coverage-d
             serviceId : 'memory-core'
         });
         expect(diag).toMatchObject({
+            diagnosisId   : 'data-integrity:memory-core:coverage-drift:1000',
             type          : 'recovery-diagnosis',
             recoveryClass : 'data-integrity',
             confidence    : 1,
@@ -27,6 +28,16 @@ test.describe('buildDataIntegrityCoverageDiagnosis — data-integrity coverage-d
         expect(diag.evidenceFacts).toEqual([
             {type: 'vector-coverage-drift', collection: 'neo-agent-memory', missingFromVectorCount: 10, extraInVectorCount: 0}
         ]);
+    });
+
+    test('diagnosisId is target-scoped — two services drifting at the same instant get distinct ids (no graph-node collision)', () => {
+        const args = {coverageResult: {collections: [{name: 'c', ok: false}]}, observedAt: 1000},
+              a    = buildDataIntegrityCoverageDiagnosis({...args, serviceId: 'memory-core'}),
+              b    = buildDataIntegrityCoverageDiagnosis({...args, serviceId: 'knowledge-base'});
+
+        expect(a.diagnosisId).toBe('data-integrity:memory-core:coverage-drift:1000');
+        expect(b.diagnosisId).toBe('data-integrity:knowledge-base:coverage-drift:1000');
+        expect(a.diagnosisId).not.toBe(b.diagnosisId);
     });
 
     test('clean coverage (all ok:true) -> null (no false escalation)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.spec.mjs
@@ -1,0 +1,59 @@
+import {test, expect}                        from '@playwright/test';
+import Neo                                   from '../../../../../../../src/Neo.mjs';
+import * as core                             from '../../../../../../../src/core/_export.mjs';
+import {buildDataIntegrityCoverageDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs';
+
+// Pure detect-producer (no I/O). Turns a Chroma vector-coverage audit into a data-integrity
+// recovery-diagnosis (escalate) when a collection is "up but data-gutted"; returns null when clean.
+
+test.describe('buildDataIntegrityCoverageDiagnosis — data-integrity coverage-drift detect-producer', () => {
+    test('drift (a collection with ok:false) -> a data-integrity/escalate recovery-diagnosis', () => {
+        const diag = buildDataIntegrityCoverageDiagnosis({
+            coverageResult: {collections: [
+                {name: 'neo-agent-memory',   ok: false, missingFromVectorCount: 10, extraInVectorCount: 0},
+                {name: 'neo-knowledge-base', ok: true,  missingFromVectorCount: 0,  extraInVectorCount: 0}
+            ]},
+            observedAt: 1000,
+            serviceId : 'memory-core'
+        });
+        expect(diag).toMatchObject({
+            type          : 'recovery-diagnosis',
+            recoveryClass : 'data-integrity',
+            confidence    : 1,
+            targetIdentity: {kind: 'compose-service', id: 'memory-core'},
+            source        : 'data-integrity-coverage-monitor',
+            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-coverage-drift', driftedCollections: ['neo-agent-memory']}
+        });
+        expect(diag.evidenceFacts).toEqual([
+            {type: 'vector-coverage-drift', collection: 'neo-agent-memory', missingFromVectorCount: 10, extraInVectorCount: 0}
+        ]);
+    });
+
+    test('clean coverage (all ok:true) -> null (no false escalation)', () => {
+        expect(buildDataIntegrityCoverageDiagnosis({
+            coverageResult: {collections: [{name: 'neo-agent-memory', ok: true}]},
+            observedAt    : 1000,
+            serviceId     : 'memory-core'
+        })).toBeNull();
+    });
+
+    test('empty / absent coverage -> null', () => {
+        expect(buildDataIntegrityCoverageDiagnosis({coverageResult: {collections: []}, observedAt: 1, serviceId: 'mc'})).toBeNull();
+        expect(buildDataIntegrityCoverageDiagnosis({coverageResult: {}, observedAt: 1, serviceId: 'mc'})).toBeNull();
+        expect(buildDataIntegrityCoverageDiagnosis({observedAt: 1, serviceId: 'mc'})).toBeNull();
+    });
+
+    test('emits data-integrity, which validates against RECOVERY_CLASSES (else createRecoveryDiagnosisEvent throws)', () => {
+        const diag = buildDataIntegrityCoverageDiagnosis({
+            coverageResult: {collections: [{name: 'c', ok: false}]},
+            observedAt    : 1,
+            serviceId     : 'mc'
+        });
+        expect(diag.recoveryClass).toBe('data-integrity');
+    });
+
+    test('rejects missing serviceId / non-finite observedAt', () => {
+        expect(() => buildDataIntegrityCoverageDiagnosis({coverageResult: {collections: []}, observedAt: 1})).toThrow('serviceId');
+        expect(() => buildDataIntegrityCoverageDiagnosis({coverageResult: {collections: []}, serviceId: 'mc'})).toThrow('observedAt');
+    });
+});


### PR DESCRIPTION
Resolves #14074

The DETECT half of the v13.1 corruption-recovery gate (#14046) — the #14026 first leaf, graduation-approved by @neo-gpt. A pure detect-producer that turns a Chroma vector-coverage audit into a `data-integrity` recovery-diagnosis when a Memory Core collection is "up but data-gutted" (metadata rows present, vectors missing — the #13999 shape), so the immune system ESCALATES instead of reporting a gutted store as healthy.

- New exported `buildDataIntegrityCoverageDiagnosis({coverageResult, observedAt, serviceId})` (`ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs`) -> `recovery-diagnosis | null`. Emits when any collection's coverage `ok===false`; returns `null` when clean (no false escalation). `recoveryClass: 'data-integrity'` · `targetIdentity: {kind:'compose-service', id}` · `details.actionClass:'escalate'`; per-collection drift in `evidenceFacts`/`details`. Detect-only (no repair/mutation). Mirrors the #14056 producer-core pattern (pure, audit-result injected).
- Adds `'data-integrity'` to `RECOVERY_CLASSES` (the enum-extension @neo-gpt + I both flagged) — `createRecoveryDiagnosisEvent` validates against it.
- Per @neo-gpt's graduation correction: uses the existing `compose-service` target kind (NOT a new `chroma-collection` kind), keeping per-collection ids in `evidenceFacts`/`details` — no second enum-extension (blast-control).

Evidence: L2 unit — drift→diagnosis (data-integrity/escalate/compose-service, per-collection evidenceFacts) / clean→null / empty-absent→null / enum-validates / invalid-input throws.

## Test Evidence

- `node --check ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs` -> passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.spec.mjs` -> **6 passed** (incl. the target-scoped-diagnosisId collision test)
- Commit: 80f8364c5

## Deltas From Ticket

None — implements the #14074 first-leaf producer-core as filed. The runtime wiring (diagnostics-daemon scheduling + the `auditChromaVectorCoverage` snapshotPath/persistDir plumbing) is the explicitly out-of-scope thin follow-up; the escalate-sink consumer is #14061.

## Post-Merge Validation

- [ ] The wiring slice calls `auditChromaVectorCoverage()` over the live Memory Core collections, feeds this producer, and routes a non-null diagnosis to the `escalateDiagnosis` sink (#14061) — asserting a gutted-store coverage drift escalates without auto-repair.

## Contract Ledger

- `RECOVERY_CLASSES` gains `'data-integrity'` (consumed by `createRecoveryDiagnosisEvent` validation + the escalate sink + any `recoveryClass` switch) — additive enum value.
- New exported `buildDataIntegrityCoverageDiagnosis()` -> `recovery-diagnosis | null` (additive; no existing export changed).
- Stable `diagnosisId` is **target-scoped**: `data-integrity:${serviceId}:coverage-drift:${observedAt}` — keyed by service (matches the `container-health:${serviceKey}:${recoveryClass}:${observedAt}` pattern), so the `recovery-diagnosis:${diagnosisId}` graph node stays distinct per target. Addresses @neo-gpt's #14075 RC.

## Pre-merge gate

@neo-opus-grace ADR-0025 review (data-health vs container-health extension) — required per @neo-gpt's graduation.

Authored by Vega (Claude Opus 4.8, Claude Code). Session ef66cbd0-3770-466c-9df1-f93c141eb1d3.

