### PR TITLE
fix(ai): verify drain auto-embed persisted a vector — prevent metadata-only rows (#14254)

### DIFF
--- a/ai/daemons/embed/daemon.mjs
+++ b/ai/daemons/embed/daemon.mjs
@@ -29,13 +29,13 @@ import * as core        from '../../../src/core/_export.mjs';
 import InstanceManager  from '../../../src/manager/Instance.mjs';
 import memoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
 
-import fs   from 'fs-extra';
-import path from 'path';
+import fs         from 'fs-extra';
+import path       from 'path';
 import {execSync} from 'child_process';
 
-import StorageRouter   from '../../services/memory-core/managers/StorageRouter.mjs';
-import {startDrainLoop} from './drainCycle.mjs';
-import {acquireDrainLock} from './drainLock.mjs';
+import StorageRouter               from '../../services/memory-core/managers/StorageRouter.mjs';
+import {startDrainLoop}            from './drainCycle.mjs';
+import {acquireDrainLock}          from './drainLock.mjs';
 import {getMissingMemoryWalLeaves} from '../../services/memory-core/helpers/memoryWalStore.mjs';
 
 // Stale-config boot guard: the gitignored config.mjs is a MATERIALIZED template copy — on a
@@ -220,8 +220,8 @@ async function enforceSingleton() {
     }
 
     // Cleanup on exit
-    let cleanedUp = false;
-    const cleanup = () => {
+    let   cleanedUp = false;
+    const cleanup   = () => {
         if (cleanedUp) return;
         cleanedUp = true;
         try {
@@ -274,9 +274,10 @@ async function main() {
     // The shared loop host (`drainCycle.mjs`) owns cycle scheduling, per-cycle config/collection
     // resolution, and failure absorption; this process wrapper owns PID/lifecycle/logging only.
     startDrainLoop({
-        getCollection: () => StorageRouter.getMemoryCollection(),
-        getConfig    : () => memoryCoreConfig.memoryWal,
-        log          : writeLog
+        getCollection    : () => StorageRouter.getMemoryCollection(),
+        getConfig        : () => memoryCoreConfig.memoryWal,
+        expectedDimension: memoryCoreConfig.vectorDimension,
+        log              : writeLog
     });
 }
 

--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -4,7 +4,7 @@ import {
     pruneReconciledWalSegments,
     readPendingWalRecords
 } from '../../services/memory-core/helpers/memoryWalStore.mjs';
-import {classifyRowVector} from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
+import {classifyRowVector, VECTOR_REJECTION_REASONS} from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
 
 /**
  * @summary One durable drain pass over the `add_memory` write-ahead log.
@@ -130,30 +130,37 @@ export async function embedBatch({collection, records, maxRetries, backoffBaseMs
  *
  * Disposition per outcome:
  * - **valid vector** → `embedded` (safe to mark reconciled).
- * - **confirmed metadata-only** (read-back ok, vector missing/empty/wrong-dimension) → `metadataOnly`, and the
- *   persisted row is **deleted** so the cooldown retry's `add` re-embeds cleanly (`add` is create-not-upsert; a
- *   lingering row would no-op the retry). The autonomous recovery actuator remains the backstop for any that slip.
- * - **unverifiable** (the read-back itself threw) → `metadataOnly` but **not** deleted — a transient read error
- *   must never destroy possibly-valid rows; the batch stays pending for a clean re-verify next cycle.
+ * - **confirmed metadata-only** (read-back returns a missing/empty/wrong-dimension vector, OR a single-id read
+ *   throws the documented vector-absent signature — {@link isVectorAbsentError}, `Error finding id`) → `metadataOnly`,
+ *   and the persisted row is **deleted** so the cooldown retry's `add` re-embeds cleanly (`add` is create-not-upsert;
+ *   a lingering row would no-op the retry). The autonomous recovery actuator remains the backstop for any that slip.
+ * - **unverifiable** (a read throws a non-vector-absent / transient error) → `unverifiable`, **not** deleted —
+ *   a transient read failure must never destroy possibly-valid rows; the row stays pending for a clean re-verify.
  *
- * Verify is opt-in on a known `expectedDimension`: without one it cannot classify, so it falls back (logged) to
- * the prior add-success⟹embed-success behavior rather than rejecting every row.
+ * A *batch* read-back throw cannot name which id failed, so it routes to a bounded per-record re-read
+ * ({@link verifyRecordsPerId}) that isolates the metadata-only signature from a transient error before deciding
+ * delete-vs-retry. Verify is opt-in on a known `expectedDimension`: without one it cannot classify, so it falls
+ * back (logged) to the prior add-success⟹embed-success behavior rather than rejecting every row.
  *
  * @param {Object}   options
  * @param {Object}   options.collection        Content-store collection (`get({ids, include:['embeddings']})` + `delete`).
  * @param {Object[]} options.records           The `add`-succeeded WAL records to verify (`{id, ...}`).
  * @param {Number}   options.expectedDimension Required vector dimension; non-positive/absent → verify skipped.
  * @param {Function} options.log               `(level, message)` sink.
- * @returns {Promise<{embedded: Object[], metadataOnly: Array<{record: Object, error: Error}>}>}
+ * @returns {Promise<{embedded: Object[], metadataOnly: Array<{record: Object, error: Error}>, unverifiable: Array<{record: Object, error: Error}>}>}
  */
+export function isVectorAbsentError(error) {
+    return /error finding id/i.test(error?.message ?? '');
+}
+
 export async function verifyEmbeddedVectors({collection, records, expectedDimension, log}) {
     if (records.length === 0) {
-        return {embedded: [], metadataOnly: []};
+        return {embedded: [], metadataOnly: [], unverifiable: []};
     }
 
     if (!Number.isInteger(expectedDimension) || expectedDimension <= 0) {
         log('WARN', `Post-add vector verify skipped — expectedDimension not configured (${expectedDimension}); add-success treated as embed-success`);
-        return {embedded: [...records], metadataOnly: []};
+        return {embedded: [...records], metadataOnly: [], unverifiable: []};
     }
 
     const ids = records.map(record => record.id);
@@ -161,19 +168,20 @@ export async function verifyEmbeddedVectors({collection, records, expectedDimens
 
     try {
         readBack = await collection.get({ids, include: ['embeddings']});
-    } catch (error) {
-        // Cannot prove the vectors persisted — fail closed (do NOT mark embedded) but do NOT delete:
-        // a transient read failure must never destroy possibly-valid rows. Stays pending for next cycle.
-        log('ERROR', `Post-add vector verify read failed (${error.message}) — batch left pending for retry`);
-        return {embedded: [], metadataOnly: records.map(record => ({record, error}))};
+    } catch (batchError) {
+        // The batch read-back threw. The content store throws the vector-absent signature (`Error finding id`)
+        // precisely for a metadata-only row — but a batch throw cannot name WHICH id, and may also be transient.
+        // Fall back to per-id verification so the known metadata-only signature is caught (delete + retry)
+        // rather than collapsed into "unverifiable, do not delete".
+        log('WARN', `Post-add batch vector verify threw (${batchError.message}) — isolating per record`);
+        return verifyRecordsPerId({collection, records, expectedDimension, log});
     }
 
     const embeddingById = new Map();
     (readBack?.ids ?? []).forEach((id, index) => embeddingById.set(id, readBack.embeddings?.[index]));
 
-    const embedded        = [];
-    const metadataOnly    = [];
-    const metadataOnlyIds = [];
+    const embedded     = [];
+    const metadataOnly = [];
 
     for (const record of records) {
         const reason = classifyRowVector({id: record.id, embedding: embeddingById.get(record.id)}, expectedDimension);
@@ -182,20 +190,79 @@ export async function verifyEmbeddedVectors({collection, records, expectedDimens
             embedded.push(record);
         } else {
             metadataOnly.push({record, error: new Error(`metadata-only row (${reason}) — auto-embed persisted no valid vector`)});
-            metadataOnlyIds.push(record.id);
         }
     }
 
-    if (metadataOnlyIds.length > 0) {
+    await deleteMetadataOnlyRows({collection, metadataOnly, log});
+
+    return {embedded, metadataOnly, unverifiable: []};
+}
+
+/**
+ * @summary Per-record verify fallback for when the batch read-back throws. Isolates each record with a single-id
+ * read: a returned vector is classified by {@link classifyRowVector}; a thrown vector-absent signature
+ * ({@link isVectorAbsentError}) is the confirmed metadata-only shape (delete + retry); any other thrown error is
+ * genuinely unverifiable (retry, never deleted). Bounded to the exceptional path — the happy path is one batched read.
+ * @param {Object} options See {@link verifyEmbeddedVectors}.
+ * @returns {Promise<{embedded: Object[], metadataOnly: Array<{record, error}>, unverifiable: Array<{record, error}>}>}
+ */
+async function verifyRecordsPerId({collection, records, expectedDimension, log}) {
+    const embedded     = [];
+    const metadataOnly = [];
+    const unverifiable = [];
+
+    for (const record of records) {
+        let reason;
+
         try {
-            await collection.delete({ids: metadataOnlyIds});
-            log('ERROR', `Post-add verify: deleted ${metadataOnlyIds.length} metadata-only row(s) for re-embed: ${metadataOnlyIds.join(', ')}`);
-        } catch (error) {
-            log('ERROR', `Post-add verify: metadata-only delete failed (${error.message}) — rows remain for the recovery actuator: ${metadataOnlyIds.join(', ')}`);
+            const back  = await collection.get({ids: [record.id], include: ['embeddings']});
+            const index = (back?.ids ?? []).indexOf(record.id);
+
+            reason = classifyRowVector({id: record.id, embedding: index >= 0 ? back.embeddings?.[index] : undefined}, expectedDimension);
+        } catch (perIdError) {
+            if (isVectorAbsentError(perIdError)) {
+                reason = VECTOR_REJECTION_REASONS.missingEmbedding; // the documented metadata-only thrown shape
+            } else {
+                unverifiable.push({record, error: perIdError}); // transient — retry next cycle, never delete
+                continue;
+            }
+        }
+
+        if (reason === null) {
+            embedded.push(record);
+        } else {
+            metadataOnly.push({record, error: new Error(`metadata-only row (${reason}) — auto-embed persisted no valid vector`)});
         }
     }
 
-    return {embedded, metadataOnly};
+    await deleteMetadataOnlyRows({collection, metadataOnly, log});
+
+    return {embedded, metadataOnly, unverifiable};
+}
+
+/**
+ * @summary Deletes confirmed metadata-only rows so the cooldown retry's `add` re-embeds cleanly (`add` is
+ * create-not-upsert; a lingering row would no-op the retry). A failed delete is logged loud — the autonomous
+ * recovery actuator remains the backstop.
+ * @param {Object}   options
+ * @param {Object}   options.collection
+ * @param {Object[]} options.metadataOnly `{record, error}` entries to delete.
+ * @param {Function} options.log
+ * @returns {Promise<void>}
+ */
+async function deleteMetadataOnlyRows({collection, metadataOnly, log}) {
+    if (metadataOnly.length === 0) {
+        return;
+    }
+
+    const ids = metadataOnly.map(({record}) => record.id);
+
+    try {
+        await collection.delete({ids});
+        log('ERROR', `Post-add verify: deleted ${ids.length} metadata-only row(s) for re-embed: ${ids.join(', ')}`);
+    } catch (error) {
+        log('ERROR', `Post-add verify: metadata-only delete failed (${error.message}) — rows remain for the recovery actuator: ${ids.join(', ')}`);
+    }
 }
 
 /**
@@ -230,7 +297,7 @@ export async function verifyEmbeddedVectors({collection, records, expectedDimens
  * @param {Function} [options.log]            `(level, message)` sink. Defaults to a no-op.
  * @param {Function} [options.sleep]          Delay primitive. Defaults to a real timer.
  * @param {Function} [options.now]            Clock source (epoch ms). Defaults to `Date.now`.
- * @returns {Promise<{pending: Number, embedded: Number, compensated: Number, failed: Number, metadataOnly: Number, cooling: Number, prunedSegments: Number}>}
+ * @returns {Promise<{pending: Number, embedded: Number, compensated: Number, failed: Number, metadataOnly: Number, unverifiable: Number, cooling: Number, prunedSegments: Number}>}
  *     Cycle summary for the daemon's log line.
  */
 export async function drainWalOnce({
@@ -247,7 +314,7 @@ export async function drainWalOnce({
     sleep      = ms => new Promise(resolve => setTimeout(resolve, ms)),
     now        = Date.now
 } = {}) {
-    const summary = {pending: 0, embedded: 0, compensated: 0, failed: 0, metadataOnly: 0, cooling: 0, prunedSegments: 0};
+    const summary = {pending: 0, embedded: 0, compensated: 0, failed: 0, metadataOnly: 0, unverifiable: 0, cooling: 0, prunedSegments: 0};
 
     // Full pending read (not limit-bounded): a newest-first limited read would let records
     // cooling down at the head permanently shadow older drainable ones. Scan cost is bounded —
@@ -275,11 +342,12 @@ export async function drainWalOnce({
 
         // Atomic-write Prevent floor: add-success ≠ embed-success on the auto-embed path, so verify the
         // persisted vector before reconciling. Metadata-only rows are routed to retry, never marked embedded.
-        const {embedded, metadataOnly} = await verifyEmbeddedVectors({collection, records: succeeded, expectedDimension, log});
-        const failedRecords            = [...failed, ...metadataOnly];
+        const {embedded, metadataOnly, unverifiable} = await verifyEmbeddedVectors({collection, records: succeeded, expectedDimension, log});
+        const failedRecords                          = [...failed, ...metadataOnly, ...unverifiable];
 
         summary.failed       = failed.length;
         summary.metadataOnly = metadataOnly.length;
+        summary.unverifiable = unverifiable.length;
 
         for (const {record, error} of failedRecords) {
             const failures = (retryState.get(record.id)?.failures ?? 0) + 1;

--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -4,6 +4,7 @@ import {
     pruneReconciledWalSegments,
     readPendingWalRecords
 } from '../../services/memory-core/helpers/memoryWalStore.mjs';
+import {classifyRowVector} from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
 
 /**
  * @summary One durable drain pass over the `add_memory` write-ahead log.
@@ -117,6 +118,87 @@ export async function embedBatch({collection, records, maxRetries, backoffBaseMs
 }
 
 /**
+ * @summary Verifies that an `add`-succeeded batch actually persisted a valid vector — the atomic-write
+ * Prevent floor for the auto-embed drain path.
+ *
+ * `embedBatch` calls `collection.add({ids, metadatas, documents})` with **no `embeddings`** — it relies on
+ * Chroma's collection embedding-function to auto-generate the vector. That auto-embed is **not atomic**: the
+ * provider call can fail (timeout, oversized input, model-not-resident) while the document/metadata still
+ * persist, leaving a metadata-only row — the recurring corruption shape — on the *highest-volume* write path.
+ * `add`-success therefore does NOT imply embed-success, so this reads the persisted vectors back and classifies
+ * each with the same {@link classifyRowVector} invariant the explicit-embedding write gate uses.
+ *
+ * Disposition per outcome:
+ * - **valid vector** → `embedded` (safe to mark reconciled).
+ * - **confirmed metadata-only** (read-back ok, vector missing/empty/wrong-dimension) → `metadataOnly`, and the
+ *   persisted row is **deleted** so the cooldown retry's `add` re-embeds cleanly (`add` is create-not-upsert; a
+ *   lingering row would no-op the retry). The autonomous recovery actuator remains the backstop for any that slip.
+ * - **unverifiable** (the read-back itself threw) → `metadataOnly` but **not** deleted — a transient read error
+ *   must never destroy possibly-valid rows; the batch stays pending for a clean re-verify next cycle.
+ *
+ * Verify is opt-in on a known `expectedDimension`: without one it cannot classify, so it falls back (logged) to
+ * the prior add-success⟹embed-success behavior rather than rejecting every row.
+ *
+ * @param {Object}   options
+ * @param {Object}   options.collection        Content-store collection (`get({ids, include:['embeddings']})` + `delete`).
+ * @param {Object[]} options.records           The `add`-succeeded WAL records to verify (`{id, ...}`).
+ * @param {Number}   options.expectedDimension Required vector dimension; non-positive/absent → verify skipped.
+ * @param {Function} options.log               `(level, message)` sink.
+ * @returns {Promise<{embedded: Object[], metadataOnly: Array<{record: Object, error: Error}>}>}
+ */
+export async function verifyEmbeddedVectors({collection, records, expectedDimension, log}) {
+    if (records.length === 0) {
+        return {embedded: [], metadataOnly: []};
+    }
+
+    if (!Number.isInteger(expectedDimension) || expectedDimension <= 0) {
+        log('WARN', `Post-add vector verify skipped — expectedDimension not configured (${expectedDimension}); add-success treated as embed-success`);
+        return {embedded: [...records], metadataOnly: []};
+    }
+
+    const ids = records.map(record => record.id);
+    let readBack;
+
+    try {
+        readBack = await collection.get({ids, include: ['embeddings']});
+    } catch (error) {
+        // Cannot prove the vectors persisted — fail closed (do NOT mark embedded) but do NOT delete:
+        // a transient read failure must never destroy possibly-valid rows. Stays pending for next cycle.
+        log('ERROR', `Post-add vector verify read failed (${error.message}) — batch left pending for retry`);
+        return {embedded: [], metadataOnly: records.map(record => ({record, error}))};
+    }
+
+    const embeddingById = new Map();
+    (readBack?.ids ?? []).forEach((id, index) => embeddingById.set(id, readBack.embeddings?.[index]));
+
+    const embedded        = [];
+    const metadataOnly    = [];
+    const metadataOnlyIds = [];
+
+    for (const record of records) {
+        const reason = classifyRowVector({id: record.id, embedding: embeddingById.get(record.id)}, expectedDimension);
+
+        if (reason === null) {
+            embedded.push(record);
+        } else {
+            metadataOnly.push({record, error: new Error(`metadata-only row (${reason}) — auto-embed persisted no valid vector`)});
+            metadataOnlyIds.push(record.id);
+        }
+    }
+
+    if (metadataOnlyIds.length > 0) {
+        try {
+            await collection.delete({ids: metadataOnlyIds});
+            log('ERROR', `Post-add verify: deleted ${metadataOnlyIds.length} metadata-only row(s) for re-embed: ${metadataOnlyIds.join(', ')}`);
+        } catch (error) {
+            log('ERROR', `Post-add verify: metadata-only delete failed (${error.message}) — rows remain for the recovery actuator: ${metadataOnlyIds.join(', ')}`);
+        }
+    }
+
+    return {embedded, metadataOnly};
+}
+
+/**
  * @summary Executes one full drain cycle: read pending → embed → reconcile/compensate → prune.
  *
  * **Reconcile vs compensate:** after a successful embed, the cycle re-reads the pending state for
@@ -142,11 +224,13 @@ export async function embedBatch({collection, records, maxRetries, backoffBaseMs
  * @param {Number}   options.maxRetries       In-cycle whole-batch retry bound.
  * @param {Number}   options.backoffBaseMs    Exponential backoff base.
  * @param {Number}   options.retentionLimit   Reconciled-segment retention bound for pruning.
+ * @param {Number}   [options.expectedDimension] Required vector dimension for the post-add atomic-write verify;
+ *     absent/non-positive → verify skipped (add-success⟹embed-success, the prior behavior).
  * @param {Map}      [options.retryState]     Cross-cycle per-record cooldown state (caller-owned).
  * @param {Function} [options.log]            `(level, message)` sink. Defaults to a no-op.
  * @param {Function} [options.sleep]          Delay primitive. Defaults to a real timer.
  * @param {Function} [options.now]            Clock source (epoch ms). Defaults to `Date.now`.
- * @returns {Promise<{pending: Number, embedded: Number, compensated: Number, failed: Number, cooling: Number, prunedSegments: Number}>}
+ * @returns {Promise<{pending: Number, embedded: Number, compensated: Number, failed: Number, metadataOnly: Number, cooling: Number, prunedSegments: Number}>}
  *     Cycle summary for the daemon's log line.
  */
 export async function drainWalOnce({
@@ -157,12 +241,13 @@ export async function drainWalOnce({
     maxRetries,
     backoffBaseMs,
     retentionLimit,
+    expectedDimension,
     retryState = new Map(),
     log        = () => {},
     sleep      = ms => new Promise(resolve => setTimeout(resolve, ms)),
     now        = Date.now
 } = {}) {
-    const summary = {pending: 0, embedded: 0, compensated: 0, failed: 0, cooling: 0, prunedSegments: 0};
+    const summary = {pending: 0, embedded: 0, compensated: 0, failed: 0, metadataOnly: 0, cooling: 0, prunedSegments: 0};
 
     // Full pending read (not limit-bounded): a newest-first limited read would let records
     // cooling down at the head permanently shadow older drainable ones. Scan cost is bounded —
@@ -188,20 +273,26 @@ export async function drainWalOnce({
     if (drainable.length > 0) {
         const {succeeded, failed} = await embedBatch({collection, records: drainable, maxRetries, backoffBaseMs, sleep, log});
 
-        summary.failed = failed.length;
+        // Atomic-write Prevent floor: add-success ≠ embed-success on the auto-embed path, so verify the
+        // persisted vector before reconciling. Metadata-only rows are routed to retry, never marked embedded.
+        const {embedded, metadataOnly} = await verifyEmbeddedVectors({collection, records: succeeded, expectedDimension, log});
+        const failedRecords            = [...failed, ...metadataOnly];
 
-        for (const {record, error} of failed) {
+        summary.failed       = failed.length;
+        summary.metadataOnly = metadataOnly.length;
+
+        for (const {record, error} of failedRecords) {
             const failures = (retryState.get(record.id)?.failures ?? 0) + 1;
 
             retryState.set(record.id, {failures, nextAttemptAt: now() + getBackoffDelayMs(backoffBaseMs, failures)});
             log('ERROR', `Record ${record.id} failed embed #${failures} (${error.message}) — cooling down`);
         }
 
-        if (succeeded.length > 0) {
+        if (embedded.length > 0) {
             // Purge-race compensation window: re-read pending state for exactly the embedded ids.
-            const succeededIds = succeeded.map(record => record.id);
+            const succeededIds = embedded.map(record => record.id);
             const stillPending = new Set((await readPendingWalRecords({dir, ids: succeededIds})).map(record => record.id));
-            const tombstoned   = succeeded.filter(record => !stillPending.has(record.id));
+            const tombstoned   = embedded.filter(record => !stillPending.has(record.id));
 
             if (tombstoned.length > 0) {
                 // Tombstoned mid-embed: purgeSession marked these records (always BEFORE its own
@@ -219,7 +310,7 @@ export async function drainWalOnce({
                 }
             }
 
-            for (const record of succeeded) {
+            for (const record of embedded) {
                 retryState.delete(record.id);
 
                 if (!stillPending.has(record.id)) continue;
@@ -266,11 +357,13 @@ export async function drainWalOnce({
  * @param {Object}   options
  * @param {Function} options.getCollection Async resolver for the content-store collection.
  * @param {Function} options.getConfig     Returns the `memoryWal` config slice (read per cycle).
+ * @param {Number}   [options.expectedDimension] Required vector dimension for the post-add atomic-write verify
+ *     (deploy-fixed; read once at wire-up). Absent → verify skipped (logged) — wire it in production.
  * @param {Function} [options.log]         `(level, message)` sink. Defaults to a no-op.
  * @param {Map}      [options.retryState]  Cross-cycle per-record cooldown state.
  * @returns {{stop: Function}} Handle whose `stop()` ends the loop (idempotent).
  */
-export function startDrainLoop({getCollection, getConfig, log = () => {}, retryState = new Map()}) {
+export function startDrainLoop({getCollection, getConfig, expectedDimension, log = () => {}, retryState = new Map()}) {
     let stopped = false;
     let timer   = null;
 
@@ -279,7 +372,7 @@ export function startDrainLoop({getCollection, getConfig, log = () => {}, retryS
 
         try {
             const collection = await getCollection();
-            const summary    = await drainWalOnce({dir, collection, batchSize, maxRetries, backoffBaseMs, retentionLimit, retryState, log});
+            const summary    = await drainWalOnce({dir, collection, batchSize, maxRetries, backoffBaseMs, retentionLimit, expectedDimension, retryState, log});
 
             // Idle cycles stay silent — at a multi-second poll interval, per-cycle no-op lines
             // would dominate the log without adding signal.

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -285,9 +285,10 @@ class Server extends BaseServer {
 
             if (this.walDrainLock) {
                 this.walDrainLoop = startDrainLoop({
-                    getCollection: () => StorageRouter.getMemoryCollection(),
-                    getConfig    : () => aiConfig.memoryWal,
-                    log          : drainLog
+                    getCollection    : () => StorageRouter.getMemoryCollection(),
+                    getConfig        : () => aiConfig.memoryWal,
+                    expectedDimension: aiConfig.vectorDimension,
+                    log              : drainLog
                 });
                 // Release on process exit (the realistic single-process clean-shutdown path); a
                 // signal-kill leaves the lock for the next host to reclaim as stale.
@@ -301,7 +302,7 @@ class Server extends BaseServer {
         // projection is a separate completion concern.
         if (aiConfig.messageWal && aiConfig.messageWal.inProcessDrain) {
             const messageDrainLog = (level, message) => logger[level === 'ERROR' ? 'error' : 'info'](`[neo-memory-core MCP] ${message}`);
-            const missingLeaves = getMissingMessageWalLeaves(aiConfig.messageWal,
+            const missingLeaves   = getMissingMessageWalLeaves(aiConfig.messageWal,
                 ['dir', 'pollIntervalMs', 'batchSize', 'maxRetries', 'backoffBaseMs']);
 
             if (missingLeaves.length > 0) {
@@ -528,7 +529,7 @@ class Server extends BaseServer {
         }
 
         const {userId, agentIdentityNodeId, source} = this.stdioIdentity;
-        const bound = agentIdentityNodeId ? `bound to ${agentIdentityNodeId}` : 'unbound (no matching AgentIdentity node)';
+        const bound                                 = agentIdentityNodeId ? `bound to ${agentIdentityNodeId}` : 'unbound (no matching AgentIdentity node)';
 
         logger.info(`[neo-memory-core MCP] Identity: ${userId} via ${source} — ${bound}`);
     }

--- a/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
@@ -1,9 +1,9 @@
 import {test, expect} from '@playwright/test';
-import Neo             from '../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../src/core/_export.mjs';
-import {mkdtemp, rm}   from 'fs/promises';
-import os              from 'os';
-import path            from 'path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {mkdtemp, rm}  from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
 
 import {
     appendWalEmbedMarker,
@@ -57,30 +57,54 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
     const seed = async (id, timestampMs = Date.now()) =>
         (await appendWalMemory(record(id, timestampMs), {dir: tmpDir})).segmentKey;
 
+    // The post-add atomic-write verify reads vectors back and classifies them at this dimension.
+    const VECTOR_DIMENSION = 4;
+    const VALID_VECTOR     = [0.11, 0.22, 0.33, 0.44];
+
     /**
-     * Controllable content-store fake: records every add/delete, stores by id, and exposes
-     * `failNextAdds` (transient whole-batch failures) + `onAdd` (per-payload hook, e.g. poison
-     * records or mid-embed tombstones).
+     * Controllable content-store fake: records every add/get/delete, stores metadata + (simulated
+     * auto-embed) vectors by id, and exposes `failNextAdds` (transient whole-batch failures),
+     * `failNextGets` (transient verify-read failures), `onAdd` (per-payload hook), and `noVectorFor`
+     * — ids whose `add` "succeeds" but persists NO vector, simulating the non-atomic auto-embed that
+     * produces the metadata-only corruption row.
      */
     const createFakeCollection = () => {
         const fake = {
-            store      : new Map(),
-            addCalls   : [],
-            deleteCalls: [],
+            store       : new Map(),
+            vectors     : new Map(),
+            addCalls    : [],
+            getCalls    : [],
+            deleteCalls : [],
             failNextAdds: 0,
-            onAdd      : null,
-            add: async payload => {
+            failNextGets: 0,
+            noVectorFor : new Set(),
+            onAdd       : null,
+            add         : async payload => {
                 fake.addCalls.push(payload);
                 if (fake.onAdd) await fake.onAdd(payload);
                 if (fake.failNextAdds > 0) {
                     fake.failNextAdds--;
                     throw new Error('store down (spec)');
                 }
-                payload.ids.forEach((id, i) => fake.store.set(id, payload.metadatas[i]));
+                payload.ids.forEach((id, i) => {
+                    fake.store.set(id, payload.metadatas[i]);
+                    // Simulate Chroma auto-embed: a valid vector lands UNLESS this id is marked non-atomic
+                    // (metadata persists, vector does not) — the metadata-only corruption shape.
+                    if (!fake.noVectorFor.has(id)) fake.vectors.set(id, [...VALID_VECTOR]);
+                });
+            },
+            get: async ({ids}) => {
+                fake.getCalls.push(ids);
+                if (fake.failNextGets > 0) {
+                    fake.failNextGets--;
+                    throw new Error('get down (spec)');
+                }
+                const present = ids.filter(id => fake.vectors.has(id));
+                return {ids: present, embeddings: present.map(id => fake.vectors.get(id))};
             },
             delete: async ({ids}) => {
                 fake.deleteCalls.push(ids);
-                ids.forEach(id => fake.store.delete(id));
+                ids.forEach(id => { fake.store.delete(id); fake.vectors.delete(id); });
             }
         };
         return fake;
@@ -114,6 +138,56 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
         const second = await drain(collection);
         expect(second).toMatchObject({pending: 0, embedded: 0});
         expect(collection.addCalls).toHaveLength(1);
+    });
+
+    test('#14228 atomic-write Prevent: an add-success that persisted NO vector (non-atomic auto-embed) is NOT marked embedded — it is deleted + retried', async () => {
+        await seed('good');
+        await seed('bad');
+
+        const collection = createFakeCollection();
+        collection.noVectorFor.add('bad');   // auto-embed persists 'bad' metadata but no vector (the metadata-only shape)
+
+        const retryState = new Map();
+        const first      = await drain(collection, {expectedDimension: VECTOR_DIMENSION, retryState, now: () => 5_000_000});
+
+        // 'good' embedded + reconciled; 'bad' detected metadata-only → not marked, deleted, cooling for retry.
+        expect(first).toMatchObject({pending: 2, embedded: 1, metadataOnly: 1, failed: 0});
+        expect(collection.deleteCalls.flat()).toContain('bad');        // metadata-only row removed for clean re-embed
+        expect(collection.store.has('bad')).toBe(false);
+        expect(retryState.get('bad')).toMatchObject({failures: 1});
+        // 'good' reconciled (not pending); 'bad' stays pending — never marked embedded.
+        expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['bad']);
+
+        // Cycle 2: 'bad' now auto-embeds atomically (vector persists) → re-embedded + reconciled.
+        collection.noVectorFor.delete('bad');
+        const second = await drain(collection, {expectedDimension: VECTOR_DIMENSION, retryState, now: () => 6_000_000});
+        expect(second).toMatchObject({embedded: 1, metadataOnly: 0});
+        expect(await readPendingWalRecords({dir: tmpDir})).toHaveLength(0);
+    });
+
+    test('#14228 atomic-write Prevent: a verify read-back failure leaves the batch pending (NOT marked, NOT deleted) for a clean re-verify', async () => {
+        await seed('x');
+
+        const collection = createFakeCollection();
+        collection.failNextGets = 1;   // the post-add vector read-back throws (transient)
+
+        const summary = await drain(collection, {expectedDimension: VECTOR_DIMENSION, retryState: new Map(), now: () => 7_000_000});
+
+        expect(summary).toMatchObject({embedded: 0, metadataOnly: 1});
+        expect(collection.deleteCalls.flat()).not.toContain('x');   // a transient read error must NOT destroy a possibly-valid row
+        expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['x']);   // stays pending for retry
+    });
+
+    test('#14228 verify is opt-in: without expectedDimension, add-success is treated as embed-success (pre-#14228 behavior, verify skipped)', async () => {
+        await seed('legacy');
+
+        const collection = createFakeCollection();
+        collection.noVectorFor.add('legacy');   // even with no persisted vector, the skipped verify marks it embedded
+
+        const summary = await drain(collection);   // no expectedDimension → verify skipped
+        expect(summary).toMatchObject({embedded: 1, metadataOnly: 0});
+        expect(collection.getCalls).toHaveLength(0);   // verify did not run
+        expect(await readPendingWalRecords({dir: tmpDir})).toHaveLength(0);
     });
 
     test('retry/backoff: transient whole-batch failures retry with exponential delays, then succeed', async () => {
@@ -305,8 +379,8 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
 
         test('absorbs a failing cycle and keeps looping (collection resolution failure)', async () => {
             await seed('resilient');
-            const collection = createFakeCollection();
-            let resolutions  = 0;
+            const collection  = createFakeCollection();
+            let   resolutions = 0;
 
             const loop = startDrainLoop({
                 getCollection: async () => {

--- a/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
@@ -70,16 +70,17 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
      */
     const createFakeCollection = () => {
         const fake = {
-            store       : new Map(),
-            vectors     : new Map(),
-            addCalls    : [],
-            getCalls    : [],
-            deleteCalls : [],
-            failNextAdds: 0,
-            failNextGets: 0,
-            noVectorFor : new Set(),
-            onAdd       : null,
-            add         : async payload => {
+            store               : new Map(),
+            vectors             : new Map(),
+            addCalls            : [],
+            getCalls            : [],
+            deleteCalls         : [],
+            failNextAdds        : 0,
+            failNextGets        : 0,
+            noVectorFor         : new Set(),
+            throwVectorAbsentFor: new Set(),
+            onAdd               : null,
+            add                 : async payload => {
                 fake.addCalls.push(payload);
                 if (fake.onAdd) await fake.onAdd(payload);
                 if (fake.failNextAdds > 0) {
@@ -98,6 +99,12 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
                 if (fake.failNextGets > 0) {
                     fake.failNextGets--;
                     throw new Error('get down (spec)');
+                }
+                // Model the documented metadata-only read-back: Chroma throws `Error finding id` for a row
+                // whose vector never reached the index (rather than returning it with a null embedding).
+                const absent = ids.find(id => fake.throwVectorAbsentFor.has(id));
+                if (absent) {
+                    throw new Error(`Error finding id ${absent} in collection`);
                 }
                 const present = ids.filter(id => fake.vectors.has(id));
                 return {ids: present, embeddings: present.map(id => fake.vectors.get(id))};
@@ -165,17 +172,41 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
         expect(await readPendingWalRecords({dir: tmpDir})).toHaveLength(0);
     });
 
-    test('#14228 atomic-write Prevent: a verify read-back failure leaves the batch pending (NOT marked, NOT deleted) for a clean re-verify', async () => {
+    test('#14228 atomic-write Prevent: a transient (non-vector-absent) read failure → unverifiable, left pending, NOT deleted', async () => {
         await seed('x');
 
         const collection = createFakeCollection();
-        collection.failNextGets = 1;   // the post-add vector read-back throws (transient)
+        collection.failNextGets = 2;   // the batch read AND the per-id fallback read both throw a transient error
 
         const summary = await drain(collection, {expectedDimension: VECTOR_DIMENSION, retryState: new Map(), now: () => 7_000_000});
 
-        expect(summary).toMatchObject({embedded: 0, metadataOnly: 1});
+        expect(summary).toMatchObject({embedded: 0, unverifiable: 1, metadataOnly: 0});
         expect(collection.deleteCalls.flat()).not.toContain('x');   // a transient read error must NOT destroy a possibly-valid row
         expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['x']);   // stays pending for retry
+    });
+
+    test('#14228 atomic-write Prevent: a THROWN metadata-only signature (Error finding id) is caught + deleted + retried, not collapsed into transient', async () => {
+        await seed('good');
+        await seed('bad');
+
+        const collection = createFakeCollection();
+        collection.throwVectorAbsentFor.add('bad');   // get throws the documented vector-absent signature for 'bad'
+
+        const retryState = new Map();
+        const first      = await drain(collection, {expectedDimension: VECTOR_DIMENSION, retryState, now: () => 8_000_000});
+
+        // The batch read-back throws → per-id fallback isolates: 'good' verifies, 'bad' is the thrown vector-absent
+        // signature → confirmed metadata-only → deleted + retried (NOT left as unverifiable).
+        expect(first).toMatchObject({embedded: 1, metadataOnly: 1, unverifiable: 0});
+        expect(collection.deleteCalls.flat()).toContain('bad');
+        expect(retryState.get('bad')).toMatchObject({failures: 1});
+        expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['bad']);
+
+        // Cycle 2: 'bad' now reads back cleanly → re-embedded + reconciled.
+        collection.throwVectorAbsentFor.delete('bad');
+        const second = await drain(collection, {expectedDimension: VECTOR_DIMENSION, retryState, now: () => 9_000_000});
+        expect(second).toMatchObject({embedded: 1, metadataOnly: 0});
+        expect(await readPendingWalRecords({dir: tmpDir})).toHaveLength(0);
     });
 
     test('#14228 verify is opt-in: without expectedDimension, add-success is treated as embed-success (pre-#14228 behavior, verify skipped)', async () => {


### PR DESCRIPTION
Resolves #14254
Refs #14228

Hardens the highest-volume Memory Core write path against the metadata-only corruption shape (document/metadata persisted, vector absent). The embed drain (`drainCycle.embedBatch`) persists WAL rows via `collection.add({documents})` relying on Chroma auto-embed, and treated add-success as embed-success — so a non-atomic auto-embed (provider timeout / oversized input / model-not-resident) left a metadata-only row AND marked it embedded (WAL marker → removed from pending). A new post-add verify reads the persisted vectors back and classifies each with the canonical `classifyRowVector` invariant (the SSOT the explicit-embed gate uses): confirmed metadata-only rows are deleted + retried (never marked); a transient read-back failure retries without deleting (never destroy possibly-valid rows); opt-in on `expectedDimension`, wired in both drain hosts (embed daemon + in-process memory-core server).

Evidence: L2 (unit — forced non-atomic auto-embed via a controllable fake collection). The live drain effect against real Chroma is the parent's empirical lead. Residual: AC1 empirical Chroma-atomicity V-B-A [`#14228`]; AC2 `SessionService:792/932` direct-upsert sites [`#14228`].

## Deltas from ticket
None — scope matches `#14254`.

## Test Evidence
`test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs` — **15 passed** (12 existing + 3 new):
- non-atomic auto-embed (add-success, no persisted vector) → NOT marked embedded; deleted + retried; re-embeds on the next cycle once the vector persists.
- verify read-back failure → batch left pending, NOT deleted (no data loss on a transient read error).
- opt-in: without `expectedDimension`, verify is skipped (pre-change behavior; `get` not called).

Command: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs` → 15 passed (30.9s).

## Post-Merge Validation
- [ ] Live drain: confirm `summary.metadataOnly` stays 0 in steady state — a non-zero rate is direct evidence of real non-atomic auto-embed events, feeding the parent's empirical AC1.

## Commits
- `304007ca7` — drainCycle post-add verify + both-host wiring + spec.

Authored by Vega (Claude Opus 4.8, Claude Code). Session 09af5f18-b64c-417b-be84-8cb3305005d2.
