### PR TITLE
feat(ai): schedule the data-integrity runner live + route to escalate (#14109)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -163,10 +163,10 @@ class Config extends ConfigProvider {
              * @type {Object}
              */
             ollama: {
-                host                 : leaf('http://127.0.0.1:11434', 'NEO_OLLAMA_HOST', 'string'),
-                model                : leaf('gemma4:26b', 'NEO_OLLAMA_MODEL', 'string'),
-                embeddingModel       : leaf('qwen3-embedding', 'NEO_OLLAMA_EMBEDDING_MODEL', 'string'),
-                keep_alive           : leaf(-1, 'NEO_OLLAMA_KEEP_ALIVE', 'keepAlive'),
+                host          : leaf('http://127.0.0.1:11434', 'NEO_OLLAMA_HOST', 'string'),
+                model         : leaf('gemma4:26b', 'NEO_OLLAMA_MODEL', 'string'),
+                embeddingModel: leaf('qwen3-embedding', 'NEO_OLLAMA_EMBEDDING_MODEL', 'string'),
+                keep_alive    : leaf(-1, 'NEO_OLLAMA_KEEP_ALIVE', 'keepAlive'),
                 // Upper bound for one native Ollama embedding HTTP request. Keeps explicit
                 // `embeddingProvider: 'ollama'` deployments from stalling the WAL drain.
                 embeddingTimeoutMs   : leaf(300000, 'NEO_OLLAMA_EMBEDDING_TIMEOUT_MS', 'number'),
@@ -573,7 +573,15 @@ class Config extends ConfigProvider {
                      * exceeds `memoryWal`-sibling `remConsolidationStallThresholdMs`.
                      * Hourly surfaces a stalled dream in hours. `<= 0` disables the lane.
                      */
-                    remConsolidationWatchdogCheckMs  : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_REM_CONSOLIDATION_WATCHDOG_INTERVAL_MS', 'number')
+                    remConsolidationWatchdogCheckMs  : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_REM_CONSOLIDATION_WATCHDOG_INTERVAL_MS', 'number'),
+                    /**
+                     * Cadence of the data-integrity sweep — the read-only, never-fail health check that
+                     * audits Memory Core metadata-vs-vector coverage and escalates a `data-integrity`
+                     * diagnosis (operator page) on drift (the "up but data-gutted reports green" blind
+                     * spot). Detect-only; data mutation stays operator-gated. Hourly surfaces a silent
+                     * vector-loss in hours, not weeks. `<= 0` disables the lane.
+                     */
+                    dataIntegritySweepCheckMs        : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_DATA_INTEGRITY_SWEEP_INTERVAL_MS', 'number')
                 },
                 /**
                  * Chroma daemon recycle policy. The orchestrator kills and respawns the supervised

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -33,6 +33,8 @@ import DeploymentRuntimeAccessService                                           
 import DeploymentStateBridgeService                                             from './services/DeploymentStateBridgeService.mjs';
 import RecoveryActuatorService                                                  from './services/RecoveryActuatorService.mjs';
 import ContainerHealthDiagnosisService                                          from './services/ContainerHealthDiagnosisService.mjs';
+import DataIntegrityDiagnosisService                                            from './services/DataIntegrityDiagnosisService.mjs';
+import {auditChromaVectorCoverage}                                              from '../../scripts/maintenance/checkChromaIntegrity.mjs';
 import DreamService                                                             from './services/DreamService.mjs';
 import SwarmHeartbeatService                                                    from './services/SwarmHeartbeatService.mjs';
 import GoldenPathSynthesizer                                                    from '../../services/graph/GoldenPathSynthesizer.mjs';
@@ -112,6 +114,7 @@ export class Orchestrator extends Base {
         deploymentStateBridgeService_   : null,
         recoveryActuatorService_        : null,
         containerHealthDiagnosisService_: null,
+        dataIntegrityDiagnosisService_  : null,
         maintenanceBackpressureService_ : MaintenanceBackpressureService,
         dataDir_                        : DEFAULT_DATA_DIR,
         taskDefinitions_                : null,
@@ -344,6 +347,18 @@ export class Orchestrator extends Base {
         });
     }
 
+    /**
+     * @param {Neo.ai.daemons.services.DataIntegrityDiagnosisService|Object|null} value
+     * @returns {Neo.ai.daemons.services.DataIntegrityDiagnosisService}
+     */
+    beforeSetDataIntegrityDiagnosisService(value) {
+        return ClassSystemUtil.beforeSetInstance(value, DataIntegrityDiagnosisService, {
+            serviceId       : this.dataIntegrityServiceId,
+            recoveryActuator: this.recoveryActuatorService,
+            coverageGatherer: this.dataIntegrityCoverageGatherer
+        });
+    }
+
     afterSetDataDir(value, oldValue) {
         if (oldValue === undefined) return;
         this.processSupervisorService.dataDir          = value;
@@ -423,6 +438,22 @@ export class Orchestrator extends Base {
     get embedDrainLivenessWatchdogThresholdMs() { return memoryCoreConfig.memoryWal.embedDrainStallThresholdMs; }
     get remConsolidationWatchdogRunStateDir()   { return memoryCoreConfig.remRunStateDir; }
     get remConsolidationWatchdogThresholdMs()   { return memoryCoreConfig.remConsolidationStallThresholdMs; }
+    /** @summary The Memory Core compose-service id targeted by data-integrity diagnoses. */
+    get dataIntegrityServiceId() { return 'mc-server'; }
+    /**
+     * @summary Builds the read-only Chroma vector-coverage gatherer for the data-integrity sweep, bound
+     * to the unified Chroma persist dir (AiConfig SSOT leaf, read here at the use-site per the config-SSOT
+     * discipline) over the Memory Core collections.
+     * @returns {Function} `() => Promise<{collections:Object[]}>`
+     */
+    get dataIntegrityCoverageGatherer() {
+        const dataDir = AiConfig.engines.chroma.dataDir;
+        return () => auditChromaVectorCoverage({
+            snapshotPath   : path.join(dataDir, 'chroma.sqlite3'),
+            persistDir     : dataDir,
+            collectionNames: ['neo-agent-memory', 'neo-agent-sessions']
+        });
+    }
     get swarmHeartbeatEnabled()          { return resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
     get goldenPathRepoEnrichmentEnabled(){ return resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
     get graphLogCompactionEnabled()      { return AiConfig.orchestrator.graphLogCompaction.enabled;      }
@@ -483,6 +514,7 @@ export class Orchestrator extends Base {
         this.containerHealthDiagnosisService = {};
         this.deploymentStateBridgeService = {};
         this.recoveryActuatorService = {};
+        this.dataIntegrityDiagnosisService = {};
         this.processSupervisorService.recoverTasks();
 
         this.db = await this.initializeDatabaseFn(this.dbPath);

--- a/ai/daemons/orchestrator/scheduling/dataIntegritySweep.mjs
+++ b/ai/daemons/orchestrator/scheduling/dataIntegritySweep.mjs
@@ -1,0 +1,36 @@
+/**
+ * @module ai/daemons/orchestrator/scheduling/dataIntegritySweep
+ * @summary Cadence projection for the periodic data-integrity sweep — the scheduling half that drives
+ * the `DataIntegrityDiagnosisService` runner live in the orchestrator poll loop. Pure and I/O-free:
+ * returns a trigger descriptor when the configured check interval has elapsed since the lane last ran,
+ * else null. Mirrors the `embedDrainLivenessWatchdog` / `swarmHeartbeat` pure-cadence `getDueTask`
+ * precedent; the coverage gather + diagnosis routing happens in the pipeline execute branch, never here.
+ *
+ * @see ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs — the runner this schedules
+ * @see ai/daemons/orchestrator/scheduling/pipeline.mjs — the health-check execute branch that runs it
+ * @see ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.mjs — the sibling pure-cadence precedent
+ */
+
+/**
+ * @summary Cadence due-trigger projection. Returns a trigger descriptor when the configured check
+ * interval has elapsed since `lastRunAt`; null otherwise. Pure — no I/O, no state writes.
+ *
+ * @param {Object} options
+ * @param {Object} [options.state] Current task state for this lane (`{lastRunAt}`).
+ * @param {Number} options.now Current epoch milliseconds.
+ * @param {Number} options.dataIntegritySweepCheckMs Check cadence; `<= 0` disables the lane.
+ * @returns {Object|null} A sweep task trigger or null when no check is due.
+ */
+export function getDueTask({state, now, dataIntegritySweepCheckMs}) {
+    const lastRunAt = state?.lastRunAt ?? 0;
+
+    if (dataIntegritySweepCheckMs > 0 && now - lastRunAt >= dataIntegritySweepCheckMs) {
+        return {
+            taskName: 'data-integrity-sweep',
+            source  : 'periodic-data-integrity-check',
+            reason  : `periodic-data-integrity-check:${dataIntegritySweepCheckMs}`
+        };
+    }
+
+    return null;
+}

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -101,7 +101,8 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
                 goldenPath                     : config.orchestrator.intervals.goldenPathMs,
                 swarmHeartbeat                 : config.orchestrator.intervals.swarmHeartbeatMs,
                 embedDrainLivenessWatchdogCheck: config.orchestrator.intervals.embedDrainLivenessWatchdogCheckMs,
-                remConsolidationWatchdogCheck  : config.orchestrator.intervals.remConsolidationWatchdogCheckMs
+                remConsolidationWatchdogCheck  : config.orchestrator.intervals.remConsolidationWatchdogCheckMs,
+                dataIntegritySweepCheck        : config.orchestrator.intervals.dataIntegritySweepCheckMs
             },
             enables: {
                 kbSync            : orchestrator.kbSyncEnabled,
@@ -136,7 +137,8 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
             taskStateService                       : orchestrator.taskStateService,
             tenantRepoSyncService                  : orchestrator.tenantRepoSyncService,
             embedDrainLivenessAlarmDispatcher      : orchestrator.embedDrainLivenessAlarmDispatcher,
-            remConsolidationLivenessAlarmDispatcher: orchestrator.remConsolidationLivenessAlarmDispatcher
+            remConsolidationLivenessAlarmDispatcher: orchestrator.remConsolidationLivenessAlarmDispatcher,
+            dataIntegrityDiagnosisService          : orchestrator.dataIntegrityDiagnosisService
         },
         runtime: {
             goldenPathRepoEnrichmentEnabled       : orchestrator.goldenPathRepoEnrichmentEnabled,
@@ -638,7 +640,9 @@ function executeHealthCheckCandidate({candidate, services, runtime}) {
         'embed-drain-liveness-watchdog': (taskName, reason) =>
             runEmbedDrainLivenessWatchdogTask({taskName, reason, services, runtime}),
         'rem-consolidation-liveness-watchdog': (taskName, reason) =>
-            runRemConsolidationLivenessWatchdogTask({taskName, reason, services, runtime})
+            runRemConsolidationLivenessWatchdogTask({taskName, reason, services, runtime}),
+        'data-integrity-sweep': (taskName, reason) =>
+            runDataIntegritySweepTask({taskName, reason, services, runtime})
     };
 
     const executeFn = runners[candidate.taskName];
@@ -861,6 +865,64 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
                 failedAt: new Date().toISOString()
             });
             runtime.writeLog?.('ERROR', `[Orchestrator] rem-consolidation-liveness-watchdog check failed (degraded to no-alarm): ${e.message}`);
+        } catch {
+            // Last-resort swallow: the never-fail guarantee dominates all observability.
+        }
+    }
+}
+
+/**
+ * @summary Runs the data-integrity sweep: the read-only coverage probe + diagnosis routing of the
+ * DataIntegrityDiagnosisService runner, recorded as a passive health signal. Never throws.
+ *
+ * The runner itself self-routes a drift diagnosis to the actuator's escalate sink (operator page) and
+ * is detect-only. This wrapper adds the passive health-record (`completed` on a clean store; `failed`
+ * when drift was escalated OR the coverage probe was unavailable — both not-healthy signals, with the
+ * `status`/`probeError` details distinguishing them) and the never-fail guarantee: any error degrades
+ * to a recorded fault and never breaks the scheduling loop.
+ *
+ * @param {Object} options
+ * @param {String} options.taskName
+ * @param {String} options.reason Scheduling reason.
+ * @param {Object} options.services Runtime collaborators (`taskStateService`, `healthService`,
+ *   `dataIntegrityDiagnosisService`).
+ * @param {Object} options.runtime Runtime policy values (`writeLog`).
+ * @returns {Promise<void>}
+ */
+async function runDataIntegritySweepTask({taskName, reason, services, runtime}) {
+    try {
+        services.taskStateService.markStarted(taskName, reason);
+        services.healthService?.recordTaskOutcome?.(taskName, 'running', {reason, startedAt: new Date().toISOString()});
+
+        const decision = await services.dataIntegrityDiagnosisService.gatherAndDiagnose();
+
+        const details = {
+            reason,
+            status         : decision.status,
+            diagnosisCount : Array.isArray(decision.diagnoses) ? decision.diagnoses.length : 0,
+            escalationCount: Array.isArray(decision.escalations) ? decision.escalations.length : 0,
+            checkedAt      : new Date().toISOString()
+        };
+        if (decision.probeError) details.probeError = decision.probeError;
+
+        // A drift escalation OR an unavailable probe is a not-healthy signal; a clean store is healthy.
+        const notHealthy = decision.status === 'escalated' || decision.status === 'probe-unavailable';
+        services.healthService?.recordTaskOutcome?.(taskName, notHealthy ? 'failed' : 'completed', details);
+
+        services.taskStateService.markCompleted(taskName);
+    } catch (e) {
+        // Degrade to "no alarm": record the fault and clear running state, never rethrow.
+        try {
+            const state = services.taskStateService.getTaskState(taskName);
+            if (state) state.lastReason = e.message;
+            services.taskStateService.markFailed(taskName, 1);
+            services.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+                reason,
+                phase   : 'data-integrity-sweep-error',
+                error   : e.message,
+                failedAt: new Date().toISOString()
+            });
+            runtime.writeLog?.('ERROR', `[Orchestrator] data-integrity-sweep check failed (degraded to no-alarm): ${e.message}`);
         } catch {
             // Last-resort swallow: the never-fail guarantee dominates all observability.
         }

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -9,6 +9,7 @@ import {getDueTask as getSwarmHeartbeatDueTask}                   from './swarmH
 import {getDueTask as getTenantRepoSyncDueTask}                   from './tenantRepoSync.mjs';
 import {getDueTask as getEmbedDrainLivenessWatchdogDueTask}       from './embedDrainLivenessWatchdog.mjs';
 import {getDueTask as getRemConsolidationLivenessWatchdogDueTask} from './remConsolidationLivenessWatchdog.mjs';
+import {getDueTask as getDataIntegritySweepDueTask}               from './dataIntegritySweep.mjs';
 
 function toTimestampMs(value) {
     if (typeof value === 'number' && Number.isFinite(value)) {
@@ -282,6 +283,25 @@ export const TASK_REGISTRY = Object.freeze([
                 state                          : state['rem-consolidation-liveness-watchdog'] ?? {},
                 now,
                 remConsolidationWatchdogCheckMs: intervals.remConsolidationWatchdogCheck
+            });
+        }
+    },
+    {
+        // The data-integrity sweep: live scheduling of the data-integrity DETECT signal (the
+        // "up but data-gutted reports green" blind spot). A read-only, no-backpressure health-check
+        // that runs the DataIntegrityDiagnosisService runner (coverage audit -> diagnosis -> escalate
+        // sink) — never a privileged action. Excluded from TASK_STALENESS_CADENCE_KEY like the watchdog
+        // siblings (health tasks keep registry-order).
+        taskName        : 'data-integrity-sweep',
+        executionKind   : 'health-check',
+        maintenanceClass: 'health-monitor',
+        backpressure    : 'none',
+        dependencies    : [],
+        getDueTask({state, now, intervals}) {
+            return getDataIntegritySweepDueTask({
+                state                    : state['data-integrity-sweep'] ?? {},
+                now,
+                dataIntegritySweepCheckMs: intervals.dataIntegritySweepCheck
             });
         }
     }

--- a/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
@@ -35,37 +35,37 @@ export class DataIntegrityDiagnosisService extends Base {
          * @member {String} className='Neo.ai.daemons.services.DataIntegrityDiagnosisService'
          * @protected
          */
-        className: 'Neo.ai.daemons.services.DataIntegrityDiagnosisService',
-        /**
-         * Async fact gatherer returning a Chroma vector-coverage audit result
-         * (`auditChromaVectorCoverage()` pre-bound with its AiConfig leaves at the use-site).
-         * @member {Function|null} coverageGatherer_=null
-         * @protected
-         * @reactive
-         */
-        coverageGatherer_: null,
-        /**
-         * The recovery actuator (or any object exposing `escalateDiagnosis(event, options)`).
-         * Only its escalate sink is ever reached — never a privileged action.
-         * @member {Object|null} recoveryActuator_=null
-         * @protected
-         * @reactive
-         */
-        recoveryActuator_: null,
-        /**
-         * The Memory Core `compose-service` identifier the diagnoses target.
-         * @member {String|null} serviceId_=null
-         * @protected
-         * @reactive
-         */
-        serviceId_: null,
-        /**
-         * @member {Function|null} nowFn_=null
-         * @protected
-         * @reactive
-         */
-        nowFn_: null
+        className: 'Neo.ai.daemons.services.DataIntegrityDiagnosisService'
     }
+
+    /**
+     * Async fact gatherer returning a Chroma vector-coverage audit result
+     * (`auditChromaVectorCoverage()` pre-bound with its AiConfig leaves at the use-site).
+     * A set-once injected dependency — a plain class field, NOT a reactive config: it is assigned once
+     * at construction, never reassigned, and never observed (no before/afterSet hook, no subscription),
+     * so the reactive Config-controller machinery would be pure overhead.
+     * @member {Function|null} coverageGatherer=null
+     */
+    coverageGatherer = null
+    /**
+     * The current-clock injection seam for deterministic tests; falls back to `Date.now()`.
+     * Set-once injected dependency — a plain class field (see `coverageGatherer`), not reactive.
+     * @member {Function|null} nowFn=null
+     */
+    nowFn = null
+    /**
+     * The recovery actuator (or any object exposing `escalateDiagnosis(event, options)`). Only its
+     * escalate sink is ever reached — never a privileged action. Set-once injected dependency — a
+     * plain class field, not reactive.
+     * @member {Object|null} recoveryActuator=null
+     */
+    recoveryActuator = null
+    /**
+     * The Memory Core `compose-service` identifier the diagnoses target. Set-once injected
+     * dependency — a plain class field, not reactive.
+     * @member {String|null} serviceId=null
+     */
+    serviceId = null
 
     /**
      * @summary Gathers integrity facts, runs the detect-producers, and routes any diagnosis to escalate.

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/dataIntegritySweep.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/dataIntegritySweep.spec.mjs
@@ -1,0 +1,30 @@
+import {test, expect} from '@playwright/test';
+import {getDueTask}   from '../../../../../../../ai/daemons/orchestrator/scheduling/dataIntegritySweep.mjs';
+
+const CHECK_MS = 60 * 60 * 1000;
+
+test.describe('dataIntegritySweep.getDueTask — periodic data-integrity cadence projection', () => {
+    test('returns a trigger when the interval has elapsed since lastRunAt', () => {
+        const now = 10 * CHECK_MS,
+              due = getDueTask({state: {lastRunAt: now - CHECK_MS}, now, dataIntegritySweepCheckMs: CHECK_MS});
+
+        expect(due).toMatchObject({taskName: 'data-integrity-sweep', source: 'periodic-data-integrity-check'});
+        expect(due.reason).toBe(`periodic-data-integrity-check:${CHECK_MS}`);
+    });
+
+    test('returns null before the interval elapses', () => {
+        const now = 10 * CHECK_MS;
+
+        expect(getDueTask({state: {lastRunAt: now - 1}, now, dataIntegritySweepCheckMs: CHECK_MS})).toBeNull();
+    });
+
+    test('fires on the first run (no prior state) once now >= interval', () => {
+        expect(getDueTask({state: undefined, now: CHECK_MS, dataIntegritySweepCheckMs: CHECK_MS}))
+            .toMatchObject({taskName: 'data-integrity-sweep'});
+    });
+
+    test('a non-positive cadence disables the lane (always null)', () => {
+        expect(getDueTask({state: {lastRunAt: 0}, now: 10 * CHECK_MS, dataIntegritySweepCheckMs: 0})).toBeNull();
+        expect(getDueTask({state: {lastRunAt: 0}, now: 10 * CHECK_MS, dataIntegritySweepCheckMs: -1})).toBeNull();
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -905,3 +905,97 @@ test.describe('orchestrator/scheduling/pipeline staleness selector (#13586)', ()
         expect(result.winner.taskName).toBe('backup');
     });
 });
+
+test.describe('orchestrator/scheduling/pipeline — data-integrity-sweep never-fail wrapper (#14109)', () => {
+    // The health-check runner is fire-and-forget (runSchedulingPipeline does not await it), so a
+    // macrotask flush drains the runner's microtasks before assertions.
+    const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+    function runSweep({gatherAndDiagnose}) {
+        const calls    = [],
+              outcomes = [],
+              state    = {};
+
+        runSchedulingPipeline({
+            registry: [makeCandidateDescriptor({
+                taskName        : 'data-integrity-sweep',
+                executionKind   : 'health-check',
+                maintenanceClass: 'health-monitor'
+            })],
+            context : makeContext(),
+            services: makeServices({
+                dataIntegrityDiagnosisService: {gatherAndDiagnose},
+                healthService                : {
+                    recordTaskOutcome(taskName, status, details) { outcomes.push({taskName, status, details}); }
+                },
+                taskStateService: {
+                    getTaskState: () => state,
+                    markCompleted(taskName)        { calls.push(['markCompleted', taskName]); },
+                    markFailed(taskName, exitCode) { calls.push(['markFailed', taskName, exitCode]); },
+                    markSkipped(taskName)          { calls.push(['markSkipped', taskName]); },
+                    markStarted(taskName, reason)  { calls.push(['markStarted', taskName, reason]); }
+                }
+            }),
+            runtime: makeRuntime()
+        });
+
+        return {calls, outcomes, state};
+    }
+
+    test('a clean decision records a completed health-outcome', async () => {
+        const {calls, outcomes} = runSweep({
+            gatherAndDiagnose: async () => ({status: 'healthy', diagnoses: [], escalations: []})
+        });
+        await flush();
+
+        expect(calls).toEqual([
+            ['markStarted', 'data-integrity-sweep', 'data-integrity-sweep-reason'],
+            ['markCompleted', 'data-integrity-sweep']
+        ]);
+        expect(outcomes.at(-1)).toMatchObject({
+            status : 'completed',
+            details: {status: 'healthy', diagnosisCount: 0, escalationCount: 0}
+        });
+    });
+
+    test('a drift escalation records a failed health-outcome (the runner already routed the page)', async () => {
+        const {calls, outcomes} = runSweep({
+            gatherAndDiagnose: async () => ({status: 'escalated', diagnoses: [{}], escalations: [{status: 'escalated'}]})
+        });
+        await flush();
+
+        expect(calls).toContainEqual(['markCompleted', 'data-integrity-sweep']);
+        expect(outcomes.at(-1)).toMatchObject({
+            status : 'failed',
+            details: {status: 'escalated', diagnosisCount: 1, escalationCount: 1}
+        });
+    });
+
+    test('a probe-unavailable decision records a failed health-outcome (a failed probe is not silently green)', async () => {
+        const {outcomes} = runSweep({
+            gatherAndDiagnose: async () => ({status: 'probe-unavailable', probeError: 'Chroma unreachable', diagnoses: [], escalations: []})
+        });
+        await flush();
+
+        expect(outcomes.at(-1)).toMatchObject({
+            status : 'failed',
+            details: {status: 'probe-unavailable', probeError: 'Chroma unreachable'}
+        });
+    });
+
+    test('a throwing gatherAndDiagnose degrades to markFailed and NEVER rethrows (the never-fail guarantee)', async () => {
+        const {calls, outcomes, state} = runSweep({
+            gatherAndDiagnose: async () => { throw new Error('runner boom'); }
+        });
+        await flush();
+
+        // The catch records the fault and clears running state; the rejection never propagates into the
+        // scheduling loop (runSchedulingPipeline returned normally above).
+        expect(calls).toContainEqual(['markFailed', 'data-integrity-sweep', 1]);
+        expect(state.lastReason).toBe('runner boom');
+        expect(outcomes.at(-1)).toMatchObject({
+            status : 'failed',
+            details: {phase: 'data-integrity-sweep-error', error: 'runner boom'}
+        });
+    });
+});


### PR DESCRIPTION
Resolves #14109

Slice 2 (the live-wiring) of #14109. (#14114, the runner unit, is now **merged**; this branch is rebased onto dev and folds in a review-driven cleanup — see Deltas.) This schedules the `DataIntegrityDiagnosisService` runner live in the orchestrator poll loop, turning the proven-but-dormant data-integrity detect signal into a running immune-system check: every cadence it audits Memory Core metadata-vs-vector coverage and routes any drift diagnosis to the recovery actuator's `escalateDiagnosis` sink (operator page) — the #13999 "up but data-gutted reports green" blind spot, now watched. This is the **"immune system live, with the data-integrity detect-signal wired in"** v13.1 bar.

Mirrors the `embed-drain-liveness-watchdog` precedent exactly: a `health-check` execution kind — read-only, no-backpressure, **never-fail** (a check error degrades to a logged outcome and never breaks the scheduling loop). Detect-only / escalate-only end-to-end (the runner reaches `escalateDiagnosis` only, never a privileged action). Cadence is an AiConfig SSOT leaf (hourly default; `NEO_ORCHESTRATOR_DATA_INTEGRITY_SWEEP_INTERVAL_MS`; `<= 0` disables).

Evidence: L2/L3 — the full orchestrator unit suite is green with this lane wired (668 passing, including the new cadence spec); the 3 failures are in files this PR does not touch (see Test Evidence).

## Deltas

- **Per @tobiu's review (configs → class fields):** the runner's injected deps (`coverageGatherer` / `recoveryActuator` / `serviceId` / `nowFn`) are now plain **class fields**, not reactive configs — they're set-once, never reassigned, never observed (no `afterSet`/subscription), so the reactive `Config`-controller machinery was unjustified overhead. Matches the Orchestrator's own idiom (class fields for plain injected collaborators; reactive configs reserved for those with real `afterSet` wiring). Behavior-transparent — 11/11 runner+scheduling specs green.
- The coverage producer is the wired signal; monotonicity (#14094) + dimension (#14102) fold into the runner's `buildDiagnoses` seam as **non-gating follow-up leaves** (the seam is ready; they need their fact-gatherers — Ada's dimension gatherer #14113 is in-flight as PR #14115).
- `ai/config.mjs` is gitignored (generated); the cadence leaf is added to the committed `ai/config.template.mjs`. The `aiConfigDefaults` fixture + `config.template.spec` snapshot are partial/`toMatchObject` mirrors (matching the `remConsolidationWatchdogCheckMs` precedent), so no mirror edit is required.
- Service id `mc-server` + the MC collection set are use-site topology constants; the Chroma persist/snapshot paths read the `AiConfig.engines.chroma.dataDir` SSOT leaf at the use-site (ADR-0019-clean).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/dataIntegritySweep.spec.mjs` → **4/4** (cadence: due / not-due / first-run / disabled).
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/` → **668 passed**. The 3 failures are in files this PR does NOT touch — `DreamServiceGoldenPath` (a 60s load-induced timeout) + `DeploymentStateBridgeService` + `HeavyMaintenanceLeaseService` (assertion failures that reproduce on the pre-wiring base — comparative confirmed; not introduced here).
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs` → **8/8** (the new leaf is tolerated by the partial snapshot).
- `npm run test-unit -- …/scheduling/pipeline.spec.mjs` → **21/21**, incl. **4 new never-fail wrapper tests** added per @neo-opus-ada's review (clean→completed · drift→failed · probe-unavailable→failed · throwing `gatherAndDiagnose`→`markFailed` + no-rethrow).

## Post-Merge Validation

- [ ] On the next orchestrator restart from dev, confirm a `data-integrity-sweep` health-record appears (status `completed` on a clean store) at the configured cadence.
- [ ] Confirm the 3 unrelated spec failures are green on a fresh full-dev CI run (they reproduce on the pre-wiring base; flagged as not-introduced-here).

## Commits

- feat(ai): schedule the data-integrity runner live + route to escalate (the orchestrator wiring)
- refactor(ai): runner injected deps as class fields, not reactive configs (per @tobiu review)

## Structural pre-flight

New `scheduling/dataIntegritySweep.mjs` is a Stage-1 sibling-lift of `scheduling/embedDrainLivenessWatchdog.mjs` (pure-cadence `getDueTask`); the registry descriptor + pipeline `health-check` runner + Orchestrator config-member wiring all mirror the embed-drain / rem-consolidation watchdog lanes exactly — no novel pattern.

Related: #14112 (slice-1 runner unit, PR #14114), #14026 (detect-signal class), #14046 (release-gate e2e), #14061 (escalate sink), #14039 (v13.1 epic).

Authored by Vega (Claude Opus 4.8, Claude Code). Session 16bbea8d-8bc9-4dad-8e1c-8e3b2cd861a3.
