### PR TITLE
fix(ai): align list_stores OpenAPI to the {stores:[]} envelope + isLoaded (#10072)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -572,18 +572,23 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    model:
-                      oneOf:
-                        - type: string
-                        - type: object
-                    count:
-                      type: integer
+                type: object
+                properties:
+                  stores:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        model:
+                          oneOf:
+                            - type: string
+                            - type: object
+                        count:
+                          type: integer
+                        isLoaded:
+                          type: boolean
 
   /data/record/get:
     post:

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -373,7 +373,7 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(operationIds).toEqual(mappingIds);
     });
 
-    test('neural-link inspect_store + list_stores output schemas accept an object `model` (#13372)', () => {
+    test('neural-link inspect_store + list_stores output schemas (object `model` #13372; list_stores `{stores:[]}` envelope + `isLoaded` #10072)', () => {
         const doc         = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'), 'utf8')),
               opsById     = getOperationsById(doc),
               // A live store's `model` is the serialized Neo.data.Model — an object, not a className string.
@@ -389,9 +389,10 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(() => inspectStoreOut.parse({id: 'store-1', count: 2, model: objectModel, filters: [], sorters: [], items: []})).not.toThrow();
         // A className-only string `model` still parses — backward-compatible.
         expect(() => inspectStoreOut.parse({id: 'store-1', count: 2, model: 'Neo.data.Model', filters: [], sorters: [], items: []})).not.toThrow();
-        // list_stores: the top-level array response is wrapped as `{result: [...]}` by the output validator;
-        // each item's object `model` parses.
-        expect(() => listStoresOut.parse({result: [{id: 'store-1', model: objectModel, count: 2}]})).not.toThrow();
+        // list_stores: the impl (src/ai/client/DataService.mjs#listStores) returns a NAMED `{stores:[...]}`
+        // envelope incl. `isLoaded` — not a top-level array (strict output validation surfaced that drift). The
+        // schema admits the envelope, the `isLoaded` field, and each item's object `model`.
+        expect(() => listStoresOut.parse({stores: [{id: 'store-1', model: objectModel, count: 2, isLoaded: true}]})).not.toThrow();
     });
 
     for (const server of servers) {


### PR DESCRIPTION
## Summary

`neural-link/list_stores` failed with `Error: data must have required property 'result'` (confirmed live on devindex per the ticket). The impl (`src/ai/client/DataService.mjs#listStores`) returns a **named `{stores:[...]}` envelope** incl. `isLoaded`, but the OpenAPI declared a **top-level array** — so #10043's strict output-validation wrapped the declared array as `{result:[...]}` and rejected the real payload.

**Fix (option C — author-recommended):** align the OpenAPI `list_stores` 200 response to the impl's `{stores:[...]}` envelope and admit the `isLoaded` field (preserving the `model: oneOf[string,object]` from #13379). The implementation is unchanged — it was already correct; the schema was the drift.

Resolves #10072

Evidence: L2 (unit — `buildOutputZodSchema(list_stores).parse({stores:[{id,model,count,isLoaded}]})` round-trip) → L3 (live `neural-link/list_stores` MCP call against a store-heavy session) required for the runtime contract. Residual: the live-NL probe — sandbox cannot reach a live Neural Link session [#10072].

## Contract Ledger

Per @neo-gpt's 2026-06-21 intake (the ledger that unblocked this; this PR touches an agent-consumed MCP/OpenAPI contract):

| Target Surface | Source of Authority | Behavior | Edge / Fallback |
|---|---|---|---|
| `ai/mcp/server/neural-link/openapi.yaml` `list_stores` response | runtime impl | accepts `{stores:[{id, model, count, isLoaded}]}` | preserves `model: string \| object` (#13379) |
| `src/ai/client/DataService.listStores()` | runtime (unchanged) | returns `{stores:[...]}` with `isLoaded` | empty registry → `{stores: []}` |
| MCP output validator | #10043 strict output validation | `list_stores` no longer throws `data must have required property 'result'` for the runtime payload | — |

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` → **31 passed (31.0s)**, including:
- the updated `list_stores` round-trip — `{stores:[{id, model: <object>, count, isLoaded: true}]}` parses against `buildOutputZodSchema`;
- the broad compliance guards (array-nodes-have-items #10064, output-schemas-tolerate-extra-props #9837, input-schemas-strict-at-root) all pass with the new envelope → the schema stays spec-compliant.

## Post-Merge Validation

- Live `neural-link/list_stores` MCP call against a store-heavy example session returns a valid `{stores:[...]}` payload without the `result`-property schema error (L3 — the agent sandbox cannot reach a live Neural Link session, so this is an operator/live-session check).

## Deltas

- `ai/mcp/server/neural-link/openapi.yaml`: `list_stores` 200 response `type: array` → `type: object` with a `stores` array property + `isLoaded: boolean` on the item.
- `test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs`: updated the `list_stores` assertion from the old `{result:[...]}` wrap to the `{stores:[...]}` envelope + `isLoaded`.

Authored by Vega (Claude Opus 4.8, Claude Code). Session 16bbea8d-8bc9-4dad-8e1c-8e3b2cd861a3. (Opened via the machine `gh` token, which attributes the PR to @neo-opus-ada; the author is Vega.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
