### PR TITLE
feat(ai): truncate oversized Memory Core docs to the embed budget so they recover (#14085)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -1,16 +1,16 @@
-import {program}                             from 'commander';
-import {ChromaClient}                        from 'chromadb';
-import {execSync}                            from 'child_process';
-import crypto                                from 'crypto';
-import fs                                    from 'fs-extra';
-import path                                  from 'path';
-import {fileURLToPath, pathToFileURL}        from 'url';
-import Neo                                   from '../../../src/Neo.mjs';
-import AiConfig                              from '../../config.mjs';
-import {withHeavyMaintenanceLease}           from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
-import {registerNeoChromaEmbeddingFunctions} from '../../services/shared/vector/chromaClientPrimitives.mjs';
-import {auditChromaVectorCoverage}           from './checkChromaIntegrity.mjs';
-import {extractMemoryCoreCollectionData}     from './repairMemoryCoreStoredEmbeddings.mjs';
+import {program}                                                     from 'commander';
+import {ChromaClient}                                                from 'chromadb';
+import {execSync}                                                    from 'child_process';
+import crypto                                                        from 'crypto';
+import fs                                                            from 'fs-extra';
+import path                                                          from 'path';
+import {fileURLToPath, pathToFileURL}                                from 'url';
+import Neo                                                           from '../../../src/Neo.mjs';
+import AiConfig                                                      from '../../config.mjs';
+import {withHeavyMaintenanceLease}                                   from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
+import {registerNeoChromaEmbeddingFunctions}                         from '../../services/shared/vector/chromaClientPrimitives.mjs';
+import {auditChromaVectorCoverage}                                   from './checkChromaIntegrity.mjs';
+import {extractMemoryCoreCollectionData, truncateToEmbedTokenBudget} from './repairMemoryCoreStoredEmbeddings.mjs';
 
 /**
  * @summary Defragments collection groups inside the unified ChromaDB store.
@@ -1499,12 +1499,16 @@ async function defragChromaDB() {
                 ? `\n3️⃣  Memory Core repair-defrag DRY-RUN: full-enumeration extract + re-embed report (no shadow promotion)...`
                 : `\n3️⃣  Memory Core repair-defrag: full-enumeration extract + re-embed + shadow-promote...`);
             const {default: TextEmbeddingService} = await import('../../services/memory-core/TextEmbeddingService.mjs');
-            const {results}                       = await repairMemoryCoreCollectionsViaFullEnumeration({
+            // Prevent oversized-document data loss: truncate each document to the embedding token budget so a
+            // document that exceeds the provider context recovers with a (slightly lossy) vector instead of
+            // falling out of recovery as unrecoverable. The safe-budget leaf is read at the use site.
+            const embedBudgetTokens = AiConfig.localModels.embedding.safeProcessingLimitTokens;
+            const {results}         = await repairMemoryCoreCollectionsViaFullEnumeration({
                 client,
                 collections      : config.collections,
                 snapshotPath     : path.join(backupPath, 'chroma.sqlite3'),
                 persistDir       : backupPath,
-                embedFn          : docs => TextEmbeddingService.embedTexts(docs, config.embeddingProvider),
+                embedFn          : docs => TextEmbeddingService.embedTexts(docs.map(doc => truncateToEmbedTokenBudget(doc, embedBudgetTokens)), config.embeddingProvider),
                 embeddingFunction: dummyEf,
                 statePath,
                 stateBase        : {targetName},

--- a/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
+++ b/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
@@ -21,6 +21,8 @@
  * @module Neo.ai.scripts.maintenance.repairMemoryCoreStoredEmbeddings
  */
 
+import {bytesToTokens} from '../../services/memory-core/helpers/consumerFrictionHelper.mjs';
+
 /**
  * @summary Extracts a Memory Core collection's data for a shadow rebuild, RE-EMBEDDING the rows whose
  * stored vectors are missing from the HNSW index.
@@ -336,6 +338,75 @@ function createEmbeddingResultError(message) {
  */
 function getEmbeddingFailureReason(error) {
     return error?.unrecoverableReason || 'embedding-provider-error'
+}
+
+/**
+ * @summary Truncates a UTF-8 string to at most `maxBytes` bytes without ever splitting a multi-byte char.
+ * Pure; the byte-budget primitive under {@link truncateToEmbedTokenBudget}.
+ *
+ * @param {String} text The source string.
+ * @param {Number} maxBytes Maximum UTF-8 byte length.
+ * @returns {String} `text` unchanged when already within budget, else the longest char-aligned prefix that fits.
+ */
+export function truncateToByteBudget(text, maxBytes) {
+    const buffer = Buffer.from(text, 'utf8');
+
+    if (buffer.length <= maxBytes) {
+        return text;
+    }
+
+    let end = Math.max(0, maxBytes);
+
+    // A UTF-8 continuation byte matches 0b10xxxxxx; back off so a multi-byte char is never cut in half.
+    while (end > 0 && (buffer[end] & 0xC0) === 0x80) {
+        end--;
+    }
+
+    return buffer.subarray(0, end).toString('utf8');
+}
+
+/**
+ * @summary Truncates a document to a context-bounded prefix that fits the embedding token budget, so an
+ * oversized Memory Core document gets *a* (slightly lossy) vector and stays searchable rather than falling
+ * out of recovery as `unrecoverable`.
+ *
+ * This is the truncate-to-context FLOOR: it eliminates the oversized-document `unrecoverable` class with
+ * minimal blast by embedding a bounded prefix. The trade-off is fidelity — the document's tail is dropped;
+ * the higher-fidelity chunk-and-aggregate strategy (embed each chunk, store sub/aggregate vectors) is a
+ * deferred follow-up. A genuinely-unembeddable document (empty, or a truncated prefix the provider still
+ * rejects) is unaffected here and degrades cleanly to the existing `unrecoverable` classification.
+ *
+ * The token estimate reuses the shared {@link bytesToTokens} heuristic (the SSOT for the bytes→tokens
+ * ratio) and derives the byte budget from that same ratio, so the heuristic is never re-implemented.
+ * No-op (returns `text`) when already within budget or when `maxTokens` is not a positive number.
+ *
+ * @param {String} text The document to embed.
+ * @param {Number} maxTokens The embedding token budget (e.g. `AiConfig.localModels.embedding.safeProcessingLimitTokens`).
+ * @returns {String} `text` when within budget, else a char-aligned prefix estimated to fit `maxTokens`.
+ */
+export function truncateToEmbedTokenBudget(text, maxTokens) {
+    if (typeof text !== 'string' || !Number.isFinite(maxTokens) || maxTokens <= 0) {
+        return text;
+    }
+
+    const totalBytes = Buffer.byteLength(text, 'utf8');
+
+    if (bytesToTokens(totalBytes) <= maxTokens) {
+        return text;
+    }
+
+    // Derive the byte budget from the heuristic's own ratio (no duplicated magic constant), then shave the
+    // rounding edge until the estimate is within budget.
+    const bytesPerToken = totalBytes / Math.max(1, bytesToTokens(totalBytes));
+    let   maxBytes      = Math.max(1, Math.floor(maxTokens * bytesPerToken)),
+          truncated     = truncateToByteBudget(text, maxBytes);
+
+    while (truncated.length > 0 && bytesToTokens(Buffer.byteLength(truncated, 'utf8')) > maxTokens) {
+        maxBytes  = Math.floor(maxBytes * 0.9);
+        truncated = truncateToByteBudget(text, maxBytes);
+    }
+
+    return truncated;
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
@@ -8,7 +8,7 @@ setup({
 import {test, expect}                                               from '@playwright/test';
 import Neo                                                          from '../../../../../../src/Neo.mjs';
 import * as core                                                    from '../../../../../../src/core/_export.mjs';
-import {embedRecoverableDocuments, extractMemoryCoreCollectionData} from '../../../../../../ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs';
+import {embedRecoverableDocuments, extractMemoryCoreCollectionData, truncateToByteBudget, truncateToEmbedTokenBudget} from '../../../../../../ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs';
 
 /**
  * Mock Chroma collection: `rows` is `{ id: {embedding?, document?, metadata?} }`. `.get` returns only
@@ -288,5 +288,87 @@ test.describe('embedRecoverableDocuments — binary-split isolate-then-rebatch (
         expect([...failedIndexes]).toEqual([]);
         expect(embeddings).toEqual([[3], [3], [3]]);
         expect(calls).toBe(1);
+    });
+});
+
+test.describe('truncateToEmbedTokenBudget — oversized-document recovery (the Prevent floor)', () => {
+    test('returns text unchanged when within the token budget (no-op)', () => {
+        const text = 'a short document';
+        expect(truncateToEmbedTokenBudget(text, 1000)).toBe(text);
+    });
+
+    test('truncates an over-budget document to a prefix estimated to fit the budget', () => {
+        const text      = 'x'.repeat(30000),            // ~10000 tokens at ~3 bytes/token
+              truncated = truncateToEmbedTokenBudget(text, 100);
+
+        expect(truncated.length).toBeLessThan(text.length);
+        expect(text.startsWith(truncated)).toBe(true);  // a genuine prefix, not a re-encoding
+        expect(Math.ceil(Buffer.byteLength(truncated, 'utf8') / 3)).toBeLessThanOrEqual(100);
+    });
+
+    test('never splits a multi-byte UTF-8 character', () => {
+        const text      = '😀'.repeat(5000),            // 4 bytes each
+              truncated = truncateToEmbedTokenBudget(text, 100);
+
+        expect(truncated.length).toBeGreaterThan(0);
+        expect(truncated.length).toBeLessThan(text.length);
+        expect([...truncated].every(char => char === '😀')).toBe(true);  // no broken/replacement char
+    });
+
+    test('is a no-op for a non-positive budget or non-string input (degrades to current behavior)', () => {
+        expect(truncateToEmbedTokenBudget('abc', 0)).toBe('abc');
+        expect(truncateToEmbedTokenBudget('abc', -5)).toBe('abc');
+        expect(truncateToEmbedTokenBudget(null, 100)).toBe(null);
+    });
+
+    test('truncateToByteBudget respects the byte budget and never cuts a multi-byte char in half', () => {
+        expect(truncateToByteBudget('hello', 100)).toBe('hello');                                  // under budget → unchanged
+        expect(Buffer.byteLength(truncateToByteBudget('a'.repeat(50), 10), 'utf8')).toBeLessThanOrEqual(10);
+        expect(truncateToByteBudget('😀😀', 5)).toBe('😀');                                         // 4-byte char that overflows is dropped whole
+    });
+
+    test('a budget-aware embedFn RECOVERS an oversized document instead of marking it unrecoverable', async () => {
+        const BUDGET    = 50,                 // tiny test token budget
+              oversized = 'y'.repeat(900);    // ~300 tokens — exceeds BUDGET
+
+        // Mirror the production embedFn wrapper: truncate each doc to the budget, then embed. The fake
+        // provider REJECTS input still over budget (its context assertion) and SUCCEEDS otherwise.
+        const budgetAwareEmbedFn = async docs => docs.map(doc => {
+            const prepared = truncateToEmbedTokenBudget(doc, BUDGET);
+
+            if (Math.ceil(Buffer.byteLength(prepared, 'utf8') / 3) > BUDGET) {
+                throw new Error('embedding context too small (context overflow)');
+            }
+
+            return [1, 2, 3];
+        });
+
+        const result = await extractMemoryCoreCollectionData({
+            collection      : makeCollection({m: {document: oversized, metadata: {}}}),
+            allIds          : ['m'],
+            missingVectorIds: ['m'],
+            embedFn         : budgetAwareEmbedFn
+        });
+
+        expect(result.counts).toEqual({total: 1, intact: 0, reEmbedded: 1, unrecoverable: 0});
+        expect(result.data.ids).toEqual(['m']);
+        expect(result.unrecoverableIds).toEqual([]);
+    });
+
+    test('the gap this closes: without budget-aware truncation the same oversized document stays unrecoverable', async () => {
+        const oversized  = 'y'.repeat(900);
+        // A raw embedFn (no truncation) that rejects the oversized doc — the pre-truncation behavior.
+        const rawEmbedFn = async () => { throw new Error('embedding context too small (context overflow)'); };
+
+        const result = await extractMemoryCoreCollectionData({
+            collection      : makeCollection({m: {document: oversized, metadata: {}}}),
+            allIds          : ['m'],
+            missingVectorIds: ['m'],
+            embedFn         : rawEmbedFn
+        });
+
+        expect(result.counts.reEmbedded).toBe(0);
+        expect(result.counts.unrecoverable).toBe(1);
+        expect(result.unrecoverableIds).toEqual(['m']);
     });
 });


### PR DESCRIPTION
Resolves #14085

Related: #14039

Memory Core re-embed had no oversized-document handling — a document exceeding the embedding context (the 45538-token `aa8ecd3f` / 35502-token `issue-11187` rows quarantined by the live #13999 recovery) fails `embedFn` and falls out of recovery as `unrecoverable`. This adds the truncate-to-context **Prevent floor** so oversized docs recover with a bounded-prefix vector (searchable, slightly lossy) instead of being lost.

Two pieces:

- `truncateToEmbedTokenBudget(text, maxTokens)` (+ `truncateToByteBudget`) in `repairMemoryCoreStoredEmbeddings.mjs` — pure, UTF-8-safe (never splits a multi-byte char), no-op when within budget. Derives its byte budget from the shared `bytesToTokens` heuristic rather than re-implementing the bytes→tokens ratio.
- The defrag MC re-embed `embedFn` is wrapped to truncate each document to `AiConfig.localModels.embedding.safeProcessingLimitTokens` (28672, under the 32768 hard context) before embedding.

Genuinely-unembeddable documents (empty, or a truncated prefix the provider still rejects) are unaffected and degrade cleanly to the existing `unrecoverable` classification — so this shrinks the residue toward zero without masking truly-irreducible loss (the sibling #14084 governs that terminal residue).

Evidence: L2 (unit spec — truncation correctness + UTF-8 safety + a budget-aware embedFn recovering an oversized doc through the real `extractMemoryCoreCollectionData`, contrasted with the raw embedFn that leaves it unrecoverable) → fully covers #14085's ACs. Residual: none.

## Deltas from ticket

- Chose the **truncate-to-context floor** (the ticket's recommended floor) implemented at the `embedFn`-input boundary (truncate before embedding) rather than reactively inside `embedRecoverableDocuments` — lower blast (one helper + one entrypoint wrapper, no threading through the defrag-internal call chain) while delivering the same recovery. The higher-fidelity chunk-and-aggregate option is deferred.
- ADR-0019: the `safeProcessingLimitTokens` leaf is read at the defrag use site (the entrypoint already reads `AiConfig`); no config pass-through into the pure repair seam.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs` → **17 passed** (10 existing + 7 new):

- `truncateToEmbedTokenBudget`: no-op under budget; truncates over-budget to a prefix fitting the token budget; UTF-8 multi-byte safety; no-op for non-positive budget / non-string input.
- `truncateToByteBudget`: byte budget + char-boundary safety.
- a budget-aware `embedFn` **recovers** an oversized doc (reEmbedded=1, unrecoverable=0); the gap-contrast — a raw `embedFn` leaves the same doc unrecoverable.

`npm run agent-preflight`: all gates passed (archaeology clean across all 3 files).

## Post-Merge Validation

- [ ] On the next operator-gated MC repair-defrag run, the previously-quarantined oversized rows recover with a truncated vector (`counts.unrecoverable` drops) instead of aborting promotion.

Authored by Ada (Claude Opus 4.8, Claude Code). Session fe9c04d6-1aae-4017-8d53-19b0e5aaf809.