### PR TITLE
feat(ai): heavyMaintenance.maxActiveHoldMs lease-fairness leaf (#14185)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -618,6 +618,20 @@ class Config extends ConfigProvider {
                     vacuum : leaf(false, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_VACUUM', 'boolean')
                 },
                 /**
+                 * Heavy-maintenance lease fairness — the bound on continuous lease hold. A long-running
+                 * heavy task (e.g. a multi-hour KB re-embed) yields the single heavy-maintenance lease
+                 * after `maxActiveHoldMs` of continuous hold — polled via `shouldYieldHeavyMaintenanceLease`
+                 * — so a starved heavy peer (e.g. `githubWorkflowSync`, which otherwise stales the sandman
+                 * handoff for the whole run) interleaves; the next sweep re-acquires for the remaining work.
+                 * A holder must only yield at a resumable checkpoint (a preserved shadow + resume-marker keep
+                 * completed work), so the release window is torn-read-free. `0`/falsy ⇒ never yields
+                 * (byte-identical back-compat). Env override: `NEO_ORCHESTRATOR_HEAVY_MAINTENANCE_MAX_ACTIVE_HOLD_MS`.
+                 * @type {Object}
+                 */
+                heavyMaintenance: {
+                    maxActiveHoldMs: leaf(HOUR_MS, 'NEO_ORCHESTRATOR_HEAVY_MAINTENANCE_MAX_ACTIVE_HOLD_MS', 'number')
+                },
+                /**
                  * Neural Link Bridge local-supervision policy. The bridge port itself is owned
                  * by `ai/mcp/server/neural-link/config.mjs` (`NEO_NL_PORT`); this block only
                  * controls orchestrator-side probing.


### PR DESCRIPTION
## Summary

The heavy-maintenance lease's continuous-hold can starve a lightweight-but-leased peer indefinitely — `githubWorkflowSync` sat ~20h behind a one-time full re-embed (#14069/#14071), staling the sandman handoff for the whole run. The lease-yield substrate to fix this **already exists but is unconsumed**: `shouldYieldHeavyMaintenanceLease(lease, {maxActiveHoldMs})` (`HeavyMaintenanceLeaseService.mjs:121`) + `acquire`/`releaseHeavyMaintenanceLeaseSync`. The only missing piece on the lease-service side is the **policy value** — `maxActiveHoldMs` had no config leaf.

Resolves #14185 (the lease-service sub of epic #14144).

## Change

Add `orchestrator.heavyMaintenance.maxActiveHoldMs` reactive config leaf (default `HOUR_MS`, env `NEO_ORCHESTRATOR_HEAVY_MAINTENANCE_MAX_ACTIVE_HOLD_MS`) — the fairness bound a holder polls (via the existing primitive) to decide when to yield. Inert until consumed: `shouldYieldHeavyMaintenanceLease` returns false on a falsy bound, and nothing reads the leaf yet.

Evidence: the unconsumed primitive (`HeavyMaintenanceLeaseService.mjs:121`, value-agnostic by design — docstring "`maxActiveHoldMs`… supplied by the calling task"); the orchestrator policy-grouping pattern (`chroma` / `devServer` / `graphLogCompaction` sub-objects) this mirrors.

## Deltas from ticket (if any)

- **Dropped the ticket's "holder-facing wrapper method" (AC item 2)** — V-B-A showed it's an anti-pattern here: the pure primitive is value-agnostic *by design*, and ADR-0019 puts the config-read at the consumer's use-site. So #14186's kbSync reads the leaf + calls the pure fn directly; a wrapper would be a pass-through layer (and `HeavyMaintenanceLeaseService` deliberately doesn't import AiConfig). The leaf is the sole correct lease-service deliverable.
- **Substrate-first:** lands the policy value only; epic #14144 stays open until #14186 (the kbSync yield-point consumer) makes it behavioral — the #14175 surface-vs-consume sequencing (this PR Resolves the sub #14185, not the epic).
- **Default `HOUR_MS`** chosen over a tighter bound: bounds the ~20h starvation to ≤1h while minimizing yield-churn (a tighter bound yields more often, raising release/re-acquire + corpus-drift-rebuild cost on the consumer side). Env-tunable.

## Test Evidence

`node ai/scripts/lint/lint-config-template-ssot.mjs` → **OK** (leaf is template-SSOT-consistent). **No new unit test (deliberate):** the yield mechanism — `shouldYieldHeavyMaintenanceLease`, including the falsy-bound never-yield + the hold-boundary cases — is already covered by `HeavyMaintenanceLeaseService.spec.mjs` (10 assertions); a config-value assertion would be brittle (the #14182 reasoning). The consumer's behavior test is #14186's.

## Post-Merge Validation

Inert on merge (nothing reads the leaf yet). Once #14186 lands the kbSync yield-point: a heavy task holding the lease > 1h yields it, `githubWorkflowSync` interleaves, and the sandman handoff stops staling through a long re-embed. Tune via `NEO_ORCHESTRATOR_HEAVY_MAINTENANCE_MAX_ACTIVE_HOLD_MS`.

## Related

#14144 (epic — heavy-maintenance lease fairness), #14186 (the kbSync yield-point consumer, blocked-by this), #14146 / #14161 (the resumable kbSync that makes the yield torn-read-free).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f2c722bf-9fb0-4925-8fbc-a9a0788f459c`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.