### PR TITLE
feat(ai): guard module-scope AiConfig captures (#14239)

### DIFF
--- a/ai/daemons/embed/daemon.mjs
+++ b/ai/daemons/embed/daemon.mjs
@@ -52,13 +52,45 @@ if (missingLeaves.length > 0) {
     process.exit(1);
 }
 
-const DAEMON_DATA_DIR    = memoryCoreConfig.memoryWal.daemonDataDir;
-const LOG_FILE           = path.join(DAEMON_DATA_DIR, 'embed-daemon.log');
-const PID_FILE           = path.join(DAEMON_DATA_DIR, 'embed-daemon.pid');
 const LOG_RETENTION_DAYS = 30;
 
+/**
+ * @summary Reads the live daemon data directory from AiConfig at use time.
+ * @returns {String}
+ */
+function getDaemonDataDir() {
+    return memoryCoreConfig.memoryWal.daemonDataDir;
+}
+
+/**
+ * @summary Ensures the live daemon data directory exists and returns it.
+ * @returns {String}
+ */
+function ensureDaemonDataDir() {
+    const dir = getDaemonDataDir();
+
+    fs.ensureDirSync(dir);
+    return dir;
+}
+
+/**
+ * @summary Resolves the live embed daemon log file path.
+ * @returns {String}
+ */
+function getLogFile() {
+    return path.join(ensureDaemonDataDir(), 'embed-daemon.log');
+}
+
+/**
+ * @summary Resolves the live embed daemon PID file path.
+ * @returns {String}
+ */
+function getPidFile() {
+    return path.join(ensureDaemonDataDir(), 'embed-daemon.pid');
+}
+
 // Ensure daemon data dir exists
-fs.ensureDirSync(DAEMON_DATA_DIR);
+ensureDaemonDataDir();
 
 /**
  * Rotates `embed-daemon.log` if its mtime falls on a calendar day different from today's.
@@ -68,13 +100,15 @@ fs.ensureDirSync(DAEMON_DATA_DIR);
  * @protected
  */
 function rotateLogIfNewDay() {
-    if (!fs.existsSync(LOG_FILE)) return;
+    const logFile = getLogFile();
+
+    if (!fs.existsSync(logFile)) return;
     try {
-        const stats    = fs.statSync(LOG_FILE);
+        const stats    = fs.statSync(logFile);
         const fileDay  = stats.mtime.toISOString().split('T')[0];
         const todayDay = new Date().toISOString().split('T')[0];
         if (fileDay !== todayDay) {
-            fs.renameSync(LOG_FILE, `${LOG_FILE}.${fileDay}`);
+            fs.renameSync(logFile, `${logFile}.${fileDay}`);
         }
     } catch (e) {
         process.stderr.write(`[Embed Daemon] Log rotation failed: ${e.message}\n`);
@@ -88,11 +122,12 @@ function rotateLogIfNewDay() {
  * @protected
  */
 function pruneOldLogs() {
-    const cutoff = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    const cutoff        = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+          daemonDataDir = getDaemonDataDir();
     try {
-        for (const entry of fs.readdirSync(DAEMON_DATA_DIR)) {
+        for (const entry of fs.readdirSync(daemonDataDir)) {
             if (!entry.startsWith('embed-daemon.log.') || entry === 'embed-daemon.log') continue;
-            const fullPath = path.join(DAEMON_DATA_DIR, entry);
+            const fullPath = path.join(daemonDataDir, entry);
             try {
                 if (fs.statSync(fullPath).mtime.getTime() < cutoff) {
                     fs.unlinkSync(fullPath);
@@ -120,10 +155,11 @@ function pruneOldLogs() {
  */
 function writeLog(level, message) {
     rotateLogIfNewDay();
-    const line = `[${new Date().toISOString()}] [PID:${process.pid}] [${level}] ${message}`;
+    const line    = `[${new Date().toISOString()}] [PID:${process.pid}] [${level}] ${message}`,
+          logFile = getLogFile();
 
     try {
-        fs.appendFileSync(LOG_FILE, line + '\n', 'utf8');
+        fs.appendFileSync(logFile, line + '\n', 'utf8');
     } catch (e) {
         // Best-effort; daemon must stay alive even if file-write fails
     }
@@ -149,9 +185,11 @@ const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
  * @protected
  */
 async function enforceSingleton() {
-    if (fs.existsSync(PID_FILE)) {
+    const pidFile = getPidFile();
+
+    if (fs.existsSync(pidFile)) {
         try {
-            const oldPid = parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10);
+            const oldPid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
             if (!isNaN(oldPid) && oldPid > 0 && oldPid !== process.pid) {
                 let isAlive = false;
                 try {
@@ -199,7 +237,7 @@ async function enforceSingleton() {
                 }
 
                 try {
-                    fs.unlinkSync(PID_FILE);
+                    fs.unlinkSync(pidFile);
                 } catch (e) {}
             }
         } catch (e) {
@@ -209,7 +247,7 @@ async function enforceSingleton() {
 
     // Write new PID using atomic wx claim
     try {
-        fs.writeFileSync(PID_FILE, process.pid.toString(), {encoding: 'utf8', flag: 'wx'});
+        fs.writeFileSync(pidFile, process.pid.toString(), {encoding: 'utf8', flag: 'wx'});
     } catch (e) {
         if (e.code === 'EEXIST') {
             writeLog('ERROR', '[Embed Daemon] Failed to claim PID file (EEXIST). Another instance started simultaneously. Exiting.');
@@ -225,10 +263,10 @@ async function enforceSingleton() {
         if (cleanedUp) return;
         cleanedUp = true;
         try {
-            if (fs.existsSync(PID_FILE)) {
-                const currentPid = parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10);
+            if (fs.existsSync(pidFile)) {
+                const currentPid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
                 if (currentPid === process.pid) {
-                    fs.unlinkSync(PID_FILE);
+                    fs.unlinkSync(pidFile);
                 }
             }
         } catch (e) {}

--- a/ai/daemons/message/daemon.mjs
+++ b/ai/daemons/message/daemon.mjs
@@ -33,21 +33,55 @@ if (missingLeaves.length > 0) {
     process.exit(1);
 }
 
-const DAEMON_DATA_DIR    = memoryCoreConfig.messageWal.daemonDataDir;
-const LOG_FILE           = path.join(DAEMON_DATA_DIR, 'message-daemon.log');
-const PID_FILE           = path.join(DAEMON_DATA_DIR, 'message-daemon.pid');
 const LOG_RETENTION_DAYS = 30;
 
-fs.ensureDirSync(DAEMON_DATA_DIR);
+/**
+ * @summary Reads the live daemon data directory from AiConfig at use time.
+ * @returns {String}
+ */
+function getDaemonDataDir() {
+    return memoryCoreConfig.messageWal.daemonDataDir;
+}
+
+/**
+ * @summary Ensures the live daemon data directory exists and returns it.
+ * @returns {String}
+ */
+function ensureDaemonDataDir() {
+    const dir = getDaemonDataDir();
+
+    fs.ensureDirSync(dir);
+    return dir;
+}
+
+/**
+ * @summary Resolves the live message daemon log file path.
+ * @returns {String}
+ */
+function getLogFile() {
+    return path.join(ensureDaemonDataDir(), 'message-daemon.log');
+}
+
+/**
+ * @summary Resolves the live message daemon PID file path.
+ * @returns {String}
+ */
+function getPidFile() {
+    return path.join(ensureDaemonDataDir(), 'message-daemon.pid');
+}
+
+ensureDaemonDataDir();
 
 function rotateLogIfNewDay() {
-    if (!fs.existsSync(LOG_FILE)) return;
+    const logFile = getLogFile();
+
+    if (!fs.existsSync(logFile)) return;
     try {
-        const stats    = fs.statSync(LOG_FILE);
+        const stats    = fs.statSync(logFile);
         const fileDay  = stats.mtime.toISOString().split('T')[0];
         const todayDay = new Date().toISOString().split('T')[0];
         if (fileDay !== todayDay) {
-            fs.renameSync(LOG_FILE, `${LOG_FILE}.${fileDay}`);
+            fs.renameSync(logFile, `${logFile}.${fileDay}`);
         }
     } catch (e) {
         process.stderr.write(`[Message Daemon] Log rotation failed: ${e.message}\n`);
@@ -55,11 +89,12 @@ function rotateLogIfNewDay() {
 }
 
 function pruneOldLogs() {
-    const cutoff = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    const cutoff        = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+          daemonDataDir = getDaemonDataDir();
     try {
-        for (const entry of fs.readdirSync(DAEMON_DATA_DIR)) {
+        for (const entry of fs.readdirSync(daemonDataDir)) {
             if (!entry.startsWith('message-daemon.log.') || entry === 'message-daemon.log') continue;
-            const fullPath = path.join(DAEMON_DATA_DIR, entry);
+            const fullPath = path.join(daemonDataDir, entry);
             try {
                 if (fs.statSync(fullPath).mtime.getTime() < cutoff) {
                     fs.unlinkSync(fullPath);
@@ -71,10 +106,11 @@ function pruneOldLogs() {
 
 function writeLog(level, message) {
     rotateLogIfNewDay();
-    const line = `[${new Date().toISOString()}] [PID:${process.pid}] [${level}] ${message}`;
+    const line    = `[${new Date().toISOString()}] [PID:${process.pid}] [${level}] ${message}`,
+          logFile = getLogFile();
 
     try {
-        fs.appendFileSync(LOG_FILE, line + '\n', 'utf8');
+        fs.appendFileSync(logFile, line + '\n', 'utf8');
     } catch (e) {}
 
     if (level === 'ERROR') {
@@ -89,9 +125,11 @@ pruneOldLogs();
 const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 async function enforceSingleton() {
-    if (fs.existsSync(PID_FILE)) {
+    const pidFile = getPidFile();
+
+    if (fs.existsSync(pidFile)) {
         try {
-            const oldPid = parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10);
+            const oldPid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
             if (!isNaN(oldPid) && oldPid > 0 && oldPid !== process.pid) {
                 let isAlive = false;
                 try {
@@ -135,7 +173,7 @@ async function enforceSingleton() {
                 }
 
                 try {
-                    fs.unlinkSync(PID_FILE);
+                    fs.unlinkSync(pidFile);
                 } catch (e) {}
             }
         } catch (e) {
@@ -144,7 +182,7 @@ async function enforceSingleton() {
     }
 
     try {
-        fs.writeFileSync(PID_FILE, process.pid.toString(), {encoding: 'utf8', flag: 'wx'});
+        fs.writeFileSync(pidFile, process.pid.toString(), {encoding: 'utf8', flag: 'wx'});
     } catch (e) {
         if (e.code === 'EEXIST') {
             writeLog('ERROR', '[Message Daemon] Failed to claim PID file (EEXIST). Another instance started simultaneously. Exiting.');
@@ -158,10 +196,10 @@ async function enforceSingleton() {
         if (cleanedUp) return;
         cleanedUp = true;
         try {
-            if (fs.existsSync(PID_FILE)) {
-                const currentPid = parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10);
+            if (fs.existsSync(pidFile)) {
+                const currentPid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
                 if (currentPid === process.pid) {
-                    fs.unlinkSync(PID_FILE);
+                    fs.unlinkSync(pidFile);
                 }
             }
         } catch (e) {}

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -46,10 +46,17 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const ROOT_DIR   = path.resolve(__dirname, '../../..');
 
-const CONFIG_TEMPLATE_BASENAME = 'config.template.mjs';
-const CONFIG_OVERLAY_BASENAME  = 'config.mjs';
-const SCAN_ROOT_REL            = 'ai';
-const SELF_REL_FILE            = 'ai/scripts/lint/lint-config-template-ssot.mjs';
+const CONFIG_TEMPLATE_BASENAME           = 'config.template.mjs';
+const CONFIG_OVERLAY_BASENAME            = 'config.mjs';
+const SCAN_ROOT_REL                      = 'ai';
+const SELF_REL_FILE                      = 'ai/scripts/lint/lint-config-template-ssot.mjs';
+const CONFIG_TEMPLATE_KIND_CACHE         = new Map();
+const SERVICE_EXPORT_CONFIG_TEMPLATE_REL = Object.freeze({
+    GH_Config        : 'ai/mcp/server/github-workflow/config.template.mjs',
+    KB_Config        : 'ai/mcp/server/knowledge-base/config.template.mjs',
+    Memory_Config    : 'ai/mcp/server/memory-core/config.template.mjs',
+    NeuralLink_Config: 'ai/mcp/server/neural-link/config.template.mjs'
+});
 
 /**
  * Pre-existing inline-env leaf defaults, keyed by `<file>::<envVar>`. Each entry is a
@@ -101,89 +108,40 @@ export const AI_CONFIG_IMPLEMENTATION_BASELINE = Object.freeze([
 ]);
 
 /**
- * Existing module-scope AiConfig leaf captures that are classified as non-self-heal P1 debt.
- * These rows are not permission to add more captures: they document the residual #14239 audit
- * and keep the lint fail-build for any NEW module-load Provider leaf capture, especially in
- * self-heal / repair paths where stale values can block runtime healing.
+ * Existing module-scope AiConfig primitive leaf captures that freeze resolved Provider values at
+ * module load. These rows are not permission to add more captures: they document residual #14239
+ * P1 debt while the lint fails NEW primitive/formula leaf freezes. Namespace and object-valued
+ * leaves are deliberately excluded because their nested reads stay live through the Provider proxy.
  * @type {ReadonlyArray<{file: String, kind: String, text: String, ticket: String, reason: String}>}
  */
 export const AI_CONFIG_MODULE_SCOPE_BASELINE = Object.freeze([
     {
         file  : 'ai/scripts/diagnostics/analyzeNlTelemetry.mjs',
-        kind  : 'module-scope-capture',
+        kind  : 'module-scope-leaf-capture',
         text  : 'const DB_PATH = aiConfig.storagePaths.graph;',
         ticket: '#14239',
-        reason: 'One-shot diagnostic CLI path capture; not a self-heal runtime consumer.'
+        reason: 'Frozen primitive path leaf; existing P1 burndown debt.'
     },
     {
         file  : 'ai/scripts/diagnostics/analyzeNlTelemetry.mjs',
-        kind  : 'module-scope-capture',
+        kind  : 'module-scope-leaf-capture',
         text  : 'const RLAIF_PATH = aiConfig.datasets.rlaif.trajectories;',
         ticket: '#14239',
-        reason: 'One-shot diagnostic CLI output path capture; not a self-heal runtime consumer.'
-    },
-    {
-        file  : 'ai/services/github-workflow/sync/DiscussionSyncer.mjs',
-        kind  : 'module-scope-capture',
-        text  : 'const issueSyncConfig = aiConfig.issueSync;',
-        ticket: '#14239',
-        reason: 'GitHub mirror sync P1 config capture; not a self-heal repair/actuator path.'
-    },
-    {
-        file  : 'ai/services/github-workflow/sync/IssueSyncer.mjs',
-        kind  : 'module-scope-capture',
-        text  : 'const issueSyncConfig = aiConfig.issueSync;',
-        ticket: '#14239',
-        reason: 'GitHub mirror sync P1 config capture; not a self-heal repair/actuator path.'
-    },
-    {
-        file  : 'ai/services/github-workflow/sync/MetadataManager.mjs',
-        kind  : 'module-scope-capture',
-        text  : 'const issueSyncConfig = aiConfig.issueSync;',
-        ticket: '#14239',
-        reason: 'GitHub mirror metadata P1 config capture; not a self-heal repair/actuator path.'
-    },
-    {
-        file  : 'ai/services/github-workflow/sync/PullRequestSyncer.mjs',
-        kind  : 'module-scope-capture',
-        text  : 'const issueSyncConfig = aiConfig.issueSync;',
-        ticket: '#14239',
-        reason: 'GitHub mirror sync P1 config capture; not a self-heal repair/actuator path.'
-    },
-    {
-        file  : 'ai/services/github-workflow/sync/PullRequestSyncer.mjs',
-        kind  : 'module-scope-capture',
-        text  : 'const pullRequestConfig = aiConfig.pullRequest;',
-        ticket: '#14239',
-        reason: 'GitHub PR mirror P1 config capture; not a self-heal repair/actuator path.'
-    },
-    {
-        file  : 'ai/services/github-workflow/sync/ReleaseNotesSyncer.mjs',
-        kind  : 'module-scope-capture',
-        text  : 'const issueSyncConfig = aiConfig.issueSync;',
-        ticket: '#14239',
-        reason: 'Release-note mirror sync P1 config capture; not a self-heal repair/actuator path.'
+        reason: 'Frozen primitive dataset leaf; existing P1 burndown debt.'
     },
     {
         file  : 'ai/services/knowledge-base/DatabaseService.mjs',
-        kind  : 'module-scope-capture',
+        kind  : 'module-scope-leaf-capture',
         text  : 'const cwd       = aiConfig.neoRootDir;',
         ticket: '#14239',
-        reason: 'Knowledge Base startup path P1 capture; not a self-heal repair/actuator path.'
+        reason: 'Frozen primitive root path leaf; existing P1 burndown debt.'
     },
     {
         file  : 'ai/services/knowledge-base/QueryService.mjs',
-        kind  : 'module-scope-capture',
-        text  : 'const {queryScoreWeights} = aiConfig;',
-        ticket: '#14239',
-        reason: 'Knowledge Base scoring-weight P1 capture; not a self-heal repair/actuator path.'
-    },
-    {
-        file  : 'ai/services/knowledge-base/QueryService.mjs',
-        kind  : 'module-scope-capture',
+        kind  : 'module-scope-leaf-capture',
         text  : 'const cwd       = aiConfig.neoRootDir;',
         ticket: '#14239',
-        reason: 'Knowledge Base startup path P1 capture; not a self-heal repair/actuator path.'
+        reason: 'Frozen primitive root path leaf; existing P1 burndown debt.'
     }
 ]);
 
@@ -339,16 +297,198 @@ export function detectAiConfigImplementationViolations(source) {
 }
 
 /**
- * @summary Detects module-load AiConfig leaf captures (`const x = aiConfig.y` / destructuring).
+ * @summary Collects config paths that resolve to frozen leaves versus live Provider proxies.
  *
- * Direct use-site reads remain valid. This detector specifically targets values frozen at module
- * evaluation time, the #14239 failure mode where a runtime self-heal config mutation can be ignored
- * by a stale closure. Function bodies and module-scope functions that read AiConfig when invoked are
- * intentionally out of scope.
+ * The scanner follows the `config.template.mjs` meta-leaf style: namespace objects are live proxy
+ * paths, object-valued leaves return nested live proxies, and primitive/formula leaves return the
+ * value itself. It intentionally reads source text instead of importing config modules so this lint
+ * stays a static guard with no Neo bootstrap side effects.
+ * @param {String} source Config template source.
+ * @returns {{primitiveLeafPaths: Set<String>, liveProxyPaths: Set<String>}}
+ */
+export function collectConfigPathKindsFromSource(source) {
+    const primitiveLeafPaths = new Set(),
+          liveProxyPaths     = new Set(),
+          stack              = [];
+    let   insideData    = false,
+          dataIndent    = 0,
+          leafCallDepth = 0;
+
+    for (const text of source.split('\n')) {
+        const code    = stripStringsAndLineComment(text),
+              trimmed = code.trim(),
+              indent  = (code.match(/^\s*/) || [''])[0].length;
+
+        if (!insideData) {
+            if (/^\s*data\s*:\s*\{/.test(code)) {
+                insideData = true;
+                dataIndent = indent;
+                stack.length = 0;
+            }
+            continue;
+        }
+
+        if (leafCallDepth > 0) {
+            leafCallDepth += countChar(code, '(') - countChar(code, ')');
+            if (leafCallDepth <= 0) {
+                leafCallDepth = 0;
+            }
+            continue;
+        }
+
+        if (trimmed.startsWith('}') && indent <= dataIndent) {
+            insideData = false;
+            stack.length = 0;
+            continue;
+        }
+
+        while (stack.length > 0 && stack[stack.length - 1].indent >= indent) {
+            stack.pop();
+        }
+
+        const match = code.match(/^(\s*)([A-Za-z_$][\w$]*)\s*:\s*(leaf\s*\(|\{)/);
+        if (!match) continue;
+
+        const prop = match[2],
+              rhs  = match[3],
+              key  = [...stack.map(entry => entry.prop), prop].join('.');
+
+        if (rhs.startsWith('leaf')) {
+            if (/:\s*leaf\s*\(\s*\{/.test(code)) {
+                liveProxyPaths.add(key);
+            } else {
+                primitiveLeafPaths.add(key);
+            }
+
+            leafCallDepth = countChar(code.slice(code.indexOf('leaf')), '(') -
+                countChar(code.slice(code.indexOf('leaf')), ')');
+            if (leafCallDepth < 0) {
+                leafCallDepth = 0;
+            }
+        } else {
+            liveProxyPaths.add(key);
+            stack.push({indent, prop});
+        }
+    }
+
+    return {primitiveLeafPaths, liveProxyPaths};
+}
+
+/**
+ * @summary Counts single-character occurrences in a string.
+ * @param {String} text Source text.
+ * @param {String} ch Character to count.
+ * @returns {Number}
+ */
+function countChar(text, ch) {
+    let count = 0;
+
+    for (const current of text) {
+        if (current === ch) count++;
+    }
+
+    return count;
+}
+
+/**
+ * @summary Resolves a `config.mjs` import specifier to its matching `config.template.mjs`.
+ * @param {Object} options
+ * @param {String} options.rootDir Repo root.
+ * @param {String} options.file Repo-relative importer file.
+ * @param {String} options.specifier Import specifier.
+ * @returns {String|null} Absolute template path.
+ */
+function resolveConfigTemplatePath({rootDir, file, specifier}) {
+    let abs;
+
+    if (specifier.startsWith('neo.mjs/')) {
+        abs = path.join(rootDir, specifier.slice('neo.mjs/'.length));
+    } else if (specifier.startsWith('.')) {
+        abs = path.resolve(path.dirname(path.join(rootDir, file)), specifier);
+    } else {
+        return null;
+    }
+
+    const template = abs.replace(/config\.mjs$/, 'config.template.mjs');
+    return fs.existsSync(template) ? template : null;
+}
+
+/**
+ * @summary Reads and caches config-template path classifications.
+ * @param {String} templatePath Absolute template path.
+ * @returns {{primitiveLeafPaths: Set<String>, liveProxyPaths: Set<String>}}
+ */
+function getConfigPathKindsForTemplate(templatePath) {
+    const key = normalizeFile(templatePath);
+
+    if (!CONFIG_TEMPLATE_KIND_CACHE.has(key)) {
+        CONFIG_TEMPLATE_KIND_CACHE.set(
+            key,
+            collectConfigPathKindsFromSource(fs.readFileSync(templatePath, 'utf8'))
+        );
+    }
+
+    return CONFIG_TEMPLATE_KIND_CACHE.get(key);
+}
+
+/**
+ * @summary Maps imported config identifiers in one implementation file to config path kinds.
+ * @param {Object} options
+ * @param {String} [options.rootDir] Repo root.
+ * @param {String} options.file Repo-relative file.
+ * @param {String} options.source File source.
+ * @returns {Map<String,{primitiveLeafPaths: Set<String>, liveProxyPaths: Set<String>}>}
+ */
+export function buildConfigPathKindsByIdentifier({rootDir = ROOT_DIR, file, source} = {}) {
+    const out = new Map();
+
+    if (!file || !source) return out;
+
+    for (const match of source.matchAll(/\bimport\s+([A-Za-z_$][\w$]*)\s+from\s+['"]([^'"]*config\.mjs)['"]/g)) {
+        const template = resolveConfigTemplatePath({rootDir, file, specifier: match[2]});
+        if (template) {
+            out.set(match[1], getConfigPathKindsForTemplate(template));
+        }
+    }
+
+    for (const match of source.matchAll(/\bimport\s*\{([^}]+)\}\s*from\s+['"]([^'"]*services\.mjs)['"]/g)) {
+        for (const rawBinding of match[1].split(',')) {
+            const binding = rawBinding.trim();
+            if (!binding) continue;
+
+            const [imported, alias] = binding.split(/\s+as\s+/),
+                  rel               = SERVICE_EXPORT_CONFIG_TEMPLATE_REL[imported];
+
+            if (rel) {
+                out.set(alias || imported, getConfigPathKindsForTemplate(path.join(rootDir, rel)));
+            }
+        }
+    }
+
+    if (!out.has('AiConfig')) {
+        const rootTemplate = path.join(rootDir, 'ai/config.template.mjs');
+        if (fs.existsSync(rootTemplate)) {
+            out.set('AiConfig', getConfigPathKindsForTemplate(rootTemplate));
+        }
+    }
+
+    return out;
+}
+
+/**
+ * @summary Detects module-load AiConfig primitive/formula leaf captures.
+ *
+ * Direct use-site reads remain valid. Namespace captures and object-valued leaf captures also remain
+ * valid because later property reads go through live nested Provider proxies. This detector targets
+ * primitive/formula leaves frozen at module evaluation time, the #14239 failure mode where a runtime
+ * self-heal config mutation can be ignored by a stale closure. Function bodies and module-scope
+ * functions that read AiConfig when invoked are intentionally out of scope.
  * @param {String} source File contents.
+ * @param {Object} [options]
+ * @param {Map<String,{primitiveLeafPaths: Set<String>, liveProxyPaths: Set<String>}>} [options.configPathKindsByIdentifier]
  * @returns {Array<{line: Number, kind: String, text: String}>}
  */
-export function detectModuleScopeAiConfigCaptures(source) {
+export function detectModuleScopeAiConfigCaptures(source, {configPathKindsByIdentifier = new Map()} = {}) {
     const violations = [];
     let   depth      = 0;
 
@@ -356,18 +496,10 @@ export function detectModuleScopeAiConfigCaptures(source) {
         const trimmed = text.trim(),
               before  = depth;
 
-        if (before === 0 &&
-            !trimmed.startsWith('//') &&
-            !trimmed.startsWith('*') &&
-            !trimmed.startsWith('/*') &&
-            !trimmed.startsWith('*/') &&
-            /\b(?:const|let|var)\b/.test(trimmed) &&
-            (
-                /\b(?:const|let|var)\s*\{[^}]+\}\s*=\s*(?:aiConfig|AiConfig|KB_Config|Memory_Config)\b/.test(trimmed) ||
-                /=\s*(?:aiConfig|AiConfig|KB_Config|Memory_Config)(?:\?\.|\.)/.test(trimmed)
-            )
+        if (before === 0 && isPotentialModuleScopeConfigCapture(trimmed) &&
+            shouldFlagModuleScopeCapture(trimmed, configPathKindsByIdentifier)
         ) {
-            violations.push({line: index + 1, kind: 'module-scope-capture', text: trimmed});
+            violations.push({line: index + 1, kind: 'module-scope-leaf-capture', text: trimmed});
         }
 
         const code = stripStringsAndLineComment(text);
@@ -381,6 +513,100 @@ export function detectModuleScopeAiConfigCaptures(source) {
     });
 
     return violations;
+}
+
+/**
+ * @summary Checks whether a line can be a module-scope config capture before kind classification.
+ * @param {String} trimmed Trimmed source line.
+ * @returns {Boolean}
+ */
+function isPotentialModuleScopeConfigCapture(trimmed) {
+    return Boolean(trimmed) &&
+        !trimmed.startsWith('//') &&
+        !trimmed.startsWith('*') &&
+        !trimmed.startsWith('/*') &&
+        !trimmed.startsWith('*/') &&
+        /\b(?:const|let|var)\b/.test(trimmed);
+}
+
+/**
+ * @summary Decides whether a module-scope config capture freezes a primitive/formula leaf.
+ * @param {String} trimmed Trimmed source line.
+ * @param {Map<String,{primitiveLeafPaths: Set<String>, liveProxyPaths: Set<String>}>} configPathKindsByIdentifier
+ * @returns {Boolean}
+ */
+function shouldFlagModuleScopeCapture(trimmed, configPathKindsByIdentifier) {
+    const captures = readModuleScopeCapturePaths(trimmed, configPathKindsByIdentifier);
+
+    if (captures.length === 0) return false;
+
+    return captures.some(({identifier, path: capturePath}) => {
+        const kinds = configPathKindsByIdentifier.get(identifier);
+
+        if (!kinds) return true;
+
+        const key = capturePath.join('.');
+
+        if (kinds.liveProxyPaths.has(key)) return false;
+        if (kinds.primitiveLeafPaths.has(key)) return true;
+
+        for (const knownPath of [...kinds.liveProxyPaths, ...kinds.primitiveLeafPaths]) {
+            if (knownPath.startsWith(`${key}.`)) return false;
+        }
+
+        return true;
+    });
+}
+
+/**
+ * @summary Extracts captured config paths from one module-scope declaration line.
+ * @param {String} trimmed Trimmed source line.
+ * @param {Map<String,{primitiveLeafPaths: Set<String>, liveProxyPaths: Set<String>}>} configPathKindsByIdentifier
+ * @returns {Array<{identifier: String, path: String[]}>}
+ */
+function readModuleScopeCapturePaths(trimmed, configPathKindsByIdentifier) {
+    const direct = trimmed.match(/\b(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=\s*([A-Za-z_$][\w$]*)(?:\?\.|\.)((?:[A-Za-z_$][\w$]*)(?:\.[A-Za-z_$][\w$]*)*)/);
+
+    if (direct) {
+        if (!isConfigCaptureIdentifier(direct[1], configPathKindsByIdentifier)) return [];
+        return [{identifier: direct[1], path: direct[2].split('.')}];
+    }
+
+    const destructured = trimmed.match(/\b(?:const|let|var)\s*\{([^}]+)\}\s*=\s*([A-Za-z_$][\w$]*)\b/);
+    if (!destructured) return [];
+    if (!isConfigCaptureIdentifier(destructured[2], configPathKindsByIdentifier)) return [];
+
+    return destructured[1]
+        .split(',')
+        .map(part => part.trim())
+        .filter(Boolean)
+        .map(part => {
+            const localDefaultFree = part.split('=')[0].trim(),
+                  prop             = localDefaultFree.split(':')[0].trim();
+
+            return {identifier: destructured[2], path: [prop]};
+        })
+        .filter(({path}) => /^[A-Za-z_$][\w$]*$/.test(path[0]));
+}
+
+/**
+ * @summary Checks whether an identifier is a config provider alias worth classifying.
+ * @param {String} identifier Source identifier.
+ * @param {Map<String,{primitiveLeafPaths: Set<String>, liveProxyPaths: Set<String>}>} configPathKindsByIdentifier
+ * @returns {Boolean}
+ */
+function isConfigCaptureIdentifier(identifier, configPathKindsByIdentifier) {
+    return configPathKindsByIdentifier.has(identifier) || [
+        'aiConfig',
+        'AiConfig',
+        'GH_Config',
+        'KB_Config',
+        'MC_Config',
+        'Memory_Config',
+        'kbConfig',
+        'mcConfig',
+        'memoryCoreConfig'
+    ].includes(identifier);
 }
 
 /**
@@ -525,7 +751,9 @@ export function lintAiConfigModuleScopeCaptures({
     for (const {file, source} of records) {
         if (!shouldScanAiConfigImplementation(file)) continue;
 
-        for (const hit of detectModuleScopeAiConfigCaptures(source)) {
+        const configPathKindsByIdentifier = buildConfigPathKindsByIdentifier({rootDir, file, source});
+
+        for (const hit of detectModuleScopeAiConfigCaptures(source, {configPathKindsByIdentifier})) {
             violations.push({file, ...hit});
         }
     }
@@ -547,9 +775,10 @@ const FIX_HINT = 'Move env access into the leaf env-var-name argument — leaf(d
 const AI_CONFIG_FIX_HINT = 'Read resolved AiConfig leaves inline at the use site; local Provider subtree references are OK. ' +
     'Do not export config values, pass config-shaped objects through consumers, add hidden defaults/type coercions, ' +
     'or add defensive optional chaining unless the code names an ADR-19-sanctioned boundary. Authority: ADR 0019.';
-const AI_CONFIG_MODULE_SCOPE_FIX_HINT = 'Do not freeze Provider leaves at module load. Read AiConfig at the use site, ' +
-    'or document an existing non-self-heal P1 capture in AI_CONFIG_MODULE_SCOPE_BASELINE as a burndown row. ' +
-    'New self-heal / repair / actuator captures must be converted, not baselined. Authority: #14239 + ADR 0019.';
+const AI_CONFIG_MODULE_SCOPE_FIX_HINT = 'Do not freeze primitive/formula Provider leaves at module load. ' +
+    'Read the leaf at the use site, or document an existing frozen primitive leaf in AI_CONFIG_MODULE_SCOPE_BASELINE ' +
+    'as explicit #14239 burndown debt. Namespace and object-valued leaf captures stay live through nested Provider ' +
+    'proxies and must not be baselined as violations. Authority: #14239 + ADR 0019.';
 
 /**
  * @summary CLI wrapper. Returns an exit code (0 clean, 1 on new violations or stale baseline rows).

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -101,6 +101,93 @@ export const AI_CONFIG_IMPLEMENTATION_BASELINE = Object.freeze([
 ]);
 
 /**
+ * Existing module-scope AiConfig leaf captures that are classified as non-self-heal P1 debt.
+ * These rows are not permission to add more captures: they document the residual #14239 audit
+ * and keep the lint fail-build for any NEW module-load Provider leaf capture, especially in
+ * self-heal / repair paths where stale values can block runtime healing.
+ * @type {ReadonlyArray<{file: String, kind: String, text: String, ticket: String, reason: String}>}
+ */
+export const AI_CONFIG_MODULE_SCOPE_BASELINE = Object.freeze([
+    {
+        file  : 'ai/scripts/diagnostics/analyzeNlTelemetry.mjs',
+        kind  : 'module-scope-capture',
+        text  : 'const DB_PATH = aiConfig.storagePaths.graph;',
+        ticket: '#14239',
+        reason: 'One-shot diagnostic CLI path capture; not a self-heal runtime consumer.'
+    },
+    {
+        file  : 'ai/scripts/diagnostics/analyzeNlTelemetry.mjs',
+        kind  : 'module-scope-capture',
+        text  : 'const RLAIF_PATH = aiConfig.datasets.rlaif.trajectories;',
+        ticket: '#14239',
+        reason: 'One-shot diagnostic CLI output path capture; not a self-heal runtime consumer.'
+    },
+    {
+        file  : 'ai/services/github-workflow/sync/DiscussionSyncer.mjs',
+        kind  : 'module-scope-capture',
+        text  : 'const issueSyncConfig = aiConfig.issueSync;',
+        ticket: '#14239',
+        reason: 'GitHub mirror sync P1 config capture; not a self-heal repair/actuator path.'
+    },
+    {
+        file  : 'ai/services/github-workflow/sync/IssueSyncer.mjs',
+        kind  : 'module-scope-capture',
+        text  : 'const issueSyncConfig = aiConfig.issueSync;',
+        ticket: '#14239',
+        reason: 'GitHub mirror sync P1 config capture; not a self-heal repair/actuator path.'
+    },
+    {
+        file  : 'ai/services/github-workflow/sync/MetadataManager.mjs',
+        kind  : 'module-scope-capture',
+        text  : 'const issueSyncConfig = aiConfig.issueSync;',
+        ticket: '#14239',
+        reason: 'GitHub mirror metadata P1 config capture; not a self-heal repair/actuator path.'
+    },
+    {
+        file  : 'ai/services/github-workflow/sync/PullRequestSyncer.mjs',
+        kind  : 'module-scope-capture',
+        text  : 'const issueSyncConfig = aiConfig.issueSync;',
+        ticket: '#14239',
+        reason: 'GitHub mirror sync P1 config capture; not a self-heal repair/actuator path.'
+    },
+    {
+        file  : 'ai/services/github-workflow/sync/PullRequestSyncer.mjs',
+        kind  : 'module-scope-capture',
+        text  : 'const pullRequestConfig = aiConfig.pullRequest;',
+        ticket: '#14239',
+        reason: 'GitHub PR mirror P1 config capture; not a self-heal repair/actuator path.'
+    },
+    {
+        file  : 'ai/services/github-workflow/sync/ReleaseNotesSyncer.mjs',
+        kind  : 'module-scope-capture',
+        text  : 'const issueSyncConfig = aiConfig.issueSync;',
+        ticket: '#14239',
+        reason: 'Release-note mirror sync P1 config capture; not a self-heal repair/actuator path.'
+    },
+    {
+        file  : 'ai/services/knowledge-base/DatabaseService.mjs',
+        kind  : 'module-scope-capture',
+        text  : 'const cwd       = aiConfig.neoRootDir;',
+        ticket: '#14239',
+        reason: 'Knowledge Base startup path P1 capture; not a self-heal repair/actuator path.'
+    },
+    {
+        file  : 'ai/services/knowledge-base/QueryService.mjs',
+        kind  : 'module-scope-capture',
+        text  : 'const {queryScoreWeights} = aiConfig;',
+        ticket: '#14239',
+        reason: 'Knowledge Base scoring-weight P1 capture; not a self-heal repair/actuator path.'
+    },
+    {
+        file  : 'ai/services/knowledge-base/QueryService.mjs',
+        kind  : 'module-scope-capture',
+        text  : 'const cwd       = aiConfig.neoRootDir;',
+        ticket: '#14239',
+        reason: 'Knowledge Base startup path P1 capture; not a self-heal repair/actuator path.'
+    }
+]);
+
+/**
  * @summary Normalizes paths for deterministic lint keys.
  * @param {String} file Path to normalize.
  * @returns {String}
@@ -252,6 +339,93 @@ export function detectAiConfigImplementationViolations(source) {
 }
 
 /**
+ * @summary Detects module-load AiConfig leaf captures (`const x = aiConfig.y` / destructuring).
+ *
+ * Direct use-site reads remain valid. This detector specifically targets values frozen at module
+ * evaluation time, the #14239 failure mode where a runtime self-heal config mutation can be ignored
+ * by a stale closure. Function bodies and module-scope functions that read AiConfig when invoked are
+ * intentionally out of scope.
+ * @param {String} source File contents.
+ * @returns {Array<{line: Number, kind: String, text: String}>}
+ */
+export function detectModuleScopeAiConfigCaptures(source) {
+    const violations = [];
+    let   depth      = 0;
+
+    source.split('\n').forEach((text, index) => {
+        const trimmed = text.trim(),
+              before  = depth;
+
+        if (before === 0 &&
+            !trimmed.startsWith('//') &&
+            !trimmed.startsWith('*') &&
+            !trimmed.startsWith('/*') &&
+            !trimmed.startsWith('*/') &&
+            /\b(?:const|let|var)\b/.test(trimmed) &&
+            (
+                /\b(?:const|let|var)\s*\{[^}]+\}\s*=\s*(?:aiConfig|AiConfig|KB_Config|Memory_Config)\b/.test(trimmed) ||
+                /=\s*(?:aiConfig|AiConfig|KB_Config|Memory_Config)(?:\?\.|\.)/.test(trimmed)
+            )
+        ) {
+            violations.push({line: index + 1, kind: 'module-scope-capture', text: trimmed});
+        }
+
+        const code = stripStringsAndLineComment(text);
+        for (const ch of code) {
+            if (ch === '{') {
+                depth++;
+            } else if (ch === '}') {
+                depth = Math.max(0, depth - 1);
+            }
+        }
+    });
+
+    return violations;
+}
+
+/**
+ * @summary Removes quoted strings and line comments for brace-depth scanning.
+ * @param {String} line Source line.
+ * @returns {String}
+ */
+function stripStringsAndLineComment(line) {
+    let out     = '',
+        quote   = null,
+        escaped = false;
+
+    for (let i = 0; i < line.length; i++) {
+        const ch   = line[i],
+              next = line[i + 1];
+
+        if (!quote && ch === '/' && next === '/') {
+            break;
+        }
+
+        if (quote) {
+            out += ' ';
+            if (escaped) {
+                escaped = false;
+            } else if (ch === '\\') {
+                escaped = true;
+            } else if (ch === quote) {
+                quote = null;
+            }
+            continue;
+        }
+
+        if (ch === '"' || ch === '\'' || ch === '`') {
+            quote = ch;
+            out += ' ';
+            continue;
+        }
+
+        out += ch;
+    }
+
+    return out;
+}
+
+/**
  * @summary Core lint: scans config templates and partitions inline-env leaf defaults into
  * baselined, new (unbaselined), and stale-baseline sets.
  * @param {Object} [options]
@@ -326,12 +500,56 @@ export function lintAiConfigImplementationSsot({
     };
 }
 
+/**
+ * @summary Scans `ai/` implementation files for module-scope AiConfig leaf captures.
+ * @param {Object} [options]
+ * @param {String} [options.rootDir] Repo root.
+ * @param {Array<{file: String, source: String}>} [options.files] Injected file records (test seam).
+ * @param {ReadonlyArray<Object>} [options.baseline] Baseline rows.
+ * @returns {{violations: Object[], newViolations: Object[], staleBaseline: Object[]}}
+ */
+export function lintAiConfigModuleScopeCaptures({
+    rootDir  = ROOT_DIR,
+    files,
+    baseline = AI_CONFIG_MODULE_SCOPE_BASELINE
+} = {}) {
+    const records = files || walkMjsFiles(path.join(rootDir, SCAN_ROOT_REL))
+        .map(abs => ({
+            file  : normalizeFile(path.relative(rootDir, abs)),
+            source: fs.readFileSync(abs, 'utf8')
+        }))
+        .filter(({file}) => shouldScanAiConfigImplementation(file));
+
+    const violations = [];
+
+    for (const {file, source} of records) {
+        if (!shouldScanAiConfigImplementation(file)) continue;
+
+        for (const hit of detectModuleScopeAiConfigCaptures(source)) {
+            violations.push({file, ...hit});
+        }
+    }
+
+    const keyOf         = row => `${row.file}::${row.kind}::${row.text}`,
+          baselineKeys  = new Set(baseline.map(keyOf)),
+          violationKeys = new Set(violations.map(keyOf));
+
+    return {
+        violations,
+        newViolations: violations.filter(v => !baselineKeys.has(keyOf(v))),
+        staleBaseline: baseline.filter(b => !violationKeys.has(keyOf(b)))
+    };
+}
+
 const FIX_HINT = 'Move env access into the leaf env-var-name argument — leaf(default, \'ENV_VAR\', type) — ' +
     'and relocate any UNIT_TEST_MODE branch to the test layer (the test-unit npm script shell env). ' +
     'Authority: the AiConfig reactive Provider SSOT decision record (issue #12451).';
 const AI_CONFIG_FIX_HINT = 'Read resolved AiConfig leaves inline at the use site; local Provider subtree references are OK. ' +
     'Do not export config values, pass config-shaped objects through consumers, add hidden defaults/type coercions, ' +
     'or add defensive optional chaining unless the code names an ADR-19-sanctioned boundary. Authority: ADR 0019.';
+const AI_CONFIG_MODULE_SCOPE_FIX_HINT = 'Do not freeze Provider leaves at module load. Read AiConfig at the use site, ' +
+    'or document an existing non-self-heal P1 capture in AI_CONFIG_MODULE_SCOPE_BASELINE as a burndown row. ' +
+    'New self-heal / repair / actuator captures must be converted, not baselined. Authority: #14239 + ADR 0019.';
 
 /**
  * @summary CLI wrapper. Returns an exit code (0 clean, 1 on new violations or stale baseline rows).
@@ -344,7 +562,9 @@ export function runLint(options = {}) {
               files,
               baseline               = BASELINE,
               implementationFiles,
-              implementationBaseline = AI_CONFIG_IMPLEMENTATION_BASELINE
+              implementationBaseline = AI_CONFIG_IMPLEMENTATION_BASELINE,
+              moduleScopeFiles,
+              moduleScopeBaseline    = AI_CONFIG_MODULE_SCOPE_BASELINE
           } = options,
           result               = lintConfigTemplateSsot({rootDir, files, baseline}),
           implementationResult = lintAiConfigImplementationSsot({
@@ -352,13 +572,20 @@ export function runLint(options = {}) {
               files   : implementationFiles,
               baseline: implementationBaseline
           }),
+          moduleScopeResult = lintAiConfigModuleScopeCaptures({
+              rootDir,
+              files   : moduleScopeFiles,
+              baseline: moduleScopeBaseline
+          }),
           {violations, newViolations, staleBaseline} = result,
           hasImplementationFailures = implementationResult.newViolations.length > 0 ||
-              implementationResult.staleBaseline.length > 0;
+              implementationResult.staleBaseline.length > 0,
+          hasModuleScopeFailures = moduleScopeResult.newViolations.length > 0 ||
+              moduleScopeResult.staleBaseline.length > 0;
 
-    if (newViolations.length === 0 && staleBaseline.length === 0 && !hasImplementationFailures) {
-        console.log(`[lint-config-template-ssot] OK - ${violations.length} inline-env leaf default(s), ${implementationResult.violations.length} AiConfig implementation SSOT hit(s), all baselined.`);
-        return {exitCode: 0, ...result, implementation: implementationResult};
+    if (newViolations.length === 0 && staleBaseline.length === 0 && !hasImplementationFailures && !hasModuleScopeFailures) {
+        console.log(`[lint-config-template-ssot] OK - ${violations.length} inline-env leaf default(s), ${implementationResult.violations.length} AiConfig implementation SSOT hit(s), ${moduleScopeResult.violations.length} module-scope AiConfig capture(s), all baselined.`);
+        return {exitCode: 0, ...result, implementation: implementationResult, moduleScope: moduleScopeResult};
     }
 
     if (newViolations.length > 0) {
@@ -403,7 +630,28 @@ export function runLint(options = {}) {
         console.error('');
     }
 
-    return {exitCode: 1, ...result, implementation: implementationResult};
+    if (moduleScopeResult.newViolations.length > 0) {
+        console.error(`[lint-config-template-ssot] FAILED - ${moduleScopeResult.newViolations.length} new module-scope AiConfig capture(s):\n`);
+
+        for (const v of moduleScopeResult.newViolations) {
+            console.error(`- ${v.file}:${v.line}  (${v.kind})`);
+            console.error(`    ${v.text}`);
+        }
+
+        console.error(`\n${AI_CONFIG_MODULE_SCOPE_FIX_HINT}\n`);
+    }
+
+    if (moduleScopeResult.staleBaseline.length > 0) {
+        console.error(`[lint-config-template-ssot] FAILED - ${moduleScopeResult.staleBaseline.length} module-scope AiConfig baseline row(s) no longer match live code (cleanup landed — remove the row):\n`);
+
+        for (const b of moduleScopeResult.staleBaseline) {
+            console.error(`- ${b.file}::${b.kind}::${b.text}  (${b.ticket})`);
+        }
+
+        console.error('');
+    }
+
+    return {exitCode: 1, ...result, implementation: implementationResult, moduleScope: moduleScopeResult};
 }
 
 function main() {
@@ -414,7 +662,8 @@ function main() {
         console.log('');
         console.log('Fails when a config.template.mjs leaf default reads process.env inline');
         console.log('(outside the BASELINE), when a BASELINE row no longer matches a violation,');
-        console.log('or when ai/ implementation code adds mechanical ADR-19 AiConfig SSOT violations.');
+        console.log('when ai/ implementation code adds mechanical ADR-19 AiConfig SSOT violations,');
+        console.log('or when ai/ implementation code adds module-scope AiConfig leaf captures.');
         process.exit(0);
     }
 

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -4,10 +4,13 @@ import path           from 'node:path';
 
 import {
     AI_CONFIG_IMPLEMENTATION_BASELINE,
+    AI_CONFIG_MODULE_SCOPE_BASELINE,
     BASELINE,
     detectAiConfigImplementationViolations,
     detectInlineEnvLeaves,
+    detectModuleScopeAiConfigCaptures,
     lintAiConfigImplementationSsot,
+    lintAiConfigModuleScopeCaptures,
     lintConfigTemplateSsot,
     runLint
 } from '../../../../../../ai/scripts/lint/lint-config-template-ssot.mjs';
@@ -100,6 +103,33 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
         )).toHaveLength(0);
     });
 
+    test('detects module-scope AiConfig leaf captures', () => {
+        const hits = detectModuleScopeAiConfigCaptures([
+            `import aiConfig from './config.mjs';`,
+            `const issueSyncConfig = aiConfig.issueSync;`,
+            `const {queryScoreWeights} = aiConfig;`,
+            `const memoryPath = Memory_Config.storagePaths.memory;`
+        ].join('\n'));
+
+        expect(hits.map(hit => hit.text)).toEqual([
+            'const issueSyncConfig = aiConfig.issueSync;',
+            'const {queryScoreWeights} = aiConfig;',
+            'const memoryPath = Memory_Config.storagePaths.memory;'
+        ]);
+    });
+
+    test('ignores invocation-time and function-local AiConfig reads', () => {
+        const hits = detectModuleScopeAiConfigCaptures([
+            `const isRemoteIngestTransport = () => aiConfig.transport === 'sse';`,
+            `function getSnapshotPath() {`,
+            `    const snapshotPath = AiConfig.orchestrator.deploymentStateBridge.snapshotPath;`,
+            `    return snapshotPath;`,
+            `}`
+        ].join('\n'));
+
+        expect(hits).toHaveLength(0);
+    });
+
     // ---- baseline partitioning (injected files, no disk) ----
 
     const fileOf = (file, source) => ({file, source});
@@ -175,6 +205,46 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
         expect(result.implementation.newViolations.map(hit => hit.kind)).toEqual(['type-coercion', 'hidden-default']);
     });
 
+    test('a baselined module-scope AiConfig capture is suppressed (documented P1 debt)', () => {
+        const baseline = [{
+            file  : 'ai/fixture.mjs',
+            kind  : 'module-scope-capture',
+            text  : 'const issueSyncConfig = aiConfig.issueSync;',
+            ticket: '#14239',
+            reason: 'fixture P1 capture'
+        }];
+        const files = [fileOf(
+            'ai/fixture.mjs',
+            `const issueSyncConfig = aiConfig.issueSync;`
+        )];
+
+        const {violations, newViolations} = lintAiConfigModuleScopeCaptures({files, baseline});
+
+        expect(violations).toHaveLength(1);
+        expect(newViolations).toHaveLength(0);
+    });
+
+    test('a fresh module-scope AiConfig capture fails the combined lint', () => {
+        const moduleScopeFiles = [fileOf(
+            'ai/daemons/orchestrator/services/SelfHealFixture.mjs',
+            `const recoveryActuatorConfig = aiConfig.orchestrator.recoveryActuator;`
+        )];
+
+        const result = runLint({
+            files                 : [],
+            implementationFiles   : [],
+            implementationBaseline: [],
+            moduleScopeFiles,
+            moduleScopeBaseline   : []
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(result.moduleScope.newViolations).toHaveLength(1);
+        expect(result.moduleScope.newViolations[0].text).toBe(
+            'const recoveryActuatorConfig = aiConfig.orchestrator.recoveryActuator;'
+        );
+    });
+
     // ---- the shipped baseline is internally well-formed ----
 
     test('every shipped BASELINE row carries file, env, and a reshape note', () => {
@@ -193,6 +263,16 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
             expect(row.kind.length).toBeGreaterThan(0);
             expect(row.text.length).toBeGreaterThan(0);
             expect(row.reason.length).toBeGreaterThan(0);
+        }
+    });
+
+    test('every shipped AI_CONFIG_MODULE_SCOPE_BASELINE row carries #14239 burndown context', () => {
+        for (const row of AI_CONFIG_MODULE_SCOPE_BASELINE) {
+            expect(row.file).toMatch(/^ai\/.*\.mjs$/);
+            expect(row.kind).toBe('module-scope-capture');
+            expect(row.text.length).toBeGreaterThan(0);
+            expect(row.ticket).toBe('#14239');
+            expect(row.reason).toContain('not a self-heal');
         }
     });
 });

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -6,6 +6,8 @@ import {
     AI_CONFIG_IMPLEMENTATION_BASELINE,
     AI_CONFIG_MODULE_SCOPE_BASELINE,
     BASELINE,
+    buildConfigPathKindsByIdentifier,
+    collectConfigPathKindsFromSource,
     detectAiConfigImplementationViolations,
     detectInlineEnvLeaves,
     detectModuleScopeAiConfigCaptures,
@@ -28,7 +30,11 @@ import {
  * a fresh violation fails, and a stale baseline row fails (burndown hygiene).
  */
 test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative config SSOT guard)', () => {
-    const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lint/lint-config-template-ssot.mjs');
+    const scriptPath  = path.resolve(process.cwd(), 'ai/scripts/lint/lint-config-template-ssot.mjs');
+    const configKinds = ({primitive = [], live = []} = {}) => ({
+        primitiveLeafPaths: new Set(primitive),
+        liveProxyPaths    : new Set(live)
+    });
 
     // ---- CLI ----
 
@@ -103,19 +109,60 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
         )).toHaveLength(0);
     });
 
-    test('detects module-scope AiConfig leaf captures', () => {
+    test('classifies config-template paths as frozen leaves versus live proxies', () => {
+        const kinds = collectConfigPathKindsFromSource([
+            `class Config {`,
+            `    static config = {`,
+            `        data: {`,
+            `            neoRootDir: leaf('/repo'),`,
+            `            issueSync: {`,
+            `                maxIssues: leaf(20, 'NEO_MAX_ISSUES', 'number')`,
+            `            },`,
+            `            queryScoreWeights: leaf({`,
+            `                baseIncrement: 1`,
+            `            })`,
+            `        }`,
+            `    }`,
+            `}`
+        ].join('\n'));
+
+        expect(kinds.primitiveLeafPaths.has('neoRootDir')).toBe(true);
+        expect(kinds.primitiveLeafPaths.has('issueSync.maxIssues')).toBe(true);
+        expect(kinds.liveProxyPaths.has('issueSync')).toBe(true);
+        expect(kinds.liveProxyPaths.has('queryScoreWeights')).toBe(true);
+    });
+
+    test('detects module-scope AiConfig primitive leaf captures', () => {
+        const configPathKindsByIdentifier = new Map([
+            ['aiConfig', configKinds({
+                primitive: ['neoRootDir', 'storagePaths.graph', 'datasets.rlaif.trajectories'],
+                live     : ['issueSync', 'pullRequest', 'queryScoreWeights']
+            })],
+            ['Memory_Config', configKinds({primitive: ['storagePaths.memory']})]
+        ]);
+
         const hits = detectModuleScopeAiConfigCaptures([
             `import aiConfig from './config.mjs';`,
             `const issueSyncConfig = aiConfig.issueSync;`,
             `const {queryScoreWeights} = aiConfig;`,
+            `const cwd = aiConfig.neoRootDir;`,
             `const memoryPath = Memory_Config.storagePaths.memory;`
-        ].join('\n'));
+        ].join('\n'), {configPathKindsByIdentifier});
 
         expect(hits.map(hit => hit.text)).toEqual([
-            'const issueSyncConfig = aiConfig.issueSync;',
-            'const {queryScoreWeights} = aiConfig;',
+            'const cwd = aiConfig.neoRootDir;',
             'const memoryPath = Memory_Config.storagePaths.memory;'
         ]);
+    });
+
+    test('maps config.mjs imports to templates for module-scope capture classification', () => {
+        const configPathKindsByIdentifier = buildConfigPathKindsByIdentifier({
+            file  : 'ai/services/github-workflow/sync/IssueSyncer.mjs',
+            source: `import aiConfig from '../../../mcp/server/github-workflow/config.mjs';`
+        });
+
+        expect(configPathKindsByIdentifier.get('aiConfig').liveProxyPaths.has('issueSync')).toBe(true);
+        expect(configPathKindsByIdentifier.get('aiConfig').primitiveLeafPaths.has('issueSync.maxIssues')).toBe(true);
     });
 
     test('ignores invocation-time and function-local AiConfig reads', () => {
@@ -205,17 +252,17 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
         expect(result.implementation.newViolations.map(hit => hit.kind)).toEqual(['type-coercion', 'hidden-default']);
     });
 
-    test('a baselined module-scope AiConfig capture is suppressed (documented P1 debt)', () => {
+    test('a baselined module-scope AiConfig primitive leaf capture is suppressed (documented P1 debt)', () => {
         const baseline = [{
             file  : 'ai/fixture.mjs',
-            kind  : 'module-scope-capture',
-            text  : 'const issueSyncConfig = aiConfig.issueSync;',
+            kind  : 'module-scope-leaf-capture',
+            text  : 'const cwd = aiConfig.neoRootDir;',
             ticket: '#14239',
-            reason: 'fixture P1 capture'
+            reason: 'fixture frozen primitive leaf'
         }];
         const files = [fileOf(
             'ai/fixture.mjs',
-            `const issueSyncConfig = aiConfig.issueSync;`
+            `const cwd = aiConfig.neoRootDir;`
         )];
 
         const {violations, newViolations} = lintAiConfigModuleScopeCaptures({files, baseline});
@@ -224,10 +271,13 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
         expect(newViolations).toHaveLength(0);
     });
 
-    test('a fresh module-scope AiConfig capture fails the combined lint', () => {
+    test('a fresh module-scope AiConfig primitive leaf capture fails the combined lint', () => {
         const moduleScopeFiles = [fileOf(
             'ai/daemons/orchestrator/services/SelfHealFixture.mjs',
-            `const recoveryActuatorConfig = aiConfig.orchestrator.recoveryActuator;`
+            [
+                `import AiConfig from '../../../config.mjs';`,
+                `const recoveryRunStateDir = AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir;`
+            ].join('\n')
         )];
 
         const result = runLint({
@@ -241,8 +291,29 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
         expect(result.exitCode).toBe(1);
         expect(result.moduleScope.newViolations).toHaveLength(1);
         expect(result.moduleScope.newViolations[0].text).toBe(
-            'const recoveryActuatorConfig = aiConfig.orchestrator.recoveryActuator;'
+            'const recoveryRunStateDir = AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir;'
         );
+    });
+
+    test('a fresh module-scope namespace proxy capture passes the combined lint', () => {
+        const moduleScopeFiles = [fileOf(
+            'ai/daemons/orchestrator/services/SelfHealFixture.mjs',
+            [
+                `import AiConfig from '../../../config.mjs';`,
+                `const recoveryActuatorConfig = AiConfig.orchestrator.recoveryActuator;`
+            ].join('\n')
+        )];
+
+        const result = runLint({
+            files                 : [],
+            implementationFiles   : [],
+            implementationBaseline: [],
+            moduleScopeFiles,
+            moduleScopeBaseline   : []
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.moduleScope.newViolations).toHaveLength(0);
     });
 
     // ---- the shipped baseline is internally well-formed ----
@@ -269,10 +340,10 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
     test('every shipped AI_CONFIG_MODULE_SCOPE_BASELINE row carries #14239 burndown context', () => {
         for (const row of AI_CONFIG_MODULE_SCOPE_BASELINE) {
             expect(row.file).toMatch(/^ai\/.*\.mjs$/);
-            expect(row.kind).toBe('module-scope-capture');
+            expect(row.kind).toBe('module-scope-leaf-capture');
             expect(row.text.length).toBeGreaterThan(0);
             expect(row.ticket).toBe('#14239');
-            expect(row.reason).toContain('not a self-heal');
+            expect(row.reason).toContain('Frozen primitive');
         }
     });
 });


### PR DESCRIPTION
Resolves #14239

Adds an ADR-0019 guard for module-load AiConfig primitive/formula leaf captures without false-flagging live Provider proxies. The guard now classifies captures from each imported `config.mjs` template: primitive/formula leaves are frozen and fail unless explicitly baselined as #14239 burndown debt; namespace paths and object-valued leaves stay live through nested Provider proxies and are not violations.

Evidence: L2 static lint + L2 unit coverage -> L3 required for close-target guard confidence. Residual: #14165 remains the deferred runtime soak for mutate-config-at-runtime heal cycles.

## Deltas from Ticket

- Audited current module-scope AiConfig captures and narrowed `AI_CONFIG_MODULE_SCOPE_BASELINE` to the four remaining frozen primitive leaf captures.
- Removed live proxy captures (`issueSync`, `pullRequest`, `queryScoreWeights`) from the violation baseline.
- Added config-template capture-kind classification so the lint can distinguish primitive/formula leaves from namespace/object-valued proxy captures.
- Converted the embed/message daemon WAL data-dir captures to use-time reads so current dev has no unbaselined primitive leaf freezes.

## Test Evidence

- `node --check ai/scripts/lint/lint-config-template-ssot.mjs` -> passed.
- `node --check ai/daemons/embed/daemon.mjs` -> passed.
- `node --check ai/daemons/message/daemon.mjs` -> passed.
- `node ai/scripts/lint/lint-config-template-ssot.mjs` -> OK; 0 inline-env defaults, 4 existing AiConfig implementation hits, 4 module-scope primitive leaf captures, all baselined.
- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs` -> 24 passed.
- `npm run agent-preflight -- ai/scripts/lint/lint-config-template-ssot.mjs ai/daemons/embed/daemon.mjs ai/daemons/message/daemon.mjs test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs` -> passed; 0 ticket-archaeology violations.
- `git diff --check` -> passed.

## Post-Merge Validation

- [ ] CI runs `lint-config-template-ssot` against the merged tree and fails if any peer branch adds a new module-scope primitive/formula AiConfig leaf capture before merge.
- [ ] #14165 later proves the runtime soak path with mutate-config-at-runtime heal cycles.

## Commits

- `8be90f2ad3` - `feat(ai): guard module-scope AiConfig captures (#14239)`
- `12a0317945` - `fix(ai): classify module AiConfig leaf captures (#14239)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019efe4c-5d55-76c0-aba5-665f86d9cbdc.
