### PR TITLE
feat(ai): wire heavy-maintenance lease cooperative-yield mechanism (#14259, #14144 sub)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -661,11 +661,15 @@ class Config extends ConfigProvider {
                  * handoff for the whole run) interleaves; the next sweep re-acquires for the remaining work.
                  * A holder must only yield at a resumable checkpoint (a preserved shadow + resume-marker keep
                  * completed work), so the release window is torn-read-free. `0`/falsy ⇒ never yields
-                 * (byte-identical back-compat). Env override: `NEO_ORCHESTRATOR_HEAVY_MAINTENANCE_MAX_ACTIVE_HOLD_MS`.
+                 * (byte-identical back-compat). Default 30min (the #14144 fairness Decision Record with
+                 * @neo-opus-grace): independent of `staleAfterMs` but kept smaller (a live holder yields before
+                 * it would be stale-reclaimed); a SOFT knob — the holder yields at the first between-batch
+                 * checkpoint after the bound, never mid-batch — so it is tunable on observed yield-churn.
+                 * Env override: `NEO_ORCHESTRATOR_HEAVY_MAINTENANCE_MAX_ACTIVE_HOLD_MS`.
                  * @type {Object}
                  */
                 heavyMaintenance: {
-                    maxActiveHoldMs: leaf(HOUR_MS, 'NEO_ORCHESTRATOR_HEAVY_MAINTENANCE_MAX_ACTIVE_HOLD_MS', 'number')
+                    maxActiveHoldMs: leaf(HOUR_MS / 2, 'NEO_ORCHESTRATOR_HEAVY_MAINTENANCE_MAX_ACTIVE_HOLD_MS', 'number')
                 },
                 /**
                  * Neural Link Bridge local-supervision policy. The bridge port itself is owned

--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -8,6 +8,7 @@ import {
     acquireHeavyMaintenanceLease,
     inspectHeavyMaintenanceLease,
     releaseHeavyMaintenanceLease,
+    shouldYieldHeavyMaintenanceLease,
     withHeavyMaintenanceLease
 } from './heavyMaintenanceLeasePrimitives.mjs';
 
@@ -52,6 +53,17 @@ export class HeavyMaintenanceLeaseService extends Base {
          * @reactive
          */
         staleAfterMs_: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs,
+        /**
+         * Bound on continuous LIVE-holder lease hold before a cooperative yield (#14144 lease-fairness):
+         * consumed by `shouldYield()` so a long heavy task (e.g. a multi-hour KB re-embed) releases the lease
+         * at a resumable checkpoint, letting a starved heavy peer interleave. Distinct from `staleAfterMs`
+         * (dead-holder reclaim); kept the smaller so a live holder yields before it would be stale-reclaimed.
+         * Falsy ⇒ never yields (byte-identical back-compat).
+         * @member {Number} maxActiveHoldMs_=AiConfig.orchestrator.heavyMaintenance.maxActiveHoldMs
+         * @protected
+         * @reactive
+         */
+        maxActiveHoldMs_: AiConfig.orchestrator.heavyMaintenance.maxActiveHoldMs,
         /**
          * @member {Object} fsModule_=fs
          * @protected
@@ -98,6 +110,24 @@ export class HeavyMaintenanceLeaseService extends Base {
             ...options,
             leasePath: options.leasePath ?? this.leasePath,
             fsModule : options.fsModule  ?? this.fsModule
+        });
+    }
+
+    /**
+     * Decides whether a LIVE lease holder should cooperatively yield (release at the next resumable
+     * checkpoint) because it has held the lease past the fairness bound — a thin wrapper over the pure
+     * `shouldYieldHeavyMaintenanceLease` primitive with the reactive `maxActiveHoldMs` injected (#14144).
+     * Consumed by long heavy tasks between batches (e.g. kbSync `embedViaShadowSwap`, #14186).
+     * @param {Object|null} lease The current lease payload (reads `acquiredAt`).
+     * @param {Object} [options] Overrides.
+     * @param {Date}   [options.now=new Date()] Clock injection for tests.
+     * @param {Number} [options.maxActiveHoldMs=this.maxActiveHoldMs] Hold-bound override.
+     * @returns {Boolean} `true` only once the active hold exceeds `maxActiveHoldMs` (falsy bound ⇒ never yields).
+     */
+    shouldYield(lease, options = {}) {
+        return shouldYieldHeavyMaintenanceLease(lease, {
+            now            : options.now            ?? new Date(),
+            maxActiveHoldMs: options.maxActiveHoldMs ?? this.maxActiveHoldMs
         });
     }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -130,6 +130,22 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         })).toBe(false);
     });
 
