### PR TITLE
fix(memory-core): raise embed-write canary timeout 5s->30s for a cold 8b embedder (#14181)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -313,9 +313,14 @@ class Config extends ConfigProvider {
                 chromaProbeTimeoutMs: leaf(1500, 'NEO_MEMORY_HEALTHCHECK_CHROMA_PROBE_TIMEOUT_MS', 'number'),
                 /**
                  * Max time to wait for the active embedding provider during the write canary.
+                 * Must tolerate a cold embedder load: an 8b embedding model VRAM-evicted under chat-model
+                 * pressure cold-reloads in ~11-19s, so a tighter bound false-negatives a healthy-but-slow
+                 * provider and trips the embed-canary health gate. Still a bound, not removal — the embed
+                 * operation itself budgets 300s, so this gate stays well under that while surviving a
+                 * realistic cold-load.
                  * @type {number}
                  */
-                embeddingWriteCanaryTimeoutMs: leaf(5000, 'NEO_MEMORY_HEALTHCHECK_EMBEDDING_WRITE_CANARY_TIMEOUT_MS', 'number'),
+                embeddingWriteCanaryTimeoutMs: leaf(30000, 'NEO_MEMORY_HEALTHCHECK_EMBEDDING_WRITE_CANARY_TIMEOUT_MS', 'number'),
                 /**
                  * Max time to wait for each REM pipeline-state axis.
                  * @type {number}

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -79,7 +79,7 @@ paths:
           schema:
             type: integer
             minimum: 1
-            default: 5000
+            default: 30000
       responses:
         '200':
           description: Server is healthy and database is accessible


### PR DESCRIPTION
## Summary

The Memory Core embed-write health canary defaulted to **5000ms** — but the live `openAiCompatible` embedder (LM Studio :1234, `text-embedding-qwen3-embedding-8b`, an 8b model) cold-reloads in **~11–19s** when VRAM-evicted under the co-resident gemma-4 chat models. So the canary false-negatives a healthy-but-slow provider and trips the embed-canary health gate, blocking every embedding-dependent MC tool (`query_raw_memories`, `add_memory`) while non-embedding paths keep working. Surfaced live (#14154) + operator-flagged: the embed *operation* itself budgets 300s, so the health gate was **60× stricter** than the operation it guards.

Resolves #14181

## Change

Raise `healthcheck.embeddingWriteCanaryTimeoutMs` default **5000 → 30000** in `config.template.mjs` (the SSOT) + the mirrored `openapi.yaml` schema default, with the rationale added to the JSDoc (must tolerate a cold 8b embedder load; still a bound, not removal). Stays env-overridable via `NEO_MEMORY_HEALTHCHECK_EMBEDDING_WRITE_CANARY_TIMEOUT_MS`.

Evidence: the canary timeout leaf (`config.template.mjs:318`) consumed at `HealthService.mjs:187`; the embed-op budget `embeddingTimeoutMs: leaf(300000)` (`ai/config.template.mjs:172`); measured embed latency 11.5s cold / 19s under thrash (`lms ps` showed `qwen3-embedding-8b` + `gemma-4-26b` co-resident).

## Deltas from ticket (if any)

- Preserves #13458's "bound health probes" intent — 30s is still a bound (a genuinely-hung embedder fails at 30s), not a removal. Only the value overshot the real cold-load latency.
- **No new test (deliberate, not skipped):** the canary timeout MECHANISM is already covered by `HealthService.spec.mjs` (the timeout path with an injected tiny timeout), and template↔openapi default sync is guarded by the `config-template-ssot` lint (green). A default-VALUE assertion would be brittle + out-of-pattern — `McpServerToolLimits.spec` asserts schema *shape* (type/minimum), not values. Adding one would be theater, not coverage.

## Test Evidence

`node ai/scripts/lint/lint-config-template-ssot.mjs` → **OK** (template ↔ openapi consistent at 30000). No existing test asserts the old 5000 default (the canary references in `McpServerToolLimits.spec` / `HealthService.spec` are schema-shape assertions + injected test values, unaffected by a default change).

## Post-Merge Validation

After the materialized overlay regenerates (or `NEO_MEMORY_HEALTHCHECK_EMBEDDING_WRITE_CANARY_TIMEOUT_MS=30000` is set), a cold embedder (11–19s) no longer trips the canary: `query_raw_memories` / `add_memory` survive a cold-but-working provider, and MC stops reporting intermittent `not fully operational: Embedding write canary timed out` under embedder cold-load.

## Related

#14154 (the VRAM co-eviction this false-negatives on — the deeper root, separate lane: pin embedder / reduce VRAM pressure), #13458 / #13459 (the bound-health-probes origin), #14124 (the embed-canary gate + read-only exemptions).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f2c722bf-9fb0-4925-8fbc-a9a0788f459c`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005. Friction surfaced by @tobiu.