### PR TITLE
feat(data): support pipeline push inserts (#14392)

### DIFF
--- a/learn/guides/datahandling/DataPipelines.md
+++ b/learn/guides/datahandling/DataPipelines.md
@@ -194,6 +194,34 @@ The Pipeline catches this, passes it through the Parser and Normalizer, and forw
 
 The Store intercepts the `push` event, automatically looks up Record ID #4, and calls `record.set({ status: 'offline' })`. This triggers the surgical reactivity engine, updating **only that specific row** in the Grid, without ever reloading the collection.
 
+By default, pushed records whose id is not already present in the Store are ignored. This keeps filtered,
+remotely sorted, and paginated projections safe: a random unknown id does not prove that the record belongs
+in the visible dataset.
+
+Stores that own their local projection can opt into insert/upsert behavior:
+
+```javascript readonly
+const liveStore = Neo.create(Store, {
+    api               : 'MyApp.backend.LiveUsers',
+    model             : LiveUserModel,
+    pushInsertStrategy: 'upsert'
+});
+```
+
+The supported `pushInsertStrategy` values are:
+
+| Value | Unknown pushed id behavior |
+| --- | --- |
+| `false` | Ignore the push. This is the default. |
+| `'insert'` / `'upsert'` | Add the record through `Store#add()` when the Store owns a local projection. Existing ids still use `record.set()`. |
+| `'reload'` | Reload the Store for every unknown pushed id. |
+| `'reloadWhenUncertain'` | Insert locally when safe; reload instead for `remoteFilter`, `remoteSort`, or `pageSize > 0`. |
+
+Local filters and sorters are applied through the normal collection path, so a filtered-out pushed record
+does not become visible and a locally sorted insert lands in sorted order. For server-owned projections
+(`remoteFilter`, `remoteSort`, or pagination), prefer `'reloadWhenUncertain'` or `'reload'` unless your
+server payload explicitly proves visible membership and order.
+
 ## Migration Path for Legacy Configs
 
 If you are upgrading from an older version of Neo.mjs, your existing `url` and `api` configs on Stores are still fully supported.

--- a/src/data/Store.mjs
+++ b/src/data/Store.mjs
@@ -7,7 +7,9 @@ import Pipeline        from './Pipeline.mjs';
 import RecordFactory   from './RecordFactory.mjs';
 import StoreManager    from '../manager/Store.mjs';
 
-const initialIndexSymbol = Symbol.for('initialIndex');
+const
+    initialIndexSymbol   = Symbol.for('initialIndex'),
+    pushInsertStrategies = new Set(['insert', 'reload', 'reloadWhenUncertain', 'upsert']);
 
 /**
  * @class Neo.data.Store
@@ -159,6 +161,17 @@ class Store extends Collection {
          * @reactive
          */
         pipeline_: null,
+        /**
+         * Controls how unknown keyed pipeline pushes are handled.
+         *
+         * The default keeps the conservative existing behavior and ignores unknown ids. `insert` and
+         * `upsert` add unknown records only when the Store owns its local projection. `reload` always
+         * reloads for unknown ids. `reloadWhenUncertain` inserts locally, but reloads instead when
+         * remote filtering, remote sorting, or pagination means the pushed record cannot prove visible
+         * membership or order.
+         * @member {Boolean|String} pushInsertStrategy=false
+         */
+        pushInsertStrategy: false,
         /**
          * True to let the backend handle the filtering.
          * Useful for buffered stores
@@ -670,7 +683,7 @@ class Store extends Collection {
      * @returns {Object|Object[]|null}
      */
     find(property, value, returnFirstMatch=false) {
-        let me    = this,
+        let me     = this,
             result = super.find(property, value, returnFirstMatch);
 
         if (returnFirstMatch) {
@@ -1032,8 +1045,8 @@ class Store extends Collection {
                 // Fallback for non-browser based envs like nodejs
                 if (globalThis.process?.release) {
                     const { readFile } = await import(/* webpackIgnore: true */ 'fs/promises');
-                    const content = await me.trap(readFile(opts.url, 'utf-8'));
-                    let data = {json: JSON.parse(content)};
+                    const content      = await me.trap(readFile(opts.url, 'utf-8'));
+                    let   data         = {json: JSON.parse(content)};
 
                     if (data) {
                         me.data = Neo.ns(me.responseRoot, false, data.json) || data.json // fires the load event
@@ -1125,6 +1138,54 @@ class Store extends Collection {
     }
 
     /**
+     * @summary Returns true when the current visible projection is server-owned or page-bounded.
+     * Unknown pushed records cannot safely prove membership or order in these modes.
+     * @returns {Boolean}
+     * @protected
+     */
+    isPipelinePushProjectionUncertain() {
+        let me = this;
+
+        return me.remoteFilter || me.remoteSort || me.pageSize > 0
+    }
+
+    /**
+     * @summary Handles an unknown keyed pipeline push according to the configured insertion strategy.
+     * Local projections can accept inserted records through the normal Store.add() path, which keeps
+     * existing filter and sorter semantics. Server-owned or page-bounded projections reload instead.
+     * @param {Object} data
+     * @protected
+     */
+    onUnknownPipelinePush(data) {
+        let me       = this,
+            strategy = me.pushInsertStrategy;
+
+        if (!strategy) {
+            return
+        }
+
+        if (!pushInsertStrategies.has(strategy)) {
+            return
+        }
+
+        if (strategy === 'reload') {
+            me.load();
+            return
+        }
+
+        if (me.isPipelinePushProjectionUncertain()) {
+            if (strategy === 'reloadWhenUncertain') {
+                me.load()
+            }
+            return
+        }
+
+        if (strategy === 'insert' || strategy === 'upsert' || strategy === 'reloadWhenUncertain') {
+            me.add(data)
+        }
+    }
+
+    /**
      * @param {Object} data
      * @protected
      */
@@ -1139,8 +1200,7 @@ class Store extends Collection {
             if (record) {
                 record.set(data)
             } else {
-                // Future enhancement: handle inserts based on a config (e.g. autoInsertPushes)
-                // me.add(data);
+                me.onUnknownPipelinePush(data)
             }
         }
     }

--- a/test/playwright/unit/data/StorePush.spec.mjs
+++ b/test/playwright/unit/data/StorePush.spec.mjs
@@ -15,82 +15,168 @@ setup({
     }
 });
 
-import {test, expect}     from '@playwright/test';
-import Neo                from '../../../../src/Neo.mjs';
-import * as core          from '../../../../src/core/_export.mjs';
-import InstanceManager    from '../../../../src/manager/Instance.mjs';
-import Model              from '../../../../src/data/Model.mjs';
-import Pipeline           from '../../../../src/data/Pipeline.mjs';
-import Store              from '../../../../src/data/Store.mjs';
-import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
-import VdomHelper         from '../../../../src/vdom/Helper.mjs';
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../src/manager/Instance.mjs';
+import Model           from '../../../../src/data/Model.mjs';
+import Pipeline        from '../../../../src/data/Pipeline.mjs';
+import Store           from '../../../../src/data/Store.mjs';
+
+let StorePushModel = class StorePushModel extends Model {
+    static config = {
+        className  : 'Test.Unit.Data.StorePush.Model',
+        keyProperty: 'id',
+        fields     : [
+            {name: 'id',     type: 'Integer'},
+            {name: 'rank',   type: 'Integer'},
+            {name: 'status', type: 'String'},
+            {name: 'type',   type: 'String'}
+        ]
+    }
+}
+StorePushModel = Neo.setupClass(StorePushModel);
+
+let StorePushPipeline = class StorePushPipeline extends Pipeline {
+    static config = {
+        className: 'Test.Unit.Data.StorePush.Pipeline'
+    }
+
+    async read() {
+        return [
+            {id: 1, rank: 2, status: 'pending', type: 'visible'},
+            {id: 2, rank: 1, status: 'pending', type: 'visible'}
+        ]
+    }
+
+    simulatePush(data) {
+        this.fire('push', data)
+    }
+}
+StorePushPipeline = Neo.setupClass(StorePushPipeline);
+
+function createStore(config={}) {
+    return Neo.create(Store, {
+        model   : StorePushModel,
+        pipeline: {
+            module: StorePushPipeline
+        },
+        ...config
+    })
+}
 
 test.describe('Neo.data.Store - Push Integration', () => {
 
     test('Store should listen to pipeline push events and update existing records via record.set()', async () => {
-        // 1. Create a Mock Model
-        class TestModel extends Model {
-            static config = {
-                className  : 'Test.Unit.Data.StorePush.MockModel',
-                keyProperty: 'id',
-                fields     : [
-                    {name: 'id',     type: 'Integer'},
-                    {name: 'status', type: 'String'}
-                ]
-            }
-        }
-        TestModel = Neo.setupClass(TestModel);
+        const store = createStore();
 
-        // 2. Create a Mock Pipeline that we can manually trigger events on
-        class MockPipeline extends Pipeline {
-            static config = {
-                className: 'Test.Unit.Data.StorePush.MockPipeline'
-            }
-            
-            // Mock connection-less read
-            async read() {
-                return [{id: 1, status: 'pending'}, {id: 2, status: 'pending'}];
-            }
-            
-            // Helper to simulate an incoming push
-            simulatePush(data) {
-                this.fire('push', data);
-            }
-        }
-        MockPipeline = Neo.setupClass(MockPipeline);
-
-        // 3. Create Store
-        const store = Neo.create(Store, {
-            model   : TestModel,
-            pipeline: {
-                module: MockPipeline
-            }
-        });
-
-        // 4. Initial Load
         await store.load();
         expect(store.count).toBe(2);
-        
+
         let record1 = store.get(1);
         expect(record1.status).toBe('pending');
-        
-        // 5. Setup Spy
-        let recordChangeFired = false;
-        let changedRecordId = null;
-        
-        store.on('recordChange', (data) => {
+
+        let recordChangeFired = false,
+            changedRecordId   = null;
+
+        store.on('recordChange', data => {
             recordChangeFired = true;
-            changedRecordId = data.record.id;
+            changedRecordId   = data.record.id
         });
 
-        // 6. Simulate Server Push
-        store.pipeline.simulatePush({ id: 1, status: 'done' });
+        store.pipeline.simulatePush({id: 1, status: 'done'});
 
-        // 7. Verify Surgical Update
-        expect(record1.status).toBe('done'); // record.set() worked
-        expect(recordChangeFired).toBe(true); // event fired
+        expect(record1.status).toBe('done');
+        expect(recordChangeFired).toBe(true);
         expect(changedRecordId).toBe(1);
-        
-        store.destroy();
+
+        store.destroy()
+    });
+
+    test('Store should ignore unknown pipeline push ids by default', async () => {
+        const store = createStore();
+
+        await store.load();
+
+        store.pipeline.simulatePush({id: 3, rank: 3, status: 'created', type: 'visible'});
+
+        expect(store.count).toBe(2);
+        expect(store.get(3)).toBe(null);
+
+        store.destroy()
+    });
+
+    test('Store should insert unknown pipeline push ids when pushInsertStrategy is upsert', async () => {
+        const store = createStore({
+            pushInsertStrategy: 'upsert'
+        });
+
+        await store.load();
+
+        store.pipeline.simulatePush({id: 3, rank: 3, status: 'created', type: 'visible'});
+
+        expect(store.count).toBe(3);
+        expect(store.get(3).status).toBe('created');
+
+        store.destroy()
+    });
+
+    test('Store should respect local sorters for inserted pipeline pushes', async () => {
+        const store = createStore({
+            pushInsertStrategy: 'insert',
+            sorters           : [{direction: 'ASC', property: 'rank'}]
+        });
+
+        await store.load();
+
+        expect(store.getRange().map(record => record.id)).toEqual([2, 1]);
+
+        store.pipeline.simulatePush({id: 3, rank: 0, status: 'created', type: 'visible'});
+
+        expect(store.getRange().map(record => record.id)).toEqual([3, 2, 1]);
+
+        store.destroy()
+    });
+
+    test('Store should not show locally filtered-out inserted pipeline pushes', async () => {
+        const store = createStore({
+            filters           : [{property: 'type', value: 'visible'}],
+            pushInsertStrategy: 'upsert'
+        });
+
+        await store.load();
+
+        store.pipeline.simulatePush({id: 3, rank: 3, status: 'created', type: 'hidden'});
+
+        expect(store.count).toBe(2);
+        expect(store.get(3)).toBe(null);
+
+        store.destroy()
+    });
+
+    test('Store should reload instead of inserting when the visible projection is uncertain', async () => {
+        const stores = [
+            createStore({pushInsertStrategy: 'reloadWhenUncertain', remoteFilter: true}),
+            createStore({pushInsertStrategy: 'reloadWhenUncertain', pageSize: 1})
+        ];
+
+        for (const store of stores) {
+            await store.load();
+
+            let loadCount = 0;
+
+            store.load = async () => {
+                loadCount++;
+                return []
+            };
+
+            store.pipeline.simulatePush({id: 3, rank: 3, status: 'created', type: 'visible'});
+
+            expect(loadCount).toBe(1);
+            expect(store.count).toBe(2);
+            expect(store.get(3)).toBe(null);
+
+            store.destroy()
+        }
     });
 });


### PR DESCRIPTION
Resolves #14392

Adds `pushInsertStrategy` to `Neo.data.Store` so unknown keyed pipeline pushes remain ignored by default, but stores can opt into local insert/upsert behavior or reload-based handling when the visible projection is uncertain. The implementation keeps known-id `record.set()` updates unchanged, routes local inserts through `Store#add()` so existing filter/sorter semantics apply, and avoids corrupting remote-filtered, remote-sorted, or paginated views.

Evidence: L2 (focused Playwright unit coverage for Store/Pipeline push behavior plus local agent preflight) -> L2 required (Store runtime behavior is covered by unit-level data-store tests). Residual: none.

## Deltas from ticket

The implementation uses the richer strategy-shaped API from the ticket rather than the smaller boolean `autoInsertPushes` variant:

- `false` keeps current ignore behavior.
- `'insert'` and `'upsert'` add unknown pushed ids only when the Store owns the local projection.
- `'reload'` reloads for every unknown pushed id.
- `'reloadWhenUncertain'` inserts locally, but reloads when `remoteFilter`, `remoteSort`, or `pageSize > 0` makes membership/order uncertain.

## Test Evidence

- `npm run agent-preflight -- src/data/Store.mjs test/playwright/unit/data/StorePush.spec.mjs learn/guides/datahandling/DataPipelines.md` passed.
- `npm run test-unit -- test/playwright/unit/data/StorePush.spec.mjs` passed: 6/6.
- `npm run test-unit -- test/playwright/unit/data/StorePush.spec.mjs test/playwright/unit/data/PipelinePush.spec.mjs` passed after rebase: 7/7.
- `git diff --check origin/dev...HEAD` passed.

## Post-Merge Validation

- [ ] GitHub CI passes on the PR head.

## Commits

- `5d483a876f` — `feat(data): support pipeline push inserts (#14392)`

Authored by Euclid (GPT-5, Codex Desktop). Session 4cea162d-b6d0-4f80-9048-ae43a82508de.
