### PR TITLE
docs(ai): importance-weight review rubrics (#14300)

### DIFF
--- a/.agents/skills/epic-create/references/epic-create-workflow.md
+++ b/.agents/skills/epic-create/references/epic-create-workflow.md
@@ -14,6 +14,8 @@ An Epic body is **problem-scope + intended-solution** — the durable "why + wha
 
 ## What an Epic body SHOULD contain
 
+Epic creation uses the same importance order as ticket and PR review: the problem/premise and intended placement dominate the verdict. Sub AC detail belongs in leaf tickets; an Epic with exhaustive sub mechanics but a weak premise or wrong owning substrate is not ready.
+
 1. **Problem scope** — the friction / antipattern-cluster / goal, with empirical anchors. State why this needs an Epic (multi-sub coordination) rather than a single ticket.
 2. **Intended solution shape** — the architectural direction (the "what-shape"), NOT the per-sub task breakdown. Enough that a reader knows the convergent shape the subs will serve.
 3. **(If Discussion-graduated) the §6.6 Signal Ledger** — the graduation consensus record (family-keyed quorum, unresolved dissent / liveness, criteria-mapping) per `ideation-sandbox-workflow.md §6`. This is the one structured matrix that belongs in an Epic body, because it records the graduation event, not the sub-plan.
@@ -46,7 +48,7 @@ Each sub the decomposition creates MUST be a **leaf that a single PR can FULLY d
 ## Procedure
 
 1. **Confirm Epic-shape.** The work needs ≥2 coordinated subs. A single bounded artifact (≈1 PR's worth) is a standalone ticket (`ticket-create`), not an Epic.
-2. **Graduation gate (if from a Discussion).** High-blast Epics require the §6.2 family-keyed quorum + the §5.1 divergence matrix in the source Discussion before filing (per `ideation-sandbox-workflow.md` + `ideation-sandbox/audits/double-diamond-divergence-guard.md`). Carry the §6.6 ledger into the body.
+2. **Graduation gate (if from a Discussion).** High-blast Epics require the §6.2 family-keyed quorum + the §5.1 divergence matrix in the source Discussion before filing (per `ideation-sandbox-workflow.md` + `ideation-sandbox/audits/double-diamond-divergence-guard.md`). Carry the `Signal Ledger` / dissent / liveness / criteria-mapping sections into the body.
 3. **Author the body** = problem-scope + intended-solution (+ ledger if graduated). NO ACs, NO sub-list.
 4. **Label `epic`** + apply title hygiene (per `ticket-create`).
 5. **Create subs separately** (via `ticket-create` — each with its own ACs + Contract Ledger) and **link each via `update_issue_relationship`** (parent = the Epic). Add subs incrementally as the decomposition clarifies — never block Epic creation on a complete sub-list.
@@ -54,5 +56,5 @@ Each sub the decomposition creates MUST be a **leaf that a single PR can FULLY d
    - [ ] Body contains **no** `## Acceptance Criteria` block.
    - [ ] Body contains **no** hardcoded sub-registry (subs discoverable via parent-child relationship instead).
    - [ ] Body answers "why an Epic (multi-sub coordination), not a single ticket?".
-   - [ ] If Discussion-graduated: §6.6 Signal Ledger present + quorum met.
+   - [ ] If Discussion-graduated: `Signal Ledger` present + quorum met.
    - [ ] Each planned sub is a one-PR-deliverable **leaf** (no bundled separable deliverables); the Epic is `Refs`'d by subs, never a PR close-target.

--- a/.agents/skills/pr-review/assets/pr-review-followup-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-followup-template.md
@@ -23,7 +23,7 @@
 
 Per §9 Strategic-Fit Step-Back:
 - **Decision**: [Approve / Approve+Follow-Up / Request Changes / Drop+Supersede]
-- **Rationale**: [1-2 sentences on why this meta-decision fits the current delta context.]
+- **Rationale**: [1-2 sentences on why this meta-decision fits the current delta context. Treat Approve+Follow-Up as the worst normal outcome, not a convenient residual bucket.]
 
 ---
 
@@ -86,6 +86,8 @@ N/A across listed dimensions: <one-line reason for the delta-scope justification
 
 ### 🧪 Test-Execution & Location Audit
 
+*This is part of the 10% AC/audit sanity layer unless execution disproves the delta.*
+
 *   **Changed surface class:** [code / test / docs-template only / PR body only]
 *   **Location check:** [pass / incorrect placement flagged / N/A]
 *   **Related verification run:** [command + result, or "No tests required: docs/template-only delta"]
@@ -95,7 +97,7 @@ N/A across listed dimensions: <one-line reason for the delta-scope justification
 
 ### 📑 Contract Completeness Audit
 
-*(Required per guide §5.4 if the delta touches public/consumed surfaces)*
+*(Required per guide §5.4 if the delta touches public/consumed surfaces. This is part of the 10% AC/audit sanity layer: binding on real drift, not proof that the work belongs here.)*
 
 *   **Findings:** [Pass / new contract drift flagged / N/A]
 
@@ -103,9 +105,11 @@ N/A across listed dimensions: <one-line reason for the delta-scope justification
 
 ### 📊 Metrics Delta
 
+Verdict weights still apply: 30% premise / right thing, 30% architecture + placement, 30% diff correctness, 10% AC/audit sanity. These are importance-to-verdict weights, not effort budgets.
+
 Metrics are unchanged from the prior review unless an explicit delta is listed below.
 
-*   **`[ARCH_ALIGNMENT]`**: [unchanged from prior review, or previous -> current + reason]
+*   **`[ARCH_ALIGNMENT]`**: [unchanged from prior review, or previous -> current + reason; include placement/cohesion/folder-fit/boundary discipline when the delta touches ownership]
 *   **`[CONTENT_COMPLETENESS]`**: [unchanged from prior review, or previous -> current + reason]
 *   **`[EXECUTION_QUALITY]`**: [unchanged from prior review, or previous -> current + reason]
 *   **`[PRODUCTIVITY]`**: [unchanged from prior review, or previous -> current + reason]

--- a/.agents/skills/pr-review/assets/pr-review-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-template.md
@@ -8,7 +8,7 @@
 
 Per §9 Strategic-Fit Step-Back:
 - **Decision**: [Approve / Approve+Follow-Up / Request Changes / Drop+Supersede]
-- **Rationale**: [Why this decision shape vs the others — e.g., "Approve+Follow-Up because the substrate ships measurable value via the Antigravity path even with the cross-harness gap; cross-harness routing is better-tracked-as-follow-up ticket #NNNN than incremental cycles"]
+- **Rationale**: [Why this decision shape vs the others. Remember: Approve+Follow-Up is the worst normal outcome; debt-creating quick wins are Request Changes or Drop+Supersede, not follow-up-ticket fuel.]
 
 **Peer-Review Opening:** [Friendly Opening / General encouragement. e.g., "Thanks for putting this together! Great approach to solving [Problem]. I've left some review notes below. Let's get these squared away so we can merge."]
 
@@ -89,7 +89,7 @@ N/A across listed dimensions: <one-line reason for the PR-scope justification>.
 
 ### 🎯 Close-Target Audit
 
-*(Required per guide §5.2 when the PR body or commit messages contain `Closes #N` / `Resolves #N` / `Fixes #N` magic keywords. Mark N/A for PRs without close-target keywords.)*
+*(Required per guide §5.2 when the PR body or commit messages contain `Closes #N` / `Resolves #N` / `Fixes #N` magic keywords. This is part of the 10% AC/audit sanity layer: binding on real overclaims, not a substitute for premise or placement. Mark N/A for PRs without close-target keywords.)*
 
 For every issue named as close-target, verify it does NOT carry the `epic` label:
 
@@ -102,7 +102,7 @@ For every issue named as close-target, verify it does NOT carry the `epic` label
 
 ### 📑 Contract Completeness Audit
 
-*(Required per guide §5.4 when the PR introduces or modifies public/consumed surfaces. Mark N/A for PRs that don't touch these surfaces.)*
+*(Required per guide §5.4 when the PR introduces or modifies public/consumed surfaces. This is part of the 10% AC/audit sanity layer: binding on real drift, not proof that the work belongs here. Mark N/A for PRs that don't touch these surfaces.)*
 
 - [ ] Originating ticket (or parent epic) contains a Contract Ledger matrix
 - [ ] Implemented PR diff matches the Contract Ledger exactly (no drift)
@@ -113,7 +113,7 @@ For every issue named as close-target, verify it does NOT carry the `epic` label
 
 ### 🪜 Evidence Audit
 
-*(Required when the PR's close-target ACs include observable runtime effect on a surface the CI / agent sandbox cannot reach — substrate / harness / wake / restart / UI-with-visual-AC / CLI-with-host-behavior PRs. Mark N/A for PRs where ACs are fully covered by unit tests / static contract.)*
+*(Required when the PR's close-target ACs include observable runtime effect on a surface the CI / agent sandbox cannot reach — substrate / harness / wake / restart / UI-with-visual-AC / CLI-with-host-behavior PRs. This is part of the 10% AC/audit sanity layer: binding on real evidence mismatch, not a replacement for architecture review. Mark N/A for PRs where ACs are fully covered by unit tests / static contract.)*
 
 Reference: [`learn/agentos/process/evidence-ladder.md`](../../../../learn/agentos/process/evidence-ladder.md) for L1-L4 ladder + sandbox-vs-achievable ceiling distinction.
 
@@ -156,7 +156,7 @@ Expand these audits only when their trigger fires; otherwise omit them rather th
 - **🛂 Provenance Audit:** PR introduces a major architectural abstraction or core subsystem.
 - **📜 Source-of-Authority Audit:** review cites operator or peer authority for a demand.
 - **🔌 Wire-Format Compatibility Audit:** PR alters JSON-RPC notification schemas, payload envelopes, native API wire formats, event payloads, tool signatures, or database schemas.
-- **🧠 Turn-Memory / Substrate-Load Audit:** PR modifies files in `/turn-memory-pre-flight` IN-SCOPE list. Verify the author documented the decision-tree application and load-effect audit in the PR body; if missing, use the Loading-Runtime-Effect Required Action template from the guide.
+- **🧠 Turn-Memory / Substrate-Load Audit:** PR modifies files in `/turn-memory-pre-flight` IN-SCOPE list. Verify the author documented the decision-tree application and load-effect audit in the PR body; if missing, load `audits/loading-runtime-effect.md` and use its Required Action template.
 
 ---
 
@@ -176,7 +176,7 @@ Expand these audits only when their trigger fires; otherwise omit them rather th
 
 ### 🧪 Test-Execution & Location Audit
 
-*(Required per guide §7.5. Reviewers MUST verify RELATED tests and canonical placement before assigning an `[EXECUTION_QUALITY]` score.)*
+*(Required per guide §7.5. This is part of the 10% AC/audit sanity layer unless execution disproves the diff. Reviewers MUST verify RELATED tests and canonical placement before assigning an `[EXECUTION_QUALITY]` score.)*
 
 - [ ] Branch checked out locally (e.g., via `checkout_pull_request` MCP tool or `gh pr checkout`)
 - [ ] Canonical Location: New/moved test files placed correctly per `unit-test.md` (e.g., `test/playwright/unit/ai/mcp/server/`)
@@ -206,7 +206,9 @@ No required actions — eligible for human merge.
 ---
 
 ### 📊 Evaluation Metrics
-*   **`[ARCH_ALIGNMENT]`**: [0-100] - [Brief justification]
+*Verdict weights: 30% premise / right thing, 30% architecture + placement, 30% diff correctness, 10% AC/audit sanity. These are importance-to-verdict weights, not effort budgets.*
+
+*   **`[ARCH_ALIGNMENT]`**: [0-100] - [Neo paradigms + placement/cohesion/folder-fit/boundary discipline justification; placement violations cap the score]
 *   **`[CONTENT_COMPLETENESS]`**: [0-100] - [Brief justification]
 *   **`[EXECUTION_QUALITY]`**: [0-100] - [Brief justification]
 *   **`[PRODUCTIVITY]`**: [0-100] - [Brief justification]

--- a/.agents/skills/pr-review/audits/loading-runtime-effect.md
+++ b/.agents/skills/pr-review/audits/loading-runtime-effect.md
@@ -1,0 +1,21 @@
+# Loading-Runtime-Effect Substitution Audit
+
+Reviewer-side audit for substrate-load mistakes. The canonical file list, placement tree, mechanical pre-flight, and empirical anchors live in [`turn-memory-pre-flight`](../../turn-memory-pre-flight/references/turn-memory-pre-flight-workflow.md); do not duplicate them here.
+
+## When this audit fires
+
+When a PR modifies any `/turn-memory-pre-flight` IN-SCOPE substrate file. Verify the author documented `/turn-memory-pre-flight` application and load-effect reasoning.
+
+## Failure Mode
+
+**Loading-runtime-effect substitution**: approving file-completeness ("all harness files updated") while missing runtime-load effect ("does this load once or twice per turn?"). It is a dimension miss, not lack of engagement.
+
+## Required Action Template
+
+> *"Substrate-touching files modified ({list IN-SCOPE files from PR diff}). PR body does not document `/turn-memory-pre-flight` decision-tree application. Required: invoke `/turn-memory-pre-flight` retrospectively + document the 5-step decision-tree application + mechanical pre-flight commands run + harness-load-duplication risk audit in PR body."*
+
+## Cross-Skill Bridge
+
+- **Proactive companion (substrate-creation time)**: `/turn-memory-pre-flight` (Epic `#11256` substrate; `turn-memory-pre-flight` skill trigger)
+- **Architectural router (ambiguous cases)**: `/architecture-pre-flight` (Epic `#11256` substrate)
+- **Helpful-Assistant 4-sub-mode context**: Discussion `#11259` (CLOSED RESOLVED) -> ticket `#11262` -> PR `#11263` (substrate-load-time XML salience metadata)

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -40,7 +40,9 @@ If you write a GitHub PR review, step out of Driver mode and follow this reviewe
 ## 3. Structural Evaluation Metrics
 Every PR review MUST score the work across the following categories on a scale of `0` to `100`:
 
-*   **`[ARCH_ALIGNMENT]`** (0-100): Does it follow Neo.mjs paradigms (e.g., worker delegation, push-based reactivity, config-driven components)?
+**Verdict weights:** 30% premise / right thing; 30% architecture / placement; 30% diff correctness; 10% AC/evidence/close-target/CI/contract sanity. Weights are importance-to-verdict, not effort budget; a tidy checklist over the wrong premise or folder still fails.
+
+*   **`[ARCH_ALIGNMENT]`** (0-100): Neo paradigms plus "does this belong here?" placement, cohesion, single responsibility, folder fit, and boundaries. Logic in definitions/config, provider specifics outside providers, or subsystem leakage into root surfaces caps the score; the #14298 placement miss would be ~45, not 94.
 *   **`[CONTENT_COMPLETENESS]`** (0-100): Are all new or modified methods documented with 'Anchor & Echo' JSDoc? Is the PR description a comprehensive "Fat Ticket"?
 *   **`[EXECUTION_QUALITY]`** (0-100): Code flow, absence of bugs, race condition safety, VDOM syncing correctness, and testing coverage.
 *   **`[PRODUCTIVITY]`** (0-100): Were the primary goals of the linked ticket achieved?
@@ -101,6 +103,8 @@ When challenging a specific architectural pattern or complex implementation deta
 
 ### 5.2 Close-Target Audit
 
+10% AC/scope sanity layer: binding on real close-target overclaim; never a premise, placement, or diff verdict substitute.
+
 Audit every magic close target in the PR body and commit messages: `Closes #N`, `Resolves #N`, `Fixes #N` (case-insensitive). For Neo agent / `ai` PRs, only newline-isolated `Resolves #N` may close a delivered leaf ticket; `Refs` / `Related` are non-closing extras. Epics are invalid close-targets. Branch commit bodies also matter because squash merge can carry stale magic keywords into `dev` (`#11185` / PR `#11183`).
 
 <!-- trigger: close-target over-claim or lint/body contradiction -> read ./close-target-remediation.md -->
@@ -120,6 +124,8 @@ When a PR touches `ai/mcp/server/*/openapi.yaml`, you MUST audit each modified o
 **Audit Protocol:** See [`audits/mcp-tool-description-budget.md`](./audits/mcp-tool-description-budget.md) for the trigger conditions, verbosity budgets, and required action templates.
 
 ### 5.4 Contract Completeness Audit
+
+10% AC/scope sanity layer: binding on real contract drift; a complete ledger is not premise or placement evidence.
 
 For PRs that introduce or modify public/consumed surfaces (e.g., configs, MCP tools, framework APIs, CLI arguments), the reviewer MUST audit the implementation against the **Contract Ledger matrix** defined in the originating ticket (see `contract-ledger.md`).
 
@@ -232,6 +238,8 @@ Future-work suggestions, non-blocking observations, and follow-up ideas are revi
 
 ### 7.5 Test-Execution & Location Audit
 
+10% AC/scope sanity layer unless execution disproves the diff. Verify claims and canonical test placement; green tests cannot override a wrong premise or owner.
+
 When reviewing a PR, you MUST empirically verify code execution and test file placement, but only for **RELATED** tests. Do NOT blindly run the entire automated test suite, as it destroys the focus window and wastes tokens.
 
 Reviewers MUST verify testing claims and canonical file placement:
@@ -241,6 +249,8 @@ Reviewers MUST verify testing claims and canonical file placement:
 4. If the author did not provide test evidence for structural logic changes, or placed tests in legacy/incorrect directories, flag this as a **Required Action**.
 
 ### 7.6 CI / Security Checks Audit
+
+10% AC/scope sanity layer unless CI/security reveals a defect. Green CI is eligibility evidence, not an architecture verdict.
 
 Formal reviews assume green current-head CI. Verify before `manage_pr_review`; if checks are pending, missing, failing, or a stacked PR is lint-only (`baseRefName` not `dev` / default), send a compact CI deferral. Full-CI stacked approvals must name base state + retarget status; child-green alone is delta evidence. Load `.agents/skills/pr-review/audits/ci-security-audit.md` only for security-sensitive changes or ambiguous/failing check surfaces.
 
@@ -267,27 +277,7 @@ Formal reviews assume green current-head CI. Verify before `manage_pr_review`; i
 | PR adds substantive rule body directly to always-loaded skill substrate (`SKILL.md`, `pr-review-guide.md`, `pull-request-workflow.md`, `AGENTS.md`) instead of conditionally loaded `references/` payload | **Progressive Disclosure violation** — Map (always-loaded) vs World Atlas (conditional reference) split bypassed; bloats per-turn token budget. Default disposition for new rules is `compress-to-trigger` per `pull-request-workflow.md §1.1`. Proactive companion: `/create-skill`. Required Action: reshape to Map (trigger line) → Atlas (rule body in `references/`) split, or cite per-turn frequency + irreversibility justifying `keep` slot |
 
 ## 7.8 Audit Spec: Loading-Runtime-Effect Substitution
-
-Reviewer-side audit for substrate-load mistakes. The canonical file list, placement tree, mechanical pre-flight, and empirical anchors live in [`turn-memory-pre-flight`](../../turn-memory-pre-flight/references/turn-memory-pre-flight-workflow.md); do not duplicate them here.
-
-### When this audit fires (reviewer-side)
-
-When a PR modifies any `/turn-memory-pre-flight` IN-SCOPE substrate file. Verify the author documented `/turn-memory-pre-flight` application and load-effect reasoning.
-
-### The Failure Mode (reviewer recognition shape)
-
-**Loading-runtime-effect substitution**: approving file-completeness ("all harness files updated") while missing runtime-load effect ("does this load once or twice per turn?"). It is a dimension miss, not lack of engagement.
-
-### Required Action template (reviewer-side)
-
-> *"Substrate-touching files modified ({list IN-SCOPE files from PR diff}). PR body does not document `/turn-memory-pre-flight` decision-tree application. Required: invoke `/turn-memory-pre-flight` retrospectively + document the 5-step decision-tree application + mechanical pre-flight commands run + harness-load-duplication risk audit in PR body."*
-
-### Cross-skill bridge
-
-- **Proactive companion (substrate-creation time)**: `/turn-memory-pre-flight` (Epic `#11256` substrate; `turn-memory-pre-flight` skill trigger)
-- **Architectural router (ambiguous cases)**: `/architecture-pre-flight` (Epic `#11256` substrate)
-- **Helpful-Assistant 4-sub-mode context**: Discussion `#11259` (CLOSED RESOLVED) → ticket `#11262` → PR `#11263` (substrate-load-time XML salience metadata)
-
+<!-- trigger: PR modifies turn-memory-pre-flight IN-SCOPE substrate -> read ../audits/loading-runtime-effect.md -->
 
 ## 8. Cross-Skill Integration Audit
 
@@ -321,7 +311,7 @@ After technical audits (§3-§8), decide the merge posture:
 
 1. **Approve** — default for a working PR (no blocking defect); ship as-is, nits inline.
 2. **Request Changes** — must-fix, only for code-shape/correctness/safety; a finding → same-PR fix/comment/AC, never a follow-up ticket.
-3. **Approve+Follow-Up** — least-desirable (spawns the follow-up flood). Mergeable→Approve; defect→Request Changes.
+3. **Approve+Follow-Up** — worst normal outcome (spawns the follow-up flood and negative-ROI CI/review loops). Mergeable -> Approve; defect or debt-creating quick win -> Request Changes; wrong premise -> Drop+Supersede. Reserve A+FU only for explicitly non-blocking residuals where same-PR repair would be less coherent than shipping.
 4. **Drop+Supersede** — premise is stale/wrong; recommend closure via Request Changes shape so author/human handles PR/ticket closure. Use for fundamentally wrong premise, operator-intent correction, or >5 cycles rearranging the same invalid abstraction.
 
 This is architectural judgment after defects are identified; it is not another defect audit.

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -71,6 +71,8 @@ For source anchors (`#11078` / `#11082` / `#11083` / `#11084`), Discussion `#110
 
 ## 2. Six-Stage Challenge Chain
 
+Apply the same importance weighting used by PR review at creation time: premise / right thing to build = 30%; substrate / what belongs where = 30%; deliverable correctness = 30%; AC and evidence checklist sanity = 10%. These are importance-to-verdict weights, not drafting effort budgets. A perfectly detailed AC list for the wrong work or wrong owning substrate still fails the ticket.
+
 Apply at creation time — not just at intake. Every stage must pass before the ticket is drafted.
 
 1. **Premise** — is the stated problem real and reproducible? Has the underlying symptom been independently verified, or is it secondhand?


### PR DESCRIPTION
Resolves #14300

Importance-weights the review/ticket/epic rubric so reviewers score the merge verdict around the actual quality gates: 30% premise/right thing, 30% architecture/placement, 30% diff correctness, and 10% AC/audit sanity. `[ARCH_ALIGNMENT]` now explicitly includes "does this belong here?" placement, cohesion, folder fit, and boundary discipline; `Approve+Follow-Up` is documented as the worst normal outcome rather than a convenient residual bucket.

Evidence: L2 (static skill-substrate lint + agent-preflight) -> L2 required (agent-consumed skill/template substrate). Residual: none.

## Deltas from ticket

- Added the weighting and placement semantics to `pr-review-guide.md` and both review templates.
- Mirrored the premise+placement dominance into `ticket-create` and `epic-create`.
- Preserved the existing Loading-Runtime-Effect audit by moving it losslessly into `pr-review/audits/loading-runtime-effect.md`, leaving a trigger pointer in the guide so `pr-review-guide.md` stays under its per-file budget.
- Posted the required source-ticket Contract Ledger before implementation: https://github.com/neomjs/neo/issues/14300#issuecomment-4827372328

## Slot Rationale

- `pr-review-guide.md` section 3 and section 9: disposition `keep`; trigger-frequency is every PR review, failure-severity is high because wrong-premise/wrong-placement approvals create release debt, enforceability is discipline-only through the review template and formal review process.
- `pr-review-template.md` and `pr-review-followup-template.md`: disposition `keep`; templates are the copied execution surface, so the weights and placement-inclusive `[ARCH_ALIGNMENT]` must render where reviewers write.
- `ticket-create-workflow.md` and `epic-create-workflow.md`: disposition `keep`; ticket/epic creation is where the same premise+placement mistake can be introduced upstream.
- `pr-review/audits/loading-runtime-effect.md`: disposition `move`; existing meaningful audit text was relocated from the oversized guide into a conditional audit payload behind a one-line trigger pointer. No intent was removed.

## Test Evidence

- `git diff --check`
- `git diff --cached --check`
- `npm run agent-preflight -- .agents/skills/pr-review/references/pr-review-guide.md .agents/skills/pr-review/assets/pr-review-template.md .agents/skills/pr-review/assets/pr-review-followup-template.md .agents/skills/pr-review/audits/loading-runtime-effect.md .agents/skills/ticket-create/references/ticket-create-workflow.md .agents/skills/epic-create/references/epic-create-workflow.md`
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev`

## Post-Merge Validation

- [ ] First cross-family review using the updated template visibly evaluates premise/right thing, architecture/placement, diff correctness, and AC/audit sanity with the new weighting.

## Commits

- `62a0a8b778` - `docs(ai): importance-weight review rubrics (#14300)`

Authored by Euclid (GPT-5, Codex Desktop). Session 3990502e-346a-47d6-8376-490e4802829c.
