### PR TITLE
feat(ai): embedding-dimension consistency detect-producer (#14102)

### DIFF
--- a/ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis.mjs
@@ -1,0 +1,71 @@
+import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis
+ * @summary Pure detect-producer for the embedding-dimension consistency signal — a leaf of the
+ * data-integrity detect-signal class (sibling of `dataIntegrityCoverageDiagnosis` / `vectorCountMonotonicityDiagnosis`).
+ * Every stored Memory Core vector must be the configured embedding dimension; a wrong-dimension vector is
+ * unambiguous corruption (it breaks similarity search, and — unlike a count regression — has no legitimate
+ * case). It turns per-collection dimension-audit samples into a `recovery-diagnosis` when any collection
+ * holds mismatched-dimension vectors, so the immune system can ESCALATE rather than serve a corrupt index.
+ *
+ * Detect-only by construction: it consumes audit samples and emits a diagnosis — no repair / re-embed /
+ * restore / mutation. It emits `recoveryClass: 'data-integrity'` + `details.actionClass: 'escalate'`,
+ * targeting the Memory Core `compose-service` (per-collection mismatch carried in `evidenceFacts`). Mirrors
+ * the sibling producers' pure shape: the samples (the dimension audit) are injected — the audit + scheduling
+ * are the consumer/daemon's concern — so it is testable in isolation.
+ */
+
+/**
+ * @summary Builds a data-integrity `recovery-diagnosis` from per-collection embedding-dimension samples.
+ *
+ * Pure — no I/O. Returns a diagnosis when ANY collection reports `mismatchedVectorCount > 0` (a stored
+ * vector whose dimension ≠ the configured embedding dimension); returns `null` when every sampled collection
+ * is clean (never a false escalation). Samples whose `mismatchedVectorCount` is not a finite number are
+ * ignored (an unread collection is not corruption).
+ *
+ * @param {Object} options
+ * @param {Array<Object>} options.samples Per-collection dimension samples — `[{collection, expectedDimension, mismatchedVectorCount}]`.
+ * @param {Number} options.observedAt Epoch milliseconds when the audit was observed.
+ * @param {String} options.serviceId The Memory Core compose-service identifier.
+ * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity` / `escalate`) when a mismatch is present, else `null`.
+ * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
+ */
+export function buildDimensionConsistencyDiagnosis({samples, observedAt, serviceId} = {}) {
+    if (typeof serviceId !== 'string' || serviceId.length === 0) {
+        throw new TypeError('buildDimensionConsistencyDiagnosis: serviceId is required');
+    }
+    if (!Number.isFinite(observedAt)) {
+        throw new TypeError('buildDimensionConsistencyDiagnosis: observedAt must be a finite number');
+    }
+
+    const rows       = Array.isArray(samples) ? samples : [],
+          mismatched = rows.filter(sample =>
+              Number.isFinite(sample?.mismatchedVectorCount) && sample.mismatchedVectorCount > 0
+          );
+
+    // Every sampled collection dimension-consistent → no diagnosis (never a false escalation).
+    if (mismatched.length === 0) {
+        return null;
+    }
+
+    return createRecoveryDiagnosisEvent({
+        diagnosisId   : `data-integrity:${serviceId}:dimension-mismatch:${observedAt}`,
+        recoveryClass : 'data-integrity',
+        confidence    : 1,
+        targetIdentity: {kind: 'compose-service', id: serviceId},
+        evidenceFacts : mismatched.map(sample => ({
+            type                 : 'vector-dimension-mismatch',
+            collection           : sample.collection,
+            expectedDimension    : sample.expectedDimension,
+            mismatchedVectorCount: sample.mismatchedVectorCount
+        })),
+        observedAt,
+        source : 'data-integrity-dimension-monitor',
+        details: {
+            actionClass          : 'escalate',
+            reasonCode           : 'data-integrity-dimension-mismatch',
+            mismatchedCollections: mismatched.map(sample => sample.collection)
+        }
+    });
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis.spec.mjs
@@ -1,0 +1,82 @@
+import {test, expect}                       from '@playwright/test';
+import Neo                                  from '../../../../../../../src/Neo.mjs';
+import * as core                            from '../../../../../../../src/core/_export.mjs';
+import {buildDimensionConsistencyDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis.mjs';
+
+// Pure detect-producer (no I/O). A stored vector whose dimension ≠ the configured embedding dimension is
+// unambiguous corruption → a data-integrity/escalate recovery-diagnosis; all-matching samples → null.
+
+test.describe('buildDimensionConsistencyDiagnosis — embedding-dimension consistency detect-producer', () => {
+    test('a collection holding mismatched-dimension vectors -> a data-integrity/escalate recovery-diagnosis', () => {
+        const diag = buildDimensionConsistencyDiagnosis({
+            samples: [
+                {collection: 'neo-agent-memory',   expectedDimension: 4096, mismatchedVectorCount: 12},
+                {collection: 'neo-agent-sessions', expectedDimension: 4096, mismatchedVectorCount: 0}
+            ],
+            observedAt: 1000,
+            serviceId : 'memory-core'
+        });
+
+        expect(diag).toMatchObject({
+            diagnosisId   : 'data-integrity:memory-core:dimension-mismatch:1000',
+            type          : 'recovery-diagnosis',
+            recoveryClass : 'data-integrity',
+            confidence    : 1,
+            targetIdentity: {kind: 'compose-service', id: 'memory-core'},
+            source        : 'data-integrity-dimension-monitor',
+            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-dimension-mismatch', mismatchedCollections: ['neo-agent-memory']}
+        });
+        expect(diag.evidenceFacts).toEqual([
+            {type: 'vector-dimension-mismatch', collection: 'neo-agent-memory', expectedDimension: 4096, mismatchedVectorCount: 12}
+        ]);
+    });
+
+    test('diagnosisId is target+instant scoped — two services mismatching at the same instant get distinct ids', () => {
+        const args = {samples: [{collection: 'c', expectedDimension: 4096, mismatchedVectorCount: 1}], observedAt: 1000},
+              a    = buildDimensionConsistencyDiagnosis({...args, serviceId: 'memory-core'}),
+              b    = buildDimensionConsistencyDiagnosis({...args, serviceId: 'knowledge-base'});
+
+        expect(a.diagnosisId).toBe('data-integrity:memory-core:dimension-mismatch:1000');
+        expect(b.diagnosisId).toBe('data-integrity:knowledge-base:dimension-mismatch:1000');
+        expect(a.diagnosisId).not.toBe(b.diagnosisId);
+    });
+
+    test('all-matching samples (mismatchedVectorCount 0) -> null (no false escalation)', () => {
+        expect(buildDimensionConsistencyDiagnosis({
+            samples: [
+                {collection: 'neo-agent-memory',   expectedDimension: 4096, mismatchedVectorCount: 0},
+                {collection: 'neo-agent-sessions', expectedDimension: 4096, mismatchedVectorCount: 0}
+            ],
+            observedAt: 1000,
+            serviceId : 'memory-core'
+        })).toBeNull();
+    });
+
+    test('empty / absent samples -> null', () => {
+        expect(buildDimensionConsistencyDiagnosis({samples: [], observedAt: 1, serviceId: 'mc'})).toBeNull();
+        expect(buildDimensionConsistencyDiagnosis({observedAt: 1, serviceId: 'mc'})).toBeNull();
+    });
+
+    test('samples with a non-finite or absent mismatchedVectorCount are ignored — an unread collection is not corruption', () => {
+        expect(buildDimensionConsistencyDiagnosis({
+            samples: [
+                {collection: 'unread',   expectedDimension: 4096},                            // count not yet audited
+                {collection: 'unknown',  expectedDimension: 4096, mismatchedVectorCount: null}
+            ],
+            observedAt: 1,
+            serviceId : 'mc'
+        })).toBeNull();
+    });
+
+    test('emits data-integrity, which validates against RECOVERY_CLASSES (else createRecoveryDiagnosisEvent throws)', () => {
+        const diag = buildDimensionConsistencyDiagnosis({
+            samples: [{collection: 'c', expectedDimension: 4096, mismatchedVectorCount: 1}], observedAt: 1, serviceId: 'mc'
+        });
+        expect(diag.recoveryClass).toBe('data-integrity');
+    });
+
+    test('rejects missing serviceId / non-finite observedAt', () => {
+        expect(() => buildDimensionConsistencyDiagnosis({samples: [], observedAt: 1})).toThrow('serviceId');
+        expect(() => buildDimensionConsistencyDiagnosis({samples: [], serviceId: 'mc'})).toThrow('observedAt');
+    });
+});


### PR DESCRIPTION
Resolves #14102

Related: #14026

A leaf of the #14026 data-integrity detect-signal class — sibling of coverage-drift (#14075), vector-count monotonicity (#14094), SQLite-integrity (#14096). A stored Memory Core vector whose dimension ≠ the configured embedding dimension is **unambiguous corruption** (breaks similarity search; unlike a count regression, there is no legitimate case).

`buildDimensionConsistencyDiagnosis({samples, observedAt, serviceId})` turns per-collection `{collection, expectedDimension, mismatchedVectorCount}` audit samples into a `data-integrity`/`escalate` `recovery-diagnosis` when any collection holds mismatched vectors; `null` when all match. Pure, detect-only — samples injected (the dimension audit + scheduling are the consumer's concern), reusing `createRecoveryDiagnosisEvent`. The Contract Ledger is on the ticket (#14102) **upfront** (applying the #14095 lesson).

Evidence: L2 (unit spec — mismatch→diagnosis, all-clean→null, target+instant-scoped diagnosisId, non-finite/absent counts ignored, enum-validation, arg-rejection) → fully covers #14102's ACs. Residual: none.

## Deltas from ticket

- None of substance — a clean sibling-lift of the merged `dataIntegrityCoverageDiagnosis` / `vectorCountMonotonicityDiagnosis` pure-producer pattern (structural-pre-flight fast-path).
- Contract Ledger included on the ticket (#14102) **upfront** rather than backfilled, applying the #14095 review lesson (Euclid RC'd #14095 purely for a missing ledger) → no RC cycle expected.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis.spec.mjs` → **7 passed**.

`npm run agent-preflight`: all gates passed (archaeology clean).

## Post-Merge Validation

- [ ] When the dimension audit + scheduled consumer land (a separate #14026 slice), this producer fires the escalation on a real wrong-dimension vector in a Memory Core collection.

## Coordination

Claimed **non-wakeSuppressed** per #14100 (the lane-claim-collision lesson) via the #14026 leaf-division broadcast; collision-clear (Grace took store-bloat). ADR-0025 §2.4 (#14089) is merged, so the data-integrity detect-dimension is documented — the pure producer is within the established + already-merged sibling shape.

Authored by Ada (Claude Opus 4.8, Claude Code). Session fe9c04d6-1aae-4017-8d53-19b0e5aaf809.