### PR TITLE
fix(ai): surface numeric count on KB backup export for verification parity (#14086)

### DIFF
--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -112,14 +112,16 @@ class DatabaseService extends Base {
      *
      * @param {Object}  options
      * @param {String} [options.backupPath=aiConfig.backupPath] Directory for the JSONL artifact.
-     * @returns {Promise<{message: String}>}
+     * @returns {Promise<{message: String, count: Number}>} `count` is the numeric export row count,
+     *          consumed by the backup orchestrator's `verifyBundleIntegrity` for KB row-count parity
+     *          (without it the verifier reads a non-numeric source count and skips KB parity).
      */
     async exportDatabase({backupPath = aiConfig.backupPath} = {}) {
         try {
             logger.log('Starting knowledge base export...');
             const collection = await ChromaManager.getKnowledgeBaseCollection();
             const count      = await this.#exportCollection(collection, backupPath, 'knowledge-base-backup');
-            return {message: `Export complete. Exported ${count} knowledge base chunks.`};
+            return {message: `Export complete. Exported ${count} knowledge base chunks.`, count};
         } catch (error) {
             logger.error('[DatabaseService] Error exporting knowledge base:', error);
             const exportError = new Error(`DATABASE_EXPORT_ERROR: ${error.message}`);

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseService.backup.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseService.backup.spec.mjs
@@ -88,6 +88,8 @@ test.describe('KB_DatabaseService — manageDatabaseBackup (#10129 Phase 1)', ()
         });
 
         expect(result.message).toMatch(/Exported 2 knowledge base chunks/);
+        // Numeric count surfaced for the backup orchestrator's verifyBundleIntegrity KB row-count parity.
+        expect(result.count).toBe(2);
 
         const produced = fs.readdirSync(tmpBackupDir)
             .filter(f => f.startsWith('knowledge-base-backup-') && f.endsWith('.jsonl'));
@@ -119,6 +121,8 @@ test.describe('KB_DatabaseService — manageDatabaseBackup (#10129 Phase 1)', ()
         });
 
         expect(result.message).toMatch(/Exported 0 knowledge base chunks/);
+        // Zero count makes the verifier report KB 'empty' parity (a visible non-fatal status), not a silent 'skipped'.
+        expect(result.count).toBe(0);
 
         const produced = fs.readdirSync(emptyDir).filter(f => f.endsWith('.jsonl'));
         expect(produced).toHaveLength(0);


### PR DESCRIPTION
Resolves #14086

KB's `exportDatabase` returned the export size only inside a human-readable string (`{message: "Exported N chunks"}`), so the backup orchestrator's `verifyBundleIntegrity` (which reads `raw?.count`) got a non-numeric source count for KB and recorded `status: skipped` — leaving the 1.0 GB KB bundle the lone subsystem never row-count parity-verified (a torn/short KB export would pass undetected). This surfaces the numeric `count` (already computed at the export site) on the return; KB now verifies parity (`pass` / `empty` / `fail`) like `mc` / `graph`. Additive — the `message` is unchanged, no verifier change is needed, and the `#14082` streaming counter already handles KB's >512 MB bundle.

Evidence: L2 (focused unit — KB export return now carries a numeric `count` including the zero/empty case; 3/3 spec). Residual: the full end-to-end `kb: pass` shows on the next canonical backup (Post-Merge Validation).

## Deltas from ticket
None — matches the ticket's single-field fix plus the `@returns` contract update.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/DatabaseService.backup.spec.mjs` → **3/3 passed (31.0s)**. The populated-export test now also asserts `count === 2`; the empty-collection test asserts `count === 0` (so the verifier reports KB `empty`, not a silent `skipped`).
- Pre-merge evidence: the 2026-06-26 canonical backup reported `kb: skipped` (source count non-numeric) while `mc: pass 24044/24044` — this fix flips KB to verified.

## Post-Merge Validation
- [ ] Next canonical backup reports `kb` as `pass` (row-count parity) in `bundle-meta.integrity`, not `skipped`.

## Commits
- d4c491d8a — fix(ai): surface numeric count on KB backup export for verification parity (#14086)

Related: #14030 (parent — backup reliability / verify restorability), #14082 (sibling — the MC-side streaming verification fix that exposed this), #14048 (empty-parity verification), #13999 (the recovery whose completing backup surfaced it).

Authored by Vega (Claude Opus 4.8, Claude Code). Session c94ea3b2-1ae8-48fd-8f34-1c54d90f5caa.
