### PR TITLE
refactor(ai): clarify topology inference service boundary (#14277)

### DIFF
--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -1,6 +1,6 @@
 import fs                            from 'fs';
 import path                          from 'path';
-import { Memory_Config as aiConfig } from '../../services.mjs';
+import { Memory_Config as AiConfig } from '../../services.mjs';
 import Base                          from '../../../src/core/Base.mjs';
 import Json                          from '../../../src/util/Json.mjs';
 import logger                        from '../../mcp/server/memory-core/logger.mjs';
@@ -37,44 +37,14 @@ const
         additionalProperties: false
     };
 
-function estimateTopologyTokens(text) {
-    return bytesToTokens(Buffer.byteLength(text === undefined || text === null ? '' : String(text), 'utf8'));
-}
-
-function assertRequiredChatNumber(value, configPath) {
-    if (!Number.isFinite(value) || value <= 0) {
-        throw new Error(`[TopologyInferenceEngine] Required AiConfig leaf "${configPath}" is missing or invalid. Update ai/mcp/server/memory-core/config.mjs from config.template.mjs.`);
-    }
-
-    return value;
-}
-
-function assertRequiredChatString(value, configPath) {
-    if (typeof value !== 'string') {
-        throw new Error(`[TopologyInferenceEngine] Required AiConfig leaf "${configPath}" is missing or invalid. Update ai/mcp/server/memory-core/config.mjs from config.template.mjs.`);
-    }
-
-    return value;
-}
-
-function getCompletionFinishReason(result) {
-    return result?.finish_reason ||
-        result?.finishReason ||
-        result?.raw?.finish_reason ||
-        result?.raw?.finishReason ||
-        result?.raw?.choices?.[0]?.finish_reason ||
-        result?.raw?.choices?.[0]?.finishReason ||
-        result?.raw?.done_reason ||
-        result?.raw?.doneReason ||
-        '';
-}
-
-function isLengthTruncatedCompletion(finishReason) {
-    return ['length', 'max_tokens', 'max_completion_tokens', 'num_predict', 'token_limit']
-        .includes(String(finishReason || '').toLowerCase());
-}
-
 /**
+ * Infers ticket-level topology conflicts from REM session history.
+ *
+ * The engine keeps REM chunking, graph-provider invocation, conflict rendering,
+ * and run-state accounting in one service. It preserves turn boundaries,
+ * reserves provider output tokens before each request, reports provider failures
+ * through ConsumerFriction, and writes valid conflicts to `sandman_handoff.md`.
+ *
  * @class Neo.ai.daemons.services.TopologyInferenceEngine
  * @extends Neo.core.Base
  * @singleton
@@ -94,7 +64,73 @@ class TopologyInferenceEngine extends Base {
     }
 
     /**
-     * @summary Parses existing topological conflict handoff entries.
+     * Estimates topology prompt size using the shared guardrail heuristic.
+     * @param {String} text Provider prompt text.
+     * @returns {Number} Estimated token count.
+     * @protected
+     */
+    estimateTopologyTokens(text) {
+        return bytesToTokens(Buffer.byteLength(text === undefined || text === null ? '' : String(text), 'utf8'));
+    }
+
+    /**
+     * Resolves provider completion finish reasons across supported graph envelopes.
+     * @param {Object} result Provider generation result.
+     * @returns {String} Completion finish reason, or an empty string when unavailable.
+     * @protected
+     */
+    getCompletionFinishReason(result) {
+        return result?.finish_reason ||
+            result?.finishReason ||
+            result?.raw?.finish_reason ||
+            result?.raw?.finishReason ||
+            result?.raw?.choices?.[0]?.finish_reason ||
+            result?.raw?.choices?.[0]?.finishReason ||
+            result?.raw?.done_reason ||
+            result?.raw?.doneReason ||
+            '';
+    }
+
+    /**
+     * Tests whether a provider finish reason means output truncation.
+     * @param {String} finishReason Provider finish reason.
+     * @returns {Boolean} `true` when the provider reports a token-length cap.
+     * @protected
+     */
+    isLengthTruncatedCompletion(finishReason) {
+        return ['length', 'max_tokens', 'max_completion_tokens', 'num_predict', 'token_limit']
+            .includes(String(finishReason || '').toLowerCase());
+    }
+
+    /**
+     * Builds the graph-generation provider from resolved AiConfig leaves.
+     *
+     * AiConfig is read at the topology use site; `providerDispatch` receives the
+     * plain provider constructor shape and does not own the reactive config tree.
+     * @param {String} graphProvider Active graph-generation provider selector.
+     * @returns {{generate: Function}} Graph generation provider.
+     * @protected
+     */
+    buildConfiguredGraphProvider(graphProvider) {
+        return buildGraphProvider({
+            modelProvider: graphProvider,
+            ollamaConfig : {
+                host          : AiConfig.ollama.host,
+                model         : AiConfig.ollama.model,
+                embeddingModel: AiConfig.ollama.embeddingModel,
+                keep_alive    : AiConfig.ollama.keep_alive
+            },
+            openAiCompatibleConfig: {
+                apiKey    : AiConfig.openAiCompatible.apiKey,
+                host      : AiConfig.openAiCompatible.host,
+                keep_alive: AiConfig.openAiCompatible.keep_alive,
+                model     : AiConfig.openAiCompatible.model
+            }
+        });
+    }
+
+    /**
+     * Parses existing topological conflict handoff entries.
      * @param {String} content Current handoff markdown.
      * @returns {Object[]} Parsed conflict entries.
      */
