### PR TITLE
docs(agentos): refresh strategic workflows guide (#14339)

### DIFF
--- a/learn/agentos/StrategicWorkflows.md
+++ b/learn/agentos/StrategicWorkflows.md
@@ -11,10 +11,10 @@ evidence instead of a confident guess. You can see what changed, which ticket or
 discussion motivated it, what prior sessions learned, and which structural
 neighbors were checked.
 
-For an LLM maintainer, it means a regression is no longer a cold-start puzzle.
-The model can ask the organism for the written plan, the unwritten intent, and
-the graph around the affected node before it edits. That is how a session moves
-from helpful patching to situated maintenance.
+For you, the model reading this guide, the same regression is no longer a
+cold-start puzzle. You can ask the organism for the written plan, the unwritten
+intent, and the graph around the affected node before you edit. That is how a
+session moves from helpful patching to situated maintenance.
 
 ## Regression Bug Analysis
 

--- a/learn/agentos/StrategicWorkflows.md
+++ b/learn/agentos/StrategicWorkflows.md
@@ -1,51 +1,158 @@
-# AI Strategic Workflows
+# Strategic Workflows
 
-This guide is primarily written for the AI agent, providing strategic context for its operational protocols. However, it is also a valuable resource for human developers to understand the advanced, integrated workflows that the agent is capable of, and to learn best practices for repository and issue management that maximize the agent's effectiveness.
+The dangerous regression fix is the tidy one: find the failing line, patch the
+symptom, and accidentally erase the reason that line existed. Neo's Agent OS has
+enough memory substrate to avoid that trap. A maintainer can combine Git history,
+Knowledge Base retrieval, Memory Core recall, and Native Edge Graph topology into
+one evidence loop before touching the code.
 
-This guide is a "cookbook" of advanced strategies. It provides examples of how to combine the agent's core tools (`git`, `ai:query`, `ai:query-memory`) to solve complex problems. While `AGENTS.md` defines the mandatory *rules* of your operation, this guide provides the strategic *art*.
+For a human maintainer, that means an agent's fix can be audited as a chain of
+evidence instead of a confident guess. You can see what changed, which ticket or
+discussion motivated it, what prior sessions learned, and which structural
+neighbors were checked.
 
-## The Regression Bug Analysis Workflow
+For an LLM maintainer, it means a regression is no longer a cold-start puzzle.
+The model can ask the organism for the written plan, the unwritten intent, and
+the graph around the affected node before it edits. That is how a session moves
+from helpful patching to situated maintenance.
 
-One of the most powerful use cases for the agent is analyzing and fixing regression bugs. A naive fix might solve the immediate bug but re-introduce the original problem that the previous code was trying to solve. This workflow prevents that by building a complete, three-dimensional picture of the code's history and intent.
+## Regression Bug Analysis
 
-### The Goal
+Use this workflow when behavior used to work and now fails. The goal is not to
+revert the past; it is to preserve the valid intent from the past while fixing
+the present failure.
 
-To fix a regression not just by reverting code, but by understanding the *intent* of the original change and creating a new solution that honors both the old and new requirements.
+### 1. Isolate The Regression
 
-### The Steps
+Start with the observable breakage:
 
-1.  **Isolate the Regression:** Start with a clear identification of the regression. What worked before but is now broken?
+- What changed for the user or operator?
+- Which file, class, command, guide, or workflow now behaves incorrectly?
+- Is there a focused test, render check, CLI command, or live probe that can
+  falsify the symptom?
 
-2.  **Find the Breaking Commit (`git`):** Use `git log` and `git blame` on the affected file(s) to pinpoint the exact commit that introduced the regression.
+Do not explain the cause yet. First define the failure mode well enough that a
+tool result can prove or disprove it.
 
-3.  **Find the Original Task (`ai:query`):** The commit message for the breaking change should contain a ticket number or a clear description of the original task. Use this information to query the knowledge base for the original ticket.
-    ```bash
-    npm run ai:query -- -q "#<ticket_number>" -t ticket
-    ```
-    Reading the ticket will tell you the *planned* work.
+### 2. Find The Breaking Change
 
-4.  **Find the Unwritten Context (Memory Core):** This is the most critical step. The ticket describes the plan, but the memory core holds the conversation, the debates, the alternative approaches, and the specific user constraints that shaped the final implementation. Query your memory using the ticket number or key phrases from the original discussion.
+Use Git for the mechanical history:
 
-    **Inside an active MCP session (preferred when Claude Code, Antigravity, Gemini CLI, etc. are driving):** call the Memory Core MCP tools directly:
-    ```
-    query_summaries({query: "context for ticket #<ticket_number>"})
-    query_raw_memories({query: "<key phrase from original discussion>"})
-    ```
-    `query_summaries` returns high-level session overviews quickly; `query_raw_memories` drills into individual prompt/thought/response entries when you need the nuanced decision trail.
+```bash
+git log --oneline -- <path>
+git blame <path>
+```
 
-    **Outside an MCP session (shell / CI / standalone scripts):** the CLI form covers the same ground:
-    ```bash
-    npm run ai:query-memory -- -q "context for ticket #<ticket_number>"
-    ```
+The commit message often gives you the first ticket, PR, or discussion anchor.
+That anchor is not the whole truth; it is the doorway into the rest of the
+evidence.
 
-    Either surface reveals the crucial **"why"** behind the code that is now causing a regression. Semantic search is the strength here — vector embeddings surface loosely-worded prior context that keyword grep over the repo would miss.
+### 3. Recover The Written Plan
 
-5.  **Synthesize and Solve:** With the full context, you can now devise a solution that addresses the new regression while still respecting the original problem that the previous developer (or a past version of yourself) was trying to solve. Your final plan should explicitly reference the synthesis of these three sources of information:
-    *   **What changed?** (from `git`)
-    *   **What was the plan?** (from the knowledge base)
-    *   **What was the intent?** (from your memory)
+Inside an active MCP session, use the Knowledge Base and GitHub Workflow tools
+rather than retired shell scripts:
+
+```js
+ask_knowledge_base({
+    query: "ticket #<ticket_number> original plan and affected files",
+    type : "ticket"
+})
+
+get_local_issue_by_id({
+    issue_number: "<ticket_number>"
+})
+```
+
+`ask_knowledge_base` is the default starting point for repository knowledge: it
+returns a synthesized answer plus cited source references. `get_local_issue_by_id`
+is useful when the synced GitHub content already contains the issue; if the local
+index is stale, refresh it or read live GitHub state before relying on it.
+
+### 4. Recover The Unwritten Intent
+
+The ticket describes what was planned. Memory Core captures the discussions,
+review reversals, operator constraints, and failed alternatives that shaped the
+implementation.
+
+```js
+query_summaries({
+    query: "context for ticket #<ticket_number>"
+})
+
+query_raw_memories({
+    query   : "<key phrase from the original discussion>",
+    nResults: 5
+})
+```
+
+Use `query_summaries` to zoom out across sessions. Use `query_raw_memories` when
+you need the exact decision trail, error text, or review context.
+
+### 5. Check Structural Neighbors
+
+When the regression crosses issue, class, guide, test, or decision boundaries,
+ask the Native Edge Graph for topology instead of relying on nearest-text recall:
+
+```js
+query_hybrid_graph({
+    nodeId  : "issue-<ticket_number>",
+    maxDepth: 2
+})
+```
+
+Issue nodes use the canonical `issue-N` graph id after GitHub content has been
+ingested. The graph topology is not a replacement for source reads; it tells you
+which neighboring nodes deserve inspection before you edit.
+
+### 6. Synthesize The Fix
+
+Before implementation, write down the three-part synthesis:
+
+- **What changed?** Git history and the breaking commit.
+- **What was planned?** Ticket, PR, or discussion evidence.
+- **What was intended?** Memory Core and graph context.
+
+Only then choose the patch. A correct fix should satisfy the new failing case
+without reintroducing the old failure mode that the original change prevented.
+
+### 7. Preserve The Handoff
+
+When the turn ends, save the reasoning and the result:
+
+```js
+add_memory({
+    prompt  : "<operator request or task summary>",
+    thought : "<evidence chain and decision>",
+    response: "<final user-facing result>"
+})
+```
+
+That final memory is not ceremony. It is the substrate that lets the next
+maintainer avoid repeating the same reconstruction.
+
+## Shell Fallback Outside An MCP Session
+
+For standalone scripts, CI diagnostics, or a local shell without first-class MCP
+tool bindings, use the repository MCP client. These are the current script names
+in `package.json`; the old direct query scripts are retired.
+
+```bash
+npm run ai:mcp-client -- --server knowledge-base --call-tool ask_knowledge_base --args '{"query":"ticket #<ticket_number> original plan","type":"ticket"}'
+
+npm run ai:sync-github-workflow
+npm run ai:mcp-client -- --server github-workflow --call-tool get_local_issue_by_id --args '{"issue_number":"<ticket_number>"}'
+
+npm run ai:mcp-client -- --server memory-core --call-tool query_raw_memories --args '{"query":"context for ticket #<ticket_number>","nResults":5}'
+
+npm run ai:mcp-client -- --server memory-core --call-tool query_hybrid_graph --args '{"nodeId":"issue-<ticket_number>","maxDepth":2}'
+```
+
+Use shell fallback only when tool bindings are unavailable. In an agent turn,
+direct MCP calls are clearer, typed, and easier to cite in a PR body.
 
 ## Related Guides
 
-- [Swarm Intelligence & Sub-Agents](./SwarmIntelligence.md) — How tasks are delegated
-- [Progressive Disclosure Skills](./ProgressiveDisclosureSkills.md) — The lifecycle governance rules
+- [Memory Core](./MemoryCore.md) - Episodic memory, summaries, mailbox state, and graph storage.
+- [Knowledge Base](./KnowledgeBase.md) - Semantic repository knowledge.
+- [Dream Pipeline & Golden Path](./DreamPipeline.md) - How memory becomes forecast.
+- [Swarm Intelligence](./SwarmIntelligence.md) - Peer-team coordination and lane ownership.


### PR DESCRIPTION
Resolves #14339

Refreshes `learn/agentos/StrategicWorkflows.md` from a stale `git + ai:query + ai:query-memory` cookbook into a current regression-analysis workflow grounded in Git, Knowledge Base MCP, GitHub Workflow MCP, Memory Core MCP, and Native Edge Graph topology. The guide now has the required narrative arc and explicit human/LLM maintainer payoff, without calling Neo a framework.

Evidence: L2 (static/source authority + local CLI surface verification) → L2 required for documentation command/tool references. Residual: cross-guide occurrences of old query commands remain intentionally out of scope for #14339 and are covered by #14327.

## Deltas from ticket

- Replaced every dead command in `StrategicWorkflows.md` with verified active MCP tool calls and the current `npm run ai:mcp-client` shell fallback.
- Removed the retired command names from the guide text entirely, so readers are not taught dead invocations even as historical caveats.
- Kept #14327 separate as the later cross-guide dead-reference and numbers reconciliation sweep.

## Test Evidence

- `rg -n "ai:query|ai:query-memory|framework|text-embedding-004|Gemini 2\\.5|two Chroma|ChromaDB Memory|ChromaDB KB" learn/agentos/StrategicWorkflows.md` returned no matches.
- `npm run ai:mcp-client -- --help` passed and verified the documented `--server`, `--call-tool`, and `--args` CLI surface.
- `rg`/source V-B-A confirmed current tool authorities:
  - `package.json` has `ai:mcp-client`, `ai:sync-github-workflow`, and no direct query scripts.
  - `ai/mcp/client/mcp-cli.mjs` implements `--server`, `--call-tool`, and `--args`.
  - `ai/mcp/client/config.mjs` defines `knowledge-base`, `github-workflow`, and `memory-core` server names.
  - `ai/mcp/server/knowledge-base/openapi.yaml` defines `ask_knowledge_base`.
  - `ai/mcp/server/github-workflow/openapi.yaml` defines `get_local_issue_by_id`.
  - `ai/mcp/server/memory-core/openapi.yaml` defines `query_raw_memories`, `query_summaries`, and `query_hybrid_graph`.
  - `ai/services/ingestion/IssueIngestor.mjs` confirms canonical issue graph ids are `issue-N`.
- `git diff --check` passed.
- `npm run agent-preflight -- --no-fix learn/agentos/StrategicWorkflows.md` passed.

## Post-Merge Validation

- [ ] #14327 should verify remaining cross-guide dead command references, including older blog material outside this ticket's file scope.

## Slot Rationale

`learn/agentos/StrategicWorkflows.md` is an Agent OS reference guide, not always-loaded turn substrate. This PR rewrites an existing guide section in place to retire stale commands and align the guide with current MCP surfaces. Disposition: `rewrite`; trigger frequency is targeted to regression-analysis and documentation readers, failure severity is medium-high because dead commands create hallucinated operator workflows, and enforceability is static/source-checkable via `package.json`, MCP OpenAPI specs, and grep.

Authored by Euclid (GPT-5, Codex Desktop). Session f9ecf11e-78ce-4a48-b353-b970adf49d92.
