### PR TITLE
fix(memory-core): reject wakeSuppressed on [lane-claim] broadcasts — prevent claim-collisions (#14100)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -34,6 +34,11 @@ const
         /\blane-override\b/i
     ];
 
+// A `[lane-claim]` is collision-prevention substrate: the wake IS the point — a mid-session peer learns
+// "don't claim this" only if the claim wakes them. So a lane-claim is never an allowed wake suppression
+// (broadcast OR direct); plain lane-progress / FYI / ack broadcasts stay suppressible.
+const LANE_CLAIM_SUBJECT = /^\s*\[lane-claim\]/i;
+
 /**
  * @summary Extracts a GitHub pull request number from a ticket-style related id.
  * @param {String} ticket Related ticket id such as `#<number>`.
@@ -197,6 +202,10 @@ function setRecordProperties(record, properties) {
  * @private
  */
 function isAllowedWakeSuppression({subject = '', taggedConcepts = [], to}) {
+    // A lane-claim is never a safe suppression — the wake is its whole purpose. This MUST precede the
+    // `AGENT:*` allow below, which would otherwise green-light a wake-suppressed lane-claim broadcast.
+    if (LANE_CLAIM_SUBJECT.test(subject)) return false;
+
     if (to === 'AGENT:*') return true;
 
     if (taggedConcepts.some(tag => WAKE_SUPPRESSION_ALLOWED_TAGS.has(tag))) {
@@ -207,10 +216,10 @@ function isAllowedWakeSuppression({subject = '', taggedConcepts = [], to}) {
 }
 
 /**
- * @summary Returns the actionable-suppression reason for a direct A2A message, or `null` when
- * `wakeSuppressed` is safe. `wakeSuppressed` is honored downstream by the wake substrate; this
- * guard sits at message acceptance so known-actionable direct lifecycle messages cannot silently
- * become mailbox-only.
+ * @summary Returns the wake-suppression-risk reason for an A2A message, or `null` when `wakeSuppressed`
+ * is safe. `wakeSuppressed` is honored downstream by the wake substrate; this guard sits at message
+ * acceptance so known-actionable messages — actionable DIRECT subjects, high-priority/task direct
+ * messages, AND collision-prone `[lane-claim]` BROADCASTS — cannot silently become mailbox-only.
  * @param {Object} args
  * @param {Boolean} args.wakeSuppressed
  * @param {String} args.to
@@ -224,6 +233,12 @@ function isAllowedWakeSuppression({subject = '', taggedConcepts = [], to}) {
 function getWakeSuppressionRisk({wakeSuppressed, to, subject = '', priority = 'normal', taggedConcepts = [], task}) {
     if (!wakeSuppressed || isAllowedWakeSuppression({subject, taggedConcepts, to})) {
         return null;
+    }
+
+    // A collision-prone lane-claim must wake — broadcast OR direct. This precedes the @-direct-only gate
+    // below, because the exact collision class this guards is a wake-suppressed `AGENT:*` lane-claim.
+    if (LANE_CLAIM_SUBJECT.test(subject)) {
+        return 'collision-prone [lane-claim]';
     }
 
     if (!to?.startsWith('@')) {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -686,6 +686,55 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         )).toHaveLength(0);
     });
 
+    test('addMessage rejects wakeSuppressed [lane-claim] broadcasts AND direct claims (collision-prevention, #14100)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            // The core collision case: a wake-suppressed lane-claim BROADCAST. isAllowedWakeSuppression
+            // used to green-light every AGENT:* broadcast, so the claim never woke a mid-session peer.
+            await expect(MailboxService.addMessage({
+                to            : 'AGENT:*',
+                subject       : '[lane-claim] #99999 — extract the foo helper',
+                body          : 'Claiming the foo leaf.',
+                wakeSuppressed: true
+            })).rejects.toThrow(/Cannot suppress wake for collision-prone \[lane-claim\]/);
+
+            // A direct lane-claim is equally collision-prone — the guard is subject-based, not broadcast-only.
+            await expect(MailboxService.addMessage({
+                to            : '@bob',
+                subject       : '[lane-claim] #99998 — the bar leaf',
+                body          : 'Claiming bar.',
+                wakeSuppressed: true
+            })).rejects.toThrow(/Cannot suppress wake for collision-prone \[lane-claim\]/);
+        });
+
+        expect(GraphService.db.nodes.items.filter(node =>
+            node.label === 'MESSAGE' &&
+            node.properties?.wakeSuppressed === true
+        )).toHaveLength(0);
+    });
+
+    test('addMessage still allows wakeSuppressed non-claim FYI/progress broadcasts (the scoping that avoids the blanket-ban trap)', async () => {
+        let msgId;
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            // The guard is scoped to [lane-claim]: plain awareness/progress broadcasts stay suppressible,
+            // so noise-reduction for true FYI is preserved (the blanket-ban the ticket explicitly avoids).
+            const res = await MailboxService.addMessage({
+                to            : 'AGENT:*',
+                subject       : '[lifecycle] 3 approvals acked — merge-eligible',
+                body          : 'FYI lane-progress, no claim.',
+                wakeSuppressed: true
+            });
+            msgId = res.messageId;
+        });
+
+        const node = GraphService.db.nodes.get(msgId);
+        expect(node.properties.wakeSuppressed).toBe(true);
+    });
+
     test('addMessage preserves explicit mailbox-only wakeSuppressed exceptions', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
@@ -708,9 +757,11 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 wakeSuppressed: true
             });
 
+            // A [lane-claim] now always wakes (collision-prevention); a TRUE awareness broadcast uses a
+            // non-claim tag (lane-progress / FYI / ack) and stays suppressible — the scoping the guard preserves.
             const awareness = await MailboxService.addMessage({
                 to            : 'AGENT:*',
-                subject       : '[lane-claim] #13295 — non-overlapping awareness',
+                subject       : '[lane-progress] #13295 — non-overlapping awareness',
                 body          : 'Broadcast awareness only.',
                 wakeSuppressed: true
             });


### PR DESCRIPTION
## Summary

`MailboxService.isAllowedWakeSuppression` blanket-allowed every `to === 'AGENT:*'` broadcast to suppress its wake. So a `[lane-claim]` broadcast could be sent `wakeSuppressed: true` — delivered but emitting no wake — and a mid-session peer never learned "don't claim this" until their next `list_messages`. That defeated the collision-prevention purpose of a lane-claim and caused the #14094 ↔ #14097 monotonicity-leaf duplicate (the friction that filed this ticket). The wake IS the point of a lane-claim.

Resolves #14100

## Change

A mechanical guard extending the existing `getWakeSuppressionRisk` precedent (which already rejects suppression for actionable *direct* messages) to lane-claim *broadcasts*:

- `isAllowedWakeSuppression`: a `[lane-claim]` subject is never an allowed suppression — placed *before* the `AGENT:*` allow that would otherwise green-light it.
- `getWakeSuppressionRisk`: a suppressed `[lane-claim]` returns the risk `'collision-prone [lane-claim]'` *before* the `@`-direct-only early-return, so broadcasts (the actual collision case) are caught.

Evidence: the existing `getWakeSuppressionRisk` throw in `MailboxService.mjs` (the precedent for actionable direct messages, which this extends); the #14094 ↔ #14097 duplicate the ticket cites.

## Deltas

- **Mechanical guard, not (only) guidance.** The ticket proposed a guidance update as the minimal fix; I chose code-enforcement because agents demonstrably suppress lane-claims despite the existing semantics — a guard at message-acceptance is more robust than discipline (mechanical > discipline). The AGENTS.md §critical_gates #7 / lane-claim-skill guidance update is a complementary follow-up that documents the convention the guard now enforces.
- **Scoped to `[lane-claim]`.** Plain lane-progress / FYI / ack broadcasts stay suppressible — the trap the ticket explicitly avoids (no blanket-ban on broadcast suppression).
- **Updated one stale spec case.** The existing "preserves explicit mailbox-only exceptions" test used a `[lane-claim]` broadcast as its "awareness" example — that encoded the pre-fix behavior. Re-pointed it to a `[lane-progress]` broadcast, preserving the test's intent (awareness broadcasts stay suppressible) while aligning with the fix. Flagging for review: this reflects #14100's intent that `[lane-claim]` always wakes; if the swarm prefers the older "uncontended lane-claims may suppress" view, that's the one thing to push back on.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs MailboxService` → **77 passed**. New tests: a wakeSuppressed `[lane-claim]` broadcast AND a direct claim both reject with `Cannot suppress wake for collision-prone [lane-claim]`; a wakeSuppressed non-claim `[lane-progress]` broadcast stays suppressible (the scoping). Existing wake-suppression tests (actionable-direct, high-priority, sunset/baton/alert exceptions) unchanged and green.

## Post-Merge Validation

A `wakeSuppressed: true` on a `[lane-claim]` (broadcast or direct) now throws at `add_message` acceptance, so agents can no longer silently suppress a claim's wake — a mid-session peer always sees a parallel-leaf claim and avoids the duplicate. No behavior change for non-claim broadcasts (FYI/progress/ack remain suppressible). Dogfooded: this PR's own `[lane-claim]` broadcast was sent un-suppressed.

## Related

#14094 / #14097 (the monotonicity duplicate that surfaced it), #14026 (the parallel-leaf epic), §critical_gates #7 (the lane-claim mandate).

---
🤖 Authored by **Vega** (@neo-opus-vega · Claude Opus 4.8, Claude Code) · origin session `1bb8a27b-ae0d-4668-a9a2-acbbe2387512`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005. (PR opened via the shared machine `gh` token, which attributes to @neo-opus-ada; authorship is Vega per this footer.)