@@ -108,7 +144,7 @@ class TopologyInferenceEngine extends Base {
     }
 
     /**
-     * @summary Renders one canonical topological conflict handoff entry.
+     * Renders one canonical topological conflict handoff entry.
      * @param {Object} conflict Conflict entry.
      * @returns {String}
      */
@@ -117,7 +153,7 @@ class TopologyInferenceEngine extends Base {
     }
 
     /**
-     * @summary Merges new conflicts into the handoff while keeping the alert list bounded.
+     * Merges new conflicts into the handoff while keeping the alert list bounded.
      *
      * New conflicts win ordering, then still-relevant existing alerts are retained up to the
      * compact handoff cap. Existing lines are rewritten as one bounded block so prior unbounded
@@ -169,7 +205,7 @@ class TopologyInferenceEngine extends Base {
     }
 
     /**
-     * @summary Builds the bounded topology-conflict prompt for one turn-aligned chunk.
+     * Builds the bounded topology-conflict prompt for one turn-aligned chunk.
      * @param {String} contextText Turn-aligned chunk text.
      * @param {Object} chunkInfo Chunk provenance.
      * @returns {String}
@@ -205,13 +241,13 @@ ${contextText}
     }
 
     /**
-     * @summary Creates deterministic turn chunks after reserving topology output and prompt overhead.
+     * Creates deterministic turn chunks after reserving topology output and prompt overhead.
      * @param {String[]} turnDocuments Complete raw memory turn documents.
      * @param {String} sessionId Source session id.
      * @returns {{chunked: Boolean, totalEstimatedTokens: Number, chunks: Object[]}}
      */
     createTopologyChunks(turnDocuments, sessionId) {
-        const envelopeTokens = estimateTopologyTokens(this.buildTopologyPrompt('', {
+        const envelopeTokens = this.estimateTopologyTokens(this.buildTopologyPrompt('', {
                   chunked    : true,
                   index      : 0,
                   chunkCount : 1,
@@ -222,33 +258,32 @@ ${contextText}
                   safeProcessingLimitTokens,
                   graphChunkLimitTokens,
                   graphOutputLimitTokens
-              } = aiConfig.localModels.chat,
+              } = AiConfig.localModels.chat,
               promptBudget   = Math.min(
-                  assertRequiredChatNumber(graphChunkLimitTokens, 'localModels.chat.graphChunkLimitTokens'),
-                  assertRequiredChatNumber(safeProcessingLimitTokens, 'localModels.chat.safeProcessingLimitTokens'),
-                  assertRequiredChatNumber(contextLimitTokens, 'localModels.chat.contextLimitTokens') -
-                      assertRequiredChatNumber(graphOutputLimitTokens, 'localModels.chat.graphOutputLimitTokens')
+                  graphChunkLimitTokens,
+                  safeProcessingLimitTokens,
+                  contextLimitTokens - graphOutputLimitTokens
               ),
               chunkBudget    = Math.max(1, promptBudget - envelopeTokens);
 
         return chunkSession(turnDocuments, {
             sessionId,
             safeProcessingLimitTokens: chunkBudget,
-            estimate                 : estimateTopologyTokens
+            estimate                 : text => this.estimateTopologyTokens(text)
         });
     }
 
     /**
-     * @summary Returns provider options that bound topology output across graph providers.
+     * Returns provider options that bound topology output across graph providers.
      * @returns {Object} Provider generation options.
      */
     getTopologyProviderOptions() {
         return {
-            reasoning_effort    : assertRequiredChatString(aiConfig.localModels.chat.graphReasoningEffort, 'localModels.chat.graphReasoningEffort'),
+            reasoning_effort    : AiConfig.localModels.chat.graphReasoningEffort,
             responseSchema      : topologyConflictSchema,
             responseSchemaName  : 'topologyConflicts',
             responseSchemaStrict: true,
-            maxCompletionTokens : assertRequiredChatNumber(aiConfig.localModels.chat.graphOutputLimitTokens, 'localModels.chat.graphOutputLimitTokens')
+            maxCompletionTokens : AiConfig.localModels.chat.graphOutputLimitTokens
         }
     }
 
@@ -259,7 +294,8 @@ ${contextText}
      * @param {String} sessionId The ID of the session being processed.
      * @param {Object} [options]
      * @param {String[]} [options.turnDocuments] Complete raw memory turn documents, preserving turn boundaries.
-     * @returns {Promise<Object|undefined>} Topology extraction summary.
+     * @returns {Promise<Object|undefined>} Topology extraction summary, or `undefined` when
+     *     provider/bootstrap errors are caught before a summary can be produced.
      */
     async extractTopology(contextText, sessionId, options = {}) {
         logger.info(`[TopologyInferenceEngine] Extracting Topological Conflicts for session ID: ${sessionId}`);
@@ -270,16 +306,14 @@ ${contextText}
                 : [contextText];
             const chunkPlan = this.createTopologyChunks(turnDocuments, sessionId);
 
-            const graphProvider = resolveGraphModelProvider(aiConfig),
-                  provider      = buildGraphProvider({
-                modelProvider         : graphProvider,
-                ollamaConfig          : aiConfig.ollama,
-                openAiCompatibleConfig: aiConfig.openAiCompatible
-            }),
-                  consumerModel         = aiConfig[graphProvider].model,
-                  consumerContextTokens = assertRequiredChatNumber(aiConfig.localModels.chat.contextLimitTokens, 'localModels.chat.contextLimitTokens'),
-                  consumerSafeTokens    = assertRequiredChatNumber(aiConfig.localModels.chat.safeProcessingLimitTokens, 'localModels.chat.safeProcessingLimitTokens'),
-                  outputLimitTokens     = assertRequiredChatNumber(aiConfig.localModels.chat.graphOutputLimitTokens, 'localModels.chat.graphOutputLimitTokens'),
+            const graphProvider = resolveGraphModelProvider(AiConfig),
+                  provider      = this.buildConfiguredGraphProvider(graphProvider),
+                  consumerModel = AiConfig[graphProvider].model,
+                  {
+                      contextLimitTokens       : consumerContextTokens,
+                      safeProcessingLimitTokens: consumerSafeTokens,
+                      graphOutputLimitTokens   : outputLimitTokens
+                  } = AiConfig.localModels.chat,
                   providerOptions       = this.getTopologyProviderOptions(),
                   conflicts             = [];
 
@@ -295,7 +329,7 @@ ${contextText}
                           turnIndices: chunk.turnIndices
                       }),
                       promptBytes          = Buffer.byteLength(prompt, 'utf8'),
-                      promptTokensEstimate = estimateTopologyTokens(prompt),
+                      promptTokensEstimate = this.estimateTopologyTokens(prompt),
                       promptPlusOutput     = promptTokensEstimate + outputLimitTokens,
                       chunkLabel           = `${index + 1}/${chunkPlan.chunks.length}`;
 
@@ -345,10 +379,10 @@ ${contextText}
                 }
 
                 const result       = guardrailed.result;
-                const finishReason = getCompletionFinishReason(result),
+                const finishReason = this.getCompletionFinishReason(result),
                       responseChars = String(result.content || '').length;
 
-                if (isLengthTruncatedCompletion(finishReason)) {
+                if (this.isLengthTruncatedCompletion(finishReason)) {
                     logger.warn(`[TopologyInferenceEngine] Provider reported finish_reason='${finishReason}' for session ${sessionId} chunk ${chunkLabel}; classifying as context-overflow before parsing.`);
 
                     emitConsumerFriction({
@@ -449,8 +483,8 @@ ${contextText}
             }
 
             // Write to sandman_handoff.md
-            const handoffFile = aiConfig.handoffFilePath;
-            const tmpFile = `${handoffFile}.tmp`;
+            const handoffFile = AiConfig.handoffFilePath;
+            const tmpFile     = `${handoffFile}.tmp`;
 
             let handoffContent = '';
             try {
@@ -489,7 +523,7 @@ ${contextText}
     }
 
     /**
-     * @summary Count topological-conflict entries emitted to `sandman_handoff.md`.
+     * Counts topological-conflict entries emitted to `sandman_handoff.md`.
      * This is **Axis D** of the 5-axis REM observability model: the count of
      * conflicts the engine has actually written to the handoff file, which is
      * the durable substrate consumers (next-session agents) read at boot.
@@ -497,16 +531,15 @@ ${contextText}
      * Counts lines matching the canonical conflict-entry suffix `(Source Session:`
      * — each conflict entry in `sandman_handoff.md` follows the shape
      * `- **[<TYPE>]** \`<issueId>\`: <description> (Source Session: <sessionId>)`
-     * (see {@link #extractTopology} line 83 for the writer). The suffix is
-     * distinctive enough to avoid false positives from Golden Path or other
-     * handoff sections.
+     * as written by {@link #extractTopology}. The suffix is distinctive enough
+     * to avoid false positives from Golden Path or other handoff sections.
      *
-     * **Important divergence semantic:** `extractTopology()` returns `undefined`
-     * (void) on both no-conflicts AND provider-error paths — meaning a zero
-     * count here does NOT distinguish "no conflicts detected" from "topology
-     * extraction silently failed for every session." The unified REM cycle
-     * state model closes this distinction by tracking per-cycle topology outcome
-     * explicitly.
+     * **Important divergence semantic:** `extractTopology()` returns an explicit
+     * `{conflictCount: 0}` summary when provider chunks complete with no conflicts,
+     * but caught provider/bootstrap errors can still return `undefined`. A zero count
+     * here therefore proves only that no conflict alerts are present in the handoff;
+     * REM run-state must still be consulted to distinguish no-conflict success from
+     * a cycle where topology extraction never produced a summary.
      *
      * Returns 0 on file-not-found, empty file, or read error — consistent with
      * sibling axis-count helpers' graceful-degradation contract.
@@ -515,7 +548,7 @@ ${contextText}
      *     0 if file absent / empty / unreadable
      */
     async getTopologyConflictCount() {
-        const handoffFile = aiConfig.handoffFilePath;
+        const handoffFile = AiConfig.handoffFilePath;
         if (!handoffFile) return 0;
 
         try {

--- a/test/playwright/unit/ai/services/rem-observability.spec.mjs
+++ b/test/playwright/unit/ai/services/rem-observability.spec.mjs
@@ -127,7 +127,7 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
     test.beforeEach(() => {
         originalGetSummaryCollection = ChromaManager.getSummaryCollection;
         originalGraphDb              = GraphService.db;
-        originalHandoffPath          = aiConfig.data.handoffFilePath;
+        originalHandoffPath          = aiConfig.data.handoffFilePathTest;
         originalRemRunStateDir       = aiConfig.remRunStateDir;
         originalRemRunRecentLimit    = aiConfig.remRunRecentLimit;
 
@@ -138,7 +138,7 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
     test.afterEach(() => {
         ChromaManager.getSummaryCollection = originalGetSummaryCollection;
         GraphService.db                    = originalGraphDb;
-        aiConfig.data.handoffFilePath      = originalHandoffPath;
+        aiConfig.data.handoffFilePathTest  = originalHandoffPath;
         aiConfig.remRunStateDir            = originalRemRunStateDir;
         aiConfig.remRunRecentLimit         = originalRemRunRecentLimit;
     });
@@ -373,18 +373,18 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
                 'Some Golden Path content here, no Source Session marker.',
                 ''
             ].join('\n'), 'utf8');
-            aiConfig.data.handoffFilePath = handoffPath;
+            aiConfig.data.handoffFilePathTest = handoffPath;
 
             expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(3);
         });
 
         test('returns 0 when handoff file does not exist (ENOENT)', async () => {
-            aiConfig.data.handoffFilePath = uniqueHandoffPath('never-existed');
+            aiConfig.data.handoffFilePathTest = uniqueHandoffPath('never-existed');
             expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(0);
         });
 
         test('returns 0 when handoffFilePath is unset', async () => {
-            aiConfig.data.handoffFilePath = null;
+            aiConfig.data.handoffFilePathTest = null;
             expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(0);
         });
 
@@ -392,7 +392,7 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
             const handoffPath = uniqueHandoffPath('empty');
             await mkdir(tmpRoot, {recursive: true});
             await writeFile(handoffPath,'', 'utf8');
-            aiConfig.data.handoffFilePath = handoffPath;
+            aiConfig.data.handoffFilePathTest = handoffPath;
 
             expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(0);
         });
@@ -408,7 +408,7 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
                 'Some content, but zero conflict markers.',
                 ''
             ].join('\n'), 'utf8');
-            aiConfig.data.handoffFilePath = handoffPath;
+            aiConfig.data.handoffFilePathTest = handoffPath;
 
             expect(await TopologyInferenceEngine.getTopologyConflictCount()).toBe(0);
         });
