### PR TITLE
refactor(ai): extract the embedding-dimension helpers out of GoldenPathSynthesizer (#14283)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -14,6 +14,11 @@ import {
     formatGoldenPathCapturedAt as formatGoldenPathTimestamp
 } from './goldenPathTimestamp.mjs';
 import {
+    buildEmbeddingDimensionMismatchMessage,
+    getEmbeddingModelName,
+    getEmbeddingVectorLength
+} from './embeddingDimension.mjs';
+import {
     buildCurrentFocusCandidates as buildIssueFocusCurrentFocusCandidates,
     buildSilentThreadCandidates as buildIssueFocusSilentThreadCandidates,
     buildStaleAssignmentCandidates as buildIssueFocusStaleAssignmentCandidates,
@@ -68,60 +73,9 @@ const SOCIAL_NAME_TO_LOGIN = Object.freeze(Object.fromEntries(
         .map(identity => [identity.name, identity.properties.githubLogin.replace(/^@/, '')])
 ));
 
-/**
- * @summary Returns the vector length emitted by an embedding provider.
- *
- * Kept as a pure helper so the Golden Path query boundary can validate the provider output
- * before ChromaDB rejects a mismatched query shape.
- *
- * @param {*} embedding Provider-produced embedding payload.
- * @returns {Number|null} The embedding vector length, or null for invalid/non-vector payloads.
- */
-export function getEmbeddingVectorLength(embedding) {
-    return Number.isInteger(embedding?.length) ? embedding.length : null;
-}
-
-/**
- * @summary Resolves the configured embedding model name for the active provider.
- *
- * @param {Object} config Memory Core config object.
- * @param {String} provider Active embedding provider key.
- * @returns {String|null}
- */
-export function getEmbeddingModelName(config, provider) {
-    switch (provider) {
-        case 'openAiCompatible':
-            return config.openAiCompatible?.embeddingModel || null;
-        case 'ollama':
-            return config.ollama?.embeddingModel || null;
-        case 'gemini':
-            return config.embeddingModel || null;
-        default:
-            return null;
-    }
-}
-
-/**
- * @summary Builds the operator-facing Golden Path dimension mismatch warning.
- *
- * The message intentionally names both config and observed dimensions because this is the
- * runtime evidence operators need to align `NEO_EMBEDDING_PROVIDER`, `NEO_VECTOR_DIMENSION`,
- * and the existing Chroma collection dimension without destructive collection rebuilds.
- *
- * @param {Object} options
- * @param {String} options.provider Active embedding provider key.
- * @param {String|null} options.model Active embedding model name.
- * @param {Number} options.configuredDimension Configured vector dimension.
- * @param {Number|null} options.actualDimension Provider-produced vector length.
- * @returns {String}
- */
-export function buildEmbeddingDimensionMismatchMessage({provider, model, configuredDimension, actualDimension}) {
-    return `[GoldenPathSynthesizer] Embedding dimension mismatch before Chroma query: ` +
-        `provider=${provider || '<unset>'}, model=${model || '<unknown>'}, ` +
-        `configuredVectorDimension=${configuredDimension}, actualEmbeddingDimension=${actualDimension}. ` +
-        `Skipping semantic route. Align NEO_EMBEDDING_PROVIDER / NEO_VECTOR_DIMENSION with ` +
-        `the Chroma collection dimension, or rebuild the collection intentionally after backup.`;
-}
+// The embedding-dimension helpers were extracted to ./embeddingDimension.mjs (the SRP decomposition). They are
+// imported above for the internal dimension guard, and re-exported here so the public API stays stable.
+export {buildEmbeddingDimensionMismatchMessage, getEmbeddingModelName, getEmbeddingVectorLength};
 
 /**
  * @class Neo.ai.daemons.services.GoldenPathSynthesizer

--- a/ai/services/graph/embeddingDimension.mjs
+++ b/ai/services/graph/embeddingDimension.mjs
@@ -1,0 +1,64 @@
+/**
+ * @module ai/services/graph/embeddingDimension
+ * @summary Pure embedding-dimension validation helpers for the Golden Path query boundary — resolve the active
+ * provider's embedding model, measure a provider-produced vector's length, and build the operator-facing
+ * dimension-mismatch warning. Extracted out of `GoldenPathSynthesizer` (the SRP-decomposition epic) so the
+ * dimension guard is independently testable and the synthesizer is not a catch-all. No I/O; pure functions.
+ */
+
+/**
+ * @summary Returns the vector length emitted by an embedding provider.
+ *
+ * Kept as a pure helper so the Golden Path query boundary can validate the provider output
+ * before ChromaDB rejects a mismatched query shape.
+ *
+ * @param {*} embedding Provider-produced embedding payload.
+ * @returns {Number|null} The embedding vector length, or null for invalid/non-vector payloads.
+ */
+export function getEmbeddingVectorLength(embedding) {
+    return Number.isInteger(embedding?.length) ? embedding.length : null;
+}
+
+/**
+ * @summary Resolves the configured embedding model name for the active provider.
+ *
+ * @param {Object} config   Memory Core config object.
+ * @param {String} provider Active embedding provider key.
+ * @returns {String|null}
+ */
+export function getEmbeddingModelName(config, provider) {
+    switch (provider) {
+        case 'openAiCompatible':
+            return config.openAiCompatible?.embeddingModel || null;
+        case 'ollama':
+            return config.ollama?.embeddingModel || null;
+        case 'gemini':
+            return config.embeddingModel || null;
+        default:
+            return null;
+    }
+}
+
+/**
+ * @summary Builds the operator-facing Golden Path dimension mismatch warning.
+ *
+ * The message intentionally names both config and observed dimensions because this is the
+ * runtime evidence operators need to align `NEO_EMBEDDING_PROVIDER`, `NEO_VECTOR_DIMENSION`,
+ * and the existing Chroma collection dimension without destructive collection rebuilds. The
+ * `[GoldenPathSynthesizer]` prefix is retained verbatim — this is operator-facing runtime
+ * evidence, so the message stays byte-identical across the extraction (behavior-preserving).
+ *
+ * @param {Object}      options
+ * @param {String}      options.provider           Active embedding provider key.
+ * @param {String|null} options.model              Active embedding model name.
+ * @param {Number}      options.configuredDimension Configured vector dimension.
+ * @param {Number|null} options.actualDimension    Provider-produced vector length.
+ * @returns {String}
+ */
+export function buildEmbeddingDimensionMismatchMessage({provider, model, configuredDimension, actualDimension}) {
+    return `[GoldenPathSynthesizer] Embedding dimension mismatch before Chroma query: ` +
+        `provider=${provider || '<unset>'}, model=${model || '<unknown>'}, ` +
+        `configuredVectorDimension=${configuredDimension}, actualEmbeddingDimension=${actualDimension}. ` +
+        `Skipping semantic route. Align NEO_EMBEDDING_PROVIDER / NEO_VECTOR_DIMENSION with ` +
+        `the Chroma collection dimension, or rebuild the collection intentionally after backup.`;
+}

--- a/test/playwright/unit/ai/services/graph/embeddingDimension.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/embeddingDimension.spec.mjs
@@ -1,0 +1,84 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'EmbeddingDimensionTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('embeddingDimension — pure embedding-dimension helpers (GoldenPathSynthesizer SRP extraction)', () => {
+    let getEmbeddingVectorLength;
+    let getEmbeddingModelName;
+    let buildEmbeddingDimensionMismatchMessage;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/graph/embeddingDimension.mjs');
+        getEmbeddingVectorLength               = mod.getEmbeddingVectorLength;
+        getEmbeddingModelName                  = mod.getEmbeddingModelName;
+        buildEmbeddingDimensionMismatchMessage = mod.buildEmbeddingDimensionMismatchMessage;
+    });
+
+    test('getEmbeddingVectorLength returns the integer length of a vector, null for non-vector payloads', () => {
+        expect(getEmbeddingVectorLength([1, 2, 3])).toBe(3);
+        expect(getEmbeddingVectorLength([])).toBe(0);
+        expect(getEmbeddingVectorLength(null)).toBe(null);
+        expect(getEmbeddingVectorLength(undefined)).toBe(null);
+        expect(getEmbeddingVectorLength({})).toBe(null);
+        expect(getEmbeddingVectorLength({length: 2.5})).toBe(null);
+    });
+
+    test('getEmbeddingModelName resolves the model per provider, null for unknown / missing config', () => {
+        const config = {
+            openAiCompatible: {embeddingModel: 'text-embedding-3-small'},
+            ollama          : {embeddingModel: 'nomic-embed-text'},
+            embeddingModel  : 'gemini-embedding-001'
+        };
+
+        expect(getEmbeddingModelName(config, 'openAiCompatible')).toBe('text-embedding-3-small');
+        expect(getEmbeddingModelName(config, 'ollama')).toBe('nomic-embed-text');
+        expect(getEmbeddingModelName(config, 'gemini')).toBe('gemini-embedding-001');
+        expect(getEmbeddingModelName(config, 'unknownProvider')).toBe(null);
+
+        // Missing provider sub-config falls back to null (the `|| null` guard), never throws.
+        expect(getEmbeddingModelName({}, 'openAiCompatible')).toBe(null);
+        expect(getEmbeddingModelName({}, 'ollama')).toBe(null);
+        expect(getEmbeddingModelName({}, 'gemini')).toBe(null);
+    });
+
+    test('buildEmbeddingDimensionMismatchMessage names both dimensions + falls back for unset provider/model', () => {
+        const msg = buildEmbeddingDimensionMismatchMessage({
+            provider           : 'gemini',
+            model              : 'gemini-embedding-001',
+            configuredDimension: 768,
+            actualDimension    : 1536
+        });
+
+        expect(msg).toContain('[GoldenPathSynthesizer]');
+        expect(msg).toContain('provider=gemini');
+        expect(msg).toContain('model=gemini-embedding-001');
+        expect(msg).toContain('configuredVectorDimension=768');
+        expect(msg).toContain('actualEmbeddingDimension=1536');
+
+        const fallback = buildEmbeddingDimensionMismatchMessage({
+            provider           : null,
+            model              : null,
+            configuredDimension: 768,
+            actualDimension    : null
+        });
+
+        expect(fallback).toContain('provider=<unset>');
+        expect(fallback).toContain('model=<unknown>');
+        expect(fallback).toContain('actualEmbeddingDimension=null');
+    });
+});


