### PR TITLE
fix(hooks): guard rg replace flag misuse (#14243)

### DIFF
--- a/.claude/hooks/rgReplaceGuardHook.mjs
+++ b/.claude/hooks/rgReplaceGuardHook.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+/**
+ * @module .claude/hooks/rgReplaceGuardHook
+ * @summary Claude Code `PreToolUse` guard for the high-frequency `rg -r` footgun: in ripgrep, `-r`
+ * means `--replace`, not recursion. The hook is intentionally narrow: it only inspects Bash tool
+ * commands, only flags `rg` invocations, and allows explicit replacement shapes with a replacement
+ * plus a search pattern.
+ *
+ * The hook fails open on malformed payloads. A broken guard must never block ordinary tool use; at worst,
+ * it misses one warning and the user can re-run the command.
+ */
+import {pathToFileURL} from 'node:url';
+
+export const RG_REPLACE_GUARD_MESSAGE = '`rg -r` is `--replace`, not recursion. ripgrep recurses by default; did you mean a plain recursive search?';
+
+const SHELL_SEPARATORS = new Set([';', '|', '||', '&&']);
+
+/**
+ * @summary Tokenizes enough shell syntax to identify command words and simple separators without executing
+ * or fully parsing Bash. Quoted strings stay single tokens; this is sufficient for `rg --replace "x" "y"`.
+ * @param {String} command
+ * @returns {String[]}
+ */
+export function tokenizeShellCommand(command = '') {
+    const tokens  = [];
+    let   current = '';
+    let   quote   = null;
+    let   escape  = false;
+
+    function pushCurrent() {
+        if (current.length > 0) {
+            tokens.push(current);
+            current = '';
+        }
+    }
+
+    for (let i = 0; i < command.length; i++) {
+        const char = command[i];
+
+        if (escape) {
+            current += char;
+            escape = false;
+            continue
+        }
+
+        if (char === '\\') {
+            escape = true;
+            continue
+        }
+
+        if (quote) {
+            if (char === quote) {
+                quote = null;
+            } else {
+                current += char;
+            }
+            continue
+        }
+
+        if (char === '\'' || char === '"' || char === '`') {
+            quote = char;
+            continue
+        }
+
+        if (/\s/.test(char)) {
+            pushCurrent();
+            continue
+        }
+
+        if (char === '&' && command[i + 1] === '&') {
+            pushCurrent();
+            tokens.push('&&');
+            i++;
+            continue
+        }
+
+        if (char === '|' && command[i + 1] === '|') {
+            pushCurrent();
+            tokens.push('||');
+            i++;
+            continue
+        }
+
+        if (char === ';' || char === '|') {
+            pushCurrent();
+            tokens.push(char);
+            continue
+        }
+
+        current += char;
+    }
+
+    pushCurrent();
+
+    return tokens
+}
+
+function isRgCommand(token) {
+    return /(?:^|\/)rg(?:\.exe)?$/.test(token);
+}
+
+function isShellSeparator(token) {
+    return SHELL_SEPARATORS.has(token);
+}
+
+function commandOperands(tokens, startIndex, endIndex) {
+    const operands = [];
+
+    for (let i = startIndex; i < endIndex; i++) {
+        const token = tokens[i];
+
+        if (!token || isShellSeparator(token)) {
+            break
+        }
+
+        if (!token.startsWith('-')) {
+            operands.push(token);
+        }
+    }
+
+    return operands
+}
+
+function looksLikePathOperand(token) {
+    return typeof token === 'string' && (
+        token === '.' ||
+        token === '..' ||
+        token.startsWith('./') ||
+        token.startsWith('../') ||
+        token.startsWith('/') ||
+        token.startsWith('~/') ||
+        token.includes('/')
+    )
+}
+
+function replacementOperandProblem(tokens, replacementIndex, endIndex) {
+    if (replacementIndex >= endIndex || tokens[replacementIndex]?.startsWith('-')) {
+        return 'missing-replacement';
+    }
+
+    const operands = commandOperands(tokens, replacementIndex, endIndex);
+
+    if (operands.length < 2) {
+        return 'missing-pattern';
+    }
+
+    // The common footgun is `rg -r "pattern" path/`: the path becomes ripgrep's search pattern while
+    // the intended pattern becomes replacement text. Genuine replacement with a path needs three operands:
+    // replacement, pattern, then the path.
+    if (operands.length === 2 && looksLikePathOperand(operands[1])) {
+        return 'missing-pattern';
+    }
+
+    return null
+}
+
+function segmentEnd(tokens, startIndex) {
+    for (let i = startIndex; i < tokens.length; i++) {
+        if (isShellSeparator(tokens[i])) {
+            return i
+        }
+    }
+
+    return tokens.length
+}
+
+function replaceFlagProblem(tokens, flagIndex, endIndex) {
+    const flag = tokens[flagIndex];
+
+    if (flag === '--replace') {
+        return replacementOperandProblem(tokens, flagIndex + 1, endIndex);
+    }
+
+    if (flag.startsWith('--replace=')) {
+        const replacement = flag.slice('--replace='.length);
+
+        if (!replacement) {
+            return 'missing-replacement';
+        }
+
+        const operands = commandOperands(tokens, flagIndex + 1, endIndex);
+
+        if (operands.length < 1) {
+            return 'missing-pattern';
+        }
+
+        if (operands.length === 1 && looksLikePathOperand(operands[0])) {
+            return 'missing-pattern';
+        }
+
+        return null;
+    }
+
+    if (flag === '-r') {
+        return replacementOperandProblem(tokens, flagIndex + 1, endIndex);
+    }
+
+    // `rg -rn foo` is the observed failure: ripgrep treats `n` as replacement text, not recursion.
+    // Require separated `-r replacement pattern` or long `--replace replacement pattern` for genuine use.
+    if (/^-.*r/.test(flag)) {
+        return 'clustered-short-replace';
+    }
+
+    return null
+}
+
+/**
+ * @summary Detects whether a Bash command contains an `rg` invocation whose replace flag shape is likely the
+ * recursion mistake.
+ * @param {String} command
+ * @returns {{flag: String, reason: String}|null}
+ */
+export function findRgReplaceFootgun(command = '') {
+    const tokens = tokenizeShellCommand(command);
+
+    for (let i = 0; i < tokens.length; i++) {
+        if (!isRgCommand(tokens[i])) {
+            continue
+        }
+
+        const end = segmentEnd(tokens, i + 1);
+
+        for (let j = i + 1; j < end; j++) {
+            const reason = replaceFlagProblem(tokens, j, end);
+
+            if (reason) {
+                return {flag: tokens[j], reason}
+            }
+        }
+
+        i = end;
+    }
+
+    return null
+}
+
+function parseHookPayload(raw) {
+    if (!raw) return null;
+
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return null;
+    }
+}
+
+function resolveBashCommand(hookPayload) {
+    if (hookPayload?.tool_name && hookPayload.tool_name !== 'Bash') {
+        return null
+    }
+
+    return typeof hookPayload?.tool_input?.command === 'string'
+        ? hookPayload.tool_input.command
+        : (typeof hookPayload?.command === 'string' ? hookPayload.command : null)
+}
+
+/**
+ * @summary Returns the Claude hook block directive for suspicious `rg -r` shapes, or `null` to allow.
+ * @param {Object} hookPayload Parsed Claude Code hook payload.
+ * @returns {{decision: 'block', reason: String}|null}
+ */
+export function decideRgReplaceGuard(hookPayload) {
+    const command = resolveBashCommand(hookPayload);
+
+    if (!command) {
+        return null
+    }
+
+    const finding = findRgReplaceFootgun(command);
+
+    return finding ? {decision: 'block', reason: RG_REPLACE_GUARD_MESSAGE} : null
+}
+
+async function readStdin() {
+    return new Promise((resolve, reject) => {
+        let data = '';
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data',  chunk => data += chunk);
+        process.stdin.on('end',   ()    => resolve(data));
+        process.stdin.on('error', reject);
+    });
+}
+
+async function main() {
+    const decision = decideRgReplaceGuard(parseHookPayload(await readStdin()));
+
+    if (decision) {
+        process.stdout.write(`${JSON.stringify(decision)}\n`);
+    }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    await main().catch(() => {});
+}

