### PR TITLE
fix(ai): write-ahead KB resume marker — no orphan shadow on double failure (#14176)

### DIFF
--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -742,6 +742,13 @@ class VectorService extends Base {
             chunksToEmbed   = knowledgeBase;
             alreadyEmbedded = 0;
             logger.log(`Building shadow knowledge-base collection '${shadowName}' (${decision.reason}).`);
+
+            // Write-ahead resume marker: record the shadow BEFORE creating + embedding it, so a non-promoted
+            // shadow is ALWAYS indexed by a marker. Otherwise a transient embed failure whose catch-path
+            // marker-write ALSO fails strands the shadow with no marker — the next fresh-build's
+            // discardResumeShadow(resumeState?.shadowName) then no-ops and the shadow orphans permanently. A
+            // failure here throws before createCollection, so no shadow is ever created without its marker.
+            await writeResumeState({dir: stateDir, fingerprint, shadowName, attempts});
             shadowCollection = await ChromaManager.client.createCollection({name: shadowName, embeddingFunction: aiConfig.dummyEmbeddingFunction});
         }
 
@@ -794,9 +801,10 @@ class VectorService extends Base {
 
             if (!shadowPromoted) {
                 // A too-big chunk (KB_EMBEDDING_INPUT_SIZE_EXCEEDED) will NEVER embed — resuming it is futile,
-                // so park the shadow as a dead artifact (the prior behavior). A TRANSIENT embed failure (a
-                // provider blip) instead PRESERVES the shadow + records resume-state, so the next run resumes
-                // from here rather than re-embedding the whole corpus.
+                // so park the shadow as a dead artifact (the prior behavior) and clear its marker. A TRANSIENT
+                // embed failure (a provider blip) instead PRESERVES the shadow so the next run resumes from
+                // here. This re-write advances the attempt counter; fresh builds already wrote the marker
+                // ahead of embedding and resumes carry a prior marker, so the shadow is already indexed.
                 if (error?.message?.includes('KB_EMBEDDING_INPUT_SIZE_EXCEEDED')) {
                     await this.parkFailedShadowCollection({shadowCollection, shadowName});
                     await clearResumeState({dir: stateDir});
@@ -805,7 +813,9 @@ class VectorService extends Base {
                         await writeResumeState({dir: stateDir, fingerprint, shadowName, attempts});
                         logger.warn(`[VectorService] Preserved shadow '${shadowName}' for resume (attempt ${attempts}) after a transient embedding failure: ${error.message}`);
                     } catch (preserveError) {
-                        logger.error(`[VectorService] Failed to record resume-state for '${shadowName}': ${preserveError.message}`);
+                        // The write-ahead (fresh build) or prior (resume) marker still indexes the shadow, so
+                        // it is not orphaned — only the attempt-counter refresh was lost.
+                        logger.error(`[VectorService] Could not refresh resume-state for '${shadowName}' (${preserveError.message}); the write-ahead marker still protects the shadow.`);
                     }
                 }
             }

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -580,6 +580,46 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         }
     });
 
