### PR TITLE
feat(ai): bound the accepted-loss audit store — retention + prune + fail-safe read (#14128)

### DIFF
--- a/ai/services/memory-core/helpers/acceptedLossAuditStore.mjs
+++ b/ai/services/memory-core/helpers/acceptedLossAuditStore.mjs
@@ -27,6 +27,12 @@ const MAX_AUTO_ACCEPTED_LOSS_EVENTS = 2000;
  * Append-time prune trigger. An O(1) size stat is far cheaper than reading the whole log every append, so a
  * prune fires only once the file crosses this threshold — bounding the file with amortized, not per-append,
  * cost. Picked well above the steady-state size (accepted losses are minted rarely).
+ *
+ * Coupling with `MAX_AUTO_ACCEPTED_LOSS_EVENTS`: this 2 MB trigger assumes entries < ~1 KB, so the byte gate
+ * trips at ≈ the 2000-entry cap. If the entry shape grows past ~1 KB the gate trips *before* 2000 entries, so
+ * the prune no-ops (count ≤ cap) and each subsequent append pays an O(N) re-read until growth stops — still
+ * bounded (the file never exceeds the trigger by more than one entry), a perf not a correctness concern.
+ * Keep the two in step if the entry shape grows.
  * @type {Number}
  */
 const AUTO_ACCEPTED_LOSS_PRUNE_TRIGGER_BYTES = 2 * 1024 * 1024;
@@ -41,14 +47,18 @@ export function getAcceptedLossAuditFilePath(dir) {
 }
 
 /**
- * @summary Appends one `auto-accepted-loss` audit entry to the durable JSONL log (creating the dir if needed).
+ * @summary Appends one `auto-accepted-loss` audit entry to the durable JSONL log (creating the dir if needed),
+ * then self-bounds via an O(1) size stat-gate (see `triggerBytes`).
  * @param {Object} entry The `decideAcceptedLossSettlement` `auditRecord` (or any JSON-serializable record).
  * @param {Object} options
  * @param {String} options.dir The durable state directory.
+ * @param {Number} [options.triggerBytes=AUTO_ACCEPTED_LOSS_PRUNE_TRIGGER_BYTES] Size threshold above which the
+ *   append auto-prunes. Injectable so a test can drive the self-bounding gate with a tiny threshold.
+ * @param {Number} [options.maxEvents=MAX_AUTO_ACCEPTED_LOSS_EVENTS] Retention cap the triggered auto-prune enforces.
  * @returns {Promise<String>} The audit-log file path written to.
  * @throws {TypeError} when `entry` is not an object or `dir` is missing/empty.
  */
-export async function appendAutoAcceptedLoss(entry, {dir} = {}) {
+export async function appendAutoAcceptedLoss(entry, {dir, triggerBytes = AUTO_ACCEPTED_LOSS_PRUNE_TRIGGER_BYTES, maxEvents = MAX_AUTO_ACCEPTED_LOSS_EVENTS} = {}) {
     if (!entry || typeof entry !== 'object') {
         throw new TypeError('appendAutoAcceptedLoss: entry object is required');
     }
@@ -66,8 +76,8 @@ export async function appendAutoAcceptedLoss(entry, {dir} = {}) {
     // not a gate.
     try {
         const {size} = await stat(filePath);
-        if (size > AUTO_ACCEPTED_LOSS_PRUNE_TRIGGER_BYTES) {
-            await pruneAutoAcceptedLossAudit({dir, maxEvents: MAX_AUTO_ACCEPTED_LOSS_EVENTS});
+        if (size > triggerBytes) {
+            await pruneAutoAcceptedLossAudit({dir, maxEvents});
         }
     } catch (error) {
         // a partial/failed prune leaves the prior log intact; the next append re-tries the gate

--- a/ai/services/memory-core/helpers/acceptedLossAuditStore.mjs
+++ b/ai/services/memory-core/helpers/acceptedLossAuditStore.mjs
@@ -1,5 +1,5 @@
-import {appendFile, mkdir, readFile} from 'fs/promises';
-import path                          from 'path';
+import {appendFile, mkdir, readFile, rename, stat, writeFile} from 'fs/promises';
+import path                                                   from 'path';
 
 /**
  * @module ai/services/memory-core/helpers/acceptedLossAuditStore
@@ -13,6 +13,23 @@ import path                          from 'path';
  */
 
 const AUDIT_FILE_NAME = 'auto-accepted-loss.jsonl';
+
+/**
+ * Bounded-retention cap. The audit log is append-only telemetry — operator-review only, with NO functional
+ * reader (the auto-reopen is `computeResidueFingerprint`-recompute-driven, not audit-read-driven). So
+ * retention is a plain keep-most-recent cap: the newest `MAX_AUTO_ACCEPTED_LOSS_EVENTS` survive a prune,
+ * and there is no per-entry state to preserve (unlike the heal-event ledger's frozen-set fold).
+ * @type {Number}
+ */
+const MAX_AUTO_ACCEPTED_LOSS_EVENTS = 2000;
+
+/**
+ * Append-time prune trigger. An O(1) size stat is far cheaper than reading the whole log every append, so a
+ * prune fires only once the file crosses this threshold — bounding the file with amortized, not per-append,
+ * cost. Picked well above the steady-state size (accepted losses are minted rarely).
+ * @type {Number}
+ */
+const AUTO_ACCEPTED_LOSS_PRUNE_TRIGGER_BYTES = 2 * 1024 * 1024;
 
 /**
  * @summary The JSONL audit-log path within a state directory.
@@ -44,6 +61,18 @@ export async function appendAutoAcceptedLoss(entry, {dir} = {}) {
     const filePath = getAcceptedLossAuditFilePath(dir);
     await appendFile(filePath, `${JSON.stringify(entry)}\n`, 'utf8');
 
+    // Self-bound: an O(1) size stat-gate (not a full read every append) triggers a prune only once the log
+    // crosses the byte threshold. A stat/prune failure must never break the settlement path — telemetry,
+    // not a gate.
+    try {
+        const {size} = await stat(filePath);
+        if (size > AUTO_ACCEPTED_LOSS_PRUNE_TRIGGER_BYTES) {
+            await pruneAutoAcceptedLossAudit({dir, maxEvents: MAX_AUTO_ACCEPTED_LOSS_EVENTS});
+        }
+    } catch (error) {
+        // a partial/failed prune leaves the prior log intact; the next append re-tries the gate
+    }
+
     return filePath;
 }
 
@@ -66,5 +95,47 @@ export async function readAutoAcceptedLossAudit({dir} = {}) {
         throw error;
     }
 
-    return text.split('\n').filter(Boolean).map(line => JSON.parse(line));
+    const entries = [];
+    for (const line of text.split('\n')) {
+        if (!line) continue;
+        try {
+            entries.push(JSON.parse(line));
+        } catch (error) {
+            // skip a corrupt line — a partial append (or a torn write) must not break the whole audit read
+        }
+    }
+    return entries;
+}
+
+/**
+ * @summary Prunes the audit log to its most-recent `maxEvents` entries (oldest dropped first), written
+ * atomically via a temp file + rename so a concurrent reader never observes a torn log. A no-op when the log
+ * is already within the cap, empty, or absent. The audit is telemetry-only (no functional reader; the
+ * auto-reopen is fingerprint-recompute-driven), so a plain keep-most-recent cap is correct — there is no
+ * per-fingerprint state to preserve, unlike `healEventLedgerStore`'s frozen-set fold.
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @param {Number} [options.maxEvents=MAX_AUTO_ACCEPTED_LOSS_EVENTS] Max entries to retain.
+ * @returns {Promise<{pruned: Number, retained: Number}>} Counts; `pruned: 0` when no prune was needed.
+ * @throws {TypeError} when `dir` is missing/empty.
+ */
+export async function pruneAutoAcceptedLossAudit({dir, maxEvents = MAX_AUTO_ACCEPTED_LOSS_EVENTS} = {}) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('pruneAutoAcceptedLossAudit: dir is required');
+    }
+
+    const events = await readAutoAcceptedLossAudit({dir});
+
+    if (!Number.isFinite(maxEvents) || maxEvents <= 0 || events.length <= maxEvents) {
+        return {pruned: 0, retained: events.length};
+    }
+
+    const retained = events.slice(events.length - maxEvents),
+          filePath = getAcceptedLossAuditFilePath(dir),
+          tmpPath  = `${filePath}.tmp`;
+
+    await writeFile(tmpPath, retained.map(entry => JSON.stringify(entry)).join('\n') + '\n', 'utf8');
+    await rename(tmpPath, filePath);
+
+    return {pruned: events.length - retained.length, retained: retained.length};
 }

--- a/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAuditStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAuditStore.spec.mjs
@@ -106,4 +106,16 @@ test.describe('acceptedLossAuditStore — durable autonomous accepted-loss audit
         await appendAutoAcceptedLoss(entry(), {dir: tmpDir});
         expect(await pruneAutoAcceptedLossAudit({dir: tmpDir, maxEvents: 0})).toEqual({pruned: 0, retained: 1});
     });
+
+    test('append self-bounds: crossing the byte trigger auto-prunes to maxEvents (the wiring, not just the prune)', async () => {
+        // A tiny injected trigger fires the append-time stat-gate every append; each prune caps to maxEvents.
+        for (let i = 0; i < 6; i++) {
+            await appendAutoAcceptedLoss(entry({fingerprint: `fp-${i}`}), {dir: tmpDir, triggerBytes: 1, maxEvents: 2});
+        }
+
+        const records = await readAutoAcceptedLossAudit({dir: tmpDir});
+        // The self-bounding gate kept the file at the cap (the prune actually fired on append, not just on demand).
+        expect(records).toHaveLength(2);
+        expect(records.map(r => r.fingerprint)).toEqual(['fp-4', 'fp-5']); // newest two
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAuditStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAuditStore.spec.mjs
@@ -1,13 +1,14 @@
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
-import {mkdtemp, rm}  from 'fs/promises';
+import {appendFile, mkdtemp, rm} from 'fs/promises';
 import os             from 'os';
 import path           from 'path';
 
 import {
     appendAutoAcceptedLoss,
     getAcceptedLossAuditFilePath,
+    pruneAutoAcceptedLossAudit,
     readAutoAcceptedLossAudit
 } from '../../../../../../../ai/services/memory-core/helpers/acceptedLossAuditStore.mjs';
 
@@ -65,5 +66,44 @@ test.describe('acceptedLossAuditStore — durable autonomous accepted-loss audit
     test('rejects a missing entry / missing dir', async () => {
         await expect(appendAutoAcceptedLoss(null, {dir: tmpDir})).rejects.toThrow('entry');
         await expect(appendAutoAcceptedLoss(entry(), {})).rejects.toThrow('dir');
+    });
+
+    test('a corrupt line is skipped on read (fail-safe — a torn append must not break the audit)', async () => {
+        await appendAutoAcceptedLoss(entry({fingerprint: 'fp-good-1'}), {dir: tmpDir});
+        await appendFile(getAcceptedLossAuditFilePath(tmpDir), '{ not json\n', 'utf8');
+        await appendAutoAcceptedLoss(entry({fingerprint: 'fp-good-2'}), {dir: tmpDir});
+
+        const records = await readAutoAcceptedLossAudit({dir: tmpDir});
+        expect(records.map(r => r.fingerprint)).toEqual(['fp-good-1', 'fp-good-2']); // corrupt middle line dropped
+    });
+
+    test('prune is a no-op under the cap (returns pruned:0, log untouched)', async () => {
+        await appendAutoAcceptedLoss(entry({fingerprint: 'fp-1'}), {dir: tmpDir});
+        await appendAutoAcceptedLoss(entry({fingerprint: 'fp-2'}), {dir: tmpDir});
+
+        expect(await pruneAutoAcceptedLossAudit({dir: tmpDir, maxEvents: 10})).toEqual({pruned: 0, retained: 2});
+        expect(await readAutoAcceptedLossAudit({dir: tmpDir})).toHaveLength(2);
+    });
+
+    test('prune caps to the most-recent maxEvents (oldest dropped, append order preserved)', async () => {
+        for (let i = 0; i < 5; i++) {
+            await appendAutoAcceptedLoss(entry({fingerprint: `fp-${i}`}), {dir: tmpDir});
+        }
+
+        const result  = await pruneAutoAcceptedLossAudit({dir: tmpDir, maxEvents: 2});
+        const records = await readAutoAcceptedLossAudit({dir: tmpDir});
+
+        expect(result).toEqual({pruned: 3, retained: 2});
+        expect(records.map(r => r.fingerprint)).toEqual(['fp-3', 'fp-4']); // newest kept
+    });
+
+    test('prune on a missing / empty log is a safe no-op', async () => {
+        expect(await pruneAutoAcceptedLossAudit({dir: tmpDir, maxEvents: 5})).toEqual({pruned: 0, retained: 0});
+    });
+
+    test('prune rejects a missing dir; maxEvents<=0 is a no-op', async () => {
+        await expect(pruneAutoAcceptedLossAudit({})).rejects.toThrow('dir');
+        await appendAutoAcceptedLoss(entry(), {dir: tmpDir});
+        expect(await pruneAutoAcceptedLossAudit({dir: tmpDir, maxEvents: 0})).toEqual({pruned: 0, retained: 1});
     });
 });


### PR DESCRIPTION
## Summary

`acceptedLossAuditStore.mjs` appended `auto-accepted-loss` entries to a single JSONL (`auto-accepted-loss.jsonl`) with **no retention** — the sibling durable store `recoveryRunStateStore` documents + enforces a `retentionLimit`, this didn't. Closes that boundedness gap.

Resolves #14128.

## Deltas

- `MAX_AUTO_ACCEPTED_LOSS_EVENTS` (2000) + `AUTO_ACCEPTED_LOSS_PRUNE_TRIGGER_BYTES` (2 MB).
- `appendAutoAcceptedLoss` self-bounds via an **O(1) size stat-gate** — prunes only once the file crosses the threshold (amortized, not per-append, cost).
- `pruneAutoAcceptedLossAudit({dir, maxEvents})` — keep-most-recent cap, written **atomically** (tmp + rename) so a concurrent reader never sees a torn log.
- `readAutoAcceptedLossAudit` hardened to **skip a corrupt / torn line** (fail-safe), needed so the prune's read is robust.

## Design (Verify-Before-Assert)

- **Telemetry-only → simple count-prune.** V-B-A'd the consumers: `readAutoAcceptedLossAudit` has **zero functional callers**; the auto-reopen is `computeResidueFingerprint`-recompute-driven (`freezeReprobeDecision.mjs`), not audit-read-driven. So a plain keep-most-recent cap is correct — **no per-fingerprint force-keep** (unlike `healEventLedgerStore`'s frozen-set fold, where the fold IS functional and dropping a still-in-effect freeze would silently un-freeze).
- **Issue wording corrected.** #14128 described "one ledger file per residue fingerprint / a re-ack appends a fresh line" — the *actual* store is single-file append (`auto-accepted-loss.jsonl`). The gap (unbounded growth) is real; the model is single-file. (Issue updated with the correction.)
- Reuses the #14178 heal-ledger retention pattern (stat-gate + atomic prune + fail-safe read).

## Test Evidence

`UNIT_TEST_MODE=true npm run test-unit -- acceptedLossAuditStore` → **10/10 pass** (5 existing + 5 new):
- a corrupt line is skipped on read (fail-safe)
- prune is a no-op under the cap (`pruned:0`, log untouched)
- prune caps to the most-recent `maxEvents` (oldest dropped, append order preserved)
- prune on a missing / empty log is a safe no-op
- prune rejects a missing `dir`; `maxEvents<=0` is a no-op

Evidence: 10/10 unit pass; `node --check` clean on store + spec; the prune is atomic (tmp+rename).

## Post-Merge Validation

`.neo-ai-data/.../auto-accepted-loss.jsonl` stays bounded under repeated autonomous settlements; an operator review (`readAutoAcceptedLossAudit`) returns the most-recent ≤ 2000 entries. (Steady-state volume is tiny — accepted losses are minted rarely — so the cap is a safety ceiling, not a routine trigger.)

Authored by Grace (Claude Opus 4.8, Claude Code). Session 090a68e6-1a28-4b20-a5fd-842ebac3e729.

Resolves #14128
Refs #14118 #14178
