### PR TITLE
refactor(ai): remove duplicate dead synthesizeGoldenPath() in DreamService (#14197)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -1028,16 +1028,6 @@ class DreamService extends Base {
     }
 
     /**
-     * Backward compatibility passthrough to GoldenPathSynthesizer.
-     * @deprecated Trigger GoldenPathSynthesizer directly or use MemoryService.mutateFrontier hook.
-     */
-    async synthesizeGoldenPath() {
-        // We dynamically import it here to avoid circular dependency loops during initialization
-        const { default: GoldenPathSynthesizer } = await import('./services/GoldenPathSynthesizer.mjs');
-        return GoldenPathSynthesizer.synthesizeGoldenPath();
-    }
-
-    /**
      * Cycle-scoped GUIDE_GAP / EXAMPLE_GAP inference entry point. Delegates to
      * `GapInferenceEngine` for deterministic concept-graph edge traversal (`EXPLAINED_BY` /
      * `EXEMPLIFIED_BY`). Output depends only on ontology state, not on any individual session —


### PR DESCRIPTION
## Summary

A tech-debt-radar Vector-C sweep found a duplicate method: `DreamService` defined `async synthesizeGoldenPath()` **twice** (~line 1034 + ~line 1140). JS shadows the first with the second, so the ~1034 copy was **unreachable dead code** — and it carried a **broken import**: `'./services/GoldenPathSynthesizer.mjs'` from a file already in `.../orchestrator/services/`, resolving to a non-existent `.../services/services/` double-path that would throw `ERR_MODULE_NOT_FOUND` if ever reached.

Resolves #14197

## Change

Remove the shadowed duplicate (~1034 — the JSDoc + the dead method + the broken dynamic import). The active definition (~1140, a module-level `GoldenPathSynthesizer` import, exercised by the DreamService specs) is now the sole `synthesizeGoldenPath()`. Production callers already use `GoldenPathSynthesizer.synthesizeGoldenPath()` directly (`pipeline.mjs:560`, `MemoryService.mjs:2082`).

Evidence: the two method defs in `DreamService.mjs`; the broken `./services/` path (no `.../services/services/` dir exists); the surviving def is the module-import, test-covered one.

## Deltas from ticket (if any)

- None — exactly the AC (remove the dead duplicate, keep the active one, specs green). 10-line deletion, zero behavior change (JS shadowing guarantees the removed copy was never the runtime method).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs DreamService` → **52 passed, 1 failed**. The single failure (`DreamServiceGoldenPath:77 "executes without crashing"`) is the **pre-existing CI-skipped flake** — a synthesis-write race, `test.skip(NEO_TEST_SKIP_CI, '...#10946')` — **proven identical on clean dev** with the edit stashed (so unrelated to this change, and skipped in CI). After the edit: one `synthesizeGoldenPath` definition remains, the broken `./services/` import is gone.

## Post-Merge Validation

`DreamService.synthesizeGoldenPath()` continues to resolve to the module-import passthrough (unchanged runtime behavior); the dead broken-import duplicate is gone. No production caller is affected (they call `GoldenPathSynthesizer` directly).

## Related

Surfaced by a tech-debt-radar Vector-C sweep. The `@deprecated` markers on the passthrough predate this (the separate "should this passthrough exist at all?" question is out of scope — this PR only removes the unreachable, broken duplicate).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f2c722bf-9fb0-4925-8fbc-a9a0788f459c`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.