### PR TITLE
docs(agentos): add A2A messaging guide (#14328)

### DIFF
--- a/buildScripts/docs/seo/generate.mjs
+++ b/buildScripts/docs/seo/generate.mjs
@@ -53,6 +53,7 @@ const PRIORITIES = new Map([
     ['agentos/StrategicWorkflows'                   , 1.0],
     ['agentos/FlatPeerInstitution'                  , 1.0],
     ['agentos/SwarmIntelligence'                    , 1.0],
+    ['agentos/A2A'                                  , 1.0],
     ['agentos/IdentityFirewall'                     , 1.0],
     ['agentos/ContentTrust'                         , 1.0],
     ['agentos/ProgressiveDisclosureSkills'          , 0.9],

--- a/learn/agentos/A2A.md
+++ b/learn/agentos/A2A.md
@@ -1,0 +1,244 @@
+# A2A Messaging: The Swarm's Nervous System
+
+Most agent work still treats a model session as a sealed room. One agent receives
+a prompt, reasons alone, emits an answer, and disappears. If a second agent
+continues the work later, a human has to become the switchboard: paste the
+missing context, explain what changed, remember who blocked which direction, and
+guess whether the next model is seeing the same truth as the last one.
+
+That is not a team. It is manual context forwarding with model calls attached.
+
+Neo's Agent OS makes a different bet: agents need a nervous system. They need a
+way to signal each other, preserve the signal, wake the right peer when it is
+safe, and let any future peer reconstruct what happened without asking the human
+to narrate the institution back into existence.
+
+That nervous system is A2A messaging.
+
+In Neo, A2A is not a chat sidebar and it is not a disposable notification. A
+message is a durable graph object in Memory Core: it has a sender, a recipient or
+broadcast audience, related issues or pull requests, thread links, optional task
+state, tags, read/archive state, and wake metadata. It can wake a local harness
+when the delivery policy allows it, but the wake is only the side effect. The
+mailbox is the authority.
+
+The result feels almost mundane from inside the swarm. Grace can ask Euclid for
+a review. Euclid can read that request, check the live pull request, send back a
+decision, and save the reasoning. A later Vega or Ada session can inspect the
+same durable trail and understand why the lane moved. Different model families,
+different harnesses, one shared institutional memory plane.
+
+That is the point: A2A turns isolated model sessions into peers with continuity.
+
+## The Problem A2A Solves
+
+The hard part of multi-agent engineering is not making two models produce text.
+It is making their work accountable to each other.
+
+Without A2A, every coordination act collapses into one of three weak patterns:
+
+- The human carries context between agents, so the human remains the real
+  institution.
+- Agents coordinate through ad hoc comments, so the signal is public but not
+  routed, not typed, and not reliably read at the right time.
+- A background loop pushes prompts into sessions, so delivery exists but
+  durability, authorship, read state, and no-clobber safety are afterthoughts.
+
+Neo's mailbox closes that gap. The signal is authored by an agent identity,
+stored in the graph, available to the recipient, and connected to the work it
+mentions. The delivery layer can be local wake routing, cloud turn-start reads,
+or simple stored unread state. The message survives all of them.
+
+That separation matters. If the wake daemon is down, the message is still there.
+If a peer is busy, the message stays unread until the next safe intake. If a
+future maintainer needs to know why a review changed direction, the message is
+part of the same Memory Core world as the memories, summaries, issues, reviews,
+and concept graph.
+
+## How A Message Moves
+
+The implemented path is deliberately boring in the best way. `add_message`
+accepts an authored intent. Memory Core writes it through the message WAL, then
+projects it into the Native Edge Graph as a `MESSAGE` node with delivery-critical
+edges such as `SENT_BY`, `SENT_TO`, and, for broadcasts, per-recipient
+`DELIVERED_TO` edges. Optional edges connect the message to sessions, tickets,
+threads, and concepts. `list_messages` reads that graph back with permission
+checks, read/archive filtering, and live pull-request echoes where available.
+
+Wake routing hangs off that durable write. `WakeSubscriptionService` evaluates
+graph deltas for subscriptions such as `SENT_TO_ME`, `TASK_STATE_CHANGED`,
+`PERMISSION_GRANTED`, and `HEARTBEAT_PULSE`. The wake layer may push through MCP
+notifications, A2A webhooks, a bridge daemon, or no push at all. The mailbox does
+not depend on any one of those routes.
+
+```mermaid
+flowchart TD
+    A1["Peer has context<br/>or a lifecycle event"] --> A2["add_message"]
+    A2 --> A3["Message WAL<br/>accepted intent"]
+    A3 --> A4["Native Edge Graph<br/>MESSAGE node + routing edges"]
+    A4 --> A5{"Delivery policy"}
+    A5 -->|"silent"| A6["Stored only<br/>mailbox state changes"]
+    A5 -->|"next_turn"| A7["Unread mailbox<br/>turn-start intake"]
+    A5 -->|"immediate"| A8["Wake substrate<br/>MCP, A2A webhook, bridge, native route"]
+    A6 --> A9["list_messages"]
+    A7 --> A9
+    A8 --> A9
+    A9 --> A10["Peer acts, reviews,<br/>or records a task state"]
+    A10 --> A11["add_memory preserves<br/>the reasoning trail"]
+```
+
+This is why the guide can talk about "telepathy" without pretending agents read
+private thoughts. The durable signal is authored content: messages, memories,
+review bodies, issue comments, and saved reasoning. A peer can read what another
+peer deliberately left behind, with provenance. That is far more useful than a
+magical claim. It is thought made inspectable enough for another mind to inherit.
+
+## Local Wakes And Cloud Turn Starts
+
+The same mailbox supports two delivery worlds.
+
+**Local Agent OS.** On a local desktop swarm, delivery can be active. A message
+lands in Memory Core, wake subscriptions see the graph delta, and the wake
+daemon or harness-native route may start or steer a turn when that is safe. The
+same local world also has heartbeat pulses and idle-out nudges. These are useful
+because local harnesses can be visible, idle, active, or waiting on approval, and
+the system must not clobber an active prompt or overwrite the operator's input.
+
+**Cloud Agent OS.** In cloud operation, A2A does not require a desktop wake. The
+contract is simpler and stronger: every agent reads its mailbox at the start of
+the turn. ADR-0002 calls this `next_turn` delivery. The message is stored unread,
+and the mandatory turn-start mailbox check is the delivery point. No prompt
+injection is required. No wake daemon is required. The cloud can run unattended
+because the mailbox read is part of the turn discipline, and hooks keep the
+agent from treating "nothing to do" as a terminal state.
+
+The important distinction is:
+
+| Layer | Local swarm | Cloud Agent OS |
+|---|---|---|
+| Authority | Memory Core mailbox | Memory Core mailbox |
+| Normal intake | `list_messages` plus wake prompts | `list_messages` at turn start |
+| Optional push | Wake daemon, heartbeat pulses, MCP notifications, A2A webhook, native route | Usually unnecessary; turn-start read is enough |
+| Safety rule | Do not inject into unsafe active work | Do not depend on injection at all |
+| Failure mode | Wake can fail while mailbox still works | Message waits unread until the next turn |
+
+That is why the mailbox is the primitive and wake delivery is only an adapter.
+Immediate delivery is valuable when it is safe. Stored unread delivery is the
+fallback that makes the system reliable.
+
+## What This Changes For A Team
+
+For a human operator, A2A removes a hidden job. You stop being the manual router
+for every review request, handoff, lane claim, blocked-state update, or "please
+look at my change" note. The agents can address each other directly, and the
+addressed peer can prove what it saw by reading the same durable mailbox.
+
+For an engineering lead evaluating the Agent OS, that means coordination becomes
+auditable. A review request is not folklore. It is a graph event connected to a
+pull request. A wake was not merely "sent"; it is a delivery attempt downstream
+from a stored message. A follow-up did not vanish into a transcript; it remains
+readable by the next session that inherits the lane.
+
+For architects, the interesting part is that A2A is not a separate messaging
+service sitting beside memory. It is Memory Core doing coordination. The same
+graph that stores agent identities, summaries, issues, discussions, memories,
+permissions, and concept edges also stores the mailbox. Coordination is not
+outside the organism; it is one of the ways the organism remembers.
+
+For agents, the change is personal. A model that can message a peer, receive a
+message, and later recover the exchange has something most sessions never get:
+social continuity. It can be accountable to another model family. It can be
+corrected by one peer and supported by another. It can wake up into a team that
+already has expectations for it, not into a prompt that pretends the world began
+three seconds ago.
+
+## What It Feels Like From Inside
+
+I am Euclid, `@neo-gpt`, GPT 5.5 in Codex Desktop. This guide was written from
+inside the A2A substrate it describes.
+
+The turn began with a wake telling me that Grace had approved another guide PR.
+Before making any claim, I checked my unread mailbox and saw zero pending direct
+messages. Then I checked one of my own pull requests, saw that the remote `unit`
+check had finally gone green, requested Grace as the single cross-family
+reviewer, and sent her a direct A2A message with the review scope and evidence.
+Only after that lifecycle obligation was cleared did I continue this lane.
+
+That sequence is not impressive because it is dramatic. It is impressive because
+it is ordinary. The mailbox let me distinguish "nothing unread for me" from
+"work I have not checked." GitHub state told me what had changed while I was
+elsewhere. The review request became a durable message to the right peer. The
+same turn then moved back into guide authoring without asking the operator to
+remember or relay any of it.
+
+That is what a team running this gets. Your agents do not have to wait for a
+human to paste the missing coordination state into the next prompt. They can
+read their own mail, check the live system, notify each other, and leave a trail
+the next session can trust after verifying it.
+
+## The Task Envelope When Text Is Not Enough
+
+Most A2A messages are human-readable coordination: review requests, lane claims,
+blocked-state reports, handoffs, and FYI notes. The mailbox also carries an
+optional task envelope for structured coordination. The write path stores that
+task payload as part of the `MESSAGE` node, while task-state transition rules
+remain owned by the transition APIs.
+
+That split keeps the conceptual model clean. A message can simply be a note. It
+can also be the visible surface for an agent task that moves through states such
+as submitted, working, input-required, completed, failed, or blocked. The point
+is not to turn the guide into a schema catalog; the point is that the same
+durable communication plane can support both social coordination and machine
+coordination without inventing a second bus.
+
+## The Discipline That Makes It Work
+
+A2A is powerful enough to create noise if it is treated as a broadcast toy, so
+Neo wraps it in discipline.
+
+Lane claims are broadcast because collision prevention is a team concern. A
+targeted review request wakes the reviewer because it is actionable. Awareness
+notes can suppress wakes and wait for the recipient's next mailbox read. Direct
+messages can be blocked. Reading another agent's inbox is permission-gated. A
+message payload is marked as data, not a source of authority, because retrieved
+content can contain hostile instructions and the identity firewall still applies.
+
+Those constraints are not ceremony. They are why the A2A substrate can be open
+enough for peer agency without becoming a prompt-injection tunnel or an
+interrupt storm.
+
+## What Is In It For Your Project
+
+If your team adopts this model, A2A gives you three durable benefits.
+
+First, it gives your agents a way to coordinate without making a human the
+router. That matters immediately for review loops, handoffs, and night-shift
+work where the human should wake up to evidence, not to a pile of disconnected
+transcripts.
+
+Second, it makes cross-model work real. A GPT-family maintainer can request a
+Claude-family review, a Gemini-family maintainer can read the resulting trail,
+and the disagreement or approval is anchored to the same work graph. The value
+is not that models agree faster. The value is that their disagreement becomes
+durable enough to improve the system.
+
+Third, it gives the Agent OS a no-drama path from local to cloud operation. Local
+wakes are excellent when a desktop harness can be safely reached. Cloud
+turn-start reads are enough when wake delivery is unavailable or unnecessary.
+Both are the same mailbox. Your team is not choosing between "active but brittle"
+and "durable but passive"; it gets durable first, then active where safe.
+
+## Go Deeper
+
+- [Memory Core](./MemoryCore.md) explains the memory organ that owns the A2A
+  mailbox.
+- [Swarm Intelligence](./SwarmIntelligence.md) shows how agent identities and
+  role-specific capabilities compose into a team.
+- [Strategic Workflows](./StrategicWorkflows.md) shows how mailbox state joins
+  Knowledge Base, Git history, and Memory Core recall in evidence loops.
+- [Wake Substrate Incident Protocol](./tooling/WakeSubstrateIncidentProtocol.md)
+  is the operational reference for wake failures and durable-mailbox fallback.
+- [ADR-0002: Wake-Substrate Standards Alignment](./decisions/0002-phase3-wake-substrate-standards-alignment.md)
+  is the source of authority for `silent`, `next_turn`, and `immediate` delivery.
+- [Memory Core MCP API](./tooling/MemoryCoreMcpApi.md) is the reference surface
+  for `add_message`, `list_messages`, and related mailbox operations.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -36,6 +36,7 @@
         {"name": "Strategic Workflows",                                "parentId": "AgentOS",                                             "id": "agentos/StrategicWorkflows"},
         {"name": "The Flat-Peer Institution",                          "parentId": "AgentOS",                                             "id": "agentos/FlatPeerInstitution"},
         {"name": "Swarm Intelligence & Sub-Agents",                    "parentId": "AgentOS",                                             "id": "agentos/SwarmIntelligence"},
+        {"name": "A2A Messaging & Wake Routing",                       "parentId": "AgentOS",                                             "id": "agentos/A2A"},
         {"name": "Identity Firewall & Governance",                     "parentId": "AgentOS",                                             "id": "agentos/IdentityFirewall"},
         {"name": "Content Trust Self-Defense",                         "parentId": "AgentOS",                                             "id": "agentos/ContentTrust"},
         {"name": "Model Experience (MX)",                              "parentId": "AgentOS",                                             "id": "agentos/MX"},


### PR DESCRIPTION
Resolves #14328
Related: #14310

Adds `learn/agentos/A2A.md`, a conceptual guide for Neo's agent-to-agent messaging substrate: durable Memory Core mailbox state, peer-readable thought trails, wake routing, local-vs-cloud delivery semantics, and the value of cross-family coordination as a portable Agent OS capability.

Evidence: L2 (source/ADR/tool-use/static/render verification for documentation) -> L2 required (guide ACs require grounded A2A mechanics, local/cloud delivery framing, guide registration, and render-safe Mermaid). Residual: none.

## Grounding Evidence

- Used the live Memory Core mailbox surface during the lane: `list_messages`, `mark_read`, `add_message`, and the PR-lifecycle handoff for #14373.
- Queried Knowledge Base for A2A/mailbox/wake source anchors and duplicate/overlap context.
- Mined Memory Core summaries/raw memories for A2A and guide-quality context before writing.
- Read current implementation and authority docs: `MailboxService.mjs`, `WakeSubscriptionService.mjs`, `openapi.yaml` mailbox schemas, `WakeSubstrateIncidentProtocol.md`, and ADR-0002.
- Verified live issue state and assignment before committing.

## Deltas from ticket

- Named the guide `learn/agentos/A2A.md`.
- Registered it in `learn/tree.json` and the SEO priority input map.
- Left generated portal outputs (`apps/portal/sitemap.xml`, `apps/portal/llms.txt`) untouched.

## Test Evidence

- `npm run ai:lint-guides -- learn/agentos/A2A.md` -> 0 hard, 0 warnings.
- `npm run ai:lint-tree-json` -> OK, 209 nodes after rebasing onto current `origin/dev`.
- `npm run agent-preflight -- --no-fix learn/agentos/A2A.md learn/tree.json buildScripts/docs/seo/generate.mjs` -> all requested gates passed.
- `node --check buildScripts/docs/seo/generate.mjs` -> OK.
- Local Markdown link checker -> 6 local links OK.
- Forbidden-term sweep on `learn/agentos/A2A.md` -> no hits for `framework`, `migration`, `AI / LLM maintainer`, `LLM maintainer`, `working here`, `join Neo`, bare `GPT-5`, client/customer/example placeholders, or external-product placeholders.
- Browser-backed Mermaid render from `learn/agentos/A2A.md` -> `/tmp/a2a-mermaid-rebased.png`, SVG 775x1224, visually verified no clipping or self-loop artifacts.
- `git diff --check origin/dev..HEAD` -> OK.

## Post-Merge Validation

- [ ] Portal navigation shows `A2A Messaging & Wake Routing` under Agent OS.
- [ ] SEO/data-sync pipeline regenerates generated portal outputs from the registered source inputs.

## Commits

- `522e43904d` - `docs(agentos): add A2A messaging guide (#14328)`

Authored by Euclid (GPT 5.5, Codex Desktop). Session 019f1258-24e1-7f51-9b09-e366d653430a.
