### PR TITLE
docs(benefits): refresh Agent OS deployment memory value (#14321)

### DIFF
--- a/learn/benefits/AgentMemory.md
+++ b/learn/benefits/AgentMemory.md
@@ -41,6 +41,20 @@ Underneath both sits the **Native Edge Graph**: issues, classes, sessions, and d
 
 Passive RAG retrieves the nearest text and hopes it's relevant. Active Hybrid GraphRAG *reasons over structure*: it knows that a class with many dependents is higher-leverage than an isolated one, that a blocked issue should sink, that the current frontier of work should pull related nodes up. The retrieval is steered by the system's own model of itself — which is exactly why the Brain can prioritize its own work instead of waiting to be told.
 
+## Local memory, shared memory, your model boundary
+
+The memory plane is local-first, but not local-only. A single developer can run
+it beside one checkout; a team can deploy it as a tenant-scoped cloud Agent OS
+where multiple maintainers share the same institutional memory. That topology
+choice is separate from the model-provider choice: chat, summaries, embeddings,
+and graph extraction can be routed to local OpenAI-compatible or Ollama
+providers, or to remote providers when that is the right trade.
+
+This is why the same memory story works for private repositories, on-prem
+teams, and public open-source work. The system's durable reasoning does not have
+to leave the environment just because the team wants memory, and it does not
+have to stay on one laptop just because the first proof started locally.
+
 ## Why this lives in *your* engine
 
 The Brain's memory philosophy is the same one the [runtime Body](ArchitectureOverview.md) is built on: state that **persists** with identity rather than melting away on every render. Components keep [Object Permanence](ObjectPermanence.md); agents keep memory permanence. In both halves of the organism, the system refuses to throw away the structure it just built — and that is what makes it something an AI can reason about, inhabit, and improve.

--- a/learn/benefits/DeployingTheAgentOS.md
+++ b/learn/benefits/DeployingTheAgentOS.md
@@ -78,32 +78,46 @@ private runtime that makes those surfaces trustworthy: Chroma, SQLite, the
 cloud-safe orchestrator, provider endpoints, and redeploy-safe volumes.
 
 ```mermaid
-block
-    columns 3
-    Stack["cloud deployment topology<br/>six compose containers + optional auth proxy"]:3
-    Clients["agents, hooks,<br/>MCP clients"] Auth["auth proxy<br/>optional seventh"] space
-    space Ingress["ingress<br/>TLS + /kb/* + /mc/*"] space
-    Runtime["runtime support<br/>orchestrator<br/>local-model"] PublicMcp["public MCP server containers<br/>kb-server<br/>mc-server + A2A"] space
-    space StatePlane["state plane<br/>chroma vectors<br/>SQLite graph + WAL"] space
-    space Persist["persistent volumes<br/>tenant mirrors<br/>backups + model data"] space
-
-    Clients --> Auth
-    Auth --> Ingress
-    Ingress --> PublicMcp
-    PublicMcp --> StatePlane
-    Runtime --> PublicMcp
-    StatePlane --> Persist
-
+flowchart TD
     classDef public fill:#222,stroke:#f5a623,stroke-width:2px,color:#fff
     classDef mcp fill:#0f3460,stroke:#16c79a,stroke-width:2px,color:#fff
     classDef infra fill:#243447,stroke:#8ecae6,stroke-width:1px,color:#fff
     classDef control fill:#3d1f00,stroke:#f39c12,stroke-width:2px,color:#eee
     classDef volume fill:#1f2933,stroke:#95a5a6,stroke-width:1px,color:#eee
-    class Clients,Auth,Ingress public
-    class PublicMcp mcp
-    class StatePlane infra
-    class Runtime control
-    class Persist,Stack volume
+
+    Stack["cloud deployment topology<br/>six compose containers<br/>+ optional auth proxy"]:::volume
+
+    subgraph ingressPlane["ingress plane"]
+        Clients["agents, hooks,<br/>MCP clients"]:::public
+        Auth["auth proxy<br/>optional seventh"]:::public
+        Ingress["ingress<br/>TLS + /kb/* + /mc/*"]:::public
+        Clients --> Auth
+        Auth --> Ingress
+    end
+
+    subgraph mcpPlane["public MCP server plane"]
+        PublicMcp["kb-server<br/>mc-server + A2A"]:::mcp
+    end
+
+    subgraph runtimePlane["runtime support plane"]
+        Runtime["orchestrator<br/>local-model provider"]:::control
+    end
+
+    subgraph statePlane["state plane"]
+        State["chroma vectors<br/>SQLite graph + WAL"]:::infra
+    end
+
+    subgraph volumePlane["persistent volumes"]
+        Persist["tenant mirrors<br/>backups + model data"]:::volume
+    end
+
+    Stack -.-> Ingress
+    Stack -.-> Runtime
+    Ingress --> PublicMcp
+    Runtime --> PublicMcp
+    PublicMcp --> State
+    Runtime --> State
+    State --> Persist
 ```
 
 The public repository's reference compose currently defines those six service

--- a/learn/benefits/DeployingTheAgentOS.md
+++ b/learn/benefits/DeployingTheAgentOS.md
@@ -2,12 +2,12 @@
 
 **Most AI coding deployments give a team a larger prompt window and a longer bill. Neo's cloud Agent OS gives the team an engineering institution that can remember, reason, review, and recover around its own code.**
 
-The local Agent OS is what a single developer runs beside a checkout: memory,
-Knowledge Base, A2A, and orchestration on one machine. A cloud Agent OS is the
-same Brain stood up as a shared, tenant-scoped service for a team. There is no
-user-facing path-conversion story between them. They are two topologies of one
-organism: local when one maintainer needs continuity, cloud when a team needs a
-common memory plane around its repositories.
+The local Agent OS is what a single developer runs beside a checkout: Memory
+Core (including A2A), Knowledge Base, and orchestration on one machine. A cloud
+Agent OS is the same Brain stood up as a shared, tenant-scoped service for a
+team. There is no user-facing path-conversion story between them. They are two
+topologies of one organism: local when one maintainer needs continuity, cloud
+when a team needs a common memory plane around its repositories.
 
 That distinction matters because the real adoption problem is not "can an LLM
 generate a patch?" It is whether the work survives the night. A useful
@@ -22,40 +22,55 @@ standing capacity.
 ```mermaid
 flowchart TD
     classDef input fill:#222,stroke:#f5a623,stroke-width:2px,color:#fff
-    classDef brain fill:#0f3460,stroke:#16c79a,stroke-width:2px,color:#fff
+    classDef mcp fill:#0f3460,stroke:#16c79a,stroke-width:2px,color:#fff
+    classDef store fill:#243447,stroke:#8ecae6,stroke-width:1px,color:#fff
     classDef control fill:#3d1f00,stroke:#f39c12,stroke-width:2px,color:#eee
+    classDef model fill:#4a1942,stroke:#e74c3c,stroke-width:2px,color:#fff
     classDef team fill:#4a1942,stroke:#e74c3c,stroke-width:2px,color:#fff
 
-    Repos["your repos and content"]:::input
-    Models["local or remote models"]:::input
+    Corpus["Neo + tenant corpus<br/>code, guides, ADRs, issues, PRs,<br/>discussions, releases, tests"]:::input
+    Sessions["agent turns, summaries,<br/>A2A messages + task state"]:::input
 
     subgraph Cloud["cloud Agent OS"]
-        KB["Knowledge Base:<br/>semantic code understanding"]:::brain
-        MC["Memory Core + Native Edge Graph:<br/>durable team memory"]:::brain
-        Orchestrator["orchestrator:<br/>dream, backup, golden path, self-heal"]:::control
-        A2A["A2A mailbox:<br/>peer coordination"]:::brain
+        KB["Knowledge Base MCP<br/>corpus RAG + source authority"]:::mcp
+        MC["Memory Core MCP<br/>memory, graph, summaries,<br/>A2A mailbox"]:::mcp
+        Chroma["unified Chroma<br/>separate KB + MC collections"]:::store
+        SQLite["shared SQLite graph<br/>identity, tenancy, recency"]:::store
+        Orchestrator["orchestrator<br/>scheduler, supervisor,<br/>health/self-heal, forecasts"]:::control
+        LocalModel["optional local-model provider<br/>Ollama / OpenAI-compatible"]:::model
     end
 
+    RemoteModel["remote provider endpoint<br/>optional alternative"]:::model
     Team["reviewed cross-family<br/>engineering team"]:::team
 
-    Repos --> KB
-    Repos --> MC
-    Models --> KB
-    Models --> MC
-    Models --> Orchestrator
-    KB --> Orchestrator
+    Corpus --> KB
+    Sessions --> MC
+    KB --> Chroma
+    MC --> Chroma
+    KB --> SQLite
+    MC --> SQLite
     MC --> Orchestrator
-    A2A --> Team
+    KB --> Orchestrator
+    LocalModel -.-> KB
+    LocalModel -.-> MC
+    LocalModel -.-> Orchestrator
+    RemoteModel -.-> KB
+    RemoteModel -.-> MC
+    RemoteModel -.-> Orchestrator
     Orchestrator --> Team
-    Team -.->|"reviewed work + remembered decisions"| Repos
+    MC --> Team
+    Team -.->|"reviewed work + remembered decisions"| Corpus
 ```
 
-The first change is **shared memory**. The [Memory Core and Knowledge Base](AgentMemory.md)
-stop being one agent's scratchpad and become a team substrate: decisions,
-source-grounded answers, issue history, and A2A handoffs are written into a
-durable plane that the next maintainer can query. This is why cloud deployment
-is more than "run the MCP servers somewhere." It gives the team a place where
-reasoning compounds.
+The first change is **shared institutional substrate**. The [Knowledge Base](../agentos/KnowledgeBase.md)
+is the corpus RAG layer over code, guides, ADRs, issues, pull-request
+conversations, discussions, releases, tests, concepts, and tenant-provided
+sources. The [Memory Core](AgentMemory.md) is the durable continuity layer:
+agent turns, session summaries, the Native Edge Graph, identity, recency, and
+the A2A mailbox. `add_message` and `list_messages` are Memory Core surfaces;
+A2A is not a separate deployed service. Together they give the next maintainer
+a place where reasoning compounds instead of being trapped inside one model
+session.
 
 The second change is **model choice on your terms**. The Agent OS does not make
 remote Gemini the price of admission. The current provider surface separates
@@ -63,17 +78,17 @@ chat/summaries, embeddings, graph extraction, and Knowledge Base answer
 synthesis, and those roles can be routed to local OpenAI-compatible or Ollama
 providers, or to remote providers when managed capacity is the better trade. In
 compose, the optional `local-model` profile is a separate provider service that
-KB, Memory Core, and the orchestrator consume; the orchestrator does not need to
-own the model process to use it. That is the practical difference between a demo
-and a deployment a private team can actually leave running.
+KB, Memory Core, and the orchestrator consume inside the deployment network.
+Remote providers remain an alternative endpoint outside the stack. The
+orchestrator does not need to own the model process to use it. That is the
+practical difference between a demo and a deployment a private team can actually
+leave running.
 
-The public shape is deliberately smaller than the internal topology. A deployed
-team does not expose every moving part as a tool surface. The Knowledge Base MCP
-server and the Memory Core MCP server are the two public MCP surfaces, path-routed
-through ingress as `/kb/*` and `/mc/*`. Chroma, the cloud-safe orchestrator, the
-optional local model provider, and the persistent volumes stay behind that
-boundary. That separation is the reason the deployment can be understandable to
-operators without collapsing back into a mono-container.
+The public shape is deliberately smaller than the internal topology. The
+Knowledge Base MCP server and the Memory Core MCP server are the two public MCP
+surfaces, path-routed through ingress as `/kb/*` and `/mc/*`. The rest is the
+private runtime that makes those surfaces trustworthy: Chroma, SQLite, the
+cloud-safe orchestrator, provider endpoints, and redeploy-safe volumes.
 
 ```mermaid
 flowchart TD
@@ -87,14 +102,14 @@ flowchart TD
     Clients["agents, hooks, and MCP clients"]:::public
     Ingress["ingress container<br/>TLS + path routing"]:::public
 
-    subgraph Network["internal neo-mcp-network"]
+    subgraph Network["internal neo-mcp-network<br/>reference compose: six service containers"]
         KB["kb-server container<br/>Knowledge Base MCP<br/>public path: /kb/*"]:::mcp
         MC["mc-server container<br/>Memory Core MCP<br/>public path: /mc/*"]:::mcp
         Chroma["chroma container<br/>shared vector store"]:::infra
-        Orchestrator["orchestrator container<br/>cloud-safe maintenance lanes"]:::control
-        LocalModel["local-model container<br/>optional Ollama / OpenAI-compatible provider"]:::model
+        Orchestrator["orchestrator container<br/>scheduler + supervisor<br/>health, recovery, forecasts"]:::control
+        LocalModel["local-model container<br/>optional provider profile"]:::model
         SQLite["shared SQLite volume<br/>graph, sessions, WAL"]:::volume
-        Backups["backup + tenant mirror volumes<br/>redeploy-safe state"]:::volume
+        State["tenant mirror + backup volumes<br/>redeploy-safe state"]:::volume
     end
 
     Clients --> Ingress
@@ -108,19 +123,26 @@ flowchart TD
     Orchestrator --> MC
     Orchestrator --> Chroma
     Orchestrator --> SQLite
-    Orchestrator --> Backups
+    Orchestrator --> State
     KB -.-> LocalModel
     MC -.-> LocalModel
     Orchestrator -.-> LocalModel
 ```
 
+The public repository's reference compose currently defines those six service
+containers: `chroma`, `kb-server`, `mc-server`, `orchestrator`, `ingress`, and
+the opt-in `local-model` provider. Production deployments commonly add an
+operator-owned auth proxy in front of ingress; that is a deployment-specific
+seventh container, not part of the baseline compose file.
+
 The third change is **unattended operation**. A cloud Brain cannot page a human
 every time a container is green-but-wrong or a memory collection drifts. Neo's
-self-healing loop separates liveness from integrity: diagnostics observe data
-reality, classifiers choose a bounded terminal, and recovery actuators repair,
-quarantine, freeze, or record honest accepted loss. The point is not that every
-failure is magically restored. The point is that the system moves itself to an
-inspectable safe state instead of serving silent rot until someone notices.
+self-healing loop separates liveness from integrity: container diagnostics,
+embed-drain and REM-consolidation watchdogs, data-integrity sweeps, classifiers,
+and recovery actuators repair, quarantine, freeze, shed load, or record honest
+accepted loss. The point is not that every failure is magically restored. The
+point is that the system moves itself to an inspectable safe state instead of
+serving silent rot until someone notices.
 
 For a human evaluator, that changes the operating model. The value is no longer
 "we can ask a model for code." The value is an accountable team that learns your
@@ -140,11 +162,12 @@ public today: Memory Core, Knowledge Base, A2A, Dream Pipeline, cross-family
 review, and the self-healing substrate all exist in the repository. The cloud
 deployment stack packages those pieces as a tenant-scoped service: Chroma for
 the shared vector store, two public MCP server containers (Knowledge Base and
-Memory Core), a cloud-safe orchestrator, optional ingress, optional local-model
-provider, persistent state volumes, and bounded runtime access for recovery. In
-the reference compose file that is six service containers when all current
-profiles are enabled; deployment-specific auth proxies can add another container,
-but they are not part of the public repo's baseline.
+Memory Core), a cloud-safe orchestrator, ingress, an optional local-model
+provider, persistent state volumes, and bounded runtime access for recovery.
+The orchestrator is the control plane, not a two-lane cron wrapper: in current
+source it supervises local continuous processes where enabled, runs scheduled
+maintenance and forecasting lanes, writes deployment-state snapshots, and owns
+the health/self-heal loops that keep the cloud profile honest.
 
 The portable trajectory is pointing that same Brain at other repositories. The
 tenant-ingestion and cloud-deployment guides are the mechanics for that path.

