### PR TITLE
feat(ai): store-size bloat data-integrity detect-producer (#14101)

### DIFF
--- a/ai/daemons/orchestrator/services/storeBloatDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/storeBloatDiagnosis.mjs
@@ -1,0 +1,91 @@
+import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/storeBloatDiagnosis
+ * @summary Pure detect-producer for the data-integrity store-size bloat signal — a leaf of the
+ * data-integrity detect-signal class (sibling of the coverage-drift + SQLite-integrity producers). The
+ * unified Chroma store can grow unbounded (un-pruned WAL, orphaned segments, churn); a store far over its
+ * size budget, or growing too fast between samples, is a data-integrity signal. It turns an injected
+ * `(storeSizeBytes, previousSizeBytes)` measurement + configured thresholds into a `recovery-diagnosis`
+ * so the immune system ESCALATES rather than letting the store bloat silently.
+ *
+ * Detect-only by construction: it consumes a size measurement and emits a diagnosis — it performs no
+ * prune / vacuum / mutation (operator-gated remediation). It emits `recoveryClass: 'data-integrity'` +
+ * `details.actionClass: 'escalate'`, targeting the Memory Core `compose-service`. The size measurement and
+ * the threshold config-leaves (read at the daemon use-site) are injected, so the producer is pure and
+ * testable in isolation. A sub-signal whose threshold is non-finite is skipped (graceful).
+ */
+
+/**
+ * @summary Builds a data-integrity `recovery-diagnosis` from a store-size measurement + thresholds.
+ *
+ * Pure — no I/O. Returns a diagnosis when the store is over its ABSOLUTE budget OR has GROWN faster than
+ * the growth-ratio budget since the previous sample; returns `null` when within budget (never a false
+ * escalation). A non-finite `storeSizeBytes` (no measurement) returns `null`; a missing / zero
+ * `previousSizeBytes` simply disables the growth sub-signal (absolute-only).
+ *
+ * @param {Object} options
+ * @param {Number} options.storeSizeBytes Current store size in bytes.
+ * @param {Number} [options.previousSizeBytes] The prior sample's store size (enables the growth sub-signal).
+ * @param {Object} options.thresholds `{absoluteBytes, growthRatio}` — config leaves read at the daemon use-site.
+ * @param {Number} options.observedAt Epoch milliseconds when the measurement was observed.
+ * @param {String} options.serviceId The Memory Core compose-service identifier.
+ * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity` / `escalate`) when bloated, else `null`.
+ * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
+ */
+export function buildStoreBloatDiagnosis({storeSizeBytes, previousSizeBytes, thresholds, observedAt, serviceId} = {}) {
+    if (typeof serviceId !== 'string' || serviceId.length === 0) {
+        throw new TypeError('buildStoreBloatDiagnosis: serviceId is required');
+    }
+    if (!Number.isFinite(observedAt)) {
+        throw new TypeError('buildStoreBloatDiagnosis: observedAt must be a finite number');
+    }
+
+    // No measurement → nothing to assess (not a loss).
+    if (!Number.isFinite(storeSizeBytes)) {
+        return null;
+    }
+
+    const absoluteBytes = thresholds?.absoluteBytes,
+          growthRatio   = thresholds?.growthRatio,
+          signals       = [];
+
+    if (Number.isFinite(absoluteBytes) && storeSizeBytes > absoluteBytes) {
+        signals.push({type: 'store-bloat', signal: 'absolute', storeSizeBytes, thresholdBytes: absoluteBytes});
+    }
+
+    if (Number.isFinite(growthRatio) && Number.isFinite(previousSizeBytes) && previousSizeBytes > 0) {
+        const ratio = (storeSizeBytes - previousSizeBytes) / previousSizeBytes;
+
+        if (ratio > growthRatio) {
+            signals.push({
+                type          : 'store-bloat',
+                signal        : 'growth',
+                storeSizeBytes,
+                previousSizeBytes,
+                observedGrowth: ratio,
+                thresholdRatio: growthRatio
+            });
+        }
+    }
+
+    // Within budget on every configured sub-signal → no diagnosis.
+    if (signals.length === 0) {
+        return null;
+    }
+
+    return createRecoveryDiagnosisEvent({
+        diagnosisId   : `data-integrity:${serviceId}:store-bloat:${observedAt}`,
+        recoveryClass : 'data-integrity',
+        confidence    : 1,
+        targetIdentity: {kind: 'compose-service', id: serviceId},
+        evidenceFacts : signals,
+        observedAt,
+        source        : 'data-integrity-store-bloat-monitor',
+        details       : {
+            actionClass     : 'escalate',
+            reasonCode      : 'data-integrity-store-bloat',
+            triggeredSignals: signals.map(signal => signal.signal)
+        }
+    });
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/storeBloatDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/storeBloatDiagnosis.spec.mjs
@@ -1,0 +1,105 @@
+import {test, expect}             from '@playwright/test';
+import Neo                        from '../../../../../../../src/Neo.mjs';
+import * as core                  from '../../../../../../../src/core/_export.mjs';
+import {buildStoreBloatDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/storeBloatDiagnosis.mjs';
+
+// Pure detect-producer (no I/O). Turns a store-size measurement + thresholds into a data-integrity/escalate
+// recovery-diagnosis when the store is over its absolute budget OR grew too fast since the previous sample;
+// null when within budget.
+
+const THRESHOLDS = {absoluteBytes: 2_000_000_000, growthRatio: 0.25};  // 2GB absolute, 25% growth
+
+test.describe('buildStoreBloatDiagnosis — data-integrity store-size bloat detect-producer', () => {
+    test('over the absolute budget -> a data-integrity/escalate recovery-diagnosis', () => {
+        const diag = buildStoreBloatDiagnosis({
+            storeSizeBytes: 2_500_000_000,  // 2.5GB > 2GB
+            thresholds    : THRESHOLDS,
+            observedAt    : 1000,
+            serviceId     : 'memory-core'
+        });
+        expect(diag).toMatchObject({
+            diagnosisId   : 'data-integrity:memory-core:store-bloat:1000',
+            type          : 'recovery-diagnosis',
+            recoveryClass : 'data-integrity',
+            confidence    : 1,
+            targetIdentity: {kind: 'compose-service', id: 'memory-core'},
+            source        : 'data-integrity-store-bloat-monitor',
+            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-store-bloat', triggeredSignals: ['absolute']}
+        });
+        expect(diag.evidenceFacts).toEqual([
+            {type: 'store-bloat', signal: 'absolute', storeSizeBytes: 2_500_000_000, thresholdBytes: 2_000_000_000}
+        ]);
+    });
+
+    test('grew faster than the growth-ratio budget -> a growth-signal diagnosis (even under the absolute budget)', () => {
+        const diag = buildStoreBloatDiagnosis({
+            storeSizeBytes   : 1_400_000_000,  // under 2GB absolute
+            previousSizeBytes: 1_000_000_000, // +40% > 25%
+            thresholds       : THRESHOLDS,
+            observedAt       : 1000,
+            serviceId        : 'memory-core'
+        });
+        expect(diag.details.triggeredSignals).toEqual(['growth']);
+        expect(diag.evidenceFacts[0]).toMatchObject({
+            type: 'store-bloat', signal: 'growth', storeSizeBytes: 1_400_000_000, previousSizeBytes: 1_000_000_000, thresholdRatio: 0.25
+        });
+        expect(diag.evidenceFacts[0].observedGrowth).toBeCloseTo(0.4, 5);
+    });
+
+    test('both absolute + growth crossed -> both signals carried', () => {
+        const diag = buildStoreBloatDiagnosis({
+            storeSizeBytes   : 3_000_000_000,  // over 2GB
+            previousSizeBytes: 2_000_000_000, // +50% > 25%
+            thresholds       : THRESHOLDS, observedAt: 1, serviceId: 'mc'
+        });
+        expect(diag.details.triggeredSignals).toEqual(['absolute', 'growth']);
+        expect(diag.evidenceFacts).toHaveLength(2);
+    });
+
+    test('within budget (absolute + growth both under) -> null (no false escalation)', () => {
+        expect(buildStoreBloatDiagnosis({
+            storeSizeBytes   : 1_100_000_000,  // under 2GB
+            previousSizeBytes: 1_000_000_000, // +10% < 25%
+            thresholds       : THRESHOLDS, observedAt: 1000, serviceId: 'memory-core'
+        })).toBeNull();
+    });
+
+    test('missing previousSizeBytes -> absolute-only (growth sub-signal disabled)', () => {
+        const overAbsolute  = buildStoreBloatDiagnosis({storeSizeBytes: 2_500_000_000, thresholds: THRESHOLDS, observedAt: 1, serviceId: 'mc'}),
+              underAbsolute = buildStoreBloatDiagnosis({storeSizeBytes: 1_000_000_000, thresholds: THRESHOLDS, observedAt: 1, serviceId: 'mc'});
+
+        expect(overAbsolute.details.triggeredSignals).toEqual(['absolute']);
+        expect(underAbsolute).toBeNull();  // no previous sample → no growth signal → within absolute budget → null
+    });
+
+    test('a non-finite threshold disables its sub-signal (graceful)', () => {
+        // Only a growth threshold configured → an over-absolute store does NOT fire (absolute disabled).
+        expect(buildStoreBloatDiagnosis({
+            storeSizeBytes: 9_000_000_000, thresholds: {growthRatio: 0.25}, observedAt: 1, serviceId: 'mc'
+        })).toBeNull();
+    });
+
+    test('non-finite storeSizeBytes (no measurement) -> null', () => {
+        expect(buildStoreBloatDiagnosis({storeSizeBytes: undefined, thresholds: THRESHOLDS, observedAt: 1, serviceId: 'mc'})).toBeNull();
+        expect(buildStoreBloatDiagnosis({thresholds: THRESHOLDS, observedAt: 1, serviceId: 'mc'})).toBeNull();
+    });
+
+    test('diagnosisId is target-scoped — two services bloating at the same instant get distinct ids', () => {
+        const args = {storeSizeBytes: 3_000_000_000, thresholds: THRESHOLDS, observedAt: 1000},
+              a    = buildStoreBloatDiagnosis({...args, serviceId: 'memory-core'}),
+              b    = buildStoreBloatDiagnosis({...args, serviceId: 'knowledge-base'});
+        expect(a.diagnosisId).toBe('data-integrity:memory-core:store-bloat:1000');
+        expect(b.diagnosisId).toBe('data-integrity:knowledge-base:store-bloat:1000');
+        expect(a.diagnosisId).not.toBe(b.diagnosisId);
+    });
+
+    test('emits data-integrity, which validates against RECOVERY_CLASSES (else createRecoveryDiagnosisEvent throws)', () => {
+        const diag = buildStoreBloatDiagnosis({storeSizeBytes: 3_000_000_000, thresholds: THRESHOLDS, observedAt: 1, serviceId: 'mc'});
+        expect(diag.recoveryClass).toBe('data-integrity');
+    });
+
+    test('rejects missing serviceId / non-finite observedAt', () => {
+        expect(() => buildStoreBloatDiagnosis({storeSizeBytes: 1, thresholds: THRESHOLDS, observedAt: 1})).toThrow('serviceId');
+        expect(() => buildStoreBloatDiagnosis({storeSizeBytes: 1, thresholds: THRESHOLDS, serviceId: 'mc'})).toThrow('observedAt');
+    });
+});


### PR DESCRIPTION
Resolves #14101

Adds a store-size bloat data-integrity detect-producer — #14026 leaf 4 (after coverage-drift #14075, monotonicity #14094, SQLite-integrity #14096). `buildStoreBloatDiagnosis` turns an injected `(storeSizeBytes, previousSizeBytes)` measurement + configured thresholds into a `data-integrity` / `escalate` `recovery-diagnosis` when the store is over its absolute budget OR grew faster than the growth-ratio budget (the ~2.5GB #14079 signal) — currently undetected. Pure producer mirroring the sibling pattern; detect-only (no prune/vacuum — operator-gated).

Evidence: L2 (unit spec — absolute-bloat, growth-bloat, both-signals, within-budget→null, absolute-only fallback, non-finite-threshold graceful, non-finite-size→null, target-scoped id, enum/target validation, arg-guard throws) → fully covers #14101's ACs. Residual: none.

## Deltas from ticket

None — matches the Fix + the Contract Ledger exactly (the ledger is in the #14101 body, carried at creation per the detect-leaf pattern). The thresholds are params (ADR-0019 — the daemon reads `absoluteBytes` / `growthRatio` config leaves at the use-site; the pure producer never reads config). A sub-signal whose threshold is non-finite is skipped (graceful), so a partially-configured daemon degrades cleanly rather than firing/erroring.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/storeBloatDiagnosis.spec.mjs` → **10 passed (31.3s)**:

- over the absolute budget → diagnosis (`triggeredSignals: ['absolute']`);
- grew faster than the growth-ratio (under the absolute budget) → `['growth']`;
- both crossed → both signals carried;
- within budget → `null` (no false escalation);
- missing `previousSizeBytes` → absolute-only; non-finite threshold → that sub-signal skipped; non-finite `storeSizeBytes` → `null`;
- target-scoped `diagnosisId`; `data-integrity` validates against `RECOVERY_CLASSES`; missing `serviceId` / non-finite `observedAt` throw.

`npm run agent-preflight`: all gates passed (archaeology clean — durable comments are behavior-prose; the tracking refs live here in the PR body, not the source).

## Post-Merge Validation

- [ ] None for the producer (pure, fully unit-covered). The scheduled size-measurement + threshold-leaf wiring into the diagnostics daemon is the separate #14026 wiring slice.

Related: #14026 (parent), #14075 / #14094 / #14096 (sibling producers), #14079 (the 2.5GB bloat this detects), #14089 / #14091 (the ADR-0025 §2.4 dimension), #14039.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 5ab545e1-f09e-46c5-ae62-8cf5b2b96193.
