### PR TITLE
feat(ai): author-side Contract-Ledger-vs-diff drift pre-flight (#14119)

### DIFF
--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -119,6 +119,128 @@ export function validatePrBody(body) {
     }
 }
 
+const LEDGER_SIGNATURE_PATTERN = /([A-Za-z_$][\w$]*)\s*\(([^)]*)\)/;
+
+/**
+ * @summary Extracts ledger-declared `symbol(params)` signatures from a Contract Ledger table in a PR body.
+ *
+ * Opt-in + high-precision: only markdown rows belonging to a table whose header carries BOTH a `Surface`
+ * and a `Signature` column are considered, and within them only a `name(args)` token. A body with NO
+ * Contract Ledger therefore yields `[]` and the drift check is inert — this is the author's *declared*
+ * contract surface, the only thing the drift check verifies against the diff.
+ *
+ * @param {String} body The PR / ticket markdown body.
+ * @returns {Array<{symbol: String, params: String}>} The ledger-declared signatures.
+ */
+export function extractLedgerSignatures(body = '') {
+    const signatures    = [];
+    let   inLedgerTable = false;
+
+    for (const line of body.split('\n')) {
+        if (!line.trim().startsWith('|')) { inLedgerTable = false; continue; }
+
+        // A ledger table is identified by a header row carrying both `Surface` and `Signature`; the flag
+        // then persists across the table's body rows until a non-table line resets it.
+        if (/\bsurface\b/i.test(line) && /\bsignature\b/i.test(line)) { inLedgerTable = true; continue; }
+        if (/^\s*\|[\s:|-]+\|\s*$/.test(line)) continue; // the |---|---| separator row
+
+        if (!inLedgerTable) continue;
+
+        const match = line.match(LEDGER_SIGNATURE_PATTERN);
+        if (match) signatures.push({symbol: match[1], params: match[2]});
+    }
+
+    return signatures;
+}
+
+/**
+ * @summary Finds a symbol's shipped parameter list in the ADDED (`+`) lines of a unified diff.
+ *
+ * Conservative: matches a `symbol(params)` token on an added line. Returns `null` when the symbol is not
+ * defined in the added lines — a MISS, never a false signal (a multi-line signature simply does not match
+ * and is skipped, which is the safe direction for a warn-only check).
+ *
+ * @param {String} diffText A unified diff (`git diff` output).
+ * @param {String} symbol The symbol name to locate.
+ * @returns {String|null} The shipped params string, or `null` if not found on an added line.
+ */
+export function findShippedSignature(diffText = '', symbol = '') {
+    const escaped = symbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+          definePattern = new RegExp(`^\\+(?!\\+).*\\b${escaped}\\s*\\(([^)]*)\\)`);
+
+    for (const line of diffText.split('\n')) {
+        const match = line.match(definePattern);
+        if (match) return match[1];
+    }
+
+    return null;
+}
+
+/**
+ * @summary Normalizes a parameter string to a comparable shape — positional arity vs destructured key-set —
+ * so cosmetic differences (whitespace, destructured key ORDER, defaults) never read as drift.
+ *
+ * @param {String} params The raw parameter string (between the parens).
+ * @returns {{shape: String, arity: Number, keys: String[]}}
+ */
+export function normalizeSignatureShape(params = '') {
+    const trimmed = params.trim();
+    if (trimmed === '') return {shape: 'positional', arity: 0, keys: []};
+
+    if (trimmed.startsWith('{')) {
+        const keys = trimmed.replace(/[{}]/g, '')
+            .split(',')
+            .map(key => key.split(/[:=]/)[0].trim())
+            .filter(Boolean)
+            .sort();
+        return {shape: 'destructured', arity: keys.length, keys};
+    }
+
+    const arity = trimmed.split(',').map(part => part.trim()).filter(Boolean).length;
+    return {shape: 'positional', arity, keys: []};
+}
+
+/**
+ * @summary Detects Contract-Ledger-vs-shipped-diff signature drift — the author-side dual of the pr-review
+ * Contract Completeness Audit. Catches the "ledger described the pre-evolution contract" class (a
+ * destructured-vs-positional signature; an added field the ledger omits) BEFORE the PR opens, rather than
+ * burning a scarce cross-family review cycle on a mechanical gap.
+ *
+ * **Opt-in** (no ledger → no check), **high-precision** (only ledger-declared symbols actually found in the
+ * diff), and **warn-only** (the caller never gates on it): a miss is silent; only a clear shape / arity /
+ * destructured-key mismatch warns. By construction it cannot false-positive on un-laddered code.
+ *
+ * @param {Object} options
+ * @param {String} options.body The PR / ticket body carrying the Contract Ledger.
+ * @param {String} [options.diffText] The staged unified diff to verify against. Falsy ⇒ no check.
+ * @returns {String[]} Human-readable drift warnings (empty when no drift / no ledger / no diff).
+ */
+export function detectContractLedgerDrift({body = '', diffText = ''} = {}) {
+    if (!diffText) return [];
+
+    const warnings = [];
+
+    for (const {symbol, params: ledgerParams} of extractLedgerSignatures(body)) {
+        const shippedParams = findShippedSignature(diffText, symbol);
+        if (shippedParams === null) continue;
+
+        const ledgerShape  = normalizeSignatureShape(ledgerParams),
+              shippedShape = normalizeSignatureShape(shippedParams),
+              drifted      = ledgerShape.shape !== shippedShape.shape
+                          || ledgerShape.arity !== shippedShape.arity
+                          || ledgerShape.keys.join(',') !== shippedShape.keys.join(',');
+
+        if (drifted) {
+            warnings.push(
+                `Contract Ledger drift: \`${symbol}\` — ledger declares (${ledgerParams.trim()}) but the diff ` +
+                `ships (${shippedParams.trim()}). Update the ledger or the signature before opening the PR.`
+            )
+        }
+    }
+
+    return warnings;
+}
+
 function writeLine(stream, line = '') {
     stream.write(line + '\n')
 }
