### PR TITLE
fix(ai): prefix supervised-child progress stderr so it classifies INFO/WARN, not ERROR (#14149)

### DIFF
--- a/ai/scripts/maintenance/syncKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/syncKnowledgeBase.mjs
@@ -19,15 +19,25 @@ import {withHeavyMaintenanceLease} from '../../daemons/orchestrator/services/Hea
  * `lastSuccessAt`) — the kb-sync half of the deferred-as-completed fix.
  */
 
+/**
+ * Logs supervised-child progress to STDERR (STDOUT carries the single structured outcome JSON),
+ * prefixed `[INFO]` so the orchestrator's `ProcessSupervisorService` classifies it as INFO. Its
+ * `getChildLogLevel` defaults UNPREFIXED child stderr to ERROR, which otherwise mis-stamps routine
+ * progress as errors and camouflages real failures. Genuine failures stay on raw `console.error`
+ * (unprefixed → ERROR).
+ * @param {...*} args
+ */
+const logProgress = (...args) => console.error('[INFO]', ...args);
+
 async function syncKnowledgeBase() {
     // Enable debug logging to see progress. B4-safe activation: drive NEO_DEBUG via the Provider
     // override API, never mutate the read-only reactive Provider.
     KB_Config.setEnvOverride('NEO_DEBUG', true);
     const staleStrategy = process.env.NEO_KB_STALE_STRATEGY || undefined;
 
-    console.error('⏳ Initializing Knowledge Base Services...');
+    logProgress('⏳ Initializing Knowledge Base Services...');
     if (staleStrategy) {
-        console.error(`   Using explicit stale strategy: ${staleStrategy}`);
+        logProgress(`   Using explicit stale strategy: ${staleStrategy}`);
     }
 
     // Run the full sync under the shared heavy-maintenance lease so this CLI cannot
@@ -37,19 +47,19 @@ async function syncKnowledgeBase() {
     try {
         outcome = await withHeavyMaintenanceLease(
             async () => {
-                console.error('   Waiting for Lifecycle Service...');
+                logProgress('   Waiting for Lifecycle Service...');
                 await KB_LifecycleService.ready();
-                console.error('   Lifecycle Service Ready. Database should be running.');
+                logProgress('   Lifecycle Service Ready. Database should be running.');
 
-                console.error('   Waiting for Chroma Manager...');
+                logProgress('   Waiting for Chroma Manager...');
                 await KB_ChromaManager.ready();
-                console.error('   Chroma Manager Ready.');
+                logProgress('   Chroma Manager Ready.');
 
-                console.error('   Waiting for Database Service...');
+                logProgress('   Waiting for Database Service...');
                 await KB_DatabaseService.ready();
-                console.error('   Database Service Ready.');
+                logProgress('   Database Service Ready.');
 
-                console.error('✅ Services Ready. Starting Synchronization...');
+                logProgress('✅ Services Ready. Starting Synchronization...');
 
                 // Execute the full sync (create + embed). `NEO_KB_STALE_STRATEGY=shadow-swap`
                 // opts into the shadow-swap stale-data strategy; default CLI sync remains unchanged.
@@ -64,8 +74,8 @@ async function syncKnowledgeBase() {
 
     if (outcome.status === 'held') {
         const held = outcome.lease;
-        console.error(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
-        console.error('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
+        logProgress(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
+        logProgress('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
         // Structured outcome → ProcessSupervisorService records `skipped` (not false-green
         // `completed`), so a lease-held run does not refresh kbSync's lastSuccessAt.
         console.log(JSON.stringify({
@@ -76,7 +86,7 @@ async function syncKnowledgeBase() {
         process.exit(0);
     }
 
-    console.error('✅ Synchronization Complete:', outcome.result);
+    logProgress(`✅ Synchronization Complete: ${JSON.stringify(outcome.result)}`);
     // Real run → `completed` (falls through the classify) + the embed/delete counts as details.
     console.log(JSON.stringify({deferred: false, ...(outcome.result || {})}));
     process.exit(0);

--- a/ai/services/github-workflow/shared/reconcileActiveChunks.mjs
+++ b/ai/services/github-workflow/shared/reconcileActiveChunks.mjs
@@ -65,7 +65,9 @@ export default async function reconcileActiveChunks(issueSyncConfig = {}, {type,
         if (unique.length > 0 && unique[unique.length - 1].id === item.id) {
             await fs.unlink(item.absPath);
             deduped++;
-            console.warn(`[reconcileActiveChunks] removed duplicate ${filePrefix}${item.id}.md at ${item.absPath}`)
+            // `[WARN]` prefix so the orchestrator's ProcessSupervisor classifies this child-stderr
+            // line as WARN, not its unprefixed-default ERROR (routine dedup ≠ error).
+            console.warn(`[WARN] [reconcileActiveChunks] removed duplicate ${filePrefix}${item.id}.md at ${item.absPath}`)
         } else {
             unique.push(item)
         }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -99,6 +99,21 @@ function createManualChild() {
 }
 
 test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
+    test('getChildLogLevel honors the [LOG]/[INFO]/[WARN] prefix contract; unprefixed child stderr fails safe to ERROR', () => {
+        const { service } = createTestService();
+
+        // Prefixed progress — the contract the supervised maintenance children (syncKnowledgeBase,
+        // reconcileActiveChunks) now honor — classifies to its declared level.
+        expect(service.getChildLogLevel('[INFO]    Waiting for Lifecycle Service...')).toBe('INFO');
+        expect(service.getChildLogLevel('[INFO] ✅ Services Ready. Starting Synchronization...')).toBe('INFO');
+        expect(service.getChildLogLevel('[LOG] Processed and embedded batch 2 of 328')).toBe('INFO');
+        expect(service.getChildLogLevel('[WARN] [reconcileActiveChunks] removed duplicate pr-1.md')).toBe('WARN');
+
+        // Unprefixed → ERROR fail-safe: a genuine unprefixed failure must never be silently downgraded.
+        expect(service.getChildLogLevel('❌ Synchronization Failed: Error: boom')).toBe('ERROR');
+        expect(service.getChildLogLevel('some unexpected line')).toBe('ERROR');
+    });
+
     test('getTaskPidFile returns correct path', () => {
         const { service, dataDir } = createTestService();
         const pidFile              = service.getTaskPidFile('mockTask');


### PR DESCRIPTION
## Summary

`ProcessSupervisor.getChildLogLevel` (`ProcessSupervisorService.mjs:332`) defaults **unprefixed** child stderr to ERROR — a correct fail-safe. But the kbSync child (`syncKnowledgeBase.mjs`) and the shared `reconcileActiveChunks` helper emitted **unprefixed progress** (`✅ Services Ready`, `Waiting for Lifecycle Service...`, `[reconcileActiveChunks] removed duplicate`), so all of it was mis-stamped **ERROR** in the orchestrator log — inflating the apparent error rate and **camouflaging the genuine `❌ Synchronization Failed` batch-214 abort** sitting in the same ERROR stream.

Resolves #14149

## Change

Producer-side, honoring the existing prefix contract (the default-ERROR fail-safe is kept):
- `syncKnowledgeBase.mjs`: route the 12 progress lines through a `logProgress()` helper that prefixes `[INFO]`. The genuine `❌ Synchronization Failed` stays on raw `console.error` (unprefixed → ERROR).
- `reconcileActiveChunks.mjs`: prefix the routine dedup `console.warn` with `[WARN]` (honors the author's severity intent; classifies WARN, not ERROR).
- githubWorkflowSync's other emitters need no change: its `console.log` progress goes to stdout (which that task `ignore`s — no `captureStdoutJson`), and its `console.error`s are genuine failures.

Evidence: the live `orchestrator.log` showed `✅ Services Ready`, `⏳ Initializing`, `Waiting for...`, `[reconcileActiveChunks] removed duplicate` all at `[ERROR]`, interleaved with the real `❌ Synchronization Failed: ... batch 214` abort.

## Deltas from ticket (if any)

- Scoping refinement: the ticket named "kbSync + githubWorkflowSync". On inspection, githubWorkflowSync's progress uses `console.log` → stdout, which that task `ignore`s (no `captureStdoutJson`), and its `console.error`s are genuine failures — so the only githubWorkflowSync emitter needing a fix was the shared `reconcileActiveChunks` dedup warn. kbSync (`syncKnowledgeBase.mjs`) carried the bulk.
- Kept the `getChildLogLevel` default-ERROR fail-safe rather than demoting it — a producer-side prefix fix preserves ERROR for genuine unprefixed failures.

## Test Evidence

- New `getChildLogLevel` contract test locks the mapping (`[INFO]`/`[LOG]`→INFO, `[WARN]`→WARN, unprefixed→ERROR fail-safe). `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs ProcessSupervisorService` → **39 passed**.
- Node sanity over the actual emitted strings: all classify as intended — `[INFO]    Waiting...`→INFO, `[INFO] ✅ Services Ready...`→INFO, `[WARN] [reconcileActiveChunks]...`→WARN, `❌ Synchronization Failed...`→ERROR.

## Post-Merge Validation

After the orchestrator picks this up on `dev`: confirm a live kbSync / githubWorkflowSync run no longer puts routine progress (`✅ Services Ready`, dedup-removed) in the ERROR stream, while a genuine sync failure (e.g. the embedder-404 batch abort) still appears at ERROR.

## Related

Discovered alongside #14147 (the DeploymentStateBridge log-flood, PR #14148). Together they de-noise the orchestrator log so the real fire — the KB-sync batch-214 embedder-404 failure (#14124 domain) — stands out. Sibling follow-up #14150 (immune-system local/cloud scoping).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `fe9c04d6-1aae-4017-8d53-19b0e5aaf809`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
