### PR TITLE
feat(ai): heal-event ledger substrate — durable store + status-summary + query (#14177)

### DIFF
--- a/ai/services/memory-core/helpers/healEventLedgerStore.mjs
+++ b/ai/services/memory-core/helpers/healEventLedgerStore.mjs
@@ -1,0 +1,135 @@
+import {appendFile, mkdir, readFile} from 'fs/promises';
+import path                          from 'path';
+
+/**
+ * @module ai/services/memory-core/helpers/healEventLedgerStore
+ * @summary Durable append-only ledger for autonomous self-heal events — the observability sink for the
+ * data-recovery actuator (the dispatch outcomes), the accepted-loss settlements, and the freeze →
+ * auto-unfreeze cycle. Under the zero-operator-ack mandate the immune system never blocks on a human, so the
+ * ledger is how an operator (when present) reviews what the system healed, froze, or contained — asynchronously,
+ * never as a gate. `summarizeHealLedger` folds the append-only stream into a queryable status surface
+ * (counts + the currently-frozen set) without a second source of truth. Mirrors the `acceptedLossAuditStore`
+ * JSONL shape: I/O at the edge only, deterministic content.
+ */
+
+const HEAL_LEDGER_FILENAME = 'heal-events.jsonl';
+
+/**
+ * Event types the ledger recognises for the folded status surface. `freeze` adds a collection to the
+ * currently-frozen set; `unfreeze` removes it; everything else is a point-in-time heal/containment record.
+ * @type {{FREEZE: String, UNFREEZE: String}}
+ */
+export const HEAL_LEDGER_FROZEN_TRANSITIONS = Object.freeze({FREEZE: 'freeze', UNFREEZE: 'unfreeze'});
+
+/**
+ * @summary The JSONL ledger path within a state directory.
+ * @param {String} dir
+ * @returns {String}
+ */
+export function getHealLedgerFilePath(dir) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('getHealLedgerFilePath: dir is required');
+    }
+    return path.join(dir, HEAL_LEDGER_FILENAME);
+}
+
+/**
+ * @summary Appends one heal-event entry to the durable JSONL ledger (creating the dir if needed). Stamps
+ * `at` from the injected clock when absent so every entry is time-ordered.
+ * @param {Object} entry A JSON-serializable heal event (`{type, collection, status, detail, at?}`).
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @param {Number} [options.now] Epoch ms used to stamp `at` when the entry omits it.
+ * @returns {Promise<String>} The ledger file path written to.
+ * @throws {TypeError} when `entry` is not an object or `dir` is missing/empty.
+ */
+export async function appendHealEvent(entry, {dir, now} = {}) {
+    if (!entry || typeof entry !== 'object') {
+        throw new TypeError('appendHealEvent: entry object is required');
+    }
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('appendHealEvent: dir is required');
+    }
+
+    const stamped = {...entry, at: Number.isFinite(entry.at) ? entry.at : (Number.isFinite(now) ? now : null)};
+
+    await mkdir(dir, {recursive: true});
+    const filePath = getHealLedgerFilePath(dir);
+    await appendFile(filePath, `${JSON.stringify(stamped)}\n`, 'utf8');
+
+    return filePath;
+}
+
+/**
+ * @summary Reads all heal-event entries (oldest → newest). A missing ledger returns `[]` (nothing healed yet);
+ * a corrupt line is skipped rather than crashing the read (fail-safe — observability must never break the loop).
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @returns {Promise<Object[]>} The parsed events in append order.
+ */
+export async function readHealLedger({dir} = {}) {
+    let text;
+
+    try {
+        text = await readFile(getHealLedgerFilePath(dir), 'utf8');
+    } catch (error) {
+        return []; // ENOENT or any unreadable ledger → nothing recorded yet
+    }
+
+    const events = [];
+    for (const line of text.split('\n')) {
+        if (!line) continue;
+        try {
+            events.push(JSON.parse(line));
+        } catch (error) {
+            // skip a corrupt line — a partial write must not break the whole status surface
+        }
+    }
+    return events;
+}
+
+/**
+ * @summary Folds a heal-event stream into the queryable immune-system status surface: totals, counts by
+ * status and by type, the currently-frozen set (freeze adds, unfreeze removes — last transition wins), and the
+ * latest event timestamp. Pure — no I/O; the caller reads the ledger then summarizes.
+ * @param {Object[]} [events=[]] The heal events (as read from the ledger).
+ * @returns {Object} `{total, byStatus, byType, currentlyFrozen, lastEventAt}`.
+ */
+export function summarizeHealLedger(events = []) {
+    const rows     = Array.isArray(events) ? events : [],
+          byStatus = {},
+          byType   = {},
+          frozen   = new Set();
+
+    let lastEventAt = null;
+
+    for (const event of rows) {
+        if (!event || typeof event !== 'object') continue;
+
+        const status = typeof event.status === 'string' ? event.status : 'unknown',
+              type   = typeof event.type   === 'string' ? event.type   : 'unknown';
+
+        byStatus[status] = (byStatus[status] ?? 0) + 1;
+        byType[type]     = (byType[type] ?? 0) + 1;
+
+        if (typeof event.collection === 'string' && event.collection.length > 0) {
+            if (type === HEAL_LEDGER_FROZEN_TRANSITIONS.FREEZE) {
+                frozen.add(event.collection);
+            } else if (type === HEAL_LEDGER_FROZEN_TRANSITIONS.UNFREEZE) {
+                frozen.delete(event.collection);
+            }
+        }
+
+        if (Number.isFinite(event.at) && (lastEventAt === null || event.at > lastEventAt)) {
+            lastEventAt = event.at;
+        }
+    }
+
+    return {
+        total          : rows.length,
+        byStatus,
+        byType,
+        currentlyFrozen: [...frozen].sort(),
+        lastEventAt
+    };
+}

