### PR TITLE
fix(ai): edge-trigger deployment-state-bridge success log (#14147)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -67,6 +67,9 @@ export class DeploymentStateBridgeService extends Base {
     lastWriteAt           = 0
     writeInFlight         = false
     statsSamplesByService = new Map()
+    // Last service-state signature written to the log; gates the edge-triggered success line so a
+    // healthy steady-state stops re-emitting an identical INFO line on every snapshot write.
+    lastLoggedSignature   = null
 
     /**
      * Writes a snapshot when enabled and due.
@@ -100,9 +103,22 @@ export class DeploymentStateBridgeService extends Base {
                   });
 
             this.lastWriteAt = now;
-            this.writeLog?.('INFO', `[DeploymentStateBridge] wrote ${snapshot.services.length} service snapshots to ${AiConfig.orchestrator.deploymentStateBridge.snapshotPath}`);
 
-            return {ok: true, status: 'written', snapshot, ...result};
+            // Edge-trigger the success line: a healthy deployment writes an identical snapshot every
+            // interval, so logging each write floods the daemon log and buries real signal. Emit only
+            // on the first write or when a service appears/disappears or changes status. Liveness is
+            // still observable via the snapshot's own `generatedAt` + the `staleAfterMs` watchdog.
+            const signature = buildServiceStateSignature(snapshot.services),
+                  logged    = signature !== this.lastLoggedSignature;
+
+            if (logged) {
+                const transition = this.lastLoggedSignature === null ? 'first write' : 'service-state changed';
+
+                this.writeLog?.('INFO', `[DeploymentStateBridge] wrote ${snapshot.services.length} service snapshots to ${AiConfig.orchestrator.deploymentStateBridge.snapshotPath} (${transition})`);
+                this.lastLoggedSignature = signature;
+            }
+
+            return {ok: true, status: 'written', snapshot, logged, ...result};
         } catch (error) {
             this.writeLog?.('ERROR', `[DeploymentStateBridge] snapshot write failed: ${error.message}`);
             throw error;
@@ -387,6 +403,20 @@ function summarizeLogs(logs, maxBytes) {
 
 function isSafeServiceKey(value) {
     return typeof value === 'string' && /^[a-zA-Z0-9_.-]+$/.test(value);
+}
+
+/**
+ * Builds a stable, order-independent signature of the snapshot's per-service status. Used to
+ * edge-trigger the success log: an unchanged signature means a healthy steady-state write whose
+ * log line carries no new information and is therefore suppressed.
+ * @param {Object[]} services Collected per-service snapshot envelopes.
+ * @returns {String}
+ */
+function buildServiceStateSignature(services) {
+    return (Array.isArray(services) ? services : [])
+        .map(service => `${service.serviceKey}:${service.status}`)
+        .sort()
+        .join(',');
 }
 
 export default Neo.setupClass(DeploymentStateBridgeService);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1,4 +1,7 @@
 import {test, expect}                 from '@playwright/test';
+import fs                             from 'fs';
+import os                             from 'os';
+import path                           from 'path';
 import Neo                            from '../../../../../../../src/Neo.mjs';
 import * as core                      from '../../../../../../../src/core/_export.mjs';
 import AiConfig                       from '../../../../../../../ai/config.mjs';
@@ -260,5 +263,42 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                 target       : {kind: 'compose-service', id: 'model'}
             }
         });
