### PR TITLE
feat(ai): composeTurnDocumentText helper — single-source the canonical turn-document derivation (#14193)

### DIFF
--- a/ai/services/memory-core/helpers/turnDocumentText.mjs
+++ b/ai/services/memory-core/helpers/turnDocumentText.mjs
@@ -1,0 +1,35 @@
+/**
+ * @module ai/services/memory-core/helpers/turnDocumentText
+ * @summary Single source of the canonical turn-document text — the `User Prompt: … / Agent Thought: … /
+ * Agent Response: …` representation derived from a turn memory's split fields.
+ *
+ * Background: a per-turn memory carries its content BOTH as three split fields
+ * (`metadata.prompt` / `metadata.thought` / `metadata.response`) AND as a redundant combined document
+ * that is exactly their join. The split fields are the canonical representation; the combined text is pure
+ * derivation. This helper IS that derivation, extracted so the format lives in ONE place — used both to
+ * BUILD the text for embedding at write time and to RECONSTRUCT it on read once the redundant stored copy
+ * is dropped. A reconstruct that did not byte-match the original construction would corrupt any
+ * content-fingerprint/hash, so single-sourcing the format is the prerequisite for the de-dup.
+ *
+ * Pure + deterministic: no I/O, no mutation, no time/randomness. Turns ONLY — a summary memory has a
+ * distinct document shape and must NOT be passed through this helper.
+ */
+
+/**
+ * @summary Composes the canonical turn-document text from a turn's split fields.
+ *
+ * Byte-identical to the inline construction it single-sources: the three fields are joined with the fixed
+ * `User Prompt:` / `Agent Thought:` / `Agent Response:` labels and `\n` separators, in that exact order.
+ * Reconstruct-on-read calls this with the SAME stored field values, so the derived document matches the
+ * original construction exactly (the property the de-dup relies on). Values are coerced by the template
+ * literal exactly as the original did — no added defaults or guards that would diverge the output.
+ *
+ * @param {Object} fields
+ * @param {String} fields.prompt The turn's user prompt.
+ * @param {String} fields.thought The agent's thought.
+ * @param {String} fields.response The agent's response.
+ * @returns {String} The canonical `User Prompt: … \n Agent Thought: … \n Agent Response: …` text.
+ */
+export function composeTurnDocumentText({prompt, thought, response} = {}) {
+    return `User Prompt: ${prompt}\nAgent Thought: ${thought}\nAgent Response: ${response}`;
+}

--- a/test/playwright/unit/ai/services/memory-core/helpers/turnDocumentText.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/turnDocumentText.spec.mjs
@@ -1,0 +1,44 @@
+import {test, expect}            from '@playwright/test';
+import Neo                       from '../../../../../../../src/Neo.mjs';
+import * as core                 from '../../../../../../../src/core/_export.mjs';
+import {composeTurnDocumentText} from '../../../../../../../ai/services/memory-core/helpers/turnDocumentText.mjs';
+
+// Pure derivation (no I/O). Composes the canonical turn-document text from a turn's split fields — the
+// single source of the `User Prompt: … / Agent Thought: … / Agent Response: …` representation that the
+// field↔document de-dup reconstructs on read in place of a redundant stored copy.
+
+test.describe('turnDocumentText — canonical turn-document derivation', () => {
+    test('composes the exact User Prompt / Agent Thought / Agent Response format', () => {
+        expect(composeTurnDocumentText({prompt: 'p', thought: 't', response: 'r'}))
+            .toBe('User Prompt: p\nAgent Thought: t\nAgent Response: r')
+    });
+
+    test('is byte-identical to the inline construction it single-sources (the de-dup invariant)', () => {
+        // The exact construction performed inline at the MemoryService write path. Reconstruct-on-read MUST
+        // match this byte-for-byte, or any content fingerprint/hash over the document breaks.
+        const prompt   = 'Fix the rotation bug',
+              thought  = 'two writers share the log',
+              response = 'guarded both';
+        const inline = `User Prompt: ${prompt}\nAgent Thought: ${thought}\nAgent Response: ${response}`;
+        expect(composeTurnDocumentText({prompt, thought, response})).toBe(inline)
+    });
+
+    test('preserves newlines and label-like text inside field values (plain join, no parsing)', () => {
+        const prompt   = 'line1\nline2',
+              thought  = 'has Agent Response: inside it',
+              response = 'multi\nline\nresponse';
+        expect(composeTurnDocumentText({prompt, thought, response}))
+            .toBe('User Prompt: line1\nline2\nAgent Thought: has Agent Response: inside it\nAgent Response: multi\nline\nresponse')
+    });
+
+    test('is deterministic — identical fields yield an identical string', () => {
+        const fields = {prompt: 'a', thought: 'b', response: 'c'};
+        expect(composeTurnDocumentText(fields)).toBe(composeTurnDocumentText(fields))
+    });
+
+    test('coerces values exactly as the template literal does — no added defaults that diverge output', () => {
+        // Matches the original construction's behavior for the same inputs; no guards that would change bytes.
+        expect(composeTurnDocumentText({prompt: 1, thought: true, response: null}))
+            .toBe('User Prompt: 1\nAgent Thought: true\nAgent Response: null')
+    })
+});


### PR DESCRIPTION
## Summary

A per-turn memory stores its content twice: as three split fields (`metadata.prompt` / `thought` / `response`) AND as a redundant combined `document` that is exactly their join — the field↔document duplication #14193 targets (~910MB across the store). The split fields are the canonical representation; the combined document is pure derivation. Eliminating the redundancy means reconstructing the document on read from the canonical fields, **byte-identically** to how it was built — which first requires the construction to live in ONE place.

Resolves #14203 — slice 1 of the #14193 consumer-aware de-dup.

## Change

Adds a pure, single-source helper `composeTurnDocumentText({prompt, thought, response})` (`ai/services/memory-core/helpers/turnDocumentText.mjs`) that derives the canonical `User Prompt: … \n Agent Thought: … \n Agent Response: …` text — currently constructed inline at the MemoryService write path. Matches the sibling pure-helper pattern (`classifyRepairResidue.mjs` et al.): no Neo/Base import, rich `@module` / `@summary` JSDoc, deterministic, no I/O.

Evidence: the inline `User Prompt: … / Agent Thought: … / Agent Response: …` construction at the MemoryService write path (the exact format this single-sources); the sibling pure-helper convention in `ai/services/memory-core/helpers/`.

## Deltas from ticket (if any)

- **Primitive-first slicing.** This PR is ONLY the pure derivation helper + its test — zero data touch, no `MemoryService` edit. The write-path single-sourcing + the read-path reconstruct wiring is a coordinated next slice, gated on @neo-opus-grace confirming the load-bearing premise: **no consumer relies on Chroma document-FTS** (dropping the stored document drops that index — that IS the reclaim). The one-time data migration that reclaims existing records is a separate, gated slice. **Summaries are excluded throughout** — they have a distinct document shape and must not be reconstructed through this helper.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs turnDocumentText` → **5 passed**. Tests: exact format; **byte-identity with the inline construction** (the de-dup's load-bearing invariant — a reconstruct that didn't match would corrupt any content fingerprint/hash over the document); newline + label-like text preserved inside field values (plain join, no parsing); determinism; template-literal coercion match (no added defaults that diverge output).

## Post-Merge Validation

On its own this is an inert, tested building block — the established primitive-first pattern (cf. the `auditCollectionVectorDimensions` / document-presence primitives #14113/#14135 that shipped ahead of their runner consumers). No behavior change, no consumer touched, so it's safe to land ahead of the wiring; slice 2 makes it the single source the MemoryService write path calls and the read path reconstructs from.

## Related

#14193 (parent de-dup), #14079 (bloat epic). Sibling pure-helper pattern: `classifyRepairResidue.mjs`.

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f2c722bf-9fb0-4925-8fbc-a9a0788f459c`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
