### PR TITLE
feat(ai): persist the dispatch heal outcome to the heal-event ledger (#14260)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -453,8 +453,9 @@ export class Orchestrator extends Base {
                     }
                 })
             },
-            recentRunsReader: async collectionName => healEventsToRecentRuns(queryHealLedger(await readHealLedger({dir: healLedgerDir}), {collections: [collectionName]})),
-            recordRun       : async ({action, collection, at}) => appendHealEvent({type: action, collection, status: 'attempt'}, {dir: healLedgerDir, now: at})
+            recentRunsReader : async collectionName => healEventsToRecentRuns(queryHealLedger(await readHealLedger({dir: healLedgerDir}), {collections: [collectionName]})),
+            recordRun        : async ({action, collection, at}) => appendHealEvent({type: action, collection, status: 'attempt'}, {dir: healLedgerDir, now: at}),
+            recordHealOutcome: async ({action, collection, status, detail, healedAt}) => appendHealEvent({type: action, collection, status, detail}, {dir: healLedgerDir, now: healedAt})
         });
     }
 

--- a/ai/daemons/orchestrator/services/DataRecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/DataRecoveryActuatorService.mjs
@@ -62,6 +62,15 @@ class DataRecoveryActuatorService extends Base {
      * @member {Function|null} recordRun=null
      */
     recordRun = null
+    /**
+     * Injected OUTCOME recorder: `async ({action, collection, status, detail, healedAt}) => void` — persists the
+     * dispatch outcome (what actually happened) to the heal-event ledger, the complement to `recordRun`'s
+     * pre-execution attempt. This is the durable substrate the chronic-`unsafe-input` detector and the systemic
+     * circuit-breaker read; without it the ledger holds only attempts. null → not recorded (observability-only; a
+     * recording failure never breaks the heal path). A set-once injected dependency.
+     * @member {Function|null} recordHealOutcome=null
+     */
+    recordHealOutcome = null
 
     /**
      * @summary The autonomous heal terminal — routes the classifier's action through the dispatch core's safety
@@ -78,7 +87,7 @@ class DataRecoveryActuatorService extends Base {
     async applyHeal({action, collection, evidence, now} = {}) {
         const recentRuns = typeof this.recentRunsReader === 'function' ? await this.recentRunsReader(collection) : [];
 
-        return dispatchHeal({
+        const outcome = await dispatchHeal({
             action,
             collection,
             evidence,
@@ -87,6 +96,19 @@ class DataRecoveryActuatorService extends Base {
             healOperations: this.healOperations,
             recordRun     : this.recordRun
         });
+
+        // Persist the OUTCOME (what happened) — `recordRun` only captured the pre-execution attempt. This is the
+        // durable record the chronic-`unsafe-input` detector + the systemic circuit-breaker read. Observability,
+        // never a gate: a recording failure must not break or re-trigger the heal, so it is swallowed.
+        if (typeof this.recordHealOutcome === 'function') {
+            try {
+                await this.recordHealOutcome(outcome);
+            } catch (recordError) {
+                // best-effort telemetry — the heal already happened; never let a ledger-write fault break it
+            }
+        }
+
+        return outcome;
     }
 }
 

--- a/ai/services/memory-core/helpers/healEventLedgerStore.mjs
+++ b/ai/services/memory-core/helpers/healEventLedgerStore.mjs
@@ -95,12 +95,17 @@ export async function readHealLedger({dir} = {}) {
  * would never match its own action and the anti-thrash bound would silently never fire (a just-recorded
  * attempt would re-`execute` instead of `thrash-cooldown`). This projection (`type` → `action`, keeping the
  * epoch-ms `at` and the collection) is the seam where the ledger schema meets the dispatch contract.
+ *
+ * **Only `status: 'attempt'` rows project.** The pre-execution attempt is the anti-thrash unit (one per heal).
+ * Outcome rows (the recorded dispatch result — `failed`, `healed`, etc.) carry the SAME `{type, collection}`
+ * key but are observability, NOT additional runs; counting them would double the run-count per heal — silently
+ * tightening the rate-limit (3 → 2 heals/window) and dragging the cooldown `lastAt` to the later outcome-time.
  * @param {Object[]} [events=[]] Heal-event entries (as read/filtered from the ledger).
  * @returns {Object[]} `[{action, collection, at}]` for `decideHealAction`.
  */
 export function healEventsToRecentRuns(events = []) {
     return (Array.isArray(events) ? events : [])
-        .filter(event => event && typeof event === 'object')
+        .filter(event => event && typeof event === 'object' && event.status === 'attempt')
         .map(event => ({action: event.type, collection: event.collection, at: event.at}));
 }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DataRecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DataRecoveryActuatorService.spec.mjs
@@ -62,3 +62,35 @@ test.describe('DataRecoveryActuatorService.applyHeal — autonomous terminal (no
         expect(['escalate', 'escalated', 'page', 'paged']).not.toContain(outcome.status);
     });
 });
