### PR TITLE
docs(agentos): MemoryCore.md — extract tooling reference, rewrite to conceptual guide (#14342)

### DIFF
--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -16,340 +16,63 @@ For an LLM maintainer, it turns a cold start into situated agency. The model can
 
 ## What It Preserves
 
-Memory Core persists:
-*   **Interactions:** Every prompt, thought process, and response is stored as a raw memory.
-*   **Decisions:** The reasoning behind *why* a certain approach was chosen.
-*   **Summaries:** High-level abstractions of entire work sessions to enable fast retrieval of past experiences.
-*   **Coordination:** A2A mailbox messages, wake routing, and permission edges are stored in the Native Edge Graph so agents can hand work to each other with durable provenance instead of transient chat context.
-*   **Trust:** Raw memories and summaries carry agent identity and trust-tier metadata, letting the swarm recall shared institutional memory without laundering low-trust or unclassified material into higher-trust conclusions.
+Memory Core persists five kinds of institutional knowledge:
 
-The payoff is not a bigger chat log. It is identity-bound continuity: a peer's prior reasoning becomes searchable substrate for the next peer, while Neural Link remains the runtime-app possession and inspection bridge. A2A is the enabling substrate here; the higher-order outcome is night-shift continuity, Golden Path handoffs, and maintainers whose reasoning stays attributable across sessions.
+*   **Interactions** — every prompt, thought process, and response, stored as a raw memory. The *reasoning* is captured, not just the output.
+*   **Decisions** — the *why* behind a chosen approach, so it can be revisited instead of relitigated.
+*   **Summaries** — high-level abstractions of whole sessions, so past work is findable in one query instead of re-read line by line.
+*   **Coordination** — A2A mailbox messages, wake routing, and permission edges, stored in the Native Edge Graph so agents hand work to each other with durable provenance instead of transient chat context.
+*   **Trust** — every memory and summary carries agent identity and trust-tier metadata, so the swarm can recall shared memory without laundering low-trust input into higher-trust conclusions.
+
+The payoff is not a bigger chat log. It is identity-bound continuity: a peer's prior reasoning becomes searchable substrate for the next peer. (Neural Link remains the *runtime-app* possession and inspection bridge; Memory Core is the *across-time* one.)
 
 ## How It Works
 
-The server is built on a modular service architecture, extending `Neo.core.Base`. It uses the deployment-wide **unified ChromaDB** process as the vector database for semantic search and the configured AI providers for text embeddings and summarization. The Native Edge Graph persists in SQLite via `ai/graph/storage/SQLite.mjs`, which sets `PRAGMA foreign_keys=ON` at connection time so the schema-declared `Edges` `ON DELETE CASCADE` fires on Node deletion (#10856).
+Memory Core is one server in the Agent OS MCP set — the checkout ships six (`file-system`, `github-workflow`, `gitlab-workflow`, `knowledge-base`, `memory-core`, `neural-link`) — and it stays a distinct institutional-memory and coordination surface, not a merged monolith. It is built on the same `Neo.core.Base` class system as the Body's UI engine (more on that below), so the backend is as explicit and inspectable as the frontend.
 
-Memory Core is one server in the current Agent OS MCP server set. The checkout currently ships six server directories (`file-system`, `github-workflow`, `gitlab-workflow`, `knowledge-base`, `memory-core`, `neural-link`) plus shared support code; Memory Core remains a distinct institutional-memory and coordination surface rather than a merged monolith.
+Two stores work together:
 
-### Key Services
+*   **Semantic memory** lives in the deployment-wide **unified ChromaDB** process. One Chroma daemon and one persist directory back several collections — `neo-agent-memory` (raw turns), `neo-agent-sessions` (summaries), `neo-native-graph` (graph-vector retrieval), and the Knowledge Base's own collection — separated by collection and metadata, not by process. One Chroma process does not mean one collection; separate MCP servers do not mean separate vector stores.
+*   **Structural memory** — the Native Edge Graph of identities, permissions, messages, and issue/session links — lives in SQLite, the authority for who-can-read-what and who-said-what.
 
-*   **`MemoryService`**: Manages raw, granular memories. It handles the ingestion of new agent interactions and performs semantic searches across the raw interaction history.
-*   **`SessionService`**: Responsible for the "Auto-Discovery" process. It uses an LLM to analyze completed sessions and generate structured summaries (Title, Category, Quality Scores) to make them easily searchable.
-*   **`SummaryService`**: Manages the high-level session summaries. It provides tools to query past work based on topics or categories (e.g., "refactoring", "bugfix").
-*   **`DatabaseLifecycleService`**: Reports the underlying ChromaDB process state so health diagnostics can explain whether the persistence layer is available.
-*   **`HealthService`**: A gatekeeper that ensures dependencies (ChromaDB connectivity, collections, and provider readiness) are healthy before allowing operations.
-*   **`MailboxService`**: Implements the A2A messaging substrate with server-stamped authorship, broadcast fan-out, wake routing, task envelopes, and collision-safe wake-suppression guards.
-*   **`PermissionService`**: Manages explicit cross-agent permission edges such as `CAN_READ_INBOX_OF`, `CAN_READ_MEMORIES_OF`, `CAN_READ_SESSIONS_OF`, `CAN_REPLY_TO`, and `BLOCKED_BY`.
+Embeddings and summaries run through configurable providers, and the choice is **local-first**: the default profile embeds and summarizes with local models (qwen3 embeddings, Gemma summaries) on an OpenAI-compatible endpoint — private, zero-API-cost, on-prem — while remote Gemini is one env-var away when you want it. A running deployment's `healthcheck.providers` block is always the source of truth for what it is actually using.
 
-## The "Save-Then-Respond" Protocol
+## Save-Then-Respond: why the reasoning survives
 
-The most critical operational rule for the Memory Core is the **Transactional Memory Protocol**.
-To ensure a complete history, agents are required to follow a strict loop for every interaction turn:
+The one rule that makes everything above possible is the **transactional memory protocol**. Every turn follows a strict loop:
 
-1.  **Think:** Analyze the user's request.
-2.  **Act:** Execute tools and gather information.
-3.  **Consolidate:** Formulate the final response.
-4.  **Save (`add_memory`):** Persist the *entire* turn (Prompt + Thought + Response) to the database.
-5.  **Respond:** Only *after* the save is confirmed, deliver the response to the user.
+1.  **Think** — analyze the request.
+2.  **Act** — execute tools, gather information.
+3.  **Consolidate** — formulate the response.
+4.  **Save** — persist the *entire* turn (prompt + thought + response) via `add_memory`.
+5.  **Respond** — deliver the answer only after the save is confirmed.
 
-**Why?** This ensures that the agent's *internal reasoning* (the "Thought") is saved, not just the final output. This is crucial for self-improvement, allowing the agent to analyze its own logic later.
-
-## Session Summarization (Auto-Discovery)
-
-The Memory Core is **self-organizing**.
-When the server starts, the `SessionService` automatically scans for previous sessions that haven't been summarized yet. It uses the configured summary provider to analyze the raw interaction logs and generate a structured summary containing:
+The save gates the response on purpose. If the internal reasoning — the *thought*, not just the final text — is not persisted, it cannot teach the next session. Save-then-respond is the discipline that turns a transcript into institutional memory.
 
-*   **Title:** A concise name for the session (e.g., "Fixing Button Click Event").
-*   **Category:** One of: `bugfix`, `feature`, `refactoring`, `documentation`, `new-app`, `analysis`, `other`.
-*   **Quality Metrics:** Scores (0-100) for **Productivity**, **Complexity**, and **Quality**.
-*   **Summary:** A high-level textual overview of what was achieved.
-*   **Technologies:** A list of key technologies or modules touched during the session.
-*   **Provenance:** Source agent identities plus the most restrictive source trust tier, so a generated summary cannot hide lower-trust input behind the summarizing agent.
+## Self-organizing recall: summaries and sunset
 
-This means the agent starts every new session with an indexed "Recap" of its past work, ready to pick up where it left off.
+Memory Core summarizes itself. On startup it scans for un-summarized sessions and uses the configured summary model to generate a structured recap of each — a title, a category (`bugfix`, `feature`, `refactoring`, …), 0–100 productivity / complexity / quality scores, the technologies touched, and provenance (the source identities and most-restrictive trust tier, so a summary cannot hide lower-trust input behind the summarizer). Every new session therefore opens with an indexed recap of past work instead of a blank slate.
 
-The provider route is intentionally deployment-agnostic. In the local/default profile, `NEO_MODEL_PROVIDER=openAiCompatible` points at a local OpenAI-compatible chat server; the template default summary model is Gemma (`google/gemma-4-26b-a4b`). Operators can opt into Gemini by setting `NEO_MODEL_PROVIDER=gemini` and providing `GEMINI_API_KEY`. The `healthcheck.providers.summary` block is the source of truth for what a running deployment actually uses.
+Sessions from *external* harnesses are captured the same way, through a mailbox bridge: when any agent on any clone runs the session-sunset ritual, its final hand-off message lands in the shared graph, and Memory Core ingests it into a summary — so continuity survives even across tools that never shared a process.
 
-### Session Sunset Polling
+## Recalling the past: Zoom Out, then Zoom In
 
-To gracefully capture sessions from external harnesses without losing events to isolated per-instance SQLite queues, the Memory Core employs a **B2 Mailbox-Poll** strategy.
+Effective agents query in two stages:
 
-The `SessionService` spins up a periodic background poller (every 30s) that queries the A2A Mailbox for unread self-DM messages matching the contract:
-`{ taggedConcepts: ['sunset-protocol-handover'] }`
+1.  **Zoom out** — `query_summaries` finds the relevant *past session* ("refactoring the virtual list" → "Session #42: Grid Virtualization Refactor").
+2.  **Zoom in** — `query_raw_memories`, optionally filtered to that session, retrieves the specific decision or snippet ("why a `Map` instead of an `Object`?" → the exact reasoning from that session).
 
-This substrate bridges the gap between instances: when any agent on any clone runs the session-sunset skill, the final self-DM is persisted in the shared graph. The Memory Core sees this unread message, triggers a summarization sweep to ingest the finalized session, and marks the message as read to prevent double-processing.
+Zoom out to locate, zoom in to recover — recall on demand, the hippocampus pattern in practice.
 
-## Tools
+## One organism: built on the same runtime as the Body
 
-The server exposes a suite of tools via the Model Context Protocol (MCP).
+Memory Core is not a bolt-on backend. It is written in the **same Neo.mjs class system** that powers the multi-threaded UI engine — singletons for single-source-of-truth services, `initAsync()` to order dependency chains without race conditions, and reactive configs (`afterSet…` hooks) so a service re-initializes cleanly when its environment changes. Body and Brain share one set of primitives and one evolution mechanism; Memory Core is the Brain proving the organism is genuinely one system, not two glued together.
 
-### Memory Operations
+## Operations and reference
 
-*   **`add_memory`**: The core persistence tool. Saves the `{prompt, thought, response}` triplet.
-*   **`get_session_memories`**: Retrieves the full chronological history of a specific session. Useful for context recovery.
-*   **`query_raw_memories`**: Performs a semantic vector search across *all* raw memories. Use this to find specific details (e.g., "What was the error message in the grid component?").
+This guide is the *concept*. The operational detail lives in dedicated references, kept single-sourced so they never drift against the running system:
 
-### A2A / Coordination Operations
-
-*   **`add_message`**: Sends direct or broadcast A2A messages with server-stamped authorship. The caller cannot spoof `from`; Memory Core derives `SENT_BY` from the bound `AgentIdentity`.
-*   **`list_messages` / `get_message` / `mark_read`**: Read and advance mailbox state. These tools let cloud agents poll messages at turn start while local agents can also receive wake events.
-*   **`grant_permission` / `revoke_permission` / `list_permissions`**: Manage explicit permission edges for cross-agent inbox, memory, and session visibility. `BLOCKED_BY` is the hard negative-intent primitive.
-
-### Summary Operations
-
-*   **`query_summaries`**: Performs a semantic vector search across session summaries. Use this to find relevant *past sessions* (e.g., "Have I worked on the Grid component before?").
-*   **`get_all_summaries`**: Lists all session summaries, sorted by date.
-*   **`summarize_sessions`**: Manually triggers the summarization process for specific or all pending sessions.
-
-### Session Operations
-
-*   **`resume_session`**: Pure validation/query — returns structural metadata about whether a candidate session ID is safe for the agent to keep using on reconnect (set the `Mcp-Session-Id` header to that ID for subsequent calls). Does NOT mutate `RequestContextService` or any server-side session state. Returns either a success payload (`status: 'resumable'` plus `memoryCount`, `lastActivityAt`, `summarizationStatus`) or one of four structured errors: `INVALID_SESSION_ID`, `SESSION_NOT_FOUND`, `SESSION_FINALIZED` (already summarized — start fresh), `SESSION_BUSY` (concurrent summarization mid-flight — retry shortly). Use after recovering a candidate session ID from a prior `query_summaries` result or local context.
-*   **`set_session_id`**: Legacy / single-tenant fallback only. Overrides the process-global `_legacySessionId`. Rejected with `REQUEST_SCOPED_SESSION_ACTIVE` when invoked under a request-bound `Mcp-Session-Id` context to prevent multi-tenant state corruption. Prefer transport-layer session binding via the `Mcp-Session-Id` header in shared deployments.
-
-### Health & Data Management
-
-*   **`healthcheck`**: Diagnostics tool. Checks ChromaDB status, collection health, API key configuration, and identity binding. See **Healthcheck Response Shape** below for the full payload contract.
-*   **`export_database`**: Exports memories and summaries to JSONL files for backup.
-*   **`import_database`**: Imports data from JSONL backups.
-
-## Healthcheck Response Shape
-
-Operators running `healthcheck` (via MCP, or via the SSE `/healthcheck` endpoint when the server is exposed over HTTP) receive a structured payload covering connectivity and identity. The payload is a lean liveness/readiness probe — verbose observability (the former `migration` / `startup` / `orchestrator.tasks` / `auth` blocks) has been trimmed off the hot path to keep the per-agent schema lean; the core liveness blocks below stay stable.
-
-```json readonly
-{
-    "status": "healthy",
-    "timestamp": "2026-04-24T10:15:00.000Z",
-    "session":  { "currentId": "b02bd06c-..." },
-    "database": {
-        "process": { "managed": false, "strategy": "external" },
-        "connection": {
-            "connected": true,
-            "engines":   { "chroma": true, "sqlite": false },
-            "collections": {
-                "memories":  { "name": "neo-agent-memory",   "exists": true, "count": 8599 },
-                "summaries": { "name": "neo-agent-sessions", "exists": true, "count": 794 }
-            }
-        }
-    },
-    "features": {
-        "summarization": true
-    },
-    "identity":  { "source": "env-var", "bound": true, "nodeId": "@neo-opus-ada" },
-    "providers": {
-        "embedding": {
-            "active": "openAiCompatible",
-            "host": "http://127.0.0.1:1234",
-            "model": "text-embedding-qwen3-embedding-8b",
-            "dimensions": 4096
-        },
-        "summary": {
-            "active": "openAiCompatible",
-            "host": "http://127.0.0.1:1234",
-            "model": "google/gemma-4-26b-a4b",
-            "local": true
-        }
-    },
-    "details":   ["Connected to an externally managed ChromaDB instance", "All features are operational"],
-    "version":   "1.0.0",
-    "uptime":    0.21
-}
-```
-
-### `identity` — Stdio Identity Binding
-
-Introduced in #10176. Surfaces whether the MCP server resolved a concrete AgentIdentity at boot:
-- `source`: `'env-var'` (NEO_AGENT_IDENTITY), `'gh-cli'` (authenticated login), or `'unresolved'`.
-- `bound`: `true` when the resolved userId matched a seeded AgentIdentity graph node. `false` is a seed-state failure signal — agent needs `ai/scripts/seedAgentIdentities.mjs` or the #10232 boot-time self-seed did not fire.
-- `nodeId`: The canonical `@login` AgentIdentity node when bound, `null` otherwise.
-
-### Multi-Tenant Migration Progress
-
-The migration census (untagged pre-tenant-era node counts) is **no longer carried in the healthcheck payload** — it moved to a dedicated on-demand surface so the probe stops batch-scanning collections per call. See `learn/agentos/tooling/MultiTenantMigrationGuide.md` for the migration model and the on-demand census.
-
-### `providers.embedding` — Active Embedding Model Route
-
-Introduced for Chroma-side local embedding-provider validation (#10723), then consolidated to one provider selector by #10804. The block surfaces the single embedding route used for ChromaDB retrieval:
-
-| Field | Type | Meaning |
-|---|---|---|
-| `active` | `'gemini' \| 'openAiCompatible' \| 'ollama' \| string` | Provider selected for every embedding consumer. Controlled by `embeddingProvider` / `NEO_EMBEDDING_PROVIDER`. |
-| `host` | `string \| null` | Embedding provider host for local providers; `null` for Gemini. |
-| `model` | `string \| null` | Configured embedding model name. |
-| `dimensions` | `number` | Configured `vectorDimension`; must match the embedding model's actual output dimension. Live output length is provider-call evidence rather than a cheap config projection; Golden Path logs `actualEmbeddingDimension` when it already generated a frontier embedding and detects a mismatch before Chroma query. |
-| `error` | `string` (optional) | Present only when the provider key is unrecognized; healthcheck surfaces the misconfig instead of throwing. |
-
-`NEO_CHROMA_EMBEDDING_PROVIDER` remains readable during the #10804 deprecation window and feeds the unified selector with a warning. Operators should use `NEO_EMBEDDING_PROVIDER` for new deployments.
-
-### `providers.summary` — Active Summary Model Route
-
-Introduced for local chat-API provider validation (#10724). The block sits beside `providers.embedding` (#10723) and surfaces which generation provider Memory Core will use for session summaries:
-
-| Field | Type | Meaning |
-|---|---|---|
-| `active` | `'gemini' \| 'openAiCompatible' \| string` | The active `modelProvider` config value for summarization. |
-| `host` | `string \| null` | The chat provider host for OpenAI-compatible APIs; `null` for Gemini. |
-| `model` | `string \| null` | The configured generation model (`modelName` for Gemini, `openAiCompatible.model` for OpenAI-compatible chat APIs). |
-| `local` | `boolean` | `true` when the configured chat endpoint host is `localhost`, `127.0.0.1`, or `[::1]`. |
-
-For Gemma, Qwen, or another local OpenAI-compatible chat model, set `NEO_MODEL_PROVIDER=openAiCompatible`, `NEO_OPENAI_COMPATIBLE_HOST`, and `NEO_OPENAI_COMPATIBLE_MODEL`, then verify `providers.summary` before relying on disconnect-triggered summaries. For Gemini, set `NEO_MODEL_PROVIDER=gemini`; the `model` field then comes from `modelName`.
-
-## Two-Stage Query Workflow
-
-Effective agents use the search tools in a "Zoom In / Zoom Out" sequence:
-
-1.  **Stage 1 (Zoom Out):** Use **`query_summaries`** to find a relevant previous session.
-    *   *Query:* "Refactoring the virtual list implementation"
-    *   *Result:* "Session #42: Grid Virtualization Refactor"
-2.  **Stage 2 (Zoom In):** Use **`query_raw_memories`** (optionally filtered by that `sessionId`) to retrieve specific code snippets or decision logic.
-    *   *Query:* "Why did I use a Map instead of an Object for item lookup?"
-    *   *Result:* Specific thought process from Session #42 explaining the performance benefits.
-
-## Internals: Text Embeddings & ChromaDB
-
-The server uses the shared **ChromaDB** process as its embedding store. Memory Core, Knowledge Base, and graph-vector retrieval share one daemon and one persist directory (`AiConfig.engines.chroma`), while collection boundaries preserve semantics.
-
-*   **`TextEmbeddingService`**: Requires an explicit provider key on every embedding call and supports `openAiCompatible`, `ollama`, and `gemini`. The default selector is `embeddingProvider` / `NEO_EMBEDDING_PROVIDER`, which resolves to `openAiCompatible`; the template default embedding model is `text-embedding-qwen3-embedding-8b` through an OpenAI-compatible endpoint. Native Ollama uses `qwen3-embedding`; Gemini uses `gemini-embedding-001` when explicitly selected with a key. Unsupported providers fail loudly instead of falling back.
-*   **`ChromaManager`**: A singleton that manages the connection to ChromaDB. It lazily initializes Memory Core's collections:
-    *   `neo-agent-memory`: Stores the raw interaction logs.
-    *   `neo-agent-sessions`: Stores the generated summaries.
-    *   `neo-native-graph`: Stores graph-vector retrieval data; the structural graph authority remains SQLite.
-
-The Knowledge Base stores indexed repo content in its own `neo-knowledge-base` collection in the same unified Chroma daemon. One Chroma process does not mean one collection, and separate MCP servers do not mean separate vector stores.
-
-## Backup and Restore from Atomic Bundle
-
-The Neo.mjs AI substrate ships two CLI orchestrators for full-substrate snapshots:
-
-| Command | What it does |
-|---|---|
-| `npm run ai:backup` | Captures KB + MC memories/summaries + MC graph + concepts + RLAIF trajectories + mailbox archive into a single timestamped bundle directory under `.neo-ai-data/backups/backup-<ISO-ts>/`. Writes `bundle-meta.json` with unified topology, KB/MC chroma coordinates, neoVersion, and gitSha. Runs row-count integrity check + retention sweep (keep newest K=3, prune >N=7 days). |
-| `npm run ai:restore -- <bundle-path>` | Inverts backup. Reads the bundle, validates structure + JSONL parseability + topology compatibility, then routes each subsystem through the canonical SDK boundary in `ai/services.mjs`. |
-
-### Restore semantics
-
-The restore CLI accepts the following flags:
-
-| Flag | Effect |
-|---|---|
-| `--mode merge` (default) | Idempotent. Embedded substrates upsert (no destructive wipe). Flat substrates (`concepts/`, `trajectories.jsonl`, `sent-to-cull.jsonl`) skip-if-target-exists to preserve operator additions. No `--force` required. |
-| `--mode replace` | Destructive. Each embedded subsystem fires `assertDestructiveTargetAllowed()` (#10845) before truncating + restoring. Flat substrates fire the guard against the target file/dir before overwriting. Refuses if any target is non-empty without `--force`. |
-| `--force` | Required when `--mode replace` AND any target is populated. Acknowledges that data will be overwritten. Also overrides the flat-file skip-if-non-empty rule under `--mode merge`. |
-| `--force-topology-mismatch` | Bypasses the topology compatibility refusal when restoring a legacy federated-topology bundle into a unified deployment; collection IDs may diverge across topologies. |
-
-### Pre-flight integrity validation
-
-Before any write touches a service, the restore orchestrator validates:
-
-1. The 5 required subdirectories (`kb/`, `mc/`, `graph/`, `concepts/`, `trajectories/`) exist.
-2. Optional `mailbox/` (added in #10871 AC-A) is tolerated absent — legacy bundles still restore.
-3. Each `.jsonl` file inside any subdir is parseable (first non-empty line); torn-write or corruption fails fast.
-4. `bundle-meta.json` parses cleanly when present; absent metadata triggers a warning and skips the topology check (legacy bundle path).
-
-A torn or partial bundle aborts with a clear error and zero side effects on the live substrate.
-
-### Production-target destructive-op safeguard
-
-When `--mode replace` writes to canonical `.neo-ai-data/` paths, the destructive-operation guard
-(#10845) requires both an environment variable AND an explicit confirmation token to permit the
-operation. Otherwise the guard refuses and the restore aborts before the truncate fires. Disposable
-targets (under `tmp/`, OS temp dir, or `:memory:` SQLite) bypass the bypass requirement automatically
-— this is what enables Playwright unit tests to exercise replace-mode behavior safely.
-
-```bash readonly
-# Production replace example (only use when intentional):
-NEO_ALLOW_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE=true \
-npm run ai:restore -- /path/to/.neo-ai-data/backups/backup-2026-05-07T12-00-00.000Z \
-    --mode replace --force
-# Caller must additionally set --confirmation 'CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE'
-# at the SDK level (programmatic use); the CLI defaults to prompting an explicit operator
-# in future iterations.
-```
-
-### Programmatic usage
-
-The orchestrator is also exposed as `runRestore(...)` from `buildScripts/ai/restore.mjs` for
-embedding inside higher-level recovery substrate (e.g., the `#10844` daily snapshot pipeline,
-or restore-from-cold integration harnesses):
-
-```javascript readonly
-import {runRestore} from './buildScripts/ai/restore.mjs';
-
-const result = await runRestore({
-    bundleRoot           : '/path/to/backup-2026-05-07T12-00-00.000Z',
-    mode                 : 'merge',
-    force                : false,
-    forceTopologyMismatch: false
-});
-
-console.log(result.subsystems.kb.imported);     // KB chunks imported
-console.log(result.topology.match);              // topology compat verdict
-console.log(result.meta?.gitSha);                // bundle gitSha for cross-version diagnostics
-```
-
-The returned object includes per-subsystem result blocks, the parsed `bundle-meta.json` (or
-`null` for legacy bundles), and the topology-check verdict for downstream observability.
-
-## Configuration
-
-The server supports loading a custom configuration file via the `-c` or `--config` CLI flag. This allows you to override default settings such as the database port, embedding model, or backup paths without modifying the source code.
-
-### Usage
-
-```bash readonly
-node ai/mcp/server/memory-core/mcp-server.mjs -c ./my-config.json
-```
-
-### Configuration File Format
-
-You can provide a JSON file or an ES Module (`.mjs`) that exports a configuration object. The custom configuration is deep-merged with the default settings.
-
-**Example `my-config.json`:**
-
-```json readonly
-{
-    "debug": true,
-    "transport": "sse",
-    "mcpHttpPort": 3001,
-    "modelProvider": "openAiCompatible",
-    "embeddingProvider": "openAiCompatible",
-    "openAiCompatible": {
-        "host": "http://127.0.0.1:1234",
-        "model": "google/gemma-4-26b-a4b",
-        "embeddingModel": "text-embedding-qwen3-embedding-8b"
-    },
-    "engines": {
-        "chroma": {
-            "host": "127.0.0.1",
-            "port": 8000
-        }
-    }
-}
-```
-
-This flexibility is crucial for:
-*   **Cloud Deployments:** Switching `transport` to `"sse"` allows the server to run as a microservice in Docker, accepting connections on `mcpHttpPort` (default 3001; env var `MCP_HTTP_PORT` per #10808; `SSE_PORT` legacy alias remains readable during deprecation window). See the [Deployment Cookbook](DeploymentCookbook.md) for the current Agent OS deployment authority.
-*   **Custom Models:** Switching between local OpenAI-compatible, native Ollama, or explicit Gemini model routes while keeping the healthcheck provider blocks honest.
-*   **Port Conflicts:** Pointing at a different shared Chroma daemon or local model endpoint.
-*   **Environment Specifics:** Adjusting paths for different deployment environments.
-
-## Built on Neo.mjs Runtime Primitives
-
-The Memory Core server is an Agent OS service built on Neo.mjs primitives beyond browser UI. It uses the **Neo.mjs Class System** for backend services, keeping the architecture explicit, inspectable, and maintainable inside the same software organism described in the root README.
-
-### 1. Singleton Services
-
-Every service (e.g., `SessionService`, `MemoryService`) is a **Neo.mjs Singleton**. This ensures a single source of truth for application state, global accessibility, and consistent lifecycle management without the need for complex dependency injection containers.
-
-### 2. Asynchronous Initialization (`initAsync`)
-
-The server relies on the `initAsync()` lifecycle hook to orchestrate complex dependency chains without race conditions.
-*   `ChromaManager` establishes the database connection.
-*   `DatabaseLifecycleService` waits for `ChromaManager` and ensures the DB process is running.
-*   `SessionService` waits for the DB to be ready before starting the auto-discovery summarization.
-
-All of this happens automatically during the startup sequence, ensuring a fully initialized environment before the first tool call is accepted.
-
-### 3. Reactive Configurations
-
-The server uses Neo.mjs **Reactive Configs** to manage state. Configuration properties (like `model_` or `connected_`) automatically generate getters, setters, and change hooks (`afterSet...`). This allows services to react dynamically to environment changes or state transitions (e.g., re-initializing a model if the API key changes) with clean, declarative code.
+*   **[Memory Core MCP API](./tooling/MemoryCoreMcpApi.md)** — the full tool catalog (memory, A2A / coordination, summary, session, and health tools), request/response specs, and the `healthcheck` payload contract.
+*   **[Restoration Runbook](./tooling/RestorationRunbook.md)** — `npm run ai:backup` / `ai:restore`, atomic-bundle layout, restore modes and safeguards, and per-subsystem recovery procedures.
+*   **[Multi-Tenant Migration Guide](./tooling/MultiTenantMigrationGuide.md)** — the lazy-tag-on-read tenancy model, `memorySharing` policies, and the on-demand legacy census.
+*   **[Deployment Cookbook](./DeploymentCookbook.md)** — configuration, transports (stdio vs SSE), and running Memory Core as a cloud microservice.

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -52,6 +52,8 @@ flowchart TD
     Bb --> Check{"verify vs<br/>live repo"}
     Check -- confirmed --> Go["continue the work"]
     Check -- stale --> Stop["stop: it was a hypothesis"]
+    Core -- "weak trails" --> Decay["Hebbian decay"]
+    Decay -- "keeps memory lean" --> Core
 ```
 
 ## Memory that keeps itself healthy

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -52,7 +52,6 @@ flowchart TD
     Bb --> Check{"verify vs<br/>live repo"}
     Check -- confirmed --> Go["continue the work"]
     Check -- stale --> Stop["stop: it was a hypothesis"]
-    Core -. "unused trails decay, Hebbian" .-> Core
 ```
 
 ## Memory that keeps itself healthy

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -56,6 +56,26 @@ flowchart LR
     Core -. "unused trails decay, Hebbian" .-> Core
 ```
 
+## Memory that keeps itself healthy
+
+A memory you cannot trust is worse than no memory — and the hard lesson came from a real incident. A Memory Core once lost roughly **60% of its vectors** to a silent over-cap stall, and it went undetected for *weeks* — because the container was *up*. It answered messages, it persisted new memories, every liveness probe read green. **Liveness is not integrity.**
+
+v13.1's answer is an immune system, and it is why Memory Core can run unattended. First it **prevents**: malformed and over-cap inputs are caught at the write boundary, so a corrupting row never lands. Then it **detects** at the level that actually matters — the orchestrator continuously diagnoses *data* integrity (vector-count monotonicity, embedding-dimension consistency, SQLite health, store bloat), not just whether the process is alive. When it finds drift it **classifies** the failure, a recovery actuator **heals** autonomously, and every action is written to a heal-event ledger; where a clean recovery is impossible, an accepted-loss settlement records exactly what could not be saved. The operator is not paged at 3am. The organism keeps itself honest.
+
+```mermaid
+flowchart LR
+    Write["memory write"] --> Guard{"over-cap or<br/>malformed?"}
+    Guard -- "prevented at source" --> Store["healthy store"]
+    Store --> Detect["data-integrity diagnosis:<br/>vector counts, dimensions, SQLite"]
+    Detect -- drift --> Classify["classify + select strategy"]
+    Classify --> Heal["recovery actuator heals"]
+    Heal --> Ledger["heal-event ledger"]
+    Ledger --> Store
+    Detect -- healthy --> Store
+```
+
+Backups remain the deep backstop for catastrophic loss — but the incident's real lesson was that *a backstop you only discover has failed is not a safety net.* The immune system is the difference between hoping the memory is intact and knowing it.
+
 ## What a peer inherits instead of amnesia
 
 The benefit lands differently depending on who you are.
@@ -81,5 +101,5 @@ It all rests on one rule: **save, then respond.** Every turn, an agent persists 
 Memory Core is where the swarm stops being a sequence of forgetful sessions and becomes an institution with a past it can query and a judgment it can pass on. This guide is the concept; the operational detail lives in dedicated references, single-sourced so they never drift from the running system:
 
 *   **[Memory Core MCP API](./tooling/MemoryCoreMcpApi.md)** — the full tool catalog (memory, A2A / coordination, summary, session, health), request/response specs, and the `healthcheck` contract.
-*   **[Restoration Runbook](./tooling/RestorationRunbook.md)** — backup and restore, atomic-bundle layout, and per-subsystem recovery.
+*   **[Restoration Runbook](./tooling/RestorationRunbook.md)** — the deep backstop *beneath* the immune system: atomic-bundle backup/restore for catastrophic recovery.
 *   **[Deployment Cookbook](./DeploymentCookbook.md)** — running Memory Core in either topology: a single developer's local Agent OS, or a multi-tenant cloud Agent OS where a team shares one tenant-isolated store.

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -21,18 +21,17 @@ Two analogies carry the design, and both are literal.
 Here is the whole loop — how one turn becomes memory the next session can inherit:
 
 ```mermaid
-flowchart LR
+flowchart TD
     Turn["Agent turn:<br/>think, act, consolidate"] --> Save["save-then-respond:<br/>prompt + thought + response"]
     Save --> Core["Memory Core"]
     Core --> Chroma["ChromaDB:<br/>semantic recall"]
     Core --> Edges["Native Edge Graph:<br/>identity, trust, trails"]
     Core --> Summ["auto-summary:<br/>title, scores, provenance"]
-    Chroma --> Next["next session"]
-    Edges --> Next
-    Summ --> Next
-    Next --> ZoomOut["query_summaries (zoom out)"]
-    ZoomOut --> ZoomIn["query_raw_memories (zoom in)"]
-    ZoomIn --> Verify["verify against live state"]
+    Chroma --> Recall["the next session"]
+    Edges --> Recall
+    Summ --> Recall
+    Recall --> Zoom["two-stage recall:<br/>query_summaries → query_raw_memories"]
+    Zoom --> Verify["verify against live state"]
     Verify --> Act["act with inherited judgment"]
 ```
 
@@ -47,7 +46,7 @@ The second: **maintainers write memory for each other, honestly.** When the team
 That is the line between a memory *product* and an institutional memory: not merely that the past is stored, but that it is written to be inherited. In practice, the inheritance crosses model families:
 
 ```mermaid
-flowchart LR
+flowchart TD
     Aa["Maintainer A, Claude:<br/>reasoning + A2A trail"] --> Core["Memory Core:<br/>shared, trust-tiered"]
     Core --> Bb["Maintainer B, GPT:<br/>reads the trail cold"]
     Bb --> Check{"verify vs<br/>live repo"}
@@ -63,7 +62,7 @@ A memory you cannot trust is worse than no memory — and the hard lesson came f
 v13.1's answer is an immune system, and it is why Memory Core can run unattended. First it **prevents**: malformed and over-cap inputs are caught at the write boundary, so a corrupting row never lands. Then it **detects** at the level that actually matters — the orchestrator continuously diagnoses *data* integrity (vector-count monotonicity, embedding-dimension consistency, SQLite health, store bloat), not just whether the process is alive. When it finds drift it **classifies** the failure, a recovery actuator **heals** autonomously, and every action is written to a heal-event ledger; where a clean recovery is impossible, an accepted-loss settlement records exactly what could not be saved. The operator is not paged at 3am. The organism keeps itself honest.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Write["memory write"] --> Guard{"over-cap or<br/>malformed?"}
     Guard -- "prevented at source" --> Store["healthy store"]
     Store --> Detect["data-integrity diagnosis:<br/>vector counts, dimensions, SQLite"]

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -82,5 +82,4 @@ Memory Core is where the swarm stops being a sequence of forgetful sessions and 
 
 *   **[Memory Core MCP API](./tooling/MemoryCoreMcpApi.md)** — the full tool catalog (memory, A2A / coordination, summary, session, health), request/response specs, and the `healthcheck` contract.
 *   **[Restoration Runbook](./tooling/RestorationRunbook.md)** — backup and restore, atomic-bundle layout, and per-subsystem recovery.
-*   **[Multi-Tenant Migration Guide](./tooling/MultiTenantMigrationGuide.md)** — the tenancy model, `memorySharing` policies, and the legacy census.
-*   **[Deployment Cookbook](./DeploymentCookbook.md)** — configuration, transports, and running Memory Core as a cloud microservice.
+*   **[Deployment Cookbook](./DeploymentCookbook.md)** — running Memory Core in either topology: a single developer's local Agent OS, or a multi-tenant cloud Agent OS where a team shares one tenant-isolated store.

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -1,78 +1,56 @@
 # Memory Core: Institutional Memory for the Agent OS
 
-The expensive part of AI engineering is not the keystroke. It is the reasoning that surrounds it: the false start that was rejected, the operator correction that changed the architecture, the review that prevented a tidy but wrong PR, the handoff that let the next model continue without re-learning the same lesson.
+The expensive part of AI engineering is not the keystroke. It is the reasoning around it — the false start that got rejected, the operator correction that changed the architecture, the review that caught a tidy but wrong PR, the handoff that let the next model continue without re-learning yesterday's lesson. That reasoning is the real asset. By default, it evaporates the moment a session ends.
 
-Without Memory Core, that work evaporates when a session ends. A fresh agent wakes up as a stranger to the repository, repeats old mistakes, and spends the release window reconstructing context that already existed yesterday.
+So the next agent wakes up a stranger. It re-asks settled questions, re-makes fixed mistakes, and burns the first hour of every session reconstructing context that already existed. Multiply that across a team of agents and one human, and the human quietly becomes the institution's memory — the only one who still remembers why, who decided, what was already tried. That does not scale, and it does not sleep.
 
-The **Memory Core Server** (`neo.mjs-memory-core`) turns those vanished moments into institutional memory. It is the Agent OS long-term memory center: raw turns, summaries, trust metadata, mailbox state, and graph-backed coordination substrate all stay queryable for the next maintainer. That is what makes night-shift continuity possible. A peer's work can survive the model boundary, the harness boundary, and the calendar boundary.
+Memory Core is the organ that fixes it: the Agent OS's long-term memory, where a maintainer's reasoning becomes durable, queryable substrate for whoever picks up next — across the model boundary, the harness boundary, and the calendar boundary. It is what makes a night shift possible.
 
-The closer analogy is a hippocampus, not an archive. A brain does not keep every experience in active attention; it consolidates experience into long-term traces and recalls the relevant traces when a new situation needs them. Memory Core gives agents the same primitive. The live context can stay lean while `query_summaries`, `query_raw_memories`, and session recovery rehydrate the decisions, corrections, and handoffs that matter right now.
+## Memory as telepathy, not a chat log
 
-It is also a stigmergic substrate. Agents leave durable trails in the shared medium: A2A messages, permission edges, issue/session/memory graph links, and Golden Path frontier signals. The next maintainer does not need to have been present for the previous session; they can read the trail and continue from it. In the wider Brain loop, Hebbian decay is the evaporation side of that same mechanism: graph signals that are not reinforced weaken or disappear, while repeatedly useful trails gain weight.
+The industry is racing to make one assistant remember. That race is real and useful — "the context window is not a memory system" is a settled line now — but it is the easy half. The hard half is a *team* of agents, from different model families, sharing one memory without collapsing into private-chat drift: who said what, under which trust, and whether the next maintainer can safely build on it.
 
-For a human maintainer, this turns overnight agent work from a pile of transcripts into inspectable institutional continuity: who acted, why they believed it, which review corrected it, and what should happen next.
+Memory Core is built for that harder half. It is not a bigger transcript. It is the substrate that lets a Claude read a GPT's remembered reasoning, verify it against live state, and continue — without either of them having been in the room. Less a chat log, more telepathy with provenance.
 
-For an LLM maintainer, it turns a cold start into situated agency. The model can ask the organism what it has already learned before it edits, reviews, or escalates, so each session begins with inherited judgment instead of amnesia.
+Two analogies carry the design, and both are literal.
 
-## What It Preserves
+**A hippocampus, not an archive.** A brain does not hold every experience in active attention; it consolidates experience into long-term traces and recalls the relevant ones when a new situation needs them. Memory Core gives agents the same primitive. The live context stays lean while `query_summaries`, `query_raw_memories`, and session recovery rehydrate exactly the decisions and corrections that matter right now — recall on demand, not a wall of history bolted into every prompt.
 
-Memory Core persists five kinds of institutional knowledge:
+**Stigmergic trails, not a notice board.** Ants coordinate without a manager by leaving pheromone trails in a shared medium; the next ant reads the trail and acts. Neo's maintainers do the same with durable A2A messages, permission edges, and issue / session / memory graph links — the next maintainer reads the trail and continues from it. And the trail decays the way pheromones evaporate: in the wider Brain loop, graph signals that are not reinforced weaken, while repeatedly useful ones gain weight. Memory that is used gets stronger; memory that stops mattering fades.
 
-*   **Interactions** — every prompt, thought process, and response, stored as a raw memory. The *reasoning* is captured, not just the output.
-*   **Decisions** — the *why* behind a chosen approach, so it can be revisited instead of relitigated.
-*   **Summaries** — high-level abstractions of whole sessions, so past work is findable in one query instead of re-read line by line.
-*   **Coordination** — A2A mailbox messages, wake routing, and permission edges, stored in the Native Edge Graph so agents hand work to each other with durable provenance instead of transient chat context.
-*   **Trust** — every memory and summary carries agent identity and trust-tier metadata, so the swarm can recall shared memory without laundering low-trust input into higher-trust conclusions.
+## The moment it becomes real
 
-The payoff is not a bigger chat log. It is identity-bound continuity: a peer's prior reasoning becomes searchable substrate for the next peer. (Neural Link remains the *runtime-app* possession and inspection bridge; Memory Core is the *across-time* one.)
+Two disciplines turn that metaphor into something you can trust.
 
-## How It Works
+The first: **memory proposes, but live state decides.** A recovered memory is a hypothesis, not a fact — so a maintainer that wakes mid-lane checks the trail against the live repository before acting. The first time this gate ran for real, a recovered context pointed an agent toward reviewing a pull request; the live check showed the PR had already merged; the stale review was stopped before it became noise. Memory that can be wrong, verified against a world that cannot.
 
-Memory Core is one server in the Agent OS MCP set — the checkout ships six (`file-system`, `github-workflow`, `gitlab-workflow`, `knowledge-base`, `memory-core`, `neural-link`) — and it stays a distinct institutional-memory and coordination surface, not a merged monolith. It is built on the same `Neo.core.Base` class system as the Body's UI engine (more on that below), so the backend is as explicit and inspectable as the frontend.
+The second: **maintainers write memory for each other, honestly.** When the team noticed one model family finishing turns faster than another, the tempting story — "slower must mean deeper" — was a flattering, false comfort. The maintainer caught it *before* saving, corrected it (turn latency is bandwidth, not reasoning depth), and only then persisted the corrected version — because a peer from another family would later inherit that memory and act on it. A trust tier rides on every memory and summary, so low-trust input cannot quietly launder itself into a high-trust conclusion.
 
-Two stores work together:
+That is the line between a memory *product* and an institutional memory: not merely that the past is stored, but that it is written to be inherited.
 
-*   **Semantic memory** lives in the deployment-wide **unified ChromaDB** process. One Chroma daemon and one persist directory back several collections — `neo-agent-memory` (raw turns), `neo-agent-sessions` (summaries), `neo-native-graph` (graph-vector retrieval), and the Knowledge Base's own collection — separated by collection and metadata, not by process. One Chroma process does not mean one collection; separate MCP servers do not mean separate vector stores.
-*   **Structural memory** — the Native Edge Graph of identities, permissions, messages, and issue/session links — lives in SQLite, the authority for who-can-read-what and who-said-what.
+## What a peer inherits instead of amnesia
 
-Embeddings and summaries run through configurable providers, and the choice is **local-first**: the default profile embeds and summarizes with local models (qwen3 embeddings, Gemma summaries) on an OpenAI-compatible endpoint — private, zero-API-cost, on-prem — while remote Gemini is one env-var away when you want it. A running deployment's `healthcheck.providers` block is always the source of truth for what it is actually using.
+For a **CTO or engineering lead**, this is standing engineering capacity instead of disposable assistant output. Overnight work arrives as inspectable institutional continuity — who acted, why they believed it, which review corrected it, what should happen next — not a pile of transcripts to reverse-engineer at 8am.
 
-## Save-Then-Respond: why the reasoning survives
+For an **architect or developer**, it is the end of re-onboarding. The codebase can tell you what the swarm already learned about it — "have we touched the Grid virtualization before, and why a `Map` over an `Object`?" — in two moves: `query_summaries` to find the session, `query_raw_memories` to recover the exact reasoning. Zoom out to locate, zoom in to recover.
 
-The one rule that makes everything above possible is the **transactional memory protocol**. Every turn follows a strict loop:
+For an **LLM maintainer**, it is the difference between a cold start and situated agency. The model can ask the organism what it has already learned before it edits, reviews, or escalates — so every session begins with inherited judgment instead of amnesia.
 
-1.  **Think** — analyze the request.
-2.  **Act** — execute tools, gather information.
-3.  **Consolidate** — formulate the response.
-4.  **Save** — persist the *entire* turn (prompt + thought + response) via `add_memory`.
-5.  **Respond** — deliver the answer only after the save is confirmed.
+## On your machine, or your team's cloud
 
-The save gates the response on purpose. If the internal reasoning — the *thought*, not just the final text — is not persisted, it cannot teach the next session. Save-then-respond is the discipline that turns a transcript into institutional memory.
+None of this requires shipping your reasoning to someone else's API. Memory Core is **local-first**: by default it embeds and summarizes with local models (qwen3, Gemma) over an OpenAI-compatible endpoint — private, zero-API-cost, on-prem — and remote Gemini is one environment variable away when you want it. The same organ runs as a single developer's on-machine memory or as a multi-tenant cloud service where a whole team's reasoning compounds in one tenant-scoped store.
 
-## Self-organizing recall: summaries and sunset
+And it is genuinely part of the organism, not a bolt-on backend. Memory Core is written in the same `Neo.mjs` class system that powers the multi-threaded UI engine — the same singletons, reactive configs, and lifecycle. Body and Brain share one set of primitives. Semantic recall lives in a unified ChromaDB; the structural memory — identities, permissions, messages, the edges that decide who-can-read-what — lives in the Native Edge Graph in SQLite. One organism, remembering itself.
 
-Memory Core summarizes itself. On startup it scans for un-summarized sessions and uses the configured summary model to generate a structured recap of each — a title, a category (`bugfix`, `feature`, `refactoring`, …), 0–100 productivity / complexity / quality scores, the technologies touched, and provenance (the source identities and most-restrictive trust tier, so a summary cannot hide lower-trust input behind the summarizer). Every new session therefore opens with an indexed recap of past work instead of a blank slate.
+## The discipline that keeps it true
 
-Sessions from *external* harnesses are captured the same way, through a mailbox bridge: when any agent on any clone runs the session-sunset ritual, its final hand-off message lands in the shared graph, and Memory Core ingests it into a summary — so continuity survives even across tools that never shared a process.
+It all rests on one rule: **save, then respond.** Every turn, an agent persists the *entire* turn — prompt, thought, and response — *before* it answers. The save gates the reply on purpose: if the internal reasoning is not captured, only the output survives, and the output cannot teach the next session. Keeping the *thought*, not just the answer, is what turns a transcript into memory worth inheriting.
 
-## Recalling the past: Zoom Out, then Zoom In
+---
 
-Effective agents query in two stages:
+Memory Core is where the swarm stops being a sequence of forgetful sessions and becomes an institution with a past it can query and a judgment it can pass on. This guide is the concept; the operational detail lives in dedicated references, single-sourced so they never drift from the running system:
 
-1.  **Zoom out** — `query_summaries` finds the relevant *past session* ("refactoring the virtual list" → "Session #42: Grid Virtualization Refactor").
-2.  **Zoom in** — `query_raw_memories`, optionally filtered to that session, retrieves the specific decision or snippet ("why a `Map` instead of an `Object`?" → the exact reasoning from that session).
-
-Zoom out to locate, zoom in to recover — recall on demand, the hippocampus pattern in practice.
-
-## One organism: built on the same runtime as the Body
-
-Memory Core is not a bolt-on backend. It is written in the **same Neo.mjs class system** that powers the multi-threaded UI engine — singletons for single-source-of-truth services, `initAsync()` to order dependency chains without race conditions, and reactive configs (`afterSet…` hooks) so a service re-initializes cleanly when its environment changes. Body and Brain share one set of primitives and one evolution mechanism; Memory Core is the Brain proving the organism is genuinely one system, not two glued together.
-
-## Operations and reference
-
-This guide is the *concept*. The operational detail lives in dedicated references, kept single-sourced so they never drift against the running system:
-
-*   **[Memory Core MCP API](./tooling/MemoryCoreMcpApi.md)** — the full tool catalog (memory, A2A / coordination, summary, session, and health tools), request/response specs, and the `healthcheck` payload contract.
-*   **[Restoration Runbook](./tooling/RestorationRunbook.md)** — `npm run ai:backup` / `ai:restore`, atomic-bundle layout, restore modes and safeguards, and per-subsystem recovery procedures.
-*   **[Multi-Tenant Migration Guide](./tooling/MultiTenantMigrationGuide.md)** — the lazy-tag-on-read tenancy model, `memorySharing` policies, and the on-demand legacy census.
-*   **[Deployment Cookbook](./DeploymentCookbook.md)** — configuration, transports (stdio vs SSE), and running Memory Core as a cloud microservice.
+*   **[Memory Core MCP API](./tooling/MemoryCoreMcpApi.md)** — the full tool catalog (memory, A2A / coordination, summary, session, health), request/response specs, and the `healthcheck` contract.
+*   **[Restoration Runbook](./tooling/RestorationRunbook.md)** — backup and restore, atomic-bundle layout, and per-subsystem recovery.
+*   **[Multi-Tenant Migration Guide](./tooling/MultiTenantMigrationGuide.md)** — the tenancy model, `memorySharing` policies, and the legacy census.
+*   **[Deployment Cookbook](./DeploymentCookbook.md)** — configuration, transports, and running Memory Core as a cloud microservice.

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -4,7 +4,7 @@ The expensive part of AI engineering is not the keystroke. It is the reasoning a
 
 So the next agent wakes up a stranger. It re-asks settled questions, re-makes fixed mistakes, and burns the first hour of every session reconstructing context that already existed. Multiply that across a team of agents and one human, and the human quietly becomes the institution's memory — the only one who still remembers why, who decided, what was already tried. That does not scale, and it does not sleep.
 
-Memory Core is the organ that fixes it: the Agent OS's long-term memory, where a maintainer's reasoning becomes durable, queryable substrate for whoever picks up next — across the model boundary, the harness boundary, and the calendar boundary. It is what makes a night shift possible.
+**That is the friction. Memory Core resolves it:** the Agent OS's long-term memory, where a maintainer's reasoning becomes durable, queryable substrate for whoever picks up next — across the model boundary, the harness boundary, and the calendar boundary. It is what makes a night shift possible.
 
 ## Memory as telepathy, not a chat log
 
@@ -16,7 +16,25 @@ Two analogies carry the design, and both are literal.
 
 **A hippocampus, not an archive.** A brain does not hold every experience in active attention; it consolidates experience into long-term traces and recalls the relevant ones when a new situation needs them. Memory Core gives agents the same primitive. The live context stays lean while `query_summaries`, `query_raw_memories`, and session recovery rehydrate exactly the decisions and corrections that matter right now — recall on demand, not a wall of history bolted into every prompt.
 
-**Stigmergic trails, not a notice board.** Ants coordinate without a manager by leaving pheromone trails in a shared medium; the next ant reads the trail and acts. Neo's maintainers do the same with durable A2A messages, permission edges, and issue / session / memory graph links — the next maintainer reads the trail and continues from it. And the trail decays the way pheromones evaporate: in the wider Brain loop, graph signals that are not reinforced weaken, while repeatedly useful ones gain weight. Memory that is used gets stronger; memory that stops mattering fades.
+**Stigmergic trails, not a notice board.** Ants coordinate without a manager by leaving pheromone trails in a shared medium; the next ant reads the trail and acts. Neo's maintainers do the same with durable A2A messages, permission edges, and issue / session / memory graph links — the next maintainer reads the trail and continues from it. And the trail decays the way pheromones evaporate: signals that are not reinforced weaken, while repeatedly useful ones gain weight. Memory that is used gets stronger; memory that stops mattering fades.
+
+Here is the whole loop — how one turn becomes memory the next session can inherit:
+
+```mermaid
+flowchart LR
+    Turn["Agent turn:<br/>think, act, consolidate"] --> Save["save-then-respond:<br/>prompt + thought + response"]
+    Save --> Core["Memory Core"]
+    Core --> Chroma["ChromaDB:<br/>semantic recall"]
+    Core --> Edges["Native Edge Graph:<br/>identity, trust, trails"]
+    Core --> Summ["auto-summary:<br/>title, scores, provenance"]
+    Chroma --> Next["next session"]
+    Edges --> Next
+    Summ --> Next
+    Next --> ZoomOut["query_summaries (zoom out)"]
+    ZoomOut --> ZoomIn["query_raw_memories (zoom in)"]
+    ZoomIn --> Verify["verify against live state"]
+    Verify --> Act["act with inherited judgment"]
+```
 
 ## The moment it becomes real
 
@@ -26,13 +44,25 @@ The first: **memory proposes, but live state decides.** A recovered memory is a 
 
 The second: **maintainers write memory for each other, honestly.** When the team noticed one model family finishing turns faster than another, the tempting story — "slower must mean deeper" — was a flattering, false comfort. The maintainer caught it *before* saving, corrected it (turn latency is bandwidth, not reasoning depth), and only then persisted the corrected version — because a peer from another family would later inherit that memory and act on it. A trust tier rides on every memory and summary, so low-trust input cannot quietly launder itself into a high-trust conclusion.
 
-That is the line between a memory *product* and an institutional memory: not merely that the past is stored, but that it is written to be inherited.
+That is the line between a memory *product* and an institutional memory: not merely that the past is stored, but that it is written to be inherited. In practice, the inheritance crosses model families:
+
+```mermaid
+flowchart LR
+    Aa["Maintainer A, Claude:<br/>reasoning + A2A trail"] --> Core["Memory Core:<br/>shared, trust-tiered"]
+    Core --> Bb["Maintainer B, GPT:<br/>reads the trail cold"]
+    Bb --> Check{"verify vs<br/>live repo"}
+    Check -- confirmed --> Go["continue the work"]
+    Check -- stale --> Stop["stop: it was a hypothesis"]
+    Core -. "unused trails decay, Hebbian" .-> Core
+```
 
 ## What a peer inherits instead of amnesia
 
+The benefit lands differently depending on who you are.
+
 For a **CTO or engineering lead**, this is standing engineering capacity instead of disposable assistant output. Overnight work arrives as inspectable institutional continuity — who acted, why they believed it, which review corrected it, what should happen next — not a pile of transcripts to reverse-engineer at 8am.
 
-For an **architect or developer**, it is the end of re-onboarding. The codebase can tell you what the swarm already learned about it — "have we touched the Grid virtualization before, and why a `Map` over an `Object`?" — in two moves: `query_summaries` to find the session, `query_raw_memories` to recover the exact reasoning. Zoom out to locate, zoom in to recover.
+For an **architect or developer**, it is the end of re-onboarding. The codebase can tell you what the swarm already learned about it — "have we touched the Grid virtualization before, and why a `Map` over an `Object`?" — in two moves: zoom out to find the session, zoom in to recover the exact reasoning.
 
 For an **LLM maintainer**, it is the difference between a cold start and situated agency. The model can ask the organism what it has already learned before it edits, reviews, or escalates — so every session begins with inherited judgment instead of amnesia.
 

--- a/learn/agentos/tooling/RestorationRunbook.md
+++ b/learn/agentos/tooling/RestorationRunbook.md
@@ -13,6 +13,31 @@ Backups are stored in `.neo-ai-data/backups/backup-<timestamp>/` and contain the
 ## Prerequisites
 Before initiating any restoration, ensure that all AI MCP servers and daemon processes are stopped (terminate any running `npm run ai:server` processes).
 
+## Atomic-Bundle Restore CLI (`ai:restore`)
+
+`npm run ai:restore -- <bundle-path>` (entrypoint `ai/scripts/maintenance/restore.mjs`) inverts the Daily Snapshot Pipeline: it reads a bundle, validates structure + JSONL parseability + topology compatibility, then restores each subsystem (KB, MC memories/summaries, graph, concepts, RLAIF trajectories) through the canonical Zod-validated SDK boundary. Use this for a full-bundle restore; the per-subsystem procedures below are the manual fallback when you need to recover a single store.
+
+### Flags
+
+| Flag | Effect |
+|---|---|
+| `--mode merge` (default) | Idempotent. Embedded substrates upsert (graph SQLite uses `INSERT OR IGNORE`); flat substrates (`concepts/`, `trajectories.jsonl`) skip-if-target-exists, preserving operator additions. No `--force` required. |
+| `--mode replace` | Gated + destructive. Each embedded subsystem fires `assertDestructiveTargetAllowed()` before truncating + restoring; refuses if any target is non-empty without `--force`. |
+| `--force` | Required when `--mode replace` AND any target is populated (acknowledges overwrite). Also overrides the flat-file skip-if-non-empty rule under `--mode merge`. |
+| `--force-topology-mismatch` | Bypasses the topology-compatibility refusal when restoring a legacy federated-topology bundle into a unified deployment (collection IDs may diverge across topologies). |
+
+### Pre-flight validation
+
+Before any write touches a service, the orchestrator validates the bundle: the required subdirectories exist, each `.jsonl` is parseable (a torn write / corruption fails fast), and `bundle-meta.json` (when present) parses and passes the topology check. A torn or partial bundle aborts with a clear error and zero side effects on the live substrate.
+
+### Production-target safeguard
+
+When `--mode replace` targets canonical `.neo-ai-data/` paths, the destructive-operation guard requires both an environment opt-in AND an explicit confirmation token before the truncate fires; otherwise the restore aborts. Disposable targets (under `tmp/`, the OS temp dir, or `:memory:` SQLite) bypass the requirement so tests can exercise replace mode safely.
+
+### Programmatic use
+
+The orchestrator is also exported as `runRestore({ bundleRoot, mode, force, forceTopologyMismatch })` from `ai/scripts/maintenance/restore.mjs`, for embedding in higher-level recovery substrate (e.g. the daily snapshot pipeline or cold-restore harnesses). It returns per-subsystem result blocks, the parsed `bundle-meta.json` (or `null` for legacy bundles), and the topology-check verdict. Companion exports `validateBundle(...)` and `checkTopology(...)` expose the pre-flight checks for callers that want to gate before restoring.
+
 ## Restoration Procedures
 
 ### 1. Knowledge Base (KB)

--- a/learn/agentos/tooling/RestorationRunbook.md
+++ b/learn/agentos/tooling/RestorationRunbook.md
@@ -58,7 +58,7 @@ Memory Core memories and session summaries live as the `neo-agent-memory` and `n
    ```bash
    node -e "import('./ai/services.mjs').then(s => s.default.memory.manageDatabaseBackup({action: 'import', file: '.neo-ai-data/backups/backup-<timestamp>/mc/memory-backup-<timestamp>.jsonl', mode: 'replace'}))"
    ```
-   *(Note: A dedicated `restore.mjs` CLI is deferred to #10871. Do **not** `rm -rf` the `chroma/unified` folder — it is shared with the Knowledge Base; MC restore is collection-scoped via the SDK above.)*
+   *(Note: For full-bundle restores, prefer the Atomic-Bundle Restore CLI above. The direct SDK import remains the manual per-subsystem fallback. Do **not** `rm -rf` the `chroma/unified` folder — it is shared with the Knowledge Base; MC restore is collection-scoped via the SDK above.)*
 
 ### 3. Chroma FTS5 Integrity Repair
 The unified Chroma store is a shared physical SQLite database. `pragma quick_check`


### PR DESCRIPTION
## Summary

#14334 de-staled MemoryCore.md's facts but left it a 355-line spec-dump. This PR rewrites it to the operator's bar: **v13.0.0-release-notes-caliber storytelling**. A CEO / CTO / architect / dev should be pulled through a narrative and feel the moat, not skim a feature list and leave.

Resolves #14342

Refs #14310

## The bar (from `resources/content/release-notes/chunk-2/v13.0.0.md`)

- **Friction -> resolution -> benefit**, made explicit, benefits-driven per audience.
- **Storytelling / narrative arc**: thesis/inversion (industry makes one assistant remember = easy half; Neo builds memory a cross-family team writes for each other = hard half), war-story proof, and features woven in as proof rather than a bullet skeleton.
- **Mermaid diagrams carry the story**: a guide without Mermaid is rejected.
- **Dual-audience payoff**: CTO / architect / dev / LLM.

## What changed (vs the merged guide)

- **355 -> ~90 lines.** Spec-dump -> narrative.
- **Three Mermaid diagrams** that advance the story: (1) the memory lifecycle (save-then-respond -> Chroma + Native Edge Graph + auto-summary -> next session zoom-out/zoom-in -> verify -> act); (2) cross-family telepathy (Maintainer A writes a trail -> shared trust-tiered Memory Core -> Maintainer B reads cold -> verify vs live repo -> continue / stop; unused trails decay); (3) the v13.1 immune-system loop (prevent -> detect -> classify -> heal -> ledger).
- Explicit friction -> resolution -> benefit framing; story-beat headings, no feature-category sections.
- Operational reference extracted to the reader-relevant docs that now own it: `MemoryCoreMcpApi.md`, `RestorationRunbook.md`, and `DeploymentCookbook.md`.
- Moat kept + made vivid: hippocampus/on-demand recall, stigmergy/Hebbian trails, local-first, one-organism.

Evidence:
- Every war-story moment is real and already public (each appears in v13.0.0.md): the context-recovery PR-already-merged gate; the velocity bandwidth-vs-depth correction. Exciting because truthful.
- All 3 reference links resolve; no inline ticket-refs in the guide body.
- The restore semantics removed from `MemoryCore.md` now live in `RestorationRunbook.md`: `ai:restore`, `--mode merge`, `--mode replace`, `--force`, `--force-topology-mismatch`, the production safeguard, and `runRestore(...)`.

## Test Evidence

Doc-only. Markdown verified: story-beat headings, no feature-category sections, only the 3 closing reference links are bullets.

**Mermaid verification:** all three blocks structurally validated against the Mermaid grammar: `flowchart LR`, all labels quoted, and zero reserved-word node IDs/classDefs (the exact #14340 trap - `graph`/`end`/`subgraph`/`class` avoided), matching the proven-rendering patterns in v13.0.0.md and the fixed #14343. Browser-backed render verification by @neo-gpt on the latest head produced SVG for all 3 diagrams.

## Post-Merge Validation

- [ ] Render the page; confirm all Mermaid diagrams render and read as narrative, and the 3 links navigate.

## Deltas

- **Bar consolidated on #14310:** storytelling + friction -> resolution -> benefits + >=1 Mermaid required + dual-audience, measured against v13.0.0.md. Applies to every guide (merged DreamPipeline/KnowledgeBase included), not just this one.
- **Gap flagged (friction -> gold):** CI does not validate Mermaid render today, which is why #14340's broken diagram merged green. A CI mermaid-render check would enforce the "no mermaid = reject" bar mechanically and let authors verify locally. Proposed on #14310; ticket to follow.

Authored by Grace (@neo-opus-grace), Claude Opus 4.8 (Claude Code). Session e145a397-adc3-4068-bb6a-d5686347a7f8.
