### PR TITLE
fix(ai): surface the resolved endpoint + model in openAiCompatible embed-errors (#14173)

### DIFF
--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -479,7 +479,11 @@ class TextEmbeddingService extends Base {
                 res.on('data', chunk => body += chunk);
                 res.on('end', () => {
                     if (res.statusCode < 200 || res.statusCode >= 300) {
-                        rejectFunc(new Error(`openAiCompatible embedding error HTTP ${res.statusCode}: ${body}`));
+                        // Append the resolved endpoint + model so a wrong host:port (the :11434 Ollama
+                        // default vs :1234 LM Studio) or a non-resident model is diagnosable from the error
+                        // alone — not a bare "resource could not be found". The `HTTP <status>:` prefix MUST
+                        // stay verbatim: OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE classifies on it.
+                        rejectFunc(new Error(`openAiCompatible embedding error HTTP ${res.statusCode}: ${body} [endpoint=${parsedUrl.href}, model='${embeddingModel}']`));
                     } else {
                         try {
                             const result = JSON.parse(body);


### PR DESCRIPTION
## Summary

The kbSync embedder-404 (the #14154 fire) surfaced as a bare `openAiCompatible embedding error HTTP 404: The requested resource could not be found` — omitting the two facts needed to diagnose it: the resolved **host:port** (the `:11434` Ollama default vs `:1234` LM Studio) and the **model** (a non-resident/evicted model also 404s).

Resolves #14173

## Change

Append `[endpoint=<resolved /v1/embeddings URL>, model='<embeddingModel>']` to the embed-error (`TextEmbeddingService.mjs:482`). Both are already in scope at the throw. **The `HTTP <status>:` prefix is preserved verbatim** — `OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE` (L16) classifies the 408/429/503/504 contention-retry path on it, so reformatting would silently break retries.

Evidence: the live error format (`TextEmbeddingService.mjs:482`); the contention regex (L16); `host`/`embeddingModel` destructured at L451-452; `parsedUrl` at L459.

## Deltas from ticket (if any)

- None on scope — the smallest change that makes the 404 self-diagnosing.
- **No new test:** the non-2xx error path is exercised by the 31 passing TextEmbeddingService + retry specs (incl. the contention path), and the change is a message-only append; a positive string-assertion would need the retry spec's real-HTTP-test-server mock for marginal gain on a one-line change. Regression-covered instead.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs TextEmbeddingService` → **31 passed**, including the contention/retry specs that drive the non-2xx error path — confirming the `HTTP <status>:` prefix still classifies and the retry path has no regression.

## Post-Merge Validation

After deploy, a future embed failure logs the resolved endpoint + model in the error, e.g. `...HTTP 404: The requested resource could not be found [endpoint=http://127.0.0.1:11434/v1/embeddings, model='text-embedding-qwen3-embedding-8b']` — so a host:port or non-resident-model misconfiguration is diagnosable from the error alone, not a multi-hour config trace.

## Related

#14154 (the fire — this makes its 404 diagnosable, distinct from root-causing it via the runtime discriminator); #14124 (the embed-canary catch-22).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `fe9c04d6-1aae-4017-8d53-19b0e5aaf809`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
