### PR TITLE
feat(ai): autonomous accepted-loss settlement — bounded-terminal self-settle, no ack/escalate (#14118)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -11,6 +11,8 @@ import {withHeavyMaintenanceLease}                                   from '../..
 import {registerNeoChromaEmbeddingFunctions}                         from '../../services/shared/vector/chromaClientPrimitives.mjs';
 import {auditChromaVectorCoverage}                                   from './checkChromaIntegrity.mjs';
 import {extractMemoryCoreCollectionData, truncateToEmbedTokenBudget} from './repairMemoryCoreStoredEmbeddings.mjs';
+import {resolveAutonomousRepairExit}                                 from '../../services/memory-core/helpers/acceptedLossSettlement.mjs';
+import {appendAutoAcceptedLoss}                                      from '../../services/memory-core/helpers/acceptedLossAuditStore.mjs';
 
 /**
  * @summary Defragments collection groups inside the unified ChromaDB store.
@@ -1535,6 +1537,27 @@ async function defragChromaDB() {
             // Fail loud at the operator boundary: non-clean repair work is NOT a successful repair
             // (mirrors the KB extractionErrors / hasRestoreErrors -> process.exit(1) discipline below).
             if (anyRepairNonClean(results)) {
+                // Autonomous accepted-loss settlement (zero operator-ack, no runtime escalate): when EVERY
+                // non-clean collection's residue is bounded AND deterministically-terminal, self-settle it —
+                // record a durable audit entry per collection and exit clean, with no human. Transient residue
+                // (heal-path → the data-recovery actuator) or a systemic-fault (mass terminal = a misconfigured
+                // embedder, frozen) keeps the loud non-clean exit below.
+                const settleExit = resolveAutonomousRepairExit({
+                    results,
+                    normalizeResidue: normalizeUnrecoverableEntry,
+                    provider        : config.embeddingProvider,
+                    contextBudget   : embedBudgetTokens
+                });
+
+                if (!dryRun && settleExit.allSettled) {
+                    const auditDir = path.dirname(statePath);
+                    for (const entry of settleExit.perCollection) {
+                        await appendAutoAcceptedLoss(entry.auditRecord, {dir: auditDir});
+                    }
+                    console.log(`   ♻️  Autonomous accepted-loss: all ${settleExit.perCollection.length} non-clean collection(s) held only bounded, deterministically-terminal residue — settled + recorded to ${path.join(auditDir, 'auto-accepted-loss.jsonl')}. No operator page; zero ack.`);
+                    return;
+                }
+
                 const abortedNames  = results.filter(result => result.aborted).map(result => result.collectionName),
                       partialNames  = results.filter(result => result.partialPromoted).map(result => result.collectionName),
                       nonCleanNames = [...abortedNames, ...partialNames];

--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -1399,6 +1399,62 @@ export function anyRepairNonClean(results = []) {
 }
 
 /**
+ * @summary Applies the AUTONOMOUS accepted-loss settlement over a non-clean repair result set and — when EVERY
+ * non-clean collection self-settles — resolves the durable defrag state marker so the next maintenance pass is
+ * not blocked as `DEFRAG_INCOMPLETE_STATE`. A clean process exit is not enough: the repair already wrote a
+ * `memory-core-repair-partial-promoted` / `-aborted` marker, so a settled run must clear it or the next run aborts.
+ *
+ * Pure orchestration over injected I/O (`appendFn` / `clearFn`): runs `resolveAutonomousRepairExit`; if
+ * `allSettled`, carries each collection's retained-parking context into the durable `auto-accepted-loss` audit
+ * record (the audit log becomes the inspection surface that replaces the cleared marker), appends it, then clears
+ * the marker. Zero operator-ack, no runtime escalate. Returns `{settled:false}` (no mutation) when any collection
+ * is heal-path / systemic-fault, so the caller keeps the loud non-clean exit.
+ *
+ * @param {Object} options
+ * @param {Object[]} options.results Per-collection repair results.
+ * @param {String} options.statePath The defrag state-marker path (cleared on full settlement).
+ * @param {String} options.auditDir The durable audit-log directory.
+ * @param {Function} [options.normalizeResidue=normalizeUnrecoverableEntry]
+ * @param {String} [options.provider='']
+ * @param {Number|String} [options.contextBudget='']
+ * @param {Function} [options.appendFn=appendAutoAcceptedLoss] Audit-append seam (test injection).
+ * @param {Function} [options.clearFn=clearDefragState] Marker-clear seam (test injection).
+ * @param {Function} [options.writeLog] Optional logger, called with the settled-collection count.
+ * @returns {Promise<Object>} `{settled, perCollection}` — `settled` true iff every non-clean collection auto-settled and the marker was cleared.
+ */
+export async function applyAutonomousSettlement({
+    results,
+    statePath,
+    auditDir,
+    normalizeResidue = normalizeUnrecoverableEntry,
+    provider         = '',
+    contextBudget    = '',
+    appendFn         = appendAutoAcceptedLoss,
+    clearFn          = clearDefragState,
+    writeLog
+} = {}) {
+    const settleExit = resolveAutonomousRepairExit({results, normalizeResidue, provider, contextBudget});
+
+    if (!settleExit.allSettled) {
+        return {settled: false, perCollection: settleExit.perCollection};
+    }
+
+    for (const entry of settleExit.perCollection) {
+        const result = (Array.isArray(results) ? results : []).find(item => item?.collectionName === entry.collectionName);
+
+        await appendFn({...entry.auditRecord, collectionName: entry.collectionName, parkingName: result?.promotion?.parkingName ?? null}, {dir: auditDir});
+    }
+
+    // Resolve the non-clean marker the repair wrote — the run is now genuinely settled across runs, not just for
+    // this process's exit code.
+    await clearFn({statePath});
+
+    writeLog?.(settleExit.perCollection.length);
+
+    return {settled: true, perCollection: settleExit.perCollection};
+}
+
+/**
  * Main execution function for the defragmentation process.
  *
  * It orchestrates the Snapshot -> Extract -> Shadow Load -> Promote -> Cleanup pipeline.
@@ -1539,23 +1595,23 @@ async function defragChromaDB() {
             if (anyRepairNonClean(results)) {
                 // Autonomous accepted-loss settlement (zero operator-ack, no runtime escalate): when EVERY
                 // non-clean collection's residue is bounded AND deterministically-terminal, self-settle it —
-                // record a durable audit entry per collection and exit clean, with no human. Transient residue
+                // record a durable audit entry per collection AND clear the non-clean defrag marker (so the next
+                // run is not blocked as DEFRAG_INCOMPLETE_STATE), then exit clean with no human. Transient residue
                 // (heal-path → the data-recovery actuator) or a systemic-fault (mass terminal = a misconfigured
                 // embedder, frozen) keeps the loud non-clean exit below.
-                const settleExit = resolveAutonomousRepairExit({
-                    results,
-                    normalizeResidue: normalizeUnrecoverableEntry,
-                    provider        : config.embeddingProvider,
-                    contextBudget   : embedBudgetTokens
-                });
+                if (!dryRun) {
+                    const settlement = await applyAutonomousSettlement({
+                        results,
+                        statePath,
+                        auditDir     : path.dirname(statePath),
+                        provider     : config.embeddingProvider,
+                        contextBudget: embedBudgetTokens,
+                        writeLog     : settledCount => console.log(`   ♻️  Autonomous accepted-loss: all ${settledCount} non-clean collection(s) held only bounded, deterministically-terminal residue — settled + recorded to ${path.join(path.dirname(statePath), 'auto-accepted-loss.jsonl')}, and the defrag marker cleared so the next run is unblocked. No operator page; zero ack.`)
+                    });
 
-                if (!dryRun && settleExit.allSettled) {
-                    const auditDir = path.dirname(statePath);
-                    for (const entry of settleExit.perCollection) {
-                        await appendAutoAcceptedLoss(entry.auditRecord, {dir: auditDir});
+                    if (settlement.settled) {
+                        return;
                     }
-                    console.log(`   ♻️  Autonomous accepted-loss: all ${settleExit.perCollection.length} non-clean collection(s) held only bounded, deterministically-terminal residue — settled + recorded to ${path.join(auditDir, 'auto-accepted-loss.jsonl')}. No operator page; zero ack.`);
-                    return;
                 }
 
                 const abortedNames  = results.filter(result => result.aborted).map(result => result.collectionName),

--- a/ai/services/memory-core/helpers/acceptedLossAuditStore.mjs
+++ b/ai/services/memory-core/helpers/acceptedLossAuditStore.mjs
@@ -1,0 +1,70 @@
+import {appendFile, mkdir, readFile} from 'fs/promises';
+import path                          from 'path';
+
+/**
+ * @module ai/services/memory-core/helpers/acceptedLossAuditStore
+ * @summary Durable JSONL audit log for AUTONOMOUS accepted-loss settlements — the observability sink for
+ * `decideAcceptedLossSettlement`'s `auto-settle` disposition. Append-only: every autonomous settlement
+ * records its `auto-accepted-loss` audit entry (ids + reasons + the shared residue fingerprint) so an
+ * operator, when one is present, can review the accepted losses asynchronously — but the system NEVER
+ * blocks on a human and there is no ack. This is telemetry, not a gate. Mirrors the `recoveryRunStateStore`
+ * JSONL shape: I/O at the edge only, deterministic content. The fingerprint is the auto-reopen key — a later
+ * embedding-capability change re-opens the residue, so an audited loss is recorded-and-reversible, not silent.
+ */
+
+const AUDIT_FILE_NAME = 'auto-accepted-loss.jsonl';
+
+/**
+ * @summary The JSONL audit-log path within a state directory.
+ * @param {String} dir
+ * @returns {String}
+ */
+export function getAcceptedLossAuditFilePath(dir) {
+    return path.join(dir, AUDIT_FILE_NAME);
+}
+
+/**
+ * @summary Appends one `auto-accepted-loss` audit entry to the durable JSONL log (creating the dir if needed).
+ * @param {Object} entry The `decideAcceptedLossSettlement` `auditRecord` (or any JSON-serializable record).
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @returns {Promise<String>} The audit-log file path written to.
+ * @throws {TypeError} when `entry` is not an object or `dir` is missing/empty.
+ */
+export async function appendAutoAcceptedLoss(entry, {dir} = {}) {
+    if (!entry || typeof entry !== 'object') {
+        throw new TypeError('appendAutoAcceptedLoss: entry object is required');
+    }
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('appendAutoAcceptedLoss: dir is required');
+    }
+
+    await mkdir(dir, {recursive: true});
+
+    const filePath = getAcceptedLossAuditFilePath(dir);
+    await appendFile(filePath, `${JSON.stringify(entry)}\n`, 'utf8');
+
+    return filePath;
+}
+
+/**
+ * @summary Reads all `auto-accepted-loss` audit entries from the durable JSONL log (oldest → newest).
+ * A missing log returns `[]` (no settlements recorded yet) — never throws on absence.
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @returns {Promise<Object[]>} The parsed audit entries in append order.
+ */
+export async function readAutoAcceptedLossAudit({dir} = {}) {
+    let text;
+
+    try {
+        text = await readFile(getAcceptedLossAuditFilePath(dir), 'utf8');
+    } catch (error) {
+        if (error?.code === 'ENOENT') {
+            return [];
+        }
+        throw error;
+    }
+
+    return text.split('\n').filter(Boolean).map(line => JSON.parse(line));
+}

