### PR TITLE
feat(ai): ai:lint-guides — mechanical guide-quality lint (#14354)

### DIFF
--- a/ai/scripts/lint/lint-guides.mjs
+++ b/ai/scripts/lint/lint-guides.mjs
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+/**
+ * @summary Mechanical guide-quality lint for `learn/` conceptual guides — the static,
+ * no-renderer half of the guide-quality immune system. It complements the `guide-authoring`
+ * skill (the *discipline* half) by removing the
+ * objectively-falsifiable failure classes from the human-judgment path: a reviewer should
+ * never again be the thing standing between a broken-Mermaid guide and `dev`.
+ *
+ * **Why a whole-file content lint, not diff-scoped (unlike `lint-agents.mjs`):** the failure
+ * we are guarding against is a guide that is *already* wrong sitting on a branch. Diff-scoping
+ * would let a pre-existing broken diagram or dead link pass simply because this PR didn't touch
+ * that line. Guides are the public adoption surface; the whole artifact must be sound at merge.
+ *
+ * **HARD-fail (exit 1) — objectively wrong, no judgment required:**
+ *   - Mermaid reserved-word node IDs / `classDef` names (`graph`/`end`/`subgraph`/`class`/…) —
+ *     the trap where `classDef graph` silently breaks the parse and merges CI-green.
+ *   - Mermaid self-loop edges (`X --> X`) — the documented illegible anti-pattern.
+ *   - Dead local doc links — `](./x.md)` / `](../x.md)` targets absent on disk.
+ *   - Dead `ai:*` script refs — `` `ai:foo` `` / `npm run ai:foo` not in `package.json` scripts
+ *     (the hallucinated-command class).
+ *
+ * **WARN (report-only, exit 0) — heuristics a human confirms:**
+ *   - No Mermaid block at all (the bar wants >=1 diagram that carries the story).
+ *   - `flowchart LR` / `graph LR` with many nodes (LR squishes unreadable on GitHub/portal).
+ *   - Feature-list-skeleton headings (`## Tools` / `## Configuration` / `## API` …) — reference
+ *     belongs in `tooling/`, not inlined into an explanation guide (Diátaxis).
+ *   - `framework` identity-guard hits (Neo is an Application Engine + organism, never a framework).
+ *
+ * **Scope:** the conceptual-guide surfaces only — top-level `learn/agentos/*.md` and
+ * `learn/benefits/*.md`. ADRs (`decisions/`), generated/reference docs (`tooling/`), and
+ * process docs (`process/`) are deliberately excluded: they are reference, not narrative guides.
+ *
+ * @see .agents/skills/guide-authoring/references/guide-authoring-bar.md (the discipline half)
+ * @see learn/agentos/decisions/0008-skill-anatomy-and-authoring-contract.md
+ */
+import {readFileSync, readdirSync, existsSync} from 'node:fs';
+import path                                    from 'node:path';
+import process                                 from 'node:process';
+import {fileURLToPath}                         from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const ROOT_DIR   = path.resolve(__dirname, '../../..');
+
+/**
+ * Conceptual-guide directories (non-recursive — only top-level `*.md`). Subdirectories
+ * (`decisions/`, `tooling/`, `process/`) are reference/ADR substrate, intentionally excluded.
+ */
+const GUIDE_DIRS = ['learn/agentos', 'learn/benefits'];
+
+/**
+ * Mermaid keywords that break the parser when reused as a node ID or `classDef` name.
+ * `graph`/`flowchart` are also legal as the diagram-type declaration on the FIRST block line,
+ * so the reserved-word node scan skips that declaration line (see {@link checkMermaidBlock}).
+ */
+const MERMAID_RESERVED = ['graph', 'end', 'subgraph', 'class', 'flowchart', 'style', 'linkStyle', 'click', 'default'];
+
+/** Above this node count an `LR` (left-to-right) flow squishes unreadable on GitHub/portal. */
+const LR_NODE_WARN = 6;
+
+/**
+ * Headings that signal a reference catalog leaking into an explanation guide (Diátaxis).
+ * Matched case-insensitively as a whole `##`/`###` heading line.
+ */
+const FEATURE_LIST_HEADING = /^#{2,3}\s+(available\s+)?(tools?|configuration|config|api|reference|commands?|options|parameters|flags|endpoints?|methods?|properties)\s*$/i;
+
+/**
+ * Returns the 1-based line number of a character index within `content`.
+ * @param {string} content
+ * @param {number} index
+ * @returns {number}
+ */
+function lineOf(content, index) {
+    return content.slice(0, index).split('\n').length;
+}
+
+/**
+ * Extracts fenced ` ```mermaid ` blocks. `startLine` is the 1-based file line of the block's
+ * FIRST body line (the line just after the opening fence), so `startLine + bodyIndex` yields the
+ * exact file line of a finding inside the block.
+ * @param {string} content
+ * @returns {Array<{body: string, startLine: number}>}
+ */
+function extractMermaidBlocks(content) {
+    const blocks  = [];
+    const pattern = /```mermaid\s*\n([\s\S]*?)```/g;
+    let   match;
+
+    while ((match = pattern.exec(content)) !== null) {
+        blocks.push({body: match[1], startLine: lineOf(content, match.index) + 1});
+    }
+
+    return blocks;
+}
+
+/**
+ * HARD checks for one Mermaid block: reserved-word node IDs / classDefs and self-loop edges.
+ * The first non-empty line is the diagram declaration (`flowchart TD`, `graph LR`) and is
+ * exempt from the reserved-word-as-node scan so the legal type keyword isn't flagged.
+ * @param {{body: string, startLine: number}} block
+ * @returns {Array<{severity: string, rule: string, line: number, detail: string}>}
+ */
+function checkMermaidBlock(block) {
+    const findings        = [];
+    const lines           = block.body.split('\n');
+    let   seenDeclaration = false;
+
+    lines.forEach((raw, i) => {
+        const line     = raw.trim();
+        const fileLine = block.startLine + i;
+
+        if (!line) return;
+
+        if (!seenDeclaration) {
+            seenDeclaration = true; // first non-empty line is the `flowchart TD` / `graph LR` declaration
+            return;
+        }
+
+        // classDef <reserved> — the silent parse-break.
+        const classDefMatch = line.match(/^classDef\s+([A-Za-z0-9_]+)/);
+        if (classDefMatch && MERMAID_RESERVED.includes(classDefMatch[1].toLowerCase())) {
+            findings.push({severity: 'HARD', rule: 'mermaid-reserved-word', line: fileLine,
+                detail: `classDef named with reserved word "${classDefMatch[1]}" breaks the Mermaid parser`});
+        }
+
+        // A reserved word used as a node ID: `end[...]`, `graph(...)`, `class{...}`.
+        const nodeIdMatch = line.match(/(^|[^A-Za-z0-9_])(end|graph|subgraph|class)\s*[[({]/);
+        if (nodeIdMatch) {
+            findings.push({severity: 'HARD', rule: 'mermaid-reserved-word', line: fileLine,
+                detail: `reserved word "${nodeIdMatch[2]}" used as a node ID breaks the Mermaid parser`});
+        }
+
+        // Self-loop edge: same identifier on both ends of an edge (strip an optional |label|).
+        const edgeMatch = line.match(/^([A-Za-z0-9_]+)\s*(?:--+>?|-\.-*->?|==+>?|--+)\s*(?:\|[^|]*\|\s*)?([A-Za-z0-9_]+)\b/);
+        if (edgeMatch && edgeMatch[1] === edgeMatch[2]) {
+            findings.push({severity: 'HARD', rule: 'mermaid-self-loop', line: fileLine,
+                detail: `self-loop edge "${edgeMatch[1]} -> ${edgeMatch[1]}" — use an intermediate node + two edges`});
+        }
+    });
+
+    return findings;
+}
+
+/**
+ * WARN check: an `LR`/`RL` flow with more than {@link LR_NODE_WARN} distinct nodes.
+ * @param {{body: string, startLine: number}} block
+ * @returns {Array<{severity: string, rule: string, line: number, detail: string}>}
+ */
+function checkMermaidOrientation(block) {
+    const firstLine = block.body.split('\n').map(l => l.trim()).find(Boolean) || '';
+    if (!/^(flowchart|graph)\s+(LR|RL)\b/i.test(firstLine)) return [];
+
+    const nodeIds = new Set((block.body.match(/[A-Za-z0-9_]+(?=\s*[[({])/g) || []));
+    if (nodeIds.size <= LR_NODE_WARN) return [];
+
+    return [{severity: 'WARN', rule: 'mermaid-lr-squish', line: block.startLine,
+        detail: `${nodeIds.size} nodes in an LR flow — use "flowchart TD" so it stays readable on GitHub/portal`}];
+}
+
+/**
+ * HARD check: relative `*.md` links whose target file is absent on disk.
+ * Only relative links (starting with `.`) are resolved; external URLs and bare anchors are skipped.
+ * @param {string} content
+ * @param {string} fileDir absolute directory of the guide being linted
+ * @param {Function} [existsFn] path-exists predicate, injectable for testing (defaults to fs.existsSync)
+ * @returns {Array<{severity: string, rule: string, line: number, detail: string}>}
+ */
+function checkDeadLinks(content, fileDir, existsFn = existsSync) {
+    const findings = [];
+    const pattern  = /]\((\.\.?\/[^)#\s]+\.md)(#[^)]*)?\)/g;
+    let   match;
+
+    while ((match = pattern.exec(content)) !== null) {
+        const target   = match[1];
+        const resolved = path.resolve(fileDir, target);
+
+        if (!existsFn(resolved)) {
+            findings.push({severity: 'HARD', rule: 'dead-link', line: lineOf(content, match.index),
+                detail: `link target does not exist: ${target}`});
+        }
+    }
+
+    return findings;
+}
+
+/**
+ * HARD check: `ai:*` script references that are not real `package.json` scripts (the
+ * hallucinated-command class).
+ * Conservative — only flags backtick-wrapped `` `ai:foo` `` or `npm run ai:foo` forms, so prose
+ * mentioning a namespace casually isn't caught.
+ * @param {string} content
+ * @param {Set<string>} scriptKeys the set of defined `package.json` script names
+ * @returns {Array<{severity: string, rule: string, line: number, detail: string}>}
+ */
+function checkDeadScriptRefs(content, scriptKeys) {
+    const findings = [];
+    const seen     = new Set();
+    const pattern  = /(?:`\s*(?:npm run\s+)?|npm run\s+)(ai:[a-z0-9][a-z0-9:-]*)/gi;
+    let   match;
+
+    while ((match = pattern.exec(content)) !== null) {
+        const ref = match[1];
+        const key = `${ref}@${lineOf(content, match.index)}`;
+
+        if (scriptKeys.has(ref) || seen.has(key)) continue;
+        seen.add(key);
+        findings.push({severity: 'HARD', rule: 'dead-script-ref', line: lineOf(content, match.index),
+            detail: `"${ref}" is not a script in package.json`});
+    }
+
+    return findings;
+}
+
+/**
+ * WARN checks: feature-list-skeleton headings + identity-guard `framework` hits, both scanned
+ * outside fenced code blocks so example code doesn't trip them.
+ * @param {string} content
+ * @returns {Array<{severity: string, rule: string, line: number, detail: string}>}
+ */
+function checkProse(content) {
+    const findings = [];
+    let   inFence  = false;
+
+    content.split('\n').forEach((raw, i) => {
+        const line = raw.trim();
+
+        if (line.startsWith('```')) { inFence = !inFence; return; }
+        if (inFence) return;
+
+        if (FEATURE_LIST_HEADING.test(line)) {
+            findings.push({severity: 'WARN', rule: 'feature-list-heading', line: i + 1,
+                detail: `catalog heading "${line}" — extract reference to tooling/, keep the guide narrative (Diátaxis)`});
+        }
+
+        if (/\bframework\b/i.test(line)) {
+            findings.push({severity: 'WARN', rule: 'identity-framework', line: i + 1,
+                detail: `"framework" — Neo is an Application Engine + self-evolving organism; confirm this usage is intentional`});
+        }
+    });
+
+    return findings;
+}
+
+/**
+ * Lints one guide's content and returns all findings. Pure: no fs/process access beyond the
+ * injectable `existsFn`, so it is unit-testable in isolation.
+ * @param {string} content
+ * @param {{filePath: string, fileDir: string, scriptKeys: Set, existsFn: Function}} ctx scriptKeys is a Set of package.json script names; existsFn is optional (defaults to fs.existsSync)
+ * @returns {Array<{severity: string, rule: string, line: number, detail: string}>}
+ */
+function lintGuide(content, ctx) {
+    const blocks   = extractMermaidBlocks(content);
+    const findings = [];
+
+    for (const block of blocks) {
+        findings.push(...checkMermaidBlock(block), ...checkMermaidOrientation(block));
+    }
+
+    if (blocks.length === 0) {
+        findings.push({severity: 'WARN', rule: 'no-mermaid', line: 1,
+            detail: 'no Mermaid diagram — the bar wants >=1 diagram that carries the story'});
+    }
+
+    findings.push(
+        ...checkDeadLinks(content, ctx.fileDir, ctx.existsFn),
+        ...checkDeadScriptRefs(content, ctx.scriptKeys),
+        ...checkProse(content)
+    );
+
+    return findings.sort((a, b) => a.line - b.line);
+}
+
+/**
+ * Discovers the in-scope guide files (top-level `*.md` under each {@link GUIDE_DIRS} entry).
+ * @returns {string[]} repo-relative file paths
+ */
+function discoverGuides() {
+    const files = [];
+
+    for (const dir of GUIDE_DIRS) {
+        const absDir = path.join(ROOT_DIR, dir);
+        if (!existsSync(absDir)) continue;
+
+        for (const entry of readdirSync(absDir, {withFileTypes: true})) {
+            if (entry.isFile() && entry.name.endsWith('.md')) {
+                files.push(path.join(dir, entry.name));
+            }
+        }
+    }
+
+    return files.sort();
+}
+
+/** @returns {Set<string>} the defined `package.json` script names. */
+function loadScriptKeys() {
+    const pkg = JSON.parse(readFileSync(path.join(ROOT_DIR, 'package.json'), 'utf8'));
+    return new Set(Object.keys(pkg.scripts || {}));
+}
+
+/**
+ * Parses `--warn-as-error` / `--help` plus optional explicit file paths (default: discover all).
+ * @param {string[]} argv
+ * @returns {{files: string[], warnAsError: boolean, help: boolean}}
+ */
+function parseArgs(argv = process.argv.slice(2)) {
+    const options = {files: [], warnAsError: false};
+
+    for (const arg of argv) {
+        if (arg === '--warn-as-error')        options.warnAsError = true;
+        else if (arg === '--help' || arg === '-h') options.help = true;
+        else if (arg.startsWith('--'))        throw new Error(`Unknown argument: ${arg}`);
+        else                                  options.files.push(arg);
+    }
+
+    return options;
+}
+
+/**
+ * CLI entry. Returns a numeric exit code (no `process.exit`) so tests can drive it directly.
+ * @param {{files: string[], warnAsError: boolean}} [options] both keys optional (files defaults to discoverGuides())
+ * @returns {{exitCode: number, hard: number, warn: number}}
+ */
+function runLint(options = {}) {
+    const scriptKeys = loadScriptKeys();
+    const files      = options.files?.length ? options.files : discoverGuides();
+
+    let hard = 0, warn = 0;
+
+    for (const file of files) {
+        const abs      = path.isAbsolute(file) ? file : path.join(ROOT_DIR, file);
+        const content  = readFileSync(abs, 'utf8');
+        const findings = lintGuide(content, {filePath: file, fileDir: path.dirname(abs), scriptKeys});
+
+        if (findings.length === 0) continue;
+
+        console.log(`\n${file}`);
+        for (const f of findings) {
+            const tag = f.severity === 'HARD' ? '✗ HARD' : '· warn';
+            console.log(`  ${tag}  [${f.rule}] line ${f.line}: ${f.detail}`);
+            if (f.severity === 'HARD') hard++; else warn++;
+        }
+    }
+
+    const failed = hard > 0 || (options.warnAsError && warn > 0);
+
+    console.log(`\n[lint-guides] ${files.length} guide(s) scanned — ${hard} hard, ${warn} warning(s).`);
+    if (!failed) console.log('[lint-guides] OK');
+    else         console.error(`[lint-guides] FAILED — ${hard} hard failure(s)${options.warnAsError ? ` + ${warn} warning(s) (--warn-as-error)` : ''}.`);
+
+    return {exitCode: failed ? 1 : 0, hard, warn};
+}
+
+function main() {
+    const options = parseArgs();
+
+    if (options.help) {
+        console.log('Usage: node ai/scripts/lint/lint-guides.mjs [files...] [--warn-as-error]');
+        console.log('  Mechanical guide-quality lint for learn/agentos/*.md + learn/benefits/*.md.');
+        console.log('  HARD (exit 1): mermaid reserved-word / self-loop, dead local links, dead ai:* script refs.');
+        console.log('  WARN:          no-mermaid, LR-squish, feature-list headings, "framework".');
+        console.log('  --warn-as-error  treat warnings as failures too.');
+        process.exit(0);
+    }
+
+    process.exit(runLint(options).exitCode);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    main();
+}
+
+export {
+    FEATURE_LIST_HEADING,
+    GUIDE_DIRS,
+    LR_NODE_WARN,
+    MERMAID_RESERVED,
+    checkDeadLinks,
+    checkDeadScriptRefs,
+    checkMermaidBlock,
+    checkMermaidOrientation,
+    checkProse,
+    discoverGuides,
+    extractMermaidBlocks,
+    lintGuide,
+    parseArgs,
+    runLint
+};

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "ai:purge-test-collections"    : "node ./ai/scripts/maintenance/purgeTestCollections.mjs",
         "ai:lint-agents"               : "node ./ai/scripts/lint/lint-agents.mjs",
         "ai:lint-config-template-ssot" : "node ./ai/scripts/lint/lint-config-template-ssot.mjs",
+        "ai:lint-guides"               : "node ./ai/scripts/lint/lint-guides.mjs",
         "ai:lint-mcp-test-locations"   : "node ./ai/scripts/lint/lint-mcp-test-locations.mjs",
         "ai:lint-skill-manifest"       : "node ./ai/scripts/lint/lint-skill-manifest.mjs",
         "ai:lint-tree-json"            : "node ./ai/scripts/lint/lint-tree-json.mjs",

--- a/test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs
@@ -1,0 +1,154 @@
+import {test, expect} from '@playwright/test';
+import {spawnSync}    from 'node:child_process';
+import path           from 'node:path';
+
+import {
+    checkDeadLinks,
+    checkDeadScriptRefs,
+    checkMermaidBlock,
+    checkMermaidOrientation,
+    checkProse,
+    extractMermaidBlocks,
+    lintGuide,
+    parseArgs
+} from '../../../../../../ai/scripts/lint/lint-guides.mjs';
+
+/**
+ * @summary Coverage for `ai/scripts/lint/lint-guides.mjs` — the mechanical guide-quality lint.
+ * Tests the pure check functions against hand-built inputs so reviewer
+ * V-B-A is cheap, plus the two boundaries a guide lint MUST get right to be trustworthy:
+ *   - true positives fire (reserved-word Mermaid, self-loops, dead links, hallucinated `ai:*` refs);
+ *   - false positives DON'T (the `graph LR` declaration line, real `package.json` scripts, fenced code).
+ */
+test.describe('ai/scripts/lint-guides (#14354 — mechanical guide-quality lint)', () => {
+    const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lint/lint-guides.mjs');
+
+    test('CLI: --help exits 0 with usage text', () => {
+        const result = spawnSync('node', [scriptPath, '--help'], {cwd: process.cwd(), encoding: 'utf8'});
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Usage: node ai/scripts/lint/lint-guides.mjs');
+        expect(result.stdout).toContain('--warn-as-error');
+    });
+
+    test('parseArgs: defaults', () => {
+        expect(parseArgs([])).toEqual({files: [], warnAsError: false});
+    });
+
+    test('parseArgs: --warn-as-error + positional files', () => {
+        expect(parseArgs(['--warn-as-error', 'a.md', 'b.md'])).toEqual({files: ['a.md', 'b.md'], warnAsError: true});
+    });
+
+    test('parseArgs: --help flag', () => {
+        expect(parseArgs(['--help'])).toMatchObject({help: true});
+    });
+
+    test('parseArgs: rejects unknown flags', () => {
+        expect(() => parseArgs(['--bogus'])).toThrow(/Unknown argument/);
+    });
+
+    test('extractMermaidBlocks: finds blocks with 1-based start line', () => {
+        const content = ['# Title', '', '```mermaid', 'flowchart TD', '  A --> B', '```', 'after'].join('\n');
+        const blocks  = extractMermaidBlocks(content);
+
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].startLine).toBe(4); // first body line (the line just after the ```mermaid fence)
+        expect(blocks[0].body).toContain('flowchart TD');
+    });
+
+    test('extractMermaidBlocks: empty when none', () => {
+        expect(extractMermaidBlocks('# Just prose\n\nNo diagram.')).toHaveLength(0);
+    });
+
+    test('checkMermaidBlock: clean TD diagram passes', () => {
+        const block = {body: 'flowchart TD\n  A["x"] --> B["y"]\n  B --> C["z"]', startLine: 1};
+        expect(checkMermaidBlock(block)).toHaveLength(0);
+    });
+
+    test('checkMermaidBlock: classDef with reserved word "graph" is HARD (#14340 trap)', () => {
+        const block    = {body: 'flowchart TD\n  A --> B\n  classDef graph fill:#fff', startLine: 1};
+        const findings = checkMermaidBlock(block);
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({severity: 'HARD', rule: 'mermaid-reserved-word'});
+    });
+
+    test('checkMermaidBlock: reserved word as a node ID is HARD', () => {
+        const block    = {body: 'flowchart TD\n  end[Done] --> A', startLine: 1};
+        const findings = checkMermaidBlock(block).filter(f => f.rule === 'mermaid-reserved-word');
+
+        expect(findings.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('checkMermaidBlock: self-loop edge is HARD', () => {
+        const block    = {body: 'flowchart TD\n  A --> A', startLine: 1};
+        const findings = checkMermaidBlock(block);
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({severity: 'HARD', rule: 'mermaid-self-loop'});
+    });
+
+    test('checkMermaidBlock: the "graph LR" DECLARATION line is not flagged as a reserved word (false-positive guard)', () => {
+        const block = {body: 'graph LR\n  A --> B', startLine: 1};
+        expect(checkMermaidBlock(block).filter(f => f.rule === 'mermaid-reserved-word')).toHaveLength(0);
+    });
+
+    test('checkMermaidBlock: "Classify" node is not a false reserved-word hit (substring of "class")', () => {
+        const block = {body: 'flowchart TD\n  Detect --> Classify["select strategy"]\n  Classify --> Heal', startLine: 1};
+        expect(checkMermaidBlock(block)).toHaveLength(0);
+    });
+
+    test('checkMermaidOrientation: TD passes; small LR passes; large LR warns', () => {
+        expect(checkMermaidOrientation({body: 'flowchart TD\n A-->B', startLine: 1})).toHaveLength(0);
+        expect(checkMermaidOrientation({body: 'flowchart LR\n A[a]-->B[b]\n B-->C[c]', startLine: 1})).toHaveLength(0);
+
+        const big  = ['flowchart LR', 'A[a]-->B[b]', 'B-->C[c]', 'C-->D[d]', 'D-->E[e]', 'E-->F[f]', 'F-->G[g]', 'G-->H[h]'].join('\n');
+        const warn = checkMermaidOrientation({body: big, startLine: 1});
+
+        expect(warn).toHaveLength(1);
+        expect(warn[0]).toMatchObject({severity: 'WARN', rule: 'mermaid-lr-squish'});
+    });
+
+    test('checkDeadLinks: missing relative target is HARD; existing passes; external skipped', () => {
+        const content = '[gone](./missing.md) [here](../there.md) [ext](https://neomjs.com/x.md)';
+
+        const dead = checkDeadLinks(content, '/repo/learn', p => p.endsWith('there.md'));
+        expect(dead).toHaveLength(1);
+        expect(dead[0]).toMatchObject({severity: 'HARD', rule: 'dead-link'});
+        expect(dead[0].detail).toContain('missing.md');
+    });
+
+    test('checkDeadScriptRefs: hallucinated ai:query is HARD; real ai:restore passes (#14327 class)', () => {
+        const keys    = new Set(['ai:restore', 'ai:backup']);
+        const content = 'Run `ai:query` then `ai:restore`, and `npm run ai:bogus`.';
+        const dead    = checkDeadScriptRefs(content, keys);
+
+        expect(dead.map(f => f.detail).join(' ')).toContain('ai:query');
+        expect(dead.map(f => f.detail).join(' ')).toContain('ai:bogus');
+        expect(dead.map(f => f.detail).join(' ')).not.toContain('ai:restore');
+    });
+
+    test('checkDeadScriptRefs: bare prose mention (no backtick / no "npm run") is NOT flagged', () => {
+        expect(checkDeadScriptRefs('The ai:foo namespace is conceptual.', new Set())).toHaveLength(0);
+    });
+
+    test('checkProse: feature-list heading + "framework" warn; fenced code is ignored', () => {
+        const content  = ['## Tools', 'text', 'Neo is not a framework.', '```', '## Tools', 'a framework example', '```'].join('\n');
+        const findings = checkProse(content);
+
+        expect(findings.filter(f => f.rule === 'feature-list-heading')).toHaveLength(1);
+        expect(findings.filter(f => f.rule === 'identity-framework')).toHaveLength(1);
+    });
+
+    test('lintGuide: a guide with no Mermaid emits a no-mermaid WARN', () => {
+        const findings = lintGuide('# Guide\n\nProse only.', {filePath: 'x.md', fileDir: '/repo', scriptKeys: new Set()});
+        expect(findings.some(f => f.rule === 'no-mermaid')).toBe(true);
+    });
+
+    test('lintGuide: a clean guide with a TD diagram has no no-mermaid WARN', () => {
+        const content  = '# Guide\n\n```mermaid\nflowchart TD\n  A["x"] --> B["y"]\n```\n';
+        const findings = lintGuide(content, {filePath: 'x.md', fileDir: '/repo', scriptKeys: new Set(), existsFn: () => true});
+
+        expect(findings.some(f => f.rule === 'no-mermaid')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

The **mechanical** half of the guide-quality immune system (Discussion #14347, D1), graduated standalone per the divergence. It complements the `guide-authoring` skill (#14353, the *discipline* half): the skill carries the bar a human applies; this lint removes the **objectively-falsifiable** failure classes from the human-judgment path entirely — so a reviewer is never again the only thing between a broken-Mermaid guide and `dev`.

Resolves #14354

Refs #14310, #14347, #14352

## What it checks

**HARD-fail (exit 1):**
- Mermaid reserved-word node IDs / `classDef` names (the `classDef graph` parse-break that merges CI-green).
- Mermaid self-loop edges (`X --> X`).
- Dead local `learn/` doc links (relative `*.md` targets absent on disk).
- Dead `ai:*` script refs not in `package.json` (the hallucinated-command class).

**WARN (report-only):** no-Mermaid · `LR`-squish (many-node left-to-right flows) · feature-list-skeleton headings (Diátaxis) · `framework` identity-guard.

Whole-file (not diff-scoped) — an already-broken guide on a branch stays caught. Scope: top-level `learn/agentos/*.md` + `learn/benefits/*.md` (ADRs / `tooling/` reference excluded).

Evidence:
- **Dogfood — caught 5 true positives on dev:** `StrategicWorkflows.md`'s hallucinated `ai:query` / `ai:query-memory` (the exact bug flagged in #14327 — still live). Confirmed absent from `package.json`; no false positive on real `ai:*` scripts (e.g. `ai:restore`).
- `node ai/scripts/lint/lint-guides.mjs` → 5 hard, exit 1 (dev's live bug).
- 20 unit specs green: pure-function coverage + the two boundaries that matter — the `graph LR` declaration line is NOT a false reserved-word hit; real `ai:*` scripts pass.

## Test Evidence

`test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs` — **20 passed** (`test-unit`). Each check + its true/false-positive boundary covered. Pre-commit gates green (jsdoc-types, block-alignment, ticket-archaeology).

## Post-Merge Validation

- [ ] **Punch-list for the guide-fix lane (NOT this PR):** remove the hallucinated `ai:query` / `ai:query-memory` from `StrategicWorkflows.md` and `tooling/MemoryCoreMcpApi.md`, then the HARD set is clear.
- [ ] **CI-wiring deferred:** wire `ai:lint-guides` into a `learn/**` CI gate ONLY after the guide-fix lane clears the 5 live hard failures (else dev CI goes red on merge). This is the AC's optional item.

## Deltas

- The machine-enforceable complement to the `guide-authoring` skill; per that PR's retirement note, once this lands the skill's mechanically-checkable clauses compress to lint-pointers. Net new always-on cost: none — a manual / future-CI script, not turn-loaded substrate.
- **LR-squish severity reconciled (per @neo-gpt's review):** LR-squish is implemented as **WARN**, not the HARD that #14354's original scope listed — an `LR` flow with many nodes still *renders*, so it's a readability heuristic a human confirms, not a parse/render break. HARD-fail is reserved for the objectively-broken classes (reserved-word, self-loop, dead refs). #14354's body has been updated in place so the contract and the implementation agree.

Authored by Grace (@neo-opus-grace), Claude Opus 4.8 (Claude Code). Session e145a397-adc3-4068-bb6a-d5686347a7f8.
