### PR TITLE
feat(ai): wire the chronic unsafe-input mis-wire detector — the immune system observes itself (#14158)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -851,6 +851,19 @@ class Config extends ConfigProvider {
                         systemicThreshold: leaf(3,              'NEO_RECOVERY_ACTUATOR_SYSTEMIC_CIRCUIT_THRESHOLD',        'number'),
                         windowMs         : leaf(10 * 60 * 1000, 'NEO_RECOVERY_ACTUATOR_SYSTEMIC_CIRCUIT_WINDOW_MS',        'number'),
                         openDurationMs   : leaf(10 * 60 * 1000, 'NEO_RECOVERY_ACTUATOR_SYSTEMIC_CIRCUIT_OPEN_DURATION_MS', 'number')
+                    },
+                    /**
+                     * Chronic `unsafe-input` detector bounds — the immune system's self-observability for a
+                     * MIS-WIRE. `dispatchHeal` fails CLOSED to `unsafe-input` on under-specified input (no
+                     * collection / non-finite clock / missing recordRun); a single one is routine, but >=
+                     * `threshold` for the SAME (action, collection) inside `windowMs` means a caller is
+                     * chronically mis-wired and that heal silently never executes. Consumed by
+                     * `detectChronicUnsafeInput`: read at the use-site and passed as its bounds.
+                     * @type {Object}
+                     */
+                    chronicUnsafeInput: {
+                        threshold: leaf(5,              'NEO_RECOVERY_ACTUATOR_CHRONIC_UNSAFE_INPUT_THRESHOLD', 'number'),
+                        windowMs : leaf(60 * 60 * 1000, 'NEO_RECOVERY_ACTUATOR_CHRONIC_UNSAFE_INPUT_WINDOW_MS', 'number')
                     }
                 },
                 /**

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -38,6 +38,7 @@ import DataRecoveryActuatorService                                              
 import {auditChromaVectorCoverage}                                                                  from '../../scripts/maintenance/checkChromaIntegrity.mjs';
 import {createReEmbedMissingHeal, createReEmbedMissingHealOperation}                                from '../../services/memory-core/helpers/reEmbedMissingHeal.mjs';
 import {appendHealEvent, healEventsToRecentRuns, queryHealLedger, readHealLedger}                   from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
+import {detectChronicUnsafeInput}                                                                   from '../../services/memory-core/helpers/healActionDispatch.mjs';
 import {quarantineCollection, storeFenceTargets, unquarantineCollection}                            from '../../services/memory-core/helpers/quarantineStore.mjs';
 import {decideSystemicCircuit, foldSystemicCircuitState}                                            from '../../services/memory-core/helpers/healSystemicCircuit.mjs';
 import {Memory_StorageRouter as StorageRouter, Memory_TextEmbeddingService as TextEmbeddingService} from '../../services.mjs';
@@ -502,7 +503,14 @@ export class Orchestrator extends Base {
             recordCircuitEvent: async ({type, at, detail}) => appendHealEvent(
                 {type, collection: '*', status: type === 'circuit-open' ? 'open' : 'close', detail},
                 {dir: path.join(this.dataDir, 'data-heal-events'), now: at}
-            )
+            ),
+            // Chronic unsafe-input mis-wire detector (observability): fold the heal-ledger for sustained
+            // unsafe-input per (action, collection); bounds read FRESH from the AiConfig recovery-actuator leaf.
+            chronicUnsafeInputDetector: async ({now}) => {
+                const dir    = path.join(this.dataDir, 'data-heal-events'),
+                      bounds = AiConfig.orchestrator.recoveryActuator.chronicUnsafeInput;
+                return detectChronicUnsafeInput(await readHealLedger({dir}), {threshold: bounds.threshold, windowMs: bounds.windowMs, now});
+            }
         });
     }
 

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -905,6 +905,14 @@ async function runDataIntegritySweepTask({taskName, reason, services, runtime}) 
         };
         if (decision.probeError) details.probeError = decision.probeError;
 
+        // Chronic unsafe-input mis-wire alert: a sustained fail-closed for the same (action, collection) means a
+        // caller is mis-wired and that heal silently never executes — surface it (the immune system's own
+        // self-observability), since a single fail-closed is correct but a chronic one is otherwise invisible.
+        if (Array.isArray(decision.chronicUnsafeInput) && decision.chronicUnsafeInput.length > 0) {
+            details.chronicUnsafeInput = decision.chronicUnsafeInput;
+            runtime.writeLog?.('WARN', `[Orchestrator] chronic unsafe-input mis-wire: ${decision.chronicUnsafeInput.map(c => `${c.action}/${c.collection}×${c.count}`).join(', ')} — a heal is silently never executing`);
+        }
+
         // Self-heal semantics: a clean store AND an autonomously-healed store are both healthy outcomes (the
         // immune system worked). Only an unavailable probe is a not-healthy signal — there is no escalate state.
         const notHealthy = decision.status === 'probe-unavailable';

--- a/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
@@ -87,6 +87,13 @@ export class DataIntegrityDiagnosisService extends Base {
      * @member {Function|null} recordCircuitEvent=null
      */
     recordCircuitEvent = null
