### PR TITLE
fix(ai): surface Golden Path focus epics (#14337)

### DIFF
--- a/ai/services/graph/issueFocusSections.mjs
+++ b/ai/services/graph/issueFocusSections.mjs
@@ -12,6 +12,8 @@ import {IDENTITIES}                          from '../../graph/identityRoots.mjs
 
 const DAY_MS                  = 24 * 60 * 60 * 1000;
 const CURRENT_FOCUS_WINDOW_MS = 3 * DAY_MS;
+const EPIC_LABEL              = 'epic';
+const V13_1_PATTERN           = /\bv13\.1\b/i;
 
 const CURRENT_FOCUS_EXCLUDED_LABELS = Object.freeze(new Set([
     'deferred-by-design',
@@ -24,6 +26,12 @@ const CURRENT_FOCUS_EXCLUDED_LABELS = Object.freeze(new Set([
     'not code ready',
     'wontfix',
     'wont fix'
+]));
+
+const EPIC_CURRENT_FOCUS_REASONS = Object.freeze(new Set([
+    'incident',
+    'prio-zero',
+    'v13.1'
 ]));
 
 const MAINTAINER_PROGRESS_PATTERN = /\b(?:in[-\s]?progress|picking up|taking|claim(?:ed|ing)?|lane-claim|lane-state:\s*next-lane|working|implement(?:ing)?|opened\s+(?:PR|pull request)|PR\s*#\d+)\b/i;
@@ -568,6 +576,25 @@ export function normalizeLabels(labels = []) {
 }
 
 /**
+ * @summary Derives the visible open-sub count from synced issue frontmatter counters.
+ *
+ * GitHub issue sync records parent-child topology in deterministic frontmatter
+ * (`subIssuesTotal`, `subIssuesCompleted`). Current Focus consumes that local
+ * substrate rather than making live GitHub calls during Golden Path generation.
+ *
+ * @param {Object} meta Issue frontmatter.
+ * @returns {Number|null} Open sub-issue count, or `null` when counters are absent.
+ */
+export function getOpenSubIssueCount(meta = {}) {
+    const total = Number(meta.subIssuesTotal);
+    if (!Number.isFinite(total) || total < 0) return null;
+
+    const completed = Number(meta.subIssuesCompleted);
+
+    return Math.max(0, total - (Number.isFinite(completed) && completed > 0 ? completed : 0))
+}
+
+/**
  * @summary Scores one synced issue as a current release / incident focus candidate.
  *
  * This is deliberately a local-sync signal, not graph-centrality routing. It
@@ -590,7 +617,8 @@ export function scoreCurrentFocusIssue({
     if (!meta || meta.state !== 'OPEN') return null;
 
     const labels = normalizeLabels(meta.labels);
-    if (labels.some(label => CURRENT_FOCUS_EXCLUDED_LABELS.has(label))) return null;
+    const isEpic = labels.includes(EPIC_LABEL);
+    if (labels.some(label => CURRENT_FOCUS_EXCLUDED_LABELS.has(label) && label !== EPIC_LABEL)) return null;
 
     const nowDate      = now instanceof Date ? now : new Date(now);
     const createdAt    = new Date(meta.createdAt);
@@ -598,6 +626,7 @@ export function scoreCurrentFocusIssue({
     const freshCreated = !Number.isNaN(createdAt.getTime()) && nowDate - createdAt <= windowMs;
     const freshUpdated = !Number.isNaN(updatedAt.getTime()) && nowDate - updatedAt <= windowMs;
     const milestone    = typeof meta.milestone === 'string' ? meta.milestone : meta.milestone?.title;
+    const title        = String(meta.title || '');
     const issueText    = `${meta.title || ''}\n${content || ''}`;
 
     let score = 0;
@@ -614,7 +643,7 @@ export function scoreCurrentFocusIssue({
         reasons.push('incident');
         hasFocusSignal = true;
     }
-    if (milestone === 'v13.1') {
+    if (milestone === 'v13.1' || (isEpic && V13_1_PATTERN.test(title))) {
         score += 70;
         reasons.push('v13.1');
         hasFocusSignal = true;
@@ -630,17 +659,20 @@ export function scoreCurrentFocusIssue({
     }
 
     if (!hasFocusSignal || (!freshCreated && !freshUpdated && milestone !== 'v13.1')) return null;
+    if (isEpic && !reasons.some(reason => EPIC_CURRENT_FOCUS_REASONS.has(reason))) return null;
 
     const rawNumber = meta.id || meta.number;
 
     return {
+        isEpic,
         labels,
-        lastActivityAt: Number.isNaN(updatedAt.getTime()) ? null : updatedAt.toISOString(),
+        lastActivityAt   : Number.isNaN(updatedAt.getTime()) ? null : updatedAt.toISOString(),
         milestone,
-        number        : Number(rawNumber) || rawNumber,
-        reasons       : [...new Set(reasons)],
+        number           : Number(rawNumber) || rawNumber,
+        openSubIssueCount: isEpic ? getOpenSubIssueCount(meta) : null,
+        reasons          : [...new Set(reasons)],
         score,
-        title         : meta.title || '(no title)'
+        title            : meta.title || '(no title)'
     }
 }
 
@@ -718,11 +750,15 @@ export function renderCurrentFocusCandidatesSection(candidates, {
     }
 
     for (const candidate of visibleCandidates) {
-        const labels = candidate.labels.length > 0 ? ` [\`${candidate.labels.join('`, `')}\`]` : '';
+        const labels    = candidate.labels.length > 0 ? ` [\`${candidate.labels.join('`, `')}\`]` : '';
+        const epic      = candidate.isEpic ? ' — **epic umbrella**' : '';
         const milestone = candidate.milestone ? ` — milestone ${candidate.milestone}` : '';
+        const openSubs  = candidate.isEpic && Number.isFinite(candidate.openSubIssueCount)
+            ? ` — ${candidate.openSubIssueCount} open sub${candidate.openSubIssueCount === 1 ? '' : 's'}`
+            : '';
         const reasons = candidate.reasons.length > 0 ? ` — reasons: ${candidate.reasons.join(', ')}` : '';
 
-        section += `- **#${candidate.number}**${labels}${milestone} — score ${candidate.score}${reasons}\n`;
+        section += `- **#${candidate.number}**${epic}${labels}${milestone}${openSubs} — score ${candidate.score}${reasons}\n`;
         section += `  - *${candidate.title}*\n`;
     }
 

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -162,6 +162,70 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         ]));
     });
 
+    test('scoreCurrentFocusIssue surfaces focused epic umbrellas without routing them (#14337)', () => {
+        const Synthesizer = GoldenPathSynthesizer.constructor;
+        const now         = new Date('2026-06-29T12:00:00Z');
+        const candidate   = issueFocusSections.scoreCurrentFocusIssue({
+            meta: {
+                id                : 14310,
+                title             : 'Documentation & learning-experience overhaul (v13.1)',
+                state             : 'OPEN',
+                labels            : ['documentation', 'epic', 'ai', 'architecture'],
+                createdAt         : '2026-06-29T08:46:57Z',
+                updatedAt         : '2026-06-29T09:44:27Z',
+                milestone         : 'v13.1',
+                subIssuesCompleted: 3,
+                subIssuesTotal    : 22
+            },
+            now
+        });
+
+        expect(candidate).toMatchObject({
+            isEpic           : true,
+            milestone        : 'v13.1',
+            number           : 14310,
+            openSubIssueCount: 19
+        });
+        expect(candidate.reasons).toContain('v13.1');
+        expect(Synthesizer.isActionableComputedRecommendation({
+            id        : 'issue-14310',
+            type      : 'ISSUE',
+            properties: {labels: ['epic', 'ai']}
+        })).toBe(false);
+        expect(issueFocusSections.scoreCurrentFocusIssue({
+            meta: {
+                id       : 14000,
+                title    : 'Generic architecture epic',
+                state    : 'OPEN',
+                labels   : ['epic', 'ai', 'architecture'],
+                createdAt: '2026-06-29T08:00:00Z',
+                updatedAt: '2026-06-29T09:00:00Z'
+            },
+            now
+        })).toBeNull();
+
+        const staleSyncCandidate = issueFocusSections.scoreCurrentFocusIssue({
+            meta: {
+                id                : 14310,
+                title             : 'Documentation & learning-experience overhaul (v13.1)',
+                state             : 'OPEN',
+                labels            : ['documentation', 'epic', 'ai', 'architecture'],
+                createdAt         : '2026-06-29T08:46:57Z',
+                updatedAt         : '2026-06-29T09:44:27Z',
+                subIssuesCompleted: 0,
+                subIssuesTotal    : 22
+            },
+            now
+        });
+
+        expect(staleSyncCandidate).toMatchObject({
+            isEpic           : true,
+            milestone        : undefined,
+            openSubIssueCount: 22
+        });
+        expect(staleSyncCandidate.reasons).toContain('v13.1');
+    });
+
     test('hasCrossFamilyReview accepts injected identity-family maps', () => {
         const Synthesizer = GoldenPathSynthesizer.constructor;
         const pr          = {
@@ -664,7 +728,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(capturedWhere).toEqual({type: {'$in': ['ISSUE', 'DISCUSSION']}})
     });
 
-    test('synthesizeGoldenPath surfaces current incidents and filters non-actionable computed recommendations', async () => {
+    test('synthesizeGoldenPath surfaces current incidents, focus epics, and filters non-actionable computed recommendations', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
         const originalEmbedText            = TextEmbeddingService.embedText;
@@ -709,12 +773,15 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             'state: OPEN',
             'labels:',
             '  - enhancement',
+            '  - epic',
             '  - ai',
             '  - architecture',
             'assignees: []',
             "createdAt: '2026-06-10T00:00:00Z'",
             "updatedAt: '2026-06-21T09:00:00Z'",
             'milestone: v13.1',
+            'subIssuesCompleted: 5',
+            'subIssuesTotal: 22',
             '---',
             '# Agent Harness v13.1 release epic'
         ].join('\n'));
@@ -793,6 +860,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(directFocusCandidates.map(candidate => candidate.number)).toEqual([13750, 13012]);
         expect(focusSection).toContain('**#13750**');
         expect(focusSection).toContain('**#13012**');
+        expect(focusSection).toContain('**epic umbrella**');
+        expect(focusSection).toContain('17 open subs');
         expect(focusSection).not.toContain('Old generic AI enhancement');
         expect(handoffContent).toContain(readyId);
         expect(handoffContent).toContain(discussionId);  // discussions are now actionable (an open converge-to-drive)


### PR DESCRIPTION
Resolves #14337

Current Release / Incident Focus now treats focused epics as visibility-only umbrella signals while leaving the computed Golden Path route leaves-only. Focused epics can pass Current Focus when they carry an incident/prio-zero/v13.1 signal, render as `epic umbrella`, and show the open sub-issue count derived from local issue-sync frontmatter. Computed route actionability still rejects `epic` labels.

Evidence: L2 (focused Playwright unit coverage + real local-sync probe) -> L3 required for the next generated `sandman_handoff.md` artifact after a Golden Path run. Residual: AC3 requires post-merge/run validation that #14310 appears in the regenerated Current Release / Incident Focus section.

## Deltas from ticket
Live GitHub shows #14310 is milestoned `v13.1`, but the current checked-in issue sync can lag and omit the milestone frontmatter. The implementation therefore accepts an epic title containing `v13.1` as a narrow release-focus fallback for visibility only; it does not change computed-route eligibility.

## Test Evidence
- `git diff --check` passed.
- `npm run agent-preflight -- ai/services/graph/issueFocusSections.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` passed before final scope-trim.
- Real local-sync probe confirmed #14310 is now found as an epic Current Focus candidate with 22 open subs.
- `NEO_CHROMA_PORT_TEST=18182 NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` passed: 37 passed.
- Full `npm run test-unit` was attempted on `NEO_CHROMA_PORT_TEST=18182`; it completed with 5426 passed, 114 skipped, 9 not run, and 6 unrelated failures outside this change set.

## Post-Merge Validation
- [ ] Rerun the Golden Path after issue sync and confirm #14310 appears in Current Release / Incident Focus as an epic umbrella.
- [ ] Confirm the Computed Golden Path section still does not render #14310 as a numbered immediate route.

Authored by Euclid (GPT-5, Codex Desktop). Session f9ecf11e-78ce-4a48-b353-b970adf49d92.
