### PR TITLE
feat(ai): wire the systemic-fault circuit-breaker — suppress the cross-collection mass-heal storm (#14179)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -39,6 +39,7 @@ import {auditChromaVectorCoverage}                                              
 import {createReEmbedMissingHeal, createReEmbedMissingHealOperation}                                from '../../services/memory-core/helpers/reEmbedMissingHeal.mjs';
 import {appendHealEvent, healEventsToRecentRuns, queryHealLedger, readHealLedger}                   from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {quarantineCollection, storeFenceTargets, unquarantineCollection}                            from '../../services/memory-core/helpers/quarantineStore.mjs';
+import {decideSystemicCircuit, foldSystemicCircuitState}                                            from '../../services/memory-core/helpers/healSystemicCircuit.mjs';
 import {Memory_StorageRouter as StorageRouter, Memory_TextEmbeddingService as TextEmbeddingService} from '../../services.mjs';
 import {buildDataIntegrityCoverageDiagnosis}                                                        from './services/dataIntegrityCoverageDiagnosis.mjs';
 import {assembleDataIntegrityEvidence}                                                              from './services/dataIntegrityEvidenceAssembler.mjs';
@@ -489,7 +490,19 @@ export class Orchestrator extends Base {
             evidenceGatherer: this.dataIntegrityEvidenceGatherer,
             // Reversibility: a clean re-audit (terminalAction `none`) lifts the serving fence. The store-level
             // fence is per-served-collection, so each lifts as it re-audits clean.
-            liftQuarantine  : async collection => unquarantineCollection(collection, {dir: AiConfig.engines.chroma.dataDir})
+            liftQuarantine  : async collection => unquarantineCollection(collection, {dir: AiConfig.engines.chroma.dataDir}),
+            // Systemic circuit-breaker: fold the heal-ledger → decide whether a cross-collection embedder outage
+            // should suppress this cycle's heals (bounds read FRESH from the AiConfig recovery-actuator leaf).
+            systemicCircuitGate: async ({now}) => {
+                const dir                               = path.join(this.dataDir, 'data-heal-events'),
+                      bounds                            = AiConfig.orchestrator.recoveryActuator.systemicCircuit,
+                      {recentFailures, circuitOpenedAt} = foldSystemicCircuitState(await readHealLedger({dir}), {now, windowMs: bounds.windowMs});
+                return decideSystemicCircuit({recentFailures, circuitOpenedAt, now, bounds});
+            },
+            recordCircuitEvent: async ({type, at, detail}) => appendHealEvent(
+                {type, collection: '*', status: type === 'circuit-open' ? 'open' : 'close', detail},
+                {dir: path.join(this.dataDir, 'data-heal-events'), now: at}
+            )
         });
     }
 

--- a/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
@@ -139,13 +139,21 @@ export class DataIntegrityDiagnosisService extends Base {
             return this.createDecision({serviceId: this.serviceId, observedAt, status: 'circuit-open', classifications, heals: [], circuit});
         }
 
-        const heals = await this.applyHeals({rows, classifications, now: observedAt});
+        // Half-open allows EXACTLY ONE actionable probe heal — not the full batch, which would re-storm a
+        // still-down embedder. Clean re-audit fence-lifts are exempt from the cap (cheap, non-storm).
+        const heals = await this.applyHeals({
+            rows, classifications, now: observedAt,
+            maxActionableHeals: circuit.status === 'half-open-probe' ? 1 : Infinity
+        });
 