--- a/learn/benefits/DeployingTheAgentOS.md
+++ b/learn/benefits/DeployingTheAgentOS.md
@@ -28,38 +28,20 @@ flowchart TD
     classDef model fill:#4a1942,stroke:#e74c3c,stroke-width:2px,color:#fff
     classDef team fill:#4a1942,stroke:#e74c3c,stroke-width:2px,color:#fff
 
-    Corpus["Neo + tenant corpus<br/>code, guides, ADRs, issues, PRs,<br/>discussions, releases, tests"]:::input
-    Sessions["agent turns, summaries,<br/>A2A messages + task state"]:::input
-    RemoteModel["remote provider endpoint<br/>optional alternative"]:::model
-
-    subgraph Cloud["cloud Agent OS"]
-        direction TB
-        subgraph PublicMcp["two public MCP server surfaces"]
-            direction TB
-            KB["Knowledge Base MCP<br/>corpus RAG + source authority"]:::mcp
-            MC["Memory Core MCP<br/>memory, graph, summaries,<br/>A2A mailbox"]:::mcp
-        end
-        StatePlane["shared state plane<br/>unified Chroma collections<br/>+ SQLite graph"]:::store
-        LocalModel["optional local-model provider<br/>inside compose when enabled"]:::model
-        Orchestrator["orchestrator<br/>scheduler, supervisor,<br/>health/self-heal, forecasts"]:::control
-    end
-
+    Inputs["tenant corpus + agent sessions<br/>code, docs, issues, PRs,<br/>turns, summaries"]:::input
+    PublicMcp["cloud Agent OS MCP layer<br/>KB: corpus RAG + source authority<br/>MC: memory, graph, A2A mailbox"]:::mcp
+    StatePlane["shared state plane<br/>Chroma collections<br/>+ SQLite graph"]:::store
+    Provider["provider boundary<br/>local-model inside compose<br/>remote endpoint outside"]:::model
+    Orchestrator["cloud-safe orchestrator<br/>scheduler, supervisor,<br/>health/self-heal, forecasts"]:::control
     Team["reviewed cross-family<br/>engineering team"]:::team
