### PR TITLE
fix(agentos): restore DreamPipeline Mermaid rendering (#14340)

### DIFF
--- a/learn/agentos/DreamPipeline.md
+++ b/learn/agentos/DreamPipeline.md
@@ -201,14 +201,14 @@ rendered from the current graph.
 ```mermaid
 flowchart TD
     classDef vector fill:#0f3460,stroke:#16c79a,stroke-width:2px,color:#fff
-    classDef graph fill:#1a1a2e,stroke:#e94560,stroke-width:1px,color:#eee
+    classDef structural fill:#1a1a2e,stroke:#e94560,stroke-width:1px,color:#eee
     classDef handoff fill:#1a3c34,stroke:#2ecc71,stroke-width:1px,color:#eee
 
     Summaries["Recent session summaries"]:::vector
     Frontier["Frontier baseline embedding"]:::vector
     Chroma["Chroma graph query: ISSUE + DISCUSSION"]:::vector
-    SQLite["SQLite open-state, blocker, and edge-weight checks"]:::graph
-    Score["priority = semanticScore * 2 + structuralWeight"]:::graph
+    SQLite["SQLite open-state, blocker, and edge-weight checks"]:::structural
+    Score["priority = semanticScore * 2 + structuralWeight"]:::structural
     Handoff["sandman_handoff.md"]:::handoff
 
     Summaries --> Frontier --> Chroma --> SQLite --> Score --> Handoff


### PR DESCRIPTION
Resolves #14340
Related: #14310

Restores the second Mermaid diagram in `learn/agentos/DreamPipeline.md` by renaming the diagram style class from `graph` to `structural`. The portal path was verified first: `Neo.component.Markdown` extracts Mermaid fences verbatim, `Neo.component.wrapper.Mermaid` prepends theme YAML, and `Neo.main.addon.Mermaid` hands the resulting text to Mermaid. The failure was therefore the guide content itself: Mermaid tokenized `classDef graph` as the reserved `GRAPH` token.

Evidence: L2 (browser-backed Mermaid render of the extracted second guide block) -> L2 required (the close target is a rendered-guide regression).

## Deltas from ticket

No scope expansion. This keeps the Golden Path narrative and diagram shape intact, changing only the reserved Mermaid class name that prevented rendering.

## Slot Rationale

Modified existing `learn/agentos/DreamPipeline.md` guide content. Disposition remains `keep`: this is flagship Agent OS narrative/reference material, and the placement did not change.

## Test Evidence

- `npm run agent-preflight -- --no-fix learn/agentos/DreamPipeline.md`
- `git diff --check`
- Browser-backed Mermaid check with `node_modules/mermaid/dist/mermaid.min.js`: reconstructed old block returned `{"label":"old","ok":false,"message":"Parse error on line 3:"}`; current block returned `{"label":"current","ok":true,"svg":true}`.
- `rg -n "classDef graph|:::graph|ai:query|ai:query-memory" learn/agentos/DreamPipeline.md` returned no matches.

## Post-Merge Validation

- [ ] Confirm https://neomjs.com/learn/agentos/DreamPipeline renders the Golden Path diagram without an inline Mermaid error after deployment.

## Commits

- `5e24e5bbb5` - `fix(agentos): restore DreamPipeline Mermaid rendering (#14340)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019f1258-24e1-7f51-9b09-e366d653430a.
