### PR TITLE
fix(ai): stream backup row-count verification for >512MB JSONL files (#14082)

### DIFF
--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -1,6 +1,7 @@
 import {execFile}      from 'child_process';
 import fs              from 'fs-extra';
 import path            from 'path';
+import readline        from 'readline';
 import {promisify}     from 'util';
 import {fileURLToPath} from 'url';
 
@@ -255,10 +256,38 @@ export async function runBackup({
 }
 
 /**
+ * Counts non-empty (trimmed) lines in a JSONL file by streaming, so files larger than V8's
+ * maximum string length (`0x1fffffe8`, ~512 MB) are counted without `ERR_STRING_TOO_LONG`.
+ * Replaces a whole-file `fs.readFile(..., 'utf8').split('\n')`, which throws on the 1+ GB
+ * Memory Core / Knowledge Base exports. Each JSONL record is exactly one line, so the
+ * non-empty line count is the row count.
+ *
+ * @param {String} filePath Absolute path to the JSONL file.
+ * @returns {Promise<Number>} Count of non-empty lines.
+ */
+export async function countNonEmptyJsonlLines(filePath) {
+    const rl = readline.createInterface({
+        input    : fs.createReadStream(filePath),
+        crlfDelay: Infinity
+    });
+
+    let count = 0;
+
+    for await (const line of rl) {
+        if (line.trim()) {
+            count++;
+        }
+    }
+
+    return count
+}
+
+/**
  * Verifies row-count parity between source collections and the JSONL files written into the
  * bundle. For subsystems whose `manageDatabaseBackup({action: 'export'})` SDK call returns a
- * numeric count (KB, MC memories+summaries, MC graph), this function counts non-empty lines
- * in the bundle's JSONL files and compares — mismatch indicates a partial/torn write that the
+ * numeric count (KB, MC memories+summaries, MC graph), this function streams the bundle's JSONL
+ * files to count non-empty lines (streaming so 1+ GB exports do not exceed V8's max string length)
+ * and compares — mismatch indicates a partial/torn write that the
  * caller treats as a fail-the-bundle condition. Zero-zero parity (source and bundle both empty) is
  * reported as `empty`, not `pass`: a backup of an empty/gutted store is surfaced non-fatally because
  * it is not a usable recovery source (a fresh environment is legitimately empty; a populated
@@ -297,8 +326,7 @@ export async function verifyBundleIntegrity(layout, subsystems) {
         let   bundleCount = 0;
 
         for (const file of files) {
-            const content = await fs.readFile(path.join(dir, file), 'utf8');
-            bundleCount += content.split('\n').filter(line => line.trim()).length;
+            bundleCount += await countNonEmptyJsonlLines(path.join(dir, file));
         }
 
         if (bundleCount === sourceCount) {

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -49,10 +49,11 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
     });
 
     let verifyBundleIntegrity;
+    let countNonEmptyJsonlLines;
 
     test.beforeAll(async () => {
         SDK                   = await import('../../../../../../ai/services.mjs');
-        ({runBackup, verifyBundleIntegrity} = await import('../../../../../../ai/scripts/maintenance/backup.mjs'));
+        ({runBackup, verifyBundleIntegrity, countNonEmptyJsonlLines} = await import('../../../../../../ai/scripts/maintenance/backup.mjs'));
         KB_ChromaManager      = SDK.KB_ChromaManager;
         Memory_StorageRouter  = SDK.Memory_StorageRouter;
 
@@ -328,5 +329,23 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
             Memory_StorageRouter.getMemoryCollection  = savedMem;
             Memory_StorageRouter.getSummaryCollection = savedSum;
         }
+    });
+
+    test('countNonEmptyJsonlLines: streams a JSONL file, counting non-empty lines (#14082)', async () => {
+        // Regression: verifyBundleIntegrity used to read each bundle file fully into a string
+        // (fs.readFile + split('\n')), which threw ERR_STRING_TOO_LONG on the 1+ GB Memory Core /
+        // Knowledge Base exports (past V8's ~512 MB max string length). The streaming counter has no
+        // such ceiling. This locks the exact non-empty-line semantics the parity check depends on:
+        // blank lines and a missing trailing newline must not change the row count. The >512 MB
+        // no-throw property is proven manually against the real ~1.2 GB MC export (PR evidence) —
+        // materializing a 512 MB+ file in CI is prohibitively heavy.
+        const tempRoot = path.join(workRoot, 'count-nonempty');
+        const file     = path.join(tempRoot, 'rows.jsonl');
+
+        fs.mkdirSync(tempRoot, {recursive: true});
+        // 3 records — with a blank line, a whitespace-only line, and NO trailing newline on the last.
+        fs.writeFileSync(file, '{"id":"1"}\n\n{"id":"2"}\n   \n{"id":"3"}');
+
+        expect(await countNonEmptyJsonlLines(file)).toBe(3);
     });
 });


### PR DESCRIPTION
Resolves #14082

`verifyBundleIntegrity` counted bundle rows for parity by reading each JSONL fully into a string (`fs.readFile(..., 'utf8').split('\n')`). Once the `#13999` recovery restored a complete Memory Core export, that export is 1.2 GB (KB 1.0 GB) — past V8's ~512 MB max string length — so the parity check crashed with `ERR_STRING_TOO_LONG`, failing every backup even though the bundle data is fully written. This swaps the whole-file read for a streaming `readline` line count (the established pattern in `restore.mjs` / `ingestTenant.mjs`): bounded memory, no string-size ceiling, identical non-empty-line semantics. All four verdicts (`pass` / `empty` / `fail` / `skipped`) are unchanged.

Evidence: L3 (streamed the real 1.2 GB MC export → 22636 rows with no throw, and reproduced the old `ERR_STRING_TOO_LONG` on the same file; 10/10 unit). Sufficient for #14082's ACs. Residual: end-to-end backup completion is confirmed on the next orchestrator backup (Post-Merge Validation).

## Deltas from ticket
- Exported `countNonEmptyJsonlLines` (previously an internal helper) so the streaming counter is unit-testable directly, mirroring the existing test-export of `verifyBundleIntegrity`. No behavioral delta beyond the ticket scope.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs` → **10/10 passed (31.6s)**. The 4 pre-existing `verifyBundleIntegrity` parity tests (pass / fail / skipped / empty) still pass — semantics preserved — plus the new `countNonEmptyJsonlLines` non-empty-line test (blank lines + missing trailing newline).
- `npm run agent-preflight -- ai/scripts/maintenance/backup.mjs test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs` → all gates passed (`check-ticket-archaeology` clean).
- Real-artifact proof against the live 1.2 GB MC export (`mc/memory-backup-2026-06-26T11-58-51.738Z.jsonl`, 1227 MB):
  - NEW streaming counter → **22636 rows, 1.8s, no throw** (matches the canonical `neo-agent-memory` row count).
  - OLD whole-file approach on the same file → **threw `ERR_STRING_TOO_LONG`** (the reproduced bug).

## Post-Merge Validation
- [ ] The next orchestrator (or manual) canonical backup completes the verification step on the >512 MB MC/KB exports — writes `bundle-meta.json` and logs `✅ Backup complete` rather than crashing in row-count parity.

## Commits
- c2db02747 — fix(ai): stream backup row-count verification for >512MB JSONL files (#14082)

Related: #14030 (parent — backup reliability / verify restorability), #14048 (sibling — the empty-parity fix in the same `verifyBundleIntegrity` function), #13999 (the Memory Core recovery whose now-completing export exposed this), #14079 (why the exports exceed 512 MB).

Authored by Vega (Claude Opus 4.8, Claude Code). Session c94ea3b2-1ae8-48fd-8f34-1c54d90f5caa.