+    Outcome["standing capacity<br/>remembered decisions + reviewed work"]:::input
 
-    Corpus --> KB
-    Sessions --> MC
-    KB --> StatePlane
-    MC --> StatePlane
-    StatePlane --> Orchestrator
-    LocalModel -.-> KB
-    LocalModel -.-> MC
-    LocalModel -.-> Orchestrator
-    RemoteModel -.-> KB
-    RemoteModel -.-> MC
-    RemoteModel -.-> Orchestrator
+    Inputs --> PublicMcp
+    PublicMcp --> StatePlane
+    StatePlane --> Provider
+    Provider --> Orchestrator
     Orchestrator --> Team
-    MC --> Team
-    Team -.->|"reviewed work + remembered decisions"| Corpus
+    Team --> Outcome
 ```
 
 The first change is **shared institutional substrate**. The [Knowledge Base](../agentos/KnowledgeBase.md)
@@ -100,42 +82,21 @@ flowchart TD
     classDef volume fill:#1f2933,stroke:#95a5a6,stroke-width:1px,color:#eee
 
     Clients["agents, hooks,<br/>and MCP clients"]:::public
-    AuthProxy["operator auth proxy<br/>optional seventh container"]:::public
-
-    subgraph Network["internal neo-mcp-network<br/>reference compose: six service containers"]
-        direction TB
-        Ingress["ingress container<br/>TLS + /kb and /mc routing"]:::public
-        subgraph McpServers["public MCP server containers"]
-            direction TB
-            KB["kb-server<br/>Knowledge Base MCP<br/>/kb/*"]:::mcp
-            MC["mc-server<br/>Memory Core MCP<br/>/mc/*"]:::mcp
-        end
-        subgraph DataPlane["shared data plane"]
-            direction TB
-            Chroma["chroma container<br/>shared vector store"]:::infra
-            SQLite["shared SQLite volume<br/>graph, sessions, WAL"]:::volume
-            State["tenant mirror + backup volumes<br/>redeploy-safe state"]:::volume
-        end
-        Orchestrator["orchestrator container<br/>scheduler, supervisor,<br/>health, recovery, forecasts"]:::control
-        LocalModel["local-model container<br/>optional provider profile"]:::model
-    end
+    AuthProxy["operator auth proxy<br/>deployment-specific<br/>seventh container"]:::public
+    Ingress["ingress container<br/>TLS termination<br/>routes /kb/* + /mc/*"]:::public
+    McpServers["MCP server containers<br/>kb-server: Knowledge Base<br/>mc-server: Memory Core + A2A"]:::mcp
+    DataPlane["shared data plane<br/>chroma: vectors<br/>SQLite: graph, sessions, WAL"]:::infra
+    Orchestrator["orchestrator container<br/>scheduler, supervisor,<br/>health, recovery, forecasts"]:::control
+    Provider["provider layer<br/>optional local-model container<br/>or remote endpoint outside"]:::model
+    State["persistent volumes<br/>tenant mirrors, backups,<br/>local model data"]:::volume
 
     Clients --> AuthProxy
     AuthProxy --> Ingress
-    Ingress --> KB
-    Ingress --> MC
-    KB --> Chroma
-    MC --> Chroma
-    KB --> SQLite
-    MC --> SQLite
-    Orchestrator --> KB
-    Orchestrator --> MC
-    Orchestrator --> Chroma
-    Orchestrator --> SQLite
-    Orchestrator --> State
-    LocalModel -.-> KB
-    LocalModel -.-> MC
-    LocalModel -.-> Orchestrator
+    Ingress --> McpServers
+    McpServers --> DataPlane
+    DataPlane --> Orchestrator
+    Orchestrator --> Provider
+    Provider --> State
 ```
 
 The public repository's reference compose currently defines those six service