--- a/ai/services/memory-core/helpers/healEventLedgerStore.mjs
+++ b/ai/services/memory-core/helpers/healEventLedgerStore.mjs
@@ -133,3 +133,40 @@ export function summarizeHealLedger(events = []) {
         lastEventAt
     };
 }
+
+/**
+ * @summary Filters a heal-event stream into a queryable view — the "what happened" surface that complements
+ * `summarizeHealLedger`'s folded counts. Pure: restrict by an optional inclusive time window, event types,
+ * collections, and statuses; returns newest-first (by `at`), capped at `limit`. A non-object entry, or one
+ * outside a requested time window, is dropped; an untimed event is excluded when a time bound is requested.
+ * @param {Object[]} [events=[]] The heal events (as read from the ledger).
+ * @param {Object} [options]
+ * @param {Number} [options.sinceMs] Lower bound (inclusive) on `at`.
+ * @param {Number} [options.untilMs] Upper bound (inclusive) on `at`.
+ * @param {String[]} [options.types] Restrict to these event types (e.g. `['freeze', 'unfreeze']`).
+ * @param {String[]} [options.collections] Restrict to these collections.
+ * @param {String[]} [options.statuses] Restrict to these statuses (e.g. `['failed']`).
+ * @param {Number} [options.limit] Max events returned (newest-first); omitted → all matches.
+ * @returns {Object[]} The matching events, newest-first.
+ */
+export function queryHealLedger(events = [], {sinceMs, untilMs, types, collections, statuses, limit} = {}) {
+    const rows      = Array.isArray(events) ? events : [],
+          typeSet   = Array.isArray(types)       && types.length       ? new Set(types)       : null,
+          collSet   = Array.isArray(collections) && collections.length ? new Set(collections) : null,
+          statusSet = Array.isArray(statuses)    && statuses.length    ? new Set(statuses)    : null;
+
+    const filtered = rows.filter(event => {
+        if (!event || typeof event !== 'object')                                            return false;
+        if (Number.isFinite(sinceMs) && !(Number.isFinite(event.at) && event.at >= sinceMs)) return false;
+        if (Number.isFinite(untilMs) && !(Number.isFinite(event.at) && event.at <= untilMs)) return false;
+        if (typeSet   && !typeSet.has(event.type))         return false;
+        if (collSet   && !collSet.has(event.collection))   return false;
+        if (statusSet && !statusSet.has(event.status))     return false;
+        return true;
+    });
+
+    // Newest-first by `at`; untimed events (-Infinity) sink to the end (Array.sort is stable in V8).
+    filtered.sort((a, b) => (Number.isFinite(b.at) ? b.at : -Infinity) - (Number.isFinite(a.at) ? a.at : -Infinity));
+
+    return Number.isFinite(limit) && limit >= 0 ? filtered.slice(0, limit) : filtered;
+}

