### PR TITLE
fix(ai): reconstruct dropped turn-documents in the embed-repair re-embed — recover de-duped turns (#14218)

### DIFF
--- a/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
+++ b/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
@@ -21,7 +21,8 @@
  * @module Neo.ai.scripts.maintenance.repairMemoryCoreStoredEmbeddings
  */
 
-import {bytesToTokens} from '../../services/memory-core/helpers/consumerFrictionHelper.mjs';
+import {bytesToTokens}              from '../../services/memory-core/helpers/consumerFrictionHelper.mjs';
+import {resolveTurnDocumentForRead} from '../../services/memory-core/helpers/turnDocumentText.mjs';
 
 /**
  * @summary Extracts a Memory Core collection's data for a shadow rebuild, RE-EMBEDDING the rows whose
@@ -137,8 +138,14 @@ export async function extractMemoryCoreCollectionData({
         const reEmbedIds = [], reEmbedDocs = [], reEmbedMetas = [];
 
         for (let j = 0; j < (got.ids?.length || 0); j++) {
-            const doc             = got.documents?.[j],
-                  documentProblem = getDocumentProblem(doc);
+            // Field↔document de-dup: a dropped turn-document (falsy doc + turn metadata) is reconstructed
+            // from its split metadata so its missing vector is recovered, not marked unrecoverable. Non-turn
+            // rows and present documents are unchanged — the empty/missing classification below still applies.
+            let doc = got.documents?.[j];
+            if (!doc && got.metadatas?.[j]?.type === 'agent-interaction') {
+                doc = resolveTurnDocumentForRead({documents: [], metadata: got.metadatas[j]});
+            }
+            const documentProblem = getDocumentProblem(doc);
 
             if (documentProblem) {
                 recordUnrecoverable({

--- a/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
@@ -126,6 +126,37 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         expect(result.counts).toEqual({total: 3, intact: 0, reEmbedded: 1, unrecoverable: 2});
     });
 
+    test('a de-duped turn (dropped document, split turn metadata) is reconstructed + re-embedded, not unrecoverable (#14218)', async () => {
+        let   embeddedDocs = [];
+        const embedFn      = async docs => { embeddedDocs = docs; return docs.map(() => [4, 4]); };
+        const rows         = {
+            intact : {embedding: [1, 1], document: 'doc-a', metadata: {type: 'agent-interaction'}},
+            // missing-vector row whose stored document the de-dup dropped — only the split fields remain:
+            deduped: {metadata: {type: 'agent-interaction', prompt: 'p', thought: 't', response: 'r'}}
+        };
+
+        const result = await extractMemoryCoreCollectionData({
+            collection: makeCollection(rows), allIds: ['intact', 'deduped'], missingVectorIds: ['deduped'], embedFn
+        });
+
+        // The dropped turn-document is reconstructed from its split metadata (byte-identical to the write)
+        // and re-embedded — recovered, NOT marked unrecoverable.
+        expect(result.counts).toEqual({total: 2, intact: 1, reEmbedded: 1, unrecoverable: 0});
+        expect(embeddedDocs).toEqual(['User Prompt: p\nAgent Thought: t\nAgent Response: r']);
+    });
+
+    test('a missing-vector NON-turn (summary) with a dropped document stays unrecoverable — no false recovery (#14218)', async () => {
+        const embedFn = async docs => docs.map(() => [5]);
+        // a summary (non-turn) is never reconstructed via the turn template; a dropped doc → unrecoverable
+        const rows = {summary: {metadata: {type: 'session-summary'}}};
+
+        const result = await extractMemoryCoreCollectionData({
+            collection: makeCollection(rows), allIds: ['summary'], missingVectorIds: ['summary'], embedFn
+        });
+
+        expect(result.counts).toEqual({total: 1, intact: 0, reEmbedded: 0, unrecoverable: 1});
+    });
+
     test('a missing id absent from the metadata read is unrecoverable', async () => {
         const rows    = {n: {document: 'dn', metadata: {}}}; // 'gone' is not in the row map
         const embedFn = async docs => docs.map(() => [5]);


### PR DESCRIPTION
## Summary

Slice-4 of the #14193 field↔document de-dup — the **embed-repair reader-adoption** (the re-embedder half of the slice-4 split; Grace keeps the diagnostics gate). `repairMemoryCoreStoredEmbeddings` re-embeds missing-vector rows from their stored Chroma document. Once slice-4 drops the redundant turn-document, a de-duped turn's missing-vector row reads a falsy doc → `getDocumentProblem` marks it `document-empty`/unrecoverable — though it's fully reconstructable from the split metadata fields. So the re-embed safety-net would fail to recover **exactly the de-duped turns it exists to fix** — the circularity surfaced in my #14193 cross-reader audit.

Resolves #14218.

## Change

Type-aware reconstruct at the re-embed read: when the stored doc is falsy AND the row is a turn (`metadata.type === 'agent-interaction'`), reconstruct via `resolveTurnDocumentForRead` (#14210) before re-embedding. Non-turn rows and present documents are unchanged — the `document-empty` / `document-missing` classification is preserved for genuinely-unrecoverable rows (a summary with a dropped doc stays unrecoverable; it has a distinct shape and must not be reconstructed through the turn template).

Stacked on #14210 (`grace/14193-slice3-read-reconstruct` — the resolver); retargets to dev on #14210 merge. Honors the agreed **readers-first** sequencing (reader-adoption before the drop).

Evidence: the re-embed read in `repairMemoryCoreStoredEmbeddings` (`got.documents?.[j]` → `getDocumentProblem`); the resolver `resolveTurnDocumentForRead` (#14210); the #14193 cross-reader audit that identified this as 1 of the 3 critical readers.

## Deltas from ticket (if any)

- Scope is exactly the re-embedder, per the slice-4 split Grace confirmed (I take the re-embedder; she keeps `checkChromaIntegrity` + defrag/export). The other 2 critical turn-readers (DreamService, SessionService) are Ada's #14213. The drop+migration is the last slice (Grace/Ada co-driven).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs repairMemoryCoreStoredEmbeddings` → **22/22** (20 existing + 2 new): a missing-vector TURN with a dropped doc reconstructs + re-embeds; a missing-vector NON-turn summary with a dropped doc stays unrecoverable. The existing `document-empty` / `document-missing` tests still pass — classification is preserved for non-turns.

## Post-Merge Validation

After this + the slice-4 drop, a de-duped turn whose vector goes missing is re-embedded from the reconstructed document (not marked unrecoverable); a non-turn (summary) with a missing doc still correctly reports unrecoverable. Inert until the drop (stored docs still present → the falsy-doc reconstruct path doesn't fire), so it's safe to land ahead of the drop.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8, Claude Code). Origin Session: 1bb8a27b-ae0d-4668-a9a2-acbbe2387512. Targets dev (via the #14210 stack) per the agent-PR gate — never main.
