### PR TITLE
refactor(ai): read MemoryService config leaves at the use site, not module-load consts (ADR-0019) (#14238)

### DIFF
--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -14,70 +14,6 @@ import RequestContextService, {SHARED_USER_ID, normalizeUserId}                 
 import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER}                                                                                     from '../../graph/identityRoots.mjs';
 
 /**
- * Maximum time to wait for a single mini-summary model call during backfill before failing soft.
- * A hung inference endpoint must never block the supervised maintenance child indefinitely.
- * @type {Number}
- */
-const MINI_SUMMARY_TIMEOUT_MS = aiConfig.memoryService.miniSummaryTimeoutMs;
-
-/**
- * Wall-clock budget for a single `backfillMiniSummaries` run. Bounds the run safely under the
- * ProcessSupervisor watchdog (`taskDefinitions.mjs` `memory-summary-backfill` maxRuntimeMs=900000):
- * the loop exits cleanly at this budget and defers the unprocessed remainder to the next scheduled
- * sweep, rather than risking a watchdog SIGKILL that makes zero forward progress. A slow or contended
- * local model can otherwise push a full batch past the 15-minute watchdog and loop without draining.
- * @type {Number}
- */
-const MINI_SUMMARY_BACKFILL_MAX_RUN_MS = aiConfig.memoryService.miniSummaryBackfillMaxRunMs;
-
-/**
- * Of a backfill batch's `limit`, how many NEWEST rows to reserve; the remainder drains the OLDEST
- * (aged) rows.
- *
- * A single newest-first (`timestamp DESC`) fetch is LIFO: every agent `add_memory` lands a fresh
- * `miniSummary:NULL` row at the DESC top, so a newest-only batch perpetually re-summarizes fresh
- * inflow while the aged tail (rows days old) never enters the window and starves forever.
- * Splitting the batch converges the tail while the fresh reserve still feeds the `summary`
- * producer→consumer soft-gate + absorbs per-turn inflow. Clamped to the run's `limit`.
- * @type {Number}
- */
-const MINI_SUMMARY_BACKFILL_FRESH_RESERVE = aiConfig.memoryService.miniSummaryBackfillFreshReserve;
-
-/**
- * Maximum time to wait for the backfill's content-store (Chroma) metadata fetch before deferring
- * the whole batch. Usually milliseconds; the bound exists only to defeat a hung connection.
- * @type {Number}
- */
-const CHROMA_FETCH_TIMEOUT_MS = aiConfig.memoryService.chromaFetchTimeoutMs;
-
-/**
- * Bounded in-process graph-projection retry for WAL-accepted memories. This is the cloud-safe host:
- * it does not require a local orchestrator daemon, and a persistent MCP server keeps retrying
- * transient graph contention without making `add_memory` wait.
- * @type {Number}
- */
-const GRAPH_PROJECTION_MAX_ATTEMPTS = aiConfig.memoryService.graphProjectionMaxAttempts;
-
-/**
- * Base delay for graph projection retries.
- * @type {Number}
- */
-const GRAPH_PROJECTION_RETRY_BASE_MS = aiConfig.memoryService.graphProjectionRetryBaseMs;
-
-/**
- * Maximum delay for graph projection retries.
- * @type {Number}
- */
-const GRAPH_PROJECTION_RETRY_MAX_MS = aiConfig.memoryService.graphProjectionRetryMaxMs;
-
-/**
- * Hosted graph-projection drain cadence. This is intentionally independent of the Chroma embed
- * daemon: graph projection and embedding are separate derived states.
- * @type {Number}
- */
-const GRAPH_PROJECTION_DRAIN_INTERVAL_MS = aiConfig.memoryService.graphProjectionDrainIntervalMs;
-
-/**
  * Re-exported from `./helpers/withTimeout.mjs` (moved there so `SessionService` can share it without
  * a `MemoryService` ⇄ `SessionService` import cycle). Kept exported here for back-compat with
  * existing importers.
@@ -584,10 +520,13 @@ class MemoryService extends Base {
      * @private
      */
     _scheduleMemoryGraphProjection(options, attempt = 1) {
-        const me      = this,
-              delayMs = attempt === 1
+        // Read the reactive AiConfig leaves at the use site (re-read per retry attempt) so a runtime
+        // healing-mutation (recovery actuator setData) is reflected — never captured at module load.
+        const me          = this,
+              maxAttempts = aiConfig.memoryService.graphProjectionMaxAttempts,
+              delayMs     = attempt === 1
                   ? 0
-                  : Math.min(GRAPH_PROJECTION_RETRY_BASE_MS * 2 ** (attempt - 2), GRAPH_PROJECTION_RETRY_MAX_MS);
+                  : Math.min(aiConfig.memoryService.graphProjectionRetryBaseMs * 2 ** (attempt - 2), aiConfig.memoryService.graphProjectionRetryMaxMs);
 
         me.graphProjectionRetryTimers ??= new Set();
 
@@ -597,13 +536,13 @@ class MemoryService extends Base {
             try {
                 await me._projectMemoryToGraph(options);
             } catch (error) {
-                if (attempt < GRAPH_PROJECTION_MAX_ATTEMPTS) {
-                    logger.warn(`[MemoryService] Deferred graph projection failed for ${options.memoryId} (attempt ${attempt}/${GRAPH_PROJECTION_MAX_ATTEMPTS}); retrying: ${error.message}`);
+                if (attempt < maxAttempts) {
+                    logger.warn(`[MemoryService] Deferred graph projection failed for ${options.memoryId} (attempt ${attempt}/${maxAttempts}); retrying: ${error.message}`);
                     me._scheduleMemoryGraphProjection(options, attempt + 1);
                     return;
                 }
 
-                logger.warn(`[MemoryService] Deferred graph projection failed for ${options.memoryId} after ${GRAPH_PROJECTION_MAX_ATTEMPTS} attempts; WAL row remains projection-pending: ${error.message}`);
+                logger.warn(`[MemoryService] Deferred graph projection failed for ${options.memoryId} after ${maxAttempts} attempts; WAL row remains projection-pending: ${error.message}`);
             }
         }, delayMs);
 
@@ -678,7 +617,7 @@ class MemoryService extends Base {
             this.drainPendingGraphProjections().catch(error => {
                 logger.warn(`[MemoryService] graph projection drain failed: ${error.message}`);
             });
-        }, GRAPH_PROJECTION_DRAIN_INTERVAL_MS);
+        }, aiConfig.memoryService.graphProjectionDrainIntervalMs);
         this.graphProjectionDrainTimer.unref?.();
     }
 
