### PR TITLE
fix(ai): coordinate chroma recycle with kb sync (#14293)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -61,6 +61,9 @@ import {
     DEFAULT_DATA_DIR,
     DEFAULT_SCRIPT_DIR
 } from './taskDefinitions.mjs';
+import {
+    inspectHeavyMaintenanceLeaseSync
+} from './services/heavyMaintenanceLeasePrimitives.mjs';
 
 /** @summary Opens/creates the orchestrator sqlite DB via the shared Memory Core schema bootstrap. */
 export async function initializeDatabaseSelfBootstrap(dbPath) {
@@ -217,6 +220,7 @@ export class Orchestrator extends Base {
     goldenPathGetDueTask     = goldenPathGetDueTaskImport
     embedDrainLivenessWatchdogGetDueTask = embedDrainLivenessWatchdogGetDueTaskImport
     buildConfiguredTaskDefinitionsService = buildConfiguredTaskDefinitionsImport
+    inspectHeavyMaintenanceLeaseFn = inspectHeavyMaintenanceLeaseSync
 
     isPolling                     = false
     pollHandle                    = null
@@ -854,6 +858,19 @@ export class Orchestrator extends Base {
         return Boolean(state?.running) && maxRuntimeMs > 0 && lastRunAt > 0 && (now - lastRunAt) > maxRuntimeMs;
     }
 
+    /** @summary Returns true while an active heavy-maintenance lease owns the shared Chroma substrate. */
+    isHeavyMaintenanceLeaseActive(now) {
+        try {
+            return Boolean(this.inspectHeavyMaintenanceLeaseFn({
+                leasePath: this.maintenanceBackpressureService.resolveHeavyMaintenanceLeasePath(),
+                now
+            }).active);
+        } catch (e) {
+            this.writeLog('ERROR', `[Orchestrator] Heavy-maintenance lease inspection failed; deferring Chroma recycle: ${e.message}`);
+            return true;
+        }
+    }
+
     /** @summary Resolves true when Chroma's TCP port accepts a connection. */
     probeChromaReady({timeoutMs = 2000} = {}) {
         return new Promise(resolve => {
@@ -892,6 +909,11 @@ export class Orchestrator extends Base {
             const state = this.taskStateService.getTaskState(taskName);
 
             if (taskName === 'chroma' && this.isChromaRecycleDue(state, now)) {
+                if (this.isHeavyMaintenanceLeaseActive(now)) {
+                    this.processSupervisorService.superviseTask(taskName, now, RESTART_COOLDOWN_MS);
+                    continue;
+                }
+
                 this.processSupervisorService.killTask('chroma', `max-runtime:${now - (state.lastRunAt || 0)}ms>${AiConfig.orchestrator.chroma.maxRuntimeMs}ms`);
                 this._chromaDefragPending = true;
                 continue;
@@ -899,7 +921,13 @@ export class Orchestrator extends Base {
 
             this.processSupervisorService.superviseTask(taskName, now, RESTART_COOLDOWN_MS);
 
-            if (taskName === 'chroma' && state?.running && this._chromaDefragPending && !this._chromaDefragInFlight) {
+            if (
+                taskName === 'chroma' &&
+                state?.running &&
+                this._chromaDefragPending &&
+                !this._chromaDefragInFlight &&
+                !this.isHeavyMaintenanceLeaseActive(now)
+            ) {
                 this._chromaDefragInFlight = true;
                 this.probeChromaReady()
                     .then(ready => {

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -1,8 +1,8 @@
-import os              from 'os';
-import path            from 'path';
-import AiConfig        from '../../../config.template.mjs';
+import os                                          from 'os';
+import path                                        from 'path';
+import AiConfig                                    from '../../../config.template.mjs';
 import ConfigProvider, { createConfigProxy, leaf } from '../../../ConfigProvider.mjs';
-import {fileURLToPath} from 'url';
+import {fileURLToPath}                             from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -267,6 +267,21 @@ class Config extends ConfigProvider {
              */
             collectionName: leaf('neo-knowledge-base'),
             /**
+             * @summary Bounded retry policy for resolving the canonical Chroma KB collection.
+             *
+             * Long-running syncs can overlap a local Chroma restart or recycle. `ChromaManager`
+             * consumes these leaves only for transient `ChromaConnectionError` failures while
+             * resolving the canonical collection name; not-found and shadow-swap promotion paths
+             * keep their existing handling. `maxAttempts` includes the initial call.
+             * @type {Object}
+             */
+            collectionResolveRetry: {
+                maxAttempts    : leaf(5,    'NEO_KB_COLLECTION_RESOLVE_RETRY_MAX_ATTEMPTS', 'number'),
+                initialDelayMs : leaf(500,  'NEO_KB_COLLECTION_RESOLVE_RETRY_INITIAL_DELAY_MS', 'number'),
+                maxDelayMs     : leaf(2000, 'NEO_KB_COLLECTION_RESOLVE_RETRY_MAX_DELAY_MS', 'number'),
+                maxTotalDelayMs: leaf(5000, 'NEO_KB_COLLECTION_RESOLVE_RETRY_MAX_TOTAL_DELAY_MS', 'number')
+            },
+            /**
              * When `true` (default), the SourceRegistry auto-registers Neo's
              * 10 curated default Source classes. Cloud deployments that ingest only tenant content
              * can set `false` to skip Neo's curated sources entirely.
@@ -465,22 +480,22 @@ class Config extends ConfigProvider {
              * @type {Object}
              */
             queryScoreWeights: leaf({
-                baseIncrement    : 1,
-                sourcePathMatch  : 40,
-                fileNameMatch    : 30,
-                classNameMatch   : 20,
-                guideMatch       : 50,
-                conceptMatch     : 15,
-                blogMatch        : 5,
-                namePartMatch    : 30,
+                baseIncrement     : 1,
+                sourcePathMatch   : 40,
+                fileNameMatch     : 30,
+                classNameMatch    : 20,
+                guideMatch        : 50,
+                conceptMatch      : 15,
+                blogMatch         : 5,
+                namePartMatch     : 30,
                 lexicalRescueMatch: 3200,
-                ticketPenalty    : -70,
-                pullPenalty      : -250,
-                releasePenalty   : -50,
-                baseFileBonus    : 20,
-                releaseExactMatch: 1000,
-                inheritanceBoost : 80,
-                inheritanceDecay : 0.6
+                ticketPenalty     : -70,
+                pullPenalty       : -250,
+                releasePenalty    : -50,
+                baseFileBonus     : 20,
+                releaseExactMatch : 1000,
+                inheritanceBoost  : 80,
+                inheritanceDecay  : 0.6
             })
         }
     }

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -1,8 +1,8 @@
-import {ChromaClient}                       from 'chromadb';
-import aiConfig                             from '../../mcp/server/knowledge-base/config.mjs';
-import logger                               from '../../mcp/server/knowledge-base/logger.mjs';
-import Base                                 from '../../../src/core/Base.mjs';
-import DatabaseLifecycleService             from './DatabaseLifecycleService.mjs';
+import {ChromaClient}           from 'chromadb';
+import aiConfig                 from '../../mcp/server/knowledge-base/config.mjs';
+import logger                   from '../../mcp/server/knowledge-base/logger.mjs';
+import Base                     from '../../../src/core/Base.mjs';
+import DatabaseLifecycleService from './DatabaseLifecycleService.mjs';
 import {
     chromaConnect,
     chromaDeleteCollection,
@@ -13,6 +13,11 @@ import {
 
 const COLLECTION_ALREADY_EXISTS_RE = /already exists|already contains|conflict/i;
 const SWAP_ACTIVE_PHASES           = ['parking', 'shadow'];
+
+/** @summary Waits for the configured collection-resolve retry backoff interval. */
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, Math.max(0, ms)));
+}
 
 registerNeoChromaEmbeddingFunctions({
     dummyEmbeddingFunction: aiConfig.dummyEmbeddingFunction
@@ -49,6 +54,11 @@ class ChromaManager extends Base {
          * @protected
          */
         knowledgeBaseCollection: null,
+        /**
+         * @member {Function} collectionResolveRetrySleepFn=sleep
+         * @protected
+         */
+        collectionResolveRetrySleepFn: sleep,
         /**
          * @member {Boolean} singleton=true
          * @protected
@@ -145,7 +155,7 @@ class ChromaManager extends Base {
         const options = this.#getKnowledgeBaseCollectionOptions();
 
         try {
-            return await this.client.getCollection(options);
+            return await this.#getCollectionWithConnectionRetry(options);
         } catch (error) {
             if (!this.#isCollectionNotFoundError(error)) {
                 throw error;
@@ -174,6 +184,78 @@ class ChromaManager extends Base {
     }
 
     /**
+     * @summary Resolves the canonical collection with bounded retries for transient Chroma restarts.
+     * @param {Object} options Chroma getCollection options.
+     * @returns {Promise<Object>}
+     * @throws {Error}
+     */
+    async #getCollectionWithConnectionRetry(options) {
+        const retry        = this.#getCollectionResolveRetryPolicy();
+        let   totalDelayMs = 0;
+
+        for (let attempt = 1; attempt <= retry.maxAttempts; attempt++) {
+            try {
+                return await this.client.getCollection(options);
+            } catch (error) {
+                if (!this.#isChromaConnectionError(error) || attempt >= retry.maxAttempts) {
+                    throw this.#createCollectionResolveError(error, {attempt, retry, totalDelayMs});
+                }
+
+                const delayMs = this.#getCollectionResolveRetryDelay({attempt, retry, totalDelayMs});
+
+                if (delayMs <= 0 && totalDelayMs >= retry.maxTotalDelayMs) {
+                    throw this.#createCollectionResolveError(error, {attempt, retry, totalDelayMs});
+                }
+
+                logger.debug?.(`[ChromaManager] Transient Chroma collection resolve failure; retrying in ${delayMs}ms (attempt ${attempt + 1}/${retry.maxAttempts}).`);
+                await this.collectionResolveRetrySleepFn(delayMs);
+                totalDelayMs += delayMs;
+            }
+        }
+    }
+
+    /**
+     * @returns {{maxAttempts: Number, initialDelayMs: Number, maxDelayMs: Number, maxTotalDelayMs: Number}}
+     */
+    #getCollectionResolveRetryPolicy() {
+        const policy  = aiConfig.collectionResolveRetry;
+        const missing = ['maxAttempts', 'initialDelayMs', 'maxDelayMs', 'maxTotalDelayMs']
+            .filter(key => !Number.isFinite(Number(policy?.[key])));
+
+        if (missing.length > 0) {
+            throw new Error(`collectionResolveRetry config leaves missing or invalid: ${missing.join(', ')}. Sync ai/mcp/server/knowledge-base/config.mjs from config.template.mjs (node ai/scripts/setup/initServerConfigs.mjs --migrate-config) and restart knowledge-base.`);
+        }
+
+        const retry = {
+            maxAttempts    : Math.trunc(Number(policy.maxAttempts)),
+            initialDelayMs : Number(policy.initialDelayMs),
+            maxDelayMs     : Number(policy.maxDelayMs),
+            maxTotalDelayMs: Number(policy.maxTotalDelayMs)
+        };
+
+        if (retry.maxAttempts < 1 || retry.initialDelayMs < 0 || retry.maxDelayMs < 0 || retry.maxTotalDelayMs < 0) {
+            throw new Error('collectionResolveRetry config leaves are invalid: maxAttempts must be >= 1 and delay values must be >= 0.');
+        }
+
+        return retry
+    }
+
+    /**
+     * @param {Object} options
+     * @param {Number} options.attempt Completed attempt number.
+     * @param {Object} options.retry Retry policy.
+     * @param {Number} options.totalDelayMs Delay already spent.
+     * @returns {Number}
+     */
+    #getCollectionResolveRetryDelay({attempt, retry, totalDelayMs}) {
+        const exponentialDelayMs = retry.initialDelayMs * 2 ** (attempt - 1);
+        const cappedDelayMs      = retry.maxDelayMs > 0 ? Math.min(exponentialDelayMs, retry.maxDelayMs) : exponentialDelayMs;
+        const remainingDelayMs   = retry.maxTotalDelayMs - totalDelayMs;
+
+        return Math.max(0, Math.min(cappedDelayMs, remainingDelayMs))
+    }
+
+    /**
      * @returns {{name: String, embeddingFunction: Object}}
      */
     #getKnowledgeBaseCollectionOptions() {
@@ -189,6 +271,36 @@ class ChromaManager extends Base {
      */
     #isCollectionNotFoundError(error) {
         return isChromaCollectionNotFoundError(error)
+    }
+
+    /**
+     * @param {Error} error
+     * @returns {Boolean}
+     */
+    #isChromaConnectionError(error) {
+        return error?.name === 'ChromaConnectionError' || error?.constructor?.name === 'ChromaConnectionError'
+    }
+
+    /**
+     * @param {Error} error
+     * @param {Object} context
+     * @returns {Error}
+     */
+    #createCollectionResolveError(error, {attempt, retry, totalDelayMs}) {
+        if (!this.#isChromaConnectionError(error)) {
+            return error
+        }
+
+        const failure = new Error(
+            `Knowledge base collection resolve failed after ${attempt}/${retry.maxAttempts} attempts ` +
+            `and ${totalDelayMs}ms retry delay: ${error.message}`
+        );
+
+        failure.name         = error.name || 'ChromaConnectionError';
+        failure.code         = error.code;
+        failure.cause        = error;
+        failure.retryContext = {attempt, maxAttempts: retry.maxAttempts, totalDelayMs};
+        return failure
     }
 
     /**
@@ -217,9 +329,9 @@ class ChromaManager extends Base {
      * @returns {Promise<String[]>}
      */
     async #getActiveKnowledgeBaseSwapCollections() {
-        const names = [];
-        const limit = 1000;
-        let offset  = 0;
+        const names  = [];
+        const limit  = 1000;
+        let   offset = 0;
 
         do {
             const collections = await this.client.listCollections({limit, offset});

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1,4 +1,5 @@
 import {test, expect}             from '@playwright/test';
+import fs                         from 'fs-extra';
 import path                       from 'path';
 import Neo                        from '../../../../../../src/Neo.mjs';
 import * as core                  from '../../../../../../src/core/_export.mjs';
@@ -1884,6 +1885,7 @@ test.describe('Neo.ai.daemons.Orchestrator — chroma max-runtime recycle (#1213
         return {
             reapDuplicateListeners() {},
             killTask(taskName, reason) { sink.killed.push({taskName, reason}); },
+            superviseTask(taskName)    { sink.supervised?.push(taskName); },
             runTask(taskName, reason)  { sink.started.push({taskName, reason}); return true; }
         };
     }
@@ -1943,6 +1945,42 @@ test.describe('Neo.ai.daemons.Orchestrator — chroma max-runtime recycle (#1213
         expect(orchestrator._chromaDefragPending).toBe(true);
     });
 
+    test('defers an over-age chroma recycle while the heavy-maintenance lease is active', () => {
+        AiConfig.orchestrator.chroma = {maxRuntimeMs: 1000};
+        const sink         = {killed: [], started: [], supervised: []};
+        const orchestrator = createTestOrchestrator();
+        const now          = Date.now();
+
+        fs.ensureDirSync(path.dirname(orchestrator.heavyMaintenanceLeasePath));
+        fs.writeJsonSync(orchestrator.heavyMaintenanceLeasePath, {
+            owner       : 'kbSync',
+            reason      : 'scheduled',
+            pid         : process.pid,
+            token       : 'test-token',
+            acquiredAt  : new Date(now - 1000).toISOString(),
+            staleAfterMs: 600000,
+            expiresAt   : new Date(now + 600000).toISOString()
+        });
+
+        TaskStateService.taskState.chroma.running   = true;
+        TaskStateService.taskState.chroma.lastRunAt = now - 5000;
+        orchestrator.processSupervisorService = recycleMock(sink);
+
+        orchestrator.poll();
+
+        expect(sink.killed).toEqual([]);
+        expect(sink.supervised).toContain('chroma');
+        expect(orchestrator._chromaDefragPending).toBeFalsy();
+
+        fs.removeSync(orchestrator.heavyMaintenanceLeasePath);
+
+        orchestrator.poll();
+
+        expect(sink.killed).toHaveLength(1);
+        expect(sink.killed[0].taskName).toBe('chroma');
+        expect(orchestrator._chromaDefragPending).toBe(true);
+    });
+
     test('does not recycle a chroma daemon within its max-runtime ceiling', () => {
         AiConfig.orchestrator.chroma = {maxRuntimeMs: 60000};
         const sink         = {killed: [], started: []};
@@ -1990,6 +2028,38 @@ test.describe('Neo.ai.daemons.Orchestrator — chroma max-runtime recycle (#1213
 
         expect(sink.started).toContainEqual({taskName: 'chromaDefrag', reason: 'chroma-recycle-defrag'});
         expect(orchestrator._chromaDefragPending).toBe(false);
+    });
+
+    test('does not start pending chroma defrag while the heavy-maintenance lease is active', async () => {
+        AiConfig.orchestrator.chroma = {maxRuntimeMs: 60000};
+        const sink         = {killed: [], started: []};
+        const orchestrator = createTestOrchestrator();
+        const now          = Date.now();
+
+        fs.ensureDirSync(path.dirname(orchestrator.heavyMaintenanceLeasePath));
+        fs.writeJsonSync(orchestrator.heavyMaintenanceLeasePath, {
+            owner       : 'kbSync',
+            reason      : 'scheduled',
+            pid         : process.pid,
+            token       : 'test-token',
+            acquiredAt  : new Date(now - 1000).toISOString(),
+            staleAfterMs: 600000,
+            expiresAt   : new Date(now + 600000).toISOString()
+        });
+
+        TaskStateService.taskState.chroma.running   = true;
+        TaskStateService.taskState.chroma.lastRunAt = now;
+        orchestrator._chromaDefragPending = true;
+        orchestrator.probeChromaReady     = () => Promise.resolve(true);
+        orchestrator.processSupervisorService = recycleMock(sink);
+
+        orchestrator.poll();
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(sink.started.find(s => s.taskName === 'chromaDefrag')).toBeUndefined();
+        expect(orchestrator._chromaDefragPending).toBe(true);
+
+        fs.removeSync(orchestrator.heavyMaintenanceLeasePath);
     });
 
     test('does not spawn the defrag while the restarted chroma is not yet connection-ready', async () => {

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -100,6 +100,10 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         expect(config.port).toBe(TIER1_DEFAULTS.engines.chroma.portTest);
         expect(config.collectionName).toBe('neo-knowledge-base');
         expect(config.path).toBe(TIER1_DEFAULTS.engines.chroma.dataDirTest);
+        expect(config.collectionResolveRetry.maxAttempts).toBe(5);
+        expect(config.collectionResolveRetry.initialDelayMs).toBe(500);
+        expect(config.collectionResolveRetry.maxDelayMs).toBe(2000);
+        expect(config.collectionResolveRetry.maxTotalDelayMs).toBe(5000);
     });
 
     test('env overrides win — KB-local leaves at the child, Tier-1-owned leaves at the owner (inherited)', () => {

--- a/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
@@ -23,6 +23,7 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
     let originalClient;
     let originalCollectionPromise;
     let originalKnowledgeBaseCollection;
+    let originalCollectionResolveRetrySleepFn;
 
     test.beforeAll(async () => {
         aiConfig      = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
@@ -31,6 +32,7 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
         originalClient                  = ChromaManager.client;
         originalCollectionPromise       = ChromaManager._knowledgeBaseCollectionPromise;
         originalKnowledgeBaseCollection = ChromaManager.knowledgeBaseCollection;
+        originalCollectionResolveRetrySleepFn = ChromaManager.collectionResolveRetrySleepFn;
     });
 
     test.beforeEach(() => {
@@ -43,6 +45,7 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
         ChromaManager.connected                      = false;
         ChromaManager._knowledgeBaseCollectionPromise = originalCollectionPromise;
         ChromaManager.knowledgeBaseCollection        = originalKnowledgeBaseCollection;
+        ChromaManager.collectionResolveRetrySleepFn  = originalCollectionResolveRetrySleepFn;
     });
 
     test('connect marks the manager connected when heartbeat succeeds', async () => {
@@ -67,8 +70,8 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
 
     test('getKnowledgeBaseCollection creates and caches the configured collection after missing get', async () => {
         let createCount = 0;
-        let getCount = 0;
-        let created = false;
+        let getCount    = 0;
+        let created     = false;
         let capturedOptions;
 
         ChromaManager.client = {
@@ -79,7 +82,7 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
                 }
                 return {name: options.name};
             },
-            listCollections: async () => [],
+            listCollections : async () => [],
             createCollection: async options => {
                 createCount++;
                 created = true;
@@ -100,6 +103,61 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
         });
     });
 
+    test('getKnowledgeBaseCollection retries transient ChromaConnectionError while resolving the canonical collection', async () => {
+        const delays   = [];
+        let   getCount = 0;
+
+        ChromaManager.collectionResolveRetrySleepFn = async delayMs => { delays.push(delayMs); };
+        ChromaManager.client = {
+            getCollection: async options => {
+                getCount++;
+
+                if (getCount < 3) {
+                    const error = new Error('Failed to connect to chromadb');
+                    error.name  = 'ChromaConnectionError';
+                    throw error;
+                }
+
+                return {name: options.name};
+            }
+        };
+
+        const collection = await ChromaManager.getKnowledgeBaseCollection();
+
+        expect(collection.name).toBe(aiConfig.collectionName);
+        expect(getCount).toBe(3);
+        expect(delays).toEqual([
+            aiConfig.collectionResolveRetry.initialDelayMs,
+            aiConfig.collectionResolveRetry.initialDelayMs * 2
+        ]);
+    });
+
+    test('getKnowledgeBaseCollection fails loud after bounded ChromaConnectionError retries', async () => {
+        let getCount = 0;
+
+        ChromaManager.collectionResolveRetrySleepFn = async () => {};
+        ChromaManager.client = {
+            getCollection: async () => {
+                getCount++;
+                const error = new Error('Failed to connect to chromadb');
+                error.name  = 'ChromaConnectionError';
+                throw error;
+            }
+        };
+
+        await expect(ChromaManager.getKnowledgeBaseCollection())
+            .rejects.toMatchObject({
+                name        : 'ChromaConnectionError',
+                retryContext: {
+                    maxAttempts: aiConfig.collectionResolveRetry.maxAttempts
+                }
+            });
+
+        expect(getCount).toBe(aiConfig.collectionResolveRetry.maxAttempts);
+        expect(ChromaManager._knowledgeBaseCollectionPromise).toBe(null);
+        expect(ChromaManager.knowledgeBaseCollection).toBe(null);
+    });
+
     test('getKnowledgeBaseCollection treats ChromaNotFoundError as missing canonical collection', async () => {
         let createCount = 0;
         let capturedOptions;
@@ -110,7 +168,7 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
                 error.name  = 'ChromaNotFoundError';
                 throw error;
             },
-            listCollections: async () => [],
+            listCollections : async () => [],
             createCollection: async options => {
                 createCount++;
                 capturedOptions = options;
@@ -157,8 +215,8 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
 
         await expect(ChromaManager.getKnowledgeBaseCollection())
             .rejects.toMatchObject({
-                code                  : 'KB_COLLECTION_SWAP_IN_PROGRESS',
-                activeSwapCollections : [
+                code                 : 'KB_COLLECTION_SWAP_IN_PROGRESS',
+                activeSwapCollections: [
                     `${aiConfig.collectionName}-parking-123`,
                     `${aiConfig.collectionName}-shadow-123`
                 ]
@@ -183,7 +241,7 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
 
     test('checkConnectivity returns heartbeat and cached collection name', async () => {
         ChromaManager.client = {
-            heartbeat: async () => 456,
+            heartbeat    : async () => 456,
             getCollection: async () => ({name: 'knowledge-base-test'})
         };
 


### PR DESCRIPTION
Resolves #14293

Coordinates the local Chroma recycle path with the existing heavy-maintenance lease so a running kbSync keeps Chroma alive until the lease clears. Adds bounded, configurable `ChromaConnectionError` retries while resolving the canonical KB collection, so a brief Chroma restart no longer abandons a long sync at the first transient blip.

Evidence: L2 (lease-overlap unit coverage, ChromaConnectionError retry unit coverage, config-template lint) -> L2 required (the close target asks for unit coverage around recycle deferral and bounded resolve retry). No residuals.

## Deltas from ticket

Added env-backed KB config leaves instead of hard-coded retry constants:

- `collectionResolveRetry.maxAttempts` / `NEO_KB_COLLECTION_RESOLVE_RETRY_MAX_ATTEMPTS`
- `collectionResolveRetry.initialDelayMs` / `NEO_KB_COLLECTION_RESOLVE_RETRY_INITIAL_DELAY_MS`
- `collectionResolveRetry.maxDelayMs` / `NEO_KB_COLLECTION_RESOLVE_RETRY_MAX_DELAY_MS`
- `collectionResolveRetry.maxTotalDelayMs` / `NEO_KB_COLLECTION_RESOLVE_RETRY_MAX_TOTAL_DELAY_MS`

ADR-0019 impact: aligned. The new retry policy lives in the reactive KB config template and is read at the ChromaManager use site; no env re-derivation, pass-through plumbing, or hidden constants.

Config template follow-up: active clones need to refresh the gitignored KB overlay after merge with `node ai/scripts/setup/initServerConfigs.mjs --migrate-config`. Restart is recommended for long-running local orchestrator and KB MCP processes so they load the recycle guard and new config leaves. One-shot CLI sync processes started after merge pick up the code/config on process start.

## Test Evidence

- `git diff --check`
- `npm run agent-preflight -- ai/daemons/orchestrator/Orchestrator.mjs ai/mcp/server/knowledge-base/config.template.mjs ai/services/knowledge-base/ChromaManager.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs`
- `npm run ai:lint-config-template-ssot`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs` -> 72 passed

## Post-Merge Validation

- [ ] Refresh gitignored KB config overlays in active clones and restart long-running local orchestrator/KB processes.
- [ ] Observe the next long local `npm run ai:sync-kb` while Chroma is recycle-eligible; recycle should defer while the heavy-maintenance lease is active, and transient collection-resolve connection failures should retry before failing loud.

## Commits

- `6961666a8a` - `fix(ai): coordinate chroma recycle with kb sync (#14293)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019f0da6-ba3b-7f42-a571-b0d6f71abc38.
