### PR TITLE
feat(ai): autonomous freeze re-probe substrate — decider + store + cycle orchestrator (#14171)

### DIFF
--- a/ai/services/memory-core/helpers/freezeRecordStore.mjs
+++ b/ai/services/memory-core/helpers/freezeRecordStore.mjs
@@ -1,0 +1,133 @@
+import {mkdir, readFile, writeFile} from 'fs/promises';
+import path                         from 'path';
+
+/**
+ * @module ai/services/memory-core/helpers/freezeRecordStore
+ * @summary Durable, mutable freeze-STATE store for the autonomous freeze → re-probe → auto-unfreeze cycle.
+ * Keyed by collection name, it remembers WHICH collections the actuator has frozen, the fault fingerprint each
+ * was frozen for, and the mutable re-probe bookkeeping (`unfreezeAttempts`, `lastProbeAt`) that
+ * `decideFreezeReprobe` consumes to drive the bounded back-off + anti-thrash cap. A single small JSON map under
+ * the gitignored `.neo-ai-data` tree (read-modify-write the whole map — the frozen set is tiny). Fail-safe: a
+ * missing or corrupt file reads as an empty set, never crashing the recovery loop.
+ *
+ * This is OPERATIONAL state (mutable, keyed), distinct from the append-only heal-event ledger (the telemetry
+ * sink an operator reviews asynchronously): a freeze is recorded here so the re-probe loop can find it and
+ * decide unfreeze-vs-stay; the ledger separately records the freeze/unfreeze EVENTS. Mirrors the
+ * `kbEmbeddingResumeStore` fail-safe shape: I/O at the edge only, deterministic content.
+ */
+
+const FREEZE_RECORDS_FILENAME = 'freeze-records.json';
+
+/**
+ * @summary The freeze-records JSON path within a state directory.
+ * @param {String} dir
+ * @returns {String}
+ */
+export function getFreezeRecordsFilePath(dir) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('getFreezeRecordsFilePath: dir is required');
+    }
+    return path.join(dir, FREEZE_RECORDS_FILENAME);
+}
+
+/**
+ * @summary Reads the full freeze-record map (`{[collectionName]: record}`), or `{}` if none / unreadable
+ * (fail-safe → an empty frozen set, never a crash).
+ * @param {Object} options
+ * @param {String} options.dir State directory.
+ * @returns {Promise<Object>} The keyed freeze-record map.
+ */
+export async function readFreezeRecords({dir} = {}) {
+    let raw;
+
+    try {
+        raw = await readFile(getFreezeRecordsFilePath(dir), 'utf8');
+    } catch (error) {
+        return {}; // ENOENT or any unreadable marker degrades to an empty set
+    }
+
+    try {
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch (error) {
+        return {}; // a corrupt map must not crash the recovery loop
+    }
+}
+
+/**
+ * @summary Reads one collection's freeze-record, or `null` if it is not frozen.
+ * @param {Object} options
+ * @param {String} options.dir State directory.
+ * @param {String} options.collectionName
+ * @returns {Promise<Object|null>}
+ */
+export async function getFreezeRecord({dir, collectionName} = {}) {
+    if (typeof collectionName !== 'string' || collectionName.length === 0) {
+        return null;
+    }
+    const records = await readFreezeRecords({dir});
+    return Object.hasOwn(records, collectionName) ? records[collectionName] : null;
+}
+
+/**
+ * @summary Inserts or updates one collection's freeze-record (records a freeze, or bumps the re-probe
+ * bookkeeping after a probe tick). Merges onto any existing record so a partial update preserves prior fields.
+ * @param {Object} options
+ * @param {String} options.dir State directory.
+ * @param {String} options.collectionName The frozen collection (the map key).
+ * @param {String} [options.faultFingerprint] The fault the collection was frozen for.
+ * @param {Number} [options.frozenAt] Epoch ms the freeze was first recorded (preserved across updates).
+ * @param {Number} [options.unfreezeAttempts] Auto-unfreeze attempts so far (the anti-thrash counter).
+ * @param {Number} [options.lastProbeAt] Epoch ms of the last re-probe (the back-off clock).
+ * @returns {Promise<Object>} The written record.
+ */
+export async function upsertFreezeRecord({dir, collectionName, faultFingerprint, frozenAt, unfreezeAttempts, lastProbeAt} = {}) {
+    if (typeof collectionName !== 'string' || collectionName.length === 0) {
+        throw new TypeError('upsertFreezeRecord: collectionName is required');
+    }
+
+    const records  = await readFreezeRecords({dir}),
+          existing = Object.hasOwn(records, collectionName) && records[collectionName] && typeof records[collectionName] === 'object'
+              ? records[collectionName] : {},
+          merged   = {
+              ...existing,
+              collectionName,
+              ...(faultFingerprint !== undefined ? {faultFingerprint} : {}),
+              ...(frozenAt         !== undefined ? {frozenAt}         : {}),
+              ...(unfreezeAttempts !== undefined ? {unfreezeAttempts} : {}),
+              ...(lastProbeAt      !== undefined ? {lastProbeAt}      : {})
+          };
+
+    records[collectionName] = merged;
+
+    await mkdir(dir, {recursive: true});
+    await writeFile(getFreezeRecordsFilePath(dir), `${JSON.stringify(records, null, 2)}\n`, 'utf8');
+
+    return merged;
+}
+
+/**
+ * @summary Removes one collection's freeze-record (on a successful unfreeze + re-heal). A no-op if absent.
+ * @param {Object} options
+ * @param {String} options.dir State directory.
+ * @param {String} options.collectionName
+ * @returns {Promise<Boolean>} True if a record was removed.
+ */
+export async function removeFreezeRecord({dir, collectionName} = {}) {
+    if (typeof collectionName !== 'string' || collectionName.length === 0) {
+        return false;
+    }
+
+    const records = await readFreezeRecords({dir});
+
+    if (!Object.hasOwn(records, collectionName)) {
+        return false;
+    }
+
+    delete records[collectionName];
+
+    await mkdir(dir, {recursive: true});
+    await writeFile(getFreezeRecordsFilePath(dir), `${JSON.stringify(records, null, 2)}\n`, 'utf8');
+
+    return true;
+}

--- a/ai/services/memory-core/helpers/freezeReprobeDecision.mjs
+++ b/ai/services/memory-core/helpers/freezeReprobeDecision.mjs
@@ -97,3 +97,100 @@ export function decideFreezeReprobe({freezeRecord, probe, bounds = DEFAULT_REPRO
     }
     return {unfreeze: false, status: 'stay-frozen', reason: 'probe inconclusive — stay frozen (fail closed)', nextProbeAfterMs};
 }
+
+/**
+ * @summary Runs one re-probe tick across every frozen collection: for each record it makes a cheap pre-decision
+ * (skipping a probe entirely when the collection is within its back-off, contained, or has a bad record), then
+ * probes only the ones actually due, re-decides with the live probe, and executes the disposition via INJECTED
+ * operations — returning a uniform outcome per collection. Pure orchestration: the health probe, the privileged
+ * unfreeze + re-heal, and the freeze-record persistence are all injected, so this is fully testable without a
+ * live daemon (mirrors `dispatchHeal`). No operator, no escalate.
+ *
+ * **Anti-hot-loop:** an unfreeze bumps `unfreezeAttempts` + `lastProbeAt` via `persistProbe` BEFORE executing the
+ * unfreeze, so a collection that unfreezes then immediately re-freezes keeps a climbing attempt count and is
+ * eventually `contained` rather than thrashing. A failed unfreeze leaves the record (the attempt is already
+ * recorded); a successful one clears it via `clearFreeze`.
+ *
+ * @param {Object} options
+ * @param {Object} [options.freezeRecords={}] The keyed freeze-record map (`{[collectionName]: record}`) — the caller reads it from the store.
+ * @param {Function} [options.probe] `async (collectionName) => {embedderHealthy, dimensionConsistent}` — the injected health probe. A throw / missing probe is treated as inconclusive (stay frozen).
+ * @param {Number} [options.now] Epoch milliseconds (injected clock).
+ * @param {Object} [options.bounds] Re-probe bounds (defaults to `DEFAULT_REPROBE_BOUNDS` in `decideFreezeReprobe`).
+ * @param {Function} [options.unfreezeAndReheal] `async (collectionName) => any` — the injected privileged unfreeze + re-enter-heal. Absent → an `unfreeze` disposition is recorded `deferred` (not executed).
+ * @param {Function} [options.persistProbe] `async ({collectionName, lastProbeAt, unfreezeAttempts?}) => void` — persists the re-probe bookkeeping.
+ * @param {Function} [options.clearFreeze] `async (collectionName) => void` — removes the freeze-record on a successful unfreeze.
+ * @returns {Promise<Object[]>} `[{collectionName, status, reason, unfroze}]` per frozen collection.
+ */
+export async function runFreezeReprobeCycle({freezeRecords = {}, probe, now, bounds, unfreezeAndReheal, persistProbe, clearFreeze} = {}) {
+    const records  = freezeRecords && typeof freezeRecords === 'object' ? freezeRecords : {},
+          outcomes = [];
+
+    for (const collectionName of Object.keys(records)) {
+        const freezeRecord = records[collectionName];
+
+        // Cheap pre-decision (no probe): a within-back-off `defer`, a `contained` cap, or an `unsafe-input` bad
+        // record needs no probe — only a past-back-off collection (which reads `stay-frozen` against a null probe)
+        // is actually due for a live re-probe.
+        const preDecision = decideFreezeReprobe({freezeRecord, probe: null, bounds, now});
+
+        if (preDecision.status !== 'stay-frozen') {
+            outcomes.push({collectionName, status: preDecision.status, reason: preDecision.reason, unfroze: false});
+            continue;
+        }
+
+        let probeResult = null;
+        if (typeof probe === 'function') {
+            try {
+                probeResult = await probe(collectionName);
+            } catch (probeError) {
+                probeResult = null; // a failed probe is inconclusive → the decider stays frozen
+            }
+        }
+
+        const decision = decideFreezeReprobe({freezeRecord, probe: probeResult, bounds, now});
+
+        if (decision.status === 'unfreeze') {
+            // Record the unfreeze ATTEMPT before executing — a re-freeze then keeps the climbing count (anti-thrash).
+            const attempts = (Number.isFinite(freezeRecord?.unfreezeAttempts) ? freezeRecord.unfreezeAttempts : 0) + 1;
+
+            if (typeof persistProbe === 'function') {
+                try {
+                    await persistProbe({collectionName, lastProbeAt: now, unfreezeAttempts: attempts});
+                } catch (persistError) {
+                    outcomes.push({collectionName, status: 'failed', reason: `persist pre-unfreeze failed: ${persistError?.message ?? String(persistError)}`, unfroze: false});
+                    continue;
+                }
+            }
+
+            if (typeof unfreezeAndReheal !== 'function') {
+                outcomes.push({collectionName, status: 'deferred', reason: 'no unfreezeAndReheal operation wired', unfroze: false});
+                continue;
+            }
+
+            try {
+                await unfreezeAndReheal(collectionName);
+                if (typeof clearFreeze === 'function') {
+                    await clearFreeze(collectionName);
+                }
+                outcomes.push({collectionName, status: 'unfrozen', reason: decision.reason, unfroze: true});
+            } catch (unfreezeError) {
+                // Unfreeze / re-heal failed — the attempt is already recorded; stays frozen, re-probed next cycle.
+                outcomes.push({collectionName, status: 'failed', reason: `unfreeze/re-heal failed: ${unfreezeError?.message ?? String(unfreezeError)}`, unfroze: false});
+            }
+            continue;
+        }
+
+        // stay-frozen after a real probe: advance the probe clock so the back-off measures from this tick.
+        if (decision.status === 'stay-frozen' && typeof persistProbe === 'function') {
+            try {
+                await persistProbe({collectionName, lastProbeAt: now});
+            } catch (persistError) {
+                // best-effort clock update — a missed bookkeeping write just re-probes a touch sooner next tick
+            }
+        }
+
+        outcomes.push({collectionName, status: decision.status, reason: decision.reason, unfroze: false});
+    }
+
+    return outcomes;
+}

--- a/ai/services/memory-core/helpers/freezeReprobeDecision.mjs
+++ b/ai/services/memory-core/helpers/freezeReprobeDecision.mjs
@@ -1,0 +1,99 @@
+/**
+ * @module ai/services/memory-core/helpers/freezeReprobeDecision
+ * @summary Pure decider for the autonomous freeze → re-probe → auto-unfreeze / re-heal cycle. `freeze` is the
+ * actuator's safe containment for a systemic / dimension-systemic fault, but in a cloud deployment there is no
+ * operator to lift it — so a TRANSIENT fault (a briefly-down or briefly-misconfigured embedder) that tripped
+ * `freeze` would otherwise kill a collection permanently, defeating the weeks-bar. This decider is the
+ * counterpart that makes `freeze` recoverable WITHOUT a human: given a frozen collection's durable freeze-record,
+ * a current health probe, the back-off / thrash bounds, and the injected clock, it decides whether to
+ * `unfreeze` (the fault cleared → re-enter the heal path), `defer` (still inside the re-probe back-off),
+ * `stay-frozen` (the fault persists), or treat it as `contained` (the unfreeze-attempt cap is exhausted — a
+ * persistent fault that must stay frozen + ledgered, never thrash freeze↔unfreeze).
+ *
+ * **Safety inversion vs the heal dispatcher.** In `healActionDispatch` a mutating heal fails CLOSED to
+ * "do not execute". Here the contained-safe state is *frozen*, and unfreezing is the risky act — so this
+ * decider fails CLOSED to `stay-frozen`: a missing record, a non-finite clock, or an inconclusive probe never
+ * auto-unfreezes. Only an affirmatively-cleared fault, inside the bounds, lifts containment.
+ *
+ * Pure + deterministic (no I/O, no time/randomness): the durable freeze-record persistence, the live health
+ * probe, and the unfreeze + re-heal execution are separate wired consumers.
+ */
+
+/**
+ * The freeze-reprobe dispositions. `unfreeze` lifts containment and re-enters the heal path; `defer` waits out
+ * the back-off; `stay-frozen` keeps containment for a still-present fault; `contained` is the terminal
+ * thrash-capped state (persistent fault, ledgered, no further auto-unfreeze); `unsafe-input` is the
+ * fail-closed-to-frozen guard.
+ * @type {String[]}
+ */
+export const FREEZE_REPROBE_STATUSES = Object.freeze(['unfreeze', 'defer', 'stay-frozen', 'contained', 'unsafe-input']);
+
+/**
+ * Default re-probe bounds: a 10-minute base interval between probes, at most 3 auto-unfreeze attempts before a
+ * collection is treated as a persistent fault (contained), and a 2x exponential widening of the probe interval
+ * per prior unfreeze attempt (so a flapping collection is probed ever less often — the anti-thrash back-off).
+ * @type {{minReprobeIntervalMs: Number, maxUnfreezeAttempts: Number, backoffMultiplier: Number}}
+ */
+export const DEFAULT_REPROBE_BOUNDS = Object.freeze({minReprobeIntervalMs: 600000, maxUnfreezeAttempts: 3, backoffMultiplier: 2});
+
+/**
+ * @summary Decides whether a frozen collection should auto-unfreeze now, under the autonomous back-off +
+ * anti-thrash bounds. Fails CLOSED to `stay-frozen` (never auto-unfreezes on missing/ambiguous input).
+ *
+ * @param {Object} options
+ * @param {Object} [options.freezeRecord] The durable freeze-record `{collectionName, frozenAt, faultFingerprint, unfreezeAttempts, lastProbeAt}`. Missing → `unsafe-input` (stay frozen).
+ * @param {Object} [options.probe] The current health probe `{embedderHealthy, dimensionConsistent}`. Both strictly `true` → fault cleared. Either strictly `false` → fault persists. Otherwise inconclusive → stay frozen.
+ * @param {{minReprobeIntervalMs: Number, maxUnfreezeAttempts: Number, backoffMultiplier: Number}} [options.bounds=DEFAULT_REPROBE_BOUNDS] Partial bounds are normalized onto the defaults so an incomplete object cannot disable the gate.
+ * @param {Number} [options.now] Epoch milliseconds (the injected clock). Non-finite → `unsafe-input` (stay frozen).
+ * @returns {Object} `{unfreeze, status, reason, nextProbeAfterMs}`. `unfreeze` is true only for `status: 'unfreeze'`. `nextProbeAfterMs` is the back-off-widened interval the re-probe loop should wait before the next tick.
+ */
+export function decideFreezeReprobe({freezeRecord, probe, bounds = DEFAULT_REPROBE_BOUNDS, now} = {}) {
+    // Fail CLOSED to frozen: a frozen collection is the contained-safe state, so any missing safety context
+    // must keep it frozen rather than risk an unfreeze on bad input.
+    if (!freezeRecord || typeof freezeRecord !== 'object' || typeof freezeRecord.collectionName !== 'string' || freezeRecord.collectionName.length === 0) {
+        return {unfreeze: false, status: 'unsafe-input', reason: 'freezeRecord with a collectionName is required (stay frozen)', nextProbeAfterMs: null};
+    }
+    if (!Number.isFinite(now)) {
+        return {unfreeze: false, status: 'unsafe-input', reason: 'a finite now (re-probe clock) is required (stay frozen)', nextProbeAfterMs: null};
+    }
+
+    // Normalize partial/empty bounds onto the safe defaults, then fail closed if any resolved bound is non-finite.
+    const {minReprobeIntervalMs, maxUnfreezeAttempts, backoffMultiplier} = {...DEFAULT_REPROBE_BOUNDS, ...(bounds && typeof bounds === 'object' ? bounds : {})};
+
+    if (![minReprobeIntervalMs, maxUnfreezeAttempts, backoffMultiplier].every(Number.isFinite)) {
+        return {unfreeze: false, status: 'unsafe-input', reason: 'finite bounds {minReprobeIntervalMs, maxUnfreezeAttempts, backoffMultiplier} are required (stay frozen)', nextProbeAfterMs: null};
+    }
+
+    const attempts = Number.isFinite(freezeRecord.unfreezeAttempts) && freezeRecord.unfreezeAttempts > 0 ? freezeRecord.unfreezeAttempts : 0,
+          // Back-off widens the probe interval by backoffMultiplier^attempts so a flapping collection is
+          // probed ever less often — the anti-thrash cadence guard (AC: freeze↔unfreeze is bounded).
+          nextProbeAfterMs = minReprobeIntervalMs * Math.pow(backoffMultiplier, attempts);
+
+    // Thrash cap: a collection that has been auto-unfrozen maxUnfreezeAttempts times and keeps re-freezing is a
+    // persistent fault — stay contained (frozen + ledgered), no further auto-unfreeze. A later capability change
+    // (the residue-fingerprint reopen path) can still reopen it; this only stops the autonomous unfreeze loop.
+    if (attempts >= maxUnfreezeAttempts) {
+        return {unfreeze: false, status: 'contained', reason: `unfreeze-attempt cap reached (${attempts}/${maxUnfreezeAttempts}) — persistent fault, stays frozen`, nextProbeAfterMs};
+    }
+
+    // Back-off: too soon since the last probe → defer (no re-probe this tick).
+    const lastProbeAt = Number.isFinite(freezeRecord.lastProbeAt) ? freezeRecord.lastProbeAt : -Infinity,
+          sinceProbe  = now - lastProbeAt;
+
+    if (Number.isFinite(lastProbeAt) && sinceProbe < nextProbeAfterMs) {
+        return {unfreeze: false, status: 'defer', reason: `within re-probe back-off (${sinceProbe}ms < ${nextProbeAfterMs}ms)`, nextProbeAfterMs};
+    }
+
+    // Probe assessment. Both signals strictly true → fault cleared → unfreeze + re-heal. Either strictly false →
+    // fault persists → stay frozen. Anything else (missing/partial probe) is inconclusive → stay frozen (safe).
+    const healthy  = probe?.embedderHealthy === true && probe?.dimensionConsistent === true,
+          persists = probe?.embedderHealthy === false || probe?.dimensionConsistent === false;
+
+    if (healthy) {
+        return {unfreeze: true, status: 'unfreeze', reason: 'fault cleared (embedder healthy + dimensions consistent) — unfreeze + re-heal', nextProbeAfterMs};
+    }
+    if (persists) {
+        return {unfreeze: false, status: 'stay-frozen', reason: 'fault persists (embedder unhealthy or dimensions inconsistent)', nextProbeAfterMs};
+    }
+    return {unfreeze: false, status: 'stay-frozen', reason: 'probe inconclusive — stay frozen (fail closed)', nextProbeAfterMs};
+}

--- a/test/playwright/unit/ai/services/memory-core/helpers/freezeRecordStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/freezeRecordStore.spec.mjs
@@ -1,0 +1,86 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import fs             from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+import {
+    getFreezeRecordsFilePath,
+    readFreezeRecords,
+    getFreezeRecord,
+    upsertFreezeRecord,
+    removeFreezeRecord
+} from '../../../../../../../ai/services/memory-core/helpers/freezeRecordStore.mjs';
+
+async function tmpDir() {
+    return await fs.mkdtemp(path.join(os.tmpdir(), 'freeze-records-'));
+}
+
+test.describe('freezeRecordStore — durable mutable freeze-state', () => {
+    test('upsert → read round-trips a record', async () => {
+        const dir = await tmpDir();
+        await upsertFreezeRecord({dir, collectionName: 'neo-native-graph', faultFingerprint: 'fp-1', frozenAt: 100, unfreezeAttempts: 0, lastProbeAt: 100});
+
+        expect(await getFreezeRecord({dir, collectionName: 'neo-native-graph'}))
+            .toMatchObject({collectionName: 'neo-native-graph', faultFingerprint: 'fp-1', frozenAt: 100, unfreezeAttempts: 0, lastProbeAt: 100});
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a missing file reads as an empty set (fail-safe → nothing frozen)', async () => {
+        const dir = await tmpDir();
+        expect(await readFreezeRecords({dir})).toEqual({});
+        expect(await getFreezeRecord({dir, collectionName: 'absent'})).toBeNull();
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a corrupt file reads as an empty set, never throws', async () => {
+        const dir = await tmpDir();
+        await fs.writeFile(getFreezeRecordsFilePath(dir), '{ not json', 'utf8');
+        expect(await readFreezeRecords({dir})).toEqual({});
+
+        await fs.writeFile(getFreezeRecordsFilePath(dir), JSON.stringify(['array-not-map']), 'utf8');
+        expect(await readFreezeRecords({dir})).toEqual({}); // a non-object map degrades to empty
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('upsert merges — a partial update preserves prior fields (bump lastProbeAt, keep frozenAt)', async () => {
+        const dir = await tmpDir();
+        await upsertFreezeRecord({dir, collectionName: 'c1', faultFingerprint: 'fp', frozenAt: 100, unfreezeAttempts: 0, lastProbeAt: 100});
+        await upsertFreezeRecord({dir, collectionName: 'c1', lastProbeAt: 700, unfreezeAttempts: 1}); // a probe tick
+
+        expect(await getFreezeRecord({dir, collectionName: 'c1'}))
+            .toMatchObject({collectionName: 'c1', faultFingerprint: 'fp', frozenAt: 100, unfreezeAttempts: 1, lastProbeAt: 700});
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('multiple collections are keyed independently', async () => {
+        const dir = await tmpDir();
+        await upsertFreezeRecord({dir, collectionName: 'c1', faultFingerprint: 'fp1'});
+        await upsertFreezeRecord({dir, collectionName: 'c2', faultFingerprint: 'fp2'});
+
+        const records = await readFreezeRecords({dir});
+        expect(Object.keys(records).sort()).toEqual(['c1', 'c2']);
+        expect(records.c1.faultFingerprint).toBe('fp1');
+        expect(records.c2.faultFingerprint).toBe('fp2');
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('remove deletes one record (true), leaves the rest, and is a no-op when absent (false)', async () => {
+        const dir = await tmpDir();
+        await upsertFreezeRecord({dir, collectionName: 'c1', faultFingerprint: 'fp1'});
+        await upsertFreezeRecord({dir, collectionName: 'c2', faultFingerprint: 'fp2'});
+
+        expect(await removeFreezeRecord({dir, collectionName: 'c1'})).toBe(true);
+        expect(await getFreezeRecord({dir, collectionName: 'c1'})).toBeNull();
+        expect(await getFreezeRecord({dir, collectionName: 'c2'})).not.toBeNull(); // sibling intact
+
+        expect(await removeFreezeRecord({dir, collectionName: 'c1'})).toBe(false); // already gone
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('upsert guards the required collectionName', async () => {
+        const dir = await tmpDir();
+        await expect(upsertFreezeRecord({dir})).rejects.toThrow(/collectionName is required/);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeDecision.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeDecision.spec.mjs
@@ -3,6 +3,7 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
     decideFreezeReprobe,
+    runFreezeReprobeCycle,
     DEFAULT_REPROBE_BOUNDS,
     FREEZE_REPROBE_STATUSES
 } from '../../../../../../../ai/services/memory-core/helpers/freezeReprobeDecision.mjs';
@@ -103,5 +104,120 @@ test.describe('decideFreezeReprobe — anti-thrash back-off + cap', () => {
             now         : NOW
         });
         expect(decision).toMatchObject({unfreeze: false, status: 'contained'});
+    });
+});
+
+test.describe('runFreezeReprobeCycle — orchestration over the frozen set', () => {
+    function harness() {
+        const calls = {probe: [], unfreeze: [], persist: [], clear: []};
+        return {
+            calls,
+            probe   : async name => { calls.probe.push(name); return CLEAR; },
+            unfreeze: async name => { calls.unfreeze.push(name); },
+            persist : async args => { calls.persist.push(args); },
+            clear   : async name => { calls.clear.push(name); }
+        };
+    }
+
+    test('a due collection with a cleared fault → unfreeze + clear, attempt recorded before execution', async () => {
+        const h        = harness();
+        const outcomes = await runFreezeReprobeCycle({
+            freezeRecords    : {'c1': record({collectionName: 'c1', unfreezeAttempts: 0, lastProbeAt: -Infinity})},
+            probe            : h.probe,
+            now              : NOW,
+            unfreezeAndReheal: h.unfreeze,
+            persistProbe     : h.persist,
+            clearFreeze      : h.clear
+        });
+
+        expect(outcomes).toEqual([{collectionName: 'c1', status: 'unfrozen', reason: expect.any(String), unfroze: true}]);
+        expect(h.calls.unfreeze).toEqual(['c1']);
+        expect(h.calls.clear).toEqual(['c1']);
+        expect(h.calls.persist[0]).toMatchObject({collectionName: 'c1', unfreezeAttempts: 1}); // bumped pre-unfreeze
+    });
+
+    test('a deferred (within back-off) collection is NOT probed', async () => {
+        const h        = harness();
+        const outcomes = await runFreezeReprobeCycle({
+            freezeRecords    : {'c1': record({collectionName: 'c1', unfreezeAttempts: 0, lastProbeAt: NOW - 1000})}, // 1s ago < 10min
+            probe            : h.probe,
+            now              : NOW,
+            unfreezeAndReheal: h.unfreeze,
+            persistProbe     : h.persist,
+            clearFreeze      : h.clear
+        });
+
+        expect(outcomes[0].status).toBe('defer');
+        expect(h.calls.probe).toEqual([]);   // never probed
+        expect(h.calls.unfreeze).toEqual([]); // never unfrozen
+    });
+
+    test('a contained (cap-hit) collection is NOT probed and is not unfrozen', async () => {
+        const h        = harness();
+        const outcomes = await runFreezeReprobeCycle({
+            freezeRecords    : {'c1': record({collectionName: 'c1', unfreezeAttempts: DEFAULT_REPROBE_BOUNDS.maxUnfreezeAttempts, lastProbeAt: -Infinity})},
+            probe            : h.probe,
+            now              : NOW,
+            unfreezeAndReheal: h.unfreeze,
+            persistProbe     : h.persist,
+            clearFreeze      : h.clear
+        });
+
+        expect(outcomes[0].status).toBe('contained');
+        expect(h.calls.probe).toEqual([]);
+        expect(h.calls.unfreeze).toEqual([]);
+    });
+
+    test('a still-faulted collection stays frozen + advances the probe clock', async () => {
+        const calls    = {persist: []};
+        const outcomes = await runFreezeReprobeCycle({
+            freezeRecords    : {'c1': record({collectionName: 'c1', unfreezeAttempts: 0, lastProbeAt: -Infinity})},
+            probe            : async () => ({embedderHealthy: false, dimensionConsistent: true}),
+            now              : NOW,
+            unfreezeAndReheal: async () => { throw new Error('should not be called'); },
+            persistProbe     : async args => { calls.persist.push(args); }
+        });
+
+        expect(outcomes[0].status).toBe('stay-frozen');
+        expect(calls.persist).toEqual([{collectionName: 'c1', lastProbeAt: NOW}]); // clock advanced, no attempt bump
+    });
+
+    test('a throwing probe is inconclusive → stay frozen (never auto-unfreezes on a probe error)', async () => {
+        const outcomes = await runFreezeReprobeCycle({
+            freezeRecords    : {'c1': record({collectionName: 'c1', lastProbeAt: -Infinity})},
+            probe            : async () => { throw new Error('probe down'); },
+            now              : NOW,
+            unfreezeAndReheal: async () => { throw new Error('should not be called'); }
+        });
+        expect(outcomes[0].status).toBe('stay-frozen');
+    });
+
+    test('a failed unfreeze stays frozen (record NOT cleared) — attempt already recorded', async () => {
+        const calls    = {clear: [], persist: []};
+        const outcomes = await runFreezeReprobeCycle({
+            freezeRecords    : {'c1': record({collectionName: 'c1', lastProbeAt: -Infinity})},
+            probe            : async () => CLEAR,
+            now              : NOW,
+            unfreezeAndReheal: async () => { throw new Error('reheal blew up'); },
+            persistProbe     : async args => { calls.persist.push(args); },
+            clearFreeze      : async name => { calls.clear.push(name); }
+        });
+
+        expect(outcomes[0].status).toBe('failed');
+        expect(calls.clear).toEqual([]);                              // not cleared — still frozen
+        expect(calls.persist[0]).toMatchObject({unfreezeAttempts: 1}); // attempt recorded pre-execution
+    });
+
+    test('a missing unfreezeAndReheal records deferred (not executed)', async () => {
+        const outcomes = await runFreezeReprobeCycle({
+            freezeRecords: {'c1': record({collectionName: 'c1', lastProbeAt: -Infinity})},
+            probe        : async () => CLEAR,
+            now          : NOW
+        });
+        expect(outcomes[0].status).toBe('deferred');
+    });
+
+    test('an empty frozen set yields no outcomes', async () => {
+        expect(await runFreezeReprobeCycle({freezeRecords: {}, now: NOW})).toEqual([]);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeDecision.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeDecision.spec.mjs
@@ -1,0 +1,107 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    decideFreezeReprobe,
+    DEFAULT_REPROBE_BOUNDS,
+    FREEZE_REPROBE_STATUSES
+} from '../../../../../../../ai/services/memory-core/helpers/freezeReprobeDecision.mjs';
+
+const NOW    = 1_000_000_000_000;
+const record = (overrides = {}) => ({collectionName: 'neo-native-graph', frozenAt: 0, faultFingerprint: 'fp', unfreezeAttempts: 0, lastProbeAt: -Infinity, ...overrides});
+const CLEAR  = {embedderHealthy: true,  dimensionConsistent: true};
+
+test.describe('decideFreezeReprobe — fail-closed-to-frozen guards', () => {
+    test('a missing freezeRecord stays frozen (unsafe-input)', () => {
+        expect(decideFreezeReprobe({freezeRecord: null, probe: CLEAR, now: NOW}))
+            .toMatchObject({unfreeze: false, status: 'unsafe-input'});
+    });
+
+    test('a record without a collectionName stays frozen', () => {
+        expect(decideFreezeReprobe({freezeRecord: {unfreezeAttempts: 0}, probe: CLEAR, now: NOW}))
+            .toMatchObject({unfreeze: false, status: 'unsafe-input'});
+    });
+
+    test('a non-finite now stays frozen (no clock → no unfreeze)', () => {
+        expect(decideFreezeReprobe({freezeRecord: record(), probe: CLEAR, now: undefined}))
+            .toMatchObject({unfreeze: false, status: 'unsafe-input'});
+    });
+
+    test('non-finite bounds stay frozen (a broken bound cannot disable the gate)', () => {
+        expect(decideFreezeReprobe({freezeRecord: record(), probe: CLEAR, now: NOW, bounds: {minReprobeIntervalMs: NaN}}))
+            .toMatchObject({unfreeze: false, status: 'unsafe-input'});
+    });
+
+    test('every status is in the exported vocabulary', () => {
+        expect(FREEZE_REPROBE_STATUSES).toContain('unfreeze');
+        expect(FREEZE_REPROBE_STATUSES).toContain('contained');
+    });
+});
+
+test.describe('decideFreezeReprobe — unfreeze on a cleared fault', () => {
+    test('fault cleared + past back-off + under cap → unfreeze + re-heal', () => {
+        const decision = decideFreezeReprobe({freezeRecord: record({lastProbeAt: -Infinity}), probe: CLEAR, now: NOW});
+        expect(decision).toMatchObject({unfreeze: true, status: 'unfreeze'});
+    });
+
+    test('the very first probe (no prior lastProbeAt) is not deferred', () => {
+        const decision = decideFreezeReprobe({freezeRecord: record({lastProbeAt: -Infinity}), probe: CLEAR, now: NOW});
+        expect(decision.status).toBe('unfreeze');
+    });
+});
+
+test.describe('decideFreezeReprobe — stay frozen on a present / inconclusive fault', () => {
+    test('embedder still unhealthy → stay frozen', () => {
+        expect(decideFreezeReprobe({freezeRecord: record(), probe: {embedderHealthy: false, dimensionConsistent: true}, now: NOW}))
+            .toMatchObject({unfreeze: false, status: 'stay-frozen'});
+    });
+
+    test('dimensions still inconsistent → stay frozen', () => {
+        expect(decideFreezeReprobe({freezeRecord: record(), probe: {embedderHealthy: true, dimensionConsistent: false}, now: NOW}))
+            .toMatchObject({unfreeze: false, status: 'stay-frozen'});
+    });
+
+    test('a missing / partial probe is inconclusive → stay frozen (fail closed)', () => {
+        expect(decideFreezeReprobe({freezeRecord: record(), probe: undefined, now: NOW}))
+            .toMatchObject({unfreeze: false, status: 'stay-frozen'});
+        expect(decideFreezeReprobe({freezeRecord: record(), probe: {embedderHealthy: true}, now: NOW}))
+            .toMatchObject({unfreeze: false, status: 'stay-frozen'});
+    });
+});
+
+test.describe('decideFreezeReprobe — anti-thrash back-off + cap', () => {
+    test('within the re-probe interval → defer (no re-probe this tick)', () => {
+        const decision = decideFreezeReprobe({
+            freezeRecord: record({unfreezeAttempts: 0, lastProbeAt: NOW - 1000}), // 1s ago, < 10min base
+            probe       : CLEAR,
+            now         : NOW
+        });
+        expect(decision).toMatchObject({unfreeze: false, status: 'defer'});
+    });
+
+    test('past the re-probe interval → assesses the probe (not deferred)', () => {
+        const decision = decideFreezeReprobe({
+            freezeRecord: record({unfreezeAttempts: 0, lastProbeAt: NOW - DEFAULT_REPROBE_BOUNDS.minReprobeIntervalMs - 1}),
+            probe       : CLEAR,
+            now         : NOW
+        });
+        expect(decision.status).toBe('unfreeze');
+    });
+
+    test('back-off widens the probe interval exponentially per prior unfreeze attempt', () => {
+        const at1 = decideFreezeReprobe({freezeRecord: record({unfreezeAttempts: 1, lastProbeAt: -Infinity}), probe: CLEAR, now: NOW}),
+              at2 = decideFreezeReprobe({freezeRecord: record({unfreezeAttempts: 2, lastProbeAt: -Infinity}), probe: CLEAR, now: NOW});
+
+        expect(at1.nextProbeAfterMs).toBe(DEFAULT_REPROBE_BOUNDS.minReprobeIntervalMs * 2);  // 2^1
+        expect(at2.nextProbeAfterMs).toBe(DEFAULT_REPROBE_BOUNDS.minReprobeIntervalMs * 4);  // 2^2
+    });
+
+    test('the unfreeze-attempt cap → contained (persistent fault), even when the probe reads clear', () => {
+        const decision = decideFreezeReprobe({
+            freezeRecord: record({unfreezeAttempts: DEFAULT_REPROBE_BOUNDS.maxUnfreezeAttempts, lastProbeAt: -Infinity}),
+            probe       : CLEAR, // cap wins over a clear probe — no thrash
+            now         : NOW
+        });
+        expect(decision).toMatchObject({unfreeze: false, status: 'contained'});
+    });
+});


### PR DESCRIPTION
Resolves #14171

The pure substrate of the autonomous freeze → re-probe → auto-unfreeze / re-heal cycle (#14166, the #1 weeks-bar risk): the decision logic, the durable freeze-state, and the orchestration — all unit-tested without a live daemon. In cloud there is no operator to lift a `freeze`, so a TRANSIENT fault that tripped containment would otherwise kill a collection permanently; this is the logic that makes `freeze` autonomously recoverable, bounded against thrash.

This is the substrate half of #14166. The live wiring half is **gated** — V-B-A confirms `DataIntegrityDiagnosisService.mjs:154` is still escalate-only ("never a privileged action"), so `freeze` isn't yet applied through the live diagnosis→actuator path and there is no freeze-record to re-probe yet. Landing the substrate now (tested, contracts fixed) de-risks the gated integration — the #14146 pure-helpers-first precedent.

- **`freezeReprobeDecision.mjs` — `decideFreezeReprobe`** (pure): `unfreeze` / `defer` / `stay-frozen` / `contained` / `unsafe-input`. **Safety inversion vs `healActionDispatch`:** a frozen collection is the contained-safe state, so this fails CLOSED to *stay-frozen* — a missing record, a non-finite clock, or an inconclusive probe never auto-unfreezes; only an affirmatively-cleared fault (embedder healthy + dimensions consistent), past the back-off and under the cap, lifts containment. Exponential back-off (`backoffMultiplier^attempts`) + unfreeze-attempt cap are the anti-thrash bound.
- **`freezeRecordStore.mjs`** — durable, mutable, keyed-by-collection freeze-STATE; fail-safe (missing/corrupt → empty set, never crashes the recovery loop). Distinct from the append-only heal-event ledger (#14163 telemetry).
- **`runFreezeReprobeCycle`** — orchestrates the frozen set: a cheap pre-decision skips a probe for within-back-off / contained / bad-record collections, then probes only the due ones, re-decides with the live probe, and executes via INJECTED ops (`probe` / `unfreezeAndReheal` / `persistProbe` / `clearFreeze`) — fully testable without a daemon (mirrors `dispatchHeal`). Anti-hot-loop: the unfreeze attempt is recorded BEFORE execution, so a re-freeze keeps the climbing count → eventually `contained`.

Evidence: L2 (in-process unit — pure decider, keyed store over a tmpdir, and the cycle orchestrator with injected probe/unfreeze/persist/clear stubs; fail-closed, back-off, cap, anti-hot-loop all asserted) → L4 required for the live cycle (real embedder/dimension probe + privileged unfreeze + the periodic daemon tick). Residual: the live re-probe behavior [#14166, gated on the apply()-cutover].

## Deltas from ticket

- This PR delivers #14171 in full (the substrate). The live wiring (real probe + unfreeze execution + the periodic data-integrity-sweep tick + the freeze-record WRITE at the freeze-apply point) stays on the parent #14166 and is gated on the apply()-cutover (#14138 producer re-route + `DataIntegrityDiagnosisService` heal-wiring) — at which point `freeze` becomes a live applied action with a record to re-probe.
- Design call: the re-probe rides the existing data-integrity sweep tick (the decider owns the per-collection back-off), so no new cadence/config leaf is added.

## Test Evidence

```
UNIT_TEST_MODE=true npm run test-unit -- \
  test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeDecision.spec.mjs \
  test/playwright/unit/ai/services/memory-core/helpers/freezeRecordStore.spec.mjs
→ 29 passed (22 decider+cycle + 7 store)
```

`agent-preflight` (ticket-archaeology + PR-body lint) clean.

## Post-Merge Validation

- [ ] When the apply()-cutover lands, wire `runFreezeReprobeCycle` into the data-integrity sweep with the real probe + unfreeze execution, and the freeze-WRITE at the freeze-apply point (the #14166 follow-up).
- [ ] Live: induce a transient systemic fault → confirm the collection freezes, is re-probed on the sweep cadence, and auto-unfreezes + re-heals once the fault clears; a persistent fault stays `contained`.

## Commits

- `9329db547` — `decideFreezeReprobe` (the pure decider)
- `cf7955076` — `freezeRecordStore` (durable mutable freeze-state)
- `c82775ffd` — `runFreezeReprobeCycle` (the cycle orchestrator)

Related: #14166 (parent cycle) · #14134 (actuator) · #14039 (v13.1 epic)

Authored by Grace (Claude Opus 4.8, Claude Code). Session 090a68e6-1a28-4b20-a5fd-842ebac3e729.