### PR TITLE
feat(ai): KB shadow-swap resume — preserve on transient failure, resume from completed batches (#14146)

### DIFF
--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -6,13 +6,15 @@ import {
     bytesToTokens,
     emitConsumerFriction
 }                             from '../memory-core/helpers/consumerFrictionHelper.mjs';
-import ChromaManager             from './ChromaManager.mjs';
-import crypto                    from 'crypto';
-import fs                        from 'fs-extra';
-import logger                    from '../../mcp/server/knowledge-base/logger.mjs';
-import path                      from 'path';
-import readline                  from 'readline';
-import DestructiveOperationGuard from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+import ChromaManager                                                   from './ChromaManager.mjs';
+import crypto                                                          from 'crypto';
+import fs                                                              from 'fs-extra';
+import logger                                                          from '../../mcp/server/knowledge-base/logger.mjs';
+import path                                                            from 'path';
+import readline                                                        from 'readline';
+import DestructiveOperationGuard                                       from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+import {computeCorpusFingerprint, decideResume, selectResumableChunks} from './helpers/resumableEmbedding.mjs';
+import {clearResumeState, readResumeState, writeResumeState}           from './helpers/kbEmbeddingResumeStore.mjs';
 
 const TENANT_GUARDED_FIELDS = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion', 'ingestedAt'];
 const STALE_STRATEGIES      = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
@@ -699,21 +701,57 @@ class VectorService extends Base {
      * @returns {Promise<Object>} Embedding result.
      */
     async embedViaShadowSwap({liveCollection, knowledgeBase, idsToDeleteCount}) {
-        const shadowName  = this.createSwapCollectionName('shadow');
+        const stateDir    = this.getResumeStateDir();
+        const fingerprint = computeCorpusFingerprint(knowledgeBase);
+        const resumeState = await readResumeState({dir: stateDir});
+        const decision    = decideResume({resumeState, currentFingerprint: fingerprint});
+
+        let shadowCollection = null;
+        let shadowName       = null;
+        let chunksToEmbed    = knowledgeBase;
+        let attempts         = 1;
+        let alreadyEmbedded  = 0;
+
+        // Resume into the preserved shadow (it holds the completed batches), skipping already-embedded chunks.
+        if (decision.resume) {
+            try {
+                shadowName       = resumeState.shadowName;
+                attempts         = decision.attempts;
+                shadowCollection = await ChromaManager.client.getCollection({name: shadowName, embeddingFunction: aiConfig.dummyEmbeddingFunction});
+
+                const selection = selectResumableChunks({chunks: knowledgeBase, existingIds: await this.readCollectionIds(shadowCollection)});
+
+                chunksToEmbed   = selection.remaining;
+                alreadyEmbedded = selection.alreadyEmbedded;
+                logger.log(`Resuming KB embedding into '${shadowName}' — ${alreadyEmbedded} already embedded, ${chunksToEmbed.length} remaining (attempt ${attempts}).`);
+            } catch (resumeError) {
+                logger.warn(`[VectorService] Could not resume into preserved shadow '${shadowName}' (${resumeError.message}); rebuilding fresh.`);
+                shadowCollection = null;
+            }
+        }
+
+        // Fresh build: discard any stale preserved shadow (corpus-drift / attempt-cap / vanished), then rebuild.
+        if (!shadowCollection) {
+            if (resumeState?.shadowName) {
+                await this.discardResumeShadow(resumeState.shadowName);
+            }
+            await clearResumeState({dir: stateDir});
+
+            shadowName      = this.createSwapCollectionName('shadow');
+            attempts        = 1;
+            chunksToEmbed   = knowledgeBase;
+            alreadyEmbedded = 0;
+            logger.log(`Building shadow knowledge-base collection '${shadowName}' (${decision.reason}).`);
+            shadowCollection = await ChromaManager.client.createCollection({name: shadowName, embeddingFunction: aiConfig.dummyEmbeddingFunction});
+        }
+
         const parkingName = this.createSwapCollectionName('parking');
-
-        logger.log(`Building shadow knowledge-base collection '${shadowName}'.`);
-
-        const shadowCollection = await ChromaManager.client.createCollection({
-            name             : shadowName,
-            embeddingFunction: aiConfig.dummyEmbeddingFunction
-        });
 
         let liveParked     = false;
         let shadowPromoted = false;
 
         try {
-            const embedResult = await this.embedChunks({collection: shadowCollection, chunksToProcess: knowledgeBase});
+            const embedResult = await this.embedChunks({collection: shadowCollection, chunksToProcess: chunksToEmbed});
 
             if (embedResult.skipped > 0) {
                 throw new Error(`KB_EMBEDDING_INPUT_SIZE_EXCEEDED: shadow-swap refused to promote an incomplete corpus after skipping ${embedResult.skipped} over-budget embedding chunk(s).`);
@@ -726,6 +764,7 @@ class VectorService extends Base {
             shadowPromoted = true;
 
             ChromaManager.invalidateKnowledgeBaseCollectionCache();
+            await clearResumeState({dir: stateDir}); // promoted → nothing to resume
 
             const collection = await ChromaManager.getKnowledgeBaseCollection();
             const count      = await collection.count();
@@ -734,7 +773,7 @@ class VectorService extends Base {
 
             return {
                 message,
-                embedded           : embedResult.embedded,
+                embedded           : embedResult.embedded + alreadyEmbedded,
                 deleted            : idsToDeleteCount,
                 staleStrategy      : 'shadow-swap',
                 shadowCollection   : shadowName,
@@ -754,9 +793,69 @@ class VectorService extends Base {
             }
 
             if (!shadowPromoted) {
-                await this.parkFailedShadowCollection({shadowCollection, shadowName});
+                // A too-big chunk (KB_EMBEDDING_INPUT_SIZE_EXCEEDED) will NEVER embed — resuming it is futile,
+                // so park the shadow as a dead artifact (the prior behavior). A TRANSIENT embed failure (a
+                // provider blip) instead PRESERVES the shadow + records resume-state, so the next run resumes
+                // from here rather than re-embedding the whole corpus.
+                if (error?.message?.includes('KB_EMBEDDING_INPUT_SIZE_EXCEEDED')) {
+                    await this.parkFailedShadowCollection({shadowCollection, shadowName});
+                    await clearResumeState({dir: stateDir});
+                } else {
+                    try {
+                        await writeResumeState({dir: stateDir, fingerprint, shadowName, attempts});
+                        logger.warn(`[VectorService] Preserved shadow '${shadowName}' for resume (attempt ${attempts}) after a transient embedding failure: ${error.message}`);
+                    } catch (preserveError) {
+                        logger.error(`[VectorService] Failed to record resume-state for '${shadowName}': ${preserveError.message}`);
+                    }
+                }
             }
             throw error;
+        }
+    }
+
+    /**
+     * @summary Resolves the gitignored directory holding the KB embedding resume-state marker.
+     * @returns {String}
+     */
+    getResumeStateDir() {
+        return this.resumeStateDir ?? path.resolve(aiConfig.neoRootDir, '.neo-ai-data', 'kb-sync');
+    }
+
+    /**
+     * @summary Reads every document id present in a Chroma collection (paginated id-only fetch).
+     * Used to compute which chunks a preserved resume-shadow already holds.
+     * @param {Object} collection Chroma collection handle.
+     * @returns {Promise<Set<String>>}
+     */
+    async readCollectionIds(collection) {
+        const ids    = [];
+        const limit  = 1000;
+        let   offset = 0;
+
+        while (true) {
+            const batch    = await collection.get({include: [], limit, offset});
+            const batchIds = batch?.ids ?? [];
+
+            ids.push(...batchIds);
+            if (batchIds.length < limit) break;
+            offset += limit;
+        }
+
+        return new Set(ids);
+    }
+
+    /**
+     * @summary Parks a stale preserved resume-shadow (corpus drifted / attempt cap reached) so the fresh
+     * rebuild starts clean. Best-effort: a vanished/unreadable shadow is simply nothing to discard.
+     * @param {String} shadowName The preserved resume-shadow collection name.
+     * @returns {Promise<void>}
+     */
+    async discardResumeShadow(shadowName) {
+        try {
+            const shadowCollection = await ChromaManager.client.getCollection({name: shadowName, embeddingFunction: aiConfig.dummyEmbeddingFunction});
+            await this.parkFailedShadowCollection({shadowCollection, shadowName});
+        } catch (error) {
+            logger.warn(`[VectorService] Could not discard stale resume-shadow '${shadowName}': ${error.message}`);
         }
     }
 

--- a/ai/services/knowledge-base/helpers/kbEmbeddingResumeStore.mjs
+++ b/ai/services/knowledge-base/helpers/kbEmbeddingResumeStore.mjs
@@ -1,0 +1,98 @@
+/**
+ * @module ai/services/knowledge-base/helpers/kbEmbeddingResumeStore
+ * @summary Durable resume-state for the KB shadow-swap resume. A failed shadow-swap preserves its
+ * partially-built shadow collection; this tiny JSON store remembers WHICH shadow holds that progress, the
+ * corpus fingerprint it was built for (so a drifted corpus is never resumed into), and how many resume
+ * attempts have been made (so a persistent failure eventually falls back to a clean rebuild). Mirrors the
+ * `acceptedLossAuditStore` shape: a single small JSON file under the gitignored `.neo-ai-data` tree, written
+ * on a preserve-on-failure and cleared on a successful promote. Chroma collection metadata is deliberately
+ * NOT used (its `modify`-metadata path is unverified in this codebase).
+ */
+
+import fs   from 'fs/promises';
+import path from 'path';
+
+const RESUME_STATE_FILENAME = 'kb-embedding-resume-state.json';
+
+/**
+ * @summary The absolute path to the KB embedding resume-state file inside `dir`.
+ * @param {String} dir State directory (e.g. `.neo-ai-data/kb-sync`).
+ * @returns {String}
+ */
+export function getResumeStateFilePath(dir) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('getResumeStateFilePath: dir is required');
+    }
+    return path.join(dir, RESUME_STATE_FILENAME);
+}
+
+/**
+ * @summary Reads the preserved resume-state, or null if none / unreadable (fail-safe → a clean rebuild).
+ * @param {Object} options
+ * @param {String} options.dir State directory.
+ * @returns {Promise<{fingerprint: String, shadowName: String, attempts: Number}|null>}
+ */
+export async function readResumeState({dir} = {}) {
+    const filePath = getResumeStateFilePath(dir);
+
+    let raw;
+    try {
+        raw = await fs.readFile(filePath, 'utf8');
+    } catch (error) {
+        if (error?.code === 'ENOENT') return null;
+        return null; // a corrupt/unreadable marker must degrade to a clean rebuild, never crash the sync
+    }
+
+    try {
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed.fingerprint !== 'string' || typeof parsed.shadowName !== 'string') {
+            return null;
+        }
+        return {
+            fingerprint: parsed.fingerprint,
+            shadowName : parsed.shadowName,
+            attempts   : Number.isInteger(parsed.attempts) && parsed.attempts > 0 ? parsed.attempts : 1
+        };
+    } catch (error) {
+        return null;
+    }
+}
+
+/**
+ * @summary Persists the resume-state (preserve-on-failure). Creates the dir if needed.
+ * @param {Object} options
+ * @param {String} options.dir State directory.
+ * @param {String} options.fingerprint Corpus fingerprint the preserved shadow was built for.
+ * @param {String} options.shadowName The preserved resume-shadow collection name.
+ * @param {Number} [options.attempts=1] Resume attempts so far.
+ * @returns {Promise<String>} The written file path.
+ */
+export async function writeResumeState({dir, fingerprint, shadowName, attempts = 1} = {}) {
+    if (typeof fingerprint !== 'string' || fingerprint.length === 0) {
+        throw new TypeError('writeResumeState: fingerprint is required');
+    }
+    if (typeof shadowName !== 'string' || shadowName.length === 0) {
+        throw new TypeError('writeResumeState: shadowName is required');
+    }
+
+    const filePath = getResumeStateFilePath(dir);
+    await fs.mkdir(dir, {recursive: true});
+    await fs.writeFile(filePath, `${JSON.stringify({schemaVersion: 1, fingerprint, shadowName, attempts}, null, 2)}\n`, 'utf8');
+    return filePath;
+}
+
+/**
+ * @summary Clears the resume-state (on a successful promote, or when discarding a stale/drifted shadow).
+ * @param {Object} options
+ * @param {String} options.dir State directory.
+ * @returns {Promise<Boolean>} True if a marker was removed.
+ */
+export async function clearResumeState({dir} = {}) {
+    const filePath = getResumeStateFilePath(dir);
+    try {
+        await fs.rm(filePath, {force: true});
+        return true;
+    } catch (error) {
+        return false;
+    }
+}

--- a/ai/services/knowledge-base/helpers/resumableEmbedding.mjs
+++ b/ai/services/knowledge-base/helpers/resumableEmbedding.mjs
@@ -1,0 +1,86 @@
+/**
+ * @module ai/services/knowledge-base/helpers/resumableEmbedding
+ * @summary Pure helpers for resumable KB shadow-swap embedding — the fix for the all-or-nothing rebuild
+ * that loses ALL embedding progress when a single batch fails (a transient provider blip costing a full
+ * re-embed of the corpus). The shadow collection that holds the completed batches is preserved across runs
+ * and resumed into: these pure helpers decide (a) whether a preserved resume-shadow is valid for the CURRENT
+ * corpus (the fingerprint guard — never resume into a drifted corpus), and (b) which chunks still need
+ * embedding (the resume-skip). The Chroma I/O (read existing IDs, preserve/promote the shadow) is the
+ * VectorService wiring's concern; THIS is the placement-independent, fully-testable decision.
+ */
+
+import crypto from 'crypto';
+
+/**
+ * @summary Deterministic fingerprint of a corpus's chunk-ID set — the resume-shadow validity key.
+ *
+ * A resume-shadow built for one corpus must NOT be resumed into for a drifted corpus (added/removed chunks),
+ * or the promoted collection would carry stale rows. The fingerprint is order-independent (sorted unique IDs)
+ * so re-deriving it for the same corpus is stable.
+ *
+ * @param {Object[]} chunks Tenant-stamped chunks each carrying a string `.id`.
+ * @returns {String} sha256 hex of the sorted unique chunk IDs.
+ */
+export function computeCorpusFingerprint(chunks) {
+    const ids = [...new Set(
+        (Array.isArray(chunks) ? chunks : [])
+            .map(chunk => chunk?.id)
+            .filter(id => typeof id === 'string' && id.length > 0)
+    )].sort();
+
+    return crypto.createHash('sha256').update(ids.join('\n')).digest('hex');
+}
+
+/**
+ * @summary Selects the chunks NOT yet embedded into a resumed shadow collection (the resume-skip).
+ *
+ * Given the IDs already present in the preserved resume-shadow, return only the remaining chunks to embed
+ * plus the count already done. A fresh run (empty `existingIds`) returns every chunk — so the same code path
+ * serves both the from-scratch build and the resume.
+ *
+ * @param {Object} options
+ * @param {Object[]} options.chunks The full current-corpus chunks (each with a string `.id`).
+ * @param {Set<String>|String[]} [options.existingIds] IDs already embedded in the resume-shadow.
+ * @returns {{remaining: Object[], alreadyEmbedded: Number}} remaining chunks to embed + count already present.
+ */
+export function selectResumableChunks({chunks, existingIds} = {}) {
+    const present = existingIds instanceof Set
+        ? existingIds
+        : new Set(Array.isArray(existingIds) ? existingIds : []);
+
+    const all       = Array.isArray(chunks) ? chunks : [];
+    const remaining = all.filter(chunk => !present.has(chunk?.id));
+
+    return {remaining, alreadyEmbedded: all.length - remaining.length};
+}
+
+/**
+ * @summary Decides whether a preserved resume-shadow may be resumed for the current corpus.
+ *
+ * Resume only when a resume-shadow exists AND its stamped fingerprint matches the current corpus AND the
+ * resume-attempt cap has not been exhausted (a persistently-failing chunk must eventually fall back to a
+ * clean rebuild rather than resume forever). Fail-safe: any uncertainty → rebuild fresh (never resume into
+ * stale or runaway state).
+ *
+ * @param {Object} options
+ * @param {Object|null} [options.resumeState] Preserved marker `{fingerprint, attempts}` or null if none.
+ * @param {String} options.currentFingerprint Fingerprint of the current corpus.
+ * @param {Number} [options.maxAttempts=3] Resume attempts before a forced clean rebuild.
+ * @returns {{resume: Boolean, reason: String, attempts: Number}} resume decision + the next attempt number.
+ */
+export function decideResume({resumeState, currentFingerprint, maxAttempts = 3} = {}) {
+    if (!resumeState || typeof resumeState !== 'object') {
+        return {resume: false, reason: 'no-resume-shadow', attempts: 1};
+    }
+    if (resumeState.fingerprint !== currentFingerprint) {
+        return {resume: false, reason: 'corpus-drift', attempts: 1};
+    }
+
+    const priorAttempts = Number.isInteger(resumeState.attempts) && resumeState.attempts > 0 ? resumeState.attempts : 1;
+
+    if (priorAttempts >= maxAttempts) {
+        return {resume: false, reason: 'attempt-cap-exhausted', attempts: 1};
+    }
+
+    return {resume: true, reason: 'fingerprint-match', attempts: priorAttempts + 1};
+}

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -15,13 +15,14 @@ setup({
     }
 });
 
-import {test, expect}  from '@playwright/test';
-import Neo             from '../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../src/core/_export.mjs';
-import fs              from 'fs';
-import path            from 'path';
-import os              from 'os';
-import {fileURLToPath} from 'url';
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../../../src/Neo.mjs';
+import * as core         from '../../../../../../src/core/_export.mjs';
+import fs                from 'fs';
+import path              from 'path';
+import os                from 'os';
+import {fileURLToPath}   from 'url';
+import {readResumeState} from '../../../../../../ai/services/knowledge-base/helpers/kbEmbeddingResumeStore.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -231,6 +232,10 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         KB_ChromaManager.client         = originalClient;
         KB_ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
         KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+        // Isolate the shadow-swap resume-state marker per test (never touch the real .neo-ai-data tree).
+        KB_VectorService.resumeStateDir = path.join(tmpDir, 'kb-resume-state');
+        fs.rmSync(KB_VectorService.resumeStateDir, {recursive: true, force: true});
     });
 
     test('zero-changes fast-path is unchanged (existing chunks dedup to empty queue)', async () => {
@@ -540,7 +545,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         expect(registry.get(KB_Config.data.collectionName).rows.size).toBe(1);
     });
 
