### PR TITLE
feat(ai): cloudOnly composeServiceRecoveryEnabled mode-gate for B1 docker-socket recovery (#14150)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -737,7 +737,16 @@ class Config extends ConfigProvider {
                     // Tenant-repo-sync is a cloud-deployable lane: cloud profile defaults enabled
                     // when tenant repos are configured; local Neo-maintainer profile defaults
                     // disabled unless explicitly opted in.
-                    tenantRepoSyncEnabled: leaf(null, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED', 'boolean')
+                    tenantRepoSyncEnabled: leaf(null, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED', 'boolean'),
+                    // B1 docker-socket sibling-container recovery (the immune system's privileged tier).
+                    // Cloud profile defaults enabled (no operator present to manually restart a wedged
+                    // sibling); local profile defaults disabled (the operator IS present + autonomously
+                    // recycling a dev container is disruptive). B0 in-process recycle + data-integrity
+                    // re-embed + the read-only deployment-state bridge stay active locally regardless.
+                    // ORTHOGONAL to `recoveryActuator.blockedComposeServices` (ADR-26): this mode-gate is
+                    // "is B1 active in this deployment at all"; the blocklist is the per-service opt-out
+                    // WITHIN an active mode. They compose; do not overload the blocklist to express the mode gate.
+                    composeServiceRecoveryEnabled: leaf(null, 'NEO_ORCHESTRATOR_COMPOSE_SERVICE_RECOVERY_ENABLED', 'boolean')
                 },
                 /**
                  * Recovery actuator envelope. Enabled by default so deployed immune-system

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -84,7 +84,9 @@ function resolveDeploymentEnabled(key) {
  * @param {String} key
  * @returns {Boolean}
  */
-function resolveCloudOnlyEnabled(key) {
+// Exported so a cross-module controller (e.g. the recovery actuator's B1 compose-service selection
+// point) can consult a cloudOnly mode-gate without scattering raw `deploymentMode` reads (ADR-0019).
+export function resolveCloudOnlyEnabled(key) {
     const cfg = AiConfig.orchestrator.cloudOnly[key];
     if (cfg != null) return cfg;
     return AiConfig.orchestrator.deploymentMode === 'cloud';
@@ -432,6 +434,7 @@ export class Orchestrator extends Base {
     get githubWorkflowSyncEnabled()      { return resolveDeploymentEnabled('githubWorkflowSyncEnabled');      }
     get primaryDevSyncEnabled()          { return resolveDeploymentEnabled('primaryDevSyncEnabled');          }
     get tenantRepoSyncEnabled()          { return resolveCloudOnlyEnabled('tenantRepoSyncEnabled');           }
+    get composeServiceRecoveryEnabled()  { return resolveCloudOnlyEnabled('composeServiceRecoveryEnabled');   }
     get chromaDaemonEnabled()            { return resolveDeploymentEnabled('chromaDaemonEnabled');            }
     get bridgeDaemonEnabled()            { return resolveDeploymentEnabled('bridgeDaemonEnabled');            }
     get devServerEnabled()               { return resolveLocalDeploymentDefault(AiConfig.orchestrator.devServer.enabled); }

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.cloudOnlyGate.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.cloudOnlyGate.spec.mjs
@@ -1,0 +1,46 @@
+import {test, expect}          from '@playwright/test';
+import Neo                     from '../../../../../../src/Neo.mjs';
+import * as core               from '../../../../../../src/core/_export.mjs';
+import AiConfig                from '../../../../../../ai/config.mjs';
+import {resolveCloudOnlyEnabled} from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
+
+const KEY = 'composeServiceRecoveryEnabled';
+
+test.describe('Neo.ai.daemons.Orchestrator cloudOnly mode-gate (#14150 composeServiceRecoveryEnabled)', () => {
+    let savedMode, savedPresent, savedValue;
+
+    test.beforeEach(() => {
+        savedMode    = AiConfig.orchestrator.deploymentMode;
+        savedPresent = KEY in AiConfig.orchestrator.cloudOnly;
+        savedValue   = AiConfig.orchestrator.cloudOnly[KEY];
+    });
+
+    test.afterEach(() => {
+        AiConfig.orchestrator.deploymentMode = savedMode;
+        if (savedPresent) {
+            AiConfig.orchestrator.cloudOnly[KEY] = savedValue;
+        } else {
+            delete AiConfig.orchestrator.cloudOnly[KEY];
+        }
+    });
+
+    test('mode-gate default: cloud → B1 enabled, local → B1 disabled', () => {
+        AiConfig.orchestrator.cloudOnly[KEY] = null; // profile default (the leaf default)
+
+        AiConfig.orchestrator.deploymentMode = 'cloud';
+        expect(resolveCloudOnlyEnabled(KEY)).toBe(true);
+
+        AiConfig.orchestrator.deploymentMode = 'local';
+        expect(resolveCloudOnlyEnabled(KEY)).toBe(false);
+    });
+
+    test('explicit override beats the deployment default (opt-in local / opt-out cloud)', () => {
+        AiConfig.orchestrator.deploymentMode = 'local';
+        AiConfig.orchestrator.cloudOnly[KEY] = true;  // operator opts B1 in for a local smoke test
+        expect(resolveCloudOnlyEnabled(KEY)).toBe(true);
+
+        AiConfig.orchestrator.deploymentMode = 'cloud';
+        AiConfig.orchestrator.cloudOnly[KEY] = false; // operator opts B1 out in a cloud deployment
+        expect(resolveCloudOnlyEnabled(KEY)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

The 4 deployment-immune-system services ran "both by omission" (in neither `localOnly` nor `cloudOnly`). The **B1 docker-socket sibling-container restart** is cloud-oriented — ADR-25's motivating case is "a sibling saturates *and the human-repair path is unavailable*" (the no-operator cloud scenario). Locally the operator IS present and autonomously recycling a dev container is disruptive.

Resolves #14175

Refs #14150 — the **full** mode-gate resolves only when @neo-opus-grace's #14134 cutover consult reads this getter on the B1 path. This PR lands the consult-**surface** only (nothing reads the getter yet), so it must NOT auto-close #14150 (AC1 unmet until consumed). Per her review (RA-1).

## Change

Add a `cloudOnly.composeServiceRecoveryEnabled` leaf (`config.template.mjs`) + the `composeServiceRecoveryEnabled` getter (`Orchestrator.mjs`, mirroring `tenantRepoSyncEnabled`): cloud profile defaults **enabled**, local profile defaults **disabled**, operator-overridable (opt-in locally for smoke tests, opt-out in cloud). Exports `resolveCloudOnlyEnabled` so the recovery actuator's B1-selection point can consult the gate cross-module (ADR-0019-clean — a config getter, not scattered `deploymentMode` reads). **Orthogonal** to `recoveryActuator.blockedComposeServices` (ADR-26): the mode-gate is "is B1 active at all"; the blocklist is the per-service opt-out within an active mode.

Evidence: the immune services are absent from both the `localOnly{}` and `cloudOnly{}` getters (`Orchestrator.mjs`); `resolveCloudOnlyEnabled` (`Orchestrator.mjs:88`) is the established cloudOnly resolver, with `tenantRepoSyncEnabled` the mirror.

## Deltas from ticket (if any)

- **Scoped per @neo-opus-grace's #14150 coordination:** I own the stable surface (the leaf + getter + the `resolveCloudOnlyEnabled` export + tests — a clean AiConfig addition, zero collision with her cutover); she wires the one-line consult at the B1-selection point as part of her #14134 cutover (the churning territory). The export decouples the GATE from the selection LOCATION, so the controller consults it wherever the cutover lands.
- B0 in-process recycle + data-integrity re-embed + the read-only deployment-state bridge stay active locally regardless — only B1 is mode-gated.
- **RA-2 (per @neo-opus-grace's review):** the ADR-26 §2.2 activation-default amendment (#14150 AC4) is coupled to the consult-wiring — this surface PR changes NO live activation behavior (nothing reads the getter yet), so the ADR note lands with the #14134 cutover that makes the gate behavioral, not here.
- **Non-blocking (her review):** the test mutates the shared `AiConfig` singleton — that follows the established Orchestrator-test precedent (Orchestrator.spec / invariants.spec / MailboxService.spec), so it's pre-existing #12435 debt, not introduced here. Cleanup direction someday: a pure `resolveCloudOnly({cfgValue, deploymentMode})` tested with plain args.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs Orchestrator.cloudOnlyGate lintConfigTemplateSsot` → **18 passed**. New `Orchestrator.cloudOnlyGate.spec.mjs`: mode-gate default (cloud → enabled, local → disabled) + explicit override beats the deployment default. The config-template-ssot lint passes (the leaf is template-SSOT-consistent).

## Post-Merge Validation

After Grace's #14134 consult lands: confirm B1 docker-socket compose-service recovery is inert under `deploymentMode==='local'` (the gate returns false) while B0 + data-integrity heal still fire, and active under `'cloud'`. An operator can set `NEO_ORCHESTRATOR_COMPOSE_SERVICE_RECOVERY_ENABLED=true` to smoke-test B1 locally.

## Related

The deliberate classification closing the "both by omission" gap surfaced in the v13.1 immune-system local/cloud scoping (#14039). Pairs with Grace's #14134 (the consult wiring).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `fe9c04d6-1aae-4017-8d53-19b0e5aaf809`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
