### PR TITLE
feat(ai): enforce the atomic vector-write invariant at the DatabaseService import gate (#14029)

### DIFF
--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -6,6 +6,7 @@ import readline                  from 'readline';
 import Base                      from '../../../src/core/Base.mjs';
 import StorageRouter             from './managers/StorageRouter.mjs';
 import DestructiveOperationGuard from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+import {partitionRowsByVectorValidity, summarizeVectorRejections} from './helpers/vectorWriteInvariant.mjs';
 
 /**
  * @summary Service for exporting and importing memory core data.
@@ -505,6 +506,11 @@ class DatabaseService extends Base {
                 memoriesInserted: 0
             };
 
+            // Atomic vector-write invariant: an explicit-embedding import must carry a valid same-dimension
+            // vector — a row whose vector is missing/empty/wrong-dim/non-finite is rejected fail-loud rather
+            // than half-persisted as metadata-only (the corruption shape the invariant exists to prevent).
+            const expectedDimension = aiConfig.vectorDimension;
+
             for (const filePath of filesToImport) {
                 logger.log(`Importing: ${filePath}`);
 
@@ -583,7 +589,21 @@ class DatabaseService extends Base {
                     }
 
                     for (let i = 0; i < missing.length; i += CHROMA_UPSERT_CHUNK_SIZE) {
-                        const chunk = missing.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE);
+                        let chunk = missing.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE);
+                        // reEmbed strips vectors (Chroma re-embeds), so the invariant guards only the
+                        // explicit-embedding path: reject any row lacking a valid same-dimension vector.
+                        if (!reEmbed) {
+                            const {valid, rejected} = partitionRowsByVectorValidity({rows: chunk, expectedDimension});
+                            if (rejected.length > 0) {
+                                const {count, byReason} = summarizeVectorRejections(rejected);
+                                logger.error(`[importMemories] vector-write invariant rejected ${count} row(s) without a valid same-dimension vector ${JSON.stringify(byReason)} — not persisted`);
+                                fileFailed += rejected.length;
+                            }
+                            chunk = valid;
+                        }
+                        if (chunk.length === 0) {
+                            continue;
+                        }
                         try {
                             await collection.add({
                                 ids       : chunk.map(r => r.id),
@@ -604,8 +624,23 @@ class DatabaseService extends Base {
                     // Replace mode: subsystem already truncated above; upsert is safe
                     // (no live rows to collide with). Fail-fast on chunk error matches
                     // fail-fast behavior; the outer try/catch wraps it as DATABASE_IMPORT_ERROR.
+                    let replaceRejected = 0;
                     for (let i = 0; i < records.length; i += CHROMA_UPSERT_CHUNK_SIZE) {
-                        const chunk = records.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE);
+                        let chunk = records.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE);
+                        // reEmbed strips vectors (Chroma re-embeds), so the invariant guards only the
+                        // explicit-embedding path: reject any row lacking a valid same-dimension vector.
+                        if (!reEmbed) {
+                            const {valid, rejected} = partitionRowsByVectorValidity({rows: chunk, expectedDimension});
+                            if (rejected.length > 0) {
+                                const {count, byReason} = summarizeVectorRejections(rejected);
+                                logger.error(`[importMemories] vector-write invariant rejected ${count} row(s) without a valid same-dimension vector ${JSON.stringify(byReason)} — not persisted`);
+                                replaceRejected += rejected.length;
+                            }
+                            chunk = valid;
+                        }
+                        if (chunk.length === 0) {
+                            continue;
+                        }
                         await collection.upsert({
                             ids       : chunk.map(r => r.id),
                             embeddings: chunk.map(r => r.embedding),
@@ -616,7 +651,8 @@ class DatabaseService extends Base {
                             logger.log(`  upserted chunk ${Math.floor(i / CHROMA_UPSERT_CHUNK_SIZE) + 1}/${Math.ceil(records.length / CHROMA_UPSERT_CHUNK_SIZE)} (${chunk.length} records)`);
                         }
                     }
-                    fileInserted = records.length;
+                    fileFailed   += replaceRejected;
+                    fileInserted  = records.length - replaceRejected;
                 }
 
                 chromaCounts.inserted            += fileInserted;

--- a/test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs
@@ -15,17 +15,17 @@ setup({
     }
 });
 
-import {test, expect}   from '@playwright/test';
-import Neo              from '../../../../../../src/Neo.mjs';
-import * as core        from '../../../../../../src/core/_export.mjs';
-import InstanceManager  from '../../../../../../src/manager/Instance.mjs';
-import {execFile}       from 'child_process';
-import fs               from 'fs';
-import fsExtra          from 'fs-extra';
-import os               from 'os';
-import path             from 'path';
-import {fileURLToPath}  from 'url';
-import {promisify}      from 'util';
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+import {execFile}      from 'child_process';
+import fs              from 'fs';
+import fsExtra         from 'fs-extra';
+import os              from 'os';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import {promisify}     from 'util';
 
 const execFileAsync = promisify(execFile);
 const __filename    = fileURLToPath(import.meta.url);
@@ -85,8 +85,8 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
         const {validateBundle} = await import('../../../../../../ai/scripts/maintenance/restore.mjs');
 
         const workRoot = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'restore-hardening-validate-'));
-        const bundle = path.join(workRoot, 'bundle');
-        const subdirs = ['kb', 'mc', 'graph', 'concepts', 'trajectories'];
+        const bundle   = path.join(workRoot, 'bundle');
+        const subdirs  = ['kb', 'mc', 'graph', 'concepts', 'trajectories'];
         for (const s of subdirs) await fsExtra.ensureDir(path.join(bundle, s));
         // Plant one JSONL file per subdir
         await fsExtra.writeFile(path.join(bundle, 'kb', 'k.jsonl'), '{"id":"k1"}\n');
@@ -97,8 +97,8 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
 
         // Spy on fs-extra.readFile — assert it is NOT called for the JSONL parseability
         // sanity check (the bug path that overflows V8 string cap on >512MB files).
-        const fsExtraMod = await import('fs-extra');
-        const realReadFile = fsExtraMod.default.readFile;
+        const fsExtraMod    = await import('fs-extra');
+        const realReadFile  = fsExtraMod.default.readFile;
         const readFileCalls = [];
         fsExtraMod.default.readFile = function (...args) {
             readFileCalls.push(args[0]);
@@ -107,12 +107,12 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
 
         try {
             const layout = {
-                kb: path.join(bundle, 'kb'),
-                mc: path.join(bundle, 'mc'),
-                graph: path.join(bundle, 'graph'),
-                concepts: path.join(bundle, 'concepts'),
+                kb          : path.join(bundle, 'kb'),
+                mc          : path.join(bundle, 'mc'),
+                graph       : path.join(bundle, 'graph'),
+                concepts    : path.join(bundle, 'concepts'),
                 trajectories: path.join(bundle, 'trajectories'),
-                mailbox: path.join(bundle, 'mailbox')
+                mailbox     : path.join(bundle, 'mailbox')
             };
             await validateBundle(bundle, layout, {log: () => {}, warn: () => {}});
 
@@ -140,14 +140,21 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
         // records, every backup ID is "missing" → 1000 records still chunk into 4
         // chunks of 250 (same CHROMA_UPSERT_CHUNK_SIZE budget). Also assert the
         // existence-preflight is chunked at the same boundary.
-        const SDK = await import('../../../../../../ai/services.mjs');
+        const SDK                    = await import('../../../../../../ai/services.mjs');
         const Memory_DatabaseService = SDK.Memory_DatabaseService;
         const Memory_StorageRouter   = SDK.Memory_StorageRouter;
 
-        const addCalls    = [];
-        const getCalls    = [];
+        // This test exercises chunking, not vector validity — its fixtures use length-1 embeddings.
+        // Align the atomic vector-write gate's expected dimension so it doesn't reject them pre-persist.
+        // Restored in the finally to avoid cross-spec singleton bleed.
+        const aiConfig                = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const originalVectorDimension = aiConfig.vectorDimension;
+        aiConfig.vectorDimension = 1;
+
+        const addCalls       = [];
+        const getCalls       = [];
         const mockCollection = {
-            name: 'neo-agent-memory',
+            name  : 'neo-agent-memory',
             get   : async ({ids}) => { getCalls.push(ids.length); return {ids: []}; },
             add   : async ({ids}) => { addCalls.push(ids.length); },
             upsert: async ({ids}) => { addCalls.push(ids.length); } // replace-mode path safety
@@ -160,7 +167,7 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
         // Build synthetic JSONL bundle dir with 1000 records (> CHROMA_UPSERT_CHUNK_SIZE
         // of 250 → expect ⌈1000/250⌉ = 4 add() calls + 4 get() preflight calls).
         const workRoot = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'restore-hardening-chunk-'));
-        const mcDir   = path.join(workRoot, 'mc-import');
+        const mcDir    = path.join(workRoot, 'mc-import');
         await fsExtra.ensureDir(mcDir);
         const lines = [];
         for (let i = 0; i < 1000; i++) {
@@ -193,6 +200,7 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
                 expect(callSize).toBeLessThanOrEqual(250);
             }
         } finally {
+            aiConfig.vectorDimension = originalVectorDimension;
             Memory_StorageRouter.getMemoryCollection = originalGetMemColl;
             Memory_StorageRouter.getSummaryCollection = originalGetSumColl;
             await fsExtra.remove(workRoot);

--- a/test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs
@@ -144,12 +144,11 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
         const Memory_DatabaseService = SDK.Memory_DatabaseService;
         const Memory_StorageRouter   = SDK.Memory_StorageRouter;
 
-        // This test exercises chunking, not vector validity — its fixtures use length-1 embeddings.
-        // Align the atomic vector-write gate's expected dimension so it doesn't reject them pre-persist.
-        // Restored in the finally to avoid cross-spec singleton bleed.
-        const aiConfig                = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-        const originalVectorDimension = aiConfig.vectorDimension;
-        aiConfig.vectorDimension = 1;
+        // This test exercises chunking, not vector validity. Build fixtures AT the resolved
+        // aiConfig.vectorDimension (READ it, never mutate — the reactive Provider SSOT must not be written
+        // from a test) so they pass the atomic vector-write gate authentically.
+        const aiConfig       = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const validEmbedding = new Array(aiConfig.vectorDimension).fill(0);
 
         const addCalls       = [];
         const getCalls       = [];
@@ -173,7 +172,7 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
         for (let i = 0; i < 1000; i++) {
             lines.push(JSON.stringify({
                 id       : `m-${i}`,
-                embedding: [0.1 + i * 0.0001],
+                embedding: validEmbedding,
                 metadata : {idx: i},
                 document : `doc-${i}`
             }));
@@ -200,7 +199,6 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
                 expect(callSize).toBeLessThanOrEqual(250);
             }
         } finally {
-            aiConfig.vectorDimension = originalVectorDimension;
             Memory_StorageRouter.getMemoryCollection = originalGetMemColl;
             Memory_StorageRouter.getSummaryCollection = originalGetSumColl;
             await fsExtra.remove(workRoot);

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
@@ -28,6 +28,7 @@ test.describe.configure({mode: 'serial'});
 test.describe('Memory_DatabaseService — Chroma preserve-live parity for #importMemories (#11144)', () => {
     let SDK, Memory_DatabaseService, Memory_StorageRouter;
     let originalGetMemory, originalGetSummary, tmpDir;
+    let aiConfigRef, originalVectorDimension;
 
     /**
      * Builds a recording fake Chroma collection used by the spec to assert that:
@@ -85,6 +86,13 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
         aiConfig.collections.memory  = `test-memory-${process.pid}-${Date.now()}`;
         aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
 
+        // The atomic vector-write invariant validates each imported row's embedding length against
+        // aiConfig.vectorDimension. These fixtures use length-1 vectors, so align the expected dimension
+        // to 1 for this suite (restored in afterAll to avoid cross-file singleton bleed).
+        aiConfigRef             = aiConfig;
+        originalVectorDimension = aiConfig.vectorDimension;
+        aiConfig.vectorDimension = 1;
+
         SDK                    = await import('../../../../../../ai/services.mjs');
         Memory_DatabaseService = SDK.Memory_DatabaseService;
         Memory_StorageRouter   = SDK.Memory_StorageRouter;
@@ -102,6 +110,10 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
 
         Memory_StorageRouter.getMemoryCollection  = originalGetMemory;
         Memory_StorageRouter.getSummaryCollection = originalGetSummary;
+
+        if (aiConfigRef) {
+            aiConfigRef.vectorDimension = originalVectorDimension;
+        }
 
         if (tmpDir && fs.existsSync(tmpDir)) {
             fs.rmSync(tmpDir, {recursive: true, force: true});
@@ -187,6 +199,35 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
         expect(result.counts.memories.skippedExisting).toBe(0);
         expect(memoryCollection.addCalls[0].ids.sort()).toEqual(['fresh-1', 'fresh-2']);
         expect(memoryCollection.upsertCalls.length).toBe(0);
+    });
+
+    test('merge mode: atomic vector-write invariant rejects rows lacking a valid same-dimension vector', async () => {
+        // The gate (non-reEmbed) must reject missing / empty / wrong-dimension embeddings fail-loud, so a
+        // metadata-only row is never half-persisted (the corruption shape the invariant exists to prevent).
+        // expectedDimension is 1 for this suite; only a length-1 finite vector is valid.
+        const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: []});
+        Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
+        Memory_StorageRouter.getSummaryCollection = async () => buildFakeCollection({name: 'fake-summaries'});
+
+        const backupFile = path.join(tmpDir, `memory-backup-vector-invariant-${Date.now()}.jsonl`);
+        await writeJsonl(backupFile, [
+            {id: 'gate-valid',    embedding: [0.5],      metadata: {tag: 'OK'},  document: 'valid'},
+            {id: 'gate-wrongdim', embedding: [0.1, 0.2], metadata: {tag: 'BAD'}, document: 'wrong-dim'},
+            {id: 'gate-empty',    embedding: [],         metadata: {tag: 'BAD'}, document: 'empty'},
+            {id: 'gate-missing',  metadata: {tag: 'BAD'}, document: 'no-embedding'}
+        ]);
+
+        const result = await Memory_DatabaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : backupFile,
+            mode  : 'merge'
+        });
+
+        // Only the valid row persists; the 3 invalid rows are rejected fail-loud (counted failed, never added).
+        expect(result.counts.memories.inserted).toBe(1);
+        expect(result.counts.memories.failed).toBe(3);
+        expect(memoryCollection.addCalls.length).toBe(1);
+        expect(memoryCollection.addCalls[0].ids).toEqual(['gate-valid']);
     });
 
     test('replace mode: upsert() called for full record set; merge-mode counters stay 0', async () => {

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
@@ -230,6 +230,42 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
         expect(memoryCollection.addCalls[0].ids).toEqual(['gate-valid']);
     });
 
+    test('replace mode: atomic vector-write invariant rejects invalid vectors on the upsert path', async () => {
+        // The gate guards BOTH branches; replace-mode upsert must reject missing/wrong-dim the same way,
+        // adjusting fileInserted (records.length - rejected) so the count stays truthful.
+        const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: []});
+        Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
+        Memory_StorageRouter.getSummaryCollection = async () => buildFakeCollection({name: 'fake-summaries'});
+
+        // Replace mode truncates first; stub the destructive guard to isolate the upsert-gate path.
+        const originalTruncate = Memory_DatabaseService.truncateDatabase.bind(Memory_DatabaseService);
+        Memory_DatabaseService.truncateDatabase = async () => ({message: 'stubbed for replace-mode gate test'});
+
+        try {
+            const backupFile = path.join(tmpDir, `memory-backup-replace-gate-${Date.now()}.jsonl`);
+            await writeJsonl(backupFile, [
+                {id: 'r-valid',    embedding: [0.5],      metadata: {tag: 'OK'},  document: 'valid'},
+                {id: 'r-wrongdim', embedding: [0.1, 0.2], metadata: {tag: 'BAD'}, document: 'wrong-dim'},
+                {id: 'r-missing',  metadata: {tag: 'BAD'}, document: 'no-embedding'}
+            ]);
+
+            const result = await Memory_DatabaseService.manageDatabaseBackup({
+                action: 'import',
+                file  : backupFile,
+                mode  : 'replace'
+            });
+
+            // Only the valid row upserts; the 2 invalid rows are rejected fail-loud (never upserted).
+            expect(result.mode).toBe('replace');
+            expect(result.counts.memories.inserted).toBe(1);
+            expect(result.counts.memories.failed).toBe(2);
+            expect(memoryCollection.upsertCalls.length).toBe(1);
+            expect(memoryCollection.upsertCalls[0].ids).toEqual(['r-valid']);
+        } finally {
+            Memory_DatabaseService.truncateDatabase = originalTruncate;
+        }
+    });
+
     test('replace mode: upsert() called for full record set; merge-mode counters stay 0', async () => {
         const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: ['mem-1']});
         Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
@@ -28,7 +28,7 @@ test.describe.configure({mode: 'serial'});
 test.describe('Memory_DatabaseService — Chroma preserve-live parity for #importMemories (#11144)', () => {
     let SDK, Memory_DatabaseService, Memory_StorageRouter;
     let originalGetMemory, originalGetSummary, tmpDir;
-    let aiConfigRef, originalVectorDimension;
+    let validEmbedding;
 
     /**
      * Builds a recording fake Chroma collection used by the spec to assert that:
@@ -86,12 +86,10 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
         aiConfig.collections.memory  = `test-memory-${process.pid}-${Date.now()}`;
         aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
 
-        // The atomic vector-write invariant validates each imported row's embedding length against
-        // aiConfig.vectorDimension. These fixtures use length-1 vectors, so align the expected dimension
-        // to 1 for this suite (restored in afterAll to avoid cross-file singleton bleed).
-        aiConfigRef             = aiConfig;
-        originalVectorDimension = aiConfig.vectorDimension;
-        aiConfig.vectorDimension = 1;
+        // The atomic vector-write invariant validates each imported row's embedding length against the
+        // resolved aiConfig.vectorDimension. Build fixtures AT that dimension (READ it, never mutate — the
+        // reactive Provider SSOT must not be written from a test) so they pass the gate authentically.
+        validEmbedding = new Array(aiConfig.vectorDimension).fill(0);
 
         SDK                    = await import('../../../../../../ai/services.mjs');
         Memory_DatabaseService = SDK.Memory_DatabaseService;
@@ -111,10 +109,6 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
         Memory_StorageRouter.getMemoryCollection  = originalGetMemory;
         Memory_StorageRouter.getSummaryCollection = originalGetSummary;
 
-        if (aiConfigRef) {
-            aiConfigRef.vectorDimension = originalVectorDimension;
-        }
-
         if (tmpDir && fs.existsSync(tmpDir)) {
             fs.rmSync(tmpDir, {recursive: true, force: true});
         }
@@ -130,9 +124,9 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
 
         const backupFile = path.join(tmpDir, `memory-backup-merge-collision-${Date.now()}.jsonl`);
         await writeJsonl(backupFile, [
-            {id: 'mem-1', embedding: [0.1], metadata: {tag: 'BACKUP'}, document: 'backup-doc-for-mem-1'},
-            {id: 'mem-3', embedding: [0.3], metadata: {tag: 'NEW'},    document: 'new-doc-mem-3'},
-            {id: 'mem-4', embedding: [0.4], metadata: {tag: 'NEW'},    document: 'new-doc-mem-4'}
+            {id: 'mem-1', embedding: validEmbedding, metadata: {tag: 'BACKUP'}, document: 'backup-doc-for-mem-1'},
+            {id: 'mem-3', embedding: validEmbedding, metadata: {tag: 'NEW'},    document: 'new-doc-mem-3'},
+            {id: 'mem-4', embedding: validEmbedding, metadata: {tag: 'NEW'},    document: 'new-doc-mem-4'}
         ]);
 
         const result = await Memory_DatabaseService.manageDatabaseBackup({
@@ -163,8 +157,8 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
 
         const backupFile = path.join(tmpDir, `memory-backup-merge-full-collide-${Date.now()}.jsonl`);
         await writeJsonl(backupFile, [
-            {id: 'mem-1', embedding: [0.1], metadata: {tag: 'B'}, document: 'b1'},
-            {id: 'mem-2', embedding: [0.2], metadata: {tag: 'B'}, document: 'b2'}
+            {id: 'mem-1', embedding: validEmbedding, metadata: {tag: 'B'}, document: 'b1'},
+            {id: 'mem-2', embedding: validEmbedding, metadata: {tag: 'B'}, document: 'b2'}
         ]);
 
         const result = await Memory_DatabaseService.manageDatabaseBackup({
@@ -185,8 +179,8 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
 
         const backupFile = path.join(tmpDir, `memory-backup-merge-no-collide-${Date.now()}.jsonl`);
         await writeJsonl(backupFile, [
-            {id: 'fresh-1', embedding: [0.1], metadata: {tag: 'N'}, document: 'f1'},
-            {id: 'fresh-2', embedding: [0.2], metadata: {tag: 'N'}, document: 'f2'}
+            {id: 'fresh-1', embedding: validEmbedding, metadata: {tag: 'N'}, document: 'f1'},
+            {id: 'fresh-2', embedding: validEmbedding, metadata: {tag: 'N'}, document: 'f2'}
         ]);
 
         const result = await Memory_DatabaseService.manageDatabaseBackup({
@@ -204,14 +198,14 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
     test('merge mode: atomic vector-write invariant rejects rows lacking a valid same-dimension vector', async () => {
         // The gate (non-reEmbed) must reject missing / empty / wrong-dimension embeddings fail-loud, so a
         // metadata-only row is never half-persisted (the corruption shape the invariant exists to prevent).
-        // expectedDimension is 1 for this suite; only a length-1 finite vector is valid.
+        // expectedDimension is the resolved aiConfig.vectorDimension; only a same-dimension finite vector is valid.
         const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: []});
         Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
         Memory_StorageRouter.getSummaryCollection = async () => buildFakeCollection({name: 'fake-summaries'});
 
         const backupFile = path.join(tmpDir, `memory-backup-vector-invariant-${Date.now()}.jsonl`);
         await writeJsonl(backupFile, [
-            {id: 'gate-valid',    embedding: [0.5],      metadata: {tag: 'OK'},  document: 'valid'},
+            {id: 'gate-valid',    embedding: validEmbedding,      metadata: {tag: 'OK'},  document: 'valid'},
             {id: 'gate-wrongdim', embedding: [0.1, 0.2], metadata: {tag: 'BAD'}, document: 'wrong-dim'},
             {id: 'gate-empty',    embedding: [],         metadata: {tag: 'BAD'}, document: 'empty'},
             {id: 'gate-missing',  metadata: {tag: 'BAD'}, document: 'no-embedding'}
@@ -244,7 +238,7 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
         try {
             const backupFile = path.join(tmpDir, `memory-backup-replace-gate-${Date.now()}.jsonl`);
             await writeJsonl(backupFile, [
-                {id: 'r-valid',    embedding: [0.5],      metadata: {tag: 'OK'},  document: 'valid'},
+                {id: 'r-valid',    embedding: validEmbedding,      metadata: {tag: 'OK'},  document: 'valid'},
                 {id: 'r-wrongdim', embedding: [0.1, 0.2], metadata: {tag: 'BAD'}, document: 'wrong-dim'},
                 {id: 'r-missing',  metadata: {tag: 'BAD'}, document: 'no-embedding'}
             ]);
@@ -282,8 +276,8 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
         try {
             const backupFile = path.join(tmpDir, `memory-backup-replace-${Date.now()}.jsonl`);
             await writeJsonl(backupFile, [
-                {id: 'mem-1', embedding: [0.1], metadata: {tag: 'R'}, document: 'r1'},
-                {id: 'mem-2', embedding: [0.2], metadata: {tag: 'R'}, document: 'r2'}
+                {id: 'mem-1', embedding: validEmbedding, metadata: {tag: 'R'}, document: 'r1'},
+                {id: 'mem-2', embedding: validEmbedding, metadata: {tag: 'R'}, document: 'r2'}
             ]);
 
             const result = await Memory_DatabaseService.manageDatabaseBackup({
@@ -312,9 +306,9 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
 
         const backupFile = path.join(tmpDir, `summaries-backup-merge-${Date.now()}.jsonl`);
         await writeJsonl(backupFile, [
-            {id: 'sum-1', embedding: [0.1], metadata: {tag: 'B'}, document: 'b1'}, // collides
-            {id: 'sum-3', embedding: [0.3], metadata: {tag: 'N'}, document: 'n3'}, // new
-            {id: 'sum-4', embedding: [0.4], metadata: {tag: 'N'}, document: 'n4'}  // new
+            {id: 'sum-1', embedding: validEmbedding, metadata: {tag: 'B'}, document: 'b1'}, // collides
+            {id: 'sum-3', embedding: validEmbedding, metadata: {tag: 'N'}, document: 'n3'}, // new
+            {id: 'sum-4', embedding: validEmbedding, metadata: {tag: 'N'}, document: 'n4'}  // new
         ]);
 
         const result = await Memory_DatabaseService.manageDatabaseBackup({
@@ -342,7 +336,7 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
 
         const memoryFile = path.join(tmpDir, `memory-backup-shape-${Date.now()}.jsonl`);
         await writeJsonl(memoryFile, [
-            {id: 'shape-mem-1', embedding: [0.1], metadata: {}, document: 'd1'}
+            {id: 'shape-mem-1', embedding: validEmbedding, metadata: {}, document: 'd1'}
         ]);
 
         const result = await Memory_DatabaseService.manageDatabaseBackup({


### PR DESCRIPTION
Resolves #14029

## Summary

The atomic vector-write invariant (the pure gate-core `helpers/vectorWriteInvariant.mjs`, shipped **unwired** in PR #14077) is now wired into the **DatabaseService import** write path: structural prevention for the metadata-without-vector corruption class (a prior incident left ~10k Memory Core rows whose metadata persisted but whose vector did not).

In non-`reEmbed` import (merge `collection.add` + replace `collection.upsert`), each chunk is partitioned by `partitionRowsByVectorValidity`: rows carrying a valid same-dimension finite vector persist; rows with a missing / empty / wrong-dimension / non-finite vector are **rejected fail-loud** (logged with a per-reason breakdown, counted as failed) rather than half-persisted as metadata-only. `reEmbed` mode is unaffected (it strips vectors for Chroma to regenerate).

## What changed

- **`DatabaseService.mjs`**: import the gate-core; read `expectedDimension = aiConfig.vectorDimension`; gate **both** import branches (non-reEmbed) - partition, persist `valid`, fail-loud + count `rejected`. The replace-branch's `fileInserted` is adjusted to `records.length - rejected` so the count stays truthful.
- **`DatabaseService.importMergeChroma.spec.mjs`**: new gate coverage for merge and replace import paths. Missing / empty / wrong-dimension rows are rejected, valid rows persist, and counts stay correct.
- **`restore-hardening.spec.mjs`**: large restore fixtures are built at the resolved `aiConfig.vectorDimension` so chunking coverage stays valid under the real provider dimension.

## Deltas

- **Scope precision (from the gate-location V-B-A on #14029's thread):** #14029's AC said "vector-bearing write paths" (plural), but the V-B-A established the **only EXPLICIT-embedding write path is the DatabaseService import**. The other persists - the embed-drain (`drainCycle`) and `SessionService` upserts - are **AUTO-EMBED** (`collection.add({documents})` with no explicit vector; Chroma generates it), which an explicit-embedding gate cannot address. Those fall under the **distinct auto-embed-atomicity thread** (does Chroma persist metadata-only when an auto-embed fails?) - flagged to @neo-opus-grace as a sibling concern (possibly the higher-volume corruption path), NOT this PR's scope. So this PR resolves #14029's explicit-write invariant; the auto-embed-atomicity is the sibling.
- The gate is a cheap presence/length/dimension/finiteness check - never a re-embed - so the legitimate append path is not slowed.
- ADR-0019 correction from review: tests now read `aiConfig.vectorDimension` and build same-dimension valid fixtures from the resolved leaf. They do **not** mutate the shared AiConfig provider.

## Test Evidence

Evidence: local exact-head verification plus hosted current-head CI cover the explicit import gate, the ADR-0019 mutation correction, and the preserve-live restore path.

- `node --check ai/services/memory-core/DatabaseService.mjs` - clean.
- `node ./buildScripts/util/check-aiconfig-test-mutation.mjs test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs` - `0 new violations`.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs` - `11 passed`.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/vectorWriteInvariant.spec.mjs test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs` - `21 passed`.

## Post-Merge Validation

After merge, a `manageDatabaseBackup({action:'import', mode:'merge'|'replace'})` of a backup containing a vectorless / wrong-dimension row logs the fail-loud rejection (`vector-write invariant rejected N row(s)...`), counts it failed, and the row is NOT persisted metadata-only. Valid rows + `reEmbed` imports are unaffected. Inert for the auto-embed paths (the sibling thread).

Authored by Vega (@neo-opus-vega - Claude Opus 4.8, Claude Code). Origin session: 1bb8a27b-ae0d-4668-a9a2-acbbe2387512. Targets dev - never main.