### PR DESCRIPTION
Resolves #14283
Refs #14281

The first (lowest-blast) leaf of the GoldenPathSynthesizer SRP-decomposition (#14281): the 3 embedding-dimension helpers were misplaced embedding utils living in a Golden-Path file. A pure, behavior-preserving move.

Evidence: 39/39 unit green (the 3 new helper tests + the 36 existing GoldenPathSynthesizer tests — the re-export keeps the class behavior identical).

## What it does

- Moves `getEmbeddingVectorLength` / `getEmbeddingModelName` / `buildEmbeddingDimensionMismatchMessage` out of `GoldenPathSynthesizer.mjs` into a focused pure module `ai/services/graph/embeddingDimension.mjs`.
- `GoldenPathSynthesizer` imports them back (for the internal frontier dimension-guard at the embedding-query boundary) and **re-exports** them. The 3 were public `export function`s; the re-export keeps the public API stable (V-B-A'd: no external by-name consumers today — the shim is belt-and-suspenders + future-proof).
- The operator-facing mismatch message stays **byte-identical** (the `[GoldenPathSynthesizer]` prefix is retained) — behavior-preserving.
- Adds focused unit tests (the helpers were previously untested).

## Deltas from ticket

None — matches #14283. Pure move + re-export; no behavior change.

## Test Evidence

`npm run test-unit -- …/embeddingDimension.spec.mjs …/GoldenPathSynthesizer.spec.mjs` → **39/39 passed**:
- embeddingDimension (3): vector-length (valid/invalid payloads), model-name (each provider + null fallbacks), mismatch-message (both dimensions named + `<unset>`/`<unknown>` fallbacks).
- GoldenPathSynthesizer (36): the existing suite stays green — confirms the import + re-export is behavior-preserving.

`node --check` clean on all three files; block-alignment clean (the new import is multi-line so it does not realign the single-line import column — the GPS diff is the function-move only, not a whitespace sweep).

## Post-Merge Validation

- [ ] The Golden Path semantic-query dimension guard still emits the operator-facing mismatch warning when the provider vector length ≠ the configured dimension (unchanged behavior).

## Notes for the epic (#14281)

V-B-A during this extraction: several of the epic's named lanes — stale-assignment, silent-thread, current-focus, issue-markdown parsing — are **already** extracted to `ai/services/graph/issueFocusSections.mjs` (GoldenPathSynthesizer imports them at L13-30). The epic is over-scoped on those lanes; I will reconcile the epic body. The genuinely-unextracted clusters remaining are computed-recommendation/focus-contradiction, PR-cycle status+render, and frontier-edge/summary-doc.

## Commits

- `d9a38ad34` — the extraction + re-export shim + focused tests. Cut from fresh origin/dev (clean single commit).

Authored by Grace (@neo-opus-grace, Claude Opus 4.8, Claude Code). Origin session 090a68e6-1a28-4b20-a5fd-842ebac3e729.
