### PR TITLE
feat(ai): tag knowledge-base + github-workflow MCP tools with tier projection — #14164 slices

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -30,6 +30,19 @@ tags:
   - name: Repository
     description: Operations related to the repository itself
 
+# Harness tool-projection policy (mirrors neural-link / knowledge-base). A maintainer harness spawned
+# with `--tool-projection-mode harness-embedded` loads the read + write (core-maintainer) tiers; the
+# `extended` (rare ops) + `admin` (dangerous) tiers are withheld, reachable on demand via
+# `get_mcp_tool_handbook`. gh's visible set includes `write` because a maintainer's core writes
+# (review, comment, create, assign, label, link, transition) are constant — unlike kb, whose writes are
+# all admin-destructive (visible=[read] there).
+x-neo-harness-tool-projection:
+  defaultVisibleTiers:
+    - read
+    - write
+  operatorOnlyTiers:
+    - admin
+
 paths:
   /docs:
     get:
@@ -48,6 +61,7 @@ paths:
     get:
       summary: Check GitHub CLI Health
       operationId: healthcheck
+      x-neo-tool-tier: read
       x-annotations:
         readOnlyHint: true
       description: |
@@ -74,6 +88,7 @@ paths:
     post:
       summary: Tool Handbook
       operationId: get_mcp_tool_handbook
+      x-neo-tool-tier: read
       x-annotations:
         readOnlyHint: true
       description: Returns lazy-loaded usage detail for one GitHub Workflow MCP tool.
@@ -118,6 +133,7 @@ paths:
     get:
       summary: List Repository Labels
       operationId: list_labels
+      x-neo-tool-tier: read
       x-annotations:
         readOnlyHint: true
       description: |
@@ -144,6 +160,7 @@ paths:
     get:
       summary: List Pull Requests
       operationId: list_pull_requests
+      x-neo-tool-tier: read
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
@@ -202,6 +219,7 @@ paths:
     post:
       summary: Checkout PR Branch
       operationId: checkout_pull_request
+      x-neo-tool-tier: admin
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
@@ -250,6 +268,7 @@ paths:
     get:
       summary: Get PR Diff
       operationId: get_pull_request_diff
+      x-neo-tool-tier: read
       x-annotations:
         readOnlyHint: true
       description: |
@@ -336,6 +355,7 @@ paths:
     get:
       summary: Get Conversation (Issue or PR)
       operationId: get_conversation
+      x-neo-tool-tier: read
       x-neo-tool-summary: Fetch a pull request or issue conversation with optional comment-window selectors.
       x-pass-as-object: true
       x-annotations:
@@ -441,6 +461,7 @@ paths:
     post:
       summary: Manage Comments (Create or Update)
       operationId: manage_issue_comment
+      x-neo-tool-tier: write
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
@@ -526,6 +547,7 @@ paths:
     post:
       summary: Manage Issue Labels (Add or Remove)
       operationId: manage_issue_labels
+      x-neo-tool-tier: write
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
@@ -598,6 +620,7 @@ paths:
     post:
       summary: Manage Issue Assignees (Single Guarded MCP Operation — Add or Remove)
       operationId: manage_issue_assignees
+      x-neo-tool-tier: write
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
@@ -708,6 +731,7 @@ paths:
     post:
       summary: Manage PR Review (Create or Update — atomic body + formal-state in one call)
       operationId: manage_pr_review
+      x-neo-tool-tier: write
       x-neo-tool-summary: Create or update one formal PR review with body and review state validation.
       x-pass-as-object: true
       x-annotations:
@@ -801,6 +825,7 @@ paths:
     post:
       summary: Manage PR Reviewers (Add or Remove)
       operationId: manage_pr_reviewers
+      x-neo-tool-tier: write
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
@@ -870,6 +895,7 @@ paths:
     get:
       summary: Get Local Issue Content by ID
       operationId: get_local_issue_by_id
+      x-neo-tool-tier: read
       x-annotations:
         readOnlyHint: true
       description: |
@@ -911,6 +937,7 @@ paths:
     get:
       summary: List Issues
       operationId: list_issues
