### PR TITLE
feat(ai): expose tenant repo sync diagnostics (#14396)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -396,10 +396,13 @@ export class Orchestrator extends Base {
      */
     beforeSetDeploymentStateBridgeService(value) {
         return ClassSystemUtil.beforeSetInstance(value, DeploymentStateBridgeService, {
-            runtimeAccessService: this.deploymentRuntimeAccessService,
-            diagnosisService    : this.containerHealthDiagnosisService,
-            healLedgerDir       : path.join(this.dataDir, 'data-heal-events'),
-            writeLog            : this.deploymentStateBridgeWriteLog
+            runtimeAccessService       : this.deploymentRuntimeAccessService,
+            diagnosisService           : this.containerHealthDiagnosisService,
+            taskStateService           : this.taskStateService,
+            tenantRepoSyncService      : this.tenantRepoSyncService,
+            tenantRepoSyncEnabledReader: () => this.tenantRepoSyncEnabled,
+            healLedgerDir              : path.join(this.dataDir, 'data-heal-events'),
+            writeLog                   : this.deploymentStateBridgeWriteLog
         });
     }
 
@@ -682,6 +685,9 @@ export class Orchestrator extends Base {
         if (oldValue === undefined) return;
         this.processSupervisorService.taskStateService       = value;
         this.maintenanceBackpressureService.taskStateService = value;
+        if (this.deploymentStateBridgeService) {
+            this.deploymentStateBridgeService.taskStateService = value;
+        }
     }
     afterSetHealthService(value, oldValue) {
         if (oldValue === undefined) return;

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -1,3 +1,4 @@
+import {createHash}                         from 'node:crypto';
 import Base                                 from '../../../../src/core/Base.mjs';
 import AiConfig                             from '../../../config.mjs';
 import {probeProviderParallelModelCapacity} from '../../../services/graph/providerReadinessHelper.mjs';
@@ -17,6 +18,10 @@ import {
     calculateDockerCpuPercent,
     calculateDockerMemoryPercent
 } from './ContainerHealthDiagnosisService.mjs';
+import {
+    buildTenantRepoSyncTrigger,
+    isRepoDue
+} from '../scheduling/tenantRepoSync.mjs';
 
 /**
  * @summary Writes a bounded, graph-independent deployment-state snapshot for KB/MC tools.
@@ -47,6 +52,21 @@ export class DeploymentStateBridgeService extends Base {
          * @protected
          */
         diagnosisService: null,
+        /**
+         * @member {Object|null} taskStateService=null
+         * @protected
+         */
+        taskStateService: null,
+        /**
+         * @member {Object|null} tenantRepoSyncService=null
+         * @protected
+         */
+        tenantRepoSyncService: null,
+        /**
+         * @member {Function|null} tenantRepoSyncEnabledReader=null
+         * @protected
+         */
+        tenantRepoSyncEnabledReader: null,
         /**
          * @member {Function|null} nowFn=null
          * @protected
@@ -158,14 +178,16 @@ export class DeploymentStateBridgeService extends Base {
             services.push(await this.collectServiceSnapshot({serviceKey, observedAt: generatedAt}));
         }
 
-        const recoveryRuns = await this.collectRecoveryRunSnapshot();
-        const selfHeal     = await this.collectSelfHealSnapshot();
+        const recoveryRuns   = await this.collectRecoveryRunSnapshot();
+        const selfHeal       = await this.collectSelfHealSnapshot();
+        const tenantRepoSync = await this.collectTenantRepoSyncSnapshot({observedAt: generatedAt});
 
         return createDeploymentStateSnapshot({
             generatedAt,
             services,
             recoveryRuns,
-            selfHeal
+            selfHeal,
+            tenantRepoSync
         });
     }
 
@@ -419,6 +441,118 @@ export class DeploymentStateBridgeService extends Base {
     }
 
     /**
+     * @summary Projects tenant-repo-sync scheduler, task, config, and revision state into the
+     * deployment diagnostic snapshot without exposing repo names, clone URLs, credentials, or logs.
+     * @param {Object} options
+     * @param {Number} options.observedAt Epoch ms.
+     * @returns {Promise<Object>}
+     */
+    async collectTenantRepoSyncSnapshot({observedAt}) {
+        const
+            taskName  = 'tenant-repo-sync',
+            source    = 'orchestrator-tenant-repo-sync',
+            scheduler = {
+                globalCadenceMs: AiConfig.orchestrator.intervals.tenantRepoSyncMs,
+                sweepCadenceMs : AiConfig.orchestrator.tenantRepoSync.sweepCadenceMs,
+                jitterRatio    : AiConfig.orchestrator.tenantRepoSync.jitterRatio,
+                due            : null
+            },
+            errors         = [];
+
+        let enabled       = null,
+            taskState     = null,
+            configSummary = {
+                status       : 'unavailable',
+                repoCount    : 0,
+                disabledCount: 0,
+                tierCounts   : {},
+                errors       : []
+            },
+            repos              = [],
+            persistedRevisions = {};
+
+        try {
+            if (typeof this.tenantRepoSyncEnabledReader !== 'function') {
+                throw createDiagnosticError('tenant-repo-sync-enabled-reader-missing');
+            }
+            enabled = Boolean(this.tenantRepoSyncEnabledReader());
+        } catch (error) {
+            errors.push(summarizeDiagnosticError(error, 'tenant-repo-sync-enabled-read-failed'));
+        }
+
+        try {
+            if (!this.taskStateService?.getTaskState) {
+                throw createDiagnosticError('task-state-service-missing');
+            }
+            taskState = this.taskStateService.getTaskState(taskName) || null;
+        } catch (error) {
+            errors.push(summarizeDiagnosticError(error, 'task-state-read-failed'));
+        }
+
+        if (taskState) {
+            scheduler.due = Boolean(buildTenantRepoSyncTrigger({
+                enabled   : enabled === true,
+                now       : observedAt,
+                intervalMs: scheduler.sweepCadenceMs,
+                lastRunAt : taskState.lastRunAt || 0
+            }));
+        }
+
+        try {
+            if (!this.tenantRepoSyncService?.resolveTenantReposConfig) {
+                throw createDiagnosticError('tenant-repo-sync-service-missing');
+            }
+
+            const resolvedConfig = await this.tenantRepoSyncService.resolveTenantReposConfig();
+            repos = Array.isArray(resolvedConfig.tenantRepos) ? resolvedConfig.tenantRepos : [];
+            configSummary = summarizeTenantRepoConfig(repos);
+        } catch (error) {
+            errors.push(summarizeDiagnosticError(error, 'tenant-repo-config-read-failed'));
+            configSummary = {
+                ...configSummary,
+                status: 'degraded',
+                errors: [summarizeDiagnosticError(error, 'tenant-repo-config-read-failed')]
+            };
+        }
+
+        try {
+            if (!this.tenantRepoSyncService?.readPersistedRevisions || !this.tenantRepoSyncService?.defaultRevisionsFilePath) {
+                throw createDiagnosticError('tenant-repo-revision-reader-missing');
+            }
+
+            persistedRevisions = await this.tenantRepoSyncService.readPersistedRevisions({
+                filePath: this.tenantRepoSyncService.defaultRevisionsFilePath(),
+                strict  : true
+            });
+        } catch (error) {
+            errors.push(summarizeDiagnosticError(error, 'tenant-repo-revision-state-read-failed'));
+        }
+
+        const repoStates = repos.map(repo => summarizeTenantRepoState({
+            repo,
+            observedAt,
+            taskState,
+            persistedRepoState: persistedRevisions[createTenantRepoLabel(repo)] || null,
+            globalCadenceMs   : scheduler.globalCadenceMs,
+            jitterRatio       : scheduler.jitterRatio
+        }));
+
+        return {
+            schemaVersion: 1,
+            recordType   : 'tenant-repo-sync-deployment-state',
+            source,
+            observedAt,
+            status       : classifyTenantRepoSyncStatus({enabled, taskState, repoCount: repos.length, schedulerDue: scheduler.due, errors}),
+            enabled,
+            scheduler,
+            task         : summarizeTenantRepoTaskState(taskState),
+            config       : configSummary,
+            repos        : repoStates,
+            errors
+        };
+    }
+
+    /**
      * Returns current time in epoch ms.
      * @returns {Number}
      */
@@ -493,6 +627,229 @@ function buildServiceStateSignature(services) {
         .map(service => `${service.serviceKey}:${service.status}`)
         .sort()
         .join(',');
+}
+
+function createDiagnosticError(code) {
+    const error = new Error(code);
+
+    error.code = code;
+
+    return error;
+}
+
+function summarizeDiagnosticError(error, reason) {
+    return {
+        reason,
+        code        : error.code || null,
+        messageClass: error.name || 'Error'
+    };
+}
+
+function summarizeTenantRepoConfig(repos) {
+    const tierCounts    = {};
+    let   disabledCount = 0;
+
+    for (const repo of repos) {
+        const tier = repo.configTier || 'unreported';
+        tierCounts[tier] = (tierCounts[tier] || 0) + 1;
+
+        if (isTenantRepoDisabled(repo)) {
+            disabledCount++;
+        }
+    }
+
+    return {
+        status   : 'available',
+        repoCount: repos.length,
+        disabledCount,
+        tierCounts,
+        errors   : []
+    };
+}
+
+function summarizeTenantRepoTaskState(taskState) {
+    if (!taskState || typeof taskState !== 'object') {
+        return null;
+    }
+
+    return {
+        running       : taskState.running === true,
+        pid           : Number.isFinite(taskState.pid) ? taskState.pid : null,
+        lastRunAt     : Number.isFinite(taskState.lastRunAt) && taskState.lastRunAt > 0 ? new Date(taskState.lastRunAt).toISOString() : null,
+        lastSuccessAt : taskState.lastSuccessAt || null,
+        lastErrorAt   : taskState.lastErrorAt || null,
+        lastExitCode  : Number.isFinite(taskState.lastExitCode) ? taskState.lastExitCode : null,
+        lastReason    : taskState.lastReason || null,
+        lastCompletion: summarizeTenantRepoTaskCompletion(taskState.lastCompletion)
+    };
+}
+
+function summarizeTenantRepoTaskCompletion(completion) {
+    if (!completion || typeof completion !== 'object') {
+        return null;
+    }
+
+    const summary = {
+        status        : completion.status || null,
+        reason        : completion.reason || null,
+        reasonCode    : completion.reasonCode || null,
+        repoCount     : numberOrNull(completion.repoCount),
+        completedCount: numberOrNull(completion.completedCount),
+        failedCount   : numberOrNull(completion.failedCount),
+        notDueCount   : numberOrNull(completion.notDueCount),
+        repos         : []
+    };
+
+    if (Array.isArray(completion.repos)) {
+        summary.repos = completion.repos.slice(0, 50).map(summarizeTenantRepoOutcome);
+    }
+
+    return summary;
+}
+
+function summarizeTenantRepoOutcome(outcome) {
+    if (!outcome || typeof outcome !== 'object') {
+        return null;
+    }
+
+    return {
+        identityHash        : hashTenantRepoIdentity(outcome),
+        status              : outcome.status || null,
+        lastIngestedRev     : shortRevision(outcome.lastIngestedRev || outcome.headRevision),
+        lastErrorCode       : outcome.lastErrorCode || outcome.code || null,
+        lastSyncDeletedCount: numberOrNull(outcome.lastSyncDeletedCount ?? outcome.deleted),
+        consecutiveFailures : numberOrNull(outcome.consecutiveFailures)
+    };
+}
+
+function summarizeTenantRepoState({repo, observedAt, taskState, persistedRepoState, globalCadenceMs, jitterRatio}) {
+    const
+        disabled = isTenantRepoDisabled(repo),
+        dueState = disabled
+            ? {due: false, effectiveCadenceMs: null, jitterMs: null, backoffMultiplier: null, lastRunAttemptAt: persistedRepoState?.lastRunAttemptAt || 0}
+            : isRepoDue({repo, persistedRepoState, now: observedAt, globalCadenceMs, jitterRatio}),
+        nextDueAtMs  = Number.isFinite(dueState.effectiveCadenceMs)
+            ? ((dueState.lastRunAttemptAt || 0) > 0 ? dueState.lastRunAttemptAt + dueState.effectiveCadenceMs : observedAt)
+            : null,
+        lastOutcome  = findTenantRepoOutcome(taskState?.lastCompletion, repo),
+        lastAttempt  = persistedRepoState?.lastRunAttemptAt || 0,
+        failures     = persistedRepoState?.consecutiveFailures ?? 0;
+
+    return {
+        identityHash       : hashTenantRepoIdentity(repo),
+        tenantHash         : hashValue(repo.tenantId),
+        repoHash           : hashValue(repo.repoSlug),
+        configTier         : repo.configTier || 'unreported',
+        disabled,
+        status             : classifyTenantRepoState({disabled, due: dueState.due, persistedRepoState, lastOutcome}),
+        due                : disabled ? false : dueState.due,
+        nextDueAt          : Number.isFinite(nextDueAtMs) ? new Date(nextDueAtMs).toISOString() : null,
+        lastIngestedRev    : shortRevision(persistedRepoState?.lastIngestedRev),
+        lastRunAttemptAt   : lastAttempt > 0 ? new Date(lastAttempt).toISOString() : null,
+        consecutiveFailures: failures,
+        effectiveCadenceMs : dueState.effectiveCadenceMs,
+        jitterMs           : dueState.jitterMs,
+        backoffMultiplier  : dueState.backoffMultiplier,
+        lastOutcome
+    };
+}
+
+function classifyTenantRepoSyncStatus({enabled, taskState, repoCount, schedulerDue, errors}) {
+    if (errors.length > 0) {
+        return 'degraded';
+    }
+
+    if (enabled === false) {
+        return 'disabled';
+    }
+
+    if (taskState?.running) {
+        return 'running';
+    }
+
+    if (taskState && isLatestTaskOutcomeFailure(taskState)) {
+        return 'failed';
+    }
+
+    if (repoCount === 0) {
+        return 'no-configured-repos';
+    }
+
+    if (schedulerDue === false) {
+        return 'not-due';
+    }
+
+    if (taskState?.lastSuccessAt) {
+        return 'completed';
+    }
+
+    return 'idle';
+}
+
+function classifyTenantRepoState({disabled, due, persistedRepoState, lastOutcome}) {
+    if (disabled) {
+        return 'disabled';
+    }
+
+    if (lastOutcome?.status) {
+        return lastOutcome.status;
+    }
+
+    if (!due) {
+        return 'not-due';
+    }
+
+    if ((persistedRepoState?.consecutiveFailures ?? 0) > 0) {
+        return 'degraded';
+    }
+
+    if (persistedRepoState?.lastIngestedRev) {
+        return 'active';
+    }
+
+    return 'due';
+}
+
+function findTenantRepoOutcome(completion, repo) {
+    if (!completion || !Array.isArray(completion.repos)) {
+        return null;
+    }
+
+    const match = completion.repos.find(entry => entry?.tenantId === repo.tenantId && entry?.repoSlug === repo.repoSlug);
+
+    return match ? summarizeTenantRepoOutcome(match) : null;
+}
+
+function isLatestTaskOutcomeFailure(taskState) {
+    const
+        errorAt   = Date.parse(taskState.lastErrorAt || ''),
+        successAt = Date.parse(taskState.lastSuccessAt || '');
+
+    return Number.isFinite(errorAt) && (!Number.isFinite(successAt) || errorAt >= successAt);
+}
+
+function createTenantRepoLabel(repo) {
+    return `${repo.tenantId}/${repo.repoSlug}`;
+}
+
+function hashTenantRepoIdentity(value) {
+    return hashValue(createTenantRepoLabel(value));
+}
+
+function hashValue(value) {
+    return createHash('sha256').update(String(value || '')).digest('hex').slice(0, 12);
+}
+
+function shortRevision(value) {
+    return value ? String(value).slice(0, 12) : null;
+}
+
+function isTenantRepoDisabled(repo) {
+    return repo.disabled === true || repo.enabled === false;
+}
+
+function numberOrNull(value) {
+    return Number.isFinite(value) ? value : null;
 }
 
 export default Neo.setupClass(DeploymentStateBridgeService);

--- a/ai/daemons/orchestrator/services/TaskStateService.mjs
+++ b/ai/daemons/orchestrator/services/TaskStateService.mjs
@@ -9,13 +9,14 @@ import Base from '../../../../src/core/Base.mjs';
 export function createInitialTaskState(taskDefinitions) {
     return Object.keys(taskDefinitions).reduce((state, taskName) => {
         state[taskName] = {
-            running      : false,
-            pid          : null,
-            lastRunAt    : 0,
-            lastSuccessAt: null,
-            lastErrorAt  : null,
-            lastExitCode : null,
-            lastReason   : null
+            running       : false,
+            pid           : null,
+            lastRunAt     : 0,
+            lastSuccessAt : null,
+            lastErrorAt   : null,
+            lastExitCode  : null,
+            lastReason    : null,
+            lastCompletion: null
         };
         return state;
     }, {});
@@ -213,14 +214,15 @@ export class TaskStateService extends Base {
     /**
      * Marks a task as skipped without treating the no-op as a successful run.
      * @param {String} taskName
+     * @param {Object|null} [lastCompletion=null] Bounded task-specific completion metadata.
      * @returns {void}
      */
-    markSkipped(taskName) {
+    markSkipped(taskName, lastCompletion=null) {
         const state = this.taskState[taskName];
         state.running      = false;
         state.pid          = null;
         state.lastExitCode = null;
-        state.lastCompletion = null;
+        state.lastCompletion = lastCompletion;
         this.writeState();
     }
 
@@ -243,15 +245,16 @@ export class TaskStateService extends Base {
      * Marks a task as failed.
      * @param {String} taskName
      * @param {Number|null} code
+     * @param {Object|null} [lastCompletion=null] Bounded task-specific completion metadata.
      * @returns {void}
      */
-    markFailed(taskName, code) {
+    markFailed(taskName, code, lastCompletion=null) {
         const state = this.taskState[taskName];
         state.running      = false;
         state.pid          = null;
         state.lastExitCode = code;
         state.lastErrorAt  = new Date().toISOString();
-        state.lastCompletion = null;
+        state.lastCompletion = lastCompletion;
         this.writeState();
     }
 

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -242,13 +242,18 @@ class TenantRepoSyncService extends Base {
                 globalCadenceMs, jitterRatio, seedBootstrap
             });
             const status = result.status;
+            const lastCompletion = {
+                status,
+                reason,
+                ...result.details
+            };
 
             if (status === 'completed') {
-                taskStateService.markCompleted(taskName);
+                taskStateService.markCompleted(taskName, lastCompletion);
             } else if (status === 'failed') {
-                taskStateService.markFailed(taskName, null);
+                taskStateService.markFailed(taskName, null, lastCompletion);
             } else {
-                taskStateService.markSkipped(taskName);
+                taskStateService.markSkipped(taskName, lastCompletion);
             }
 
             healthService?.recordTaskOutcome?.(taskName, status, {reason, ...result.details});
@@ -267,7 +272,7 @@ class TenantRepoSyncService extends Base {
                 ...(meta ? {meta} : {})
             };
 
-            taskStateService.markFailed(taskName, null);
+            taskStateService.markFailed(taskName, null, {status: 'failed', ...details});
             writeLog?.('ERROR', `[TenantRepoSync] Failed: ${code} (${e.message})`);
             healthService?.recordTaskOutcome?.(taskName, 'failed', details);
             return {status: 'failed', details};
@@ -633,9 +638,10 @@ class TenantRepoSyncService extends Base {
      *
      * @param {Object} options
      * @param {String} options.filePath
+     * @param {Boolean} [options.strict=false] Throw on corrupt/unreadable files instead of returning an empty map.
      * @returns {Promise<Object<String, {lastIngestedRev: String, lastRunAttemptAt: Number, consecutiveFailures: Number}>>}
      */
-    async readPersistedRevisions({filePath}) {
+    async readPersistedRevisions({filePath, strict = false}) {
         if (!await fs.pathExists(filePath)) {
             return {};
         }
@@ -661,7 +667,12 @@ class TenantRepoSyncService extends Base {
                 }
             }
             return normalized;
-        } catch {
+        } catch (e) {
+            if (strict) {
+                const error = new Error(`Failed to read tenant-repo-sync revisions at ${filePath}: ${e.message}`);
+                error.code = e.code || 'KB_TENANT_REPO_SYNC_REVISIONS_READ_FAILED';
+                throw error;
+            }
             return {};
         }
     }

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -154,7 +154,9 @@ paths:
         Reads the bounded deployment-state bridge snapshot written by the internal orchestrator.
         This is a read-only public KB surface: it does not expose Docker, shell, exec, restart,
         or any public daemon/orchestrator route. It exists so MC-unhealthy / graph-unavailable
-        incidents still have a KB-hosted current-state path when KB is healthy.
+        incidents still have a KB-hosted current-state path when KB is healthy. The snapshot
+        also includes redacted tenant-repo-sync scheduler/task/config state for pull-mode
+        ingestion diagnostics.
       tags: [Health]
       requestBody:
         required: false
@@ -186,7 +188,8 @@ paths:
       description: |
         Reads the bounded deployment inspection snapshot written by the internal orchestrator.
         This is a read-only public KB surface: it exposes allowlisted service state, bounded
-        log tails, current diagnoses, and recent recovery-run ledger entries without exposing
+        log tails, current diagnoses, recent recovery-run ledger entries, and redacted
+        tenant-repo-sync scheduler/task/config state without exposing
         Docker, shell, exec, restart, or any public daemon/orchestrator route.
       tags: [Health]
       requestBody:

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -1355,17 +1355,25 @@ class IngestionService extends Base {
             // non-empty array: a graph record / yaml entry that declares `tenantRepos: []`
             // intentionally means "no repos for this tenant" and MUST suppress lower tiers
             // wholesale — selecting on `length > 0` would leak lower-tier repos through.
-            let repos;
+            let repos,
+                configTier;
 
             if (graphRecord?.properties) {
-                repos = graphRecord.properties.tenantRepos || [];
+                repos       = graphRecord.properties.tenantRepos || [];
+                configTier  = 'graph';
             } else if (yamlEntry) {
-                repos = yamlEntry.tenantRepos || [];
+                repos       = yamlEntry.tenantRepos || [];
+                configTier  = 'yaml';
             } else {
-                repos = defaultRepos.filter(entry => (normalizeUserId(entry.tenantId) || entry.tenantId) === tenantId);
+                repos       = defaultRepos.filter(entry => (normalizeUserId(entry.tenantId) || entry.tenantId) === tenantId);
+                configTier  = 'aiConfig';
             }
 
-            repos.forEach(repo => effective.push(repo.tenantId ? repo : {...repo, tenantId}));
+            repos.forEach(repo => effective.push({
+                ...repo,
+                tenantId: repo.tenantId || tenantId,
+                configTier
+            }));
         }
 
         return normalizeTenantRepoConfig({tenantRepos: effective});

--- a/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
@@ -19,6 +19,7 @@ const DEFAULT_STALE_AFTER_MS     = 2 * 60 * 1000;
  * @param {Object[]} [options.services=[]] Bounded per-service snapshots.
  * @param {Object|null} [options.recoveryRuns=null] Bounded recovery-run ledger snapshot.
  * @param {Object|null} [options.selfHeal=null] Bounded self-heal immune-system status (heal-ledger summary + recent events).
+ * @param {Object|null} [options.tenantRepoSync=null] Bounded tenant-repo-sync scheduler/task/config snapshot.
  * @returns {Object}
  */
 export function createDeploymentStateSnapshot({
@@ -26,7 +27,8 @@ export function createDeploymentStateSnapshot({
     source = 'orchestrator-deployment-state-bridge',
     services = [],
     recoveryRuns = null,
-    selfHeal = null
+    selfHeal = null,
+    tenantRepoSync = null
 } = {}) {
     if (!Number.isFinite(generatedAt)) {
         throw new TypeError('createDeploymentStateSnapshot: generatedAt must be finite');
@@ -43,7 +45,8 @@ export function createDeploymentStateSnapshot({
         source,
         services,
         recoveryRuns,
-        selfHeal
+        selfHeal,
+        tenantRepoSync
     };
 }
 

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -283,6 +283,12 @@ Per-repo freshness is surfaced through the existing Memory Core healthcheck orch
 
 The operator readiness endpoint reads this shape from `HealthService` — there is no need to read Chroma rows for freshness checks. Empty `tenantRepos[]` produces `repos: []`, not an omission.
 
+For authenticated remote MCP diagnostics, the deployment-state bridge also projects a redacted
+`tenantRepoSync` section into `inspect_deployment` / `get_deployment_state_snapshot`. Use that
+surface when a cloud KB is healthy but empty: it combines the orchestrator enablement gate, task
+state, config-tier counts, per-repo due/backoff state, and bounded failure codes without exposing
+clone URLs, credentials, or raw logs.
+
 ### Repo Freshness Status Enum
 
 | Status | Meaning | Transition |

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -147,7 +147,11 @@ A healthy server returns `event: message` SSE framing carrying the JSON-RPC resu
 
 ## First query returns nothing — the empty-KB gap
 
-A freshly deployed Knowledge Base is **healthy but empty**: `healthcheck` reports `count: 0` and queries return nothing until an ingest runs. In the cloud-safe profile the continuous ingestion lane is off by design, so the first ingest is a deliberate step — trigger the deployment's ingestion entry point once, then queries return results. A `count: 0` immediately after deploy is expected, not a failure.
+A freshly deployed Knowledge Base can be **healthy but empty**: `healthcheck` reports `count: 0` and queries return nothing until an ingest writes chunks. Treat that as an ingestion-state question, not a Chroma readiness question.
+
+For push-mode deployments, trigger the deployment's ingestion entry point once, then query again.
+
+For pull-mode deployments with configured `tenantRepos[]`, call `inspect_deployment` or `get_deployment_state_snapshot` and inspect the `tenantRepoSync` section before taking manual action. It distinguishes disabled, no configured repos, not-due, running, completed, failed, and degraded/unreadable state without exposing credentials or raw logs. If the task is configured but has not advanced, use the stable reason code and per-repo hashed state there to decide whether to wait for the next due sweep, fix credentials/config, or run `node ./ai/scripts/maintenance/syncTenantRepos.mjs` inside the orchestrator container.
 
 ## See also
 

--- a/learn/agentos/tooling/KnowledgeBaseMcpApi.md
+++ b/learn/agentos/tooling/KnowledgeBaseMcpApi.md
@@ -43,6 +43,13 @@ implementation surface.
 The deployment tools expose read-only bridge data. They do not expose Docker,
 shell, restart, or daemon control routes.
 
+Deployment snapshots include a bounded `tenantRepoSync` section for pull-mode
+cloud ingestion. Use it when a KB is healthy but empty and tenant repositories
+are expected: it reports the orchestrator enablement gate, scheduler cadence,
+task state, effective repo-config counts/tiers, redacted per-repo due state, and
+stable failure reason codes without exposing clone URLs, credentials, or raw
+logs.
+
 ## Admin Tools
 
 | Tool | Use |

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -238,13 +238,14 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
-            running      : false,
-            pid          : null,
-            lastRunAt    : 0,
-            lastSuccessAt: null,
-            lastErrorAt  : null,
-            lastExitCode : null,
-            lastReason   : null
+            running       : false,
+            pid           : null,
+            lastRunAt     : 0,
+            lastSuccessAt : null,
+            lastErrorAt   : null,
+            lastExitCode  : null,
+            lastReason    : null,
+            lastCompletion: null
         });
         expect(state.kbSync).not.toBe(state.summary);
     });
@@ -458,6 +459,12 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             .toBe(orchestrator.deploymentRuntimeAccessService);
         expect(orchestrator.deploymentStateBridgeService.diagnosisService)
             .toBe(orchestrator.containerHealthDiagnosisService);
+        expect(orchestrator.deploymentStateBridgeService.taskStateService)
+            .toBe(orchestrator.taskStateService);
+        expect(orchestrator.deploymentStateBridgeService.tenantRepoSyncService)
+            .toBe(orchestrator.tenantRepoSyncService);
+        expect(orchestrator.deploymentStateBridgeService.tenantRepoSyncEnabledReader())
+            .toBe(false);
     });
 
     test('refreshes golden path while dream graph mutation is active — decoupled for hourly freshness', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -42,11 +42,17 @@ function createService({
     providerResidencyProbe = async () => null,
     recoveryRunStateReader = null,
     healLedgerDir = null,
-    healLedgerReader = null
+    healLedgerReader = null,
+    taskStateService = null,
+    tenantRepoSyncService = null,
+    tenantRepoSyncEnabledReader = null
 } = {}) {
     return Neo.create(DeploymentStateBridgeService, {
         runtimeAccessService,
         diagnosisService,
+        taskStateService,
+        tenantRepoSyncService,
+        tenantRepoSyncEnabledReader,
         providerResidencyProbe,
         recoveryRunStateReader,
         healLedgerDir,
@@ -336,6 +342,255 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                 missingModels: ['gemma4:26b'],
                 target       : {kind: 'compose-service', id: 'model'}
             }
+        });
+    });
+
+    test('collectTenantRepoSyncSnapshot distinguishes no configured repos from a missing KB ingest', async () => {
+        const service = createService({
+            taskStateService: {
+                getTaskState(taskName) {
+                    expect(taskName).toBe('tenant-repo-sync');
+
+                    return {
+                        running       : false,
+                        pid           : null,
+                        lastRunAt     : OBSERVED_AT - 10_000,
+                        lastSuccessAt : null,
+                        lastErrorAt   : null,
+                        lastExitCode  : null,
+                        lastReason    : 'periodic-sweep:60000',
+                        lastCompletion: {
+                            status   : 'skipped',
+                            reason   : 'periodic-sweep:60000',
+                            repoCount: 0
+                        }
+                    };
+                }
+            },
+            tenantRepoSyncService: {
+                async resolveTenantReposConfig() {
+                    return {tenantRepos: []};
+                },
+                defaultRevisionsFilePath() {
+                    return '/state/tenant-repo-sync-revisions.json';
+                },
+                async readPersistedRevisions({filePath, strict}) {
+                    expect(filePath).toBe('/state/tenant-repo-sync-revisions.json');
+                    expect(strict).toBe(true);
+
+                    return {};
+                }
+            },
+            tenantRepoSyncEnabledReader: () => true
+        });
+
+        const tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(tenantRepoSync).toMatchObject({
+            status : 'no-configured-repos',
+            enabled: true,
+            config : {
+                status   : 'available',
+                repoCount: 0
+            },
+            task: {
+                lastCompletion: {
+                    status   : 'skipped',
+                    repoCount: 0
+                }
+            },
+            repos : [],
+            errors: []
+        });
+    });
+
+    test('collectTenantRepoSyncSnapshot reports not-due repos with hashed identities only', async () => {
+        const service = createService({
+            taskStateService: {
+                getTaskState() {
+                    return {
+                        running       : false,
+                        pid           : null,
+                        lastRunAt     : OBSERVED_AT - 1,
+                        lastSuccessAt : '2024-03-09T16:00:00.000Z',
+                        lastErrorAt   : null,
+                        lastExitCode  : 0,
+                        lastReason    : 'periodic-sweep:60000',
+                        lastCompletion: null
+                    };
+                }
+            },
+            tenantRepoSyncService: {
+                async resolveTenantReposConfig() {
+                    return {
+                        tenantRepos: [{
+                            tenantId     : 'tenant-a',
+                            repoSlug     : 'private/repo',
+                            cloneUrl     : 'https://git.example/private/repo.git',
+                            credentialRef: 'env:TOKEN',
+                            cadenceMs    : 60_000,
+                            configTier   : 'yaml'
+                        }]
+                    };
+                },
+                defaultRevisionsFilePath() {
+                    return '/state/revisions.json';
+                },
+                async readPersistedRevisions() {
+                    return {
+                        'tenant-a/private/repo': {
+                            lastIngestedRev    : 'abcdef1234567890',
+                            lastRunAttemptAt   : OBSERVED_AT - 1_000,
+                            consecutiveFailures: 0
+                        }
+                    };
+                }
+            },
+            tenantRepoSyncEnabledReader: () => true
+        });
+
+        const tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(tenantRepoSync.status).toBe('not-due');
+        expect(tenantRepoSync.config).toMatchObject({
+            repoCount : 1,
+            tierCounts: {yaml: 1}
+        });
+        expect(tenantRepoSync.repos[0]).toMatchObject({
+            configTier         : 'yaml',
+            disabled           : false,
+            status             : 'not-due',
+            due                : false,
+            lastIngestedRev    : 'abcdef123456',
+            consecutiveFailures: 0
+        });
+        expect(JSON.stringify(tenantRepoSync)).not.toContain('tenant-a');
+        expect(JSON.stringify(tenantRepoSync)).not.toContain('private/repo');
+        expect(JSON.stringify(tenantRepoSync)).not.toContain('TOKEN');
+    });
+
+    test('collectTenantRepoSyncSnapshot surfaces bounded failure outcome codes', async () => {
+        const service = createService({
+            taskStateService: {
+                getTaskState() {
+                    return {
+                        running       : false,
+                        pid           : null,
+                        lastRunAt     : OBSERVED_AT - 60_000,
+                        lastSuccessAt : '2024-03-09T14:00:00.000Z',
+                        lastErrorAt   : '2024-03-09T15:00:00.000Z',
+                        lastExitCode  : null,
+                        lastReason    : 'periodic-sweep:60000',
+                        lastCompletion: {
+                            status     : 'failed',
+                            reason     : 'periodic-sweep:60000',
+                            repoCount  : 1,
+                            failedCount: 1,
+                            repos      : [{
+                                tenantId           : 'tenant-a',
+                                repoSlug           : 'private/repo',
+                                status             : 'degraded',
+                                lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+                                consecutiveFailures: 2
+                            }]
+                        }
+                    };
+                }
+            },
+            tenantRepoSyncService: {
+                async resolveTenantReposConfig() {
+                    return {
+                        tenantRepos: [{
+                            tenantId     : 'tenant-a',
+                            repoSlug     : 'private/repo',
+                            cloneUrl     : 'https://git.example/private/repo.git',
+                            credentialRef: 'env:TOKEN',
+                            configTier   : 'graph'
+                        }]
+                    };
+                },
+                defaultRevisionsFilePath() {
+                    return '/state/revisions.json';
+                },
+                async readPersistedRevisions() {
+                    return {
+                        'tenant-a/private/repo': {
+                            lastIngestedRev    : 'fedcba9876543210',
+                            lastRunAttemptAt   : OBSERVED_AT - 60_000,
+                            consecutiveFailures: 2
+                        }
+                    };
+                }
+            },
+            tenantRepoSyncEnabledReader: () => true
+        });
+
+        const tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(tenantRepoSync.status).toBe('failed');
+        expect(tenantRepoSync.task.lastCompletion).toMatchObject({
+            status     : 'failed',
+            repoCount  : 1,
+            failedCount: 1
+        });
+        expect(tenantRepoSync.repos[0]).toMatchObject({
+            configTier         : 'graph',
+            status             : 'degraded',
+            consecutiveFailures: 2,
+            lastOutcome        : {
+                status       : 'degraded',
+                lastErrorCode: 'KB_TENANT_REPO_SYNC_SYNC_FAILED'
+            }
+        });
+    });
+
+    test('collectTenantRepoSyncSnapshot degrades when revision state is unreadable', async () => {
+        const error = new Error('bad json');
+        error.code = 'KB_TENANT_REPO_SYNC_REVISIONS_READ_FAILED';
+
+        const service = createService({
+            taskStateService: {
+                getTaskState() {
+                    return {
+                        running       : false,
+                        pid           : null,
+                        lastRunAt     : OBSERVED_AT - 60_000,
+                        lastSuccessAt : null,
+                        lastErrorAt   : null,
+                        lastExitCode  : null,
+                        lastReason    : null,
+                        lastCompletion: null
+                    };
+                }
+            },
+            tenantRepoSyncService: {
+                async resolveTenantReposConfig() {
+                    return {
+                        tenantRepos: [{
+                            tenantId     : 'tenant-a',
+                            repoSlug     : 'private/repo',
+                            cloneUrl     : 'https://git.example/private/repo.git',
+                            credentialRef: 'env:TOKEN',
+                            configTier   : 'aiConfig'
+                        }]
+                    };
+                },
+                defaultRevisionsFilePath() {
+                    return '/state/revisions.json';
+                },
+                async readPersistedRevisions() {
+                    throw error;
+                }
+            },
+            tenantRepoSyncEnabledReader: () => true
+        });
+
+        const tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(tenantRepoSync.status).toBe('degraded');
+        expect(tenantRepoSync.errors[0]).toMatchObject({
+            reason: 'tenant-repo-revision-state-read-failed',
+            code  : 'KB_TENANT_REPO_SYNC_REVISIONS_READ_FAILED'
         });
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
@@ -38,13 +38,14 @@ test.describe('Neo.ai.daemons.services.TaskStateService', () => {
         const state       = service.getTaskState('mockTask');
 
         expect(state).toMatchObject({
-            running      : false,
-            pid          : null,
-            lastRunAt    : 0,
-            lastSuccessAt: null,
-            lastErrorAt  : null,
-            lastExitCode : null,
-            lastReason   : null
+            running       : false,
+            pid           : null,
+            lastRunAt     : 0,
+            lastSuccessAt : null,
+            lastErrorAt   : null,
+            lastExitCode  : null,
+            lastReason    : null,
+            lastCompletion: null
         });
     });
 
@@ -134,6 +135,16 @@ test.describe('Neo.ai.daemons.services.TaskStateService', () => {
         service.markFailed('mockTask', 1);
         stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
         expect(stateData.mockTask.lastCompletion).toBeNull();
+
+        const skippedCompletion = {status: 'skipped', reason: 'no-config'};
+        service.markSkipped('mockTask', skippedCompletion);
+        stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        expect(stateData.mockTask.lastCompletion).toEqual(skippedCompletion);
+
+        const failedCompletion = {status: 'failed', reasonCode: 'TEST_FAILURE'};
+        service.markFailed('mockTask', 1, failedCompletion);
+        stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        expect(stateData.mockTask.lastCompletion).toEqual(failedCompletion);
     });
 
     test('adoptRunning sets state without immediately writing to disk', () => {

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -22,7 +22,7 @@ import fs             from 'fs-extra';
 import aiConfig       from '../../../../../../ai/mcp/server/knowledge-base/config.mjs';
 
 /**
- * Contract coverage for IngestionService (#11633).
+ * Contract coverage for IngestionService.
  *
  * The suite uses mock VectorService / Chroma / telemetry dependencies so it verifies the
  * Phase 2A orchestration contract without touching the real ChromaDB collection or external
@@ -135,7 +135,7 @@ test.describe('IngestionService.ingestSourceFiles', () => {
             getKnowledgeBaseCollection: async () => collection
         };
         Service.graphService = createGraphStub();
-        // ingestSourceFiles resolves the tenant-config version for chunk stamping (#11637);
+        // ingestSourceFiles resolves the tenant-config version for chunk stamping;
         // stubbed here so this suite stays focused on ingestion orchestration.
         Service.getTenantConfig = async () => ({version: 0});
         Service.recorderService = {
@@ -800,9 +800,9 @@ test.describe('IngestionService.tenantConfig (#11637)', () => {
         await Service.setTenantConfig({tenantId: 'tenant-a', config: {}});
 
         // `GraphService.upsertNode` stamps the request identity onto `properties.userId`; without an
-        // explicit `visibility:'team'` marker the node is invisible to the offline #11640 reconciliation
+        // explicit `visibility:'team'` marker the node is invisible to the offline reconciliation
         // daemon (which reads `getTenantConfig` with no request context). The marker is the offline-read
-        // authorization, parallel to the `kb-manifest` sibling node (#11711).
+        // authorization, parallel to the `kb-manifest` sibling node.
         const node = graphStub.store.get('kb-config:tenant-a');
         expect(node.type).toBe('KnowledgeBaseTenantConfig');
         expect(node.properties.visibility).toBe('team');
@@ -976,10 +976,10 @@ test.describe('IngestionService.listConfiguredTenantRepos (#12145)', () => {
 
         expect(tenantRepos).toHaveLength(2);
         expect(tenantRepos.find(r => r.tenantId === 'tenant-a')).toMatchObject({
-            cloneUrl: 'https://github.com/neomjs/a.git', credentialRef: 'env:A', repoSlug: 'github.com/neomjs/a'
+            cloneUrl: 'https://github.com/neomjs/a.git', credentialRef: 'env:A', repoSlug: 'github.com/neomjs/a', configTier: 'yaml'
         });
         expect(tenantRepos.find(r => r.tenantId === 'tenant-b')).toMatchObject({
-            cloneUrl: 'https://github.com/neomjs/b.git', credentialRef: 'env:B'
+            cloneUrl: 'https://github.com/neomjs/b.git', credentialRef: 'env:B', configTier: 'yaml'
         });
     });
 
@@ -993,7 +993,7 @@ test.describe('IngestionService.listConfiguredTenantRepos (#12145)', () => {
 
         expect(tenantRepos).toHaveLength(1);
         expect(tenantRepos[0]).toMatchObject({
-            tenantId: 'tenant-a', cloneUrl: 'https://github.com/neomjs/graph.git', credentialRef: 'env:G'
+            tenantId: 'tenant-a', cloneUrl: 'https://github.com/neomjs/graph.git', credentialRef: 'env:G', configTier: 'graph'
         });
     });
 


### PR DESCRIPTION
Resolves #14396

This adds a bounded `tenantRepoSync` section to the deployment-state bridge snapshot so authenticated KB diagnostics can distinguish empty-KB causes across the orchestrator gate, scheduler cadence, task state, effective repo config, redacted per-repo due/backoff state, and bounded outcome/error codes. The implementation reuses the existing `TaskStateService`, `TenantRepoSyncService`, and `isRepoDue()` primitives instead of adding a new actuator or shell/log surface.

Evidence: L2 focused unit/static checks plus pre-commit hooks -> L2 required for the deployment diagnostic contract. Residual: live cloud deployment validation must confirm the snapshot volume is shared and the remote `inspect_deployment` result includes `tenantRepoSync`.

## Deltas from ticket

- `TaskStateService` now permits skipped/failed service tasks to persist bounded `lastCompletion` metadata, which `tenant-repo-sync` uses for last outcome diagnostics.
- `IngestionService.listConfiguredTenantRepos()` annotates resolved repos with `configTier` so diagnostics can summarize graph/yaml/aiConfig winner tiers without exposing raw config.
- The KB MCP OpenAPI descriptions and cloud docs now point empty-KB troubleshooting at the deployment diagnostic before manual sync action.

## Test Evidence

- `git diff --check`
- `git diff --cached --check`
- pre-commit hook passed: whitespace, shorthand, AiConfig test-mutation, JSDoc types, ticket archaeology, block alignment
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs` -> 122 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` -> 35 passed

## Post-Merge Validation

- [ ] In a cloud deployment with pull-mode repo ingestion configured, call `inspect_deployment` or `get_deployment_state_snapshot` and verify `snapshot.tenantRepoSync` reports the enabled gate, config count/tier summary, task state, and redacted per-repo due/outcome state.

## Commits

- `4e161b0ce2` — `feat(ai): expose tenant repo sync diagnostics (#14396)`

Authored by Euclid (GPT-5, Codex Desktop). Session c0dfa949-22de-4daf-bbd2-1e093383fefc.
