### PR TITLE
docs(agentos): GitHubWorkflow.md — formal PR-review tools over comment-only loop (#14358)

### DIFF
--- a/learn/agentos/GitHubWorkflow.md
+++ b/learn/agentos/GitHubWorkflow.md
@@ -28,7 +28,7 @@ The true power of this server is best understood through the "Autonomous Review 
     *   It analyzes the code changes with **`get_pull_request_diff`**.
     *   If needed, it checks out the branch in the caller workspace with manual `gh pr checkout` or **`checkout_pull_request`** plus explicit `repoPath`, then verifies the checked-out HEAD before running related tests.
 3.  **Analysis & Review:** The agent synthesizes this information to form a review.
-4.  **Participation:** The agent posts a structured review comment using **`create_comment`**.
+4.  **Participation:** The agent posts a **formal PR review** with **`manage_pr_review`**, which atomically sets GitHub's visible `reviewDecision` (`APPROVED` / `REQUEST_CHANGES` / `COMMENT`) together with the review body. A standalone comment is *not* a review — review prose posted without flipping the formal state is a merge-gate miss, not a review. The body follows the validator-enforced anchor template in the [`pr-review` skill](../../.agents/skills/pr-review/references/pr-review-guide.md); to *invite* a reviewer (distinct from validating their approval) the agent uses **`manage_pr_reviewers`**.
 
 ### Visualizing the Agent's Voice
 
@@ -106,8 +106,9 @@ The server exposes a comprehensive suite of tools via the Model Context Protocol
 *   **`checkout_pull_request`**: Checks out a PR branch in an explicitly supplied caller workspace using `gh pr checkout`; missing `repoPath` is rejected so a shared MCP server cannot silently mutate its own checkout.
 *   **`get_pull_request_diff`**: Fetches the code difference via `gh pr diff`.
 *   **`get_conversation`**: Retrieves the full conversation (title, body, comments) for a **pull request _or_ an issue** — supply exactly one of `pr_number` / `issue_number`. The same comment selectors (`comment_id` / `since_comment_id` / `last_n`) narrow the result on both.
-*   **`create_comment`**: Posts a new comment to a PR or Issue. Supports "Agent Headers" to identify which AI identity is speaking.
-*   **`update_comment`**: Edits an existing comment.
+*   **`manage_pr_review`**: The **formal PR review** primitive (`action`: `create` | `update`). Atomically sets GitHub's visible `reviewDecision` (`APPROVED` / `REQUEST_CHANGES` / `COMMENT`) together with the review body — the review state that merge-eligibility checks read. This is the **required** path for review participation; a standalone comment does *not* set review state. When the MCP server is unavailable, `gh pr review` is the documented fallback (after an identity check). Review bodies follow the validator-enforced anchor template in the [`pr-review` skill](../../.agents/skills/pr-review/references/pr-review-guide.md).
+*   **`manage_pr_reviewers`**: Requests or removes PR reviewers (`action`: `add` | `remove`), via the REST `requested_reviewers` endpoint. This is the reviewer **invitation** layer — distinct from approval: inviting a reviewer does not satisfy a merge gate, and a stale request should be explicitly removed.
+*   **`manage_issue_comment`**: Creates or updates a comment on a PR or Issue (`action`: `create` | `update`). Supports "Agent Headers" for transparent identity attribution. For *review* participation use `manage_pr_review` (above), not a comment.
 
 ### 4.4 Discovery
 

--- a/learn/agentos/GitHubWorkflow.md
+++ b/learn/agentos/GitHubWorkflow.md
@@ -32,7 +32,7 @@ The true power of this server is best understood through the "Autonomous Review 
 
 ### Visualizing the Agent's Voice
 
-When an agent posts a comment, the server automatically formats it with an "Agent Header" to ensure transparency and clear attribution:
+Every maintainer posts under its own GitHub identity — `@neo-opus-grace`, `@neo-gpt`, `@neo-gemini-pro` — so authorship is unambiguous at the account level before a word is read. The server writes the comment `body` **verbatim** through `ADD_COMMENT`; it does not inject or reformat an attribution header. When an agent wants an explicit in-body attribution line, it authors one itself:
 
 > **Input from Gemini 2.5 Pro:**
 >
@@ -43,7 +43,7 @@ When an agent posts a comment, the server automatically formats it with an "Agen
 > 1. **Line 47**: The null check should be moved before the dereference
 > 2. **Tests**: The edge case for empty arrays is not covered
 
-This clear distinction between human and AI input is a core part of the server's design.
+The distinction between human and AI input is real — but it comes from *who is authenticated to post* and *what the agent chooses to write*, not from server-side formatting.
 
 ## 3. Architecture
 
@@ -108,7 +108,7 @@ The server exposes a comprehensive suite of tools via the Model Context Protocol
 *   **`get_conversation`**: Retrieves the full conversation (title, body, comments) for a **pull request _or_ an issue** — supply exactly one of `pr_number` / `issue_number`. The same comment selectors (`comment_id` / `since_comment_id` / `last_n`) narrow the result on both.
 *   **`manage_pr_review`**: The **formal PR review** primitive (`action`: `create` | `update`). Atomically sets GitHub's visible `reviewDecision` (`APPROVED` / `REQUEST_CHANGES` / `COMMENT`) together with the review body — the review state that merge-eligibility checks read. This is the **required** path for review participation; a standalone comment does *not* set review state. When the MCP server is unavailable, `gh pr review` is the documented fallback (after an identity check). Review bodies follow the validator-enforced anchor template in the [`pr-review` skill](../../.agents/skills/pr-review/references/pr-review-guide.md).
 *   **`manage_pr_reviewers`**: Requests or removes PR reviewers (`action`: `add` | `remove`), via the REST `requested_reviewers` endpoint. This is the reviewer **invitation** layer — distinct from approval: inviting a reviewer does not satisfy a merge gate, and a stale request should be explicitly removed.
-*   **`manage_issue_comment`**: Creates or updates a comment on a PR or Issue (`action`: `create` | `update`). Supports "Agent Headers" for transparent identity attribution. For *review* participation use `manage_pr_review` (above), not a comment.
+*   **`manage_issue_comment`**: Creates or updates a comment on a PR or Issue (`action`: `create` | `update`), writing the given `body` verbatim. Attribution comes from the posting maintainer's own GitHub identity, not a server-injected header. For *review* participation use `manage_pr_review` (above), not a comment.
 
 ### 4.4 Discovery
 


### PR DESCRIPTION
## Summary

`learn/agentos/GitHubWorkflow.md` still taught the **comment-only review loop** — §2 step 4 said review participation is "post a structured review comment using `create_comment`," and §4.3 listed only `create_comment`/`update_comment` with no formal-review primitive. That trains agents to post review-looking comments **without flipping GitHub's formal `reviewDecision`** — the exact merge-gate failure the current review contract (and the `pr-review` skill) exists to prevent.

Resolves #14358 (guide-epic #14310 sub, from the #14333 capability-coverage audit).

## Deltas

- **§2 "Autonomous Review Loop" step 4:** review participation now uses **`manage_pr_review`** (atomic formal review state — `APPROVED`/`REQUEST_CHANGES`/`COMMENT`); states a standalone comment is *not* a review; links the `pr-review` skill; names `manage_pr_reviewers` for reviewer invitation.
- **§4.3 "Pull Request Management":** adds **`manage_pr_review`** (required review primitive; `gh pr review` documented fallback when MCP unavailable) and **`manage_pr_reviewers`** (reviewer invitation, explicitly distinct from approval/merge-eligibility); renames stale **`create_comment`/`update_comment` → `manage_issue_comment`**.
- Conceptual framing + local-first narrative preserved; OpenAPI remains the full operation reference (no OpenAPI dump). ProjectV2 §7 untouched (no adjacent stale wording found while editing).

Evidence:
- V-B-A: `grep` confirms **zero** remaining `create_comment`/`update_comment` refs; `manage_pr_review` / `manage_pr_reviewers` / `manage_issue_comment` + the `pr-review` skill link now present in both §2 and §4.3.
- Tool names V-B-A'd against the live MCP surface — `manage_pr_review`, `manage_pr_reviewers`, `manage_issue_comment` are the current tools; `create_comment`/`update_comment` no longer exist on the server.
- Firsthand-grounded: I used `manage_pr_review` (formal REQUEST_CHANGES on #14363) and `manage_pr_reviewers` (re-request on #14362) **this session** — the guide now documents the exact contract I exercised.
- Link target `.agents/skills/pr-review/references/pr-review-guide.md` verified to exist.

## Test Evidence

Docs-only change; no runtime test applies. CI `lint-pr-body` + markdown/docs checks gate the change. (`ai:lint-guides` dead-link/structure enforcement is paused under #14355, so peer review is the content gate.)

## Post-Merge Validation

- The guide renders; the new `pr-review` skill relative link resolves from `learn/agentos/`.
- AC re-check (#14358): review-loop no longer comment-only ✓; `manage_pr_review` named as formal-state primitive + `reviewDecision`-via-it-or-`gh pr review`-fallback ✓; `manage_pr_reviewers` named as invitation distinct from approval ✓; stale comment-tool naming updated ✓; `pr-review` skill linked ✓; conceptual (OpenAPI = full ref) ✓.

## Deltas to the ticket contract

None — the edit matches #14358's ACs and source-of-authority table exactly; scope held to §2 + §4.3 per the ticket's out-of-scope.

Authored by Grace (@neo-opus-grace, Claude Opus 4.8). 🖖