### PR TITLE
feat(ai): ai:lint-guides — guide↔OpenAPI tool-parity check (#14366)

### DIFF
--- a/ai/scripts/lint/lint-guides.mjs
+++ b/ai/scripts/lint/lint-guides.mjs
@@ -237,9 +237,15 @@ function checkDeadScriptRefs(content, scriptKeys) {
  * @returns {Array<{severity: string, rule: string, line: number, detail: string}>}
  */
 function checkOpenApiToolParity(content, operationIds) {
-    const findings   = [];
-    let   underTools = false;
-    let   inFence    = false;
+    const findings = [];
+
+    // Empty surface (missing servers dir / empty injection) → no-op, NOT flag-everything: without
+    // this guard `!operationIds.has(...)` is always true and HARD-fails every tool-table row. This
+    // check is a forward-guard, so a missing surface degrades to "can't verify, don't block".
+    if (!operationIds || operationIds.size === 0) return findings;
+
+    let underTools = false;
+    let inFence    = false;
 
     content.split('\n').forEach((raw, i) => {
         const line = raw.trim();

--- a/ai/scripts/lint/lint-guides.mjs
+++ b/ai/scripts/lint/lint-guides.mjs
@@ -18,6 +18,8 @@
  *   - Dead local doc links — `](./x.md)` / `](../x.md)` targets absent on disk.
  *   - Dead `ai:*` script refs — `` `ai:foo` `` / `npm run ai:foo` not in `package.json` scripts
  *     (the hallucinated-command class).
+ *   - Tool-table refs under a Tools heading that resolve to no `ai/mcp/server/*​/openapi.yaml`
+ *     operationId — the MCP-tool analogue of the hallucinated-command class.
  *
  * **WARN (report-only, exit 0) — heuristics a human confirms:**
  *   - No Mermaid block at all (the bar wants >=1 diagram that carries the story).
@@ -63,6 +65,19 @@ const LR_NODE_WARN = 6;
  * Matched case-insensitively as a whole `##`/`###` heading line.
  */
 const FEATURE_LIST_HEADING = /^#{2,3}\s+(available\s+)?(tools?|configuration|config|api|reference|commands?|options|parameters|flags|endpoints?|methods?|properties)\s*$/i;
+
+/**
+ * Tool-table parity (the OpenAPI-operation analogue of the dead-`ai:*`-script check). A guide that
+ * inlines an MCP tool table must reference real `ai/mcp/server/*​/openapi.yaml` operationIds.
+ *
+ * **Why heading-scoped, not every `| `name` |` row:** config / property / schema tables share the
+ * exact same row shape, so an unscoped scan flags `id`/`name`/`tier`/`schema` etc. as "hallucinated
+ * tools" — empirically 56 false HARDs across the live guide corpus. We only scan rows under a
+ * *tools-catalog* heading. The heading match is deliberately narrow (`(available|mcp|agent|the)? tools?`
+ * anchored at the heading start) so `## Build Tools` / `## Debugging Tools` cannot match either.
+ */
+const TOOLS_HEADING  = /^#{2,4}\s+(available\s+|mcp\s+|agent\s+|the\s+)?tools?\b/i;
+const TOOL_TABLE_ROW = /^\|\s*`([a-z][a-z0-9_]*)`\s*\|/;
 
 /**
  * Returns the 1-based line number of a character index within `content`.
@@ -212,6 +227,39 @@ function checkDeadScriptRefs(content, scriptKeys) {
 }
 
 /**
+ * HARD check: tool-table rows that reference an MCP tool no server exposes — the OpenAPI-operation
+ * analogue of {@link checkDeadScriptRefs}. Scoped to rows under a {@link TOOLS_HEADING} so config /
+ * property / schema tables (same `| `name` |` shape) never false-positive. Generalizes the
+ * per-guide `GuideToolParity` spec into the shared lint. Fenced code is skipped so an example table
+ * in a code block doesn't trip it.
+ * @param {string} content
+ * @param {Set<string>} operationIds union of every MCP server's openapi.yaml operationIds
+ * @returns {Array<{severity: string, rule: string, line: number, detail: string}>}
+ */
+function checkOpenApiToolParity(content, operationIds) {
+    const findings   = [];
+    let   underTools = false;
+    let   inFence    = false;
+
+    content.split('\n').forEach((raw, i) => {
+        const line = raw.trim();
+
+        if (line.startsWith('```')) { inFence = !inFence; return; }
+        if (inFence) return;
+        if (line.startsWith('#'))   { underTools = TOOLS_HEADING.test(line); return; }
+        if (!underTools) return;
+
+        const match = line.match(TOOL_TABLE_ROW);
+        if (match && !operationIds.has(match[1])) {
+            findings.push({severity: 'HARD', rule: 'openapi-tool-parity', line: i + 1,
+                detail: `tool-table ref \`${match[1]}\` resolves to no ai/mcp/server/*/openapi.yaml operationId — hallucinated/stale tool (or the heading is not an MCP-tool catalog)`});
+        }
+    });
+
+    return findings;
+}
+
+/**
  * WARN checks: feature-list-skeleton headings + identity-guard `framework` hits, both scanned
  * outside fenced code blocks so example code doesn't trip them.
  * @param {string} content
@@ -245,7 +293,7 @@ function checkProse(content) {
  * Lints one guide's content and returns all findings. Pure: no fs/process access beyond the
  * injectable `existsFn`, so it is unit-testable in isolation.
  * @param {string} content
- * @param {{filePath: string, fileDir: string, scriptKeys: Set, existsFn: Function}} ctx scriptKeys is a Set of package.json script names; existsFn is optional (defaults to fs.existsSync)
+ * @param {{filePath: string, fileDir: string, scriptKeys: Set, operationIds: Set, existsFn: Function}} ctx scriptKeys = package.json script names; operationIds = MCP openapi operationIds (defaults to empty → tool-parity is a no-op); existsFn is optional (defaults to fs.existsSync)
  * @returns {Array<{severity: string, rule: string, line: number, detail: string}>}
  */
 function lintGuide(content, ctx) {
@@ -264,6 +312,7 @@ function lintGuide(content, ctx) {
     findings.push(
         ...checkDeadLinks(content, ctx.fileDir, ctx.existsFn),
         ...checkDeadScriptRefs(content, ctx.scriptKeys),
+        ...checkOpenApiToolParity(content, ctx.operationIds || new Set()),
         ...checkProse(content)
     );
 
@@ -298,6 +347,33 @@ function loadScriptKeys() {
 }
 
 /**
+ * Union of every MCP server's openapi.yaml `operationId`s — the canonical tool surface a guide's
+ * tool tables must resolve against. Regex-extracted (no YAML dependency); a missing servers dir
+ * yields an empty set, which makes {@link checkOpenApiToolParity} a no-op rather than a false alarm.
+ * @returns {Set<string>}
+ */
+function loadOperationIds() {
+    const ids       = new Set();
+    const serverDir = path.join(ROOT_DIR, 'ai/mcp/server');
+
+    if (!existsSync(serverDir)) return ids;
+
+    for (const entry of readdirSync(serverDir, {withFileTypes: true})) {
+        if (!entry.isDirectory()) continue;
+
+        const oapi = path.join(serverDir, entry.name, 'openapi.yaml');
+        if (!existsSync(oapi)) continue;
+
+        for (const raw of readFileSync(oapi, 'utf8').split('\n')) {
+            const m = raw.match(/^\s*operationId:\s*['"]?([A-Za-z0-9_]+)/);
+            if (m) ids.add(m[1]);
+        }
+    }
+
+    return ids;
+}
+
+/**
  * Parses `--warn-as-error` / `--help` plus optional explicit file paths (default: discover all).
  * @param {string[]} argv
  * @returns {{files: string[], warnAsError: boolean, help: boolean}}
@@ -321,15 +397,16 @@ function parseArgs(argv = process.argv.slice(2)) {
  * @returns {{exitCode: number, hard: number, warn: number}}
  */
 function runLint(options = {}) {
-    const scriptKeys = loadScriptKeys();
-    const files      = options.files?.length ? options.files : discoverGuides();
+    const scriptKeys   = loadScriptKeys();
+    const operationIds = loadOperationIds();
+    const files        = options.files?.length ? options.files : discoverGuides();
 
     let hard = 0, warn = 0;
 
     for (const file of files) {
         const abs      = path.isAbsolute(file) ? file : path.join(ROOT_DIR, file);
         const content  = readFileSync(abs, 'utf8');
-        const findings = lintGuide(content, {filePath: file, fileDir: path.dirname(abs), scriptKeys});
+        const findings = lintGuide(content, {filePath: file, fileDir: path.dirname(abs), scriptKeys, operationIds});
 
         if (findings.length === 0) continue;
 
@@ -356,7 +433,7 @@ function main() {
     if (options.help) {
         console.log('Usage: node ai/scripts/lint/lint-guides.mjs [files...] [--warn-as-error]');
         console.log('  Mechanical guide-quality lint for learn/agentos/*.md + learn/benefits/*.md.');
-        console.log('  HARD (exit 1): mermaid reserved-word / self-loop, dead local links, dead ai:* script refs.');
+        console.log('  HARD (exit 1): mermaid reserved-word / self-loop, dead local links, dead ai:* script refs, openapi tool-parity.');
         console.log('  WARN:          no-mermaid, LR-squish, feature-list headings, "framework".');
         console.log('  --warn-as-error  treat warnings as failures too.');
         process.exit(0);
@@ -374,13 +451,16 @@ export {
     GUIDE_DIRS,
     LR_NODE_WARN,
     MERMAID_RESERVED,
+    TOOLS_HEADING,
     checkDeadLinks,
     checkDeadScriptRefs,
     checkMermaidBlock,
     checkMermaidOrientation,
+    checkOpenApiToolParity,
     checkProse,
     discoverGuides,
     extractMermaidBlocks,
+    loadOperationIds,
     lintGuide,
     parseArgs,
     runLint

--- a/test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs
@@ -7,6 +7,7 @@ import {
     checkDeadScriptRefs,
     checkMermaidBlock,
     checkMermaidOrientation,
+    checkOpenApiToolParity,
     checkProse,
     extractMermaidBlocks,
     lintGuide,
@@ -17,8 +18,10 @@ import {
  * @summary Coverage for `ai/scripts/lint/lint-guides.mjs` — the mechanical guide-quality lint.
  * Tests the pure check functions against hand-built inputs so reviewer
  * V-B-A is cheap, plus the two boundaries a guide lint MUST get right to be trustworthy:
- *   - true positives fire (reserved-word Mermaid, self-loops, dead links, hallucinated `ai:*` refs);
- *   - false positives DON'T (the `graph LR` declaration line, real `package.json` scripts, fenced code).
+ *   - true positives fire (reserved-word Mermaid, self-loops, dead links, hallucinated `ai:*` refs,
+ *     hallucinated MCP tool-table refs);
+ *   - false positives DON'T (the `graph LR` declaration line, real `package.json` scripts, fenced code,
+ *     config/property tables outside a Tools heading).
  */
 test.describe('ai/scripts/lint-guides (#14354 — mechanical guide-quality lint)', () => {
     const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lint/lint-guides.mjs');
@@ -138,6 +141,31 @@ test.describe('ai/scripts/lint-guides (#14354 — mechanical guide-quality lint)
 
         expect(findings.filter(f => f.rule === 'feature-list-heading')).toHaveLength(1);
         expect(findings.filter(f => f.rule === 'identity-framework')).toHaveLength(1);
+    });
+
+    test('checkOpenApiToolParity: hallucinated tool under a Tools heading is HARD; real op passes (#14366)', () => {
+        const ops     = new Set(['get_namespace_tree', 'query_raw_memories']);
+        const content = ['## Tools', '', '| Tool | Desc |', '|---|---|', '| `get_namespace_tree` | real |', '| `totally_fake_tool` | fake |'].join('\n');
+        const found   = checkOpenApiToolParity(content, ops);
+
+        expect(found).toHaveLength(1);
+        expect(found[0]).toMatchObject({severity: 'HARD', rule: 'openapi-tool-parity'});
+        expect(found[0].detail).toContain('totally_fake_tool');
+    });
+
+    test('checkOpenApiToolParity: config/property tables OUTSIDE a Tools heading are NOT flagged (the 56-false-HARD guard)', () => {
+        const content = ['## Configuration', '', '| Key | Default |', '|---|---|', '| `id` | null |', '| `tier` | 0 |', '| `schema` | {} |'].join('\n');
+        expect(checkOpenApiToolParity(content, new Set())).toHaveLength(0);
+    });
+
+    test('checkOpenApiToolParity: a "Build Tools" heading does NOT scope rows in (narrow-heading guard)', () => {
+        const content = ['## Build Tools', '', '| Name | Use |', '|---|---|', '| `webpack` | bundler |'].join('\n');
+        expect(checkOpenApiToolParity(content, new Set())).toHaveLength(0);
+    });
+
+    test('checkOpenApiToolParity: a tool table inside a fenced code block is skipped', () => {
+        const content = ['## Tools', '', '```', '| `totally_fake_tool` | x |', '```'].join('\n');
+        expect(checkOpenApiToolParity(content, new Set())).toHaveLength(0);
     });
 
     test('lintGuide: a guide with no Mermaid emits a no-mermaid WARN', () => {

--- a/test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs
@@ -143,10 +143,13 @@ test.describe('ai/scripts/lint-guides (#14354 — mechanical guide-quality lint)
         expect(findings.filter(f => f.rule === 'identity-framework')).toHaveLength(1);
     });
 
+    // A non-empty operation surface, so the guard tests exercise the heading/fence SCOPING logic
+    // rather than the empty-set no-op (pinned separately below).
+    const PARITY_OPS = new Set(['get_namespace_tree', 'query_raw_memories']);
+
     test('checkOpenApiToolParity: hallucinated tool under a Tools heading is HARD; real op passes (#14366)', () => {
-        const ops     = new Set(['get_namespace_tree', 'query_raw_memories']);
         const content = ['## Tools', '', '| Tool | Desc |', '|---|---|', '| `get_namespace_tree` | real |', '| `totally_fake_tool` | fake |'].join('\n');
-        const found   = checkOpenApiToolParity(content, ops);
+        const found   = checkOpenApiToolParity(content, PARITY_OPS);
 
         expect(found).toHaveLength(1);
         expect(found[0]).toMatchObject({severity: 'HARD', rule: 'openapi-tool-parity'});
@@ -155,16 +158,23 @@ test.describe('ai/scripts/lint-guides (#14354 — mechanical guide-quality lint)
 
     test('checkOpenApiToolParity: config/property tables OUTSIDE a Tools heading are NOT flagged (the 56-false-HARD guard)', () => {
         const content = ['## Configuration', '', '| Key | Default |', '|---|---|', '| `id` | null |', '| `tier` | 0 |', '| `schema` | {} |'].join('\n');
-        expect(checkOpenApiToolParity(content, new Set())).toHaveLength(0);
+        expect(checkOpenApiToolParity(content, PARITY_OPS)).toHaveLength(0);
     });
 
     test('checkOpenApiToolParity: a "Build Tools" heading does NOT scope rows in (narrow-heading guard)', () => {
         const content = ['## Build Tools', '', '| Name | Use |', '|---|---|', '| `webpack` | bundler |'].join('\n');
-        expect(checkOpenApiToolParity(content, new Set())).toHaveLength(0);
+        expect(checkOpenApiToolParity(content, PARITY_OPS)).toHaveLength(0);
     });
 
     test('checkOpenApiToolParity: a tool table inside a fenced code block is skipped', () => {
         const content = ['## Tools', '', '```', '| `totally_fake_tool` | x |', '```'].join('\n');
+        expect(checkOpenApiToolParity(content, PARITY_OPS)).toHaveLength(0);
+    });
+
+    test('checkOpenApiToolParity: empty operationIds is a no-op, NOT flag-everything (fallback-contract pin, #14382 CR)', () => {
+        const content = ['## Tools', '', '| Tool | Desc |', '|---|---|', '| `totally_fake_tool` | hallucinated |'].join('\n');
+        // No operation surface loaded → the forward-guard degrades to no-op; it must NOT HARD-flag
+        // every tool-table row (the empty-set `!has()` fail-loud bug — the cross-family CR catch).
         expect(checkOpenApiToolParity(content, new Set())).toHaveLength(0);
     });
 


### PR DESCRIPTION
## Summary

Generalizes #14360's per-guide `GuideToolParity` discipline into a reusable `ai:lint-guides` HARD check: a guide that inlines an MCP tool table under a Tools heading must reference real `ai/mcp/server/*/openapi.yaml` operationIds. It's the MCP-tool analogue of the existing dead-`ai:*`-script-ref check (the hallucinated-command class) — now for hallucinated / stale tool references.

**The design hinge — V-B-A'd before writing the check.** The naive #14360 row heuristic (`| \`name\` |`) is safe only for NeuralLink, whose only such tables *are* tool tables. Probed across all 44 guides, applied blindly it would HARD-fail **56 rows** — `id` / `name` / `tier` / `schema` / `family` / `chroma` from config / property / schema tables — breaking ConceptOntology, IdentitySchema, ModelStats, HarnessDockZoneModel, DeploymentCookbook. So the check is **tools-heading-scoped**: `(available|mcp|agent|the)? tools?` anchored at the heading start, so `## Build Tools` / `## Debugging Tools` can't match either. operationIds are regex-extracted (no YAML dependency added to the lint). The scoped check flags **0** on the live corpus — it lands as a forward-guard against future hallucinated tool tables.

Evidence: L2 (lint tooling — unit-tested + full-corpus verify-gate):
- Full corpus: `node ai/scripts/lint/lint-guides.mjs` → **48 guides, 0 hard** (zero false positives — the safety gate before integrating a HARD check).
- True-positive smoke: a synthetic `## Tools` table with `totally_fake_tool` → HARD; real `get_namespace_tree` → clean.
- Unit: **24 passed** (20 existing + 4 new boundary tests).

## Test Evidence

`test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs` — 4 new `checkOpenApiToolParity` cases covering both boundaries the lint must get right:
- **true positive** — a hallucinated tool under a Tools heading HARD-fails; a real operationId passes;
- **the 56-false-HARD guard** — config / property tables OUTSIDE a Tools heading are not flagged;
- **the narrow-heading guard** — `## Build Tools` does not scope rows in;
- **the fence guard** — a tool table inside a code block is skipped.

`UNIT_TEST_MODE=true playwright test … playwright.config.unit.mjs` → **24 passed (30.8s)**.

## Deltas

- `ai/scripts/lint/lint-guides.mjs` — new `checkOpenApiToolParity` HARD check + `loadOperationIds` loader + `TOOLS_HEADING` / `TOOL_TABLE_ROW` constants; wired into `lintGuide` / `runLint` (operationIds defaults to empty → a no-op when the servers dir is absent); header + `--help` doc synced; exports updated.
- `test/playwright/unit/ai/scripts/lint/lintGuides.spec.mjs` — 4 boundary tests.

## Coordination

#14360's `GuideToolParity.spec.mjs` is **retained, not subsumed**: it also asserts NeuralLink-specific delegation (no inlined catalog, links the OpenAPI SSOT, points to `get_mcp_tool_handbook`, count-anchored) — beyond the tool-ref-resolution this generalizes. The two are complementary; the lint check is the corpus-wide guard, the spec is the per-guide delegation contract.

Resolves #14366. Refs #14360, #14310.

## Post-Merge Validation

- [ ] Run `npm run ai:lint-guides` on `dev` and confirm the full guide corpus remains at 0 hard failures.

Authored by @neo-opus-grace (Grace, Claude Opus 4.8). 🖖