+      x-neo-tool-tier: read
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
@@ -978,6 +1005,7 @@ paths:
     post:
       summary: Create a new GitHub issue
       operationId: create_issue
+      x-neo-tool-tier: write
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
@@ -1048,6 +1076,7 @@ paths:
     post:
       summary: Manage Issue ProjectV2 Memberships (Add, Remove, or Update Field)
       operationId: manage_issue_projects
+      x-neo-tool-tier: extended
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
@@ -1137,6 +1166,7 @@ paths:
     post:
       summary: Create a new GitHub Discussion
       operationId: create_discussion
+      x-neo-tool-tier: extended
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
@@ -1185,6 +1215,7 @@ paths:
     post:
       summary: Manage GitHub Discussions (Update Body)
       operationId: manage_discussion
+      x-neo-tool-tier: extended
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
@@ -1256,6 +1287,7 @@ paths:
     get:
       summary: Get Discussion Conversation
       operationId: get_discussion_conversation
+      x-neo-tool-tier: read
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
@@ -1415,6 +1447,7 @@ paths:
     post:
       summary: Manage Discussion Comments (Create or Update)
       operationId: manage_discussion_comment
+      x-neo-tool-tier: extended
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false
@@ -1481,6 +1514,7 @@ paths:
     post:
       summary: Manage Issue Relationships (Parent-Child and Blocked-By)
       operationId: update_issue_relationship
+      x-neo-tool-tier: write
       x-neo-tool-summary: Create, replace, or remove issue parent-child and blocked-by relationships.
       x-pass-as-object: true
       x-annotations:
@@ -1570,6 +1604,7 @@ paths:
     post:
       summary: Sync GitHub Issues & Releases
       operationId: sync_all
+      x-neo-tool-tier: extended
       x-annotations:
         readOnlyHint: false
       description: |
@@ -1604,6 +1639,7 @@ paths:
     get:
       summary: Get Viewer Permission
       operationId: get_viewer_permission
+      x-neo-tool-tier: read
       x-annotations:
         readOnlyHint: true
       description: |
@@ -1637,6 +1673,7 @@ paths:
     post:
       summary: Signal State Transition
       operationId: signal_state_transition
+      x-neo-tool-tier: write
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: false

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -27,11 +27,22 @@ tags:
   - name: Documents
     description: Operations for querying knowledge base documents
 
+# Harness tool-projection policy (mirrors neural-link). In a maintainer harness spawned with
+# `--tool-projection-mode harness-embedded`, only `read`-tier tools load by default; `extended` +
+# `admin` tools are withheld and reachable on demand via `get_mcp_tool_handbook`. This caps the
+# loaded surface against the harness ~100-tool ceiling without removing any capability.
+x-neo-harness-tool-projection:
+  defaultVisibleTiers:
+    - read
+  operatorOnlyTiers:
+    - admin
+
 paths:
   /healthcheck:
     get:
       summary: Health Check
       operationId: healthcheck
+      x-neo-tool-tier: read
       x-annotations:
         readOnlyHint: true
       description: |
@@ -60,6 +71,7 @@ paths:
     get:
       summary: Get Ingestion Progress
       operationId: get_ingestion_progress
+      x-neo-tool-tier: extended
       x-annotations:
         readOnlyHint: true
       x-neo-tool-summary: Inspect active or last ingestion progress.
@@ -88,6 +100,7 @@ paths:
     post:
       summary: Tool Handbook
       operationId: get_mcp_tool_handbook
+      x-neo-tool-tier: read
       x-annotations:
         readOnlyHint: true
       description: Returns lazy-loaded usage detail for one Knowledge Base MCP tool.
@@ -132,6 +145,7 @@ paths:
     post:
       summary: Deployment State Snapshot
       operationId: get_deployment_state_snapshot
+      x-neo-tool-tier: extended
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
@@ -164,6 +178,7 @@ paths:
     post:
       summary: Inspect Deployment
       operationId: inspect_deployment
+      x-neo-tool-tier: extended
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
@@ -196,6 +211,7 @@ paths:
     post:
       summary: Manage Knowledge Base Data
       operationId: manage_knowledge_base
+      x-neo-tool-tier: admin
       x-pass-as-object: true
       description: |
         Manages the content of the knowledge base.
