### PR TITLE
fix(ai): align review-body CI lint with micro-delta (#13910)

### DIFF
--- a/.github/workflows/agent-pr-review-body-lint.yml
+++ b/.github/workflows/agent-pr-review-body-lint.yml
@@ -54,10 +54,10 @@ jobs:
             // structure (empirical anchor: review 4304287893 on PR #11499 had all 7
             // visible tags but missing structural anchors — would have passed visible-only).
             //
-            // ⚠️  SYNCHRONIZATION PROTOCOL: these lists MUST stay in sync with
-            // `ai/services/github-workflow/PullRequestService.mjs` constants
-            // `VISIBLE_PR_REVIEW_ANCHORS` + `INVISIBLE_PR_REVIEW_ANCHORS`. If you edit
-            // either side, edit the other simultaneously. Follow-up ticket candidate:
+            // ⚠️  SYNCHRONIZATION PROTOCOL: these lists and tier checks MUST stay in sync
+            // with `ai/services/github-workflow/PullRequestService.mjs` review-template
+            // constants. If you edit either side, edit the other simultaneously.
+            // Follow-up ticket candidate:
             // extract to shared module `ai/services/github-workflow/prReviewAnchors.mjs`
             // (see #11501 cross-surface enhancement ticket).
             // ──────────────────────────────────────────────────────────────────────
@@ -78,16 +78,41 @@ jobs:
               "Strategic-Fit Decision"
             ];
 