--- a/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
@@ -8,7 +8,8 @@ import {
     getHealLedgerFilePath,
     appendHealEvent,
     readHealLedger,
-    summarizeHealLedger
+    summarizeHealLedger,
+    queryHealLedger
 } from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
 
 async function tmpDir() {
@@ -90,5 +91,44 @@ test.describe('summarizeHealLedger — the queryable status surface', () => {
         const withGarbage = summarizeHealLedger([null, {type: 'heal', status: 'healed', at: 5}, 'nope']);
         expect(withGarbage.total).toBe(3);          // counts rows
         expect(withGarbage.byStatus).toEqual({healed: 1}); // but only valid objects contribute
+    });
+});
+
+test.describe('queryHealLedger — the filtered "what happened" surface', () => {
+    const sample = [
+        {type: 'heal',     collection: 'c1', status: 'healed',    at: 10},
+        {type: 'freeze',   collection: 'c2', status: 'contained', at: 20},
+        {type: 'heal',     collection: 'c1', status: 'failed',    at: 30},
+        {type: 'unfreeze', collection: 'c2', status: 'unfrozen',  at: 40}
+    ];
+
+    test('returns newest-first by `at`', () => {
+        expect(queryHealLedger(sample).map(e => e.at)).toEqual([40, 30, 20, 10]);
+    });
+
+    test('time window (sinceMs / untilMs, inclusive)', () => {
+        expect(queryHealLedger(sample, {sinceMs: 20, untilMs: 30}).map(e => e.at)).toEqual([30, 20]);
+    });
+
+    test('filters by type / collection / status', () => {
+        expect(queryHealLedger(sample, {types: ['freeze', 'unfreeze']}).map(e => e.type)).toEqual(['unfreeze', 'freeze']);
+        expect(queryHealLedger(sample, {collections: ['c1']}).map(e => e.at)).toEqual([30, 10]);
+        expect(queryHealLedger(sample, {statuses: ['failed']}).map(e => e.at)).toEqual([30]);
+    });
+
+    test('combined filters intersect', () => {
+        expect(queryHealLedger(sample, {collections: ['c2'], types: ['freeze']}).map(e => e.at)).toEqual([20]);
+    });
+
+    test('limit caps the result newest-first', () => {
+        expect(queryHealLedger(sample, {limit: 2}).map(e => e.at)).toEqual([40, 30]);
+        expect(queryHealLedger(sample, {limit: 0})).toEqual([]);
+    });
+
+    test('drops non-objects, and excludes untimed events when a time bound is requested', () => {
+        const withGarbage = [null, 'nope', {type: 'heal', status: 'healed'} /* no at */, {type: 'heal', status: 'healed', at: 50}];
+        expect(queryHealLedger(withGarbage).length).toBe(2);                          // both objects, no time bound
+        expect(queryHealLedger(withGarbage, {sinceMs: 0}).map(e => e.at)).toEqual([50]); // untimed excluded under a bound
+        expect(queryHealLedger(undefined)).toEqual([]);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
@@ -1,0 +1,94 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import fs             from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+import {
+    getHealLedgerFilePath,
+    appendHealEvent,
+    readHealLedger,
+    summarizeHealLedger
+} from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
+
+async function tmpDir() {
+    return await fs.mkdtemp(path.join(os.tmpdir(), 'heal-ledger-'));
+}
+
+test.describe('healEventLedgerStore — durable append-only heal ledger', () => {
+    test('append → read round-trips in append order (oldest → newest)', async () => {
+        const dir = await tmpDir();
+        await appendHealEvent({type: 'heal', collection: 'c1', status: 'healed', at: 100}, {dir});
+        await appendHealEvent({type: 'freeze', collection: 'c2', status: 'contained', at: 200}, {dir});
+
+        const events = await readHealLedger({dir});
+        expect(events.map(e => e.collection)).toEqual(['c1', 'c2']);
+        expect(events[1]).toMatchObject({type: 'freeze', status: 'contained', at: 200});
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a missing ledger reads as [] (nothing healed yet)', async () => {
+        const dir = await tmpDir();
+        expect(await readHealLedger({dir})).toEqual([]);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a corrupt line is skipped, the rest still read (fail-safe)', async () => {
+        const dir = await tmpDir();
+        await appendHealEvent({type: 'heal', collection: 'c1', status: 'healed', at: 1}, {dir});
+        await fs.appendFile(getHealLedgerFilePath(dir), '{ not json\n', 'utf8');
+        await appendHealEvent({type: 'heal', collection: 'c2', status: 'healed', at: 2}, {dir});
+
+        const events = await readHealLedger({dir});
+        expect(events.map(e => e.collection)).toEqual(['c1', 'c2']); // corrupt middle line dropped
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('append stamps `at` from the injected clock when absent', async () => {
+        const dir = await tmpDir();
+        await appendHealEvent({type: 'unfreeze', collection: 'c1', status: 'unfrozen'}, {dir, now: 777});
+        expect((await readHealLedger({dir}))[0].at).toBe(777);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('append guards required args', async () => {
+        const dir = await tmpDir();
+        await expect(appendHealEvent(null, {dir})).rejects.toThrow(/entry object is required/);
+        await expect(appendHealEvent({type: 'heal'}, {})).rejects.toThrow(/dir is required/);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+});
+
+test.describe('summarizeHealLedger — the queryable status surface', () => {
+    test('counts by status and by type + reports the latest timestamp', () => {
+        const summary = summarizeHealLedger([
+            {type: 'heal',   collection: 'c1', status: 'healed', at: 10},
+            {type: 'heal',   collection: 'c2', status: 'failed', at: 20},
+            {type: 'freeze', collection: 'c3', status: 'contained', at: 30}
+        ]);
+
+        expect(summary.total).toBe(3);
+        expect(summary.byStatus).toEqual({healed: 1, failed: 1, contained: 1});
+        expect(summary.byType).toEqual({heal: 2, freeze: 1});
+        expect(summary.lastEventAt).toBe(30);
+    });
+
+    test('folds freeze/unfreeze into the currently-frozen set (last transition wins)', () => {
+        const summary = summarizeHealLedger([
+            {type: 'freeze',   collection: 'c1', status: 'contained', at: 1},
+            {type: 'freeze',   collection: 'c2', status: 'contained', at: 2},
+            {type: 'unfreeze', collection: 'c1', status: 'unfrozen',  at: 3}, // c1 recovered
+            {type: 'freeze',   collection: 'c3', status: 'contained', at: 4}
+        ]);
+
+        expect(summary.currentlyFrozen).toEqual(['c2', 'c3']); // c1 unfrozen, sorted
+    });
+
+    test('empty / garbage input yields safe defaults', () => {
+        expect(summarizeHealLedger([])).toEqual({total: 0, byStatus: {}, byType: {}, currentlyFrozen: [], lastEventAt: null});
+        expect(summarizeHealLedger(undefined).total).toBe(0);
+        const withGarbage = summarizeHealLedger([null, {type: 'heal', status: 'healed', at: 5}, 'nope']);
+        expect(withGarbage.total).toBe(3);          // counts rows
+        expect(withGarbage.byStatus).toEqual({healed: 1}); // but only valid objects contribute
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#14177

The pure substrate of autonomous self-heal observability (#14163): a durable append-only heal-event ledger plus the fold + filter query layer that turns it into a queryable immune-system status surface — all unit-tested without a live daemon. Under the zero-operator-ack mandate the immune system never blocks on a human; this is how an operator (when present) reviews what the system healed, froze, or contained — asynchronously, never as a gate.

This is the substrate half of neomjs/neo#14163. The live wiring half (the actuator / freeze / accepted-loss paths *appending* events, and any MCP/service exposure) is gated on the apply()-cutover (#14138 + the `DataIntegrityDiagnosisService` heal-wiring) — events don't flow until the actuator is a live producer. Landing the substrate now (tested, contracts fixed) de-risks that integration and unblocks the readers (Ada's neomjs/neo#14158 alert; neomjs/neo#14166's `contained` records).

- **`healEventLedgerStore.mjs`** — `appendHealEvent` (append-only JSONL; stamps `at` from the injected clock when absent) + `readHealLedger` (fail-safe: missing → `[]`, corrupt line skipped — observability must never break the recovery loop). Mirrors `acceptedLossAuditStore`.
- **`summarizeHealLedger`** (pure) — folds the stream into the status surface: totals, counts by status + type, and the currently-frozen set (freeze adds / unfreeze removes, last transition wins) — no second source of truth.
- **`queryHealLedger`** (pure) — the filtered "what happened" view: inclusive time window + type/collection/status filters, newest-first, capped at limit; drops non-objects; excludes untimed events under a time bound.

Evidence: L2 (in-process unit — append-only store over a tmpdir with fail-safe missing/corrupt-line handling; the pure fold + filter asserted across counts, the frozen-set transitions, time-window/type/collection/status filters, ordering, and limit) → L4 required for the live ledger (the actuator appending real heal-events under load). Residual: live event flow [#14163, gated on the apply()-cutover].

## Deltas from ticket

- Delivers neomjs/neo#14177 in full (the substrate). The live wiring (actuator-append + status exposure) stays on the parent neomjs/neo#14163, gated on the apply()-cutover.
- The freeze-STATE store (#14171 `freezeRecordStore`, mutable operational) and this heal-event LEDGER (append-only telemetry) are deliberately distinct — operational state vs the observability stream — so they don't conflate.

## Test Evidence

```
UNIT_TEST_MODE=true npm run test-unit -- \
  test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
→ 14 passed (store round-trip + fail-safe + summarize fold + query filters)
```

`agent-preflight` (ticket-archaeology + PR-body lint) clean.

## Post-Merge Validation

- [ ] When the apply()-cutover lands, wire the actuator / freeze / accepted-loss paths to `appendHealEvent`, and expose the status surface (MCP tool or consumer) — the neomjs/neo#14163 follow-up.
- [ ] Live: confirm a heal/freeze/unfreeze cycle records to the ledger and `summarizeHealLedger` reflects the currently-frozen set.

## Commits

- `129542439` — heal-event ledger store + `summarizeHealLedger`
- `331f709a0` — `queryHealLedger` (the filtered view)

Related: neomjs/neo#14163 (parent) · neomjs/neo#14166 (the freeze cycle that records `contained`) · neomjs/neo#14158 (Ada's alert reader) · neomjs/neo#14134 (actuator) · neomjs/neo#14039 (v13.1 epic)

Authored by Grace (Claude Opus 4.8, Claude Code). Session 090a68e6-1a28-4b20-a5fd-842ebac3e729.