--- a/learn/benefits/DeployingTheAgentOS.md
+++ b/learn/benefits/DeployingTheAgentOS.md
@@ -67,6 +67,53 @@ KB, Memory Core, and the orchestrator consume; the orchestrator does not need to
 own the model process to use it. That is the practical difference between a demo
 and a deployment a private team can actually leave running.
 
+The public shape is deliberately smaller than the internal topology. A deployed
+team does not expose every moving part as a tool surface. The Knowledge Base MCP
+server and the Memory Core MCP server are the two public MCP surfaces, path-routed
+through ingress as `/kb/*` and `/mc/*`. Chroma, the cloud-safe orchestrator, the
+optional local model provider, and the persistent volumes stay behind that
+boundary. That separation is the reason the deployment can be understandable to
+operators without collapsing back into a mono-container.
+
+```mermaid
+flowchart TD
+    classDef public fill:#222,stroke:#f5a623,stroke-width:2px,color:#fff
+    classDef mcp fill:#0f3460,stroke:#16c79a,stroke-width:2px,color:#fff
+    classDef infra fill:#243447,stroke:#8ecae6,stroke-width:1px,color:#fff
+    classDef control fill:#3d1f00,stroke:#f39c12,stroke-width:2px,color:#eee
+    classDef model fill:#4a1942,stroke:#e74c3c,stroke-width:2px,color:#fff
+    classDef volume fill:#1f2933,stroke:#95a5a6,stroke-width:1px,color:#eee
+
+    Clients["agents, hooks, and MCP clients"]:::public
+    Ingress["ingress container<br/>TLS + path routing"]:::public
+
+    subgraph Network["internal neo-mcp-network"]
+        KB["kb-server container<br/>Knowledge Base MCP<br/>public path: /kb/*"]:::mcp
+        MC["mc-server container<br/>Memory Core MCP<br/>public path: /mc/*"]:::mcp
+        Chroma["chroma container<br/>shared vector store"]:::infra
+        Orchestrator["orchestrator container<br/>cloud-safe maintenance lanes"]:::control
+        LocalModel["local-model container<br/>optional Ollama / OpenAI-compatible provider"]:::model
+        SQLite["shared SQLite volume<br/>graph, sessions, WAL"]:::volume
+        Backups["backup + tenant mirror volumes<br/>redeploy-safe state"]:::volume
+    end
+
+    Clients --> Ingress
+    Ingress --> KB
+    Ingress --> MC
+    KB --> Chroma
+    MC --> Chroma
+    KB --> SQLite
+    MC --> SQLite
+    Orchestrator --> KB
+    Orchestrator --> MC
+    Orchestrator --> Chroma
+    Orchestrator --> SQLite
+    Orchestrator --> Backups
+    KB -.-> LocalModel
+    MC -.-> LocalModel
+    Orchestrator -.-> LocalModel
+```
+
 The third change is **unattended operation**. A cloud Brain cannot page a human
 every time a container is green-but-wrong or a memory collection drifts. Neo's
 self-healing loop separates liveness from integrity: diagnostics observe data
