### PR TITLE
feat(ai): accepted-loss recovery closing leaf — store + decider + defrag exit-wiring + operator ack (#14118)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -11,6 +11,40 @@ import {withHeavyMaintenanceLease}                                   from '../..
 import {registerNeoChromaEmbeddingFunctions}                         from '../../services/shared/vector/chromaClientPrimitives.mjs';
 import {auditChromaVectorCoverage}                                   from './checkChromaIntegrity.mjs';
 import {extractMemoryCoreCollectionData, truncateToEmbedTokenBudget} from './repairMemoryCoreStoredEmbeddings.mjs';
+import {evaluateAcceptedLossOutcome}                                 from '../../services/memory-core/helpers/acceptedLossOutcome.mjs';
+import {readAcceptedLossAckByFingerprint}                            from '../../services/memory-core/helpers/acceptedLossAckStore.mjs';
+import {TERMINAL_REASONS}                                            from '../../services/memory-core/helpers/classifyRepairResidue.mjs';
+
+// Bumped whenever the recovery strategy's embeddability changes (e.g. oversized-document chunking ships),
+// so a strategy change invalidates a stale accepted-loss acknowledgement by construction.
+const MC_REPAIR_STRATEGY_VERSION = 'mc-repair-v1';
+
+/**
+ * @summary Builds the recovery context bound into accepted-loss fingerprints — the shared source both the
+ * defrag accepted-loss check and the operator acknowledgement read, so their fingerprints match by
+ * construction. Provider + embedding context budget come from the live config/SSOT (read at the use site);
+ * the strategy version is the constant above.
+ * @param {Object} config The resolved target config (`{embeddingProvider, ...}`).
+ * @returns {Object} `{strategyVersion, provider, contextBudget, terminalReasons}`.
+ */
+function buildMemoryCoreRecoveryContext(config) {
+    return {
+        strategyVersion: MC_REPAIR_STRATEGY_VERSION,
+        provider       : config?.embeddingProvider ?? '',
+        contextBudget  : AiConfig.localModels.embedding.safeProcessingLimitTokens,
+        terminalReasons: TERMINAL_REASONS
+    };
+}
+
+/**
+ * @summary The durable accepted-loss acknowledgement directory — a stable sibling of the defrag state
+ * marker, so an operator acknowledgement persists across runs and a later repair finds it by fingerprint.
+ * @param {String} statePath The defrag durable state-marker path.
+ * @returns {String}
+ */
+function acceptedLossAckDir(statePath) {
+    return path.join(path.dirname(statePath), 'accepted-loss-acks');
+}
 
 /**
  * @summary Defragments collection groups inside the unified ChromaDB store.
@@ -1538,10 +1572,26 @@ async function defragChromaDB() {
                 const abortedNames  = results.filter(result => result.aborted).map(result => result.collectionName),
                       partialNames  = results.filter(result => result.partialPromoted).map(result => result.collectionName),
                       nonCleanNames = [...abortedNames, ...partialNames];
-                console.error(dryRun
-                    ? `❌ Memory Core repair dry-run found unrecoverable rows for ${abortedNames.join(', ')} — no promotion was attempted; resolve the unrecoverable rows before running the mutating repair. Counts and reasons logged above.`
-                    : `❌ Memory Core repair non-clean for ${nonCleanNames.join(', ')} (aborted: ${abortedNames.join(', ') || 'none'}; partial-promoted: ${partialNames.join(', ') || 'none'}) — recovered rows are durable where partial-promoted, but this is NOT a successful repair. Resolve unrecoverable rows using the retained parking/source state. Counts and reasons logged above.`);
-                process.exit(1);
+
+                // Accepted-loss settlement: a partial-promotion (NO aborted collection) whose entire residue is
+                // operator-acknowledged terminal loss is a bounded, accepted outcome — the recovered rows are
+                // durable and the residue is genuinely unembeddable, so it must not page "repair failed" forever.
+                // Every other path (aborted, dry-run, any transient/unacknowledged/stale residue) still exits 1.
+                const acceptedLoss = !dryRun && Boolean(statePath) && abortedNames.length === 0 && partialNames.length > 0 &&
+                    (await evaluateAcceptedLossOutcome({
+                        partialResults : results.filter(result => result.partialPromoted),
+                        recoveryContext: buildMemoryCoreRecoveryContext(config),
+                        readAck        : fingerprint => readAcceptedLossAckByFingerprint({fingerprint, dir: acceptedLossAckDir(statePath)})
+                    })).allAccepted;
+
+                if (acceptedLoss) {
+                    console.log(`✅ Memory Core repair: the bounded unrecoverable residue is operator-acknowledged accepted-loss for ${partialNames.join(', ')} — recovered rows are durable; not escalating. Acknowledge new residue with --acknowledge-accepted-loss.`);
+                } else {
+                    console.error(dryRun
+                        ? `❌ Memory Core repair dry-run found unrecoverable rows for ${abortedNames.join(', ')} — no promotion was attempted; resolve the unrecoverable rows before running the mutating repair. Counts and reasons logged above.`
+                        : `❌ Memory Core repair non-clean for ${nonCleanNames.join(', ')} (aborted: ${abortedNames.join(', ') || 'none'}; partial-promoted: ${partialNames.join(', ') || 'none'}) — recovered rows are durable where partial-promoted, but this is NOT a successful repair. Resolve unrecoverable rows using the retained parking/source state, or acknowledge accepted terminal loss with --acknowledge-accepted-loss. Counts and reasons logged above.`);
+                    process.exit(1);
+                }
             }
             return;
         }

--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -11,7 +11,7 @@ import {withHeavyMaintenanceLease}                                   from '../..
 import {registerNeoChromaEmbeddingFunctions}                         from '../../services/shared/vector/chromaClientPrimitives.mjs';
 import {auditChromaVectorCoverage}                                   from './checkChromaIntegrity.mjs';
 import {extractMemoryCoreCollectionData, truncateToEmbedTokenBudget} from './repairMemoryCoreStoredEmbeddings.mjs';
-import {acknowledgeAcceptedLossResidue, evaluateAcceptedLossOutcome} from '../../services/memory-core/helpers/acceptedLossOutcome.mjs';
+import {acknowledgeAcceptedLossResidue, resolveAcceptedLossExit}     from '../../services/memory-core/helpers/acceptedLossOutcome.mjs';
 import {appendAcceptedLossAck, readAcceptedLossAckByFingerprint}     from '../../services/memory-core/helpers/acceptedLossAckStore.mjs';
 import {TERMINAL_REASONS}                                            from '../../services/memory-core/helpers/classifyRepairResidue.mjs';
 
@@ -1626,12 +1626,12 @@ async function defragChromaDB() {
                 // operator-acknowledged terminal loss is a bounded, accepted outcome — the recovered rows are
                 // durable and the residue is genuinely unembeddable, so it must not page "repair failed" forever.
                 // Every other path (aborted, dry-run, any transient/unacknowledged/stale residue) still exits 1.
-                const acceptedLoss = !dryRun && Boolean(statePath) && abortedNames.length === 0 && partialNames.length > 0 &&
-                    (await evaluateAcceptedLossOutcome({
-                        partialResults : results.filter(result => result.partialPromoted),
-                        recoveryContext: buildMemoryCoreRecoveryContext(config),
-                        readAck        : fingerprint => readAcceptedLossAckByFingerprint({fingerprint, dir: acceptedLossAckDir(statePath)})
-                    })).allAccepted;
+                const {acceptedLoss} = await resolveAcceptedLossExit({
+                    results,
+                    dryRun,
+                    recoveryContext: buildMemoryCoreRecoveryContext(config),
+                    readAck        : statePath ? (fingerprint => readAcceptedLossAckByFingerprint({fingerprint, dir: acceptedLossAckDir(statePath)})) : null
+                });
 
                 if (acceptedLoss) {
                     console.log(`✅ Memory Core repair: the bounded unrecoverable residue is operator-acknowledged accepted-loss for ${partialNames.join(', ')} — recovered rows are durable; not escalating. Acknowledge new residue with --acknowledge-accepted-loss.`);

--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -11,8 +11,8 @@ import {withHeavyMaintenanceLease}                                   from '../..
 import {registerNeoChromaEmbeddingFunctions}                         from '../../services/shared/vector/chromaClientPrimitives.mjs';
 import {auditChromaVectorCoverage}                                   from './checkChromaIntegrity.mjs';
 import {extractMemoryCoreCollectionData, truncateToEmbedTokenBudget} from './repairMemoryCoreStoredEmbeddings.mjs';
-import {evaluateAcceptedLossOutcome}                                 from '../../services/memory-core/helpers/acceptedLossOutcome.mjs';
-import {readAcceptedLossAckByFingerprint}                            from '../../services/memory-core/helpers/acceptedLossAckStore.mjs';
+import {acknowledgeAcceptedLossResidue, evaluateAcceptedLossOutcome} from '../../services/memory-core/helpers/acceptedLossOutcome.mjs';
+import {appendAcceptedLossAck, readAcceptedLossAckByFingerprint}     from '../../services/memory-core/helpers/acceptedLossAckStore.mjs';
 import {TERMINAL_REASONS}                                            from '../../services/memory-core/helpers/classifyRepairResidue.mjs';
 
 // Bumped whenever the recovery strategy's embeddability changes (e.g. oversized-document chunking ships),
@@ -44,6 +44,46 @@ function buildMemoryCoreRecoveryContext(config) {
  */
 function acceptedLossAckDir(statePath) {
     return path.join(path.dirname(statePath), 'accepted-loss-acks');
+}
+
+/**
+ * @summary Mints + persists a durable operator accepted-loss acknowledgement over the live partial-promotion
+ * residue read from the defrag state marker, so a subsequent repair settles it as accepted-loss instead of
+ * paging. Fails closed (exit 1) when the target is not memory-core, when `--operator-id` is missing, or when
+ * there is no partial-promoted state to acknowledge. Does not run the repair pipeline.
+ * @param {Object} options
+ * @param {String} options.targetName
+ * @param {Object} options.config Resolved target config (for the shared recovery context).
+ * @param {String} options.statePath Defrag durable state-marker path.
+ * @param {String} options.operatorId Acknowledging operator identity.
+ * @returns {Promise<void>}
+ */
+async function acknowledgeOperatorAcceptedLoss({targetName, config, statePath, operatorId}) {
+    if (targetName !== 'memory-core') {
+        console.error('❌ --acknowledge-accepted-loss is only valid for --target memory-core.');
+        process.exit(1);
+    }
+    if (!operatorId) {
+        console.error('❌ --acknowledge-accepted-loss requires --operator-id <id>.');
+        process.exit(1);
+    }
+
+    const state = await fs.pathExists(statePath) ? await fs.readJson(statePath) : null;
+    if (!state || state.phase !== 'memory-core-repair-partial-promoted' || !state.unrecoverableByCollection) {
+        console.error('❌ No partial-promoted Memory Core repair state to acknowledge. Run the repair first; only a partial-promotion with retained unrecoverable residue is acknowledgeable.');
+        process.exit(1);
+    }
+
+    const {acknowledged} = await acknowledgeAcceptedLossResidue({
+        unrecoverableByCollection: state.unrecoverableByCollection,
+        recoveryContext          : buildMemoryCoreRecoveryContext(config),
+        operatorId,
+        acknowledgedAt           : Date.now(),
+        recoveryRunId            : state.recoveryRunId ?? null,
+        persist                  : ack => appendAcceptedLossAck({entry: ack, dir: acceptedLossAckDir(statePath)})
+    });
+
+    console.log(`✅ Acknowledged accepted-loss for ${acknowledged.length} collection(s): ${acknowledged.map(a => `${a.collection} (${a.residueCount} row(s))`).join(', ')}. Re-run the repair to settle it as accepted-loss.`);
 }
 
 /**
@@ -1452,6 +1492,8 @@ async function defragChromaDB() {
         .requiredOption('-t, --target <name>', 'Database target (knowledge-base, memory-core)')
         .option('--allow-memory-core', 'Opt in to the Memory Core repair-defrag path (default: fails closed)')
         .option('--dry-run', 'For memory-core, run full enumeration/extraction report without shadow promotion')
+        .option('--acknowledge-accepted-loss', 'For memory-core, acknowledge the live partial-promotion residue as accepted terminal loss (mints a durable ack; requires --operator-id)')
+        .option('--operator-id <id>', 'Operator identity recorded on an accepted-loss acknowledgement')
         .parse(process.argv);
 
     const options    = program.opts();
@@ -1464,6 +1506,13 @@ async function defragChromaDB() {
 
         const config    = await loadConfig(targetName);
         const statePath = resolveDefragStatePath({targetName});
+
+        // Operator accepted-loss acknowledgement: mint + persist a durable ack over the live partial-promotion
+        // residue so a subsequent repair settles it as accepted-loss. Reads the state marker; runs no pipeline.
+        if (options.acknowledgeAcceptedLoss) {
+            await acknowledgeOperatorAcceptedLoss({targetName, config, statePath, operatorId: options.operatorId});
+            return;
+        }
 
         assertDefragTargetSupported({targetName, allowMemoryCore: options.allowMemoryCore});
         const resumeState = await assertNoIncompleteDefragState({

--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -27,7 +27,7 @@ const MC_REPAIR_STRATEGY_VERSION = 'mc-repair-v1';
  * @param {Object} config The resolved target config (`{embeddingProvider, ...}`).
  * @returns {Object} `{strategyVersion, provider, contextBudget, terminalReasons}`.
  */
-function buildMemoryCoreRecoveryContext(config) {
+export function buildMemoryCoreRecoveryContext(config) {
     return {
         strategyVersion: MC_REPAIR_STRATEGY_VERSION,
         provider       : config?.embeddingProvider ?? '',
@@ -42,7 +42,7 @@ function buildMemoryCoreRecoveryContext(config) {
  * @param {String} statePath The defrag durable state-marker path.
  * @returns {String}
  */
-function acceptedLossAckDir(statePath) {
+export function acceptedLossAckDir(statePath) {
     return path.join(path.dirname(statePath), 'accepted-loss-acks');
 }
 
@@ -84,6 +84,47 @@ async function acknowledgeOperatorAcceptedLoss({targetName, config, statePath, o
     });
 
     console.log(`✅ Acknowledged accepted-loss for ${acknowledged.length} collection(s): ${acknowledged.map(a => `${a.collection} (${a.residueCount} row(s))`).join(', ')}. Re-run the repair to settle it as accepted-loss.`);
+}
+
+/**
+ * @summary Settles an operator-acknowledged partial-promotion on a rerun: when the durable state marker is
+ * `memory-core-repair-partial-promoted` and its residue is operator-acknowledged accepted-loss, it clears the
+ * marker and reports success (the caller returns → exit 0) instead of aborting at the incomplete-state guard.
+ * This is what makes the operator workflow reachable end-to-end: repair → partial-promotion (exit 1 + marker)
+ * → `--acknowledge-accepted-loss` → rerun. Returns false when there is nothing acknowledged to settle (no
+ * marker, not a partial-promotion, or unacknowledged/stale residue) — the caller then proceeds to the normal
+ * incomplete-state guard, which escalates an unacknowledged partial-promotion.
+ *
+ * @param {Object} options
+ * @param {Object} options.config Resolved target config (for the shared recovery context).
+ * @param {String} options.statePath Defrag durable state-marker path.
+ * @returns {Promise<Boolean>} True when settled (the caller should return); false to proceed to the guard.
+ */
+export async function settleAcknowledgedPartialPromotion({config, statePath} = {}) {
+    const state = statePath && await fs.pathExists(statePath) ? await fs.readJson(statePath) : null;
+
+    if (!state || state.phase !== 'memory-core-repair-partial-promoted' || !state.unrecoverableByCollection) {
+        return false;
+    }
+
+    const partialResults = Object.entries(state.unrecoverableByCollection).map(
+        ([collectionName, unrecoverable]) => ({collectionName, partialPromoted: true, unrecoverable})
+    );
+
+    const {acceptedLoss, perCollection} = await resolveAcceptedLossExit({
+        results        : partialResults,
+        dryRun         : false,
+        recoveryContext: buildMemoryCoreRecoveryContext(config),
+        readAck        : fingerprint => readAcceptedLossAckByFingerprint({fingerprint, dir: acceptedLossAckDir(statePath)})
+    });
+
+    if (!acceptedLoss) {
+        return false;
+    }
+
+    await clearDefragState({statePath});
+    console.log(`✅ Memory Core repair: the partial-promotion residue is operator-acknowledged accepted-loss for ${perCollection.map(entry => entry.collection).join(', ')} — recovered rows are durable; clearing the state marker and settling clean.`);
+    return true;
 }
 
 /**
@@ -1515,6 +1556,15 @@ async function defragChromaDB() {
         }
 
         assertDefragTargetSupported({targetName, allowMemoryCore: options.allowMemoryCore});
+
+        // A rerun over an operator-acknowledged partial-promotion settles as accepted-loss (clear the marker +
+        // exit 0) rather than aborting at the incomplete-state guard below — the repair → acknowledge → rerun
+        // workflow. An unacknowledged partial-promotion falls through to the guard, which escalates it.
+        if (targetName === 'memory-core' && options.allowMemoryCore &&
+            await settleAcknowledgedPartialPromotion({config, statePath})) {
+            return;
+        }
+
         const resumeState = await assertNoIncompleteDefragState({
             statePath,
             allowedPhases: targetName === 'memory-core' && options.allowMemoryCore ? [

--- a/ai/services/memory-core/helpers/acceptedLossAckStore.mjs
+++ b/ai/services/memory-core/helpers/acceptedLossAckStore.mjs
@@ -1,0 +1,101 @@
+import fs   from 'fs/promises';
+import path from 'path';
+
+/**
+ * @module ai/services/memory-core/helpers/acceptedLossAckStore
+ * @summary Durable persistence for operator accepted-loss acknowledgements — the store half that closes
+ * the produce → store → classify loop. It persists the typed `accepted-loss-ack` record (built by the ack
+ * constructor) keyed by its residue `fingerprint`, and retrieves the most-recent ack for a given
+ * fingerprint, so the residue classifier can find the durable acknowledgement that lets a genuinely
+ * unembeddable, operator-acknowledged residue settle as accepted-loss instead of paging "repair failed"
+ * forever — without ever letting an unacknowledged or stale loss settle silently.
+ *
+ * One JSONL ledger per fingerprint (`<fingerprint>.jsonl`): a re-acknowledgement appends a fresh line and
+ * retrieval reads the last (most-recent) line, so a later ack supersedes an earlier one for the same
+ * residue+policy identity. The fingerprint is the shared residue-fingerprint hex digest, so a residue /
+ * strategy / provider / terminality-policy change produces a different fingerprint → a different ledger →
+ * a stale ack can never be found for changed loss. I/O lives only at the edge; no time/randomness.
+ */
+
+const ACK_FILE_SUFFIX = '.jsonl';
+
+/**
+ * @summary The per-fingerprint ledger file name.
+ *
+ * The fingerprint is a sha256 hex digest (already filename-safe); it is sanitized defensively so a
+ * malformed fingerprint can never escape the store directory or collide with path separators.
+ *
+ * @param {String} fingerprint The residue fingerprint hex digest.
+ * @returns {String}
+ */
+export function getAcceptedLossAckFileName(fingerprint) {
+    return `${String(fingerprint).replace(/[^a-zA-Z0-9_.-]/g, '_')}${ACK_FILE_SUFFIX}`;
+}
+
+/**
+ * @summary Persists one accepted-loss acknowledgement record, keyed by its residue fingerprint.
+ *
+ * Appends the record as a JSONL line to the per-fingerprint ledger; re-acknowledging the same
+ * residue+policy identity appends a fresh line that supersedes the earlier one on read.
+ *
+ * @param {Object} options
+ * @param {Object} options.entry A typed `accepted-loss-ack` record; must carry a non-empty `fingerprint`.
+ * @param {String} options.dir Directory for the per-fingerprint ack ledgers.
+ * @returns {Promise<String>} The written file path.
+ * @throws {TypeError} when `dir` is missing or `entry.fingerprint` is absent/empty.
+ */
+export async function appendAcceptedLossAck({entry, dir} = {}) {
+    if (!dir) {
+        throw new TypeError('appendAcceptedLossAck: dir is required');
+    }
+    if (!entry || typeof entry.fingerprint !== 'string' || entry.fingerprint.length === 0) {
+        throw new TypeError('appendAcceptedLossAck: entry.fingerprint is required');
+    }
+
+    await fs.mkdir(dir, {recursive: true});
+
+    const filePath = path.join(dir, getAcceptedLossAckFileName(entry.fingerprint));
+    await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, 'utf8');
+
+    return filePath;
+}
+
+/**
+ * @summary Retrieves the most-recent durable accepted-loss ack for a residue fingerprint, or null.
+ *
+ * Reads the per-fingerprint ledger and returns its last (newest) record. A missing ledger (no ack ever
+ * stored for this fingerprint), an empty ledger, or a corrupt trailing line returns null — an
+ * unacknowledged or unreadable residue must escalate, never silently settle as accepted-loss. The
+ * returned record's own `fingerprint` is re-checked against the key, so a sanitized-name collision can
+ * never surface an ack for a different residue.
+ *
+ * @param {Object} options
+ * @param {String} options.fingerprint The residue fingerprint to look up.
+ * @param {String} options.dir Directory for the per-fingerprint ack ledgers.
+ * @returns {Promise<Object|null>} The most-recent matching ack record, or null when none is durably stored.
+ */
+export async function readAcceptedLossAckByFingerprint({fingerprint, dir} = {}) {
+    if (!dir || typeof fingerprint !== 'string' || fingerprint.length === 0) {
+        return null;
+    }
+
+    const filePath = path.join(dir, getAcceptedLossAckFileName(fingerprint));
+
+    let text;
+    try {
+        text = await fs.readFile(filePath, 'utf8');
+    } catch (e) {
+        if (e?.code === 'ENOENT') return null;
+        throw e;
+    }
+
+    const lines = text.trim().split('\n').filter(Boolean);
+    if (lines.length === 0) return null;
+
+    try {
+        const record = JSON.parse(lines[lines.length - 1]);
+        return record && record.fingerprint === fingerprint ? record : null;
+    } catch (e) {
+        return null;
+    }
+}

--- a/ai/services/memory-core/helpers/acceptedLossOutcome.mjs
+++ b/ai/services/memory-core/helpers/acceptedLossOutcome.mjs
@@ -3,6 +3,7 @@ import {
     classifyRepairResidue,
     computeResidueFingerprint
 } from './classifyRepairResidue.mjs';
+import {createAcceptedLossAckEntry} from './acceptedLossAck.mjs';
 
 /**
  * @module ai/services/memory-core/helpers/acceptedLossOutcome
@@ -48,12 +49,8 @@ export async function evaluateAcceptedLossOutcome({partialResults = [], recovery
     let allAccepted = rows.length > 0;
 
     for (const result of rows) {
-        const residue = (result?.unrecoverable || []).map(row => ({
-            id    : row?.id ?? null,
-            reason: row?.reason ?? null
-        }));
-
-        const fingerprint = computeResidueFingerprint({residue, strategyVersion, provider, contextBudget, terminalReasons}),
+        const residue     = mapUnrecoverableToResidue(result?.unrecoverable),
+              fingerprint = computeResidueFingerprint({residue, strategyVersion, provider, contextBudget, terminalReasons}),
               ack         = typeof readAck === 'function' ? await readAck(fingerprint) : null,
               verdict     = classifyRepairResidue({residue, ack, strategyVersion, provider, contextBudget, terminalReasons});
 
@@ -70,4 +67,76 @@ export async function evaluateAcceptedLossOutcome({partialResults = [], recovery
     }
 
     return {allAccepted, perCollection};
+}
+
+/**
+ * @summary Maps a partial-promotion's unrecoverable manifest rows to the classifier's residue shape.
+ *
+ * The SINGLE shared mapping used by BOTH the accepted-loss check (read side) and the operator
+ * acknowledgement (write side), so the two compute identical fingerprints by construction — never a
+ * hand-duplicated map that could silently drift and break the match.
+ *
+ * @param {Array<Object>} rows `[{id, reason, ...}]` unrecoverable rows.
+ * @returns {Array<Object>} `[{id, reason}]`.
+ */
+export function mapUnrecoverableToResidue(rows) {
+    return (Array.isArray(rows) ? rows : []).map(row => ({
+        id    : row?.id ?? null,
+        reason: row?.reason ?? null
+    }));
+}
+
+/**
+ * @summary Mints + persists an operator accepted-loss acknowledgement over a partial-promotion's
+ * unrecoverable manifest, one ack per collection.
+ *
+ * Pure except for the injected `persist` and the supplied `acknowledgedAt` (no time/randomness of its
+ * own), so it round-trips with the accepted-loss check by construction: an ack minted here under the same
+ * recovery context is exactly the one `evaluateAcceptedLossOutcome` accepts. A collection with no residue
+ * is skipped (nothing to acknowledge).
+ *
+ * @param {Object} options
+ * @param {Object} [options.unrecoverableByCollection={}] `{collection: [{id, reason}]}` from the state marker.
+ * @param {Object} [options.recoveryContext={}] The shared recovery context (same as the check reads).
+ * @param {String} options.operatorId The acknowledging operator identity.
+ * @param {Number} options.acknowledgedAt Epoch milliseconds of the acknowledgement.
+ * @param {Function} options.persist `async ack => void` — the durable ack writer (injected).
+ * @param {String|null} [options.recoveryRunId=null] Optional originating recovery-run id (provenance).
+ * @returns {Promise<Object>} `{acknowledged:[{collection, fingerprint, residueCount}]}`.
+ */
+export async function acknowledgeAcceptedLossResidue({
+    unrecoverableByCollection = {},
+    recoveryContext           = {},
+    operatorId,
+    acknowledgedAt,
+    persist,
+    recoveryRunId             = null
+} = {}) {
+    const {
+        strategyVersion = '',
+        provider        = '',
+        contextBudget   = '',
+        terminalReasons = TERMINAL_REASONS
+    } = recoveryContext;
+
+    const acknowledged = [];
+
+    for (const [collection, rows] of Object.entries(unrecoverableByCollection || {})) {
+        const residue = mapUnrecoverableToResidue(rows);
+        if (residue.length === 0) {
+            continue;
+        }
+
+        const ack = createAcceptedLossAckEntry({
+            residue, operatorId, acknowledgedAt, strategyVersion, provider, contextBudget, terminalReasons, recoveryRunId
+        });
+
+        if (typeof persist === 'function') {
+            await persist(ack);
+        }
+
+        acknowledged.push({collection, fingerprint: ack.fingerprint, residueCount: residue.length});
+    }
+
+    return {acknowledged};
 }

--- a/ai/services/memory-core/helpers/acceptedLossOutcome.mjs
+++ b/ai/services/memory-core/helpers/acceptedLossOutcome.mjs
@@ -1,0 +1,73 @@
+import {
+    TERMINAL_REASONS,
+    classifyRepairResidue,
+    computeResidueFingerprint
+} from './classifyRepairResidue.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/acceptedLossOutcome
+ * @summary Pure decider for whether a Memory Core partial-promotion's residue is operator-acknowledged
+ * accepted-loss — the composition leaf that joins the residue classifier, the durable ack store, and the
+ * defrag partial-promotion manifest into the single exit-0-vs-escalate decision the repair CLI consults.
+ *
+ * For each partial-promoted collection it maps the unrecoverable manifest to the classifier's residue
+ * shape, computes the shared residue fingerprint, looks up the durable ack (injected — so this stays pure
+ * and testable without I/O), and classifies. The whole run is accepted-loss ONLY when there is at least
+ * one partial-promoted collection AND every one classifies as accepted-loss (all-terminal residue + a
+ * matching durable ack). Any transient/unknown reason, a missing or stale ack, or zero collections leaves
+ * the run NOT accepted → the caller escalates (exit 1) exactly as before. An aborted collection is never
+ * accepted-loss; the caller must exclude aborted runs before consulting this (no promotion happened, so it
+ * is a real failure, not bounded loss).
+ *
+ * The `recoveryContext` (strategy/provider/context/terminality-policy) is bound into the fingerprint, so it
+ * MUST be the same context the operator ack was minted under — both read from one shared recovery-context
+ * source so they match by construction.
+ */
+
+/**
+ * @summary Decides, per partial-promoted collection, whether the residue is operator-acknowledged accepted-loss.
+ *
+ * @param {Object} options
+ * @param {Object[]} [options.partialResults=[]] Partial-promoted repair results (`{collectionName, unrecoverable:[{id,reason}]}`).
+ * @param {Object} [options.recoveryContext={}] The recovery context bound into the fingerprint (`{strategyVersion, provider, contextBudget, terminalReasons}`).
+ * @param {Function} options.readAck `async fingerprint => ack|null` — the durable ack lookup (injected).
+ * @returns {Promise<Object>} `{allAccepted, perCollection:[{collection, outcome, reasonCode, fingerprint}]}`.
+ */
+export async function evaluateAcceptedLossOutcome({partialResults = [], recoveryContext = {}, readAck} = {}) {
+    const {
+        strategyVersion = '',
+        provider        = '',
+        contextBudget   = '',
+        terminalReasons = TERMINAL_REASONS
+    } = recoveryContext;
+
+    const rows          = Array.isArray(partialResults) ? partialResults : [],
+          perCollection = [];
+
+    // Zero partial-promoted collections is NOT an accepted-loss outcome — nothing was acknowledged.
+    let allAccepted = rows.length > 0;
+
+    for (const result of rows) {
+        const residue = (result?.unrecoverable || []).map(row => ({
+            id    : row?.id ?? null,
+            reason: row?.reason ?? null
+        }));
+
+        const fingerprint = computeResidueFingerprint({residue, strategyVersion, provider, contextBudget, terminalReasons}),
+              ack         = typeof readAck === 'function' ? await readAck(fingerprint) : null,
+              verdict     = classifyRepairResidue({residue, ack, strategyVersion, provider, contextBudget, terminalReasons});
+
+        perCollection.push({
+            collection: result?.collectionName ?? null,
+            outcome   : verdict.outcome,
+            reasonCode: verdict.reasonCode,
+            fingerprint
+        });
+
+        if (verdict.outcome !== 'accepted-loss') {
+            allAccepted = false;
+        }
+    }
+
+    return {allAccepted, perCollection};
+}

--- a/ai/services/memory-core/helpers/acceptedLossOutcome.mjs
+++ b/ai/services/memory-core/helpers/acceptedLossOutcome.mjs
@@ -140,3 +140,43 @@ export async function acknowledgeAcceptedLossResidue({
 
     return {acknowledged};
 }
+
+/**
+ * @summary Decides whether a non-clean Memory Core repair is an operator-acknowledged accepted-loss exit
+ * (exit 0) or must escalate (exit 1) — the testable exit-decision the defrag CLI consults.
+ *
+ * Accepted-loss applies ONLY to a non-dry-run partial-promotion with NO aborted collection (an aborted
+ * collection means no promotion happened — a real failure, never bounded loss) whose every partial residue
+ * classifies as accepted-loss. Pure: the durable-ack lookup is injected (a null/absent `readAck` — e.g. no
+ * durable ack location — means nothing is acknowledged → not accepted).
+ *
+ * @param {Object} options
+ * @param {Object[]} [options.results=[]] Per-collection repair results (`{aborted, partialPromoted, unrecoverable}`).
+ * @param {Boolean} [options.dryRun=false]
+ * @param {Object} [options.recoveryContext={}] The shared recovery context bound into the fingerprint.
+ * @param {Function} [options.readAck] `async fingerprint => ack|null`.
+ * @returns {Promise<Object>} `{acceptedLoss, reason, perCollection}`.
+ */
+export async function resolveAcceptedLossExit({results = [], dryRun = false, recoveryContext = {}, readAck} = {}) {
+    const rows    = Array.isArray(results) ? results : [],
+          aborted = rows.filter(result => result?.aborted),
+          partial = rows.filter(result => result?.partialPromoted);
+
+    if (dryRun) {
+        return {acceptedLoss: false, reason: 'dry-run', perCollection: []};
+    }
+    if (aborted.length > 0) {
+        return {acceptedLoss: false, reason: 'aborted-present', perCollection: []};
+    }
+    if (partial.length === 0) {
+        return {acceptedLoss: false, reason: 'no-partial-promotion', perCollection: []};
+    }
+
+    const {allAccepted, perCollection} = await evaluateAcceptedLossOutcome({partialResults: partial, recoveryContext, readAck});
+
+    return {
+        acceptedLoss: allAccepted,
+        reason      : allAccepted ? 'all-acknowledged' : 'unacknowledged-or-non-terminal',
+        perCollection
+    };
+}

--- a/test/playwright/unit/ai/scripts/maintenance/defragAcceptedLossSettlement.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defragAcceptedLossSettlement.spec.mjs
@@ -1,0 +1,76 @@
+import {test, expect} from '@playwright/test';
+import os             from 'os';
+import fsp            from 'fs/promises';
+import path           from 'path';
+import {
+    acceptedLossAckDir,
+    buildMemoryCoreRecoveryContext,
+    settleAcknowledgedPartialPromotion,
+    writeDefragState
+}                                  from '../../../../../../ai/scripts/maintenance/defragChromaDB.mjs';
+import {createAcceptedLossAckEntry} from '../../../../../../ai/services/memory-core/helpers/acceptedLossAck.mjs';
+import {appendAcceptedLossAck}      from '../../../../../../ai/services/memory-core/helpers/acceptedLossAckStore.mjs';
+
+// The end-to-end operator workflow: a partial-promoted repair leaves a state marker; the operator
+// acknowledges the terminal residue; a RERUN must settle it as accepted-loss (clear the marker -> exit 0)
+// instead of aborting at the incomplete-state guard (which excludes the partial-promoted phase). An
+// UNacknowledged marker must NOT settle — it falls through to the guard, which escalates it.
+
+const config  = {embeddingProvider: 'openAiCompatible'},
+      residue = [{id: 'a', reason: 'embedding-context-exceeded'}];
+
+async function exists(p) {
+    return fsp.access(p).then(() => true, () => false);
+}
+
+test.describe('settleAcknowledgedPartialPromotion — the acknowledge -> rerun settlement (#14118)', () => {
+    let dir, statePath;
+
+    test.beforeEach(async () => {
+        dir       = await fsp.mkdtemp(path.join(os.tmpdir(), 'neo-defrag-settle-'));
+        statePath = path.join(dir, 'defrag-state.json');
+        await writeDefragState({statePath, state: {
+            phase                    : 'memory-core-repair-partial-promoted',
+            unrecoverableByCollection: {'mc-memory': residue}
+        }});
+    });
+
+    test.afterEach(async () => {
+        await fsp.rm(dir, {recursive: true, force: true});
+    });
+
+    async function acknowledge() {
+        const ctx = buildMemoryCoreRecoveryContext(config),
+              ack = createAcceptedLossAckEntry({residue, operatorId: '@tobiu', acknowledgedAt: 1, ...ctx});
+        await appendAcceptedLossAck({entry: ack, dir: acceptedLossAckDir(statePath)});
+    }
+
+    test('an acknowledged partial-promotion marker settles: clears the marker + returns true', async () => {
+        await acknowledge();
+
+        expect(await settleAcknowledgedPartialPromotion({config, statePath})).toBe(true);
+        expect(await exists(statePath)).toBe(false);   // marker cleared -> the rerun is clean -> exit 0
+    });
+
+    test('an UNacknowledged partial-promotion marker does NOT settle: returns false, marker stays (escalates at the guard)', async () => {
+        expect(await settleAcknowledgedPartialPromotion({config, statePath})).toBe(false);
+        expect(await exists(statePath)).toBe(true);
+    });
+
+    test('a stale ack (residue changed since the ack) does NOT settle', async () => {
+        await acknowledge();
+        // The live marker residue changed after the ack -> the fingerprint no longer matches.
+        await writeDefragState({statePath, state: {
+            phase                    : 'memory-core-repair-partial-promoted',
+            unrecoverableByCollection: {'mc-memory': [...residue, {id: 'c', reason: 'document-absent'}]}
+        }});
+
+        expect(await settleAcknowledgedPartialPromotion({config, statePath})).toBe(false);
+        expect(await exists(statePath)).toBe(true);
+    });
+
+    test('no marker -> returns false (a normal first run proceeds to the pipeline)', async () => {
+        await fsp.rm(statePath, {force: true});
+        expect(await settleAcknowledgedPartialPromotion({config, statePath})).toBe(false);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAckStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAckStore.spec.mjs
@@ -1,0 +1,99 @@
+import {test, expect} from '@playwright/test';
+import os             from 'os';
+import fs             from 'fs/promises';
+import path           from 'path';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    appendAcceptedLossAck,
+    getAcceptedLossAckFileName,
+    readAcceptedLossAckByFingerprint
+}                                  from '../../../../../../../ai/services/memory-core/helpers/acceptedLossAckStore.mjs';
+import {createAcceptedLossAckEntry} from '../../../../../../../ai/services/memory-core/helpers/acceptedLossAck.mjs';
+import {classifyRepairResidue}      from '../../../../../../../ai/services/memory-core/helpers/classifyRepairResidue.mjs';
+
+// Durable per-fingerprint JSONL store for operator accepted-loss acks. The end-to-end test is the
+// contract: an ack built (the ack constructor) + stored here is found by fingerprint and accepted by the
+// classifier — closing the produce -> store -> classify loop; a missing/stale ack returns null -> escalate.
+
+const CTX = {strategyVersion: 'v1', provider: 'openAiCompatible', contextBudget: 32768};
+
+test.describe('acceptedLossAckStore — durable per-fingerprint ack persistence', () => {
+    let dir;
+
+    test.beforeEach(async () => {
+        dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-accepted-loss-ack-'));
+    });
+
+    test.afterEach(async () => {
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('ROUND-TRIP: an ack stored here is retrieved by fingerprint', async () => {
+        const residue = [{id: 'a', reason: 'embedding-context-exceeded'}],
+              ack     = createAcceptedLossAckEntry({residue, operatorId: '@tobiu', acknowledgedAt: 1000, ...CTX});
+
+        await appendAcceptedLossAck({entry: ack, dir});
+        const found = await readAcceptedLossAckByFingerprint({fingerprint: ack.fingerprint, dir});
+
+        expect(found).not.toBeNull();
+        expect(found.fingerprint).toBe(ack.fingerprint);
+        expect(found.operatorId).toBe('@tobiu');
+    });
+
+    test('END-TO-END: a stored ack lets the classifier settle the live residue as accepted-loss', async () => {
+        const residue = [{id: 'a', reason: 'embedding-context-exceeded'}, {id: 'b', reason: 'document-absent'}],
+              ack     = createAcceptedLossAckEntry({residue, operatorId: '@tobiu', acknowledgedAt: 1000, ...CTX});
+
+        await appendAcceptedLossAck({entry: ack, dir});
+
+        const stored  = await readAcceptedLossAckByFingerprint({fingerprint: ack.fingerprint, dir}),
+              verdict = classifyRepairResidue({residue, ack: stored, ...CTX});
+
+        expect(verdict.outcome).toBe('accepted-loss');
+        expect(verdict.reasonCode).toBe('terminal-residue-acknowledged');
+    });
+
+    test('a re-acknowledgement supersedes: read returns the most-recent ack for the fingerprint', async () => {
+        const residue = [{id: 'a', reason: 'document-absent'}],
+              first   = createAcceptedLossAckEntry({residue, operatorId: '@tobiu', acknowledgedAt: 1000, recoveryRunId: 'run-1', ...CTX}),
+              second  = createAcceptedLossAckEntry({residue, operatorId: '@tobiu', acknowledgedAt: 2000, recoveryRunId: 'run-2', ...CTX});
+
+        await appendAcceptedLossAck({entry: first,  dir});
+        await appendAcceptedLossAck({entry: second, dir});
+
+        const found = await readAcceptedLossAckByFingerprint({fingerprint: first.fingerprint, dir});
+
+        expect(found.recoveryRunId).toBe('run-2');     // newest line wins
+        expect(found.acknowledgedAt).toBe(2000);
+    });
+
+    test('no stored ack for a fingerprint -> null (the classifier then escalates)', async () => {
+        expect(await readAcceptedLossAckByFingerprint({fingerprint: 'deadbeef'.repeat(8), dir})).toBeNull();
+    });
+
+    test('a residue change yields a different fingerprint -> the old ledger is not found', async () => {
+        const residue = [{id: 'a', reason: 'embedding-context-exceeded'}],
+              ack     = createAcceptedLossAckEntry({residue, operatorId: '@tobiu', acknowledgedAt: 1000, ...CTX});
+
+        await appendAcceptedLossAck({entry: ack, dir});
+
+        const changedAck = createAcceptedLossAckEntry({
+            residue   : [{id: 'a', reason: 'embedding-context-exceeded'}, {id: 'c', reason: 'document-absent'}],
+            operatorId: '@tobiu', acknowledgedAt: 1000, ...CTX
+        });
+
+        expect(ack.fingerprint).not.toBe(changedAck.fingerprint);
+        expect(await readAcceptedLossAckByFingerprint({fingerprint: changedAck.fingerprint, dir})).toBeNull();
+    });
+
+    test('the ledger file name is the sanitized fingerprint (path separators neutralized)', () => {
+        expect(getAcceptedLossAckFileName('abc123')).toBe('abc123.jsonl');
+        expect(getAcceptedLossAckFileName('a/b..c')).toBe('a_b..c.jsonl');
+    });
+
+    test('rejects missing dir / missing entry.fingerprint', async () => {
+        await expect(appendAcceptedLossAck({entry: {fingerprint: 'x'}})).rejects.toThrow('dir');
+        await expect(appendAcceptedLossAck({entry: {}, dir})).rejects.toThrow('fingerprint');
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossOutcome.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossOutcome.spec.mjs
@@ -1,7 +1,11 @@
-import {test, expect}                from '@playwright/test';
-import Neo                           from '../../../../../../../src/Neo.mjs';
-import * as core                     from '../../../../../../../src/core/_export.mjs';
-import {evaluateAcceptedLossOutcome} from '../../../../../../../ai/services/memory-core/helpers/acceptedLossOutcome.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    acknowledgeAcceptedLossResidue,
+    evaluateAcceptedLossOutcome,
+    mapUnrecoverableToResidue
+}                                    from '../../../../../../../ai/services/memory-core/helpers/acceptedLossOutcome.mjs';
 import {createAcceptedLossAckEntry}  from '../../../../../../../ai/services/memory-core/helpers/acceptedLossAck.mjs';
 
 // Pure decider that joins the classifier + an injected durable-ack lookup + the partial-promotion manifest
@@ -99,5 +103,54 @@ test.describe('evaluateAcceptedLossOutcome — operator-acknowledged accepted-lo
         expect(allAccepted).toBe(true);
         expect(perCollection[0]).toMatchObject({collection: 'mc-memory', outcome: 'accepted-loss'});
         expect(perCollection[0].fingerprint).toEqual(expect.any(String));
+    });
+});
+
+test.describe('acknowledgeAcceptedLossResidue — operator ack minting + the round-trip', () => {
+    test('mints + persists one ack per collection; the persisted acks then satisfy the accepted-loss check', async () => {
+        const unrecoverableByCollection = {
+                  'mc-memory'       : [{id: 'a', reason: 'embedding-context-exceeded'}],
+                  'neo-native-graph': [{id: 'b', reason: 'document-absent'}]
+              },
+              store = new Map();
+
+        const {acknowledged} = await acknowledgeAcceptedLossResidue({
+            unrecoverableByCollection,
+            recoveryContext: CTX,
+            operatorId     : '@tobiu',
+            acknowledgedAt : 1000,
+            persist        : ack => { store.set(ack.fingerprint, ack); }
+        });
+
+        expect(acknowledged).toHaveLength(2);
+
+        // The persisted acks make the decider settle the SAME manifest as accepted-loss (the closed loop).
+        const partialResults = Object.entries(unrecoverableByCollection)
+            .map(([collectionName, unrecoverable]) => ({collectionName, partialPromoted: true, unrecoverable}));
+
+        const {allAccepted} = await evaluateAcceptedLossOutcome({
+            partialResults, recoveryContext: CTX, readAck: async fp => store.get(fp) ?? null
+        });
+
+        expect(allAccepted).toBe(true);
+    });
+
+    test('skips a collection with no residue', async () => {
+        const store = new Map();
+
+        const {acknowledged} = await acknowledgeAcceptedLossResidue({
+            unrecoverableByCollection: {'mc-memory': [], 'neo-native-graph': [{id: 'b', reason: 'document-absent'}]},
+            recoveryContext          : CTX,
+            operatorId               : '@tobiu',
+            acknowledgedAt           : 1000,
+            persist                  : ack => { store.set(ack.fingerprint, ack); }
+        });
+
+        expect(acknowledged.map(a => a.collection)).toEqual(['neo-native-graph']);
+    });
+
+    test('mapUnrecoverableToResidue is the shared mapping (id+reason only, defensive on non-arrays)', () => {
+        expect(mapUnrecoverableToResidue([{id: 'a', reason: 'r', extra: 1}])).toEqual([{id: 'a', reason: 'r'}]);
+        expect(mapUnrecoverableToResidue(undefined)).toEqual([]);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossOutcome.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossOutcome.spec.mjs
@@ -1,0 +1,103 @@
+import {test, expect}                from '@playwright/test';
+import Neo                           from '../../../../../../../src/Neo.mjs';
+import * as core                     from '../../../../../../../src/core/_export.mjs';
+import {evaluateAcceptedLossOutcome} from '../../../../../../../ai/services/memory-core/helpers/acceptedLossOutcome.mjs';
+import {createAcceptedLossAckEntry}  from '../../../../../../../ai/services/memory-core/helpers/acceptedLossAck.mjs';
+
+// Pure decider that joins the classifier + an injected durable-ack lookup + the partial-promotion manifest
+// into the single exit-0-vs-escalate decision. allAccepted iff there is >=1 partial collection AND every one
+// classifies accepted-loss (all-terminal residue + a matching durable ack under the same recovery context).
+
+const CTX = {strategyVersion: 'v1', provider: 'openAiCompatible', contextBudget: 32768};
+
+// In-memory ack lookup keyed by fingerprint, built from REAL acks so the fingerprints match the helper's.
+function ackStoreFrom(...residues) {
+    const map = new Map();
+    for (const residue of residues) {
+        const ack = createAcceptedLossAckEntry({residue, operatorId: '@tobiu', acknowledgedAt: 1000, ...CTX});
+        map.set(ack.fingerprint, ack);
+    }
+    return async fingerprint => map.get(fingerprint) ?? null;
+}
+
+const partial = (collectionName, unrecoverable) => ({collectionName, partialPromoted: true, unrecoverable});
+
+test.describe('evaluateAcceptedLossOutcome — operator-acknowledged accepted-loss decider', () => {
+    test('every partial collection terminal + acked -> allAccepted', async () => {
+        const rA      = [{id: 'a', reason: 'embedding-context-exceeded'}],
+              rB      = [{id: 'b', reason: 'document-absent'}],
+              readAck = ackStoreFrom(rA, rB);
+
+        const {allAccepted, perCollection} = await evaluateAcceptedLossOutcome({
+            partialResults : [partial('mc-memory', rA), partial('neo-native-graph', rB)],
+            recoveryContext: CTX,
+            readAck
+        });
+
+        expect(allAccepted).toBe(true);
+        expect(perCollection.every(c => c.outcome === 'accepted-loss')).toBe(true);
+    });
+
+    test('a transient reason in any collection -> NOT accepted (that collection escalates)', async () => {
+        const rA      = [{id: 'a', reason: 'embedding-context-exceeded'}],
+              rB      = [{id: 'b', reason: 'provider-timeout'}],   // transient
+              readAck = ackStoreFrom(rA, rB);
+
+        const {allAccepted, perCollection} = await evaluateAcceptedLossOutcome({
+            partialResults : [partial('mc-memory', rA), partial('neo-native-graph', rB)],
+            recoveryContext: CTX,
+            readAck
+        });
+
+        expect(allAccepted).toBe(false);
+        expect(perCollection.find(c => c.collection === 'neo-native-graph').outcome).toBe('escalate');
+    });
+
+    test('a missing ack for any collection -> NOT accepted', async () => {
+        const rA      = [{id: 'a', reason: 'embedding-context-exceeded'}],
+              rB      = [{id: 'b', reason: 'document-absent'}],
+              readAck = ackStoreFrom(rA);   // only A is acknowledged
+
+        const {allAccepted} = await evaluateAcceptedLossOutcome({
+            partialResults : [partial('mc-memory', rA), partial('neo-native-graph', rB)],
+            recoveryContext: CTX,
+            readAck
+        });
+
+        expect(allAccepted).toBe(false);
+    });
+
+    test('zero partial-promoted collections -> NOT accepted (nothing was acknowledged)', async () => {
+        const {allAccepted} = await evaluateAcceptedLossOutcome({
+            partialResults: [], recoveryContext: CTX, readAck: async () => null
+        });
+
+        expect(allAccepted).toBe(false);
+    });
+
+    test('a recovery-context (policy) mismatch -> the acked fingerprint differs -> NOT accepted', async () => {
+        const rA      = [{id: 'a', reason: 'document-absent'}],
+              readAck = ackStoreFrom(rA);   // acked under the broad default terminality policy
+
+        const {allAccepted} = await evaluateAcceptedLossOutcome({
+            partialResults : [partial('mc-memory', rA)],
+            recoveryContext: {...CTX, terminalReasons: ['document-absent']},   // narrowed policy → different fingerprint
+            readAck
+        });
+
+        expect(allAccepted).toBe(false);
+    });
+
+    test('a single acked terminal collection -> allAccepted, with the per-collection fingerprint surfaced', async () => {
+        const rA      = [{id: 'a', reason: 'document-absent'}],
+              readAck = ackStoreFrom(rA);
+
+        const {allAccepted, perCollection} = await evaluateAcceptedLossOutcome({
+            partialResults: [partial('mc-memory', rA)], recoveryContext: CTX, readAck
+        });
+
+        expect(allAccepted).toBe(true);
+        expect(perCollection[0]).toMatchObject({collection: 'mc-memory', outcome: 'accepted-loss'});
+        expect(perCollection[0].fingerprint).toEqual(expect.any(String));
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossOutcome.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossOutcome.spec.mjs
@@ -4,7 +4,8 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
     acknowledgeAcceptedLossResidue,
     evaluateAcceptedLossOutcome,
-    mapUnrecoverableToResidue
+    mapUnrecoverableToResidue,
+    resolveAcceptedLossExit
 }                                    from '../../../../../../../ai/services/memory-core/helpers/acceptedLossOutcome.mjs';
 import {createAcceptedLossAckEntry}  from '../../../../../../../ai/services/memory-core/helpers/acceptedLossAck.mjs';
 
@@ -152,5 +153,41 @@ test.describe('acknowledgeAcceptedLossResidue — operator ack minting + the rou
     test('mapUnrecoverableToResidue is the shared mapping (id+reason only, defensive on non-arrays)', () => {
         expect(mapUnrecoverableToResidue([{id: 'a', reason: 'r', extra: 1}])).toEqual([{id: 'a', reason: 'r'}]);
         expect(mapUnrecoverableToResidue(undefined)).toEqual([]);
+    });
+});
+
+test.describe('resolveAcceptedLossExit — the defrag exit decision (gating + accepted-loss)', () => {
+    const terminal = [{id: 'a', reason: 'embedding-context-exceeded'}],
+          partialR = (name, residue) => ({collectionName: name, partialPromoted: true, unrecoverable: residue}),
+          abortedR = name => ({collectionName: name, aborted: true, unrecoverable: [{id: 'x', reason: 'document-absent'}]});
+
+    test('dry-run -> not accepted (reason dry-run), even with matching acks', async () => {
+        const r = await resolveAcceptedLossExit({results: [partialR('mc-memory', terminal)], dryRun: true, recoveryContext: CTX, readAck: ackStoreFrom(terminal)});
+        expect(r).toMatchObject({acceptedLoss: false, reason: 'dry-run'});
+    });
+
+    test('an aborted collection present -> not accepted (reason aborted-present) — no promotion is never bounded loss', async () => {
+        const r = await resolveAcceptedLossExit({results: [partialR('mc-memory', terminal), abortedR('neo-native-graph')], recoveryContext: CTX, readAck: ackStoreFrom(terminal)});
+        expect(r).toMatchObject({acceptedLoss: false, reason: 'aborted-present'});
+    });
+
+    test('no partial-promotion -> not accepted (reason no-partial-promotion)', async () => {
+        const r = await resolveAcceptedLossExit({results: [{collectionName: 'mc-memory', promotion: {}}], recoveryContext: CTX, readAck: ackStoreFrom()});
+        expect(r).toMatchObject({acceptedLoss: false, reason: 'no-partial-promotion'});
+    });
+
+    test('partial-promotion, all residue acknowledged -> accepted (reason all-acknowledged)', async () => {
+        const r = await resolveAcceptedLossExit({results: [partialR('mc-memory', terminal)], recoveryContext: CTX, readAck: ackStoreFrom(terminal)});
+        expect(r).toMatchObject({acceptedLoss: true, reason: 'all-acknowledged'});
+    });
+
+    test('partial-promotion, no matching ack -> escalate (reason unacknowledged-or-non-terminal)', async () => {
+        const r = await resolveAcceptedLossExit({results: [partialR('mc-memory', terminal)], recoveryContext: CTX, readAck: async () => null});
+        expect(r).toMatchObject({acceptedLoss: false, reason: 'unacknowledged-or-non-terminal'});
+    });
+
+    test('a null readAck (no durable ack location) -> not accepted', async () => {
+        const r = await resolveAcceptedLossExit({results: [partialR('mc-memory', terminal)], recoveryContext: CTX, readAck: null});
+        expect(r.acceptedLoss).toBe(false);
     });
 });


### PR DESCRIPTION
Resolves #14118

#14084 leaf 3 (the value-delivering closing leaf, after leaf 1 #14106 + leaf 2 #14110, both merged). Closes the accepted-loss loop end-to-end: a fully-recovered Memory Core store whose only residue is genuinely-unembeddable + operator-acknowledged terminal loss now settles as accepted-loss + exits 0 instead of paging "repair failed" forever — without ever letting transient or unacknowledged loss settle silently.

## What it does (4 parts, all on this branch)

1. **`acceptedLossAckStore.mjs`** — durable per-fingerprint ack persistence (`appendAcceptedLossAck` / `readAcceptedLossAckByFingerprint`); one JSONL ledger per fingerprint, a re-ack supersedes on read, a missing/stale fingerprint → null. **7/7 unit.**
2. **`acceptedLossOutcome.mjs`** — the pure decider (`evaluateAcceptedLossOutcome`) joining the classifier + an injected ack-lookup + the partial-promotion manifest into one exit-0-vs-escalate decision (`allAccepted` iff ≥1 partial-promoted collection AND every one classifies accepted-loss); plus the write side (`acknowledgeAcceptedLossResidue`) and the shared `mapUnrecoverableToResidue` used by BOTH sides so their fingerprints match by construction. **9/9 unit** (incl. the acknowledge→check round-trip + policy-mismatch).
3. **`defragChromaDB.mjs` exit-path wiring** — a partial-promotion (NO aborted collection) whose entire residue is operator-acknowledged terminal → record accepted-loss + exit 0. Behavior-preserving: every other path (aborted, dry-run, transient/unacknowledged/stale, missing state-marker) keeps the existing `console.error` + `exit 1` verbatim. Reads the durable ack via the shared recovery-context (provider + embed budget + strategy version + terminality policy). Behind `--allow-memory-core`; default unchanged.
4. **`--acknowledge-accepted-loss --operator-id <id>` operator surface** — reads the live partial-promotion state marker, mints + persists one ack per collection over the same recovery-context, exits 0. Fails closed (non-memory-core target, missing operator-id, no partial-promoted state).
5. **`settleAcknowledgedPartialPromotion` — the rerun reachability** (@neo-gpt's cycle-2 catch). The `memory-core-repair-partial-promoted` phase is excluded from the incomplete-state guard's `allowedPhases`, so without this the `acknowledge → rerun` workflow aborted at the guard *before* the accepted-loss decision ran. It runs **before** the guard: an acknowledged marker → clear + settle clean (exit 0); an unacknowledged/stale marker → falls through to the guard → escalates as before.

Evidence: L2 (26 new unit tests — the two pure helpers incl. the closed-loop round-trip + the `resolveAcceptedLossExit` exit-decision, **plus the end-to-end `settleAcknowledgedPartialPromotion` rerun-settlement spec**) + the existing defrag repair suite **27/27 green** (no regression).

## Deltas from ticket

None — matches the #14118 Contract Ledger. Chosen shape: per-collection acks (each partial collection's residue → its own fingerprint → its own ack); the run is accepted only when every partial collection is acknowledged. The manifest→residue mapping is DRY'd into one shared helper so the ack-mint and the check can never silently drift apart (the fingerprint-parity guarantee).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAckStore.spec.mjs` → **7 passed**.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/acceptedLossOutcome.spec.mjs` → **15 passed** (decider + acknowledge round-trip + the shared mapper + the `resolveAcceptedLossExit` exit-decision gating).
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/defragAcceptedLossSettlement.spec.mjs` → **4 passed** (the end-to-end acknowledge→rerun workflow: acknowledged settles+clears; unacknowledged + stale-ack + no-marker do not).
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs` → **27 passed** (regression — no change to existing exit behavior).
- `npm run agent-preflight`: all gates passed (archaeology clean — behavior-prose comments; refs in the commits + this body).

## Post-Merge Validation

- [ ] The exit DECISION + the end-to-end **acknowledge→rerun settlement** are now both unit-tested (`resolveAcceptedLossExit` 6 tests + `settleAcknowledgedPartialPromotion` 4 tests, incl. clear-on-settle + escalate-on-unacknowledged/stale). Remaining untested glue is thin: the in-repair `if (acceptedLoss) … else exit(1)` call + `acknowledgeOperatorAcceptedLoss`'s exact `process.exit` paths. A single operator live-fire would fully close it: real partial-promoted repair → `--acknowledge-accepted-loss` → rerun → confirm `exit 0`; non-acknowledged → `exit 1`.

Related: #14084 (parent), #14106 (leaf 1, merged), #14110 (leaf 2, merged), #14068 (parking-retained lifecycle), #14061 (the escalate sink this stops over-paging), #14039 (v13.1 epic).

Authored by Grace (Claude Opus 4.8, Claude Code). Session 5ab545e1-f09e-46c5-ae62-8cf5b2b96193.