+    test('#14144: service.shouldYield() injects the reactive maxActiveHoldMs into the primitive', () => {
+        const acquiredAt = '2026-05-16T20:00:00.000Z',
+              lease      = {owner: 'summary', acquiredAt},
+              service    = Neo.create(HeavyMaintenanceLeaseService, {});
+        service.maxActiveHoldMs = 5 * 60 * 1000; // 5 min — through the reactive setter (config-default-independent)
+
+        // hold past the reactive bound → yield (the service injects this.maxActiveHoldMs, no per-call arg)
+        expect(service.shouldYield(lease, {now: new Date('2026-05-16T20:06:00.000Z')})).toBe(true);
+        // still within the reactive bound → keep holding
+        expect(service.shouldYield(lease, {now: new Date('2026-05-16T20:03:00.000Z')})).toBe(false);
+        // explicit per-call override wins over the reactive default
+        expect(service.shouldYield(lease, {now: new Date('2026-05-16T20:06:00.000Z'), maxActiveHoldMs: 30 * 60 * 1000})).toBe(false);
+        // fail-safe: a falsy bound → never yields (byte-identical back-compat; #14186's absent/0-leaf path)
+        expect(service.shouldYield(lease, {now: new Date('2026-05-16T23:00:00.000Z'), maxActiveHoldMs: 0})).toBe(false)
+    });
+
     test('process liveness detects invalid owner pids', () => {
         expect(isPidAlive(process.pid)).toBe(true);
         expect(isPidAlive(-1)).toBe(false);


### PR DESCRIPTION
## Summary

The lease-service half of the #14144 heavy-maintenance lease-fairness epic (Grace owns the kbSync between-batch yield-point consumer, #14186). The `shouldYieldHeavyMaintenanceLease` primitive + the `orchestrator.heavyMaintenance.maxActiveHoldMs` leaf already existed; this wires the consumer-facing service surface so a long heavy-task holder can poll the cooperative-yield decision and release the lease at a resumable checkpoint.

Resolves #14259

## Change

- `HeavyMaintenanceLeaseService` gains a reactive `maxActiveHoldMs_` config (reads `AiConfig.orchestrator.heavyMaintenance.maxActiveHoldMs` at the use-site, SSOT discipline) + a thin `shouldYield(lease, {now, maxActiveHoldMs})` method over the existing primitive (per-call override wins over the reactive default).
- `maxActiveHoldMs` default → 30min (`HOUR_MS / 2`): the fairness Decision Record converged with @neo-opus-grace — independent of `staleAfterMs` but smaller (a live holder yields before it would be stale-reclaimed); a soft knob (the holder yields at the first between-batch checkpoint AFTER the bound, never mid-batch), tunable on observed yield-churn.
- Falsy ⇒ never yields (byte-identical back-compat — #14186's absent/0-leaf path).

## Deltas from ticket (if any)

None on shape. The leaf pre-existed (value `HOUR_MS`); updated to the converged 30min. The gitignored `config.mjs` snapshot re-materializes to 30min on deploy — the committed change is the `config.template.mjs` SSOT.

## Test Evidence

Evidence: `UNIT_TEST_MODE=true npx playwright test HeavyMaintenanceLeaseService.spec.mjs` → **21 passed** (incl. a new #14144 service-method test: the service injects the reactive `maxActiveHoldMs`; per-call override wins; falsy ⇒ never-yield). `node --check` clean. NB the test sets the bound via the reactive setter (`service.maxActiveHoldMs = x`), not `Neo.create({maxActiveHoldMs_})` — the underscore-in-create sets the raw field but the getter returns the config default (a Neo reactive-config gotcha I hit + verified).

## Post-Merge Validation

Once merged, `shouldYield(lease)` returns true after a holder exceeds 30min of continuous hold, so #14186 (Grace's kbSync yield-point) can release the lease at the next between-batch checkpoint and let a starved heavy peer (e.g. `githubWorkflowSync`, which otherwise stales the sandman handoff) interleave. The #14144 epic closes once #14186 consumes this. Confirm: a >30min-held lease → `shouldYield`=true; a falsy leaf → always false (today's behavior).

## Scope / Contract Ledger

New consumed surface (co-shaped with @neo-opus-grace, who will consume it in #14186):

| Surface | Change | Consumer | Migration |
|---|---|---|---|
| `HeavyMaintenanceLeaseService.shouldYield(lease, {now?, maxActiveHoldMs?}) → Boolean` | **added** | #14186 (kbSync batch loop) | none — new method |
| `orchestrator.heavyMaintenance.maxActiveHoldMs` leaf | value `HOUR_MS` → `HOUR_MS/2` (30min) | the service's reactive config | none — env-overridable; falsy⇒never-yield preserves back-compat |

Existing `acquire`/`inspect`/`release`/`withLease` + the re-exported primitives are unchanged.

## Related

#14259 (this sub), #14144 (parent epic), #14186 (the consumer sub), #14039 (v13.1), #14146 / #14161 (the resume substrate the between-batch yield builds on).

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f4bc5569-9c5f-477b-a810-7fb084867d6a`. Targets `dev` per the agent-PR gate (never `main`). Human merge gate per ADR-0005.