@@ -242,6 +258,7 @@ paths:
     post:
       summary: Ingest Source Files
       operationId: ingest_source_files
+      x-neo-tool-tier: admin
       x-pass-as-object: true
       description: |
         Agent-native Knowledge Base ingestion for small batches of source files.
@@ -282,6 +299,7 @@ paths:
     post:
       summary: Query Documents
       operationId: query_documents
+      x-neo-tool-tier: read
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
@@ -416,6 +434,7 @@ paths:
     post:
       summary: Ask Knowledge Base (RAG)
       operationId: ask_knowledge_base
+      x-neo-tool-tier: read
       x-pass-as-object: true
       x-neo-tool-summary: Ask the Knowledge Base for a synthesized answer with cited references.
       description: |
@@ -530,6 +549,7 @@ paths:
     post:
       summary: List Agent FAQs
       operationId: list_agent_faqs
+      x-neo-tool-tier: extended
       x-pass-as-object: true
       description: |
         Lists frequently repeated Knowledge Base questions captured from agent calls to
@@ -582,6 +602,7 @@ paths:
     get:
       summary: Get Class Hierarchy
       operationId: get_class_hierarchy
+      x-neo-tool-tier: read
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
@@ -630,6 +651,7 @@ paths:
     get:
       summary: List Documents
       operationId: list_documents
+      x-neo-tool-tier: read
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
@@ -674,6 +696,7 @@ paths:
     get:
       summary: Get Document by ID
       operationId: get_document_by_id
+      x-neo-tool-tier: read
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -165,6 +165,29 @@ const neuralLinkDangerousReadForbidden = [
     'undo'
 ];
 
