### PR TITLE
feat(ai): wire dimension-consistency producer into the data-integrity runner (#14129)

### DIFF
--- a/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
@@ -1,6 +1,7 @@
 import Base from '../../../../src/core/Base.mjs';
 
 import {buildDataIntegrityCoverageDiagnosis} from './dataIntegrityCoverageDiagnosis.mjs';
+import {buildDimensionConsistencyDiagnosis}  from './dimensionConsistencyDiagnosis.mjs';
 
 /**
  * @module ai/daemons/orchestrator/services/DataIntegrityDiagnosisService
@@ -10,8 +11,9 @@ import {buildDataIntegrityCoverageDiagnosis} from './dataIntegrityCoverageDiagno
  * wiring between the producers (which are proven by the release-gate end-to-end corruption proof but
  * not yet running) and the recovery actuator's escalate sink.
  *
- * The runner gathers bounded read-observe facts (a Chroma vector-coverage audit), runs the producers
- * over them, and routes every emitted `recovery-diagnosis` to the actuator's `escalateDiagnosis` sink —
+ * The runner gathers bounded read-observe facts (a Chroma vector-coverage audit, plus per-collection
+ * embedding-dimension samples when a dimension gatherer is injected), runs the producers over them, and
+ * routes every emitted `recovery-diagnosis` to the actuator's `escalateDiagnosis` sink —
  * the operator-page path. It is DETECT-ONLY / ESCALATE-ONLY by construction: it never calls a
  * privileged recovery action (`apply` / restart / re-embed / restore / Chroma mutation). Data mutation
  * stays operator-gated (the two-worlds boundary); a gutted store pages a human, it is not
@@ -47,6 +49,16 @@ export class DataIntegrityDiagnosisService extends Base {
      * @member {Function|null} coverageGatherer=null
      */
     coverageGatherer = null
+    /**
+     * Async fact gatherer returning per-collection embedding-dimension samples
+     * (`[{collection, expectedDimension, mismatchedVectorCount}]`) for `buildDimensionConsistencyDiagnosis`.
+     * OPTIONAL — a set-once injected dependency (a plain class field, like `coverageGatherer`). The
+     * dimension signal is secondary: when this is absent (the live-Chroma binding not yet wired) or its
+     * probe fails, dimension is skipped for the cycle and the coverage signal still runs — a
+     * dimension-probe issue must never suppress the primary coverage probe.
+     * @member {Function|null} dimensionGatherer=null
+     */
+    dimensionGatherer = null
     /**
      * The current-clock injection seam for deterministic tests; falls back to `Date.now()`.
      * Set-once injected dependency — a plain class field (see `coverageGatherer`), not reactive.
@@ -96,7 +108,9 @@ export class DataIntegrityDiagnosisService extends Base {
             });
         }
 
-        const diagnoses   = this.buildDiagnoses({coverageResult, observedAt}),
+        const dimensionSamples = await this.gatherDimensionSamples();
+
+        const diagnoses   = this.buildDiagnoses({coverageResult, dimensionSamples, observedAt}),
               escalations = await this.routeDiagnoses({diagnoses, now: observedAt});
 
         return this.createDecision({
@@ -109,18 +123,42 @@ export class DataIntegrityDiagnosisService extends Base {
     }
 
     /**
+     * @summary Gathers per-collection dimension samples from the injected dimension gatherer, if present.
+     *
+     * The dimension signal is secondary and degrades independently: an absent gatherer (the live-Chroma
+     * binding not yet wired) or a probe failure yields no samples (dimension is skipped this cycle) and
+     * never aborts the cycle — the primary coverage probe has already run and must not be suppressed.
+     *
+     * @returns {Promise<Object[]>} Per-collection dimension samples, or `[]` when unavailable.
+     */
+    async gatherDimensionSamples() {
+        if (typeof this.dimensionGatherer !== 'function') {
+            return [];
+        }
+
+        try {
+            const samples = await this.dimensionGatherer();
+            return Array.isArray(samples) ? samples : [];
+        } catch (error) {
+            return [];
+        }
+    }
+
+    /**
      * @summary Runs the pure detect-producers over the gathered facts and collects non-null diagnoses.
      *
-     * This is the extension seam: follow-up slices add the monotonicity producer (fed by the runner's
-     * own per-collection history) and the dimension-consistency producer (fed by an injected dimension
-     * fact-gatherer) alongside the coverage-drift producer wired here.
+     * Wires the coverage-drift producer (snapshot-derived) and the dimension-consistency producer (fed by
+     * the optional injected dimension gatherer). The remaining extension is the monotonicity producer
+     * (fed by the runner's own per-collection history). Each producer is pure and returns `null` on a
+     * clean signal, so an absent dimension gatherer (empty samples) simply yields no dimension diagnosis.
      *
      * @param {Object} options
      * @param {Object} options.coverageResult The `auditChromaVectorCoverage()` result.
+     * @param {Object[]} [options.dimensionSamples=[]] Per-collection dimension samples; empty when no gatherer is injected.
      * @param {Number} options.observedAt Epoch milliseconds for the observation.
      * @returns {Object[]} The non-null `recovery-diagnosis` events emitted this cycle.
      */
-    buildDiagnoses({coverageResult, observedAt}) {
+    buildDiagnoses({coverageResult, dimensionSamples = [], observedAt}) {
         const diagnoses = [],
               coverage  = buildDataIntegrityCoverageDiagnosis({
                   coverageResult,
@@ -130,6 +168,16 @@ export class DataIntegrityDiagnosisService extends Base {
 
         if (coverage) {
             diagnoses.push(coverage);
+        }
+
+        const dimension = buildDimensionConsistencyDiagnosis({
+            samples  : dimensionSamples,
+            observedAt,
+            serviceId: this.serviceId
+        });
+
+        if (dimension) {
+            diagnoses.push(dimension);
         }
 
         return diagnoses;

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
@@ -42,6 +42,18 @@ function coverage({ok}) {
     };
 }
 
+/**
+ * Per-collection dimension samples in the `auditCollectionVectorDimensions` shape the producer consumes.
+ * `mismatched: true` reports a wrong-dimension vector (corruption → escalate); `false` is clean.
+ */
+function dimensionSamples({mismatched}) {
+    return [{
+        collection           : 'neo-agent-memory',
+        expectedDimension    : 4096,
+        mismatchedVectorCount: mismatched ? 5 : 0
+    }];
+}
+
 function createService(config = {}) {
     return Neo.create(DataIntegrityDiagnosisService, {
         serviceId: 'memory-core',
@@ -156,5 +168,95 @@ test.describe('Neo.ai.daemons.services.DataIntegrityDiagnosisService', () => {
         });
 
         await expect(service.gatherAndDiagnose()).rejects.toThrow(/recoveryActuator with escalateDiagnosis/);
+    });
+
+    test('dimension mismatch → routes a data-integrity dimension diagnosis to escalateDiagnosis', async () => {
+        const actuator = fakeActuator(),
+              service  = createService({
+                  coverageGatherer : async () => coverage({ok: true}),
+                  dimensionGatherer: async () => dimensionSamples({mismatched: true}),
+                  recoveryActuator : actuator
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision.status).toBe('escalated');
+        expect(decision.diagnoses).toHaveLength(1);
+        expect(decision.diagnoses[0]).toMatchObject({
+            recoveryClass : 'data-integrity',
+            targetIdentity: {kind: 'compose-service', id: 'memory-core'},
+            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-dimension-mismatch'}
+        });
+        expect(decision.diagnoses[0].diagnosisId).toBe(`data-integrity:memory-core:dimension-mismatch:${OBSERVED_AT}`);
+        expect(decision.diagnoses[0].evidenceFacts).toContainEqual(
+            expect.objectContaining({type: 'vector-dimension-mismatch', collection: 'neo-agent-memory', mismatchedVectorCount: 5})
+        );
+        expect(actuator.calls.escalate).toHaveLength(1);
+        expect(actuator.calls.apply).toHaveLength(0);
+    });
+
+    test('clean dimension samples → no dimension diagnosis (never a false escalation)', async () => {
+        const actuator = fakeActuator(),
+              service  = createService({
+                  coverageGatherer : async () => coverage({ok: true}),
+                  dimensionGatherer: async () => dimensionSamples({mismatched: false}),
+                  recoveryActuator : actuator
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision.status).toBe('healthy');
+        expect(decision.diagnoses).toHaveLength(0);
+        expect(actuator.calls.escalate).toHaveLength(0);
+    });
+
+    test('coverage drift AND dimension mismatch → both diagnoses escalated', async () => {
+        const actuator = fakeActuator(),
+              service  = createService({
+                  coverageGatherer : async () => coverage({ok: false}),
+                  dimensionGatherer: async () => dimensionSamples({mismatched: true}),
+                  recoveryActuator : actuator
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision.status).toBe('escalated');
+        expect(decision.diagnoses).toHaveLength(2);
+        expect(decision.escalations).toHaveLength(2);
+        expect(actuator.calls.escalate).toHaveLength(2);
+        expect(decision.diagnoses.map(diagnosis => diagnosis.details.reasonCode))
+            .toContain('data-integrity-dimension-mismatch');
+    });
+
+    test('a throwing dimension gatherer is skipped — coverage still runs, never probe-unavailable', async () => {
+        const actuator = fakeActuator(),
+              service  = createService({
+                  coverageGatherer : async () => coverage({ok: false}),
+                  dimensionGatherer: async () => { throw new Error('Chroma read failed'); },
+                  recoveryActuator : actuator
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        // The secondary dimension probe failing must NOT suppress the primary coverage signal.
+        expect(decision.status).toBe('escalated');
+        expect(decision.diagnoses).toHaveLength(1);
+        expect(decision.diagnoses[0].evidenceFacts).toContainEqual(
+            expect.objectContaining({type: 'vector-coverage-drift'})
+        );
+    });
+
+    test('absent dimension gatherer → dimension skipped (backward-compatible), coverage unaffected', async () => {
+        const actuator = fakeActuator(),
+              service  = createService({
+                  coverageGatherer: async () => coverage({ok: true}),
+                  recoveryActuator: actuator
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        // No dimensionGatherer injected (the live-Chroma binding not wired) → no dimension diagnosis, no error.
+        expect(decision.status).toBe('healthy');
+        expect(decision.diagnoses).toHaveLength(0);
     });
 });


### PR DESCRIPTION
Resolves #14129 (Slice A — the pure runner-seam). The Orchestrator live-Chroma binding is Slice B, split to #14130 and not in this PR.

Wires the dimension-consistency producer (`buildDimensionConsistencyDiagnosis`) into the live data-integrity runner's `buildDiagnoses`, fed by an optional injected `dimensionGatherer` — the extension seam the runner's own JSDoc already reserved. #14117 made the immune loop LIVE but coverage-signal-only; this adds the dimension signal to the runner half (pure + unit-tested with a mock gatherer; the live-Chroma fact-gathering is Slice B).

### What changed
- `DataIntegrityDiagnosisService` gains a set-once injected `dimensionGatherer` class field (mirrors `coverageGatherer` — never reassigned/observed, so a plain class field, not a reactive config).
- `gatherAndDiagnose` gathers dimension samples via a new `gatherDimensionSamples()` helper; `buildDiagnoses` runs the dimension producer alongside coverage.
- **Secondary-signal degradation (the key design point):** an absent gatherer (Slice B not wired) OR a throwing gatherer yields empty samples → dimension is skipped for the cycle, and the PRIMARY coverage probe still runs. A dimension-probe issue never escalates to `probe-unavailable` (which would suppress the proven coverage signal). The producer returns `null` on empty/clean samples, so it is always safe to call.

Evidence: L2 — 12/12 runner spec (7 existing + 5 new: mismatch escalates, clean never escalates, both-fire, throwing-gatherer-skipped-not-probe-unavailable, absent-gatherer-backward-compatible).

## Deltas

- Made `dimensionGatherer` OPTIONAL (NOT in `validateDependencies`), unlike `coverageGatherer`. Rationale: the dimension signal is secondary; the runner must keep emitting the proven coverage signal when the dimension binding is absent (Slice B not yet merged) or its probe fails. Documented at the field + `gatherDimensionSamples`.

## Test Evidence

- `npx playwright test test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs` → **12/12 passed**.

## Post-Merge Validation

- [ ] (Slice B / #14130) Once the Orchestrator injects a live dimension gatherer, a wrong-dimension vector in a Memory Core collection escalates on the hourly sweep.

## Commits

- 1b7ab948b — feat(ai): wire dimension-consistency producer into the data-integrity runner (#14129)

## Structural pre-flight

Extends the existing runner + spec only; no new files, no shared-base change. Mirrors the merged coverage-producer wiring pattern exactly.

Related: #14129 (Slice A — resolved here), #14130 (Slice B — the Orchestrator live-Chroma binding), #14102 (the producer), #14115 (the gatherer, consumed in Slice B), #14117 (the live loop this extends), #14039 (v13.1 epic).

Authored by Vega (Claude Opus 4.8, Claude Code). Session 16bbea8d-8bc9-4dad-8e1c-8e3b2cd861a3.
