### PR TITLE
docs(ai): data-integrity sweep config → autonomous-heal model, drop operator-gated framing (#14236)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -611,9 +611,10 @@ class Config extends ConfigProvider {
                     remConsolidationWatchdogCheckMs  : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_REM_CONSOLIDATION_WATCHDOG_INTERVAL_MS', 'number'),
                     /**
                      * Cadence of the data-integrity sweep — the read-only, never-fail health check that
-                     * audits Memory Core metadata-vs-vector coverage and escalates a `data-integrity`
-                     * diagnosis (operator page) on drift (the "up but data-gutted reports green" blind
-                     * spot). Detect-only; data mutation stays operator-gated. Hourly surfaces a silent
+                     * audits Memory Core metadata-vs-vector coverage and emits a `data-integrity`
+                     * diagnosis on drift (the "up but data-gutted reports green" blind spot). The
+                     * diagnosis routes to the autonomous data-recovery actuator — the store is HEALED,
+                     * not paged: a cloud deployment has no operator to gate. Hourly surfaces a silent
                      * vector-loss in hours, not weeks. `<= 0` disables the lane.
                      */
                     dataIntegritySweepCheckMs        : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_DATA_INTEGRITY_SWEEP_INTERVAL_MS', 'number')


### PR DESCRIPTION
Resolves #14236

## Summary

The data-integrity sweep config comment (`ai/config.template.mjs`, the tracked SSOT — `config.mjs` is the gitignored per-deployment generation) still described the DELETED escalate/operator-gated model: *"escalates a `data-integrity` diagnosis (operator page) on drift ... Detect-only; data mutation stays operator-gated."* That is the smoke-detector anti-pattern #14132 deletes and Epic #14039 forbids — and it re-seeded the wrong mental model for any peer reading the config. Operator-flagged ("the OPPOSITE of our self healing goal").

Corrected to the autonomous-heal model: the sweep emits a `data-integrity` diagnosis routed to the autonomous data-recovery actuator — the store is HEALED, not paged (no operator in cloud).

## Deltas

- Comment-only change to the data-integrity sweep leaf. The runtime already routes every diagnosis to `applyHeal` autonomously (the cutover landed in `DataIntegrityDiagnosisService` — "no escalate, no operator"); only the comment lagged. **No behavior change.**
- Lands in `config.template.mjs` (the tracked SSOT); `config.mjs` is gitignored (per-deployment) and regenerates from the template.

## Test Evidence

Evidence: `node ai/scripts/lint/lint-config-template-ssot.mjs` → OK (0 inline-env leaf defaults, 4 AiConfig implementation SSOT hits, all baselined). `node --check ai/config.template.mjs` clean. Comment-only — no spec impact.

## Post-Merge Validation

After merge, the data-integrity sweep config comment carries no operator-gated / operator-page / "detect-only; data mutation stays operator-gated" framing; a peer reading the config sees the autonomous-heal model (diagnosis → autonomous actuator → HEALED, no operator).

Authored by Vega (@neo-opus-vega · Claude Opus 4.8, Claude Code). Origin session 3f32bbc7-1bfe-4f85-9232-c957de0d22f1. Targets dev — never main. Part of #14132.