### PR TITLE
feat(ai): dense-content embedding budget margin for the MC truncate floor (#14105)

### DIFF
--- a/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
+++ b/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
@@ -366,6 +366,15 @@ export function truncateToByteBudget(text, maxBytes) {
 }
 
 /**
+ * Safety margin on the truncate budget. `bytesToTokens` (≈3 bytes/token) UNDER-estimates tokens for dense
+ * content (CJK/emoji run fewer bytes/token), so a naive prefix sized at the raw estimate can still exceed
+ * the real provider budget. Shaving the byte budget lands a dense prefix safely under budget — raising
+ * dense-content recovery instead of degrading it to `unrecoverable`.
+ * @type {Number}
+ */
+const EMBED_TRUNCATE_SAFETY_FACTOR = 0.9;
+
+/**
  * @summary Truncates a document to a context-bounded prefix that fits the embedding token budget, so an
  * oversized Memory Core document gets *a* (slightly lossy) vector and stays searchable rather than falling
  * out of recovery as `unrecoverable`.
@@ -395,10 +404,10 @@ export function truncateToEmbedTokenBudget(text, maxTokens) {
         return text;
     }
 
-    // Derive the byte budget from the heuristic's own ratio (no duplicated magic constant), then shave the
-    // rounding edge until the estimate is within budget.
+    // Derive the byte budget from the heuristic's own ratio (no duplicated magic constant), apply the
+    // dense-content safety margin (see EMBED_TRUNCATE_SAFETY_FACTOR), then shave any residual rounding edge.
     const bytesPerToken = totalBytes / Math.max(1, bytesToTokens(totalBytes));
-    let   maxBytes      = Math.max(1, Math.floor(maxTokens * bytesPerToken)),
+    let   maxBytes      = Math.max(1, Math.floor(maxTokens * bytesPerToken * EMBED_TRUNCATE_SAFETY_FACTOR)),
           truncated     = truncateToByteBudget(text, maxBytes);
 
     while (truncated.length > 0 && bytesToTokens(Buffer.byteLength(truncated, 'utf8')) > maxTokens) {

--- a/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
@@ -5,9 +5,9 @@ setup({
     appConfig: {name: 'RepairMcStoredEmbeddingsTest', isMounted: () => true, vnodeInitialising: false}
 });
 
-import {test, expect}                                               from '@playwright/test';
-import Neo                                                          from '../../../../../../src/Neo.mjs';
-import * as core                                                    from '../../../../../../src/core/_export.mjs';
+import {test, expect}                                                                                                 from '@playwright/test';
+import Neo                                                                                                            from '../../../../../../src/Neo.mjs';
+import * as core                                                                                                      from '../../../../../../src/core/_export.mjs';
 import {embedRecoverableDocuments, extractMemoryCoreCollectionData, truncateToByteBudget, truncateToEmbedTokenBudget} from '../../../../../../ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs';
 
 /**
@@ -298,7 +298,7 @@ test.describe('truncateToEmbedTokenBudget — oversized-document recovery (the P
     });
 
     test('truncates an over-budget document to a prefix estimated to fit the budget', () => {
-        const text      = 'x'.repeat(30000),            // ~10000 tokens at ~3 bytes/token
+        const text = 'x'.repeat(30000),            // ~10000 tokens at ~3 bytes/token
               truncated = truncateToEmbedTokenBudget(text, 100);
 
         expect(truncated.length).toBeLessThan(text.length);
@@ -306,8 +306,19 @@ test.describe('truncateToEmbedTokenBudget — oversized-document recovery (the P
         expect(Math.ceil(Buffer.byteLength(truncated, 'utf8') / 3)).toBeLessThanOrEqual(100);
     });
 
+    test('applies the dense-content safety margin — the truncated prefix lands UNDER budget, not just at it', () => {
+        // Dense multi-byte content (CJK, 3 bytes/char): bytesToTokens under-estimates real tokens here, so
+        // the ~0.9 margin shaves the prefix below the raw budget to keep dense docs recoverable.
+        const text = '世'.repeat(4000),   // ~12000 bytes ≈ 4000 heuristic-tokens
+              truncated = truncateToEmbedTokenBudget(text, 100);
+
+        expect(text.startsWith(truncated)).toBe(true);
+        // estimate sits at/below the margin (0.9 × 100), leaving headroom for the denser real tokenization
+        expect(Math.ceil(Buffer.byteLength(truncated, 'utf8') / 3)).toBeLessThanOrEqual(90);
+    });
+
     test('never splits a multi-byte UTF-8 character', () => {
-        const text      = '😀'.repeat(5000),            // 4 bytes each
+        const text = '😀'.repeat(5000),            // 4 bytes each
               truncated = truncateToEmbedTokenBudget(text, 100);
 
         expect(truncated.length).toBeGreaterThan(0);
@@ -328,7 +339,7 @@ test.describe('truncateToEmbedTokenBudget — oversized-document recovery (the P
     });
 
     test('a budget-aware embedFn RECOVERS an oversized document instead of marking it unrecoverable', async () => {
-        const BUDGET    = 50,                 // tiny test token budget
+        const BUDGET = 50,                 // tiny test token budget
               oversized = 'y'.repeat(900);    // ~300 tokens — exceeds BUDGET
 
         // Mirror the production embedFn wrapper: truncate each doc to the budget, then embed. The fake
@@ -356,7 +367,7 @@ test.describe('truncateToEmbedTokenBudget — oversized-document recovery (the P
     });
 
     test('the gap this closes: without budget-aware truncation the same oversized document stays unrecoverable', async () => {
-        const oversized  = 'y'.repeat(900);
+        const oversized = 'y'.repeat(900);
         // A raw embedFn (no truncation) that rejects the oversized doc — the pre-truncation behavior.
         const rawEmbedFn = async () => { throw new Error('embedding context too small (context overflow)'); };
 


### PR DESCRIPTION
Resolves #14105

Related: #14085, #14092

The #14085 truncate-to-context floor (merged via #14092) derives its byte budget from `bytesToTokens` (~3 bytes/token), which **under-estimates tokens for dense content** (CJK / emoji run fewer bytes/token) — so a dense oversized doc's prefix could still exceed the real provider budget and degrade to `unrecoverable`, partly defeating the floor for emoji/CJK-heavy memories. Applies a named `EMBED_TRUNCATE_SAFETY_FACTOR` (0.9) to the truncate budget so a dense prefix lands safely under budget, raising dense-content recovery. Surfaced in @neo-opus-grace's #14092 review (non-blocking follow-up #2).

Evidence: L2 (unit — a dense CJK oversized doc truncates to ≤ 0.9×budget; all existing #14085 tests remain green) → fully covers #14105's ACs. Residual: none.

## Deltas from ticket

- Implemented the **0.9× margin** (the ticket's recommended minimal-blast fix) as a named constant; the real-token-re-check alternative is unnecessary.
- Grace's #14092 follow-up **#1** (truncated-row count visibility) is **out of scope** here — a separate follow-up (it needs the `embedFn`-wrapper → repair-counts plumbing, and feeds #14084's accepted-loss "recovered-with-truncation" taxonomy).

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs` → **20 passed** (the new dense-content margin test + all existing #14085 truncate tests + the #14081 binary-split tests).

`npm run agent-preflight`: all gates passed (archaeology clean).

## Post-Merge Validation

- [ ] On a real CJK / emoji-heavy oversized Memory Core memory, the truncated prefix embeds successfully (recovered) rather than being marked `unrecoverable`.

Authored by Ada (Claude Opus 4.8, Claude Code). Session fe9c04d6-1aae-4017-8d53-19b0e5aaf809.