### PR TITLE
fix(codex): restore operator stop fallback (#14308)

### DIFF
--- a/.codex/hooks/codex-context.mjs
+++ b/.codex/hooks/codex-context.mjs
@@ -1,10 +1,17 @@
-import {readFileSync}                 from 'node:fs';
-import {fileURLToPath, pathToFileURL} from 'node:url';
+import {mkdirSync, readFileSync, writeFileSync} from 'node:fs';
+import os                                       from 'node:os';
+import path                                     from 'node:path';
+import {fileURLToPath, pathToFileURL}           from 'node:url';
 import {
     extractWakeSubmitNonce,
     readHookPayload,
     recordTurnPresenceFromHook
 } from '../../ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs';
+
+const LOG_DIR_NAME              = 'codex-lane-state-hook',
+      PROMPT_CONTEXT_FILE_NAME  = 'codex-prompt-context.json',
+      PROMPT_CONTEXT_TEXT_LIMIT = 4000,
+      PROMPT_CONTEXT_SOURCE     = 'codex-user-prompt-submit';
 
 /**
  * @summary Extracts a wake-submit nonce from a Codex hook payload or raw prompt text.
@@ -13,6 +20,136 @@ import {
  * @returns {String|null}
  */
 export {extractWakeSubmitNonce, readHookPayload};
+
+/**
+ * @summary Resolves the Codex prompt-context file shared by UserPromptSubmit and Stop hooks.
+ * @param {Object} [options]
+ * @param {Object} [options.env=process.env] Environment source.
+ * @returns {String}
+ */
+export function getCodexPromptContextPath({env = process.env} = {}) {
+    const logDir = env.NEO_AI_DAEMON_DIR || path.join(os.homedir(), '.neo-ai-data', LOG_DIR_NAME);
+
+    return path.join(logDir, PROMPT_CONTEXT_FILE_NAME);
+}
+
+/**
+ * @summary Extracts content text from Codex/OpenAI-style message content containers.
+ * @param {*} content
+ * @returns {String}
+ * @protected
+ */
+function extractTextFromContent(content) {
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+        return content.map(block => {
+            if (typeof block === 'string') return block;
+            if (typeof block?.text === 'string') return block.text;
+            if (typeof block?.content === 'string') return block.content;
+            return '';
+        }).filter(Boolean).join('\n');
+    }
+    if (content && typeof content === 'object') {
+        if (typeof content.text === 'string') return content.text;
+        if (typeof content.content === 'string') return content.content;
+    }
+    return '';
+}
+
+/**
+ * @summary Extracts the operator prompt text from representative Codex UserPromptSubmit payloads.
+ * @param {*} value Hook payload value.
+ * @param {Number} [depth=0] Recursion guard for untrusted hook payloads.
+ * @returns {String}
+ */
+export function extractPromptingTextFromHookPayload(value, depth = 0) {
+    if (depth > 8 || value == null) return '';
+    if (typeof value === 'string') return value;
+    if (Array.isArray(value)) {
+        for (let i = value.length - 1; i >= 0; i--) {
+            const text = extractPromptingTextFromHookPayload(value[i], depth + 1);
+            if (text.trim()) return text;
+        }
+        return '';
+    }
+    if (typeof value !== 'object') return '';
+
+    const role = value.role || value.payload?.role || value.message?.role || value.item?.role;
+    if (role === 'user') {
+        const text = extractTextFromContent(
+            value.content ??
+            value.payload?.content ??
+            value.message?.content ??
+            value.item?.content ??
+            value.text ??
+            value.payload?.text
+        );
+        if (text.trim()) return text;
+    }
+    if (role && role !== 'user') return '';
+
+    const priorityKeys = [
+        'prompt', 'user_prompt', 'userPrompt', 'last_user_message', 'lastUserMessage',
+        'messages', 'conversation', 'transcript', 'payload', 'message', 'item', 'content', 'text', 'input'
+    ];
+
+    for (const key of priorityKeys) {
+        if (!(key in value)) continue;
+
+        const text = extractPromptingTextFromHookPayload(value[key], depth + 1);
+        if (text.trim()) return text;
+    }
+
+    return '';
+}
+
+/**
+ * @summary Writes a bounded same-turn prompt provenance record for the Codex Stop hook fallback.
+ * @param {Object} [options]
+ * @param {Object} [options.env=process.env] Environment source.
+ * @param {*} [options.hookPayload] UserPromptSubmit hook payload.
+ * @param {Date} [options.now] Creation time.
+ * @returns {{status: String, path: String, source: String, textLength?: Number, reason?: String}}
+ */
+export function writePromptContextFromHookPayload({
+    env = process.env,
+    hookPayload,
+    now = new Date()
+} = {}) {
+    const text              = extractPromptingTextFromHookPayload(hookPayload).trim(),
+          promptContextPath = getCodexPromptContextPath({env});
+
+    mkdirSync(path.dirname(promptContextPath), {recursive: true});
+
+    if (!text) {
+        writeFileSync(promptContextPath, JSON.stringify({
+            createdAt    : now.toISOString(),
+            promptingText: '',
+            reason       : 'no-prompting-text',
+            source       : PROMPT_CONTEXT_SOURCE
+        }, null, 2), 'utf8');
+
+        return {
+            path  : promptContextPath,
+            reason: 'no-prompting-text',
+            source: PROMPT_CONTEXT_SOURCE,
+            status: 'cleared'
+        };
+    }
+
+    writeFileSync(promptContextPath, JSON.stringify({
+        createdAt    : now.toISOString(),
+        promptingText: text.slice(0, PROMPT_CONTEXT_TEXT_LIMIT),
+        source       : PROMPT_CONTEXT_SOURCE
+    }, null, 2), 'utf8');
+
+    return {
+        path      : promptContextPath,
+        source    : PROMPT_CONTEXT_SOURCE,
+        status    : 'written',
+        textLength: Math.min(text.length, PROMPT_CONTEXT_TEXT_LIMIT)
+    };
+}
 
 /**
  * @summary Emits a fail-soft Codex turn-start beacon without importing Neo singletons.
@@ -27,6 +164,12 @@ export async function recordTurnStarted({
     rootDir = fileURLToPath(new URL('../../', import.meta.url)),
     hookPayload
 } = {}) {
+    try {
+        writePromptContextFromHookPayload({env, hookPayload});
+    } catch {
+        // Fail-soft hook: prompt provenance improves Stop parity but must not block context loading.
+    }
+
     return recordTurnPresenceFromHook({
         env,
         hookPayload,

--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -18,14 +18,27 @@ import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneSta
 import {classifyPromptingContext,
         decideDeferenceStopHookAction,
         decideStopHookAction,
+        isSyntheticPromptingText,
         LANE_STATE_SCHEMA_HINT,
         parseOutcomeToVerdict,
         STOP_HOOK_TURN_OPTIONS_HINT} from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
 export const CODEX_STOP_BLOCK_INJECTION_SUPPORTED = true;
+export const CODEX_PROMPT_CONTEXT_TTL_MS           = 10 * 60 * 1000;
 
-const LOG_DIR = process.env.NEO_AI_DAEMON_DIR || path.join(os.homedir(), '.neo-ai-data', 'codex-lane-state-hook');
+const LOG_DIR                  = process.env.NEO_AI_DAEMON_DIR || path.join(os.homedir(), '.neo-ai-data', 'codex-lane-state-hook'),
+      PROMPT_CONTEXT_FILE_NAME = 'codex-prompt-context.json';
+
+/**
+ * @summary Resolves the hook-local prompt-context fallback file path.
+ * @param {Object} [options]
+ * @param {String} [options.logDir]
+ * @returns {String}
+ */
+export function getCodexPromptContextPath({logDir = LOG_DIR} = {}) {
+    return path.join(logDir, PROMPT_CONTEXT_FILE_NAME);
+}
 
 /**
  * @summary Reads all of stdin, which Codex passes to command hooks as the event payload.
@@ -96,8 +109,10 @@ function extractTextFromMessage(message) {
     return extractTextFromContent(
         message.content ??
         message.message?.content ??
+        message.payload?.content ??
         message.text ??
         message.message?.text ??
+        message.payload?.text ??
         message.output_text ??
         message.output
     );
@@ -115,7 +130,8 @@ function isAssistantMessage(message) {
     return message.role === 'assistant' ||
         message.type === 'assistant' ||
         message.message?.role === 'assistant' ||
-        message.item?.role === 'assistant';
+        message.item?.role === 'assistant' ||
+        message.payload?.role === 'assistant';
 }
 
 /**
@@ -130,7 +146,37 @@ function isUserMessage(message) {
     return message.role === 'user' ||
         message.type === 'user' ||
         message.message?.role === 'user' ||
-        message.item?.role === 'user';
+        message.item?.role === 'user' ||
+        message.payload?.role === 'user';
+}
+
+/**
+ * @summary Returns likely message containers from Claude/Codex/OpenAI hook records.
+ * @param {*} record
+ * @returns {Array}
+ * @protected
+ */
+function getMessageCandidates(record) {
+    if (!record || typeof record !== 'object') return [record];
+
+    const candidates = [],
+          seen       = new Set(),
+          add        = candidate => {
+              if (!candidate || seen.has(candidate)) return;
+              seen.add(candidate);
+              candidates.push(candidate);
+          };
+
+    add(record);
+    add(record.payload);
+    add(record.payload?.message);
+    add(record.payload?.item);
+    add(record.message);
+    add(record.item);
+    add(record.message?.payload);
+    add(record.item?.payload);
+
+    return candidates;
 }
 
 /**
@@ -143,13 +189,14 @@ export function extractLastAssistantTextFromMessages(messages = []) {
     if (!Array.isArray(messages)) return '';
 
     for (let i = messages.length - 1; i >= 0; i--) {
-        const record  = messages[i],
-              message = record?.message || record?.item || record;
+        const record = messages[i];
 
-        if (!isAssistantMessage(record) && !isAssistantMessage(message)) continue;
+        for (const message of getMessageCandidates(record)) {
+            if (!isAssistantMessage(record) && !isAssistantMessage(message)) continue;
 
-        const text = extractTextFromMessage(message);
-        if (text) return text;
+            const text = extractTextFromMessage(message);
+            if (text) return text;
+        }
     }
 
     return '';
@@ -165,13 +212,16 @@ export function extractLastUserTextFromMessages(messages = []) {
     if (!Array.isArray(messages)) return '';
 
     for (let i = messages.length - 1; i >= 0; i--) {
-        const record  = messages[i],
-              message = record?.message || record?.item || record;
+        const record = messages[i];
 
-        if (!isUserMessage(record) && !isUserMessage(message)) continue;
+        for (const message of getMessageCandidates(record)) {
+            if (!isUserMessage(record) && !isUserMessage(message)) continue;
 
-        const text = extractTextFromMessage(message);
-        if (text) return text;
+            const text = extractTextFromMessage(message);
+            if (!text || isSyntheticPromptingText(text)) continue;
+
+            return text;
+        }
     }
 
     return '';
@@ -224,6 +274,43 @@ export function extractLastUserTextFromJsonl(jsonl = '') {
 }
 
 /**
+ * @summary Reads the short-lived prompt-class fallback written by the Codex UserPromptSubmit hook.
+ * @param {Object} [options]
+ * @param {String} [options.promptContextPath]
+ * @param {Number} [options.now]
+ * @param {Number} [options.ttlMs]
+ * @returns {{text: String, source: String, ageMs: Number}|null}
+ */
+export function readPromptContext({
+    now               = Date.now(),
+    promptContextPath = getCodexPromptContextPath(),
+    ttlMs             = CODEX_PROMPT_CONTEXT_TTL_MS
+} = {}) {
+    let record;
+
+    try {
+        record = JSON.parse(fs.readFileSync(promptContextPath, 'utf8'));
+    } catch {
+        return null;
+    }
+
+    const createdAt = Date.parse(record?.createdAt || '');
+    if (!Number.isFinite(createdAt)) return null;
+
+    const ageMs = now - createdAt;
+    if (ageMs < 0 || ageMs > ttlMs) return null;
+
+    const text = typeof record?.promptingText === 'string' ? record.promptingText : '';
+    if (!text.trim()) return null;
+
+    return {
+        ageMs,
+        source: record.source || 'prompt_context',
+        text
+    };
+}
+
+/**
  * @summary Resolves the best available final assistant text from known and representative Codex shapes.
  * @param {Object} [input={}]
  * @returns {{text: String, source: String}}
@@ -259,6 +346,12 @@ export function extractFinalAssistantText(input = {}) {
  * @returns {{text: String, source: String}}
  */
 export function extractPromptingText(input = {}) {
+    const direct = input.last_user_message ?? input.lastUserMessage ?? input.prompting_message ?? input.promptingMessage;
+    if (direct) {
+        const text = extractTextFromMessage(direct);
+        if (text.trim() && !isSyntheticPromptingText(text)) return {text, source: 'last_user_message'};
+    }
+
     const messages = input.messages ?? input.conversation ?? input.transcript;
     if (Array.isArray(messages)) {
         const text = extractLastUserTextFromMessages(messages);
@@ -267,11 +360,12 @@ export function extractPromptingText(input = {}) {
 
     const transcriptPath = input.transcript_path ?? input.transcriptPath;
     if (transcriptPath) {
-        return {
-            text  : extractLastUserTextFromJsonl(fs.readFileSync(transcriptPath, 'utf8')),
-            source: 'transcript_path'
-        };
+        const text = extractLastUserTextFromJsonl(fs.readFileSync(transcriptPath, 'utf8'));
+        if (text.trim()) return {text, source: 'transcript_path'};
     }
+
+    const promptContext = readPromptContext();
+    if (promptContext) return {text: promptContext.text, source: 'prompt_context'};
 
     return {text: '', source: 'none'};
 }

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -32,6 +32,11 @@ const AUTONOMOUS_HANDOFF_PATTERNS = Object.freeze([
     {label: 'you-drive-window', re: /\byou drive\b[\s\S]{0,160}\b(?:for the next|next|until I|while I)\b/i}
 ]);
 
+const SYNTHETIC_PROMPT_PATTERNS = Object.freeze([
+    /^\s*<hook_prompt\b/i,
+    /^\s*<turn_aborted\b/i
+]);
+
 /**
  * @summary Extracts a bounded handoff window from operator prose when one is explicitly stated.
  * @param {String} text Operator prompting text.
@@ -74,15 +79,25 @@ export function detectAutonomousHandoffPrompt(promptingText = '') {
 }
 
 /**
+ * @summary Detects hook-generated user records that are lifecycle noise, not human operator prompts.
+ * @param {String} text Prompting text candidate.
+ * @returns {Boolean}
+ */
+export function isSyntheticPromptingText(text = '') {
+    return typeof text === 'string' && SYNTHETIC_PROMPT_PATTERNS.some(re => re.test(text));
+}
+
+/**
  * @summary Classifies the prompting text into operator-dialogue vs autonomous handoff.
  * @param {{stopHookActive: Boolean, promptingText: String}} signals
  * @returns {{operatorInLoop: Boolean, autonomousHandoff: Boolean, handoffReason: String|null, handoffWindowMs: Number|null}}
  */
 export function classifyPromptingContext({stopHookActive, promptingText = ''}) {
-    const handoff = detectAutonomousHandoffPrompt(promptingText);
+    const handoff   = detectAutonomousHandoffPrompt(promptingText),
+          synthetic = isSyntheticPromptingText(promptingText);
 
     return {
-        operatorInLoop   : !stopHookActive && !!promptingText.trim() && !/^\s*\[WAKE\]/.test(promptingText) && !handoff.active,
+        operatorInLoop   : !stopHookActive && !!promptingText.trim() && !/^\s*\[WAKE\]/.test(promptingText) && !synthetic && !handoff.active,
         autonomousHandoff: handoff.active,
         handoffReason    : handoff.reason,
         handoffWindowMs  : handoff.windowMs

--- a/test/playwright/unit/hooks/codexContextHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexContextHook.spec.mjs
@@ -5,8 +5,11 @@ import os             from 'node:os';
 import path           from 'node:path';
 
 import {
+    extractPromptingTextFromHookPayload,
     extractWakeSubmitNonce,
-    recordTurnStarted
+    getCodexPromptContextPath,
+    recordTurnStarted,
+    writePromptContextFromHookPayload
 } from '../../../../.codex/hooks/codex-context.mjs';
 import {recordClaudeTurnPresence} from '../../../../.claude/hooks/turnPresenceHook.mjs';
 
@@ -57,6 +60,82 @@ test.describe('codex-context hook - wake submit nonce', () => {
             expect(node.properties.wakeSubmitNonce).toBe(nonce);
         } finally {
             db.close();
+            fs.rmSync(dir, {recursive: true, force: true});
+        }
+    });
+
+    test('extracts operator prompt text from Codex payload-shaped hook records', () => {
+        expect(extractPromptingTextFromHookPayload({
+            payload: {
+                type   : 'message',
+                role   : 'user',
+                content: [{type: 'input_text', text: 'operator planning prompt'}]
+            }
+        })).toBe('operator planning prompt');
+
+        expect(extractPromptingTextFromHookPayload({
+            messages: [
+                {role: 'assistant', content: 'ignore'},
+                {role: 'user', content: [{type: 'text', text: 'latest user prompt'}]}
+            ]
+        })).toBe('latest user prompt');
+    });
+
+    test('writes bounded prompt context for the Stop hook fallback', () => {
+        const dir               = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-context-prompt-')),
+              promptContextPath = getCodexPromptContextPath({env: {NEO_AI_DAEMON_DIR: dir}});
+
+        try {
+            const result = writePromptContextFromHookPayload({
+                env        : {NEO_AI_DAEMON_DIR: dir},
+                hookPayload: {prompt: 'operator dialogue fallback'},
+                now        : new Date('2026-06-28T22:00:00.000Z')
+            });
+
+            expect(result).toMatchObject({
+                path      : promptContextPath,
+                source    : 'codex-user-prompt-submit',
+                status    : 'written',
+                textLength: 'operator dialogue fallback'.length
+            });
+
+            expect(JSON.parse(fs.readFileSync(promptContextPath, 'utf8'))).toEqual({
+                createdAt    : '2026-06-28T22:00:00.000Z',
+                promptingText: 'operator dialogue fallback',
+                source       : 'codex-user-prompt-submit'
+            });
+        } finally {
+            fs.rmSync(dir, {recursive: true, force: true});
+        }
+    });
+
+    test('clears stale prompt context when UserPromptSubmit exposes no prompt text', () => {
+        const dir               = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-context-prompt-')),
+              promptContextPath = getCodexPromptContextPath({env: {NEO_AI_DAEMON_DIR: dir}});
+
+        try {
+            writePromptContextFromHookPayload({
+                env        : {NEO_AI_DAEMON_DIR: dir},
+                hookPayload: {prompt: 'operator dialogue fallback'},
+                now        : new Date('2026-06-28T22:00:00.000Z')
+            });
+
+            const result = writePromptContextFromHookPayload({
+                env        : {NEO_AI_DAEMON_DIR: dir},
+                hookPayload: {hook_event_name: 'UserPromptSubmit'},
+                now        : new Date('2026-06-28T22:01:00.000Z')
+            });
+
+            expect(result).toMatchObject({
+                reason: 'no-prompting-text',
+                status: 'cleared'
+            });
+            expect(JSON.parse(fs.readFileSync(promptContextPath, 'utf8'))).toMatchObject({
+                promptingText: '',
+                reason       : 'no-prompting-text',
+                source       : 'codex-user-prompt-submit'
+            });
+        } finally {
             fs.rmSync(dir, {recursive: true, force: true});
         }
     });

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -15,12 +15,22 @@ import {
     extractLastUserTextFromJsonl,
     extractLastUserTextFromMessages,
     extractPromptingText,
+    getCodexPromptContextPath,
+    readPromptContext,
     summarizePayloadShape
 } from '../../../../.codex/hooks/codex-lane-state-stop.mjs';
 
 const block       = body => '```lane-state\n' + body + '\n```',
       fixturePath = new URL('./fixtures/codex-stop-payload.json', import.meta.url),
-      fixture     = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+      fixture     = JSON.parse(fs.readFileSync(fixturePath, 'utf8')),
+      codexRecord = (role, text) => JSON.stringify({
+          type   : 'response_item',
+          payload: {
+              type   : 'message',
+              role,
+              content: [{type: role === 'assistant' ? 'output_text' : 'input_text', text}]
+          }
+      });
 
 test.describe('codex-lane-state-stop - contract boundary', () => {
     test('Codex block/inject is active, so enforced invalid terminals block', () => {
@@ -128,24 +138,66 @@ test.describe('codex-lane-state-stop - input resolution', () => {
         });
     });
 
-    test('JSONL fallback tolerates malformed lines and skips user records', () => {
+    test('message arrays normalize real Codex response_item.payload records', () => {
+        const records = [
+            {type: 'response_item', payload: {type: 'message', role: 'user', content: [{type: 'input_text', text: 'operator prompt'}]}},
+            {type: 'response_item', payload: {type: 'message', role: 'assistant', content: [{type: 'output_text', text: 'assistant answer'}]}}
+        ];
+
+        expect(extractLastUserTextFromMessages(records)).toBe('operator prompt');
+        expect(extractLastAssistantTextFromMessages(records)).toBe('assistant answer');
+    });
+
+    test('JSONL fallback tolerates malformed lines and reads Codex response_item.payload records', () => {
         const jsonl = [
             '{ not json }',
-            JSON.stringify({type: 'user', message: {role: 'user', content: 'question'}}),
-            JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'answer'}]}})
+            codexRecord('user', 'question'),
+            codexRecord('assistant', 'answer')
         ].join('\n');
 
         expect(extractLastAssistantTextFromJsonl(jsonl)).toBe('answer');
+        expect(extractLastUserTextFromJsonl(jsonl)).toBe('question');
     });
 
-    test('JSONL prompt fallback tolerates malformed lines and skips assistant records', () => {
+    test('JSONL prompt fallback skips synthetic hook user records and returns the human prompt', () => {
         const jsonl = [
             '{ not json }',
-            JSON.stringify({type: 'assistant', message: {role: 'assistant', content: 'answer'}}),
-            JSON.stringify({type: 'user', message: {role: 'user', content: [{type: 'text', text: '[WAKE][priority:normal] 1 events'}]}})
+            codexRecord('user', 'operator wants to stop for planning'),
+            codexRecord('assistant', 'answer'),
+            codexRecord('user', '<hook_prompt hook_run_id="stop:1">No-hold reminder</hook_prompt>'),
+            codexRecord('user', '<turn_aborted>interrupted by new prompt</turn_aborted>')
         ].join('\n');
 
-        expect(extractLastUserTextFromJsonl(jsonl)).toBe('[WAKE][priority:normal] 1 events');
+        expect(extractLastUserTextFromJsonl(jsonl)).toBe('operator wants to stop for planning');
+    });
+
+    test('prompt-context fallback is short-lived and ignores expired records', () => {
+        const dir               = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-prompt-context-')),
+              promptContextPath = getCodexPromptContextPath({logDir: dir}),
+              createdAt         = '2026-06-28T22:00:00.000Z';
+
+        try {
+            fs.writeFileSync(promptContextPath, JSON.stringify({
+                createdAt,
+                promptingText: 'operator dialogue fallback',
+                source       : 'codex-user-prompt-submit'
+            }), 'utf8');
+
+            expect(readPromptContext({
+                now: Date.parse('2026-06-28T22:05:00.000Z'),
+                promptContextPath
+            })).toMatchObject({
+                source: 'codex-user-prompt-submit',
+                text  : 'operator dialogue fallback'
+            });
+
+            expect(readPromptContext({
+                now: Date.parse('2026-06-28T22:20:01.000Z'),
+                promptContextPath
+            })).toBeNull();
+        } finally {
+            fs.rmSync(dir, {recursive: true, force: true});
+        }
     });
 });
 
@@ -175,6 +227,30 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
         expect(result.source).toBe('messages');
         expect(result.promptSource).toBe('messages');
         expect(result.operatorInLoop).toBe(true);
+    });
+
+    test('real Codex transcript_path payload records allow confirmed operator dialogue', () => {
+        const dir            = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-transcript-')),
+              transcriptPath = path.join(dir, 'transcript.jsonl'),
+              jsonl          = [
+                  codexRecord('user', 'please stop after this planning response'),
+                  codexRecord('assistant', fixture.last_assistant_message),
+                  codexRecord('user', '<hook_prompt hook_run_id="stop:1">No-hold reminder</hook_prompt>')
+              ].join('\n');
+
+        try {
+            fs.writeFileSync(transcriptPath, jsonl, 'utf8');
+
+            const result = classifyCodexStopPayload({transcript_path: transcriptPath}, {enforcing: true});
+
+            expect(result.action).toBe('allow');
+            expect(result.reason).toContain('live operator dialogue');
+            expect(result.source).toBe('transcript_path');
+            expect(result.promptSource).toBe('transcript_path');
+            expect(result.operatorInLoop).toBe(true);
+        } finally {
+            fs.rmSync(dir, {recursive: true, force: true});
+        }
     });
 
     test('handoff-to-autonomous operator prompt would-blocks instead of allowing', () => {
@@ -310,15 +386,23 @@ test.describe('codex-lane-state-stop - spawned hook', () => {
      * @param {Object} [options]
      * @param {Boolean} [options.enforce=false]
      * @param {Boolean} [options.capture=false]
+     * @param {String} [options.promptContextText]
      * @returns {Promise<{stdout: String, log: String}>}
      */
-    function runHook(payload, {enforce = false, capture = false} = {}) {
+    function runHook(payload, {enforce = false, capture = false, promptContextText} = {}) {
         return new Promise((resolve, reject) => {
             const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-lane-hook-')),
                   env = {...process.env, NEO_AI_DAEMON_DIR: dir};
 
             if (enforce) env.NEO_CODEX_LANE_STATE_ENFORCE = '1';
             if (capture) env.NEO_CODEX_LANE_STATE_CAPTURE = '1';
+            if (promptContextText) {
+                fs.writeFileSync(path.join(dir, 'codex-prompt-context.json'), JSON.stringify({
+                    createdAt    : new Date().toISOString(),
+                    promptingText: promptContextText,
+                    source       : 'codex-user-prompt-submit'
+                }), 'utf8');
+            }
 
             const proc = spawn('node', ['.codex/hooks/codex-lane-state-stop.mjs'], {
                 cwd  : path.resolve(new URL('../../../..', import.meta.url).pathname),
@@ -367,6 +451,48 @@ test.describe('codex-lane-state-stop - spawned hook', () => {
         expect(log).toContain('operatorInLoop=true');
     });
 
+    test('missing Stop prompt falls back to UserPromptSubmit prompt context and allows operator dialogue', async () => {
+        const {stdout, log} = await runHook({
+            session_id            : 'prompt-context-operator',
+            last_assistant_message: fixture.last_assistant_message
+        }, {
+            enforce          : true,
+            promptContextText: 'please end here; we are in live planning dialogue'
+        });
+
+        expect(stdout).toBe('');
+        expect(log).toContain('ALLOW');
+        expect(log).toContain('source=last_assistant_message');
+        expect(log).toContain('promptSource=prompt_context');
+        expect(log).toContain('operatorInLoop=true');
+    });
+
+    test('prompt-context fallback does not allow wake or hook-generated continuations', async () => {
+        const wake = await runHook({
+            session_id            : 'prompt-context-wake',
+            last_assistant_message: fixture.last_assistant_message
+        }, {
+            enforce          : true,
+            promptContextText: '[WAKE][priority:normal] 1 events for @neo-gpt'
+        });
+
+        expect(JSON.parse(wake.stdout).decision).toBe('block');
+        expect(wake.log).toContain('promptSource=prompt_context');
+        expect(wake.log).toContain('operatorInLoop=false');
+
+        const hook = await runHook({
+            session_id            : 'prompt-context-hook',
+            last_assistant_message: fixture.last_assistant_message
+        }, {
+            enforce          : true,
+            promptContextText: '<hook_prompt hook_run_id="stop:1">No-hold reminder</hook_prompt>'
+        });
+
+        expect(JSON.parse(hook.stdout).decision).toBe('block');
+        expect(hook.log).toContain('promptSource=prompt_context');
+        expect(hook.log).toContain('operatorInLoop=false');
+    });
+
     test('handoff-to-autonomous prompt logs autonomous context and blocks while enforcing', async () => {
         const {stdout, log} = await runHook({
             session_id: 'handoff',
@@ -395,6 +521,18 @@ test.describe('codex-lane-state-stop - spawned hook', () => {
         expect(log).toContain('promptSource=none');
         expect(log).toContain('operatorInLoop=false');
         expect(log).toContain('Unknown laneContinuation');
+    });
+
+    test('malformed transcript fallback fails open instead of trapping Stop', async () => {
+        const {stdout, log} = await runHook({
+            session_id            : 'missing-transcript',
+            last_assistant_message: fixture.last_assistant_message,
+            transcript_path       : path.join(os.tmpdir(), 'does-not-exist.jsonl')
+        }, {enforce: true});
+
+        expect(stdout).toBe('');
+        expect(log).toContain('HOOK-ERROR');
+        expect(log).toContain('allowing stop');
     });
 
     test('capture mode logs only the redacted payload shape', async () => {

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -7,6 +7,7 @@ import {
     detectAutonomousHandoffPrompt,
     extractAutonomousHandoffWindowMs,
     isOperatorInLoop,
+    isSyntheticPromptingText,
     LANE_STATE_SCHEMA_HINT,
     parseOutcomeToVerdict,
     scanHoldLexicon,
@@ -81,6 +82,13 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
     test('isOperatorInLoop: a [WAKE] prompt is an autonomous injection, not an operator turn', () => {
         expect(isOperatorInLoop({stopHookActive: false, promptingText: '[WAKE] 1 event'})).toBe(false);
         expect(isOperatorInLoop({stopHookActive: false, promptingText: '  [WAKE] leading whitespace'})).toBe(false);
+    });
+
+    test('isOperatorInLoop: synthetic hook prompts are lifecycle noise, not operator turns', () => {
+        expect(isSyntheticPromptingText('<hook_prompt hook_run_id="stop:1">No-hold reminder</hook_prompt>')).toBe(true);
+        expect(isSyntheticPromptingText('<turn_aborted>interrupted by new prompt</turn_aborted>')).toBe(true);
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: '<hook_prompt hook_run_id="stop:1">No-hold reminder</hook_prompt>'})).toBe(false);
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: '<turn_aborted>interrupted by new prompt</turn_aborted>'})).toBe(false);
     });
 
     test('isOperatorInLoop: a genuine operator prompt is the one operator-in-loop signal', () => {


### PR DESCRIPTION
Resolves #14308

Restores the Codex Stop-hook operator-dialogue path without weakening autonomous no-hold enforcement. Codex Stop now understands real `response_item.payload` transcript records, ignores synthetic hook prompts when looking for the human prompt, and can fall back to a short-lived `UserPromptSubmit` prompt-context record when Stop itself cannot see prompt text.

Evidence: L2 (focused unit and spawned-hook coverage for payload JSONL, prompt-context fallback, wake/hook blocks, malformed transcript fail-open) -> L3/L4 required only for live Codex Desktop operator-turn observation. Residual: live post-merge harness validation below.

## Deltas from ticket

- Added a stale-cache guard: promptless `UserPromptSubmit` events clear the fallback record so an old operator prompt cannot authorize a later autonomous Stop.
- Kept the shared semantics in `stopHookDecision.mjs`; the Codex adapter owns payload normalization and prompt provenance.
- Did not create a new `ai/agent/hooks` substrate in this leaf PR; broader adapter extraction remains with #13796 / #14304.

## Test Evidence

- `npm run agent-preflight -- .codex/hooks/codex-context.mjs .codex/hooks/codex-lane-state-stop.mjs ai/scripts/lifecycle/stopHookDecision.mjs test/playwright/unit/hooks/codexContextHook.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/stopHookDecision.spec.mjs` passed after escalated rerun; sandboxed first attempt hit EPERM when the preflight formatter opened `.codex/hooks/codex-context.mjs`.
- `npm run test-unit -- test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/codexContextHook.spec.mjs` -> 72 passed on rebased head.
- `git diff --cached --check` passed before commit.

## Post-Merge Validation

- [ ] In a live Codex Desktop operator-dialogue turn, a final response without `lane-state` exits cleanly with Stop logging `ALLOW` and `operatorInLoop=true`.
- [ ] In a live Codex Desktop `[WAKE]` / stop-hook continuation, Stop still blocks and emits the no-hold lane-state reminder.

## Commits

- `3ac8bf724a` - `fix(codex): restore operator stop fallback (#14308)`

Authored by Euclid (GPT-5, Codex Desktop). Session 3990502e-346a-47d6-8376-490e4802829c.
