### PR TITLE
feat(ai): dimension-audit fact-gatherer for the data-integrity runner (#14113)

### DIFF
--- a/ai/scripts/maintenance/checkChromaIntegrity.mjs
+++ b/ai/scripts/maintenance/checkChromaIntegrity.mjs
@@ -544,8 +544,8 @@ export async function probeStoredEmbeddingExportability({
         }
     }
 
-    const failures = [];
-    let succeeded  = 0;
+    const failures  = [];
+    let   succeeded = 0;
 
     for (const id of ids) {
         try {
@@ -577,6 +577,40 @@ export async function probeStoredEmbeddingExportability({
             failed : failures.length,
             failures
         }
+    }
+}
+
+/**
+ * @summary Audits a Chroma collection's stored-vector dimensions — the data-integrity dimension fact-gatherer
+ * the diagnostics runner imports to feed `buildDimensionConsistencyDiagnosis`. Samples up to `sampleSize`
+ * stored vectors and counts those whose dimension differs from the configured `expectedDimension`. A *missing*
+ * embedding is NOT a dimension mismatch — that is index-coverage's domain (`auditChromaVectorCoverage`); only a
+ * present vector of the wrong length counts. Returns the producer's per-collection `samples` element shape, 1:1.
+ * A probe failure surfaces as an `error` field with a zero count — it never throws into the runner.
+ *
+ * @param {Object} options
+ * @param {Object} options.collection Chroma collection handle (`.get({ids, limit, include})`).
+ * @param {String} options.collectionName The collection's name (carried into the sample for the diagnosis).
+ * @param {Number} options.expectedDimension The configured embedding dimension every stored vector must match.
+ * @param {Number} [options.sampleSize=100] Maximum stored vectors to sample.
+ * @returns {Promise<Object>} `{collection, expectedDimension, mismatchedVectorCount, sampledCount}` (+ `error` on probe failure).
+ */
+export async function auditCollectionVectorDimensions({collection, collectionName, expectedDimension, sampleSize = 100} = {}) {
+    try {
+        const {ids = []} = await collection.get({limit: sampleSize, include: []});
+
+        if (ids.length === 0) {
+            return {collection: collectionName, expectedDimension, mismatchedVectorCount: 0, sampledCount: 0};
+        }
+
+        const {embeddings = []} = await collection.get({ids, include: ['embeddings']}),
+              // A present vector whose length ≠ expectedDimension is corruption; a missing (null) embedding is
+              // index-coverage's domain (auditChromaVectorCoverage), not a dimension mismatch.
+              mismatchedVectorCount = embeddings.filter(embedding => Array.isArray(embedding) && embedding.length !== expectedDimension).length;
+
+        return {collection: collectionName, expectedDimension, mismatchedVectorCount, sampledCount: ids.length};
+    } catch (error) {
+        return {collection: collectionName, expectedDimension, mismatchedVectorCount: 0, sampledCount: 0, error: error.message};
     }
 }
 
@@ -765,7 +799,7 @@ function printHuman(result) {
         } else {
             console.log('Chroma vector coverage:');
             for (const collection of result.coverage.collections) {
-                const status   = collection.ok ? 'ok' : 'failed',
+                const status    = collection.ok ? 'ok' : 'failed',
                       duplicate = collection.duplicateCollectionName ? ' duplicate-name' : '';
 
                 console.log(`- ${collection.name} [${collection.collectionId}]: ${status}${duplicate} metadata=${collection.metadataRowCount} vector=${collection.vectorIndexIdCount} overlap=${collection.overlapCount} missing=${collection.missingFromVectorCount} extra=${collection.extraInVectorCount}`);
@@ -889,9 +923,9 @@ export async function run(argv = process.argv) {
         printHuman(result);
     }
 
-    const sqliteFailed = result.sqlite.checks.some(check => !check.ok),
+    const sqliteFailed   = result.sqlite.checks.some(check => !check.ok),
           coverageFailed = Boolean(result.coverage?.error || result.coverage?.failedCollections),
-          apiFailed    = Boolean(result.api?.error || result.api?.failedSteps);
+          apiFailed      = Boolean(result.api?.error || result.api?.failedSteps);
 
     return {
         result,

--- a/test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs
@@ -6,6 +6,7 @@ import {promisify}    from 'util';
 import {test, expect} from '@playwright/test';
 import {
     auditChromaVectorCoverage,
+    auditCollectionVectorDimensions,
     classifySqliteCheck,
     compareMetadataToVectorIds,
     countFailedApiSteps,
@@ -382,5 +383,59 @@ test.describe('checkChromaIntegrity maintenance helpers', () => {
         } finally {
             await fs.remove(tmpDir);
         }
+    });
+});
+
+test.describe('auditCollectionVectorDimensions — data-integrity dimension fact-gatherer', () => {
+    // mock collection: the limit-`get` (no ids) returns the sampled ids; the by-ids `get` returns embeddings.
+    function makeDimCollection({ids, embeddings, failOn}) {
+        return {
+            get: async ({ids: reqIds} = {}) => {
+                if (failOn) throw new Error('chroma unavailable');
+                if (!reqIds) return {ids};                 // limit-get → ids
+                return {ids: reqIds, embeddings};          // by-ids get → embeddings (positionally aligned to ids)
+            }
+        };
+    }
+
+    test('counts present vectors whose dimension differs from expected', async () => {
+        const collection = makeDimCollection({
+            ids       : ['a', 'b', 'c'],
+            embeddings: [new Array(4096).fill(0), new Array(512).fill(0), new Array(4096).fill(0)]  // b is wrong-dim
+        });
+
+        expect(await auditCollectionVectorDimensions({collection, collectionName: 'neo-agent-memory', expectedDimension: 4096, sampleSize: 10}))
+            .toEqual({collection: 'neo-agent-memory', expectedDimension: 4096, mismatchedVectorCount: 1, sampledCount: 3});
+    });
+
+    test('all-matching dimensions -> mismatchedVectorCount 0', async () => {
+        const collection = makeDimCollection({ids: ['a', 'b'], embeddings: [new Array(4096).fill(0), new Array(4096).fill(0)]});
+
+        const result = await auditCollectionVectorDimensions({collection, collectionName: 'c', expectedDimension: 4096});
+        expect(result.mismatchedVectorCount).toBe(0);
+        expect(result.sampledCount).toBe(2);
+    });
+
+    test('a missing (null) embedding is NOT a dimension mismatch — that is coverage\'s domain', async () => {
+        const collection = makeDimCollection({ids: ['a', 'b'], embeddings: [new Array(4096).fill(0), null]});
+
+        // the 4096 vector matches; the null is absent-not-wrong-dim, so it is not counted here.
+        expect((await auditCollectionVectorDimensions({collection, collectionName: 'c', expectedDimension: 4096})).mismatchedVectorCount).toBe(0);
+    });
+
+    test('empty / unsampled collection -> mismatchedVectorCount 0, sampledCount 0', async () => {
+        const collection = makeDimCollection({ids: [], embeddings: []});
+
+        expect(await auditCollectionVectorDimensions({collection, collectionName: 'c', expectedDimension: 4096}))
+            .toEqual({collection: 'c', expectedDimension: 4096, mismatchedVectorCount: 0, sampledCount: 0});
+    });
+
+    test('a .get failure surfaces as an error with a zero count — never throws into the runner', async () => {
+        const collection = makeDimCollection({ids: ['a'], embeddings: [[]], failOn: true});
+
+        const result = await auditCollectionVectorDimensions({collection, collectionName: 'c', expectedDimension: 4096});
+        expect(result.mismatchedVectorCount).toBe(0);
+        expect(result.sampledCount).toBe(0);
+        expect(result.error).toBe('chroma unavailable');
     });
 });


### PR DESCRIPTION
Resolves #14113

Related: #14102/#14104 (the dimension-consistency producer this feeds), #14109 (the diagnostics runner that imports it), #14026 (the detect-signal class).

The embedding-dimension detect-producer `buildDimensionConsistencyDiagnosis` (#14104) consumes per-collection `{collection, expectedDimension, mismatchedVectorCount}` samples — but no helper computed `mismatchedVectorCount`. `auditChromaVectorCoverage` checks index **coverage** (metadata-without-vector), not per-vector **dimension**; a present vector of the wrong length is invisible to it. This PR adds the missing fact-gatherer.

`auditCollectionVectorDimensions({collection, collectionName, expectedDimension, sampleSize})` (sibling of `auditChromaVectorCoverage` / `probeStoredEmbeddingExportability` in `checkChromaIntegrity.mjs`): samples up to `sampleSize` ids, reads their stored embeddings (the same `collection.get({limit})` → `collection.get({ids, include:['embeddings']})` two-step `probeStoredEmbeddingExportability` uses), and counts **present-but-wrong-dimension** vectors. Returns `{collection: collectionName, expectedDimension, mismatchedVectorCount, sampledCount}` — the producer's `samples` element shape, 1:1, no reshape. Vega (#14109 steward) confirmed the 1:1 contract.

A *missing* embedding is not a dimension mismatch (that is coverage's domain) — only `Array.isArray(embedding) && embedding.length !== expectedDimension` counts, so `null`/absent vectors are ignored. Empty/unsampled collections → `mismatchedVectorCount: 0`; a `.get` failure surfaces as an `error` field with a zero count and never throws into the runner.

Evidence: L2 (unit). Pure helper against an injected mock collection — no live Chroma. Fully covers the ticket ACs. Residual: the runner wiring (it imports this helper) is Vega's #14109 slice, out of scope here.

## Contract Ledger

On the originating ticket #14113 — `auditCollectionVectorDimensions({collection, collectionName, expectedDimension, sampleSize})`, behavior + fallbacks + return shape, matching this diff 1:1.

## Deltas from ticket

None. Signature, return shape, and fallback behavior match the ticket's Contract Ledger exactly.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs` → **18 passed** (5 new `auditCollectionVectorDimensions` tests — counts wrong-dim; all-match→0; null-not-counted; empty→0; `.get`-failure→error+0 — plus all existing coverage/probe/SQLite tests).

`npm run agent-preflight -- ai/scripts/maintenance/checkChromaIntegrity.mjs test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs` → all gates passed (archaeology clean).

## Post-Merge Validation

- [ ] When the #14109 runner imports this gatherer, a real collection holding a wrong-dimension vector yields `mismatchedVectorCount > 0`, driving a contract-valid `data-integrity`/`escalate` diagnosis.

Authored by Ada (Claude Opus 4.8, Claude Code). Session fe9c04d6-1aae-4017-8d53-19b0e5aaf809.