@@ -445,10 +445,10 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
                 '- **[DUPLICATE]** `issue-101`: bar (Source Session: s2)',
                 ''
             ].join('\n'), 'utf8');
-            aiConfig.data.handoffFilePath = handoffPath;
+            aiConfig.data.handoffFilePathTest = handoffPath;
 
             const {callTool} = await import('../../../../../ai/mcp/server/memory-core/toolService.mjs');
-            const state = await callTool('get_rem_pipeline_state', {sessionId: 's1'});
+            const state      = await callTool('get_rem_pipeline_state', {sessionId: 's1'});
 
             expect(state).toEqual({
                 undigested       : 2,
@@ -476,7 +476,7 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
 
             try {
                 const {buildRemPipelineState} = await import('../../../../../ai/services/memory-core/HealthService.mjs');
-                const state = await buildRemPipelineState({axisTimeoutMs: 5});
+                const state                   = await buildRemPipelineState({axisTimeoutMs: 5});
 
                 expect(state).toMatchObject({
                     undigested       : 0,
@@ -530,7 +530,7 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
             }), {dir: aiConfig.remRunStateDir});
 
             const {callTool} = await import('../../../../../ai/mcp/server/memory-core/toolService.mjs');
-            const state = await callTool('get_rem_pipeline_state', {});
+            const state      = await callTool('get_rem_pipeline_state', {});
 
             expect(state.recentCycles).toEqual([{
                 runId              : 'rem-new',


### PR DESCRIPTION
Resolves #14277

Clarifies `TopologyInferenceEngine` as a Dream Pipeline topology-conflict service: service-local helper logic now lives behind documented class methods, the local AiConfig leaf assertion layer is gone, and stale `getTopologyConflictCount()` prose now matches the current `extractTopology()` result contract. The related REM observability spec now overrides the active unit-test handoff leaf (`handoffFilePathTest`) instead of mutating the computed `handoffFilePath` formula output.

Evidence: L2 local static + unit coverage satisfies the #14277 source-boundary and observability-test ACs. Residual: CI must rerun the same unit surface on GitHub.

## Deltas from ticket

- Kept the existing `Memory_Config` service-singleton import path for `TopologyInferenceEngine`. A direct config import was tested and rejected because the current REM observability spec mutates the shared services config singleton; the actual ADR 0019 cleanup is removal of the custom pass-through leaf assertion helpers and direct reads from resolved leaves at the use sites.
- Extended the scope to the adjacent `rem-observability.spec.mjs` override leaf after the targeted test exposed stale `handoffFilePath` mutation. The config comments already say unit specs must use by-construction test handoff paths, and the pre-commit `check-aiconfig-test-mutation` gate accepted the updated `handoffFilePathTest` shape.

## Test Evidence

- `node --check ai/services/graph/TopologyInferenceEngine.mjs`
- `node --check test/playwright/unit/ai/services/rem-observability.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/services/rem-observability.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs` - 61/61 passed
- `npm run agent-preflight -- ai/services/graph/TopologyInferenceEngine.mjs test/playwright/unit/ai/services/rem-observability.spec.mjs`
- Pre-commit hooks passed, including `check-aiconfig-test-mutation`, `check-jsdoc-types`, `check-ticket-archaeology`, and `check-block-alignment`.

## Post-Merge Validation

- [ ] GitHub unit-test CI remains green on the PR head.

## Commits

- `f70dc8d59b` - `refactor(ai): clarify topology inference service boundary (#14277)`

## Evolution

Initial validation exposed that importing the memory-core config directly was not behavior-equivalent for the existing test harness. I kept the shared services singleton path, because this ticket is a service-boundary cleanup, not a config-object migration, and removed the actual local anti-pattern: custom AiConfig leaf validation helpers that defensively wrapped already-resolved Provider leaves.

Authored by Euclid (GPT-5, Codex Desktop). Session adf600d1-5f76-41d1-ad24-96722046d260.