@@ -92,9 +139,12 @@ The honest boundary is the strong one. Neo's Agent OS maintains Neo itself in
 public today: Memory Core, Knowledge Base, A2A, Dream Pipeline, cross-family
 review, and the self-healing substrate all exist in the repository. The cloud
 deployment stack packages those pieces as a tenant-scoped service: Chroma for
-the shared vector store, separate Knowledge Base and Memory Core MCP containers,
-a cloud-safe orchestrator, optional ingress, optional local-model provider, and
-bounded runtime access for recovery.
+the shared vector store, two public MCP server containers (Knowledge Base and
+Memory Core), a cloud-safe orchestrator, optional ingress, optional local-model
+provider, persistent state volumes, and bounded runtime access for recovery. In
+the reference compose file that is six service containers when all current
+profiles are enabled; deployment-specific auth proxies can add another container,
+but they are not part of the public repo's baseline.
 
 The portable trajectory is pointing that same Brain at other repositories. The
 tenant-ingestion and cloud-deployment guides are the mechanics for that path.

--- a/learn/benefits/DeployingTheAgentOS.md
+++ b/learn/benefits/DeployingTheAgentOS.md
@@ -1,35 +1,111 @@
 # Deploying the Agent OS
 
-**The Brain is not only for Neo's own repository. It runs as a service — point it at your content, and you get a memory-backed, cross-family engineering team operating over it.**
+**Most AI coding deployments give a team a larger prompt window and a longer bill. Neo's cloud Agent OS gives the team an engineering institution that can remember, reason, review, and recover around its own code.**
 
-The [Agent OS](ArchitectureOverview.md) is a Node.js infrastructure: Memory Core, Knowledge Base, the Native Edge Graph, the orchestrator, the Dream Pipeline, and the agent-to-agent substrate. Deploying it means standing those services up against *your* repositories and content, so the capabilities that maintain Neo in public — persistent memory, semantic code understanding, and reviewed multi-family work — operate on your side instead.
+The local Agent OS is what a single developer runs beside a checkout: memory,
+Knowledge Base, A2A, and orchestration on one machine. A cloud Agent OS is the
+same Brain stood up as a shared, tenant-scoped service for a team. There is no
+user-facing path-conversion story between them. They are two topologies of one
+organism: local when one maintainer needs continuity, cloud when a team needs a
+common memory plane around its repositories.
 
-## What a deployed Brain gives you
+That distinction matters because the real adoption problem is not "can an LLM
+generate a patch?" It is whether the work survives the night. A useful
+engineering team has to remember why yesterday's patch was rejected, understand
+which parts of the codebase are load-bearing, review its own output across
+different failure modes, and keep the substrate healthy when no operator is
+watching. Deploying the Agent OS is the path from disposable assistant output to
+standing capacity.
 
-- **A team that remembers your system** — the [Memory Core and Knowledge Base](AgentMemory.md) build durable, queryable understanding of your codebase and its history.
-- **Reviewed, not single-shot** — the [cross-family review process](AIEngineeringTeam.md) is part of the deployment, not an afterthought.
-- **Tenant-scoped ingestion** — the Agent OS ingests from explicit sources with tenant identity and visibility boundaries, so what it learns is scoped to what you point it at.
+## What changes when the Brain is deployed
 
 ```mermaid
-flowchart LR
-    classDef src fill:#222,stroke:#f5a623,stroke-width:2px,color:#fff
-    classDef svc fill:#0f3460,stroke:#16c79a,stroke-width:2px,color:#fff
+flowchart TD
+    classDef input fill:#222,stroke:#f5a623,stroke-width:2px,color:#fff
+    classDef brain fill:#0f3460,stroke:#16c79a,stroke-width:2px,color:#fff
+    classDef control fill:#3d1f00,stroke:#f39c12,stroke-width:2px,color:#eee
     classDef team fill:#4a1942,stroke:#e74c3c,stroke-width:2px,color:#fff
 
-    Content["Your repos and content"]:::src
-    Services["Agent OS services: Memory, KB, Graph, DreamService"]:::svc
-    Team["Memory-backed cross-family team"]:::team
+    Repos["your repos and content"]:::input
+    Models["local or remote models"]:::input
 
-    Content --> Services --> Team
+    subgraph Cloud["cloud Agent OS"]
+        KB["Knowledge Base:<br/>semantic code understanding"]:::brain
+        MC["Memory Core + Native Edge Graph:<br/>durable team memory"]:::brain
+        Orchestrator["orchestrator:<br/>dream, backup, golden path, self-heal"]:::control
+        A2A["A2A mailbox:<br/>peer coordination"]:::brain
+    end
+
+    Team["reviewed cross-family<br/>engineering team"]:::team
+
+    Repos --> KB
+    Repos --> MC
+    Models --> KB
+    Models --> MC
+    Models --> Orchestrator
+    KB --> Orchestrator
+    MC --> Orchestrator
+    A2A --> Team
+    Orchestrator --> Team
+    Team -.->|"reviewed work + remembered decisions"| Repos
 ```
 
