### PR TITLE
fix(ai): supervisor adopts a defer-policy task's live port holder instead of respawning (#14291)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -887,7 +887,7 @@ export class Orchestrator extends Base {
         ];
         const RESTART_COOLDOWN_MS = 15000;
         for (const taskName of continuousTasks) {
-            this.processSupervisorService.reapDuplicateListeners(taskName);
+            this.processSupervisorService.reconcileSingletonPort(taskName);
 
             const state = this.taskStateService.getTaskState(taskName);
 

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -316,6 +316,41 @@ export class ProcessSupervisorService extends Base {
     }
 
     /**
+     * @summary Whether any process currently holds a LISTEN socket on the given singleton port.
+     * @param {Number} port
+     * @returns {Boolean}
+     */
+    isSingletonPortHeld(port) {
+        return this.listPortListeners(port).length > 0
+    }
+
+    /**
+     * @summary Allows only the first defer-port-held restart-skip log per held-period.
+     * @param {String} taskName Task key.
+     * @returns {Boolean}
+     */
+    shouldLogDeferPortHeldSkip(taskName) {
+        this.deferPortHeldLogKeys ??= new Set();
+
+        if (this.deferPortHeldLogKeys.has(taskName)) {
+            return false;
+        }
+
+        this.deferPortHeldLogKeys.add(taskName);
+
+        return true
+    }
+
+    /**
+     * @summary Resets the defer-port-held skip-log guard once the port frees or is adopted.
+     * @param {String} taskName Task key.
+     * @returns {void}
+     */
+    clearDeferPortHeldLogState(taskName) {
+        this.deferPortHeldLogKeys?.delete(taskName)
+    }
+
+    /**
      * Maps child-process stderr log prefixes to daemon log severities.
      * @param {String} line Child stderr line.
      * @returns {String}
@@ -841,6 +876,21 @@ export class ProcessSupervisorService extends Base {
             return;
         }
 
+        // A `defer` singleton-port task must never (re)spawn into an already-held port. A matching
+        // holder would have been adopted by reconcileSingletonPort (running=true, handled above); if
+        // the port is still held here it is a foreign / non-adoptable instance — leave it untouched
+        // (never kill, never spawn-into) and wait for it to free. This gates the restart on PORT
+        // OCCUPANCY, not just tracked-running, which the restart path alone would check.
+        if (task?.duplicateListenerPolicy === 'defer' && task?.singletonPort && this.isSingletonPortHeld(task.singletonPort)) {
+            if (this.shouldLogDeferPortHeldSkip(taskName)) {
+                this.writeLog?.('WARN', `[ProcessSupervisor] ${task.label} port ${task.singletonPort} held by an external instance; deferring restart (no spawn-into, no kill).`);
+                this.recordTaskOutcome(taskName, 'deferred-port-held', {port: task.singletonPort, deferredAt: new Date().toISOString()});
+            }
+            return;
+        }
+
+        this.clearDeferPortHeldLogState(taskName);
+
         if (typeof task?.livenessProbe === 'function') {
             this.gateRestartOnLivenessProbe(taskName, task, now, cooldownMs);
         } else {
@@ -931,37 +981,35 @@ export class ProcessSupervisorService extends Base {
     }
 
     /**
-     * @summary Enforces or observes a single live process for a port-owning task.
+     * @summary Reconciles a port-owning task's tracked state against the live listener(s) on its `singletonPort`.
      *
      * Default policy is authoritative ownership: when more than one process binds the task's
      * `singletonPort`, keep the orchestrator-tracked pid and SIGKILL verified duplicates. This
      * is required for daemons like Chroma where duplicate writers corrupt a shared persist dir.
      *
-     * Tasks that expose shared local infrastructure may opt into
-     * `duplicateListenerPolicy: 'defer'`: matching listeners are treated as externally-owned
-     * live instances and are never killed by this supervisor. The task's liveness probe then
-     * decides whether a restart is needed.
+     * Tasks that expose shared local infrastructure opt into `duplicateListenerPolicy: 'defer'`:
+     * a matching listener is an externally-owned live instance that is never killed. For those this
+     * delegates to {@link adoptExistingSingletonListener} — it ADOPTS the live holder into tracked
+     * state so the supervisor resumes it instead of re-spawning into the held port (the EADDRINUSE
+     * this closes). The task's liveness probe then governs recycle.
      *
      * @param {String} taskName Task key.
-     * @returns {Number} Count of duplicate processes reaped.
+     * @returns {Number} Count of duplicate processes reaped (always 0 for `defer`).
      */
-    reapDuplicateListeners(taskName) {
+    reconcileSingletonPort(taskName) {
         const task = this.taskDefinitions[taskName];
         if (!task?.singletonPort) {
             return 0;
         }
 
         if (task.duplicateListenerPolicy === 'defer') {
+            this.adoptExistingSingletonListener(taskName);
             return 0;
         }
 
         const listenerPids = this.listPortListeners(task.singletonPort);
         const canonicalPid = this.taskStateService.getTaskState(taskName)?.pid;
         let   reaped       = 0;
-
-        if (task.duplicateListenerPolicy === 'defer') {
-            return 0;
-        }
 
         for (const pid of listenerPids) {
             if (!Number.isInteger(pid) || pid === canonicalPid) {
@@ -990,6 +1038,62 @@ export class ProcessSupervisorService extends Base {
         }
 
         return reaped;
+    }
+
+    /**
+     * @summary Adopts an externally-owned live listener on a `defer`-policy task's `singletonPort`.
+     *
+     * `defer` tasks (shared local infra — the Neural Link Bridge, the dev-server) treat a matching
+     * port listener as an externally-owned live instance. When tracked state shows the task as NOT
+     * running but a process whose command matches `expectedCommand` already holds the port, this
+     * adopts it (running flag + pid + pidfile + exit watch) so the supervisor resumes it rather than
+     * re-spawning into the held port — the `EADDRINUSE` failure mode. It NEVER kills (defer never
+     * reaps); a foreign command on the port is left untouched (no adopt, no kill, no spawn-into).
+     *
+     * @param {String} taskName Task key.
+     * @returns {Boolean} True when a live holder was adopted.
+     */
+    adoptExistingSingletonListener(taskName) {
+        const task  = this.taskDefinitions[taskName];
+        const state = this.taskStateService.getTaskState(taskName);
+
+        // Already tracked-running (or no state to mutate) → nothing to reconcile.
+        if (!state || state.running) {
+            return false;
+        }
+
+        for (const pid of this.listPortListeners(task.singletonPort)) {
+            if (!Number.isInteger(pid)) {
+                continue;
+            }
+
+            let command;
+            try {
+                command = this.processCommand(pid);
+            } catch (e) {
+                continue;
+            }
+
+            if (!command.includes(task.expectedCommand)) {
+                continue;
+            }
+
+            this.taskStateService.adoptRunning(taskName, pid);
+            this.watchRecoveredTask(taskName, pid);
+
+            try {
+                fs.writeFileSync(this.getTaskPidFile(taskName), pid.toString(), 'utf8');
+            } catch (e) {
+                this.writeLog?.('ERROR', `[ProcessSupervisor] Failed to write adopted ${task.label} PID: ${e.message}`);
+            }
+
+            this.writeLog?.('INFO', `[ProcessSupervisor] Adopting externally-owned ${task.label} (PID: ${pid}) on port ${task.singletonPort}; not re-spawning.`);
+            this.recordTaskOutcome(taskName, 'adopted', {pid, port: task.singletonPort, adoptedAt: new Date().toISOString()});
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -764,18 +764,22 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             },
             taskStateService: {
                 getTaskState() {
-                    return {pid: 222};
-                }
+                    return {running: false, pid: null};
+                },
+                adoptRunning() {}
             },
             healthService: {recordTaskOutcome() {}},
             writeLog     : () => {}
         });
 
-        supervisor.listPortListeners = () => [111, 222];
-        supervisor.processCommand    = () => '/node ai/mcp/server/neural-link/run-bridge.mjs';
-        supervisor.killProcess       = pid => killed.push(pid);
+        supervisor.listPortListeners  = () => [111, 222];
+        supervisor.processCommand     = () => '/node ai/mcp/server/neural-link/run-bridge.mjs';
+        supervisor.killProcess        = pid => killed.push(pid);
+        supervisor.watchRecoveredTask = () => {};
+        supervisor.getTaskPidFile     = () => null;
 
-        expect(supervisor.reapDuplicateListeners('neuralLinkBridge')).toBe(0);
+        // defer policy adopts the externally-owned live holder; it must NEVER kill it.
+        expect(supervisor.reconcileSingletonPort('neuralLinkBridge')).toBe(0);
         expect(killed).toEqual([]);
     });
 