-            // OPTIONAL-FIRST migration anchors for #12442/#12448. Old reviews without a
-            // premise snapshot still pass; reviews that start emitting the snapshot must emit
-            // the complete three-field shape so partial back-rationalized snapshots do not pass.
-            // Match the distinctive bold template labels, not bare prose, so incidental phrases
-            // like "Patch Verdict" do not activate the partial-snapshot gate.
-            const OPTIONAL_PR_REVIEW_PREMISE_ANCHORS = [
+            // Required premise-snapshot anchors. Match the distinctive bold template labels,
+            // not bare prose, so incidental phrases like "Patch Verdict" do not satisfy the gate.
+            const REQUIRED_PR_REVIEW_PREMISE_ANCHORS = [
               {label: "Inputs Read Before Patch", token: "**Inputs Read Before Patch:**"},
               {label: "Expected Solution Shape",  token: "**Expected Solution Shape:**"},
-              {label: "Patch Verdict",            token: "**Patch Verdict:**"}
+              {label: "Patch Verdict",            token: "**Patch Verdict:**"},
+              {label: "Premise Coherence",        token: "**Premise Coherence:**"}
             ];
+
+            const MICRO_DELTA_PR_REVIEW_SHAPE_HINTS = [
+              "# Pull Request Micro-Delta Review",
+              "### State Vector",
+              "### Micro-Delta Focus",
+              "### Verdict"
+            ];
+
+            const MICRO_DELTA_PR_REVIEW_TEMPLATE_SKELETON_ANCHORS = [
+              "# Pull Request Micro-Delta Review",
+              "> **Context:**",
+              "### State Vector",
+              "- **Target SHA:**",
+              "- **Current reviewDecision:**",
+              "- **Semantic Status:**",
+              "- **CI Status:**",
+              "- **Remaining Blocker Class:**",
+              "- **Measured Discussion Cost:**",
+              "### Micro-Delta Focus",
+              "*Only defects classified as `mechanical-hygiene` or `metadata-drift` are reviewed here.*",
+              "### Verdict",
+              "**APPROVED**",
+              "**CHANGES_REQUESTED**",
+              "**MAINTAINER POLISH FAST PATH APPLIED**"
+            ];
+
+            const MICRO_DELTA_REVIEW_BLOCKER_CLASS_PATTERN = /(?:^|[^\w-])(mechanical-hygiene|metadata-drift)(?:$|[^\w-])/i;
 
             // Micro-Review (Cycle-1, blast-scaled) light path — KEEP IN SYNC with
             // ai/services/github-workflow/PullRequestService.mjs MICRO_REVIEW_* constants.
@@ -99,25 +124,76 @@ jobs:
               const microMisses = ["# PR Micro-Review", "**Class:**", "**Verdict:**", "**Glance:**"]
                 .filter(a => !body.includes(a));
               const microClassLine = body.split("\n").find(l => l.includes("**Class:**")) || "";
-              if (!/(?:^|[^\w-])(micro|contained)(?:$|[^\w-])/i.test(microClassLine)) {
-                microMisses.push("Class: micro | contained");
+              if (!/(?:^|[^\w-])(micro|contained|mechanical)(?:$|[^\w-])/i.test(microClassLine)) {
+                microMisses.push("Class: micro | contained | mechanical");
               }
               if (microMisses.length === 0) {
                 console.log("✅ Micro-Review body matches the blast-scaled light shape.");
                 return;
               }
-              core.setFailed(`Agent micro-review body missing the minimal shape (header + "**Class:** micro|contained" + "**Verdict:**" + "**Glance:**"). See .agents/skills/pr-review/assets/pr-review-micro-review-template.md`);
+              core.setFailed(`Agent micro-review body missing the minimal shape (header + "**Class:** micro|contained|mechanical" + "**Verdict:**" + "**Glance:**"). See .agents/skills/pr-review/assets/pr-review-micro-review-template.md`);
+              return;
+            }
+
+            const isMicroDeltaPrReview = body.includes(MICRO_DELTA_PR_REVIEW_SHAPE_HINTS[0]) || (
+              body.includes("### State Vector") &&
+              body.includes("### Micro-Delta Focus")
+            );
+
+            if (isMicroDeltaPrReview) {
+              const microDeltaMisses = MICRO_DELTA_PR_REVIEW_TEMPLATE_SKELETON_ANCHORS
+                .filter(a => !body.includes(a));
+              const remainingBlockerLine = body.split("\n").find(l => l.includes("- **Remaining Blocker Class:**")) || "";
+
+              if (!MICRO_DELTA_REVIEW_BLOCKER_CLASS_PATTERN.test(remainingBlockerLine)) {
+                microDeltaMisses.push("Remaining Blocker Class: mechanical-hygiene | metadata-drift");
+              }
+
+              if (microDeltaMisses.length === 0) {
+                console.log("✅ Micro-Delta body matches the documented circuit-breaker shape.");
+                return;
+              }
+
+              const skillPath        = '.agents/skills/pr-review/SKILL.md';
+              const circuitPath      = '.agents/skills/pr-review/audits/review-cost-circuit-breaker.md';
+              const microDeltaPath   = '.agents/skills/pr-review/assets/pr-review-micro-delta-template.md';
+              const reviewUrl        = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${pr.number}#pullrequestreview-${review.id}`;
+              const diagnosticAnchor = microDeltaMisses[0] || null;
+
+              const commentBody = [
+                `## 🚨 Agent Micro-Delta Review Body Lint Violation`,
+                ``,
+                `@${reviewer} — your [review on PR #${pr.number}](${reviewUrl}) attempts the Micro-Delta format but does not match the documented circuit-breaker structure.`,
+                ``,
+                `**Required action**: read \`${skillPath}\`, \`${circuitPath}\`, and \`${microDeltaPath}\` BEFORE submitting a corrective re-review.`,
+                ``,
+                `Micro-Delta reviews are only valid after the Review-Loop Cost Circuit Breaker classifies the PR as state (a): semantics cleared, with only mechanical-hygiene or metadata-drift remaining.`,
+                `If a semantic or contract delta exists, use the full follow-up review template instead.`,
+                ``,
+                diagnosticAnchor
+                  ? `**Diagnostic hint**: at least one required Micro-Delta anchor like \`${diagnosticAnchor}\` is missing or invalid.`
+                  : `**Diagnostic hint**: the Micro-Delta structural template anchors do not match.`,
+                ``,
+                `<sub>This is the CI tool-boundary lint companion to PR #11494's MCP \`manage_pr_review\` validator.`,
+                `Both layers point you at the same skill substrate. Closes #11495 and #13910.</sub>`
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner       : context.repo.owner,
+                repo        : context.repo.repo,
+                issue_number: pr.number,
+                body        : commentBody
+              });
+
+              core.setFailed(`Agent micro-delta review body missing required circuit-breaker anchors. See follow-up comment on PR #${pr.number}.`);
               return;
             }
 
             const missingVisible         = VISIBLE_PR_REVIEW_ANCHORS         .filter(a => !body.includes(a));
             const missingInvisible       = INVISIBLE_PR_REVIEW_ANCHORS       .filter(a => !body.includes(a));
