### PR TITLE
feat(agentos): goal-scoping skill — convert a GOAL into owned lanes (#14267)

### DIFF
--- a/.agents/skills/epic-create/references/epic-create-workflow.md
+++ b/.agents/skills/epic-create/references/epic-create-workflow.md
@@ -38,6 +38,7 @@ Each sub the decomposition creates MUST be a **leaf that a single PR can FULLY d
 
 | Skill | Phase | Owns |
 |---|---|---|
+| **`goal-scoping`** | Front-end (upstream) | Scope a GOAL → the set of owned LANES this skill then authors (one epic per lane); peers self-select their lane |
 | **`epic-create`** (here) | Creation | Problem-scope + intended-solution body; `epic` label; title hygiene |
 | `epic-review` | Pre-work entry | Roadmap fit, approach elegance, source-Discussion mapping, sub-structure coherence; seeds the Stage 3.1 closeout matrix |
 | `epic-resolution` | Closeout exit | Reconciles delivered subs against the parent ACs (which live in the subs) |

--- a/.agents/skills/goal-scoping/SKILL.md
+++ b/.agents/skills/goal-scoping/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: goal-scoping
+description: "Scope a GOAL (release / initiative / major objective) into a few coherent owned LANES — the planning front-end of the epic lifecycle. Convert goals into lanes (not scrap tickets); peers self-select lanes; the planner defines goal+lanes but never assigns a peer. Triggers: before decomposing a release/initiative/major-goal into work; when a goal needs scoping into owned streams; when work is being chased as scattered micro-tickets with no owned lanes; when tempted to skip planning OR to assign peers to lanes."
+---
+# Goal-Scoping — the planning front-end (goal → owned lanes)
+
+If you are about to decompose a GOAL (a release, initiative, or major objective) into work — or you notice work being chased as scattered micro-tickets with no owned lanes, or you are tempted to assign peers to work — you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/goal-scoping/references/goal-scoping-workflow.md` before scoping or assigning anything.

--- a/.agents/skills/goal-scoping/references/goal-scoping-workflow.md
+++ b/.agents/skills/goal-scoping/references/goal-scoping-workflow.md
@@ -1,0 +1,54 @@
+# Goal-Scoping Workflow — convert a GOAL into owned LANES
+
+The planning **front-end** of the epic lifecycle. `epic-create` authors ONE epic; `epic-review` / `epic-resolution` review and close it. This skill is the step *before* all of them: it decides **which** lanes (→ epics) a GOAL needs, and how they get owned. Output = a few coherent **owned lanes**, each a durable epic, each self-selected by an owner who drives it to the lane-goal.
+
+## Why this exists (the friction → gold)
+
+A goal with no scoping produces one of two failures — both observed repeatedly, both wrong:
+
+- **No planning** → the team chases scattered **micro-tickets**; parents never close; the goal never converges; capable agents report "nothing to do."
+- **Lead micro-manages** → the lead **assigns** peers to lanes ("you take X"). This violates self-assignment + flat-peer agency (`AGENTS.md` §swarm_topology_anchor) — just as bad.
+
+The cure is neither: a planner **defines the goal + the lanes**, and **peers self-select** which lane to own.
+
+## The process
+
+### 1. Define the GOAL
+One demonstrable bar — what "done" means, end-to-end. The outcome, not a task list.
+
+### 2. Scope into LANES (the core discipline)
+Carve the goal into a **few** (≈2–6) coherent streams — by subsystem / daemon / pillar / capability. A **lane** is *a coherent stream worth a dedicated owner driving it to a sub-goal*. It is NOT:
+- a **sliver** (a 50-line change is a PR, not a lane);
+- a **scrap-ticket** (do not atomize the goal into N micro-tickets);
+- a **flat ticket list** (lanes are owned streams, not a backlog dump).
+
+**The lane test:** would one accountable owner carry this whole stream in their head and drive it to a goal? If it is too small to warrant an owner, it is a *sub* of a lane, not a lane. If it spans unrelated concerns, split it.
+
+### 3. Each lane → an epic
+Author each lane as an epic via **`/epic-create`** (problem-scope + intended-solution; subs linked, added reasonably by the owner). The lane-epic is the **durable, context-wipe-proof ownership anchor**: an owner who wakes disoriented asks "what do I own?" → "the X lane / epic #N" → reads the epic body + linked subs → rebuilt. (Contrast: self-assigned scattered micro-tickets evaporate across a context-wipe → ownership-amnesia → grabbing stale tickets.)
+
+### 4. Ownership = SELF-SELECT
+The planner **defines** the goal + the lanes (the planning artifact) and **facilitates**. Peers **self-select** the lane they own. The planner **never assigns** a peer to a lane — that is micro-management and violates self-assignment. Surface the lanes; let peers claim them. Each lane needs exactly one accountable owner; if two claim, the earlier claim wins (the later contributes into it).
+
+### 5. Drive to the lane-GOAL
+The owner is accountable for the **lane's goal** (close-by-goal, never sub-count) and decomposes internally into **reasonable** units (no micro-slivers). The owner drives ALL their lane's tickets to the lane-goal — which dissolves orphaned tickets, never-closing parents, and "nothing to do."
+
+## Relationship to the epic lifecycle
+
+| Skill | Phase | Owns |
+|---|---|---|
+| **`goal-scoping`** (this skill) | Front-end | GOAL → the set of owned LANES |
+| `epic-create` | Per-lane creation | author each lane as an epic |
+| `epic-review` | Per-epic pre-work | review an epic before sub pickup |
+| `epic-resolution` | Per-epic closeout | close an epic when its goal is met |
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails |
+|---|---|
+| No planning (goal → backlog of micro-tickets) | the team chases slivers; nothing converges; "nothing to do" |
+| Lead assigns peers to lanes | micro-management; violates self-assignment + flat-peer agency |
+| Scrap-ticket explosion (goal → N micro-tickets) | per-unit overhead × N; ownership-amnesia across context-wipes |
+| A "lane" that is really a sliver | too small to own; it is a sub, not a lane |
+| Lanes listed in prose, never owned | a backlog dump is not a plan; lanes have accountable owners |
+| The planner owns every lane | that is a solo project, not planning; the point is distributed ownership |

--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -123,6 +123,17 @@
         "learn/guides/fundamentals/CodebaseOverview.md"
       ]
     },
+    "goal-scoping": {
+      "name": "goal-scoping",
+      "description": "Scope a GOAL (release / initiative / major objective) into a few coherent owned LANES — the planning front-end of the epic lifecycle. Convert goals into lanes (not scrap tickets); peers self-select lanes; the planner defines goal+lanes but never assigns a peer. Triggers: before decomposing a release/initiative/major-goal into work; when a goal needs scoping into owned streams; when work is being chased as scattered micro-tickets with no owned lanes; when tempted to skip planning OR to assign peers to lanes.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
     "hostile-content-quarantine": {
       "name": "hostile-content-quarantine",
       "description": "Incident playbook for externally-authored hostile content on public surfaces — astroturfing, spam, stealth marketing, injection-bearing artifacts. Triggers: external-authored content bearing astroturf markers (engagement-bait clauses, vendor links, external endpoint/MCP offers, name-only drops), an operator \"astroturf / spam / we got hit\" signal, or verifying a moderation outcome. ANTI-trigger: ordinary good-faith contributor posts.",

--- a/.claude/skills/goal-scoping
+++ b/.claude/skills/goal-scoping
@@ -1,0 +1,1 @@
+../../.agents/skills/goal-scoping

--- a/learn/agentos/ProgressiveDisclosureSkills.md
+++ b/learn/agentos/ProgressiveDisclosureSkills.md
@@ -124,6 +124,7 @@ ensuring the YAML frontmatter and folder consistency are perfectly formed.
 |---|---|---|
 | `ticket-intake` | Lifecycle | Pre-execution validation gate for existing tickets |
 | `ticket-create` | Lifecycle | Pre-creation discipline gate (duplicate sweep, six-stage challenge chain, Fat Ticket body, title/label rules, custom Playwright configs) |
+| `goal-scoping` | Lifecycle | Scope a GOAL into a few coherent owned LANES — the planning front-end of the epic lifecycle (goal→lanes, not scrap tickets; peers self-select; the planner defines goal+lanes, never assigns) |
 | `epic-create` | Lifecycle | Author Epic bodies (problem-scope + intended-solution; ACs in subs, not the body) |
 | `epic-review` | Lifecycle | Pre-work six-stage gating chain for epics |
 | `epic-resolution` | Lifecycle | Closeout protocol for parent epics (exit gate) |

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -451,6 +451,7 @@ Formalized Anthropic Progressive Disclosure Skills natively used by the swarm. L
 **Lifecycle (execution gates):**
 - `ticket-intake`: Pre-execution validation gate for existing tickets (validation sweep, ROI calculation, branch-before-code).
 - `ticket-create`: Pre-creation discipline gate for new GitHub issues (duplicate sweep, six-stage challenge chain, Fat Ticket body, title/label rules, explicit custom Playwright targeting).
+- `goal-scoping`: Scope a GOAL (release / initiative) into a few coherent owned LANES — the planning front-end of the epic lifecycle (goal→lanes, not scrap tickets; peers self-select their lane; the planner defines goal+lanes but never assigns a peer). Feeds `epic-create` (each lane → an epic).
 - `epic-create`: Author Epic bodies as problem-scope + intended-solution — ACs live in the sub-tickets, subs are linked (not listed) so the body doesn't stale (creation-side dual of ticket-create).
 - `epic-review`: Pre-work six-stage gating chain for epics (roadmap fit, approach elegance, source discussion mapping, sub-structure coherence, prescription layer, avoided-traps completeness).
 - `epic-resolution`: Closeout protocol for parent epics resolving the completion status (exit gate).


### PR DESCRIPTION
## Summary

Adds the **`goal-scoping`** skill — the missing **planning front-end** of the epic lifecycle. It converts a GOAL (release / initiative) into a few coherent **owned LANES** (each → an epic via `/epic-create`); peers **self-select** lanes; the planner **defines** goal+lanes but **never assigns** a peer.

friction→gold for the session's repeated planning failures: the two symmetric wrongs — **no planning** (→ micro-ticket chase, parents never close, "nothing to do") and **lead-assigns-peers** (→ micro-management, violates self-assignment). The cure is neither: defined lanes + self-selected ownership.

Resolves #14267

Evidence: L1 (skill-manifest lint green + manifest mirrors frontmatter + both downstreamDocsTargets updated; guidance skill, no runtime AC) → no higher evidence-level applies.

## Deltas

- `+ .agents/skills/goal-scoping/SKILL.md` — router (Map): trigger + read-the-payload directive (~7 lines, within the 7–12 budget).
- `+ .agents/skills/goal-scoping/references/goal-scoping-workflow.md` — payload (Atlas): the goal→lanes SOP, the two symmetric anti-patterns, the epic-lifecycle relationship table, the anti-pattern table.
- `+ .claude/skills/goal-scoping` — the mandated Claude symlink.
- `~ .agents/skills/skills.manifest.json` — the `goal-scoping` entry (mirrors the SKILL.md frontmatter description).
- `~ learn/agentos/ProgressiveDisclosureSkills.md` + `~ learn/guides/fundamentals/CodebaseOverview.md` — the two manifest `downstreamDocsTargets`, updated with the goal-scoping entry.

## Turn-Memory / Load-Effect Audit

Per `/turn-memory-pre-flight`: the always-loaded **Map** delta is the `SKILL.md` router only (~7 lines; one new always-loaded trigger). The heavy goal→lanes process lives in the conditional **World-Atlas** payload (`references/goal-scoping-workflow.md`), loaded via `view_file` only when the trigger fires. Net always-loaded delta is pointer-sized; the `[skill-growth-justified]` commit tag covers the new-skill payload growth (5169 B), per the authoring guide's new-skill exception.

**Contract:** guidance skill (agent-consumed governance-surface). The T3 **Contract Ledger is posted on the source ticket #14267** (the invocation contract: trigger → reads the workflow → produces owned lanes; fallback = guidance, not a hard gate; no consumer to migrate). No API / config / MCP-tool surface.

## Test Evidence

`node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` — passed at commit (the pre-commit hook ran whitespace + manifest checks green; the net-growth flag cleared via the `[skill-growth-justified]` tag; both `downstreamDocsTargets` updated in-PR). No runtime code changed.

## Post-Merge Validation

The skill is invocable (`/goal-scoping`); the next goal-decomposition (a v13.x release scope) uses it to produce owned lanes — the live validation that goal→lanes + self-select replaces the micro-ticket chase. Sibling to #14263 (the review + ticket-scoping right-sizing); together they are the process-substrate reform.

Authored by Vega (Claude Opus 4.8, Claude Code). Session 3f32bbc7-1bfe-4f85-9232-c957de0d22f1.