@@ -1882,7 +1886,7 @@ test.describe('Neo.ai.daemons.Orchestrator — chroma max-runtime recycle (#1213
 
     function recycleMock(sink) {
         return {
-            reapDuplicateListeners() {},
+            reconcileSingletonPort() {},
             killTask(taskName, reason) { sink.killed.push({taskName, reason}); },
             runTask(taskName, reason)  { sink.started.push({taskName, reason}); return true; }
         };

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -649,7 +649,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         expect(degradedLogs.length).toBe(1);
     });
 
-    test('reapDuplicateListeners SIGKILLs extra listeners but keeps the canonical pid', () => {
+    test('reconcileSingletonPort SIGKILLs extra listeners but keeps the canonical pid', () => {
         const { service, taskOutcomes } = createTestService();
         const killed                    = [];
 
@@ -659,14 +659,14 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         service.processCommand    = () => 'echo serving';
         service.killProcess       = pid => killed.push(pid);
 
-        const reaped = service.reapDuplicateListeners('mockTask');
+        const reaped = service.reconcileSingletonPort('mockTask');
 
         expect(reaped).toBe(2);
         expect(killed).toEqual([200, 300]);
         expect(taskOutcomes.filter(o => o.status === 'reaped-duplicate').length).toBe(2);
     });
 
-    test('reapDuplicateListeners leaves a process whose command is not the task command', () => {
+    test('reconcileSingletonPort leaves a process whose command is not the task command', () => {
         const { service } = createTestService();
         const killed      = [];
 
@@ -676,36 +676,113 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         service.processCommand    = () => 'unrelated-process';
         service.killProcess       = pid => killed.push(pid);
 
-        expect(service.reapDuplicateListeners('mockTask')).toBe(0);
+        expect(service.reconcileSingletonPort('mockTask')).toBe(0);
         expect(killed).toEqual([]);
     });
 
-    test('reapDuplicateListeners is a no-op for tasks without a singletonPort', () => {
+    test('reconcileSingletonPort is a no-op for tasks without a singletonPort', () => {
         const { service } = createTestService();
         let   probed      = false;
 
         service.listPortListeners = () => { probed = true; return [200]; };
 
-        expect(service.reapDuplicateListeners('mockTask')).toBe(0);
+        expect(service.reconcileSingletonPort('mockTask')).toBe(0);
         expect(probed).toBe(false);
     });
 
-    test('reapDuplicateListeners defers shared local services without touching listeners', () => {
-        const { service } = createTestService();
-        const killed      = [];
-        let   probed      = false;
+    test('reconcileSingletonPort (defer) adopts the live expectedCommand holder instead of re-spawning', () => {
+        const { service, taskOutcomes } = createTestService();
+        const killed                    = [];
+        const adopted                   = [];
+        const watched                   = [];
 
-        service.taskDefinitions.mockTask.singletonPort = 8000;
+        service.taskDefinitions.mockTask.singletonPort           = 8000;
         service.taskDefinitions.mockTask.duplicateListenerPolicy = 'defer';
-        service.listPortListeners = () => { probed = true; return [200]; };
-        service.killProcess       = pid => killed.push(pid);
+        service.taskDefinitions.mockTask.expectedCommand         = 'serve';
+        service.taskStateService.getTaskState = () => ({running: false, pid: null});
+        service.taskStateService.adoptRunning = (name, pid) => adopted.push({name, pid});
+        service.watchRecoveredTask = (name, pid) => watched.push({name, pid});
+        service.getTaskPidFile     = () => null; // pidfile write is try-guarded; skip the real FS write
+        service.listPortListeners  = () => [200];
+        service.processCommand     = () => 'node serve --port 8000';
+        service.killProcess        = pid => killed.push(pid);
 
-        expect(service.reapDuplicateListeners('mockTask')).toBe(0);
-        expect(probed).toBe(false);
-        expect(killed).toEqual([]);
+        const reaped = service.reconcileSingletonPort('mockTask');
+
+        expect(reaped).toBe(0);                                   // defer never reaps
+        expect(killed).toEqual([]);                              // never kills the externally-owned holder
+        expect(adopted).toEqual([{name: 'mockTask', pid: 200}]); // adopts the live holder into tracked state
+        expect(watched).toEqual([{name: 'mockTask', pid: 200}]); // watches it for exit
+        expect(taskOutcomes.filter(o => o.status === 'adopted').length).toBe(1);
     });
 
-    test('reapDuplicateListeners reaps every matching listener when no canonical pid is tracked', () => {
+    test('reconcileSingletonPort (defer) is a no-op when the task is already tracked-running', () => {
+        const { service } = createTestService();
+        const adopted     = [];
+        let   probed      = false;
+
+        service.taskDefinitions.mockTask.singletonPort           = 8000;
+        service.taskDefinitions.mockTask.duplicateListenerPolicy = 'defer';
+        service.taskStateService.getTaskState = () => ({running: true, pid: 100});
+        service.taskStateService.adoptRunning = (name, pid) => adopted.push({name, pid});
+        service.listPortListeners = () => { probed = true; return [200]; };
+
+        expect(service.reconcileSingletonPort('mockTask')).toBe(0);
+        expect(probed).toBe(false); // already running → does not probe the port or adopt
+        expect(adopted).toEqual([]);
+    });
+
+    test('reconcileSingletonPort (defer) does not adopt a foreign command holding the port', () => {
+        const { service } = createTestService();
+        const adopted     = [];
+        const killed      = [];
+
+        service.taskDefinitions.mockTask.singletonPort           = 8000;
+        service.taskDefinitions.mockTask.duplicateListenerPolicy = 'defer';
+        service.taskDefinitions.mockTask.expectedCommand         = 'serve';
+        service.taskStateService.getTaskState = () => ({running: false, pid: null});
+        service.taskStateService.adoptRunning = (name, pid) => adopted.push({name, pid});
+        service.listPortListeners  = () => [200];
+        service.processCommand     = () => 'some-unrelated-process';
+        service.killProcess        = pid => killed.push(pid);
+
+        expect(service.reconcileSingletonPort('mockTask')).toBe(0);
+        expect(adopted).toEqual([]); // foreign command → not adopted
+        expect(killed).toEqual([]);  // defer → never killed either
+    });
+
+    test('full poll (reconcileSingletonPort → superviseTask): a defer task with a FOREIGN port holder never adopts, kills, or spawns', async () => {
+        const { service, taskOutcomes } = createTestService();
+        const spawned                   = [];
+        const adopted                   = [];
+        const killed                    = [];
+
+        service.taskDefinitions.mockTask.singletonPort           = 8000;
+        service.taskDefinitions.mockTask.duplicateListenerPolicy = 'defer';
+        // mockTask.expectedCommand is 'echo'; the holder below is a foreign command.
+        service.taskDefinitions.mockTask.livenessProbe           = async () => false; // down → the restart path (the pre-fix spawn trigger)
+        service.taskStateService.getTaskState = () => ({running: false, pid: null, lastRunAt: 0});
+        service.taskStateService.adoptRunning = (name, pid) => adopted.push({name, pid});
+        service.listPortListeners = () => [4321];            // a process holds the port
+        service.processCommand    = () => 'node server.mjs'; // FOREIGN (does not include 'echo')
+        service.killProcess       = pid => killed.push(pid);
+        service.spawnFn           = (command, args) => { spawned.push({command, args}); return {pid: 9999, on: () => {}, stderr: {on: () => {}}, stdout: {on: () => {}}}; };
+
+        // Production poll order: reconcile THEN supervise.
+        service.reconcileSingletonPort('mockTask');
+        service.superviseTask('mockTask', 1000000, 0);
+
+        // Flush the async liveness-gate path — where the pre-fix code spawned into the held port.
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await Promise.resolve();
+
+        expect(adopted).toEqual([]); // foreign command → not adopted
+        expect(killed).toEqual([]);  // defer → never killed
+        expect(spawned).toEqual([]); // gated on port occupancy → no spawn-into the held port (no EADDRINUSE)
+        expect(taskOutcomes.filter(o => o.status === 'deferred-port-held').length).toBe(1);
+    });
+
+    test('reconcileSingletonPort reaps every matching listener when no canonical pid is tracked', () => {
         const { service } = createTestService();
         const killed      = [];
 
@@ -715,7 +792,7 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         service.processCommand    = () => 'echo';
         service.killProcess       = pid => killed.push(pid);
 
-        expect(service.reapDuplicateListeners('mockTask')).toBe(2);
+        expect(service.reconcileSingletonPort('mockTask')).toBe(2);
         expect(killed).toEqual([200, 300]);
     });
 


### PR DESCRIPTION
Resolves #14291

The local `ProcessSupervisor`'s `defer` singleton-port policy was a no-op, so the Neural Link Bridge (a `defer` task) with a stale/missing pidfile **and** a live process still holding `:::8081` would respawn blindly → `listen EADDRINUSE`. `chroma` self-heals (its default reap clears the port holder first); `defer` had no equivalent path.

Evidence: L2 — behavior verified by `ProcessSupervisorService.spec` + `Orchestrator.spec` (98/98), including new defer-adopt coverage.

## The fix

Make `defer` honor its own documented contract — *"matching listeners are externally-owned live instances"* — by **adopting** the live holder instead of ignoring it:

- `reapDuplicateListeners` → **`reconcileSingletonPort`** (default policy = reap duplicates, unchanged; `defer` = adopt). Removed a redundant double `defer` check (dead code).
- New **`adoptExistingSingletonListener`**: when tracked state is not-running but a process whose command matches `expectedCommand` holds the `singletonPort`, adopt it (`adoptRunning` + `watchRecoveredTask` + pidfile write) so the supervisor **resumes** it instead of re-spawning into the held port. It **never kills** (defer never reaps); a foreign command on the port is left untouched (no adopt, no kill, no spawn-into).

Why this seam: the poll runs `reconcileSingletonPort` **before** `superviseTask` every cycle, and `superviseTask` early-returns when `state.running` — so adopting in the reconcile step short-circuits the respawn. `runTask` is untouched (no new pre-spawn guard on the shared hot path). Port-keyed, so it's robust to a stale/missing pidfile — the actual failure trigger.

## Deltas from ticket

Resolves #14291. Also drops a pre-existing decay-prone `(ADR-0019)` citation from an unrelated comment (`Orchestrator.mjs:99`) that the ticket-archaeology pre-commit hook flagged on the staged file — behavior text unchanged. The optional IPv4/IPv6 liveness-probe-parity hardening (AC-noted) is left as a potential follow-up; the adopt path closes the EADDRINUSE regardless of the probe result.

## Test Evidence

- `ProcessSupervisorService.spec.mjs` + `Orchestrator.spec.mjs`: **98/98** (clean env). New: `defer` adopts the live holder (never kills); no-op when already tracked-running; foreign command not adopted. The `#13483` "does not kill externally-owned listeners" test updated for the adopt path (still asserts no-kill). Existing default-policy reap tests unchanged + green.
- `node --check` on both source files; husky pre-commit green (jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation

- [ ] A live supervisor restart over an already-running Bridge **adopts** it (no `EADDRINUSE :::8081`); the handoff log shows `Adopting externally-owned Neural Link Bridge`.
- [ ] `chroma` default-policy reap behavior is unchanged in production.

Authored by Grace (Claude Opus 4.8, Claude Code).