### PR TITLE
fix(ai): record accepted-loss state marker (#14084)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -12,7 +12,11 @@ import {registerNeoChromaEmbeddingFunctions}                         from '../..
 import {auditChromaVectorCoverage}                                   from './checkChromaIntegrity.mjs';
 import {extractMemoryCoreCollectionData, truncateToEmbedTokenBudget} from './repairMemoryCoreStoredEmbeddings.mjs';
 import {resolveAutonomousRepairExit}                                 from '../../services/memory-core/helpers/acceptedLossSettlement.mjs';
-import {appendAutoAcceptedLoss}                                      from '../../services/memory-core/helpers/acceptedLossAuditStore.mjs';
+import {
+    appendAutoAcceptedLoss,
+    getAcceptedLossAuditFilePath,
+    writeAutoAcceptedLossState
+}                                                                    from '../../services/memory-core/helpers/acceptedLossAuditStore.mjs';
 
 /**
  * @summary Defragments collection groups inside the unified ChromaDB store.
@@ -74,6 +78,7 @@ const DEFRAG_STATE_DIR = path.join(PROJECT_ROOT, '.neo-ai-data', 'maintenance', 
 const MEMORY_CORE_UNSAFE_MESSAGE  =
     'Memory Core defrag is disabled until a safe multi-collection shadow/parking promotion exists. ' +
     'MC is an irreplaceable store; use backup/restore or a purpose-built repair lane instead of delete/recreate defrag.';
+const ACCEPTED_LOSS_STATE_SCHEMA_VERSION = 1;
 
 registerNeoChromaEmbeddingFunctions({
     dummyEmbeddingFunction: AiConfig.dummyEmbeddingFunction
@@ -1418,8 +1423,10 @@ export function anyRepairNonClean(results = []) {
  * @param {String} [options.provider='']
  * @param {Number|String} [options.contextBudget='']
  * @param {Function} [options.appendFn=appendAutoAcceptedLoss] Audit-append seam (test injection).
+ * @param {Function} [options.writeAcceptedLossStateFn=writeAutoAcceptedLossState] Latest-state marker seam.
  * @param {Function} [options.clearFn=clearDefragState] Marker-clear seam (test injection).
  * @param {Function} [options.writeLog] Optional logger, called with the settled-collection count.
+ * @param {Function} [options.now] Injectable timestamp factory for deterministic tests.
  * @returns {Promise<Object>} `{settled, perCollection}` — `settled` true iff every non-clean collection auto-settled and the marker was cleared.
  */
 export async function applyAutonomousSettlement({
@@ -1430,7 +1437,9 @@ export async function applyAutonomousSettlement({
     provider         = '',
     contextBudget    = '',
     appendFn         = appendAutoAcceptedLoss,
+    writeAcceptedLossStateFn = writeAutoAcceptedLossState,
     clearFn          = clearDefragState,
+    now              = () => new Date().toISOString(),
     writeLog
 } = {}) {
     const settleExit = resolveAutonomousRepairExit({results, normalizeResidue, provider, contextBudget});
@@ -1439,11 +1448,35 @@ export async function applyAutonomousSettlement({
         return {settled: false, perCollection: settleExit.perCollection};
     }
 
-    for (const entry of settleExit.perCollection) {
-        const result = (Array.isArray(results) ? results : []).find(item => item?.collectionName === entry.collectionName);
+    const settledCollections = [];
 
-        await appendFn({...entry.auditRecord, collectionName: entry.collectionName, parkingName: result?.promotion?.parkingName ?? null}, {dir: auditDir});
+    for (const entry of settleExit.perCollection) {
+        const result     = (Array.isArray(results) ? results : []).find(item => item?.collectionName === entry.collectionName),
+              auditEntry = {...entry.auditRecord, collectionName: entry.collectionName, parkingName: result?.promotion?.parkingName ?? null};
+
+        await appendFn(auditEntry, {dir: auditDir});
+
+        settledCollections.push({
+            collectionName: entry.collectionName,
+            reasonCode    : entry.reasonCode,
+            fingerprint   : auditEntry.fingerprint,
+            acceptedIds   : auditEntry.acceptedIds,
+            residueCount  : auditEntry.residueCount,
+            collectionSize: auditEntry.collectionSize,
+            parkingName   : auditEntry.parkingName
+        });
     }
+
+    await writeAcceptedLossStateFn({
+        schemaVersion  : ACCEPTED_LOSS_STATE_SCHEMA_VERSION,
+        type           : 'auto-accepted-loss-state',
+        phase          : 'memory-core-repair-recovered-with-accepted-loss',
+        settledAt      : now(),
+        auditPath      : getAcceptedLossAuditFilePath(auditDir),
+        defragStatePath: statePath,
+        collectionCount: settledCollections.length,
+        collections    : settledCollections
+    }, {dir: auditDir});
 
     // Resolve the non-clean marker the repair wrote — the run is now genuinely settled across runs, not just for
     // this process's exit code.
@@ -1606,7 +1639,7 @@ async function defragChromaDB() {
                         auditDir     : path.dirname(statePath),
                         provider     : config.embeddingProvider,
                         contextBudget: embedBudgetTokens,
-                        writeLog     : settledCount => console.log(`   ♻️  Autonomous accepted-loss: all ${settledCount} non-clean collection(s) held only bounded, deterministically-terminal residue — settled + recorded to ${path.join(path.dirname(statePath), 'auto-accepted-loss.jsonl')}, and the defrag marker cleared so the next run is unblocked. No operator page; zero ack.`)
+                        writeLog     : settledCount => console.log(`   ♻️  Autonomous accepted-loss: all ${settledCount} non-clean collection(s) held only bounded, deterministically-terminal residue — settled + recorded to ${path.join(path.dirname(statePath), 'auto-accepted-loss.jsonl')} and ${path.join(path.dirname(statePath), 'auto-accepted-loss-state.json')}, and the defrag marker cleared so the next run is unblocked. No operator page; zero ack.`)
                     });
 
                     if (settlement.settled) {

--- a/ai/services/memory-core/helpers/acceptedLossAuditStore.mjs
+++ b/ai/services/memory-core/helpers/acceptedLossAuditStore.mjs
@@ -8,11 +8,14 @@ import path                                                   from 'path';
  * records its `auto-accepted-loss` audit entry (ids + reasons + the shared residue fingerprint) so an
  * operator, when one is present, can review the accepted losses asynchronously — but the system NEVER
  * blocks on a human and there is no ack. This is telemetry, not a gate. Mirrors the `recoveryRunStateStore`
- * JSONL shape: I/O at the edge only, deterministic content. The fingerprint is the auto-reopen key — a later
- * embedding-capability change re-opens the residue, so an audited loss is recorded-and-reversible, not silent.
+ * JSONL shape: I/O at the edge only, deterministic content. The companion latest-state marker is the
+ * machine-readable terminal surface for maintenance tooling: the JSONL is history, the marker is the current
+ * accepted-loss outcome. The fingerprint is the auto-reopen key — a later embedding-capability change
+ * re-opens the residue, so an audited loss is recorded-and-reversible, not silent.
  */
 
-const AUDIT_FILE_NAME = 'auto-accepted-loss.jsonl';
+const AUDIT_FILE_NAME = 'auto-accepted-loss.jsonl',
+      STATE_FILE_NAME = 'auto-accepted-loss-state.json';
 
 /**
  * Bounded-retention cap. The audit log is append-only telemetry — operator-review only, with NO functional
@@ -44,6 +47,15 @@ const AUTO_ACCEPTED_LOSS_PRUNE_TRIGGER_BYTES = 2 * 1024 * 1024;
  */
 export function getAcceptedLossAuditFilePath(dir) {
     return path.join(dir, AUDIT_FILE_NAME);
+}
+
+/**
+ * @summary The latest accepted-loss state marker path within a state directory.
+ * @param {String} dir
+ * @returns {String}
+ */
+export function getAcceptedLossStateFilePath(dir) {
+    return path.join(dir, STATE_FILE_NAME);
 }
 
 /**
@@ -115,6 +127,56 @@ export async function readAutoAcceptedLossAudit({dir} = {}) {
         }
     }
     return entries;
+}
+
+/**
+ * @summary Writes the latest non-blocking `auto-accepted-loss` state marker atomically.
+ * This is the machine-distinguishable terminal state for a settled repair run; it complements the append-only
+ * audit log and intentionally does NOT replace the blocking defrag marker that `clearDefragState()` removes.
+ * @param {Object} state JSON-serializable latest-state payload.
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @returns {Promise<String>} The marker path written.
+ * @throws {TypeError} when `state` is not an object or `dir` is missing/empty.
+ */
+export async function writeAutoAcceptedLossState(state, {dir} = {}) {
+    if (!state || typeof state !== 'object') {
+        throw new TypeError('writeAutoAcceptedLossState: state object is required');
+    }
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('writeAutoAcceptedLossState: dir is required');
+    }
+
+    await mkdir(dir, {recursive: true});
+
+    const filePath = getAcceptedLossStateFilePath(dir),
+          tmpPath  = `${filePath}.tmp`;
+
+    await writeFile(tmpPath, JSON.stringify(state, null, 2) + '\n', 'utf8');
+    await rename(tmpPath, filePath);
+
+    return filePath;
+}
+
+/**
+ * @summary Reads the latest accepted-loss state marker. A missing marker returns `null`.
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @returns {Promise<Object|null>}
+ */
+export async function readAutoAcceptedLossState({dir} = {}) {
+    let text;
+
+    try {
+        text = await readFile(getAcceptedLossStateFilePath(dir), 'utf8');
+    } catch (error) {
+        if (error?.code === 'ENOENT') {
+            return null;
+        }
+        throw error;
+    }
+
+    return JSON.parse(text);
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs
@@ -1,7 +1,7 @@
-import {test, expect} from '@playwright/test';
-import {mkdtemp, rm}  from 'fs/promises';
-import os             from 'os';
-import path           from 'path';
+import {test, expect}          from '@playwright/test';
+import {mkdtemp, readFile, rm} from 'fs/promises';
+import os                      from 'os';
+import path                    from 'path';
 import {
     anyRepairNonClean,
     applyAutonomousSettlement,
@@ -816,15 +816,17 @@ test.describe('applyAutonomousSettlement — a settled clean exit clears the non
         promotion: {parkingName}
     });
 
-    test('all-bounded-terminal → settles, audits WITH the parking context, clears the marker', async () => {
-        const audits = [], cleared = [];
+    test('all-bounded-terminal → settles, audits WITH the parking context, writes accepted-loss state, clears the marker', async () => {
+        const audits = [], acceptedLossStates = [], cleared = [];
 
         const result = await applyAutonomousSettlement({
-            results  : [partial('mc-graph', [{id: 'a', reason: 'document-absent'}], 10000, 'mc-graph-parking-1')],
-            statePath: '/state/marker.json',
-            auditDir : '/state',
-            appendFn : async (entry, opts) => { audits.push({entry, opts}); },
-            clearFn  : async opts => { cleared.push(opts); }
+            results                 : [partial('mc-graph', [{id: 'a', reason: 'document-absent'}], 10000, 'mc-graph-parking-1')],
+            statePath               : '/state/marker.json',
+            auditDir                : '/state',
+            appendFn                : async (entry, opts) => { audits.push({entry, opts}); },
+            writeAcceptedLossStateFn: async (state, opts) => { acceptedLossStates.push({state, opts}); },
+            clearFn                 : async opts => { cleared.push(opts); },
+            now                     : () => '2026-06-27T13:31:00.000Z'
         });
 
         expect(result.settled).toBe(true);
@@ -832,6 +834,22 @@ test.describe('applyAutonomousSettlement — a settled clean exit clears the non
         expect(audits).toHaveLength(1);
         expect(audits[0].entry).toMatchObject({type: 'auto-accepted-loss', collectionName: 'mc-graph', parkingName: 'mc-graph-parking-1'});
         expect(audits[0].opts).toEqual({dir: '/state'});
+        expect(acceptedLossStates).toHaveLength(1);
+        expect(acceptedLossStates[0].opts).toEqual({dir: '/state'});
+        expect(acceptedLossStates[0].state).toMatchObject({
+            type           : 'auto-accepted-loss-state',
+            phase          : 'memory-core-repair-recovered-with-accepted-loss',
+            settledAt      : '2026-06-27T13:31:00.000Z',
+            auditPath      : '/state/auto-accepted-loss.jsonl',
+            defragStatePath: '/state/marker.json',
+            collectionCount: 1,
+            collections    : [{
+                collectionName: 'mc-graph',
+                parkingName   : 'mc-graph-parking-1',
+                fingerprint   : audits[0].entry.fingerprint,
+                acceptedIds   : ['a']
+            }]
+        });
     });
 
     test('any heal-path (transient) collection → NOT settled, no audit, marker left intact', async () => {
@@ -867,12 +885,16 @@ test.describe('applyAutonomousSettlement — a settled clean exit clears the non
             const result = await applyAutonomousSettlement({
                 results : [partial('mc-graph', [{id: 'a', reason: 'document-absent'}], 10000, 'parking-1')],
                 statePath,
-                auditDir: tmpDir
+                auditDir: tmpDir,
+                now     : () => '2026-06-27T13:31:00.000Z'
             });
             expect(result.settled).toBe(true);
 
             // the next run is now unblocked — the marker is resolved
             await expect(assertNoIncompleteDefragState({statePath, allowedPhases: []})).resolves.toBeUndefined();
+            const acceptedLossState = JSON.parse(await readFile(path.join(tmpDir, 'auto-accepted-loss-state.json'), 'utf8'));
+            expect(acceptedLossState.phase).toBe('memory-core-repair-recovered-with-accepted-loss');
+            expect(acceptedLossState.collections[0].parkingName).toBe('parking-1');
         } finally {
             await rm(tmpDir, {recursive: true, force: true});
         }

--- a/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAuditStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAuditStore.spec.mjs
@@ -1,15 +1,18 @@
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../../src/core/_export.mjs';
+import {test, expect}            from '@playwright/test';
+import Neo                       from '../../../../../../../src/Neo.mjs';
+import * as core                 from '../../../../../../../src/core/_export.mjs';
 import {appendFile, mkdtemp, rm} from 'fs/promises';
-import os             from 'os';
-import path           from 'path';
+import os                        from 'os';
+import path                      from 'path';
 
 import {
     appendAutoAcceptedLoss,
     getAcceptedLossAuditFilePath,
+    getAcceptedLossStateFilePath,
     pruneAutoAcceptedLossAudit,
-    readAutoAcceptedLossAudit
+    readAutoAcceptedLossAudit,
+    readAutoAcceptedLossState,
+    writeAutoAcceptedLossState
 } from '../../../../../../../ai/services/memory-core/helpers/acceptedLossAuditStore.mjs';
 
 test.describe('acceptedLossAuditStore — durable autonomous accepted-loss audit log', () => {
@@ -55,6 +58,27 @@ test.describe('acceptedLossAuditStore — durable autonomous accepted-loss audit
         expect(getAcceptedLossAuditFilePath(nested)).toBe(path.join(nested, 'auto-accepted-loss.jsonl'));
     });
 
+    test('write → read round-trips the latest accepted-loss state marker', async () => {
+        const state = {
+            schemaVersion  : 1,
+            type           : 'auto-accepted-loss-state',
+            phase          : 'memory-core-repair-recovered-with-accepted-loss',
+            settledAt      : '2026-06-27T13:31:00.000Z',
+            collectionCount: 1,
+            collections    : [{collectionName: 'mc-graph', fingerprint: 'fp-1'}]
+        };
+
+        const filePath = await writeAutoAcceptedLossState(state, {dir: tmpDir});
+
+        expect(filePath).toBe(getAcceptedLossStateFilePath(tmpDir));
+        expect(filePath).toBe(path.join(tmpDir, 'auto-accepted-loss-state.json'));
+        expect(await readAutoAcceptedLossState({dir: tmpDir})).toEqual(state);
+    });
+
+    test('a missing latest accepted-loss state marker reads as null', async () => {
+        expect(await readAutoAcceptedLossState({dir: tmpDir})).toBeNull();
+    });
+
     test('append is purely append-only (telemetry, not a gate): existing entries are preserved', async () => {
         await appendAutoAcceptedLoss(entry({fingerprint: 'fp-old'}), {dir: tmpDir});
         await appendAutoAcceptedLoss(entry({fingerprint: 'fp-new'}), {dir: tmpDir});
@@ -66,6 +90,8 @@ test.describe('acceptedLossAuditStore — durable autonomous accepted-loss audit
     test('rejects a missing entry / missing dir', async () => {
         await expect(appendAutoAcceptedLoss(null, {dir: tmpDir})).rejects.toThrow('entry');
         await expect(appendAutoAcceptedLoss(entry(), {})).rejects.toThrow('dir');
+        await expect(writeAutoAcceptedLossState(null, {dir: tmpDir})).rejects.toThrow('state');
+        await expect(writeAutoAcceptedLossState({}, {})).rejects.toThrow('dir');
     });
 
     test('a corrupt line is skipped on read (fail-safe — a torn append must not break the audit)', async () => {


### PR DESCRIPTION
Resolves #14084

Adds a distinct non-blocking `auto-accepted-loss-state.json` marker for autonomous accepted-loss settlements. The settled path now appends the historical `auto-accepted-loss.jsonl` audit entry, writes the latest accepted-loss state marker, then clears the blocking defrag marker so the next maintenance pass remains unblocked.

Evidence: L2 focused unit coverage + local static/pre-commit gates -> L2 required for the residual AC-6 internal maintenance marker contract. Residual: full unit suite currently has unrelated failures outside the touched accepted-loss files.

## Deltas from ticket

- Implements the residual AC-6 state-marker gap only; the larger autonomous settlement behavior remains the #14137 shape.
- Keeps the accepted-loss marker separate from the blocking defrag marker. A settled repair still clears the blocking marker, while the new marker preserves machine distinguishability.
- If writing the accepted-loss marker fails, settlement does not reach the clear step; the blocking marker remains and the run fails loud.

## Contract Ledger

Backfilled on #14084 before implementation: https://github.com/neomjs/neo/issues/14084#issuecomment-4817932626

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/acceptedLossAuditStore.spec.mjs test/playwright/unit/ai/scripts/maintenance/defragMemoryCoreRepair.spec.mjs` -> 43 passed.
- `git diff --check` -> passed.
- Pre-commit hooks on staged files -> passed.
- `npm run test-unit` -> 5320 passed, 23 failed, 5 skipped, 1 non-test error. The failures were outside the touched accepted-loss files, including existing Memory Core query/summarization drift, lifecycle checks, KB query anchors, and two unrelated UI/profile tests.

## Post-Merge Validation

- [ ] PR CI passes on the current head.
- [ ] A real bounded-terminal Memory Core repair leaves `.neo-ai-data/maintenance/defrag-state/auto-accepted-loss-state.json` present after the blocking defrag marker is cleared.

## Commit

- `df38dd6308` — `fix(ai): record accepted-loss state marker (#14084)`

Authored by Euclid (GPT-5, Codex Desktop). Session a725cf68-d74a-4037-9feb-22e2ac5947eb.