--- a/ai/services/memory-core/helpers/acceptedLossSettlement.mjs
+++ b/ai/services/memory-core/helpers/acceptedLossSettlement.mjs
@@ -100,3 +100,53 @@ export function decideAcceptedLossSettlement({
         }
     };
 }
+
+/**
+ * @summary Resolves the autonomous exit decision for a full set of per-collection repair results — the
+ * pure heart of the `defragChromaDB` non-clean exit path under the zero-ack / no-escalate mandate. Runs
+ * `decideAcceptedLossSettlement` over each non-clean collection's residue and reports whether EVERY
+ * non-clean collection autonomously accepted-loss-settled (so the run may exit clean) or any collection
+ * needs the heal-path (transient → the data-recovery actuator) or hit a systemic-fault (freeze). Pure: no
+ * I/O — the caller persists each `auditRecord` and chooses the exit code.
+ *
+ * @param {Object} options
+ * @param {Object[]} [options.results=[]] Per-collection repair results (`{collectionName, aborted, partialPromoted, unrecoverable, sourceCount}`).
+ * @param {Function} [options.normalizeResidue] Maps a raw `unrecoverable` entry to `{id, reason}` (the caller's `normalizeUnrecoverableEntry`).
+ * @param {Array<String>} [options.terminalReasons=TERMINAL_REASONS]
+ * @param {{maxRatio: Number, maxAbsolute: Number}} [options.systemicFaultBound=DEFAULT_SYSTEMIC_FAULT_BOUND]
+ * @param {String} [options.strategyVersion='']
+ * @param {String} [options.provider='']
+ * @param {Number|String} [options.contextBudget='']
+ * @returns {Object} `{allSettled, perCollection: [{collectionName, disposition, reasonCode, auditRecord}]}`. `allSettled` is true iff there is ≥1 non-clean collection and EVERY one's disposition is `auto-settle`.
+ */
+export function resolveAutonomousRepairExit({
+    results            = [],
+    normalizeResidue   = row => ({id: row?.id, reason: row?.reason}),
+    terminalReasons    = TERMINAL_REASONS,
+    systemicFaultBound = DEFAULT_SYSTEMIC_FAULT_BOUND,
+    strategyVersion    = '',
+    provider           = '',
+    contextBudget      = ''
+} = {}) {
+    const nonClean = (Array.isArray(results) ? results : []).filter(result => result?.aborted || result?.partialPromoted);
+
+    const perCollection = nonClean.map(result => {
+        const residue  = (Array.isArray(result.unrecoverable) ? result.unrecoverable : []).map(normalizeResidue),
+              decision = decideAcceptedLossSettlement({
+                  residue,
+                  collectionSize: result.sourceCount ?? 0,
+                  terminalReasons,
+                  systemicFaultBound,
+                  strategyVersion,
+                  provider,
+                  contextBudget
+              });
+
+        return {collectionName: result.collectionName, disposition: decision.disposition, reasonCode: decision.reasonCode, auditRecord: decision.auditRecord};
+    });
+
+    return {
+        allSettled   : perCollection.length > 0 && perCollection.every(entry => entry.disposition === 'auto-settle'),
+        perCollection
+    };
+}

