### PR TITLE
fix(hooks): treat autonomous handoff prompts as no-hold (#14041)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -42,8 +42,9 @@ import path            from 'node:path';
 import os              from 'node:os';
 import {pathToFileURL} from 'node:url';
 
-import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneState.mjs';
+import {parseLaneState} from '../../ai/scripts/lifecycle/parseLaneState.mjs';
 import {buildDeferenceStopHookDirective,
+        classifyPromptingContext,
         decideDeferenceStopHookAction,
         decideStopHookAction,
         isOperatorInLoop,
@@ -392,7 +393,11 @@ async function main() {
     } catch (e) {
         // best-effort; isOperatorInLoop falls back to stop_hook_active when promptingText is empty
     }
-    const operatorInLoop = isOperatorInLoop({stopHookActive: !!input.stop_hook_active, promptingText});
+    const promptContext = classifyPromptingContext({
+        stopHookActive: !!input.stop_hook_active,
+        promptingText
+    });
+    const {autonomousHandoff, handoffReason, handoffWindowMs, operatorInLoop} = promptContext;
 
     const deferenceDecision = decideDeferenceStopHookAction(finalText, {operatorInLoop, enforcing: ENFORCING});
     if (deferenceDecision) {
@@ -400,7 +405,7 @@ async function main() {
               session = input.session_id || '?';
 
         if (deferenceDecision.action === 'block') {
-            auditLog(`BLOCK (session=${session}): ${reason}`);
+            auditLog(`BLOCK (session=${session}, operatorInLoop=${operatorInLoop}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}`);
             process.stdout.write(JSON.stringify({
                 decision: 'block',
                 reason  : deferenceDecision.reason
@@ -408,7 +413,7 @@ async function main() {
             return;
         }
 
-        auditLog(`WOULD-BLOCK (session=${session}): ${reason}`);
+        auditLog(`WOULD-BLOCK (session=${session}, operatorInLoop=${operatorInLoop}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}`);
         process.exit(0);
     }
 
@@ -438,7 +443,7 @@ async function main() {
         // the injected directive names the SPECIFIC relapse-phrase back (a sharper mirror). Never gates
         // the block (the decision is unchanged) — only enriches the reason.
         const holdMatches = scanHoldLexicon(finalText);
-        auditLog(`BLOCK (session=${session}): ${reason}${holdMatches.length ? ` [hold-costume: ${holdMatches.join(', ')}]` : ''}`);
+        auditLog(`BLOCK (session=${session}, operatorInLoop=${operatorInLoop}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}${holdMatches.length ? ` [hold-costume: ${holdMatches.join(', ')}]` : ''}`);
         // Block the stop + inject the curated no-hold-state directive — Claude uses the injected
         // `reason` as its next instruction; the audit log keeps the terse trigger cause.
         // Exit only AFTER stdout drains so the decision JSON is never truncated on a pipe.
@@ -447,7 +452,7 @@ async function main() {
         return;
     }
 
-    auditLog(`${action === 'would-block' ? 'WOULD-BLOCK' : 'ALLOW'} (session=${session}): ${reason}`);
+    auditLog(`${action === 'would-block' ? 'WOULD-BLOCK' : 'ALLOW'} (session=${session}, operatorInLoop=${operatorInLoop}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}`);
     process.exit(0);
 }
 

--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -15,9 +15,9 @@ import os              from 'node:os';
 import {pathToFileURL} from 'node:url';
 
 import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneState.mjs';
-import {decideDeferenceStopHookAction,
+import {classifyPromptingContext,
+        decideDeferenceStopHookAction,
         decideStopHookAction,
-        isOperatorInLoop,
         LANE_STATE_SCHEMA_HINT,
         parseOutcomeToVerdict,
         STOP_HOOK_TURN_OPTIONS_HINT} from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
@@ -281,13 +281,22 @@ export function extractPromptingText(input = {}) {
  * @param {String} verdictReason
  * @returns {String}
  */
-export function buildNoHoldReminder(verdictReason, {promptSource = '', operatorInLoop = false} = {}) {
+export function buildNoHoldReminder(verdictReason, {
+    autonomousHandoff = false,
+    handoffReason = '',
+    handoffWindowMs = null,
+    operatorInLoop = false,
+    promptSource = ''
+} = {}) {
     const promptDiagnostic = !operatorInLoop && promptSource === 'none'
-        ? '\nOperator prompt was not visible to this hook (promptSource=none), so live operator dialogue could not be confirmed.'
+              ? '\nOperator prompt was not visible to this hook (promptSource=none), so live operator dialogue could not be confirmed.'
+              : '',
+          handoffDiagnostic = autonomousHandoff
+              ? `\nOperator prompt matched handoff-to-autonomous (${handoffReason || 'unknown'}${handoffWindowMs ? `, windowMs=${handoffWindowMs}` : ''}); treating this turn as autonomous no-hold.`
         : '';
 
     return `No-hold reminder: ${verdictReason}. There is no hold state: continue concrete work on the active lane, perform an assigned review that advances a named lane, or pick a fresh claimable lane. Passive waiting is not a terminal.
-${promptDiagnostic}
+${promptDiagnostic}${handoffDiagnostic}
 
 ${STOP_HOOK_TURN_OPTIONS_HINT}
 
@@ -306,8 +315,11 @@ ${LANE_STATE_SCHEMA_HINT}`;
  * @returns {{action: ('allow'|'block'|'would-block'), reason: String}}
  */
 export function decideCodexHookAction(verdict, {
+    autonomousHandoff       = false,
     enforcing               = false,
     blockInjectionSupported = CODEX_STOP_BLOCK_INJECTION_SUPPORTED,
+    handoffReason           = '',
+    handoffWindowMs         = null,
     operatorInLoop          = false,
     promptSource            = ''
 } = {}) {
@@ -321,12 +333,24 @@ export function decideCodexHookAction(verdict, {
     if (decision.action === 'allow') return decision;
     if (decision.action === 'block') return {
         action: 'block',
-        reason: buildNoHoldReminder(decision.reason, {operatorInLoop, promptSource})
+        reason: buildNoHoldReminder(decision.reason, {
+            autonomousHandoff,
+            handoffReason,
+            handoffWindowMs,
+            operatorInLoop,
+            promptSource
+        })
     };
 
     return {
         action: 'would-block',
-        reason: buildNoHoldReminder(decision.reason, {operatorInLoop, promptSource})
+        reason: buildNoHoldReminder(decision.reason, {
+            autonomousHandoff,
+            handoffReason,
+            handoffWindowMs,
+            operatorInLoop,
+            promptSource
+        })
     };
 }
 
@@ -353,10 +377,11 @@ export function summarizePayloadShape(payload = {}) {
  * @returns {{action: ('allow'|'block'|'would-block'), reason: String, source: String, promptSource: String, verdict: Object, phrase: (String|undefined)}}
  */
 export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
-    const stopHookActive                              = !!(input.stop_hook_active || input.stopHookActive),
-          {text, source}                              = extractFinalAssistantText(input),
-          {text: promptingText, source: promptSource} = extractPromptingText(input),
-          operatorInLoop                              = isOperatorInLoop({stopHookActive, promptingText});
+    const stopHookActive                                                      = !!(input.stop_hook_active || input.stopHookActive),
+          {text, source}                                                      = extractFinalAssistantText(input),
+          {text: promptingText, source: promptSource}                         = extractPromptingText(input),
+          promptContext                                                       = classifyPromptingContext({stopHookActive, promptingText}),
+          {autonomousHandoff, handoffReason, handoffWindowMs, operatorInLoop} = promptContext;
 
     // Deference-register check: shared decision, adapter-owned payload/source metadata.
     const deferenceDecision = decideDeferenceStopHookAction(text, {operatorInLoop, enforcing});
@@ -365,6 +390,9 @@ export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
             ...deferenceDecision,
             source,
             promptSource,
+            autonomousHandoff,
+            handoffReason,
+            handoffWindowMs,
             operatorInLoop,
             verdict: null
         };
@@ -380,7 +408,17 @@ export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
     const verdict = parseOutcomeToVerdict({descriptor, parseError}, validateLaneStateTerminal);
 
     return {
-        ...decideCodexHookAction(verdict, {enforcing, operatorInLoop, promptSource}),
+        ...decideCodexHookAction(verdict, {
+            autonomousHandoff,
+            enforcing,
+            handoffReason,
+            handoffWindowMs,
+            operatorInLoop,
+            promptSource
+        }),
+        autonomousHandoff,
+        handoffReason,
+        handoffWindowMs,
         operatorInLoop,
         source,
         promptSource,
@@ -418,14 +456,14 @@ async function main() {
     const session = input.session_id || input.sessionId || '?';
 
     if (result.action === 'block') {
-        auditLog(`BLOCK (session=${session}, source=${result.source}, promptSource=${result.promptSource}, operatorInLoop=${result.operatorInLoop}): ${result.reason}`);
+        auditLog(`BLOCK (session=${session}, source=${result.source}, promptSource=${result.promptSource}, operatorInLoop=${result.operatorInLoop}, autonomousHandoff=${!!result.autonomousHandoff}, handoffReason=${result.handoffReason || 'none'}, handoffWindowMs=${result.handoffWindowMs ?? 'none'}): ${result.reason}`);
         process.stdout.write(JSON.stringify({decision: 'block', reason: result.reason}), () => process.exit(0));
         return;
     }
 
     const prefix = result.action === 'allow' ? 'ALLOW' : 'WOULD-BLOCK';
 
-    auditLog(`${prefix} (session=${session}, source=${result.source}, promptSource=${result.promptSource}, operatorInLoop=${result.operatorInLoop}): ${result.reason}`);
+    auditLog(`${prefix} (session=${session}, source=${result.source}, promptSource=${result.promptSource}, operatorInLoop=${result.operatorInLoop}, autonomousHandoff=${!!result.autonomousHandoff}, handoffReason=${result.handoffReason || 'none'}, handoffWindowMs=${result.handoffWindowMs ?? 'none'}): ${result.reason}`);
     process.exit(0);
 }
 

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -25,6 +25,70 @@ Validator gotchas: if an own PR is only awaiting merge/review/CI, use laneContin
  */
 export const STOP_HOOK_TURN_OPTIONS_HINT = `Turn-end options: live operator dialogue/planning may stop only when the hook can confirm the operator prompt. Autonomous [WAKE]/stop-hook continuations must drive a named lane and emit lane-state. Before any stop, save one concise turn memory under 24KB. Missing prompt fails closed as autonomous.`;
 
+const AUTONOMOUS_HANDOFF_PATTERNS = Object.freeze([
+    {label: 'nightshift-mode', re: /\bnight\s*shift\b|\bnightshift\b/i},
+    {label: 'freely-choose-window', re: /\bfreely choose\b[\s\S]{0,160}\b(?:for the next|next)\s+\d+\s*(?:h|hr|hrs|hour|hours)\b/i},
+    {label: 'merge-when-back', re: /\b(?:you|agents?|maintainers?)\b[\s\S]{0,160}\bfreely choose\b[\s\S]{0,160}\bmerge when (?:I )?get back\b/i},
+    {label: 'you-drive-window', re: /\byou drive\b[\s\S]{0,160}\b(?:for the next|next|until I|while I)\b/i}
+]);
+
+/**
+ * @summary Extracts a bounded handoff window from operator prose when one is explicitly stated.
+ * @param {String} text Operator prompting text.
+ * @returns {Number|null} Window length in milliseconds, or null when absent/unparseable.
+ */
+export function extractAutonomousHandoffWindowMs(text = '') {
+    if (typeof text !== 'string') return null;
+
+    const match = text.match(/\b(?:for the next|next)\s+(\d+(?:\.\d+)?)\s*(h|hr|hrs|hour|hours|m|min|mins|minute|minutes)\b/i);
+    if (!match) return null;
+
+    const value = Number(match[1]);
+    if (!Number.isFinite(value) || value <= 0) return null;
+
+    const unit = match[2].toLowerCase();
+    return value * (unit.startsWith('m') ? 60 * 1000 : 60 * 60 * 1000);
+}
+
+/**
+ * @summary Detects operator prompts that delegate an autonomous work window, not active dialogue.
+ * @param {String} promptingText Text that prompted the current turn.
+ * @returns {{active: Boolean, reason: String|null, windowMs: Number|null}}
+ */
+export function detectAutonomousHandoffPrompt(promptingText = '') {
+    if (typeof promptingText !== 'string' || !promptingText.trim()) {
+        return {active: false, reason: null, windowMs: null};
+    }
+
+    for (const {label, re} of AUTONOMOUS_HANDOFF_PATTERNS) {
+        if (re.test(promptingText)) {
+            return {
+                active  : true,
+                reason  : label,
+                windowMs: extractAutonomousHandoffWindowMs(promptingText)
+            };
+        }
+    }
+
+    return {active: false, reason: null, windowMs: null};
+}
+
+/**
+ * @summary Classifies the prompting text into operator-dialogue vs autonomous handoff.
+ * @param {{stopHookActive: Boolean, promptingText: String}} signals
+ * @returns {{operatorInLoop: Boolean, autonomousHandoff: Boolean, handoffReason: String|null, handoffWindowMs: Number|null}}
+ */
+export function classifyPromptingContext({stopHookActive, promptingText = ''}) {
+    const handoff = detectAutonomousHandoffPrompt(promptingText);
+
+    return {
+        operatorInLoop   : !stopHookActive && !!promptingText.trim() && !/^\s*\[WAKE\]/.test(promptingText) && !handoff.active,
+        autonomousHandoff: handoff.active,
+        handoffReason    : handoff.reason,
+        handoffWindowMs  : handoff.windowMs
+    };
+}
+
 /**
  * @summary Pure mapping of a parse OUTCOME to a terminal verdict — the 3-bucket chain. A malformed
  * emission (parseLaneState threw) and an absent emission (null) are distinct idle-out failures from an
@@ -53,9 +117,7 @@ export function parseOutcomeToVerdict({descriptor, parseError}, validate) {
  * @returns {Boolean}
  */
 export function isOperatorInLoop({stopHookActive, promptingText = ''}) {
-    if (stopHookActive)        return false;
-    if (!promptingText.trim()) return false;
-    return !/^\s*\[WAKE\]/.test(promptingText);
+    return classifyPromptingContext({stopHookActive, promptingText}).operatorInLoop;
 }
 
 /**

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -177,6 +177,38 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
         expect(result.operatorInLoop).toBe(true);
     });
 
+    test('handoff-to-autonomous operator prompt would-blocks instead of allowing', () => {
+        const result = classifyCodexStopPayload({
+            messages: [
+                {role: 'user', content: "nightshift mode from here on for the next 5h, you and Euclid can freely choose. I merge when I get back."},
+                {role: 'assistant', content: fixture.last_assistant_message}
+            ]
+        });
+
+        expect(result.action).toBe('would-block');
+        expect(result.reason).toContain('handoff-to-autonomous');
+        expect(result.reason).toContain('windowMs=18000000');
+        expect(result.source).toBe('messages');
+        expect(result.promptSource).toBe('messages');
+        expect(result.operatorInLoop).toBe(false);
+        expect(result.autonomousHandoff).toBe(true);
+        expect(result.handoffReason).toBe('nightshift-mode');
+    });
+
+    test('handoff-to-autonomous operator prompt blocks when enforcing', () => {
+        const result = classifyCodexStopPayload({
+            messages: [
+                {role: 'user', content: "nightshift mode from here on for the next 5h, you and Euclid can freely choose. I merge when I get back."},
+                {role: 'assistant', content: fixture.last_assistant_message}
+            ]
+        }, {enforcing: true});
+
+        expect(result.action).toBe('block');
+        expect(result.reason).toContain('handoff-to-autonomous');
+        expect(result.operatorInLoop).toBe(false);
+        expect(result.autonomousHandoff).toBe(true);
+    });
+
     test('[WAKE] prompt is autonomous, so a valid terminal still would-blocks', () => {
         const result = classifyCodexStopPayload({
             messages: [
@@ -333,6 +365,23 @@ test.describe('codex-lane-state-stop - spawned hook', () => {
         expect(log).toContain('source=messages');
         expect(log).toContain('promptSource=messages');
         expect(log).toContain('operatorInLoop=true');
+    });
+
+    test('handoff-to-autonomous prompt logs autonomous context and blocks while enforcing', async () => {
+        const {stdout, log} = await runHook({
+            session_id: 'handoff',
+            messages  : [
+                {role: 'user', content: "nightshift mode from here on for the next 5h, you and Euclid can freely choose. I merge when I get back."},
+                {role: 'assistant', content: fixture.last_assistant_message}
+            ]
+        }, {enforce: true});
+
+        expect(JSON.parse(stdout).decision).toBe('block');
+        expect(log).toContain('BLOCK');
+        expect(log).toContain('operatorInLoop=false');
+        expect(log).toContain('autonomousHandoff=true');
+        expect(log).toContain('handoffReason=nightshift-mode');
+        expect(log).toContain('handoffWindowMs=18000000');
     });
 
     test('enforced invalid terminal logs BLOCK and writes the block decision to stdout', async () => {

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -89,6 +89,13 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
         test('a genuine operator message → true', () => {
             expect(isOperatorInLoop({stopHookActive: false, promptingText: 'please do X, then report'})).toBe(true);
         });
+
+        test('a handoff-to-autonomous operator message → false', () => {
+            expect(isOperatorInLoop({
+                stopHookActive: false,
+                promptingText : "nightshift mode from here on for the next 5h, you and Euclid can freely choose. I merge when I get back."
+            })).toBe(false);
+        });
     });
 
     test.describe('composeBlockDirective — the injected no-hold-state directive', () => {
@@ -328,6 +335,20 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         const {stdout, log} = await runHook('Done — over to you.', {enforce: true, promptingText: 'please do X, then report'});
         expect(log).toContain('ALLOW');
         expect(stdout).toBe('');
+    });
+
+    test('handoff-to-autonomous operator prompt + enforce → BLOCK, not operator ALLOW', async () => {
+        const {stdout, log} = await runHook(validTerminal, {
+            enforce      : true,
+            promptingText: "nightshift mode from here on for the next 5h, you and Euclid can freely choose. I merge when I get back."
+        });
+
+        expect(JSON.parse(stdout).decision).toBe('block');
+        expect(log).toContain('BLOCK');
+        expect(log).toContain('operatorInLoop=false');
+        expect(log).toContain('autonomousHandoff=true');
+        expect(log).toContain('handoffReason=nightshift-mode');
+        expect(log).toContain('handoffWindowMs=18000000');
     });
 
     test('loophole closed: a VALID terminal with NO operator prompt → WOULD-BLOCK (dry-run)', async () => {

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -1,8 +1,11 @@
 import {test, expect} from '@playwright/test';
 import {
     buildDeferenceStopHookDirective,
+    classifyPromptingContext,
     decideDeferenceStopHookAction,
     decideStopHookAction,
+    detectAutonomousHandoffPrompt,
+    extractAutonomousHandoffWindowMs,
     isOperatorInLoop,
     LANE_STATE_SCHEMA_HINT,
     parseOutcomeToVerdict,
@@ -82,6 +85,28 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
 
     test('isOperatorInLoop: a genuine operator prompt is the one operator-in-loop signal', () => {
         expect(isOperatorInLoop({stopHookActive: false, promptingText: 'please review the PR'})).toBe(true);
+    });
+
+    test('isOperatorInLoop: an operator handoff-to-autonomous prompt is not active dialogue', () => {
+        const prompt = "nightshift mode from here on for the next 5h, you and Euclid can freely choose. I merge when I get back.";
+
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: prompt})).toBe(false);
+        expect(detectAutonomousHandoffPrompt(prompt)).toMatchObject({
+            active  : true,
+            reason  : 'nightshift-mode',
+            windowMs: 5 * 60 * 60 * 1000
+        });
+        expect(classifyPromptingContext({stopHookActive: false, promptingText: prompt})).toMatchObject({
+            autonomousHandoff: true,
+            handoffReason    : 'nightshift-mode',
+            operatorInLoop   : false
+        });
+    });
+
+    test('extractAutonomousHandoffWindowMs: parses hours and minutes only when explicit', () => {
+        expect(extractAutonomousHandoffWindowMs('for the next 90 minutes')).toBe(90 * 60 * 1000);
+        expect(extractAutonomousHandoffWindowMs('next 1.5 hours')).toBe(1.5 * 60 * 60 * 1000);
+        expect(extractAutonomousHandoffWindowMs('please pick a lane')).toBe(null);
     });
 
     // ── decideStopHookAction: operatorInLoop is the only allow; block-support gates block vs would-block ──


### PR DESCRIPTION
Resolves #14041

Stop-hook operator prompts that explicitly hand off an autonomous work window now classify as autonomous no-hold instead of active operator dialogue. The shared lifecycle decision seam detects bounded handoff phrases such as nightshift/freely-choose/merge-when-back, preserves the normal active-dialogue allow path, and surfaces the handoff reason/window in Codex and Claude audit output.

Evidence: L2 focused hook unit coverage fully exercises the shared decision seam and both hook adapters. Residual: live post-merge validation should verify a real harness nightshift handoff payload logs `autonomousHandoff=true` and blocks/would-block as expected.

## Deltas from ticket

The implementation keeps the first slice deliberately narrow: a shared pure classifier plus adapter audit/reminder plumbing. It records a parsed window in milliseconds when the operator prompt contains an explicit duration, but it does not persist a cross-turn mode flag yet; the current hook payload classification covers the prompt-visible handoff case without adding a new state store.

## Test Evidence

- `node --check ai/scripts/lifecycle/stopHookDecision.mjs && node --check .codex/hooks/codex-lane-state-stop.mjs && node --check .claude/hooks/laneStateStopHook.mjs && node --check test/playwright/unit/hooks/stopHookDecision.spec.mjs && node --check test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs && node --check test/playwright/unit/hooks/laneStateStopHook.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs` passed before rebase: 100 passed.
- Same focused unit command passed after rebasing onto `origin/dev`: 100 passed.
- `npm run agent-preflight -- ai/scripts/lifecycle/stopHookDecision.mjs .codex/hooks/codex-lane-state-stop.mjs .claude/hooks/laneStateStopHook.mjs test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs` passed.
- `git diff --check` and `git diff --cached --check` passed.

## Post-Merge Validation

- [ ] Trigger a live Codex or Claude operator prompt containing a nightshift/freely-choose handoff window and verify the hook audit logs `operatorInLoop=false`, `autonomousHandoff=true`, a handoff reason, and the parsed `handoffWindowMs`.
- [ ] Trigger a normal active operator dialogue prompt and verify it still logs `operatorInLoop=true` and allows the voluntary turn-taking stop.

## Commits

- `1b03c0a28a` — `fix(hooks): treat autonomous handoff prompts as no-hold (#14041)`

Authored by Euclid (GPT-5, Codex Desktop). Session a725cf68-d74a-4037-9feb-22e2ac5947eb.
