### PR TITLE
fix(ai): seal heal-ledger retention (#14295)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -445,14 +445,6 @@ export class Orchestrator extends Base {
         const healLedgerDir    = path.join(this.dataDir, 'data-heal-events');
         const freezeRecordsDir = path.join(this.dataDir, 'data-freeze-records');
 
-        // The retention leaves, read + VALIDATED at this AiConfig boundary (call-time). An invalid operator-set
-        // maxEvents/pruneTriggerBytes fails VISIBLY here rather than being swallowed by appendHealEvent's prune gate
-        // (which would silently let the observability ledger grow unbounded).
-        const healLedgerRetention = () => validateHealLedgerRetention(
-            AiConfig.orchestrator.recoveryActuator.healLedger.maxEvents,
-            AiConfig.orchestrator.recoveryActuator.healLedger.pruneTriggerBytes
-        );
-
         return ClassSystemUtil.beforeSetInstance(value, DataRecoveryActuatorService, {
             healOperations: {
                 // The wal-stall heal terminal: the runtime<->op adapter (cross-store guard + re-audit-for-ids
@@ -522,15 +514,29 @@ export class Orchestrator extends Base {
                 }
                 return healEventsToRecentRuns(queryHealLedger(events, {collections: [collectionName]}));
             },
-            // Retention is read + VALIDATED at the AiConfig boundary (healLedgerRetention(), above) and passed explicit
-            // into the pure ledger helper (which owns no production default). Call-time, never aliased at construction.
+            // Retention is read + VALIDATED from the AiConfig provider at the append boundary; the pure ledger helper
+            // owns no production default.
             recordRun        : async ({action, collection, at}) => appendHealEvent(
                 {type: action, collection, status: 'attempt'},
-                {dir: healLedgerDir, now: at, ...healLedgerRetention()}
+                {
+                    dir: healLedgerDir,
+                    now: at,
+                    ...validateHealLedgerRetention(
+                        AiConfig.orchestrator.recoveryActuator.healLedger.maxEvents,
+                        AiConfig.orchestrator.recoveryActuator.healLedger.pruneTriggerBytes
+                    )
+                }
             ),
             recordHealOutcome: async ({action, collection, status, detail, healedAt}) => appendHealEvent(
                 {type: action, collection, status, detail},
-                {dir: healLedgerDir, now: healedAt, ...healLedgerRetention()}
+                {
+                    dir: healLedgerDir,
+                    now: healedAt,
+                    ...validateHealLedgerRetention(
+                        AiConfig.orchestrator.recoveryActuator.healLedger.maxEvents,
+                        AiConfig.orchestrator.recoveryActuator.healLedger.pruneTriggerBytes
+                    )
+                }
             )
         });
     }
