### PR TITLE
fix(ai): bound native ollama embedding timeout (#14052)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -167,6 +167,9 @@ class Config extends ConfigProvider {
                 model                : leaf('gemma4:26b', 'NEO_OLLAMA_MODEL', 'string'),
                 embeddingModel       : leaf('qwen3-embedding', 'NEO_OLLAMA_EMBEDDING_MODEL', 'string'),
                 keep_alive           : leaf(-1, 'NEO_OLLAMA_KEEP_ALIVE', 'keepAlive'),
+                // Upper bound for one native Ollama embedding HTTP request. Keeps explicit
+                // `embeddingProvider: 'ollama'` deployments from stalling the WAL drain.
+                embeddingTimeoutMs   : leaf(300000, 'NEO_OLLAMA_EMBEDDING_TIMEOUT_MS', 'number'),
                 requireParallelModels: leaf(2, 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS', 'number')
             },
             /**

--- a/ai/provider/Ollama.mjs
+++ b/ai/provider/Ollama.mjs
@@ -487,6 +487,9 @@ class OllamaProvider extends Base {
      * @param {String} [options.model] Override the configured `embeddingModel` / `modelName`.
      * @param {Boolean} [options.truncate=false] Whether Ollama may truncate inputs over context.
      * @param {Number} [options.num_ctx] Native Ollama context window for this embedding request.
+     * @param {Number} [options.timeoutMs] Abort the request after this many ms of socket inactivity.
+     * @param {String} [options.operationLabel] Safe diagnostic label surfaced in the timeout error.
+     * @param {AbortSignal} [options.signal] Upstream cancellation signal.
      * @returns {Promise<{embeddings: Number[][], raw: Object, evalSample: Object}>}
      */
     async embed(input, options = {}) {
@@ -494,11 +497,16 @@ class OllamaProvider extends Base {
             dimensions,
             keep_alive,
             model: modelOverride,
+            operationLabel = 'Ollama embedding request',
+            signal,
+            timeoutMs,
             truncate = false,
             ...ollamaOptions
         } = options;
-        const model   = modelOverride || this.embeddingModel || this.modelName;
-        const payload = {
+        const model            = modelOverride || this.embeddingModel || this.modelName;
+        const rawTimeoutMs     = Number(timeoutMs);
+        const requestTimeoutMs = Number.isFinite(rawTimeoutMs) && rawTimeoutMs > 0 ? rawTimeoutMs : 60 * 60 * 1000;
+        const payload          = {
             model,
             input,
             truncate
@@ -527,7 +535,8 @@ class OllamaProvider extends Base {
             const req = httpModule.request(parsedUrl, {
                 method : 'POST',
                 headers: {'Content-Type': 'application/json'},
-                timeout: 60 * 60 * 1000 // 1h timeout matches generate()
+                signal,
+                timeout: requestTimeoutMs
             }, (res) => {
                 let body = '';
                 res.on('data', chunk => body += chunk);
@@ -549,7 +558,13 @@ class OllamaProvider extends Base {
 
             req.on('timeout', () => {
                 req.destroy();
-                rejectFunc(new Error('Ollama embed request timed out after 1 hour'));
+                rejectFunc(createTimeoutError({
+                    provider : 'Ollama',
+                    operationLabel,
+                    timeoutMs: requestTimeoutMs,
+                    host     : this.host,
+                    modelName: model
+                }));
             });
 
             req.write(JSON.stringify(payload));

--- a/ai/provider/createTimeoutError.mjs
+++ b/ai/provider/createTimeoutError.mjs
@@ -1,13 +1,13 @@
 /**
- * @summary Shared interactive-timeout contract for the local chat providers.
+ * @summary Shared provider-timeout contract for local model requests.
  *
- * Both {@link Neo.ai.provider.OpenAiCompatible} and {@link Neo.ai.provider.Ollama}
- * throw the exact error shape produced here, so a caller can detect a provider
- * timeout via a single uniform `error.code` regardless of which provider served the
- * request. Housing the helper plus the documented `generate(options)` contract in one
- * module keeps the two parallel provider implementations from silently drifting apart
- * (their transport differs — `fetch` + `AbortController` vs node `http.request` — but
- * the observable contract here must stay uniform).
+ * Both {@link Neo.ai.provider.OpenAiCompatible} chat requests and native
+ * {@link Neo.ai.provider.Ollama} chat / embedding requests throw the exact error shape
+ * produced here, so a caller can detect a provider timeout via one uniform `error.code`
+ * regardless of which local provider served the request. Housing the helper plus the
+ * documented options contract in one module keeps the parallel provider implementations
+ * from silently drifting apart (their transports differ, but the observable contract here
+ * must stay uniform).
  *
  * @module Neo.ai.provider.createTimeoutError
  */
@@ -21,14 +21,13 @@
 const PROVIDER_TIMEOUT_CODE = 'PROVIDER_TIMEOUT';
 
 /**
- * @summary The shared interactive options contract honored by every local chat
- * provider's `generate(input, options)` / `stream(input, options)`.
+ * @summary The shared provider-request options contract honored by local providers.
  *
- * @typedef {Object} ProviderGenerateOptions
+ * @typedef {Object} ProviderTimeoutOptions
  * @property {Number} [timeoutMs] Abort the provider request after this many milliseconds.
  *     Unset/invalid falls back to the provider's default deadline.
  * @property {AbortSignal} [signal] Upstream cancellation signal. When it aborts, the
- *     in-flight request is destroyed — both providers honor it identically.
+ *     in-flight request is destroyed when the provider transport supports it.
  * @property {String} [operationLabel] Safe diagnostic label surfaced in the timeout
  *     error message; must never carry prompt content or credentials.
  */
@@ -45,7 +44,7 @@ const PROVIDER_TIMEOUT_CODE = 'PROVIDER_TIMEOUT';
  * @param {String} options.operationLabel Safe diagnostic label for the caller operation.
  * @param {Number} options.timeoutMs Timeout budget in milliseconds.
  * @param {String} options.host Provider host.
- * @param {String} options.modelName Chat model id.
+ * @param {String} options.modelName Provider model id.
  * @returns {Error} Error with `code='PROVIDER_TIMEOUT'`, plus `provider` and `timeoutMs` fields.
  */
 function createTimeoutError({provider, operationLabel, timeoutMs, host, modelName}) {

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -6,6 +6,7 @@ import OllamaProvider       from '../../provider/Ollama.mjs';
 import {
     withLmsEmbeddingInputSuffix
 }                           from '../shared/vector/lmsEmbeddingInputSuffix.mjs';
+import {PROVIDER_TIMEOUT_CODE} from '../../provider/createTimeoutError.mjs';
 import {
     bytesToTokens,
     emitConsumerFriction
@@ -237,6 +238,16 @@ class TextEmbeddingService extends Base {
      * @private
      */
     #getOpenAiCompatibleInputEstimate(inputData) {
+        return this.#getEmbeddingInputEstimate(inputData);
+    }
+
+    /**
+     * @summary Estimates the largest text input in an embedding request.
+     * @param {String|String[]} inputData The text or array of texts to embed.
+     * @returns {{inputBytes: Number, inputTokensEstimate: Number}}
+     * @private
+     */
+    #getEmbeddingInputEstimate(inputData) {
         const texts = Array.isArray(inputData) ? inputData : [inputData];
 
         let inputBytes = 0;
@@ -534,6 +545,82 @@ class TextEmbeddingService extends Base {
     }
 
     /**
+     * @summary Reads the native Ollama embedding request timeout from AiConfig.
+     * @returns {Number}
+     * @private
+     */
+    #getOllamaEmbeddingTimeoutMs() {
+        const timeoutMs = aiConfig.ollama.embeddingTimeoutMs;
+
+        if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+            throw new TypeError(`TextEmbeddingService: ollama.embeddingTimeoutMs must be a positive number, got ${timeoutMs}`);
+        }
+
+        return timeoutMs;
+    }
+
+    /**
+     * @summary Emits a structured ConsumerFriction timeout signal for native Ollama embeddings.
+     * @param {String|String[]} inputData Text input that timed out.
+     * @param {Number} requestTimeoutMs Request timeout in milliseconds.
+     * @param {Error} err Timeout error.
+     * @returns {void}
+     * @private
+     */
+    #emitOllamaEmbeddingTimeoutFriction(inputData, requestTimeoutMs, err) {
+        const
+            model    = aiConfig.ollama.embeddingModel || aiConfig.ollama.model,
+            estimate = this.#getEmbeddingInputEstimate(inputData);
+
+        try {
+            emitConsumerFriction({
+                assetRef                 : `ollama:${model}`,
+                consumer                 : 'TextEmbeddingService.ollama',
+                model,
+                symptom                  : 'timeout',
+                emissionPoint            : 'post-invocation-failure',
+                suggestionKind           : 'unknown',
+                inputBytes               : estimate.inputBytes,
+                inputTokensEstimate      : estimate.inputTokensEstimate,
+                contextLimitTokens       : aiConfig.localModels.embedding.contextLimitTokens,
+                safeProcessingLimitTokens: aiConfig.localModels.embedding.safeProcessingLimitTokens,
+                serviceDomain            : 'memory-core',
+                note                     : `Native Ollama embedding request timed out after ${requestTimeoutMs}ms: ${String(err?.message || err).substring(0, 160)}`
+            });
+        } catch (frictionError) {
+            logger.warn('[TextEmbeddingService] Failed to emit native Ollama embedding timeout friction.', frictionError.message);
+        }
+    }
+
+    /**
+     * @summary Runs the native Ollama embedding call with request-shape and timeout parity.
+     * @param {String|String[]} inputData Text input to embed.
+     * @param {String} operationLabel Safe diagnostic label for timeout errors.
+     * @returns {Promise<Object>}
+     * @private
+     */
+    async #embedOllama(inputData, operationLabel) {
+        const
+            provider         = this.#getOllamaProvider(),
+            requestTimeoutMs = this.#getOllamaEmbeddingTimeoutMs();
+
+        try {
+            return await provider.embed(inputData, {
+                num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
+                operationLabel,
+                timeoutMs: requestTimeoutMs,
+                truncate: false
+            });
+        } catch (err) {
+            if (err?.code === PROVIDER_TIMEOUT_CODE) {
+                this.#emitOllamaEmbeddingTimeoutFriction(inputData, requestTimeoutMs, err);
+            }
+
+            throw err;
+        }
+    }
+
+    /**
      * @summary Embeds a text array through OpenAI-compatible chunked batch requests.
      *
      * Local OpenAI-compatible embedding servers often serialize model requests. Sending the whole
@@ -603,11 +690,7 @@ class TextEmbeddingService extends Base {
         } else if (explicitProvider === 'ollama') {
             // Native Ollama returns `{embeddings: [[...]]}` even for single-input;
             // project the single inner array since this method is the per-text variant.
-            const provider = this.#getOllamaProvider();
-            const result   = await provider.embed(text, {
-                num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
-                truncate: false
-            });
+            const result = await this.#embedOllama(text, 'TextEmbeddingService.embedText native Ollama embedding');
             return result.embeddings?.[0];
         } else if (explicitProvider === 'gemini') {
             const geminiKey = process.env.GEMINI_API_KEY;
@@ -645,11 +728,7 @@ class TextEmbeddingService extends Base {
         } else if (explicitProvider === 'ollama') {
             // Ollama's `/api/embed` accepts array-of-strings natively + returns
             // a parallel embeddings array — no per-text fan-out needed.
-            const provider = this.#getOllamaProvider();
-            const result   = await provider.embed(texts, {
-                num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
-                truncate: false
-            });
+            const result = await this.#embedOllama(texts, 'TextEmbeddingService.embedTexts native Ollama embedding');
             return result.embeddings || [];
         } else if (explicitProvider === 'gemini') {
             const geminiKey = process.env.GEMINI_API_KEY;

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -369,6 +369,38 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
         }
     });
 
+    test('Ollama.embed() aborts a hung request at options.timeoutMs with a labeled timeout error (#14052)', async () => {
+        // Mirrors the chat timeout regression but exercises the native `/api/embed` transport.
+        const server = http.createServer((req) => {
+            req.on('data', () => {});
+            req.on('end', () => {/* intentionally never respond */});
+        });
+        await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+        const host = `http://127.0.0.1:${server.address().port}`;
+
+        try {
+            const provider = Neo.create(OllamaProvider, {
+                embeddingModel: 'qwen3-embedding-test',
+                host,
+                modelName: 'gemma4-test'
+            });
+
+            const error = await provider.embed('hello', {
+                timeoutMs     : 25,
+                operationLabel: 'native embedding probe'
+            }).then(() => null, e => e);
+
+            expect(error?.message).toMatch(
+                /\[Ollama\] native embedding probe timed out after 25ms \(host=http:\/\/127\.0\.0\.1:\d+, model=qwen3-embedding-test\)/
+            );
+            expect(error?.code).toBe('PROVIDER_TIMEOUT');
+            expect(error?.provider).toBe('Ollama');
+            expect(error?.timeoutMs).toBe(25);
+        } finally {
+            await new Promise(resolve => server.close(resolve));
+        }
+    });
+
     test('Ollama.generate() honors options.signal and aborts the in-flight request (#12814)', async () => {
         // A hung server (accepts but never responds) — so only an honored abort signal can end
         // the request quickly; the prior signal-stripping behavior would hang past the test.

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -16,6 +16,11 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    clearAggregatedFrictions,
+    getAggregatedFrictions
+}                     from '../../../../../../ai/services/memory-core/helpers/consumerFrictionHelper.mjs';
+import {PROVIDER_TIMEOUT_CODE} from '../../../../../../ai/provider/createTimeoutError.mjs';
 
 /**
  * @summary Coverage for the #10804 TextEmbeddingService Gemini-init gate.
@@ -52,16 +57,20 @@ test.describe('TextEmbeddingService #10804 — shouldInitializeGeminiEmbeddingCl
 test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', () => {
     let TextEmbeddingService;
     let aiConfig;
+    let originalEmbeddingTimeoutMs;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs');
         TextEmbeddingService = mod.default;
         aiConfig             = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        originalEmbeddingTimeoutMs = aiConfig.ollama.embeddingTimeoutMs;
     });
 
     test.afterEach(() => {
         // Restore singleton ollamaProvider slot — fake injection across tests must not leak.
         TextEmbeddingService.ollamaProvider = null;
+        aiConfig.ollama.embeddingTimeoutMs  = originalEmbeddingTimeoutMs;
+        clearAggregatedFrictions();
     });
 
     test('embedText dispatches to native Ollama provider when explicitProvider=ollama', async () => {
@@ -80,8 +89,10 @@ test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', ()
         expect(captured).toEqual([{
             input  : 'hello world',
             options: {
-                num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
-                truncate: false
+                num_ctx       : aiConfig.localModels.embedding.contextLimitTokens,
+                operationLabel: 'TextEmbeddingService.embedText native Ollama embedding',
+                timeoutMs     : aiConfig.ollama.embeddingTimeoutMs,
+                truncate      : false
             }
         }]);
     });
@@ -109,10 +120,52 @@ test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', ()
         expect(captured).toEqual([{
             input  : ['a', 'b', 'c'],
             options: {
-                num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
-                truncate: false
+                num_ctx       : aiConfig.localModels.embedding.contextLimitTokens,
+                operationLabel: 'TextEmbeddingService.embedTexts native Ollama embedding',
+                timeoutMs     : aiConfig.ollama.embeddingTimeoutMs,
+                truncate      : false
             }
         }]);
+    });
+
+    test('native Ollama timeout errors emit provider-scoped ConsumerFriction (#14052)', async () => {
+        aiConfig.ollama.embeddingTimeoutMs = 25;
+        TextEmbeddingService.ollamaProvider = {
+            async embed() {
+                const err = new Error('[Ollama] native embed timed out after 25ms');
+                err.code = PROVIDER_TIMEOUT_CODE;
+                err.provider = 'Ollama';
+                throw err;
+            }
+        };
+
+        for (let i = 0; i < 3; i++) {
+            await expect(TextEmbeddingService.embedTexts([`stuck ${i}`], 'ollama'))
+                .rejects.toThrow(/native embed timed out after 25ms/);
+        }
+
+        expect(getAggregatedFrictions()).toEqual([
+            expect.objectContaining({
+                assetRef      : `ollama:${aiConfig.ollama.embeddingModel || aiConfig.ollama.model}`,
+                consumer      : 'TextEmbeddingService.ollama',
+                model         : aiConfig.ollama.embeddingModel || aiConfig.ollama.model,
+                symptom       : 'timeout',
+                emissionPoint : 'post-invocation-failure',
+                suggestionKind: 'unknown',
+                serviceDomain : 'memory-core',
+                count         : 3
+            })
+        ]);
+    });
+
+    test('native Ollama embedding timeout config fails loud when invalid (#14052)', async () => {
+        aiConfig.ollama.embeddingTimeoutMs = 0;
+        TextEmbeddingService.ollamaProvider = {
+            async embed() { return {embeddings: [[0.1]], raw: {}}; }
+        };
+
+        await expect(TextEmbeddingService.embedText('hello', 'ollama'))
+            .rejects.toThrow(/ollama\.embeddingTimeoutMs must be a positive number/);
     });
 
     test('embedText with explicitProvider=ollama returns empty when provider returns no embeddings', async () => {


### PR DESCRIPTION
Resolves #14052

Related: #14036
Related: #14047

Native Ollama embedding requests now use the same bounded-provider contract as the local chat paths: `Ollama.embed()` accepts `timeoutMs`, emits the shared `PROVIDER_TIMEOUT` error shape, and `TextEmbeddingService` resolves the native embedding timeout from `aiConfig.ollama.embeddingTimeoutMs` at the use site. Timed-out native Ollama embeddings also emit provider-scoped `ConsumerFriction` so the failure is visible instead of a quiet long wait in WAL drain / ingestion paths.

Evidence: L2 (provider-level hung HTTP fixture + TextEmbeddingService timeout/friction unit coverage) -> L2 required (bounded native embedding call + diagnostic contract). No residuals.

## Deltas from ticket

Current-source intake corrected one stale premise before implementation: native `Ollama.embed()` was not literally infinite; it had a hardcoded 1-hour socket timeout and threw a plain `Error`. This PR preserves the ticket intent by replacing that unconfigurable timeout with an AiConfig leaf, uniform provider timeout shape, and `ConsumerFriction` visibility.

The new env var is a clean leaf: `NEO_OLLAMA_EMBEDDING_TIMEOUT_MS`. No legacy alias, deprecation chain, or fallback was added.

## Contract Ledger

| Target Surface | Source of Authority | Shipped Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `aiConfig.ollama.embeddingTimeoutMs` | ADR 0019 AiConfig Provider SSOT | Native Ollama embedding timeout is read from AiConfig at the `TextEmbeddingService` use site | Invalid or non-positive values fail loud | Config template JSDoc | TextEmbeddingService invalid-config unit |
| `Ollama.embed(input, options)` | Existing provider timeout contract | Honors `options.timeoutMs`, `operationLabel`, and `signal`, and throws `PROVIDER_TIMEOUT` on socket timeout | Unset/invalid direct-provider timeout preserves prior 1h default | Provider JSDoc + shared timeout helper JSDoc | Hung HTTP provider unit |
| `TextEmbeddingService.embedText/embedTexts(..., 'ollama')` | Native Ollama dispatch contract + #14036 duration-bound requirement | Passes `num_ctx`, `truncate:false`, `operationLabel`, and resolved `timeoutMs` to the native provider | Provider errors propagate fail-loud | Method/helper JSDoc | Dispatch + timeout/failure units |
| Timeout visibility | Existing ConsumerFriction aggregation contract | Native Ollama provider timeout emits `consumer=TextEmbeddingService.ollama`, `assetRef=ollama:<embeddingModel>`, `symptom=timeout` | Logger warning only if friction emission itself fails | ConsumerFriction contract | Aggregated-friction unit |

## Test Evidence

- `node --check ai/provider/Ollama.mjs`
- `node --check ai/provider/createTimeoutError.mjs`
- `node --check ai/services/memory-core/TextEmbeddingService.mjs`
- `node --check test/playwright/unit/ai/provider/KeepAlive.spec.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs` -> 35 passed, 1 skipped

## Post-Merge Validation

- [ ] Operators with customized local overlays can run `node ai/scripts/setup/initServerConfigs.mjs --migrate-config` to pick up `NEO_OLLAMA_EMBEDDING_TIMEOUT_MS`.

## Commit

- `55fe21029b` — `fix(ai): bound native ollama embedding timeout (#14052)`

Authored by Euclid (GPT-5, Codex Desktop). Session 35f83031-f1a6-41a7-9c3b-089b87307db9.