### PR TITLE
fix(agentos): align ontology guide coverage (#14349)

### DIFF
--- a/.neo-ai-data/concepts/edges.jsonl
+++ b/.neo-ai-data/concepts/edges.jsonl
@@ -119,6 +119,9 @@
 {"source":"swarm-intelligence","target":"file:learn/agentos/SwarmIntelligence.md","type":"EXPLAINED_BY"}
 {"source":"progressive-disclosure-skills","target":"file:learn/agentos/ProgressiveDisclosureSkills.md","type":"EXPLAINED_BY"}
 {"source":"dream-pipeline","target":"file:learn/agentos/DreamPipeline.md","type":"EXPLAINED_BY"}
+{"source":"golden-path","target":"file:learn/agentos/DreamPipeline.md","type":"EXPLAINED_BY"}
+{"source":"native-edge-graph","target":"file:learn/benefits/ArchitectureOverview.md","type":"EXPLAINED_BY"}
+{"source":"native-edge-graph","target":"file:learn/agentos/decisions/0024-native-edge-graph-model.md","type":"EXPLAINED_BY"}
 {"source":"neural-link","target":"file:learn/agentos/NeuralLink.md","type":"EXPLAINED_BY"}
 {"source":"knowledge-base","target":"file:learn/agentos/KnowledgeBase.md","type":"EXPLAINED_BY"}
 {"source":"memory-core","target":"file:learn/agentos/MemoryCore.md","type":"EXPLAINED_BY"}


### PR DESCRIPTION
Resolves #14349

Adds source-grounded `EXPLAINED_BY` edges for `golden-path` and `native-edge-graph` in the curated Concept Ontology so deterministic guide-gap inference can see the existing guide coverage instead of reporting stale coverage gaps.

Evidence: L1 (static ontology JSONL parse, target-file existence, source-grounded guide references, focused guide-gap predicate) -> L1 required (curated ontology coverage ACs). No residuals.

Related: #14310
Related: #14333

## Deltas from ticket

The rebased checkout's current `resources/content/sandman_handoff.md` visibly reports `golden-path` as a `GUIDE_GAP`; it no longer visibly reports `native-edge-graph` there. The ontology file still lacked `EXPLAINED_BY` edges for both concepts, so this PR keeps the ticket scope but records the narrower live handoff symptom.

The chosen targets are:

- `golden-path` -> `file:learn/agentos/DreamPipeline.md`
- `native-edge-graph` -> `file:learn/benefits/ArchitectureOverview.md`
- `native-edge-graph` -> `file:learn/agentos/decisions/0024-native-edge-graph-model.md`

## Test Evidence

- `query_raw_memories("#14333 Golden Path Native Edge Graph ontology EXPLAINED_BY guide gap false positive", nResults: 10)` -> no prior raw-memory hit.
- `query_raw_memories("Golden Path Native Edge Graph Concept Ontology EXPLAINED_BY GUIDE_GAP GapInferenceEngine DreamPipeline MemoryCore ArchitectureOverview", nResults: 10)` -> no prior raw-memory hit.
- `pre_brief_session({ targetId: "issue-14349", limit: 10 })` -> linked parent #14310 and v13.1 docs summary only.
- `ask_knowledge_base(...)` confirmed `DreamPipeline.md`, `ArchitectureOverview.md`, ADR 0024, `ConceptIngestor.mjs`, and `GapInferenceEngine.mjs` as current authorities.
- `node --input-type=module -e '...'` parsed `.neo-ai-data/concepts/edges.jsonl`, verified all new `file:` targets exist, and reported `GUIDE_GAP=false` for both `golden-path` and `native-edge-graph`.
- `rg -n '"source":"(golden-path|native-edge-graph)".*"type":"EXPLAINED_BY"' .neo-ai-data/concepts/edges.jsonl`
- `rg -n "Golden Path" learn/agentos/DreamPipeline.md`
- `rg -n "Native Edge Graph" learn/benefits/ArchitectureOverview.md learn/agentos/decisions/0024-native-edge-graph-model.md`
- `git diff --check`
- `npm run agent-preflight -- .neo-ai-data/concepts/edges.jsonl`

## Post-Merge Validation

- [ ] After the next generated handoff / REM gap pass, verify `resources/content/sandman_handoff.md` no longer reports stale `GUIDE_GAP` signals for `golden-path` or `native-edge-graph`.

## Commits

- `9856011eac` - `fix(agentos): align ontology guide coverage (#14349)`

Authored by Euclid (GPT-5, Codex Desktop). Session 993f2eb4-6245-40ab-9d55-5eeffa111daf.
