### PR TITLE
fix(ai): guard the live neo-native-graph collection name in DestructiveOperationGuard (#14123)

### DIFF
--- a/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
+++ b/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
@@ -16,7 +16,7 @@ export const DESTRUCTIVE_PRODUCTION_CONFIRMATION = 'CONFIRM_PRODUCTION_DESTRUCTI
  *
  * - `neo-agent-memory`   — Memory Core memories collection (`aiConfig.collections.memory`).
  * - `neo-agent-sessions` — Memory Core summaries collection (`aiConfig.collections.session`).
- * - `neo-agent-graph`    — Memory Core graph collection (`aiConfig.collections.graph`).
+ * - `neo-native-graph`   — Memory Core graph collection (`aiConfig.collections.graph`).
  * - `neo-knowledge-base` — Knowledge Base canonical collection (`aiConfig.collectionName`).
  *
  * Names are hardcoded (not derived from config) so a caller that loads runtime config
@@ -27,7 +27,7 @@ export const DESTRUCTIVE_PRODUCTION_CONFIRMATION = 'CONFIRM_PRODUCTION_DESTRUCTI
 export const GUARDED_CANONICAL_COLLECTION_NAMES = Object.freeze(new Set([
     'neo-agent-memory',
     'neo-agent-sessions',
-    'neo-agent-graph',
+    'neo-native-graph',
     'neo-knowledge-base'
 ]));
 

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -328,7 +328,7 @@ class ChromaManager extends AbstractVectorManager {
 
     /**
      * Guarded delete-collection wrapper. Refuses canonical production collection names
-     * (`neo-agent-memory`, `neo-agent-sessions`, `neo-agent-graph`, `neo-knowledge-base`)
+     * (`neo-agent-memory`, `neo-agent-sessions`, `neo-native-graph`, `neo-knowledge-base`)
      * unless `process.env.UNIT_TEST_MODE === 'true'` (test path) or a valid production
      * `confirmation` token is supplied.
      *

--- a/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs
@@ -21,7 +21,8 @@ import os             from 'os';
 import path           from 'path';
 import DestructiveOperationGuard, {
     DESTRUCTIVE_PRODUCTION_BYPASS_ENV,
-    DESTRUCTIVE_PRODUCTION_CONFIRMATION
+    DESTRUCTIVE_PRODUCTION_CONFIRMATION,
+    GUARDED_CANONICAL_COLLECTION_NAMES
 } from '../../../../../../../../ai/mcp/server/shared/services/DestructiveOperationGuard.mjs';
 import CollectionProxy       from '../../../../../../../../ai/services/memory-core/managers/CollectionProxy.mjs';
 import MemoryDatabaseService from '../../../../../../../../ai/services/memory-core/DatabaseService.mjs';
@@ -33,6 +34,20 @@ import aiConfig              from '../../../../../../../../ai/mcp/server/memory-
 const repoRoot = process.cwd();
 
 test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard (#10845)', () => {
+    test('the guarded canonical set stays in parity with the live config collection names (drift-catch)', () => {
+        // The guard hardcodes its set (deliberately, for the no-unit-test-isolation case), so this is the
+        // defense against it silently drifting from the live config — the gap that left the renamed graph
+        // collection (the stale neo-agent-graph vs the live neo-native-graph) unguarded at the name layer.
+        // Parity is checked against the PRODUCTION leaves: the guard protects production names regardless of
+        // the unit-test isolation toggle, so `collections.memory`/`.session` (test-toggled here) would be wrong.
+        for (const name of [aiConfig.collections.memoryProd, aiConfig.collections.sessionProd, aiConfig.collections.graph, kbConfig.collectionName]) {
+            expect(typeof name).toBe('string');
+            expect(GUARDED_CANONICAL_COLLECTION_NAMES.has(name)).toBe(true);
+        }
+
+        expect(GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-agent-graph')).toBe(false);
+    });
+
     test('permits in-memory SQLite targets', async () => {
         const result = await DestructiveOperationGuard.assertDestructiveTargetAllowed({
             operation: 'memory-core.graph.truncate',

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.canonicalGuard.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.canonicalGuard.spec.mjs
@@ -28,7 +28,7 @@ test.describe('Neo.ai.mcp.server.shared.services.DestructiveOperationGuard — c
     test('Set of canonical names covers MC + KB production collections', () => {
         expect(GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-agent-memory')).toBe(true);
         expect(GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-agent-sessions')).toBe(true);
-        expect(GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-agent-graph')).toBe(true);
+        expect(GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-native-graph')).toBe(true);
         expect(GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-knowledge-base')).toBe(true);
     });
 


### PR DESCRIPTION
Resolves #14123

A verified destructive-op guard fail-open found while reviewing #14117: the collection-name guard listed the stale `neo-agent-graph` while the live Memory Core graph collection is `neo-native-graph` (`config.mjs` SSOT). So `GUARDED_CANONICAL_COLLECTION_NAMES.has('neo-native-graph')` was `false`, and the real ~900-row graph collection was droppable at the very collection-name layer that exists (per its own JSDoc) to backstop the path-target guard.

## Fix

- `DestructiveOperationGuard.mjs`: `neo-agent-graph` → `neo-native-graph` in `GUARDED_CANONICAL_COLLECTION_NAMES` + the JSDoc.
- `ChromaManager.mjs`: the stale name in the delete-guard JSDoc corrected.
- **Drift-catch parity test**: asserts the hardcoded guarded set covers the live PRODUCTION config collection names (`memoryProd` / `sessionProd` / `graph` + the KB `collectionName`) and no longer contains the stale `neo-agent-graph` — so a future rename can't silently re-open the gap. (Writing it surfaced the prod-vs-test-toggle subtlety: the guard protects production names regardless of `useTestDatabase`, so parity is checked against the production leaves.)

Evidence: L2 (the guard spec 14/14 green, incl. the new drift-catch parity test). Verified correctness change — the guard now blocks a `deleteCollection({name: 'neo-native-graph'})`; confirmed `neo-agent-graph` survives nowhere else in `ai/`/`src/` (only the two JSDoc/list refs, both corrected).

## Deltas from ticket

None — matches #14123. Kept the guard hardcoded (per its deliberate no-isolation-layer design) and added the parity TEST instead of making it config-derived, per the ticket's Avoided Traps.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs` → **14 passed**.
- `npm run agent-preflight`: all gates passed (archaeology clean).

## Post-Merge Validation

- [ ] None — the fix + the drift-catch test are unit-covered. The parity test now fails loudly if the guarded set and the live config names diverge again.

Related: Refs #14117 (where it surfaced), #14084 (the recovery work on `neo-native-graph`), #14039 (v13.1 epic). Lesson: derive identity sets from config, never a hand-maintained literal.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 5ab545e1-f09e-46c5-ae62-8cf5b2b96193.
