### PR TITLE
fix(ai): verify SessionService direct-upsert auto-embed persisted a vector (#14256)

### DIFF
--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -4,6 +4,7 @@ import {buildChatModel}                              from '../../provider/buildC
 import {invokeWithGuardrail}                         from './helpers/consumerFrictionHelper.mjs';
 import {withTimeout}                                 from './helpers/withTimeout.mjs';
 import {appendWalEmbedMarker, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
+import {verifyPersistedVector}                       from './helpers/verifyPersistedVector.mjs';
 import {resolveTurnDocumentForRead}                  from './helpers/turnDocumentText.mjs';
 import crypto                                        from 'crypto';
 import GraphService                                  from './GraphService.mjs';
@@ -729,7 +730,7 @@ ${sessionContent}
                       .filter(Boolean);
 
             if (degradedEntries.length > 0) {
-                const usedTier = miniByMemoryId.size > 0 ? 'miniSummary' : 'truncatedRaw',
+                const usedTier        = miniByMemoryId.size > 0 ? 'miniSummary' : 'truncatedRaw',
                       degradedContent = degradedEntries.map((entry, index) => `Turn ${index + 1}: ${entry}`).join('\n'),
                       degradedResult  = await runGuardrailed(
                           buildSummaryPrompt(degradedContent),
@@ -798,11 +799,16 @@ ${sessionContent}
             metadatas: [summaryMetadata]
         });
 
+        // Atomic-write Prevent floor: the upsert relies on Chroma auto-embed (no explicit vector), so confirm
+        // a vector actually persisted. A metadata-only summary is logged loud for the recovery actuator; the
+        // row is expected data so it is never deleted, and a verify failure never breaks the persist.
+        await verifyPersistedVector(this.sessionsCollection, summaryId, aiConfig.vectorDimension, logger, 'session summary');
+
         // --- 1. Topological Ingestion (Graph Mapping) ---
         GraphService.upsertNode({
-            id  : summaryId,
-            type: 'SESSION_SUMMARY',
-            name: title,
+            id              : summaryId,
+            type            : 'SESSION_SUMMARY',
+            name            : title,
             description     : `${category} session by ${participatingAgents.join(', ')}`,
             semanticVectorId: summaryId,
             properties      : {
@@ -911,7 +917,7 @@ ${sessionContent}
                     const stats = fs.statSync(planPath);
                     // Match artifact to session timeframe
                     if (stats.mtimeMs >= minTimeMs && stats.mtimeMs <= maxTimeMs) {
-                        const content = fs.readFileSync(planPath, 'utf8');
+                        const content    = fs.readFileSync(planPath, 'utf8');
                         const artifactId = `plan_${convId}`;
 
                         logger.info(`[SessionService] Ingesting Antigravity artifact: ${planPath}`);
@@ -937,14 +943,18 @@ ${sessionContent}
                                 metadatas: [planMetadata],
                                 documents: [content]
                             });
+
+                            // Atomic-write Prevent floor: confirm the auto-embed actually persisted a vector;
+                            // a metadata-only plan is logged for the recovery actuator (never deleted/thrown).
+                            await verifyPersistedVector(this.memoryCollection, artifactId, aiConfig.vectorDimension, logger, 'antigravity plan');
                         } catch (e) {
                             logger.warn(`[SessionService] Failed to vector-upsert plan: ${e.message}`);
                         }
 
                         // Tie it structurally into Graph
                         GraphService.upsertNode({
-                            id  : artifactId,
-                            type: 'IMPLEMENTATION_PLAN',
+                            id              : artifactId,
+                            type            : 'IMPLEMENTATION_PLAN',
                             name            : `Antigravity Plan (${convId})`,
                             description     : `Strategically generated implementation plan via Antigravity Brain for session ${sessionId}.`,
                             semanticVectorId: artifactId

--- a/ai/services/memory-core/helpers/verifyPersistedVector.mjs
+++ b/ai/services/memory-core/helpers/verifyPersistedVector.mjs
@@ -1,0 +1,52 @@
+import {classifyRowVector} from './vectorWriteInvariant.mjs';
+
+/**
+ * @summary Post-upsert atomic-write verify for the direct (non-WAL) auto-embed persist sites — the
+ * SessionService half of the metadata-only Prevent floor.
+ *
+ * `SessionService` persists session summaries and ingested plans via `collection.upsert({documents})` with
+ * **no explicit `embeddings`**, relying on Chroma's collection embedding-function to auto-generate the vector.
+ * That auto-embed is **not atomic**: the provider call can fail (timeout, oversized input, model-not-resident)
+ * while the document/metadata still persist, leaving a metadata-only row — the recurring corruption shape — on
+ * a write path that has no WAL retry queue behind it.
+ *
+ * This reads the just-persisted vector back and classifies it with the same {@link classifyRowVector} invariant
+ * the explicit-embedding write gate and the drain verify use (single SSOT predicate). Disposition differs from
+ * the drain: these rows are **expected, single-shot persists**, so on a missing/invalid vector it logs loud and
+ * leaves the row for the autonomous recovery actuator to re-embed. It deliberately:
+ * - **never deletes** — the document is real data the caller expects to exist (delete would be data loss);
+ * - **never throws** — a verify failure (including a read-back error) must not break the persist path;
+ * - **is opt-in** on a known `expectedDimension` — without one it cannot classify, so it no-ops.
+ *
+ * @param {Object}   collection        The content-store collection just written to (`get({ids, include:['embeddings']})`).
+ * @param {String}   id                The id just upserted.
+ * @param {Number}   expectedDimension Required vector dimension; non-positive/absent → verify skipped.
+ * @param {Object}   [log]             Logger with a `warn(message)` method.
+ * @param {String}   [label='row']     Diagnostic label for the log line (e.g. `'session summary'`).
+ * @returns {Promise<String|null>} The rejection reason (from `classifyRowVector`), or `null` when the vector is
+ *     valid, the dimension is unknown, or the read-back could not confirm.
+ */
+export async function verifyPersistedVector(collection, id, expectedDimension, log, label = 'row') {
+    if (!Number.isInteger(expectedDimension) || expectedDimension <= 0) {
+        return null;
+    }
+
+    let readBack;
+
+    try {
+        readBack = await collection.get({ids: [id], include: ['embeddings']});
+    } catch (error) {
+        log?.warn?.(`[verifyPersistedVector] read-back failed for ${label} ${id} (${error.message}) — cannot confirm vector; left as-is`);
+        return null;
+    }
+
+    const index     = (readBack?.ids ?? []).indexOf(id),
+          embedding = index >= 0 ? readBack.embeddings?.[index] : undefined,
+          reason    = classifyRowVector({id, embedding}, expectedDimension);
+
+    if (reason !== null) {
+        log?.warn?.(`[verifyPersistedVector] metadata-only ${label} persisted (${reason}) — id ${id}; left for the recovery actuator to re-embed`);
+    }
+
+    return reason;
+}

--- a/test/playwright/unit/ai/services/memory-core/verifyPersistedVector.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/verifyPersistedVector.spec.mjs
@@ -1,0 +1,76 @@
+import {test, expect}          from '@playwright/test';
+import {verifyPersistedVector} from '../../../../../../ai/services/memory-core/helpers/verifyPersistedVector.mjs';
+
+const DIM   = 4;
+const VALID = [0.11, 0.22, 0.33, 0.44];
+
+/**
+ * Minimal content-store fake: only `get` (read-back) — deliberately NO `delete`, so any delete attempt
+ * by the helper would throw and fail the test. That absence IS the "never deletes expected data" assertion.
+ */
+function fakeCollection({vectors = new Map(), failGet = false} = {}) {
+    const getCalls = [];
+    return {
+        getCalls,
+        get: async ({ids}) => {
+            getCalls.push(ids);
+            if (failGet) throw new Error('get down (spec)');
+            const present = ids.filter(id => vectors.has(id));
+            return {ids: present, embeddings: present.map(id => vectors.get(id))};
+        }
+    };
+}
+
+function recordingLog() {
+    const warns = [];
+    return {warns, warn: message => warns.push(message)};
+}
+
+test.describe('verifyPersistedVector — SessionService direct-upsert atomic-write Prevent', () => {
+    test('valid persisted vector → null, no warn', async () => {
+        const log    = recordingLog();
+        const col    = fakeCollection({vectors: new Map([['a', [...VALID]]])});
+        const reason = await verifyPersistedVector(col, 'a', DIM, log, 'session summary');
+
+        expect(reason).toBeNull();
+        expect(log.warns).toHaveLength(0);
+    });
+
+    test('metadata-only (no persisted vector) → reason + loud warn, NEVER deletes', async () => {
+        const log    = recordingLog();
+        const col    = fakeCollection({vectors: new Map()}); // upserted, but auto-embed left no vector
+        const reason = await verifyPersistedVector(col, 'a', DIM, log, 'session summary');
+
+        expect(reason).toBe('missing-embedding');
+        expect(log.warns.join(' ')).toContain('metadata-only session summary');
+        // The fake exposes no `delete`; the call completing without throwing proves the helper never deletes.
+    });
+
+    test('wrong-dimension persisted vector → wrong-dimension reason + warn', async () => {
+        const log    = recordingLog();
+        const col    = fakeCollection({vectors: new Map([['a', [0.1, 0.2]]])}); // dim 2 != 4
+        const reason = await verifyPersistedVector(col, 'a', DIM, log, 'plan');
+
+        expect(reason).toBe('wrong-dimension');
+        expect(log.warns).toHaveLength(1);
+    });
+
+    test('read-back failure → null, warns, never throws (the persist path must not break)', async () => {
+        const log    = recordingLog();
+        const col    = fakeCollection({failGet: true});
+        const reason = await verifyPersistedVector(col, 'a', DIM, log, 'session summary');
+
+        expect(reason).toBeNull();
+        expect(log.warns.join(' ')).toContain('read-back failed');
+    });
+
+    test('opt-in: without a known expectedDimension the verify no-ops (no read-back)', async () => {
+        const log    = recordingLog();
+        const col    = fakeCollection({vectors: new Map()});
+        const reason = await verifyPersistedVector(col, 'a', undefined, log, 'session summary');
+
+        expect(reason).toBeNull();
+        expect(col.getCalls).toHaveLength(0);
+        expect(log.warns).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Resolves #14256
Refs #14228

Closes the SessionService half of #14228's metadata-only Prevent floor (the drain half shipped in #14255). SessionService persists session summaries (`summarizeSession`) and ingested plans (`ingestAntigravityArtifacts`) via `collection.upsert({documents})` relying on Chroma auto-embed — direct sites with no WAL retry behind them — so a non-atomic auto-embed leaves a metadata-only row. A new `verifyPersistedVector` helper reads the upserted vector back and classifies it with the canonical `classifyRowVector` (SSOT). Disposition for these single-shot persists of expected data: metadata-only → logged loud for the autonomous recovery actuator; never deleted (no data loss); never thrown (the persist path must not break); opt-in on `expectedDimension`.

Evidence: L2 (unit — the helper verified directly against a controllable fake collection). The live persist effect is covered by the same recovery-actuator backstop the drain relies on. Residual: AC1 empirical Chroma-atomicity V-B-A [`#14228`].

## Deltas from ticket
V-B-A refined the parent's AC3: both SessionService sites are background-ish (per-session / per-artifact), **not** interactive-hot, so an unconditional per-upsert verify is affordable — no config-gate / Contract-Ledger row needed for this surface (documented on `#14256`).

## Test Evidence
`test/playwright/unit/ai/services/memory-core/verifyPersistedVector.spec.mjs` — **5 passed**: valid → null; metadata-only → reason + warn + never-deletes; wrong-dimension; read-back failure → null + warn + never-throws; opt-in skip (no read-back).

Command: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/verifyPersistedVector.spec.mjs` → 5 passed (30.6s).

## Post-Merge Validation
- [ ] Live: a SessionService metadata-only warn surfaces real non-atomic auto-embed events, feeding the parent's empirical AC1.

## Commits
- `ab81011a5` — `verifyPersistedVector` helper + both SessionService sites + spec.

Authored by Vega (Claude Opus 4.8, Claude Code). Session 09af5f18-b64c-417b-be84-8cb3305005d2.
