### PR TITLE
feat(ai): signature-drift detection spike for the contract-ledger pre-flight (#14119)

### DIFF
--- a/buildScripts/util/contractLedgerDrift.mjs
+++ b/buildScripts/util/contractLedgerDrift.mjs
@@ -1,0 +1,93 @@
+/**
+ * @module buildScripts/util/contractLedgerDrift
+ * @summary Feasibility spike for an author-side Contract-Ledger-vs-diff drift pre-flight.
+ *
+ * Proves the mechanically-checkable core: given a Contract Ledger row's stated function surface
+ * (e.g. `buildDimensionConsistencyDiagnosis(samples, observedAt, serviceId)`) and the function's
+ * shipped declaration (e.g. `export function buildDimensionConsistencyDiagnosis({samples, observedAt,
+ * serviceId})`), detect when the two have drifted in a way a reviewer would otherwise catch by hand.
+ *
+ * Scope (deliberately mechanical, NOT semantic): function NAME, parameter-PASSING STYLE
+ * (positional list vs single destructured object), and the top-level parameter-NAME SET. A return-shape
+ * or behavioural drift is out of scope — that stays a human/reviewer judgement. This is a spike to inform
+ * the routing decision (implement-here vs ideation), not a finished gate; the integration point
+ * (agent-preflight step vs pull-request workflow) is the open design question.
+ *
+ * Motivating real-world drift: a pure producer shipped with a destructured config-object parameter while
+ * its Contract Ledger first stated it positional — exactly the param-passing-style drift this flags.
+ */
+
+/**
+ * @summary Extracts the function name + top-level parameter descriptor from a signature string.
+ * @param {String} signature e.g. `fn({a, b})` or `fn(a, b)` or `export function fn({a, b = 1})`.
+ * @returns {{name: String, style: 'destructured'|'positional'|'none', params: String[]}|null} null when no `name(...)` is found.
+ */
+export function parseSignature(signature) {
+    const text  = String(signature ?? '').trim(),
+          match = text.match(/([A-Za-z_$][\w$]*)\s*\(([\s\S]*)\)/);
+
+    if (!match) {
+        return null
+    }
+
+    const name = match[1],
+          raw  = match[2].trim();
+
+    if (raw === '') {
+        return {name, style: 'none', params: []}
+    }
+
+    // Single destructured-object parameter: `({a, b, c})` (the Neo config-object convention).
+    const destructured = raw.match(/^\{([\s\S]*)\}\s*(?:=\s*\{\s*\})?$/);
+
+    if (destructured) {
+        return {name, style: 'destructured', params: extractParamNames(destructured[1])}
+    }
+
+    return {name, style: 'positional', params: extractParamNames(raw)}
+}
+
+/**
+ * @summary Splits a parameter list on top-level commas and reduces each to its bare name (drops defaults / types).
+ * @param {String} body The inside of the paren or brace group.
+ * @returns {String[]}
+ */
+function extractParamNames(body) {
+    return String(body)
+        .split(',')
+        .map(part => part.split(/[=:]/)[0].replace(/[.\s]/g, ''))
+        .filter(Boolean)
+        .sort()
+}
+
+/**
+ * @summary Detects mechanical drift between a Contract Ledger signature and the shipped declaration.
+ *
+ * @param {Object} options
+ * @param {String} options.ledgerSignature The `Target Surface` signature asserted in the ticket's Contract Ledger.
+ * @param {String} options.shippedSignature The function's declaration as it appears in the diff.
+ * @returns {{drift: Boolean, kinds: String[], detail: Object}} `kinds` ⊆ {`unparseable`, `name`, `param-style`, `param-set`}.
+ */
+export function detectSignatureDrift({ledgerSignature, shippedSignature} = {}) {
+    const ledger  = parseSignature(ledgerSignature),
+          shipped = parseSignature(shippedSignature),
+          kinds   = [];
+
+    if (!ledger || !shipped) {
+        return {drift: true, kinds: ['unparseable'], detail: {ledger, shipped}}
+    }
+
+    if (ledger.name !== shipped.name) {
+        kinds.push('name')
+    }
+
+    if (ledger.style !== shipped.style) {
+        kinds.push('param-style')
+    }
+
+    if (ledger.params.join(',') !== shipped.params.join(',')) {
+        kinds.push('param-set')
+    }
+
+    return {drift: kinds.length > 0, kinds, detail: {ledger, shipped}}
+}

--- a/test/playwright/unit/ai/buildScripts/util/contractLedgerDrift.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/contractLedgerDrift.spec.mjs
@@ -1,0 +1,67 @@
+import {test, expect}                         from '@playwright/test';
+import {detectSignatureDrift, parseSignature} from '../../../../../../buildScripts/util/contractLedgerDrift.mjs';
+
+test.describe('contractLedgerDrift — author-side ledger-vs-diff signature-drift spike (#14119)', () => {
+    test('the real #14104 case: a positional ledger surface vs a destructured shipped decl is flagged as param-style drift', () => {
+        const result = detectSignatureDrift({
+            ledgerSignature : 'buildDimensionConsistencyDiagnosis(samples, observedAt, serviceId)',
+            shippedSignature: 'export function buildDimensionConsistencyDiagnosis({samples, observedAt, serviceId})'
+        });
+
+        expect(result.drift).toBe(true);
+        expect(result.kinds).toContain('param-style');
+        // the param NAMES match — only the passing style drifted, the exact reviewer-caught gap this targets
+        expect(result.kinds).not.toContain('param-set');
+    });
+
+    test('no drift when ledger and shipped declarations agree (style + param set)', () => {
+        const result = detectSignatureDrift({
+            ledgerSignature : 'buildDimensionConsistencyDiagnosis({samples, observedAt, serviceId})',
+            shippedSignature: 'export function buildDimensionConsistencyDiagnosis({samples, observedAt, serviceId})'
+        });
+
+        expect(result.drift).toBe(false);
+        expect(result.kinds).toEqual([]);
+    });
+
+    test('a shipped declaration that added a parameter the ledger omits is flagged as param-set drift', () => {
+        const result = detectSignatureDrift({
+            ledgerSignature : 'auditCollectionVectorDimensions({collection, collectionName, expectedDimension})',
+            shippedSignature: 'auditCollectionVectorDimensions({collection, collectionName, expectedDimension, sampleSize})'
+        });
+
+        expect(result.drift).toBe(true);
+        expect(result.kinds).toContain('param-set');
+    });
+
+    test('a renamed surface is flagged as name drift', () => {
+        const result = detectSignatureDrift({
+            ledgerSignature : 'buildSupervisedTaskDiagnosis({taskName, outcome})',
+            shippedSignature: 'buildSupervisedTaskOutcome({taskName, outcome})'
+        });
+
+        expect(result.drift).toBe(true);
+        expect(result.kinds).toContain('name');
+    });
+
+    test('defaults and type annotations are normalized away before comparison', () => {
+        const result = detectSignatureDrift({
+            ledgerSignature : 'fn({a, b})',
+            shippedSignature: 'export async function fn({a = 1, b = {}})'
+        });
+
+        expect(result.drift).toBe(false);
+    });
+
+    test('an unparseable signature degrades to a flagged unparseable (never a false clean)', () => {
+        expect(detectSignatureDrift({ledgerSignature: 'not a signature', shippedSignature: 'fn({a})'}).kinds)
+            .toContain('unparseable');
+    });
+
+    test('parseSignature classifies positional vs destructured vs empty', () => {
+        expect(parseSignature('fn(a, b)')).toMatchObject({name: 'fn', style: 'positional', params: ['a', 'b']});
+        expect(parseSignature('fn({b, a})')).toMatchObject({name: 'fn', style: 'destructured', params: ['a', 'b']});
+        expect(parseSignature('fn()')).toMatchObject({name: 'fn', style: 'none', params: []});
+        expect(parseSignature('garbage')).toBeNull();
+    });
+});


### PR DESCRIPTION
Refs #14119 — **feasibility spike, NOT a resolution.** Draft: do not merge until the lead routes #14119 (implement-here vs ideation); disposition is wire-or-retire after that call.

## What this proves

#14119 asks for an author-side check that flags when a PR's shipped consumed-surface drifts from the originating ticket's Contract Ledger — but flagged genuine design ambiguity ("how much of 'drift' is mechanically detectable, and where the check belongs"). This spike de-risks the **mechanical-feasibility** half of that question with a working, tested `detectSignatureDrift`:

- Parses a ledger row's stated function surface (e.g. `buildDimensionConsistencyDiagnosis(samples, observedAt, serviceId)`) and the shipped declaration (`export function buildDimensionConsistencyDiagnosis({samples, observedAt, serviceId})`).
- Flags three mechanical drift classes: **name**, **param-passing-style** (positional list vs single destructured object), and **param-name-set**.
- The **real positional-vs-destructured drift** that cost a review cycle this session is detected (a dedicated test pins it). Defaults / type-annotations are normalized away; an unparseable signature degrades to a flagged `unparseable` (never a false-clean).

**Finding: mechanical signature-drift detection is feasible and cheap.** Return-shape + semantic/behavioural drift are deliberately out of scope (they stay reviewer judgement) — so the spike does NOT claim to replace the review-time §5.4 audit; it front-runs the *mechanical signature* slice author-side.

Evidence: L2 (unit, pure function, no I/O). 7/7 green. This is a proof-of-concept; it is **not wired** into agent-preflight or the pull-request workflow — that integration point is the open design the routing decision settles.

## Deltas from ticket

- Scoped to the **mechanically-checkable signature** slice only (the de-riskable core), not the full #14119 (return-shape drift + the integration point are out of scope, pending routing).
- Opened as a **draft** spike rather than a resolution: it informs the lead's implement-vs-ideation routing with a concrete artifact rather than pre-committing the design.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/buildScripts/util/contractLedgerDrift.spec.mjs` → **7 passed** (the real positional-vs-destructured case; no-drift; param-set add; name drift; defaults/types normalized; unparseable→flagged; parser classification).

`npm run agent-preflight` → gates passed.

## Post-Merge Validation

- [ ] **Do not merge until #14119 is routed.** If routed to *implement*: wire `detectSignatureDrift` into the chosen integration point (agent-preflight step or pull-request workflow), extend toward return-shape drift, and flip Refs→Resolves on the wired PR. If routed to *ideation*: this branch is the feasibility input; retire it or fold it into the graduated design.

Authored by Ada (Claude Opus 4.8, Claude Code). Session fe9c04d6-1aae-4017-8d53-19b0e5aaf809.
