### PR TITLE
docs(agentos): codify stacked PR review-after-rebase norm (#14220)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -242,7 +242,7 @@ Reviewers MUST verify testing claims and canonical file placement:
 
 ### 7.6 CI / Security Checks Audit
 
-Formal reviews assume green current-head CI. Verify it before `manage_pr_review`; if checks are pending, missing, or failing, send a compact CI deferral instead of a full review. For stacked PRs (`baseRefName` not `dev` / default), approval/merge-ready wording also names base state + retarget/full-CI status; child-green alone is delta evidence. Load `.agents/skills/pr-review/audits/ci-security-audit.md` only for security-sensitive changes or ambiguous/failing check surfaces.
+Formal reviews assume green current-head CI. Verify before `manage_pr_review`; if checks are pending, missing, failing, or a stacked PR is lint-only (`baseRefName` not `dev` / default), send a compact CI deferral. Full-CI stacked approvals must name base state + retarget status; child-green alone is delta evidence. Load `.agents/skills/pr-review/audits/ci-security-audit.md` only for security-sensitive changes or ambiguous/failing check surfaces.
 
 ### 7.7 Anti-Patterns
 

--- a/.agents/skills/pull-request/references/ci-green-review-routing.md
+++ b/.agents/skills/pull-request/references/ci-green-review-routing.md
@@ -20,7 +20,11 @@ gh pr checks <PR_NUMBER>
 
 Use an equivalent read-only GitHub status surface only if `gh pr checks` is unavailable, and state that substitution explicitly in the PR/A2A handoff. Re-run the check after any new push before requesting review or re-review.
 
-Treat the check as current-head scoped. Re-check after peer work; for stacked PRs (`baseRefName` not `dev` / default), green means delta evidence and the handoff names base PR / merge order / retarget-CI state.
+Treat the check as current-head scoped. Re-check after peer work. Stacked PRs
+(`baseRefName` not `dev` / default) with lint-only green are observer/no-action:
+name base PR / merge order / retarget-CI, then request primary cross-family
+review only after dev-rebase/full CI. Full-CI stacked heads still name base
+state.
 
 ## 3. Outcome Branches
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -166,6 +166,10 @@ You MUST follow this exact handoff protocol:
 PR Review state (`reviewDecision: APPROVED`); a comment alone is insufficient.
 Author family is resolved from the §5 Social Name, with `author.login` fallback.
 
+Stacked PRs (`baseRefName` not `dev` / default): cross-family approval belongs
+to the dev-rebased full-CI merge candidate; same-family delta review is not a
+substitute.
+
 A formal `reviewDecision: APPROVED` is necessary but NOT sufficient: a non-empty `reviewRequests`
 blocks merge-handoff until each requested reviewer is disposed. `validateMergeReady` encodes this.
 


### PR DESCRIPTION
Resolves #14220

Codifies the stacked-PR review-after-dev-rebase norm in the existing author and reviewer workflow payloads. Stacked lint-only heads now route as observer/no-action on the author side, reviewer-side formal approval defers until dev-rebase/full CI, and the cross-family mandate explicitly attaches to the dev-rebased full-CI merge candidate.

Evidence: L1 (static Agent OS skill-substrate validation) -> L1 required (#14220 workflow ACs). Residual: none.

## Deltas from ticket

- Implemented Option A only: no CI workflow expansion and no extra full-CI spend on intermediate stacked heads.
- Corrected the source-of-authority during intake: `ADR-0019` is AiConfig-specific; this PR aligns with `pull-request-workflow.md §6.1/§6.2`, `ci-green-review-routing.md`, and `pr-review-guide.md §7.6`.
- Posted the required T3 Contract Ledger on #14220 before implementation: https://github.com/neomjs/neo/issues/14220#issuecomment-4815943114

## Slot Rationale / Turn Memory Pre-Flight

- Always-loaded routers are unchanged.
- Modified workflow payload sections use `rewrite` / compact insertion disposition: the existing stacked-PR retarget wording gains the missing review-after-rebase sequencing.
- Trigger-frequency: edge-case (stacked PRs); failure-severity: high (false cross-family merge-gate approval on lint-only heads); enforceability: discipline-only until a mechanical reviewer/author router exists.
- Net skill Markdown growth stays within `lint-skill-manifest` pointer-sized limits.
- Decision Record impact: none; source-of-authority correction noted above.

## Test Evidence

- `git diff --check` -> pass.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> pass.
- `node ai/scripts/lint/lint-agents.mjs` -> pass.
- `npm run agent-preflight -- .agents/skills/pull-request/references/ci-green-review-routing.md .agents/skills/pull-request/references/pull-request-workflow.md .agents/skills/pr-review/references/pr-review-guide.md` -> pass.
- Pre-commit hook ran `node ./buildScripts/util/check-whitespace.mjs` -> pass.
- No Playwright run: markdown-only Agent OS workflow substrate.

## Post-Merge Validation

- [ ] The next stacked lint-only PR handoff uses observer/no-action instead of assigning a primary cross-family reviewer.
- [ ] The next cross-family reviewer seeing a stacked lint-only head posts CI deferral and waits for dev-rebase/full CI before formal approval.

## Commits

- `6c78528dd2` — `docs(agentos): codify stacked PR review-after-rebase norm (#14220)`

Authored by Euclid (GPT-5, Codex Desktop). Session a725cf68-d74a-4037-9feb-22e2ac5947eb.