+    /**
+     * Chronic `unsafe-input` mis-wire detector: `async ({now}) => [{action, collection, count}]` — folds the
+     * heal-ledger for sustained `unsafe-input` per (action, collection). Observability only (does NOT gate the
+     * cycle). `null` → no detection. Set-once injected dependency — a plain class field.
+     * @member {Function|null} chronicUnsafeInputDetector=null
+     */
+    chronicUnsafeInputDetector = null
 
     /**
      * @summary Gathers per-collection evidence, classifies each, and routes every actionable finding to its
@@ -156,13 +163,21 @@ export class DataIntegrityDiagnosisService extends Base {
                 : {type: 'circuit-close', at: observedAt, detail: 'half-open probe recovered — circuit closed'});
         }
 
+        // Chronic unsafe-input mis-wire detector (observability only — does NOT gate): surface sustained
+        // unsafe-input per (action, collection) so a chronically mis-wired heal that silently never-executes is
+        // detected rather than invisible. Reads the same heal-ledger the circuit folds.
+        const chronicUnsafeInput = typeof this.chronicUnsafeInputDetector === 'function'
+            ? await this.chronicUnsafeInputDetector({now: observedAt})
+            : [];
+
         return this.createDecision({
             serviceId: this.serviceId,
             observedAt,
             status   : actionable.length > 0 ? 'healed' : 'clean',
             classifications,
             heals,
-            circuit
+            circuit,
+            chronicUnsafeInput
         });
     }
 
@@ -231,7 +246,7 @@ export class DataIntegrityDiagnosisService extends Base {
      * @param {Object} options
      * @returns {Object}
      */
