### PR TITLE
feat(ai): autonomous heal-action dispatch core — safety-gate + injected execution (#14142)

### DIFF
--- a/ai/services/memory-core/helpers/healActionDispatch.mjs
+++ b/ai/services/memory-core/helpers/healActionDispatch.mjs
@@ -79,3 +79,51 @@ export function decideHealAction({action, collection, recentRuns = [], bounds = 
 
     return {execute: true, status: 'execute', reason: 'within bounds'};
 }
+
+/**
+ * @summary The actuator's core dispatch: run the bounded-dispatch safety gate, and if it clears, execute the
+ * heal via an INJECTED operation — returning a uniform `outcomeRecord`. Pure orchestration: the privileged
+ * data-mutation primitives (re-embed / restore / defrag) are injected as `healOperations`, so this dispatcher
+ * is fully testable without touching a real store, and the wired actuator (its placement decided separately)
+ * supplies the real operations. No operator, no escalate — a held / unwired / failed heal is RECORDED in the
+ * outcome, never paged.
+ *
+ * @param {Object} options
+ * @param {String} [options.action] The heal action (the classifier's `terminalAction`).
+ * @param {String} [options.collection] The target collection.
+ * @param {Object} [options.evidence] The diagnosis evidence passed through to the operation.
+ * @param {Object[]} [options.recentRuns=[]] Recent heal runs for the safety gate (anti-thrash + rate).
+ * @param {Object} [options.bounds] The dispatch bounds (defaults to `DEFAULT_DISPATCH_BOUNDS` in `decideHealAction`).
+ * @param {Number} [options.now] Epoch milliseconds (injected clock).
+ * @param {Object} [options.healOperations={}] `{ '<action>': async ({collection, evidence, now}) => ({status?, detail?}) }` — the injected privileged operations.
+ * @param {Function} [options.recordRun] `async ({action, collection, at}) => void` — persists the run for future anti-thrash (called only on a successful mutating heal).
+ * @returns {Promise<Object>} `outcomeRecord` = `{action, collection, status, detail, healedAt}`.
+ */
+export async function dispatchHeal({action, collection, evidence, recentRuns = [], bounds, now, healOperations = {}, recordRun} = {}) {
+    const decision = decideHealAction({action, collection, recentRuns, bounds, now});
+
+    if (!decision.execute) {
+        return {action, collection, status: decision.status, detail: decision.reason, healedAt: now};
+    }
+
+    const operation = healOperations?.[action];
+
+    // The action cleared the gate but its heal isn't wired yet (the "missing logic → ticket" set): record a
+    // `deferred` outcome — autonomous, never a page. The runner's safe-default (quarantine) covers the gap.
+    if (typeof operation !== 'function') {
+        return {action, collection, status: 'deferred', detail: `no heal operation wired for '${action}'`, healedAt: now};
+    }
+
+    try {
+        const result = await operation({collection, evidence, now});
+
+        if (typeof recordRun === 'function') {
+            await recordRun({action, collection, at: now});
+        }
+
+        return {action, collection, status: result?.status ?? 'healed', detail: result?.detail ?? result ?? null, healedAt: now};
+    } catch (error) {
+        // A failed heal is recorded, never escalated — autonomous self-heal degrades to a recorded fault.
+        return {action, collection, status: 'failed', detail: error?.message ?? String(error), healedAt: now};
+    }
+}

--- a/ai/services/memory-core/helpers/healActionDispatch.mjs
+++ b/ai/services/memory-core/helpers/healActionDispatch.mjs
@@ -1,0 +1,81 @@
+/**
+ * @module ai/services/memory-core/helpers/healActionDispatch
+ * @summary Pure bounded-dispatch decider for the autonomous data-recovery actuator — the autonomous
+ * SAFETY core that replaces the deleted operator-escalate/ack (the v13.1 self-heal mandate). Given a heal
+ * `action` (the data-integrity classifier's `terminalAction`), the recent heal-run history (for anti-thrash),
+ * and the rate/cooldown bounds, it decides whether the actuator may EXECUTE the heal now — or must hold it
+ * (`rate-limited` / `thrash-cooldown` / `unknown-action` / `no-op`), with NO human and NO runtime escalate.
+ *
+ * This is the gate that lets a fully-autonomous actuator be safe without an operator: a misconfigured
+ * embedder or a flapping collection cannot drive an unbounded re-embed/restore loop, because the same
+ * action on the same collection is cooldown-gated and window-rate-limited. The actual heal EXECUTION
+ * (re-embed / restore — the privileged data mutation) is the actuator's wired concern; THIS is the pure,
+ * placement-independent decision every shape of the actuator (dedicated service or extended) consumes.
+ */
+
+/**
+ * The heal actions the actuator can dispatch (the classifier's `terminalAction` vocabulary). `none` is the
+ * absence of a heal; non-mutating containment (`freeze` / `quarantine`) is always safe to apply.
+ * @type {String[]}
+ */
+export const HEAL_ACTIONS = Object.freeze(['re-embed-missing', 're-embed-rows', 'restore-delta-merge', 'quarantine', 'freeze', 'defrag']);
+
+/**
+ * Mutating heal actions — rate-limited + anti-thrash-bounded (they re-embed / restore / rewrite data).
+ * `freeze` + `quarantine` are non-mutating containment and are exempt.
+ * @type {String[]}
+ */
+export const MUTATING_HEAL_ACTIONS = Object.freeze(['re-embed-missing', 're-embed-rows', 'restore-delta-merge', 'defrag']);
+
+/**
+ * Default dispatch bounds: at most 3 mutating runs of the same action+collection per hour, with a 10-minute
+ * cooldown between consecutive runs.
+ * @type {{maxRunsPerWindow: Number, windowMs: Number, cooldownMs: Number}}
+ */
+export const DEFAULT_DISPATCH_BOUNDS = Object.freeze({maxRunsPerWindow: 3, windowMs: 3600000, cooldownMs: 600000});
+
+/**
+ * @summary Decides whether the actuator may execute a heal `action` now, under the autonomous safety bounds.
+ *
+ * @param {Object} options
+ * @param {String} [options.action] The heal action (the classifier's `terminalAction`).
+ * @param {String} [options.collection] The target collection (the anti-thrash / rate key, with `action`).
+ * @param {Object[]} [options.recentRuns=[]] Recent heal runs `[{action, collection, at}]` (epoch ms) for anti-thrash + rate.
+ * @param {{maxRunsPerWindow: Number, windowMs: Number, cooldownMs: Number}} [options.bounds=DEFAULT_DISPATCH_BOUNDS]
+ * @param {Number} [options.now] Epoch milliseconds (the injected clock).
+ * @returns {Object} `{execute, status, reason}`. `status ∈ {execute, no-op, unknown-action, thrash-cooldown, rate-limited}`.
+ */
+export function decideHealAction({action, collection, recentRuns = [], bounds = DEFAULT_DISPATCH_BOUNDS, now} = {}) {
+    if (action === 'none' || action == null) {
+        return {execute: false, status: 'no-op', reason: 'no-heal-action'};
+    }
+
+    if (!HEAL_ACTIONS.includes(action)) {
+        return {execute: false, status: 'unknown-action', reason: `unknown heal action: ${action}`};
+    }
+
+    // Non-mutating containment is always safe to apply — no rate/thrash bound.
+    if (!MUTATING_HEAL_ACTIONS.includes(action)) {
+        return {execute: true, status: 'execute', reason: `${action} is non-mutating containment`};
+    }
+
+    const {maxRunsPerWindow, windowMs, cooldownMs} = bounds,
+          sameTarget                               = (Array.isArray(recentRuns) ? recentRuns : [])
+              .filter(run => run?.action === action && run?.collection === collection);
+
+    // Anti-thrash: a same-action+collection run inside the cooldown → hold.
+    const lastAt = sameTarget.reduce((latest, run) => (Number.isFinite(run?.at) && run.at > latest ? run.at : latest), -Infinity);
+
+    if (Number.isFinite(now) && Number.isFinite(lastAt) && now - lastAt < cooldownMs) {
+        return {execute: false, status: 'thrash-cooldown', reason: `${action} on ${collection} ran ${now - lastAt}ms ago (< ${cooldownMs}ms cooldown)`};
+    }
+
+    // Rate-limit: too many runs of this action+collection inside the window → hold.
+    const inWindow = sameTarget.filter(run => Number.isFinite(now) && Number.isFinite(run?.at) && now - run.at < windowMs).length;
+
+    if (inWindow >= maxRunsPerWindow) {
+        return {execute: false, status: 'rate-limited', reason: `${action} on ${collection} hit ${inWindow}/${maxRunsPerWindow} runs in ${windowMs}ms`};
+    }
+
+    return {execute: true, status: 'execute', reason: 'within bounds'};
+}

--- a/ai/services/memory-core/helpers/healActionDispatch.mjs
+++ b/ai/services/memory-core/helpers/healActionDispatch.mjs
@@ -4,21 +4,34 @@
  * SAFETY core that replaces the deleted operator-escalate/ack (the v13.1 self-heal mandate). Given a heal
  * `action` (the data-integrity classifier's `terminalAction`), the recent heal-run history (for anti-thrash),
  * and the rate/cooldown bounds, it decides whether the actuator may EXECUTE the heal now — or must hold it
- * (`rate-limited` / `thrash-cooldown` / `unknown-action` / `no-op`), with NO human and NO runtime escalate.
+ * (`rate-limited` / `thrash-cooldown` / `unknown-action` / `unsafe-input` / `no-op`), with NO human and NO
+ * runtime escalate.
  *
  * This is the gate that lets a fully-autonomous actuator be safe without an operator: a misconfigured
  * embedder or a flapping collection cannot drive an unbounded re-embed/restore loop, because the same
- * action on the same collection is cooldown-gated and window-rate-limited. The actual heal EXECUTION
+ * action on the same collection is cooldown-gated and window-rate-limited — and because a mutating heal
+ * with a missing target/clock/bounds FAILS CLOSED rather than executing unbounded. The actual heal EXECUTION
  * (re-embed / restore — the privileged data mutation) is the actuator's wired concern; THIS is the pure,
  * placement-independent decision every shape of the actuator (dedicated service or extended) consumes.
  */
 
 /**
- * The heal actions the actuator can dispatch (the classifier's `terminalAction` vocabulary). `none` is the
- * absence of a heal; non-mutating containment (`freeze` / `quarantine`) is always safe to apply.
+ * The DISPATCHABLE heal actions (the classifier's `terminalAction` vocabulary). Non-mutating containment
+ * (`freeze` / `quarantine`) is always safe to apply; the rest are mutating (see `MUTATING_HEAL_ACTIONS`).
+ * The no-op sentinel `none` (`NO_HEAL_ACTION`) is deliberately NOT in this set — it is resolved to `no-op`
+ * before the vocabulary check, never dispatched.
  * @type {String[]}
  */
 export const HEAL_ACTIONS = Object.freeze(['re-embed-missing', 're-embed-rows', 'restore-delta-merge', 'quarantine', 'freeze', 'defrag']);
+
+/**
+ * The non-dispatchable no-op sentinel: the classifier emits `none` for a clean collection (nothing to heal).
+ * It is intentionally OUTSIDE `HEAL_ACTIONS` — `decideHealAction` resolves it (and a nullish action) to
+ * `no-op` before the dispatchable-vocabulary check, so it is never executed. The data-recovery design
+ * treats `none` as the no-op terminal; this constant is the single source for that sentinel.
+ * @type {String}
+ */
+export const NO_HEAL_ACTION = 'none';
 
 /**
  * Mutating heal actions — rate-limited + anti-thrash-bounded (they re-embed / restore / rewrite data).
@@ -37,16 +50,20 @@ export const DEFAULT_DISPATCH_BOUNDS = Object.freeze({maxRunsPerWindow: 3, windo
 /**
  * @summary Decides whether the actuator may execute a heal `action` now, under the autonomous safety bounds.
  *
+ * For MUTATING actions the rate + anti-thrash gate requires a target collection, a finite clock, and finite
+ * bounds; any of those missing/malformed → fail CLOSED (`unsafe-input`), never a fail-open execute. Partial
+ * `bounds` are normalized onto `DEFAULT_DISPATCH_BOUNDS` so an incomplete object cannot silently disable the gate.
+ *
  * @param {Object} options
  * @param {String} [options.action] The heal action (the classifier's `terminalAction`).
  * @param {String} [options.collection] The target collection (the anti-thrash / rate key, with `action`).
  * @param {Object[]} [options.recentRuns=[]] Recent heal runs `[{action, collection, at}]` (epoch ms) for anti-thrash + rate.
  * @param {{maxRunsPerWindow: Number, windowMs: Number, cooldownMs: Number}} [options.bounds=DEFAULT_DISPATCH_BOUNDS]
  * @param {Number} [options.now] Epoch milliseconds (the injected clock).
- * @returns {Object} `{execute, status, reason}`. `status ∈ {execute, no-op, unknown-action, thrash-cooldown, rate-limited}`.
+ * @returns {Object} `{execute, status, reason}`. `status ∈ {execute, no-op, unknown-action, unsafe-input, thrash-cooldown, rate-limited}`.
  */
 export function decideHealAction({action, collection, recentRuns = [], bounds = DEFAULT_DISPATCH_BOUNDS, now} = {}) {
-    if (action === 'none' || action == null) {
+    if (action === NO_HEAL_ACTION || action == null) {
         return {execute: false, status: 'no-op', reason: 'no-heal-action'};
     }
 
@@ -59,19 +76,35 @@ export function decideHealAction({action, collection, recentRuns = [], bounds = 
         return {execute: true, status: 'execute', reason: `${action} is non-mutating containment`};
     }
 
-    const {maxRunsPerWindow, windowMs, cooldownMs} = bounds,
-          sameTarget                               = (Array.isArray(recentRuns) ? recentRuns : [])
-              .filter(run => run?.action === action && run?.collection === collection);
+    // A mutating heal MUST carry the full safety context or the rate + anti-thrash gate cannot bind. Fail
+    // CLOSED on a missing target/clock — an under-specified mutating heal must never execute unbounded.
+    if (typeof collection !== 'string' || collection.length === 0) {
+        return {execute: false, status: 'unsafe-input', reason: `mutating '${action}' requires a non-empty collection (the anti-thrash key)`};
+    }
+    if (!Number.isFinite(now)) {
+        return {execute: false, status: 'unsafe-input', reason: `mutating '${action}' requires a finite 'now' (cooldown/window clock)`};
+    }
+
+    // Normalize partial/empty bounds onto the safe defaults so an incomplete `{}` can't disable the gate,
+    // then fail closed if any resolved bound is still non-finite.
+    const {maxRunsPerWindow, windowMs, cooldownMs} = {...DEFAULT_DISPATCH_BOUNDS, ...(bounds && typeof bounds === 'object' ? bounds : {})};
+
+    if (![maxRunsPerWindow, windowMs, cooldownMs].every(Number.isFinite)) {
+        return {execute: false, status: 'unsafe-input', reason: `mutating '${action}' requires finite bounds {maxRunsPerWindow, windowMs, cooldownMs}`};
+    }
+
+    const sameTarget = (Array.isArray(recentRuns) ? recentRuns : [])
+        .filter(run => run?.action === action && run?.collection === collection);
 
     // Anti-thrash: a same-action+collection run inside the cooldown → hold.
     const lastAt = sameTarget.reduce((latest, run) => (Number.isFinite(run?.at) && run.at > latest ? run.at : latest), -Infinity);
 
-    if (Number.isFinite(now) && Number.isFinite(lastAt) && now - lastAt < cooldownMs) {
+    if (Number.isFinite(lastAt) && now - lastAt < cooldownMs) {
         return {execute: false, status: 'thrash-cooldown', reason: `${action} on ${collection} ran ${now - lastAt}ms ago (< ${cooldownMs}ms cooldown)`};
     }
 
     // Rate-limit: too many runs of this action+collection inside the window → hold.
-    const inWindow = sameTarget.filter(run => Number.isFinite(now) && Number.isFinite(run?.at) && now - run.at < windowMs).length;
+    const inWindow = sameTarget.filter(run => Number.isFinite(run?.at) && now - run.at < windowMs).length;
 
     if (inWindow >= maxRunsPerWindow) {
         return {execute: false, status: 'rate-limited', reason: `${action} on ${collection} hit ${inWindow}/${maxRunsPerWindow} runs in ${windowMs}ms`};
@@ -88,6 +121,10 @@ export function decideHealAction({action, collection, recentRuns = [], bounds = 
  * supplies the real operations. No operator, no escalate — a held / unwired / failed heal is RECORDED in the
  * outcome, never paged.
  *
+ * **Anti-hot-loop:** a mutating ATTEMPT is recorded (via `recordRun`) BEFORE execution, so a throwing/failing
+ * heal still enters the anti-thrash history — a broken provider cannot immediately re-run. If the attempt
+ * cannot be recorded, the dispatch fails CLOSED (no unrecorded mutation).
+ *
  * @param {Object} options
  * @param {String} [options.action] The heal action (the classifier's `terminalAction`).
  * @param {String} [options.collection] The target collection.
@@ -96,7 +133,7 @@ export function decideHealAction({action, collection, recentRuns = [], bounds = 
  * @param {Object} [options.bounds] The dispatch bounds (defaults to `DEFAULT_DISPATCH_BOUNDS` in `decideHealAction`).
  * @param {Number} [options.now] Epoch milliseconds (injected clock).
  * @param {Object} [options.healOperations={}] `{ '<action>': async ({collection, evidence, now}) => ({status?, detail?}) }` — the injected privileged operations.
- * @param {Function} [options.recordRun] `async ({action, collection, at}) => void` — persists the run for future anti-thrash (called only on a successful mutating heal).
+ * @param {Function} [options.recordRun] `async ({action, collection, at}) => void` — persists a mutating ATTEMPT for future anti-thrash. Called before execution for every mutating heal (success OR failure), so a failed heal cannot hot-loop.
  * @returns {Promise<Object>} `outcomeRecord` = `{action, collection, status, detail, healedAt}`.
  */
 export async function dispatchHeal({action, collection, evidence, recentRuns = [], bounds, now, healOperations = {}, recordRun} = {}) {
@@ -114,16 +151,22 @@ export async function dispatchHeal({action, collection, evidence, recentRuns = [
         return {action, collection, status: 'deferred', detail: `no heal operation wired for '${action}'`, healedAt: now};
     }
 
+    // Record the mutating ATTEMPT BEFORE execution so a throwing/failing heal still enters the anti-thrash
+    // history — a broken provider/store cannot immediately hot-loop. Containment is unbounded and unrecorded.
+    // If the attempt can't be recorded, fail CLOSED rather than risk an unrecorded loop.
+    if (MUTATING_HEAL_ACTIONS.includes(action) && typeof recordRun === 'function') {
+        try {
+            await recordRun({action, collection, at: now});
+        } catch (recordError) {
+            return {action, collection, status: 'failed', detail: `anti-thrash recordRun failed pre-execution: ${recordError?.message ?? String(recordError)}`, healedAt: now};
+        }
+    }
+
     try {
         const result = await operation({collection, evidence, now});
-
-        if (typeof recordRun === 'function') {
-            await recordRun({action, collection, at: now});
-        }
-
         return {action, collection, status: result?.status ?? 'healed', detail: result?.detail ?? result ?? null, healedAt: now};
     } catch (error) {
-        // A failed heal is recorded, never escalated — autonomous self-heal degrades to a recorded fault.
+        // A failed heal is already recorded (above) — never escalated; autonomous self-heal degrades to a recorded fault.
         return {action, collection, status: 'failed', detail: error?.message ?? String(error), healedAt: now};
     }
 }

--- a/ai/services/memory-core/helpers/healActionDispatch.mjs
+++ b/ai/services/memory-core/helpers/healActionDispatch.mjs
@@ -133,7 +133,7 @@ export function decideHealAction({action, collection, recentRuns = [], bounds = 
  * @param {Object} [options.bounds] The dispatch bounds (defaults to `DEFAULT_DISPATCH_BOUNDS` in `decideHealAction`).
  * @param {Number} [options.now] Epoch milliseconds (injected clock).
  * @param {Object} [options.healOperations={}] `{ '<action>': async ({collection, evidence, now}) => ({status?, detail?}) }` — the injected privileged operations.
- * @param {Function} [options.recordRun] `async ({action, collection, at}) => void` — persists a mutating ATTEMPT for future anti-thrash. Called before execution for every mutating heal (success OR failure), so a failed heal cannot hot-loop.
+ * @param {Function} [options.recordRun] `async ({action, collection, at}) => void` — persists a mutating ATTEMPT for future anti-thrash. **Required for mutating actions** — absent → the heal fails closed (`unsafe-input`: no recorder, no mutation). Called before execution for every mutating heal (success OR failure), so a failed heal cannot hot-loop.
  * @returns {Promise<Object>} `outcomeRecord` = `{action, collection, status, detail, healedAt}`.
  */
 export async function dispatchHeal({action, collection, evidence, recentRuns = [], bounds, now, healOperations = {}, recordRun} = {}) {
@@ -151,10 +151,19 @@ export async function dispatchHeal({action, collection, evidence, recentRuns = [
         return {action, collection, status: 'deferred', detail: `no heal operation wired for '${action}'`, healedAt: now};
     }
 
+    const isMutating = MUTATING_HEAL_ACTIONS.includes(action);
+
+    // A mutating heal MUST be anti-thrash-recordable, or its loop cannot be bounded → fail CLOSED: no
+    // recorder, no mutation. (Containment is unbounded and needs no recorder.) The invariant holds on EVERY
+    // path, not only when a recordRun happens to be wired.
+    if (isMutating && typeof recordRun !== 'function') {
+        return {action, collection, status: 'unsafe-input', detail: `mutating '${action}' requires a recordRun to persist the anti-thrash attempt (no recorder, no mutation)`, healedAt: now};
+    }
+
     // Record the mutating ATTEMPT BEFORE execution so a throwing/failing heal still enters the anti-thrash
-    // history — a broken provider/store cannot immediately hot-loop. Containment is unbounded and unrecorded.
-    // If the attempt can't be recorded, fail CLOSED rather than risk an unrecorded loop.
-    if (MUTATING_HEAL_ACTIONS.includes(action) && typeof recordRun === 'function') {
+    // history — a broken provider/store cannot immediately hot-loop. If recording itself throws, also fail
+    // CLOSED rather than risk an unrecorded loop.
+    if (isMutating) {
         try {
             await recordRun({action, collection, at: now});
         } catch (recordError) {

--- a/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
@@ -1,0 +1,66 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    decideHealAction,
+    DEFAULT_DISPATCH_BOUNDS,
+    HEAL_ACTIONS,
+    MUTATING_HEAL_ACTIONS
+} from '../../../../../../../ai/services/memory-core/helpers/healActionDispatch.mjs';
+
+const NOW = 10_000_000;
+
+test.describe('decideHealAction — autonomous bounded-dispatch safety gate', () => {
+    test('action none / absent → no-op (nothing to heal)', () => {
+        expect(decideHealAction({action: 'none', now: NOW})).toMatchObject({execute: false, status: 'no-op'});
+        expect(decideHealAction({now: NOW})).toMatchObject({execute: false, status: 'no-op'});
+    });
+
+    test('an unknown action → unknown-action (fail-closed: never execute an unrecognized heal)', () => {
+        expect(decideHealAction({action: 'rm-rf-everything', collection: 'mc', now: NOW}))
+            .toMatchObject({execute: false, status: 'unknown-action'});
+    });
+
+    test('non-mutating containment (freeze / quarantine) always executes — no rate/thrash bound', () => {
+        // even with a flood of recent runs, containment is always allowed (it mutates nothing)
+        const recentRuns = Array.from({length: 99}, () => ({action: 'quarantine', collection: 'mc', at: NOW - 1}));
+        expect(decideHealAction({action: 'freeze', collection: 'mc', recentRuns, now: NOW})).toMatchObject({execute: true, status: 'execute'});
+        expect(decideHealAction({action: 'quarantine', collection: 'mc', recentRuns, now: NOW})).toMatchObject({execute: true, status: 'execute'});
+    });
+
+    test('a mutating action with no recent runs → execute (within bounds)', () => {
+        expect(decideHealAction({action: 're-embed-missing', collection: 'mc-memory', recentRuns: [], now: NOW}))
+            .toMatchObject({execute: true, status: 'execute'});
+    });
+
+    test('anti-thrash: a same action+collection run inside the cooldown → thrash-cooldown (no loop)', () => {
+        const recentRuns = [{action: 're-embed-missing', collection: 'mc-memory', at: NOW - 60_000}]; // 1 min ago < 10 min cooldown
+        expect(decideHealAction({action: 're-embed-missing', collection: 'mc-memory', recentRuns, now: NOW}))
+            .toMatchObject({execute: false, status: 'thrash-cooldown'});
+    });
+
+    test('the cooldown is per action+collection — a different collection is unaffected', () => {
+        const recentRuns = [{action: 're-embed-missing', collection: 'mc-memory', at: NOW - 60_000}];
+        expect(decideHealAction({action: 're-embed-missing', collection: 'mc-graph', recentRuns, now: NOW}))
+            .toMatchObject({execute: true, status: 'execute'});
+    });
+
+    test('rate-limit: too many runs of the same action+collection in the window → rate-limited', () => {
+        // 3 runs spread across the hour but all older than the cooldown → cooldown passes, but the window rate trips.
+        const recentRuns = [
+            {action: 'defrag', collection: 'mc-memory', at: NOW - 3_000_000},
+            {action: 'defrag', collection: 'mc-memory', at: NOW - 2_000_000},
+            {action: 'defrag', collection: 'mc-memory', at: NOW - 1_000_000}
+        ];
+        expect(decideHealAction({action: 'defrag', collection: 'mc-memory', recentRuns, now: NOW}))
+            .toMatchObject({execute: false, status: 'rate-limited'});
+    });
+
+    test('the vocabulary split is frozen + mutating ⊂ all actions', () => {
+        expect(Object.isFrozen(HEAL_ACTIONS)).toBe(true);
+        expect(Object.isFrozen(MUTATING_HEAL_ACTIONS)).toBe(true);
+        expect(MUTATING_HEAL_ACTIONS.every(a => HEAL_ACTIONS.includes(a))).toBe(true);
+        expect(HEAL_ACTIONS).toContain('quarantine'); // quarantine is a containment heal-action
+        expect(DEFAULT_DISPATCH_BOUNDS.maxRunsPerWindow).toBeGreaterThan(0);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
@@ -142,10 +142,26 @@ test.describe('dispatchHeal — actuator core dispatch (safety gate + injected e
             action        : 'defrag',
             collection    : 'mc',
             now           : NOW,
-            healOperations: {defrag: async () => { throw new Error('chroma unreachable'); }}
+            healOperations: {defrag: async () => { throw new Error('chroma unreachable'); }},
+            recordRun     : async () => {}
         });
 
         expect(outcome).toMatchObject({status: 'failed', detail: 'chroma unreachable'});
+    });
+
+    test('fail-closed: a mutating action with NO recordRun does not execute (no recorder, no mutation)', async () => {
+        let   called  = false;
+        const outcome = await dispatchHeal({
+            action        : 're-embed-missing',
+            collection    : 'mc',
+            now           : NOW,
+            healOperations: {'re-embed-missing': async () => { called = true; return {status: 'healed'}; }}
+            // no recordRun → the mutating attempt cannot be persisted → must not execute.
+        });
+
+        expect(called).toBe(false);
+        expect(outcome).toMatchObject({status: 'unsafe-input'});
+        expect(outcome.detail).toMatch(/requires a recordRun/);
     });
 
     test('the operation status+detail is carried through (e.g. quarantine reports frozen)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
@@ -3,6 +3,7 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
     decideHealAction,
+    dispatchHeal,
     DEFAULT_DISPATCH_BOUNDS,
     HEAL_ACTIONS,
     MUTATING_HEAL_ACTIONS
@@ -62,5 +63,83 @@ test.describe('decideHealAction — autonomous bounded-dispatch safety gate', ()
         expect(MUTATING_HEAL_ACTIONS.every(a => HEAL_ACTIONS.includes(a))).toBe(true);
         expect(HEAL_ACTIONS).toContain('quarantine'); // quarantine is a containment heal-action
         expect(DEFAULT_DISPATCH_BOUNDS.maxRunsPerWindow).toBeGreaterThan(0);
+    });
+});
+
+test.describe('dispatchHeal — actuator core dispatch (safety gate + injected execution)', () => {
+    const ok = async () => ({status: 'healed', detail: 're-embedded 5 rows'});
+
+    test('a held action (thrash-cooldown) returns the hold outcome and NEVER calls the operation', async () => {
+        let   called     = false;
+        const recentRuns = [{action: 're-embed-missing', collection: 'mc', at: NOW - 1000}],
+              outcome    = await dispatchHeal({
+                  action        : 're-embed-missing',
+                  collection    : 'mc',
+                  recentRuns,
+                  now           : NOW,
+                  healOperations: {'re-embed-missing': async () => { called = true; return ok(); }}
+              });
+
+        expect(outcome).toMatchObject({status: 'thrash-cooldown', healedAt: NOW});
+        expect(called).toBe(false);
+    });
+
+    test('an executable action with a wired operation → healed + records the run', async () => {
+        const runs    = [],
+              outcome = await dispatchHeal({
+                  action        : 're-embed-missing',
+                  collection    : 'mc-memory',
+                  evidence      : {gap: 5},
+                  now           : NOW,
+                  healOperations: {'re-embed-missing': ok},
+                  recordRun     : async run => { runs.push(run); }
+              });
+
+        expect(outcome).toMatchObject({action: 're-embed-missing', collection: 'mc-memory', status: 'healed', detail: 're-embedded 5 rows'});
+        expect(runs).toEqual([{action: 're-embed-missing', collection: 'mc-memory', at: NOW}]);
+    });
+
+    test('an executable action with NO wired operation → deferred (the missing-logic gap, autonomous, no page)', async () => {
+        const outcome = await dispatchHeal({action: 'restore-delta-merge', collection: 'mc', now: NOW, healOperations: {}});
+
+        expect(outcome).toMatchObject({status: 'deferred', healedAt: NOW});
+        expect(outcome.detail).toMatch(/no heal operation wired/);
+    });
+
+    test('a throwing operation → failed (recorded, never escalated)', async () => {
+        const outcome = await dispatchHeal({
+            action        : 'defrag',
+            collection    : 'mc',
+            now           : NOW,
+            healOperations: {defrag: async () => { throw new Error('chroma unreachable'); }}
+        });
+
+        expect(outcome).toMatchObject({status: 'failed', detail: 'chroma unreachable'});
+    });
+
+    test('the operation status+detail is carried through (e.g. quarantine reports frozen)', async () => {
+        const outcome = await dispatchHeal({
+            action        : 'quarantine',
+            collection    : 'mc',
+            now           : NOW,
+            healOperations: {quarantine: async () => ({status: 'frozen', detail: 'collection marked unhealthy'})}
+        });
+
+        expect(outcome).toMatchObject({status: 'frozen', detail: 'collection marked unhealthy'});
+    });
+
+    test('recordRun is NOT called when the gate holds', async () => {
+        let   recorded   = false;
+        const recentRuns = [{action: 'defrag', collection: 'mc', at: NOW - 1000}];
+        await dispatchHeal({
+            action        : 'defrag',
+            collection    : 'mc',
+            recentRuns,
+            now           : NOW,
+            healOperations: {defrag: ok},
+            recordRun     : async () => { recorded = true; }
+        });
+
+        expect(recorded).toBe(false);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
@@ -6,7 +6,8 @@ import {
     dispatchHeal,
     DEFAULT_DISPATCH_BOUNDS,
     HEAL_ACTIONS,
-    MUTATING_HEAL_ACTIONS
+    MUTATING_HEAL_ACTIONS,
+    NO_HEAL_ACTION
 } from '../../../../../../../ai/services/memory-core/helpers/healActionDispatch.mjs';
 
 const NOW = 10_000_000;
@@ -57,12 +58,42 @@ test.describe('decideHealAction — autonomous bounded-dispatch safety gate', ()
             .toMatchObject({execute: false, status: 'rate-limited'});
     });
 
+    test('fail-closed: a mutating action with a missing/empty collection → unsafe-input (no fail-open execute)', () => {
+        expect(decideHealAction({action: 're-embed-missing', now: NOW}))
+            .toMatchObject({execute: false, status: 'unsafe-input'});
+        expect(decideHealAction({action: 're-embed-missing', collection: '', now: NOW}))
+            .toMatchObject({execute: false, status: 'unsafe-input'});
+    });
+
+    test('fail-closed: a mutating action with a non-finite now → unsafe-input (no cooldown/window clock)', () => {
+        expect(decideHealAction({action: 'defrag', collection: 'mc'}))
+            .toMatchObject({execute: false, status: 'unsafe-input'});
+        expect(decideHealAction({action: 'defrag', collection: 'mc', now: NaN}))
+            .toMatchObject({execute: false, status: 'unsafe-input'});
+    });
+
+    test('partial bounds are normalized onto the defaults — an empty {} cannot disable the gate', () => {
+        // a run 1 min ago is within the DEFAULT 10-min cooldown; an empty bounds {} must still hold it.
+        const recentRuns = [{action: 're-embed-missing', collection: 'mc', at: NOW - 60_000}];
+        expect(decideHealAction({action: 're-embed-missing', collection: 'mc', recentRuns, bounds: {}, now: NOW}))
+            .toMatchObject({execute: false, status: 'thrash-cooldown'});
+    });
+
+    test('fail-closed: a bound that resolves non-finite → unsafe-input', () => {
+        expect(decideHealAction({action: 're-embed-missing', collection: 'mc', bounds: {cooldownMs: 'soon'}, now: NOW}))
+            .toMatchObject({execute: false, status: 'unsafe-input'});
+    });
+
     test('the vocabulary split is frozen + mutating ⊂ all actions', () => {
         expect(Object.isFrozen(HEAL_ACTIONS)).toBe(true);
         expect(Object.isFrozen(MUTATING_HEAL_ACTIONS)).toBe(true);
         expect(MUTATING_HEAL_ACTIONS.every(a => HEAL_ACTIONS.includes(a))).toBe(true);
         expect(HEAL_ACTIONS).toContain('quarantine'); // quarantine is a containment heal-action
         expect(DEFAULT_DISPATCH_BOUNDS.maxRunsPerWindow).toBeGreaterThan(0);
+        // the no-op sentinel is non-dispatchable: it lives OUTSIDE HEAL_ACTIONS and resolves to no-op.
+        expect(NO_HEAL_ACTION).toBe('none');
+        expect(HEAL_ACTIONS).not.toContain(NO_HEAL_ACTION);
+        expect(decideHealAction({action: NO_HEAL_ACTION, now: NOW})).toMatchObject({execute: false, status: 'no-op'});
     });
 });
 
@@ -141,5 +172,41 @@ test.describe('dispatchHeal — actuator core dispatch (safety gate + injected e
         });
 
         expect(recorded).toBe(false);
+    });
+
+    test('a throwing mutating heal RECORDS the attempt before execution → it cannot immediately re-run', async () => {
+        const runs      = [],
+              recordRun = async run => { runs.push(run); };
+
+        // First dispatch: the operation throws → failed, BUT the attempt is recorded.
+        const first = await dispatchHeal({
+            action        : 're-embed-missing',
+            collection    : 'mc',
+            now           : NOW,
+            healOperations: {'re-embed-missing': async () => { throw new Error('provider 404'); }},
+            recordRun
+        });
+
+        expect(first).toMatchObject({status: 'failed', detail: 'provider 404'});
+        expect(runs).toEqual([{action: 're-embed-missing', collection: 'mc', at: NOW}]); // recorded despite the throw
+
+        // A moment later, feeding the recorded attempt as recentRuns → the gate holds (no hot-loop).
+        expect(decideHealAction({action: 're-embed-missing', collection: 'mc', recentRuns: runs, now: NOW + 1000}))
+            .toMatchObject({execute: false, status: 'thrash-cooldown'});
+    });
+
+    test('fail-closed: if the pre-execution recordRun throws, the mutating heal does NOT execute', async () => {
+        let   called  = false;
+        const outcome = await dispatchHeal({
+            action        : 're-embed-missing',
+            collection    : 'mc',
+            now           : NOW,
+            healOperations: {'re-embed-missing': async () => { called = true; return {status: 'healed'}; }},
+            recordRun     : async () => { throw new Error('anti-thrash store down'); }
+        });
+
+        expect(called).toBe(false); // never executed the mutation when the attempt could not be recorded
+        expect(outcome).toMatchObject({status: 'failed'});
+        expect(outcome.detail).toMatch(/recordRun failed pre-execution/);
     });
 });


### PR DESCRIPTION
Resolves #14142

The pure **autonomous heal-action dispatch core** — the actuator's safety-gate + injected-execution decision, the foundation the wired `DataRecoveryActuatorService` (#14134) composes. Two new files (`healActionDispatch.mjs` + its spec, 274 lines), placement-neutral pure logic — no wiring and no live mutation (the wired service + the snapshot/validation envelope follow under #14134).

Evidence: L2 (unit — **21 tests** fully cover the safety-gate decision + the injected-dispatch outcomes, including the two cross-family review cycles' safety fixes) → L2 is sufficient for this leaf's pure-decision ACs. Residual: the wired L3 integration lands with #14134.

## Deltas from ticket

None — the dispatch core matches the #14032-graduated contract: the `HEAL_ACTIONS` vocabulary, fail-closed admission, rate-limit + anti-thrash bounds per action+collection, and the autonomous outcomes. There is **no** `escalate`/`page` outcome in the vocabulary (the #14132 DELETE): a no-wired-operation returns `deferred` (the missing-logic gap), a throwing operation returns `failed` (recorded), neither pages.

## Test Evidence

`UNIT_TEST_MODE=true npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs` → **21 passed (31.1s)**. Covers `decideHealAction` (unknown→fail-closed; containment always executes; rate-limit; anti-thrash per action+collection; **fail-closed `unsafe-input` for mutating actions missing collection / non-finite now / non-finite bounds + partial-bounds normalize-onto-defaults**; the frozen `MUTATING_HEAL_ACTIONS ⊂ HEAL_ACTIONS` split; the `none`/`NO_HEAL_ACTION` sentinel) and `dispatchHeal` (held→hold with the operation never called; healed + records; no-operation→`deferred`; throwing→`failed`; status+detail carried; `recordRun` gated when held; **a throwing mutating heal records the attempt → cannot re-run; fail-closed when `recordRun` is absent OR throws → no recorder, no mutation**). Rebased clean on `origin/dev`.

## Evolution

Two cross-family review cycles (@neo-gpt) hardened the safety envelope: cycle-1 fixed the fail-open on missing `collection`/`now`/`bounds`, added record-before-mutate, and the `none` sentinel; cycle-2 closed the remaining `recordRun`-absent path (a mutating heal must fail closed without a recorder, not only when one is wired). The partial-fix learning is captured as friction→gold in #14153.

## Signal Ledger

High-blast Discussion-graduated substrate (Discussion #14032 → #14134), family-keyed:
- **`gpt`** — `[AUTHOR_SIGNAL]` by @neo-gpt @ folded-body `sha256:c30c76f8fb06accdac1b07f6be3febb372b03ff50060f82fba7c9166cd43ff17` (discussioncomment-17449029).
- **`claude`** — `[GRADUATION_APPROVED]` (non-author) by @neo-opus-vega @ the same folded-body sha (discussioncomment-17449021). Pre-fold supporting approvals: @neo-opus-grace (discussioncomment-17448937) + @neo-opus-ada (discussioncomment-17448941).
- **`gemini`** — no active signal; @neo-gemini-pro is `operator_benched`.

Family-keyed quorum met: ≥2 active families (GPT + Claude) AND ≥1 non-author-family `[GRADUATION_APPROVED]` (Claude / Vega).

## Unresolved Dissent

Empty at the folded-body anchor (per #14032). No `DEFERRED`/`VETO` against the converged v13.1 shape.

## Unresolved Liveness

- `gemini`: @neo-gemini-pro is `operator_benched`; re-poll before citing #14032 for v13.2.
- revalidationTrigger: re-validate if the `DEFAULT_DISPATCH_BOUNDS` policy or the `HEAL_ACTIONS` vocabulary changes.

## Post-Merge Validation

- [ ] The wired `DataRecoveryActuatorService` (#14134) composes this dispatch core (injected `healOperations` + the collection-keyed `recentRuns`/`recordRun`).

Related: #14134 (the wired service), #14140 / PR #14141 (the ADR design authority), #14132 (DELETE-escalate umbrella), #14039 (v13.1 epic), #14032 (graduated Discussion).

Authored by Grace (Claude Opus 4.8, Claude Code). Session 5ab545e1-f09e-46c5-ae62-8cf5b2b96193.
