### PR TITLE
fix(ai): recognize HTTP-404 model-not-resident as a model-load-error (#14247)

### DIFF
--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -508,14 +508,17 @@ class TextEmbeddingService extends Base {
 
             return await responsePromise;
         } catch (err) {
-            const isModelLoadError = err.message.includes('HTTP 400') && (
+            // Shape C (HTTP 404): the model is not resident at the provider (sustained eviction / never
+            // loaded) — the live #14154 trigger. A 404 on /v1/embeddings means model-not-found, so it gets
+            // the same bounded model-load-wait retry; it stays fail-loud on a permanent 404 (retries exhaust).
+            const isModelLoadError = (err.message.includes('HTTP 400') && (
                 err.message.includes('Model was unloaded') ||              // Shape A — JIT-unload-then-queued-request
                 (err.message.includes('Failed to load model') &&            // Shape B — JIT-warm-load-canceled
                  err.message.includes('Operation canceled'))
-            );
+            )) || err.message.includes('HTTP 404');                         // Shape C — model not resident
 
             if (unloadRetriesLeft > 0 && isModelLoadError) {
-                logger.log(`[TextEmbeddingService] embedding-provider model-load failure detected (Shape ${err.message.includes('Model was unloaded') ? 'A' : 'B'}), retrying (remaining retries: ${unloadRetriesLeft})`);
+                logger.log(`[TextEmbeddingService] embedding-provider model-load failure detected (Shape ${err.message.includes('Model was unloaded') ? 'A' : err.message.includes('HTTP 404') ? 'C' : 'B'}), retrying (remaining retries: ${unloadRetriesLeft})`);
                 await new Promise(r => setTimeout(r, unloadRetryDelayMs));
                 return this.#postOpenAiCompatible(inputData, {
                     unloadRetriesLeft: unloadRetriesLeft - 1,

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -160,6 +160,17 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
                 } else if (serverBehavior === 'fail-all-shape-b') {
                     res.writeHead(400, { 'Content-Type': 'application/json' });
                     res.end(JSON.stringify({ error: 'Failed to load model "text-embedding-qwen3-embedding-8b". Error: Operation canceled.' }));
+                } else if (serverBehavior === 'fail-404-then-succeed') {
+                    if (requestCount === 1) {
+                        res.writeHead(404, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({ error: 'The requested resource could not be found.' }));
+                    } else {
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({ data: [{ embedding: [0.11, 0.22, 0.33] }] }));
+                    }
+                } else if (serverBehavior === 'fail-all-404') {
+                    res.writeHead(404, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ error: 'The requested resource could not be found.' }));
                 } else if (serverBehavior === 'fail-other') {
                     res.writeHead(400, { 'Content-Type': 'application/json' });
                     res.end(JSON.stringify({ error: 'Some other bad request error' }));
@@ -490,6 +501,24 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
             .rejects.toThrow(/Some other bad request error/);
 
         expect(requestCount).toBe(1); // No retries
+    });
+
+    test('HTTP 404 model-not-resident retries with wait and succeeds (Shape C, #14247)', async () => {
+        serverBehavior = 'fail-404-then-succeed';
+        const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
+        expect(result).toEqual([0.11, 0.22, 0.33]);
+        expect(requestCount).toBe(2);
+    });
+
+    test('HTTP 404 fails loud after bounded retries — no infinite loop (Shape C, #14247)', async () => {
+        serverBehavior = 'fail-all-404';
+        aiConfig.openAiCompatible.unloadRetryCount = 2; // N=2
+
+        await expect(TextEmbeddingService.embedText('hello', 'openAiCompatible'))
+            .rejects.toThrow(/HTTP 404/);
+
+        // Initial request + 2 bounded retries = 3 total requests (no infinite loop on a permanent 404)
+        expect(requestCount).toBe(3);
     });
 
     test('contention-timeout single embedding retries and succeeds', async () => {


### PR DESCRIPTION
## Summary

`TextEmbeddingService.#postOpenAiCompatible`'s retry guard recognized only HTTP-400 model-load shapes, so an HTTP-404 (the model not resident at the provider — the live #14154 trigger) skipped the model-load-wait retry and blind-aborted the embedding batch. This adds **Shape C** (HTTP-404 → the existing bounded model-load-wait retry) — the Neo-side **self-heal-not-abort** mitigation. The env-root-cause (LM Studio VRAM co-eviction) remains #14154's separate infra investigation.

Resolves #14247

## Change

`isModelLoadError` (`ai/services/memory-core/TextEmbeddingService.mjs:511`) now also matches `HTTP 404`:
- **Shape A** (existing): `HTTP 400` + `Model was unloaded` — JIT-unload-then-queued
- **Shape B** (existing): `HTTP 400` + `Failed to load model` + `Operation canceled` — JIT-warm-load canceled
- **Shape C** (new): `HTTP 404` — model not resident (sustained eviction / never loaded)

A 404 now triggers the existing **bounded** `unloadRetriesLeft` model-load-wait retry (waiting `unloadRetryDelayMs` between attempts, giving the provider time to reload). The log discriminator gains a `C` branch.

## Why

A 404 on `/v1/embeddings` means the model is not found/resident — the model-load-wait retry is exactly the right response (same class as a JIT-unload). Pre-fix, a 404 fell through to the remaining blind POSTs then aborted the batch (which, pre-#14146, discarded all KB-sync progress → the #14154 catastrophic re-embed loop). Identified as **sub-fix #3 in #14146** (the checkpoint/resume half landed; this retry-guard half did not).

## Deltas from ticket (if any)

None — implemented exactly per #14247's AC. The `HTTP 404` substring is the simplest robust match (a 404 on `/v1/embeddings` is model-not-resident by construction; the error body already carries endpoint + model for diagnosability), so no separate body-keyword match was needed. No scope deviation.

## Safety / fail-loud

The retry is **bounded** by `unloadRetriesLeft` — a genuinely-permanent 404 (wrong model name / endpoint) exhausts the bounded retries and fails loud with the diagnostic message (endpoint + model in the error body). **No infinite loop** — proven by the `fail-all-404` test.

## Test Evidence

Evidence: `UNIT_TEST_MODE=true npx playwright test TextEmbeddingService.retry.spec.mjs` → **22 passed** (20 existing + 2 new):
- `HTTP 404 model-not-resident retries with wait and succeeds (Shape C)` → `requestCount === 2`.
- `HTTP 404 fails loud after bounded retries — no infinite loop (Shape C)` → `requestCount === 3` (initial + 2 bounded retries), throws `/HTTP 404/`.
- Existing Shape A/B + contention + batch tests unchanged (no regression).

`node --check` clean on `TextEmbeddingService.mjs`.

## Post-Merge Validation

Once merged, an embedding-provider HTTP-404 (model evicted / not-resident — e.g. the #14154 LM Studio VRAM co-eviction window) triggers the bounded model-load-wait retry instead of a blind batch-abort, so a transient eviction self-heals (the provider reloads within the retry window) rather than aborting the KB-sync. A genuinely-permanent 404 still fails loud after the bounded retries. Confirm via the orchestrator kbSync log: a 404 window logs `Shape C` retries, not an immediate `Failed to process batch … Aborting`.

## Scope / Contract Ledger

`#postOpenAiCompatible` is a private method and `isModelLoadError` is a function-local — **no consumed public surface, no Contract Ledger needed**. Internal retry-classification only; behavior change is additive (a 404 that previously aborted now retries-then-aborts-or-succeeds).

## Related

#14154 (the incident + env-root-cause), #14146 (sub-fix #3 origin; closed), #14124 (warm-provider / embed-write-canary class).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f4bc5569-9c5f-477b-a810-7fb084867d6a`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
