### PR TITLE
feat(ai): SQLite-integrity data-integrity detect-producer (#14096)

### DIFF
--- a/ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis.mjs
@@ -1,0 +1,70 @@
+import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis
+ * @summary Pure detect-producer for the data-integrity SQLite-integrity signal — a leaf of the
+ * data-integrity detect-signal. It turns a Chroma SQLite `quick_check` /
+ * `integrity_check` audit (`checkChromaIntegrity` → `result.sqlite.checks`) into a `recovery-diagnosis`
+ * when the unified store's SQLite integrity is broken — the *"malformed inverted index for FTS5"* shape
+ * that recurred all through the corruption-incident forensics but was only ever a manual CLI line, never
+ * a detect signal — so the immune system ESCALATES rather than leaving a structurally-corrupt store undetected.
+ *
+ * Detect-only by construction: it consumes a check RESULT and emits a diagnosis — it performs no
+ * repair / FTS5 rebuild / mutation (those are operator-gated). It emits `recoveryClass: 'data-integrity'`
+ * + `details.actionClass: 'escalate'`, targeting the Memory Core `compose-service` (per-pragma failure
+ * carried in `evidenceFacts`, with a bounded detail snippet — no unbounded SQLite output). Mirrors the
+ * coverage-drift detect-producer: pure, with the audit result injected so it is testable in isolation.
+ */
+
+const MAX_DETAIL_LENGTH = 280;
+
+/**
+ * @summary Builds a data-integrity `recovery-diagnosis` from a Chroma SQLite integrity audit result.
+ *
+ * Pure — no I/O. Returns a diagnosis when ANY SQLite check is `ok === false` (a failed `quick_check` /
+ * `integrity_check` — e.g. a malformed FTS5 index); returns `null` when every check passes (never a
+ * false escalation). The caller (the diagnostics daemon) supplies the `checkChromaIntegrity()`
+ * `result.sqlite` object + the Memory Core service id.
+ *
+ * @param {Object} options
+ * @param {Object} options.sqliteResult The `checkChromaIntegrity()` `result.sqlite` — `{checks:[{pragma, ok, output, error}]}`.
+ * @param {Number} options.observedAt Epoch milliseconds when the audit was observed.
+ * @param {String} options.serviceId The Memory Core compose-service identifier.
+ * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity` / `escalate`) when a check failed, else `null`.
+ * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
+ */
+export function buildSqliteIntegrityDiagnosis({sqliteResult, observedAt, serviceId} = {}) {
+    if (typeof serviceId !== 'string' || serviceId.length === 0) {
+        throw new TypeError('buildSqliteIntegrityDiagnosis: serviceId is required');
+    }
+    if (!Number.isFinite(observedAt)) {
+        throw new TypeError('buildSqliteIntegrityDiagnosis: observedAt must be a finite number');
+    }
+
+    const checks = Array.isArray(sqliteResult?.checks) ? sqliteResult.checks : [],
+          failed = checks.filter(check => check?.ok === false);
+
+    // Clean integrity → no diagnosis (never a false escalation).
+    if (failed.length === 0) {
+        return null;
+    }
+
+    return createRecoveryDiagnosisEvent({
+        diagnosisId   : `data-integrity:${serviceId}:sqlite-integrity:${observedAt}`,
+        recoveryClass : 'data-integrity',
+        confidence    : 1,
+        targetIdentity: {kind: 'compose-service', id: serviceId},
+        evidenceFacts : failed.map(check => ({
+            type  : 'sqlite-integrity-failure',
+            pragma: check.pragma,
+            detail: String(check.error || check.output || '').slice(0, MAX_DETAIL_LENGTH)
+        })),
+        observedAt,
+        source : 'data-integrity-sqlite-integrity-monitor',
+        details: {
+            actionClass  : 'escalate',
+            reasonCode   : 'data-integrity-sqlite-integrity-failure',
+            failedPragmas: failed.map(check => check.pragma)
+        }
+    });
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis.spec.mjs
@@ -1,0 +1,93 @@
+import {test, expect}                  from '@playwright/test';
+import Neo                             from '../../../../../../../src/Neo.mjs';
+import * as core                       from '../../../../../../../src/core/_export.mjs';
+import {buildSqliteIntegrityDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis.mjs';
+
+// Pure detect-producer (no I/O). Turns a Chroma SQLite quick_check/integrity_check audit into a
+// data-integrity recovery-diagnosis (escalate) when the store's SQLite integrity is broken (a malformed
+// FTS5 index — the corruption-incident forensic shape); returns null when every check passes.
+
+test.describe('buildSqliteIntegrityDiagnosis — data-integrity SQLite-integrity detect-producer', () => {
+    test('a failed integrity check -> a data-integrity/escalate recovery-diagnosis', () => {
+        const diag = buildSqliteIntegrityDiagnosis({
+            sqliteResult: {checks: [
+                {pragma: 'quick_check',     ok: false, output: 'malformed inverted index for FTS5 table main.embedding_fulltext_search'},
+                {pragma: 'integrity_check', ok: false, output: 'malformed inverted index for FTS5 table main.embedding_fulltext_search'}
+            ]},
+            observedAt: 1000,
+            serviceId : 'memory-core'
+        });
+        expect(diag).toMatchObject({
+            diagnosisId   : 'data-integrity:memory-core:sqlite-integrity:1000',
+            type          : 'recovery-diagnosis',
+            recoveryClass : 'data-integrity',
+            confidence    : 1,
+            targetIdentity: {kind: 'compose-service', id: 'memory-core'},
+            source        : 'data-integrity-sqlite-integrity-monitor',
+            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-sqlite-integrity-failure', failedPragmas: ['quick_check', 'integrity_check']}
+        });
+        expect(diag.evidenceFacts[0]).toMatchObject({type: 'sqlite-integrity-failure', pragma: 'quick_check'});
+        expect(diag.evidenceFacts[0].detail).toContain('malformed inverted index');
+    });
+
+    test('diagnosisId is target-scoped — two services failing at the same instant get distinct ids (no graph-node collision)', () => {
+        const args = {sqliteResult: {checks: [{pragma: 'integrity_check', ok: false, output: 'malformed'}]}, observedAt: 1000},
+              a    = buildSqliteIntegrityDiagnosis({...args, serviceId: 'memory-core'}),
+              b    = buildSqliteIntegrityDiagnosis({...args, serviceId: 'knowledge-base'});
+
+        expect(a.diagnosisId).toBe('data-integrity:memory-core:sqlite-integrity:1000');
+        expect(b.diagnosisId).toBe('data-integrity:knowledge-base:sqlite-integrity:1000');
+        expect(a.diagnosisId).not.toBe(b.diagnosisId);
+    });
+
+    test('clean integrity (all checks ok) -> null (no false escalation)', () => {
+        expect(buildSqliteIntegrityDiagnosis({
+            sqliteResult: {checks: [
+                {pragma: 'quick_check',     ok: true, output: 'ok'},
+                {pragma: 'integrity_check', ok: true, output: 'ok'}
+            ]},
+            observedAt: 1000,
+            serviceId : 'memory-core'
+        })).toBeNull();
+    });
+
+    test('only the failed pragma is carried in evidence + failedPragmas (partial failure)', () => {
+        const diag = buildSqliteIntegrityDiagnosis({
+            sqliteResult: {checks: [
+                {pragma: 'quick_check',     ok: true,  output: 'ok'},
+                {pragma: 'integrity_check', ok: false, error: 'database disk image is malformed'}
+            ]},
+            observedAt: 1, serviceId: 'mc'
+        });
+        expect(diag.details.failedPragmas).toEqual(['integrity_check']);
+        expect(diag.evidenceFacts).toHaveLength(1);
+        expect(diag.evidenceFacts[0]).toMatchObject({pragma: 'integrity_check', detail: 'database disk image is malformed'});
+    });
+
+    test('bounds the evidence detail snippet (never unbounded SQLite output)', () => {
+        const diag = buildSqliteIntegrityDiagnosis({
+            sqliteResult: {checks: [{pragma: 'integrity_check', ok: false, output: 'x'.repeat(5000)}]},
+            observedAt  : 1, serviceId: 'mc'
+        });
+        expect(diag.evidenceFacts[0].detail.length).toBeLessThanOrEqual(280);
+    });
+
+    test('empty / absent checks -> null', () => {
+        expect(buildSqliteIntegrityDiagnosis({sqliteResult: {checks: []}, observedAt: 1, serviceId: 'mc'})).toBeNull();
+        expect(buildSqliteIntegrityDiagnosis({sqliteResult: {}, observedAt: 1, serviceId: 'mc'})).toBeNull();
+        expect(buildSqliteIntegrityDiagnosis({observedAt: 1, serviceId: 'mc'})).toBeNull();
+    });
+
+    test('emits data-integrity, which validates against RECOVERY_CLASSES (else createRecoveryDiagnosisEvent throws)', () => {
+        const diag = buildSqliteIntegrityDiagnosis({
+            sqliteResult: {checks: [{pragma: 'integrity_check', ok: false, output: 'malformed'}]},
+            observedAt  : 1, serviceId: 'mc'
+        });
+        expect(diag.recoveryClass).toBe('data-integrity');
+    });
+
+    test('rejects missing serviceId / non-finite observedAt', () => {
+        expect(() => buildSqliteIntegrityDiagnosis({sqliteResult: {checks: []}, observedAt: 1})).toThrow('serviceId');
+        expect(() => buildSqliteIntegrityDiagnosis({sqliteResult: {checks: []}, serviceId: 'mc'})).toThrow('observedAt');
+    });
+});


### PR DESCRIPTION
Resolves #14096

Adds a SQLite-integrity data-integrity detect-producer — the third #14026 detect-heuristic leaf (after coverage-drift #14074/#14075 and MC-vector-count monotonicity #14094). `buildSqliteIntegrityDiagnosis` consumes `checkChromaIntegrity`'s `result.sqlite.checks` (the `quick_check` / `integrity_check` pragmas) and emits a `data-integrity` / `escalate` `recovery-diagnosis` when any check fails — the *"malformed inverted index for FTS5"* shape that recurred all through the #13999 forensics but was only ever a manual CLI line, never a detect signal. Pure producer mirroring the coverage-drift one; detect-only (no FTS5 rebuild — operator-gated).

Evidence: L2 (unit spec — fail→diagnosis, clean→null, partial-failure pragma scoping, bounded detail snippet, enum/target-kind contract validation, input-guard throws, target-scoped diagnosisId) → fully covers #14096's ACs. Residual: none.

## Deltas from ticket

None — matches the ticket Fix exactly (pure `buildSqliteIntegrityDiagnosis` consuming `result.sqlite.checks` → `data-integrity`/`escalate` diagnosis; `null` when clean; `compose-service` target; bounded evidence). Realizes the SQLite-integrity heuristic of the ADR-0025 §2.4 data-integrity detect dimension (the amendment is the sibling PR #14091).

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis.spec.mjs` → **8 passed (32.6s)**:

- a failed `quick_check` / `integrity_check` → a contract-valid `data-integrity` / `escalate` diagnosis (`evidenceFacts` name the pragma + a bounded detail snippet);
- clean (all `ok:true`) → `null` (no false escalation);
- partial failure → only the failed pragma in `evidenceFacts` + `failedPragmas`;
- the detail snippet is bounded (≤ 280 chars — never unbounded SQLite output);
- empty / absent checks → `null`; target-scoped `diagnosisId` (no graph-node collision); `data-integrity` validates against `RECOVERY_CLASSES`; missing `serviceId` / non-finite `observedAt` throw.

`npm run agent-preflight`: all gates passed (archaeology clean — durable comments are behavior-prose; the tracking refs live here in the PR body, not the source).

## Post-Merge Validation

- [ ] None for the producer (pure, fully unit-covered). The scheduled wiring into the diagnostics daemon (consuming a live `checkChromaIntegrity` run) is the separate #14026 wiring slice.

Related: #14026 (parent detect-signal), #14075 (coverage-drift sibling + pattern), #14094 (monotonicity sibling), #14089 / #14091 (the ADR-0025 §2.4 dimension this realizes), #13999 (the FTS5 signal source), #14039.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 5ab545e1-f09e-46c5-ae62-8cf5b2b96193.
