### PR TITLE
fix(buildScripts): block-alignment keeps single-line template-valued properties in their alignment run (#14212)

### DIFF
--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -400,11 +400,15 @@ function evaluateAssignmentAlignment(lines, maskedLines = []) {
 const EVALUATORS = [evaluateImportAlignment, evaluateColonAlignment, evaluateAssignmentAlignment];
 
 /**
- * @summary Computes which lines contain template-literal string content, excluding JavaScript code
- * inside `${...}` expressions. Backticks in comments, quoted strings, and escaped template content do
- * not toggle the mask.
+ * @summary Computes which lines BEGIN inside a template literal — i.e. are template-text continuations of
+ * a multi-line template opened on an earlier line. Such a line is not its own declaration and must break
+ * the alignment runs. A line that merely CONTAINS a single-line template value (e.g. a property whose
+ * value is a one-line template) begins in code and is NOT flagged, so it stays in its run. (A prior
+ * version flagged any line containing template content, which split a run at a single-line template-valued
+ * property — leaving the keys before it tight and the rest far.) Backticks in comments, quoted strings,
+ * and escaped content do not open a template.
  * @param {String[]} lines
- * @returns {Boolean[]}
+ * @returns {Boolean[]} Per-line: does the line begin inside an unclosed template literal?
  */
 function computeTemplateLiteralLineMask(lines) {
     const
@@ -420,6 +424,13 @@ function computeTemplateLiteralLineMask(lines) {
     for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
         const line = lines[lineIndex];
         let   i    = 0;
+
+        // A run member must START in code. A line that begins INSIDE a template literal is a continuation
+        // (template text, not its own declaration) and must break the alignment run. A line that merely
+        // CONTAINS a single-line template value begins in code and must STAY in its run — capturing the
+        // line-START template state (not any-template-content-on-the-line) keeps a single-line
+        // template-valued property aligned with its block.
+        maskedLines[lineIndex] = stack.some(frame => frame.type === 'template');
 
         while (i < line.length) {
             const
@@ -451,14 +462,12 @@ function computeTemplateLiteralLineMask(lines) {
 
             if (ctx.type === 'template') {
                 if (templateEscape) {
-                    maskedLines[lineIndex] = true;
                     templateEscape = false;
                     i++;
                     continue;
                 }
 
                 if (ch === '\\') {
-                    maskedLines[lineIndex] = true;
                     templateEscape = true;
                     i++;
                     continue;
@@ -476,7 +485,6 @@ function computeTemplateLiteralLineMask(lines) {
                     continue;
                 }
 
-                maskedLines[lineIndex] = true;
                 i++;
                 continue;
             }

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -186,6 +186,31 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
             expect(fs.readFileSync(file, 'utf8')).toBe(before);
         });
 
+        test('a single-line template-valued property stays in its run — all keys align, not split (#14212)', () => {
+            // Regression: a property whose VALUE is a single-line template begins in code, so it must stay
+            // in its colon-alignment run. A prior mask flagged any line containing template content, which
+            // split the run here — leaving the keys before it tight and the rest far.
+            const file = write('tmpl-value.mjs', [
+                'const node = {',
+                '    id: memoryId,',
+                '    type: nodeType,',
+                '    name: `Memory: ${timestamp}`,',
+                '    semanticVectorId: memoryId',
+                '};'
+            ].join('\n'));
+
+            expect(run('--fix', file).status).toBe(0);
+
+            const colonCols = fs.readFileSync(file, 'utf8').split('\n')
+                .filter(line => /^\s+\w+\s*:/.test(line))
+                .map(line => line.indexOf(':'));
+
+            expect(colonCols.length).toBe(4);
+            expect(new Set(colonCols).size).toBe(1);     // id/type/name/semanticVectorId share one column — the template value did not split the run
+            expect(run(file).status).toBe(0);            // aligned → clean
+            expect(run('--fix', file).status).toBe(0);   // idempotent
+        });
+
         test('template masking ignores quoted/comment backticks and preserves real object fixes (#13670)', () => {
             const file = write('prompt-edge.mjs', [
                 'const quoted = "`";',


### PR DESCRIPTION
## Summary

`check-block-alignment.mjs --fix` split an object's colon-alignment run at any property whose value is a single-line template literal — leaving the keys before it tightly-aligned and the rest far. This is the `_projectMemoryToGraph` regression in #14212 (`id`/`type` tightened to their own column while the template-valued `name`/`description` + `semanticVectorId` stayed far). Root cause: the template-literal line mask flagged ANY line *containing* template content, excluding a real property whose value merely *is* a one-line template.

Resolves #14212 — Bug 2 (the tight+far regression) directly; Bug 1 (whole-file over-reach) disposition in Post-Merge.

## Deltas

- `computeTemplateLiteralLineMask` now flags a line iff it **begins** inside a template literal (a true multi-line continuation) — captured from the scanner's line-START stack state — not iff it *contains* any template content. A property whose value is a single-line template begins in code and stays in its colon / `=` / import run; a genuine multi-line-template continuation still breaks the run.
- JSDoc updated to the corrected semantics.
- Reproducer + idempotency test (the `_projectMemoryToGraph` shape).

## Verify-Before-Assert

- The fix is the precise signal: `stack.some(frame => frame.type === 'template')` at line-start = "is this line a template continuation?" — distinguishing a single-line template VALUE (starts in code, real property → stays) from a continuation (starts in template → breaks). The naive "colon-before-first-backtick" heuristic was rejected: it false-positives a continuation whose template content has a colon before the closing backtick.
- Existing template tests still pass (#13670: JSON-example templates not flagged; quoted/comment backticks ignored) — multi-line continuations remain correctly excluded.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs check-block-alignment` → **24/24** (23 existing + the new single-line-template-value reproducer). `node --check` clean; husky (jsdoc-types + ticket-archaeology + block-alignment --staged) pass.

Evidence: 24/24 check-block-alignment unit green (incl. the new reproducer + idempotency assertions); zero regression in the existing template-masking suite.

## Post-Merge Validation

Hot files with template-valued config objects (e.g. `MemoryService._projectMemoryToGraph`) no longer get their alignment runs split by `--fix`.

**Bug 1 (whole-file over-reach) disposition — why this PR resolves #14212:** the reported "~10 unrelated hunks" were largely Bug-2-driven — the tool computed a *wrong* alignment for template-valued runs and re-touched blocks across the file. With Bug 2 fixed the alignment is correct + idempotent, so the **spurious re-touch churn is gone** (a `--fix` on an already-correctly-aligned file now produces no hunks). The residual whole-file behavior — `--fix` fixing genuinely-misaligned *untouched* blocks (boy-scout) — is the existing intentional design (whole-file alignment-on-touch). If a `--fix`-respects-`--staged` diff-scope is later desired, that is a separate new enhancement, not this regression — file it fresh rather than hold #14212 open on a by-design behavior.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 090a68e6-1a28-4b20-a5fd-842ebac3e729.

Resolves #14212