-    test('shadow-swap parks failed pre-promote shadow collections under a non-active name', async () => {
+    test('shadow-swap PRESERVES the shadow on a transient failure for resume (records resume-state)', async () => {
         const live                = createSpyCollection({existingIds: [], name: KB_Config.data.collectionName});
         const originalEmbedChunks = KB_VectorService.embedChunks.bind(KB_VectorService);
         let shadow;
@@ -562,10 +567,14 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
                 idsToDeleteCount: 0
             })).rejects.toThrow('forced embed failure');
 
+            // A transient embed failure PRESERVES the shadow (NOT renamed to a dead failed-shadow) and records
+            // a resume-state marker, so the next run resumes from the completed batches instead of rebuilding.
             expect(live.calls.modify).toEqual([]);
-            expect(shadow.calls.modify).toHaveLength(1);
-            expect(shadow.calls.modify[0].name).toContain(`${KB_Config.data.collectionName}-failed-shadow-`);
-            expect(shadow.calls.modify[0].name).not.toContain(`${KB_Config.data.collectionName}-shadow-`);
+            expect(shadow.calls.modify).toEqual([]);
+
+            const resumeState = await readResumeState({dir: KB_VectorService.resumeStateDir});
+            expect(resumeState?.shadowName).toBe(shadow.name);
+            expect(resumeState?.attempts).toBe(1);
         } finally {
             KB_VectorService.embedChunks = originalEmbedChunks;
         }

