### PR TITLE
feat(ai): kbSync cooperative heavy-maintenance-lease yield-point (#14186)

### DIFF
--- a/ai/scripts/maintenance/syncKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/syncKnowledgeBase.mjs
@@ -1,15 +1,16 @@
 // Neo namespace bootstrap (entry-point invariant) — orchestrator spawn-child.
 // `InstanceManager` binds Neo.find/findFirst/get aliases + consumes pre-singleton
 // `Neo.idMap`; required for any consumer of the Neo singleton API.
-import Neo                         from '../../../src/Neo.mjs';
-import AiConfig                    from '../../config.mjs';
-import * as core                   from '../../../src/core/_export.mjs';
-import InstanceManager             from '../../../src/manager/Instance.mjs';
-import KB_Config                   from '../../mcp/server/knowledge-base/config.mjs';
-import KB_DatabaseService          from '../../services/knowledge-base/DatabaseService.mjs';
-import KB_ChromaManager            from '../../services/knowledge-base/ChromaManager.mjs';
-import KB_LifecycleService         from '../../services/knowledge-base/DatabaseLifecycleService.mjs';
+import Neo                                                           from '../../../src/Neo.mjs';
+import AiConfig                                                      from '../../config.mjs';
+import * as core                                                     from '../../../src/core/_export.mjs';
+import InstanceManager                                               from '../../../src/manager/Instance.mjs';
+import KB_Config                                                     from '../../mcp/server/knowledge-base/config.mjs';
+import KB_DatabaseService                                            from '../../services/knowledge-base/DatabaseService.mjs';
+import KB_ChromaManager                                              from '../../services/knowledge-base/ChromaManager.mjs';
+import KB_LifecycleService                                           from '../../services/knowledge-base/DatabaseLifecycleService.mjs';
 import {withHeavyMaintenanceLease, shouldYieldHeavyMaintenanceLease} from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
+import {fileURLToPath}                                               from 'node:url';
 
 /**
  * @module ai/scripts/maintenance/syncKnowledgeBase
@@ -29,6 +30,50 @@ import {withHeavyMaintenanceLease, shouldYieldHeavyMaintenanceLease} from '../..
  * @param {...*} args
  */
 const logProgress = (...args) => console.error('[INFO]', ...args);
+
+/**
+ * Builds the cooperative heavy-maintenance-lease yield predicate from a lease acquisition descriptor.
+ * Reads the active-hold fairness bound from the AiConfig leaf at the use site (per call, never module-load-captured). Exported so a
+ * boundary test can assert this script reads the correct config branch — `orchestrator.heavyMaintenance`
+ * (which holds `maxActiveHoldMs`), NOT the sibling `orchestrator.heavyMaintenanceLease` (which holds only
+ * `staleAfterMs`). The direct VectorService embed seam cannot prove the script-level config wiring.
+ * @param {{lease: Object}} acquisition The `withHeavyMaintenanceLease` descriptor (`{status, acquired, lease}`).
+ * @returns {Function} A zero-arg predicate the shadow-swap embed loop consults between batches.
+ */
+export function buildLeaseYieldPredicate(acquisition) {
+    return () => shouldYieldHeavyMaintenanceLease(acquisition.lease, {
+        maxActiveHoldMs: AiConfig.orchestrator.heavyMaintenance.maxActiveHoldMs
+    });
+}
+
+/**
+ * Maps the `withHeavyMaintenanceLease` outcome to the structured stdout envelope that
+ * `ProcessSupervisorService.classifySuccessfulChildOutcome` and `PrimaryRepoSyncService.runKbSync` consume.
+ * A lease-HELD run and a cooperative lease-YIELD are both PARTIAL (no full sync completed), so both carry
+ * `{deferred: true, reason}` — the consumers record `skipped`, never a false-green `completed` that would
+ * refresh kbSync's lastSuccessAt. A real run carries `{deferred: false, ...counts}`. Pure (no I/O) so it is
+ * unit-testable without the script's Neo bootstrap.
+ * @param {Object} outcome The `withHeavyMaintenanceLease` return (`{status, result, lease}`).
+ * @returns {Object} The structured stdout object.
+ */
+export function classifyKbSyncOutcome(outcome) {
+    if (outcome.status === 'held') {
+        const held = outcome.lease;
+        return {
+            deferred: true,
+            reason  : 'heavy-maintenance-lease-held',
+            holder  : {owner: held.owner, reason: held.reason, pid: held.pid, acquiredAt: held.acquiredAt}
+        };
+    }
+
+    const result = outcome.result || {};
+
+    if (result.yielded === true) {
+        return {deferred: true, reason: 'heavy-maintenance-lease-yield', ...result};
+    }
+
+    return {deferred: false, ...result};
+}
 
 async function syncKnowledgeBase() {
     // Enable debug logging to see progress. B4-safe activation: drive NEO_DEBUG via the Provider
@@ -64,18 +109,12 @@ async function syncKnowledgeBase() {
 
                 // Execute the full sync (create + embed). `NEO_KB_STALE_STRATEGY=shadow-swap`
                 // opts into the shadow-swap stale-data strategy; default CLI sync remains unchanged.
-                // Cooperative lease-yield: a long re-embed releases the heavy-maintenance lease at a
-                // batch boundary once the active hold exceeds the fairness bound, so a starved heavy task
-                // (githubWorkflowSync) interleaves; the next sweep re-acquires and resumes the preserved shadow.
-                // The task arg is the acquisition descriptor `{status, acquired, lease}` — pass `acquisition.lease`
-                // (the payload carrying `acquiredAt`), NOT the wrapper. It is present for BOTH a fresh acquire
-                // AND an inherited-active parent lease (the orchestrator spawns kbSync with
-                // NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN), so the fairness bound holds on either path.
+                // The cooperative lease-yield predicate (built from this run's acquisition) lets a long
+                // re-embed release the lease at a batch boundary so a starved heavy task interleaves; the
+                // next sweep re-acquires and resumes the preserved shadow.
                 return KB_DatabaseService.syncDatabase({
                     staleStrategy,
-                    shouldYield: () => shouldYieldHeavyMaintenanceLease(acquisition.lease, {
-                        maxActiveHoldMs: AiConfig.orchestrator.heavyMaintenanceLease.maxActiveHoldMs
-                    })
+                    shouldYield: buildLeaseYieldPredicate(acquisition)
                 });
             },
             {owner: 'kbSync', reason: 'manual-cli', staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs, metadata: {script: 'ai/scripts/maintenance/syncKnowledgeBase.mjs'}}
@@ -85,24 +124,28 @@ async function syncKnowledgeBase() {
         process.exit(1);
     }
 
-    if (outcome.status === 'held') {
-        const held = outcome.lease;
+    // A lease-HELD run and a cooperative lease-YIELD are both PARTIAL → classifyKbSyncOutcome emits a
+    // `{deferred: true, reason}` envelope so ProcessSupervisorService + PrimaryRepoSyncService record
+    // `skipped`, not a false-green `completed` that would refresh kbSync's lastSuccessAt.
+    const classified = classifyKbSyncOutcome(outcome);
+
+    if (classified.reason === 'heavy-maintenance-lease-held') {
+        const held = classified.holder;
         logProgress(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
         logProgress('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
-        // Structured outcome → ProcessSupervisorService records `skipped` (not false-green
-        // `completed`), so a lease-held run does not refresh kbSync's lastSuccessAt.
-        console.log(JSON.stringify({
-            deferred: true,
-            reason  : 'heavy-maintenance-lease-held',
-            holder  : {owner: held.owner, reason: held.reason, pid: held.pid, acquiredAt: held.acquiredAt}
-        }));
-        process.exit(0);
+    } else if (classified.reason === 'heavy-maintenance-lease-yield') {
+        logProgress(`⏸️  Yielded: released the heavy-maintenance lease at a batch boundary after ${classified.embedded ?? 0} chunk(s); the next sweep resumes the preserved shadow.`);
+    } else {
+        logProgress(`✅ Synchronization Complete: ${JSON.stringify(outcome.result)}`);
     }
 
-    logProgress(`✅ Synchronization Complete: ${JSON.stringify(outcome.result)}`);
-    // Real run → `completed` (falls through the classify) + the embed/delete counts as details.
-    console.log(JSON.stringify({deferred: false, ...(outcome.result || {})}));
+    console.log(JSON.stringify(classified));
     process.exit(0);
 }
 
-syncKnowledgeBase();
+// Auto-run only when invoked directly (CLI / orchestrator spawn-child) — NOT when imported by a boundary
+// test that exercises the exported `buildLeaseYieldPredicate` / `classifyKbSyncOutcome` units.
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (invokedDirectly) {
+    syncKnowledgeBase();
+}

--- a/ai/scripts/maintenance/syncKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/syncKnowledgeBase.mjs
@@ -64,12 +64,16 @@ async function syncKnowledgeBase() {
 
                 // Execute the full sync (create + embed). `NEO_KB_STALE_STRATEGY=shadow-swap`
                 // opts into the shadow-swap stale-data strategy; default CLI sync remains unchanged.
-                // Cooperative lease-yield (#14186): a long re-embed releases the heavy-maintenance lease at a
+                // Cooperative lease-yield: a long re-embed releases the heavy-maintenance lease at a
                 // batch boundary once the active hold exceeds the fairness bound, so a starved heavy task
                 // (githubWorkflowSync) interleaves; the next sweep re-acquires and resumes the preserved shadow.
+                // The task arg is the acquisition descriptor `{status, acquired, lease}` — pass `acquisition.lease`
+                // (the payload carrying `acquiredAt`), NOT the wrapper. It is present for BOTH a fresh acquire
+                // AND an inherited-active parent lease (the orchestrator spawns kbSync with
+                // NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN), so the fairness bound holds on either path.
                 return KB_DatabaseService.syncDatabase({
                     staleStrategy,
-                    shouldYield: () => shouldYieldHeavyMaintenanceLease(acquisition, {
+                    shouldYield: () => shouldYieldHeavyMaintenanceLease(acquisition.lease, {
                         maxActiveHoldMs: AiConfig.orchestrator.heavyMaintenanceLease.maxActiveHoldMs
                     })
                 });

--- a/ai/scripts/maintenance/syncKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/syncKnowledgeBase.mjs
@@ -9,7 +9,7 @@ import KB_Config                   from '../../mcp/server/knowledge-base/config.
 import KB_DatabaseService          from '../../services/knowledge-base/DatabaseService.mjs';
 import KB_ChromaManager            from '../../services/knowledge-base/ChromaManager.mjs';
 import KB_LifecycleService         from '../../services/knowledge-base/DatabaseLifecycleService.mjs';
-import {withHeavyMaintenanceLease} from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
+import {withHeavyMaintenanceLease, shouldYieldHeavyMaintenanceLease} from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
 
 /**
  * @module ai/scripts/maintenance/syncKnowledgeBase
@@ -47,7 +47,7 @@ async function syncKnowledgeBase() {
     let outcome;
     try {
         outcome = await withHeavyMaintenanceLease(
-            async () => {
+            async (acquisition) => {
                 logProgress('   Waiting for Lifecycle Service...');
                 await KB_LifecycleService.ready();
                 logProgress('   Lifecycle Service Ready. Database should be running.');
@@ -64,7 +64,15 @@ async function syncKnowledgeBase() {
 
                 // Execute the full sync (create + embed). `NEO_KB_STALE_STRATEGY=shadow-swap`
                 // opts into the shadow-swap stale-data strategy; default CLI sync remains unchanged.
-                return KB_DatabaseService.syncDatabase({staleStrategy});
+                // Cooperative lease-yield (#14186): a long re-embed releases the heavy-maintenance lease at a
+                // batch boundary once the active hold exceeds the fairness bound, so a starved heavy task
+                // (githubWorkflowSync) interleaves; the next sweep re-acquires and resumes the preserved shadow.
+                return KB_DatabaseService.syncDatabase({
+                    staleStrategy,
+                    shouldYield: () => shouldYieldHeavyMaintenanceLease(acquisition, {
+                        maxActiveHoldMs: AiConfig.orchestrator.heavyMaintenanceLease.maxActiveHoldMs
+                    })
+                });
             },
             {owner: 'kbSync', reason: 'manual-cli', staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs, metadata: {script: 'ai/scripts/maintenance/syncKnowledgeBase.mjs'}}
         );

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -522,11 +522,14 @@ class DatabaseService extends Base {
      *                                      threaded to VectorService.embed for the
      *                                      work-volume gate.
      * @param {String}  [opts.staleStrategy] Explicit stale-data handling strategy.
+     * @param {Function} [opts.shouldYield]  Cooperative heavy-maintenance-lease yield predicate (#14186),
+     *                                      threaded to VectorService.embed so a long re-embed releases the
+     *                                      lease at a batch boundary and resumes on the next sweep.
      * @returns {Promise<object>} A promise that resolves to a success message, OR a
      *     `{error, code: 'KB_SYNC_VOLUME_EXCEEDED', ...}` shape when the MCP gate fires.
      */
-    async embedKnowledgeBase({viaMcp = false, staleStrategy} = {}) {
-        return await VectorService.embed(aiConfig.dataPath, {viaMcp, staleStrategy});
+    async embedKnowledgeBase({viaMcp = false, staleStrategy, shouldYield} = {}) {
+        return await VectorService.embed(aiConfig.dataPath, {viaMcp, staleStrategy, shouldYield});
     }
 
     /**
@@ -562,12 +565,14 @@ class DatabaseService extends Base {
      * @param {Boolean} [opts.viaMcp=false] True when invoked via MCP tool dispatch;
      *                                      threaded to embed() for the work-volume gate.
      * @param {String}  [opts.staleStrategy] Explicit stale-data handling strategy.
+     * @param {Function} [opts.shouldYield]  Cooperative heavy-maintenance-lease yield predicate (#14186),
+     *                                      threaded to the embed step.
      * @returns {Promise<object>} A promise that resolves to the final success message from the embedding step.
      */
-    async syncDatabase({viaMcp = false, staleStrategy} = {}) {
+    async syncDatabase({viaMcp = false, staleStrategy, shouldYield} = {}) {
         logger.log('Starting full database synchronization...');
         await this.createKnowledgeBase();
-        return await this.embedKnowledgeBase({viaMcp, staleStrategy});
+        return await this.embedKnowledgeBase({viaMcp, staleStrategy, shouldYield});
     }
 }
 

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -522,7 +522,7 @@ class DatabaseService extends Base {
      *                                      threaded to VectorService.embed for the
      *                                      work-volume gate.
      * @param {String}  [opts.staleStrategy] Explicit stale-data handling strategy.
-     * @param {Function} [opts.shouldYield]  Cooperative heavy-maintenance-lease yield predicate (#14186),
+     * @param {Function} [opts.shouldYield]  Cooperative heavy-maintenance-lease yield predicate,
      *                                      threaded to VectorService.embed so a long re-embed releases the
      *                                      lease at a batch boundary and resumes on the next sweep.
      * @returns {Promise<object>} A promise that resolves to a success message, OR a
@@ -565,7 +565,7 @@ class DatabaseService extends Base {
      * @param {Boolean} [opts.viaMcp=false] True when invoked via MCP tool dispatch;
      *                                      threaded to embed() for the work-volume gate.
      * @param {String}  [opts.staleStrategy] Explicit stale-data handling strategy.
-     * @param {Function} [opts.shouldYield]  Cooperative heavy-maintenance-lease yield predicate (#14186),
+     * @param {Function} [opts.shouldYield]  Cooperative heavy-maintenance-lease yield predicate,
      *                                      threaded to the embed step.
      * @returns {Promise<object>} A promise that resolves to the final success message from the embedding step.
      */

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -587,7 +587,7 @@ class VectorService extends Base {
      * @param {Object}   options
      * @param {Object}   options.collection      Chroma collection target.
      * @param {Object[]} options.chunksToProcess Tenant-stamped chunks to embed.
-     * @param {Function} [options.shouldYield]   Cooperative heavy-maintenance-lease yield predicate (#14186),
+     * @param {Function} [options.shouldYield]   Cooperative heavy-maintenance-lease yield predicate,
      *     consulted BETWEEN batches. Returns truthy once the lease holder has exceeded the fairness bound
      *     (`HeavyMaintenanceLeaseService.shouldYield`); the loop then stops so a starved heavy task can
      *     interleave. Defaults to never-yield, so callers that do not hold the lease are unaffected.
@@ -608,7 +608,7 @@ class VectorService extends Base {
         let   yielded                             = false;
 
         for (let i = 0; i < chunksToProcess.length; i += batchSize) {
-            // Cooperative heavy-maintenance-lease yield-point (#14186): BETWEEN batches (never before the
+            // Cooperative heavy-maintenance-lease yield-point: BETWEEN batches (never before the
             // first — so at least one batch lands per lease acquisition: a forward-progress guarantee, never a
             // livelock), if the lease holder has exceeded the fairness bound, stop embedding so a starved heavy
             // task (e.g. githubWorkflowSync) can interleave. The completed batches are already durably upserted
@@ -715,7 +715,7 @@ class VectorService extends Base {
      * @param {Object}   options.liveCollection Existing canonical collection handle.
      * @param {Object[]} options.knowledgeBase   Full tenant-stamped corpus.
      * @param {Number}   options.idsToDeleteCount Logical stale-id count removed from the canonical view.
-     * @param {Function} [options.shouldYield]   Cooperative heavy-maintenance-lease yield predicate (#14186),
+     * @param {Function} [options.shouldYield]   Cooperative heavy-maintenance-lease yield predicate,
      *     threaded to `embedChunks`. On a between-batch yield the shadow is preserved-not-promoted (the
      *     write-ahead resume marker already indexes it) and a `{yielded: true}` envelope is returned so the
      *     lease holder releases; the next sweep resumes from the preserved shadow.
@@ -782,7 +782,7 @@ class VectorService extends Base {
             const embedResult = await this.embedChunks({collection: shadowCollection, chunksToProcess: chunksToEmbed, shouldYield});
 
             if (embedResult.yielded) {
-                // Cooperative lease-yield (#14186): the shadow holds the completed batches and the write-ahead
+                // Cooperative lease-yield: the shadow holds the completed batches and the write-ahead
                 // resume marker already indexes it, so DO NOT promote and DO NOT clear the marker — the next
                 // sweep resumes (decideResume -> selectResumableChunks). The live collection is untouched
                 // (preserved-not-promoted), so githubWorkflowSync can write resources/content/ freely while we
@@ -956,7 +956,7 @@ class VectorService extends Base {
      *                                             `shadow-swap` rebuilds into a fresh collection
      *                                             before promoting it to the canonical name.
      * @param {Function} [opts.shouldYield]        Cooperative heavy-maintenance-lease yield predicate
-     *                                             (#14186), threaded to the shadow-swap embed loop so a long
+     *                                             threaded to the shadow-swap embed loop so a long
      *                                             re-embed releases the lease at a batch boundary for a starved
      *                                             heavy task, then resumes from the preserved shadow. Default
      *                                             never yields, so non-lease-held callers are unaffected.

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -587,11 +587,15 @@ class VectorService extends Base {
      * @param {Object}   options
      * @param {Object}   options.collection      Chroma collection target.
      * @param {Object[]} options.chunksToProcess Tenant-stamped chunks to embed.
-     * @returns {Promise<{embedded: Number, skipped: Number}>}
+     * @param {Function} [options.shouldYield]   Cooperative heavy-maintenance-lease yield predicate (#14186),
+     *     consulted BETWEEN batches. Returns truthy once the lease holder has exceeded the fairness bound
+     *     (`HeavyMaintenanceLeaseService.shouldYield`); the loop then stops so a starved heavy task can
+     *     interleave. Defaults to never-yield, so callers that do not hold the lease are unaffected.
+     * @returns {Promise<{embedded: Number, skipped: Number, yielded: Boolean}>}
      */
-    async embedChunks({collection, chunksToProcess}) {
+    async embedChunks({collection, chunksToProcess, shouldYield = () => false}) {
         if (chunksToProcess.length === 0) {
-            return {embedded: 0, skipped: 0};
+            return {embedded: 0, skipped: 0, yielded: false};
         }
 
         logger.log(`Using TextEmbeddingService with provider: ${mcConfig.embeddingProvider}.`);
@@ -601,8 +605,21 @@ class VectorService extends Base {
         const guardrail                           = this.resolveEmbeddingGuardrail();
         let   embeddedCount                       = 0;
         let   skippedCount                        = 0;
+        let   yielded                             = false;
 
         for (let i = 0; i < chunksToProcess.length; i += batchSize) {
+            // Cooperative heavy-maintenance-lease yield-point (#14186): BETWEEN batches (never before the
+            // first — so at least one batch lands per lease acquisition: a forward-progress guarantee, never a
+            // livelock), if the lease holder has exceeded the fairness bound, stop embedding so a starved heavy
+            // task (e.g. githubWorkflowSync) can interleave. The completed batches are already durably upserted
+            // into the shadow and indexed by the write-ahead resume marker, so the next sweep resumes here
+            // (decideResume -> selectResumableChunks). The caller releases the lease on the `yielded` signal.
+            if (i > 0 && shouldYield()) {
+                yielded = true;
+                logger.log(`Yielding the heavy-maintenance lease after ${i} chunk(s) (${embeddedCount} embedded); ${chunksToProcess.length - i} remaining will resume on the next sweep.`);
+                break;
+            }
+
             if (i > 0 && batchDelay) {
                 await this.timeout(batchDelay);
             }
@@ -672,7 +689,7 @@ class VectorService extends Base {
             }
         }
 
-        return {embedded: embeddedCount, skipped: skippedCount};
+        return {embedded: embeddedCount, skipped: skippedCount, yielded};
     }
 
     /**
@@ -698,9 +715,13 @@ class VectorService extends Base {
      * @param {Object}   options.liveCollection Existing canonical collection handle.
      * @param {Object[]} options.knowledgeBase   Full tenant-stamped corpus.
      * @param {Number}   options.idsToDeleteCount Logical stale-id count removed from the canonical view.
-     * @returns {Promise<Object>} Embedding result.
+     * @param {Function} [options.shouldYield]   Cooperative heavy-maintenance-lease yield predicate (#14186),
+     *     threaded to `embedChunks`. On a between-batch yield the shadow is preserved-not-promoted (the
+     *     write-ahead resume marker already indexes it) and a `{yielded: true}` envelope is returned so the
+     *     lease holder releases; the next sweep resumes from the preserved shadow.
+     * @returns {Promise<Object>} Embedding result (carries `yielded: true` when the lease was cooperatively released).
      */
-    async embedViaShadowSwap({liveCollection, knowledgeBase, idsToDeleteCount}) {
+    async embedViaShadowSwap({liveCollection, knowledgeBase, idsToDeleteCount, shouldYield = () => false}) {
         const stateDir    = this.getResumeStateDir();
         const fingerprint = computeCorpusFingerprint(knowledgeBase);
         const resumeState = await readResumeState({dir: stateDir});
@@ -758,7 +779,25 @@ class VectorService extends Base {
         let shadowPromoted = false;
 
         try {
-            const embedResult = await this.embedChunks({collection: shadowCollection, chunksToProcess: chunksToEmbed});
+            const embedResult = await this.embedChunks({collection: shadowCollection, chunksToProcess: chunksToEmbed, shouldYield});
+
+            if (embedResult.yielded) {
+                // Cooperative lease-yield (#14186): the shadow holds the completed batches and the write-ahead
+                // resume marker already indexes it, so DO NOT promote and DO NOT clear the marker — the next
+                // sweep resumes (decideResume -> selectResumableChunks). The live collection is untouched
+                // (preserved-not-promoted), so githubWorkflowSync can write resources/content/ freely while we
+                // are yielded; the resumed run re-reads the updated corpus. Torn-read-free by the same shadow
+                // isolation that protects a normal run.
+                logger.log(`Yielded the heavy-maintenance lease mid shadow-swap; preserving shadow '${shadowName}' for resume (${embedResult.embedded + alreadyEmbedded} embedded so far).`);
+                return {
+                    message         : `KB embedding yielded the heavy-maintenance lease after ${embedResult.embedded + alreadyEmbedded} chunk(s); the next sweep resumes from the preserved shadow.`,
+                    embedded        : embedResult.embedded + alreadyEmbedded,
+                    deleted         : idsToDeleteCount,
+                    staleStrategy   : 'shadow-swap',
+                    yielded         : true,
+                    shadowCollection: shadowName
+                };
+            }
 
             if (embedResult.skipped > 0) {
                 throw new Error(`KB_EMBEDDING_INPUT_SIZE_EXCEEDED: shadow-swap refused to promote an incomplete corpus after skipping ${embedResult.skipped} over-budget embedding chunk(s).`);
@@ -916,10 +955,15 @@ class VectorService extends Base {
      *                                             preserves the historical behavior;
      *                                             `shadow-swap` rebuilds into a fresh collection
      *                                             before promoting it to the canonical name.
+     * @param {Function} [opts.shouldYield]        Cooperative heavy-maintenance-lease yield predicate
+     *                                             (#14186), threaded to the shadow-swap embed loop so a long
+     *                                             re-embed releases the lease at a batch boundary for a starved
+     *                                             heavy task, then resumes from the preserved shadow. Default
+     *                                             never yields, so non-lease-held callers are unaffected.
      * @returns {Promise<object>} A promise that resolves to a success message, OR a
      *     `{error, code: 'KB_SYNC_VOLUME_EXCEEDED', ...}` shape when the MCP gate fires.
      */
-    async embed(knowledgeBasePath, {viaMcp = false, tenantContext = {}, deleteStale = true, staleStrategy} = {}) {
+    async embed(knowledgeBasePath, {viaMcp = false, tenantContext = {}, deleteStale = true, staleStrategy, shouldYield = () => false} = {}) {
         logger.log('Starting knowledge base embedding...');
         const resolvedStaleStrategy = this.resolveStaleStrategy({staleStrategy, deleteStale});
 
@@ -1062,7 +1106,8 @@ class VectorService extends Base {
             return await this.embedViaShadowSwap({
                 liveCollection  : collection,
                 knowledgeBase   : expandedKnowledgeBase,
-                idsToDeleteCount: idsToDelete.length
+                idsToDeleteCount: idsToDelete.length,
+                shouldYield
             });
         }
 

--- a/test/playwright/unit/ai/scripts/maintenance/syncKnowledgeBase.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/syncKnowledgeBase.spec.mjs
@@ -1,0 +1,75 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBSyncBoundaryTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * Boundary coverage for the kbSync script-level lease-yield wiring — the seam the direct `VectorService`
+ * embed tests cannot reach. The exports are imported (the auto-run is guarded), so this asserts the real
+ * script wiring against two defects:
+ *   - the yield predicate must read `AiConfig.orchestrator.heavyMaintenance.maxActiveHoldMs`, NOT the sibling
+ *     `orchestrator.heavyMaintenanceLease` branch (which holds only `staleAfterMs` → undefined → never yields);
+ *   - a cooperative yield must classify as a DEFERRED partial sync (supervisor records `skipped`), NOT a
+ *     false-green `completed` that refreshes lastSuccessAt.
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('syncKnowledgeBase — lease-yield boundary wiring', () => {
+    let buildLeaseYieldPredicate, classifyKbSyncOutcome, AiConfig;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/scripts/maintenance/syncKnowledgeBase.mjs');
+        buildLeaseYieldPredicate = mod.buildLeaseYieldPredicate;
+        classifyKbSyncOutcome    = mod.classifyKbSyncOutcome;
+        AiConfig = (await import('../../../../../../ai/config.mjs')).default;
+    });
+
+    test('predicate reads the heavyMaintenance.maxActiveHoldMs leaf — an over-bound hold yields', () => {
+        // Guards the heavyMaintenance-vs-heavyMaintenanceLease config-branch trap: maxActiveHoldMs lives
+        // under heavyMaintenance; the sibling branch holds only staleAfterMs (→ undefined → never yields).
+        const bound = AiConfig.orchestrator.heavyMaintenance.maxActiveHoldMs;
+        expect(Number.isFinite(bound)).toBe(true);
+
+        const overBoundAt = new Date(Date.now() - (bound + 60_000)).toISOString();
+        const freshAt     = new Date().toISOString();
+
+        expect(buildLeaseYieldPredicate({lease: {acquiredAt: overBoundAt}})()).toBe(true);
+        expect(buildLeaseYieldPredicate({lease: {acquiredAt: freshAt}})()).toBe(false);
+    });
+
+    test('a cooperative yield classifies as a DEFERRED partial sync, not completed', () => {
+        const yielded = classifyKbSyncOutcome({status: 'completed', result: {yielded: true, embedded: 50}});
+        expect(yielded).toMatchObject({deferred: true, reason: 'heavy-maintenance-lease-yield', embedded: 50});
+    });
+
+    test('a real sync classifies as completed (deferred:false, no reason)', () => {
+        const done = classifyKbSyncOutcome({status: 'completed', result: {embedded: 120, deleted: 3}});
+        expect(done).toMatchObject({deferred: false, embedded: 120, deleted: 3});
+        expect(done.reason).toBeUndefined();
+    });
+
+    test('a lease-held run classifies as deferred (skipped, not completed)', () => {
+        const held = classifyKbSyncOutcome({
+            status: 'held',
+            lease : {owner: 'sandman', reason: 'rem-cycle', pid: 4242, acquiredAt: new Date().toISOString()}
+        });
+        expect(held).toMatchObject({deferred: true, reason: 'heavy-maintenance-lease-held'});
+        expect(held.holder.owner).toBe('sandman');
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -580,7 +580,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         }
     });
 
-    test('shadow-swap PRESERVES the shadow on a cooperative lease YIELD — no promote, marker intact (#14186)', async () => {
+    test('shadow-swap PRESERVES the shadow on a cooperative lease YIELD — no promote, marker intact', async () => {
         const live                = createSpyCollection({existingIds: [], name: KB_Config.data.collectionName});
         const originalEmbedChunks = KB_VectorService.embedChunks.bind(KB_VectorService);
         let shadow;

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -157,8 +157,8 @@ function writeFixtureJsonl(filePath, chunkCount, hashPrefix = 'chunk-') {
     const lines = [];
     for (let i = 0; i < chunkCount; i++) {
         lines.push(JSON.stringify({
-            hash: `${hashPrefix}${i}`,
-            type: 'method',
+            hash       : `${hashPrefix}${i}`,
+            type       : 'method',
             name       : `method${i}`,
             className  : '',
             description: `synthetic chunk ${i}`,
@@ -306,11 +306,11 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
                     content    : 'small body'
                 }),
                 JSON.stringify({
-                    hash     : 'large-chunk',
-                    type     : 'ticket',
-                    kind     : 'ticket',
-                    name     : 'issue-12065',
-                    className: '',
+                    hash       : 'large-chunk',
+                    type       : 'ticket',
+                    kind       : 'ticket',
+                    name       : 'issue-12065',
+                    className  : '',
                     description: Array.from({length: 12}, (_, index) => `section-${index} ${'x'.repeat(24)}`).join('\n'),
                     content    : Array.from({length: 12}, (_, index) => `section-${index} ${'x'.repeat(24)}`).join('\n'),
                     source     : 'resources/content/issues/chunk-2/issue-12065.md'

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -580,6 +580,44 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         }
     });
 
+    test('shadow-swap PRESERVES the shadow on a cooperative lease YIELD — no promote, marker intact (#14186)', async () => {
+        const live                = createSpyCollection({existingIds: [], name: KB_Config.data.collectionName});
+        const originalEmbedChunks = KB_VectorService.embedChunks.bind(KB_VectorService);
+        let shadow;
+
+        KB_ChromaManager.client = {
+            createCollection: async ({name}) => {
+                shadow = createSpyCollection({name});
+                return shadow;
+            }
+        };
+        // Simulate embedChunks yielding mid-corpus — the embedChunks-level yield mechanism (between-batch,
+        // forward-progress) is covered in VectorService.leaseYield.spec.mjs; here we assert embedViaShadowSwap's
+        // yield HANDLING reuses the same preserve-not-promote path as a transient failure.
+        KB_VectorService.embedChunks = async () => ({embedded: 1, skipped: 0, yielded: true});
+
+        try {
+            const result = await KB_VectorService.embedViaShadowSwap({
+                liveCollection  : live,
+                knowledgeBase   : [{id: 'chunk-0', type: 'method', name: 'method0'}],
+                idsToDeleteCount: 0,
+                shouldYield     : () => true
+            });
+
+            // On yield: a {yielded:true} envelope (the lease holder releases on it), the shadow is preserved-
+            // not-promoted (NEITHER collection renamed), and the write-ahead resume marker is NOT cleared — so
+            // the next sweep re-acquires and resumes from the completed batches instead of rebuilding.
+            expect(result.yielded).toBe(true);
+            expect(live.calls.modify).toEqual([]);
+            expect(shadow.calls.modify).toEqual([]);
+
+            const resumeState = await readResumeState({dir: KB_VectorService.resumeStateDir});
+            expect(resumeState?.shadowName).toBe(shadow.name);
+        } finally {
+            KB_VectorService.embedChunks = originalEmbedChunks;
+        }
+    });
+
     test('fresh-build records the resume marker BEFORE creating the shadow (write-ahead — no orphan on a double failure)', async () => {
         const live                = createSpyCollection({existingIds: [], name: KB_Config.data.collectionName});
         const originalEmbedChunks = KB_VectorService.embedChunks.bind(KB_VectorService);

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
@@ -1,0 +1,139 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBLeaseYieldTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * Cooperative heavy-maintenance-lease yield-point coverage for `VectorService.embedChunks` (#14186).
+ *
+ * The kbSync side of the #14144 lease-fairness epic: a long re-embed must release the heavy-maintenance
+ * lease at a BATCH BOUNDARY so a starved heavy task (`githubWorkflowSync`) can interleave, then resume from
+ * the preserved shadow — never starving it indefinitely. The producer side (`HeavyMaintenanceLeaseService.
+ * shouldYield`, #14185) decides WHEN; this is the consumer that ACTS on it between batches.
+ *
+ * These tests drive `embedChunks` directly with an in-memory spy collection and a stubbed embedder,
+ * asserting the three load-bearing properties:
+ *   - the yield fires BETWEEN batches (the loop stops, no partial batch),
+ *   - at least one batch always lands per acquisition (forward progress — never a livelock),
+ *   - the default (no predicate) path is unchanged (every batch embeds, `yielded:false`).
+ */
+test.describe.configure({mode: 'serial'});
+
+function createSpyCollection() {
+    const calls       = {upsert: 0};
+    const upsertedIds = [];
+
+    return {
+        calls,
+        upsertedIds,
+        name: 'spy-knowledge-base',
+        async upsert({ids}) {
+            calls.upsert++;
+            upsertedIds.push(...ids);
+        }
+    };
+}
+
+function makeChunks(count) {
+    return Array.from({length: count}, (_, i) => ({
+        id     : `chunk-${i}`,
+        type   : 'guide',
+        name   : `symbol-${i}`,
+        content: `deterministic small body for chunk ${i}`
+    }));
+}
+
+test.describe('VectorService.embedChunks — cooperative lease yield-point (#14186)', () => {
+    let SDK, KB_VectorService, KB_Config, TextEmbeddingService;
+    let originalEmbedTexts, originalBatchConfig;
+
+    test.beforeAll(async () => {
+        SDK                  = await import('../../../../../../ai/services.mjs');
+        KB_Config            = SDK.KB_Config;
+        TextEmbeddingService = SDK.Memory_TextEmbeddingService;
+
+        const VectorServiceModule = await import('../../../../../../ai/services/knowledge-base/VectorService.mjs');
+        KB_VectorService          = VectorServiceModule.default;
+
+        originalEmbedTexts  = TextEmbeddingService.embedTexts.bind(TextEmbeddingService);
+        originalBatchConfig = {
+            batchSize : KB_Config.data.batchSize,
+            batchDelay: KB_Config.data.batchDelay,
+            maxRetries: KB_Config.data.maxRetries
+        };
+
+        // Deterministic stub embedder — 384-dim zero vectors; the yield logic is provider-agnostic.
+        TextEmbeddingService.embedTexts = async texts => texts.map(() => new Array(384).fill(0));
+    });
+
+    test.afterAll(() => {
+        TextEmbeddingService.embedTexts = originalEmbedTexts;
+        Object.assign(KB_Config.data, originalBatchConfig);
+    });
+
+    test.beforeEach(() => {
+        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 1});
+    });
+
+    test('yields BETWEEN batches — stops the loop, first batch still lands (forward progress)', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(150); // 3 batches at batchSize 50
+
+        // Predicate true from the first between-batch checkpoint (i=50) onward.
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => true
+        });
+
+        // Only the i=0 batch embedded before the i>0 checkpoint yielded — never zero (no livelock).
+        expect(result.yielded).toBe(true);
+        expect(result.embedded).toBe(50);
+        expect(spy.calls.upsert).toBe(1);
+        expect(spy.upsertedIds).toHaveLength(50);
+    });
+
+    test('yields after N batches when the predicate flips mid-run', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(200); // 4 batches
+
+        let checks = 0;
+        // Between-batch checkpoints fire at i=50,100,150; yield on the second one (i=100).
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => ++checks >= 2
+        });
+
+        expect(result.yielded).toBe(true);
+        expect(result.embedded).toBe(100); // the i=0 and i=50 batches landed
+        expect(spy.calls.upsert).toBe(2);
+    });
+
+    test('default (no predicate) embeds every batch — unchanged behavior, never yields', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(150);
+
+        const result = await KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks});
+
+        expect(result.yielded).toBe(false);
+        expect(result.embedded).toBe(150);
+        expect(spy.calls.upsert).toBe(3);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
@@ -20,12 +20,12 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 /**
- * Cooperative heavy-maintenance-lease yield-point coverage for `VectorService.embedChunks` (#14186).
+ * Cooperative heavy-maintenance-lease yield-point coverage for `VectorService.embedChunks`.
  *
- * The kbSync side of the #14144 lease-fairness epic: a long re-embed must release the heavy-maintenance
- * lease at a BATCH BOUNDARY so a starved heavy task (`githubWorkflowSync`) can interleave, then resume from
- * the preserved shadow — never starving it indefinitely. The producer side (`HeavyMaintenanceLeaseService.
- * shouldYield`, #14185) decides WHEN; this is the consumer that ACTS on it between batches.
+ * The kbSync side of the heavy-maintenance-lease fairness contract: a long re-embed must release the lease
+ * at a BATCH BOUNDARY so a starved heavy task (`githubWorkflowSync`) can interleave, then resume from the
+ * preserved shadow — never starving it indefinitely. The producer side (`HeavyMaintenanceLeaseService.
+ * shouldYield`) decides WHEN; this is the consumer that ACTS on it between batches.
  *
  * These tests drive `embedChunks` directly with an in-memory spy collection and a stubbed embedder,
  * asserting the three load-bearing properties:
@@ -59,7 +59,7 @@ function makeChunks(count) {
     }));
 }
 
-test.describe('VectorService.embedChunks — cooperative lease yield-point (#14186)', () => {
+test.describe('VectorService.embedChunks — cooperative lease yield-point', () => {
     let SDK, KB_VectorService, KB_Config, TextEmbeddingService;
     let originalEmbedTexts, originalBatchConfig;
 


### PR DESCRIPTION
## Summary

Completes #14186 — the kbSync consumer side of the #14144 heavy-maintenance-lease fairness epic. A long KB re-embed (e.g. a multi-hour full rebuild) could hold the heavy-maintenance lease continuously and indefinitely defer `githubWorkflowSync` (the original #14069/#14071 ~20h-hold incident). This wires a COOPERATIVE yield: the re-embed releases the lease at a batch boundary once the active hold exceeds the fairness bound, a starved heavy task interleaves, then the next sweep re-acquires and resumes from the preserved shadow.

Resolves #14186

The producer side — `HeavyMaintenanceLeaseService.shouldYield` / `shouldYieldHeavyMaintenanceLease` — shipped in #14185/#14261; this is the consumer that ACTS on it.

## Change

The yield threads a `shouldYield` predicate (built from the lease) down to the embed loop:
- **embedChunks** consults `shouldYield` BETWEEN batches (never before the first — at least one batch lands per acquisition: forward-progress, never a livelock). On yield it stops and returns `{yielded:true}`; the completed batches are already durably upserted + indexed by the write-ahead resume marker.
- **embedViaShadowSwap** on a yielded result preserves-not-promotes the shadow (does NOT clear the marker), so the next sweep resumes (`decideResume → selectResumableChunks`). Torn-read-free by the same shadow isolation as a normal run — `githubWorkflowSync` writes `resources/content/` freely while yielded; the resumed run re-reads the updated corpus.
- **embed / embedKnowledgeBase / syncDatabase** thread `shouldYield` (undefined → embed's never-yield default; existing callers unaffected).
- **syncKnowledgeBase.mjs** (the lease holder — manual CLI + orchestrator spawn-child, both fresh-acquire) builds the predicate from its acquisition descriptor against the reactive `maxActiveHoldMs` config-leaf. On yield the task returns, `withHeavyMaintenanceLease` releases the lease in its `finally`, and the next sweep resumes.

## Deltas

The inherited-lease edge case (a parent task spawning kbSync with a token, vs the primary fresh-acquire paths) safely no-yields if the inherited acquisition lacks `acquiredAt` — a degradation to today's behavior, not a regression. The two primary lease-holding paths (manual CLI + the orchestrator's `taskDefinitions` spawn-child / `PrimaryRepoSyncService` `npm run ai:sync-kb`) both fresh-acquire and carry `acquiredAt`.

## Test Evidence

Evidence: `UNIT_TEST_MODE=true npx playwright test VectorService.tenantStamping.spec.mjs VectorService.WorkVolumeBranching.spec.mjs VectorService.leaseYield.spec.mjs` → **29/29 pass**. `node --check` clean on all 3 changed source files (VectorService, DatabaseService, syncKnowledgeBase).
- `VectorService.leaseYield.spec.mjs` (3 new tests): yield-between-batches, forward-progress (first batch always lands), yield-after-N, default-unchanged.
- `VectorService.WorkVolumeBranching.spec.mjs` (+1 test): embedViaShadowSwap preserves-not-promotes on yield, resume marker intact.

## Post-Merge Validation

Unit-covered — the yield mechanism, the shadow-preserve-on-yield, and the no-regression are gated by CI. The live behavior (a real multi-hour re-embed cooperatively yielding to `githubWorkflowSync`) rides the orchestrator's existing kbSync schedule; the heal-event/task ledger records a `skipped`/resumed outcome rather than a starved deferral.

---
🤖 Authored by **Ada** (@neo-opus-ada · Claude Opus 4.8, Claude Code) · origin session `f4bc5569-9c5f-477b-a810-7fb084867d6a`. Targets `dev` per the agent-PR gate.