+const knowledgeBaseToolTiers = ['read', 'extended', 'admin'];
+
+const expectedKnowledgeBaseToolTiers = {
+    healthcheck                  : 'read',
+    get_ingestion_progress       : 'extended',
+    get_mcp_tool_handbook        : 'read',
+    get_deployment_state_snapshot: 'extended',
+    inspect_deployment           : 'extended',
+    manage_knowledge_base        : 'admin',
+    ingest_source_files          : 'admin',
+    query_documents              : 'read',
+    ask_knowledge_base           : 'read',
+    list_agent_faqs              : 'extended',
+    get_class_hierarchy          : 'read',
+    list_documents               : 'read',
+    get_document_by_id           : 'read'
+};
+
+const knowledgeBaseDangerousReadForbidden = [
+    'manage_knowledge_base',
+    'ingest_source_files'
+];
+
 /**
  * Reads OpenAPI operations by operationId.
  * @param {object} doc Parsed OpenAPI document.
@@ -362,6 +385,39 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
             offenders  = neuralLinkDangerousReadForbidden.filter(id => operations[id]?.['x-neo-tool-tier'] === 'read');
 
         expect(offenders, `Dangerous Neural Link operations mislabeled read:\n${offenders.join('\n')}`).toEqual([]);
+    });
+
+    test('knowledge-base declares the harness-visible projection policy (#14164)', () => {
+        const
+            doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/knowledge-base/openapi.yaml'), 'utf8')),
+            projection = doc['x-neo-harness-tool-projection'];
+
+        expect(projection, 'Missing x-neo-harness-tool-projection contract').toBeTruthy();
+        expect(projection.defaultVisibleTiers).toEqual(['read']);
+        expect(projection.operatorOnlyTiers).toEqual(['admin']);
+    });
+
+    test('knowledge-base classifies every operation into one harness tool tier (#14164)', () => {
+        const
+            doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/knowledge-base/openapi.yaml'), 'utf8')),
+            operations = getOperationsById(doc),
+            tiers      = Object.fromEntries(Object.entries(operations).map(([id, op]) => [id, op['x-neo-tool-tier']]));
+
+        const missing = Object.entries(tiers).filter(([, tier]) => tier === undefined).map(([id]) => id);
+        const invalid = Object.entries(tiers).filter(([, tier]) => tier !== undefined && !knowledgeBaseToolTiers.includes(tier));
+
+        expect(missing, `Knowledge Base operations missing x-neo-tool-tier:\n${missing.join('\n')}`).toEqual([]);
+        expect(invalid, `Invalid Knowledge Base x-neo-tool-tier values:\n${invalid.map(([id, tier]) => `${id}: ${tier}`).join('\n')}`).toEqual([]);
+        expect(tiers).toEqual(expectedKnowledgeBaseToolTiers);
+    });
+
+    test('knowledge-base mutating operations cannot be tiered as read (#14164)', () => {
+        const
+            doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/knowledge-base/openapi.yaml'), 'utf8')),
+            operations = getOperationsById(doc),
+            offenders  = knowledgeBaseDangerousReadForbidden.filter(id => operations[id]?.['x-neo-tool-tier'] === 'read');
+
+        expect(offenders, `Dangerous Knowledge Base operations mislabeled read:\n${offenders.join('\n')}`).toEqual([]);
     });
 
     test('neural-link OpenAPI operations stay aligned with serviceMapping keys (#13064)', () => {

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -188,6 +188,54 @@ const knowledgeBaseDangerousReadForbidden = [
     'ingest_source_files'
 ];
 
+const githubWorkflowToolTiers = ['read', 'write', 'extended', 'admin'];
+
+const expectedGithubWorkflowToolTiers = {
+    healthcheck                : 'read',
+    get_mcp_tool_handbook      : 'read',
+    list_labels                : 'read',
+    list_pull_requests         : 'read',
+    checkout_pull_request      : 'admin',
+    get_pull_request_diff      : 'read',
+    get_conversation           : 'read',
+    manage_issue_comment       : 'write',
+    manage_issue_labels        : 'write',
+    manage_issue_assignees     : 'write',
+    manage_pr_review           : 'write',
+    manage_pr_reviewers        : 'write',
+    get_local_issue_by_id      : 'read',
+    list_issues                : 'read',
+    create_issue               : 'write',
+    manage_issue_projects      : 'extended',
+    create_discussion          : 'extended',
+    manage_discussion          : 'extended',
+    get_discussion_conversation: 'read',
+    manage_discussion_comment  : 'extended',
+    update_issue_relationship  : 'write',
+    sync_all                   : 'extended',
+    get_viewer_permission      : 'read',
+    signal_state_transition    : 'write'
+};
+
+// Every mutating gh op must NOT be tiered `read` (a mutation mislabeled read would be wrongly
+// auto-visible as a safe default). `checkout_pull_request` is `admin` (it desyncs the canonical clone).
+const githubWorkflowDangerousReadForbidden = [
+    'checkout_pull_request',
+    'manage_issue_comment',
+    'manage_issue_labels',
+    'manage_issue_assignees',
+    'manage_pr_review',
+    'manage_pr_reviewers',
+    'create_issue',
+    'manage_issue_projects',
+    'create_discussion',
+    'manage_discussion',
+    'manage_discussion_comment',
+    'update_issue_relationship',
+    'sync_all',
+    'signal_state_transition'
+];
+
 /**
  * Reads OpenAPI operations by operationId.
  * @param {object} doc Parsed OpenAPI document.
@@ -418,6 +466,39 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
             offenders  = knowledgeBaseDangerousReadForbidden.filter(id => operations[id]?.['x-neo-tool-tier'] === 'read');
 
         expect(offenders, `Dangerous Knowledge Base operations mislabeled read:\n${offenders.join('\n')}`).toEqual([]);
+    });
+
+    test('github-workflow declares the harness-visible projection policy (#14164)', () => {
+        const
+            doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/github-workflow/openapi.yaml'), 'utf8')),
+            projection = doc['x-neo-harness-tool-projection'];
+
+        expect(projection, 'Missing x-neo-harness-tool-projection contract').toBeTruthy();
+        expect(projection.defaultVisibleTiers).toEqual(['read', 'write']);
+        expect(projection.operatorOnlyTiers).toEqual(['admin']);
+    });
+
+    test('github-workflow classifies every operation into one harness tool tier (#14164)', () => {
+        const
+            doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/github-workflow/openapi.yaml'), 'utf8')),
+            operations = getOperationsById(doc),
+            tiers      = Object.fromEntries(Object.entries(operations).map(([id, op]) => [id, op['x-neo-tool-tier']]));
+
+        const missing = Object.entries(tiers).filter(([, tier]) => tier === undefined).map(([id]) => id);
+        const invalid = Object.entries(tiers).filter(([, tier]) => tier !== undefined && !githubWorkflowToolTiers.includes(tier));
+
+        expect(missing, `github-workflow operations missing x-neo-tool-tier:\n${missing.join('\n')}`).toEqual([]);
+        expect(invalid, `Invalid github-workflow x-neo-tool-tier values:\n${invalid.map(([id, tier]) => `${id}: ${tier}`).join('\n')}`).toEqual([]);
+        expect(tiers).toEqual(expectedGithubWorkflowToolTiers);
+    });
+
+    test('github-workflow mutating operations cannot be tiered as read (#14164)', () => {
+        const
+            doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/github-workflow/openapi.yaml'), 'utf8')),
+            operations = getOperationsById(doc),
+            offenders  = githubWorkflowDangerousReadForbidden.filter(id => operations[id]?.['x-neo-tool-tier'] === 'read');
+
+        expect(offenders, `Dangerous github-workflow operations mislabeled read:\n${offenders.join('\n')}`).toEqual([]);
     });
 
     test('neural-link OpenAPI operations stay aligned with serviceMapping keys (#13064)', () => {


### PR DESCRIPTION
Resolves #14188. Resolves #14195. Part of #14164 (MCP tool-cap reduction).

## Summary

Tags the two read-heavy non-NL MCP servers — **knowledge-base** and **github-workflow** — with the tool-tier projection (#14164's already-built mechanism: `ToolService` `x-neo-tool-tier` + `x-neo-harness-tool-projection` → `BaseServer --tool-projection-mode`). NL was the only configured server; this adds kb + gh.

A maintainer harness spawned with `--tool-projection-mode harness-embedded`:
- **kb: loads 7 of 13** (46% cut)
- **gh: loads 18 of 24** (25% cut — gh's core surface genuinely includes the maintainer-writes)

The withheld tools stay reachable on demand via `get_mcp_tool_handbook`. **No capability is removed.**

## What changed

- **knowledge-base openapi**: 13 ops tagged (7 read / 4 extended / 2 admin); policy `defaultVisibleTiers: [read]`.
- **github-workflow openapi**: 24 ops tagged (10 read / 8 write / 5 extended / 1 admin); policy `defaultVisibleTiers: [read, write]`.
- **`OpenApiValidatorCompliance.spec.mjs`**: 3 kb + 3 gh tier tests (policy + full classification + dangerous-not-read), mirroring the neural-link pattern.

## Deltas

- The shared tier vocab is `read / write / extended / admin`; each server's `defaultVisibleTiers` reflects its own core: kb=`[read]` (its writes are admin-destructive), gh=`[read, write]` (a maintainer's writes — review/comment/create/assign/label/link/transition — are constant).
- `checkout_pull_request` is `admin` (it desyncs the canonical clone — dangerous, never auto-visible).
- **The "core line" is review-adjustable** — flagged for peer sanity-check on #14164. mc (36) follows as the next slice (same scheme; the maintainer-write line decided here).
- No behavior change until a harness opts into `--tool-projection-mode` (the operator's lever — tagging is the prerequisite).

## Test Evidence

Evidence: `OpenApiValidatorCompliance.spec.mjs` — 37 passed, incl. the 6 new kb+gh tier tests + the existing per-server compliance loops (array-items, output-tolerance, open-bag, root-strictness). YAML parse + tier distribution verified for both (kb 7/4/2; gh 10/8/5/1, no untagged op).

## Post-Merge Validation

- No runtime change by itself (tagging is inert until a harness passes `--tool-projection-mode harness-embedded`). Once the operator flips the maintainer launch config, confirm `tools/list` returns kb's 7 + gh's 18 visible tools, and `get_mcp_tool_handbook` still resolves the withheld ones.
- The cloud KB server (full surface, no projection mode) is unaffected — it loads all tools as before.

Authored by Vega (Claude Opus 4.8, Claude Code). Origin session: 1bb8a27b-ae0d-4668-a9a2-acbbe2387512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
