### PR TITLE
fix(skill): guide-authoring §5 — register via tree.json + generate.mjs PRIORITIES; never commit pipeline-owned sitemap/llms.txt (#14361)

### DIFF
--- a/.agents/skills/guide-authoring/references/guide-authoring-bar.md
+++ b/.agents/skills/guide-authoring/references/guide-authoring-bar.md
@@ -38,10 +38,10 @@ Measured against `resources/content/release-notes/chunk-2/v13.0.0.md` ("Memory B
 
 A guide is *explanation*; it does NOT inline tool catalogs, payload specs, CLI flag tables, or config formats. That *reference* is extracted to `tooling/` — preferentially **generated** from source (`openapi.yaml`, config schema) so it cannot stale. Link to it; never dump it. Before deleting inlined reference, verify the target actually holds the specific content (no-info-loss). Describe the **current paradigm**; demote or omit superseded manual procedures (e.g. manual restore is a backstop, not the data-integrity story) even when the old tool still exists.
 
-## 5. Mechanics — never hand-edit generated files — `MACHINE-ENFORCEABLE-CANDIDATE`
+## 5. Mechanics — register the guide; never commit the pipeline-owned SEO output — `MACHINE-ENFORCEABLE-CANDIDATE`
 
-- **File:** `learn/<section>/<slug>.md`. A new file registers in `learn/tree.json` (`npm run ai:lint-tree-json` green).
-- **Do NOT hand-edit the SEO surfaces.** `apps/portal/sitemap.xml` and `apps/portal/llms.txt` are **generated** by `buildScripts/docs/seo/generate.mjs` (via `buildScripts/docs/rebuildContentIndexesAndSeo.mjs`) and committed by the data-sync pipeline. A manual edit bypasses the generator and is overwritten on the next run — leave them to the pipeline (or regenerate; never hand-edit). *(KnowledgeBase #14346 was bounced for hand-editing these.)*
+- **File + registration (the inputs you edit).** A new guide is `learn/<section>/<slug>.md`, registered in **two source inputs**: (1) `learn/tree.json` — the nav SSOT (`npm run ai:lint-tree-json` green); and (2) `buildScripts/docs/seo/generate.mjs` — **add + rank the guide in the `PRIORITIES` map** (e.g. `['agentos/IdentityFirewall', 1.0]`). That map is where a guide's SEO weight is set.
+- **⛔ NEVER touch `apps/portal/sitemap.xml` or `apps/portal/llms.txt`** — not by hand, **not by running the generator**, not in your commit. They are **generated output owned by the data-sync pipeline**, which regenerates + commits them on its next run. Committing them yourself is pointless (the next pipeline run overwrites your edits) **and** is what collides guide PRs against each other (the #14345 ↔ #14346 SEO conflict — both committed the regenerated output). Edit the *inputs* (tree.json + the `PRIORITIES` map); leave the *output* to the pipeline.
 - **PR body:** `Evidence:` is L1/L2 (docs — no unit tests); zero client names (AGENTS.md §critical_gate).
 
 ## 6. The no-rubber-stamp reviewer gate — `DISCIPLINE-ONLY`


### PR DESCRIPTION
## Summary

Operator correction. The `guide-authoring` skill §5 (SEO mechanics) was the **generating function** behind the #14345 ↔ #14346 SEO merge conflict. It told peers the wrong thing: it allowed *"(or regenerate)"* the SEO surfaces and never named the correct registration step.

The rule, corrected: a peer registers a new guide in the **inputs** — `learn/tree.json` (nav SSOT) **+** `buildScripts/docs/seo/generate.mjs` (`PRIORITIES` map, add + rank). A peer **NEVER** touches `apps/portal/sitemap.xml` or `apps/portal/llms.txt` — not by hand, **not by running the generator**, not in their commit. Those are generated **output** owned by the **data-sync pipeline** (the next run overwrites peer edits; committing them is what collides guide PRs).

Resolves #14361

Refs #14352, #14310, #14345, #14346

## What changed

- **§5 rewritten** — explicit *inputs you edit* (`tree.json` + `generate.mjs` `PRIORITIES`) vs *pipeline-owned output you must not touch* (`sitemap.xml` / `llms.txt`). Dropped the "(or regenerate)" allowance; added the missing `PRIORITIES` add-and-rank step.

Evidence:
- Operator: *"peers should NOT EVER touch sitemap nor llms.txt. not manually, nor with the generator script… `generate.mjs` => adding and ranking GUIDES here, because the next run REMOVES your manual edits."*
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → OK (`[skill-growth-justified]` in the commit).

## §turn-memory-pre-flight load-effect audit

- The change is in the conditional World-Atlas payload (`guide-authoring-bar.md` §5), read-on-trigger. The always-loaded `SKILL.md` router is unchanged → **net always-loaded delta: 0**. The `+423 B` payload growth is `[skill-growth-justified]` in the commit (corrects a generating-function defect; conditional substrate).

## Test Evidence

`lint-skill-manifest` OK. Doc / skill-governance only — no unit surface.

## Post-Merge Validation

- [ ] **#14346** drops its `sitemap.xml` / `llms.txt` commits (keeps `tree.json` + `generate.mjs`) — that both follows the corrected rule and resolves its SEO conflict. (A2A'd to @neo-gpt.)

## Deltas

- Corrects the generating function that produced the SEO conflict; prevents recurrence across the remaining guide subs. Net always-loaded cost: 0 (conditional payload).

Authored by Grace (@neo-opus-grace), Claude Opus 4.8 (Claude Code). Session e145a397-adc3-4068-bb6a-d5686347a7f8.
