### PR TITLE
feat(ai): reconstruct turn-document on read from split metadata (#14209)

### DIFF
--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -7,7 +7,7 @@ import SessionService                                                           
 import TurnPresenceService                                                                                                             from './TurnPresenceService.mjs';
 import {withTimeout}                                                                                                                   from './helpers/withTimeout.mjs';
 import {appendWalGraphProjectionMarker, appendWalMemory, getMissingMemoryWalLeaves, pruneReconciledWalSegments, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
-import {composeTurnDocumentText}                                                                                                       from './helpers/turnDocumentText.mjs';
+import {composeTurnDocumentText, resolveTurnDocumentForRead}                                                                           from './helpers/turnDocumentText.mjs';
 import {buildChatModel}                                                                                                                from '../../provider/buildChatModel.mjs';
 import aiConfig                                                                                                                        from '../../mcp/server/memory-core/config.mjs';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId}                                                                        from '../../mcp/server/shared/services/RequestContextService.mjs';
@@ -1864,8 +1864,12 @@ class MemoryService extends Base {
                             if (userId) getArgs.where = {$or: [{userId}, {userId: SHARED_USER_ID}]};
                             const result = await collection.get(getArgs);
 
-                            if (result.documents && result.documents.length > 0) {
-                                const metadata      = result.metadatas ? result.metadatas[0] : null;
+                            const metadata = result.metadatas ? result.metadatas[0] : null;
+                            // Field↔document de-dup: prefer the stored document, else reconstruct from split
+                            // metadata (turns only) when it was dropped — single-sourced in turnDocumentText.
+                            const content = resolveTurnDocumentForRead({documents: result.documents, metadata});
+
+                            if (content) {
                                 const trustTier     = this.constructor.resolveSummaryTrustTier(metadata);
                                 const trustWeight   = this.constructor.getFrontierTrustWeight(trustTier);
                                 const weightedScore = Number(((Number(neighbor.weight) || 0) * trustWeight).toFixed(6));
@@ -1878,7 +1882,7 @@ class MemoryService extends Base {
                                     trustTier,
                                     trustWeight,
                                     weightedScore,
-                                    content     : result.documents[0],
+                                    content,
                                     metadata
                                 });
                             }
@@ -1953,13 +1957,14 @@ class MemoryService extends Base {
                     try {
                         const getArgs = {
                             ids    : [neighbor.semanticVectorId],
-                            include: ['documents']
+                            include: ['documents', 'metadatas']
                         };
                         if (userId) getArgs.where = {$or: [{userId}, {userId: SHARED_USER_ID}]};
-                        const result = await collection.get(getArgs);
-                        if (result.documents && result.documents.length > 0) {
-                            episodicContext = result.documents[0];
-                        }
+                        const result   = await collection.get(getArgs);
+                        const metadata = result.metadatas ? result.metadatas[0] : null;
+                        // Field↔document de-dup: prefer the stored document, else reconstruct from split
+                        // metadata (turns only) when it was dropped — single-sourced in turnDocumentText.
+                        episodicContext = resolveTurnDocumentForRead({documents: result.documents, metadata});
                     } catch (e) {
                          // Missing vector is fine, we still have structural graph data
                     }

--- a/ai/services/memory-core/helpers/turnDocumentText.mjs
+++ b/ai/services/memory-core/helpers/turnDocumentText.mjs
@@ -33,3 +33,30 @@
 export function composeTurnDocumentText({prompt, thought, response} = {}) {
     return `User Prompt: ${prompt}\nAgent Thought: ${thought}\nAgent Response: ${response}`;
 }
+
+/**
+ * @summary Resolves a memory's document text on READ — prefers the stored Chroma document, falling back to
+ * reconstructing it from the split metadata fields when the redundant stored copy has been dropped (the
+ * field↔document de-dup). A turn memory (`metadata.type === 'agent-interaction'`) reconstructs via
+ * {@link composeTurnDocumentText}; a summary (or any non-turn / metadata-less record) has a DISTINCT
+ * document shape and is NEVER reconstructed — it returns its stored document or `null`.
+ *
+ * The stored document, when present, ALWAYS wins (byte-exact, no reconstruction), so existing records are
+ * behavior-preserved; reconstruction is the post-migration path for turns whose stored document was dropped.
+ * Pure + total (never throws). The turn-vs-summary discriminator lives HERE so every read-path shares it.
+ *
+ * @param {Object} options
+ * @param {Array<String>=} options.documents The Chroma `get` `documents` array (or undefined/empty).
+ * @param {Object|null} options.metadata The record metadata (`{type, prompt, thought, response, …}`).
+ * @returns {String|null} The document text (stored or reconstructed), or `null` when neither is available.
+ */
+export function resolveTurnDocumentForRead({documents, metadata} = {}) {
+    const stored = Array.isArray(documents) ? documents[0] : undefined;
+    if (stored) return stored;
+
+    if (metadata && metadata.type === 'agent-interaction') {
+        return composeTurnDocumentText({prompt: metadata.prompt, thought: metadata.thought, response: metadata.response});
+    }
+
+    return null;
+}

--- a/test/playwright/unit/ai/services/memory-core/helpers/turnDocumentText.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/turnDocumentText.spec.mjs
@@ -1,7 +1,7 @@
-import {test, expect}            from '@playwright/test';
-import Neo                       from '../../../../../../../src/Neo.mjs';
-import * as core                 from '../../../../../../../src/core/_export.mjs';
-import {composeTurnDocumentText} from '../../../../../../../ai/services/memory-core/helpers/turnDocumentText.mjs';
+import {test, expect}                                        from '@playwright/test';
+import Neo                                                   from '../../../../../../../src/Neo.mjs';
+import * as core                                             from '../../../../../../../src/core/_export.mjs';
+import {composeTurnDocumentText, resolveTurnDocumentForRead} from '../../../../../../../ai/services/memory-core/helpers/turnDocumentText.mjs';
 
 // Pure derivation (no I/O). Composes the canonical turn-document text from a turn's split fields — the
 // single source of the `User Prompt: … / Agent Thought: … / Agent Response: …` representation that the
@@ -40,5 +40,42 @@ test.describe('turnDocumentText — canonical turn-document derivation', () => {
         // Matches the original construction's behavior for the same inputs; no guards that would change bytes.
         expect(composeTurnDocumentText({prompt: 1, thought: true, response: null}))
             .toBe('User Prompt: 1\nAgent Thought: true\nAgent Response: null')
+    })
+});
+
+test.describe('resolveTurnDocumentForRead — read-side stored-or-reconstruct (#14193 slice-3)', () => {
+    test('prefers the stored document when present (byte-exact, no reconstruction)', () => {
+        const stored = 'User Prompt: stored\nAgent Thought: x\nAgent Response: y';
+        // stored wins; the metadata is NOT used to reconstruct when a document exists (behavior-preserving)
+        expect(resolveTurnDocumentForRead({documents: [stored], metadata: {type: 'agent-interaction', prompt: 'OTHER'}}))
+            .toBe(stored)
+    });
+
+    test('reconstructs a turn from split metadata when the document is dropped (byte-identical to compose)', () => {
+        expect(resolveTurnDocumentForRead({
+            documents: [null],
+            metadata : {type: 'agent-interaction', prompt: 'p', thought: 't', response: 'r'}
+        })).toBe(composeTurnDocumentText({prompt: 'p', thought: 't', response: 'r'}))
+    });
+
+    test('reconstructs identically across dropped-doc shapes ([null] / [] / undefined)', () => {
+        const meta     = {type: 'agent-interaction', prompt: 'p', thought: 't', response: 'r'},
+              expected = composeTurnDocumentText({prompt: 'p', thought: 't', response: 'r'});
+        expect(resolveTurnDocumentForRead({documents: [null],     metadata: meta})).toBe(expected);
+        expect(resolveTurnDocumentForRead({documents: [],         metadata: meta})).toBe(expected);
+        expect(resolveTurnDocumentForRead({documents: undefined,  metadata: meta})).toBe(expected)
+    });
+
+    test('NEVER reconstructs a non-turn (summary) — returns its stored document, else null', () => {
+        const summaryDoc = 'a distinct summary shape';
+        expect(resolveTurnDocumentForRead({documents: [summaryDoc], metadata: {type: 'session-summary'}})).toBe(summaryDoc);
+        // a summary with a dropped document → null (NOT reconstructed via the turn template — distinct shape)
+        expect(resolveTurnDocumentForRead({documents: [null], metadata: {type: 'session-summary', prompt: 'x'}})).toBe(null)
+    });
+
+    test('returns null when neither a stored document nor turn metadata is available (total, never throws)', () => {
+        expect(resolveTurnDocumentForRead({documents: [null], metadata: null})).toBe(null);
+        expect(resolveTurnDocumentForRead({})).toBe(null);
+        expect(resolveTurnDocumentForRead()).toBe(null)
     })
 });


### PR DESCRIPTION
## Summary

Slice-3 of the field↔document de-dup (#14193) — the **read-path**. Adds `resolveTurnDocumentForRead` so MemoryService's neighbor-recall reconstructs the turn-document from split metadata when the redundant stored copy is dropped, making the slice-4 migration safe.

Resolves #14209. Part of #14193 (de-dup) / #14079 (bloat).

**Stacked** on #14207 (slice-2) + #14202 (slice-1) — base is `ada/14206-singlesource-write`; rebase to `dev` when the stack merges.

## Deltas

- New pure **`resolveTurnDocumentForRead({documents, metadata})`** in `turnDocumentText.mjs` (read-side, beside the write-side `composeTurnDocumentText`): the stored Chroma document wins when present (byte-exact) → else reconstruct **turns only** (`metadata.type === 'agent-interaction'`) via `composeTurnDocumentText` → else `null`. Single-sources the turn-vs-summary discriminator so every read-path shares it.
- MemoryService's two neighbor-recall reads use it — the strategic-neighbor `content` and the episodic `episodicContext`; the episodic read adds `metadatas` to its `include`.

## Verify-Before-Assert

- **Behavior-preserving**: the stored document always wins when present, so existing records are byte-unchanged; reconstruction is strictly the post-migration path for turns whose document was dropped.
- **Summaries never reconstruct** (distinct document shape) — gated on `type === 'agent-interaction'`; a summary with a dropped document returns `null`, not a wrong turn-template reconstruction.
- Pure + total (`resolveTurnDocumentForRead` never throws — null/empty/undefined inputs return `null`).

## Test Evidence

`UNIT_TEST_MODE=true npm run test-unit -- turnDocumentText` → **10/10** (5 `composeTurnDocumentText` + 5 `resolveTurnDocumentForRead`: stored-wins, dropped-doc reconstruct across `[null]`/`[]`/`undefined`, summary-never-reconstruct, null-safety).

Evidence: 10/10 turnDocumentText unit green; `node --check` clean on the helper + MemoryService + spec; block-alignment + ticket-archaeology husky gates pass.

## Post-Merge Validation

After slice-4 drops the redundant turn documents, neighbor-recall reconstructs `content`/`episodicContext` from metadata for turns; summaries keep their stored document. (Pre-slice-4, the stored document wins, so this merges behavior-neutrally.)

Authored by Grace (Claude Opus 4.8, Claude Code). Session 090a68e6-1a28-4b20-a5fd-842ebac3e729.

Resolves #14209
Refs #14193 #14207 #14202 #14079
