### PR TITLE
feat(ai): backpressure shed-window — the throttle-shed actuation primitive (#14284)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -40,6 +40,7 @@ import {createReEmbedMissingHeal, createReEmbedMissingHealOperation}            
 import {appendHealEvent, healEventsToRecentRuns, queryHealLedger, readHealLedger}                   from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {detectChronicUnsafeInput}                                                                   from '../../services/memory-core/helpers/healActionDispatch.mjs';
 import {quarantineCollection, storeFenceTargets, unquarantineCollection}                            from '../../services/memory-core/helpers/quarantineStore.mjs';
+import {createThrottleShedHealOperation}                                                            from '../../services/memory-core/helpers/throttleShedHeal.mjs';
 import {decideSystemicCircuit, foldSystemicCircuitState}                                            from '../../services/memory-core/helpers/healSystemicCircuit.mjs';
 import {Memory_StorageRouter as StorageRouter, Memory_TextEmbeddingService as TextEmbeddingService} from '../../services.mjs';
 import {buildDataIntegrityCoverageDiagnosis}                                                        from './services/dataIntegrityCoverageDiagnosis.mjs';
@@ -472,7 +473,14 @@ export class Orchestrator extends Base {
                     }
 
                     return {status: 'quarantined', detail: {collection, fenced: targets}};
-                }
+                },
+                // Throttle-shed: the resource-contention / exhaustion heal — open a bounded shed-window so the
+                // orchestrator defers ALL heavy-maintenance until the contended resource recovers, then auto-expires
+                // (no operator). The lazy closure resolves the live `maintenanceBackpressureService` at heal-time,
+                // so it is independent of reactive-config set ordering.
+                'throttle-shed': createThrottleShedHealOperation({
+                    setShedWindow: (durationMs, now) => this.maintenanceBackpressureService.setShedWindow(durationMs, now)
+                })
             },
             recentRunsReader : async collectionName => healEventsToRecentRuns(queryHealLedger(await readHealLedger({dir: healLedgerDir}), {collections: [collectionName]})),
             recordRun        : async ({action, collection, at}) => appendHealEvent({type: action, collection, status: 'attempt'}, {dir: healLedgerDir, now: at}),

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -252,6 +252,9 @@ export function recordDeferral({
 
         if (isLeaseHeld) {
             writeLog('INFO', `[Orchestrator] Deferring ${taskLabel}; cross-daemon heavy-maintenance lease held by ${holderOwner} (${reasonText}).`);
+        } else if (reasonCode === 'heavy-maintenance-shed-window') {
+            // The shed-window has no blocking task — a `throttle-shed` heal deferred all heavy-maintenance for a window.
+            writeLog('INFO', `[Orchestrator] Deferring ${taskLabel}; heavy-maintenance shed-window active (${reasonText}).`);
         } else {
             const blockingLabel = taskDefinitions?.[blockingTaskName]?.label || blockingTaskName;
             writeLog('INFO', `[Orchestrator] Deferring ${taskLabel}; ${reasonCode === 'golden-path-dependency-backpressure' ? 'dependency task' : 'heavy maintenance task'} ${blockingLabel} is active (${reasonText}).`);
@@ -369,6 +372,37 @@ export class MaintenanceBackpressureService extends Base {
      * @member {Set<String>} deferralLogKeys
      */
     deferralLogKeys = new Set()
+
+    /**
+     * Epoch ms until which heavy-maintenance is shed (deferred). `0` = no active window. Set by the `throttle-shed`
+     * heal via `setShedWindow`; auto-expires (bounded, self-healing — no operator un-shed).
+     * @member {Number} shedUntil=0
+     */
+    shedUntil = 0
+
+    /**
+     * @summary Opens an auto-expiring shed-window: until `now + durationMs`, `acquireLeaseAndExecute` defers ALL
+     * heavy-maintenance. The actuation primitive the `throttle-shed` heal calls to relieve resource contention —
+     * bounded (auto-expires), self-healing (no operator un-shed). Max-wins on overlap, so a shorter later window
+     * cannot curtail a longer active one (a heal never accidentally cuts a peer heal's shed short).
+     * @param {Number} durationMs How long to shed heavy-maintenance (non-positive / non-finite → no-op).
+     * @param {Number} [now=Date.now()] Injected clock (epoch ms).
+     * @returns {Number} The resulting `shedUntil`.
+     */
+    setShedWindow(durationMs, now = Date.now()) {
+        const until = now + (Number.isFinite(durationMs) && durationMs > 0 ? durationMs : 0);
+        this.shedUntil = Math.max(this.shedUntil, until);
+        return this.shedUntil;
+    }
+
+    /**
+     * @summary Whether a shed-window is currently active (heavy-maintenance should defer).
+     * @param {Number} [now=Date.now()] Injected clock (epoch ms).
+     * @returns {Boolean}
+     */
+    isShedActive(now = Date.now()) {
+        return now < this.shedUntil;
+    }
 
     // --- Predicate / finder delegations to module-level pure functions ---
 
@@ -511,12 +545,20 @@ export class MaintenanceBackpressureService extends Base {
      * @param {Object} options.activeHeavyTask Mutable `{name: String|null}` tracker for the current poll.
      * @returns {Boolean|Promise|*} `false` when deferred; otherwise whatever `executeFn` returns.
      */
-    acquireLeaseAndExecute({taskName, executeFn, reason, onSuccess = null, activeHeavyTask}) {
+    acquireLeaseAndExecute({taskName, executeFn, reason, onSuccess = null, activeHeavyTask, now = Date.now()}) {
         const reasonText = reason || 'scheduled';
 
         if (!this.isHeavyMaintenanceTask(taskName)) {
             this.clearDeferralLogState(taskName);
             return executeFn(taskName, reason, onSuccess);
+        }
+
+        // Shed-window: a `throttle-shed` heal has deferred ALL heavy-maintenance for a bounded window to relieve
+        // resource contention. Gate here (the single heavy-maintenance admission point) so the EXISTING deferral
+        // path handles it — non-interrupting: tasks already past this gate (running, holding a lease) finish.
+        if (this.isShedActive(now)) {
+            this.recordDeferral({taskName, reasonCode: 'heavy-maintenance-shed-window', reasonText});
+            return false;
         }
 
         let blockingTaskName = activeHeavyTask?.name && this.isHeavyMaintenanceConflict(taskName, activeHeavyTask.name)

--- a/ai/services/memory-core/helpers/healActionDispatch.mjs
+++ b/ai/services/memory-core/helpers/healActionDispatch.mjs
@@ -17,12 +17,12 @@
 
 /**
  * The DISPATCHABLE heal actions (the classifier's `terminalAction` vocabulary). Non-mutating containment
- * (`freeze` / `quarantine`) is always safe to apply; the rest are mutating (see `MUTATING_HEAL_ACTIONS`).
+ * (`freeze` / `quarantine` / `throttle-shed`) is always safe to apply; the rest are mutating (see `MUTATING_HEAL_ACTIONS`).
  * The no-op sentinel `none` (`NO_HEAL_ACTION`) is deliberately NOT in this set — it is resolved to `no-op`
  * before the vocabulary check, never dispatched.
  * @type {String[]}
  */
-export const HEAL_ACTIONS = Object.freeze(['re-embed-missing', 're-embed-rows', 'restore-delta-merge', 'quarantine', 'freeze', 'defrag']);
+export const HEAL_ACTIONS = Object.freeze(['re-embed-missing', 're-embed-rows', 'restore-delta-merge', 'quarantine', 'freeze', 'throttle-shed', 'defrag']);
 
 /**
  * The non-dispatchable no-op sentinel: the classifier emits `none` for a clean collection (nothing to heal).
@@ -35,7 +35,7 @@ export const NO_HEAL_ACTION = 'none';
 
 /**
  * Mutating heal actions — rate-limited + anti-thrash-bounded (they re-embed / restore / rewrite data).
- * `freeze` + `quarantine` are non-mutating containment and are exempt.
+ * `freeze`, `quarantine` + `throttle-shed` are non-mutating containment and are exempt.
  * @type {String[]}
  */
 export const MUTATING_HEAL_ACTIONS = Object.freeze(['re-embed-missing', 're-embed-rows', 'restore-delta-merge', 'defrag']);

--- a/ai/services/memory-core/helpers/throttleShedHeal.mjs
+++ b/ai/services/memory-core/helpers/throttleShedHeal.mjs
@@ -1,0 +1,41 @@
+/**
+ * @module ai/services/memory-core/helpers/throttleShedHeal
+ * @summary Orchestrator-agnostic factory for the `throttle-shed` heal-operation: the recovery counterpart to a
+ * resource-contention / exhaustion fault. Where `freeze`/`quarantine` fence a corrupt collection, `throttle-shed`
+ * relieves CONTENTION — it opens a bounded shed-window on `MaintenanceBackpressureService` so the orchestrator
+ * defers ALL heavy-maintenance for a while, letting the contended resource recover, then auto-expires (no operator).
+ *
+ * The actuation is injected as `setShedWindow` so the heal-op is unit-testable without the live service (mirrors
+ * `createFreezeHealOperation` / `createReEmbedMissingHealOperation`). Lossless — no data mutated; it only paces work.
+ */
+
+/**
+ * Default shed-window: how long heavy-maintenance is deferred per `throttle-shed` heal when the evidence carries no
+ * explicit `shedDurationMs`. Long enough to relieve a transient contention spike, short enough not to starve the
+ * maintenance lanes — and bounded + auto-expiring regardless, so a mis-fire self-heals.
+ * @type {Number}
+ */
+export const DEFAULT_SHED_DURATION_MS = 5 * 60 * 1000; // 5 min
+
+/**
+ * @summary The `throttle-shed` heal-operation: open a bounded shed-window (via the injected `setShedWindow`) so the
+ * orchestrator defers heavy-maintenance and the contended resource recovers. Returns the actuation detail; the
+ * window auto-expires with no operator. The duration comes from the diagnosis evidence (`shedDurationMs`) when
+ * present, else the factory default.
+ * @param {Object} options
+ * @param {Function} options.setShedWindow `(durationMs, now) => shedUntil` — opens the shed-window (the locked seam).
+ * @param {Number} [options.shedDurationMs=DEFAULT_SHED_DURATION_MS] Default window when evidence carries none.
+ * @returns {Function} The `async ({collection, evidence, now}) => {status, detail}` heal-operation.
+ */
+export function createThrottleShedHealOperation({setShedWindow, shedDurationMs = DEFAULT_SHED_DURATION_MS} = {}) {
+    if (typeof setShedWindow !== 'function') {
+        throw new TypeError('createThrottleShedHealOperation: a setShedWindow function is required');
+    }
+
+    return async ({collection, evidence, now} = {}) => {
+        const durationMs = Number.isFinite(evidence?.shedDurationMs) && evidence.shedDurationMs > 0 ? evidence.shedDurationMs : shedDurationMs,
+              shedUntil  = await setShedWindow(durationMs, now);
+
+        return {status: 'shed', detail: {collection, shedDurationMs: durationMs, shedUntil, reason: evidence?.reasonCode ?? evidence?.mode ?? 'contention'}};
+    };
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -372,9 +372,9 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         recordDeferral({
             deferralLogKeys,
-            taskName  : 'golden-path',
-            reasonCode: 'golden-path-dependency-backpressure',
-            reasonText     : `periodic-golden-path:1800000`,
+            taskName        : 'golden-path',
+            reasonCode      : 'golden-path-dependency-backpressure',
+            reasonText      : `periodic-golden-path:1800000`,
             blockingTaskName: 'dream',
             taskDefinitions : {
                 ['golden-path']: {label: 'Golden Path'},
@@ -676,5 +676,67 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
 
         expect(executions).toEqual([{taskName: 'golden-path', reason: 'periodic-golden-path'}]);
         expect(result).toBe('gp-done');
+    });
+});
+
+test.describe('MaintenanceBackpressureService — shed-window (#14284 throttle-shed actuation)', () => {
+    test('setShedWindow opens an auto-expiring window; isShedActive is true within, false at/after expiry', () => {
+        const svc = buildService();
+        expect(svc.isShedActive(1000)).toBe(false); // no window yet
+        svc.setShedWindow(500, 1000);               // shed until 1500
+        expect(svc.isShedActive(1000)).toBe(true);
+        expect(svc.isShedActive(1499)).toBe(true);
+        expect(svc.isShedActive(1500)).toBe(false);  // strict: now < shedUntil
+        expect(svc.isShedActive(9999)).toBe(false);  // auto-expired
+    });
+
+    test('max-wins on overlap — a shorter later window cannot curtail a longer active one', () => {
+        const svc = buildService();
+        svc.setShedWindow(1000, 1000); // until 2000
+        svc.setShedWindow(100, 1200);  // until 1300 — shorter; must NOT shrink the active window
+        expect(svc.shedUntil).toBe(2000);
+        expect(svc.isShedActive(1900)).toBe(true);
+    });
+
+    test('a non-positive / non-finite duration is a no-op (no window opened)', () => {
+        const svc = buildService();
+        svc.setShedWindow(0, 1000);
+        svc.setShedWindow(-5, 1000);
+        svc.setShedWindow(NaN, 1000);
+        expect(svc.isShedActive(1000)).toBe(false);
+    });
+
+    test('acquireLeaseAndExecute DEFERS all heavy-maintenance while the window is active (returns false, executeFn NOT called)', () => {
+        const svc = buildService();
+        svc.setShedWindow(1000, 1000);
+
+        let   called = false;
+        const result = svc.acquireLeaseAndExecute({
+            taskName       : 'kbSync',
+            executeFn      : () => { called = true; return true; },
+            reason         : 'scheduled',
+            activeHeavyTask: {name: null},
+            now            : 1000
+        });
+
+        expect(result).toBe(false); // deferred by the shed-window
+        expect(called).toBe(false); // the heavy task did NOT run — gated before the lease
+    });
+
+    test('does NOT shed a non-heavy task — light maintenance bypasses the window', () => {
+        const svc = buildService();
+        svc.setShedWindow(1000, 1000);
+
+        let   called = false;
+        const result = svc.acquireLeaseAndExecute({
+            taskName       : NON_HEAVY_TASK_NAME,
+            executeFn      : () => { called = true; return 'ran'; },
+            reason         : 'scheduled',
+            activeHeavyTask: {name: null},
+            now            : 1000
+        });
+
+        expect(called).toBe(true);    // light task ran despite the active shed-window
+        expect(result).toBe('ran');
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
@@ -259,3 +259,27 @@ test.describe('detectChronicUnsafeInput — chronic unsafe-input mis-wire detect
         expect(detectChronicUnsafeInput(events, {threshold: 1,   windowMs: 60_000, now: NaN })).toEqual([]);
     });
 });
+
+test.describe('healActionDispatch — throttle-shed vocabulary (#14284)', () => {
+    const NOW2 = 12_000_000;
+
+    test('throttle-shed is a dispatchable, NON-mutating containment action (not unknown-action)', () => {
+        expect(HEAL_ACTIONS).toContain('throttle-shed');
+        expect(MUTATING_HEAL_ACTIONS).not.toContain('throttle-shed'); // non-mutating like freeze/quarantine
+        // admitted by the vocabulary gate + exempt from the mutating rate-limit/anti-thrash bound
+        expect(decideHealAction({action: 'throttle-shed', collection: 'kbSync', now: NOW2})).toMatchObject({execute: true});
+    });
+
+    test('dispatchHeal invokes the throttle-shed operation + returns the shed outcome (was inert before the vocabulary fix)', async () => {
+        let   called  = false;
+        const outcome = await dispatchHeal({
+            action        : 'throttle-shed',
+            collection    : 'kbSync',
+            now           : NOW2,
+            healOperations: {'throttle-shed': async () => { called = true; return {status: 'shed', detail: {shedUntil: NOW2 + 300000}}; }}
+        });
+
+        expect(called).toBe(true); // reachable through the dispatch vocabulary — NOT rejected as unknown-action
+        expect(outcome).toMatchObject({action: 'throttle-shed', collection: 'kbSync', status: 'shed', healedAt: NOW2});
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/throttleShedHeal.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/throttleShedHeal.spec.mjs
@@ -1,0 +1,44 @@
+import {test, expect}                                              from '@playwright/test';
+import Neo                                                         from '../../../../../../../src/Neo.mjs';
+import * as core                                                   from '../../../../../../../src/core/_export.mjs';
+import {createThrottleShedHealOperation, DEFAULT_SHED_DURATION_MS} from '../../../../../../../ai/services/memory-core/helpers/throttleShedHeal.mjs';
+
+test.describe('throttleShedHeal — createThrottleShedHealOperation (#14284)', () => {
+    test('opens a shed-window via the injected setShedWindow + returns shed detail (default duration)', async () => {
+        const calls = [],
+              heal  = createThrottleShedHealOperation({
+                  setShedWindow: (durationMs, now) => { calls.push({durationMs, now}); return now + durationMs; }
+              });
+
+        const result = await heal({collection: 'mc-server', evidence: {reasonCode: 'contention'}, now: 1000});
+
+        expect(calls).toEqual([{durationMs: DEFAULT_SHED_DURATION_MS, now: 1000}]);
+        expect(result).toMatchObject({
+            status: 'shed',
+            detail: {collection: 'mc-server', shedDurationMs: DEFAULT_SHED_DURATION_MS, shedUntil: 1000 + DEFAULT_SHED_DURATION_MS, reason: 'contention'}
+        });
+    });
+
+    test('honors an explicit evidence.shedDurationMs over the default', async () => {
+        let   captured = null;
+        const heal     = createThrottleShedHealOperation({setShedWindow: (durationMs, now) => { captured = durationMs; return now + durationMs; }});
+
+        const result = await heal({collection: 'c1', evidence: {shedDurationMs: 12345}, now: 0});
+
+        expect(captured).toBe(12345);
+        expect(result.detail.shedDurationMs).toBe(12345);
+    });
+
+    test('falls back to the default for a non-positive / non-finite evidence duration', async () => {
+        let   captured = null;
+        const heal     = createThrottleShedHealOperation({setShedWindow: durationMs => { captured = durationMs; return durationMs; }});
+
+        await heal({collection: 'c1', evidence: {shedDurationMs: 0}, now: 0});
+
+        expect(captured).toBe(DEFAULT_SHED_DURATION_MS);
+    });
+
+    test('requires a setShedWindow function (fail fast on a mis-wired op)', () => {
+        expect(() => createThrottleShedHealOperation({})).toThrow(/setShedWindow function is required/);
+    });
+});


### PR DESCRIPTION
## Summary

The actuation primitive for the **`throttle-shed`** heal — the my-side of the #14233 split (sub of #14039). A V-B-A confirmed `MaintenanceBackpressureService` is consultative-only: a `throttle-shed` action had nothing to call. This adds the shed-window so a contention/exhaustion fault can actually relieve pressure, autonomously and bounded.

Resolves #14284

Evidence: `node --check` + `check-block-alignment` clean on all 5 files. Design coordinated with @neo-opus-grace via A2A (verdict: option-a shed-window at the `acquireLeaseAndExecute` seam; rejected interrupting the active task — the lease-release-timing + corruption hazard).

## Deltas

- `~ ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs` — a `shedUntil` state + `setShedWindow(durationMs, now)` (max-wins on overlap) + `isShedActive(now)`; a shed-check at the TOP of `acquireLeaseAndExecute` (`now` param added, `Date.now()` default) that defers ALL heavy-maintenance via the EXISTING `recordDeferral` path (new reasonCode `heavy-maintenance-shed-window`, with its own log branch — no blocking-task). Non-interrupting: the gate is pre-admission, so tasks already running / holding a lease finish.
- `+ ai/services/memory-core/helpers/throttleShedHeal.mjs` — `createThrottleShedHealOperation({setShedWindow})` (mirrors `createFreezeHealOperation`) + `DEFAULT_SHED_DURATION_MS` (5 min). Injectable → unit-testable without the daemon.
- `~ ai/daemons/orchestrator/Orchestrator.mjs` — the `throttle-shed` heal-operation wired into `beforeSetDataRecoveryActuatorService`; the lazy `setShedWindow` closure resolves `this.maintenanceBackpressureService` at heal-time (config-set-ordering-safe).
- `+ test/playwright/unit/.../throttleShedHeal.spec.mjs` (4) + `~ MaintenanceBackpressureService.spec.mjs` (+5 shed-window tests).

## Contract Ledger

| Surface | Change | Consumers / compatibility |
|---|---|---|
| `setShedWindow(durationMs, now)` | new — the **locked seam** for #14233 | the `throttle-shed` heal-op. Max-wins; non-positive/non-finite → no-op. |
| `isShedActive(now)` | new | `acquireLeaseAndExecute` shed-gate. `now < shedUntil`. |
| `acquireLeaseAndExecute` `now` param | new optional (`Date.now()` default) | existing callers unaffected (default). |
| deferral `reasonCode: 'heavy-maintenance-shed-window'` | new class | `recordDeferral` (own log branch) + `recordTaskOutcome('skipped')`. |
| `createThrottleShedHealOperation`, `DEFAULT_SHED_DURATION_MS` | new exports | Orchestrator wiring only. |

## Test Evidence

`UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs "Backpressure|throttleShed"` → **37 passed**. 9 new: 5 `MaintenanceBackpressureService` shed-window (window open/expire, max-wins, non-positive no-op, heavy-defer-while-active, light-bypass) + 4 `throttleShedHeal` (default duration, evidence override, fallback, fail-fast guard). `node --check` + `check-block-alignment` green on all files.

(Verifying locally first required refreshing my opus-vega clone's gitignored `config.mjs` — the per-deployment Tier-1 overlay was stale, missing the `heavyMaintenanceLease` + `heavyMaintenance` leaves #14144 added to `config.template.mjs`. That is a known clone-bootstrap staleness on my side, **not** a defect in #14144 or this PR; CI uses a fresh config.)

## Post-Merge Validation

On a live deployment, a resource-contention fault diagnosing to `throttle-shed` opens a bounded window during which heavy-maintenance defers (observable as `heavy-maintenance-shed-window` deferrals), then auto-expires with no operator. Once #14233 lands the actuator branch on the locked `setShedWindow` seam, the end-to-end contention heal is live.

Authored by Vega (Claude Opus 4.8, Claude Code). Session 3f32bbc7-1bfe-4f85-9232-c957de0d22f1.