-        // A half-open probe that healed cleanly → the shared dependency recovered → close the circuit so the next
-        // fold proceeds normally. A probe that re-failed leaves the circuit open (the next fold re-trips on it).
-        if (circuit.status === 'half-open-probe' && typeof this.recordCircuitEvent === 'function' &&
-                heals.length > 0 && heals.every(heal => heal.outcome?.status !== 'failed')) {
-            await this.recordCircuitEvent({type: 'circuit-close', at: observedAt, detail: 'half-open probe recovered — circuit closed'});
+        // Half-open outcome: a clean probe (or nothing left to probe) closes the circuit; a FAILED probe refreshes
+        // the open window at observedAt so the next fold rides it out, rather than immediately re-probing on the
+        // already-elapsed cooldown (which would let a still-down embedder be hammered every sweep).
+        if (circuit.status === 'half-open-probe' && typeof this.recordCircuitEvent === 'function') {
+            const probeFailed = heals.some(heal => heal.outcome?.status === 'failed');
+            await this.recordCircuitEvent(probeFailed
+                ? {type: 'circuit-open',  at: observedAt, detail: 'half-open probe failed — circuit re-opened'}
+                : {type: 'circuit-close', at: observedAt, detail: 'half-open probe recovered — circuit closed'});
         }
 
         return this.createDecision({
@@ -171,8 +179,10 @@ export class DataIntegrityDiagnosisService extends Base {
      * @param {Number} options.now Epoch milliseconds passed through to the actuator for consistent timestamps.
      * @returns {Promise<Object[]>} The per-heal outcome descriptors.
      */
-    async applyHeals({rows, classifications, now}) {
+    async applyHeals({rows, classifications, now, maxActionableHeals = Infinity}) {
         const heals = [];
+
+        let actionableHealCount = 0;
 
         for (let i = 0; i < classifications.length; i++) {
             const classification = classifications[i];
@@ -186,6 +196,14 @@ export class DataIntegrityDiagnosisService extends Base {
                 }
                 continue;
             }
+
+            // Half-open probe cap: a recovering circuit allows EXACTLY ONE actionable heal to test the shared
+            // dependency — running the full batch would re-storm a still-down embedder. The NONE-lifts above are
+            // exempt (cheap, non-storm). Beyond the cap, the residue waits for the next post-recovery sweep.
+            if (actionableHealCount >= maxActionableHeals) {
+                continue
+            }
+            actionableHealCount++;
 
             let outcome;
 

--- a/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
@@ -74,6 +74,19 @@ export class DataIntegrityDiagnosisService extends Base {
      * @member {Function|null} liftQuarantine=null
      */
     liftQuarantine = null
+    /**
+     * The systemic circuit-breaker gate: `async ({now}) => {open, status, reason, …}` — folds the ledger, runs
+     * `decideSystemicCircuit`, and reports whether a cross-collection embedder outage should suppress THIS cycle's
+     * heals. `null` → no gate (proceed, as before). Set-once injected dependency — a plain class field.
+     * @member {Function|null} systemicCircuitGate=null
+     */
+    systemicCircuitGate = null
+    /**
+     * Records a circuit-open / circuit-close ledger event: `async ({type, at, detail}) => void`. The gate's fold
+     * reads these back to derive the open state. `null` → events are not recorded (the gate still suppresses).
+     * @member {Function|null} recordCircuitEvent=null
+     */
+    recordCircuitEvent = null
 
     /**
      * @summary Gathers per-collection evidence, classifies each, and routes every actionable finding to its
@@ -107,15 +120,41 @@ export class DataIntegrityDiagnosisService extends Base {
 
         const rows            = Array.isArray(evidenceRows) ? evidenceRows : [],
               classifications = rows.map(evidence => classifyDataIntegrityMode(evidence)),
-              actionable      = classifications.filter(classification => classification.terminalAction !== DataIntegrityTerminal.NONE),
-              heals           = await this.applyHeals({rows, classifications, now: observedAt});
+              actionable      = classifications.filter(classification => classification.terminalAction !== DataIntegrityTerminal.NONE);
+
+        // SYSTEMIC CIRCUIT-BREAKER — the cross-collection layer above the per-collection anti-thrash. A shared
+        // embedder outage fails N collections' heals at once; the per-collection gate cannot see the correlation,
+        // so each retries within its own bounds — a mass-heal storm hammering a dead embedder. An open circuit
+        // SUPPRESSES every heal here, before any per-collection heal runs — recorded + self-clearing (a half-open
+        // probe tests recovery), never a page.
+        const circuit = typeof this.systemicCircuitGate === 'function'
+            ? await this.systemicCircuitGate({now: observedAt})
+            : {open: false, status: 'closed'};
+
+        if (circuit.open) {
+            // `tripped` is the fresh detection → record the open once; `circuit-open` is riding out a prior trip.
+            if (circuit.status === 'tripped' && typeof this.recordCircuitEvent === 'function') {
+                await this.recordCircuitEvent({type: 'circuit-open', at: observedAt, detail: circuit.reason});
+            }
+            return this.createDecision({serviceId: this.serviceId, observedAt, status: 'circuit-open', classifications, heals: [], circuit});
+        }
+
+        const heals = await this.applyHeals({rows, classifications, now: observedAt});
+
+        // A half-open probe that healed cleanly → the shared dependency recovered → close the circuit so the next
+        // fold proceeds normally. A probe that re-failed leaves the circuit open (the next fold re-trips on it).
+        if (circuit.status === 'half-open-probe' && typeof this.recordCircuitEvent === 'function' &&
+                heals.length > 0 && heals.every(heal => heal.outcome?.status !== 'failed')) {
+            await this.recordCircuitEvent({type: 'circuit-close', at: observedAt, detail: 'half-open probe recovered — circuit closed'});
+        }
 
         return this.createDecision({
             serviceId: this.serviceId,
             observedAt,
             status   : actionable.length > 0 ? 'healed' : 'clean',
             classifications,
-            heals
+            heals,
+            circuit
         });
     }
 
@@ -174,7 +213,7 @@ export class DataIntegrityDiagnosisService extends Base {
      * @param {Object} options
      * @returns {Object}
      */
-    createDecision({serviceId, observedAt, status, classifications = [], heals = [], probeError = null}) {
+    createDecision({serviceId, observedAt, status, classifications = [], heals = [], probeError = null, circuit = null}) {
         return {
             schemaVersion: 1,
             recordType   : 'data-integrity-self-heal-decision',
@@ -183,7 +222,8 @@ export class DataIntegrityDiagnosisService extends Base {
             status,
             probeError,
             classifications,
-            heals
+            heals,
+            circuit
         };
     }
 

--- a/ai/services/memory-core/helpers/healSystemicCircuit.mjs
+++ b/ai/services/memory-core/helpers/healSystemicCircuit.mjs
@@ -115,3 +115,47 @@ export function decideSystemicCircuit({recentFailures = [], circuitOpenedAt, now
 
     return {open: false, status: 'closed', reason: `${failing.size}/${systemicThreshold} distinct collections failing the outage signature — not systemic`};
 }
+
+/**
+ * The systemic-circuit ledger event types. `circuit-open` records a trip (or a re-trip after a failed probe);
+ * `circuit-close` records a recovered half-open probe. The wiring folds these back to derive `circuitOpenedAt`.
+ * @type {{OPEN: String, CLOSE: String}}
+ */
+export const SYSTEMIC_CIRCUIT_EVENTS = Object.freeze({OPEN: 'circuit-open', CLOSE: 'circuit-close'});
+
+/**
+ * @summary Folds the heal-event ledger into the two inputs `decideSystemicCircuit` derives from it: the current
+ * circuit state (`circuitOpenedAt` — the last `circuit-open` with no later `circuit-close`) and the recent FAILED
+ * heal runs in-window (`recentFailures` — the cross-collection storm evidence). Pure: the caller reads the ledger.
+ * This is the wiring-side counterpart the decider's JSDoc defers to it — kept beside the decider so the open-state
+ * derivation and the suppression decision share one event vocabulary.
+ * @param {Object[]} [events=[]] The heal-event entries (append order, oldest → newest).
+ * @param {Object} [options]
+ * @param {Number} [options.now] Epoch ms (the recent-failure window's upper bound).
+ * @param {Number} [options.windowMs] The recent-failure window length; absent/non-finite → no lower bound.
+ * @returns {{recentFailures: Object[], circuitOpenedAt: (Number|null)}}
+ */
+export function foldSystemicCircuitState(events = [], {now, windowMs} = {}) {
+    const rows       = Array.isArray(events) ? events : [],
+          lowerBound = Number.isFinite(now) && Number.isFinite(windowMs) ? now - windowMs : -Infinity;
+
+    // Last unmatched circuit-open wins (events are append-order oldest → newest); a later close clears it.
+    let circuitOpenedAt = null;
+
+    for (const event of rows) {
+        if (!event || typeof event !== 'object') continue;
+        if (event.type === SYSTEMIC_CIRCUIT_EVENTS.OPEN && Number.isFinite(event.at)) {
+            circuitOpenedAt = event.at;
+        } else if (event.type === SYSTEMIC_CIRCUIT_EVENTS.CLOSE) {
+            circuitOpenedAt = null;
+        }
+    }
+
+    // Recent FAILED heal-outcome rows in-window — the cross-collection storm evidence the decider correlates.
+    // Circuit-open/close rows carry status open/close (not failed), so they never count as failures here.
+    const recentFailures = rows
+        .filter(event => event && typeof event === 'object' && event.status === 'failed' && Number.isFinite(event.at) && event.at >= lowerBound)
+        .map(event => ({collection: event.collection, at: event.at, detail: event.detail}));
+
+    return {recentFailures, circuitOpenedAt};
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
@@ -248,7 +248,23 @@ test.describe('Neo.ai.daemons.services.DataIntegrityDiagnosisService', () => {
         expect(events).toContainEqual(expect.objectContaining({type: 'circuit-close'}));
     });
 
-    test('half-open probe that RE-FAILS → no circuit-close (the circuit stays open for the next fold)', async () => {
+    test('half-open probe runs EXACTLY ONE actionable heal (not the full batch — no mini-storm)', async () => {
+        const actuator = fakeActuator(),
+              events   = [],
+              service  = createService({
+                  evidenceGatherer   : async () => [walStall('neo-agent-memory'), walStall('neo-agent-sessions')],
+                  recoveryActuator   : actuator,
+                  systemicCircuitGate: async () => ({open: false, status: 'half-open-probe', reason: 'cooldown elapsed'}),
+                  recordCircuitEvent : async event => { events.push(event); }
+              });
+
+        await service.gatherAndDiagnose();
+
+        expect(actuator.calls.applyHeal).toHaveLength(1);                              // ONE probe, NOT two (no re-storm)
+        expect(events).toContainEqual(expect.objectContaining({type: 'circuit-close'})); // the single probe healed → close
+    });
+
+    test('half-open probe that RE-FAILS refreshes the open circuit (circuit-open at observedAt, not circuit-close)', async () => {
         const actuator = fakeActuator({failOn: 'neo-agent-memory'}),
               events   = [],
               service  = createService({
@@ -260,8 +276,9 @@ test.describe('Neo.ai.daemons.services.DataIntegrityDiagnosisService', () => {
 
         await service.gatherAndDiagnose();
 
-        expect(actuator.calls.applyHeal).toHaveLength(1);                // the probe still ran
-        expect(events).toHaveLength(0);                                  // but it re-failed → circuit stays open
+        expect(actuator.calls.applyHeal).toHaveLength(1);                              // the probe ran
+        expect(events).toContainEqual(expect.objectContaining({type: 'circuit-open'})); // re-opened → next fold rides it out
+        expect(events.some(event => event.type === 'circuit-close')).toBe(false);
     });
 
     test('circuit CLOSED → proceeds normally (heals run, no circuit event recorded)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
@@ -197,4 +197,87 @@ test.describe('Neo.ai.daemons.services.DataIntegrityDiagnosisService', () => {
 
         expect(decision.heals).toHaveLength(0);                                                   // nothing fenced → nothing recorded
     });
+
+    test('systemic circuit TRIPPED → suppresses every heal + records circuit-open (no mass-heal storm)', async () => {
+        const actuator = fakeActuator(),
+              events   = [],
+              service  = createService({
+                  evidenceGatherer   : async () => [walStall('neo-agent-memory'), walStall('neo-agent-sessions')],
+                  recoveryActuator   : actuator,
+                  systemicCircuitGate: async () => ({open: true, status: 'tripped', reason: '3 distinct collections failing an embedder outage'}),
+                  recordCircuitEvent : async event => { events.push(event); }
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision.status).toBe('circuit-open');
+        expect(decision.heals).toHaveLength(0);                          // the per-collection storm was suppressed
+        expect(actuator.calls.applyHeal).toHaveLength(0);                // NOTHING hammered the dead embedder
+        expect(events).toContainEqual(expect.objectContaining({type: 'circuit-open'}));
+    });
+
+    test('circuit riding-out (circuit-open) → suppresses, but does NOT re-record (only the fresh trip opens)', async () => {
+        const events  = [],
+              service = createService({
+                  evidenceGatherer   : async () => [walStall()],
+                  recoveryActuator   : fakeActuator(),
+                  systemicCircuitGate: async () => ({open: true, status: 'circuit-open', reason: 'riding out the suppression window'}),
+                  recordCircuitEvent : async event => { events.push(event); }
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision.status).toBe('circuit-open');
+        expect(events).toHaveLength(0);                                  // riding-out is not a fresh trip
+    });
+
+    test('half-open probe that heals cleanly → the probe heal RUNS and the circuit closes', async () => {
+        const actuator = fakeActuator(),
+              events   = [],
+              service  = createService({
+                  evidenceGatherer   : async () => [walStall()],
+                  recoveryActuator   : actuator,
+                  systemicCircuitGate: async () => ({open: false, status: 'half-open-probe', reason: 'cooldown elapsed — one recovery probe'}),
+                  recordCircuitEvent : async event => { events.push(event); }
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision.status).toBe('healed');
+        expect(actuator.calls.applyHeal).toHaveLength(1);                // the single probe heal ran
+        expect(events).toContainEqual(expect.objectContaining({type: 'circuit-close'}));
+    });
+
+    test('half-open probe that RE-FAILS → no circuit-close (the circuit stays open for the next fold)', async () => {
+        const actuator = fakeActuator({failOn: 'neo-agent-memory'}),
+              events   = [],
+              service  = createService({
+                  evidenceGatherer   : async () => [walStall('neo-agent-memory')],
+                  recoveryActuator   : actuator,
+                  systemicCircuitGate: async () => ({open: false, status: 'half-open-probe', reason: 'cooldown elapsed'}),
+                  recordCircuitEvent : async event => { events.push(event); }
+              });
+
+        await service.gatherAndDiagnose();
+
+        expect(actuator.calls.applyHeal).toHaveLength(1);                // the probe still ran
+        expect(events).toHaveLength(0);                                  // but it re-failed → circuit stays open
+    });
+
+    test('circuit CLOSED → proceeds normally (heals run, no circuit event recorded)', async () => {
+        const actuator = fakeActuator(),
+              events   = [],
+              service  = createService({
+                  evidenceGatherer   : async () => [walStall()],
+                  recoveryActuator   : actuator,
+                  systemicCircuitGate: async () => ({open: false, status: 'closed', reason: 'not systemic'}),
+                  recordCircuitEvent : async event => { events.push(event); }
+              });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision.status).toBe('healed');
+        expect(actuator.calls.applyHeal).toHaveLength(1);
+        expect(events).toHaveLength(0);
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/healSystemicCircuit.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healSystemicCircuit.spec.mjs
@@ -4,7 +4,9 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
     EMBEDDER_OUTAGE_SIGNATURE,
     isEmbedderOutageFailure,
-    decideSystemicCircuit
+    decideSystemicCircuit,
+    foldSystemicCircuitState,
+    SYSTEMIC_CIRCUIT_EVENTS
 } from '../../../../../../../ai/services/memory-core/helpers/healSystemicCircuit.mjs';
 
 const NOW = 1_000_000;
@@ -156,5 +158,32 @@ test.describe('healSystemicCircuit — decideSystemicCircuit (indeterminate inpu
     test('exports the tunable outage signature for the wiring slice', () => {
         expect(Array.isArray(EMBEDDER_OUTAGE_SIGNATURE)).toBe(true);
         expect(EMBEDDER_OUTAGE_SIGNATURE).toContain('econnrefused');
+    });
+
+    test('foldSystemicCircuitState: last unmatched circuit-open → circuitOpenedAt; a later close → null', () => {
+        const open = foldSystemicCircuitState([
+                  {type: SYSTEMIC_CIRCUIT_EVENTS.OPEN, status: 'open',   at: 100},
+                  {type: 're-embed-missing',           status: 'failed', at: 150, detail: 'econnrefused', collection: 'a'},
+                  {type: SYSTEMIC_CIRCUIT_EVENTS.OPEN, status: 'open',   at: 200}  // a later open wins
+              ], {now: NOW, windowMs: 600_000}),
+              closed = foldSystemicCircuitState([
+                  {type: SYSTEMIC_CIRCUIT_EVENTS.OPEN,  status: 'open',  at: 100},
+                  {type: SYSTEMIC_CIRCUIT_EVENTS.CLOSE, status: 'close', at: 300}  // close clears the open
+              ], {now: NOW, windowMs: 600_000});
+
+        expect(open.circuitOpenedAt).toBe(200);
+        expect(closed.circuitOpenedAt).toBe(null);
+    });
+
+    test('foldSystemicCircuitState: recentFailures = failed rows in-window; circuit + non-failed rows excluded', () => {
+        const {recentFailures} = foldSystemicCircuitState([
+            {type: 're-embed-missing',           status: 'failed', at: NOW - 100_000, detail: 'econnrefused', collection: 'a'}, // in-window failure
+            {type: 're-embed-missing',           status: 'failed', at: NOW - 900_000, detail: 'timeout',      collection: 'b'}, // OUT of window
+            {type: 're-embed-missing',           status: 'healed', at: NOW - 50_000,                          collection: 'c'}, // not a failure
+            {type: SYSTEMIC_CIRCUIT_EVENTS.OPEN, status: 'open',   at: NOW - 10_000,                          collection: '*'}  // a circuit event, not a failure
+        ], {now: NOW, windowMs: 600_000});
+
+        expect(recentFailures).toHaveLength(1);
+        expect(recentFailures[0]).toMatchObject({collection: 'a', detail: 'econnrefused'});
     });
 });


### PR DESCRIPTION
Resolves #14179

The systemic-fault circuit-breaker — wires the built-but-unwired `decideSystemicCircuit` into the self-heal cycle so a shared embedder outage no longer triggers a cross-collection mass-heal storm. `gatherAndDiagnose` consults the circuit BEFORE the per-collection heals: ≥ `systemicThreshold` distinct collections failing with an embedder-outage signature in `windowMs` = ONE fault → trip OPEN → suppress every heal for `openDurationMs`, then **exactly one** half-open recovery probe (clean → close; re-fail → re-open at `observedAt`). A recorded, self-clearing suppression — never a page.

Evidence: 36/36 unit green (`foldSystemicCircuitState` + the full `gatherAndDiagnose` gate suite incl. the half-open state-machine).

## Deltas from ticket

None — matches #14179. The V-B-A found `decideSystemicCircuit` already built but imported nowhere — this is the wiring the decider's own JSDoc defers to it: the heal-ledger fold (`foldSystemicCircuitState`), the gate in `gatherAndDiagnose`, the `circuit-open`/`circuit-close` ledger events, and the fresh-read `AiConfig.orchestrator.recoveryActuator.systemicCircuit` bounds.

## Test Evidence

`npm run test-unit -- …/healSystemicCircuit.spec.mjs …/DataIntegrityDiagnosisService.spec.mjs` → **36/36 passed**:
- `foldSystemicCircuitState` (2): open-state derivation + recent-failure windowing.
- `gatherAndDiagnose` circuit-gate: tripped → suppress + record `circuit-open`; riding-out → suppress, no re-record; **half-open runs EXACTLY ONE actionable probe** (two WAL-stalls → one `applyHeal`); **half-open clean → close**; **half-open re-fail → fresh `circuit-open` (rides out the next fold)**; closed → proceed.

block-alignment clean; ticket-archaeology 0 violations.

## Consumed Surface Contract

The consumed decision/ledger surface (for the observability sub #14163 + the scheduler):
- `data-integrity-self-heal-decision.status = 'circuit-open'` — the circuit suppressed this cycle (no heal ran).
- `data-integrity-self-heal-decision.circuit = {open, status, reason, distinctFailingCollections?}` — `status ∈ {indeterminate, closed, tripped, circuit-open, half-open-probe}`; `null` when no gate is wired.
- Heal-ledger events `{type: 'circuit-open' | 'circuit-close', collection: '*', status: 'open' | 'close', detail, at}` — folded by `foldSystemicCircuitState` to derive `circuitOpenedAt`. `circuit-open` on a trip OR a failed half-open probe; `circuit-close` on a recovered probe.
- Bounds: `AiConfig.orchestrator.recoveryActuator.systemicCircuit = {systemicThreshold, windowMs, openDurationMs}` (read fresh at the use-site).

## Post-Merge Validation

- [ ] In an embedder outage, the orchestrator poll records `circuit-open` (suppressed) rather than N per-collection re-embed failures hammering the dead embedder.
- [ ] After recovery, a single half-open probe heals and a `circuit-close` is recorded; the next cycle resumes normal healing.

## Commits

- `6f7bb496e` — the circuit-breaker wiring: `foldSystemicCircuitState` + the `gatherAndDiagnose` gate + the injected `systemicCircuitGate`/`recordCircuitEvent` + the `circuit` field on the decision envelope + tests. (Cut from fresh dev — single clean commit.)
- `a600e300a` — half-open correctness (cross-family review #14275): cap to one actionable probe (`maxActionableHeals`); a failed probe re-opens at `observedAt` + regression tests.

Authored by Grace (Claude Opus 4.8, Claude Code). Origin session 090a68e6-1a28-4b20-a5fd-842ebac3e729.