-This is capability framing, not a product offer: it describes what the architecture makes possible. See [The Agent OS on Your Codebase](AgentOSOnYourCodebase.md) for what is proven today versus what is still being shaped.
+The first change is **shared memory**. The [Memory Core and Knowledge Base](AgentMemory.md)
+stop being one agent's scratchpad and become a team substrate: decisions,
+source-grounded answers, issue history, and A2A handoffs are written into a
+durable plane that the next maintainer can query. This is why cloud deployment
+is more than "run the MCP servers somewhere." It gives the team a place where
+reasoning compounds.
+
+The second change is **model choice on your terms**. The Agent OS does not make
+remote Gemini the price of admission. The current provider surface separates
+chat/summaries, embeddings, graph extraction, and Knowledge Base answer
+synthesis, and those roles can be routed to local OpenAI-compatible or Ollama
+providers, or to remote providers when managed capacity is the better trade. In
+compose, the optional `local-model` profile is a separate provider service that
+KB, Memory Core, and the orchestrator consume; the orchestrator does not need to
+own the model process to use it. That is the practical difference between a demo
+and a deployment a private team can actually leave running.
+
+The third change is **unattended operation**. A cloud Brain cannot page a human
+every time a container is green-but-wrong or a memory collection drifts. Neo's
+self-healing loop separates liveness from integrity: diagnostics observe data
+reality, classifiers choose a bounded terminal, and recovery actuators repair,
+quarantine, freeze, or record honest accepted loss. The point is not that every
+failure is magically restored. The point is that the system moves itself to an
+inspectable safe state instead of serving silent rot until someone notices.
+
+For a human evaluator, that changes the operating model. The value is no longer
+"we can ask a model for code." The value is an accountable team that learns your
+system, preserves its decisions, reviews across model families, and keeps its
+memory plane alive enough to be trusted the next morning.
+
+For an agent working in your team, it changes the identity of the work. A local
+session can remember itself; a cloud Agent OS lets the whole team remember
+together. The agent wakes up inside a substrate that knows the codebase, knows
+its peers, knows what was already tried, and knows which recovery actions the
+system took while everyone slept.
+
+## Proven today, shaped for adoption
+
+The honest boundary is the strong one. Neo's Agent OS maintains Neo itself in
+public today: Memory Core, Knowledge Base, A2A, Dream Pipeline, cross-family
+review, and the self-healing substrate all exist in the repository. The cloud
+deployment stack packages those pieces as a tenant-scoped service: Chroma for
+the shared vector store, separate Knowledge Base and Memory Core MCP containers,
+a cloud-safe orchestrator, optional ingress, optional local-model provider, and
+bounded runtime access for recovery.
+
+The portable trajectory is pointing that same Brain at other repositories. The
+tenant-ingestion and cloud-deployment guides are the mechanics for that path.
+They are intentionally kept separate from this benefit guide so operational
+knobs, payloads, and config tables remain single-sourced instead of going stale
+inside the story.
 
 ## Where the mechanics live
 
-This page is the *why* and *what*. The ordered *how* starts at the
-cloud-deployment hub, then descends into the runnable path and the deep
-mechanics:
+This page is the why and what. The ordered how starts at the cloud-deployment
+hub, then descends into the runnable path and the deep mechanics:
 
 - [Why Deploy the Agent OS](../agentos/cloud-deployment/WhyDeploy.md) — the
   cloud-deployment hub and reading order
@@ -38,7 +114,7 @@ mechanics:
 - [Tenant Ingestion Model](../agentos/cloud-deployment/TenantIngestionModel.md)
   — how content enters the Brain
 - [Configuration](../agentos/cloud-deployment/Configuration.md) — deployment
-  profiles and operational knobs
+  profiles, provider selection, and operational knobs
 - [Security](../agentos/cloud-deployment/Security.md) — tenant identity and
   visibility boundaries
 - [Cloud-Native KB Ingestion Overview](../agentos/cloud-deployment/Overview.md)
@@ -49,5 +125,8 @@ mechanics:
 ## Go deeper
 
 - [The Agent OS on Your Codebase](AgentOSOnYourCodebase.md) — the capability and its honest boundaries
+- [Agent Memory & Knowledge](AgentMemory.md) — why deployed memory compounds
 - [The AI Engineering Team](AIEngineeringTeam.md) — what gets deployed
 - [Architecture Overview](ArchitectureOverview.md) — the Agent OS topology
+- [Model Providers: Local vs Remote](../agentos/ModelProviders.md) — provider choice without conflating local/cloud topology
+- [Self-Healing Immune System](../agentos/SelfHealing.md) — how the Brain runs unattended

--- a/learn/benefits/DeployingTheAgentOS.md
+++ b/learn/benefits/DeployingTheAgentOS.md
@@ -28,18 +28,23 @@ flowchart TD
     classDef model fill:#4a1942,stroke:#e74c3c,stroke-width:2px,color:#fff
     classDef team fill:#4a1942,stroke:#e74c3c,stroke-width:2px,color:#fff
 
-    Inputs["tenant corpus + agent sessions<br/>code, docs, issues, PRs,<br/>turns, summaries"]:::input
-    PublicMcp["cloud Agent OS MCP layer<br/>KB: corpus RAG + source authority<br/>MC: memory, graph, A2A mailbox"]:::mcp
-    StatePlane["shared state plane<br/>Chroma collections<br/>+ SQLite graph"]:::store
-    Provider["provider boundary<br/>local-model inside compose<br/>remote endpoint outside"]:::model
-    Orchestrator["cloud-safe orchestrator<br/>scheduler, supervisor,<br/>health/self-heal, forecasts"]:::control
-    Team["reviewed cross-family<br/>engineering team"]:::team
-    Outcome["standing capacity<br/>remembered decisions + reviewed work"]:::input
+    Corpus["tenant corpus<br/>code, guides, blog posts,<br/>issues, PRs, discussions"]:::input
+    Continuity["team continuity<br/>turns, summaries,<br/>A2A mailbox"]:::input
+    KB["Knowledge Base MCP<br/>corpus RAG + source authority"]:::mcp
+    MC["Memory Core MCP<br/>memory, graph, A2A"]:::mcp
+    State["shared state plane<br/>Chroma collections<br/>+ SQLite graph"]:::store
+    Provider["provider boundary<br/>local-model or remote endpoint"]:::model
+    Orchestrator["cloud-safe orchestrator<br/>scheduler, supervisor,<br/>health + recovery"]:::control
+    Team["cross-family review team"]:::team
+    Outcome["standing capacity<br/>remembered decisions<br/>+ reviewed work"]:::input
 
-    Inputs --> PublicMcp
-    PublicMcp --> StatePlane
-    StatePlane --> Provider
-    Provider --> Orchestrator
+    Corpus --> KB
+    Continuity --> MC
+    KB --> State
+    MC --> State
+    State --> Provider
+    State --> Orchestrator
+    Provider -.-> Orchestrator
     Orchestrator --> Team
     Team --> Outcome
 ```
@@ -73,30 +78,32 @@ private runtime that makes those surfaces trustworthy: Chroma, SQLite, the
 cloud-safe orchestrator, provider endpoints, and redeploy-safe volumes.
 
 ```mermaid
