### PR TITLE
fix(ai): daily-rotate the orchestrator log (was unbounded; the one daemon missing it) (#14159)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -90,6 +90,68 @@ function resolveCloudOnlyEnabled(key) {
     return AiConfig.orchestrator.deploymentMode === 'cloud';
 }
 
+const LOG_RETENTION_DAYS = 30;
+
+/**
+ * @summary Rotates a daemon log file when its mtime falls on a prior calendar day.
+ *
+ * Renames the previous-day file to `<logFile>.YYYY-MM-DD` so the active file only ever holds the
+ * current day's lines — bounding the otherwise-unbounded growth (the orchestrator polls every few
+ * seconds, so its `writeLog` reliably triggers this once per day). Best-effort: failures are
+ * swallowed — log integrity must never gate daemon liveness (mirrors the embed/message/wake daemons).
+ * @param {String} logFile Active log file path.
+ * @returns {void}
+ */
+export function rotateLogFileIfNewDay(logFile) {
+    if (!logFile || !fs.existsSync(logFile)) return;
+
+    try {
+        const fileDay  = fs.statSync(logFile).mtime.toISOString().split('T')[0],
+              todayDay = new Date().toISOString().split('T')[0];
+
+        if (fileDay !== todayDay) {
+            fs.renameSync(logFile, `${logFile}.${fileDay}`);
+        }
+    } catch (e) {
+        // Best-effort; the daemon stays alive even if rotation fails.
+    }
+}
+
+/**
+ * @summary Prunes archived daemon log files older than the retention window.
+ *
+ * Deletes `<baseName>.*` archives (e.g. `orchestrator.log.2026-05-01`) whose mtime is older than
+ * `retentionDays`, leaving the active `<baseName>` untouched. Best-effort; runs once at startup.
+ * @param {Object} options
+ * @param {String} options.dir Daemon data directory.
+ * @param {String} options.baseName Active log file name (archives are `<baseName>.*`).
+ * @param {Number} [options.retentionDays=LOG_RETENTION_DAYS] Days of archives to keep.
+ * @returns {void}
+ */
+export function pruneOldDailyLogs({dir, baseName, retentionDays = LOG_RETENTION_DAYS}) {
+    if (!dir || !baseName) return;
+
+    const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+
+    try {
+        for (const entry of fs.readdirSync(dir)) {
+            if (!entry.startsWith(`${baseName}.`) || entry === baseName) continue;
+
+            const fullPath = path.join(dir, entry);
+
+            try {
+                if (fs.statSync(fullPath).mtime.getTime() < cutoff) {
+                    fs.unlinkSync(fullPath);
+                }
+            } catch (e) {
+                // Per-entry failure is non-fatal.
+            }
+        }
+    } catch (e) {
+        // Directory-listing failure is non-fatal.
+    }
+}
+
 /**
  * @summary Neo daemon class for Agent OS maintenance scheduling.
  *
@@ -507,6 +569,9 @@ export class Orchestrator extends Base {
 
         fs.ensureDirSync(this.dataDir);
 
+        // Prune stale daily-rotated archives so the data dir doesn't accrue them unboundedly.
+        pruneOldDailyLogs({dir: path.dirname(this.logFile), baseName: path.basename(this.logFile)});
+
         this.taskStateService.configure({
             stateFile      : this.stateFile,
             taskDefinitions: this.taskDefinitions,
@@ -561,6 +626,8 @@ export class Orchestrator extends Base {
      * @returns {void}
      */
     writeLog(level, message) {
+        rotateLogFileIfNewDay(this.logFile);
+
         const timestamp = new Date().toISOString();
         const line      = `[${timestamp}] [PID:${process.pid}] [${level}] ${message}`;
 

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -31,7 +31,7 @@ import fs                             from 'fs-extra';
 import path                           from 'path';
 import {execSync}                     from 'child_process';
 import AiConfig                       from '../../config.mjs';
-import Orchestrator                   from './Orchestrator.mjs';
+import Orchestrator, {rotateLogFileIfNewDay} from './Orchestrator.mjs';
 import {assertConfigFresh}            from '../../scripts/setup/initServerConfigs.mjs';
 
 const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
@@ -51,6 +51,11 @@ export function isOrchestratorDaemonCommand(cmd) {
 }
 
 function writeLog(level, message) {
+    // Both this wrapper writer AND Orchestrator.writeLog append to the same orchestrator.log, so
+    // BOTH must rotate-before-append: an unguarded append here would advance the file's mtime past
+    // the day boundary and defeat the mtime-based daily rotation.
+    rotateLogFileIfNewDay(LOG_FILE);
+
     const timestamp = new Date().toISOString();
     const line      = `[${timestamp}] [PID:${process.pid}] [${level}] ${message}`;
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.logRotation.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.logRotation.spec.mjs
@@ -65,4 +65,27 @@ test.describe('Neo.ai.daemons.Orchestrator log rotation', () => {
 
         fs.removeSync(dir);
     });
+
+    test('rotate-before-append keeps a prior-day log from becoming a mixed old+new active file (two-writer / restart edge)', () => {
+        const dir = tmpDir();
+        const log = path.join(dir, 'orchestrator.log');
+
+        // A file left over from a prior day — e.g. across a restart at the day boundary, or written
+        // by the daemon.mjs wrapper writer. Both writers now rotate-before-append, so neither can
+        // advance the mtime past the boundary and leave a mixed old+new active file.
+        fs.writeFileSync(log, 'prior-day line\n');
+        const priorMs  = Date.now() - 2 * DAY_MS;
+        const priorDay = new Date(priorMs).toISOString().split('T')[0];
+        fs.utimesSync(log, new Date(priorMs), new Date(priorMs));
+
+        // The rotate-before-append contract shared by Orchestrator.writeLog AND daemon.mjs::writeLog:
+        // whichever writer fires first on the new day rotates, THEN appends to a fresh file.
+        rotateLogFileIfNewDay(log);
+        fs.appendFileSync(log, 'current-day line\n');
+
+        expect(fs.readFileSync(log, 'utf8')).toBe('current-day line\n');             // active file: only new content
+        expect(fs.readFileSync(`${log}.${priorDay}`, 'utf8')).toBe('prior-day line\n'); // prior day archived, not mixed
+
+        fs.removeSync(dir);
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.logRotation.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.logRotation.spec.mjs
@@ -1,0 +1,68 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {pruneOldDailyLogs, rotateLogFileIfNewDay} from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function tmpDir() {
+    const dir = path.join(os.tmpdir(), `neo-orch-logrotate-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    fs.ensureDirSync(dir);
+    return dir;
+}
+
+test.describe('Neo.ai.daemons.Orchestrator log rotation', () => {
+    test('rotateLogFileIfNewDay renames a prior-day log to <file>.YYYY-MM-DD; a today log + a missing file are no-ops', () => {
+        const dir = tmpDir();
+
+        // Prior-day file → rotated to `<file>.<prior-day>` (use 2 days to stay clear of midnight boundaries).
+        const oldLog  = path.join(dir, 'orchestrator.log');
+        fs.writeFileSync(oldLog, 'prior-day line\n');
+        const priorMs  = Date.now() - 2 * DAY_MS;
+        const priorDay = new Date(priorMs).toISOString().split('T')[0];
+        fs.utimesSync(oldLog, new Date(priorMs), new Date(priorMs));
+
+        rotateLogFileIfNewDay(oldLog);
+
+        expect(fs.existsSync(oldLog)).toBe(false);
+        expect(fs.existsSync(`${oldLog}.${priorDay}`)).toBe(true);
+
+        // Today file (fresh mtime) → untouched, no archive created.
+        const todayLog = path.join(dir, 'today.log');
+        fs.writeFileSync(todayLog, 'today line\n');
+        rotateLogFileIfNewDay(todayLog);
+        expect(fs.existsSync(todayLog)).toBe(true);
+        expect(fs.readdirSync(dir).filter(f => f.startsWith('today.log.'))).toEqual([]);
+
+        // Missing file → no-op, no throw.
+        expect(() => rotateLogFileIfNewDay(path.join(dir, 'nope.log'))).not.toThrow();
+
+        fs.removeSync(dir);
+    });
+
+    test('pruneOldDailyLogs deletes archives older than retention, keeps recent + never touches the active file', () => {
+        const dir      = tmpDir();
+        const baseName = 'orchestrator.log';
+
+        const active  = path.join(dir, baseName);
+        const oldArch = path.join(dir, `${baseName}.2020-01-01`);
+        const newArch = path.join(dir, `${baseName}.${new Date().toISOString().split('T')[0]}`);
+
+        fs.writeFileSync(active, 'active\n');
+        fs.writeFileSync(oldArch, 'old archive\n');
+        fs.writeFileSync(newArch, 'recent archive\n');
+        const oldMs = Date.now() - 60 * DAY_MS;
+        fs.utimesSync(oldArch, new Date(oldMs), new Date(oldMs));
+
+        pruneOldDailyLogs({dir, baseName, retentionDays: 30});
+
+        expect(fs.existsSync(oldArch)).toBe(false); // older than 30d → pruned
+        expect(fs.existsSync(newArch)).toBe(true);  // recent → kept
+        expect(fs.existsSync(active)).toBe(true);   // active file → never pruned
+
+        fs.removeSync(dir);
+    });
+});


### PR DESCRIPTION
## Summary

"How big should `orchestrator.log` grow? What is the cap?" → **None.** Both writers (`Orchestrator.writeLog`, `daemon.mjs::writeLog`) `fs.appendFileSync` to the same `orchestrator.log` with no rotation — 33MB+ in ~10h, growing indefinitely. The embed/message/wake daemons ALL rotate daily + prune (30-day retention); the orchestrator — the highest-volume logger — was the only one without it.

Resolves #14159

## Change

Add daily rotation + retention prune to the orchestrator log, matching the proven sibling pattern, in **both writers** that share `orchestrator.log`:
- `rotateLogFileIfNewDay(logFile)` at the top of **both** `Orchestrator.writeLog` AND `daemon.mjs::writeLog` — renames the active file to `orchestrator.log.YYYY-MM-DD` when its mtime is a prior calendar day. Rotate-before-append in each so neither writer can advance the mtime past the day boundary and defeat the other's rotation.
- `pruneOldDailyLogs(...)` at startup — drops `orchestrator.log.*` archives older than 30 days.
- Best-effort: rotation/prune failures are swallowed (log integrity never gates daemon liveness — the same contract as the siblings).

Evidence: live `orchestrator.log` = 33MB since the 12:42 start; no rotation in either writer; `embed/daemon.mjs:70` `rotateLogIfNewDay` + `LOG_RETENTION_DAYS=30` is the replicated pattern.

## Deltas from ticket (if any)

- **Cycle-2 (per @neo-gpt's #14160 review):** the first pass guarded only `Orchestrator.writeLog`, assuming `daemon.mjs`'s low-volume lines were carried by the same file's rotation. That was wrong — an unguarded `daemon.mjs` append advances the file's mtime past the day boundary, so the next `Orchestrator.writeLog` rotation check sees a *current-day* mtime and never rotates (a mixed old+new active file that never rolls). Fixed: **both** writers rotate-before-append. Added a two-writer/restart edge test.
- Retention is a module constant (30) matching the embed daemon, not a new config leaf — consistency with the established sibling pattern over added config surface.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs ai/daemons/orchestrator/Orchestrator ai/daemons/orchestrator/daemon Orchestrator.logRotation` → **all pass** (incl. the daemon spec, confirming the new import/rotate call is safe). New `Orchestrator.logRotation.spec.mjs` covers: prior-day → renamed; today/missing → no-op; old archives pruned, recent + active kept; and the **two-writer/restart edge** — a prior-day file rotates before current-day content is appended (active file holds only new content; prior day archived, not mixed).

## Post-Merge Validation

After the orchestrator picks this up on `dev`: confirm `orchestrator.log` rotates to `orchestrator.log.<yesterday>` at the day boundary, the active file restarts fresh, and archives older than 30 days are pruned at startup.

## Related

Bounds the *size*; the *rate* fixes (#14147 / #14149 / #14156) cut what fills each day. The four together close the orchestrator-log hygiene theme.

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `fe9c04d6-1aae-4017-8d53-19b0e5aaf809`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
