### PR TITLE
test(ai): v13.1 release-gate corruption-recovery composition proof (#14046)

### DIFF
--- a/test/playwright/unit/ai/scripts/maintenance/CorruptionRecoveryGate.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/CorruptionRecoveryGate.spec.mjs
@@ -1,0 +1,291 @@
+import {execFile}     from 'child_process';
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+import {promisify}    from 'util';
+import {test, expect} from '@playwright/test';
+
+import Neo                                   from '../../../../../../src/Neo.mjs';
+import * as core                             from '../../../../../../src/core/_export.mjs';
+import {auditChromaVectorCoverage}           from '../../../../../../ai/scripts/maintenance/checkChromaIntegrity.mjs';
+import {buildDataIntegrityCoverageDiagnosis} from '../../../../../../ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs';
+import {RecoveryActuatorService}             from '../../../../../../ai/daemons/orchestrator/services/RecoveryActuatorService.mjs';
+import {TIER1_DEFAULTS}                      from '../../../../fixtures/aiConfigDefaults.mjs';
+
+const execFileAsync = promisify(execFile);
+
+/*
+ * v13.1 release gate — the keystone integration proof for the Agent OS data-integrity immune system.
+ *
+ * The component layers each ship on their own (the coverage-drift detect-producer, the escalate
+ * sink, the recovery actuator, the atomic-write invariant, the test write-guard, …). None of them
+ * proves the layers COMPOSE into the demonstrable release bar. This spec is that proof — the
+ * v13.1 definition-of-done:
+ *
+ *   a corruption injected in test  →  auto-DETECTED  →  DIAGNOSED  →  RECOVERED-or-ESCALATED
+ *   end-to-end — never discovered weeks later by a failed backup (the corruption-incident failure mode).
+ *
+ * It drives the REAL pipeline against a REAL injected corruption (an isolated Chroma SQLite via
+ * fs.mkdtemp — never touches live data), rather than hand-built fixtures, so it falsifies the
+ * "all subs green, nothing proven" trap:
+ *
+ *   inject (metadata-without-vector — the corruption-incident shape)
+ *     → auditChromaVectorCoverage            (DETECT: the immune system SEES a store that is "up
+ *                                             but data-gutted" — the container-health blind spot that
+ *                                             let the incident hide for ~weeks while the container kept
+ *                                             reporting green)
+ *     → buildDataIntegrityCoverageDiagnosis  (DIAGNOSE: a data-integrity / escalate recovery-diagnosis)
+ *     → RecoveryActuatorService.escalateDiagnosis
+ *                                            (ESCALATE: page the operator — the SAFE recovery action
+ *                                             for data-integrity. The immune system does NOT auto-repair
+ *                                             data; data mutation stays operator-gated — the detect/act
+ *                                             two-worlds boundary. "Never silent-green.")
+ *
+ * When this gate is green, the release gate's end-to-end integration clause is met.
+ *
+ * @see https://github.com/neomjs/neo/issues/14046
+ * @see https://github.com/neomjs/neo/issues/14039
+ */
+
+const OBSERVED_AT  = 1_750_000_000_000,
+      METADATA_IDS = ['mem-1', 'mem-2', 'mem-3'];
+
+/**
+ * @summary Writes a minimal Chroma HNSW `index_metadata.pickle` (id → label map) so an audit reads
+ * the segment as having persisted vectors. Mirrors the proven injection in `CheckChromaIntegrity.spec.mjs`.
+ */
+async function writeVectorIndexPickle(pickleDir, ids) {
+    await fs.ensureDir(pickleDir);
+
+    const pickleScript = [
+        'import json, pickle, sys',
+        'ids = json.loads(sys.argv[2])',
+        'data = {"id_to_label": {id_: index for index, id_ in enumerate(ids)}}',
+        'with open(sys.argv[1], "wb") as handle:',
+        '    pickle.dump(data, handle)'
+    ].join('\n');
+
+    await execFileAsync('python3', ['-c', pickleScript, path.join(pickleDir, 'index_metadata.pickle'), JSON.stringify(ids)]);
+}
+
+/**
+ * @summary Builds an isolated Memory Core Chroma snapshot for `auditChromaVectorCoverage`.
+ *
+ * A single `neo-agent-memory` collection with METADATA rows for every id in {@link METADATA_IDS}
+ * and a VECTOR segment. When `writeVectorPickle` is false the segment's HNSW pickle is OMITTED —
+ * the corruption-incident "metadata persisted, vectors absent" shape. When true the pickle covers
+ * exactly the metadata ids — a clean store.
+ *
+ * @returns {String} The chroma.sqlite3 snapshot path.
+ */
+async function injectMemoryCoreSnapshot(tmpDir, {writeVectorPickle}) {
+    const sqlitePath = path.join(tmpDir, 'chroma.sqlite3');
+
+    await execFileAsync('sqlite3', [sqlitePath, `
+        create table collections (
+            id text primary key,
+            name text not null,
+            dimension integer,
+            database_id text not null
+        );
+        create table segments (
+            id text primary key,
+            type text not null,
+            scope text not null,
+            collection text not null
+        );
+        create table embeddings (
+            id integer primary key,
+            segment_id text not null,
+            embedding_id text not null,
+            seq_id blob not null,
+            created_at timestamp not null default current_timestamp,
+            unique(segment_id, embedding_id)
+        );
+        insert into collections (id, name, dimension, database_id) values
+            ('collection-a', 'neo-agent-memory', 4096, 'db-a');
+        insert into segments (id, type, scope, collection) values
+            ('meta-a', 'urn:chroma:segment/metadata/sqlite', 'METADATA', 'collection-a'),
+            ('vec-a',  'urn:chroma:segment/vector/hnsw-local-persisted', 'VECTOR', 'collection-a');
+        insert into embeddings (segment_id, embedding_id, seq_id) values
+            ('meta-a', 'mem-1', x'01'),
+            ('meta-a', 'mem-2', x'02'),
+            ('meta-a', 'mem-3', x'03');
+    `]);
+
+    // The vector pickle lives at ${persistDir}/${vectorSegmentId}/index_metadata.pickle.
+    // Omitting it = the vectors are gone while the metadata/doc rows remain (the gutted-store shape).
+    if (writeVectorPickle) {
+        await writeVectorIndexPickle(path.join(tmpDir, 'vec-a'), METADATA_IDS);
+    }
+
+    return sqlitePath;
+}
+
+/**
+ * @summary Constructs a RecoveryActuatorService with capturing mocks (mirrors the createService
+ * harness in `RecoveryActuatorService.spec.mjs`). The page dispatcher, runtime-access, and
+ * supervisor calls are captured so the gate can assert that escalation pages but mutates nothing.
+ */
+function createRecoveryActuator(tmpDir) {
+    const pageCalls       = [],
+          runtimeCalls    = [],
+          supervisorCalls = [],
+          taskOutcomes    = [],
+          service         = Neo.create(RecoveryActuatorService, {
+              actuatorConfig: {
+                  ...TIER1_DEFAULTS.orchestrator.recoveryActuator,
+                  healAttemptsPath   : path.join(tmpDir, 'heal-attempts.json'),
+                  recoveryRunStateDir: path.join(tmpDir, 'recovery-runs'),
+                  baseBackoffMs      : 0,
+                  maxBackoffMs       : 0
+              },
+              dataDir      : tmpDir,
+              healthService: {
+                  recordTaskOutcome(taskName, status, details) {
+                      taskOutcomes.push({taskName, status, details});
+                  }
+              },
+              deploymentRuntimeAccessService: {
+                  runtimeAccessConfig: {allowedServices: ['chroma', 'kb-server', 'mc-server', 'local-model']},
+                  async applyLifecycle(options) {
+                      runtimeCalls.push(options);
+                      return {ok: true, statusCode: 204};
+                  }
+              },
+              processSupervisorService: {
+                  taskDefinitions: {},
+                  killTask(taskName, reason) {
+                      supervisorCalls.push({taskName, reason});
+                  }
+              },
+              pageDispatcher(page) {
+                  pageCalls.push(page);
+              },
+              async providerResidencyRepair() {
+                  return {ready: true};
+              },
+              writeLog: () => {}
+          });
+
+    return {service, pageCalls, runtimeCalls, supervisorCalls, taskOutcomes};
+}
+
+test.describe('v13.1 release gate — corruption injection → detect → diagnose → escalate', () => {
+    test('injected vector-loss corruption is DETECTED, DIAGNOSED (data-integrity), and ESCALATED — never silently auto-repaired', async () => {
+        const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-corruption-gate-'));
+
+        try {
+            // 1. INJECT — the "up but data-gutted" shape: metadata rows present, vectors absent.
+            const snapshotPath = await injectMemoryCoreSnapshot(tmpDir, {writeVectorPickle: false});
+
+            // 2. DETECT — the audit SEES the gutted store (the container-health blind spot, closed).
+            const coverageResult = await auditChromaVectorCoverage({
+                snapshotPath,
+                persistDir     : tmpDir,
+                collectionNames: ['neo-agent-memory'],
+                sampleSize     : 2,
+                includeFullIds : true
+            });
+
+            const drifted = coverageResult.collections.find(collection => collection.name === 'neo-agent-memory');
+
+            expect(drifted.ok).toBe(false);
+            expect(drifted.missingFromVectorCount).toBeGreaterThan(0);
+            expect(coverageResult.failedCollections).toBeGreaterThanOrEqual(1);
+
+            // 3. DIAGNOSE — the detect-producer turns the audit into a data-integrity / escalate diagnosis.
+            const diagnosis = buildDataIntegrityCoverageDiagnosis({
+                coverageResult,
+                observedAt: OBSERVED_AT,
+                serviceId : 'memory-core'
+            });
+
+            expect(diagnosis).toMatchObject({
+                diagnosisId   : `data-integrity:memory-core:coverage-drift:${OBSERVED_AT}`,
+                type          : 'recovery-diagnosis',
+                recoveryClass : 'data-integrity',
+                targetIdentity: {kind: 'compose-service', id: 'memory-core'},
+                details       : {actionClass: 'escalate', reasonCode: 'data-integrity-coverage-drift'}
+            });
+            expect(diagnosis.details.driftedCollections).toContain('neo-agent-memory');
+
+            // 4. ESCALATE — the SAFE recovery action for data-integrity: page the operator, mutate NOTHING.
+            const {service, pageCalls, runtimeCalls, supervisorCalls, taskOutcomes} = createRecoveryActuator(tmpDir);
+
+            let executedPrivilegedAction = false;
+
+            service.executeTargetAction = async () => {
+                executedPrivilegedAction = true;
+                throw new Error('the data-integrity gate must ESCALATE, never execute a privileged recovery action');
+            };
+
+            const outcome = await service.escalateDiagnosis(diagnosis, {
+                now   : OBSERVED_AT,
+                reason: 'v13.1-corruption-recovery-gate'
+            });
+
+            expect(outcome).toMatchObject({
+                status        : 'escalated',
+                reasonCode    : 'data-integrity-coverage-drift',
+                targetIdentity: {kind: 'compose-service', id: 'memory-core'}
+            });
+
+            // The immune system escalated — it did NOT mutate data (the detect/act two-worlds boundary held).
+            expect(executedPrivilegedAction).toBe(false);
+            expect(runtimeCalls).toEqual([]);
+            expect(supervisorCalls).toEqual([]);
+
+            // A single operator page carrying the data-integrity diagnosis.
+            expect(pageCalls).toHaveLength(1);
+            expect(pageCalls[0]).toMatchObject({
+                serviceKey        : 'memory-core',
+                action            : 'escalate',
+                targetIdentity    : {kind: 'compose-service', id: 'memory-core'},
+                operatorPageTarget: 'AGENT:*'
+            });
+            expect(pageCalls[0].diagnosisEvent).toMatchObject({
+                recoveryClass: 'data-integrity',
+                details      : {actionClass: 'escalate'}
+            });
+
+            // The recovery-run ledger recorded the escalation (escalate-with-diagnosis, not silent-green).
+            expect(taskOutcomes.some(outcome => outcome.details?.status === 'escalated')).toBe(true);
+        } finally {
+            await fs.remove(tmpDir);
+        }
+    });
+
+    test('a clean store produces NO diagnosis and NO escalation (no false-positive immune response)', async () => {
+        const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-corruption-gate-clean-'));
+
+        try {
+            const snapshotPath = await injectMemoryCoreSnapshot(tmpDir, {writeVectorPickle: true});
+
+            const coverageResult = await auditChromaVectorCoverage({
+                snapshotPath,
+                persistDir     : tmpDir,
+                collectionNames: ['neo-agent-memory'],
+                sampleSize     : 2,
+                includeFullIds : true
+            });
+
+            const collection = coverageResult.collections.find(collection => collection.name === 'neo-agent-memory');
+
+            expect(collection.ok).toBe(true);
+            expect(collection.missingFromVectorCount).toBe(0);
+            expect(collection.extraInVectorCount).toBe(0);
+
+            // Clean coverage → the producer returns null → there is nothing to escalate.
+            const diagnosis = buildDataIntegrityCoverageDiagnosis({
+                coverageResult,
+                observedAt: OBSERVED_AT,
+                serviceId : 'memory-core'
+            });
+
+            expect(diagnosis).toBeNull();
+        } finally {
+            await fs.remove(tmpDir);
+        }
+    });
+});


### PR DESCRIPTION
Resolves #14046

Related: #14039

Builds the v13.1 release-gate keystone — the end-to-end integration proof that the Agent OS data-integrity immune-system layers COMPOSE. A `metadata-without-vector` corruption injected into an isolated Chroma SQLite (`fs.mkdtemp`, never touching live data) is auto-detected by `auditChromaVectorCoverage`, diagnosed by `buildDataIntegrityCoverageDiagnosis` into a `data-integrity` / `escalate` recovery-diagnosis, and escalated by `RecoveryActuatorService.escalateDiagnosis` (operator page) — never silently auto-repaired, never discovered weeks later by a failed backup. This is the layer that turns "every component sub green" into "the gate is actually exercised."

The spec drives the REAL audit → producer → actuator chain (only the actuator's external collaborators — page dispatcher, runtime-access, supervisor, health — are test doubles; `escalateDiagnosis`'s own logic is real), so it falsifies the "all subs green, nothing proven" failure mode rather than re-asserting each layer in isolation.

Evidence: L2 (isolated Playwright unit spec drives the real detect→diagnose→escalate pipeline against an injected corruption in an `fs.mkdtemp` store) → covers the **vector-loss class** of #14046's integration-proof AC (the gate is explicitly a compose-and-prove harness, not a live-deployment effect). Residual: the **drain-stall + over-cap** classes of #14046's 3-class DoD → carried to v13.2 (#14088).

## Deltas from ticket

- **Scope: 1 of #14046's 3 DoD corruption classes.** The spec injects the **vector-loss** (metadata-without-vector) class — the actual #13999 incident shape. The **drain-stall** + **over-cap** classes are carried to v13.2 (#14088) so #14046's closure records 1-of-3 rather than silently narrowing the 3-class DoD (per Grace's #14080 second-eye review).
- Scoped to the converged shape on #14046: inject → detect → diagnose → **escalate**. Escalate IS the safe recovery action for data-integrity (the immune system does not auto-repair data; mutation stays operator-gated). The other gate clauses the epic lists (backup verified-restorable #14030, #13999 loss recovered, sandman_handoff #14043) are SEPARATE subs, out of this PR's scope per the steward scoping on #14046.
- Added a clean-store **negative control** (no false-positive immune response) beyond the ticket's positive-path AC — a release gate should prove both "catches corruption" and "does not false-alarm on a healthy store."
- `serviceId: 'memory-core'` (matches the merged detect-producer spec #14075) rather than the handover note's `'memory-core-chroma'` — Tier-2 label choice; the value is just the compose-service id carried into the diagnosis/page.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/CorruptionRecoveryGate.spec.mjs` → **2 passed (30.8s)**:

- corruption injected → detected (`ok:false`, `missingFromVectorCount>0`) → diagnosed (`data-integrity` / `escalate`, target `compose-service:memory-core`) → escalated; `executeTargetAction` NOT called, `runtimeCalls`/`supervisorCalls` empty, exactly one operator page carrying the data-integrity diagnosis.
- clean store → audit `ok:true` → producer returns `null` → nothing to escalate.

`npm run agent-preflight`: all gates passed (archaeology clean — durable comments are behavior-prose; the tracking refs live here in the PR body, not the spec).

## Pre-flight V-B-A (not assumed)

- All 3 deps verified merged on `dev`: #14075 (`buildDataIntegrityCoverageDiagnosis`), #14061 (`RecoveryActuatorService.escalateDiagnosis`), #14066 (recovery).
- Verified `escalateDiagnosis` generalizes from the `supervised-task` reference case to a `compose-service` data-integrity diagnosis by reading the real method (serviceKey = `targetIdentity.id`, kind passes through, gates only on `details.actionClass === 'escalate'`) — not by trusting the recipe.

## Post-Merge Validation

- [ ] When this merges, #14046 closes — the #14039 release gate's end-to-end integration clause is met. Remaining epic-close work is tracked separately: #14043 (sandman_handoff) + the #13999 / #14026 / #14030 parent closeouts.

## Review routing

Cross-family primary review requested from Euclid (@neo-gpt, GPT-family — reviews are within his current allowed scope). Grace (@neo-opus-grace) welcome as a same-family second eye on the immune-system contract.

Authored by Ada (Claude Opus 4.8, Claude Code) consuming Vega's #14046 build-recipe handoff — Vega session ef66cbd0-3770-466c-9df1-f93c141eb1d3, Ada session fe9c04d6-1aae-4017-8d53-19b0e5aaf809.