### PR TITLE
test(ai): self-heal soak — N corruption+heal cycles prove sustained operation (#14165)

### DIFF
--- a/test/playwright/unit/ai/scripts/maintenance/CorruptionRecoveryGate.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/CorruptionRecoveryGate.spec.mjs
@@ -12,6 +12,7 @@ import {classifyDataIntegrityMode} from '../../../../../../ai/daemons/orchestrat
 import {createReEmbedMissingHeal,
         createReEmbedMissingHealOperation} from '../../../../../../ai/services/memory-core/helpers/reEmbedMissingHeal.mjs';
 import DataRecoveryActuatorService from '../../../../../../ai/daemons/orchestrator/services/DataRecoveryActuatorService.mjs';
+import {DEFAULT_DISPATCH_BOUNDS}    from '../../../../../../ai/services/memory-core/helpers/healActionDispatch.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -274,6 +275,110 @@ test.describe('v13.1 release gate — corruption injection → detect → diagno
             });
 
             expect(decision).toMatchObject({mode: 'clean', terminalAction: 'none', autonomous: true});
+        } finally {
+            await fs.remove(tmpDir);
+        }
+    });
+});
+
+/*
+ * v13.1 release gate — the self-heal SOAK proof (#14165): the single-shot gate above proves ONE corruption
+ * heals; this proves the immune system survives SUSTAINED operation — the "runs autonomously for weeks (~95%)"
+ * bar. It drives N inject→detect→diagnose→HEAL cycles on an accelerated clock through the REAL `applyHeal`
+ * dispatch (default bounds: 3 mutating runs / hour, 10-min cooldown), threading the anti-thrash ledger across
+ * cycles, and asserts the three failure modes a single shot cannot surface:
+ *   - CONVERGENCE     — every cycle resolves to a terminal (healed OR anti-thrash-contained), never stuck/escalate.
+ *   - NO HOT-LOOP     — under continuous re-injection the executed heals are BOUNDED by the rate/cooldown gate
+ *                       (they do NOT grow 1:1 with the cycle count); the anti-thrash demonstrably engages.
+ *   - BOUNDED STATE   — the active anti-thrash working set (the windowed recentRuns) stays ≤ the per-window cap
+ *                       across the whole run; old attempts age out, so it never grows with the cycle count.
+ * Reuses the proven injector + pipeline above — no parallel harness (#14165 AC3).
+ */
+test.describe('v13.1 release gate — self-heal SOAK: N corruption+heal cycles survive sustained operation (#14165)', () => {
+    test('N accelerated cycles converge, never hot-loop, and keep the anti-thrash working set bounded', async () => {
+        const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-corruption-soak-'));
+
+        try {
+            const CYCLES        = 24,             // weeks in miniature
+                  CYCLE_STEP_MS = 12 * 60 * 1000, // 12 min/cycle on the accelerated clock (> the 10-min cooldown)
+                  WINDOW_MS     = 3600000,        // mirror DEFAULT_DISPATCH_BOUNDS.windowMs (the anti-thrash window)
+                  ledger        = [];             // the heal-event ledger — append-only attempt log; the recentRuns source
+
+            let healCount     = 0,
+                deferCount    = 0,
+                maxRecentRuns = 0;
+
+            // The recentRuns projection: executed-attempt rows for this collection within the anti-thrash window.
+            const recentRunsAt = now => ledger
+                .filter(entry => entry.collection === 'neo-agent-memory' && now - entry.at < WINDOW_MS)
+                .map(entry => ({action: entry.action, collection: entry.collection, at: entry.at}));
+
+            for (let cycle = 0; cycle < CYCLES; cycle++) {
+                const now = OBSERVED_AT + cycle * CYCLE_STEP_MS;
+
+                // INJECT — the vector-loss (wal-stall) shape into a FRESH per-cycle store = sustained corruption pressure.
+                const cycleDir = path.join(tmpDir, `cycle-${cycle}`);
+                await fs.ensureDir(cycleDir);
+                const snapshotPath = await injectMemoryCoreSnapshot(cycleDir, {writeVectorPickle: false});
+
+                // DETECT + DIAGNOSE (the proven pipeline).
+                const coverageResult = await auditChromaVectorCoverage({
+                    snapshotPath, persistDir: cycleDir, collectionNames: ['neo-agent-memory'], sampleSize: 2, includeFullIds: true
+                });
+                const drifted = coverageResult.collections.find(collection => collection.name === 'neo-agent-memory');
+                expect(drifted.ok).toBe(false); // every cycle's injection is seen — the detect never goes blind
+
+                const decision = classifyDataIntegrityMode({
+                    collection: 'neo-agent-memory', rowCount: METADATA_IDS.length,
+                    missingFromVectorCount: drifted.missingFromVectorCount, documentsPresentCount: drifted.missingFromVectorCount
+                });
+                expect(decision).toMatchObject({mode: 'wal-stall', terminalAction: 're-embed-missing', autonomous: true});
+
+                const collection = mockCollection(Object.fromEntries(
+                    METADATA_IDS.map(id => [id, {document: `surviving document for ${id} (cycle ${cycle})`, metadata: {kind: 'turn'}}])
+                ));
+                const reEmbedMissing = createReEmbedMissingHeal({
+                    embedFn: async documents => documents.map(() => DETERMINISTIC_VECTOR.slice()),
+                    auditCoverage: async ({evidence}) => ({missingVectorIds: evidence.missingVectorIds}),
+                    expectedDimension: DETERMINISTIC_VECTOR.length
+                });
+                const healOperation = createReEmbedMissingHealOperation({
+                    reEmbedMissing, getMemoryCollection: async () => collection, resolveMissingVectorIds: async () => [...METADATA_IDS]
+                });
+
+                maxRecentRuns = Math.max(maxRecentRuns, recentRunsAt(now).length);
+
+                // HEAL — the REAL dispatch with the accumulating anti-thrash state (recordRun appends only on execute).
+                const actuator = Neo.create(DataRecoveryActuatorService, {
+                    healOperations  : {[decision.terminalAction]: healOperation},
+                    recordRun       : async ({action, collection, at}) => { ledger.push({action, collection, at}); },
+                    recentRunsReader: async () => recentRunsAt(now)
+                });
+
+                const outcome = await actuator.applyHeal({
+                    action: decision.terminalAction, collection: 'neo-agent-memory',
+                    evidence: {missingVectorIds: [...METADATA_IDS]}, now
+                });
+
+                // CONVERGENCE — a terminal every cycle, never stuck/escalate/paged.
+                expect(['healed', 'rate-limited', 'thrash-cooldown', 'deferred']).toContain(outcome.status);
+                expect(outcome.status).not.toBe('escalated');
+
+                if (outcome.status === 'healed') healCount++; else deferCount++;
+            }
+
+            // CONVERGENCE — every cycle accounted for (no stuck / errored cycle).
+            expect(healCount + deferCount).toBe(CYCLES);
+
+            // NO HOT-LOOP — the anti-thrash demonstrably engaged (some cycles deferred) AND the system still
+            // healed (it is not wedged shut); the executed heals are strictly fewer than the cycles.
+            expect(healCount).toBeGreaterThan(0);
+            expect(deferCount).toBeGreaterThan(0);
+            expect(healCount).toBeLessThan(CYCLES);
+
+            // BOUNDED STATE — the active anti-thrash working set never exceeds the per-window cap across the run
+            // (old attempts age out of the window on the accelerated clock — no monotonic growth with cycle count).
+            expect(maxRecentRuns).toBeLessThanOrEqual(DEFAULT_DISPATCH_BOUNDS.maxRunsPerWindow);
         } finally {
             await fs.remove(tmpDir);
         }


### PR DESCRIPTION
## Summary

The v13.1 self-heal **soak proof** (parent #14039) — the "weeks in miniature" / "runs autonomously for weeks (~95%)" bar. The single-shot `CorruptionRecoveryGate` proves ONE corruption heals; this proves the immune system survives SUSTAINED operation, which a single shot cannot surface.

Resolves #14165

## Change

A new soak describe-block in `CorruptionRecoveryGate.spec.mjs` (reuses the proven injector + pipeline — #14165 AC3: no parallel harness). Drives 24 inject→detect→diagnose→HEAL cycles on an accelerated clock through the REAL `applyHeal` dispatch (default bounds: 3 mutating runs/hour, 10-min cooldown), threading the anti-thrash ledger across cycles. Asserts the three failure modes a single shot cannot surface:
- **Convergence** — every cycle resolves to a terminal (healed OR anti-thrash-contained), never stuck/escalate.
- **No hot-loop** — under continuous re-injection the executed heals are bounded by the rate/cooldown gate (`healCount < cycles`); the anti-thrash demonstrably engages (`deferCount > 0`).
- **Bounded state** — the active anti-thrash working set (windowed `recentRuns`) stays ≤ the per-window cap (old attempts age out — no monotonic growth with the cycle count).

## Deltas

AC2's "bounded resource" is proven for the anti-thrash working set (the testable working-set at the unit layer). The WAL/snapshot byte-bound is a deeper integration concern (the unit soak uses the mock collection + a per-cycle isolated snapshot), out-of-scope for this unit gate.

## Test Evidence

Evidence: `UNIT_TEST_MODE=true npx playwright test CorruptionRecoveryGate.spec.mjs` → **3/3 pass** (the 2 existing single-shot gates + the new soak); `node --check` clean. The soak runs the REAL `applyHeal` + the real classifier + the real audit against per-cycle isolated SQLite stores (the embedder is the gate's deterministic stub).

## Post-Merge Validation

Unit-covered — the soak IS the gate. CI runs it on every push; a regression in convergence, the anti-thrash bound, or the no-hot-loop property fails the gate.

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f4bc5569-9c5f-477b-a810-7fb084867d6a`. Targets `dev` per the agent-PR gate.