-    createDecision({serviceId, observedAt, status, classifications = [], heals = [], probeError = null, circuit = null}) {
+    createDecision({serviceId, observedAt, status, classifications = [], heals = [], probeError = null, circuit = null, chronicUnsafeInput = []}) {
         return {
             schemaVersion: 1,
             recordType   : 'data-integrity-self-heal-decision',
@@ -241,7 +256,8 @@ export class DataIntegrityDiagnosisService extends Base {
             probeError,
             classifications,
             heals,
-            circuit
+            circuit,
+            chronicUnsafeInput
         };
     }
 

--- a/ai/services/memory-core/helpers/healActionDispatch.mjs
+++ b/ai/services/memory-core/helpers/healActionDispatch.mjs
@@ -180,3 +180,53 @@ export async function dispatchHeal({action, collection, evidence, recentRuns = [
         return {action, collection, status: 'failed', detail: error?.message ?? String(error), healedAt: now};
     }
 }
+
+/**
+ * @summary Detects a CHRONIC `unsafe-input` mis-wire from the heal-event ledger — the immune system observing
+ * ITSELF. `dispatchHeal` fails CLOSED to `unsafe-input` on under-specified input (no collection / non-finite
+ * clock / missing recordRun); that single fail-closed is correct safety. But a caller that CHRONICALLY fails to
+ * satisfy the safety context (a path that never threads the clock, a permanently-absent recordRun) would
+ * silently never heal — the fail-closed is right, the mis-wire is invisible unless something watches the ledger.
+ * This is that watcher: it groups recent `unsafe-input` outcomes by (action, collection) and returns the groups
+ * that crossed `threshold` inside `windowMs`. Pure (no I/O): the caller reads the ledger + surfaces/logs the
+ * result. Detection ONLY — it never touches the fail-closed gate.
+ *
+ * @param {Object[]} [events=[]] Heal-event ledger entries (`{type, collection, status, at}`, oldest → newest).
+ * @param {Object} options
+ * @param {Number} options.threshold Minimum same-(action, collection) `unsafe-input` count in-window to flag.
+ * @param {Number} options.windowMs The look-back window (an epoch-ms span ending at `now`).
+ * @param {Number} options.now Epoch ms (the window's upper bound).
+ * @returns {Object[]} `[{action, collection, count}]` (count >= threshold), worst-first. Empty when bounds are
+ *   non-finite (indeterminate input never spuriously alerts) or nothing is chronic.
+ */
+export function detectChronicUnsafeInput(events = [], {threshold, windowMs, now} = {}) {
+    // Indeterminate bounds → no alert: a detector must not fire on un-evaluable input.
+    if (![threshold, windowMs, now].every(Number.isFinite) || threshold <= 0) {
+        return []
+    }
+
+    const lowerBound = now - windowMs,
+          counts     = new Map();
+
+    for (const event of Array.isArray(events) ? events : []) {
+        if (!event || typeof event !== 'object' || event.status !== 'unsafe-input')  continue;
+        if (!Number.isFinite(event.at) || event.at < lowerBound || event.at > now)   continue;
+        if (typeof event.collection !== 'string' || typeof event.type !== 'string')  continue;
+
+        // The ledger records the heal ACTION under the event `type` field (mirrors healEventsToRecentRuns).
+        const key = `${event.type} ${event.collection}`;
+        counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+
+    const chronic = [];
+
+    for (const [key, count] of counts) {
+        if (count >= threshold) {
+            const [action, collection] = key.split(' ');
+            chronic.push({action, collection, count})
+        }
+    }
+
+    // Worst-first: descending count, then a stable key order for deterministic surfacing.
+    return chronic.sort((a, b) => b.count - a.count || `${a.action} ${a.collection}`.localeCompare(`${b.action} ${b.collection}`))
+}

--- a/ai/services/memory-core/helpers/healActionDispatch.mjs
+++ b/ai/services/memory-core/helpers/healActionDispatch.mjs
@@ -191,7 +191,7 @@ export async function dispatchHeal({action, collection, evidence, recentRuns = [
  * that crossed `threshold` inside `windowMs`. Pure (no I/O): the caller reads the ledger + surfaces/logs the
  * result. Detection ONLY — it never touches the fail-closed gate.
  *
- * @param {Object[]} [events=[]] Heal-event ledger entries (`{type, collection, status, at}`, oldest → newest).
+ * @param {Object[]} [events=[]] Heal-event ledger entries (`{type, collection, status, at}`, oldest to newest).
  * @param {Object} options
  * @param {Number} options.threshold Minimum same-(action, collection) `unsafe-input` count in-window to flag.
  * @param {Number} options.windowMs The look-back window (an epoch-ms span ending at `now`).
@@ -200,7 +200,7 @@ export async function dispatchHeal({action, collection, evidence, recentRuns = [
  *   non-finite (indeterminate input never spuriously alerts) or nothing is chronic.
  */
 export function detectChronicUnsafeInput(events = [], {threshold, windowMs, now} = {}) {
-    // Indeterminate bounds → no alert: a detector must not fire on un-evaluable input.
+    // Indeterminate bounds -> no alert: a detector must not fire on un-evaluable input.
     if (![threshold, windowMs, now].every(Number.isFinite) || threshold <= 0) {
         return []
     }
@@ -213,8 +213,9 @@ export function detectChronicUnsafeInput(events = [], {threshold, windowMs, now}
         if (!Number.isFinite(event.at) || event.at < lowerBound || event.at > now)   continue;
         if (typeof event.collection !== 'string' || typeof event.type !== 'string')  continue;
 
-        // The ledger records the heal ACTION under the event `type` field (mirrors healEventsToRecentRuns).
-        const key = `${event.type} ${event.collection}`;
+        // Text-safe tuple key: a JSON pair (never a raw separator byte in source). The ledger records the heal
+        // ACTION under the event `type` field (mirrors healEventsToRecentRuns).
+        const key = JSON.stringify([event.type, event.collection]);
         counts.set(key, (counts.get(key) ?? 0) + 1)
     }
 
@@ -222,11 +223,11 @@ export function detectChronicUnsafeInput(events = [], {threshold, windowMs, now}
 
     for (const [key, count] of counts) {
         if (count >= threshold) {
-            const [action, collection] = key.split(' ');
+            const [action, collection] = JSON.parse(key);
             chronic.push({action, collection, count})
         }
     }
 
-    // Worst-first: descending count, then a stable key order for deterministic surfacing.
-    return chronic.sort((a, b) => b.count - a.count || `${a.action} ${a.collection}`.localeCompare(`${b.action} ${b.collection}`))
+    // Worst-first: descending count, then a stable JSON-key order for deterministic surfacing.
+    return chronic.sort((a, b) => b.count - a.count || JSON.stringify([a.action, a.collection]).localeCompare(JSON.stringify([b.action, b.collection])))
 }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
@@ -297,4 +297,24 @@ test.describe('Neo.ai.daemons.services.DataIntegrityDiagnosisService', () => {
         expect(actuator.calls.applyHeal).toHaveLength(1);
         expect(events).toHaveLength(0);
     });
+
+    test('surfaces a chronic unsafe-input mis-wire in the decision (observability only — does not gate)', async () => {
+        const service = createService({
+            evidenceGatherer          : async () => [clean()],
+            recoveryActuator          : fakeActuator(),
+            chronicUnsafeInputDetector: async () => [{action: 're-embed-missing', collection: 'neo-agent-memory', count: 7}]
+        });
+
+        const decision = await service.gatherAndDiagnose();
+
+        expect(decision.chronicUnsafeInput).toEqual([{action: 're-embed-missing', collection: 'neo-agent-memory', count: 7}]);
+        expect(decision.status).toBe('clean'); // observability only — the detector does NOT change the heal status
+    });
+
+    test('no chronic detector wired → decision.chronicUnsafeInput defaults to []', async () => {
+        const service  = createService({evidenceGatherer: async () => [clean()], recoveryActuator: fakeActuator()}),
+              decision = await service.gatherAndDiagnose();
+
+        expect(decision.chronicUnsafeInput).toEqual([]);
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
@@ -3,6 +3,7 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
     decideHealAction,
+    detectChronicUnsafeInput,
     dispatchHeal,
     DEFAULT_DISPATCH_BOUNDS,
     HEAL_ACTIONS,
@@ -224,5 +225,37 @@ test.describe('dispatchHeal — actuator core dispatch (safety gate + injected e
         expect(called).toBe(false); // never executed the mutation when the attempt could not be recorded
         expect(outcome).toMatchObject({status: 'failed'});
         expect(outcome.detail).toMatch(/recordRun failed pre-execution/);
+    });
+});
+
+test.describe('detectChronicUnsafeInput — chronic unsafe-input mis-wire detector', () => {
+    const NOW = 5_000_000;
+
+    test('>= threshold unsafe-input for the same (action, collection) in-window → flagged', () => {
+        const chronic = detectChronicUnsafeInput([
+            {type: 're-embed-missing', collection: 'a', status: 'unsafe-input', at: NOW - 1000},
+            {type: 're-embed-missing', collection: 'a', status: 'unsafe-input', at: NOW - 2000},
+            {type: 're-embed-missing', collection: 'a', status: 'unsafe-input', at: NOW - 3000},
+            {type: 're-embed-missing', collection: 'b', status: 'unsafe-input', at: NOW - 1000}, // below threshold
+            {type: 're-embed-missing', collection: 'a', status: 'healed',       at: NOW - 500}   // not unsafe-input
+        ], {threshold: 3, windowMs: 60_000, now: NOW});
+
+        expect(chronic).toEqual([{action: 're-embed-missing', collection: 'a', count: 3}]);
+    });
+
+    test('out-of-window unsafe-input does NOT count toward the threshold', () => {
+        const chronic = detectChronicUnsafeInput([
+            {type: 're-embed-missing', collection: 'a', status: 'unsafe-input', at: NOW - 1000},
+            {type: 're-embed-missing', collection: 'a', status: 'unsafe-input', at: NOW - 2000},
+            {type: 're-embed-missing', collection: 'a', status: 'unsafe-input', at: NOW - 9_000_000} // out of window
+        ], {threshold: 3, windowMs: 60_000, now: NOW});
+
+        expect(chronic).toEqual([]); // only 2 in-window < 3
+    });
+
+    test('non-finite bounds → no alert (indeterminate input never spuriously fires)', () => {
+        const events = [{type: 'x', collection: 'a', status: 'unsafe-input', at: 1000}];
+        expect(detectChronicUnsafeInput(events, {threshold: NaN, windowMs: 60_000, now: 5000})).toEqual([]);
+        expect(detectChronicUnsafeInput(events, {threshold: 1,   windowMs: 60_000, now: NaN })).toEqual([]);
     });
 });


### PR DESCRIPTION
Resolves #14158

The chronic `unsafe-input` mis-wire detector — the immune system's self-observability. `dispatchHeal` fails CLOSED to `unsafe-input` on under-specified input (no collection / non-finite clock / missing recordRun) — correct safety — but a chronically mis-wired caller (a path that never threads the clock, a permanently-absent recordRun) would silently never heal, invisible unless something watches the ledger. This is that watcher.

Evidence: 43/43 unit green (the detector + the surfacing, atop the dispatch + circuit suites).

## Deltas from ticket

None — matches #14158. Detection only, **no change** to the `decideHealAction`/`dispatchHeal` fail-closed semantics (AC2). Config-driven (ADR-0019 leaf, AC3). Surfaced via the existing data-integrity sweep + the decision envelope (composes with #14163's status surface).

## What it does

- `detectChronicUnsafeInput(events, {threshold, windowMs, now})` (healActionDispatch) — pure fold of the heal-ledger for `status: 'unsafe-input'` per (action, collection) ≥ `threshold` in-window; indeterminate-safe (non-finite bounds → no alert; AC1).
- `AiConfig.orchestrator.recoveryActuator.chronicUnsafeInput = {threshold: 5, windowMs: 1h}` — ADR-0019 reactive-SSOT leaf, read fresh at the use-site.
- `gatherAndDiagnose` surfaces `chronicUnsafeInput` in the decision (observability only — does NOT gate the heal cycle); the Orchestrator injects the detector (folds the ledger with the fresh bounds); the data-integrity sweep task logs a `WARN` + records it in the task-outcome details on a chronic hit.

## Test Evidence

`npm run test-unit -- …/healActionDispatch.spec.mjs …/DataIntegrityDiagnosisService.spec.mjs` → **43/43 passed**:
- detector (3): threshold-flag (worst-first), out-of-window-excluded, non-finite-bounds-safe.
- surfacing (2): the decision carries `chronicUnsafeInput` and `status` stays `clean` (observability-only, no gating); defaults to `[]` with no detector wired.

block-alignment clean; ticket-archaeology 0 violations.

## Post-Merge Validation

- [ ] A chronically mis-wired heal (sustained `unsafe-input` for the same action+collection) logs the `WARN` in the orchestrator's data-integrity sweep, distinct from a single routine fail-closed.

## Commits

- `9fd529e82` — the detector + config leaf + the `gatherAndDiagnose` surfacing + the Orchestrator injection + the sweep-task WARN + tests. Cut from fresh dev (clean single commit).

Authored by Grace (Claude Opus 4.8, Claude Code). Origin session 090a68e6-1a28-4b20-a5fd-842ebac3e729.
