### PR TITLE
fix(ai): stabilize backpressure deferral dedup key against volatile counters (#14156)

### DIFF
--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -237,14 +237,14 @@ export function recordDeferral({
 }) {
     const isLeaseHeld = reasonCode === 'heavy-maintenance-lease-held';
     const holderOwner = holdingLease?.owner || 'unknown';
-    // Strip a trailing volatile counter (e.g. `pending-memory-minisummary:47`) from the dedup key so
-    // recurring deferrals of the same task by the same blocker collapse to ONE log line per episode.
-    // Without this, a counter that changes each poll (the memorySummaryBackfill backlog) churns the
-    // key and the dedup never fires. The full reasonText (with count) stays in the message + outcome.
-    const stableReason = String(reasonText).replace(/:\d+$/, '');
-    const dedupKey    = isLeaseHeld
-        ? `${taskName}:lease-held-by-${holderOwner}:${stableReason}`
-        : `${taskName}:${blockingTaskName}:${stableReason}`;
+    // Dedup on STABLE identifiers only — the deferred task, its blocker, and the deferral reasonCode —
+    // never the volatile `reasonText`: its `:<count>` / `:<interval>` suffix changes every poll and its
+    // source-class is already implied by `taskName`, so including it churns the key (the dedup never
+    // fires) without adding a real distinction. The full reasonText (with count) stays in the log
+    // message + the recordTaskOutcome payload below.
+    const dedupKey = isLeaseHeld
+        ? `${taskName}:lease-held-by-${holderOwner}`
+        : `${taskName}:${blockingTaskName}:${reasonCode}`;
 
     if (!deferralLogKeys.has(dedupKey)) {
         const taskLabel = taskDefinitions?.[taskName]?.label || taskName;

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -237,9 +237,14 @@ export function recordDeferral({
 }) {
     const isLeaseHeld = reasonCode === 'heavy-maintenance-lease-held';
     const holderOwner = holdingLease?.owner || 'unknown';
+    // Strip a trailing volatile counter (e.g. `pending-memory-minisummary:47`) from the dedup key so
+    // recurring deferrals of the same task by the same blocker collapse to ONE log line per episode.
+    // Without this, a counter that changes each poll (the memorySummaryBackfill backlog) churns the
+    // key and the dedup never fires. The full reasonText (with count) stays in the message + outcome.
+    const stableReason = String(reasonText).replace(/:\d+$/, '');
     const dedupKey    = isLeaseHeld
-        ? `${taskName}:lease-held-by-${holderOwner}:${reasonText}`
-        : `${taskName}:${blockingTaskName}:${reasonText}`;
+        ? `${taskName}:lease-held-by-${holderOwner}:${stableReason}`
+        : `${taskName}:${blockingTaskName}:${stableReason}`;
 
     if (!deferralLogKeys.has(dedupKey)) {
         const taskLabel = taskDefinitions?.[taskName]?.label || taskName;

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -295,8 +295,9 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         const writeLog        = (level, message) => logCalls.push({level, message});
         const taskDefinitions = {kbSync: {label: 'KB sync'}, 'memory-summary-backfill': {label: 'memory miniSummary backfill'}};
 
-        // The memorySummaryBackfill backlog counter changes every poll; without a stabilized dedup key
-        // each value churns the key and the deferral logs on every poll (the live ~8%-of-lines flood).
+        // The memorySummaryBackfill backlog counter changes every poll. The dedup key is keyed on
+        // (task, blocker, reasonCode) — NOT the volatile reasonText — so the changing count never
+        // churns it and the deferral logs once per episode (not the live ~8%-of-lines flood).
         for (const backlog of [47, 48, 49, 50]) {
             recordDeferral({
                 deferralLogKeys,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -289,6 +289,45 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(outcomeCalls[0].payload.deferredAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
 
+    test('recordDeferral dedupes across a CHANGING reasonText counter (the volatile-backlog flood fix)', () => {
+        const deferralLogKeys = new Set();
+        const logCalls        = [];
+        const writeLog        = (level, message) => logCalls.push({level, message});
+        const taskDefinitions = {kbSync: {label: 'KB sync'}, 'memory-summary-backfill': {label: 'memory miniSummary backfill'}};
+
+        // The memorySummaryBackfill backlog counter changes every poll; without a stabilized dedup key
+        // each value churns the key and the deferral logs on every poll (the live ~8%-of-lines flood).
+        for (const backlog of [47, 48, 49, 50]) {
+            recordDeferral({
+                deferralLogKeys,
+                taskName        : 'memory-summary-backfill',
+                reasonCode      : 'heavy-maintenance-backpressure',
+                reasonText      : `pending-memory-minisummary:${backlog}`,
+                blockingTaskName: 'kbSync',
+                taskDefinitions,
+                writeLog
+            });
+        }
+
+        // Four polls with a changing counter → ONE log line (the dedup now holds on the stable key).
+        expect(logCalls.length).toBe(1);
+        expect(logCalls[0].message).toContain('Deferring memory miniSummary backfill');
+        expect(logCalls[0].message).toContain('pending-memory-minisummary:47'); // first episode's live count stays in the message
+
+        // A new deferral episode after the prior one clears → re-logs exactly once.
+        clearDeferralLogState({deferralLogKeys, taskName: 'memory-summary-backfill'});
+        recordDeferral({
+            deferralLogKeys,
+            taskName        : 'memory-summary-backfill',
+            reasonCode      : 'heavy-maintenance-backpressure',
+            reasonText      : 'pending-memory-minisummary:51',
+            blockingTaskName: 'kbSync',
+            taskDefinitions,
+            writeLog
+        });
+        expect(logCalls.length).toBe(2);
+    });
+
     test('recordDeferral (cross-daemon lease-held) uses holdingLease owner in key + payload', () => {
         const deferralLogKeys = new Set();
         const logCalls        = [];


### PR DESCRIPTION
## Summary

Third orchestrator-log flood source (after #14147 bridge, #14149 child-stderr): `[Orchestrator] Deferring memory miniSummary backfill; heavy maintenance task knowledge base sync is active (pending-memory-minisummary:N)` at **~8% of log lines (123 in 1500)**. `recordDeferral` already dedups via `deferralLogKeys` + `clearDeferralLogState` (per-episode), but the dedup key embedded the full `reasonText`, and `memorySummaryBackfill.mjs:195` emits `pending-memory-minisummary:${backlog}` — a count that changes every poll → new key every poll → the dedup never fired while kbSync held the lease for hours.

Resolves #14156

## Change

**Dedup on stable, declared identifiers** — the deferred `taskName`, its blocker, and the deferral `reasonCode` — and **drop the volatile `reasonText` from the key entirely**. The deferred task's source-class is already implied by `taskName`, and the `:<count>` / `:<interval>` suffix is volatile noise, so the reasonText added no real distinction — only churn. The full `reasonText` (with count) stays in the log message + the `recordTaskOutcome` payload.

- Backpressure / golden-path: `${taskName}:${blockingTaskName}:${reasonCode}`
- Lease-held: `${taskName}:lease-held-by-${holderOwner}`

No change to deferral/lease behavior — the fully-serial heavy-maintenance mutex is untouched.

Evidence: live `orchestrator.log` had 123 `pending-memory-minisummary:N` deferral lines in 1500; `memorySummaryBackfill.mjs:195` sets `reason: pending-memory-minisummary:${backlog}`.

## Deltas from ticket (if any)

- Cycle-2 (per @neo-gpt's #14157 depth-floor): the first pass derived a stable key by regex-stripping a trailing `:<digits>` from `reasonText` — which worked but also collapsed constant interval-style reasons (`periodic-sync:1800000`), a heuristic on a display string. Replaced with keying on the explicit stable `reasonCode`, removing the regex and the breadth concern at the root.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs MaintenanceBackpressureService` → **28 passed**, incl. `recordDeferral dedupes across a CHANGING reasonText counter`: 4 polls with `pending-memory-minisummary:47..50` → 1 log; post-`clearDeferralLogState` → re-logs once. The pre-existing constant-reason dedup test still passes.

## Post-Merge Validation

After the orchestrator picks this up on `dev`: confirm the steady-state `orchestrator.log` shows the `Deferring memory miniSummary backfill; ... knowledge base sync is active` line at most once per deferral episode (not every poll) during a long kbSync.

## Related

Completes the orchestrator log-hygiene RATE trio with #14147 (PR #14148) + #14149 (PR #14152); the SIZE axis is #14159 (PR #14160). Distinct from #14144 (the backpressure *behavior* — indefinite deferral).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `fe9c04d6-1aae-4017-8d53-19b0e5aaf809`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
