### PR TITLE
fix(ai): dimension-gatherer degrade-not-throw on Chroma connection failure (#14130)

### DIFF
--- a/ai/daemons/orchestrator/services/dimensionConsistencyGatherer.mjs
+++ b/ai/daemons/orchestrator/services/dimensionConsistencyGatherer.mjs
@@ -68,11 +68,21 @@ export async function gatherDimensionConsistencyDiagnosis({
  */
 export function createLiveDimensionConsistencyGatherer({storageRouter, expectedDimension, serviceId, auditFn} = {}) {
     return async observedAt => {
-        await storageRouter.ready();
-        const collections = [
-            {collection: await storageRouter.getMemoryCollection(),  collectionName: 'neo-agent-memory'},
-            {collection: await storageRouter.getSummaryCollection(), collectionName: 'neo-agent-sessions'}
-        ];
-        return gatherDimensionConsistencyDiagnosis({collections, expectedDimension, serviceId, observedAt, auditFn});
+        // Degrade-not-throw at the live-binding boundary, not only inside the audit primitive (#14130 AC3).
+        // A Chroma *connection* failure (storageRouter.ready / getCollection) must skip the dimension signal
+        // for this cycle and return null — never throw. The shared `dataIntegrityEvidenceGatherer` gathers
+        // coverage first then awaits this; an unguarded throw here would discard the already-gathered coverage
+        // diagnosis and blank the whole hourly sweep. A down-Chroma is surfaced separately (coverage gatherer
+        // + container-health), so a silent dimension-skip is the safe degrade; null is filtered downstream.
+        try {
+            await storageRouter.ready();
+            const collections = [
+                {collection: await storageRouter.getMemoryCollection(),  collectionName: 'neo-agent-memory'},
+                {collection: await storageRouter.getSummaryCollection(), collectionName: 'neo-agent-sessions'}
+            ];
+            return await gatherDimensionConsistencyDiagnosis({collections, expectedDimension, serviceId, observedAt, auditFn});
+        } catch (error) {
+            return null;
+        }
     };
 }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/dimensionConsistencyGatherer.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/dimensionConsistencyGatherer.spec.mjs
@@ -74,5 +74,24 @@ test.describe('createLiveDimensionConsistencyGatherer', () => {
               auditFn = async ({collectionName, expectedDimension}) => ({collection: collectionName, expectedDimension, mismatchedVectorCount: 0, sampledCount: 100}),
               gather  = createLiveDimensionConsistencyGatherer({storageRouter: router, expectedDimension: 1024, serviceId: 'mc-server', auditFn});
         expect(await gather(1000)).toBeNull()
+    });
+
+    test('degrades to null (never throws) on a Chroma connection failure — coverage is not suppressed (#14130 AC3)', async () => {
+        // ready() throws (Chroma down): an unguarded throw here would discard the already-gathered coverage
+        // diagnosis in the shared evidence-gather and blank the whole sweep. Must resolve to null, not reject.
+        const downRouter = {
+            ready               : async () => { throw new Error('chroma connection refused'); },
+            getMemoryCollection : async () => ({id: 'mem'}),
+            getSummaryCollection: async () => ({id: 'sum'})
+        };
+        await expect(createLiveDimensionConsistencyGatherer({storageRouter: downRouter, expectedDimension: 1024, serviceId: 'mc-server'})(1000)).resolves.toBeNull();
+
+        // mid-resolution failure (getCollection throws after a successful ready()) — same degrade.
+        const midFailRouter = {
+            ready               : async () => {},
+            getMemoryCollection : async () => { throw new Error('chroma get failed'); },
+            getSummaryCollection: async () => ({id: 'sum'})
+        };
+        await expect(createLiveDimensionConsistencyGatherer({storageRouter: midFailRouter, expectedDimension: 1024, serviceId: 'mc-server'})(1000)).resolves.toBeNull()
     })
 });


### PR DESCRIPTION
## Summary

#14130 (Slice B: the live-Chroma dimension gatherer) had one genuinely-open AC — **AC3**: "a Chroma connection failure yields empty samples (dimension skipped), never a thrown gather or a suppressed coverage signal." The live-binding factory (`createLiveDimensionConsistencyGatherer`, landed in #14226) awaited `storageRouter.ready()` + `getMemoryCollection()`/`getSummaryCollection()` with **no guard**, so a Chroma connection failure threw. In `Orchestrator.dataIntegrityEvidenceGatherer` (coverage gathered first, then `await dimensionGatherer()`), that throw discarded the already-gathered coverage diagnosis and **blanked the whole hourly data-integrity sweep** — a v13.1 self-heal robustness gap. This fixes it (degrade-not-throw), completing #14130's last open AC.

Resolves #14130

## Change

`createLiveDimensionConsistencyGatherer` wraps its live-binding resolution in try-catch → returns `null` on any connection failure (degrade-not-throw). `null` is filtered by the evidence-gather's `.filter(Boolean)`, so the **coverage signal survives** a down-Chroma. The audit primitive already degraded on a *probe* failure; this extends the same contract to the *connection* boundary, so the module's stated "Degrade-not-throw" property now holds end-to-end.

## Deltas from ticket (if any)

None on the fix. Note: #14130's AC2 wording ("produces an escalation") predates the escalate→heal cutover (#14132 / #14240 / #14250, all merged) — the live behavior is now an autonomous **HEAL** (REEMBED_ROWS / FREEZE via `classifyDataIntegrityMode`), not an escalate. AC1 (live gatherer injected — via the factory, #14225/#14226), AC2 (signal acts, as heal), and AC4 (offline-coverage/live-dimension split documented in the module JSDoc) were already satisfied; AC3 was the last gap.

## Test Evidence

Evidence: `UNIT_TEST_MODE=true npx playwright test dimensionConsistencyGatherer.spec.mjs` → **7 passed** (incl. a new AC3 test: both `ready()`-throws and mid-resolution `getCollection()`-throws resolve to `null`, never reject). `node --check` clean on the gatherer + spec.

## Post-Merge Validation

Once merged, a Chroma connection blip during the hourly data-integrity sweep skips only the dimension signal (returns `null` → filtered) instead of throwing and discarding the coverage diagnosis — the immune system degrades to coverage-only rather than going blind for the cycle. The down-Chroma itself is surfaced by the coverage gatherer + container-health. Confirm: with Chroma unreachable, `dataIntegrityEvidenceGatherer` still returns the coverage evidence (non-empty), no thrown sweep.

## Scope / Contract Ledger

Internal degrade-hardening of a gatherer factory — no consumed public-surface change (the factory's `async (observedAt) => Object|null` contract is unchanged; `null` was already a valid return). No Contract Ledger needed.

## Related

#14130 (this slice), #14039 (v13.1 self-heal epic), #14226 (the factory this hardens), #14132 / #14240 / #14250 (the escalate→heal cutover the AC2 wording predates).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f4bc5569-9c5f-477b-a810-7fb084867d6a`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
