### PR TITLE
fix(ai): route DreamService REM turn-document read through resolveTurnDocumentForRead (#14211)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -37,7 +37,8 @@ import {
     createRemPhaseState,
     createRemRunStateEntry
 } from '../../../services/memory-core/helpers/remRunStateStore.mjs';
-import {bytesToTokens} from '../../../services/memory-core/helpers/consumerFrictionHelper.mjs';
+import {bytesToTokens}              from '../../../services/memory-core/helpers/consumerFrictionHelper.mjs';
+import {resolveTurnDocumentForRead} from '../../../services/memory-core/helpers/turnDocumentText.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -417,12 +418,14 @@ class DreamService extends Base {
                         if (memoryCollection) {
                             const rawMemories = await memoryCollection.get({
                                 where  : { sessionId: session.meta.sessionId },
-                                include: ['documents']
+                                include: ['documents', 'metadatas']
                             });
                             if (rawMemories?.documents?.length > 0) {
                                 // Send the full raw memory to the LLM. Lossless context tracking is required.
                                 // If local APIs crash, it is a configuration issue with n_ctx, not a client logic error.
-                                turnDocuments     = rawMemories.documents;
+                                // Field↔document de-dup: reconstruct a dropped turn-document from its split metadata
+                                // (resolveTurnDocumentForRead no-ops on summaries via the type discriminator).
+                                turnDocuments     = rawMemories.documents.map((doc, i) => resolveTurnDocumentForRead({documents: [doc], metadata: rawMemories.metadatas?.[i]}));
                                 rawEpisodicMemory = turnDocuments.join('\n\n---\n\n');
                             }
                         }

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -4,6 +4,7 @@ import {buildChatModel}                              from '../../provider/buildC
 import {invokeWithGuardrail}                         from './helpers/consumerFrictionHelper.mjs';
 import {withTimeout}                                 from './helpers/withTimeout.mjs';
 import {appendWalEmbedMarker, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
+import {resolveTurnDocumentForRead}                  from './helpers/turnDocumentText.mjs';
 import crypto                                        from 'crypto';
 import GraphService                                  from './GraphService.mjs';
 import {capSessionsForSweep}                         from './capSessionsForSweep.mjs';
@@ -101,7 +102,7 @@ class SessionService extends Base {
      */
     static resolveSummarySourceProvenance(metadatas = []) {
         const sourceAgentIdentities = new Set();
-        let sourceTrustTier         = null,
+        let   sourceTrustTier       = null,
             unclassifiedSourceCount = 0;
 
         for (const metadata of metadatas || []) {
@@ -109,7 +110,7 @@ class SessionService extends Base {
                 ? metadata.agentIdentity
                 : null;
             const knownTrustTier = agentIdentity ? this.identityTrustTiers.get(agentIdentity) : null;
-            const trustTier = agentIdentity
+            const trustTier      = agentIdentity
                 ? (knownTrustTier || TRUST_TIERS.UNCLASSIFIED)
                 : TRUST_TIERS.UNCLASSIFIED;
 
@@ -228,7 +229,7 @@ class SessionService extends Base {
         if (!Number.isFinite(nowMs)) return new Set();
 
         const thresholdMs = aiConfig.orchestrator.swarmHeartbeat.idleThresholdMs;
-        const cutoffMs = nowMs - thresholdMs;
+        const cutoffMs    = nowMs - thresholdMs;
 
         try {
             const rows = sqlite.prepare(`
@@ -339,13 +340,13 @@ class SessionService extends Base {
     async findSessionsToSummarize({now = Date.now()} = {}) {
         // 1. Get metadata for memories — all-time scope. (The prior 30-day window was an obsolete
         // boot/healthcheck-timeout safeguard from when MC summarized on server boot.)
-        const limit = aiConfig.summarizationBatchLimit;
+        const limit         = aiConfig.summarizationBatchLimit;
         const maxIterations = 1000; // Safety break: max 2M records (2000 * 1000)
 
         let allMetadatas = [];
-        let offset = 0;
-        let hasMore = true;
-        let iterations = 0;
+        let offset       = 0;
+        let hasMore      = true;
+        let iterations   = 0;
 
         // Build query options dynamically to avoid passing `where: undefined`
         const baseQueryOptions = {
@@ -441,12 +442,12 @@ class SessionService extends Base {
         // Re-summary churn-gate threshold. Reuses the swarm idle definition — one idle
         // concept, no new config leaf. A session whose newest memory is within this window
         // is still actively receiving turns, so summarizing it now is stale-on-write and re-churns.
-        const churnCooldownMs = aiConfig.orchestrator.swarmHeartbeat.idleThresholdMs;
+        const churnCooldownMs            = aiConfig.orchestrator.swarmHeartbeat.idleThresholdMs;
         const externallyActiveSessionIds = this.getExternallyActiveSessionIds({now: nowMs});
-        const sessionsToUpdate = [];
+        const sessionsToUpdate           = [];
 
         Object.keys(sessions).forEach(sessionId => {
-            const sessionData = sessions[sessionId];
+            const sessionData  = sessions[sessionId];
             const summaryCount = summaryMap[sessionId];
 
             // Skip the in-process current session (it summarizes on its own sunset).
@@ -518,13 +519,13 @@ class SessionService extends Base {
         // to the first page). Real Chroma respects offset, so this gathers the full set; dedup-by-id +
         // stop-when-a-page-adds-nothing-new is a defensive guard that safely terminates even if a backing
         // collection (e.g. an offset-blind mock) repeats a page, instead of looping forever.
-        const memories  = {ids: [], documents: [], metadatas: []};
-        const pageLimit = aiConfig.summarizationBatchLimit;
-        const seenIds   = new Set();
-        let pageOffset  = 0;
+        const memories   = {ids: [], documents: [], metadatas: []};
+        const pageLimit  = aiConfig.summarizationBatchLimit;
+        const seenIds    = new Set();
+        let   pageOffset = 0;
 
         while (true) {
-            const page      = await this.memoryCollection.get({
+            const page = await this.memoryCollection.get({
                 where  : {sessionId},
                 include: ['documents', 'metadatas'],
                 limit  : pageLimit,
@@ -540,7 +541,9 @@ class SessionService extends Base {
                 if (seenIds.has(page.ids[i])) continue;
                 seenIds.add(page.ids[i]);
                 memories.ids.push(page.ids[i]);
-                memories.documents.push(page.documents[i]);
+                // Field↔document de-dup: reconstruct a dropped turn-document from its split metadata
+                // (resolveTurnDocumentForRead no-ops on summaries via the type discriminator).
+                memories.documents.push(resolveTurnDocumentForRead({documents: [page.documents[i]], metadata: page.metadatas[i]}));
                 memories.metadatas.push(page.metadatas[i]);
                 addedThisPage++;
             }
@@ -560,12 +563,12 @@ class SessionService extends Base {
         // sufficient `n_ctx` capabilities (128k+).
         const aggregatedContent = memories.documents.join('\n\n---\n\n');
 
-        let lastActivity = Date.now();
-        let firstActivity = lastActivity;
+        let   lastActivity    = Date.now();
+        let   firstActivity   = lastActivity;
         const extractedAgents = new Set();
         const extractedModels = new Set();
-        let totalToolCalls = 0;
-        const allToolsUsed = new Set();
+        let   totalToolCalls  = 0;
+        const allToolsUsed    = new Set();
 
         if (memories.metadatas && memories.metadatas.length > 0) {
             const timestamps = memories.metadatas.map(m => m.timestamp).filter(Boolean);
@@ -588,7 +591,7 @@ class SessionService extends Base {
                                 if (t) {
                                     if (typeof t === 'string') {
                                         try {
-                                            const inner = JSON.parse(t);
+                                            const inner      = JSON.parse(t);
                                             const identifier = inner.name || inner.toolAction || inner.toolSummary || 'unknown_tool';
                                             allToolsUsed.add(String(identifier).substring(0, 50));
                                         } catch (e) {
@@ -611,7 +614,7 @@ class SessionService extends Base {
         }
 
         const participatingAgents = Array.from(extractedAgents);
-        const models = Array.from(extractedModels);
+        const models              = Array.from(extractedModels);
 
         const buildSummaryPrompt = sessionContent => `
 Analyze the following development session and provide a structured summary in JSON format. The JSON object should have the following properties:
@@ -656,7 +659,7 @@ ${sessionContent}
         // (~2× faster, no measured quality loss). `summarySchema` enforces valid, fence-free JSON via
         // the provider's json_schema path. Passing `undefined` effort omits the param (model default).
         const summaryReasoningEffort = aiConfig.localModels.chat.summaryReasoningEffort;
-        const summarySchema = {
+        const summarySchema          = {
             type      : 'object',
             properties: {
                 summary     : {type: 'string'},
@@ -713,7 +716,7 @@ ${sessionContent}
         const skipSymptom     = guardrailed.friction?.symptom,
               recoverableSkip = skipSymptom === 'size-precheck-skip' || skipSymptom === 'timeout';
         if (!guardrailed.result && recoverableSkip) {
-            const FALLBACK_CHARS   = 280, // truncated-raw snippet cap (matches the per-turn miniSummary cap)
+            const FALLBACK_CHARS = 280, // truncated-raw snippet cap (matches the per-turn miniSummary cap)
                   miniByMemoryId   = this.getSessionMiniSummaries(sessionId),
                   degradedEntries  = (memories.ids || [])
                       .map((id, index) => ({
@@ -726,7 +729,7 @@ ${sessionContent}
                       .filter(Boolean);
 
             if (degradedEntries.length > 0) {
-                const usedTier        = miniByMemoryId.size > 0 ? 'miniSummary' : 'truncatedRaw',
+                const usedTier = miniByMemoryId.size > 0 ? 'miniSummary' : 'truncatedRaw',
                       degradedContent = degradedEntries.map((entry, index) => `Turn ${index + 1}: ${entry}`).join('\n'),
                       degradedResult  = await runGuardrailed(
                           buildSummaryPrompt(degradedContent),
@@ -746,9 +749,9 @@ ${sessionContent}
             return null;
         }
 
-        const result = guardrailed.result;
+        const result       = guardrailed.result;
         const responseText = result.response.text();
-        const summaryData = Json.extract(responseText);
+        const summaryData  = Json.extract(responseText);
 
         if (!summaryData) {
             logger.warn(`Failed to parse summary for session ${sessionId}`);
@@ -829,7 +832,7 @@ ${sessionContent}
         }
 
         // --- 2. Semantic Extraction (Regex Linkage) ---
-        const issueRegex = /(?:#|issue-)(\d+)/gi;
+        const issueRegex   = /(?:#|issue-)(\d+)/gi;
         const linkedIssues = new Set();
         let match;
 
@@ -896,7 +899,7 @@ ${sessionContent}
      */
     async ingestAntigravityArtifacts(sessionId, summaryId, minTimeMs, maxTimeMs) {
         try {
-            const homeDir = os.homedir();
+            const homeDir  = os.homedir();
             const brainDir = path.join(homeDir, '.gemini', 'antigravity', 'brain');
 
             if (!fs.existsSync(brainDir)) return;
@@ -920,7 +923,7 @@ ${sessionContent}
                             // concurrent users summarizing overlapping time windows each produce
                             // their own tenant-tagged copy; cross-tenant isolation holds because
                             // the ChromaDB id is also conversation-scoped.
-                            const planUserId = RequestContextService.getUserId();
+                            const planUserId   = RequestContextService.getUserId();
                             const planMetadata = {
                                 sessionId,
                                 timestamp: stats.mtimeMs,
@@ -1050,8 +1053,8 @@ ${sessionContent}
 
         // Fast SQLite check on summarization-job state — gates FINALIZED + BUSY error paths
         // before the more expensive Chroma read.
-        const sqlite = GraphService.db?.storage?.db;
-        let summarizationStatus = 'none';
+        const sqlite              = GraphService.db?.storage?.db;
+        let   summarizationStatus = 'none';
         if (sqlite) {
             try {
                 const row = sqlite.prepare(
@@ -1135,7 +1138,7 @@ ${sessionContent}
         // (same tenant predicate as the Chroma where above) before declaring SESSION_NOT_FOUND.
         if (memoryCount === 0 && sqlite) {
             try {
-                const userId = normalizeUserId(RequestContextService.getUserId());
+                const userId       = normalizeUserId(RequestContextService.getUserId());
                 const tenantClause = userId
                     ? `AND (json_extract(data, '$.properties.userId') = ? OR json_extract(data, '$.properties.userId') = ?)`
                     : '';
@@ -1302,8 +1305,8 @@ ${sessionContent}
         }
 
         const allowCompletedRepair = options.allowCompletedRepair === true;
-        const now = Date.now();
-        const expiresAt = now + ttlMs;
+        const now                  = Date.now();
+        const expiresAt            = now + ttlMs;
 
         try {
             const claimTx = db.transaction(() => {
@@ -1404,7 +1407,7 @@ ${sessionContent}
      */
     async summarizeSessions({ sessionId } = {}) {
         try {
-            let processed = [];
+            let   processed  = [];
             const leaseToken = crypto.randomUUID();
 
             if (sessionId) {
@@ -1447,7 +1450,7 @@ ${sessionContent}
 
                 logger.info(`[SessionService] Found ${total} sessions to summarize. Processing in batches of ${batchSize}...`);
 
-                let completed = 0,
+                let completed     = 0,
                     skippedClaims = 0;
 
                 for (let i = 0; i < total; i += batchSize) {
@@ -1481,7 +1484,7 @@ ${sessionContent}
                         }
                     });
 
-                    const results = await Promise.all(promises);
+                    const results     = await Promise.all(promises);
                     const batchResult = results.filter(Boolean);
 
                     processed.push(...batchResult);

--- a/test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs
@@ -132,4 +132,61 @@ test.describe('SessionService.summarizeSession — memory-fetch pagination (clos
             aiConfig.summarizationBatchLimit = origLimit;
         }
     });
+
+    test('reconstructs a dropped turn-document from split metadata before synthesis (#14211 de-dup read)', async () => {
+        const svc        = SDK.Memory_SessionService,
+              aiConfig   = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
+              origMemGet = svc.memoryCollection.get,
+              origModel  = svc.model,
+              origSess   = svc.sessionsCollection,
+              origLimit  = aiConfig.summarizationBatchLimit;
+
+        aiConfig.summarizationBatchLimit = 10;
+
+        const SESSION = 'pg-dropped-doc';
+
+        // A de-duped turn (post-slice-4): the stored Chroma document is DROPPED (null); only the split
+        // metadata fields remain. The paging reader must reconstruct it, not feed null context to synthesis.
+        const TURN = {
+            id      : 'd0',
+            metadata: {type: 'agent-interaction', sessionId: SESSION, timestamp: 1, prompt: 'PROMPT-X', thought: 'THOUGHT-Y', response: 'RESPONSE-Z'}
+        };
+
+        let synthesisPrompt = null;
+
+        svc.memoryCollection.get = async ({offset = 0, limit} = {}) => {
+            const page = offset === 0 ? [TURN] : [];
+            return {
+                ids      : page.map(r => r.id),
+                documents: page.map(() => null),          // ← dropped document
+                metadatas: page.map(r => r.metadata)
+            };
+        };
+
+        svc.model = {
+            generateContent: async prompt => {
+                synthesisPrompt = prompt;
+                return {response: {text: () => JSON.stringify({
+                    summary: 's', title: 't', category: 'test', quality: 5, productivity: 5, impact: 5, complexity: 5, technologies: []
+                })}};
+            }
+        };
+
+        svc.sessionsCollection = {upsert: async () => {}, get: async () => ({ids: [], metadatas: []})};
+
+        try {
+            await svc.summarizeSession(SESSION);
+
+            // The dropped document was reconstructed from split metadata (via resolveTurnDocumentForRead) and
+            // fed to synthesis as the byte-exact canonical turn-document text — NOT null context.
+            expect(synthesisPrompt).toContain('User Prompt: PROMPT-X');
+            expect(synthesisPrompt).toContain('Agent Thought: THOUGHT-Y');
+            expect(synthesisPrompt).toContain('Agent Response: RESPONSE-Z');
+        } finally {
+            svc.memoryCollection.get         = origMemGet;
+            svc.model                        = origModel;
+            svc.sessionsCollection           = origSess;
+            aiConfig.summarizationBatchLimit = origLimit;
+        }
+    });
 });


### PR DESCRIPTION
## Summary

Slice-4 precondition for the field↔document de-dup. #14210 (**merged 2026-06-27**) is the resolver-owning base, now in `dev`; this PR routes the remaining **runtime** turn-document consumers so they reconstruct a dropped turn-document instead of feeding null context once slice-4 drops stored documents. **Rebased onto `dev` after #14210 merged** — this PR now carries only the three runtime-reader routing commits (the resolver base-commits are in dev).

Resolves #14211

## Change

Routes the two genuine runtime turn-document readers (per @neo-opus-vega's #14193 reader-map) through `resolveTurnDocumentForRead` (which no-ops on summaries via the `type === 'agent-interaction'` discriminator):
- **`DreamService:422`** — REM extraction maps `memoryCollection` documents through the resolver (+ `include: ['metadatas']`).
- **`SessionService:543`** — the REM/digest paging accumulator (its `page.metadatas` is already accumulated at :544); covers the downstream aggregate (:561) + per-turn uses (:721/:725).

Evidence: both read `StorageRouter.getMemoryCollection()` documents directly today.

## Deltas from ticket (if any)

- **Scope corrected by V-B-A (twice).** GoldenPathSynthesizer:907/:1006 are inside / call `getRecentSummaryDocuments` (only caller passes `summaryColl`) → **summaries**, never de-duped → out of scope. `DreamService:160` is an overwritten REM fallback (benign). `SessionService:1106` (validateSessionForResume) is `include:['metadatas']` only → no document read → out of scope.
- **Maintenance-half = a SEPARATE slice-4 precondition (owned by @neo-opus-grace's diagnostics-gate):** `repairMemoryCoreStoredEmbeddings` (the re-embedder — post-drop it must recognize a de-duped record as VALID, not re-embed from a null doc — the silent biter), `checkChromaIntegrity` (the diagnostics-gate), and defrag/export. These are de-dup-state *recognition* in the maintenance domain — out of scope for this runtime-reader PR. **Slice-4 drops only after BOTH halves land.**
- **Whitespace churn (`SessionService`):** the ~36 incidental `=`/`:`-realignment lines are the `check-block-alignment --fix` whole-file over-reach (#14212, claimed by @neo-opus-grace) — whitespace-only (`git diff -w` = just the import + the :543 route), CI-forced (whole-file check). They disappear once #14212 lands.

## Base & CI state

**Rebased onto `dev`** (#14210 merged 2026-06-27, now in dev) at head `7808d8cde` — base is now `dev` and the full CI surface (`unit` / `integration-unified` / `Analyze`) re-triggered on the rebased head (was previously absent because the pre-rebase head was stacked on the unmerged base). The stack cascade is cleared; the diff is the three runtime-reader routing commits only.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test ... DreamService.spec DreamService.executeRemCycle GoldenPathSynthesizer SessionService` → **88 + 39 passed** (behavior-preserving — the resolver returns the stored document when present, so present-doc paths are unchanged). The dropped-document reconstruct is covered by the resolver's own spec (#14210). Both edited files `node --check` clean. @neo-gpt's exact-head rerun: `DreamService.executeRemCycle.spec + SessionService.SummarizePagination.spec` → 19 passed.

## Post-Merge Validation

Once slice-4 drops stored turn-documents, the REM/Dream extraction and the session-digest paging both reconstruct from split metadata instead of null context. Together with MemoryService (#14210), this completes the **runtime-half** of the de-dup readers. It is NOT on its own sufficient to drop documents — slice-4 drops only after the **maintenance-half** (see Deltas) also lands.

## Related

#14193 (epic), #14210 (the resolver + MemoryService routing, stacked-on), #14212 (the --fix over-reach behind the whitespace churn), #14207, #14202.

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f2c722bf-9fb0-4925-8fbc-a9a0788f459c`. Targets `dev` (via the #14210 stack) per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