--- a/test/playwright/unit/ai/services/knowledge-base/helpers/kbEmbeddingResumeStore.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/helpers/kbEmbeddingResumeStore.spec.mjs
@@ -1,0 +1,68 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import fs             from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+import {
+    getResumeStateFilePath,
+    readResumeState,
+    writeResumeState,
+    clearResumeState
+} from '../../../../../../../ai/services/knowledge-base/helpers/kbEmbeddingResumeStore.mjs';
+
+async function tmpDir() {
+    return await fs.mkdtemp(path.join(os.tmpdir(), 'kb-resume-'));
+}
+
+test.describe('kbEmbeddingResumeStore — durable resume-state', () => {
+    test('write → read round-trips fingerprint + shadowName + attempts', async () => {
+        const dir = await tmpDir();
+        await writeResumeState({dir, fingerprint: 'fp-1', shadowName: 'kb-resume-shadow', attempts: 2});
+
+        expect(await readResumeState({dir})).toEqual({fingerprint: 'fp-1', shadowName: 'kb-resume-shadow', attempts: 2});
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a missing marker reads as null (→ clean rebuild)', async () => {
+        const dir = await tmpDir();
+        expect(await readResumeState({dir})).toBeNull();
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a corrupt marker reads as null, never throws (fail-safe → clean rebuild)', async () => {
+        const dir = await tmpDir();
+        await fs.writeFile(getResumeStateFilePath(dir), '{ not json', 'utf8');
+        expect(await readResumeState({dir})).toBeNull();
+
+        await fs.writeFile(getResumeStateFilePath(dir), JSON.stringify({fingerprint: 'fp'}), 'utf8'); // missing shadowName
+        expect(await readResumeState({dir})).toBeNull();
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('attempts defaults to 1 when absent/invalid', async () => {
+        const dir = await tmpDir();
+        await fs.writeFile(getResumeStateFilePath(dir), JSON.stringify({fingerprint: 'fp', shadowName: 's'}), 'utf8');
+        expect((await readResumeState({dir})).attempts).toBe(1);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('clear removes the marker → next read is null', async () => {
+        const dir = await tmpDir();
+        await writeResumeState({dir, fingerprint: 'fp', shadowName: 's'});
+        expect(await readResumeState({dir})).not.toBeNull();
+
+        expect(await clearResumeState({dir})).toBe(true);
+        expect(await readResumeState({dir})).toBeNull();
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('write creates the directory if absent + guards required args', async () => {
+        const dir = path.join(await tmpDir(), 'nested', 'kb-sync');
+        await writeResumeState({dir, fingerprint: 'fp', shadowName: 's'});
+        expect(await readResumeState({dir})).toMatchObject({fingerprint: 'fp', shadowName: 's'});
+
+        await expect(writeResumeState({dir, shadowName: 's'})).rejects.toThrow(/fingerprint is required/);
+        await expect(writeResumeState({dir, fingerprint: 'fp'})).rejects.toThrow(/shadowName is required/);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/helpers/resumableEmbedding.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/helpers/resumableEmbedding.spec.mjs
@@ -1,0 +1,86 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    computeCorpusFingerprint,
+    selectResumableChunks,
+    decideResume
+} from '../../../../../../../ai/services/knowledge-base/helpers/resumableEmbedding.mjs';
+
+const chunks = ids => ids.map(id => ({id, text: `body-${id}`}));
+
+test.describe('computeCorpusFingerprint — resume-shadow validity key', () => {
+    test('is deterministic + order-independent for the same corpus', () => {
+        const a = computeCorpusFingerprint(chunks(['c1', 'c2', 'c3'])),
+              b = computeCorpusFingerprint(chunks(['c3', 'c1', 'c2'])); // reordered
+
+        expect(a).toBe(b);
+        expect(a).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    test('changes when the corpus drifts (a chunk added or removed)', () => {
+        const base    = computeCorpusFingerprint(chunks(['c1', 'c2', 'c3'])),
+              added   = computeCorpusFingerprint(chunks(['c1', 'c2', 'c3', 'c4'])),
+              removed = computeCorpusFingerprint(chunks(['c1', 'c2']));
+
+        expect(added).not.toBe(base);
+        expect(removed).not.toBe(base);
+    });
+
+    test('ignores duplicates + non-string ids', () => {
+        const a = computeCorpusFingerprint([{id: 'c1'}, {id: 'c1'}, {id: 'c2'}, {id: null}, {}]),
+              b = computeCorpusFingerprint(chunks(['c1', 'c2']));
+
+        expect(a).toBe(b);
+    });
+});
+
+test.describe('selectResumableChunks — the resume-skip', () => {
+    test('a fresh run (no existing ids) returns every chunk', () => {
+        const result = selectResumableChunks({chunks: chunks(['c1', 'c2', 'c3'])});
+
+        expect(result.remaining.map(c => c.id)).toEqual(['c1', 'c2', 'c3']);
+        expect(result.alreadyEmbedded).toBe(0);
+    });
+
+    test('skips chunks already embedded in the resume-shadow', () => {
+        const result = selectResumableChunks({
+            chunks     : chunks(['c1', 'c2', 'c3', 'c4']),
+            existingIds: new Set(['c1', 'c2']) // already done last run
+        });
+
+        expect(result.remaining.map(c => c.id)).toEqual(['c3', 'c4']);
+        expect(result.alreadyEmbedded).toBe(2);
+    });
+
+    test('accepts an array of existing ids', () => {
+        const result = selectResumableChunks({chunks: chunks(['c1', 'c2']), existingIds: ['c1']});
+
+        expect(result.remaining.map(c => c.id)).toEqual(['c2']);
+        expect(result.alreadyEmbedded).toBe(1);
+    });
+});
+
+test.describe('decideResume — resume vs clean-rebuild gate', () => {
+    const FP = 'fingerprint-abc';
+
+    test('no preserved resume-shadow → rebuild fresh', () => {
+        expect(decideResume({resumeState: null, currentFingerprint: FP}))
+            .toMatchObject({resume: false, reason: 'no-resume-shadow', attempts: 1});
+    });
+
+    test('corpus drifted (fingerprint mismatch) → rebuild fresh (never resume a stale corpus)', () => {
+        expect(decideResume({resumeState: {fingerprint: 'old-fp', attempts: 1}, currentFingerprint: FP}))
+            .toMatchObject({resume: false, reason: 'corpus-drift'});
+    });
+
+    test('fingerprint matches + under the cap → resume, incrementing the attempt', () => {
+        expect(decideResume({resumeState: {fingerprint: FP, attempts: 1}, currentFingerprint: FP, maxAttempts: 3}))
+            .toMatchObject({resume: true, reason: 'fingerprint-match', attempts: 2});
+    });
+
+    test('attempt cap exhausted → forced clean rebuild (a persistent failure cannot resume forever)', () => {
+        expect(decideResume({resumeState: {fingerprint: FP, attempts: 3}, currentFingerprint: FP, maxAttempts: 3}))
+            .toMatchObject({resume: false, reason: 'attempt-cap-exhausted', attempts: 1});
+    });
+});


### PR DESCRIPTION
Resolves #14146

KB sync's shadow-swap was **all-or-nothing**: a single failed embedding batch (the operator's incident aborted at batch **214/328**) discarded all 213 completed batches and forced a full re-embed of all 16382 chunks from batch 1. This PR makes the shadow-swap **resumable** — a transient embedding failure now PRESERVES the partially-built shadow collection + a durable resume-marker, and the next sync resumes from the already-embedded chunks instead of rebuilding from scratch. A ~30s provider blip no longer costs the entire corpus re-embed.

The fix decomposes into two pure helper modules + the `embedViaShadowSwap` wiring:

- **`resumableEmbedding.mjs`** (pure) — `computeCorpusFingerprint` (order-independent sha256 of the chunk-id set: the resume-validity key), `selectResumableChunks` (skip ids already present in the preserved shadow), `decideResume` (resume vs clean-rebuild gate: `no-resume-shadow` / `corpus-drift` / `attempt-cap-exhausted` / `fingerprint-match`).
- **`kbEmbeddingResumeStore.mjs`** (durable) — a single small JSON marker under the gitignored `.neo-ai-data/kb-sync` tree recording which shadow holds the progress, the fingerprint it was built for, and the attempt count. Fail-safe: a missing/corrupt marker degrades to a clean rebuild, never crashes the sync. Chroma collection-metadata is deliberately NOT used (its `modify`-metadata path is unverified in this codebase).
- **`VectorService.embedViaShadowSwap`** — fingerprints the corpus, reads the marker, and either RESUMES into the preserved shadow (paginated `collection.get` id-read → `selectResumableChunks` → embed only the remainder) or rebuilds fresh (discarding a drifted / cap-exhausted stale shadow + clearing the marker). On a **transient** embed failure it PRESERVES the shadow + writes the marker (the resume substrate); on a **permanent** over-budget failure (`KB_EMBEDDING_INPUT_SIZE_EXCEEDED`) it still parks-as-failed + clears the marker (resuming a structurally-too-big corpus is futile). A successful promote clears the marker. `getResumeStateDir()` is a test-settable seam.

The corpus-fingerprint guard means a drifted corpus is never resumed into (stale embeddings can't leak into a promotion), and the attempt-cap means a persistent failure eventually falls back to a clean rebuild rather than looping on a doomed shadow.

Evidence: L2 (in-process unit — spy Chroma collection + tmpdir file-store; preserve-on-transient, resume-skip, fingerprint-gate, attempt-cap, and fail-safe-on-corrupt-marker all asserted) → L4 required for full incident replay (live Chroma + live LM Studio multi-batch resume across the real corpus). Residual: end-to-end live-sync resume validation [#14146 Post-Merge].

## Deltas from ticket

- **AC1 (the P0) — delivered.** A transient batch failure no longer discards completed progress; it preserves + resumes.
- **AC2 (optional sub — 404 retry-guard recognition) — out of scope, routed to #14154.** Recognizing recoverable provider-404s rather than blind-retrying-then-aborting is **trigger-side** hardening (`TextEmbeddingService` retry guard), which is squarely #14154's "stop the loop at the source" lane (root-cause the embedder eviction). Folding it here would conflate the amplifier fix (this PR) with the trigger fix (#14154). A2A to Ada accompanies this PR.
- **Config-hygiene (the `openAiCompatible.host` `:11434`-vs-`:1234` port default) — explicitly marked "(separate)" in the ticket; left to the #14154 trigger lane (it touches the ADR-0019 config SSOT and is a provider-reachability concern, not the swap-resilience concern).**

## Test Evidence

```
UNIT_TEST_MODE=true npm run test-unit -- \
  test/playwright/unit/ai/services/knowledge-base/helpers/resumableEmbedding.spec.mjs \
  test/playwright/unit/ai/services/knowledge-base/helpers/kbEmbeddingResumeStore.spec.mjs \
  test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
→ 29 passed (31.5s)
```

- `resumableEmbedding.spec.mjs` — 10 tests (fingerprint determinism/drift/dedup; resume-skip; the 4 `decideResume` branches).
- `kbEmbeddingResumeStore.spec.mjs` — 6 tests (round-trip; missing→null; corrupt→null fail-safe; attempts default; clear; dir-creation + arg guards).
- `VectorService.WorkVolumeBranching.spec.mjs` — 13 tests (the existing shadow-swap suite updated to the new failure semantics + a new `shadow-swap PRESERVES the shadow on a transient failure for resume` test asserting the marker is written and `modify` is NOT called).

`agent-preflight` (ticket-archaeology + PR-body lint) clean on all 6 files.

## Post-Merge Validation

- [ ] Live incident replay: induce a transient embedder failure mid-sync against live Chroma + LM Studio; confirm the next sync resumes from the preserved shadow (skips the embedded prefix) and promotes, rather than re-embedding from batch 1.
- [ ] Confirm the resume-marker is written under `.neo-ai-data/kb-sync/` on a real transient failure and cleared on a real successful promote.

## Commits

- `703207981` — resumable KB-embedding pure helpers (fingerprint guard + resume-skip + attempt-cap)
- `f56a2bf65` — durable KB embedding resume-state store (preserve/resume marker)
- `549b77bcc` — `embedViaShadowSwap` wiring (preserve-on-transient, resume-from-completed, park-on-permanent) + existing-suite update

Related: #14039 (v13.1 Agent OS Stability / data-integrity immune system) · #14154 (the trigger: embedder eviction root-cause)

Authored by Grace (Claude Opus 4.8, Claude Code). Session 090a68e6-1a28-4b20-a5fd-842ebac3e729.
