### PR TITLE
test(ai): document drain-stall gate equivalence (#14088)

### DIFF
--- a/test/playwright/unit/ai/scripts/maintenance/CorruptionRecoveryGate.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/CorruptionRecoveryGate.spec.mjs
@@ -13,7 +13,7 @@ import {classifyDataIntegrityMode}                                        from '
 import {createReEmbedMissingHeal,
         createReEmbedMissingHealOperation} from '../../../../../../ai/services/memory-core/helpers/reEmbedMissingHeal.mjs';
 import DataRecoveryActuatorService from '../../../../../../ai/daemons/orchestrator/services/DataRecoveryActuatorService.mjs';
-import {DEFAULT_DISPATCH_BOUNDS}    from '../../../../../../ai/services/memory-core/helpers/healActionDispatch.mjs';
+import {DEFAULT_DISPATCH_BOUNDS}   from '../../../../../../ai/services/memory-core/helpers/healActionDispatch.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -162,11 +162,14 @@ function mockCollection(docsById = {}) {
 }
 
 test.describe('v13.1 release gate — corruption injection → detect → diagnose → autonomous HEAL', () => {
-    test('injected vector-loss is DETECTED, DIAGNOSED (wal-stall), and autonomously HEALED — re-embedded in place, never paged', async () => {
+    test('injected vector-loss / drain-stall coverage shape is DETECTED, DIAGNOSED (wal-stall), and autonomously HEALED — re-embedded in place, never paged', async () => {
         const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-corruption-gate-'));
 
         try {
             // 1. INJECT — the "up but data-gutted" shape: metadata + documents present, vectors absent.
+            //    This is the drain-stall disposition at the recovery-gate layer: once the stalled deferred-embed
+            //    drain leaves persisted rows without vectors, the coverage audit is deliberately provenance-blind
+            //    and the same wal-stall → re-embed-missing gate is the recovery proof.
             const snapshotPath = await injectMemoryCoreSnapshot(tmpDir, {writeVectorPickle: false});
 
             // 2. DETECT — the audit SEES the gutted store (the container-health blind spot, closed).
@@ -376,7 +379,7 @@ test.describe('v13.1 release gate — corruption injection → detect → diagno
 });
 
 /*
- * v13.1 release gate — the self-heal SOAK proof (#14165): the single-shot gate above proves ONE corruption
+ * v13.1 release gate — the self-heal SOAK proof: the single-shot gate above proves ONE corruption
  * heals; this proves the immune system survives SUSTAINED operation — the "runs autonomously for weeks (~95%)"
  * bar. It drives N inject→detect→diagnose→HEAL cycles on an accelerated clock through the REAL `applyHeal`
  * dispatch (default bounds: 3 mutating runs / hour, 10-min cooldown), threading the anti-thrash ledger across
@@ -386,14 +389,14 @@ test.describe('v13.1 release gate — corruption injection → detect → diagno
  *                       (they do NOT grow 1:1 with the cycle count); the anti-thrash demonstrably engages.
  *   - BOUNDED STATE   — the active anti-thrash working set (the windowed recentRuns) stays ≤ the per-window cap
  *                       across the whole run; old attempts age out, so it never grows with the cycle count.
- * Reuses the proven injector + pipeline above — no parallel harness (#14165 AC3).
+ * Reuses the proven injector + pipeline above — no parallel harness.
  */
 test.describe('v13.1 release gate — self-heal SOAK: N corruption+heal cycles survive sustained operation (#14165)', () => {
     test('N accelerated cycles converge, never hot-loop, and keep the anti-thrash working set bounded', async () => {
         const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-corruption-soak-'));
 
         try {
-            const CYCLES        = 24,             // weeks in miniature
+            const CYCLES = 24,             // weeks in miniature
                   CYCLE_STEP_MS = 12 * 60 * 1000, // 12 min/cycle on the accelerated clock (> the 10-min cooldown)
                   WINDOW_MS     = 3600000,        // mirror DEFAULT_DISPATCH_BOUNDS.windowMs (the anti-thrash window)
                   ledger        = [];             // the heal-event ledger — append-only attempt log; the recentRuns source
@@ -423,7 +426,7 @@ test.describe('v13.1 release gate — self-heal SOAK: N corruption+heal cycles s
                 expect(drifted.ok).toBe(false); // every cycle's injection is seen — the detect never goes blind
 
                 const decision = classifyDataIntegrityMode({
-                    collection: 'neo-agent-memory', rowCount: METADATA_IDS.length,
+                    collection            : 'neo-agent-memory', rowCount: METADATA_IDS.length,
                     missingFromVectorCount: drifted.missingFromVectorCount, documentsPresentCount: drifted.missingFromVectorCount
                 });
                 expect(decision).toMatchObject({mode: 'wal-stall', terminalAction: 're-embed-missing', autonomous: true});
@@ -432,8 +435,8 @@ test.describe('v13.1 release gate — self-heal SOAK: N corruption+heal cycles s
                     METADATA_IDS.map(id => [id, {document: `surviving document for ${id} (cycle ${cycle})`, metadata: {kind: 'turn'}}])
                 ));
                 const reEmbedMissing = createReEmbedMissingHeal({
-                    embedFn: async documents => documents.map(() => DETERMINISTIC_VECTOR.slice()),
-                    auditCoverage: async ({evidence}) => ({missingVectorIds: evidence.missingVectorIds}),
+                    embedFn          : async documents => documents.map(() => DETERMINISTIC_VECTOR.slice()),
+                    auditCoverage    : async ({evidence}) => ({missingVectorIds: evidence.missingVectorIds}),
                     expectedDimension: DETERMINISTIC_VECTOR.length
                 });
                 const healOperation = createReEmbedMissingHealOperation({
@@ -450,7 +453,7 @@ test.describe('v13.1 release gate — self-heal SOAK: N corruption+heal cycles s
                 });
 
                 const outcome = await actuator.applyHeal({
-                    action: decision.terminalAction, collection: 'neo-agent-memory',
+                    action  : decision.terminalAction, collection: 'neo-agent-memory',
                     evidence: {missingVectorIds: [...METADATA_IDS]}, now
                 });
 


### PR DESCRIPTION
Resolves #14088
Refs #14253
Related: #14039

Narrows this PR to the drain-stall release-gate disposition. The recovery gate now explicitly names the stalled deferred-embed drain as the same provenance-blind coverage shape the existing vector-loss injector already proves: metadata/documents survive, vectors are absent, the classifier routes `wal-stall` -> `re-embed-missing`, and the actuator heals in place.

#14253 is no longer a code close target in this PR. The over-cap V-B-A found existing source-side prevention and accepted-loss repair semantics for that class; the closeout recommendation is posted on #14253.

Evidence: L2 (focused Playwright unit/release-gate suite plus over-cap guardrail V-B-A suites) -> L2 required for the changed release-gate assertion. No residuals for #14088.

## Deltas from ticket
- `#14088`: chose shape-equivalence for the recovery gate. Once a stalled deferred-embed drain leaves persisted rows without vectors, the coverage audit deliberately cannot distinguish provenance; the existing wal-stall gate is the recovery proof. A distinct drain-queue liveness signal remains prevention/early-warning scope, not a second recovery injector.
- `#14253`: changed from implementation target to V-B-A closeout. No `over-cap` classifier terminal was added; no ADR-0027 change is needed for this PR.

## Test Evidence
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityModeClassifier.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityEvidenceAssembler.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs test/playwright/unit/ai/scripts/maintenance/CorruptionRecoveryGate.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs test/playwright/unit/ai/services/graph/sessionChunker.spec.mjs test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/acceptedLossSettlement.spec.mjs test/playwright/unit/ai/services/memory-core/SessionSummaryDegradedFallback.spec.mjs` -> 203 passed (32.6s)
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/CorruptionRecoveryGate.spec.mjs` -> 5 passed (31.0s)
- Commit amend pre-commit hooks passed: whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, block alignment.

## Post-Merge Validation
- [ ] Normal v13.1 release-gate validation covers the narrowed drain-stall assertion; #14253 has no post-merge action from this PR.

## Commits
- `4e03938622` — `test(ai): document drain-stall gate equivalence (#14088)`

Authored by Euclid (GPT-5, Codex Desktop). Session current Codex Desktop thread.