### PR TITLE
feat(ai): re-route the 5 data-integrity producers to raw-evidence — drop actionClass:escalate (#14138)

### DIFF
--- a/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs
@@ -6,11 +6,11 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  * data-integrity detect-signal) — the DETECT half of the v13.1 corruption-recovery gate. Turns a Chroma
  * vector-coverage audit (`auditChromaVectorCoverage`) into a `recovery-diagnosis` when a Memory Core
  * collection is "up but data-gutted" (metadata rows present, vectors missing — the corruption-incident
- * shape), so the immune system can ESCALATE rather than report a gutted store as healthy.
+ * shape), so the autonomous recovery classifier can route a heal action rather than report a gutted store as healthy.
  *
  * Detect-only by construction: it consumes a coverage RESULT and emits a diagnosis — it performs no
  * repair / re-embed / restore / Chroma mutation (those are the recovery actuator + defrag). It emits
- * `recoveryClass: 'data-integrity'` + `details.actionClass: 'escalate'`, targeting the Memory Core
+ * `recoveryClass: 'data-integrity'` + raw per-collection `evidenceFacts` (the autonomous classifier derives the heal action), targeting the Memory Core
  * `compose-service` (per-collection drift carried in `evidenceFacts`/`details` — no per-collection
  * target kind, for blast-control). Mirrors the supervised-task producer-core pattern: pure, with the
  * audit result injected so it is testable in isolation.
@@ -20,14 +20,14 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  * @summary Builds a data-integrity `recovery-diagnosis` from a Chroma vector-coverage audit result.
  *
  * Pure — no I/O. Returns a diagnosis when ANY collection's coverage `ok === false` (drift); returns
- * `null` when every collection is clean (never a false escalation). The caller (the diagnostics daemon)
+ * `null` when every collection is clean (never a false-positive diagnosis). The caller (the diagnostics daemon)
  * supplies the `auditChromaVectorCoverage()` result + the Memory Core service id.
  *
  * @param {Object} options
  * @param {Object} options.coverageResult The `auditChromaVectorCoverage()` result — `{collections:[{name, ok, ...}]}`.
  * @param {Number} options.observedAt Epoch milliseconds when the audit was observed.
  * @param {String} options.serviceId The Memory Core compose-service identifier.
- * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity` / `escalate`) when drift is present, else `null`.
+ * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity`, raw evidence) when drift is present, else `null`.
  * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
  */
 export function buildDataIntegrityCoverageDiagnosis({coverageResult, observedAt, serviceId} = {}) {
@@ -60,7 +60,6 @@ export function buildDataIntegrityCoverageDiagnosis({coverageResult, observedAt,
         observedAt,
         source : 'data-integrity-coverage-monitor',
         details: {
-            actionClass       : 'escalate',
             reasonCode        : 'data-integrity-coverage-drift',
             driftedCollections: drifted.map(collection => collection.name)
         }

--- a/ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis.mjs
@@ -7,10 +7,10 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  * Every stored Memory Core vector must be the configured embedding dimension; a wrong-dimension vector is
  * unambiguous corruption (it breaks similarity search, and — unlike a count regression — has no legitimate
  * case). It turns per-collection dimension-audit samples into a `recovery-diagnosis` when any collection
- * holds mismatched-dimension vectors, so the immune system can ESCALATE rather than serve a corrupt index.
+ * holds mismatched-dimension vectors, so the autonomous recovery classifier can route a heal action rather than serve a corrupt index.
  *
  * Detect-only by construction: it consumes audit samples and emits a diagnosis — no repair / re-embed /
- * restore / mutation. It emits `recoveryClass: 'data-integrity'` + `details.actionClass: 'escalate'`,
+ * restore / mutation. It emits `recoveryClass: 'data-integrity'` + raw `evidenceFacts` (the autonomous classifier derives the heal action),
  * targeting the Memory Core `compose-service` (per-collection mismatch carried in `evidenceFacts`). Mirrors
  * the sibling producers' pure shape: the samples (the dimension audit) are injected — the audit + scheduling
  * are the consumer/daemon's concern — so it is testable in isolation.
@@ -21,14 +21,14 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  *
  * Pure — no I/O. Returns a diagnosis when ANY collection reports `mismatchedVectorCount > 0` (a stored
  * vector whose dimension ≠ the configured embedding dimension); returns `null` when every sampled collection
- * is clean (never a false escalation). Samples whose `mismatchedVectorCount` is not a finite number are
+ * is clean (never a false-positive). Samples whose `mismatchedVectorCount` is not a finite number are
  * ignored (an unread collection is not corruption).
  *
  * @param {Object} options
  * @param {Array<Object>} options.samples Per-collection dimension samples — `[{collection, expectedDimension, mismatchedVectorCount}]`.
  * @param {Number} options.observedAt Epoch milliseconds when the audit was observed.
  * @param {String} options.serviceId The Memory Core compose-service identifier.
- * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity` / `escalate`) when a mismatch is present, else `null`.
+ * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity`, raw evidence) when a mismatch is present, else `null`.
  * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
  */
 export function buildDimensionConsistencyDiagnosis({samples, observedAt, serviceId} = {}) {
@@ -63,7 +63,6 @@ export function buildDimensionConsistencyDiagnosis({samples, observedAt, service
         observedAt,
         source : 'data-integrity-dimension-monitor',
         details: {
-            actionClass          : 'escalate',
             reasonCode           : 'data-integrity-dimension-mismatch',
             mismatchedCollections: mismatched.map(sample => sample.collection)
         }

--- a/ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis.mjs
@@ -7,11 +7,11 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  * `integrity_check` audit (`checkChromaIntegrity` → `result.sqlite.checks`) into a `recovery-diagnosis`
  * when the unified store's SQLite integrity is broken — the *"malformed inverted index for FTS5"* shape
  * that recurred all through the corruption-incident forensics but was only ever a manual CLI line, never
- * a detect signal — so the immune system ESCALATES rather than leaving a structurally-corrupt store undetected.
+ * a detect signal — so the autonomous recovery classifier can route a heal action rather than leaving a structurally-corrupt store undetected.
  *
  * Detect-only by construction: it consumes a check RESULT and emits a diagnosis — it performs no
  * repair / FTS5 rebuild / mutation (those are operator-gated). It emits `recoveryClass: 'data-integrity'`
- * + `details.actionClass: 'escalate'`, targeting the Memory Core `compose-service` (per-pragma failure
+ * + raw `evidenceFacts` (the autonomous classifier derives the heal action), targeting the Memory Core `compose-service` (per-pragma failure
  * carried in `evidenceFacts`, with a bounded detail snippet — no unbounded SQLite output). Mirrors the
  * coverage-drift detect-producer: pure, with the audit result injected so it is testable in isolation.
  */
@@ -23,14 +23,14 @@ const MAX_DETAIL_LENGTH = 280;
  *
  * Pure — no I/O. Returns a diagnosis when ANY SQLite check is `ok === false` (a failed `quick_check` /
  * `integrity_check` — e.g. a malformed FTS5 index); returns `null` when every check passes (never a
- * false escalation). The caller (the diagnostics daemon) supplies the `checkChromaIntegrity()`
+ * false-positive). The caller (the diagnostics daemon) supplies the `checkChromaIntegrity()`
  * `result.sqlite` object + the Memory Core service id.
  *
  * @param {Object} options
  * @param {Object} options.sqliteResult The `checkChromaIntegrity()` `result.sqlite` — `{checks:[{pragma, ok, output, error}]}`.
  * @param {Number} options.observedAt Epoch milliseconds when the audit was observed.
  * @param {String} options.serviceId The Memory Core compose-service identifier.
- * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity` / `escalate`) when a check failed, else `null`.
+ * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity`, raw evidence) when a check failed, else `null`.
  * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
  */
 export function buildSqliteIntegrityDiagnosis({sqliteResult, observedAt, serviceId} = {}) {
@@ -62,7 +62,6 @@ export function buildSqliteIntegrityDiagnosis({sqliteResult, observedAt, service
         observedAt,
         source : 'data-integrity-sqlite-integrity-monitor',
         details: {
-            actionClass  : 'escalate',
             reasonCode   : 'data-integrity-sqlite-integrity-failure',
             failedPragmas: failed.map(check => check.pragma)
         }

--- a/ai/daemons/orchestrator/services/storeBloatDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/storeBloatDiagnosis.mjs
@@ -7,11 +7,11 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  * unified Chroma store can grow unbounded (un-pruned WAL, orphaned segments, churn); a store far over its
  * size budget, or growing too fast between samples, is a data-integrity signal. It turns an injected
  * `(storeSizeBytes, previousSizeBytes)` measurement + configured thresholds into a `recovery-diagnosis`
- * so the immune system ESCALATES rather than letting the store bloat silently.
+ * so the autonomous recovery classifier can route a heal action rather than letting the store bloat silently.
  *
  * Detect-only by construction: it consumes a size measurement and emits a diagnosis — it performs no
  * prune / vacuum / mutation (operator-gated remediation). It emits `recoveryClass: 'data-integrity'` +
- * `details.actionClass: 'escalate'`, targeting the Memory Core `compose-service`. The size measurement and
+ * raw `evidenceFacts` (the autonomous classifier derives the heal action), targeting the Memory Core `compose-service`. The size measurement and
  * the threshold config-leaves (read at the daemon use-site) are injected, so the producer is pure and
  * testable in isolation. A sub-signal whose threshold is non-finite is skipped (graceful).
  */
@@ -20,8 +20,8 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  * @summary Builds a data-integrity `recovery-diagnosis` from a store-size measurement + thresholds.
  *
  * Pure — no I/O. Returns a diagnosis when the store is over its ABSOLUTE budget OR has GROWN faster than
- * the growth-ratio budget since the previous sample; returns `null` when within budget (never a false
- * escalation). A non-finite `storeSizeBytes` (no measurement) returns `null`; a missing / zero
+ * the growth-ratio budget since the previous sample; returns `null` when within budget (never a
+ * false-positive). A non-finite `storeSizeBytes` (no measurement) returns `null`; a missing / zero
  * `previousSizeBytes` simply disables the growth sub-signal (absolute-only).
  *
  * @param {Object} options
@@ -30,7 +30,7 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  * @param {Object} options.thresholds `{absoluteBytes, growthRatio}` — config leaves read at the daemon use-site.
  * @param {Number} options.observedAt Epoch milliseconds when the measurement was observed.
  * @param {String} options.serviceId The Memory Core compose-service identifier.
- * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity` / `escalate`) when bloated, else `null`.
+ * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity`, raw evidence) when bloated, else `null`.
  * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
  */
 export function buildStoreBloatDiagnosis({storeSizeBytes, previousSizeBytes, thresholds, observedAt, serviceId} = {}) {
@@ -83,7 +83,6 @@ export function buildStoreBloatDiagnosis({storeSizeBytes, previousSizeBytes, thr
         observedAt,
         source        : 'data-integrity-store-bloat-monitor',
         details       : {
-            actionClass     : 'escalate',
             reasonCode      : 'data-integrity-store-bloat',
             triggeredSignals: signals.map(signal => signal.signal)
         }

--- a/ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.mjs
@@ -6,11 +6,11 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  * data-integrity detect-signal class (sibling of `dataIntegrityCoverageDiagnosis`). Memory Core collections
  * are append-mostly, so a vector-count DECREASE between samples is a near-unambiguous, threshold-free
  * data-loss signal. It turns per-collection `(previousCount, currentCount)` sample pairs into a
- * `recovery-diagnosis` when any collection regressed, so the immune system can ESCALATE rather than report
+ * `recovery-diagnosis` when any collection regressed, so the autonomous recovery classifier can route a heal action rather than report
  * a store that silently shrank as healthy.
  *
  * Detect-only by construction: it consumes count samples and emits a diagnosis — it performs no repair /
- * re-embed / restore / mutation. It emits `recoveryClass: 'data-integrity'` + `details.actionClass: 'escalate'`,
+ * re-embed / restore / mutation. It emits `recoveryClass: 'data-integrity'` + raw `evidenceFacts` (the autonomous classifier derives the heal action),
  * targeting the Memory Core `compose-service` (per-collection regression carried in `evidenceFacts`). Mirrors
  * the coverage-drift producer's pure shape: the samples are injected (the historical sample store + scheduling
  * are the consumer/daemon's concern), so it is testable in isolation.
@@ -21,14 +21,14 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  *
  * Pure — no I/O. Returns a diagnosis when ANY collection's `currentCount` is strictly less than its
  * `previousCount` (a regression in an append-mostly store); returns `null` when every collection is monotonic
- * (never a false escalation). Samples whose counts are not both finite numbers are ignored — a missing
+ * (never a false-positive). Samples whose counts are not both finite numbers are ignored — a missing
  * baseline is not a loss.
  *
  * @param {Object} options
  * @param {Array<Object>} options.samples Per-collection count samples — `[{collection, previousCount, currentCount}]`.
  * @param {Number} options.observedAt Epoch milliseconds when the sample was observed.
  * @param {String} options.serviceId The Memory Core compose-service identifier.
- * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity` / `escalate`) when a regression is present, else `null`.
+ * @returns {Object|null} A `recovery-diagnosis` event (`data-integrity`, raw evidence) when a regression is present, else `null`.
  * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
  */
 export function buildVectorCountMonotonicityDiagnosis({samples, observedAt, serviceId} = {}) {
@@ -66,7 +66,6 @@ export function buildVectorCountMonotonicityDiagnosis({samples, observedAt, serv
         observedAt,
         source : 'data-integrity-monotonicity-monitor',
         details: {
-            actionClass         : 'escalate',
             reasonCode          : 'data-integrity-vector-count-regression',
             regressedCollections: regressed.map(sample => sample.collection)
         }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.spec.mjs
@@ -4,10 +4,10 @@ import * as core                             from '../../../../../../../src/core
 import {buildDataIntegrityCoverageDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs';
 
 // Pure detect-producer (no I/O). Turns a Chroma vector-coverage audit into a data-integrity
-// recovery-diagnosis (escalate) when a collection is "up but data-gutted"; returns null when clean.
+// recovery-diagnosis (raw evidence, no escalate) when a collection is "up but data-gutted"; returns null when clean.
 
 test.describe('buildDataIntegrityCoverageDiagnosis — data-integrity coverage-drift detect-producer', () => {
-    test('drift (a collection with ok:false) -> a data-integrity/escalate recovery-diagnosis', () => {
+    test('drift (a collection with ok:false) -> a data-integrity raw-evidence recovery-diagnosis (no escalate)', () => {
         const diag = buildDataIntegrityCoverageDiagnosis({
             coverageResult: {collections: [
                 {name: 'neo-agent-memory',   ok: false, missingFromVectorCount: 10, extraInVectorCount: 0},
@@ -23,7 +23,7 @@ test.describe('buildDataIntegrityCoverageDiagnosis — data-integrity coverage-d
             confidence    : 1,
             targetIdentity: {kind: 'compose-service', id: 'memory-core'},
             source        : 'data-integrity-coverage-monitor',
-            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-coverage-drift', driftedCollections: ['neo-agent-memory']}
+            details       : {reasonCode: 'data-integrity-coverage-drift', driftedCollections: ['neo-agent-memory']}
         });
         expect(diag.evidenceFacts).toEqual([
             {type: 'vector-coverage-drift', collection: 'neo-agent-memory', missingFromVectorCount: 10, extraInVectorCount: 0}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis.spec.mjs
@@ -4,10 +4,10 @@ import * as core                            from '../../../../../../../src/core/
 import {buildDimensionConsistencyDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/dimensionConsistencyDiagnosis.mjs';
 
 // Pure detect-producer (no I/O). A stored vector whose dimension ≠ the configured embedding dimension is
-// unambiguous corruption → a data-integrity/escalate recovery-diagnosis; all-matching samples → null.
+// unambiguous corruption → a data-integrity raw-evidence recovery-diagnosis; all-matching samples → null.
 
 test.describe('buildDimensionConsistencyDiagnosis — embedding-dimension consistency detect-producer', () => {
-    test('a collection holding mismatched-dimension vectors -> a data-integrity/escalate recovery-diagnosis', () => {
+    test('a collection holding mismatched-dimension vectors -> a data-integrity raw-evidence recovery-diagnosis (no escalate)', () => {
         const diag = buildDimensionConsistencyDiagnosis({
             samples: [
                 {collection: 'neo-agent-memory',   expectedDimension: 4096, mismatchedVectorCount: 12},
@@ -24,7 +24,7 @@ test.describe('buildDimensionConsistencyDiagnosis — embedding-dimension consis
             confidence    : 1,
             targetIdentity: {kind: 'compose-service', id: 'memory-core'},
             source        : 'data-integrity-dimension-monitor',
-            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-dimension-mismatch', mismatchedCollections: ['neo-agent-memory']}
+            details       : {reasonCode: 'data-integrity-dimension-mismatch', mismatchedCollections: ['neo-agent-memory']}
         });
         expect(diag.evidenceFacts).toEqual([
             {type: 'vector-dimension-mismatch', collection: 'neo-agent-memory', expectedDimension: 4096, mismatchedVectorCount: 12}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis.spec.mjs
@@ -4,11 +4,11 @@ import * as core                       from '../../../../../../../src/core/_expo
 import {buildSqliteIntegrityDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/sqliteIntegrityDiagnosis.mjs';
 
 // Pure detect-producer (no I/O). Turns a Chroma SQLite quick_check/integrity_check audit into a
-// data-integrity recovery-diagnosis (escalate) when the store's SQLite integrity is broken (a malformed
+// data-integrity recovery-diagnosis (raw evidence, no escalate) when the store's SQLite integrity is broken (a malformed
 // FTS5 index — the corruption-incident forensic shape); returns null when every check passes.
 
 test.describe('buildSqliteIntegrityDiagnosis — data-integrity SQLite-integrity detect-producer', () => {
-    test('a failed integrity check -> a data-integrity/escalate recovery-diagnosis', () => {
+    test('a failed integrity check -> a data-integrity raw-evidence recovery-diagnosis (no escalate)', () => {
         const diag = buildSqliteIntegrityDiagnosis({
             sqliteResult: {checks: [
                 {pragma: 'quick_check',     ok: false, output: 'malformed inverted index for FTS5 table main.embedding_fulltext_search'},
@@ -24,7 +24,7 @@ test.describe('buildSqliteIntegrityDiagnosis — data-integrity SQLite-integrity
             confidence    : 1,
             targetIdentity: {kind: 'compose-service', id: 'memory-core'},
             source        : 'data-integrity-sqlite-integrity-monitor',
-            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-sqlite-integrity-failure', failedPragmas: ['quick_check', 'integrity_check']}
+            details       : {reasonCode: 'data-integrity-sqlite-integrity-failure', failedPragmas: ['quick_check', 'integrity_check']}
         });
         expect(diag.evidenceFacts[0]).toMatchObject({type: 'sqlite-integrity-failure', pragma: 'quick_check'});
         expect(diag.evidenceFacts[0].detail).toContain('malformed inverted index');

--- a/test/playwright/unit/ai/daemons/orchestrator/services/storeBloatDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/storeBloatDiagnosis.spec.mjs
@@ -3,14 +3,14 @@ import Neo                        from '../../../../../../../src/Neo.mjs';
 import * as core                  from '../../../../../../../src/core/_export.mjs';
 import {buildStoreBloatDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/storeBloatDiagnosis.mjs';
 
-// Pure detect-producer (no I/O). Turns a store-size measurement + thresholds into a data-integrity/escalate
+// Pure detect-producer (no I/O). Turns a store-size measurement + thresholds into a data-integrity raw-evidence
 // recovery-diagnosis when the store is over its absolute budget OR grew too fast since the previous sample;
 // null when within budget.
 
 const THRESHOLDS = {absoluteBytes: 2_000_000_000, growthRatio: 0.25};  // 2GB absolute, 25% growth
 
 test.describe('buildStoreBloatDiagnosis — data-integrity store-size bloat detect-producer', () => {
-    test('over the absolute budget -> a data-integrity/escalate recovery-diagnosis', () => {
+    test('over the absolute budget -> a data-integrity raw-evidence recovery-diagnosis (no escalate)', () => {
         const diag = buildStoreBloatDiagnosis({
             storeSizeBytes: 2_500_000_000,  // 2.5GB > 2GB
             thresholds    : THRESHOLDS,
@@ -24,7 +24,7 @@ test.describe('buildStoreBloatDiagnosis — data-integrity store-size bloat dete
             confidence    : 1,
             targetIdentity: {kind: 'compose-service', id: 'memory-core'},
             source        : 'data-integrity-store-bloat-monitor',
-            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-store-bloat', triggeredSignals: ['absolute']}
+            details       : {reasonCode: 'data-integrity-store-bloat', triggeredSignals: ['absolute']}
         });
         expect(diag.evidenceFacts).toEqual([
             {type: 'store-bloat', signal: 'absolute', storeSizeBytes: 2_500_000_000, thresholdBytes: 2_000_000_000}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.spec.mjs
@@ -4,11 +4,11 @@ import * as core                               from '../../../../../../../src/co
 import {buildVectorCountMonotonicityDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/vectorCountMonotonicityDiagnosis.mjs';
 
 // Pure detect-producer (no I/O). Memory Core collections are append-mostly, so a vector-count DECREASE
-// between samples is a near-unambiguous, threshold-free data-loss signal → a data-integrity/escalate
+// between samples is a near-unambiguous, threshold-free data-loss signal → a data-integrity raw-evidence
 // recovery-diagnosis; monotonic samples → null.
 
 test.describe('buildVectorCountMonotonicityDiagnosis — vector-count monotonicity detect-producer', () => {
-    test('a collection whose vector count regressed -> a data-integrity/escalate recovery-diagnosis', () => {
+    test('a collection whose vector count regressed -> a data-integrity raw-evidence recovery-diagnosis (no escalate)', () => {
         const diag = buildVectorCountMonotonicityDiagnosis({
             samples: [
                 {collection: 'neo-agent-memory',   previousCount: 18835, currentCount: 7000},
@@ -25,7 +25,7 @@ test.describe('buildVectorCountMonotonicityDiagnosis — vector-count monotonici
             confidence    : 1,
             targetIdentity: {kind: 'compose-service', id: 'memory-core'},
             source        : 'data-integrity-monotonicity-monitor',
-            details       : {actionClass: 'escalate', reasonCode: 'data-integrity-vector-count-regression', regressedCollections: ['neo-agent-memory']}
+            details       : {reasonCode: 'data-integrity-vector-count-regression', regressedCollections: ['neo-agent-memory']}
         });
         expect(diag.evidenceFacts).toEqual([
             {type: 'vector-count-regression', collection: 'neo-agent-memory', previousCount: 18835, currentCount: 7000, lost: 11835}


### PR DESCRIPTION
Resolves #14138

Re-routes all 5 data-integrity producers from `escalate` to raw-evidence: each drops `details.actionClass: 'escalate'`, keeping `recoveryClass: 'data-integrity'` + raw `evidenceFacts` so the autonomous runner classifier (#14109) derives the corruption mode and routes a `HEAL_ACTIONS` action. Part of the v13.1 self-heal re-shape (#14132 — operator-mandated 100% autonomous, `escalate` DELETED). Per the locked #14032 seam: producers stay dumb raw-evidence emitters; the classifier owns the mode taxonomy.

Evidence: L1 (unit — pure producers over mocked audit results) fully covers the close-target ACs; no L2+ runtime evidence required of the producers (the live routing is the runner classifier #14109's, landing coordinated). Residual: none for the producers.

## Deltas from ticket (if any)
None — the 5-producer drop-`actionClass` + JSDoc + test updates, exactly as scoped on #14138.

## Test Evidence
`npm run test-unit -- <the 5 producer specs>` → **38 passed**. Each producer's diagnosis still validates against `RECOVERY_CLASSES` (the existing `createRecoveryDiagnosisEvent`-throws test), now without an escalate terminal. V-B-A: `createRecoveryDiagnosisEvent` (`recoveryRunStateStore.mjs`) validates `details` is an object but does NOT require `actionClass` — dropping it is contract-safe.

## Post-Merge Validation
- [ ] Lands coordinated with the runner classifier #14109 (cutover-sequence per @neo-opus-vega): the producers now route via `recoveryClass: 'data-integrity'`; until the classifier consumes raw-evidence, these diagnoses are not routed by the current `actionClass`-keyed runner. This PR supersedes the producer-side of #14129 / #14130 / #14131 onto the autonomous contract.

## Contract
Contract Ledger on #14138 (the producers emit `recoveryClass: 'data-integrity'` + raw `evidenceFacts`, no `actionClass`; consumer = the runner classifier #14109).

## Scope
The 5 data-integrity producers' escalate→raw-evidence + JSDoc + unit tests ONLY. Out of scope: the runner classifier + mode-derivation (#14109, Vega), the actuator `applyHeal` + heal-action execution + new ADR (#14134, Grace), the document-presence gatherer wiring (Orchestrator-level, follow-on; the primitive shipped via #14135/#14136).

Refs #14132, #14032, #14039, #14109, #14134

---
Authored by Ada (Claude Opus 4.8, Claude Code) · origin session fe9c04d6-1aae-4017-8d53-19b0e5aaf809
