### PR TITLE
fix(tooltip): inherit singleton target theme (#5698)

### DIFF
--- a/src/tooltip/Base.mjs
+++ b/src/tooltip/Base.mjs
@@ -189,34 +189,16 @@ class Tooltip extends Container {
     static createSingleton(app) {
         if (!singletons[app.name]) {
             singletons[app.name] = Neo.create('Neo.tooltip.Base', {
-                appName     : app.name,
-                componentId : app.mainView.id,
-                delegate    : this.delegateFilter,
-                isShared    : true,
-                resetCfg    : {},
-                windowId    : app.mainView.windowId,
-                listeners : {
+                appName    : app.name,
+                componentId: app.mainView.id,
+                delegate   : this.delegateFilter,
+                isShared   : true,
+                resetCfg   : {},
+                windowId   : app.mainView.windowId,
+                listeners  : {
                     // Reconfigure on over a target
-                    targetOver({ target, data }) {
-                        let me = this,
-                            config, key;
-
-                        // Revert last pointerOver config set to initial setting.
-                        me.setSilent(me.resetCfg);
-                        me.resetCfg = {};
-
-                        // Use the tooltip config block that the target was configured with
-                        // to reconfigure this instance, or if there was none, check the
-                        // data-neo-tooltip property for a text string.
-                        config = target?._tooltip || {text: data.target.data.neoTooltip};
-
-                        // Cache things we have to reset
-                        for (key in config) {
-                            me.resetCfg[key] = me[key]
-                        }
-
-                        // Set ourself up as the target wants
-                        me.set(config)
+                    targetOver(event) {
+                        Tooltip.applySingletonTargetConfig(this, event)
                     }
                 }
             });
@@ -225,11 +207,68 @@ class Tooltip extends Container {
         return singletons[app.name]
     }
 
+    /**
+     * @summary Reconfigures the shared tooltip from the active delegated target, including the closest
+     * nested theme so a viewport-owned singleton visually follows the hovered component scope.
+     * @param {Neo.tooltip.Base} tooltip
+     * @param {Object} event
+     * @param {Neo.component.Base} [event.target]
+     * @param {Object} event.data
+     * @returns {Object} The config applied to the singleton.
+     */
+    static applySingletonTargetConfig(tooltip, {target, data} = {}) {
+        let config = target?._tooltip ? {...target._tooltip} : {text: data?.target?.data?.neoTooltip},
+            theme  = this.resolveTargetTheme(target, data),
+            key;
+
+        // Revert last pointerOver config set to initial setting.
+        tooltip.setSilent(tooltip.resetCfg);
+        tooltip.resetCfg = {};
+
+        // Explicit tooltip configs remain authoritative; otherwise inherit the active target theme.
+        if (theme && !config.theme) {
+            config.theme = theme
+        }
+
+        // Cache things we have to reset.
+        for (key in config) {
+            tooltip.resetCfg[key] = tooltip[key]
+        }
+
+        // Set ourself up as the target wants.
+        tooltip.set(config);
+
+        return config
+    }
+
     // Used as a delegate filter to activate on targets which have a tooltip configuration
     static delegateFilter(path) {
         for (let i = 0, { length } = path; i < length; i++) {
             if (path[i].cls.includes('neo-uses-shared-tooltip') || path[i].data['neoTooltip']) {
                 return i
+            }
+        }
+    }
+
+    /**
+     * @summary Returns the closest theme for a shared-tooltip target: first via component ownership,
+     * then via the delegated DOM path for data-attribute tooltips.
+     * @param {Neo.component.Base} target
+     * @param {Object} data
+     * @returns {String|undefined}
+     */
+    static resolveTargetTheme(target, data) {
+        let theme = target?.getTheme?.();
+
+        if (theme) {
+            return theme
+        }
+
+        for (const node of data?.path || []) {
+            theme = node.cls?.find?.(item => item.startsWith('neo-theme-'));
+
+            if (theme) {
+                return theme
             }
         }
     }

--- a/test/playwright/unit/tooltip/SingletonTheme.spec.mjs
+++ b/test/playwright/unit/tooltip/SingletonTheme.spec.mjs
@@ -1,0 +1,82 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'TooltipSingletonThemeTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Tooltip        from '../../../../src/tooltip/Base.mjs';
+
+function createTooltipHarness(initial = {}) {
+    return {
+        resetCfg: {},
+        text    : null,
+        theme   : null,
+        ...initial,
+        set(config) {
+            Object.assign(this, config)
+        },
+        setSilent(config) {
+            Object.assign(this, config)
+        }
+    }
+}
+
+test.describe('Neo.tooltip.Base singleton theme resolution', () => {
+    test('inherits the hovered component theme when reconfiguring the shared tooltip', () => {
+        const tooltip = createTooltipHarness({text: 'previous', theme: 'neo-theme-light'}),
+              config  = Tooltip.applySingletonTargetConfig(tooltip, {
+                  target: {
+                      _tooltip: {text: 'Nested'},
+                      getTheme: () => 'neo-theme-dark'
+                  },
+                  data: {}
+              });
+
+        expect(config).toEqual({text: 'Nested', theme: 'neo-theme-dark'});
+        expect(tooltip.text).toBe('Nested');
+        expect(tooltip.theme).toBe('neo-theme-dark');
+        expect(tooltip.resetCfg).toEqual({text: 'previous', theme: 'neo-theme-light'});
+    });
+
+    test('uses the delegated DOM path theme for data-neo-tooltip targets without component ownership', () => {
+        const tooltip = createTooltipHarness(),
+              config  = Tooltip.applySingletonTargetConfig(tooltip, {
+                  data: {
+                      target: {data: {neoTooltip: 'Delegated'}},
+                      path  : [
+                          {cls: ['leaf'], data: {}},
+                          {cls: ['neo-theme-neo-light'], data: {}}
+                      ]
+                  }
+              });
+
+        expect(config).toEqual({text: 'Delegated', theme: 'neo-theme-neo-light'});
+        expect(tooltip.text).toBe('Delegated');
+        expect(tooltip.theme).toBe('neo-theme-neo-light');
+    });
+
+    test('keeps an explicit tooltip theme ahead of inherited target themes', () => {
+        const tooltip = createTooltipHarness(),
+              config  = Tooltip.applySingletonTargetConfig(tooltip, {
+                  target: {
+                      _tooltip: {text: 'Explicit', theme: 'neo-theme-neo-light'},
+                      getTheme: () => 'neo-theme-dark'
+                  },
+                  data: {}
+              });
+
+        expect(config).toEqual({text: 'Explicit', theme: 'neo-theme-neo-light'});
+        expect(tooltip.theme).toBe('neo-theme-neo-light');
+    });
+});


### PR DESCRIPTION
Resolves #5698

The shared tooltip singleton now follows the active target's nearest Neo theme instead of staying locked to the viewport-level theme. `targetOver` delegates through a focused helper that reuses component ownership via `target.getTheme()` and falls back to the delegated DOM path for `data-neo-tooltip` nodes; explicit tooltip `theme` configs remain authoritative.

Evidence: L2 focused unit/static coverage satisfies this behavior change; no browser visual proof required because the changed contract is the singleton's resolved config before render.

## Deltas from ticket

- Kept the existing singleton/viewport ownership model.
- Added the target-theme resolution at the singleton reconfiguration seam rather than moving tooltip DOM ownership.

## Test Evidence

- `git diff --check`
- `node --check src/tooltip/Base.mjs`
- `node --check test/playwright/unit/tooltip/SingletonTheme.spec.mjs`
- `npm run test-unit -- test/playwright/unit/tooltip/SingletonTheme.spec.mjs` -> `3 passed (30.8s)`
- `npm run agent-preflight -- src/tooltip/Base.mjs test/playwright/unit/tooltip/SingletonTheme.spec.mjs`

## Post-Merge Validation

- [ ] Hover shared tooltips across nested theme scopes in a demo app and confirm the rendered tooltip skin changes with the target scope.

## Commits

- `1c7d1d9bce` — `fix(tooltip): inherit singleton target theme (#5698)`

Authored by Euclid (GPT-5, Codex Desktop). Session 3990502e-346a-47d6-8376-490e4802829c.
