### PR TITLE
fix(ai): consume supervised-task diagnosis helper; failed maintenance task is ambiguous, not crash (#14064)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -355,6 +355,10 @@ export class Orchestrator extends Base {
         this.processSupervisorService.taskDefinitions       = value;
         this.maintenanceBackpressureService.taskDefinitions = value;
     }
+    // Service-graph reconciliation, not arbitrary circular wiring: the supervisor needs the actuator to
+    // route its escalate-only diagnoses (a failed maintenance task), and the actuator needs the supervisor
+    // to execute restart/recover actions. Each setter back-links the other so either arrival order
+    // converges to the same bidirectional pair.
     afterSetProcessSupervisorService(value, oldValue) {
         if (this.recoveryActuatorService) {
             this.recoveryActuatorService.processSupervisorService = value;

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -2,7 +2,7 @@ import Base                           from '../../../../src/core/Base.mjs';
 import fs                             from 'fs-extra';
 import path                           from 'path';
 import {execSync}                     from 'child_process';
-import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+import {buildSupervisedTaskDiagnosis} from './taskOutcomeDiagnosis.mjs';
 
 const DEFAULT_STDOUT_JSON_MAX_BYTES = 65536;
 const ESCALATING_TASK_OUTCOMES      = Object.freeze(new Set(['backup']));
@@ -219,28 +219,16 @@ export class ProcessSupervisorService extends Base {
             return false;
         }
 
+        // Consume the shared supervised-task diagnosis producer (single source of the failed/overdue
+        // diagnosis contract) instead of building the event inline. A failed maintenance task routes as
+        // `ambiguous` (escalate-only), not `crash` — the supervisor saw the failure, not its cause.
         const observedAt = Date.now(),
-              diagnosis  = createRecoveryDiagnosisEvent({
-                  diagnosisId   : `process-supervisor:${taskName}:failed:${observedAt}`,
-                  recoveryClass : 'ambiguous',
-                  confidence    : 1,
-                  targetIdentity: {kind: 'supervised-task', id: taskName},
-                  evidenceFacts : [{
-                      type   : 'task-failure',
-                      taskName,
-                      status,
-                      details: details || {},
-                      observedAt
-                  }],
+              diagnosis  = buildSupervisedTaskDiagnosis({
+                  taskName,
+                  outcome      : 'failed',
                   observedAt,
-                  source : 'process-supervisor-task-outcome',
-                  details: {
-                      actionClass   : 'escalate',
-                      reasonCode    : 'maintenance-task-failure',
-                      taskName,
-                      taskStatus    : status,
-                      outcomeDetails: details || {}
-                  }
+                  evidenceFacts: [{type: 'task-failure', taskName, status, details: details || {}, observedAt}],
+                  details      : {reasonCode: 'maintenance-task-failure', taskName, taskStatus: status, outcomeDetails: details || {}}
               });
 
         Promise.resolve(actuator.escalateDiagnosis(diagnosis, {

--- a/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.mjs
@@ -15,10 +15,12 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  * and a scheduling-loop overdue check, both for the configured alert-on-failure task set (e.g. `backup`).
  */
 
-// A supervised task that exited non-zero / crashed maps to the `crash` recovery class; a scheduled run
-// that never started (overdue) maps to `ambiguous` — the cause is not yet known at detection time.
-const TASK_FAILURE_RECOVERY_CLASS = 'crash';
-const TASK_OVERDUE_RECOVERY_CLASS = 'ambiguous';
+// A supervised MAINTENANCE task is escalate-only: the supervisor observes the fault — a non-zero exit
+// (failed) OR a scheduled run that never started (overdue) — but NOT its cause, so BOTH outcomes map to
+// the `ambiguous` recovery class (escalate-and-page, never auto-restart). Container-crash recovery
+// (`crash` -> restart) is `ContainerHealthDiagnosisService`'s domain, not this maintenance-task helper:
+// blindly restarting a failed backup neither knows nor fixes the cause.
+const MAINTENANCE_TASK_RECOVERY_CLASS = 'ambiguous';
 
 /**
  * @summary Pure overdue detector for a periodically-scheduled supervised task.
@@ -53,10 +55,11 @@ export function detectTaskOverdue({lastRunAt, intervalMs, graceMs = 0, now} = {}
  * @param {String}  options.taskName Supervised task id (e.g. `backup`).
  * @param {'failed'|'overdue'} options.outcome The detected fault.
  * @param {Number}  options.observedAt Epoch ms when the fault was observed.
+ * @param {Object[]} [options.evidenceFacts=[]] Bounded evidence facts carried into the diagnosis.
  * @param {Object} [options.details={}] Diagnostics-owned details; merged with `actionClass: 'escalate'`.
  * @returns {Object} A `recovery-diagnosis` event (see `createRecoveryDiagnosisEvent`).
  */
-export function buildSupervisedTaskDiagnosis({taskName, outcome, observedAt, details = {}} = {}) {
+export function buildSupervisedTaskDiagnosis({taskName, outcome, observedAt, evidenceFacts = [], details = {}} = {}) {
     if (typeof taskName !== 'string' || taskName.length === 0) {
         throw new TypeError('buildSupervisedTaskDiagnosis: taskName is required');
     }
@@ -64,13 +67,14 @@ export function buildSupervisedTaskDiagnosis({taskName, outcome, observedAt, det
         throw new TypeError(`buildSupervisedTaskDiagnosis: outcome must be 'failed' or 'overdue', got ${outcome}`);
     }
 
-    const recoveryClass = outcome === 'failed' ? TASK_FAILURE_RECOVERY_CLASS : TASK_OVERDUE_RECOVERY_CLASS;
+    const recoveryClass = MAINTENANCE_TASK_RECOVERY_CLASS;
 
     return createRecoveryDiagnosisEvent({
         diagnosisId   : `supervised-task:${taskName}:${outcome}:${observedAt}`,
         recoveryClass,
         confidence    : 1,
         targetIdentity: {kind: 'supervised-task', id: taskName},
+        evidenceFacts,
         observedAt,
         source        : 'task-outcome-diagnostics',
         details       : {...details, actionClass: 'escalate', outcome}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -458,7 +458,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
             type          : 'recovery-diagnosis',
             recoveryClass : 'ambiguous',
             targetIdentity: {kind: 'supervised-task', id: 'backup'},
-            source        : 'process-supervisor-task-outcome',
+            source        : 'task-outcome-diagnostics',
             details       : expect.objectContaining({
                 actionClass   : 'escalate',
                 reasonCode    : 'maintenance-task-failure',

--- a/test/playwright/unit/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.spec.mjs
@@ -36,18 +36,20 @@ test.describe('taskOutcomeDiagnosis — supervised-task failure/overdue producer
         expect(detectTaskOverdue({intervalMs: 1000, now: 2000}).overdue).toBe(true);
     });
 
-    test('buildSupervisedTaskDiagnosis: failed→crash, overdue→ambiguous, supervised-task identity + escalate (#14030 AC1)', () => {
+    test('buildSupervisedTaskDiagnosis: failed+overdue→ambiguous (escalate-only), supervised-task identity + escalate (#14030 AC1)', () => {
         const failed = buildSupervisedTaskDiagnosis({
-            taskName: 'backup', outcome: 'failed', observedAt: 1_700_000_000_000, details: {code: 1}
+            taskName     : 'backup', outcome: 'failed', observedAt: 1_700_000_000_000,
+            evidenceFacts: [{type: 'task-failure', code: 1}], details: {code: 1}
         });
 
         expect(failed.type).toBe('recovery-diagnosis');
-        expect(failed.recoveryClass).toBe('crash');
+        expect(failed.recoveryClass).toBe('ambiguous');
         expect(failed.targetIdentity).toEqual({kind: 'supervised-task', id: 'backup'});
         expect(failed.details.actionClass).toBe('escalate');
         expect(failed.details.outcome).toBe('failed');
         expect(failed.details.code).toBe(1);
         expect(failed.confidence).toBe(1);
+        expect(failed.evidenceFacts).toEqual([{type: 'task-failure', code: 1}]);
 
         const overdue = buildSupervisedTaskDiagnosis({
             taskName: 'backup', outcome: 'overdue', observedAt: 1_700_000_000_000


### PR DESCRIPTION
Resolves #14064

Aligns the shared supervised-task diagnosis helper to the converged semantic class, then consumes it in the backup-escalation path — collapsing the two producer paths the inline build had created.

**The alignment (the Vega-owned prerequisite):** `buildSupervisedTaskDiagnosis` mapped `outcome:'failed'` → `recoveryClass:'crash'`, but the helper is escalate-only (`actionClass:'escalate'`, never-restart) and its whole domain is supervised *maintenance* tasks (backup, etc.) — the supervisor observes the failure, not its cause. So a failed maintenance task is `'ambiguous'` (escalate-and-page), NOT `'crash'` (restart — that is `ContainerHealthDiagnosisService`'s container domain). Both `failed` and `overdue` now map to `'ambiguous'`. V-B-A: no live consumer relied on the prior `failed→'crash'`, so this regresses nothing.

**The consume:** `ProcessSupervisorService.escalateFailedTaskOutcome()` now builds its diagnosis via the shared helper instead of inline, preserving the #14061 contract exactly — failed `backup` → `recoveryClass:'ambiguous'`, `reasonCode:'maintenance-task-failure'`, `targetIdentity:{kind:'supervised-task', id:'backup'}`, escalate-only, no privileged action. The helper gained an `evidenceFacts` param so the task-failure fact is carried through.

Evidence: L2 — 40/40 across the helper + supervisor specs (the consume test asserts the helper-generated failed-backup diagnosis still routes as `ambiguous` with the `maintenance-task-failure` reason/details).

## Deltas

- The diagnosis's `diagnosisId` prefix (`supervised-task:…`) and `source` (`task-outcome-diagnostics`) now come from the shared producer — the whole point of the consolidation; the spec assertions track that. `recoveryClass` / `targetIdentity` / `reasonCode` / details / evidence are preserved.
- Helper extended with an `evidenceFacts` param (was inline-only); the `createRecoveryDiagnosisEvent` import is dropped from `ProcessSupervisorService` (now unused).
- AC4: a concise comment on the `Orchestrator` supervisor↔actuator setter cross-link explains it is service-graph reconciliation, not arbitrary circular wiring.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs` → **40/40 passed**.

## Post-Merge Validation

- [ ] (observational) A failed live backup escalates once as `ambiguous` / `maintenance-task-failure` via the shared producer — no auto-restart.

## Contract Ledger — `RecoveryActuatorService.escalateDiagnosis()` return shape (AC5)

| Outcome | Return shape |
|---|---|
| Valid escalate diagnosis | `{status:'escalated', reasonCode, serviceKey, action:'escalate', targetIdentity, page, recoveryRunId, …}` — page dispatched, no privileged action |
| Malformed event | `{status:'rejected', reasonCode:'invalid-diagnosis', error}` |
| Non-escalate `actionClass` | `{status:'rejected', reasonCode:'diagnosis-not-escalatable', targetIdentity}` |

## Commits

- 1e2d39e05 — fix(ai): consume supervised-task diagnosis helper; failed maintenance task is ambiguous, not crash (#14064)

## Structural pre-flight

No new files; the change consolidates an inline producer onto the existing shared `buildSupervisedTaskDiagnosis` (same directory, same `recovery-diagnosis`/escalate contract). No novel pattern.

Related: #14056 / #14055 (the producer helper aligned here), #14061 / #14058 (the escalation hook + sink this consolidates), #14030 (parent backup reliability), #14039 (v13.1 epic).

Authored by Vega (Claude Opus 4.8, Claude Code). Session 16bbea8d-8bc9-4dad-8e1c-8e3b2cd861a3.
