### PR TITLE
fix(ai): binary-split re-embed isolation to re-batch survivors (#14081)

### DIFF
--- a/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
+++ b/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
@@ -259,7 +259,7 @@ function getDocumentProblem(document) {
 }
 
 /**
- * @summary Embeds a batch, falling back to per-document isolation when the batch fails.
+ * @summary Embeds a batch; on failure, binary-splits to isolate the failing document(s) and re-batches the survivors.
  * @param {Object} options
  * @param {Function} options.embedFn Embedding function.
  * @param {String[]} options.ids Row ids paired with `documents`.
@@ -267,38 +267,52 @@ function getDocumentProblem(document) {
  * @returns {Promise<{embeddings: Number[][], failedIndexes: Set<Number>,
  *                    failures: Array<{index: Number, reason: String, message: String}>}>}
  */
-async function embedRecoverableDocuments({embedFn, ids, documents} = {}) {
-    try {
-        const embeddings = await embedFn(documents);
+export async function embedRecoverableDocuments({embedFn, ids, documents} = {}) {
+    const embeddings = new Array(documents.length);
+    const failures   = [];
 
-        if (!Array.isArray(embeddings) || embeddings.length !== documents.length) {
-            throw createEmbeddingResultError(`embedFn returned ${Array.isArray(embeddings) ? embeddings.length : 'non-array'} embeddings for ${documents.length} documents`);
+    // Embed the widest range that succeeds as a single batch; on failure, binary-split to isolate
+    // the failing document(s) and RE-BATCH the survivors — rather than degrading the whole batch to
+    // 1-by-1 single embeds, which forfeits the provider's batch parallelism on the failure path
+    // (the graph-recovery slowdown a single oversized doc caused). Failures stay attributed to their
+    // exact source index. Common case (few bad docs in a batch): O(log n) extra batch calls vs the
+    // old O(n) singles; pathological all-fail is bounded near ~2x calls — an acceptable trade for
+    // the far-more-common single-bad-apple path.
+    await embedRange(0, documents.length);
+
+    return {embeddings, failedIndexes: new Set(failures.map(failure => failure.index)), failures};
+
+    async function embedRange(start, end) {
+        const slice = documents.slice(start, end);
+
+        if (slice.length === 0) {
+            return;
         }
 
-        return {embeddings, failedIndexes: new Set(), failures: []}
-    } catch {
-        const embeddings = new Array(documents.length);
-        const failures   = [];
+        try {
+            const vectors = await embedFn(slice);
 
-        for (let i = 0; i < documents.length; i++) {
-            try {
-                const single = await embedFn([documents[i]]);
+            if (!Array.isArray(vectors) || vectors.length !== slice.length) {
+                throw createEmbeddingResultError(`embedFn returned ${Array.isArray(vectors) ? vectors.length : 'non-array'} embeddings for ${slice.length} documents`);
+            }
 
-                if (!Array.isArray(single) || single.length !== 1) {
-                    throw createEmbeddingResultError(`single embed returned ${Array.isArray(single) ? single.length : 'non-array'} embeddings`);
-                }
-
-                embeddings[i] = single[0];
-            } catch (error) {
+            for (let i = 0; i < slice.length; i++) {
+                embeddings[start + i] = vectors[i];
+            }
+        } catch (error) {
+            if (slice.length === 1) {
                 failures.push({
-                    index  : i,
+                    index  : start,
                     reason : getEmbeddingFailureReason(error),
                     message: error?.message || String(error)
                 });
+                return;
             }
-        }
 
-        return {embeddings, failedIndexes: new Set(failures.map(failure => failure.index)), failures}
+            const mid = start + Math.floor(slice.length / 2);
+            await embedRange(start, mid);
+            await embedRange(mid, end);
+        }
     }
 }
 

--- a/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
@@ -5,10 +5,10 @@ setup({
     appConfig: {name: 'RepairMcStoredEmbeddingsTest', isMounted: () => true, vnodeInitialising: false}
 });
 
-import {test, expect}                    from '@playwright/test';
-import Neo                               from '../../../../../../src/Neo.mjs';
-import * as core                         from '../../../../../../src/core/_export.mjs';
-import {extractMemoryCoreCollectionData} from '../../../../../../ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs';
+import {test, expect}                                               from '@playwright/test';
+import Neo                                                          from '../../../../../../src/Neo.mjs';
+import * as core                                                    from '../../../../../../src/core/_export.mjs';
+import {embedRecoverableDocuments, extractMemoryCoreCollectionData} from '../../../../../../ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs';
 
 /**
  * Mock Chroma collection: `rows` is `{ id: {embedding?, document?, metadata?} }`. `.get` returns only
@@ -143,7 +143,7 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         expect(result.counts.reEmbedded).toBe(1);
     });
 
-    test('batch embed failure falls back to single-document isolation and marks only failed docs unrecoverable', async () => {
+    test('batch embed failure binary-splits to isolate only the failed doc as unrecoverable', async () => {
         const rows = {
             ok     : {document: 'small', metadata: {}},
             overcap: {document: 'too-large', metadata: {}},
@@ -166,9 +166,13 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
             }
         });
 
+        // Binary-split: the full batch fails → the [small] half succeeds as a batch → the
+        // [too-large, small-2] half fails → splits again, isolating [too-large] (the unrecoverable)
+        // while [small-2] recovers. Survivors are re-batched where possible, not forced 1-by-1.
         expect(calls).toEqual([
             ['small', 'too-large', 'small-2'],
             ['small'],
+            ['too-large', 'small-2'],
             ['too-large'],
             ['small-2']
         ]);
@@ -229,7 +233,7 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         expect(result.unrecoverable).toEqual([{
             id     : 'm',
             reason : 'embedding-result-malformed',
-            message: 'single embed returned 0 embeddings'
+            message: 'embedFn returned 0 embeddings for 1 documents'
         }]);
         expect(result.unrecoverableIds).toEqual(['m']);
         expect(result.counts).toEqual({total: 1, intact: 0, reEmbedded: 0, unrecoverable: 1});
@@ -239,5 +243,50 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         await expect(extractMemoryCoreCollectionData({
             collection: makeCollection({}), allIds: [], missingVectorIds: []
         })).rejects.toThrow(/embedFn .* is required/);
+    });
+});
+
+test.describe('embedRecoverableDocuments — binary-split isolate-then-rebatch (#14081)', () => {
+    test('isolates the failing doc to its exact index and re-batches survivors (not 1-by-1)', async () => {
+        // POISON makes any batch containing it throw — the single-oversized-doc graph-recovery case.
+        const docs               = ['d0', 'd1', 'd2', 'd3', 'd4', 'POISON', 'd6', 'd7'];
+        let   maxSuccessfulBatch = 0;
+        const embedFn            = async batch => {
+            if (batch.includes('POISON')) {
+                throw new Error('embedding-provider-error: context too small');
+            }
+            maxSuccessfulBatch = Math.max(maxSuccessfulBatch, batch.length);
+            return batch.map(() => [1, 2]);
+        };
+
+        const {embeddings, failedIndexes, failures} = await embedRecoverableDocuments({
+            embedFn, ids: docs.map((_, i) => `id-${i}`), documents: docs
+        });
+
+        // Failure pinned to the exact poison index; every survivor recovered.
+        expect([...failedIndexes]).toEqual([5]);
+        expect(failures[0].index).toBe(5);
+        expect(embeddings[5]).toBeUndefined();
+        for (const i of [0, 1, 2, 3, 4, 6, 7]) {
+            expect(embeddings[i]).toEqual([1, 2]);
+        }
+
+        // Survivors were RE-BATCHED: at least one successful embed ran with >1 doc. The old
+        // per-document fallback embedded every survivor individually, so its largest successful
+        // batch would have been 1.
+        expect(maxSuccessfulBatch).toBeGreaterThan(1);
+    });
+
+    test('all-success batch embeds in a single call, no splitting (happy path unchanged)', async () => {
+        let   calls   = 0;
+        const embedFn = async batch => { calls++; return batch.map(() => [3]); };
+
+        const {embeddings, failedIndexes} = await embedRecoverableDocuments({
+            embedFn, ids: ['a', 'b', 'c'], documents: ['a', 'b', 'c']
+        });
+
+        expect([...failedIndexes]).toEqual([]);
+        expect(embeddings).toEqual([[3], [3], [3]]);
+        expect(calls).toBe(1);
     });
 });


### PR DESCRIPTION
Resolves #14081

When a re-embed batch threw (e.g. one oversized document exceeding the embed context), `embedRecoverableDocuments` degraded the **whole** batch to 1-by-1 single embeds to isolate the failure — forfeiting the provider's batch parallelism on the failure path. On the live `#13999` recovery this turned the graph collection's 309-row re-embed into ~28 min of sequential single calls over a single oversized doc. This replaces the per-document fallback with **binary-split isolation**: embed the widest range that succeeds as a batch; on failure, split to isolate the failing document(s) and **re-batch the survivors**. Failures stay attributed to their exact source index; the happy path (whole batch succeeds) is unchanged.

Evidence: L2 (focused unit — a poison doc in an 8-doc batch is isolated to its exact index with survivors recovered via a >1-doc re-batch; 12/12 spec).

## Deltas from ticket
- **Scope narrowed (per the #14090 review):** this PR delivers the binary-split **re-batch** slice of #14081. The bounded-concurrency half was narrowed out — deferred as likely-subsumed by the `TextEmbeddingService` priority-queue serialization (repair-layer concurrency re-serializes at that queue, so it is not a real win and fights the interactive-fairness design). See the #14081 narrowing comment. `Resolves #14081` therefore closes the narrowed slice honestly.
- Exported `embedRecoverableDocuments` (was internal) for direct unit coverage, mirroring the existing test-export pattern.
- Two pre-existing tests updated for the new call shape (outcomes unchanged): the isolation test now expects the binary-split call sequence; the wrong-length test's diagnostic `message` is now the unified `embedFn returned N embeddings for M documents` — the structured `reason: embedding-result-malformed` is unchanged.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs` → **12/12 passed (30.9s)**. New: `isolates the failing doc … and re-batches survivors` + `all-success … single call`; updated: the 2 call-shape assertions above.
- `npm run agent-preflight` on both files → all gates passed.

## Trade-off
Common case (few bad docs in a batch): O(log n) extra batch calls vs the old O(n) singles — the optimization target. Pathological all-fail: bounded near ~2x calls (split overhead), an acceptable trade since all-fail signals a systemic provider issue where the old path also re-tried every document.

## Post-Merge Validation
- [ ] (observational) A future recovery with an oversized doc in a large batch re-embeds the survivors in batches, not 1-by-1.

## Commits
- 6283df0f7 — fix(ai): binary-split re-embed isolation to re-batch survivors (#14081)

Related: #14066 (the partial-promotion recovery this speeds up), #14085 (oversized-doc chunking — the complementary Prevent fix), #13999 (the recovery whose graph leg surfaced the slowdown), #14039 (v13.1 stability epic).

Authored by Vega (Claude Opus 4.8, Claude Code). Session c94ea3b2-1ae8-48fd-8f34-1c54d90f5caa.
