### PR TITLE
fix(ai): exempt non-embedding read-only diagnostics from the embed-canary health gate (#14124)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -115,7 +115,11 @@ class Server extends BaseServer {
      * WAL-overlay fallback for its optional Chroma content join), and `who_is_online` (a SQLite
      * `AgentIdentity`-roster liveness projection — graph-backed, survives an embed-drain) call no
      * embedder — they serve fine while it is down, so gating them only denied a read the outage
-     * never touched. NOT exempt:
+     * never touched. The read-only diagnostics `get_rem_pipeline_state` (REM/dream run-state),
+     * `get_sqlite_holder_diagnostics` (SQLite holder state), and `get_memory_core_tool_metrics`
+     * (tool-call metrics) are exempt for the same reason — pure state/metric projections with no
+     * embedder call, so an agent can still inspect a degraded Memory Core through them rather than
+     * losing the very diagnostics the slow-embed condition is meant to surface. NOT exempt:
      * `query_raw_memories` / `query_summaries`, which embed the query and genuinely cannot serve
      * during an embedder outage — exempting them would trade a clean gate-reject for an embed-timeout.
      * @returns {Array<String>}
@@ -138,7 +142,10 @@ class Server extends BaseServer {
             'record_turn_presence',
             'get_session_memories',
             'query_recent_turns',
-            'who_is_online'
+            'who_is_online',
+            'get_rem_pipeline_state',
+            'get_sqlite_holder_diagnostics',
+            'get_memory_core_tool_metrics'
         ];
     }
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -175,13 +175,13 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
     });
 
     test('#12199: onSessionClosed writes a pending summarization marker without summarizing inline', async () => {
-        const SDK = await import('../../../../../../../ai/services.mjs');
-        const serverInstance = await createServerWithoutBoot();
+        const SDK               = await import('../../../../../../../ai/services.mjs');
+        const serverInstance    = await createServerWithoutBoot();
         const mcpServerInstance = {id: 'mcp-session-server'};
-        const calls = [];
-        const removed = [];
+        const calls             = [];
+        const removed           = [];
 
-        const originalQueue = SDK.Memory_SessionService.queueSummarizationJob;
+        const originalQueue  = SDK.Memory_SessionService.queueSummarizationJob;
         const originalRemove = SDK.Memory_CoalescingEngineService.removeMcpServer;
 
         SDK.Memory_SessionService.queueSummarizationJob = (sessionId) => {
@@ -206,10 +206,10 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
     test('#12838: mailbox + add_memory bypass the summary-degraded health gate (never-fail WAL); embed-dependent reads do not', async () => {
         const serverInstance = await createServerWithoutBoot();
-        const handlers = new Map();
-        const healthCalls = [];
-        const toolCalls = [];
-        const degradedError = new Error([
+        const handlers       = new Map();
+        const healthCalls    = [];
+        const toolCalls      = [];
+        const degradedError  = new Error([
             'Memory Core is not fully operational:',
             "  - Summary provider 'gemini' requires GEMINI_API_KEY - summarization features unavailable"
         ].join('\n'));
@@ -317,10 +317,10 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
     test('#12978: non-embedding reads (get_session_memories, query_recent_turns) bypass the embedder-degraded health gate; embed-dependent reads do not', async () => {
         const serverInstance = await createServerWithoutBoot();
-        const handlers = new Map();
-        const healthCalls = [];
-        const toolCalls = [];
-        const degradedError = new Error([
+        const handlers       = new Map();
+        const healthCalls    = [];
+        const toolCalls      = [];
+        const degradedError  = new Error([
             'Memory Core is not fully operational:',
             "  - Summary provider 'gemini' requires GEMINI_API_KEY - summarization features unavailable"
         ].join('\n'));
@@ -449,13 +449,33 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         }
     });
 
+    test('#14124: non-embedding read-only diagnostics are health-exempt so a degraded Memory Core stays inspectable', async () => {
+        const serverInstance = await createServerWithoutBoot();
+
+        try {
+            const exemptTools = serverInstance.getHealthExemptTools();
+
+            // Pure state/metric projections with no embedder call — an agent must be able to diagnose a
+            // slow-embed Memory Core through them, not have the read gated by the very degradation it
+            // surfaces (the embedding-write canary would otherwise block the inspection tool).
+            expect(exemptTools).toContain('get_rem_pipeline_state');
+            expect(exemptTools).toContain('get_sqlite_holder_diagnostics');
+            expect(exemptTools).toContain('get_memory_core_tool_metrics');
+            // The must-embed reads stay NON-exempt (exempting them trades a clean reject for a timeout).
+            expect(exemptTools).not.toContain('query_raw_memories');
+            expect(exemptTools).not.toContain('query_summaries');
+        } finally {
+            serverInstance.destroy();
+        }
+    });
+
     test('#13312: boot keeps MCP handlers available when graph startup tiers degrade', async () => {
-        const SDK = await import('../../../../../../../ai/services.mjs');
-        const HealthService = (await import('../../../../../../../ai/services/memory-core/HealthService.mjs')).default;
-        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
-        const calls = [];
-        const startupStates = [];
-        const wakeFailure = new Error('attempt to write a readonly database');
+        const SDK                   = await import('../../../../../../../ai/services.mjs');
+        const HealthService         = (await import('../../../../../../../ai/services/memory-core/HealthService.mjs')).default;
+        const serverInstance        = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+        const calls                 = [];
+        const startupStates         = [];
+        const wakeFailure           = new Error('attempt to write a readonly database');
         const originalServerMethods = new Map([
             'loadCustomConfig',
             'createMcpServer',
@@ -480,12 +500,12 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         serverInstance.logIdentityStatus = () => calls.push('logIdentityStatus');
         serverInstance.logSiblingConcurrency = () => calls.push('logSiblingConcurrency');
 
-        const originalWakeInit = SDK.Memory_WakeSubscriptionService.init;
-        const originalInferenceReady = SDK.Memory_InferenceLifecycleService.ready;
-        const originalSessionReady = SDK.Memory_SessionService.ready;
-        const originalRecorderInitAsync = SDK.Memory_RecorderService.initAsync;
+        const originalWakeInit                = SDK.Memory_WakeSubscriptionService.init;
+        const originalInferenceReady          = SDK.Memory_InferenceLifecycleService.ready;
+        const originalSessionReady            = SDK.Memory_SessionService.ready;
+        const originalRecorderInitAsync       = SDK.Memory_RecorderService.initAsync;
         const originalRecordStartupDependency = HealthService.recordStartupDependency;
-        const originalSetStdioIdentityState = HealthService.setStdioIdentityState;
+        const originalSetStdioIdentityState   = HealthService.setStdioIdentityState;
 
         SDK.Memory_WakeSubscriptionService.init = async () => {
             calls.push('wakeInit');


### PR DESCRIPTION
Resolves #14124

The Memory Core embedding-write health gate (`BaseServer.mjs` → `getHealthExemptTools()`) was blocking `get_rem_pipeline_state` — a read-only REM-pipeline-state diagnostic — when the embed provider is slow (the write-canary times out): exactly the catch-22 this ticket names, where an agent loses the very diagnostic it needs to inspect a degraded Memory Core. (Hit live during the v13.1 rem-consolidation-stall investigation.)

The exempt list is **already curated by a precise principle** (the existing JSDoc): exempt tools that call **no embedder** (`add_memory`/WAL writes, `who_is_online`, `query_recent_turns`); keep `query_raw_memories`/`query_summaries` gated because they *embed the query*. The read-only diagnostics were simply **missed** from that list. This completes it:

- Adds `get_rem_pipeline_state` (REM/dream run-state), `get_sqlite_holder_diagnostics` (SQLite holder state), and `get_memory_core_tool_metrics` (tool-call metrics) — pure state/metric projections with no embedder call — to `getHealthExemptTools()` + extends the JSDoc rationale.
- The must-embed reads (`query_raw_memories`/`query_summaries`) stay NON-exempt — exempting them would trade a clean reject for an embed-timeout.

**Supersedes the ticket's "fix B" (a new `readOnlyHint` bypass at the shared `BaseServer` gate):** the curated per-server exempt-list IS already the principled mechanism (gated by does-it-embed, rationale in the JSDoc). Completing it is consistent + low-blast; a shared-gate mechanism would be redundant. Only confirmed non-embedding diagnostics are exempted; any read-only tool that *does* embed (e.g. `search_nodes`) stays correctly gated.

Evidence: L2 — the MC Server spec asserts the three diagnostics are exempt and the must-embed reads stay gated.

## Deltas

None — completes the established curated exempt-list per its own documented principle; supersedes fix B (noted on #14124).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs` → **11/11 passed** (incl. the new `#14124` exempt-assertion test: the 3 diagnostics exempt, the must-embed reads not).

## Post-Merge Validation

- [ ] (observational) During a slow-embed window, `get_rem_pipeline_state` / `get_sqlite_holder_diagnostics` / `get_memory_core_tool_metrics` serve their reads instead of returning "Memory Core is not fully operational".

## Commits

- 2ce4eee39 — fix(ai): exempt non-embedding read-only diagnostics from the embed-canary health gate (#14124)

## Structural pre-flight

No new files; extends the existing `memory-core/Server.mjs` `getHealthExemptTools()` curated list + its JSDoc rationale + a focused spec assertion. No shared-base change.

Related: #14039 (v13.1 immune system — surfaced during a live rem-consolidation-stall diagnosis), #12065 (REM/Sandman pipeline), #13694 (the `who_is_online` exemption this mirrors).

Authored by Vega (Claude Opus 4.8, Claude Code). Session 16bbea8d-8bc9-4dad-8e1c-8e3b2cd861a3.
