### PR TITLE
feat(state): bind provider data records by field (#6932)

### DIFF
--- a/src/state/Provider.mjs
+++ b/src/state/Provider.mjs
@@ -7,7 +7,58 @@ import Observable                    from '../core/Observable.mjs';
 import {createHierarchicalDataProxy} from './createHierarchicalDataProxy.mjs';
 import {isDescriptor}                from '../core/ConfigSymbols.mjs';
 
-const twoWayBindingSymbol = Symbol.for('twoWayBinding');
+const
+    recordChangeBindings = new WeakMap(),
+    twoWayBindingSymbol  = Symbol.for('twoWayBinding');
+
+/**
+ * Returns the shared notifyChange wrapper state for a Record instance.
+ * @summary Lets multiple StateProviders observe one Record while restoring the original method after cleanup.
+ * @param {Object} record
+ * @returns {Object}
+ */
+function getRecordChangeBinding(record) {
+    let binding = recordChangeBindings.get(record);
+
+    if (!binding) {
+        const
+            originalNotifyChange = record.notifyChange,
+            prototype            = Object.getPrototypeOf(record),
+            handlers             = new Set();
+
+        binding = {
+            handlers,
+            originalNotifyChange,
+            wrapper(data, silent=false) {
+                const result = originalNotifyChange.call(this, {
+                    changedFields: [],
+                    ...data
+                }, silent);
+
+                handlers.forEach(handler => handler(result));
+
+                return result
+            },
+            restore() {
+                if (record.notifyChange === binding.wrapper) {
+                    if (prototype.notifyChange === originalNotifyChange) {
+                        delete record.notifyChange
+                    } else {
+                        record.notifyChange = originalNotifyChange
+                    }
+                }
+            }
+        };
+
+        recordChangeBindings.set(record, binding)
+    }
+
+    if (record.notifyChange !== binding.wrapper) {
+        record.notifyChange = binding.wrapper
+    }
+
+    return binding
+}
 
 /**
  * An optional component state provider for adding bindings to configs
@@ -132,6 +183,12 @@ class Provider extends Base {
      * @private
      */
     #formulaEffects = new Map()
+    /**
+     * Tracks provider-owned Record field bindings by StateProvider data path.
+     * @member {Map} #recordDataBindings=new Map()
+     * @private
+     */
+    #recordDataBindings = new Map()
 
     /**
      * @param {Object} config
@@ -399,6 +456,8 @@ class Provider extends Base {
      */
     destroy() {
         const me = this;
+
+        me.#clearRecordDataBindings();
 
         me.#formulaEffects.forEach(effect => effect.destroy());
         me.#formulaEffects.clear();
@@ -686,6 +745,8 @@ class Provider extends Base {
                 me.#dataConfigs[fullPath] = new Config(value)
             }
 
+            me.#syncRecordDataValue(fullPath, value);
+
             // If the value is a plain object, recursively process its properties
             if (Neo.typeOf(value) === 'Object') {
                 me.processDataObject(value, fullPath)
@@ -734,9 +795,168 @@ class Provider extends Base {
         }
 
         if (hasChange) {
+            provider.#syncRecordDataValue(path, newValue);
+
             // Notify subscribers of the data property change.
             provider.onDataPropertyChange(path, newValue, oldValue)
         }
+    }
+
+    /**
+     * Releases all record-field subscriptions owned by this provider.
+     * @summary Prevents destroyed providers from retaining callbacks on external record instances.
+     * @private
+     */
+    #clearRecordDataBindings() {
+        Array.from(this.#recordDataBindings.keys()).forEach(path => this.#unbindRecordData(path))
+    }
+
+    /**
+     * Handles a field-change payload emitted by a bound Record.
+     * @summary Translates record-level changed fields into StateProvider data-path config updates.
+     * @param {String} path
+     * @param {Object} payload
+     * @private
+     */
+    #onRecordDataChange(path, payload) {
+        const {changedFields=[], silent} = payload;
+
+        if (silent || this.isDestroying || !changedFields.length) {
+            return
+        }
+
+        EffectManager.pause();
+        try {
+            changedFields.forEach(({name, oldValue, value}) => {
+                const fieldPath = `${path}.${name}`;
+
+                this.#setConfigValue(this, fieldPath, value, oldValue);
+                this.#syncRecordParentPath(path, fieldPath, value)
+            })
+        } finally {
+            EffectManager.resume()
+        }
+    }
+
+    /**
+     * Registers this provider for field changes on a Record stored in data.
+     * @summary Uses a removable wrapper around Record#notifyChange instead of an append-only sequence.
+     * @param {String} path
+     * @param {Object} record
+     * @private
+     */
+    #bindRecordData(path, record) {
+        const current = this.#recordDataBindings.get(path);
+
+        if (current?.record === record) {
+            this.#syncRecordDataFields(path, record);
+            return
+        }
+
+        this.#unbindRecordData(path);
+
+        const
+            binding = getRecordChangeBinding(record),
+            handler = payload => this.#onRecordDataChange(path, payload);
+
+        binding.handlers.add(handler);
+
+        this.#recordDataBindings.set(path, {binding, handler, record});
+        this.#syncRecordDataFields(path, record)
+    }
+
+    /**
+     * Mirrors a Record's current field values into StateProvider data-path configs.
+     * @summary Enables bindings like `currentUser.firstName` while keeping `currentUser` as the record value.
+     * @param {String} path
+     * @param {Object} record
+     * @private
+     */
+    #syncRecordDataFields(path, record) {
+        const data = record.toJSON?.();
+
+        if (Neo.typeOf(data) !== 'Object') {
+            return
+        }
+
+        Object.entries(data).forEach(([key, value]) => {
+            const fieldPath = `${path}.${key}`;
+
+            this.#setConfigValue(this, fieldPath, value);
+
+            if (Neo.typeOf(value) === 'Object') {
+                this.processDataObject(value, fieldPath)
+            }
+        })
+    }
+
+    /**
+     * Bubbles a nested record-field change up to record child-object configs.
+     * @summary Updates `recordPath.address` for a `recordPath.address.city` change without replacing the record.
+     * @param {String} recordPath
+     * @param {String} fieldPath
+     * @param {*} value
+     * @private
+     */
+    #syncRecordParentPath(recordPath, fieldPath, value) {
+        let
+            latestValue = value,
+            path        = fieldPath;
+
+        while (path.includes('.')) {
+            const leafKey = path.split('.').pop();
+            path = path.substring(0, path.lastIndexOf('.'));
+
+            if (path === recordPath) {
+                break
+            }
+
+            const
+                oldParentValue = this.getDataConfig(path)?.get(),
+                newParentValue = Neo.typeOf(oldParentValue) === 'Object'
+                    ? {...oldParentValue, [leafKey]: latestValue}
+                    : {[leafKey]: latestValue};
+
+            this.#setConfigValue(this, path, newParentValue, oldParentValue);
+            latestValue = newParentValue
+        }
+    }
+
+    /**
+     * Registers or clears Record field integration for a StateProvider data value.
+     * @summary Record values stay atomic at their own path while their fields get child configs.
+     * @param {String} path
+     * @param {*} value
+     * @private
+     */
+    #syncRecordDataValue(path, value) {
+        if (value?.isRecord) {
+            this.#bindRecordData(path, value)
+        } else {
+            this.#unbindRecordData(path)
+        }
+    }
+
+    /**
+     * Removes a previously registered Record field subscription.
+     * @summary Detaches stale record/path callbacks on replacement and provider destroy.
+     * @param {String} path
+     * @private
+     */
+    #unbindRecordData(path) {
+        const current = this.#recordDataBindings.get(path);
+
+        if (!current) {
+            return
+        }
+
+        current.binding.handlers.delete(current.handler);
+
+        if (!current.binding.handlers.size) {
+            current.binding.restore()
+        }
+
+        this.#recordDataBindings.delete(path)
     }
 
     /**

--- a/test/playwright/unit/state/ProviderNestedDataConfigs.spec.mjs
+++ b/test/playwright/unit/state/ProviderNestedDataConfigs.spec.mjs
@@ -11,6 +11,8 @@ import Neo             from '../../../../src/Neo.mjs';
 import * as core       from '../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../src/manager/Instance.mjs';
 import Component       from '../../../../src/component/Base.mjs';
+import Model           from '../../../../src/data/Model.mjs';
+import RecordFactory   from '../../../../src/data/RecordFactory.mjs';
 import StateProvider   from '../../../../src/state/Provider.mjs';
 
 class MockComponent extends Component {
@@ -42,7 +44,7 @@ test.describe('State Provider Nested Data Configs', () => {
                 data: {
                     user: {
                         name: 'John',
-                        age: 30
+                        age : 30
                     }
                 }
             }
@@ -81,8 +83,8 @@ test.describe('State Provider Nested Data Configs', () => {
             }
         });
 
-        const provider = component.getStateProvider();
-        let effectRunCount = 0;
+        const provider       = component.getStateProvider();
+        let   effectRunCount = 0;
 
         provider.createBinding(component.id, 'user', data => {
             effectRunCount++;
@@ -109,7 +111,7 @@ test.describe('State Provider Nested Data Configs', () => {
         provider.setData({
             user: {
                 firstname: 'John',
-                lastname: 'Doe'
+                lastname : 'Doe'
             }
         });
         expect(effectRunCount).toBe(3);
@@ -135,7 +137,7 @@ test.describe('State Provider Nested Data Configs', () => {
                 data: {
                     user: {
                         firstName: 'John',
-                        lastName: 'Doe'
+                        lastName : 'Doe'
                     }
                 },
                 formulas: {
@@ -274,7 +276,7 @@ test.describe('State Provider Nested Data Configs', () => {
         });
 
         const parentProvider = parentComponent.getStateProvider();
-        const childProvider = childComponent.getStateProvider();
+        const childProvider  = childComponent.getStateProvider();
 
         expect(childFormulaRunCount).toBe(1);
         expect(childProvider.getData('display')).toBe('User: Parent (admin)');
@@ -293,5 +295,148 @@ test.describe('State Provider Nested Data Configs', () => {
 
         parentComponent.destroy();
         childComponent.destroy();
+    });
+
+    test('Record fields assigned to data should update direct field bindings', () => {
+        const
+            model = Neo.create(Model, {
+                fields: [
+                    {name: 'id',        type: 'String'},
+                    {name: 'firstName', type: 'String'},
+                    {name: 'lastName',  type: 'String'}
+                ]
+            }),
+            record = RecordFactory.createRecord(model, {
+                id       : '1',
+                firstName: 'John',
+                lastName : 'Doe'
+            }),
+            component = Neo.create(MockComponent, {
+                stateProvider: {
+                    data: {
+                        currentUser: record
+                    }
+                }
+            }),
+            provider = component.getStateProvider();
+
+        let effectRunCount = 0;
+
+        provider.createBinding(component.id, 'userName', data => {
+            effectRunCount++;
+            return data['currentUser.firstName']
+        });
+
+        expect(provider.getData('currentUser')).toBe(record);
+        expect(component.userName).toBe('John');
+        expect(effectRunCount).toBe(1);
+
+        record.set({firstName: 'Jane'});
+
+        expect(component.userName).toBe('Jane');
+        expect(provider.getData('currentUser')).toBe(record);
+        expect(provider.getData('currentUser.firstName')).toBe('Jane');
+        expect(effectRunCount).toBe(2);
+
+        record.setSilent({firstName: 'Silent'});
+
+        expect(component.userName).toBe('Jane');
+        expect(effectRunCount).toBe(2);
+
+        component.destroy();
+    });
+
+    test('Record field bindings should detach on record replacement', () => {
+        const
+            model = Neo.create(Model, {
+                fields: [
+                    {name: 'id',        type: 'String'},
+                    {name: 'firstName', type: 'String'}
+                ]
+            }),
+            oldRecord = RecordFactory.createRecord(model, {
+                id       : '1',
+                firstName: 'John'
+            }),
+            newRecord = RecordFactory.createRecord(model, {
+                id       : '2',
+                firstName: 'Jane'
+            }),
+            component = Neo.create(MockComponent, {
+                stateProvider: {
+                    data: {
+                        currentUser: oldRecord
+                    }
+                }
+            }),
+            provider = component.getStateProvider();
+
+        let effectRunCount = 0;
+
+        provider.createBinding(component.id, 'userName', data => {
+            effectRunCount++;
+            return data['currentUser.firstName']
+        });
+
+        expect(component.userName).toBe('John');
+        expect(effectRunCount).toBe(1);
+
+        provider.setData('currentUser', newRecord);
+
+        expect(component.userName).toBe('Jane');
+        expect(provider.getData('currentUser')).toBe(newRecord);
+        expect(effectRunCount).toBe(2);
+
+        oldRecord.set({firstName: 'Stale'});
+
+        expect(component.userName).toBe('Jane');
+        expect(effectRunCount).toBe(2);
+
+        newRecord.set({firstName: 'Grace'});
+
+        expect(component.userName).toBe('Grace');
+        expect(effectRunCount).toBe(3);
+
+        component.destroy();
+    });
+
+    test('Record field bindings should detach on provider destroy', () => {
+        const
+            model = Neo.create(Model, {
+                fields: [
+                    {name: 'id',        type: 'String'},
+                    {name: 'firstName', type: 'String'}
+                ]
+            }),
+            record = RecordFactory.createRecord(model, {
+                id       : '1',
+                firstName: 'John'
+            }),
+            component = Neo.create(MockComponent, {
+                stateProvider: {
+                    data: {
+                        currentUser: record
+                    }
+                }
+            }),
+            provider = component.getStateProvider();
+
+        let effectRunCount = 0;
+
+        provider.createBinding(component.id, 'userName', data => {
+            effectRunCount++;
+            return data['currentUser.firstName']
+        });
+
+        expect(component.userName).toBe('John');
+        expect(effectRunCount).toBe(1);
+
+        provider.destroy();
+        record.set({firstName: 'Detached'});
+
+        expect(component.userName).toBe('John');
+        expect(effectRunCount).toBe(1);
+
+        component.destroy();
     });
 });


### PR DESCRIPTION
Resolves #6932

Adds direct StateProvider binding support for `Neo.data.Record` fields while preserving records as atomic values at their assigned provider data path. When a record is stored in provider `data`, the provider now mirrors field values into child data configs such as `currentUser.firstName`, subscribes through a removable `notifyChange` wrapper, and detaches callbacks on record replacement or provider destroy.

Evidence: L2 focused state/data unit coverage achieved -> L2 required for the close target because the behavior is framework reactivity logic fully covered by unit tests.

## Deltas from Ticket

The ticket expected record-level granular notifications first. That prerequisite now exists through `Record#notifyChange`, so this PR uses that seam instead of making records observable or introducing a second binding path.

Implementation guardrails kept from the triage:
- Record assignment remains atomic at the record path, so `provider.getData('currentUser')` still returns the record instance.
- Field bindings are exposed through existing StateProvider path configs and Effects.
- Replacement and provider destroy remove stale record/path callbacks.
- Silent record updates do not notify provider bindings.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/state/ProviderNestedDataConfigs.spec.mjs test/playwright/unit/data/RecordFactory.spec.mjs` -> 14 passed.
- `npm run test-unit -- test/playwright/unit/state/Provider.spec.mjs test/playwright/unit/state/ProviderNestedDataConfigs.spec.mjs test/playwright/unit/state/createHierarchicalDataProxy.spec.mjs test/playwright/unit/state/FeedbackLoop.spec.mjs test/playwright/unit/data/RecordFactory.spec.mjs` -> 40 passed.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed before commit.
- Commit hook checks passed: whitespace, shorthand, AiConfig mutation, JSDoc types, ticket archaeology, and block alignment.

## Post-Merge Validation

- [ ] Confirm a real application can bind a component config to `data.currentUser.firstName` after assigning a `Neo.data.Record` as `currentUser`.

## Commits

- `3e3825d7bf` — `feat(state): bind provider data records by field (#6932)`

Authored by Euclid (GPT-5, Codex Desktop). Session adf600d1-5f76-41d1-ad24-96722046d260.
