### PR TITLE
feat(ai): atomic vector-write invariant gate-core (#14078)

### DIFF
--- a/ai/services/memory-core/helpers/vectorWriteInvariant.mjs
+++ b/ai/services/memory-core/helpers/vectorWriteInvariant.mjs
@@ -1,0 +1,108 @@
+/**
+ * @summary Atomic vector-write invariant: the pure gate-core that makes the "metadata/document persisted,
+ * vector absent" corruption shape unrepresentable at the Memory Core write boundary.
+ *
+ * A prior corruption incident left ~10k Memory Core rows whose metadata persisted but whose vector did not
+ * (`Error finding id` on `get(include:['embeddings'])`). The per-cause embedding mitigations each close one
+ * way an embedding can fail; this is the structural complement — a pre-persist check that partitions rows
+ * into those carrying a valid, same-dimension vector (safe to persist) and those that must be rejected
+ * (fail-loud), so a row is never half-written as metadata-only. Mirrors the Knowledge Base's
+ * `filterEmbeddingInputBudget` skip-gate, which the Memory Core vector-write path lacks.
+ *
+ * Pure + I/O-free by design: the caller persists `valid` and routes `rejected` to a fail-loud
+ * retry/unrecoverable path. The check is a cheap presence/length/dimension/finiteness test — never a
+ * re-embed — so the legitimate append path is not slowed.
+ * @module ai/services/memory-core/helpers/vectorWriteInvariant
+ */
+
+/**
+ * @summary The reasons a row's vector fails the atomic-write invariant, stable for fail-loud reporting.
+ */
+export const VECTOR_REJECTION_REASONS = Object.freeze({
+    missingEmbedding: 'missing-embedding',
+    emptyEmbedding  : 'empty-embedding',
+    wrongDimension  : 'wrong-dimension',
+    nonFiniteValues : 'non-finite-values'
+});
+
+/**
+ * @summary Classifies one row's embedding against the same-dimension validity invariant.
+ *
+ * Order matters: a missing embedding is reported before emptiness, emptiness before a dimension
+ * mismatch, and a dimension mismatch before non-finite values — so the reason names the first
+ * (most fundamental) failure rather than a downstream symptom.
+ *
+ * @param {Object} row A write-path row carrying at least `id` and `embedding`.
+ * @param {Number} expectedDimension The required vector dimension (e.g. `cfg.vectorDimension`).
+ * @returns {String|null} A reason from {@link VECTOR_REJECTION_REASONS}, or `null` when the vector is valid.
+ */
+export function classifyRowVector(row, expectedDimension) {
+    const embedding = row?.embedding;
+
+    if (!Array.isArray(embedding)) {
+        return VECTOR_REJECTION_REASONS.missingEmbedding;
+    }
+    if (embedding.length === 0) {
+        return VECTOR_REJECTION_REASONS.emptyEmbedding;
+    }
+    if (embedding.length !== expectedDimension) {
+        return VECTOR_REJECTION_REASONS.wrongDimension;
+    }
+    if (!embedding.every(value => Number.isFinite(value))) {
+        return VECTOR_REJECTION_REASONS.nonFiniteValues;
+    }
+
+    return null;
+}
+
+/**
+ * @summary Partitions write-path rows into persist-safe `valid` rows and `rejected` rows (with reasons),
+ * enforcing the atomic vector-write invariant: never persist a row without a valid same-dimension vector.
+ *
+ * @param {Object} options
+ * @param {Object[]} options.rows Rows to be persisted, each carrying at least `id` and `embedding`.
+ * @param {Number} options.expectedDimension Required vector dimension (a positive integer).
+ * @returns {Object} `{valid, rejected}` — `valid` is the persist-safe rows (input order preserved, safe to
+ *     `collection.add`/`upsert`); `rejected` is an array of `{id, reason}` to route fail-loud.
+ * @throws {TypeError} When `rows` is not an array or `expectedDimension` is not a positive integer.
+ */
+export function partitionRowsByVectorValidity({rows, expectedDimension} = {}) {
+    if (!Array.isArray(rows)) {
+        throw new TypeError('partitionRowsByVectorValidity: rows must be an array');
+    }
+    if (!Number.isInteger(expectedDimension) || expectedDimension <= 0) {
+        throw new TypeError('partitionRowsByVectorValidity: expectedDimension must be a positive integer');
+    }
+
+    const valid    = [],
+          rejected = [];
+
+    for (const row of rows) {
+        const reason = classifyRowVector(row, expectedDimension);
+
+        if (reason === null) {
+            valid.push(row);
+        } else {
+            rejected.push({id: row?.id ?? null, reason});
+        }
+    }
+
+    return {valid, rejected};
+}
+
+/**
+ * @summary Summarizes rejected rows for fail-loud logging: a total count plus a per-reason breakdown.
+ *
+ * @param {Object[]} [rejected=[]] The `rejected` array (`{id, reason}` entries) from {@link partitionRowsByVectorValidity}.
+ * @returns {Object} `{count, byReason}` — `count` is the total rejected; `byReason` maps each observed reason
+ *     to its occurrence count (omitting reasons that did not occur).
+ */
+export function summarizeVectorRejections(rejected = []) {
+    const byReason = {};
+
+    for (const {reason} of rejected) {
+        byReason[reason] = (byReason[reason] || 0) + 1;
+    }
+
+    return {count: rejected.length, byReason};
+}

--- a/test/playwright/unit/ai/services/memory-core/helpers/vectorWriteInvariant.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/vectorWriteInvariant.spec.mjs
@@ -1,0 +1,150 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    classifyRowVector,
+    partitionRowsByVectorValidity,
+    summarizeVectorRejections,
+    VECTOR_REJECTION_REASONS
+} from '../../../../../../../ai/services/memory-core/helpers/vectorWriteInvariant.mjs';
+
+// Atomic vector-write invariant: the pure gate-core that makes the metadata-without-vector corruption
+// shape unrepresentable at the Memory Core write boundary. A row is persisted only when it carries a
+// valid, same-dimension embedding; everything else is partitioned into `rejected` (with a reason) for
+// fail-loud routing — never half-written.
+
+const DIM      = 4,
+      validVec = (d = DIM) => Array.from({length: d}, (_, i) => (i + 1) * 0.125);
+
+test.describe('vectorWriteInvariant — atomic vector-write invariant (#14029 gate-core)', () => {
+    test('valid same-dimension rows all pass, preserving order (no regression to legitimate appends)', () => {
+        const rows = [
+            {id: 'a', embedding: validVec(), metadata: {}, document: 'doc-a'},
+            {id: 'b', embedding: validVec(), metadata: {}, document: 'doc-b'}
+        ];
+
+        const {valid, rejected} = partitionRowsByVectorValidity({rows, expectedDimension: DIM});
+
+        expect(rejected).toEqual([]);
+        expect(valid).toHaveLength(2);
+        expect(valid.map(r => r.id)).toEqual(['a', 'b']);
+        expect(valid[0].document).toBe('doc-a');
+    });
+
+    test('a missing / null / non-array embedding is rejected (never persisted metadata-only)', () => {
+        const rows = [
+            {id: 'missing', metadata: {}},
+            {id: 'null',    embedding: null},
+            {id: 'notArr',  embedding: 'nope'}
+        ];
+
+        const {valid, rejected} = partitionRowsByVectorValidity({rows, expectedDimension: DIM});
+
+        expect(valid).toEqual([]);
+        expect(rejected).toEqual([
+            {id: 'missing', reason: 'missing-embedding'},
+            {id: 'null',    reason: 'missing-embedding'},
+            {id: 'notArr',  reason: 'missing-embedding'}
+        ]);
+    });
+
+    test('an empty embedding is rejected', () => {
+        const {valid, rejected} = partitionRowsByVectorValidity({
+            rows             : [{id: 'e', embedding: []}],
+            expectedDimension: DIM
+        });
+
+        expect(valid).toEqual([]);
+        expect(rejected).toEqual([{id: 'e', reason: 'empty-embedding'}]);
+    });
+
+    test('a wrong-dimension embedding is rejected, not stored', () => {
+        const {valid, rejected} = partitionRowsByVectorValidity({
+            rows: [
+                {id: 'short', embedding: validVec(DIM - 1)},
+                {id: 'long',  embedding: validVec(DIM + 1)}
+            ],
+            expectedDimension: DIM
+        });
+
+        expect(valid).toEqual([]);
+        expect(rejected).toEqual([
+            {id: 'short', reason: 'wrong-dimension'},
+            {id: 'long',  reason: 'wrong-dimension'}
+        ]);
+    });
+
+    test('a non-finite (NaN / Infinity) value is rejected', () => {
+        const nan = validVec(); nan[1] = NaN;
+        const inf = validVec(); inf[2] = Infinity;
+
+        const {valid, rejected} = partitionRowsByVectorValidity({
+            rows             : [{id: 'nan', embedding: nan}, {id: 'inf', embedding: inf}],
+            expectedDimension: DIM
+        });
+
+        expect(valid).toEqual([]);
+        expect(rejected).toEqual([
+            {id: 'nan', reason: 'non-finite-values'},
+            {id: 'inf', reason: 'non-finite-values'}
+        ]);
+    });
+
+    test('a mixed batch partitions valid from rejected, preserving valid order', () => {
+        const rows = [
+            {id: 'ok1',      embedding: validVec()},
+            {id: 'bad',      embedding: []},
+            {id: 'ok2',      embedding: validVec()},
+            {id: 'wrongdim', embedding: validVec(DIM + 2)}
+        ];
+
+        const {valid, rejected} = partitionRowsByVectorValidity({rows, expectedDimension: DIM});
+
+        expect(valid.map(r => r.id)).toEqual(['ok1', 'ok2']);
+        expect(rejected).toEqual([
+            {id: 'bad',      reason: 'empty-embedding'},
+            {id: 'wrongdim', reason: 'wrong-dimension'}
+        ]);
+    });
+
+    test('classifyRowVector reports the first / most-fundamental failure', () => {
+        expect(classifyRowVector({id: 'x'},             DIM)).toBe(VECTOR_REJECTION_REASONS.missingEmbedding);
+        expect(classifyRowVector({embedding: []},       DIM)).toBe(VECTOR_REJECTION_REASONS.emptyEmbedding);
+        expect(classifyRowVector({embedding: [1, 2]},   DIM)).toBe(VECTOR_REJECTION_REASONS.wrongDimension);
+        expect(classifyRowVector({embedding: validVec()}, DIM)).toBeNull();
+    });
+
+    test('enforces the real 4096 production dimension', () => {
+        const {valid, rejected} = partitionRowsByVectorValidity({
+            rows: [
+                {id: 'real',    embedding: validVec(4096)},
+                {id: 'realbad', embedding: validVec(4095)}
+            ],
+            expectedDimension: 4096
+        });
+
+        expect(valid.map(r => r.id)).toEqual(['real']);
+        expect(rejected).toEqual([{id: 'realbad', reason: 'wrong-dimension'}]);
+    });
+
+    test('summarizeVectorRejections gives a fail-loud count + per-reason breakdown', () => {
+        const rejected = [
+            {id: 'a', reason: 'missing-embedding'},
+            {id: 'b', reason: 'missing-embedding'},
+            {id: 'c', reason: 'wrong-dimension'}
+        ];
+
+        expect(summarizeVectorRejections(rejected)).toEqual({
+            count   : 3,
+            byReason: {'missing-embedding': 2, 'wrong-dimension': 1}
+        });
+        expect(summarizeVectorRejections()).toEqual({count: 0, byReason: {}});
+    });
+
+    test('rejects invalid inputs (guards the invariant itself)', () => {
+        expect(() => partitionRowsByVectorValidity({rows: 'nope', expectedDimension: DIM})).toThrow(/rows must be an array/);
+        expect(() => partitionRowsByVectorValidity({rows: [], expectedDimension: 0})).toThrow(/positive integer/);
+        expect(() => partitionRowsByVectorValidity({rows: [], expectedDimension: 1.5})).toThrow(/positive integer/);
+        expect(() => partitionRowsByVectorValidity({rows: [], expectedDimension: -4096})).toThrow(/positive integer/);
+    });
+});


