### PR TITLE
refactor(ai): trim ProcessSupervisor child-stderr relay — strip duplicate level + task framing (#14244)

### DIFF
--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -333,16 +333,19 @@ export class ProcessSupervisorService extends Base {
     }
 
     /**
-     * Writes child stderr lines using their child-provided severity prefix.
-     * @param {Object} task Task definition.
+     * Re-logs child stderr lines at the child's own severity (via {@link getChildLogLevel}), trimmed: the
+     * child's leading `[LEVEL]` is stripped — the outer logger already stamps that level, so it is not
+     * duplicated — and the `<task> stderr:` framing is dropped, so each line logs once as
+     * `[ProcessSupervisor] [<childSource>] <message>`. A line with no recognized `[LEVEL]` prefix passes
+     * through unstripped at the ERROR fail-safe (an unprefixed child failure is never silently downgraded).
      * @param {Buffer|String} data Stderr chunk.
      * @returns {void}
      */
-    writeChildStderr(task, data) {
+    writeChildStderr(data) {
         const lines = data.toString().split(/\r?\n/).map(line => line.trim()).filter(Boolean);
 
         for (const line of lines) {
-            this.writeLog?.(this.getChildLogLevel(line), `[ProcessSupervisor] ${task.label} stderr: ${line}`);
+            this.writeLog?.(this.getChildLogLevel(line), `[ProcessSupervisor] ${line.replace(/^\[(LOG|INFO|WARN|ERROR)\]\s*/, '')}`);
         }
     }
 
@@ -514,7 +517,7 @@ export class ProcessSupervisorService extends Base {
             child = this.spawnFn(task.command, task.args, {stdio: stdoutCapture ? ['ignore', 'pipe', 'pipe'] : ['ignore', 'ignore', 'pipe'], env});
 
             child.stderr?.on('data', data => {
-                this.writeChildStderr(task, data);
+                this.writeChildStderr(data);
             });
             child.stdout?.on('data', data => {
                 this.captureStdoutJsonChunk(stdoutCapture, data);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -114,6 +114,23 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         expect(service.getChildLogLevel('some unexpected line')).toBe('ERROR');
     });
 
+    test('writeChildStderr trims to [ProcessSupervisor] [childSource] message — single level stamp, level preserved, no task/stderr framing', () => {
+        const { service, logEntries } = createTestService();
+
+        // The child line already carries [LEVEL] [source]; the relay strips the duplicate [LEVEL] + the
+        // `<task> stderr:` framing, logging once as [ProcessSupervisor] [<childSource>] <message>.
+        service.writeChildStderr('[INFO] [MemoryService] miniSummary backfill complete: 9/9');
+        expect(logEntries.at(-1)).toEqual({level: 'INFO', message: '[ProcessSupervisor] [MemoryService] miniSummary backfill complete: 9/9'});
+
+        // The child's severity is preserved (not hardcoded INFO) and never duplicated in the message.
+        service.writeChildStderr('[WARN] [reconcileActiveChunks] removed duplicate pr-1.md');
+        expect(logEntries.at(-1)).toEqual({level: 'WARN', message: '[ProcessSupervisor] [reconcileActiveChunks] removed duplicate pr-1.md'});
+
+        // Unprefixed child failure → ERROR fail-safe, passed through unstripped (nothing to strip).
+        service.writeChildStderr('❌ Synchronization Failed: Error: boom');
+        expect(logEntries.at(-1)).toEqual({level: 'ERROR', message: '[ProcessSupervisor] ❌ Synchronization Failed: Error: boom'});
+    });
+
     test('getTaskPidFile returns correct path', () => {
         const { service, dataDir } = createTestService();
         const pidFile              = service.getTaskPidFile('mockTask');
@@ -231,9 +248,17 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
             'plain stderr output'
         ].join('\n')));
 
-        const stderrLogs = logEntries.filter(entry => entry.message.includes('stderr:'));
+        // The relay strips each child line's [LEVEL] + the `<task> stderr:` framing, logging once as
+        // [ProcessSupervisor] <message> at the child's parsed severity (unprefixed → ERROR fail-safe).
+        const childLogs = logEntries.filter(entry => /^\[ProcessSupervisor\] (Processed|Sync|Slow|Failed|plain)/.test(entry.message));
 
-        expect(stderrLogs.map(entry => entry.level)).toEqual(['INFO', 'INFO', 'WARN', 'ERROR', 'ERROR']);
+        expect(childLogs).toEqual([
+            {level: 'INFO',  message: '[ProcessSupervisor] Processed and embedded batch 83 of 237'},
+            {level: 'INFO',  message: '[ProcessSupervisor] Sync still running'},
+            {level: 'WARN',  message: '[ProcessSupervisor] Slow embedding batch'},
+            {level: 'ERROR', message: '[ProcessSupervisor] Failed embedding batch'},
+            {level: 'ERROR', message: '[ProcessSupervisor] plain stderr output'}
+        ]);
     });
 
     test('#13777: opted-in stdout JSON is recorded on successful child completion', () => {


### PR DESCRIPTION
Resolves #14244

## Summary

Operator-flagged log brittleness: ProcessSupervisor re-logged each child stderr line as `[ProcessSupervisor] <task> stderr: <raw-child-line>`, **double-stamping the level** (the raw line already carries `[LEVEL] [source]`, and the outer logger stamps `getChildLogLevel(line)` again) and adding `<task> stderr:` framing noise.

`writeChildStderr` now strips the child's leading `[LEVEL]` (the outer level already carries it — losslessly) and drops the `<task> stderr:` framing, so each line logs once as `[ProcessSupervisor] [<childSource>] <message>`.

Before:
`[INFO] [ProcessSupervisor] memory miniSummary backfill stderr: [INFO] [MemoryService] miniSummary backfill complete: 9/9 …`
After:
`[INFO] [ProcessSupervisor] [MemoryService] miniSummary backfill complete: 9/9 …`

## Deltas

- **Level is lossless:** the surviving stamp is the child's parsed severity (the relay already used `getChildLogLevel(line)` for the outer level), so a child WARN/ERROR still logs at WARN/ERROR — never masked as INFO.
- An unprefixed child line passes through unstripped at the ERROR fail-safe (unchanged `getChildLogLevel` default).
- `writeChildStderr(task, data)` → `writeChildStderr(data)`: the `task` param is dropped (unused). Per-line supervised-task attribution is recoverable from the framed `Starting <task>` + serial heavy-maintenance + the child source — a deliberate readability trade (called out in #14244).

## Test Evidence

Evidence: `UNIT_TEST_MODE=true` playwright (unit) `ProcessSupervisorService` → **40 passed** — a new `writeChildStderr` test (trimmed format + WARN/ERROR level-preservation + unprefixed→ERROR fail-safe) + the existing relay test updated to assert the trimmed shape. `node --check` clean.

## Post-Merge Validation

Orchestrator logs show child stderr as `[ProcessSupervisor] [<childSource>] <message>` — one level stamp, no `<task> stderr:` framing; a child WARN/ERROR line still surfaces at its severity (log-level filtering intact).

Authored by Vega (@neo-opus-vega · Claude Opus 4.8, Claude Code). Origin session 3f32bbc7-1bfe-4f85-9232-c957de0d22f1. Targets dev — never main. friction→gold from an operator log-readability flag.