+
+test.describe('DataRecoveryActuatorService.applyHeal — recordHealOutcome (persist the OUTCOME, not just the attempt)', () => {
+    test('persists the dispatch OUTCOME via the injected recordHealOutcome', async () => {
+        const recorded = [];
+        const actuator = Neo.create(DataRecoveryActuatorService, {
+            recordHealOutcome: async outcome => { recorded.push(outcome); }
+        });
+
+        // 'quarantine' is non-mutating containment → the gate clears it; no wired op → a 'deferred' outcome.
+        const outcome = await actuator.applyHeal({action: 'quarantine', collection: 'c1', now: NOW});
+
+        expect(outcome).toMatchObject({action: 'quarantine', collection: 'c1', status: 'deferred'});
+        expect(recorded).toHaveLength(1);
+        expect(recorded[0]).toMatchObject({action: 'quarantine', collection: 'c1', status: 'deferred', healedAt: NOW});
+    });
+
+    test('a recordHealOutcome failure never breaks the heal (best-effort telemetry, swallowed)', async () => {
+        const actuator = Neo.create(DataRecoveryActuatorService, {
+            recordHealOutcome: async () => { throw new Error('ledger write failed'); }
+        });
+
+        const outcome = await actuator.applyHeal({action: 'quarantine', collection: 'c1', now: NOW});
+        expect(outcome).toMatchObject({action: 'quarantine', collection: 'c1', status: 'deferred'}); // the heal stands
+    });
+
+    test('no recordHealOutcome wired → applyHeal still returns the outcome (observability is optional)', async () => {
+        const actuator = Neo.create(DataRecoveryActuatorService); // recordHealOutcome stays null
+        const outcome  = await actuator.applyHeal({action: 'quarantine', collection: 'c1', now: NOW});
+
+        expect(outcome).toMatchObject({action: 'quarantine', collection: 'c1', status: 'deferred'});
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
@@ -151,6 +151,20 @@ test.describe('healEventsToRecentRuns — the ledger→dispatch anti-thrash shap
         expect(healEventsToRecentRuns()).toEqual([]);
     });
 
+    test('DOUBLE-COUNT GUARD: an outcome row alongside its attempt projects to ONE run, not two', () => {
+        // recordRun writes status:'attempt' (the anti-thrash unit); recordHealOutcome writes the OUTCOME
+        // (failed/healed/...) under the SAME {type, collection}. Counting both would double the run-count and
+        // silently tighten the rate-limit + drag the cooldown to the outcome-time — keep only the attempt.
+        const events = [
+            {type: 're-embed-missing', collection: 'neo-agent-memory', status: 'attempt', at: 1000},
+            {type: 're-embed-missing', collection: 'neo-agent-memory', status: 'failed', detail: 'boom', at: 1500}
+        ];
+
+        expect(healEventsToRecentRuns(events)).toEqual([
+            {action: 're-embed-missing', collection: 'neo-agent-memory', at: 1000}
+        ]);
+    });
+
     test('REGRESSION: a just-recorded ledger attempt cools down the next dispatch (raw shape would not)', async () => {
         // The wired production seam: recordRun appends {type: action, ...}; the bug was recentRunsReader
         // returning the raw {type} entries, which decideHealAction (filtering recentRuns by run.action) never


### PR DESCRIPTION
Resolves #14260

The heal-event ledger recorded only the pre-execution attempt (`recordRun`); the dispatch OUTCOME (`unsafe-input` / `failed` / `healed` / `deferred`, with `detail`) flowed up through `applyHeal` → `applyHeals` but was never persisted. This is the durable substrate the chronic-`unsafe-input` detector (#14158) and the systemic circuit-breaker (#14179 slice-2) read.

Evidence: L1 focused unit fully covers the recorder contract — `applyHeal` persists the outcome via the injected `recordHealOutcome`, swallows a recorder fault, and no-ops when unwired (8/8). The orchestrator wiring is a one-line static injection (`recordHealOutcome` → `appendHealEvent`, same `healLedgerDir` as `recordRun`) — covered by green hosted CI (PR-body / AiConfig lint, unit, integration-unified), not a separate integration artifact.

## Deltas from ticket

Review cycle (Ada + Euclid, cross-family): the outcome-recording double-counted the anti-thrash `recentRuns` — each heal left an attempt row + an outcome row, and `decideHealAction` counted both, silently tightening the per-(action,collection) rate-limit (3 → 2 heals/window) and dragging the cooldown to the later outcome-time. Fixed: `healEventsToRecentRuns` filters to `status:'attempt'` (the anti-thrash unit; outcome rows are observability, not runs) + a double-count guard test. The recorder + wiring shape is unchanged.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test …/DataRecoveryActuatorService.spec.mjs -c …playwright.config.unit.mjs` → **8/8 passed** (5 pre-existing + 3 new):
- `applyHeal` persists the dispatch outcome via the injected `recordHealOutcome` (asserts `{action, collection, status, healedAt}`);
- a `recordHealOutcome` failure is swallowed — the heal still returns its outcome (best-effort telemetry, never a gate);
- unwired (`recordHealOutcome` null) → `applyHeal` still returns the outcome (observability is optional).

`…/healEventLedgerStore.spec.mjs` → **17/17** (incl. the new DOUBLE-COUNT GUARD: attempt + outcome for the same action+collection → ONE anti-thrash run).

block-alignment clean; agent-preflight 0 archaeology violations; no config-template change.

## Post-Merge Validation

- [ ] #14158 (chronic-`unsafe-input` detector) reads the now-recorded `unsafe-input` outcomes.
- [ ] #14179 slice-2 (systemic circuit wiring) reads the now-recorded `failed` outcomes with `detail` to feed the `decideSystemicCircuit` decider (merged in #14252).

## Commits

- `18a91d52b` — the `recordHealOutcome` recorder + the orchestrator wiring + 3 spec cases.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 090a68e6-1a28-4b20-a5fd-842ebac3e729.