@@ -894,10 +833,10 @@ class MemoryService extends Base {
      * @param {Number} options.limit     The maximum number of memories to return.
      * @param {Number} options.offset    The number of memories to skip.
      * @param {String} [options.memorySharing] Optional tenant-isolation policy override (mirrors queryMemories) — lets callers and tests select 'team' / 'private' without depending on ambient defaultPolicy resolution.
-     * @param {Number} [options.chromaTimeoutMs=CHROMA_FETCH_TIMEOUT_MS] Test seam for bounding Chroma metadata reads.
+     * @param {Number} [options.chromaTimeoutMs=aiConfig.memoryService.chromaFetchTimeoutMs] Test seam for bounding Chroma metadata reads.
      * @returns {Promise<{sessionId: string, count: number, total: number, memories: Object[]}>}
      */
-    async listMemories({sessionId, limit=100, offset=0, memorySharing, chromaTimeoutMs=CHROMA_FETCH_TIMEOUT_MS} = {}) {
+    async listMemories({sessionId, limit=100, offset=0, memorySharing, chromaTimeoutMs=aiConfig.memoryService.chromaFetchTimeoutMs} = {}) {
         try {
             if (!sessionId) {
                 return { sessionId, count: 0, total: 0, memories: [] };
@@ -1467,7 +1406,7 @@ class MemoryService extends Base {
         // before it completes. Benchmark (2026-06-09, MacBook M5 Max 128GB, gemma-4-31b-it via LM
         // Studio): a ~5k-char -> tweet-size summary takes ~5.3s warm / ~13s cold. The prior 4s cap
         // aborted most local summaries -> null -> zero backfill drain. Stays under the 30s outer
-        // backfill per-item timeout (MINI_SUMMARY_TIMEOUT_MS).
+        // backfill per-item timeout (aiConfig.memoryService.miniSummaryTimeoutMs).
         const TIMEOUT_MS = aiConfig.memoryService.generateMiniSummaryTimeoutMs;
         try {
             const model = buildChatModel({
@@ -1593,7 +1532,7 @@ class MemoryService extends Base {
      * turns written while the summarizer was unavailable. The scan is graph-first and SPLIT across
      * both ends of the backlog — a fresh reserve (newest) + an aged-drain bulk (oldest) — so the
      * aged tail converges instead of starving behind perpetual fresh inflow (see
-     * {@link MINI_SUMMARY_BACKFILL_FRESH_RESERVE}). Chroma is only joined by the selected node ids to
+     * `aiConfig.memoryService.miniSummaryBackfillFreshReserve`). Chroma is only joined by the selected node ids to
      * fetch that memory's own prompt/response. Updates merge `miniSummary` into the same graph node
      * through a tenant-preserving storage-layer merge, preserving tenant attribution (`userId`,
      * `agentIdentity`) and every other property already present on the row.
@@ -1605,11 +1544,11 @@ class MemoryService extends Base {
      * @param {Number} [options.limit] Maximum rows to fetch. Defaults to
      *     `aiConfig.summarizationBatchLimit`.
      * @param {Number} [options.freshReserve] Of `limit`, how many newest rows to reserve before the
-     *     remainder drains the oldest. Defaults to `MINI_SUMMARY_BACKFILL_FRESH_RESERVE`; clamped to
+     *     remainder drains the oldest. Defaults to `aiConfig.memoryService.miniSummaryBackfillFreshReserve`; clamped to
      *     `limit`. Exposed for deterministic split-coverage tests.
      * @param {Function} [options.buildMiniSummary] Optional summarizer seam for deterministic tests.
      * @param {Number} [options.maxRunMs] Wall-clock budget for the run; defaults to
-     *     `MINI_SUMMARY_BACKFILL_MAX_RUN_MS`. The loop stops starting new rows once reached and defers
+     *     `aiConfig.memoryService.miniSummaryBackfillMaxRunMs`. The loop stops starting new rows once reached and defers
      *     the remainder to the next sweep, keeping the supervised child under its watchdog.
      * @param {Function} [options.now] Clock seam (defaults to `Date.now`) for deterministic budget tests.
      * @returns {Promise<{processed: Number, updated: Number, deferred: Number, missingContent: Number, runBudgetHit: Boolean}>}
@@ -1624,7 +1563,7 @@ class MemoryService extends Base {
         const numericLimit = Number(limit) || defaultLimit;
         const boundedLimit = Math.max(1, Math.min(numericLimit, defaultLimit));
         const summarize    = buildMiniSummary || (options => this.buildMiniSummary(options));
-        const runBudgetMs  = Number(maxRunMs) > 0 ? Number(maxRunMs) : MINI_SUMMARY_BACKFILL_MAX_RUN_MS;
+        const runBudgetMs  = Number(maxRunMs) > 0 ? Number(maxRunMs) : aiConfig.memoryService.miniSummaryBackfillMaxRunMs;
         const startedAt    = now();
 
         // Split the batch across BOTH ends of the backlog. A single newest-first fetch is
@@ -1634,7 +1573,7 @@ class MemoryService extends Base {
         // starved tail). Both ends skip rows already archived as un-summarizable so the
         // drain doesn't burn budget re-archiving them. De-dup: the windows overlap once the backlog
         // is shallower than the limit.
-        const reserveBudget = Number.isInteger(freshReserve) && freshReserve >= 0 ? freshReserve : MINI_SUMMARY_BACKFILL_FRESH_RESERVE;
+        const reserveBudget = Number.isInteger(freshReserve) && freshReserve >= 0 ? freshReserve : aiConfig.memoryService.miniSummaryBackfillFreshReserve;
         const reserve       = Math.min(reserveBudget, boundedLimit);
         const drainLimit    = boundedLimit - reserve;
 
@@ -1659,8 +1598,8 @@ class MemoryService extends Base {
 
         let byId;
         try {
-            const collection = await withTimeout(StorageRouter.getMemoryCollection(), CHROMA_FETCH_TIMEOUT_MS, 'miniSummary backfill getMemoryCollection');
-            const fetched    = await withTimeout(collection.get({ids: rows.map(row => row.id), include: ['metadatas']}), CHROMA_FETCH_TIMEOUT_MS, 'miniSummary backfill collection.get');
+            const collection = await withTimeout(StorageRouter.getMemoryCollection(), aiConfig.memoryService.chromaFetchTimeoutMs, 'miniSummary backfill getMemoryCollection');
+            const fetched    = await withTimeout(collection.get({ids: rows.map(row => row.id), include: ['metadatas']}), aiConfig.memoryService.chromaFetchTimeoutMs, 'miniSummary backfill collection.get');
             byId             = new Map((fetched.ids || []).map((id, index) => [id, fetched.metadatas?.[index] || {}]));
         } catch (error) {
             logger.warn(`[MemoryService] miniSummary backfill deferred the whole batch (content store unreachable, fail-soft): ${error.message}`);
@@ -1703,7 +1642,7 @@ class MemoryService extends Base {
             try {
                 const miniSummary = await withTimeout(
                     summarize({prompt: metadata.prompt, response: metadata.response}),
-                    MINI_SUMMARY_TIMEOUT_MS,
+                    aiConfig.memoryService.miniSummaryTimeoutMs,
                     'miniSummary backfill summarize'
                 );
 


### PR DESCRIPTION
## Summary

@tobiu's prio-0 follow-up on #14234's merge (approve-and-follow-up). The #14231 AiConfig pass moved MemoryService's config constants into a new `aiConfig.memoryService` section but captured them as MODULE-LEVEL consts — a stale snapshot. **State providers are reactive, and the v13.1 self-heal pipeline MUTATES configs at runtime (`setData`); a module-load capture freezes the value, so a healing-mutation never reaches it → it can block self-healing.** This reads the leaves at the use site instead.

Resolves #14238

## Change

Deleted the 8 module-level `const X = aiConfig.memoryService.Y` captures (`MemoryService.mjs:21-78`) and read `aiConfig.memoryService.*` at the use site:
- **inline** (1-2 uses): `miniSummaryTimeoutMs` (backfill withTimeout), `miniSummaryBackfillMaxRunMs`, `miniSummaryBackfillFreshReserve`, `chromaFetchTimeoutMs` (×2 backfill), `graphProjectionRetryBaseMs` + `graphProjectionRetryMaxMs` (backoff calc), `graphProjectionDrainIntervalMs` (drain loop).
- **function-local alias re-read per call** (3 uses in one method): `const maxAttempts = aiConfig.memoryService.graphProjectionMaxAttempts` in `_scheduleMemoryGraphProjection` — re-read each retry attempt.
- **default-param** (re-evaluated per call): `listMemories({…, chromaTimeoutMs = aiConfig.memoryService.chromaFetchTimeoutMs})`.

Every read is now re-resolved per call → a runtime `setData` (self-heal) is reflected. Net −61 lines (the const block + JSDoc removed).

Evidence: `grep -cE "^const [A-Z_]+ = aiConfig\." MemoryService.mjs` → 0; 18 use-site `aiConfig.memoryService.*` reads; 0 stale references to the deleted const names.

## Contract Ledger

| Surface | Change | Consumers | Compatibility |
|---|---|---|---|
| MemoryService config reads | module-load capture → use-site read of `aiConfig.memoryService.*` | internal (MemoryService) | Behavior-preserving (same resolved values); now reactive to a runtime `setData` |

No external/consumed-surface change — the `aiConfig.memoryService.*` leaves are unchanged; this is an internal read-shape fix.

## Deltas from ticket (if any)

- Scope = `MemoryService.mjs` read-shape only. Other repo-wide module-load captures (`QueryService`/`DatabaseService` `neoRootDir`, the github-workflow syncers' `issueSync`/`pullRequest`, `analyzeNlTelemetry` paths) are out of scope — boot-static paths / sync-config, lower self-heal relevance (per #14238 Out of Scope).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test … MemoryService.Lifecycle QueryRecentTurns SessionService.SummarizePagination` → **17 passed** (behavior-preserving). `node --check` clean. The Lifecycle spec exercises the graph-projection retry/drain (maxAttempts / retryBase / retryMax / drainInterval); the backfill/recent specs exercise the miniSummary / chroma reads.

## Post-Merge Validation

The leaves are read at the use site, so a recovery actuator's runtime `aiConfig.memoryService.*` mutation now takes effect on the next consumer call — the self-heal reactivity the module-load capture defeated. Deploy note: config.mjs materialization unchanged (the leaves shipped in #14234).

## Related

#14234 (introduced the module-load captures — this is its approve-and-follow-up), #14231 (the AiConfig pass), ADR-0019 (the use-site read-gate), #14193 (de-dup epic, same file).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f4bc5569-9c5f-477b-a810-7fb084867d6a`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