--- a/ai/services/memory-core/helpers/acceptedLossSettlement.mjs
+++ b/ai/services/memory-core/helpers/acceptedLossSettlement.mjs
@@ -1,0 +1,102 @@
+import {TERMINAL_REASONS, computeResidueFingerprint} from './classifyRepairResidue.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/acceptedLossSettlement
+ * @summary Pure decider for the AUTONOMOUS accepted-loss settlement — the value-delivering leaf of the
+ * Memory Core accepted-loss recovery, re-scoped from operator-acknowledged to fully-autonomous per the
+ * v13.1 self-heal mandate (zero operator-ack; no runtime escalate). Given a repair's unrecoverable residue,
+ * the collection size, and a systemic-fault bound, it decides — with NO operator and NO runtime escalate —
+ * one of:
+ *
+ *   - `clean`         — no residue;
+ *   - `heal-path`     — any transient / healable reason is present → route to the autonomous data-recovery
+ *                       actuator (it is NOT accepted loss; never silent-accept recoverable loss);
+ *   - `systemic-fault`— every row is deterministically-terminal BUT the loss exceeds the systemic-fault
+ *                       bound → a misconfigured embedder reporting everything terminal, not bounded accepted
+ *                       loss → FREEZE + record telemetry; NEVER a mass auto-settle;
+ *   - `auto-settle`   — every row is deterministically-terminal AND the loss is bounded → record a durable
+ *                       `auto-accepted-loss` audit entry and let the run exit clean, autonomously.
+ *
+ * The terminal reasons (`embedding-context-exceeded` / `document-absent`) are facts from the embed attempt,
+ * not judgments, so a bounded set is safe to settle without a human. The audit record carries the shared
+ * residue fingerprint, so a later embedding-capability change (chunking, larger context) re-opens the
+ * residue by construction. Pure + deterministic (no I/O, no time/randomness): the durable audit-log
+ * persistence and the `defragChromaDB` exit-wiring are separate consumers.
+ */
+
+/**
+ * Default systemic-fault bound: a terminal-residue ratio above 5% OR more than 100 absolute rows is treated
+ * as a systemic fault (a misconfigured embedder / mass corruption), not bounded accepted loss.
+ * @type {{maxRatio: Number, maxAbsolute: Number}}
+ */
+export const DEFAULT_SYSTEMIC_FAULT_BOUND = Object.freeze({maxRatio: 0.05, maxAbsolute: 100});
+
+/**
+ * @summary Decides the autonomous disposition of a repair's unrecoverable residue: `auto-settle`,
+ * `systemic-fault`, `heal-path`, or `clean`. No operator, no runtime escalate.
+ *
+ * @param {Object} options
+ * @param {Array<Object>} [options.residue=[]] `[{id, reason}]` unrecoverable rows.
+ * @param {Number} [options.collectionSize=0] Total rows in the collection (the ratio denominator). `0` → ratio is treated as infinite (any terminal residue is over-bound unless `maxAbsolute` saves it).
+ * @param {Array<String>} [options.terminalReasons=TERMINAL_REASONS] The deterministic-terminal reason whitelist.
+ * @param {{maxRatio: Number, maxAbsolute: Number}} [options.systemicFaultBound=DEFAULT_SYSTEMIC_FAULT_BOUND] The bounded-vs-systemic threshold.
+ * @param {String} [options.strategyVersion='']
+ * @param {String} [options.provider='']
+ * @param {Number|String} [options.contextBudget='']
+ * @returns {Object} `{disposition, reasonCode, auditRecord, ...}`. `auditRecord` is populated only for `auto-settle`.
+ */
+export function decideAcceptedLossSettlement({
+    residue            = [],
+    collectionSize     = 0,
+    terminalReasons    = TERMINAL_REASONS,
+    systemicFaultBound = DEFAULT_SYSTEMIC_FAULT_BOUND,
+    strategyVersion    = '',
+    provider           = '',
+    contextBudget      = ''
+} = {}) {
+    const rows = Array.isArray(residue) ? residue : [];
+
+    if (rows.length === 0) {
+        return {disposition: 'clean', reasonCode: 'no-residue', auditRecord: null};
+    }
+
+    const nonTerminalReasons = [...new Set(rows
+        .map(row => row?.reason)
+        .filter(reason => !terminalReasons.includes(reason)))];
+
+    // Any transient / healable reason → the autonomous data-recovery actuator owns it; never silent-accept.
+    if (nonTerminalReasons.length > 0) {
+        return {disposition: 'heal-path', reasonCode: 'transient-or-healable-residue', nonTerminalReasons, auditRecord: null};
+    }
+
+    // All deterministically-terminal: bounded → auto-settle; mass → systemic-fault (freeze + record).
+    const {maxRatio, maxAbsolute} = systemicFaultBound,
+          ratio                   = collectionSize > 0 ? rows.length / collectionSize : Infinity,
+          overBound               = rows.length > maxAbsolute || ratio > maxRatio;
+
+    if (overBound) {
+        return {
+            disposition: 'systemic-fault',
+            reasonCode : 'terminal-residue-over-systemic-fault-bound',
+            auditRecord: null,
+            bound      : {residueCount: rows.length, collectionSize, ratio, maxRatio, maxAbsolute}
+        };
+    }
+
+    return {
+        disposition: 'auto-settle',
+        reasonCode : 'bounded-terminal-residue-auto-accepted',
+        auditRecord: {
+            schemaVersion  : 1,
+            type           : 'auto-accepted-loss',
+            fingerprint    : computeResidueFingerprint({residue: rows, strategyVersion, provider, contextBudget, terminalReasons}),
+            acceptedIds    : rows.map(row => row?.id).sort(),
+            residueCount   : rows.length,
+            collectionSize,
+            terminalReasons: [...(Array.isArray(terminalReasons) ? terminalReasons : [])].sort(),
+            strategyVersion,
+            provider,
+            contextBudget  : String(contextBudget)
+        }
+    };
+}

