### PR TITLE
feat(ai): data-integrity vector-count monotonicity detect-producer (#14097)

### DIFF
--- a/ai/daemons/orchestrator/services/dataIntegrityMonotonicityDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/dataIntegrityMonotonicityDiagnosis.mjs
@@ -1,0 +1,83 @@
+import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/dataIntegrityMonotonicityDiagnosis
+ * @summary Pure detect-producer for the data-integrity vector-count MONOTONICITY signal (the class's second leaf) —
+ * the threshold-free complement to the coverage-drift producer ({@link ../services/dataIntegrityCoverageDiagnosis}).
+ *
+ * Memory Core collections (`neo-agent-memory` / `neo-agent-sessions`) are append-mostly, so a vector-count
+ * **decrease** between samples is a near-unambiguous data-loss signal — robust where an absolute coverage
+ * threshold would miss or false-alarm (it would have caught the recovery-incident's ~10k-vector drop cleanly). Coverage-drift
+ * catches metadata-vs-vector desync within a single snapshot; this catches a clean count regression over time.
+ *
+ * Detect-only by construction: it compares two injected count maps and emits a diagnosis — no repair / re-embed /
+ * restore / Chroma mutation. It emits `recoveryClass: 'data-integrity'` + `details.actionClass: 'escalate'`,
+ * targeting the Memory Core `compose-service` (per-collection regression detail in `evidenceFacts`, for blast-control).
+ * Mirrors the coverage producer's pure, injected-data shape so it is testable in isolation. The caller (the
+ * diagnostics daemon) supplies `currentCounts` from `auditChromaVectorCoverage` and `previousCounts` from the
+ * persisted prior sample; that historical-sample persistence + scheduling is the integration follow-up, not this leaf.
+ */
+
+/**
+ * @summary Builds a data-integrity `recovery-diagnosis` from a current-vs-previous vector-count comparison.
+ *
+ * Pure — no I/O. Returns a diagnosis when ANY collection's current count is strictly less than its previous
+ * count (an append-mostly regression); returns `null` when every collection is flat-or-rising, or has no prior
+ * sample (no false escalation on first run). A collection absent from `previousCounts` is skipped.
+ *
+ * @param {Object} options
+ * @param {Object} options.currentCounts  Map of `{[collectionName]: vectorIndexIdCount}` from the latest audit.
+ * @param {Object} options.previousCounts Map of `{[collectionName]: vectorIndexIdCount}` from the prior sample.
+ * @param {Number} options.observedAt     Epoch milliseconds when the current sample was observed.
+ * @param {String} options.serviceId      The Memory Core compose-service identifier.
+ * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity` / `escalate`) when a regression is present, else `null`.
+ * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
+ */
+export function buildDataIntegrityMonotonicityDiagnosis({currentCounts, previousCounts, observedAt, serviceId} = {}) {
+    if (typeof serviceId !== 'string' || serviceId.length === 0) {
+        throw new TypeError('buildDataIntegrityMonotonicityDiagnosis: serviceId is required');
+    }
+    if (!Number.isFinite(observedAt)) {
+        throw new TypeError('buildDataIntegrityMonotonicityDiagnosis: observedAt must be a finite number');
+    }
+
+    const current     = currentCounts  && typeof currentCounts  === 'object' ? currentCounts  : {},
+          previous    = previousCounts && typeof previousCounts === 'object' ? previousCounts : {},
+          regressions = [];
+
+    for (const [collection, currentCount] of Object.entries(current)) {
+        const previousCount = previous[collection];
+
+        // A collection with no prior sample is skipped (no false escalation on first run). Append-mostly
+        // collections only legitimately grow or hold; a strict decrease is the data-loss signal.
+        if (Number.isFinite(previousCount) && Number.isFinite(currentCount) && currentCount < previousCount) {
+            regressions.push({
+                type : 'vector-count-regression',
+                collection,
+                previousCount,
+                currentCount,
+                delta: currentCount - previousCount
+            });
+        }
+    }
+
+    // No regression → no diagnosis (never a false escalation).
+    if (regressions.length === 0) {
+        return null;
+    }
+
+    return createRecoveryDiagnosisEvent({
+        diagnosisId   : `data-integrity:${serviceId}:vector-count-regression:${observedAt}`,
+        recoveryClass : 'data-integrity',
+        confidence    : 1,
+        targetIdentity: {kind: 'compose-service', id: serviceId},
+        evidenceFacts : regressions,
+        observedAt,
+        source        : 'data-integrity-monotonicity-monitor',
+        details       : {
+            actionClass         : 'escalate',
+            reasonCode          : 'data-integrity-vector-count-regression',
+            regressedCollections: regressions.map(regression => regression.collection)
+        }
+    });
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityMonotonicityDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityMonotonicityDiagnosis.spec.mjs
@@ -1,0 +1,83 @@
+import {test, expect}                            from '@playwright/test';
+import Neo                                       from '../../../../../../../src/Neo.mjs';
+import * as core                                 from '../../../../../../../src/core/_export.mjs';
+import {buildDataIntegrityMonotonicityDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/dataIntegrityMonotonicityDiagnosis.mjs';
+
+// Pure detect-producer (no I/O). Compares current-vs-previous per-collection vector counts; an append-mostly
+// DECREASE → a data-integrity recovery-diagnosis (escalate); flat/rising or missing-prior → null (the class's 2nd leaf).
+
+test.describe('buildDataIntegrityMonotonicityDiagnosis — vector-count monotonicity detect-producer', () => {
+    test('a count decrease -> a data-integrity/escalate recovery-diagnosis with per-collection regression evidence', () => {
+        const diag = buildDataIntegrityMonotonicityDiagnosis({
+            previousCounts: {'neo-agent-memory': 22636, 'neo-agent-sessions': 1408},
+            currentCounts : {'neo-agent-memory': 8583,  'neo-agent-sessions': 1408},  // memory dropped ~14k (the recovery-incident shape)
+            observedAt    : 1000,
+            serviceId     : 'memory-core'
+        });
+        expect(diag).toMatchObject({
+            diagnosisId   : 'data-integrity:memory-core:vector-count-regression:1000',
+            type          : 'recovery-diagnosis',
+            recoveryClass : 'data-integrity',
+            confidence    : 1,
+            targetIdentity: {kind: 'compose-service', id: 'memory-core'},
+            source        : 'data-integrity-monotonicity-monitor',
+            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-vector-count-regression', regressedCollections: ['neo-agent-memory']}
+        });
+        expect(diag.evidenceFacts).toEqual([
+            {type: 'vector-count-regression', collection: 'neo-agent-memory', previousCount: 22636, currentCount: 8583, delta: -14053}
+        ]);
+    });
+
+    test('flat or rising counts -> null (append-mostly growth is healthy, never a false escalation)', () => {
+        expect(buildDataIntegrityMonotonicityDiagnosis({
+            previousCounts: {'neo-agent-memory': 22636},
+            currentCounts : {'neo-agent-memory': 22640},  // rising
+            observedAt    : 1000,
+            serviceId     : 'memory-core'
+        })).toBeNull();
+        expect(buildDataIntegrityMonotonicityDiagnosis({
+            previousCounts: {'neo-agent-memory': 22636},
+            currentCounts : {'neo-agent-memory': 22636},  // flat
+            observedAt    : 1000,
+            serviceId     : 'memory-core'
+        })).toBeNull();
+    });
+
+    test('no prior sample for a collection -> null (no false escalation on first run)', () => {
+        expect(buildDataIntegrityMonotonicityDiagnosis({
+            previousCounts: {},                              // first run — nothing to compare
+            currentCounts : {'neo-agent-memory': 22636},
+            observedAt    : 1000,
+            serviceId     : 'memory-core'
+        })).toBeNull();
+        // A newly-appearing collection (present now, absent before) is not a regression.
+        expect(buildDataIntegrityMonotonicityDiagnosis({
+            previousCounts: {'neo-agent-memory': 22636},
+            currentCounts : {'neo-agent-memory': 22636, 'neo-agent-sessions': 1408},
+            observedAt    : 1000,
+            serviceId     : 'memory-core'
+        })).toBeNull();
+    });
+
+    test('diagnosisId is target-scoped — two services regressing at the same instant get distinct ids', () => {
+        const args = {previousCounts: {c: 10}, currentCounts: {c: 5}, observedAt: 1000},
+              a    = buildDataIntegrityMonotonicityDiagnosis({...args, serviceId: 'memory-core'}),
+              b    = buildDataIntegrityMonotonicityDiagnosis({...args, serviceId: 'knowledge-base'});
+
+        expect(a.diagnosisId).toBe('data-integrity:memory-core:vector-count-regression:1000');
+        expect(b.diagnosisId).toBe('data-integrity:knowledge-base:vector-count-regression:1000');
+        expect(a.diagnosisId).not.toBe(b.diagnosisId);
+    });
+
+    test('emits data-integrity, which validates against RECOVERY_CLASSES (else createRecoveryDiagnosisEvent throws)', () => {
+        const diag = buildDataIntegrityMonotonicityDiagnosis({
+            previousCounts: {c: 10}, currentCounts: {c: 5}, observedAt: 1, serviceId: 'mc'
+        });
+        expect(diag.recoveryClass).toBe('data-integrity');
+    });
+
+    test('rejects missing serviceId / non-finite observedAt', () => {
+        expect(() => buildDataIntegrityMonotonicityDiagnosis({previousCounts: {}, currentCounts: {}, observedAt: 1})).toThrow('serviceId');
+        expect(() => buildDataIntegrityMonotonicityDiagnosis({previousCounts: {}, currentCounts: {}, serviceId: 'mc'})).toThrow('observedAt');
+    });
+});


### PR DESCRIPTION
Resolves #14097

Second leaf of #14026's data-integrity detect-signal class, mirroring the shipped coverage-drift producer (#14075). A pure `buildDataIntegrityMonotonicityDiagnosis` producer: when an append-mostly Memory Core collection's vector-count **decreases** vs the prior sample, it emits a `data-integrity` / `escalate` recovery-diagnosis — the operator's threshold-free #13999-catching signal (it flags the exact ~10k-vector-drop shape that coverage-drift-within-a-single-snapshot can't see). Flat/rising counts, or a collection with no prior sample, → `null` (no false escalation on first run). Detect-only, pure, no I/O — the historical-sample persistence + daemon-scheduling wiring is the integration follow-up (out of this leaf, mirroring leaf 1, whose producer is likewise not yet daemon-scheduled).

Evidence: L2 (focused unit — 6/6: regression→diagnosis with per-collection evidence, flat/rising→null, missing-prior→null, target-scoped diagnosisId, enum-validates, arg-rejection).

## Deltas from ticket
None — matches the ticket's pure-producer scope. `'data-integrity'` was already added to `RECOVERY_CLASSES` by the first leaf, so no enum change here.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityMonotonicityDiagnosis.spec.mjs` → **6/6 passed (30.9s)**.

## Post-Merge Validation
- [ ] (integration follow-up, out of this leaf) wire current/previous vector-count sampling + persistence into the diagnostics-daemon schedule so the producer runs live.

## Commits
- 2fbb7c483 — feat(ai): data-integrity vector-count monotonicity detect-producer (#14097)

## Structural pre-flight
New file `ai/daemons/orchestrator/services/dataIntegrityMonotonicityDiagnosis.mjs` is a Stage-1 fast-path sibling-lift of `dataIntegrityCoverageDiagnosis.mjs` in the same directory (same pure-producer shape, same `recovery-diagnosis` contract) — no novel directory choice.

Related: #14026 (parent detect-signal class), #14075 (the coverage-drift first leaf this mirrors), #13999 (the data loss this signal catches), #14046 (the e2e gate that wires producers in-test), #14039.

Authored by Vega (Claude Opus 4.8, Claude Code). Session c94ea3b2-1ae8-48fd-8f34-1c54d90f5caa.
