### PR TITLE
feat(ai): document-presence audit primitive for WAL-stall-vs-wipe (#14135)

### DIFF
--- a/ai/scripts/maintenance/checkChromaIntegrity.mjs
+++ b/ai/scripts/maintenance/checkChromaIntegrity.mjs
@@ -615,6 +615,43 @@ export async function auditCollectionVectorDimensions({collection, collectionNam
 }
 
 /**
+ * @summary Audits document-presence for a set of Chroma row ids — the data-integrity gatherer that lets the
+ * recovery classifier separate a re-embeddable WAL-stall (documents present, vectors missing) from an
+ * unrecoverable wipe (documents also gone). Given the gutted ids (metadata present, vector absent — the
+ * `missingFromVector` set surfaced by `auditChromaVectorCoverage`), samples up to `sampleSize` and counts
+ * those whose stored document is a non-empty string: a present document is what a lossless re-embed re-drives
+ * from, an absent one means the row is unrecoverable from documents alone. A read-only `.get` does not invoke
+ * the embedder, so this is NOT gated by the embed canary. Returns the producer's per-collection sample element
+ * shape, 1:1. A probe failure surfaces as an `error` field with a zero count — it never throws into the runner.
+ *
+ * @param {Object} options
+ * @param {Object} options.collection Chroma collection handle (`.get({ids, include})`).
+ * @param {String} options.collectionName The collection's name (carried into the sample for the diagnosis).
+ * @param {String[]} [options.ids=[]] The row ids to probe — the missing-from-vector / gutted ids.
+ * @param {Number} [options.sampleSize=100] Maximum ids to sample.
+ * @returns {Promise<Object>} `{collection, documentsPresentCount, sampledCount}` (+ `error` on probe failure).
+ */
+export async function auditCollectionDocumentPresence({collection, collectionName, ids = [], sampleSize = 100} = {}) {
+    const sampledIds = ids.slice(0, sampleSize);
+
+    // No gutted ids to probe → nothing to recover from, never a probe (and never a false zero-with-error).
+    if (sampledIds.length === 0) {
+        return {collection: collectionName, documentsPresentCount: 0, sampledCount: 0};
+    }
+
+    try {
+        const {documents = []} = await collection.get({ids: sampledIds, include: ['documents']}),
+              // A present document is a non-empty string — the source a lossless re-embed re-drives from
+              // (WAL-stall); a null/empty document means the row is unrecoverable from documents alone (wipe).
+              documentsPresentCount = documents.filter(document => typeof document === 'string' && document.length > 0).length;
+
+        return {collection: collectionName, documentsPresentCount, sampledCount: sampledIds.length};
+    } catch (error) {
+        return {collection: collectionName, documentsPresentCount: 0, sampledCount: 0, error: error.message};
+    }
+}
+
+/**
  * @param {Object} options
  * @param {Object} options.collection
  * @param {String} options.name

--- a/test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs
@@ -6,6 +6,7 @@ import {promisify}    from 'util';
 import {test, expect} from '@playwright/test';
 import {
     auditChromaVectorCoverage,
+    auditCollectionDocumentPresence,
     auditCollectionVectorDimensions,
     classifySqliteCheck,
     compareMetadataToVectorIds,
@@ -435,6 +436,65 @@ test.describe('auditCollectionVectorDimensions — data-integrity dimension fact
 
         const result = await auditCollectionVectorDimensions({collection, collectionName: 'c', expectedDimension: 4096});
         expect(result.mismatchedVectorCount).toBe(0);
+        expect(result.sampledCount).toBe(0);
+        expect(result.error).toBe('chroma unavailable');
+    });
+});
+
+test.describe('auditCollectionDocumentPresence — data-integrity WAL-stall-vs-wipe discriminator', () => {
+    // mock collection: the by-ids `get` returns documents positionally aligned to the requested ids.
+    function makeDocCollection({documents, failOn}) {
+        return {
+            get: async ({ids: reqIds} = {}) => {
+                if (failOn) throw new Error('chroma unavailable');
+                return {ids: reqIds, documents};
+            }
+        };
+    }
+
+    test('counts rows whose document is present — the re-embeddable WAL-stall shape', async () => {
+        const collection = makeDocCollection({documents: ['memory text', 'another memory', 'third']});
+
+        expect(await auditCollectionDocumentPresence({collection, collectionName: 'neo-agent-memory', ids: ['a', 'b', 'c'], sampleSize: 10}))
+            .toEqual({collection: 'neo-agent-memory', documentsPresentCount: 3, sampledCount: 3});
+    });
+
+    test('gutted rows — documents absent (null/empty/undefined) -> documentsPresentCount 0 (the unrecoverable wipe shape)', async () => {
+        const collection = makeDocCollection({documents: [null, '', undefined]});
+
+        expect((await auditCollectionDocumentPresence({collection, collectionName: 'c', ids: ['a', 'b', 'c']})).documentsPresentCount).toBe(0);
+    });
+
+    test('mixed — only non-empty-string documents count', async () => {
+        const collection = makeDocCollection({documents: ['present', null, 'also present']});
+
+        const result = await auditCollectionDocumentPresence({collection, collectionName: 'c', ids: ['a', 'b', 'c']});
+        expect(result.documentsPresentCount).toBe(2);
+        expect(result.sampledCount).toBe(3);
+    });
+
+    test('sampleSize caps the ids probed', async () => {
+        // chroma returns documents for the 2 requested (sampled) ids only.
+        const collection = makeDocCollection({documents: ['t1', 't2']});
+
+        expect(await auditCollectionDocumentPresence({collection, collectionName: 'c', ids: ['a', 'b', 'c'], sampleSize: 2}))
+            .toEqual({collection: 'c', documentsPresentCount: 2, sampledCount: 2});
+    });
+
+    test('no gutted ids -> zero count, no probe (and no false error)', async () => {
+        let   probed     = false;
+        const collection = {get: async () => { probed = true; return {ids: [], documents: []}; }};
+
+        expect(await auditCollectionDocumentPresence({collection, collectionName: 'c', ids: []}))
+            .toEqual({collection: 'c', documentsPresentCount: 0, sampledCount: 0});
+        expect(probed).toBe(false);
+    });
+
+    test('a .get failure surfaces as an error with a zero count — never throws into the runner', async () => {
+        const collection = makeDocCollection({documents: [], failOn: true});
+
+        const result = await auditCollectionDocumentPresence({collection, collectionName: 'c', ids: ['a']});
+        expect(result.documentsPresentCount).toBe(0);
         expect(result.sampledCount).toBe(0);
         expect(result.error).toBe('chroma unavailable');
     });


### PR DESCRIPTION
Resolves #14135

Adds `auditCollectionDocumentPresence` to `ai/scripts/maintenance/checkChromaIntegrity.mjs` — the data-integrity gatherer that lets the autonomous recovery classifier separate a **re-embeddable WAL-stall** (documents present, vectors missing) from an **unrecoverable wipe** (documents also gone). Part of the v13.1 self-heal re-shape (#14132 — operator-mandated 100% autonomous, `escalate` deleted). Per the locked #14032 seam, this supplies `documentsPresentCount` — the one producer-evidence field that needed a net-new gatherer build (V-B-A: `auditChromaVectorCoverage` compares metadata-ids vs vector-ids only and never fetches documents). Read-only `.get(include:['documents'])`, degrade-not-throw, NOT embed-canary-gated; sibling of `auditCollectionVectorDimensions` (#14113). Pure primitive — it makes no mode decision (that is the runner classifier #14109).

Evidence: L1 (unit — pure function over a mocked Chroma collection) fully covers the close-target ACs; no L2+ runtime evidence required (read-only pure primitive with no live-Chroma or host effect of its own). Residual: none.

## Deltas from ticket (if any)
None — scope is exactly the primitive + its unit test, as filed on #14135.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs` → **24 passed** (18 existing + 6 new): documents-present (WAL-stall), documents-absent/null/empty (wipe), mixed, sampleSize cap, empty-ids-no-probe, probe-failure. `agent-preflight` (check-ticket-archaeology + alignment) clean on both files.

## Post-Merge Validation
- [ ] None for this PR — the primitive is pure and fully unit-covered. The live-Chroma exercise happens when the producer re-route (a separate #14132 sub) consumes `documentsPresentCount`; that sub carries the L2+ runtime evidence.

## Contract
The new export's Contract Ledger is on the originating ticket #14135 (Target Surface / Source of Authority / Behavior / Fallback / Docs / Evidence). Consumer: the coverage gatherer + the runner classifier #14109 consume `documentsPresentCount` per the locked #14032 seam.

## Scope
The primitive + its unit test ONLY. The producer re-route (drop `actionClass:escalate` + emit the full evidence shape) is a separate #14132 sub gated on the runner classifier landing.

Refs #14132, #14032, #14039, #14113, #14109

---
Authored by Ada (Claude Opus 4.8, Claude Code) · origin session fe9c04d6-1aae-4017-8d53-19b0e5aaf809