@@ -584,13 +590,17 @@ export class Orchestrator extends Base {
      */
     async runFreezeReprobeCycleIfActive(now = Date.now()) {
         return runFreezeReprobe({
-            freezeRecordsDir: path.join(this.dataDir, 'data-freeze-records'),
-            healLedgerDir   : path.join(this.dataDir, 'data-heal-events'),
+            freezeRecordsDir   : path.join(this.dataDir, 'data-freeze-records'),
+            healLedgerDir      : path.join(this.dataDir, 'data-heal-events'),
+            healLedgerRetention: validateHealLedgerRetention(
+                AiConfig.orchestrator.recoveryActuator.healLedger.maxEvents,
+                AiConfig.orchestrator.recoveryActuator.healLedger.pruneTriggerBytes
+            ),
             now,
-            probe           : collectionName => this.probeFrozenCollectionHealth(collectionName),
+            probe              : collectionName => this.probeFrozenCollectionHealth(collectionName),
             // The store-level unfence — paired with the `freeze` op's fence via createStoreFenceOperations, so a
             // store-level freeze and its auto-unfreeze lift exactly the same served set (no asymmetry).
-            unfence         : this.getStoreFenceOperations().unfence
+            unfence            : this.getStoreFenceOperations().unfence
         });
     }
 
@@ -616,7 +626,14 @@ export class Orchestrator extends Base {
             },
             recordCircuitEvent: async ({type, at, detail}) => appendHealEvent(
                 {type, collection: '*', status: type === 'circuit-open' ? 'open' : 'close', detail},
-                {dir: path.join(this.dataDir, 'data-heal-events'), now: at}
+                {
+                    dir: path.join(this.dataDir, 'data-heal-events'),
+                    now: at,
+                    ...validateHealLedgerRetention(
+                        AiConfig.orchestrator.recoveryActuator.healLedger.maxEvents,
+                        AiConfig.orchestrator.recoveryActuator.healLedger.pruneTriggerBytes
+                    )
+                }
             ),
             // Chronic unsafe-input mis-wire detector (observability): fold the heal-ledger for sustained
             // unsafe-input per (action, collection); bounds read FRESH from the AiConfig recovery-actuator leaf.

--- a/ai/services/memory-core/helpers/freezeReprobeRunner.mjs
+++ b/ai/services/memory-core/helpers/freezeReprobeRunner.mjs
@@ -136,6 +136,8 @@ export function createFreezeHealOperation({freezeRecordsDir, fence, flapWindowMs
  * @param {Object} options
  * @param {String} options.freezeRecordsDir Durable freeze-record state directory.
  * @param {String} options.healLedgerDir Durable heal-event ledger directory (for the `unfreeze` event).
+ * @param {{maxEvents: Number, triggerBytes: Number}} [options.healLedgerRetention] Explicit retention pair supplied
+ * by the AiConfig-aware orchestrator boundary and passed through to every shared heal-ledger append.
  * @param {Number} options.now Injected clock (epoch ms).
  * @param {Function} options.probe `async (collectionName) => {embedderHealthy, dimensionConsistent}`.
  * @param {Function} options.unfence `async (collectionName) => void` — lifts the serving fence (production: unquarantine).
@@ -143,8 +145,9 @@ export function createFreezeHealOperation({freezeRecordsDir, fence, flapWindowMs
  * @param {Number} [options.flapWindowMs=DEFAULT_FLAP_WINDOW_MS] Released-tombstone retention / flap horizon: a tombstone older than this is garbage-collected, and a re-freeze past it starts a fresh recovery budget.
  * @returns {Promise<Object[]>} Per-collection re-probe outcomes, or `[]` when nothing is actively frozen.
  */
-export async function runFreezeReprobe({freezeRecordsDir, healLedgerDir, now, probe, unfence, containedCooldownMs = DEFAULT_CONTAINED_COOLDOWN_MS, flapWindowMs = DEFAULT_FLAP_WINDOW_MS}) {
-    const freezeRecords = await readFreezeRecords({dir: freezeRecordsDir});
+export async function runFreezeReprobe({freezeRecordsDir, healLedgerDir, healLedgerRetention = null, now, probe, unfence, containedCooldownMs = DEFAULT_CONTAINED_COOLDOWN_MS, flapWindowMs = DEFAULT_FLAP_WINDOW_MS}) {
+    const freezeRecords           = await readFreezeRecords({dir: freezeRecordsDir});
+    const healLedgerAppendOptions = () => ({dir: healLedgerDir, now, ...(healLedgerRetention ?? {})});
 
     if (Object.keys(freezeRecords).length === 0) {
         return []; // nothing frozen or tombstoned → no probe, no unfreeze, no further I/O
@@ -169,7 +172,7 @@ export async function runFreezeReprobe({freezeRecordsDir, healLedgerDir, now, pr
     for (const [collectionName, record] of Object.entries(freezeRecords)) {
         if (Number.isFinite(record?.containedAt) && (now - record.containedAt) >= containedCooldownMs) {
             freezeRecords[collectionName] = await upsertFreezeRecord({dir: freezeRecordsDir, collectionName, unfreezeAttempts: 0, containedAt: now});
-            await appendHealEvent({type: 'contained-reopen', collection: collectionName, status: 'reopened'}, {dir: healLedgerDir, now});
+            await appendHealEvent({type: 'contained-reopen', collection: collectionName, status: 'reopened'}, healLedgerAppendOptions());
         }
     }
 
@@ -190,7 +193,7 @@ export async function runFreezeReprobe({freezeRecordsDir, healLedgerDir, now, pr
         unfreezeAndReheal: async collectionName => {
             // Lift the serving fence + ledger the unfreeze; the next poll's diagnosis re-heals any residue.
             await unfence(collectionName);
-            await appendHealEvent({type: 'unfreeze', collection: collectionName, status: 'unfrozen'}, {dir: healLedgerDir, now});
+            await appendHealEvent({type: 'unfreeze', collection: collectionName, status: 'unfrozen'}, healLedgerAppendOptions());
         },
         persistProbe: async ({collectionName, lastProbeAt, unfreezeAttempts}) => upsertFreezeRecord({dir: freezeRecordsDir, collectionName, lastProbeAt, unfreezeAttempts}),
         // RELEASE (not delete) on a successful unfreeze: mark a tombstone (`unfrozenAt`) that carries the just-climbed
@@ -206,7 +209,7 @@ export async function runFreezeReprobe({freezeRecordsDir, healLedgerDir, now, pr
     // `containedAt` marker so a collection that remains contained across polls is ledgered on the transition only.
     for (const outcome of outcomes) {
         if (outcome.status === 'contained' && !activeRecords[outcome.collectionName]?.containedAt) {
-            await appendHealEvent({type: 'contained', collection: outcome.collectionName, status: 'contained', detail: {reason: outcome.reason}}, {dir: healLedgerDir, now});
+            await appendHealEvent({type: 'contained', collection: outcome.collectionName, status: 'contained', detail: {reason: outcome.reason}}, healLedgerAppendOptions());
             await upsertFreezeRecord({dir: freezeRecordsDir, collectionName: outcome.collectionName, containedAt: now});
         }
     }

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -1,6 +1,8 @@
 import {test, expect}   from '@playwright/test';
+import {execFile}       from 'child_process';
 import fs               from 'fs/promises';
 import path             from 'path';
+import {promisify}      from 'util';
 import {fileURLToPath}  from 'url';
 import Neo              from '../../../../../../src/Neo.mjs';
 import * as core        from '../../../../../../src/core/_export.mjs';
@@ -17,9 +19,10 @@ import {
 } from '../../../../../../ai/daemons/orchestrator/taskDefinitions.mjs';
 import TaskStateService, {createInitialTaskState} from '../../../../../../ai/daemons/orchestrator/services/TaskStateService.mjs';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname  = path.dirname(__filename);
-const REPO_ROOT  = path.resolve(__dirname, '../../../../../..');
+const __filename    = fileURLToPath(import.meta.url);
+const __dirname     = path.dirname(__filename);
+const REPO_ROOT     = path.resolve(__dirname, '../../../../../..');
+const execFileAsync = promisify(execFile);
 
 const ORCHESTRATOR_MJS_PATH                    = path.join(REPO_ROOT, 'ai/daemons/orchestrator/Orchestrator.mjs');
 const ORCHESTRATOR_DAEMON_PATH                 = path.join(REPO_ROOT, 'ai/daemons/orchestrator/daemon.mjs');
@@ -76,14 +79,14 @@ function createMinimalOrchestrator() {
     TaskStateService.taskState = createInitialTaskState(taskDefinitions);
 
     return Neo.create(Orchestrator, {
-        dataDir  : '/tmp/orchestrator-test',
-        stateFile: '/tmp/orchestrator-test/state.json',
-        logFile  : null,
+        dataDir                  : '/tmp/orchestrator-test',
+        stateFile                : '/tmp/orchestrator-test/state.json',
+        logFile                  : null,
         heavyMaintenanceLeasePath: `/tmp/orchestrator-test/heavy-maintenance-lease-${process.pid}-${++invariantSeq}.json`,
         taskDefinitions,
-        taskStateService: TaskStateService,
-        healthService   : {recordTaskOutcome() {}},
-        spawnFn         : () => { throw new Error('spawnFn not expected'); }
+        taskStateService         : TaskStateService,
+        healthService            : {recordTaskOutcome() {}},
+        spawnFn                  : () => { throw new Error('spawnFn not expected'); }
     });
 }
 
@@ -441,6 +444,78 @@ test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
         expect(orchestrator.deploymentStateBridgeService.healLedgerDir).toBe(path.join('/tmp/orchestrator-test-mutated', 'data-heal-events'));
     });
 
+    test('systemic circuit ledger writes honor retention from the AiConfig provider (#14295)', async () => {
+        const script = `
+            const fs = await import('node:fs/promises');
+            const os = await import('node:os');
+            const path = await import('node:path');
+            const {default: Neo} = await import('./src/Neo.mjs');
+            await import('./src/core/_export.mjs');
+            const {default: AiConfig} = await import('./ai/config.mjs');
+            const {Orchestrator} = await import('./ai/daemons/orchestrator/Orchestrator.mjs');
+            const {buildTaskDefinitions} = await import('./ai/daemons/orchestrator/taskDefinitions.mjs');
+            const {default: TaskStateService, createInitialTaskState} = await import('./ai/daemons/orchestrator/services/TaskStateService.mjs');
+            const {readHealLedger} = await import('./ai/services/memory-core/helpers/healEventLedgerStore.mjs');
+
+            const root = await fs.mkdtemp(path.join(os.tmpdir(), 'orchestrator-14295-circuit-'));
+            try {
+                if (AiConfig.orchestrator.recoveryActuator.healLedger.maxEvents !== 2) {
+                    throw new Error('expected env-backed healLedger.maxEvents to resolve through AiConfig');
+                }
+                if (AiConfig.orchestrator.recoveryActuator.healLedger.pruneTriggerBytes !== 1) {
+                    throw new Error('expected env-backed healLedger.pruneTriggerBytes to resolve through AiConfig');
+                }
+
+                const taskDefinitions = buildTaskDefinitions({scriptDir: '/repo/ai/scripts', nodeBin: process.execPath});
+                TaskStateService.configure({stateFile: path.join(root, 'state.json'), taskDefinitions, writeLogFn: () => {}});
+                TaskStateService.taskState = createInitialTaskState(taskDefinitions);
+
+                const orchestrator = Neo.create(Orchestrator, {
+                    dataDir                  : root,
+                    stateFile                : path.join(root, 'state.json'),
+                    logFile                  : null,
+                    heavyMaintenanceLeasePath: path.join(root, 'heavy-maintenance-lease.json'),
+                    taskDefinitions,
+                    taskStateService         : TaskStateService,
+                    healthService            : {recordTaskOutcome() {}},
+                    spawnFn                  : () => { throw new Error('spawnFn not expected'); }
+                });
+
+                for (let i = 0; i < 5; i++) {
+                    await orchestrator.dataIntegrityDiagnosisService.recordCircuitEvent({
+                        type  : i % 2 === 0 ? 'circuit-open' : 'circuit-close',
+                        at    : i,
+                        detail: {i}
+                    });
+                }
+
+                const events = await readHealLedger({dir: path.join(root, 'data-heal-events')});
+                if (events.length !== 2) {
+                    throw new Error('expected retained ledger length 2, got ' + events.length);
+                }
+                if (JSON.stringify(events.map(event => event.at)) !== JSON.stringify([3, 4])) {
+                    throw new Error('expected newest retained event times [3,4], got ' + JSON.stringify(events.map(event => event.at)));
+                }
+                if (JSON.stringify(events.map(event => event.type)) !== JSON.stringify(['circuit-close', 'circuit-open'])) {
+                    throw new Error('expected newest circuit event types, got ' + JSON.stringify(events.map(event => event.type)));
+                }
+            } finally {
+                await fs.rm(root, {recursive: true, force: true});
+            }
+        `;
+
+        await execFileAsync(process.execPath, ['--input-type=module', '-e', script], {
+            cwd: REPO_ROOT,
+            env: {
+                ...process.env,
+                NEO_RECOVERY_ACTUATOR_HEAL_LEDGER_MAX_EVENTS         : '2',
+                NEO_RECOVERY_ACTUATOR_HEAL_LEDGER_PRUNE_TRIGGER_BYTES: '1',
+                UNIT_TEST_MODE                                       : 'true'
+            },
+            maxBuffer: 1024 * 1024
+        });
+    });
+
     test('the store-level fence fan-out resolves served collection names from the Memory Core config SSOT', () => {
         const orchestrator = createMinimalOrchestrator();
         // A store-level fault target (e.g. mc-server) is not itself a served collection, so it expands to the served
@@ -530,7 +605,7 @@ test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
         const configuredTaskDefinitionsSource = stripCommentsAndStrings(
             await fs.readFile(CONFIGURED_TASK_DEFINITIONS_SERVICE_PATH, 'utf8')
         );
-        const daemonSource = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_DAEMON_PATH, 'utf8'));
+        const daemonSource     = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_DAEMON_PATH, 'utf8'));
         const configReadSource = `${orchestratorSource}\n${configuredTaskDefinitionsSource}`;
 
         for (const snippet of [
@@ -595,7 +670,7 @@ test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
         const slotNames   = slotMatches.map(m => m[1]).filter(name => name !== 'class' && name !== 'static');
 
         const missingHook = slotNames.filter(name => {
-            const cap = name.charAt(0).toUpperCase() + name.slice(1);
+            const cap      = name.charAt(0).toUpperCase() + name.slice(1);
             const beforeRe = new RegExp(`\\bbeforeSet${cap}\\s*\\(`);
             const afterRe  = new RegExp(`\\bafterSet${cap}\\s*\\(`);
             return !beforeRe.test(codeLines) && !afterRe.test(codeLines);

--- a/test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeRunner.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeRunner.spec.mjs
@@ -187,6 +187,42 @@ test.describe('freezeReprobeRunner — contained ledgering (#14276)', () => {
             await fs.rm(dir, {recursive: true, force: true});
         }
     });
+
+    test('all freeze re-probe heal-ledger appends honor the supplied retention policy (#14295)', async () => {
+        const dir       = await tmpDir(),
+              retention = {triggerBytes: 1, maxEvents: 2};
+
+        try {
+            await upsertFreezeRecord({dir, collectionName: 'contained', faultFingerprint: 'e', frozenAt: 1000, unfreezeAttempts: 3});
+            await runFreezeReprobe({
+                freezeRecordsDir   : dir,
+                healLedgerDir      : dir,
+                healLedgerRetention: retention,
+                now                : 2_000_000,
+                probe              : async () => ({embedderHealthy: false, dimensionConsistent: false}),
+                unfence            : async () => {}
+            });
+            await removeFreezeRecord({dir, collectionName: 'contained'});
+
+            await upsertFreezeRecord({dir, collectionName: 'recovered', faultFingerprint: 'e', frozenAt: 1000, unfreezeAttempts: 3, containedAt: 1000});
+            await runFreezeReprobe({
+                freezeRecordsDir   : dir,
+                healLedgerDir      : dir,
+                healLedgerRetention: retention,
+                now                : 1000 + 7 * 60 * 60 * 1000,
+                probe              : async () => ({embedderHealthy: true, dimensionConsistent: true}),
+                unfence            : async () => {}
+            });
+
+            const ledger = await readHealLedger({dir});
+
+            expect(ledger).toHaveLength(2);
+            expect(ledger.map(event => event.type)).toEqual(['contained-reopen', 'unfreeze']);
+            expect(ledger.every(event => event.collection === 'recovered')).toBe(true);
+        } finally {
+            await fs.rm(dir, {recursive: true, force: true});
+        }
+    });
 });
 
 test.describe('freezeReprobeRunner — contained recovery (#14276 no permanent strand)', () => {


### PR DESCRIPTION
Resolves #14295

This seals the valid #14272 follow-up gap: every production append class that writes into the shared heal-event ledger now receives the validated AiConfig retention pair. The ledger helper remains pure and owns no production defaults.

ADR-0019 correction from review: `AiConfig` remains the reactive state provider. The Orchestrator append boundaries read `AiConfig.orchestrator.recoveryActuator.healLedger.{maxEvents,pruneTriggerBytes}` directly at use sites; there is no wrapper method around the provider and the regression test does not mutate the shared singleton.

Evidence: L2 (focused unit coverage exercises Orchestrator retention wiring, temp-dir ledger I/O, and retained freeze re-probe helper appends) -> L2 required (the retained close-target ACs are internal runtime contracts fully reachable by the unit suite). No residuals.

Related: #14163, #14272, #14039, #14128, #14179, #14166

## Deltas from ticket

The original ticket also asserted a `dataDir` mutation coherence gap. That premise was challenged and retracted: `dataDir` reactivity does not by itself establish that every closure constructed inside sibling `beforeSet*` hooks must migrate after later `dataDir` changes. The existing runtime-mutation contract is broader than this retention follow-up and should not be patched piecemeal here.

The surviving change is retention-only:

- Orchestrator heal-ledger append boundaries validate the live AiConfig provider leaves directly at the use site.
- `runFreezeReprobeCycleIfActive()` passes that retention pair into `runFreezeReprobe()`.
- `recordCircuitEvent()` now writes under the same bounded policy as data-recovery attempts/outcomes.
- `runFreezeReprobe()` forwards the supplied retention pair to `contained-reopen`, `unfreeze`, and `contained` ledger appends.

## Test Evidence

- `git diff --check` -> passed
- `node --check ai/daemons/orchestrator/Orchestrator.mjs` -> passed
- `node --check ai/services/memory-core/helpers/freezeReprobeRunner.mjs` -> passed
- `node --check test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs` -> passed
- `node --check test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeRunner.spec.mjs` -> passed
- `node buildScripts/util/check-aiconfig-test-mutation.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeRunner.spec.mjs` -> passed, 0 new violations
- `NEO_CHROMA_PORT_TEST=20295 NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeRunner.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs test/playwright/unit/ai/config.template.spec.mjs` -> 78 passed
- `npm run agent-preflight -- --pr-body /private/tmp/neo-pr-14295-body.md ai/daemons/orchestrator/Orchestrator.mjs ai/services/memory-core/helpers/freezeReprobeRunner.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeRunner.spec.mjs` -> passed

## Post-Merge Validation

- [ ] Watch CI confirm the same focused self-heal/orchestrator unit surface stays green on GitHub's runner.

## Commit

- `4849cc72aa` — `fix(ai): seal heal-ledger retention (#14295)`

Authored by Euclid (GPT-5.5, Codex Desktop). Session 019f0da6-ba3b-7f42-a571-b0d6f71abc38.