@@ -259,6 +381,34 @@ export function runAgentPreflight({
             if (result.missingInvisible.length > 0) {
                 writeLine(stderr, 'Structural template anchors are missing; reread .agents/skills/pull-request/SKILL.md before editing the body.');
             }
+        }
+
+        // Author-side Contract-Ledger-vs-diff drift: opt-in (only fires when the body carries a Contract
+        // Ledger), WARN-only (never added to `failures`), and best-effort (a check error never fails the
+        // preflight). Verifies a declared signature against the staged diff before the PR opens.
+        try {
+            const bodyPath = path.resolve(cwd, options.prBody);
+
+            if (existsSyncImpl(bodyPath)) {
+                let diffText = '';
+                try {
+                    diffText = String(execFileSyncImpl('git', ['diff', '--cached'], {cwd, encoding: 'utf8', stdio: 'pipe'}) || '')
+                } catch {
+                    diffText = '' // no staged diff (or not a git tree) → the drift check is inert
+                }
+
+                const driftWarnings = detectContractLedgerDrift({
+                    body: readFileSyncImpl(bodyPath, 'utf8'),
+                    diffText
+                });
+
+                if (driftWarnings.length > 0) {
+                    writeLine(stdout, 'agent-preflight: Contract Ledger drift warning(s) (non-blocking):');
+                    driftWarnings.forEach(warning => writeLine(stdout, `  ⚠ ${warning}`))
+                }
+            }
+        } catch (error) {
+            writeLine(stdout, `agent-preflight: contract-drift check skipped (${error.message}).`)
         }
     } else {
         writeLine(stdout, 'agent-preflight: no --pr-body provided; skipped PR-body lint.');

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -154,19 +154,23 @@ export function extractLedgerSignatures(body = '') {
 }
 
 /**
- * @summary Finds a symbol's shipped parameter list in the ADDED (`+`) lines of a unified diff.
+ * @summary Finds a symbol's shipped parameter list from its DEFINITION in the ADDED (`+`) lines of a diff.
  *
- * Conservative: matches a `symbol(params)` token on an added line. Returns `null` when the symbol is not
- * defined in the added lines — a MISS, never a false signal (a multi-line signature simply does not match
- * and is skipped, which is the safe direction for a warn-only check).
+ * Conservative + definition-only: matches `symbol(params)` only when it is a definition — the params are
+ * followed by `{` (function/method body) or `=>` (arrow). A bare CALL-site `symbol(args)` (followed by `;`,
+ * `,`, `)`, `.`) is NOT matched, so a call appearing before the def can never be mistaken for the shipped
+ * signature. Returns `null` when no definition is found — a MISS, never a false signal (a multi-line
+ * signature simply does not match and is skipped, the safe direction for a warn-only check).
  *
  * @param {String} diffText A unified diff (`git diff` output).
  * @param {String} symbol The symbol name to locate.
- * @returns {String|null} The shipped params string, or `null` if not found on an added line.
+ * @returns {String|null} The shipped params string, or `null` if no definition is found on an added line.
  */
 export function findShippedSignature(diffText = '', symbol = '') {
     const escaped = symbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
-          definePattern = new RegExp(`^\\+(?!\\+).*\\b${escaped}\\s*\\(([^)]*)\\)`);
+          // Require a definition shape — `)` followed by `{` (function/method body) or `=>` (arrow) — so a
+          // bare call-site `symbol(args)` is never mistaken for the def (the call-before-def false-warn).
+          definePattern = new RegExp(`^\\+(?!\\+).*\\b${escaped}\\s*\\(([^)]*)\\)\\s*(?:\\{|=>)`);
 
     for (const line of diffText.split('\n')) {
         const match = line.match(definePattern);

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -125,7 +125,8 @@ const LEDGER_SIGNATURE_PATTERN = /([A-Za-z_$][\w$]*)\s*\(([^)]*)\)/;
  * @summary Extracts ledger-declared `symbol(params)` signatures from a Contract Ledger table in a PR body.
  *
  * Opt-in + high-precision: only markdown rows belonging to a table whose header carries BOTH a `Surface`
- * and a `Signature` column are considered, and within them only a `name(args)` token. A body with NO
+ * and a `Signature` column are considered, and within each row only the `Signature` *cell* is scanned for a
+ * `name(args)` token (an incidental `name(args)` in a Surface/Notes column is ignored). A body with NO
  * Contract Ledger therefore yields `[]` and the drift check is inert — this is the author's *declared*
  * contract surface, the only thing the drift check verifies against the diff.
  *
@@ -134,19 +135,27 @@ const LEDGER_SIGNATURE_PATTERN = /([A-Za-z_$][\w$]*)\s*\(([^)]*)\)/;
  */
 export function extractLedgerSignatures(body = '') {
     const signatures    = [];
-    let   inLedgerTable = false;
+    let   inLedgerTable = false,
+          signatureColumn = -1;
 
     for (const line of body.split('\n')) {
         if (!line.trim().startsWith('|')) { inLedgerTable = false; continue; }
 
         // A ledger table is identified by a header row carrying both `Surface` and `Signature`; the flag
-        // then persists across the table's body rows until a non-table line resets it.
-        if (/\bsurface\b/i.test(line) && /\bsignature\b/i.test(line)) { inLedgerTable = true; continue; }
+        // then persists across the table's body rows until a non-table line resets it. We also record the
+        // `Signature` column index so extraction scans ONLY that cell — an incidental `name(args)` in a
+        // Surface/Notes column must never be mistaken for the declared signature.
+        if (/\bsurface\b/i.test(line) && /\bsignature\b/i.test(line)) {
+            inLedgerTable   = true;
+            signatureColumn = line.split('|').findIndex(cell => /\bsignature\b/i.test(cell));
+            continue;
+        }
         if (/^\s*\|[\s:|-]+\|\s*$/.test(line)) continue; // the |---|---| separator row
 
-        if (!inLedgerTable) continue;
+        if (!inLedgerTable || signatureColumn < 0) continue;
 
-        const match = line.match(LEDGER_SIGNATURE_PATTERN);
+        const cell  = line.split('|')[signatureColumn],
+              match = cell?.match(LEDGER_SIGNATURE_PATTERN);
         if (match) signatures.push({symbol: match[1], params: match[2]});
     }
 
@@ -156,11 +165,13 @@ export function extractLedgerSignatures(body = '') {
 /**
  * @summary Finds a symbol's shipped parameter list from its DEFINITION in the ADDED (`+`) lines of a diff.
  *
- * Conservative + definition-only: matches `symbol(params)` only when it is a definition — the params are
- * followed by `{` (function/method body) or `=>` (arrow). A bare CALL-site `symbol(args)` (followed by `;`,
- * `,`, `)`, `.`) is NOT matched, so a call appearing before the def can never be mistaken for the shipped
- * signature. Returns `null` when no definition is found — a MISS, never a false signal (a multi-line
- * signature simply does not match and is skipped, the safe direction for a warn-only check).
+ * Conservative + definition-only + SINGLE-LINE: matches `symbol(params)` only when the whole `name(params) {`
+ * (or `name(params) =>`) sits on ONE added line. A bare CALL-site `symbol(args)` (followed by `;`, `,`, `)`,
+ * `.`) is NOT matched, so a call appearing before the def can never be mistaken for the shipped signature.
+ * A MULTI-LINE definition — params spanning several lines, as large destructured params often are — is a
+ * silent MISS (returns `null`), never a false signal. This is the safe direction for a warn-only check: a
+ * miss costs nothing, a false-warn costs a review cycle. Multi-line coverage via a brace-balanced
+ * accumulator is a tracked follow-up; authors must not read a non-warn as proof of no drift.
  *
  * @param {String} diffText A unified diff (`git diff` output).
  * @param {String} symbol The symbol name to locate.

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -224,10 +224,26 @@ test.describe('agent-preflight — Contract Ledger drift (#14119)', () => {
         expect(normalizeSignatureShape('')).toEqual({shape: 'positional', arity: 0, keys: []})
     });
 
-    test('findShippedSignature returns the params or null — a miss, never a guess', () => {
+    test('findShippedSignature returns the DEFINITION params (not a call-site) or null', () => {
         expect(findShippedSignature('+function foo(a, b) {', 'foo')).toBe('a, b');
         expect(findShippedSignature('+function foo(a) {', 'bar')).toBe(null);
-        expect(findShippedSignature('-function foo(a) {', 'foo')).toBe(null)
+        expect(findShippedSignature('-function foo(a) {', 'foo')).toBe(null);
+        // A bare call-site (no `{`/`=>` after the params) is NOT a definition — never matched.
+        expect(findShippedSignature('+    const r = foo(a, b);', 'foo')).toBe(null);
+        // Call-before-def: the call-site is skipped, the definition wins (not the call's args).
+        expect(findShippedSignature('+    if (shouldYield(lease)) return;\n+function shouldYield(lease, now) {', 'shouldYield')).toBe('lease, now')
+    });
+
+    test('a call-site before the definition does NOT produce a false drift warning', () => {
+        const callBeforeDefLedger = [
+            '| Surface | Signature | Consumer | Notes |',
+            '|---|---|---|---|',
+            '| yield | `shouldYield(lease, now)` | runner | the bound |'
+        ].join('\n');
+        // The CALL `shouldYield(lease)` (arity 1) precedes the DEF `shouldYield(lease, now)` (arity 2);
+        // without definition-only matching this false-warns (ledger 2 vs call-site 1).
+        const diff = '+    if (shouldYield(lease)) return;\n+function shouldYield(lease, now) {';
+        expect(detectContractLedgerDrift({body: callBeforeDefLedger, diffText: diff})).toEqual([])
     });
 
     test('runAgentPreflight emits a non-blocking drift WARNING through the --pr-body path', () => {

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -177,6 +177,20 @@ test.describe('agent-preflight — Contract Ledger drift (#14119)', () => {
         ])
     });
 
+    test('scans only the Signature cell — incidental parens in a Surface/Notes column are ignored', () => {
+        // Surface has `reconfigure(key)` and Notes has `migrate(old)`; neither is the declared signature.
+        // Only the Signature cell's `applyHeal(action, evidence)` must be extracted (without cell-scoping the
+        // whole-row match would wrongly return reconfigure(key) — the first paren token in the row).
+        const incidentalBody = [
+            '| Surface | Signature | Consumer | Notes |',
+            '|---|---|---|---|',
+            '| reconfigure(key) drift | `applyHeal(action, evidence)` | actuator | replaces migrate(old) |'
+        ].join('\n');
+        expect(extractLedgerSignatures(incidentalBody)).toEqual([
+            {symbol: 'applyHeal', params: 'action, evidence'}
+        ])
+    });
+
     test('a non-ledger body yields no signatures — the check is opt-in/inert', () => {
         expect(extractLedgerSignatures('## Summary\njust prose, foo(bar) in a sentence')).toEqual([]);
         expect(detectContractLedgerDrift({body: 'no ledger here', diffText: '+ foo(a, b, c)'})).toEqual([])

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -2,7 +2,11 @@ import {test, expect} from '@playwright/test';
 import path           from 'node:path';
 import {
     createProgram,
+    detectContractLedgerDrift,
+    extractLedgerSignatures,
     filterMjsFiles,
+    findShippedSignature,
+    normalizeSignatureShape,
     parseArgs,
     runAgentPreflight,
     validatePrBody
@@ -153,5 +157,100 @@ test.describe('agent-preflight utility', () => {
         expect(stderr).toContain('Visible/body-closing misses:');
         expect(stderr).toContain('Structural template anchors are missing');
         expect(stderr).toContain('agent-preflight: 1 gate(s) failed: pr-body')
+    })
+});
+
+test.describe('agent-preflight — Contract Ledger drift (#14119)', () => {
+    const ledgerBody = [
+        '## Contract Ledger',
+        '',
+        '| Surface | Signature | Consumer | Notes |',
+        '|---|---|---|---|',
+        '| yield check | `shouldYieldLease(lease)` | kbSync | reads the bound |',
+        '| assemble | `assembleEvidence({diagnoses, serviceId})` | runner | folds diagnoses |'
+    ].join('\n');
+
+    test('extracts only signatures from a Surface+Signature ledger table', () => {
+        expect(extractLedgerSignatures(ledgerBody)).toEqual([
+            {symbol: 'shouldYieldLease', params: 'lease'},
+            {symbol: 'assembleEvidence', params: '{diagnoses, serviceId}'}
+        ])
+    });
+
+    test('a non-ledger body yields no signatures — the check is opt-in/inert', () => {
+        expect(extractLedgerSignatures('## Summary\njust prose, foo(bar) in a sentence')).toEqual([]);
+        expect(detectContractLedgerDrift({body: 'no ledger here', diffText: '+ foo(a, b, c)'})).toEqual([])
+    });
+
+    test('no staged diff → no check (falsy diffText is inert)', () => {
+        expect(detectContractLedgerDrift({body: ledgerBody, diffText: ''})).toEqual([])
+    });
+
+    test('a matching shipped signature is NOT flagged', () => {
+        expect(detectContractLedgerDrift({
+            body: ledgerBody, diffText: '+function shouldYieldLease(lease) {\n+    return true\n+}'
+        })).toEqual([])
+    });
+
+    test('destructured key REORDER is normalized — NOT flagged (no false positive)', () => {
+        expect(detectContractLedgerDrift({
+            body: ledgerBody, diffText: '+export function assembleEvidence({serviceId, diagnoses}) {'
+        })).toEqual([])
+    });
+
+    test('a symbol absent from the diff is NOT flagged — a miss is silent', () => {
+        expect(detectContractLedgerDrift({body: ledgerBody, diffText: '+const unrelated = 1'})).toEqual([])
+    });
+
+    test('a genuine arity increase IS flagged', () => {
+        const warnings = detectContractLedgerDrift({
+            body: ledgerBody, diffText: '+function shouldYieldLease(lease, now, force) {'
+        });
+        expect(warnings.length).toBe(1);
+        expect(warnings[0]).toContain('shouldYieldLease')
+    });
+
+    test('a positional→destructured shape change IS flagged (the #14104 class)', () => {
+        const warnings = detectContractLedgerDrift({
+            body: ledgerBody, diffText: '+function shouldYieldLease({lease, now}) {'
+        });
+        expect(warnings.length).toBe(1);
+        expect(warnings[0]).toContain('shouldYieldLease')
+    });
+
+    test('normalizeSignatureShape: positional arity vs destructured key-set, order-insensitive', () => {
+        expect(normalizeSignatureShape('a, b')).toEqual({shape: 'positional', arity: 2, keys: []});
+        expect(normalizeSignatureShape('{b, a}')).toEqual({shape: 'destructured', arity: 2, keys: ['a', 'b']});
+        expect(normalizeSignatureShape('')).toEqual({shape: 'positional', arity: 0, keys: []})
+    });
+
+    test('findShippedSignature returns the params or null — a miss, never a guess', () => {
+        expect(findShippedSignature('+function foo(a, b) {', 'foo')).toBe('a, b');
+        expect(findShippedSignature('+function foo(a) {', 'bar')).toBe(null);
+        expect(findShippedSignature('-function foo(a) {', 'foo')).toBe(null)
+    });
+
+    test('runAgentPreflight emits a non-blocking drift WARNING through the --pr-body path', () => {
+        let stdout = '';
+        let stderr = '';
+
+        const status = runAgentPreflight({
+            argv            : ['--pr-body', 'body.md'],
+            cwd             : '/repo',
+            execFileSyncImpl: (cmd, args) => {
+                if (cmd === 'git' && args.includes('--name-only')) return '';      // no staged source files
+                if (cmd === 'git') return '+function shouldYieldLease(lease, now, force) {'; // the drifted diff
+                return ''
+            },
+            existsSyncImpl  : () => true,
+            readFileSyncImpl: () => `${validBody}\n${ledgerBody}`,
+            stderr: {write: value => { stderr += value }},
+            stdout: {write: value => { stdout += value }}
+        });
+
+        expect(status).toBe(0); // drift is WARN-only — never fails the preflight
+        expect(stdout).toContain('Contract Ledger drift warning');
+        expect(stdout).toContain('shouldYieldLease');
+        expect(stderr).toBe('')
     })
 });


### PR DESCRIPTION
## Summary

Three PRs in one session (#14104, #14108, #14111) each burned an extra cross-family review cycle on the same mechanical defect: the PR body's Contract Ledger described the *pre-evolution* contract while the shipped diff had moved on (a destructured-vs-positional signature; an added field the ledger omitted). The drift passed every author-side gate and was caught only at scarce cross-family review time. There was no author-side check comparing the shipped surface against the ledger BEFORE the PR opens.

Resolves #14119

## Change

Extends `buildScripts/util/agent-preflight.mjs` with `detectContractLedgerDrift` + pure helpers (`extractLedgerSignatures`, `findShippedSignature`, `normalizeSignatureShape`), wired into the `--pr-body` path: when the body carries a Contract Ledger, the preflight reads the staged diff and WARNS (non-blocking) if a ledger-declared signature's shipped shape / arity / destructured-keys drifted.

**Designed NOT to be a smoke detector** (the explicit bar):
- **Opt-in** — fires only when the body has a `Surface`+`Signature` ledger table; no ledger → inert.
- **High-precision** — only ledger-*declared* symbols actually *found* in the diff; an un-laddered export or an absent symbol is never flagged.
- **Normalized** — whitespace + destructured key-ORDER differences are not drift.
- **Warn-only** — never added to `failures`; preflight status is unchanged. Best-effort (a check error is swallowed).

Evidence: `agent-preflight.mjs` `validatePrBody` (the existing anchor lint this sits beside); the existing `git`-via-`execFileSyncImpl` pattern (reused for `git diff --cached`).

## Deltas from ticket (if any)

- **Conservative-first scope:** a *signature-shape* drift check (positional↔destructured, arity, destructured key-set) — the exact #14104/#14108 failure shapes — rather than a full semantic surface-diff. The shape check is provably no-false-positive (a miss is silent); a deeper semantic comparison can extend it later if the shape check proves insufficient.
- **No Contract Ledger on THIS PR (dogfood):** the new exports are tool-internal (exported for unit-testability, not a consumed cross-module surface), so the new check is correctly inert on its own PR body.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs agent-preflight` → **20 passed** (9 existing + 11 new). The new tests PROVE the conservative behavior: no-ledger / matching-sig / destructured-reorder / absent-symbol / no-diff all → **no warning**; a genuine arity increase + a positional→destructured shape change → **warning**; plus a `runAgentPreflight` wiring test (drift WARNING through the `--pr-body` path, status unchanged).

## Post-Merge Validation

Authors running `agent-preflight --pr-body <file>` on a PR whose body has a Contract Ledger get an immediate drift warning if a declared signature no longer matches the staged diff — catching the mechanical gap at author-time instead of at the scarce cross-family review. Inert (zero behavior change) for PRs without a ledger.

## Related

#14104 / #14108 / #14111 (the three review-cycle-burning instances that motivated it); the pr-review Contract Completeness Audit (the review-time dual this front-runs).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f2c722bf-9fb0-4925-8fbc-a9a0788f459c`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.