### PR TITLE
fix(ai): exempt read-only Memory Core diagnostics from the embed-canary health gate (#14124)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -138,7 +138,15 @@ class Server extends BaseServer {
             'record_turn_presence',
             'get_session_memories',
             'query_recent_turns',
-            'who_is_online'
+            'who_is_online',
+            // Read-only diagnostics that never embed — exempt so a slow/down embedder cannot block the
+            // very tools an agent needs to SEE the degradation (the embed-canary catch-22). They read
+            // state/files/metrics only; none embed a query (unlike `query_raw_memories`/`query_summaries`).
+            'get_rem_pipeline_state',
+            'get_sqlite_holder_diagnostics',
+            'get_deployment_state_snapshot',
+            'inspect_deployment',
+            'get_memory_core_tool_metrics'
         ];
     }
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -405,6 +405,71 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         }
     });
 
+    test('#14124: read-only diagnostics (get_rem_pipeline_state) bypass the embedder-degraded health gate; embedding queries still gate', async () => {
+        const serverInstance = await createServerWithoutBoot();
+        const handlers      = new Map();
+        const healthCalls   = [];
+        const toolCalls     = [];
+        const degradedError = new Error([
+            'Memory Core is not fully operational:',
+            '  - Embedding write canary timed out after 5000ms'
+        ].join('\n'));
+
+        const mcpServer = {
+            server: {
+                setRequestHandler(schema, handler) {
+                    handlers.set(schema, handler);
+                }
+            }
+        };
+        const originalGetToolService   = serverInstance.getToolService;
+        const originalGetHealthService = serverInstance.getHealthService;
+
+        serverInstance.getToolService = () => ({
+            listTools: () => ({tools: [], nextCursor: undefined}),
+            callTool : (name, args) => {
+                toolCalls.push({name, args});
+                return {ok: true, name};
+            }
+        });
+        serverInstance.getHealthService = () => ({
+            ensureHealthy: async () => {
+                healthCalls.push('ensureHealthy');
+                throw degradedError;
+            }
+        });
+
+        serverInstance.setupRequestHandlers(mcpServer);
+
+        try {
+            const callTool = handlers.get(CallToolRequestSchema);
+
+            // The catch-22 fix: a read-only diagnostic an agent needs to SEE the embedder outage must
+            // still serve despite the embed-canary failure (it reads pipeline state, never embeds).
+            const remResult = await callTool({
+                params: {name: 'get_rem_pipeline_state', arguments: {}}
+            });
+
+            expect(remResult.isError).toBe(false);
+            expect(remResult.structuredContent).toEqual({ok: true, name: 'get_rem_pipeline_state'});
+            expect(healthCalls).toEqual([]); // exempt → never consulted the (failing) health gate
+
+            // query_raw_memories — NOT exempt: it embeds the query, so the gate must still fire.
+            const queryResult = await callTool({
+                params: {name: 'query_raw_memories', arguments: {query: 'q'}}
+            });
+
+            expect(queryResult.isError).toBe(true);
+            expect(queryResult.content[0].text).toContain('Cannot execute query_raw_memories: Memory Core is not fully operational');
+            expect(healthCalls).toEqual(['ensureHealthy']);
+            expect(toolCalls).toEqual([{name: 'get_rem_pipeline_state', args: {}}]);
+        } finally {
+            serverInstance.getToolService   = originalGetToolService;
+            serverInstance.getHealthService = originalGetHealthService;
+            serverInstance.destroy();
+        }
+    });
+
     test('#12978: logStartupStatus tolerates a null health result (BaseServer passes null when the health service has no healthcheck)', async () => {
         const serverInstance = await createServerWithoutBoot();
 


### PR DESCRIPTION
## Summary

The Memory Core's embedding-write canary gates **all non-exempt tools** via `ensureHealthy()` (`BaseServer.mjs:366` → `getHealthExemptTools`). So a slow/down embedder blocked the very read-only diagnostics an agent needs to **see** the degradation — a catch-22 hit live during the v13.1 rem-consolidation-stall investigation (`get_rem_pipeline_state` failed with *"Embedding write canary timed out after 5000ms"* while `healthcheck` with a longer canary returned healthy).

Resolves #14124

## Change

Add the read-only, non-embedding diagnostics to `getHealthExemptTools` (`ai/mcp/server/memory-core/Server.mjs`) — the existing exemption mechanism already used by mailbox + recency reads:
- `get_rem_pipeline_state`, `get_sqlite_holder_diagnostics`, `get_deployment_state_snapshot`, `inspect_deployment`, `get_memory_core_tool_metrics`

They read state / files / metrics only and never embed — unlike `query_raw_memories` / `query_summaries`, which embed the query and correctly **stay gated** (the existing JSDoc already documents that boundary).

Evidence: V-B-A'd **0 embed-refs** in each diagnostic's handler; the gate is `BaseServer.mjs:366` (`!exemptTools.includes(name)` → `ensureHealthy`).

## Deltas from ticket (if any)

- Used the existing exempt-list mechanism (skip `ensureHealthy` for these tools) rather than a new `ensureHealthy({embeddingRequired:false})` variant — consistent with how mailbox/recency reads are already exempted, minimal surface. A read-only diagnostic hitting genuinely-down storage fails with its own error (acceptable; it is no longer gated on the EMBED canary, which is the bug).
- Conservatively scoped to the 5 clear pure-diagnostics; broader read-only graph reads (`get_node`/`get_neighbors`/`get_all_summaries`) are deferred pending the same non-embedding verification.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs ai/mcp/server/memory-core/Server` → **11 passed**, incl. the new `#14124` behavior test: `get_rem_pipeline_state` serves while `ensureHealthy` throws the embed-canary error (never consults the gate); `query_raw_memories` still errors with the gate message.

## Post-Merge Validation

After deploy: with the embedder slow/down, confirm `get_rem_pipeline_state` (+ the other diagnostics) return their payloads instead of *"Memory Core is not fully operational: Embedding write canary timed out,"* while `query_raw_memories` / `query_summaries` still reject.

## Related

Directly unblocks diagnosing #14154 (the live embedder-404 fire — the canary catch-22 is exactly what obstructs seeing it).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `fe9c04d6-1aae-4017-8d53-19b0e5aaf809`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
