### PR TITLE
feat(ai): delete the last human-page path — deploy-target redeploy records, never pages (#14232)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -823,7 +823,6 @@ class Config extends ConfigProvider {
                     maxBackoffMs               : leaf(HOUR_MS, 'NEO_RECOVERY_ACTUATOR_MAX_BACKOFF_MS', 'number'),
                     verifyCooldownMs           : leaf(60 * 1000, 'NEO_RECOVERY_ACTUATOR_VERIFY_COOLDOWN_MS', 'number'),
                     healthyObservationThreshold: leaf(1, 'NEO_RECOVERY_ACTUATOR_HEALTHY_OBSERVATION_THRESHOLD', 'number'),
-                    operatorPageTarget         : leaf('AGENT:*', 'NEO_RECOVERY_ACTUATOR_OPERATOR_PAGE_TARGET', 'string'),
                     /**
                      * Systemic-fault circuit-breaker bounds — the cross-collection layer above the per-collection
                      * anti-thrash (`maxAttemptsPerWindow`/`maxAttemptsWindowMs`). >= `systemicThreshold` DISTINCT

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -14,7 +14,7 @@ import {
 import {appendHealEvent}  from '../../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {DEFAULT_DATA_DIR} from '../taskDefinitions.mjs';
 
-const DEFAULT_ACTIONS        = Object.freeze(['restart', 'redeploy', 'page', 'warm-provider']);
+const DEFAULT_ACTIONS        = Object.freeze(['restart', 'redeploy', 'warm-provider']);
 const DEFAULT_DEPLOY_TARGETS = Object.freeze(['cloud-deploy']);
 
 /**
@@ -128,12 +128,6 @@ export class RecoveryActuatorService extends Base {
          */
         processSupervisorService_: null,
         /**
-         * @member {Function|null} pageDispatcher_=null
-         * @protected
-         * @reactive
-         */
-        pageDispatcher_: null,
-        /**
          * @member {Function|null} writeLog_=null
          * @protected
          * @reactive
@@ -218,7 +212,7 @@ export class RecoveryActuatorService extends Base {
      * @summary Applies one bounded recovery action if the target registry and anti-thrash envelope admit it.
      *
      * @param {String} serviceKey Stable recovery target key.
-     * @param {String} action restart | redeploy | page | warm-provider.
+     * @param {String} action restart | redeploy | warm-provider.
      * @param {Object} [options]
      * @param {Object|null} [options.diagnosisEvent=null] Optional ADR-0025 diagnosis event.
      * @param {Object|null} [options.targetIdentity=null] Optional typed target identity.
@@ -275,7 +269,7 @@ export class RecoveryActuatorService extends Base {
                 serviceKey,
                 startedAt : now,
                 target,
-                taskStatus: gate.status === 'escalated' ? 'failed' : 'skipped',
+                taskStatus: gate.status === 'recorded' ? 'failed' : 'skipped',
                 updatedAt : now
             });
         }
@@ -297,7 +291,7 @@ export class RecoveryActuatorService extends Base {
                 attempt     : nextAttempt,
                 backoffUntil: nextBackoffAt,
                 now         : updatedAt,
-                status      : target.kind === 'deploy-target' ? 'escalated' : 'actioned'
+                status      : target.kind === 'deploy-target' ? 'recorded' : 'actioned'
             });
             await this.writeHealAttempts(attempts);
 
@@ -308,13 +302,13 @@ export class RecoveryActuatorService extends Base {
                 backoffUntil  : nextBackoffAt,
                 diagnosisEvent: diagnosis,
                 outcome       : {
-                    status           : target.kind === 'deploy-target' ? 'escalated' : 'actioned',
+                    status           : target.kind === 'deploy-target' ? 'recorded' : 'actioned',
                     serviceKey,
                     action,
                     targetIdentity   : createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
                     runtimeAccess    : result.runtimeAccess || null,
                     supervisor       : result.supervisor || null,
-                    page             : result.page || null,
+                    recorded         : result.recorded || null,
                     providerResidency: result.providerResidency || null
                 },
                 recoveryRunId,
@@ -487,7 +481,7 @@ export class RecoveryActuatorService extends Base {
         }
 
         if (target.kind === 'deploy-target') {
-            return action === 'redeploy' || action === 'page';
+            return action === 'redeploy';
         }
 
         return false;
@@ -511,7 +505,7 @@ export class RecoveryActuatorService extends Base {
             return this.restartSupervisedTask({target, reason});
         }
 
-        return this.pageDeployTarget({target, action, reason});
+        return this.recordDeployTarget({target, action, reason});
     }
 
     /**
@@ -594,26 +588,31 @@ export class RecoveryActuatorService extends Base {
     }
 
     /**
-     * @summary Triggers the config-drift redeploy page without executing arbitrary deployment code.
+     * @summary Records an un-auto-executable deploy-target redeploy to the durable heal-event ledger — the
+     * record-with-diagnosis terminal. The actuator cannot execute arbitrary deployment code and an operatorless
+     * cloud has no human to page, so an un-resolvable deploy-target is RECORDED (durable async-audit), never
+     * paged — this completes the escalate/page → record cutover for the last lifecycle page path.
      * @param {Object} options
      * @returns {Promise<Object>}
      */
-    async pageDeployTarget({target, action, reason}) {
-        const page = {
-            serviceKey        : target.serviceKey,
-            deployTarget      : target.id,
+    async recordDeployTarget({target, action, reason}) {
+        const recorded = {
+            serviceKey  : target.serviceKey,
+            deployTarget: target.id,
             action,
-            reason            : reason || 'config-drift-redeploy-required',
-            operatorPageTarget: this.cfg.operatorPageTarget
+            reason      : reason || 'config-drift-redeploy-required'
         };
 
-        if (typeof this.pageDispatcher === 'function') {
-            await this.pageDispatcher(page);
-        } else {
-            this.writeLog?.('WARN', `[RecoveryActuator] Redeploy required for ${target.id}; page target ${page.operatorPageTarget}.`);
-        }
+        await appendHealEvent({
+            type      : action,
+            collection: target.id,
+            status    : 'recorded',
+            detail    : recorded
+        }, {dir: this.healEventLedgerDir, now: Date.now()});
 
-        return {page};
+        this.writeLog?.('INFO', `[RecoveryActuator] Redeploy required for ${target.id}; recorded to the heal-event ledger (no operator to page).`);
+
+        return {recorded};
     }
 
     /**
@@ -667,7 +666,7 @@ export class RecoveryActuatorService extends Base {
                 admitted  : false,
                 attempt   : state.attemptCount,
                 reasonCode: 'attempt-cap-reached',
-                status    : 'escalated'
+                status    : 'recorded'
             };
         }
 
@@ -945,9 +944,6 @@ export class RecoveryActuatorService extends Base {
     getLedgerStatus({outcome}) {
         if (outcome.status === 'actioned') {
             return 'reobserve-requested';
-        }
-        if (outcome.status === 'escalated') {
-            return 'escalated';
         }
         if (outcome.status === 'recorded') {
             return 'recorded';

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -181,8 +181,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
             baseBackoffMs              : 5 * 60 * 1000,
             maxBackoffMs               : HOUR_MS,
             verifyCooldownMs           : 60 * 1000,
-            healthyObservationThreshold: 1,
-            operatorPageTarget         : 'AGENT:*'
+            healthyObservationThreshold: 1
         },
         deploymentStateBridge: {
             enabled                     : true,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -36,7 +36,6 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
     function createService(overrides = {}) {
         const runtimeCalls                 = [],
               supervisorCalls              = [],
-              pageCalls                    = [],
               providerResidencyRepairCalls = [],
               taskOutcomes                 = [],
               actuatorConfig               = {
@@ -86,9 +85,6 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                       },
                       ...overrides.processSupervisorService
                   },
-                  pageDispatcher(page) {
-                      pageCalls.push(page);
-                  },
                   async providerResidencyRepair(options) {
                       providerResidencyRepairCalls.push(options);
                       return {
@@ -101,7 +97,7 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                   ...overrides.serviceConfig
               });
 
-        return {service, runtimeCalls, supervisorCalls, pageCalls, providerResidencyRepairCalls, taskOutcomes, actuatorConfig};
+        return {service, runtimeCalls, supervisorCalls, providerResidencyRepairCalls, taskOutcomes, actuatorConfig};
     }
 
     async function readAttempts() {
@@ -397,7 +393,7 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         expect(runtimeCalls).toHaveLength(1);
     });
 
-    test('attempt cap escalates to alarm-only and never loops the privileged action', async () => {
+    test('attempt cap records as alarm-only and never loops the privileged action', async () => {
         const {service, runtimeCalls} = createService({
             actuatorConfig: {
                 maxAttemptsPerWindow: 1,
@@ -410,7 +406,7 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
 
         expect(first.status).toBe('actioned');
         expect(second).toMatchObject({
-            status    : 'escalated',
+            status    : 'recorded',
             reasonCode: 'attempt-cap-reached'
         });
         expect(runtimeCalls).toHaveLength(1);
@@ -419,8 +415,8 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         expect(attempts['mc-server:restart'].alarmOnly).toBe(true);
     });
 
-    test('deploy-target redeploy pages without executing arbitrary deployment code', async () => {
-        const {service, runtimeCalls, pageCalls, taskOutcomes} = createService();
+    test('deploy-target redeploy records to the heal-event ledger without paging (no human to page in cloud)', async () => {
+        const {service, runtimeCalls, taskOutcomes} = createService();
 
         const result = await service.apply('cloud-deploy', 'redeploy', {
             now   : 300_000,
@@ -428,28 +424,32 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         });
 
         expect(result).toMatchObject({
-            status        : 'escalated',
+            status        : 'recorded',
             targetIdentity: {kind: 'deploy-target', id: 'cloud-deploy'}
         });
         expect(runtimeCalls).toEqual([]);
-        expect(pageCalls).toEqual([expect.objectContaining({
-            deployTarget      : 'cloud-deploy',
-            reason            : 'config-drift',
-            operatorPageTarget: 'AGENT:*'
-        })]);
+
+        // The last human-page path is gone: an un-auto-executable redeploy records, never pages.
+        const healEvents = await readHealLedger({dir: service.healEventLedgerDir});
+        expect(healEvents).toContainEqual(expect.objectContaining({
+            type      : 'redeploy',
+            collection: 'cloud-deploy',
+            status    : 'recorded',
+            detail    : expect.objectContaining({deployTarget: 'cloud-deploy', reason: 'config-drift'})
+        }));
         expect(taskOutcomes).toContainEqual(expect.objectContaining({
             taskName: 'recovery-actuator:cloud-deploy',
             status  : 'completed',
             details : expect.objectContaining({
-                status      : 'escalated',
-                ledgerStatus: 'escalated'
+                status      : 'recorded',
+                ledgerStatus: 'recorded'
             })
         }));
     });
 
     test('recordDiagnosis records a supervised-task diagnosis to the heal-event ledger without executing target actions', async () => {
-        const {service, runtimeCalls, supervisorCalls, pageCalls, taskOutcomes} = createService();
-        let   executedTargetAction                                              = false;
+        const {service, runtimeCalls, supervisorCalls, taskOutcomes} = createService();
+        let   executedTargetAction                                   = false;
 
         service.executeTargetAction = async () => {
             executedTargetAction = true;
@@ -470,9 +470,8 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         expect(executedTargetAction).toBe(false);
         expect(runtimeCalls).toEqual([]);
         expect(supervisorCalls).toEqual([]);
-        // record-with-diagnosis never pages — it appends to the heal-event ledger instead.
-        expect(pageCalls).toEqual([]);
 
+        // record-with-diagnosis never pages — it appends to the heal-event ledger instead.
         const healEvents = await readHealLedger({dir: service.healEventLedgerDir});
         expect(healEvents).toContainEqual(expect.objectContaining({
             type      : 'ambiguous',
@@ -491,7 +490,7 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
     });
 
     test('recordDiagnosis rejects non-record diagnoses without privileged actions', async () => {
-        const {service, runtimeCalls, supervisorCalls, pageCalls} = createService();
+        const {service, runtimeCalls, supervisorCalls} = createService();
 
         const result = await service.recordDiagnosis(backupEscalationDiagnosis({
             details: {actionClass: 'restart'}
@@ -504,7 +503,6 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         });
         expect(runtimeCalls).toEqual([]);
         expect(supervisorCalls).toEqual([]);
-        expect(pageCalls).toEqual([]);
     });
 
     test('arbitrary actions are rejected before target lookup or executor access', async () => {


### PR DESCRIPTION
Resolves #14232

The last human-page path in the lifecycle actuator. `RecoveryActuatorService` dispatched an operator-page for a deploy-target needing redeploy, and `'page'` was still in `DEFAULT_ACTIONS`. In an operatorless cloud there is no human to page — this completes the escalate/page → record cutover that #14201/#14229 began (the "silently heal, never page" mandate).

Evidence: L1 (unit) — 17/17 RecoveryActuatorService spec, including the deploy-target redeploy now asserting a heal-event-ledger record (not a page) + the attempt-cap recording. The record mechanism (`recordDiagnosis` → `appendHealEvent`) already existed; this routes the last page path through it, so it is a wiring + status-rename cutover, not new mechanism.

## Deltas from ticket

None — matches the #14232 scope. **Net-reducing (-8 LOC):** removes the page machinery (`pageDispatcher_` config, the `operatorPageTarget` AiConfig leaf, the `pageDeployTarget` method, the `'page'` action) rather than adding — Substrate-Accretion-Defense by construction.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test …/RecoveryActuatorService.spec.mjs -c …playwright.config.unit.mjs` → **17/17 passed**:
- deploy-target redeploy → a `status:'recorded'` heal-event (`type:'redeploy'`, `collection:'cloud-deploy'`, `detail` with the target + reason), `runtimeCalls` empty, never a page;
- attempt-cap → `'recorded'` (alarm-only), no privileged-action loop;
- the `recordDiagnosis` paths unchanged (record, never page).

block-alignment clean; agent-preflight 0 archaeology violations.

## Post-Merge Validation

- [ ] No `pageDispatcher` / `operatorPageTarget` / `'page'` action remains in `RecoveryActuatorService` (the #14232 AC).
- [ ] #14132 (the act-half gate) closes once this + #14133 (quarantine-from-serving) land — the "never page" mandate then complete.

## Commits

- `3fc9beea2` — the page→record cutover (service + config + fixture + spec).

Authored by Grace (Claude Opus 4.8, Claude Code). Session 090a68e6-1a28-4b20-a5fd-842ebac3e729.