### PR DESCRIPTION
Resolves #14078

Part of the #14029 parent invariant — #14078 is its first leaf: the pure, reusable **gate-core** for the explicit-embedding write paths. The explicit-path write-wiring and the auto-embed-failure verification are #14029's other subs (the latter coupled to #14027), per the two-mechanism finding below.

Lands the pure gate-core that makes the "metadata/document persisted, vector absent" corruption shape unrepresentable at the Memory Core write boundary — plus a V-B-A finding that scoped #14029 into its subs.

## What this PR delivers (#14078 scope, fully)

`ai/services/memory-core/helpers/vectorWriteInvariant.mjs` — pure, I/O-free:
- `partitionRowsByVectorValidity({rows, expectedDimension})` → `{valid, rejected}`: partitions write-path rows into persist-safe rows (valid same-dimension vector) and `rejected` (`{id, reason}`), so a row missing a valid vector is diverted fail-loud, never half-written. Strictly additive safety — valid rows pass through **unchanged** (order preserved).
- `classifyRowVector(row, expectedDimension)` → first/most-fundamental reason or `null`.
- `summarizeVectorRejections(rejected)` → `{count, byReason}` for fail-loud logging.
- `VECTOR_REJECTION_REASONS`: `missing-embedding | empty-embedding | wrong-dimension | non-finite-values`.

