### PR TITLE
feat(ai): dimensionConsistencyGatherer — live-Chroma audit→producer wire-up (#14130 slice-1)

### DIFF
--- a/ai/daemons/orchestrator/services/dimensionConsistencyGatherer.mjs
+++ b/ai/daemons/orchestrator/services/dimensionConsistencyGatherer.mjs
@@ -1,0 +1,48 @@
+/**
+ * @module ai/daemons/orchestrator/services/dimensionConsistencyGatherer
+ * @summary Orchestrator live-Chroma gatherer for the dimension-consistency detect signal — the audit +
+ * scheduling half that `dimensionConsistencyDiagnosis` (detect-only, samples-injected) deliberately omits.
+ *
+ * It runs the pure, embedder-free `auditCollectionVectorDimensions` primitive across the supplied live
+ * collections to produce the producer's per-collection samples, then feeds them to
+ * `buildDimensionConsistencyDiagnosis` to emit a `recovery-diagnosis` (or `null` when every sampled
+ * collection's vectors match the configured embedding dimension).
+ *
+ * Degrade-not-throw: the audit primitive returns a zero-count sample with an `error` field on probe failure
+ * rather than throwing, so one unreachable collection never aborts the gather — the remaining collections'
+ * mismatches still surface. The audit is a read-only `.get` and does NOT invoke the embedder, so this
+ * gatherer is not gated by the embed canary. Pure-ish: the only I/O is the injected collections' reads.
+ */
+
+import {auditCollectionVectorDimensions}    from '../../../scripts/maintenance/checkChromaIntegrity.mjs';
+import {buildDimensionConsistencyDiagnosis} from './dimensionConsistencyDiagnosis.mjs';
+
+/**
+ * @summary Gathers per-collection vector-dimension samples from live Chroma collections and builds a
+ * dimension-consistency `recovery-diagnosis`.
+ *
+ * @param {Object} options
+ * @param {Array<{collection: Object, collectionName: String}>} [options.collections=[]] Live collections to audit.
+ * @param {Number} options.expectedDimension The configured embedding dimension.
+ * @param {String} options.serviceId The Memory Core compose-service identifier.
+ * @param {Number} options.observedAt Epoch milliseconds when the audit is observed.
+ * @param {Number} [options.sampleSize=100] Vectors to sample per collection.
+ * @param {Function} [options.auditFn=auditCollectionVectorDimensions] The dimension-audit primitive — injectable for tests.
+ * @returns {Promise<Object|null>} A `recovery-diagnosis` event when any collection has a dimension mismatch, else `null`.
+ */
+export async function gatherDimensionConsistencyDiagnosis({
+    collections      = [],
+    expectedDimension,
+    serviceId,
+    observedAt,
+    sampleSize       = 100,
+    auditFn          = auditCollectionVectorDimensions
+} = {}) {
+    const samples = [];
+
+    for (const {collection, collectionName} of collections) {
+        samples.push(await auditFn({collection, collectionName, expectedDimension, sampleSize}));
+    }
+
+    return buildDimensionConsistencyDiagnosis({samples, observedAt, serviceId});
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/dimensionConsistencyGatherer.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/dimensionConsistencyGatherer.spec.mjs
@@ -1,0 +1,41 @@
+import {test, expect}                        from '@playwright/test';
+import Neo                                   from '../../../../../../../src/Neo.mjs';
+import * as core                             from '../../../../../../../src/core/_export.mjs';
+import {gatherDimensionConsistencyDiagnosis} from '../../../../../../../ai/daemons/orchestrator/services/dimensionConsistencyGatherer.mjs';
+
+// The live-Chroma audit+scheduling half of the dimension-consistency detect signal: it samples each
+// collection via the (injected) dimension-audit primitive and feeds the samples to the pure producer.
+
+const collections = [{collection: {}, collectionName: 'c1'}, {collection: {}, collectionName: 'c2'}];
+const matchSample = name => ({collection: name, expectedDimension: 1024, mismatchedVectorCount: 0, sampledCount: 100});
+
+test.describe('dimensionConsistencyGatherer', () => {
+    test('samples every collection (one audit call each) and builds a diagnosis on a mismatch', async () => {
+        const audited = [];
+        const auditFn = async ({collectionName}) => {
+            audited.push(collectionName);
+            return collectionName === 'c1'
+                ? {collection: 'c1', expectedDimension: 1024, mismatchedVectorCount: 3, sampledCount: 100}
+                : matchSample('c2');
+        };
+        const diagnosis = await gatherDimensionConsistencyDiagnosis({collections, expectedDimension: 1024, serviceId: 'svc', observedAt: 1000, auditFn});
+        expect(audited).toEqual(['c1', 'c2']);
+        expect(diagnosis).not.toBeNull()
+    });
+
+    test('returns null when every sampled collection matches the dimension', async () => {
+        const auditFn = async ({collectionName}) => matchSample(collectionName);
+        expect(await gatherDimensionConsistencyDiagnosis({collections, expectedDimension: 1024, serviceId: 'svc', observedAt: 1000, auditFn})).toBeNull()
+    });
+
+    test('empty collections → null (nothing to diagnose)', async () => {
+        expect(await gatherDimensionConsistencyDiagnosis({collections: [], expectedDimension: 1024, serviceId: 'svc', observedAt: 1000})).toBeNull()
+    });
+
+    test('a degraded audit (probe error, zero count) does not abort the gather — other mismatches still surface', async () => {
+        const auditFn = async ({collectionName}) => collectionName === 'c1'
+            ? {collection: 'c1', expectedDimension: 1024, mismatchedVectorCount: 0, sampledCount: 0, error: 'unreachable'}
+            : {collection: 'c2', expectedDimension: 1024, mismatchedVectorCount: 2, sampledCount: 100};
+        expect(await gatherDimensionConsistencyDiagnosis({collections, expectedDimension: 1024, serviceId: 'svc', observedAt: 1000, auditFn})).not.toBeNull()
+    })
+});


### PR DESCRIPTION
## Summary

#14130 (Slice B) needs a live-Chroma gatherer that turns the dimension-audit primitive into the data-integrity runner's evidence. This is its primitive-first half — the gatherer function — buildable off dev because both inputs already exist there.

Resolves #14215 — slice 1 of #14130.

## Change

`gatherDimensionConsistencyDiagnosis(...)` runs `auditCollectionVectorDimensions` (#14113) across the supplied live collections → per-collection samples → `buildDimensionConsistencyDiagnosis` (#14104) → a `recovery-diagnosis` (null when all collections match). `auditFn` is injectable (defaults to the real primitive) for tests.

Evidence: `auditCollectionVectorDimensions` returns exactly the producer's sample shape (`{collection, expectedDimension, mismatchedVectorCount, sampledCount}`) and is degrade-not-throw + embedder-free (read-only `.get`, no embedder → not embed-canary-gated).

## Deltas from ticket (if any)

- **Primitive-first / off-dev split.** The gatherer FUNCTION is interface-stable — it emits a standard `recovery-diagnosis` regardless of the runner's escalate-vs-heal routing — so it ships off dev with no #14184 dependency. The runner **injection** (#14130 slice-2: wiring it into `DataIntegrityDiagnosisService`'s evidence seam) targets #14184's post-cutover runner and is gated on its 8am merge.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs dimensionConsistencyGatherer` → **4 passed**: samples every collection (one audit call each) + builds a diagnosis on a mismatch; returns null when all match; empty collections → null; a degraded probe (error / zero-count) does not abort the gather (other collections' mismatches still surface). `node --check` clean.

## Post-Merge Validation

The gatherer produces a dimension-consistency `recovery-diagnosis` from live collections, embedder-free + degrade-safe. Slice-2 injects it into the data-integrity runner once #14184's cutover lands — completing #14130.

## Related

#14130 (parent / Slice B), #14113 (audit primitive), #14104 (producer), #14184 (runner cutover — slice-2 gate), #14132 (v13.1 self-heal epic).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f2c722bf-9fb0-4925-8fbc-a9a0788f459c`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
