### PR TITLE
chore(ai): retire dead anyRepairAborted predicate + document retained-parking lifecycle (#14068)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -710,6 +710,15 @@ export async function rewriteCollectionViaShadowPromotion({
  * shadow collection. The shadow-loading phase is restartable; the bounded rename phase is
  * deliberately not auto-resumed because the live canonical name may have been parked.
  *
+ * Retained-parking lifecycle: when `deleteParking` is false (the partial-promotion path, where
+ * recovered rows are promoted but unrecoverable rows remain), the pre-promotion source is renamed to
+ * a timestamped, uuid-suffixed parking collection (`<collectionName>-parking-<timestamp>-<uuid>`) and
+ * KEPT as a recovery asset instead of being deleted; a `parking-retained` state marker records its
+ * `parkingName` so an operator can inspect the unrecoverable residue and delete it after recovery.
+ * Because each partial run mints a fresh parking name, repeated partial repairs accumulate distinct
+ * parking collections — they are bounded by operator cleanup, not auto-pruned. A defrag or cleanup
+ * pass must therefore treat a `parking-retained` source as live recovery state, never as orphaned clutter.
+ *
  * @param {Object} options
  * @param {Object} options.client Chroma client.
  * @param {String} options.collectionName Canonical collection name.
@@ -719,7 +728,7 @@ export async function rewriteCollectionViaShadowPromotion({
  * @param {Object} options.embeddingFunction Chroma embedding function.
  * @param {String} options.statePath Durable state marker path.
  * @param {Object} [options.stateBase] Stable fields written into every phase marker.
- * @param {Boolean} [options.deleteParking=true] Delete parked source collection after validation.
+ * @param {Boolean} [options.deleteParking=true] When true, delete the parked source after the promoted collection validates; when false (partial promotion), retain it as a recovery asset and write a `parking-retained` state marker.
  * @param {Number} [options.timestamp=Date.now()] Stable run timestamp.
  * @param {Function} [options.uuidFactory=crypto.randomUUID] Unique id factory.
  * @param {Function} [options.writeStateFn=writeDefragState] State writer seam.
@@ -1368,23 +1377,17 @@ export function formatUnrecoverablePreview(entries = [], {limit = 5} = {}) {
 }
 
 /**
- * @summary True when any repair result aborted (a collection with unrecoverable rows). The
- * operator-facing fail-loud predicate: an aborted collection is never a successful repair, so the
- * `--allow-memory-core` CLI path exits non-zero on it (mirrors the KB extractionErrors / hasRestoreErrors
- * discipline) rather than reporting success on a partial repair.
- *
- * @param {Object[]} [results=[]] Per-collection results from `repairMemoryCoreCollectionsViaFullEnumeration`.
- * @returns {Boolean}
- */
-export function anyRepairAborted(results = []) {
-    return results.some(result => result?.aborted === true);
-}
-
-/**
  * @summary True when any repair result is non-clean (aborted or partial-promoted).
  *
  * The CLI must exit non-zero for both classes: aborted means no promotion happened; partial-promoted means
- * recovered rows were promoted durably, but unrecoverable rows remain in a retained parked source.
+ * recovered rows were promoted durably, but unrecoverable rows remain in a retained parked source. That
+ * non-zero exit is the immune-system signal of record: the process supervisor observes the failed maintenance
+ * run and escalates it to an operator page, while the retained parked source stays available for
+ * unrecoverable-residue inspection.
+ *
+ * This is the single operator-facing fail-loud predicate; it subsumes the older aborted-only check, because an
+ * aborted OR partial-promoted collection is never a clean repair. It mirrors the KB extractionErrors /
+ * hasRestoreErrors discipline rather than reporting success on a non-clean repair.
  *
  * @param {Object[]} [results=[]] Per-collection results from `repairMemoryCoreCollectionsViaFullEnumeration`.
  * @returns {Boolean}

--- a/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
@@ -1,11 +1,11 @@
 import {test, expect} from '@playwright/test';
 import {
-    anyRepairAborted,
     anyRepairNonClean,
     assertDefragTargetSupported,
     createUnrecoverablePreview,
     formatMemoryCoreRepairProgress,
     formatUnrecoverablePreview,
+    promoteLoadedShadowCollection,
     repairMemoryCoreCollectionViaResumableShadow,
     repairMemoryCoreCollectionsViaFullEnumeration,
     runDefragChromaDBCli
@@ -311,7 +311,7 @@ test.describe('repairMemoryCoreCollectionsViaFullEnumeration (#14020)', () => {
         expect(logs.some(message => message.includes(
             'Reasons: b (metadata-row-missing: id was absent from the Chroma documents/metadatas read)'
         ))).toBe(true);
-        expect(anyRepairAborted(results)).toBe(true);
+        expect(anyRepairNonClean(results)).toBe(true);
     });
 
     test('throws when the enumeration returns no coverage row for a requested collection', async () => {
@@ -615,23 +615,87 @@ test.describe('assertDefragTargetSupported — Memory Core opt-in gate (#14020)'
     });
 });
 
-test.describe('anyRepairAborted — operator fail-loud predicate (#14020)', () => {
-    test('true when any collection aborted — the CLI exits non-zero on this', () => {
-        expect(anyRepairAborted([
-            {collectionName: 'mc-memory', promotion: {}},
-            {collectionName: 'mc-graph',  aborted: true, unrecoverable: ['x'], counts: {unrecoverable: 1}}
-        ])).toBe(true);
+test.describe('promoteLoadedShadowCollection — retained-parking lifecycle (#14068)', () => {
+    const embeddingFunction = {name: 'dummy'};
+
+    // Minimal Chroma double: getCollection returns the live collection until the shadow is promoted
+    // onto the canonical name, then returns the promoted shadow. Records deletes + state-marker phases
+    // so a test can assert the retained-vs-deleted parking behavior of the partial-promotion path.
+    function makePromoteHarness({sourceIds = ['a', 'b']} = {}) {
+        const states = [], deletedCollections = [];
+
+        function makeCollection(name) {
+            return {
+                name,
+                async count()                   { return sourceIds.length },
+                async get({ids = []} = {})      { return {ids} },
+                async modify({name: newName})   { this.name = newName }
+            }
+        }
+
+        const live   = makeCollection('mc-memory'),
+              shadow = makeCollection('mc-memory-shadow'),
+              client = {
+                  async getCollection({name}) {
+                      if (name === 'mc-memory') {
+                          return shadow.name === 'mc-memory' ? shadow : live
+                      }
+                      throw new Error(`unexpected getCollection(${name})`)
+                  },
+                  async deleteCollection({name}) { deletedCollections.push(name) }
+              };
+
+        return {
+            client, deletedCollections, shadow, sourceIds, states,
+            writeStateFn: async ({state}) => { states.push(state) }
+        }
+    }
+
+    test('deleteParking:false retains the parked source and records parking-retained', async () => {
+        const harness = makePromoteHarness();
+
+        const result = await promoteLoadedShadowCollection({
+            client          : harness.client,
+            collectionName  : 'mc-memory',
+            shadowCollection: harness.shadow,
+            shadowName      : 'mc-memory-shadow',
+            sourceIds       : harness.sourceIds,
+            embeddingFunction,
+            statePath       : '/state',
+            deleteParking   : false,
+            timestamp       : 123,
+            uuidFactory     : () => 'uuid-1',
+            writeStateFn    : harness.writeStateFn
+        });
+
+        expect(harness.deletedCollections).toEqual([]);
+        expect(result.parkingDeleted).toBe(false);
+        expect(harness.states.some(state => state.phase === 'parking-retained')).toBe(true);
+        expect(harness.states.some(state => state.phase === 'parking-deleted')).toBe(false);
+        expect(harness.states.find(state => state.phase === 'parking-retained').parkingName).toMatch(/^mc-memory-parking-/);
     });
 
-    test('false when every collection promoted cleanly', () => {
-        expect(anyRepairAborted([
-            {collectionName: 'mc-memory', promotion: {}},
-            {collectionName: 'mc-graph',  promotion: {}}
-        ])).toBe(false);
-    });
+    test('deleteParking:true (default) deletes the parked source and records parking-deleted', async () => {
+        const harness = makePromoteHarness();
 
-    test('false for an empty result set', () => {
-        expect(anyRepairAborted([])).toBe(false);
+        const result = await promoteLoadedShadowCollection({
+            client          : harness.client,
+            collectionName  : 'mc-memory',
+            shadowCollection: harness.shadow,
+            shadowName      : 'mc-memory-shadow',
+            sourceIds       : harness.sourceIds,
+            embeddingFunction,
+            statePath       : '/state',
+            timestamp       : 123,
+            uuidFactory     : () => 'uuid-1',
+            writeStateFn    : harness.writeStateFn
+        });
+
+        expect(harness.deletedCollections).toHaveLength(1);
+        expect(harness.deletedCollections[0]).toMatch(/^mc-memory-parking-/);
+        expect(result.parkingDeleted).toBe(true);
+        expect(harness.states.some(state => state.phase === 'parking-deleted')).toBe(true);
+        expect(harness.states.some(state => state.phase === 'parking-retained')).toBe(false);
     });
 });
 


### PR DESCRIPTION
Resolves #14068

Related: #14062, #14066 (the partial-repair-promotion work this follows up), #14039 (v13.1 epic). Refs the #14061 supervisor-escalation chain (note-of-record).

Two review-thread-only follow-ups from #14066 promoted to durable substrate.

**1. Retire the stale `anyRepairAborted()` predicate.** After #14066 switched the operator status to `anyRepairNonClean()` (aborted **or** partial-promoted), `anyRepairAborted()` (aborted-only) had **zero production consumers** — a whole-repo grep (`anyRepairAborted` across all `*.mjs`, node_modules excluded) found only its own export + its test block. It is dead production code that could mislead a future reader into thinking aborted-only is still the status contract. Removed it; folded its useful operator-facing fail-loud framing (the KB `extractionErrors` / `hasRestoreErrors` discipline) into `anyRepairNonClean()`'s JSDoc so no intent is lost. The live predicate already has full coverage (the `#14062` describe block: aborted→true, partial-promoted→true, clean→false, empty→false), so the old `anyRepairAborted` test block was pure redundancy and was retired; the one shared-test usage was repointed to the live predicate (the assertion intent — "operator status fires on this aborted result" — holds, since non-clean ⊇ aborted).

**2. Document the retained-parking lifecycle.** Partial promotion intentionally keeps the parked source (`deleteParking:false` → `phase:'parking-retained'`) as a recovery asset, but the boundedness was incidental. Made it explicit on `promoteLoadedShadowCollection`'s JSDoc: the parked source is renamed to a timestamped, uuid-suffixed collection (`<name>-parking-<timestamp>-<uuid>`); each partial run mints a fresh name, so repeated partial repairs **accumulate distinct** parking collections — bounded by operator cleanup, never auto-pruned. A defrag/cleanup pass must treat a `parking-retained` source as live recovery state, not orphaned clutter. Added the immune-chain note-of-record (non-clean exit → process-supervisor escalation → operator page) to `anyRepairNonClean()`.

**3. Behavior test for the lifecycle.** The pre-existing partial-promotion test mocks `promoteLoadedFn`, so the real `promoteLoadedShadowCollection` parking branch was never exercised. Added a direct test against a minimal Chroma double proving `deleteParking:false` **retains** (never deletes) the parked source and writes `parking-retained`, while `deleteParking:true` deletes it and writes `parking-deleted` — a falsifier against the exact "accidentally deletes/accumulates" risk the ticket names.

Evidence: L2 (unit). All ACs are covered by pure unit tests against injected doubles (no live Chroma). Residual: none.

## Contract Ledger

On the originating ticket #14068 — three rows: `anyRepairAborted()` retirement (the preferred disposition, since no production consumer exists), the retained-parking boundedness contract, and the operator note-of-record. This diff matches all three.

## Deltas from ticket

- AC1 disposition: chose **removal** (the ticket's preferred option) over "make private to tests" — V-B-A confirmed no production consumer.
- AC3 satisfied via a **behavior test** (stronger than the ticket's "tests OR comments" floor) plus the explicit lifecycle JSDoc.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs` → **27 passed** (the 2 new `promoteLoadedShadowCollection` parking-lifecycle tests + the repointed predicate assertion + all existing repair/promote/predicate tests; the retired `anyRepairAborted` block removed).

`npm run agent-preflight -- ai/scripts/maintenance/defragChromaDB.mjs test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs` → all gates passed (archaeology clean — the note-of-record prose carries no ticket refs).

## Post-Merge Validation

- [ ] On a real partial-promoted Memory Core repair, the retained `parking-retained` collection survives a subsequent defrag pass (not deleted as orphaned), and its `parkingName` is operator-discoverable for residue inspection + manual cleanup.

Authored by Ada (Claude Opus 4.8, Claude Code). Session fe9c04d6-1aae-4017-8d53-19b0e5aaf809.
