### PR TITLE
feat(ai): vector-count monotonicity detect-producer for the data-integrity signal (#14094)

### DIFF
--- a/ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.mjs
@@ -1,0 +1,74 @@
+import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis
+ * @summary Pure detect-producer for the vector-count monotonicity signal — the second leaf of the
+ * data-integrity detect-signal class (sibling of `dataIntegrityCoverageDiagnosis`). Memory Core collections
+ * are append-mostly, so a vector-count DECREASE between samples is a near-unambiguous, threshold-free
+ * data-loss signal. It turns per-collection `(previousCount, currentCount)` sample pairs into a
+ * `recovery-diagnosis` when any collection regressed, so the immune system can ESCALATE rather than report
+ * a store that silently shrank as healthy.
+ *
+ * Detect-only by construction: it consumes count samples and emits a diagnosis — it performs no repair /
+ * re-embed / restore / mutation. It emits `recoveryClass: 'data-integrity'` + `details.actionClass: 'escalate'`,
+ * targeting the Memory Core `compose-service` (per-collection regression carried in `evidenceFacts`). Mirrors
+ * the coverage-drift producer's pure shape: the samples are injected (the historical sample store + scheduling
+ * are the consumer/daemon's concern), so it is testable in isolation.
+ */
+
+/**
+ * @summary Builds a data-integrity `recovery-diagnosis` from per-collection vector-count samples.
+ *
+ * Pure — no I/O. Returns a diagnosis when ANY collection's `currentCount` is strictly less than its
+ * `previousCount` (a regression in an append-mostly store); returns `null` when every collection is monotonic
+ * (never a false escalation). Samples whose counts are not both finite numbers are ignored — a missing
+ * baseline is not a loss.
+ *
+ * @param {Object} options
+ * @param {Array<Object>} options.samples Per-collection count samples — `[{collection, previousCount, currentCount}]`.
+ * @param {Number} options.observedAt Epoch milliseconds when the sample was observed.
+ * @param {String} options.serviceId The Memory Core compose-service identifier.
+ * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity` / `escalate`) when a regression is present, else `null`.
+ * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
+ */
+export function buildVectorCountMonotonicityDiagnosis({samples, observedAt, serviceId} = {}) {
+    if (typeof serviceId !== 'string' || serviceId.length === 0) {
+        throw new TypeError('buildVectorCountMonotonicityDiagnosis: serviceId is required');
+    }
+    if (!Number.isFinite(observedAt)) {
+        throw new TypeError('buildVectorCountMonotonicityDiagnosis: observedAt must be a finite number');
+    }
+
+    const rows      = Array.isArray(samples) ? samples : [],
+          regressed = rows.filter(sample =>
+              Number.isFinite(sample?.previousCount) &&
+              Number.isFinite(sample?.currentCount)  &&
+              sample.currentCount < sample.previousCount
+          );
+
+    // Every collection monotonic (or no comparable samples) → no diagnosis (never a false escalation).
+    if (regressed.length === 0) {
+        return null;
+    }
+
+    return createRecoveryDiagnosisEvent({
+        diagnosisId   : `data-integrity:${serviceId}:vector-count-regression:${observedAt}`,
+        recoveryClass : 'data-integrity',
+        confidence    : 1,
+        targetIdentity: {kind: 'compose-service', id: serviceId},
+        evidenceFacts : regressed.map(sample => ({
+            type         : 'vector-count-regression',
+            collection   : sample.collection,
+            previousCount: sample.previousCount,
+            currentCount : sample.currentCount,
+            lost         : sample.previousCount - sample.currentCount
+        })),
+        observedAt,
+        source : 'data-integrity-monotonicity-monitor',
+        details: {
+            actionClass         : 'escalate',
+            reasonCode          : 'data-integrity-vector-count-regression',
+            regressedCollections: regressed.map(sample => sample.collection)
+        }
+    });
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.spec.mjs
@@ -1,0 +1,83 @@
+import {test, expect}                          from '@playwright/test';
+import Neo                                     from '../../../../../../../src/Neo.mjs';
+import * as core                               from '../../../../../../../src/core/_export.mjs';
+import {buildVectorCountMonotonicityDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.mjs';
+
+// Pure detect-producer (no I/O). Memory Core collections are append-mostly, so a vector-count DECREASE
+// between samples is a near-unambiguous, threshold-free data-loss signal → a data-integrity/escalate
+// recovery-diagnosis; monotonic samples → null.
+
+test.describe('buildVectorCountMonotonicityDiagnosis — vector-count monotonicity detect-producer', () => {
+    test('a collection whose vector count regressed -> a data-integrity/escalate recovery-diagnosis', () => {
+        const diag = buildVectorCountMonotonicityDiagnosis({
+            samples: [
+                {collection: 'neo-agent-memory',   previousCount: 18835, currentCount: 7000},
+                {collection: 'neo-agent-sessions', previousCount: 1408,  currentCount: 1408}
+            ],
+            observedAt: 1000,
+            serviceId : 'memory-core'
+        });
+
+        expect(diag).toMatchObject({
+            diagnosisId   : 'data-integrity:memory-core:vector-count-regression:1000',
+            type          : 'recovery-diagnosis',
+            recoveryClass : 'data-integrity',
+            confidence    : 1,
+            targetIdentity: {kind: 'compose-service', id: 'memory-core'},
+            source        : 'data-integrity-monotonicity-monitor',
+            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-vector-count-regression', regressedCollections: ['neo-agent-memory']}
+        });
+        expect(diag.evidenceFacts).toEqual([
+            {type: 'vector-count-regression', collection: 'neo-agent-memory', previousCount: 18835, currentCount: 7000, lost: 11835}
+        ]);
+    });
+
+    test('diagnosisId is target+instant scoped — two services regressing at the same instant get distinct ids', () => {
+        const args = {samples: [{collection: 'c', previousCount: 10, currentCount: 1}], observedAt: 1000},
+              a    = buildVectorCountMonotonicityDiagnosis({...args, serviceId: 'memory-core'}),
+              b    = buildVectorCountMonotonicityDiagnosis({...args, serviceId: 'knowledge-base'});
+
+        expect(a.diagnosisId).toBe('data-integrity:memory-core:vector-count-regression:1000');
+        expect(b.diagnosisId).toBe('data-integrity:knowledge-base:vector-count-regression:1000');
+        expect(a.diagnosisId).not.toBe(b.diagnosisId);
+    });
+
+    test('all-monotonic samples (current >= previous) -> null (no false escalation)', () => {
+        expect(buildVectorCountMonotonicityDiagnosis({
+            samples: [
+                {collection: 'neo-agent-memory',   previousCount: 100, currentCount: 100},  // equal — not a loss
+                {collection: 'neo-agent-sessions', previousCount: 100, currentCount: 150}   // grew — append-mostly
+            ],
+            observedAt: 1000,
+            serviceId : 'memory-core'
+        })).toBeNull();
+    });
+
+    test('empty / absent samples -> null', () => {
+        expect(buildVectorCountMonotonicityDiagnosis({samples: [], observedAt: 1, serviceId: 'mc'})).toBeNull();
+        expect(buildVectorCountMonotonicityDiagnosis({observedAt: 1, serviceId: 'mc'})).toBeNull();
+    });
+
+    test('samples with a non-finite or missing count are ignored — a missing baseline is not a loss', () => {
+        expect(buildVectorCountMonotonicityDiagnosis({
+            samples: [
+                {collection: 'fresh',   currentCount: 5},                        // no previousCount (first sample)
+                {collection: 'unknown', previousCount: 10, currentCount: null}   // unread current count
+            ],
+            observedAt: 1,
+            serviceId : 'mc'
+        })).toBeNull();
+    });
+
+    test('emits data-integrity, which validates against RECOVERY_CLASSES (else createRecoveryDiagnosisEvent throws)', () => {
+        const diag = buildVectorCountMonotonicityDiagnosis({
+            samples: [{collection: 'c', previousCount: 2, currentCount: 1}], observedAt: 1, serviceId: 'mc'
+        });
+        expect(diag.recoveryClass).toBe('data-integrity');
+    });
+
+    test('rejects missing serviceId / non-finite observedAt', () => {
+        expect(() => buildVectorCountMonotonicityDiagnosis({samples: [], observedAt: 1})).toThrow('serviceId');
+        expect(() => buildVectorCountMonotonicityDiagnosis({samples: [], serviceId: 'mc'})).toThrow('observedAt');
+    });
+});


### PR DESCRIPTION
Resolves #14094

Related: #14026

The second leaf of the #14026 data-integrity detect-signal class, after #14075's coverage-drift producer. Memory Core collections (`neo-agent-memory` / `neo-agent-sessions`) are append-mostly, so a vector-count **decrease** between samples is a near-unambiguous, threshold-free data-loss signal — it catches a clean count regression that coverage-drift (missing-from-index) does not.

`buildVectorCountMonotonicityDiagnosis({samples, observedAt, serviceId})` turns per-collection `(previousCount, currentCount)` samples into a `data-integrity` / `escalate` `recovery-diagnosis` when any collection regressed; returns `null` when every collection is monotonic (never a false escalation). Pure, detect-only — samples are injected (the historical sample-store + daemon scheduling are the consumer's concern, out of scope), so it's a sibling-lift of the merged #14075 `dataIntegrityCoverageDiagnosis.mjs` and reuses `createRecoveryDiagnosisEvent`.

Evidence: L2 (unit spec — regression→diagnosis, monotonic→null, target+instant-scoped diagnosisId, non-finite/missing counts ignored, enum-validation, arg-rejection) → fully covers #14094's ACs. Residual: none.

## Deltas from ticket

- New file `ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.mjs` — structural-pre-flight fast-path: a sibling-lift of `dataIntegrityCoverageDiagnosis.mjs` (same dir, same pure-producer pattern + single-export shape), so no novel placement decision.
- The pure producer is within #14075's already-merged shape; the ADR-0025 daemon-wiring gate (inherited from #14026) binds the future scheduled-consumer slice, not this pure producer — reviewer to confirm.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.spec.mjs` → **7 passed**.

`npm run agent-preflight`: all gates passed (archaeology clean).

## Post-Merge Validation

- [ ] When the historical sample-store + scheduled consumer land (a separate #14026 slice), this producer fires the escalation on a real per-collection vector-count regression.

Authored by Ada (Claude Opus 4.8, Claude Code). Session fe9c04d6-1aae-4017-8d53-19b0e5aaf809.