+    test('fresh-build records the resume marker BEFORE creating the shadow (write-ahead — no orphan on a double failure)', async () => {
+        const live                = createSpyCollection({existingIds: [], name: KB_Config.data.collectionName});
+        const originalEmbedChunks = KB_VectorService.embedChunks.bind(KB_VectorService);
+        let shadow;
+        let markerShadowAtCreate = null;
+
+        KB_ChromaManager.client = {
+            createCollection: async ({name}) => {
+                // The write-ahead marker must already be on disk when the shadow is created, so a shadow can
+                // never exist without a marker indexing it. Without write-ahead, a transient embed failure
+                // whose catch-path marker-write ALSO fails would strand the shadow with no marker, and the
+                // next fresh-build's discardResumeShadow(resumeState?.shadowName) would no-op — orphaning it.
+                const stateAtCreate = await readResumeState({dir: KB_VectorService.resumeStateDir});
+                markerShadowAtCreate = stateAtCreate?.shadowName ?? null;
+                shadow = createSpyCollection({name});
+                return shadow;
+            }
+        };
+        KB_VectorService.embedChunks = async () => {
+            throw new Error('forced embed failure');
+        };
+
+        try {
+            await expect(KB_VectorService.embedViaShadowSwap({
+                liveCollection  : live,
+                knowledgeBase   : [{id: 'chunk-0', type: 'method', name: 'method0'}],
+                idsToDeleteCount: 0
+            })).rejects.toThrow('forced embed failure');
+
+            // Write-ahead: the marker indexed THIS shadow at creation time, not only in the failure catch.
+            expect(markerShadowAtCreate).toBe(shadow.name);
+
+            // And it persists through the failure for the next run to resume into / reclaim.
+            const resumeState = await readResumeState({dir: KB_VectorService.resumeStateDir});
+            expect(resumeState?.shadowName).toBe(shadow.name);
+        } finally {
+            KB_VectorService.embedChunks = originalEmbedChunks;
+        }
+    });
+
     test('shadow-swap MCP gate measures full-corpus rebuild volume before creating shadow collection', async () => {
         const live                  = createSpyCollection({existingIds: [], name: KB_Config.data.collectionName});
         let   createCollectionCalls = 0;


### PR DESCRIPTION
## Summary

#14161's resumable shadow-swap preserves a shadow + writes a resume-marker on a transient embed failure, so the next sync resumes instead of re-embedding the whole corpus. But that marker write is best-effort in the failure `catch`: if a transient embed failure coincides with a **resume-marker write failure** (disk-full / permission glitch), the shadow is preserved on disk with **no marker pointing at it**. The next fresh-build's `discardResumeShadow(resumeState?.shadowName)` then no-ops (resumeState is null), the shadow is never reclaimed, and it orphans permanently — a net-new source of the #14079 Chroma bloat.

Resolves #14176

## Change

Write the resume marker **ahead** of `createCollection` in the fresh-build path — the only path that creates a marker-less shadow (the resume path always carries a prior marker). A non-promoted shadow is now ALWAYS indexed by a marker:

- Marker write fails → throws **before** `createCollection` → no shadow is ever created without its marker.
- `createCollection` fails after the marker → the marker references a ghost shadow → the next run's resume `getCollection` fails → fresh-build → `discardResumeShadow` no-ops gracefully (it already degrades on a vanished collection). Self-heals.
- The catch-path `writeResumeState` stays as the attempt-counter refresh (and the sole record on the resume path); its failure can no longer orphan — the write-ahead (fresh build) or prior (resume) marker still indexes the shadow.

Evidence: the orphan path is the one I traced filing #14176 — `VectorService.embedViaShadowSwap` fresh-build creates the shadow at `createCollection`, and `discardResumeShadow(resumeState?.shadowName)` no-ops when the marker is absent; `discardResumeShadow` already degrades on a vanished/unreadable collection (so the ghost-marker case self-heals).

## Deltas from ticket (if any)

- Implements fix-direction **(A)** from #14176 (write-ahead marker), chosen over (B) marker-less sweep: (A) closes the window structurally — the marker becomes the single source of truth for shadow existence — rather than sweeping orphans after the fact.
- Scoped to the **fresh-build** path only — the resume path cannot orphan (its marker pre-exists). Minimal one-site write-ahead + a catch-comment refinement, not a both-paths restructure.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs VectorService.WorkVolumeBranching` → **14 passed** (13 existing + 1 new). The new test `fresh-build records the resume marker BEFORE creating the shadow (write-ahead — no orphan on a double failure)` asserts the marker is on disk at `createCollection` time. Verified it's a **true regression test**: `git stash`-ing the fix makes it FAIL (`markerShadowAtCreate` = null — marker absent until the catch), confirming it catches the bug, not a vacuous pass.

## Post-Merge Validation

A KB sync that hits a transient embed failure concurrent with a resume-marker write failure (e.g. disk-full) leaves no unreferenced shadow collection after the next fresh-build run — verifiable via `listCollections()` showing no accumulating `*-shadow-*` orphans across repeated double-failures.

## Related

#14161 (the resumable shadow-swap this hardens), #14146 (the P0 it resolved), #14079 (the bloat epic this prevents a new source of).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f2c722bf-9fb0-4925-8fbc-a9a0788f459c`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