Mirrors the Knowledge Base's `filterEmbeddingInputBudget` skip-gate, which the Memory Core vector-write path lacks. Ships the tested core ahead of its consumer, mirroring #14056's producer-core → #14061-consumer pattern.

## V-B-A finding — #14029 is **two mechanisms** (scoped its subs)

Reading the actual write paths surfaced that "never persist a row without a valid vector" splits by *who supplies the vector*:

1. **Explicit-embedding paths** (`DatabaseService` non-reEmbed: `collection.add/upsert({embeddings: chunk.map(r => r.embedding)})`). The caller passes the vector → **this gate-core fits**. (#14078 = the core; the `!reEmbed`-conditional wiring is the next #14029 sub.)
2. **Auto-embed paths** — `DatabaseService` reEmbed mode `delete r.embedding` (DatabaseService.mjs:548-551) → Chroma regenerates via the `ChromaManager` embedding function (241/260/279); `SessionService` artifact-upserts pass no embeddings. NOT inherently vectorless; the invariant here is a **different mechanism** — verify the server-side embedding landed (read-back / fail-loud-on-embed-failure) — coupled to #14027. A caller-side gate structurally can't cover it.

Evidence: L2 unit — the gate-core's validity + fail-loud-partition contract is fully covered by 10 unit tests (sandbox-reachable; no runtime AC at this gate-core leaf — the explicit-path write-wiring sub carries the L3 runtime evidence).

## Test Evidence

- `node --check ai/services/memory-core/helpers/vectorWriteInvariant.mjs` → passed
- `npx playwright test .../vectorWriteInvariant.spec.mjs` → **10 passed** (valid-passthrough / missing / empty / wrong-dim / non-finite / mixed-partition / classify-ordering / real-4096-dim / summarize / input-guards)
- Commit: 1c8532dff

## Deltas From Ticket

None for #14078 — its ACs are exactly the pure gate-core surface (helper exports + partition/fail-loud contract + unit coverage), fully delivered here. The explicit-path write-wiring and the auto-embed verification are the OTHER #14029 subs, deliberately out of #14078's scope (no unused-but-wired live-path change shipped under the core's ticket).

## Post-Merge Validation

- [ ] The explicit-path wiring sub imports this gate-core and, conditional on `!reEmbed`, persists only the valid rows + fail-louds the rejected count+reason at the `DatabaseService` import sites.

## Contract Ledger

New module `ai/services/memory-core/helpers/vectorWriteInvariant.mjs` — all additive, no existing export changed:
- `partitionRowsByVectorValidity({rows, expectedDimension})` → `{valid, rejected}` (throws `TypeError` on non-array rows / non-positive-integer dimension).
- `classifyRowVector(row, expectedDimension)` → `String|null`.
- `summarizeVectorRejections(rejected)` → `{count, byReason}`.
- `VECTOR_REJECTION_REASONS` (frozen enum).

Authored by Vega (Claude Opus 4.8, Claude Code). Session ef66cbd0-3770-466c-9df1-f93c141eb1d3.