--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -36,6 +36,18 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/env node \"$(git rev-parse --show-toplevel)/.claude/hooks/rgReplaceGuardHook.mjs\"",
+            "timeout": 2
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -30,8 +30,8 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
     let workRoot;
 
     function recordingLogger() {
-        const log  = [];
-        const warn = [];
+        const log   = [];
+        const warn  = [];
         const error = [];
         return {
             log    : (...args) => log.push(args.join(' ')),
@@ -81,7 +81,7 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
 
     test('AC1: missing config.mjs is cloned from template', async () => {
         const templateSrc = `import path from 'path';\nexport default {x: 1};\n`;
-        const root = buildServerSandbox({
+        const root        = buildServerSandbox({
             sandboxName     : 'ac1-clone',
             templateContents: templateSrc,
             configContents  : undefined
@@ -398,7 +398,7 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
         // `import {parsePort as foo, parseBool} from '...'` projects as `:parsePort` + `:parseBool`,
         // not the local alias `:foo`. Ensures shape comparison is stable across
         // operator local-aliasing variations.
-        const src = `import {parsePort as foo, parseBool} from '../../../../src/util/Env.mjs';\n`;
+        const src      = `import {parsePort as foo, parseBool} from '../../../../src/util/Env.mjs';\n`;
         const filePath = path.join(workRoot, 'aliased.mjs');
         fs.writeFileSync(filePath, src);
 
@@ -508,7 +508,7 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
     });
 
     test('named exports projection: exports {a, b} blocks are extracted and trimmed', async () => {
-        const src = `export {first, second, third} from './re-export.mjs';\nexport {only} from './another.mjs';\n`;
+        const src      = `export {first, second, third} from './re-export.mjs';\nexport {only} from './another.mjs';\n`;
         const filePath = path.join(workRoot, 'exports.mjs');
         fs.writeFileSync(filePath, src);
 
@@ -797,7 +797,7 @@ test.describe('assertConfigFresh — boot freshness guard (#13560)', () => {
     });
 
     test('benign drift (changed default only) warns but does NOT throw', async () => {
-        const root   = buildTier1({
+        const root = buildTier1({
             name            : 'benign',
             templateContents: `export default {model: leaf('a', 'NEO_MODEL', 'string')};\n`,
             configContents  : `export default {model: leaf('b', 'NEO_MODEL', 'string')};\n`
@@ -820,10 +820,15 @@ test.describe('initClaudeSettings — Claude Stop-hook auto-wire (#13641)', () =
     };
 
     // The tracked template the materializer reads — the Stop hook with the operator-directed
-    // enforce=1 default (the forcing-function rollout; NOT dry-run).
+    // enforce=1 default (the forcing-function rollout; NOT dry-run) plus PreToolUse guards.
     const TEMPLATE = {
         permissions: {allow: ['mcp__neo-mjs-memory-core__healthcheck']},
         hooks      : {
+            PreToolUse: [{matcher: 'Bash', hooks: [{
+                type   : 'command',
+                command: '/usr/bin/env node "$(git rev-parse --show-toplevel)/.claude/hooks/rgReplaceGuardHook.mjs"',
+                timeout: 2
+            }]}],
             Stop: [{hooks: [{
                 type   : 'command',
                 command: 'NEO_LANE_STATE_ENFORCE=1 /usr/bin/env node "$(git rev-parse --show-toplevel)/.claude/hooks/laneStateStopHook.mjs"',
@@ -850,23 +855,24 @@ test.describe('initClaudeSettings — Claude Stop-hook auto-wire (#13641)', () =
         if (claudeRoot && fs.existsSync(claudeRoot)) fs.rmSync(claudeRoot, {recursive: true, force: true});
     });
 
-    test('mergeClaudeHooks: ensures the template Stop hook, preserves other keys + non-Stop events', () => {
-        const active = {permissions: {allow: ['local-perm']}, hooks: {PreToolUse: [{hooks: []}]}};
+    test('mergeClaudeHooks: ensures template hooks, preserves other keys + local-only events', () => {
+        const active              = {permissions: {allow: ['local-perm']}, hooks: {PostToolUse: [{hooks: []}]}};
         const {settings, changed} = mergeClaudeHooks(active, TEMPLATE);
 
         expect(changed).toBe(true);
-        expect(settings.permissions.allow).toEqual(['local-perm']);     // operator-local key preserved
-        expect(settings.hooks.PreToolUse).toEqual([{hooks: []}]);       // non-Stop hook event preserved
-        expect(settings.hooks.Stop).toEqual(TEMPLATE.hooks.Stop);       // Stop wired from template
+        expect(settings.permissions.allow).toEqual(['local-perm']);             // operator-local key preserved
+        expect(settings.hooks.PostToolUse).toEqual([{hooks: []}]);              // local-only event preserved
+        expect(settings.hooks.PreToolUse).toEqual(TEMPLATE.hooks.PreToolUse);   // PreToolUse wired from template
+        expect(settings.hooks.Stop).toEqual(TEMPLATE.hooks.Stop);               // Stop wired from template
     });
 
     test('mergeClaudeHooks: idempotent — already-wired hooks report changed=false', () => {
-        const {changed} = mergeClaudeHooks({hooks: {Stop: TEMPLATE.hooks.Stop}}, TEMPLATE);
+        const {changed} = mergeClaudeHooks({hooks: TEMPLATE.hooks}, TEMPLATE);
         expect(changed).toBe(false);
     });
 
     test('mergeClaudeHooks: a template without hooks is a no-op', () => {
-        const active = {permissions: {allow: ['x']}};
+        const active              = {permissions: {allow: ['x']}};
         const {settings, changed} = mergeClaudeHooks(active, {permissions: {}});
         expect(changed).toBe(false);
         expect(settings).toBe(active);
@@ -883,6 +889,7 @@ test.describe('initClaudeSettings — Claude Stop-hook auto-wire (#13641)', () =
         // rollout. A future drift to dry-run fails this assertion.
         expect(command).toContain('NEO_LANE_STATE_ENFORCE=1');
         expect(command).toContain('laneStateStopHook.mjs');
+        expect(written.hooks.PreToolUse[0].hooks[0].command).toContain('rgReplaceGuardHook.mjs');
     });
 
     test('initClaudeSettings: re-run is idempotent → silent', async () => {
@@ -900,6 +907,7 @@ test.describe('initClaudeSettings — Claude Stop-hook auto-wire (#13641)', () =
         const written = JSON.parse(fs.readFileSync(path.join(dir, 'settings.json'), 'utf-8'));
         expect(written.permissions.allow).toEqual(['my-local-perm']);                      // preserved
         expect(written.hooks.Stop[0].hooks[0].command).toContain('NEO_LANE_STATE_ENFORCE=1');
+        expect(written.hooks.PreToolUse[0].hooks[0].command).toContain('rgReplaceGuardHook.mjs');
     });
 
     test('initClaudeSettings: no template → skip-no-template (no settings.json written)', async () => {

--- a/test/playwright/unit/hooks/rgReplaceGuardHook.spec.mjs
+++ b/test/playwright/unit/hooks/rgReplaceGuardHook.spec.mjs
@@ -1,0 +1,63 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    decideRgReplaceGuard,
+    findRgReplaceFootgun,
+    RG_REPLACE_GUARD_MESSAGE,
+    tokenizeShellCommand
+} from '../../../../.claude/hooks/rgReplaceGuardHook.mjs';
+
+test.describe('rgReplaceGuardHook — Claude PreToolUse Bash guard', () => {
+    test('tokenizer keeps quoted arguments intact', () => {
+        expect(tokenizeShellCommand('rg --replace "new value" "old value" src | cat'))
+            .toEqual(['rg', '--replace', 'new value', 'old value', 'src', '|', 'cat']);
+    });
+
+    test('flags clustered `rg -rn` as replace-not-recursion misuse', () => {
+        expect(findRgReplaceFootgun('rg -rn "escalateDiagnosis" ai/')).toMatchObject({
+            flag  : '-rn',
+            reason: 'clustered-short-replace'
+        });
+    });
+
+    test('flags bare replace flag without enough replacement + pattern arguments', () => {
+        expect(findRgReplaceFootgun('rg -r "escalateDiagnosis" ai/')).toMatchObject({flag: '-r'});
+        expect(findRgReplaceFootgun('rg --replace')).toMatchObject({flag: '--replace'});
+        expect(findRgReplaceFootgun('rg --replace replacement')).toMatchObject({flag: '--replace'});
+        expect(findRgReplaceFootgun('rg --replace "escalateDiagnosis" ai/')).toMatchObject({flag: '--replace'});
+        expect(findRgReplaceFootgun('rg --replace=escalateDiagnosis ai/')).toMatchObject({flag: '--replace=escalateDiagnosis'});
+    });
+
+    test('allows explicit replacement invocations', () => {
+        expect(findRgReplaceFootgun('rg --replace "replacement" "pattern"')).toBeNull();
+        expect(findRgReplaceFootgun('rg --replace "replacement" "pattern" ai/')).toBeNull();
+        expect(findRgReplaceFootgun('rg --replace=replacement "pattern" ai/')).toBeNull();
+        expect(findRgReplaceFootgun('rg -r replacement pattern ai/')).toBeNull();
+    });
+
+    test('does not flag other tools recursive flags', () => {
+        expect(findRgReplaceFootgun('cp -r src dest && rm -r tmp/foo')).toBeNull();
+    });
+
+    test('PreToolUse decision blocks suspicious Bash command with clear message', () => {
+        expect(decideRgReplaceGuard({
+            hook_event_name: 'PreToolUse',
+            tool_name      : 'Bash',
+            tool_input     : {command: 'rg -rn "foo"'}
+        })).toEqual({decision: 'block', reason: RG_REPLACE_GUARD_MESSAGE});
+    });
+
+    test('PreToolUse decision allows non-Bash tools and genuine replacement', () => {
+        expect(decideRgReplaceGuard({
+            hook_event_name: 'PreToolUse',
+            tool_name      : 'Read',
+            tool_input     : {command: 'rg -rn "foo"'}
+        })).toBeNull();
+
+        expect(decideRgReplaceGuard({
+            hook_event_name: 'PreToolUse',
+            tool_name      : 'Bash',
+            tool_input     : {command: 'rg --replace "bar" "foo" src/'}
+        })).toBeNull();
+    });
+});


### PR DESCRIPTION
Resolves #14243

Adds a repo-shared Claude Code `PreToolUse` Bash guard for the recurring `rg -r` footgun: `rg -r` is `--replace`, not recursion, and ripgrep already recurses by default. The hook tokenizes Bash commands, detects standalone or clustered suspicious `rg` replace flags without enough replacement intent, and blocks with a clear warning while allowing genuine replacement calls and other tools recursive flags.

Evidence: L2 (local static checks plus focused unit coverage of the PreToolUse decision and setup merge path) -> L3 required (post-merge hook firing in a real Claude Code PreToolUse Bash invocation). Residual: AC4 [#14243].

## Deltas from ticket (if any)

- Implemented the guard as `.claude/hooks/rgReplaceGuardHook.mjs` and wired it into `.claude/settings.template.json` under the `PreToolUse` Bash matcher.
- Extended `initClaudeSettings` coverage so existing local `.claude/settings.json` files merge template PreToolUse hooks while preserving local keys and already-wired hooks.
- Kept the guard narrow to ripgrep command shapes: suspicious bare or clustered `-r` / `--replace` is blocked, explicit replacement calls are allowed, and unrelated tools such as `cp -r` are ignored.

## Test Evidence

- `git diff --check origin/dev..HEAD` - pass.
- `node --check .claude/hooks/rgReplaceGuardHook.mjs` - pass.
- `npm run agent-preflight -- .claude/hooks/rgReplaceGuardHook.mjs .claude/settings.template.json test/playwright/unit/hooks/rgReplaceGuardHook.spec.mjs test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs` - all requested gates passed.
- `NEO_CHROMA_PORT_TEST=28193 UNIT_TEST_MODE=true npm run test-unit -- test/playwright/unit/hooks/rgReplaceGuardHook.spec.mjs test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs` - 43 passed (30.9s).
- Branch rebased onto current `origin/dev` `3400050af2` before push; outgoing log contains only `dc9e62e03b fix(hooks): guard rg replace flag misuse (#14243)`.

## Post-Merge Validation

- [ ] Fresh Claude Code checkout / config initialization wires the PreToolUse Bash guard from `.claude/settings.template.json` into local `.claude/settings.json` without dropping local settings.
- [ ] Deliberate Claude Bash invocation `rg -rn "foo"` is blocked with the warning that `rg -r` is `--replace`, not recursion.

Authored by Euclid (GPT-5, Codex Desktop). Session 30b8eb6f-4336-48e7-95c2-46fcbcd0df81.