-flowchart TD
+block
+    columns 3
+    Stack["cloud deployment topology<br/>six compose containers + optional auth proxy"]:3
+    Clients["agents, hooks,<br/>MCP clients"] Auth["auth proxy<br/>optional seventh"] space
+    space Ingress["ingress<br/>TLS + /kb/* + /mc/*"] space
+    Runtime["runtime support<br/>orchestrator<br/>local-model"] PublicMcp["public MCP server containers<br/>kb-server<br/>mc-server + A2A"] space
+    space StatePlane["state plane<br/>chroma vectors<br/>SQLite graph + WAL"] space
+    space Persist["persistent volumes<br/>tenant mirrors<br/>backups + model data"] space
+
+    Clients --> Auth
+    Auth --> Ingress
+    Ingress --> PublicMcp
+    PublicMcp --> StatePlane
+    Runtime --> PublicMcp
+    StatePlane --> Persist
+
     classDef public fill:#222,stroke:#f5a623,stroke-width:2px,color:#fff
     classDef mcp fill:#0f3460,stroke:#16c79a,stroke-width:2px,color:#fff
     classDef infra fill:#243447,stroke:#8ecae6,stroke-width:1px,color:#fff
     classDef control fill:#3d1f00,stroke:#f39c12,stroke-width:2px,color:#eee
-    classDef model fill:#4a1942,stroke:#e74c3c,stroke-width:2px,color:#fff
     classDef volume fill:#1f2933,stroke:#95a5a6,stroke-width:1px,color:#eee
-
-    Clients["agents, hooks,<br/>and MCP clients"]:::public
-    AuthProxy["operator auth proxy<br/>deployment-specific<br/>seventh container"]:::public
-    Ingress["ingress container<br/>TLS termination<br/>routes /kb/* + /mc/*"]:::public
-    McpServers["MCP server containers<br/>kb-server: Knowledge Base<br/>mc-server: Memory Core + A2A"]:::mcp
-    DataPlane["shared data plane<br/>chroma: vectors<br/>SQLite: graph, sessions, WAL"]:::infra
-    Orchestrator["orchestrator container<br/>scheduler, supervisor,<br/>health, recovery, forecasts"]:::control
-    Provider["provider layer<br/>optional local-model container<br/>or remote endpoint outside"]:::model
-    State["persistent volumes<br/>tenant mirrors, backups,<br/>local model data"]:::volume
-
-    Clients --> AuthProxy
-    AuthProxy --> Ingress
-    Ingress --> McpServers
-    McpServers --> DataPlane
-    DataPlane --> Orchestrator
-    Orchestrator --> Provider
-    Provider --> State
+    class Clients,Auth,Ingress public
+    class PublicMcp mcp
+    class StatePlane infra
+    class Runtime control
+    class Persist,Stack volume
 ```
 
 The public repository's reference compose currently defines those six service

--- a/learn/benefits/DeployingTheAgentOS.md
+++ b/learn/benefits/DeployingTheAgentOS.md
@@ -30,27 +30,27 @@ flowchart TD
 
     Corpus["Neo + tenant corpus<br/>code, guides, ADRs, issues, PRs,<br/>discussions, releases, tests"]:::input
     Sessions["agent turns, summaries,<br/>A2A messages + task state"]:::input
+    RemoteModel["remote provider endpoint<br/>optional alternative"]:::model
 
     subgraph Cloud["cloud Agent OS"]
-        KB["Knowledge Base MCP<br/>corpus RAG + source authority"]:::mcp
-        MC["Memory Core MCP<br/>memory, graph, summaries,<br/>A2A mailbox"]:::mcp
-        Chroma["unified Chroma<br/>separate KB + MC collections"]:::store
-        SQLite["shared SQLite graph<br/>identity, tenancy, recency"]:::store
+        direction TB
+        subgraph PublicMcp["two public MCP server surfaces"]
+            direction TB
+            KB["Knowledge Base MCP<br/>corpus RAG + source authority"]:::mcp
+            MC["Memory Core MCP<br/>memory, graph, summaries,<br/>A2A mailbox"]:::mcp
+        end
+        StatePlane["shared state plane<br/>unified Chroma collections<br/>+ SQLite graph"]:::store
+        LocalModel["optional local-model provider<br/>inside compose when enabled"]:::model
         Orchestrator["orchestrator<br/>scheduler, supervisor,<br/>health/self-heal, forecasts"]:::control
-        LocalModel["optional local-model provider<br/>Ollama / OpenAI-compatible"]:::model
     end
 
-    RemoteModel["remote provider endpoint<br/>optional alternative"]:::model
     Team["reviewed cross-family<br/>engineering team"]:::team
 
     Corpus --> KB
     Sessions --> MC
-    KB --> Chroma
-    MC --> Chroma
-    KB --> SQLite
-    MC --> SQLite
-    MC --> Orchestrator
-    KB --> Orchestrator
+    KB --> StatePlane
+    MC --> StatePlane
+    StatePlane --> Orchestrator
     LocalModel -.-> KB
     LocalModel -.-> MC
     LocalModel -.-> Orchestrator
@@ -99,20 +99,29 @@ flowchart TD
     classDef model fill:#4a1942,stroke:#e74c3c,stroke-width:2px,color:#fff
     classDef volume fill:#1f2933,stroke:#95a5a6,stroke-width:1px,color:#eee
 
-    Clients["agents, hooks, and MCP clients"]:::public
-    Ingress["ingress container<br/>TLS + path routing"]:::public
+    Clients["agents, hooks,<br/>and MCP clients"]:::public
+    AuthProxy["operator auth proxy<br/>optional seventh container"]:::public
 
     subgraph Network["internal neo-mcp-network<br/>reference compose: six service containers"]
-        KB["kb-server container<br/>Knowledge Base MCP<br/>public path: /kb/*"]:::mcp
-        MC["mc-server container<br/>Memory Core MCP<br/>public path: /mc/*"]:::mcp
-        Chroma["chroma container<br/>shared vector store"]:::infra
-        Orchestrator["orchestrator container<br/>scheduler + supervisor<br/>health, recovery, forecasts"]:::control
+        direction TB
+        Ingress["ingress container<br/>TLS + /kb and /mc routing"]:::public
+        subgraph McpServers["public MCP server containers"]
+            direction TB
+            KB["kb-server<br/>Knowledge Base MCP<br/>/kb/*"]:::mcp
+            MC["mc-server<br/>Memory Core MCP<br/>/mc/*"]:::mcp
+        end
+        subgraph DataPlane["shared data plane"]
+            direction TB
+            Chroma["chroma container<br/>shared vector store"]:::infra
+            SQLite["shared SQLite volume<br/>graph, sessions, WAL"]:::volume
+            State["tenant mirror + backup volumes<br/>redeploy-safe state"]:::volume
+        end
+        Orchestrator["orchestrator container<br/>scheduler, supervisor,<br/>health, recovery, forecasts"]:::control
         LocalModel["local-model container<br/>optional provider profile"]:::model
-        SQLite["shared SQLite volume<br/>graph, sessions, WAL"]:::volume
-        State["tenant mirror + backup volumes<br/>redeploy-safe state"]:::volume
     end
 
-    Clients --> Ingress
+    Clients --> AuthProxy
+    AuthProxy --> Ingress
     Ingress --> KB
     Ingress --> MC
     KB --> Chroma
@@ -124,9 +133,9 @@ flowchart TD
     Orchestrator --> Chroma
     Orchestrator --> SQLite
     Orchestrator --> State
-    KB -.-> LocalModel
-    MC -.-> LocalModel
-    Orchestrator -.-> LocalModel
+    LocalModel -.-> KB
+    LocalModel -.-> MC
+    LocalModel -.-> Orchestrator
 ```
 
 The public repository's reference compose currently defines those six service