--- a/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
@@ -1,14 +1,20 @@
 import {test, expect} from '@playwright/test';
+import {mkdtemp, rm}  from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
 import {
     anyRepairNonClean,
+    applyAutonomousSettlement,
     assertDefragTargetSupported,
+    assertNoIncompleteDefragState,
     createUnrecoverablePreview,
     formatMemoryCoreRepairProgress,
     formatUnrecoverablePreview,
     promoteLoadedShadowCollection,
     repairMemoryCoreCollectionViaResumableShadow,
     repairMemoryCoreCollectionsViaFullEnumeration,
-    runDefragChromaDBCli
+    runDefragChromaDBCli,
+    writeDefragState
 } from '../../../../../../ai/scripts/maintenance/defragChromaDB.mjs';
 
 /**
@@ -799,5 +805,74 @@ test.describe('formatMemoryCoreRepairProgress — timestamped operator progress 
                 total    : 4
             }
         })).toBe(`   [${now}] ⏳ 'neo-agent-memory': unexpected-phase 75% (3/4)`);
+    });
+});
+
+test.describe('applyAutonomousSettlement — a settled clean exit clears the non-clean marker', () => {
+    const partial = (collectionName, residue, sourceCount, parkingName) => ({
+        collectionName, partialPromoted: true, aborted: false, unrecoverable: residue, sourceCount,
+        promotion: {parkingName}
+    });
+
+    test('all-bounded-terminal → settles, audits WITH the parking context, clears the marker', async () => {
+        const audits = [], cleared = [];
+
+        const result = await applyAutonomousSettlement({
+            results  : [partial('mc-graph', [{id: 'a', reason: 'document-absent'}], 10000, 'mc-graph-parking-1')],
+            statePath: '/state/marker.json',
+            auditDir : '/state',
+            appendFn : async (entry, opts) => { audits.push({entry, opts}); },
+            clearFn  : async opts => { cleared.push(opts); }
+        });
+
+        expect(result.settled).toBe(true);
+        expect(cleared).toEqual([{statePath: '/state/marker.json'}]);
+        expect(audits).toHaveLength(1);
+        expect(audits[0].entry).toMatchObject({type: 'auto-accepted-loss', collectionName: 'mc-graph', parkingName: 'mc-graph-parking-1'});
+        expect(audits[0].opts).toEqual({dir: '/state'});
+    });
+
+    test('any heal-path (transient) collection → NOT settled, no audit, marker left intact', async () => {
+        const audits = [], cleared = [];
+
+        const result = await applyAutonomousSettlement({
+            results: [
+                partial('mc-graph',  [{id: 'a', reason: 'document-absent'}],  10000, 'p1'),
+                partial('mc-memory', [{id: 'b', reason: 'provider-timeout'}], 10000, 'p2')
+            ],
+            statePath: '/state/marker.json',
+            auditDir : '/state',
+            appendFn : async entry => { audits.push(entry); },
+            clearFn  : async opts => { cleared.push(opts); }
+        });
+
+        expect(result.settled).toBe(false);
+        expect(audits).toHaveLength(0);
+        expect(cleared).toHaveLength(0);
+    });
+
+    test('the next maintenance pass is NOT blocked after a settled run (real marker lifecycle)', async () => {
+        const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'neo-defrag-settle-'));
+
+        try {
+            const statePath = path.join(tmpDir, 'defrag-state.json');
+
+            // the repair wrote a non-clean marker; it WOULD block the next run (anchor the defect)
+            await writeDefragState({statePath, state: {phase: 'memory-core-repair-partial-promoted', targetName: 'memory-core'}});
+            await expect(assertNoIncompleteDefragState({statePath, allowedPhases: []})).rejects.toThrow(/Incomplete Chroma defrag state/);
+
+            // a settled autonomous run (real clearDefragState + real audit append into tmpDir)
+            const result = await applyAutonomousSettlement({
+                results : [partial('mc-graph', [{id: 'a', reason: 'document-absent'}], 10000, 'parking-1')],
+                statePath,
+                auditDir: tmpDir
+            });
+            expect(result.settled).toBe(true);
+
+            // the next run is now unblocked — the marker is resolved
+            await expect(assertNoIncompleteDefragState({statePath, allowedPhases: []})).resolves.toBeUndefined();
+        } finally {
+            await rm(tmpDir, {recursive: true, force: true});
+        }
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAuditStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAuditStore.spec.mjs
@@ -1,0 +1,69 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {mkdtemp, rm}  from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+
+import {
+    appendAutoAcceptedLoss,
+    getAcceptedLossAuditFilePath,
+    readAutoAcceptedLossAudit
+} from '../../../../../../../ai/services/memory-core/helpers/acceptedLossAuditStore.mjs';
+
+test.describe('acceptedLossAuditStore — durable autonomous accepted-loss audit log', () => {
+    let tmpDir;
+
+    test.beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), 'neo-accepted-loss-audit-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(tmpDir, {recursive: true, force: true});
+    });
+
+    const entry = (overrides = {}) => ({
+        schemaVersion: 1,
+        type         : 'auto-accepted-loss',
+        fingerprint  : 'fp-abc',
+        acceptedIds  : ['a', 'b'],
+        residueCount : 2,
+        ...overrides
+    });
+
+    test('append → read round-trips entries in append order', async () => {
+        await appendAutoAcceptedLoss(entry({fingerprint: 'fp-1'}), {dir: tmpDir});
+        await appendAutoAcceptedLoss(entry({fingerprint: 'fp-2'}), {dir: tmpDir});
+
+        const records = await readAutoAcceptedLossAudit({dir: tmpDir});
+
+        expect(records).toHaveLength(2);
+        expect(records.map(r => r.fingerprint)).toEqual(['fp-1', 'fp-2']);
+        expect(records[0]).toMatchObject({type: 'auto-accepted-loss', acceptedIds: ['a', 'b']});
+    });
+
+    test('a missing log reads as [] (no settlements yet) — never throws on absence', async () => {
+        expect(await readAutoAcceptedLossAudit({dir: tmpDir})).toEqual([]);
+    });
+
+    test('append creates the state dir if it does not exist', async () => {
+        const nested = path.join(tmpDir, 'deep', 'state');
+        await appendAutoAcceptedLoss(entry(), {dir: nested});
+
+        expect(await readAutoAcceptedLossAudit({dir: nested})).toHaveLength(1);
+        expect(getAcceptedLossAuditFilePath(nested)).toBe(path.join(nested, 'auto-accepted-loss.jsonl'));
+    });
+
+    test('append is purely append-only (telemetry, not a gate): existing entries are preserved', async () => {
+        await appendAutoAcceptedLoss(entry({fingerprint: 'fp-old'}), {dir: tmpDir});
+        await appendAutoAcceptedLoss(entry({fingerprint: 'fp-new'}), {dir: tmpDir});
+
+        const records = await readAutoAcceptedLossAudit({dir: tmpDir});
+        expect(records.map(r => r.fingerprint)).toEqual(['fp-old', 'fp-new']);
+    });
+
+    test('rejects a missing entry / missing dir', async () => {
+        await expect(appendAutoAcceptedLoss(null, {dir: tmpDir})).rejects.toThrow('entry');
+        await expect(appendAutoAcceptedLoss(entry(), {})).rejects.toThrow('dir');
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossSettlement.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossSettlement.spec.mjs
@@ -1,0 +1,82 @@
+import {test, expect}                                               from '@playwright/test';
+import Neo                                                          from '../../../../../../../src/Neo.mjs';
+import * as core                                                    from '../../../../../../../src/core/_export.mjs';
+import {decideAcceptedLossSettlement, DEFAULT_SYSTEMIC_FAULT_BOUND} from '../../../../../../../ai/services/memory-core/helpers/acceptedLossSettlement.mjs';
+import {computeResidueFingerprint, TERMINAL_REASONS}                from '../../../../../../../ai/services/memory-core/helpers/classifyRepairResidue.mjs';
+
+// Pure AUTONOMOUS decider (no operator, no runtime escalate). Decides clean / heal-path / systemic-fault /
+// auto-settle for a repair's unrecoverable residue, bounded by a systemic-fault threshold.
+
+const CTX = {strategyVersion: 'v1', provider: 'openAiCompatible', contextBudget: 32768};
+
+test.describe('decideAcceptedLossSettlement — autonomous accepted-loss disposition', () => {
+    test('no residue → clean (no settlement, no escalate)', () => {
+        expect(decideAcceptedLossSettlement({residue: [], collectionSize: 1000, ...CTX}))
+            .toMatchObject({disposition: 'clean', reasonCode: 'no-residue', auditRecord: null});
+    });
+
+    test('any transient/healable reason → heal-path (route to the actuator, never silent-accept)', () => {
+        const residue = [{id: 'a', reason: 'embedding-context-exceeded'}, {id: 'b', reason: 'provider-timeout'}],
+              result  = decideAcceptedLossSettlement({residue, collectionSize: 1000, ...CTX});
+
+        expect(result.disposition).toBe('heal-path');
+        expect(result.nonTerminalReasons).toEqual(['provider-timeout']);
+        expect(result.auditRecord).toBeNull();
+    });
+
+    test('all-terminal + bounded → auto-settle with a durable audit record (no ack, no escalate)', () => {
+        const residue = [{id: 'a', reason: 'embedding-context-exceeded'}, {id: 'b', reason: 'document-absent'}],
+              result  = decideAcceptedLossSettlement({residue, collectionSize: 10000, ...CTX});
+
+        expect(result.disposition).toBe('auto-settle');
+        expect(result.reasonCode).toBe('bounded-terminal-residue-auto-accepted');
+        expect(result.auditRecord).toMatchObject({
+            schemaVersion : 1,
+            type          : 'auto-accepted-loss',
+            acceptedIds   : ['a', 'b'],
+            residueCount  : 2,
+            collectionSize: 10000
+        });
+        // the audit fingerprint is leaf-1's shared hash → auto-reopens on a capability change
+        expect(result.auditRecord.fingerprint).toBe(
+            computeResidueFingerprint({residue, ...CTX, terminalReasons: TERMINAL_REASONS})
+        );
+    });
+
+    test('all-terminal but over the ratio bound → systemic-fault (freeze + record, never mass auto-settle)', () => {
+        // 60 terminal rows in a 1000-row collection = 6% > the 5% default ratio bound.
+        const residue = Array.from({length: 60}, (_, i) => ({id: `x${i}`, reason: 'document-absent'})),
+              result  = decideAcceptedLossSettlement({residue, collectionSize: 1000, ...CTX});
+
+        expect(result.disposition).toBe('systemic-fault');
+        expect(result.reasonCode).toBe('terminal-residue-over-systemic-fault-bound');
+        expect(result.auditRecord).toBeNull();
+        expect(result.bound).toMatchObject({residueCount: 60, collectionSize: 1000, maxRatio: 0.05});
+    });
+
+    test('all-terminal but over the absolute bound → systemic-fault even when the ratio is tiny', () => {
+        // 150 terminal rows but in a huge 1,000,000-row collection (0.015% ratio) → still systemic by maxAbsolute.
+        const residue = Array.from({length: 150}, (_, i) => ({id: `x${i}`, reason: 'embedding-context-exceeded'})),
+              result  = decideAcceptedLossSettlement({residue, collectionSize: 1_000_000, ...CTX});
+
+        expect(result.disposition).toBe('systemic-fault');
+        expect(result.bound.maxAbsolute).toBe(DEFAULT_SYSTEMIC_FAULT_BOUND.maxAbsolute);
+    });
+
+    test('a custom (tighter) systemic-fault bound flips a small terminal residue to systemic-fault', () => {
+        const residue = [{id: 'a', reason: 'document-absent'}, {id: 'b', reason: 'document-absent'}],
+              result  = decideAcceptedLossSettlement({residue, collectionSize: 1000, systemicFaultBound: {maxRatio: 0.001, maxAbsolute: 1}, ...CTX});
+
+        expect(result.disposition).toBe('systemic-fault');
+    });
+
+    test('the audit record is order-independent (sorted acceptedIds + fingerprint)', () => {
+        const ordered   = [{id: 'a', reason: 'document-absent'}, {id: 'b', reason: 'embedding-context-exceeded'}],
+              reordered = [{id: 'b', reason: 'embedding-context-exceeded'}, {id: 'a', reason: 'document-absent'}],
+              r1        = decideAcceptedLossSettlement({residue: ordered, collectionSize: 10000, ...CTX}),
+              r2        = decideAcceptedLossSettlement({residue: reordered, collectionSize: 10000, ...CTX});
+
+        expect(r1.auditRecord.acceptedIds).toEqual(['a', 'b']);
+        expect(r1.auditRecord.fingerprint).toBe(r2.auditRecord.fingerprint);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossSettlement.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossSettlement.spec.mjs
@@ -1,8 +1,8 @@
-import {test, expect}                                               from '@playwright/test';
-import Neo                                                          from '../../../../../../../src/Neo.mjs';
-import * as core                                                    from '../../../../../../../src/core/_export.mjs';
-import {decideAcceptedLossSettlement, DEFAULT_SYSTEMIC_FAULT_BOUND} from '../../../../../../../ai/services/memory-core/helpers/acceptedLossSettlement.mjs';
-import {computeResidueFingerprint, TERMINAL_REASONS}                from '../../../../../../../ai/services/memory-core/helpers/classifyRepairResidue.mjs';
+import {test, expect}                                                                            from '@playwright/test';
+import Neo                                                                                       from '../../../../../../../src/Neo.mjs';
+import * as core                                                                                 from '../../../../../../../src/core/_export.mjs';
+import {decideAcceptedLossSettlement, DEFAULT_SYSTEMIC_FAULT_BOUND, resolveAutonomousRepairExit} from '../../../../../../../ai/services/memory-core/helpers/acceptedLossSettlement.mjs';
+import {computeResidueFingerprint, TERMINAL_REASONS}                                             from '../../../../../../../ai/services/memory-core/helpers/classifyRepairResidue.mjs';
 
 // Pure AUTONOMOUS decider (no operator, no runtime escalate). Decides clean / heal-path / systemic-fault /
 // auto-settle for a repair's unrecoverable residue, bounded by a systemic-fault threshold.
@@ -78,5 +78,56 @@ test.describe('decideAcceptedLossSettlement — autonomous accepted-loss disposi
 
         expect(r1.auditRecord.acceptedIds).toEqual(['a', 'b']);
         expect(r1.auditRecord.fingerprint).toBe(r2.auditRecord.fingerprint);
+    });
+});
+
+test.describe('resolveAutonomousRepairExit — per-results autonomous exit decision', () => {
+    const nonClean = (collectionName, residue, sourceCount, partialPromoted = true) => ({
+        collectionName, partialPromoted, aborted: !partialPromoted, unrecoverable: residue, sourceCount
+    });
+
+    test('every non-clean collection bounded-terminal → allSettled true (run may exit clean)', () => {
+        const results = [
+                  {collectionName: 'mc-memory', partialPromoted: false, aborted: false}, // clean → ignored
+                  nonClean('mc-graph', [{id: 'a', reason: 'document-absent'}], 10000)
+              ],
+              exit = resolveAutonomousRepairExit({results, ...CTX});
+
+        expect(exit.allSettled).toBe(true);
+        expect(exit.perCollection).toHaveLength(1);
+        expect(exit.perCollection[0]).toMatchObject({collectionName: 'mc-graph', disposition: 'auto-settle'});
+        expect(exit.perCollection[0].auditRecord).toMatchObject({type: 'auto-accepted-loss'});
+    });
+
+    test('any heal-path (transient) collection → allSettled false (route to the actuator, never exit clean)', () => {
+        const results = [
+                  nonClean('mc-graph', [{id: 'a', reason: 'document-absent'}], 10000),
+                  nonClean('mc-memory', [{id: 'b', reason: 'provider-timeout'}], 10000)
+              ],
+              exit = resolveAutonomousRepairExit({results, ...CTX});
+
+        expect(exit.allSettled).toBe(false);
+        expect(exit.perCollection.map(e => e.disposition).sort()).toEqual(['auto-settle', 'heal-path']);
+    });
+
+    test('a systemic-fault collection → allSettled false (freeze, never mass auto-settle)', () => {
+        const residue = Array.from({length: 80}, (_, i) => ({id: `x${i}`, reason: 'document-absent'})),
+              exit    = resolveAutonomousRepairExit({results: [nonClean('mc-graph', residue, 1000)], ...CTX});
+
+        expect(exit.allSettled).toBe(false);
+        expect(exit.perCollection[0].disposition).toBe('systemic-fault');
+        expect(exit.perCollection[0].auditRecord).toBeNull();
+    });
+
+    test('normalizeResidue maps raw entries → {id, reason} (mirrors normalizeUnrecoverableEntry)', () => {
+        const raw = [{id: 42, reason: 'document-absent', message: 'gone'}], // raw id is a number
+              exit = resolveAutonomousRepairExit({
+                  results         : [nonClean('mc-graph', raw, 10000)],
+                  normalizeResidue: row => ({id: String(row.id), reason: row.reason}),
+                  ...CTX
+              });
+
+        expect(exit.perCollection[0].disposition).toBe('auto-settle');
+        expect(exit.perCollection[0].auditRecord.acceptedIds).toEqual(['42']);
     });
 });


### PR DESCRIPTION
Resolves #14118

Re-scopes #14084 leaf 3 from the operator-acknowledged accepted-loss store to **fully-autonomous accepted-loss settlement**, per @tobiu's v13.1 mandate (#14132: 100% autonomous self-healing; zero operator-ack; DELETE runtime escalate). Supersedes the dropped operator-ack PR #14120.

When a Memory Core repair leaves only **bounded, deterministically-terminal** residue (documents that exceed the embedding context / absent sources — facts from the embed attempt, not judgments), the defrag run now **settles it autonomously**: records a durable `auto-accepted-loss` audit entry and exits clean — with **no operator, no ack, no runtime escalate**. This stops the perpetual `exit 1` (a page into an operatorless-cloud void) that #13999 surfaced, without ever silently accepting recoverable or mass loss.

## What changed

Three pure + tested helpers and one thin CLI wiring:

- **`decideAcceptedLossSettlement`** (`ai/services/memory-core/helpers/acceptedLossSettlement.mjs`) — pure disposition decider: `clean` / `heal-path` (any transient reason → route to the #14134 data-recovery actuator, never silent-accept) / `systemic-fault` (terminal residue over the bound = a misconfigured embedder → freeze + record, never mass-settle — the #14115 `expectedDimension` false-storm class) / `auto-settle` (bounded deterministic-terminal → a durable audit record + clean exit). Reuses the merged #14106 classifier's `TERMINAL_REASONS` + `computeResidueFingerprint` (the fingerprint is the auto-reopen key: a later embedding-capability change re-opens the residue, so the loss is recorded-and-reversible, not silent).
- **`resolveAutonomousRepairExit`** — pure per-results gate: `allSettled` iff there is ≥1 non-clean collection and every one's disposition is `auto-settle`.
- **`acceptedLossAuditStore`** (`appendAutoAcceptedLoss` / `readAutoAcceptedLossAudit`) — durable JSONL telemetry log (observability, NOT a gate; the system never blocks on a human).
- **`defragChromaDB.mjs` exit-path wiring** (`:1537`) via the extracted, testable **`applyAutonomousSettlement`** — before the non-clean `exit 1`, run the resolver; if `allSettled` (and not dry-run), carry each collection's retained-parking context into the durable audit, persist it, **clear the non-clean defrag marker** (so the next maintenance pass isn't blocked as `DEFRAG_INCOMPLETE_STATE`), and exit 0; else keep the loud non-clean exit (heal-path → the actuator; systemic-fault → frozen).

## Review cycle 2 (@neo-gpt RC — durable-marker lifecycle)

Correct, sharp catch: the prior revision exited 0 but left the `memory-core-repair-partial-promoted` marker the repair had already written, so the *next* run would abort as `DEFRAG_INCOMPLETE_STATE` — a clean process exit that isn't settled across runs. Fixed: the settle path is extracted into `applyAutonomousSettlement`, which carries the retained-parking context into the durable `auto-accepted-loss` audit (the inspection surface that replaces the marker) **and then clears the marker** — so the run is genuinely settled across runs. Covered by a real-fs marker-lifecycle test that **fails against the pre-fix code** (RA2).

Evidence: L2 (unit) — 19 new tests cover the pure disposition decider + resolver + audit-store **+ the durable marker lifecycle** (a real-fs test proves the next maintenance pass is unblocked after a settled run; it fails against the pre-marker-clear code). Fully covers #14118's ACs, *including* the across-runs settled contract — not only the process exit code. Residual: the live end-to-end exit-0 on a real store is the orchestrator/operator-run domain (L3, deferred).

## Deltas from ticket

None of substance — matches the re-scoped #14118 Fix + Contract Ledger. The `heal-path` branch routes to the autonomous data-recovery actuator #14134 (sibling sub of #14132; design-choice converging in /ideation); until #14134 lands, transient residue keeps the non-clean exit — correct, it is genuinely not-yet-healable. No `strategyVersion` config leaf exists, so the fingerprint omits it (still binds residue + provider + context + terminality-policy).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/acceptedLossSettlement.spec.mjs` → **11 passed** (decider 7 + resolver 4: clean / heal-path / systemic-fault by ratio + absolute / auto-settle + fingerprint / order-independence / per-results allSettled gate / normalizeResidue).
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAuditStore.spec.mjs` → **5 passed** (round-trip, missing-log→[], dir-create, append-only, arg-guards).
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs` → **30 passed** (27 existing + 3 new `applyAutonomousSettlement` marker-lifecycle: settled → audits-with-parking-context + clears-marker; heal-path → not-settled + marker-intact; and a real-fs test proving the next run is unblocked after a settled run — it fails against the pre-fix code, per the review's RA2).

## Post-Merge Validation

- [ ] (orchestrator/operator domain, L3) On a real store whose only residue is a bounded set of unembeddable docs, the mutating defrag run exits 0 + writes `auto-accepted-loss.jsonl` to the state dir — no perpetual page. Pairs with the #14134 actuator landing for the heal-path branch.

Related: #14132 (DELETE-escalate umbrella), #14084 (parent), #14106 (classifier — merged, reused), #14134 (sibling — the data-recovery actuator for heal-path), #14068 (parking-retained lifecycle), #14039 (v13.1 epic). Supersedes the operator-ack approach (dropped PR #14120).

Authored by Grace (Claude Opus 4.8, Claude Code). Session 5ab545e1-f09e-46c5-ae62-8cf5b2b96193.
