### PR TITLE
feat(ai): data-integrity diagnostics runner unit — coverage detect leaf (#14112)

### DIFF
--- a/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
@@ -1,0 +1,204 @@
+import Base from '../../../../src/core/Base.mjs';
+
+import {buildDataIntegrityCoverageDiagnosis} from './dataIntegrityCoverageDiagnosis.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/DataIntegrityDiagnosisService
+ * @summary The data-integrity diagnostics runner — the integration leaf of the data-integrity
+ * detect-signal class that turns the pure detect-producers (coverage-drift, and, as they land,
+ * monotonicity / dimension / store-bloat / SQLite) into a LIVE immune-system signal. It is the missing
+ * wiring between the producers (which are proven by the release-gate end-to-end corruption proof but
+ * not yet running) and the recovery actuator's escalate sink.
+ *
+ * The runner gathers bounded read-observe facts (a Chroma vector-coverage audit), runs the producers
+ * over them, and routes every emitted `recovery-diagnosis` to the actuator's `escalateDiagnosis` sink —
+ * the operator-page path. It is DETECT-ONLY / ESCALATE-ONLY by construction: it never calls a
+ * privileged recovery action (`apply` / restart / re-embed / restore / Chroma mutation). Data mutation
+ * stays operator-gated (the two-worlds boundary); a gutted store pages a human, it is not
+ * silently "repaired".
+ *
+ * All collaborators are injected (the fact gatherer, the actuator, the Memory Core service id, the
+ * clock), so the unit is pure-testable in isolation and the AiConfig SSOT leaves are read at the
+ * orchestrator use-site, never re-derived here (config-SSOT discipline).
+ */
+
+/**
+ * @class Neo.ai.daemons.services.DataIntegrityDiagnosisService
+ * @extends Neo.core.Base
+ * @see learn/agentos/decisions/0025-orchestrator-container-health-self-healing.md
+ * @see learn/agentos/decisions/0026-recovery-actuator.md
+ * @see learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
+ */
+export class DataIntegrityDiagnosisService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.DataIntegrityDiagnosisService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.DataIntegrityDiagnosisService',
+        /**
+         * Async fact gatherer returning a Chroma vector-coverage audit result
+         * (`auditChromaVectorCoverage()` pre-bound with its AiConfig leaves at the use-site).
+         * @member {Function|null} coverageGatherer_=null
+         * @protected
+         * @reactive
+         */
+        coverageGatherer_: null,
+        /**
+         * The recovery actuator (or any object exposing `escalateDiagnosis(event, options)`).
+         * Only its escalate sink is ever reached — never a privileged action.
+         * @member {Object|null} recoveryActuator_=null
+         * @protected
+         * @reactive
+         */
+        recoveryActuator_: null,
+        /**
+         * The Memory Core `compose-service` identifier the diagnoses target.
+         * @member {String|null} serviceId_=null
+         * @protected
+         * @reactive
+         */
+        serviceId_: null,
+        /**
+         * @member {Function|null} nowFn_=null
+         * @protected
+         * @reactive
+         */
+        nowFn_: null
+    }
+
+    /**
+     * @summary Gathers integrity facts, runs the detect-producers, and routes any diagnosis to escalate.
+     *
+     * On a clean store this returns a `healthy` decision with no escalation. When a producer fires, the
+     * diagnosis is routed to the actuator's escalate sink (operator page) and the decision is `escalated`.
+     * If the probe itself cannot run (e.g. Chroma unreachable), the decision is `probe-unavailable` and
+     * NOTHING is escalated — a failed probe must never be mistaken for a data-integrity drift signal.
+     *
+     * @param {Object} [options]
+     * @param {Number} [options.observedAt=this.now()] Epoch milliseconds for the observation.
+     * @returns {Promise<Object>} A `data-integrity-diagnosis-decision` envelope.
+     * @throws {TypeError} when a required collaborator (serviceId / coverageGatherer / recoveryActuator) is missing.
+     */
+    async gatherAndDiagnose({observedAt = this.now()} = {}) {
+        this.validateDependencies();
+
+        let coverageResult;
+
+        try {
+            coverageResult = await this.coverageGatherer();
+        } catch (error) {
+            return this.createDecision({
+                serviceId : this.serviceId,
+                observedAt,
+                status    : 'probe-unavailable',
+                probeError: error.message
+            });
+        }
+
+        const diagnoses   = this.buildDiagnoses({coverageResult, observedAt}),
+              escalations = await this.routeDiagnoses({diagnoses, now: observedAt});
+
+        return this.createDecision({
+            serviceId: this.serviceId,
+            observedAt,
+            status   : diagnoses.length > 0 ? 'escalated' : 'healthy',
+            diagnoses,
+            escalations
+        });
+    }
+
+    /**
+     * @summary Runs the pure detect-producers over the gathered facts and collects non-null diagnoses.
+     *
+     * This is the extension seam: follow-up slices add the monotonicity producer (fed by the runner's
+     * own per-collection history) and the dimension-consistency producer (fed by an injected dimension
+     * fact-gatherer) alongside the coverage-drift producer wired here.
+     *
+     * @param {Object} options
+     * @param {Object} options.coverageResult The `auditChromaVectorCoverage()` result.
+     * @param {Number} options.observedAt Epoch milliseconds for the observation.
+     * @returns {Object[]} The non-null `recovery-diagnosis` events emitted this cycle.
+     */
+    buildDiagnoses({coverageResult, observedAt}) {
+        const diagnoses = [],
+              coverage  = buildDataIntegrityCoverageDiagnosis({
+                  coverageResult,
+                  observedAt,
+                  serviceId: this.serviceId
+              });
+
+        if (coverage) {
+            diagnoses.push(coverage);
+        }
+
+        return diagnoses;
+    }
+
+    /**
+     * @summary Routes each diagnosis to the actuator's escalate sink — the only recovery surface reached.
+     *
+     * Detect-only by construction: this method calls `escalateDiagnosis` exclusively and never a
+     * privileged action. A `rejected` escalation outcome is recorded, not thrown — a single
+     * malformed diagnosis must not abort the cycle.
+     *
+     * @param {Object} options
+     * @param {Object[]} options.diagnoses Emitted `recovery-diagnosis` events.
+     * @param {Number} options.now Epoch milliseconds passed through to the actuator for consistent timestamps.
+     * @returns {Promise<Object[]>} The per-diagnosis escalation outcome descriptors.
+     */
+    async routeDiagnoses({diagnoses, now}) {
+        const escalations = [];
+
+        for (const diagnosis of diagnoses) {
+            escalations.push(await this.recoveryActuator.escalateDiagnosis(diagnosis, {now}));
+        }
+
+        return escalations;
+    }
+
+    /**
+     * @summary Builds the top-level decision envelope for one diagnostics cycle.
+     * @param {Object} options
+     * @returns {Object}
+     */
+    createDecision({serviceId, observedAt, status, diagnoses = [], escalations = [], probeError = null}) {
+        return {
+            schemaVersion: 1,
+            recordType   : 'data-integrity-diagnosis-decision',
+            serviceId,
+            observedAt,
+            status,
+            probeError,
+            diagnoses,
+            escalations
+        };
+    }
+
+    /**
+     * @summary Returns the current clock value (injected clock for tests, else wall-clock).
+     * @returns {Number}
+     */
+    now() {
+        return this.nowFn ? this.nowFn() : Date.now();
+    }
+
+    /**
+     * @summary Fail-closed guard: the immune-system runner must not silently no-op on a missing collaborator.
+     * @returns {void}
+     * @throws {TypeError} when serviceId / coverageGatherer / recoveryActuator is missing or malformed.
+     */
+    validateDependencies() {
+        if (typeof this.serviceId !== 'string' || this.serviceId.length === 0) {
+            throw new TypeError('DataIntegrityDiagnosisService: serviceId is required');
+        }
+        if (typeof this.coverageGatherer !== 'function') {
+            throw new TypeError('DataIntegrityDiagnosisService: coverageGatherer is required');
+        }
+        if (typeof this.recoveryActuator?.escalateDiagnosis !== 'function') {
+            throw new TypeError('DataIntegrityDiagnosisService: recoveryActuator with escalateDiagnosis() is required');
+        }
+    }
+}
+
+export default Neo.setupClass(DataIntegrityDiagnosisService);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
@@ -1,0 +1,160 @@
+import {test, expect}                  from '@playwright/test';
+import Neo                             from '../../../../../../../src/Neo.mjs';
+import * as core                       from '../../../../../../../src/core/_export.mjs';
+import {DataIntegrityDiagnosisService} from '../../../../../../../ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs';
+
+const OBSERVED_AT = 1710000000000;
+
+/**
+ * Records every actuator surface reached so a test can assert detect-only behavior:
+ * `escalateDiagnosis` is expected; `apply` (the privileged path) must never be called.
+ */
+function fakeActuator() {
+    const calls = {escalate: [], apply: []};
+
+    return {
+        calls,
+        async escalateDiagnosis(diagnosisEvent, options) {
+            calls.escalate.push({diagnosisEvent, options});
+            return {
+                status        : 'escalated',
+                reasonCode    : diagnosisEvent.details?.reasonCode || 'diagnosis-escalation',
+                targetIdentity: diagnosisEvent.targetIdentity
+            };
+        },
+        async apply(...args) {
+            calls.apply.push(args);
+            return {status: 'actioned'};
+        }
+    };
+}
+
+function coverage({ok}) {
+    return {
+        collections: [{
+            name                  : 'neo-agent-memory',
+            ok,
+            missingFromVectorCount: ok ? 0 : 2000,
+            extraInVectorCount    : 0
+        }],
+        failedCollections       : ok ? 0 : 1,
+        duplicateCollectionNames: []
+    };
+}
+
+function createService(config = {}) {
+    return Neo.create(DataIntegrityDiagnosisService, {
+        serviceId: 'memory-core',
+        nowFn    : () => OBSERVED_AT,
+        ...config
+    });
+}
+
+test.describe('Neo.ai.daemons.services.DataIntegrityDiagnosisService', () => {
+    test('clean coverage → healthy decision, nothing escalated', async () => {
+        const actuator = fakeActuator(),
+              service  = createService({
+                  coverageGatherer: async () => coverage({ok: true}),
+                  recoveryActuator: actuator
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision).toMatchObject({
+            recordType: 'data-integrity-diagnosis-decision',
+            serviceId : 'memory-core',
+            observedAt: OBSERVED_AT,
+            status    : 'healthy'
+        });
+        expect(decision.diagnoses).toHaveLength(0);
+        expect(decision.escalations).toHaveLength(0);
+        expect(actuator.calls.escalate).toHaveLength(0);
+        expect(actuator.calls.apply).toHaveLength(0);
+    });
+
+    test('coverage drift → routes a data-integrity/escalate diagnosis to escalateDiagnosis', async () => {
+        const actuator = fakeActuator(),
+              service  = createService({
+                  coverageGatherer: async () => coverage({ok: false}),
+                  recoveryActuator: actuator
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision.status).toBe('escalated');
+        expect(decision.diagnoses).toHaveLength(1);
+        expect(decision.diagnoses[0]).toMatchObject({
+            type          : 'recovery-diagnosis',
+            recoveryClass : 'data-integrity',
+            targetIdentity: {kind: 'compose-service', id: 'memory-core'},
+            details       : {actionClass: 'escalate'}
+        });
+        expect(decision.diagnoses[0].evidenceFacts).toContainEqual(
+            expect.objectContaining({type: 'vector-coverage-drift', collection: 'neo-agent-memory'})
+        );
+
+        expect(actuator.calls.escalate).toHaveLength(1);
+        expect(actuator.calls.escalate[0].diagnosisEvent.recoveryClass).toBe('data-integrity');
+        expect(decision.escalations[0]).toMatchObject({status: 'escalated'});
+    });
+
+    test('detect-only: never reaches the privileged apply path, even on drift', async () => {
+        const actuator = fakeActuator(),
+              service  = createService({
+                  coverageGatherer: async () => coverage({ok: false}),
+                  recoveryActuator: actuator
+              });
+
+        await service.gatherAndDiagnose();
+
+        expect(actuator.calls.apply).toHaveLength(0);
+        expect(actuator.calls.escalate).toHaveLength(1);
+    });
+
+    test('probe-unavailable: a failing gatherer escalates NOTHING (failed probe ≠ drift signal)', async () => {
+        const actuator = fakeActuator(),
+              service  = createService({
+                  coverageGatherer: async () => { throw new Error('Chroma unreachable'); },
+                  recoveryActuator: actuator
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision).toMatchObject({
+            status    : 'probe-unavailable',
+            probeError: 'Chroma unreachable'
+        });
+        expect(decision.diagnoses).toHaveLength(0);
+        expect(actuator.calls.escalate).toHaveLength(0);
+        expect(actuator.calls.apply).toHaveLength(0);
+    });
+
+    test('threads the injected clock into the diagnosis id and the escalate call', async () => {
+        const actuator = fakeActuator(),
+              service  = createService({
+                  coverageGatherer: async () => coverage({ok: false}),
+                  recoveryActuator: actuator
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision.diagnoses[0].diagnosisId).toBe(`data-integrity:memory-core:coverage-drift:${OBSERVED_AT}`);
+        expect(decision.diagnoses[0].observedAt).toBe(OBSERVED_AT);
+        expect(actuator.calls.escalate[0].options).toMatchObject({now: OBSERVED_AT});
+    });
+
+    test('fail-closed: a missing coverageGatherer throws', async () => {
+        const service = createService({recoveryActuator: fakeActuator()});
+
+        await expect(service.gatherAndDiagnose()).rejects.toThrow(/coverageGatherer is required/);
+    });
+
+    test('fail-closed: a recoveryActuator without escalateDiagnosis throws', async () => {
+        const service = createService({
+            coverageGatherer: async () => coverage({ok: true}),
+            recoveryActuator: {}
+        });
+
+        await expect(service.gatherAndDiagnose()).rejects.toThrow(/recoveryActuator with escalateDiagnosis/);
+    });
+});


### PR DESCRIPTION
Resolves #14112

Slice 1 of #14109 (the data-integrity diagnostics runner). Wires the merged coverage-drift detect-producer into a live-routable runner: a pure `DataIntegrityDiagnosisService` (`core.Base`) that gathers a Chroma vector-coverage audit, runs `buildDataIntegrityCoverageDiagnosis` over it, and routes every emitted `recovery-diagnosis` to the ADR-0026 actuator's `escalateDiagnosis` sink — the operator-page path proven generic + behavior-tested by #14046. This is the missing wiring that turns the proven-but-dormant detect-producers into a runnable signal (the #13999 "up but data-gutted reports green" blind spot).

Detect-only / escalate-only by construction: it reaches `escalateDiagnosis` exclusively, never a privileged `apply`/restart/mutation (asserted). A failing probe escalates NOTHING — `probe-unavailable` is reported, never mistaken for a drift signal. Fail-closed on a missing collaborator. All deps injected, so AiConfig leaves are read at the orchestrator use-site per ADR-0019 (not re-derived here) and the unit is testable in isolation.

Evidence: L2 (focused unit — 7/7: clean→healthy, drift→`data-integrity`/`escalate` routed to the sink, detect-only never-apply, probe-unavailable→no-escalation, injected-clock threading, two fail-closed guards).

## Deltas from ticket

None — matches the #14112 slice scope exactly. The schedule-tick + cadence AiConfig leaf (slice 2 → resolves #14109), history-persistence + monotonicity wiring, and dimension wiring are explicitly out of this slice.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs` → **7/7 passed (30.8s)**.

## Post-Merge Validation

- [ ] (slice 2, out of this leaf) Wire the runner into the Orchestrator schedule-tick + a cadence AiConfig leaf so it runs live; that PR resolves #14109.

## Commits

- ae91f821e — feat(ai): data-integrity diagnostics runner unit — coverage detect leaf (#14112)

## Structural pre-flight

New file `ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs` is a Stage-1 sibling-lift of `ContainerHealthDiagnosisService.mjs` in the same directory (same `core.Base` injected-deps + `now()` shape, same `recovery-diagnosis` / escalate contract) — no novel directory choice.

Related: #14109 (parent integration), #14026 (detect-signal class), #14046 (release-gate e2e proving the escalate sink generic), #14075 (the coverage producer wired), #14061 (the escalate sink), #14039 (v13.1 epic).

Authored by Vega (Claude Opus 4.8, Claude Code). Session 16bbea8d-8bc9-4dad-8e1c-8e3b2cd861a3.