+    });
+
+    test('edge-triggers the success log: silent on unchanged state, re-logs on a service-state transition', async () => {
+        const snapshotPath = path.join(os.tmpdir(), 'neo-deployment-bridge-edge-trigger.spec.json');
+
+        AiConfig.orchestrator.deploymentStateBridge.snapshotPath     = snapshotPath;
+        AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes = 256 * 1024;
+
+        const
+            logs    = [],
+            service = createService({});
+
+        service.writeLog = (level, message) => logs.push({level, message});
+
+        let services = [{serviceKey: 'model', status: 'available'}, {serviceKey: 'memory', status: 'available'}];
+
+        // Override the gatherer so the test controls the per-service status that drives the signature.
+        service.collectSnapshot = async () => ({generatedAt: OBSERVED_AT, services, recoveryRuns: {entries: []}});
+
+        const first     = await service.writeSnapshotIfDue({force: true}); // first write → logs
+        const unchanged = await service.writeSnapshotIfDue({force: true}); // identical state → silent
+
+        services = [{serviceKey: 'model', status: 'available'}, {serviceKey: 'memory', status: 'degraded'}];
+
+        const transitioned = await service.writeSnapshotIfDue({force: true}); // status flip → logs again
+
+        expect(first.logged).toBe(true);
+        expect(unchanged.logged).toBe(false);
+        expect(transitioned.logged).toBe(true);
+
+        const infoLines = logs.filter(entry => entry.level === 'INFO' && entry.message.includes('service snapshots'));
+
+        expect(infoLines).toHaveLength(2);
+        expect(infoLines[0].message).toContain('first write');
+        expect(infoLines[1].message).toContain('service-state changed');
+
+        try { fs.unlinkSync(snapshotPath); } catch {}
     });
 });


### PR DESCRIPTION
## Summary

The orchestrator's `DeploymentStateBridge` logged an INFO line on **every** successful snapshot write — **~2879 lines since the 12:42 start (~11s avg)**, about half of all orchestrator-log volume — with no operational value, and it **camouflaged a real failure** (a KB-sync batch-214 abort surfaced in the same window). `Orchestrator.writeLog` (Orchestrator.mjs:563) has **no level filter** — every level is appended to disk — so demote-to-DEBUG would not help; the line must not be *emitted* on an unchanged snapshot.

Resolves #14147

## Change

Edge-trigger the success log via a stable, order-independent per-service `serviceKey:status` signature (`buildServiceStateSignature`): emit the INFO line **only on the first write or when a service appears/disappears or changes status** (available↔degraded). Steady-state is silent. The WARN/ERROR write-failure path is unchanged. A `logged` boolean is added to the result for observability + testability.

Evidence: `grep -c "DeploymentStateBridge] wrote"` on the live `.neo-ai-data/orchestrator-daemon/orchestrator.log` = **2879** since the 12:42:53Z start; per-minute sampling shows ~2/min recently but a ~11s run-average (the `writeIntervalMs:30000` gate isn't holding consistently); `writeLog` appends all levels to disk (no DEBUG suppression).

## Deltas from ticket (if any)

- Added a `logged` boolean to the `writeSnapshotIfDue` result (beyond the ticket's literal AC) so the edge-trigger is observable + unit-testable without spying on `writeLog`.
- Confirmed during implementation that `Orchestrator.writeLog` has no level filter (every level → disk), which rules out demote-to-DEBUG and validates edge-trigger (suppress-on-unchanged) as the only shape that reduces the flood.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs DeploymentStateBridgeService` → **5 passed (32.5s)**, including the new case `edge-triggers the success log: silent on unchanged state, re-logs on a service-state transition`:
- first write → `logged: true` (`first write`)
- identical state → `logged: false` (silent)
- status transition (available→degraded) → `logged: true` (`service-state changed`)
- exactly **2** INFO `service snapshots` lines emitted across 3 writes.

## Post-Merge Validation

Once the orchestrator picks this up on `dev`: confirm the steady-state `orchestrator.log` no longer emits the recurring `[DeploymentStateBridge] wrote N service snapshots` line, while a genuine service-status transition still produces a single INFO line (`service-state changed`).

## Scope / Follow-ups (separate tickets — NOT this PR)

1. **Child-stderr default-ERROR misclassification** (#14149, PR #14152) — `ProcessSupervisor.getChildLogLevel` defaults unprefixed child lines to ERROR, mis-stamping kbSync progress.
2. **Immune-system local/cloud scoping** (#14150) — the 4 immune services are "both by omission"; gate only the B1 docker-socket sibling-restart to cloud (operator-confirmed: keep bridge + data-integrity + B0 local).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `fe9c04d6-1aae-4017-8d53-19b0e5aaf809`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