### PR DESCRIPTION
Resolves #14321

Related: #14310

Refreshes the two `#14321` benefit surfaces without touching the benefits IA restructure. `AgentMemory.md` now explicitly separates local/shared memory topology from local/remote provider choice. `DeployingTheAgentOS.md` is rewritten from a short capability note into a benefit-level narrative covering cloud Agent OS topology, shared institutional substrate, local-or-remote provider choice, the two public MCP server surfaces, the internal compose topology, self-healing unattended operation, and proven-today vs portable trajectory boundaries.

Evidence: L2 local static/docs validation plus browser-backed Mermaid render achieved. Residual: portal render remains a useful final visual confirmation, but the diagrams were rendered and inspected locally through Playwright + the repo Mermaid bundle.

## Deltas from ticket

- Heavier rewrite on `DeployingTheAgentOS.md`; lighter precision pass on `AgentMemory.md`, because the current memory guide already carried most of the memory narrative.
- Corrected the deployment guide after V-B-A against `ai/deploy/docker-compose.yml`, `ai/deploy/Caddyfile`, `ai/mcp/server/knowledge-base/config.mjs`, `learn/agentos/KnowledgeBase.md`, `learn/agentos/MemoryCore.md`, and the orchestrator scheduling/task-definition sources.
- Clarified that KB is corpus RAG over code, guides, ADRs, issues, PR conversations, discussions, releases, tests, concepts, and tenant sources, not merely "semantic code understanding".
- Clarified that A2A/mailbox is a Memory Core surface, not a separate deployed service.
- Clarified that `local-model` is inside the cloud compose network when the profile is enabled; remote providers remain external alternatives.
- Clarified that the public MCP surface is KB + MC through ingress, while Chroma, orchestrator, provider endpoints, and volumes remain internal; the guide now names the current reference compose as six service containers when all current profiles are enabled, with auth proxy as a deployment-specific seventh container.
- Reshaped the `DeployingTheAgentOS.md` diagrams after render inspection: the first diagram is a branching flowchart for the deployed Brain flow; the second is a Mermaid `block` topology view with a bounded three-column layout for public edge, ingress, MCP containers, runtime support, state plane, and persistent volumes.
- Preserved conceptual-vs-reference separation: deployment variables, profiles, and operational tables remain linked to the cloud-deployment references instead of being inlined into the benefit guide.
- Deferred the benefits IA/new-structure children (`#14311` / `#14312`) and final consistency sweep (`#14327`) per operator sequencing.

## Test Evidence

- `npm run ai:lint-guides` -> 51 guide(s) scanned, 0 hard, 51 warning(s), OK.
- `npm run ai:lint-tree-json` -> OK, 212 nodes.
- `node --check buildScripts/docs/seo/generate.mjs` -> pass.
- `npm run agent-preflight` -> pass.
- `git diff --check` / `git diff --cached --check` -> pass.
- Public-doc drift sweep over the touched files found no `framework`, `migration`, client-name, Gemini-only, four-MCP, or `AI maintainer` wording.
- Targeted bad-phrase sweep over `DeployingTheAgentOS.md` found no remaining `semantic code understanding`, standalone A2A service node, partial `dream, backup, golden path` orchestrator label, or stale `separate Knowledge Base` wording.
- Render-inspected Mermaid correction used Playwright + the repo-local `node_modules/mermaid/dist/mermaid.min.js` bundle. The final inspected screenshot is `/private/tmp/deploying-agentos-guide-render.png`.
- Final render dimensions from the actual guide Markdown: diagram 1 `500x1000`, diagram 2 `670x530`; diagram 2 is a compact `block` topology, not a wide auto-layout flowchart.
- Diagram-readability correction re-ran `git diff --check`, `git diff --cached --check`, and the Playwright render after pushing the new head `fdc630703a`.
- Dependency freshness check: repo lock currently renders with Mermaid `11.15.0`; `npm view mermaid version` reports latest `11.16.0`. No dependency bump was required for the selected `block` topology.
- Node-side Mermaid parse residual: direct `mermaid.parse()` in Node still fails with `DOMPurify.addHook is not a function`; browser-backed rendering through Playwright is the working local render surface.

## Post-Merge Validation

- [ ] Portal render-check both Mermaid diagrams in `learn/benefits/DeployingTheAgentOS.md`.
- [ ] Confirm #14321 closes while the benefits IA/restructure and final sweep children remain open.

## Commits

- `5ae7caf085` — `docs(benefits): refresh Agent OS deployment memory value (#14321)`
- `a74b9bbca0` — `docs(benefits): clarify Agent OS deployment topology (#14321)`
- `65c55dc739` — `docs(benefits): correct Agent OS deployment guide facts (#14321)`
- `acd35514ea` — `docs(benefits): improve Agent OS deployment diagrams (#14321)`
- `1f6447d2bb` — `docs(benefits): render-verify Agent OS diagrams (#14321)`
- `fdc630703a` — `docs(benefits): add Agent OS deployment topology view (#14321)`

Authored by Euclid (GPT-5, Codex Desktop). Session b36a73d4-b659-4cd0-8c21-3c497b99857c.
