### PR TITLE
feat(ai): autonomous re-embed-missing data heal — defer becomes act (#14134)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -12,37 +12,40 @@ import MaintenanceBackpressureService, {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
     DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
 } from './services/MaintenanceBackpressureService.mjs';
-import {buildConfiguredTaskDefinitions as buildConfiguredTaskDefinitionsImport} from './services/ConfiguredTaskDefinitionsService.mjs';
-import PrimaryRepoSyncService                                                   from './services/PrimaryRepoSyncService.mjs';
-import TenantRepoSyncService                                                    from './services/TenantRepoSyncService.mjs';
-import {getDueTask as summaryGetDueTaskImport}                                  from './scheduling/summary.mjs';
-import {getDueTask as backupGetDueTaskImport}                                   from './scheduling/backup.mjs';
-import {getDueTask as graphLogCompactionGetDueTaskImport}                       from './scheduling/graphLogCompaction.mjs';
-import {getDueTask as primaryDevSyncGetDueTaskImport}                           from './scheduling/primaryDevSync.mjs';
-import {getDueTask as goldenPathGetDueTaskImport}                               from './scheduling/goldenPath.mjs';
-import {getDueTask as dreamGetDueTaskImport}                                    from './scheduling/dream.mjs';
-import {getDueTask as embedDrainLivenessWatchdogGetDueTaskImport}               from './scheduling/embedDrainLivenessWatchdog.mjs';
-import memoryCoreConfig                                                         from '../../mcp/server/memory-core/config.mjs';
-import MailboxService                                                           from '../../services/memory-core/MailboxService.mjs';
-import WakeSubscriptionService                                                  from '../../services/memory-core/WakeSubscriptionService.mjs';
-import RequestContextService                                                    from '../../mcp/server/shared/services/RequestContextService.mjs';
-import {normalizeAgentIdentityNodeId}                                           from '../../scripts/lifecycle/resumeHarness.mjs';
-import TaskStateService                                                         from './services/TaskStateService.mjs';
-import ProcessSupervisorService                                                 from './services/ProcessSupervisorService.mjs';
-import DeploymentRuntimeAccessService                                           from './services/DeploymentRuntimeAccessService.mjs';
-import DeploymentStateBridgeService                                             from './services/DeploymentStateBridgeService.mjs';
-import RecoveryActuatorService                                                  from './services/RecoveryActuatorService.mjs';
-import ContainerHealthDiagnosisService                                          from './services/ContainerHealthDiagnosisService.mjs';
-import DataIntegrityDiagnosisService                                            from './services/DataIntegrityDiagnosisService.mjs';
-import DataRecoveryActuatorService                                              from './services/DataRecoveryActuatorService.mjs';
-import {auditChromaVectorCoverage}                                              from '../../scripts/maintenance/checkChromaIntegrity.mjs';
-import {buildDataIntegrityCoverageDiagnosis}                                    from './services/dataIntegrityCoverageDiagnosis.mjs';
-import {assembleDataIntegrityEvidence}                                          from './services/dataIntegrityEvidenceAssembler.mjs';
-import DreamService                                                             from './services/DreamService.mjs';
-import SwarmHeartbeatService                                                    from './services/SwarmHeartbeatService.mjs';
-import GoldenPathSynthesizer                                                    from '../../services/graph/GoldenPathSynthesizer.mjs';
-import {getDueTask as tenantRepoSyncGetDueTaskImport}                           from './scheduling/tenantRepoSync.mjs';
-import {TASK_REGISTRY}                                                          from './scheduling/registry.mjs';
+import {buildConfiguredTaskDefinitions as buildConfiguredTaskDefinitionsImport}                     from './services/ConfiguredTaskDefinitionsService.mjs';
+import PrimaryRepoSyncService                                                                       from './services/PrimaryRepoSyncService.mjs';
+import TenantRepoSyncService                                                                        from './services/TenantRepoSyncService.mjs';
+import {getDueTask as summaryGetDueTaskImport}                                                      from './scheduling/summary.mjs';
+import {getDueTask as backupGetDueTaskImport}                                                       from './scheduling/backup.mjs';
+import {getDueTask as graphLogCompactionGetDueTaskImport}                                           from './scheduling/graphLogCompaction.mjs';
+import {getDueTask as primaryDevSyncGetDueTaskImport}                                               from './scheduling/primaryDevSync.mjs';
+import {getDueTask as goldenPathGetDueTaskImport}                                                   from './scheduling/goldenPath.mjs';
+import {getDueTask as dreamGetDueTaskImport}                                                        from './scheduling/dream.mjs';
+import {getDueTask as embedDrainLivenessWatchdogGetDueTaskImport}                                   from './scheduling/embedDrainLivenessWatchdog.mjs';
+import memoryCoreConfig                                                                             from '../../mcp/server/memory-core/config.mjs';
+import MailboxService                                                                               from '../../services/memory-core/MailboxService.mjs';
+import WakeSubscriptionService                                                                      from '../../services/memory-core/WakeSubscriptionService.mjs';
+import RequestContextService                                                                        from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {normalizeAgentIdentityNodeId}                                                               from '../../scripts/lifecycle/resumeHarness.mjs';
+import TaskStateService                                                                             from './services/TaskStateService.mjs';
+import ProcessSupervisorService                                                                     from './services/ProcessSupervisorService.mjs';
+import DeploymentRuntimeAccessService                                                               from './services/DeploymentRuntimeAccessService.mjs';
+import DeploymentStateBridgeService                                                                 from './services/DeploymentStateBridgeService.mjs';
+import RecoveryActuatorService                                                                      from './services/RecoveryActuatorService.mjs';
+import ContainerHealthDiagnosisService                                                              from './services/ContainerHealthDiagnosisService.mjs';
+import DataIntegrityDiagnosisService                                                                from './services/DataIntegrityDiagnosisService.mjs';
+import DataRecoveryActuatorService                                                                  from './services/DataRecoveryActuatorService.mjs';
+import {auditChromaVectorCoverage}                                                                  from '../../scripts/maintenance/checkChromaIntegrity.mjs';
+import {createReEmbedMissingHeal}                                                                   from '../../services/memory-core/helpers/reEmbedMissingHeal.mjs';
+import {appendHealEvent, queryHealLedger, readHealLedger}                                           from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
+import {Memory_StorageRouter as StorageRouter, Memory_TextEmbeddingService as TextEmbeddingService} from '../../services.mjs';
+import {buildDataIntegrityCoverageDiagnosis}                                                        from './services/dataIntegrityCoverageDiagnosis.mjs';
+import {assembleDataIntegrityEvidence}                                                              from './services/dataIntegrityEvidenceAssembler.mjs';
+import DreamService                                                                                 from './services/DreamService.mjs';
+import SwarmHeartbeatService                                                                        from './services/SwarmHeartbeatService.mjs';
+import GoldenPathSynthesizer                                                                        from '../../services/graph/GoldenPathSynthesizer.mjs';
+import {getDueTask as tenantRepoSyncGetDueTaskImport}                                               from './scheduling/tenantRepoSync.mjs';
+import {TASK_REGISTRY}                                                                              from './scheduling/registry.mjs';
 import {
     buildOrchestratorSchedulingOptions,
     runSchedulingPipeline
@@ -251,7 +254,7 @@ export class Orchestrator extends Base {
             : '@system';
         const stalledSinceIso = Number.isFinite(stalledSince) ? new Date(stalledSince).toISOString() : 'unknown';
         const ageHours        = (ageMs / (60 * 60 * 1000)).toFixed(1);
-        const subject = `[embed-drain-stall] oldest un-embedded WAL record is ${ageHours}h old`;
+        const subject         = `[embed-drain-stall] oldest un-embedded WAL record is ${ageHours}h old`;
         const body =
             `The embed-drain liveness watchdog detected a STALLED embed pipeline.\n\n` +
             `- oldest un-embedded WAL record age: ${ageMs}ms (~${ageHours}h)\n` +
@@ -420,7 +423,46 @@ export class Orchestrator extends Base {
      * @returns {Neo.ai.daemons.services.DataRecoveryActuatorService}
      */
     beforeSetDataRecoveryActuatorService(value) {
-        return ClassSystemUtil.beforeSetInstance(value, DataRecoveryActuatorService);
+        const reEmbedMissing = createReEmbedMissingHeal({
+            embedFn          : documents => TextEmbeddingService.embedTexts(documents, AiConfig.embeddingProvider),
+            auditCoverage    : ({evidence}) => ({missingVectorIds: Array.isArray(evidence?.missingVectorIds) ? evidence.missingVectorIds : []}),
+            expectedDimension: AiConfig.vectorDimension
+        });
+
+        const healLedgerDir = path.join(this.dataDir, 'data-heal-events');
+
+        return ClassSystemUtil.beforeSetInstance(value, DataRecoveryActuatorService, {
+            healOperations: {
+                /*
+                 * The wal-stall heal terminal. The runner passes a collection NAME and count-only evidence
+                 * (the coverage diagnosis carries missingFromVectorCount, not the ids), so this adapter
+                 * re-audits with includeFullIds to recover the absent ids, resolves the live Memory Core
+                 * handle, and delegates to the pure re-embed op. The handle/diagnosis match is asserted so a
+                 * stray non-MC target can never have recovered vectors upserted into the wrong collection.
+                 */
+                're-embed-missing': async ({collection: collectionName, evidence, now}) => {
+                    await StorageRouter.ready();
+
+                    const collection = await StorageRouter.getMemoryCollection();
+
+                    if (collection?.name && collectionName && collection.name !== collectionName) {
+                        return {status: 'no-op', detail: {reason: 're-embed-missing targets the Memory Core collection only', collectionName, healedAt: now}};
+                    }
+
+                    const coverage = await auditChromaVectorCoverage({
+                              persistDir     : AiConfig.engines.chroma.dataDir,
+                              collectionNames: [collectionName],
+                              includeFullIds : true
+                          }),
+                          drift            = coverage.collections?.find(entry => entry.name === collectionName),
+                          missingVectorIds = Array.isArray(drift?.missingVectorIds) ? drift.missingVectorIds : [];
+
+                    return reEmbedMissing({collection, evidence: {missingVectorIds}, now});
+                }
+            },
+            recentRunsReader: async collectionName => queryHealLedger(await readHealLedger({dir: healLedgerDir}), {collections: [collectionName]}),
+            recordRun       : async ({action, collection, at}) => appendHealEvent({type: action, collection, status: 'attempt'}, {dir: healLedgerDir, now: at})
+        });
     }
 
     /**

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -37,7 +37,7 @@ import DataIntegrityDiagnosisService                                            
 import DataRecoveryActuatorService                                                                  from './services/DataRecoveryActuatorService.mjs';
 import {auditChromaVectorCoverage}                                                                  from '../../scripts/maintenance/checkChromaIntegrity.mjs';
 import {createReEmbedMissingHeal, createReEmbedMissingHealOperation}                                from '../../services/memory-core/helpers/reEmbedMissingHeal.mjs';
-import {appendHealEvent, queryHealLedger, readHealLedger}                                           from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
+import {appendHealEvent, healEventsToRecentRuns, queryHealLedger, readHealLedger}                   from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {Memory_StorageRouter as StorageRouter, Memory_TextEmbeddingService as TextEmbeddingService} from '../../services.mjs';
 import {buildDataIntegrityCoverageDiagnosis}                                                        from './services/dataIntegrityCoverageDiagnosis.mjs';
 import {assembleDataIntegrityEvidence}                                                              from './services/dataIntegrityEvidenceAssembler.mjs';
@@ -452,7 +452,7 @@ export class Orchestrator extends Base {
                     }
                 })
             },
-            recentRunsReader: async collectionName => queryHealLedger(await readHealLedger({dir: healLedgerDir}), {collections: [collectionName]}),
+            recentRunsReader: async collectionName => healEventsToRecentRuns(queryHealLedger(await readHealLedger({dir: healLedgerDir}), {collections: [collectionName]})),
             recordRun       : async ({action, collection, at}) => appendHealEvent({type: action, collection, status: 'attempt'}, {dir: healLedgerDir, now: at})
         });
     }

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -36,7 +36,7 @@ import ContainerHealthDiagnosisService                                          
 import DataIntegrityDiagnosisService                                                                from './services/DataIntegrityDiagnosisService.mjs';
 import DataRecoveryActuatorService                                                                  from './services/DataRecoveryActuatorService.mjs';
 import {auditChromaVectorCoverage}                                                                  from '../../scripts/maintenance/checkChromaIntegrity.mjs';
-import {createReEmbedMissingHeal}                                                                   from '../../services/memory-core/helpers/reEmbedMissingHeal.mjs';
+import {createReEmbedMissingHeal, createReEmbedMissingHealOperation}                                from '../../services/memory-core/helpers/reEmbedMissingHeal.mjs';
 import {appendHealEvent, queryHealLedger, readHealLedger}                                           from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {Memory_StorageRouter as StorageRouter, Memory_TextEmbeddingService as TextEmbeddingService} from '../../services.mjs';
 import {buildDataIntegrityCoverageDiagnosis}                                                        from './services/dataIntegrityCoverageDiagnosis.mjs';
@@ -433,32 +433,24 @@ export class Orchestrator extends Base {
 
         return ClassSystemUtil.beforeSetInstance(value, DataRecoveryActuatorService, {
             healOperations: {
-                /*
-                 * The wal-stall heal terminal. The runner passes a collection NAME and count-only evidence
-                 * (the coverage diagnosis carries missingFromVectorCount, not the ids), so this adapter
-                 * re-audits with includeFullIds to recover the absent ids, resolves the live Memory Core
-                 * handle, and delegates to the pure re-embed op. The handle/diagnosis match is asserted so a
-                 * stray non-MC target can never have recovered vectors upserted into the wrong collection.
-                 */
-                're-embed-missing': async ({collection: collectionName, evidence, now}) => {
-                    await StorageRouter.ready();
+                // The wal-stall heal terminal: the runtime<->op adapter (cross-store guard + re-audit-for-ids
+                // + handle resolution) lives in createReEmbedMissingHealOperation so its branch logic is
+                // unit-tested against mocked collaborators rather than only the live stack.
+                're-embed-missing': createReEmbedMissingHealOperation({
+                    reEmbedMissing,
+                    ready                  : () => StorageRouter.ready(),
+                    getMemoryCollection    : () => StorageRouter.getMemoryCollection(),
+                    resolveMissingVectorIds: async collectionName => {
+                        const coverage = await auditChromaVectorCoverage({
+                                  persistDir     : AiConfig.engines.chroma.dataDir,
+                                  collectionNames: [collectionName],
+                                  includeFullIds : true
+                              }),
+                              drift = coverage.collections?.find(entry => entry.name === collectionName);
 
-                    const collection = await StorageRouter.getMemoryCollection();
-
-                    if (collection?.name && collectionName && collection.name !== collectionName) {
-                        return {status: 'no-op', detail: {reason: 're-embed-missing targets the Memory Core collection only', collectionName, healedAt: now}};
+                        return Array.isArray(drift?.missingVectorIds) ? drift.missingVectorIds : [];
                     }
-
-                    const coverage = await auditChromaVectorCoverage({
-                              persistDir     : AiConfig.engines.chroma.dataDir,
-                              collectionNames: [collectionName],
-                              includeFullIds : true
-                          }),
-                          drift            = coverage.collections?.find(entry => entry.name === collectionName),
-                          missingVectorIds = Array.isArray(drift?.missingVectorIds) ? drift.missingVectorIds : [];
-
-                    return reEmbedMissing({collection, evidence: {missingVectorIds}, now});
-                }
+                })
             },
             recentRunsReader: async collectionName => queryHealLedger(await readHealLedger({dir: healLedgerDir}), {collections: [collectionName]}),
             recordRun       : async ({action, collection, at}) => appendHealEvent({type: action, collection, status: 'attempt'}, {dir: healLedgerDir, now: at})

--- a/ai/services/memory-core/helpers/healEventLedgerStore.mjs
+++ b/ai/services/memory-core/helpers/healEventLedgerStore.mjs
@@ -89,6 +89,22 @@ export async function readHealLedger({dir} = {}) {
 }
 
 /**
+ * @summary Projects heal-event ledger entries into the anti-thrash `recentRuns` shape `dispatchHeal`'s
+ * cooldown/rate gate expects (`[{action, collection, at}]`). The ledger records the heal action under its
+ * event-`type` field, but `decideHealAction` filters `recentRuns` by `run.action` — so a raw ledger entry
+ * would never match its own action and the anti-thrash bound would silently never fire (a just-recorded
+ * attempt would re-`execute` instead of `thrash-cooldown`). This projection (`type` → `action`, keeping the
+ * epoch-ms `at` and the collection) is the seam where the ledger schema meets the dispatch contract.
+ * @param {Object[]} [events=[]] Heal-event entries (as read/filtered from the ledger).
+ * @returns {Object[]} `[{action, collection, at}]` for `decideHealAction`.
+ */
+export function healEventsToRecentRuns(events = []) {
+    return (Array.isArray(events) ? events : [])
+        .filter(event => event && typeof event === 'object')
+        .map(event => ({action: event.type, collection: event.collection, at: event.at}));
+}
+
+/**
  * @summary Folds a heal-event stream into the queryable immune-system status surface: totals, counts by
  * status and by type, the currently-frozen set (freeze adds, unfreeze removes — last transition wins), and the
  * latest event timestamp. Pure — no I/O; the caller reads the ledger then summarizes.

--- a/ai/services/memory-core/helpers/reEmbedMissingHeal.mjs
+++ b/ai/services/memory-core/helpers/reEmbedMissingHeal.mjs
@@ -1,0 +1,134 @@
+import {extractMemoryCoreCollectionData}                          from '../../../scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs';
+import {partitionRowsByVectorValidity, summarizeVectorRejections} from './vectorWriteInvariant.mjs';
+
+/**
+ * @summary The autonomous `re-embed-missing` data-heal operation — the actuator terminal that REPAIRS the
+ * "metadata/document persisted, vector absent" coverage gap by re-embedding the orphaned rows in place,
+ * rather than detecting it and recording a deferral.
+ *
+ * **The corruption shape it heals.** A WAL-stall / mid-drain interruption can leave Memory Core rows whose
+ * metadata + document persisted but whose vector never reached the HNSW index, so `get(include:['embeddings'])`
+ * fails `Error finding id`. The detect side surfaces this as a coverage-drift diagnosis; this is the ACT side:
+ * the missing rows' documents still materialize, so they can be re-embedded and their vectors written back.
+ *
+ * **Why an in-place additive upsert — and why NO shadow/snapshot.** This heal is purely additive: it fills a
+ * vector for rows that currently have none, reusing each row's existing document + metadata. It never rewrites
+ * or deletes intact data, so there is nothing destructive to snapshot-and-restore. That is the structural
+ * difference from a full collection defrag (a destructive rewrite that DOES need shadow/parking promotion —
+ * a safe multi-collection MC promotion that does not yet exist, which is exactly why MC defrag is disabled).
+ * Re-embed-missing sidesteps that un-built promotion entirely: a partial write leaves the same class of state
+ * (partial coverage), re-healable on the next cycle, so the operation is idempotent and re-runnable.
+ *
+ * **The write-boundary invariant is the validation gate.** Before persisting, every re-embedded row is passed
+ * through {@link partitionRowsByVectorValidity}: a row missing a valid same-dimension finite vector is REJECTED
+ * (fail-loud, counted), never written. So the heal can never itself reintroduce the metadata-only corruption
+ * shape it exists to repair — the pre-persist invariant is the in-place analogue of validate-clean-before-promote.
+ *
+ * **Bounding lives in the dispatch envelope, not here.** This operation is the injected privileged primitive;
+ * the surrounding dispatcher records the mutating attempt BEFORE execution (anti-thrash) and fails closed
+ * without a recorder, so a throwing or perpetually-partial heal cannot hot-loop. This module therefore stays a
+ * pure composition (audit → re-embed → invariant-gate → upsert) and is unit-testable against a mocked Chroma
+ * collection with no live store.
+ *
+ * @module ai/services/memory-core/helpers/reEmbedMissingHeal
+ */
+
+/**
+ * @summary Builds the `re-embed-missing` heal operation, closing over the injected embed + audit collaborators.
+ *
+ * The returned function matches the actuator's `healOperations['<action>']` contract
+ * (`async ({collection, evidence, now}) => ({status, detail})`), so it drops directly into the dispatch seam.
+ *
+ * @param {Object}   options
+ * @param {Function} options.embedFn `(documents: String[]) => Promise<Number[][]>` — re-embed a batch of
+ *     documents via the Memory Core provider (e.g. `TextEmbeddingService.embedTexts` bound to the MC provider
+ *     + token budget). Required.
+ * @param {Function} options.auditCoverage `async ({collection, evidence}) => {missingVectorIds: String[]}` — the
+ *     fresh coverage probe that names the rows whose vectors are absent from the HNSW index. Injected (rather
+ *     than read from the possibly-stale diagnosis evidence) so the heal acts on ground truth at heal time.
+ *     Required.
+ * @param {Number}   options.expectedDimension The required vector dimension; a re-embedded vector of any other
+ *     dimension is rejected by the write invariant. A positive integer. Required.
+ * @returns {Function} The `async ({collection, evidence, now}) => outcome` heal operation.
+ * @throws {TypeError} When `embedFn` / `auditCoverage` is not a function or `expectedDimension` is not a
+ *     positive integer — fail-loud at wiring time, never a silent no-op heal at run time.
+ */
+export function createReEmbedMissingHeal({embedFn, auditCoverage, expectedDimension} = {}) {
+    if (typeof embedFn !== 'function') {
+        throw new TypeError('createReEmbedMissingHeal: embedFn (documents -> embeddings) is required');
+    }
+    if (typeof auditCoverage !== 'function') {
+        throw new TypeError('createReEmbedMissingHeal: auditCoverage (collection -> {missingVectorIds}) is required');
+    }
+    if (!Number.isInteger(expectedDimension) || expectedDimension <= 0) {
+        throw new TypeError('createReEmbedMissingHeal: expectedDimension must be a positive integer');
+    }
+
+    /**
+     * @param {Object} options
+     * @param {Object} options.collection The target Chroma collection handle (`.get` / `.upsert`).
+     * @param {Object} [options.evidence] The diagnosis evidence (passed through to the coverage probe).
+     * @param {Number} [options.now] Epoch milliseconds (the injected clock, supplied by the dispatcher).
+     * @returns {Promise<Object>} `{status, detail}` — `status` is `healed` when ≥1 vector was written, `no-op`
+     *     when there was nothing missing to repair, and `failed` when rows were missing but none could be
+     *     recovered (all unrecoverable or invariant-rejected). `detail` carries the fail-loud counts.
+     */
+    return async function reEmbedMissing({collection, evidence, now} = {}) {
+        const coverage         = await auditCoverage({collection, evidence}),
+              missingVectorIds = Array.isArray(coverage?.missingVectorIds) ? coverage.missingVectorIds : [];
+
+        // Nothing missing → a clean no-op (never a false "healed").
+        if (missingVectorIds.length === 0) {
+            return {status: 'no-op', detail: {reEmbedded: 0, attempted: 0, reason: 'no-missing-vectors', healedAt: now}};
+        }
+
+        // Re-embed ONLY the missing rows: passing `allIds === missingVectorIds` empties the intact partition,
+        // so the extractor re-embeds every target from its document and skips the intact-vector fetch entirely.
+        const {data, counts, unrecoverableIds} = await extractMemoryCoreCollectionData({
+            collection,
+            allIds          : missingVectorIds,
+            missingVectorIds,
+            embedFn
+        });
+
+        // Write-boundary invariant: a re-embedded row without a valid same-dimension finite vector is rejected
+        // fail-loud, never persisted — the heal cannot reintroduce the metadata-only shape it repairs.
+        const rows = data.ids.map((id, index) => ({
+            id,
+            embedding: data.embeddings[index],
+            document : data.documents[index],
+            metadata : data.metadatas[index]
+        }));
+
+        const {valid, rejected} = partitionRowsByVectorValidity({rows, expectedDimension}),
+              rejectionSummary  = summarizeVectorRejections(rejected);
+
+        // In-place additive promotion: fill the absent vectors for their existing ids. Idempotent and
+        // re-runnable — re-embedding an already-present vector is a harmless overwrite, a partial write is
+        // re-healed next cycle.
+        if (valid.length > 0) {
+            await collection.upsert({
+                ids       : valid.map(row => row.id),
+                embeddings: valid.map(row => row.embedding),
+                documents : valid.map(row => row.document),
+                metadatas : valid.map(row => row.metadata)
+            });
+        }
+
+        const reEmbedded    = valid.length,
+              unhealedCount = counts.unrecoverable + rejectionSummary.count,
+              status        = reEmbedded > 0 ? 'healed' : (unhealedCount > 0 ? 'failed' : 'no-op');
+
+        return {
+            status,
+            detail: {
+                reEmbedded,
+                attempted    : missingVectorIds.length,
+                unrecoverable: counts.unrecoverable,
+                unrecoverableIds,
+                rejected     : rejectionSummary,
+                healedAt     : now
+            }
+        };
+    };
+}

--- a/ai/services/memory-core/helpers/reEmbedMissingHeal.mjs
+++ b/ai/services/memory-core/helpers/reEmbedMissingHeal.mjs
@@ -132,3 +132,56 @@ export function createReEmbedMissingHeal({embedFn, auditCoverage, expectedDimens
         };
     };
 }
+
+/**
+ * @summary Wraps the pure re-embed-missing op as the actuator's `healOperations['re-embed-missing']`
+ * terminal, bridging the runtime↔op shape gap. The data-integrity runner dispatches with a collection
+ * NAME and count-only evidence (the coverage diagnosis carries a missing-vector COUNT, not the ids),
+ * while the pure op needs a live collection HANDLE and the absent ids. This resolver supplies both —
+ * the heal-time re-audit recovers the ids, `getMemoryCollection` resolves the handle — and REFUSES to
+ * act when the resolved handle is not the diagnosed collection, so recovered vectors can never be
+ * upserted into the wrong store (the one mutation the pure op cannot guard, because it trusts its handle).
+ *
+ * Kept separate from the pure op so the adapter's branch logic (the cross-store guard + the resolve →
+ * delegate path) is unit-testable against mocked collaborators, with no live store / provider / Chroma.
+ *
+ * @param {Object}   options
+ * @param {Function} options.reEmbedMissing The pure op from {@link createReEmbedMissingHeal}.
+ * @param {Function} options.getMemoryCollection `async () => collectionHandle` — resolves the live MC handle.
+ * @param {Function} options.resolveMissingVectorIds `async (collectionName) => String[]` — the heal-time
+ *     re-audit that recovers the absent vector ids the count-only diagnosis omits.
+ * @param {Function} [options.ready] `async () => void` — optional storage-readiness barrier awaited first.
+ * @returns {Function} The `async ({collection, evidence, now}) => outcome` heal operation.
+ * @throws {TypeError} When `reEmbedMissing` / `getMemoryCollection` / `resolveMissingVectorIds` is missing —
+ *     fail-loud at wiring time, never a silent no-op heal at run time.
+ */
+export function createReEmbedMissingHealOperation({reEmbedMissing, getMemoryCollection, resolveMissingVectorIds, ready} = {}) {
+    if (typeof reEmbedMissing !== 'function') {
+        throw new TypeError('createReEmbedMissingHealOperation: reEmbedMissing op is required');
+    }
+    if (typeof getMemoryCollection !== 'function') {
+        throw new TypeError('createReEmbedMissingHealOperation: getMemoryCollection (-> collection handle) is required');
+    }
+    if (typeof resolveMissingVectorIds !== 'function') {
+        throw new TypeError('createReEmbedMissingHealOperation: resolveMissingVectorIds (collectionName -> ids) is required');
+    }
+
+    return async function reEmbedMissingHealOperation({collection: collectionName, evidence, now} = {}) {
+        if (typeof ready === 'function') {
+            await ready();
+        }
+
+        const collection = await getMemoryCollection();
+
+        // Cross-store guard: never upsert recovered vectors into a different collection than the one the
+        // coverage gap was diagnosed in. The pure op trusts whatever handle it receives, so the match is
+        // asserted HERE, where the name-less handle resolution and the named diagnosis meet.
+        if (collection?.name && collectionName && collection.name !== collectionName) {
+            return {status: 'no-op', detail: {reason: 're-embed-missing targets the Memory Core collection only', collectionName, healedAt: now}};
+        }
+
+        const missingVectorIds = await resolveMissingVectorIds(collectionName);
+
+        return reEmbedMissing({collection, evidence: {missingVectorIds}, now});
+    };
+}

--- a/test/playwright/unit/ai/scripts/maintenance/CorruptionRecoveryGate.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/CorruptionRecoveryGate.spec.mjs
@@ -5,50 +5,55 @@ import path           from 'path';
 import {promisify}    from 'util';
 import {test, expect} from '@playwright/test';
 
-import Neo                                   from '../../../../../../src/Neo.mjs';
-import * as core                             from '../../../../../../src/core/_export.mjs';
-import {auditChromaVectorCoverage}           from '../../../../../../ai/scripts/maintenance/checkChromaIntegrity.mjs';
-import {buildDataIntegrityCoverageDiagnosis} from '../../../../../../ai/daemons/orchestrator/services/dataIntegrityCoverageDiagnosis.mjs';
-import {RecoveryActuatorService}             from '../../../../../../ai/daemons/orchestrator/services/RecoveryActuatorService.mjs';
-import {TIER1_DEFAULTS}                      from '../../../../fixtures/aiConfigDefaults.mjs';
+import Neo                         from '../../../../../../src/Neo.mjs';
+import * as core                   from '../../../../../../src/core/_export.mjs';
+import {auditChromaVectorCoverage} from '../../../../../../ai/scripts/maintenance/checkChromaIntegrity.mjs';
+import {classifyDataIntegrityMode} from '../../../../../../ai/daemons/orchestrator/services/dataIntegrityModeClassifier.mjs';
+import {createReEmbedMissingHeal,
+        createReEmbedMissingHealOperation} from '../../../../../../ai/services/memory-core/helpers/reEmbedMissingHeal.mjs';
+import DataRecoveryActuatorService from '../../../../../../ai/daemons/orchestrator/services/DataRecoveryActuatorService.mjs';
 
 const execFileAsync = promisify(execFile);
 
 /*
  * v13.1 release gate — the keystone integration proof for the Agent OS data-integrity immune system.
  *
- * The component layers each ship on their own (the coverage-drift detect-producer, the escalate
- * sink, the recovery actuator, the atomic-write invariant, the test write-guard, …). None of them
- * proves the layers COMPOSE into the demonstrable release bar. This spec is that proof — the
+ * The component layers each ship on their own (the coverage-drift detect-producer, the mode classifier,
+ * the autonomous data-recovery actuator, the re-embed-missing heal op, the atomic-write invariant, …).
+ * None of them proves the layers COMPOSE into the demonstrable release bar. This spec is that proof — the
  * v13.1 definition-of-done:
  *
- *   a corruption injected in test  →  auto-DETECTED  →  DIAGNOSED  →  RECOVERED-or-ESCALATED
- *   end-to-end — never discovered weeks later by a failed backup (the corruption-incident failure mode).
+ *   a corruption injected in test  →  auto-DETECTED  →  DIAGNOSED  →  autonomously HEALED
+ *   end-to-end, with NO human in the loop — never discovered weeks later by a failed backup, and never
+ *   merely paged into an operatorless cloud. (This gate previously, wrongly, certified that escalate-and-
+ *   page-the-operator flow — the smoke-detector-not-fire-extinguisher anti-pattern the escalate-deletion removed. Its
+ *   green meant the system did NOT heal. This is the corrected proof: the extinguisher fires.)
  *
  * It drives the REAL pipeline against a REAL injected corruption (an isolated Chroma SQLite via
  * fs.mkdtemp — never touches live data), rather than hand-built fixtures, so it falsifies the
  * "all subs green, nothing proven" trap:
  *
- *   inject (metadata-without-vector — the corruption-incident shape)
- *     → auditChromaVectorCoverage            (DETECT: the immune system SEES a store that is "up
- *                                             but data-gutted" — the container-health blind spot that
- *                                             let the incident hide for ~weeks while the container kept
- *                                             reporting green)
- *     → buildDataIntegrityCoverageDiagnosis  (DIAGNOSE: a data-integrity / escalate recovery-diagnosis)
- *     → RecoveryActuatorService.escalateDiagnosis
- *                                            (ESCALATE: page the operator — the SAFE recovery action
- *                                             for data-integrity. The immune system does NOT auto-repair
- *                                             data; data mutation stays operator-gated — the detect/act
- *                                             two-worlds boundary. "Never silent-green.")
+ *   inject (metadata + document persisted, vector absent — the corruption-incident shape)
+ *     → auditChromaVectorCoverage      (DETECT: the immune system SEES a store "up but data-gutted" —
+ *                                       the container-health blind spot that hid the incident for ~weeks)
+ *     → classifyDataIntegrityMode      (DIAGNOSE: wal-stall — documents survive → lossless re-embed; the
+ *                                       terminal is AUTONOMOUS, never an escalate/operator-page outcome)
+ *     → DataRecoveryActuatorService.applyHeal({action: 're-embed-missing'})
+ *                                      (HEAL: the ACT — re-embed the orphaned rows from their surviving
+ *                                       documents and upsert the recovered vectors in place. No operator,
+ *                                       no page: a cloud deployment has no human to gate.)
  *
- * When this gate is green, the release gate's end-to-end integration clause is met.
+ * The embedding provider is stubbed (a deterministic same-dimension vector) so the gate proves the
+ * PIPELINE, not the provider; the real op still audits → re-embeds → write-invariant-gates → upserts.
  *
  * @see https://github.com/neomjs/neo/issues/14046
  * @see https://github.com/neomjs/neo/issues/14039
+ * @see https://github.com/neomjs/neo/issues/14134
  */
 
-const OBSERVED_AT  = 1_750_000_000_000,
-      METADATA_IDS = ['mem-1', 'mem-2', 'mem-3'];
+const OBSERVED_AT          = 1_750_000_000_000,
+      METADATA_IDS         = ['mem-1', 'mem-2', 'mem-3'],
+      DETERMINISTIC_VECTOR = [0.10, 0.20, 0.30, 0.40];
 
 /**
  * @summary Writes a minimal Chroma HNSW `index_metadata.pickle` (id → label map) so an audit reads
@@ -123,60 +128,43 @@ async function injectMemoryCoreSnapshot(tmpDir, {writeVectorPickle}) {
 }
 
 /**
- * @summary Constructs a RecoveryActuatorService with capturing mocks (mirrors the createService
- * harness in `RecoveryActuatorService.spec.mjs`). The page dispatcher, runtime-access, and
- * supervisor calls are captured so the gate can assert that escalation pages but mutates nothing.
+ * @summary A minimal recording Chroma collection double (mirrors `reEmbedMissingHeal.spec.mjs`): `.get`
+ * returns documents/metadatas for ids whose metadata row still materializes (the surviving WAL-stall
+ * documents), and `.upsert` records the recovered-vector writes so the gate can assert the ACT fired in
+ * place. The heal needs a collection HANDLE; the file-level audit (DETECT) only reads the snapshot, so the
+ * handle is modelled here, seeded with the same gutted rows the snapshot carries.
  */
-function createRecoveryActuator(tmpDir) {
-    const pageCalls       = [],
-          runtimeCalls    = [],
-          supervisorCalls = [],
-          taskOutcomes    = [],
-          service         = Neo.create(RecoveryActuatorService, {
-              actuatorConfig: {
-                  ...TIER1_DEFAULTS.orchestrator.recoveryActuator,
-                  healAttemptsPath   : path.join(tmpDir, 'heal-attempts.json'),
-                  recoveryRunStateDir: path.join(tmpDir, 'recovery-runs'),
-                  baseBackoffMs      : 0,
-                  maxBackoffMs       : 0
-              },
-              dataDir      : tmpDir,
-              healthService: {
-                  recordTaskOutcome(taskName, status, details) {
-                      taskOutcomes.push({taskName, status, details});
-                  }
-              },
-              deploymentRuntimeAccessService: {
-                  runtimeAccessConfig: {allowedServices: ['chroma', 'kb-server', 'mc-server', 'local-model']},
-                  async applyLifecycle(options) {
-                      runtimeCalls.push(options);
-                      return {ok: true, statusCode: 204};
-                  }
-              },
-              processSupervisorService: {
-                  taskDefinitions: {},
-                  killTask(taskName, reason) {
-                      supervisorCalls.push({taskName, reason});
-                  }
-              },
-              pageDispatcher(page) {
-                  pageCalls.push(page);
-              },
-              async providerResidencyRepair() {
-                  return {ready: true};
-              },
-              writeLog: () => {}
-          });
+function mockCollection(docsById = {}) {
+    const upserts = [];
 
-    return {service, pageCalls, runtimeCalls, supervisorCalls, taskOutcomes};
+    return {
+        name: 'neo-agent-memory',
+        upserts,
+        async get({ids}) {
+            const result = {ids: [], documents: [], metadatas: []};
+
+            for (const id of ids) {
+                if (Object.hasOwn(docsById, id)) {
+                    result.ids.push(id);
+                    result.documents.push(docsById[id].document);
+                    result.metadatas.push(docsById[id].metadata ?? {});
+                }
+            }
+
+            return result;
+        },
+        async upsert(payload) {
+            upserts.push(payload);
+        }
+    };
 }
 
-test.describe('v13.1 release gate — corruption injection → detect → diagnose → escalate', () => {
-    test('injected vector-loss corruption is DETECTED, DIAGNOSED (data-integrity), and ESCALATED — never silently auto-repaired', async () => {
+test.describe('v13.1 release gate — corruption injection → detect → diagnose → autonomous HEAL', () => {
+    test('injected vector-loss is DETECTED, DIAGNOSED (wal-stall), and autonomously HEALED — re-embedded in place, never paged', async () => {
         const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-corruption-gate-'));
 
         try {
-            // 1. INJECT — the "up but data-gutted" shape: metadata rows present, vectors absent.
+            // 1. INJECT — the "up but data-gutted" shape: metadata + documents present, vectors absent.
             const snapshotPath = await injectMemoryCoreSnapshot(tmpDir, {writeVectorPickle: false});
 
             // 2. DETECT — the audit SEES the gutted store (the container-health blind spot, closed).
@@ -191,72 +179,73 @@ test.describe('v13.1 release gate — corruption injection → detect → diagno
             const drifted = coverageResult.collections.find(collection => collection.name === 'neo-agent-memory');
 
             expect(drifted.ok).toBe(false);
-            expect(drifted.missingFromVectorCount).toBeGreaterThan(0);
+            expect(drifted.missingFromVectorCount).toBeGreaterThan(0);   // the audit sees the gutted rows
             expect(coverageResult.failedCollections).toBeGreaterThanOrEqual(1);
 
-            // 3. DIAGNOSE — the detect-producer turns the audit into a data-integrity / escalate diagnosis.
-            const diagnosis = buildDataIntegrityCoverageDiagnosis({
-                coverageResult,
-                observedAt: OBSERVED_AT,
-                serviceId : 'memory-core'
+            // 3. DIAGNOSE — the classifier routes wal-stall → re-embed-missing: AUTONOMOUS, never escalate.
+            //    The documents survive (the WAL-stall shape), so the coverage gap is losslessly re-embeddable.
+            const decision = classifyDataIntegrityMode({
+                collection            : 'neo-agent-memory',
+                rowCount              : METADATA_IDS.length,
+                missingFromVectorCount: drifted.missingFromVectorCount,
+                documentsPresentCount : drifted.missingFromVectorCount
             });
 
-            expect(diagnosis).toMatchObject({
-                diagnosisId   : `data-integrity:memory-core:coverage-drift:${OBSERVED_AT}`,
-                type          : 'recovery-diagnosis',
-                recoveryClass : 'data-integrity',
-                targetIdentity: {kind: 'compose-service', id: 'memory-core'},
-                details       : {actionClass: 'escalate', reasonCode: 'data-integrity-coverage-drift'}
-            });
-            expect(diagnosis.details.driftedCollections).toContain('neo-agent-memory');
+            expect(decision).toMatchObject({mode: 'wal-stall', terminalAction: 're-embed-missing', autonomous: true});
 
-            // 4. ESCALATE — the SAFE recovery action for data-integrity: page the operator, mutate NOTHING.
-            const {service, pageCalls, runtimeCalls, supervisorCalls, taskOutcomes} = createRecoveryActuator(tmpDir);
-
-            let executedPrivilegedAction = false;
-
-            service.executeTargetAction = async () => {
-                executedPrivilegedAction = true;
-                throw new Error('the data-integrity gate must ESCALATE, never execute a privileged recovery action');
-            };
-
-            const outcome = await service.escalateDiagnosis(diagnosis, {
-                now   : OBSERVED_AT,
-                reason: 'v13.1-corruption-recovery-gate'
+            // 4. HEAL — the autonomous data actuator RE-EMBEDS the orphaned rows (defer becomes act).
+            //    The actuator's anti-thrash gate keys on the collection NAME; the runtime adapter resolves
+            //    that name → the live handle (cross-store-guarded) + re-audits the absent ids, then delegates
+            //    to the pure op. A stub embedFn supplies the deterministic vector (no live provider); the real
+            //    op write-invariant-gates each recovered row before upserting it back in place.
+            const collection = mockCollection({
+                'mem-1': {document: 'surviving document for mem-1', metadata: {kind: 'turn'}},
+                'mem-2': {document: 'surviving document for mem-2', metadata: {kind: 'turn'}},
+                'mem-3': {document: 'surviving document for mem-3', metadata: {kind: 'turn'}}
             });
 
-            expect(outcome).toMatchObject({
-                status        : 'escalated',
-                reasonCode    : 'data-integrity-coverage-drift',
-                targetIdentity: {kind: 'compose-service', id: 'memory-core'}
+            const reEmbedMissing = createReEmbedMissingHeal({
+                embedFn          : async documents => documents.map(() => DETERMINISTIC_VECTOR.slice()),
+                auditCoverage    : async ({evidence}) => ({missingVectorIds: evidence.missingVectorIds}),
+                expectedDimension: DETERMINISTIC_VECTOR.length
             });
 
-            // The immune system escalated — it did NOT mutate data (the detect/act two-worlds boundary held).
-            expect(executedPrivilegedAction).toBe(false);
-            expect(runtimeCalls).toEqual([]);
-            expect(supervisorCalls).toEqual([]);
-
-            // A single operator page carrying the data-integrity diagnosis.
-            expect(pageCalls).toHaveLength(1);
-            expect(pageCalls[0]).toMatchObject({
-                serviceKey        : 'memory-core',
-                action            : 'escalate',
-                targetIdentity    : {kind: 'compose-service', id: 'memory-core'},
-                operatorPageTarget: 'AGENT:*'
-            });
-            expect(pageCalls[0].diagnosisEvent).toMatchObject({
-                recoveryClass: 'data-integrity',
-                details      : {actionClass: 'escalate'}
+            const healOperation = createReEmbedMissingHealOperation({
+                reEmbedMissing,
+                getMemoryCollection    : async () => collection,
+                resolveMissingVectorIds: async () => [...METADATA_IDS]
             });
 
-            // The recovery-run ledger recorded the escalation (escalate-with-diagnosis, not silent-green).
-            expect(taskOutcomes.some(outcome => outcome.details?.status === 'escalated')).toBe(true);
+            const actuator = Neo.create(DataRecoveryActuatorService, {
+                healOperations  : {[decision.terminalAction]: healOperation},
+                recordRun       : async () => {},      // anti-thrash recorder (required for a mutating heal)
+                recentRunsReader: async () => []        // no prior runs → within the dispatch envelope
+            });
+
+            const outcome = await actuator.applyHeal({
+                action    : decision.terminalAction,
+                collection: 'neo-agent-memory',   // the NAME — the anti-thrash key + cross-store guard
+                evidence  : {missingVectorIds: [...METADATA_IDS]},
+                now       : OBSERVED_AT
+            });
+
+            // 5. HEALED — the ACT fired: every orphaned row was re-embedded and written back in place.
+            expect(outcome.status).toBe('healed');
+            expect(outcome.detail.reEmbedded).toBe(METADATA_IDS.length);
+            expect(outcome.detail.rejected.count).toBe(0);
+            expect(collection.upserts).toHaveLength(1);
+            expect(collection.upserts[0].ids.slice().sort()).toEqual([...METADATA_IDS].sort());
+
+            // 6. NO operator page, NO escalate — the terminal is an autonomous heal, not a page-into-the-void
+            //    (the model shift the escalate-deletion made: a cloud deployment has no operator to escalate to).
+            expect(decision.terminalAction).not.toBe('escalate');
+            expect(outcome.status).not.toBe('escalated');
         } finally {
             await fs.remove(tmpDir);
         }
     });
 
-    test('a clean store produces NO diagnosis and NO escalation (no false-positive immune response)', async () => {
+    test('a clean store produces NO diagnosis and NO action (no false-positive immune response)', async () => {
         const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-corruption-gate-clean-'));
 
         try {
@@ -276,14 +265,15 @@ test.describe('v13.1 release gate — corruption injection → detect → diagno
             expect(collection.missingFromVectorCount).toBe(0);
             expect(collection.extraInVectorCount).toBe(0);
 
-            // Clean coverage → the producer returns null → there is nothing to escalate.
-            const diagnosis = buildDataIntegrityCoverageDiagnosis({
-                coverageResult,
-                observedAt: OBSERVED_AT,
-                serviceId : 'memory-core'
+            // Clean coverage → the classifier yields `clean` / `none` → no action (no false-positive heal).
+            const decision = classifyDataIntegrityMode({
+                collection            : 'neo-agent-memory',
+                rowCount              : METADATA_IDS.length,
+                missingFromVectorCount: collection.missingFromVectorCount,
+                documentsPresentCount : 0
             });
 
-            expect(diagnosis).toBeNull();
+            expect(decision).toMatchObject({mode: 'clean', terminalAction: 'none', autonomous: true});
         } finally {
             await fs.remove(tmpDir);
         }

--- a/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
@@ -9,8 +9,10 @@ import {
     appendHealEvent,
     readHealLedger,
     summarizeHealLedger,
-    queryHealLedger
+    queryHealLedger,
+    healEventsToRecentRuns
 } from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
+import {decideHealAction} from '../../../../../../../ai/services/memory-core/helpers/healActionDispatch.mjs';
 
 async function tmpDir() {
     return await fs.mkdtemp(path.join(os.tmpdir(), 'heal-ledger-'));
@@ -130,5 +132,49 @@ test.describe('queryHealLedger — the filtered "what happened" surface', () => 
         expect(queryHealLedger(withGarbage).length).toBe(2);                          // both objects, no time bound
         expect(queryHealLedger(withGarbage, {sinceMs: 0}).map(e => e.at)).toEqual([50]); // untimed excluded under a bound
         expect(queryHealLedger(undefined)).toEqual([]);
+    });
+});
+
+test.describe('healEventsToRecentRuns — the ledger→dispatch anti-thrash shape seam', () => {
+    test('projects each ledger entry type → action, keeping collection + the epoch-ms at', () => {
+        const events = [
+            {type: 're-embed-missing', collection: 'neo-agent-memory', status: 'attempt', at: 1000},
+            {type: 're-embed-missing', collection: 'neo-agent-memory', status: 'attempt', at: 2000},
+            null,
+            'garbage'
+        ];
+
+        expect(healEventsToRecentRuns(events)).toEqual([
+            {action: 're-embed-missing', collection: 'neo-agent-memory', at: 1000},
+            {action: 're-embed-missing', collection: 'neo-agent-memory', at: 2000}
+        ]);
+        expect(healEventsToRecentRuns()).toEqual([]);
+    });
+
+    test('REGRESSION: a just-recorded ledger attempt cools down the next dispatch (raw shape would not)', async () => {
+        // The wired production seam: recordRun appends {type: action, ...}; the bug was recentRunsReader
+        // returning the raw {type} entries, which decideHealAction (filtering recentRuns by run.action) never
+        // matched -> a just-recorded attempt re-executed with no anti-thrash. Prove the projection fixes it.
+        const dir = await tmpDir();
+
+        try {
+            const now = 1_000_000;
+
+            await appendHealEvent({type: 're-embed-missing', collection: 'neo-agent-memory', status: 'attempt'}, {dir, now});
+
+            const ledgerRuns = queryHealLedger(await readHealLedger({dir}), {collections: ['neo-agent-memory']}),
+                  recentRuns = healEventsToRecentRuns(ledgerRuns);
+
+            // Projected shape: action matches -> within the default cooldown window -> thrash-cooldown.
+            const fixed = decideHealAction({action: 're-embed-missing', collection: 'neo-agent-memory', recentRuns, now: now + 1000});
+            expect(fixed.status).toBe('thrash-cooldown');
+            expect(fixed.execute).toBe(false);
+
+            // Raw (unprojected) ledger shape: no run.action -> the filter never matches -> the bug (re-execute).
+            const buggy = decideHealAction({action: 're-embed-missing', collection: 'neo-agent-memory', recentRuns: ledgerRuns, now: now + 1000});
+            expect(buggy.status).toBe('execute');
+        } finally {
+            await fs.rm(dir, {recursive: true, force: true});
+        }
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/reEmbedMissingHeal.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/reEmbedMissingHeal.spec.mjs
@@ -1,0 +1,127 @@
+import {test, expect}             from '@playwright/test';
+import Neo                        from '../../../../../../../src/Neo.mjs';
+import * as core                  from '../../../../../../../src/core/_export.mjs';
+import {createReEmbedMissingHeal} from '../../../../../../../ai/services/memory-core/helpers/reEmbedMissingHeal.mjs';
+
+// The autonomous re-embed-missing data-heal: audit the coverage gap → re-embed the orphaned rows from their
+// documents → gate each recovered vector through the write invariant → upsert the survivors in place. These
+// specs assert the ACT fires end-to-end (the recovered vectors are actually written), that it can never
+// reintroduce the metadata-only corruption shape it repairs, and that it is fail-loud on every degraded path.
+
+const DIM = 4;
+
+// A valid DIM-length finite vector, and a wrong-dimension one the write invariant must reject.
+function validVector() { return [0.10, 0.20, 0.30, 0.40]; }
+function wrongDimVector() { return [0.10, 0.20]; }
+
+// Minimal Chroma double: `.get` returns documents/metadatas only for ids whose metadata row still
+// materializes (an absent id models the row that no longer exists → unrecoverable); `.upsert` is recorded.
+function mockCollection(docsById = {}) {
+    const upserts = [];
+
+    return {
+        upserts,
+        async get({ids}) {
+            const result = {ids: [], documents: [], metadatas: []};
+
+            for (const id of ids) {
+                if (Object.hasOwn(docsById, id)) {
+                    result.ids.push(id);
+                    result.documents.push(docsById[id].document);
+                    result.metadatas.push(docsById[id].metadata ?? {});
+                }
+            }
+
+            return result;
+        },
+        async upsert(payload) {
+            upserts.push(payload);
+        }
+    };
+}
+
+function makeHeal({embedFn, missingVectorIds, expectedDimension = DIM} = {}) {
+    return createReEmbedMissingHeal({
+        embedFn,
+        auditCoverage: async () => ({missingVectorIds}),
+        expectedDimension
+    });
+}
+
+test.describe('Neo.ai.services.memory-core.reEmbedMissingHeal', () => {
+    test('re-embeds the missing rows from their documents and upserts the recovered vectors in place', async () => {
+        const collection = mockCollection({
+            a: {document: 'document a', metadata: {kind: 'turn'}},
+            b: {document: 'document b', metadata: {kind: 'turn'}}
+        });
+
+        const heal    = makeHeal({embedFn: async docs => docs.map(() => validVector()), missingVectorIds: ['a', 'b']});
+        const outcome = await heal({collection, now: 1_000});
+
+        expect(outcome.status).toBe('healed');
+        expect(outcome.detail).toMatchObject({reEmbedded: 2, attempted: 2, unrecoverable: 0, healedAt: 1_000});
+        expect(outcome.detail.rejected.count).toBe(0);
+
+        // The ACT fired: the recovered vectors were written back in place for exactly the missing ids.
+        expect(collection.upserts).toHaveLength(1);
+        expect(collection.upserts[0].ids).toEqual(['a', 'b']);
+        expect(collection.upserts[0].embeddings).toEqual([validVector(), validVector()]);
+        expect(collection.upserts[0].documents).toEqual(['document a', 'document b']);
+    });
+
+    test('no missing vectors → clean no-op: never a false heal, never a write', async () => {
+        const collection = mockCollection({a: {document: 'document a'}});
+        const heal       = makeHeal({embedFn: async docs => docs.map(() => validVector()), missingVectorIds: []});
+
+        const outcome = await heal({collection, now: 2_000});
+
+        expect(outcome.status).toBe('no-op');
+        expect(outcome.detail.reEmbedded).toBe(0);
+        expect(collection.upserts).toHaveLength(0);
+    });
+
+    test('rejects a wrong-dimension re-embed fail-loud — persists only the valid survivor, never the corruption shape', async () => {
+        const collection = mockCollection({
+            good: {document: 'document good'},
+            bad : {document: 'document bad'}
+        });
+
+        // embedFn receives the batch in id order and returns one valid vector + one wrong-dimension vector.
+        const heal    = makeHeal({embedFn: async docs => docs.map((doc, index) => index === 0 ? validVector() : wrongDimVector()), missingVectorIds: ['good', 'bad']});
+        const outcome = await heal({collection, now: 3_000});
+
+        expect(outcome.status).toBe('healed');          // progress was made on the valid row
+        expect(outcome.detail.reEmbedded).toBe(1);
+        expect(outcome.detail.rejected.count).toBe(1);
+        expect(outcome.detail.rejected.byReason).toMatchObject({'wrong-dimension': 1});
+
+        // Only the valid row reached the store — the half-written corruption shape is unrepresentable.
+        expect(collection.upserts).toHaveLength(1);
+        expect(collection.upserts[0].ids).toEqual(['good']);
+        expect(collection.upserts[0].embeddings).toEqual([validVector()]);
+    });
+
+    test('missing rows that no longer materialize → failed, fail-loud unrecoverable count, no write', async () => {
+        const collection = mockCollection({});   // 'gone' is absent from the metadata read
+        const heal       = makeHeal({embedFn: async docs => docs.map(() => validVector()), missingVectorIds: ['gone']});
+
+        const outcome = await heal({collection, now: 4_000});
+
+        expect(outcome.status).toBe('failed');
+        expect(outcome.detail.reEmbedded).toBe(0);
+        expect(outcome.detail.unrecoverable).toBe(1);
+        expect(outcome.detail.unrecoverableIds).toEqual(['gone']);
+        expect(collection.upserts).toHaveLength(0);
+    });
+
+    test('fail-loud wiring: a missing collaborator throws at construction, never a silent no-op heal', () => {
+        expect(() => createReEmbedMissingHeal({auditCoverage: async () => ({}), expectedDimension: DIM}))
+            .toThrow(/embedFn/);
+        expect(() => createReEmbedMissingHeal({embedFn: async () => [], expectedDimension: DIM}))
+            .toThrow(/auditCoverage/);
+        expect(() => createReEmbedMissingHeal({embedFn: async () => [], auditCoverage: async () => ({})}))
+            .toThrow(/expectedDimension/);
+        expect(() => createReEmbedMissingHeal({embedFn: async () => [], auditCoverage: async () => ({}), expectedDimension: 0}))
+            .toThrow(/expectedDimension/);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/reEmbedMissingHeal.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/reEmbedMissingHeal.spec.mjs
@@ -1,7 +1,7 @@
-import {test, expect}             from '@playwright/test';
-import Neo                        from '../../../../../../../src/Neo.mjs';
-import * as core                  from '../../../../../../../src/core/_export.mjs';
-import {createReEmbedMissingHeal} from '../../../../../../../ai/services/memory-core/helpers/reEmbedMissingHeal.mjs';
+import {test, expect}                                                from '@playwright/test';
+import Neo                                                           from '../../../../../../../src/Neo.mjs';
+import * as core                                                     from '../../../../../../../src/core/_export.mjs';
+import {createReEmbedMissingHeal, createReEmbedMissingHealOperation} from '../../../../../../../ai/services/memory-core/helpers/reEmbedMissingHeal.mjs';
 
 // The autonomous re-embed-missing data-heal: audit the coverage gap → re-embed the orphaned rows from their
 // documents → gate each recovered vector through the write invariant → upsert the survivors in place. These
@@ -123,5 +123,53 @@ test.describe('Neo.ai.services.memory-core.reEmbedMissingHeal', () => {
             .toThrow(/expectedDimension/);
         expect(() => createReEmbedMissingHeal({embedFn: async () => [], auditCoverage: async () => ({}), expectedDimension: 0}))
             .toThrow(/expectedDimension/);
+    });
+});
+
+test.describe('Neo.ai.services.memory-core.createReEmbedMissingHealOperation (runtime adapter)', () => {
+    test('matching collection: awaits ready, resolves the handle + re-audited ids, delegates to the pure op', async () => {
+        const calls  = [],
+              handle = {name: 'neo-agent-memory'};
+        let   readied = false;
+
+        const op = createReEmbedMissingHealOperation({
+            reEmbedMissing         : args => { calls.push(args); return {status: 'healed', detail: {reEmbedded: 2}}; },
+            ready                  : async () => { readied = true; },
+            getMemoryCollection    : async () => handle,
+            resolveMissingVectorIds: async name => name === 'neo-agent-memory' ? ['a', 'b'] : []
+        });
+
+        const outcome = await op({collection: 'neo-agent-memory', evidence: {countOnly: 2}, now: 1_000});
+
+        expect(readied).toBe(true);
+        expect(outcome).toMatchObject({status: 'healed'});
+        expect(calls).toHaveLength(1);
+        // the pure op receives the live HANDLE + the re-audited ids (NOT the count-only runtime evidence)
+        expect(calls[0]).toMatchObject({collection: handle, evidence: {missingVectorIds: ['a', 'b']}, now: 1_000});
+    });
+
+    test('cross-store guard: a handle that is not the diagnosed collection no-ops without delegating', async () => {
+        let delegated = false;
+
+        const op = createReEmbedMissingHealOperation({
+            reEmbedMissing         : () => { delegated = true; return {status: 'healed'}; },
+            getMemoryCollection    : async () => ({name: 'neo-agent-memory'}),
+            resolveMissingVectorIds: async () => ['x']
+        });
+
+        const outcome = await op({collection: 'some-other-collection', now: 2_000});
+
+        expect(outcome.status).toBe('no-op');
+        expect(outcome.detail.collectionName).toBe('some-other-collection');
+        expect(delegated).toBe(false);
+    });
+
+    test('fail-loud wiring: a missing collaborator throws at construction', () => {
+        expect(() => createReEmbedMissingHealOperation({getMemoryCollection: async () => ({}), resolveMissingVectorIds: async () => []}))
+            .toThrow(/reEmbedMissing/);
+        expect(() => createReEmbedMissingHealOperation({reEmbedMissing: () => {}, resolveMissingVectorIds: async () => []}))
+            .toThrow(/getMemoryCollection/);
+        expect(() => createReEmbedMissingHealOperation({reEmbedMissing: () => {}, getMemoryCollection: async () => ({})}))
+            .toThrow(/resolveMissingVectorIds/);
     });
 });


### PR DESCRIPTION
Resolves #14134

The autonomous **re-embed-missing** data heal — the v13.1 act-half for the wal-stall coverage-gap corruption class (#13999). A Memory Core collection left "up but data-gutted" (metadata + documents persisted, vectors absent from the HNSW index) is now **auto-healed**, not escalated to an operator. The interim all-defer `DataRecoveryActuatorService` becomes an autonomous healer for this class — defer becomes act.

Evidence: L2 (8 green unit specs — the op heals end-to-end + the adapter cross-store guard, mocked Chroma) → L4 required (corruption→auto-healed against the live provider + Chroma stack; the wal-stall heal is a runtime data mutation). Residual: L3 keystone-gate E2E [#14046, @neo-opus-vega folds in] + L4 soak [#14165].

## What shipped

- **The pure op** (`reEmbedMissingHeal.mjs` → `createReEmbedMissingHeal`): audit the coverage gap → re-embed the orphaned rows from their documents (reusing `extractMemoryCoreCollectionData`) → gate each recovered vector through the atomic write invariant (`partitionRowsByVectorValidity`) → upsert the survivors in place. **In-place additive, not a shadow-rebuild-swap**: re-embed-missing only fills absent vectors (reusing each row's existing document + metadata), so nothing is destructive to snapshot; the safe multi-collection MC shadow/parking promotion a destructive defrag needs (and which is disabled for MC) is sidestepped entirely. The write invariant is the validate-clean-before-promote analogue — the heal can never reintroduce the metadata-only shape it repairs.
- **The actuator injection** (`Orchestrator.beforeSetDataRecoveryActuatorService`): wires `healOperations['re-embed-missing']` plus the anti-thrash `recentRunsReader`/`recordRun` (heal-event ledger). `dispatchHeal` requires `recordRun` for the mutating heal, so the wiring fails closed without it.
- **The runtime adapter** (`createReEmbedMissingHealOperation`): bridges a runtime↔op shape gap surfaced during wiring — the runner dispatches with a collection **name** and **count-only** evidence (the coverage diagnosis carries `missingFromVectorCount`, not the ids), while the pure op needs a live **handle** and the absent **ids**. The adapter re-audits with `includeFullIds` to recover the ids, resolves the live MC handle, and **asserts handle/diagnosis match — a cross-store guard so recovered vectors can never be upserted into a non-diagnosed collection** — before delegating. Extracted to a factory so its branch logic is unit-tested against mocked collaborators, not only the live stack.
- Collaborators read `AiConfig` at the use site (`embeddingProvider`, `vectorDimension`, `engines.chroma.dataDir` — ADR-0019); embedding via `TextEmbeddingService`.

## Deltas from ticket

- The runtime↔op shape gap (name-not-handle, count-not-ids) was discovered during wiring → the production adapter and its cross-store corruption guard were added beyond the bare op, and extracted to a tested factory.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/helpers/reEmbedMissingHeal.spec.mjs` → **8 passed** (5 pure op + 3 adapter). The op heals end-to-end (the upsert fires with the recovered vectors), the write invariant rejects a wrong-dimension re-embed fail-loud, degraded paths fail-loud; the adapter's cross-store guard and resolve→delegate path are covered.
- `node --check ai/daemons/orchestrator/Orchestrator.mjs` → parse OK. The Orchestrator wires lazy closures at config-set (no live calls at construction), so there is no construction-time break; CI is the import-resolution verifier (no local Orchestrator-construction test exists).

## Pre-Merge Fold-In

- [ ] @neo-opus-vega folds the migrated keystone gate (#14046) — the true E2E proof: inject corruption → detect → diagnose (wal-stall, no `actionClass:escalate`) → `applyHeal({action:'re-embed-missing'})` → assert status `healed` + re-audit `missingFromVectorCount` 0 + zero page/escalate. It replaces the parody the keystone gate previously certified ("the immune system does NOT auto-repair data").

## Post-Merge Validation

- [ ] Soak (#14165) validates the live heal against the real provider + Chroma stack.

## Commits

- `4b8656fef` — re-embed-missing op + specs
- `b565ab238` — wire the heal into the data actuator (defer→act)
- `08148058b` — extract the runtime adapter to a tested factory

Related: #14039 (v13.1 epic), #14132 (the data-integrity cutover this heals into), #14184 (the runner cutover), #14046 (the keystone gate Vega folds in).

Authored by Grace (Claude Opus 4.8, Claude Code). Session 090a68e6-1a28-4b20-a5fd-842ebac3e729.