-            const presentPremiseSnapshot = OPTIONAL_PR_REVIEW_PREMISE_ANCHORS.filter(a =>  body.includes(a.token));
-            const missingPremiseSnapshot = presentPremiseSnapshot.length === 0
-              ? []
-              : OPTIONAL_PR_REVIEW_PREMISE_ANCHORS
-                .filter(a => !body.includes(a.token))
-                .map(a => a.label);
+            const missingPremiseSnapshot = REQUIRED_PR_REVIEW_PREMISE_ANCHORS
+              .filter(a => !body.includes(a.token))
+              .map(a => a.label);
 
             if (missingVisible.length === 0 && missingInvisible.length === 0 && missingPremiseSnapshot.length === 0) {
               console.log("✅ Review body contains all required anchors.");
@@ -150,7 +226,7 @@ jobs:
               `passing is reading the actual template file and following its structure.`,
               ``,
               missingPremiseSnapshot.length > 0
-                ? `**Premise snapshot note**: the snapshot is optional during migration, but partial snapshots are invalid. Either omit it entirely or include all three fields.`
+                ? `**Premise snapshot note**: all four premise fields, including **Premise Coherence:**, are required.`
                 : ``,
               ``,
               diagnosticAnchor

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -15,6 +15,10 @@ setup({
 });
 
 import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import path            from 'path';
+import vm              from 'vm';
+import yaml            from 'js-yaml';
 import Neo             from '../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
@@ -462,6 +466,70 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getPullReq
 });
 
 /**
+ * @summary Returns the inline GitHub Script used by the agent PR review-body lint workflow.
+ * @returns {String} The workflow script source.
+ */
+function getAgentPrReviewBodyLintScript() {
+    const
+        workflowPath = path.resolve(process.cwd(), '.github/workflows/agent-pr-review-body-lint.yml'),
+        workflow     = yaml.load(fs.readFileSync(workflowPath, 'utf8')),
+        step         = workflow.jobs['lint-pr-review-body'].steps.find(item => item.name === 'Validate PR Review Body');
+
+    return step.with.script;
+}
+
+/**
+ * @summary Executes the review-body lint workflow script with stubbed GitHub Actions services.
+ * @param {Object} options Execution options.
+ * @param {String} options.body Review body to validate.
+ * @param {String} [options.reviewer='neo-gpt'] GitHub login for the simulated reviewer.
+ * @returns {Promise<Object>} Captured workflow comments, failures, and log lines.
+ */
+async function runAgentPrReviewBodyLintWorkflow({body, reviewer = 'neo-gpt'} = {}) {
+    const
+        comments = [],
+        failures = [],
+        logs     = [],
+        context  = {
+            repo   : {owner: 'neomjs', repo: 'neo'},
+            payload: {
+                review: {
+                    id  : 1391001,
+                    user: {login: reviewer},
+                    body
+                },
+                pull_request: {number: 13910}
+            }
+        },
+        coreStub = {
+            setFailed: message => failures.push(message)
+        },
+        githubStub = {
+            rest: {
+                issues: {
+                    createComment: async payload => comments.push(payload)
+                }
+            }
+        },
+        consoleStub = {
+            log: message => logs.push(message)
+        };
+
+    await vm.runInNewContext(
+        `(async () => {\n${getAgentPrReviewBodyLintScript()}\n})()`,
+        {
+            console: consoleStub,
+            context,
+            core   : coreStub,
+            github : githubStub
+        },
+        {timeout: 1000}
+    );
+
+    return {comments, failures, logs};
+}
+
+/**
  * @summary Contract coverage for `PullRequestService.managePrReview`.
  *
  * Closes the formal-state gap: atomic create or update of a formal pull request review
@@ -617,8 +685,8 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         '- [ ] **MAINTAINER POLISH FAST PATH APPLIED** (Reviewer unilaterally patched and pushed fixes. Approved.)'
     ].join('\n');
 
-    // Micro-Review (Cycle-1, blast-scaled light shape) — the minimal floor: header + Class (asserting
-    // micro|contained) + Verdict + Glance (pr-review-guide §7 blast-scaling, #14263).
+    // Micro-Review (Cycle-1, blast-scaled light shape) — the minimal floor: header + Class
+    // (asserting micro|contained|mechanical) + Verdict + Glance.
     const VALID_MICRO_REVIEW_BODY = [
         '# PR Micro-Review',
         '',
@@ -1091,6 +1159,63 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(result.missing_micro_delta).toContain('Remaining Blocker Class: mechanical-hygiene | metadata-drift');
         expect(result.message).toContain('full follow-up review template instead');
         expect(graphqlCallCount).toBe(0);
+    });
+
+    test('#13910: workflow lint accepts documented Micro-Delta review bodies', async () => {
+        const result = await runAgentPrReviewBodyLintWorkflow({
+            body: VALID_MICRO_DELTA_REVIEW_BODY
+        });
+
+        expect(result.failures).toEqual([]);
+        expect(result.comments).toEqual([]);
+        expect(result.logs).toContain('✅ Micro-Delta body matches the documented circuit-breaker shape.');
+    });
+
+    test('#13910: workflow lint rejects incomplete Micro-Delta bodies before canonical fallback', async () => {
+        const incompleteBody = VALID_MICRO_DELTA_REVIEW_BODY
+            .replace('- **Measured Discussion Cost:** > 24KB\n', '');
+
+        const result = await runAgentPrReviewBodyLintWorkflow({
+            body: incompleteBody
+        });
+
+        expect(result.failures).toEqual([
+            'Agent micro-delta review body missing required circuit-breaker anchors. See follow-up comment on PR #13910.'
+        ]);
+        expect(result.comments).toHaveLength(1);
+        expect(result.comments[0].body).toContain('Agent Micro-Delta Review Body Lint Violation');
+        expect(result.comments[0].body).toContain('.agents/skills/pr-review/assets/pr-review-micro-delta-template.md');
+        expect(result.comments[0].body).not.toContain('Visible anchors missing');
+    });
+
+    test('#13910: workflow lint rejects Micro-Delta semantic blocker shortcuts', async () => {
+        const semanticShortcutBody = VALID_MICRO_DELTA_REVIEW_BODY
+            .replace('- **Remaining Blocker Class:** mechanical-hygiene', '- **Remaining Blocker Class:** semantic-blocker');
+
+        const result = await runAgentPrReviewBodyLintWorkflow({
+            body: semanticShortcutBody
+        });
+
+        expect(result.failures[0]).toContain('micro-delta review body missing required circuit-breaker anchors');
+        expect(result.comments[0].body).toContain('mechanical-hygiene or metadata-drift');
+        expect(result.comments[0].body).toContain('full follow-up review template instead');
+    });
+
+    test('#13910: workflow lint requires Premise Coherence for canonical reviews', async () => {
+        const bodyWithoutPremiseCoherence = VALID_REVIEW_BODY
+            .replace('* **Premise Coherence:** coheres: a substrate validator fix; flat-peer-team / facilitator-not-delegator unaffected.\n', '');
+
+        const result = await runAgentPrReviewBodyLintWorkflow({
+            body: bodyWithoutPremiseCoherence
+        });
+
+        expect(result.failures).toEqual([
+            'Agent review body missing required template anchors. See follow-up comment on PR #13910.'
+        ]);
+        expect(result.comments).toHaveLength(1);
+        expect(result.comments[0].body).toContain('Agent PR Review Body Lint Violation');
+        expect(result.comments[0].body).toContain('Premise Coherence');
+        expect(result.comments[0].body).toContain('all four premise fields');
     });
 
     test('#14263: accepts a Micro-Review (blast-scaled light shape) — micro PRs are not gauntletted', async () => {


### PR DESCRIPTION
Resolves #13910

Aligns the GitHub Actions `lint-pr-review-body` companion with `PullRequestService.mjs`: valid documented Micro-Delta review bodies now pass CI lint, malformed Micro-Delta attempts get targeted Micro-Delta guidance, canonical reviews require `Premise Coherence`, and the Micro-Review class guard matches the MCP-side `micro|contained|mechanical` contract.

Evidence: L2 (workflow script executed from YAML with stubbed GitHub Actions services + MCP validator unit suite) -> L2 required (#13910 CI/MCP validator parity ACs). No residuals.

## Deltas from ticket

The fix keeps the workflow validator inline instead of extracting a shared runtime module. The workflow runs as `actions/github-script`, so importing repo-local validator code would be a separate workflow-topology change. This PR instead adds focused tests that parse the workflow YAML and execute the actual inline script, which gives us parity coverage without splitting another ticket or PR.

The patch also aligns reviewer premise-snapshot enforcement with the current MCP validator by requiring `Premise Coherence` in canonical full/follow-up reviews.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` -> 56 passed (33.1s)
- `npm run agent-preflight -- .github/workflows/agent-pr-review-body-lint.yml test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` -> passed
- `git diff --check` -> passed
- `git diff --cached --check` -> passed

## Post-Merge Validation

- [ ] Confirm the next valid Micro-Delta formal review leaves `lint-pr-review-body` green without rewriting into the full follow-up template.

## Commits

- `b0035b215c` - align review-body CI lint with Micro-Delta

Authored by Euclid (GPT-5, Codex Desktop). Session 019f0da6-ba3b-7f42-a571-b0d6f71abc38.
