### PR TITLE
fix(ai): prove Chroma health before keeping adopted PID (#14297)

### DIFF
--- a/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
+++ b/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
@@ -34,6 +34,7 @@ export function buildConfiguredTaskDefinitions({
     const tasks = buildTaskDefinitions({
         scriptDir,
         nodeBin,
+        chromaHost                : AiConfig.engines.chroma.host,
         chromaPort                : AiConfig.engines.chroma.port,
         devServerPort             : AiConfig.orchestrator.devServer.port,
         devServerLivenessTimeoutMs: AiConfig.orchestrator.devServer.livenessProbeTimeoutMs,

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -128,7 +128,14 @@ export class ProcessSupervisorService extends Base {
     }
 
     /**
-     * Adopts or clears an existing child-task PID file during daemon boot.
+     * @summary Adopts or clears an existing child-task PID file during daemon boot.
+     *
+     * This is process adoption only: `process.kill(pid, 0)` plus `expectedCommand`
+     * proves the persisted PID still belongs to the intended executable, not that
+     * the service behind that process is usable. Long-running tasks that can be
+     * process-alive but service-dead must expose `healthProbe()`; the poll loop
+     * then recycles the adopted/running task through {@link gateRecycleOnHealthProbe}.
+     *
      * @param {String} taskName Task key.
      * @returns {void}
      */
@@ -859,12 +866,13 @@ export class ProcessSupervisorService extends Base {
 
         const task = this.taskDefinitions[taskName];
 
-        // Running-but-stuck recycle. A long-running child can be alive yet not serving — a stuck
-        // inference grinding CPU while a residency/process check still passes. A `healthProbe()`
-        // checks the RUNNING child; on a sustained-unhealthy result the child is recycled (killed,
-        // then respawned by the next poll). This is distinct from `livenessProbe()`, which answers
-        // "is the service up while my process flag says down" for a fire-and-exit launcher — the
-        // running-process branch below never reached the down-only liveness path.
+        // Running-but-stuck recycle. A long-running child can be alive yet not serving — Chroma can
+        // leave a process/PID that passes adoption while its HTTP API is dead; an inference runner can
+        // grind CPU while residency/process checks still pass. A `healthProbe()` checks the RUNNING
+        // child; on an unhealthy result the child is recycled (killed, then respawned by the next
+        // poll). This is distinct from `livenessProbe()`, which answers "is the service up while my
+        // process flag says down" for a fire-and-exit launcher — the running-process branch below
+        // never reaches the down-only liveness path.
         if (state.running) {
             if (typeof task?.healthProbe === 'function') {
                 this.gateRecycleOnHealthProbe(taskName, task, now, cooldownMs);
@@ -903,9 +911,10 @@ export class ProcessSupervisorService extends Base {
      *
      * Mirrors {@link gateRestartOnLivenessProbe}'s confirmed-at + in-flight de-dup (at most one
      * probe per cooldown, no overlap), but acts on the RUNNING-child surface: a healthy result is
-     * silent; a sustained-unhealthy result `killTask`s the child (recycle → respawn next poll). The
-     * task owns the actual "is it serving" check via `healthProbe()` (the sustained-stuck hysteresis
-     * lives there); this method only schedules it and acts on the boolean.
+     * silent; an unhealthy result `killTask`s the child (recycle → respawn next poll). The task owns
+     * the actual "is it serving" check via `healthProbe()` and may implement its own hysteresis
+     * (the Ollama stuck-runner path does; Chroma's heartbeat probe intentionally does not); this
+     * method only schedules the probe and acts on the boolean.
      *
      * A THROWN probe is treated as healthy (no recycle): unlike the liveness path, the child is
      * already running, so a probe fault must never kill a working process.

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -9,6 +9,9 @@ export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sq
 export const DEFAULT_DATA_DIR   = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
 export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
 
+const DEFAULT_CHROMA_HEALTH_ENDPOINT   = '/api/v2/heartbeat';
+const DEFAULT_CHROMA_HEALTH_TIMEOUT_MS = 1000;
+
 /**
  * @summary Probes whether a local TCP port is accepting connections.
  * @param {Object} options
@@ -42,6 +45,95 @@ function probeTcpPort({port, timeoutMs}) {
         socket.once('timeout', () => finish(false));
         socket.once('error',   () => finish(false));
     });
+}
+
+/**
+ * @summary Builds a Chroma HTTP health URL from the configured host/port.
+ *
+ * Chroma can bind IPv6-only in local development while the config host stays `localhost`.
+ * Preserve the configured host instead of forcing `127.0.0.1`, and bracket literal IPv6
+ * hosts so `fetch` receives a valid URL.
+ * @param {Object} options
+ * @param {String} [options.host='localhost'] Configured Chroma host.
+ * @param {String|Number} options.port Configured Chroma port.
+ * @param {String} [options.endpoint='/api/v2/heartbeat'] Chroma health endpoint.
+ * @returns {String|null}
+ */
+export function buildChromaHealthUrl({
+    host     = 'localhost',
+    port,
+    endpoint = DEFAULT_CHROMA_HEALTH_ENDPOINT
+} = {}) {
+    const normalizedPort = Number(port);
+
+    if (!Number.isFinite(normalizedPort) || normalizedPort <= 0) {
+        return null;
+    }
+
+    const rawHost = String(host || 'localhost').trim();
+
+    if (!rawHost) {
+        return null;
+    }
+
+    try {
+        const hasScheme      = rawHost.includes('://'),
+              colonCount     = rawHost.split(':').length - 1,
+              isBareIpv6Host = colonCount > 1 && !rawHost.startsWith('['),
+              normalizedHost = isBareIpv6Host ? `[${rawHost}]` : rawHost,
+              url            = hasScheme ? new URL(rawHost) : new URL(`http://${normalizedHost}`);
+
+        url.port     = String(normalizedPort);
+        url.pathname = endpoint;
+        url.search   = '';
+        url.hash     = '';
+
+        return url.toString();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * @summary Probes Chroma's HTTP API, not just PID or TCP liveness.
+ * @param {Object} options
+ * @param {String} [options.host='localhost'] Configured Chroma host.
+ * @param {String|Number} options.port Configured Chroma port.
+ * @param {Number} [options.timeoutMs=1000] Request timeout in milliseconds.
+ * @param {String} [options.endpoint='/api/v2/heartbeat'] Chroma health endpoint.
+ * @param {Function} [options.fetchFn=globalThis.fetch] Fetch implementation seam.
+ * @returns {Promise<Boolean>}
+ */
+export async function probeChromaHttpHealth({
+    host,
+    port,
+    timeoutMs = DEFAULT_CHROMA_HEALTH_TIMEOUT_MS,
+    endpoint,
+    fetchFn = globalThis.fetch
+} = {}) {
+    const url = buildChromaHealthUrl({host, port, endpoint});
+
+    if (!url || typeof fetchFn !== 'function') {
+        return false;
+    }
+
+    const controller = new AbortController(),
+          timeout    = Number(timeoutMs);
+    let timeoutId = null;
+
+    if (Number.isFinite(timeout) && timeout > 0) {
+        timeoutId = setTimeout(() => controller.abort(), timeout);
+        timeoutId.unref?.();
+    }
+
+    try {
+        const response = await fetchFn(url, {signal: controller.signal});
+        return Boolean(response?.ok);
+    } catch {
+        return false;
+    } finally {
+        clearTimeout(timeoutId);
+    }
 }
 
 /**
@@ -131,6 +223,9 @@ export function buildOllamaServeEnv({host, keepAlive, contextLength, requirePara
  * @param {String} [options.scriptDir] Script directory.
  * @param {String} [options.nodeBin] Node executable.
  * @param {String|Number} [options.chromaPort] Chroma daemon port — used for the `--port` arg and as the chroma task's `singletonPort` (the port the orchestrator reaps duplicate listeners on).
+ * @param {String} [options.chromaHost='localhost'] Chroma daemon host for HTTP service-health probes.
+ * @param {Number} [options.chromaHealthProbeTimeoutMs=1000] Chroma HTTP health probe timeout.
+ * @param {Function} [options.chromaHealthFetchFn] Optional fetch implementation seam for tests.
  * @param {String|Number} [options.devServerPort] Local webpack dev-server port — used for the `--port` arg, singleton detection, and TCP liveness probe.
  * @param {Number} [options.devServerLivenessTimeoutMs] TCP liveness probe timeout.
  * @param {String|Number} [options.neuralLinkBridgePort] Neural Link Bridge port — sourced from the Neural Link config provider by the orchestrator entrypoint.
@@ -140,7 +235,10 @@ export function buildOllamaServeEnv({host, keepAlive, contextLength, requirePara
 export function buildTaskDefinitions({
     scriptDir  = DEFAULT_SCRIPT_DIR,
     nodeBin    = process.argv[0],
+    chromaHost = 'localhost',
     chromaPort,
+    chromaHealthProbeTimeoutMs = DEFAULT_CHROMA_HEALTH_TIMEOUT_MS,
+    chromaHealthFetchFn,
     devServerPort,
     devServerLivenessTimeoutMs,
     neuralLinkBridgePort,
@@ -161,7 +259,13 @@ export function buildTaskDefinitions({
             args           : ['run', '--path', '.neo-ai-data/chroma/unified', '--port', String(chromaPort)],
             pidFileName    : 'chroma.pid',
             expectedCommand: 'chroma',
-            singletonPort  : chromaPort
+            singletonPort  : chromaPort,
+            healthProbe    : () => probeChromaHttpHealth({
+                host     : chromaHost,
+                port     : chromaPort,
+                timeoutMs: chromaHealthProbeTimeoutMs,
+                fetchFn  : chromaHealthFetchFn
+            })
         },
         // `bridgeDaemon` lane id is a frozen lane-taxonomy / continuousTasks wire constant —
         // kept verbatim on the wake-daemon rename so the orchestrator keeps scheduling the lane.

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -10,6 +10,7 @@ import {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
 } from '../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
 import {
+    buildChromaHealthUrl,
     buildTaskDefinitions
 } from '../../../../../../ai/daemons/orchestrator/taskDefinitions.mjs';
 import TaskStateService, { createInitialTaskState } from '../../../../../../ai/daemons/orchestrator/services/TaskStateService.mjs';
@@ -586,6 +587,42 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             taskName: 'embedDaemon',
             reason  : 'supervisor-restart'
         });
+    });
+
+    test('defines Chroma with an HTTP health probe on the configured host (#14297)', async () => {
+        const fetchCalls      = [];
+        const taskDefinitions = buildTaskDefinitions({
+            scriptDir                 : '/repo/ai/scripts',
+            nodeBin                   : '/node',
+            chromaHost                : 'localhost',
+            chromaPort                : 8000,
+            chromaHealthProbeTimeoutMs: 25,
+            chromaHealthFetchFn       : async (url, options) => {
+                fetchCalls.push({url, hasSignal: Boolean(options.signal)});
+                return {ok: true};
+            }
+        });
+
+        expect(taskDefinitions.chroma).toMatchObject({
+            expectedCommand: 'chroma',
+            singletonPort  : 8000
+        });
+        expect(taskDefinitions.chroma.duplicateListenerPolicy).toBeUndefined();
+        expect(typeof taskDefinitions.chroma.healthProbe).toBe('function');
+        await expect(taskDefinitions.chroma.healthProbe()).resolves.toBe(true);
+        expect(fetchCalls).toEqual([{
+            url      : 'http://localhost:8000/api/v2/heartbeat',
+            hasSignal: true
+        }]);
+    });
+
+    test('buildChromaHealthUrl preserves IPv6-capable local Chroma hosts (#14297)', () => {
+        expect(buildChromaHealthUrl({host: '::1', port: 8000}))
+            .toBe('http://[::1]:8000/api/v2/heartbeat');
+        expect(buildChromaHealthUrl({host: '[::1]', port: 8000, endpoint: '/api/v2/healthcheck'}))
+            .toBe('http://[::1]:8000/api/v2/healthcheck');
+        expect(buildChromaHealthUrl({host: 'localhost:9999', port: 8000}))
+            .toBe('http://localhost:8000/api/v2/heartbeat');
     });
 
     test('defines the local dev-server task without browser auto-open (#13482)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -956,6 +956,49 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         expect(killed).toEqual([9999]);
     });
 
+    test('superviseTask recycles adopted/running Chroma when its service health fails (#14297)', async () => {
+        const {service, taskOutcomes} = createTestService();
+        const killed                  = [];
+        const recycled                = [];
+        const started                 = [];
+        const state                   = {running: true, lastRunAt: 0, pid: 4242};
+
+        service.taskDefinitions = {
+            chroma: {
+                label      : 'chroma daemon',
+                healthProbe: async () => false
+            }
+        };
+        service.taskStateService.getTaskState = () => state;
+        service.taskStateService.markRecycled = taskName => {
+            recycled.push(taskName);
+            state.running = false;
+            state.pid     = null;
+        };
+        service.killProcess = pid => killed.push(pid);
+        service.runTask     = (taskName, reason) => {
+            started.push({taskName, reason});
+            return true;
+        };
+
+        service.superviseTask('chroma', 1_000_000, 15000);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(killed).toEqual([4242]);
+        expect(recycled).toEqual(['chroma']);
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status  : 'recycled',
+            taskName: 'chroma',
+            details : expect.objectContaining({
+                reason: 'supervisor-health-recycle',
+                pid   : 4242
+            })
+        }));
+
+        service.superviseTask('chroma', 1_020_000, 15000);
+        expect(started).toEqual([{taskName: 'chroma', reason: 'supervisor-restart'}]);
+    });
+
     test('superviseTask leaves a RUNNING task healthy per its healthProbe (no recycle)', async () => {
         const {service} = createTestService();
         const killed    = [];

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -138,6 +138,42 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         expect(pidFile).toBe(path.join(dataDir, 'mockTask.pid'));
     });
 
+    test('recoverTask clears a dead Chroma pidfile instead of adopting it (#14297)', () => {
+        const {service, dataDir} = createTestService();
+        const adopted            = [];
+        const watched            = [];
+        const probed             = [];
+        const pidFile            = path.join(dataDir, 'chroma.pid');
+        const originalKill       = process.kill;
+
+        service.taskDefinitions.chroma = {
+            label          : 'chroma daemon',
+            command        : 'chroma',
+            args           : ['run'],
+            pidFileName    : 'chroma.pid',
+            expectedCommand: 'chroma'
+        };
+        service.taskStateService.adoptRunning = (taskName, pid) => adopted.push({pid, taskName});
+        service.watchRecoveredTask            = (taskName, pid) => watched.push({pid, taskName});
+        fs.writeFileSync(pidFile, '4242');
+
+        process.kill = (pid, signal) => {
+            probed.push({pid, signal});
+            throw Object.assign(new Error('stale pid'), {code: 'ESRCH'});
+        };
+
+        try {
+            service.recoverTask('chroma');
+        } finally {
+            process.kill = originalKill;
+        }
+
+        expect(probed).toEqual([{pid: 4242, signal: 0}]);
+        expect(fs.existsSync(pidFile)).toBe(false);
+        expect(adopted).toEqual([]);
+        expect(watched).toEqual([]);
+    });
+
     test('runTask spawns child and updates state', () => {
         const { service, mockTaskStateService } = createTestService();
 


### PR DESCRIPTION
Resolves #14297
Related: #14039

Chroma now participates in the existing supervisor health-recycle contract. The task definition builds a configured-host HTTP health URL for Chroma, probes `/api/v2/heartbeat` with a timeout, and wires that probe into the Chroma task without changing Chroma ownership, SIGKILL recycle semantics, or authoritative singleton-port reaping. A process-alive but service-dead adopted Chroma can no longer sit forever as `running=true`; the supervisor recycles it through `killTask('chroma', 'supervisor-health-recycle')`, then the next poll can start a fresh daemon. The recovery tests also pin the process-dead/pidfile-exists facet: a stale Chroma PID file is unlinked and never adopted when `process.kill(pid, 0)` fails.

Evidence: L3 (live non-destructive endpoint probe on the current Chroma bind, plus L2 unit coverage for task wiring and supervisor recycle behavior) -> L3 required (HTTP endpoint behavior and adopted/running recycle contract). No residuals.

## Deltas from ticket

No `livenessProbe` was added for Chroma's not-running path. The fix stays narrower: Chroma keeps the default authoritative singleton behavior, and only running/adopted Chroma state gains HTTP service-health proof.

The health URL helper preserves the configured host and handles the local IPv6-capable bind shape (`localhost` / `[::1]`) instead of hardcoding `127.0.0.1`.

## Test Evidence

- `gh issue view 14297 --json body,title,url` confirmed the close-target ACs before PR body drafting.
- Pre-ticket live V-B-A documented in #14297: current Chroma answered on `localhost` / `[::1]` for `/api/v2/heartbeat` and `/api/v2/healthcheck`; `127.0.0.1` failed on the IPv6-only bind.
- `npm run agent-preflight -- ai/daemons/orchestrator/taskDefinitions.mjs ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs` passed.
- `git diff --check origin/dev...HEAD` passed after rebasing onto current `origin/dev`.
- `git show --patch 7dacaf83f4 -- ai/services/knowledge-base/ChromaManager.mjs ai/daemons/orchestrator/Orchestrator.mjs` verified #14294 did not replace `ProcessSupervisorService.killProcess()`; current source still uses `SIGKILL` and documents that Chroma ignores SIGTERM.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs` passed after the stale-pidfile regression: 45 passed in 31.2s.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs` passed after adding both Chroma facets: 105 passed in 31.9s.

## Post-Merge Validation

- [ ] Restart the local orchestrator with Chroma already present and verify healthy Chroma is kept only when the HTTP probe responds.
- [ ] Simulate or observe a process-alive/service-dead Chroma and verify the supervisor records `supervisor-health-recycle` before starting a fresh daemon.

## Commits

- `8838896ff1` - `fix(ai): prove Chroma health before keeping adopted PID (#14297)`
- `57449c82fa` - `test(ai): pin stale Chroma pidfile recovery (#14297)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019f0f79-7af4-7a70-893a-dd58e03337d6.
