### PR TITLE
feat(ai): lifecycle escalate→record via heal-event ledger (#14201)

### DIFF
--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -473,10 +473,10 @@ export class ContainerHealthDiagnosisService extends Base {
 
             return {
                 recoveryClass : 'config-drift',
-                actionClass   : CONTAINER_HEALTH_ACTION_CLASSES.record,
+                actionClass   : CONTAINER_HEALTH_ACTION_CLASSES.warmProvider,
                 confidence    : 0.95,
                 evidenceFacts : configDriftFacts,
-                reason        : 'config-drift-record',
+                reason        : 'config-drift-reconfigure',
                 targetIdentity: providerTargetIdentity
             };
         }

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -18,7 +18,7 @@ export const CONTAINER_HEALTH_FACT_TYPES = Object.freeze({
 });
 
 export const CONTAINER_HEALTH_ACTION_CLASSES = Object.freeze({
-    escalate    : 'escalate',
+    record      : 'record',
     restart     : 'restart',
     throttleShed: 'throttle-shed',
     warmProvider: 'warm-provider'
@@ -473,10 +473,10 @@ export class ContainerHealthDiagnosisService extends Base {
 
             return {
                 recoveryClass : 'config-drift',
-                actionClass   : CONTAINER_HEALTH_ACTION_CLASSES.escalate,
+                actionClass   : CONTAINER_HEALTH_ACTION_CLASSES.record,
                 confidence    : 0.95,
                 evidenceFacts : configDriftFacts,
-                reason        : 'config-drift-escalate',
+                reason        : 'config-drift-record',
                 targetIdentity: providerTargetIdentity
             };
         }

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -200,7 +200,7 @@ export class ProcessSupervisorService extends Base {
      * @summary Escalates allowlisted failed task outcomes through the recovery diagnosis sink.
      *
      * This is alarm-only: it creates a `supervised-task` diagnosis and calls
-     * `RecoveryActuatorService.escalateDiagnosis()` without restarting the task.
+     * `RecoveryActuatorService.recordDiagnosis()` without restarting the task.
      *
      * @param {Object} options
      * @param {String} options.taskName Task key.
@@ -215,7 +215,7 @@ export class ProcessSupervisorService extends Base {
 
         const actuator = this.recoveryActuatorService;
 
-        if (typeof actuator?.escalateDiagnosis !== 'function') {
+        if (typeof actuator?.recordDiagnosis !== 'function') {
             return false;
         }
 
@@ -231,7 +231,7 @@ export class ProcessSupervisorService extends Base {
                   details      : {reasonCode: 'maintenance-task-failure', taskName, taskStatus: status, outcomeDetails: details || {}}
               });
 
-        Promise.resolve(actuator.escalateDiagnosis(diagnosis, {
+        Promise.resolve(actuator.recordDiagnosis(diagnosis, {
             now   : observedAt,
             reason: 'maintenance-task-failure'
         })).catch(error => {

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -11,6 +11,7 @@ import {
     createRecoveryRunStateEntry,
     createRecoveryTargetIdentity
 } from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+import {appendHealEvent}  from '../../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {DEFAULT_DATA_DIR} from '../taskDefinitions.mjs';
 
 const DEFAULT_ACTIONS        = Object.freeze(['restart', 'redeploy', 'page', 'warm-provider']);
@@ -158,6 +159,14 @@ export class RecoveryActuatorService extends Base {
     /** @summary Resolves the durable recovery-run ledger directory. */
     get recoveryRunStateDir() {
         return this.cfg.recoveryRunStateDir;
+    }
+
+    /**
+     * @summary Resolves the durable heal-event ledger directory — a sibling of the recovery-run dir; the
+     * shared record sink for the lifecycle (this actuator) and data worlds of the immune system.
+     */
+    get healEventLedgerDir() {
+        return path.join(path.dirname(this.recoveryRunStateDir), 'heal-events');
     }
 
     /** @summary Resolves the configured compose-service recovery blocklist. */
@@ -357,20 +366,22 @@ export class RecoveryActuatorService extends Base {
     }
 
     /**
-     * @summary Escalates a diagnosis without executing a privileged recovery action.
+     * @summary Records a diagnosis to the durable heal-event ledger without executing a privileged
+     * recovery action — the **record-with-diagnosis** terminal of the operatorless self-heal loop.
      *
-     * Backup/task-failure alerting needs the recovery-run ledger and operator page path, but
-     * must not coerce a supervised task into the deploy-target `page` action. This sink accepts
-     * only controller-produced alarm diagnoses and records them as escalated.
+     * An operatorless cloud deploy has no human to page, so an un-healable / alarm-only lifecycle
+     * diagnosis is written to the shared heal-event ledger (durable async-audit, never a blocking page)
+     * and recorded as `recorded`; the recovery-run ledger still captures the outcome. This sink accepts
+     * only controller-produced alarm diagnoses; it never coerces a supervised task into a privileged action.
      *
-     * @param {Object} diagnosisEvent Recovery diagnosis event with `details.actionClass = 'escalate'`.
+     * @param {Object} diagnosisEvent Recovery diagnosis event with `details.actionClass = 'record'`.
      * @param {Object} [options]
      * @param {String|null} [options.recoveryRunId=null] Optional stable recovery run id.
      * @param {Number} [options.now=Date.now()] Epoch milliseconds.
-     * @param {String|null} [options.reason=null] Operator/controller reason.
-     * @returns {Promise<Object>} Escalation outcome descriptor.
+     * @param {String|null} [options.reason=null] Controller reason.
+     * @returns {Promise<Object>} Record outcome descriptor.
      */
-    async escalateDiagnosis(diagnosisEvent, {
+    async recordDiagnosis(diagnosisEvent, {
         recoveryRunId = null,
         now = Date.now(),
         reason = null
@@ -387,10 +398,10 @@ export class RecoveryActuatorService extends Base {
             };
         }
 
-        if (diagnosis.details?.actionClass !== 'escalate') {
+        if (diagnosis.details?.actionClass !== 'record') {
             return {
                 status        : 'rejected',
-                reasonCode    : 'diagnosis-not-escalatable',
+                reasonCode    : 'diagnosis-not-recordable',
                 targetIdentity: diagnosis.targetIdentity
             };
         }
@@ -401,28 +412,35 @@ export class RecoveryActuatorService extends Base {
                   serviceKey,
                   id  : serviceKey
               },
-              page       = this.createDiagnosisPage({diagnosisEvent: diagnosis, reason});
+              reasonCode = reason || diagnosis.details.reasonCode || 'diagnosis-record';
 
-        if (typeof this.pageDispatcher === 'function') {
-            await this.pageDispatcher(page);
-        } else {
-            this.writeLog?.('WARN', `[RecoveryActuator] Escalation required for ${serviceKey}; page target ${page.operatorPageTarget}.`);
-        }
+        // Record-with-diagnosis: durable async-audit to the shared heal-event ledger, never a blocking
+        // page (an operatorless cloud has no human to page). The lifecycle and data worlds share this
+        // sink for the immune-system status surface (summarizeHealLedger).
+        await appendHealEvent({
+            type      : diagnosis.recoveryClass,
+            collection: serviceKey,
+            status    : 'recorded',
+            detail    : {
+                reasonCode,
+                targetIdentity: createRecoveryTargetIdentity(diagnosis.targetIdentity),
+                evidenceFacts : diagnosis.evidenceFacts || []
+            }
+        }, {dir: this.healEventLedgerDir, now});
 
         const updatedAt = Date.now();
 
         return this.finishAction({
-            action        : 'escalate',
+            action        : 'record',
             attempt       : 1,
             backoffUntil  : null,
             diagnosisEvent: diagnosis,
             outcome       : {
-                status        : 'escalated',
-                reasonCode    : diagnosis.details.reasonCode || 'diagnosis-escalation',
+                status        : 'recorded',
+                reasonCode,
                 serviceKey,
-                action        : 'escalate',
-                targetIdentity: createRecoveryTargetIdentity(diagnosis.targetIdentity),
-                page
+                action        : 'record',
+                targetIdentity: createRecoveryTargetIdentity(diagnosis.targetIdentity)
             },
             recoveryRunId,
             serviceKey,
@@ -596,22 +614,6 @@ export class RecoveryActuatorService extends Base {
         }
 
         return {page};
-    }
-
-    /**
-     * @summary Builds the operator page payload for an alarm-only diagnosis escalation.
-     * @param {Object} options
-     * @returns {Object}
-     */
-    createDiagnosisPage({diagnosisEvent, reason}) {
-        return {
-            serviceKey        : diagnosisEvent.targetIdentity.id,
-            targetIdentity    : createRecoveryTargetIdentity(diagnosisEvent.targetIdentity),
-            action            : 'escalate',
-            reason            : reason || diagnosisEvent.details?.reasonCode || 'diagnosis-escalation',
-            diagnosisEvent,
-            operatorPageTarget: this.cfg.operatorPageTarget
-        };
     }
 
     /**
@@ -946,6 +948,9 @@ export class RecoveryActuatorService extends Base {
         }
         if (outcome.status === 'escalated') {
             return 'escalated';
+        }
+        if (outcome.status === 'recorded') {
+            return 'recorded';
         }
         if (outcome.status === 'failed') {
             return 'failed';

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -412,7 +412,7 @@ export class RecoveryActuatorService extends Base {
                   serviceKey,
                   id  : serviceKey
               },
-              reasonCode = reason || diagnosis.details.reasonCode || 'diagnosis-record';
+              reasonCode = diagnosis.details.reasonCode || reason || 'diagnosis-record';
 
         // Record-with-diagnosis: durable async-audit to the shared heal-event ledger, never a blocking
         // page (an operatorless cloud has no human to page). The lifecycle and data worlds share this

--- a/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.mjs
@@ -8,8 +8,8 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
  * (which is container CPU/memory/config-drift-scoped) and NOT modeling a maintenance task as a pageable
  * recovery-actuator target. These are pure functions: they detect a failed/overdue supervised task and
  * build a `recovery-diagnosis` event (`targetIdentity.kind: 'supervised-task'`, `details.actionClass:
- * 'escalate'`) for a diagnosis-escalation sink to route. They never restart or retry the task — the
- * recovery boundary (e.g. `escalateDiagnosis` in the actuator) owns dispatch; this owns detection.
+ * 'record'`) for a diagnosis-record sink to route. They never restart or retry the task — the
+ * recovery boundary (e.g. `recordDiagnosis` in the actuator) owns dispatch; this owns detection.
  *
  * Consumed by (next slice): the `ProcessSupervisorService.recordTaskOutcome('<task>', 'failed', …)` hook
  * and a scheduling-loop overdue check, both for the configured alert-on-failure task set (e.g. `backup`).
@@ -49,14 +49,14 @@ export function detectTaskOverdue({lastRunAt, intervalMs, graceMs = 0, now} = {}
 /**
  * @summary Builds the recovery-diagnosis event for a failed or overdue supervised maintenance task.
  *
- * Producer half of the parent backup-reliability AC1 — does NOT restart/retry the task; the event routes to the escalation sink.
+ * Producer half of the parent backup-reliability AC1 — does NOT restart/retry the task; the event routes to the record sink (the heal-event ledger, never an operator page).
  *
  * @param {Object}  options
  * @param {String}  options.taskName Supervised task id (e.g. `backup`).
  * @param {'failed'|'overdue'} options.outcome The detected fault.
  * @param {Number}  options.observedAt Epoch ms when the fault was observed.
  * @param {Object[]} [options.evidenceFacts=[]] Bounded evidence facts carried into the diagnosis.
- * @param {Object} [options.details={}] Diagnostics-owned details; merged with `actionClass: 'escalate'`.
+ * @param {Object} [options.details={}] Diagnostics-owned details; merged with `actionClass: 'record'`.
  * @returns {Object} A `recovery-diagnosis` event (see `createRecoveryDiagnosisEvent`).
  */
 export function buildSupervisedTaskDiagnosis({taskName, outcome, observedAt, evidenceFacts = [], details = {}} = {}) {
@@ -77,6 +77,6 @@ export function buildSupervisedTaskDiagnosis({taskName, outcome, observedAt, evi
         evidenceFacts,
         observedAt,
         source        : 'task-outcome-diagnostics',
-        details       : {...details, actionClass: 'escalate', outcome}
+        details       : {...details, actionClass: 'record', outcome}
     });
 }

--- a/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
@@ -29,6 +29,7 @@ export const RECOVERY_RUN_STATUSES = Object.freeze([
     'failed',
     'no-action',
     'pending',
+    'recorded',
     'recovered',
     'reobserve-requested'
 ]);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -363,12 +363,12 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         });
 
         expect(decision.status).toBe('diagnosed');
-        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.escalate);
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.record);
         expect(decision.diagnosis).toMatchObject({
             recoveryClass: 'config-drift',
             details      : {
-                actionClass         : CONTAINER_HEALTH_ACTION_CLASSES.escalate,
-                classificationReason: 'config-drift-escalate'
+                actionClass         : CONTAINER_HEALTH_ACTION_CLASSES.record,
+                classificationReason: 'config-drift-record'
             }
         });
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -363,12 +363,12 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         });
 
         expect(decision.status).toBe('diagnosed');
-        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.record);
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.warmProvider);
         expect(decision.diagnosis).toMatchObject({
             recoveryClass: 'config-drift',
             details      : {
-                actionClass         : CONTAINER_HEALTH_ACTION_CLASSES.record,
-                classificationReason: 'config-drift-record'
+                actionClass         : CONTAINER_HEALTH_ACTION_CLASSES.warmProvider,
+                classificationReason: 'config-drift-reconfigure'
             }
         });
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -467,14 +467,14 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         }));
     });
 
-    test('recordTaskOutcome escalates failed backup outcomes without breaking HealthService', async () => {
+    test('recordTaskOutcome records failed backup outcomes without breaking HealthService', async () => {
         const { service, taskOutcomes } = createTestService();
         const escalations               = [];
 
         service.recoveryActuatorService = {
-            async escalateDiagnosis(diagnosisEvent, options) {
+            async recordDiagnosis(diagnosisEvent, options) {
                 escalations.push({diagnosisEvent, options});
-                return {status: 'escalated'};
+                return {status: 'recorded'};
             }
         };
 
@@ -500,7 +500,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
             targetIdentity: {kind: 'supervised-task', id: 'backup'},
             source        : 'task-outcome-diagnostics',
             details       : expect.objectContaining({
-                actionClass   : 'escalate',
+                actionClass   : 'record',
                 reasonCode    : 'maintenance-task-failure',
                 taskName      : 'backup',
                 taskStatus    : 'failed',
@@ -509,11 +509,11 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         });
     });
 
-    test('recordTaskOutcome logs but swallows backup escalation failures', async () => {
+    test('recordTaskOutcome logs but swallows backup record failures', async () => {
         const { service, logEntries } = createTestService();
 
         service.recoveryActuatorService = {
-            async escalateDiagnosis() {
+            async recordDiagnosis() {
                 throw new Error('page unavailable');
             }
         };

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -14,6 +14,7 @@ import {
     createRecoveryDiagnosisEvent,
     createRecoveryTargetIdentity
 } from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
+import {readHealLedger} from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
 import {TIER1_DEFAULTS} from '../../../../../fixtures/aiConfigDefaults.mjs';
 
 const DEFAULT_ACTUATOR_CONFIG       = TIER1_DEFAULTS.orchestrator.recoveryActuator;
@@ -117,7 +118,7 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
             observedAt    : 500_000,
             source        : 'process-supervisor-task-outcome',
             details       : {
-                actionClass: 'escalate',
+                actionClass: 'record',
                 reasonCode : 'maintenance-task-failure'
             },
             ...overrides
@@ -446,7 +447,7 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         }));
     });
 
-    test('escalateDiagnosis pages a supervised-task diagnosis without executing target actions', async () => {
+    test('recordDiagnosis records a supervised-task diagnosis to the heal-event ledger without executing target actions', async () => {
         const {service, runtimeCalls, supervisorCalls, pageCalls, taskOutcomes} = createService();
         let   executedTargetAction                                              = false;
 
@@ -455,13 +456,13 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
             throw new Error('should not execute');
         };
 
-        const result = await service.escalateDiagnosis(backupEscalationDiagnosis(), {
+        const result = await service.recordDiagnosis(backupEscalationDiagnosis(), {
             now   : 500_000,
             reason: 'backup-failed'
         });
 
         expect(result).toMatchObject({
-            status        : 'escalated',
+            status        : 'recorded',
             reasonCode    : 'maintenance-task-failure',
             targetIdentity: {kind: 'supervised-task', id: 'backup'}
         });
@@ -469,38 +470,36 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         expect(executedTargetAction).toBe(false);
         expect(runtimeCalls).toEqual([]);
         expect(supervisorCalls).toEqual([]);
-        expect(pageCalls).toEqual([expect.objectContaining({
-            serviceKey        : 'backup',
-            action            : 'escalate',
-            reason            : 'backup-failed',
-            targetIdentity    : {kind: 'supervised-task', id: 'backup'},
-            operatorPageTarget: 'AGENT:*'
-        })]);
-        expect(pageCalls[0].diagnosisEvent).toMatchObject({
-            type          : 'recovery-diagnosis',
-            targetIdentity: {kind: 'supervised-task', id: 'backup'},
-            details       : expect.objectContaining({actionClass: 'escalate'})
-        });
+        // record-with-diagnosis never pages — it appends to the heal-event ledger instead.
+        expect(pageCalls).toEqual([]);
+
+        const healEvents = await readHealLedger({dir: service.healEventLedgerDir});
+        expect(healEvents).toContainEqual(expect.objectContaining({
+            type      : 'ambiguous',
+            collection: 'backup',
+            status    : 'recorded',
+            detail    : expect.objectContaining({reasonCode: 'maintenance-task-failure'})
+        }));
         expect(taskOutcomes).toContainEqual(expect.objectContaining({
             taskName: 'recovery-actuator:backup',
             status  : 'failed',
             details : expect.objectContaining({
-                status      : 'escalated',
-                ledgerStatus: 'escalated'
+                status      : 'recorded',
+                ledgerStatus: 'recorded'
             })
         }));
     });
 
-    test('escalateDiagnosis rejects non-escalate diagnoses without privileged actions', async () => {
+    test('recordDiagnosis rejects non-record diagnoses without privileged actions', async () => {
         const {service, runtimeCalls, supervisorCalls, pageCalls} = createService();
 
-        const result = await service.escalateDiagnosis(backupEscalationDiagnosis({
+        const result = await service.recordDiagnosis(backupEscalationDiagnosis({
             details: {actionClass: 'restart'}
         }), {now: 510_000});
 
         expect(result).toEqual({
             status        : 'rejected',
-            reasonCode    : 'diagnosis-not-escalatable',
+            reasonCode    : 'diagnosis-not-recordable',
             targetIdentity: {kind: 'supervised-task', id: 'backup'}
         });
         expect(runtimeCalls).toEqual([]);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/taskOutcomeDiagnosis.spec.mjs
@@ -36,7 +36,7 @@ test.describe('taskOutcomeDiagnosis — supervised-task failure/overdue producer
         expect(detectTaskOverdue({intervalMs: 1000, now: 2000}).overdue).toBe(true);
     });
 
-    test('buildSupervisedTaskDiagnosis: failed+overdue→ambiguous (escalate-only), supervised-task identity + escalate (#14030 AC1)', () => {
+    test('buildSupervisedTaskDiagnosis: failed+overdue→ambiguous (record-only), supervised-task identity + record (#14030 AC1)', () => {
         const failed = buildSupervisedTaskDiagnosis({
             taskName     : 'backup', outcome: 'failed', observedAt: 1_700_000_000_000,
             evidenceFacts: [{type: 'task-failure', code: 1}], details: {code: 1}
@@ -45,7 +45,7 @@ test.describe('taskOutcomeDiagnosis — supervised-task failure/overdue producer
         expect(failed.type).toBe('recovery-diagnosis');
         expect(failed.recoveryClass).toBe('ambiguous');
         expect(failed.targetIdentity).toEqual({kind: 'supervised-task', id: 'backup'});
-        expect(failed.details.actionClass).toBe('escalate');
+        expect(failed.details.actionClass).toBe('record');
         expect(failed.details.outcome).toBe('failed');
         expect(failed.details.code).toBe(1);
         expect(failed.confidence).toBe(1);
@@ -56,7 +56,7 @@ test.describe('taskOutcomeDiagnosis — supervised-task failure/overdue producer
         });
 
         expect(overdue.recoveryClass).toBe('ambiguous');
-        expect(overdue.details.actionClass).toBe('escalate');
+        expect(overdue.details.actionClass).toBe('record');
         expect(overdue.targetIdentity.kind).toBe('supervised-task');
 
         expect(() => buildSupervisedTaskDiagnosis({taskName: 'backup', outcome: 'bogus', observedAt: 1}))


### PR DESCRIPTION
## Summary
The lifecycle half of v13.1 self-healing. **config-drift now acts** — routes to the warm-provider reconfigure heal (`repairProviderRoleSetResidency` re-applies the drifted provider role-set residency config), recording only when the warm exhausts (un-resolvable). `escalateDiagnosis` → `recordDiagnosis`: the un-resolvable lifecycle terminal writes the heal-event ledger, never pages a (nonexistent cloud) human.

Resolves #14201

Scope narrowed via #14201's comment (the lease gates the issue-body edit for author + assignee alike) to this slice: config-drift-acts + the lifecycle escalate→record + specs. The page-removal half (`DEFAULT_ACTIONS` `'page'` + the deploy-target redeploy page → record) is split to #14232. Refs #14132.

Evidence: L1 (orchestrator service unit) fully covers the #14201 ACs — config-drift→warm-provider classification, the actuator warm routing, and the `recordDiagnosis` ledger write are unit-decidable, with the merged `CorruptionRecoveryGate` release-gate spec as the keystone E2E. Residual: the page-removal half is #14232.

## Deltas
- `ContainerHealthDiagnosisService` config-drift → `CONTAINER_HEALTH_ACTION_CLASSES.warmProvider` (acts — re-applies the provider config), reason `config-drift-reconfigure`.
- `RecoveryActuatorService` `escalateDiagnosis` → `recordDiagnosis` (appends to `healEventLedgerStore`, the first writer); `getLedgerStatus` maps `'recorded'`; removed dead `createDiagnosisPage`.
- `recoveryRunStateStore` += `'recorded'`; `taskOutcomeDiagnosis` → record (genuinely un-resolvable — supervisor does not retry); `ProcessSupervisorService` caller → `recordDiagnosis`.

## Test Evidence
**30/30** orchestrator service specs green — config-drift→warm-provider classification, the actuator warm routing, the `recordDiagnosis` ledger write (`readHealLedger`). Rebased onto dev post-#14240: the `CorruptionRecoveryGate` release-gate spec (the keystone E2E, owned by #14240's gate rewrite) passes against the merged `recordDiagnosis` API — the prior `unit` red was the stale `escalateDiagnosis` assertion, resolved by the rebase, not a #14229-side change.

## Post-Merge Validation
- [ ] No `actionClass: 'escalate'` / no human-page path remains in the lifecycle code (the escalate→record half of #14132 AC #1 + #2 — backed by the merged gate spec).
- [ ] #14232 lands the page-removal half (`DEFAULT_ACTIONS` `'page'` + deploy-target page → record) to complete #14132's no-page mandate.

## Review
Cross-model only (@tobiu) → @neo-gpt on CI-green.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 090a68e6-1a28-4b20-a5fd-842ebac3e729.
