### PR TITLE
feat(ai): explain compose lookup diagnostics (#14397)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
@@ -16,7 +16,9 @@ export const DEPLOYMENT_RUNTIME_LIFECYCLE_OPERATIONS = Object.freeze([
     'restart'
 ]);
 
-const DEFAULT_RESPONSE_MAX_BYTES = 1024 * 1024;
+const DEFAULT_RESPONSE_MAX_BYTES      = 1024 * 1024;
+const DOCKER_SOCKET_FORBIDDEN_CODES   = new Set(['EACCES', 'EPERM']);
+const DOCKER_SOCKET_UNAVAILABLE_CODES = new Set(['ENOENT', 'ECONNREFUSED']);
 
 /**
  * @summary Performs one bounded HTTP request against the Docker Engine Unix socket.
@@ -231,7 +233,11 @@ export class DeploymentRuntimeAccessService extends Base {
      */
     assertEnabled() {
         if (!this.configValues.enabled) {
-            throw new Error('Deployment runtime access is disabled');
+            throw createRuntimeAccessError({
+                reason : 'runtime-access-disabled',
+                message: 'Deployment runtime access is disabled',
+                details: this.createEffectiveConfigSummary()
+            });
         }
     }
 
@@ -241,11 +247,19 @@ export class DeploymentRuntimeAccessService extends Base {
      */
     assertMechanismSupported() {
         if (!DEPLOYMENT_RUNTIME_MECHANISMS.includes(this.mechanism)) {
-            throw new Error(`Unsupported deployment runtime mechanism '${this.mechanism}'`);
+            throw createRuntimeAccessError({
+                reason : 'runtime-mechanism-unsupported',
+                message: `Unsupported deployment runtime mechanism '${this.mechanism}'`,
+                details: this.createEffectiveConfigSummary()
+            });
         }
 
         if (this.mechanism === 'sidecar') {
-            throw new Error('Deployment runtime sidecar mechanism is documented fallback only; docker-socket is the MVP implementation');
+            throw createRuntimeAccessError({
+                reason : 'runtime-sidecar-unimplemented',
+                message: 'Deployment runtime sidecar mechanism is documented fallback only; docker-socket is the MVP implementation',
+                details: this.createEffectiveConfigSummary()
+            });
         }
     }
 
@@ -261,7 +275,15 @@ export class DeploymentRuntimeAccessService extends Base {
             : this.configValues.lifecycleOperations;
 
         if (!Array.isArray(allowed) || !allowed.includes(operation)) {
-            throw new Error(`Deployment runtime ${envelope} operation '${operation}' is not allowlisted`);
+            throw createRuntimeAccessError({
+                reason : 'runtime-operation-not-allowlisted',
+                message: `Deployment runtime ${envelope} operation '${operation}' is not allowlisted`,
+                details: {
+                    ...this.createEffectiveConfigSummary(),
+                    envelope,
+                    operation
+                }
+            });
         }
     }
 
@@ -282,22 +304,50 @@ export class DeploymentRuntimeAccessService extends Base {
             filters.label.push(`com.docker.compose.project=${composeProject}`);
         }
 
-        const response = await this.dockerRequest({
-            method: 'GET',
-            path  : `/containers/json?all=true&filters=${encodeURIComponent(JSON.stringify(filters))}`
-        });
-        const containers = this.parseJson(response.body, 'container list');
+        let response,
+            containers;
+
+        try {
+            response = await this.dockerRequest({
+                method: 'GET',
+                path  : `/containers/json?all=true&filters=${encodeURIComponent(JSON.stringify(filters))}`
+            });
+        } catch (error) {
+            throw this.createDockerListError({serviceKey, filters, error});
+        }
+
+        try {
+            containers = this.parseJson(response.body, 'container list');
+        } catch (error) {
+            throw createRuntimeAccessError({
+                reason : 'docker-container-list-invalid-json',
+                message: error.message,
+                details: this.createLookupDetails({serviceKey, filters})
+            });
+        }
 
         if (!Array.isArray(containers)) {
-            throw new Error('Docker API container list response is not an array');
+            throw createRuntimeAccessError({
+                reason : 'docker-container-list-invalid-shape',
+                message: 'Docker API container list response is not an array',
+                details: this.createLookupDetails({serviceKey, filters})
+            });
         }
 
         if (containers.length === 0) {
-            throw new Error(`No Docker container found for compose service '${serviceKey}'`);
+            throw createRuntimeAccessError({
+                reason : 'compose-service-no-match',
+                message: `No Docker container found for compose service '${serviceKey}'`,
+                details: this.createLookupDetails({serviceKey, filters, matchCount: 0})
+            });
         }
 
         if (containers.length > 1) {
-            throw new Error(`Compose service '${serviceKey}' resolved to ${containers.length} containers; configure composeProject to disambiguate`);
+            throw createRuntimeAccessError({
+                reason : 'compose-service-ambiguous',
+                message: `Compose service '${serviceKey}' resolved to ${containers.length} containers; configure composeProject to disambiguate`,
+                details: this.createLookupDetails({serviceKey, filters, matchCount: containers.length})
+            });
         }
 
         const [container] = containers;
@@ -324,18 +374,108 @@ export class DeploymentRuntimeAccessService extends Base {
      */
     assertServiceKeyAllowed(serviceKey) {
         if (typeof serviceKey !== 'string' || serviceKey.length === 0) {
-            throw new TypeError('Deployment runtime serviceKey is required');
+            throw createRuntimeAccessError({
+                Type   : TypeError,
+                reason : 'runtime-service-key-required',
+                message: 'Deployment runtime serviceKey is required',
+                details: this.createEffectiveConfigSummary()
+            });
         }
 
         if (!/^[a-zA-Z0-9_.-]+$/.test(serviceKey)) {
-            throw new TypeError(`Deployment runtime serviceKey '${serviceKey}' contains unsupported characters`);
+            throw createRuntimeAccessError({
+                Type   : TypeError,
+                reason : 'runtime-service-key-invalid',
+                message: `Deployment runtime serviceKey '${serviceKey}' contains unsupported characters`,
+                details: {
+                    ...this.createEffectiveConfigSummary(),
+                    serviceKey
+                }
+            });
         }
 
         const allowedServices = this.configValues.allowedServices;
 
         if (!Array.isArray(allowedServices) || !allowedServices.includes(serviceKey)) {
-            throw new Error(`Deployment runtime service '${serviceKey}' is not allowlisted`);
+            throw createRuntimeAccessError({
+                reason : 'runtime-service-not-allowlisted',
+                message: `Deployment runtime service '${serviceKey}' is not allowlisted`,
+                details: {
+                    ...this.createEffectiveConfigSummary(),
+                    serviceKey
+                }
+            });
         }
+    }
+
+    /**
+     * Builds a non-secret summary of runtime-access config needed to debug service resolution.
+     * @returns {Object}
+     */
+    createEffectiveConfigSummary() {
+        const config = this.configValues;
+
+        return {
+            enabled             : Boolean(config.enabled),
+            mechanism           : this.mechanism,
+            composeProject      : config.composeProject || null,
+            allowedServices     : Array.isArray(config.allowedServices) ? [...config.allowedServices] : [],
+            readOperations      : Array.isArray(config.readOperations) ? [...config.readOperations] : [],
+            lifecycleOperations : Array.isArray(config.lifecycleOperations) ? [...config.lifecycleOperations] : [],
+            auditMode           : config.auditMode || 'metadata',
+            socketPathConfigured: Boolean(config.socketPath)
+        };
+    }
+
+    /**
+     * Builds bounded lookup context for compose-label resolution failures.
+     * @param {Object} options
+     * @param {String} options.serviceKey Compose service key.
+     * @param {Object} options.filters Docker label filter descriptor.
+     * @param {Number|null} [options.matchCount=null] Number of matched containers when known.
+     * @returns {Object}
+     */
+    createLookupDetails({serviceKey, filters, matchCount = null}) {
+        return {
+            ...this.createEffectiveConfigSummary(),
+            serviceKey,
+            filters,
+            matchCount,
+            hints: [
+                'Set NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT when multiple compose projects share the Docker socket.',
+                'Align NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES with Docker com.docker.compose.service labels.',
+                'Mount /var/run/docker.sock into the orchestrator only when B1 runtime diagnostics/recovery are intended.',
+                'Disable NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED when the deployment intentionally has no runtime handle.'
+            ]
+        };
+    }
+
+    /**
+     * Wraps Docker container-list transport failures with stable reason metadata.
+     * @param {Object} options
+     * @param {String} options.serviceKey Compose service key.
+     * @param {Object} options.filters Docker label filter descriptor.
+     * @param {Error} options.error Underlying request error.
+     * @returns {Error}
+     */
+    createDockerListError({serviceKey, filters, error}) {
+        let reason  = 'docker-container-list-failed',
+            message = error.message;
+
+        if (DOCKER_SOCKET_FORBIDDEN_CODES.has(error.code)) {
+            reason  = 'docker-socket-forbidden';
+            message = 'Docker socket access is forbidden';
+        } else if (DOCKER_SOCKET_UNAVAILABLE_CODES.has(error.code)) {
+            reason  = 'docker-socket-unavailable';
+            message = 'Docker socket is unavailable';
+        }
+
+        return createRuntimeAccessError({
+            reason,
+            message,
+            code   : error.code || null,
+            details: this.createLookupDetails({serviceKey, filters})
+        });
     }
 
     /**
@@ -469,10 +609,10 @@ export class DeploymentRuntimeAccessService extends Base {
             runtimeMechanism  : this.mechanism,
             capabilityEnvelope: envelope,
             operation,
-            auditLabel       : `${envelope}:${operation}`,
-            auditMode     : this.configValues.auditMode || 'metadata',
-            serviceKey    : target.serviceKey,
-            targetIdentity: {
+            auditLabel        : `${envelope}:${operation}`,
+            auditMode         : this.configValues.auditMode || 'metadata',
+            serviceKey        : target.serviceKey,
+            targetIdentity    : {
                 kind: 'compose-service',
                 id  : target.serviceKey
             },
@@ -489,6 +629,26 @@ export class DeploymentRuntimeAccessService extends Base {
             reason: reason || null
         };
     }
+}
+
+/**
+ * Creates a runtime-access error that remains compatible with callers expecting thrown Error objects.
+ * @param {Object} options
+ * @param {Function} [options.Type=Error] Error constructor.
+ * @param {String} options.reason Stable machine reason.
+ * @param {String} options.message Human-readable message.
+ * @param {String|null} [options.code=null] Optional low-level error code.
+ * @param {Object|null} [options.details=null] Bounded diagnostic details.
+ * @returns {Error}
+ */
+function createRuntimeAccessError({Type = Error, reason, message, code = null, details = null}) {
+    const error = new Type(message);
+
+    error.reason  = reason;
+    error.code    = code;
+    error.details = details;
+
+    return error;
 }
 
 export default Neo.setupClass(DeploymentRuntimeAccessService);

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -178,13 +178,15 @@ export class DeploymentStateBridgeService extends Base {
             services.push(await this.collectServiceSnapshot({serviceKey, observedAt: generatedAt}));
         }
 
-        const recoveryRuns   = await this.collectRecoveryRunSnapshot();
-        const selfHeal       = await this.collectSelfHealSnapshot();
-        const tenantRepoSync = await this.collectTenantRepoSyncSnapshot({observedAt: generatedAt});
+        const recoveryRuns      = await this.collectRecoveryRunSnapshot();
+        const selfHeal          = await this.collectSelfHealSnapshot();
+        const tenantRepoSync    = await this.collectTenantRepoSyncSnapshot({observedAt: generatedAt});
+        const bridgeDiagnostics = this.collectBridgeDiagnostics({services, observedAt: generatedAt});
 
         return createDeploymentStateSnapshot({
             generatedAt,
             services,
+            bridgeDiagnostics,
             recoveryRuns,
             selfHeal,
             tenantRepoSync
@@ -214,7 +216,7 @@ export class DeploymentStateBridgeService extends Base {
                 proofs.push(result.proof);
                 return result.data;
             } catch (error) {
-                errors.push({operation, message: error.message});
+                errors.push(summarizeRuntimeAccessError(error, {operation}));
                 return null;
             }
         };
@@ -259,6 +261,56 @@ export class DeploymentStateBridgeService extends Base {
             diagnosis,
             proofs,
             errors
+        };
+    }
+
+    /**
+     * Collects bridge-level diagnostics for broad runtime-access misconfiguration.
+     * @param {Object} options
+     * @param {Object[]} options.services Per-service deployment snapshots.
+     * @param {Number} options.observedAt Epoch ms.
+     * @returns {Object}
+     */
+    collectBridgeDiagnostics({services, observedAt}) {
+        const
+            serviceList          = Array.isArray(services) ? services : [],
+            degradedServices     = serviceList.filter(service => service.status === 'degraded'),
+            serviceFailureStates = serviceList.map(service => ({
+                serviceKey: service.serviceKey,
+                status    : service.status,
+                reasons   : unique((service.errors || []).map(error => error.reason).filter(Boolean))
+            })),
+            failureReasonCounts    = countBy(serviceList.flatMap(service => (service.errors || []).map(error => error.reason || 'unknown'))),
+            operationFailureCounts = countBy(serviceList.flatMap(service => (service.errors || []).map(error => error.operation || 'unknown'))),
+            lookupFailureCount     = serviceList.filter(hasLookupFailure).length,
+            allServicesDegraded    = serviceList.length > 0 && degradedServices.length === serviceList.length,
+            broadLookupFailure     = serviceList.length > 0 && lookupFailureCount === serviceList.length,
+            reason                 = broadLookupFailure
+                ? 'broad-service-lookup-failure'
+                : degradedServices.length > 0 ? 'partial-service-observation-failure' : null;
+
+        return {
+            schemaVersion: 1,
+            recordType   : 'deployment-state-bridge-diagnostics',
+            observedAt,
+            status       : degradedServices.length > 0 ? 'degraded' : 'available',
+            reason,
+            runtimeAccess: summarizeRuntimeAccessConfig(AiConfig.orchestrator.deploymentRuntimeAccess),
+            bridgeConfig : summarizeBridgeConfig({
+                bridgeConfig        : AiConfig.orchestrator.deploymentStateBridge,
+                effectiveServiceKeys: this.getServiceKeys()
+            }),
+            serviceResolution: {
+                serviceCount        : serviceList.length,
+                degradedServiceCount: degradedServices.length,
+                allServicesDegraded,
+                broadLookupFailure,
+                lookupFailureCount,
+                failureReasonCounts,
+                operationFailureCounts,
+                services            : serviceFailureStates
+            },
+            hints: buildBridgeHints({reason, failureReasonCounts})
         };
     }
 
@@ -609,6 +661,112 @@ function summarizeLogs(logs, maxBytes) {
         truncated: bounded.truncated,
         maxBytes : bounded.maxBytes
     };
+}
+
+function summarizeRuntimeAccessError(error, {operation}) {
+    return {
+        operation,
+        message: error.message,
+        reason : error.reason || 'runtime-access-error',
+        code   : error.code || null,
+        details: sanitizeRuntimeAccessDetails(error.details)
+    };
+}
+
+function sanitizeRuntimeAccessDetails(details) {
+    if (!details || typeof details !== 'object') {
+        return null;
+    }
+
+    return {
+        enabled             : Boolean(details.enabled),
+        mechanism           : details.mechanism || null,
+        composeProject      : details.composeProject || null,
+        allowedServices     : Array.isArray(details.allowedServices) ? [...details.allowedServices] : [],
+        readOperations      : Array.isArray(details.readOperations) ? [...details.readOperations] : [],
+        lifecycleOperations : Array.isArray(details.lifecycleOperations) ? [...details.lifecycleOperations] : [],
+        auditMode           : details.auditMode || null,
+        socketPathConfigured: Boolean(details.socketPathConfigured),
+        serviceKey          : details.serviceKey || null,
+        filters             : details.filters || null,
+        matchCount          : Number.isFinite(details.matchCount) ? details.matchCount : null,
+        hints               : Array.isArray(details.hints) ? unique(details.hints.filter(Boolean)) : []
+    };
+}
+
+function summarizeRuntimeAccessConfig(config = {}) {
+    return {
+        enabled             : Boolean(config.enabled),
+        mechanism           : config.mechanism || null,
+        composeProject      : config.composeProject || null,
+        allowedServices     : Array.isArray(config.allowedServices) ? [...config.allowedServices] : [],
+        readOperations      : Array.isArray(config.readOperations) ? [...config.readOperations] : [],
+        lifecycleOperations : Array.isArray(config.lifecycleOperations) ? [...config.lifecycleOperations] : [],
+        auditMode           : config.auditMode || null,
+        socketPathConfigured: Boolean(config.socketPath)
+    };
+}
+
+function summarizeBridgeConfig({bridgeConfig = {}, effectiveServiceKeys = []} = {}) {
+    return {
+        allowedServices             : Array.isArray(bridgeConfig.allowedServices) ? [...bridgeConfig.allowedServices] : [],
+        effectiveServiceKeys        : Array.isArray(effectiveServiceKeys) ? [...effectiveServiceKeys] : [],
+        includeLogs                 : Boolean(bridgeConfig.includeLogs),
+        logTail                     : Number.isFinite(bridgeConfig.logTail) ? bridgeConfig.logTail : null,
+        logMaxBytes                 : Number.isFinite(bridgeConfig.logMaxBytes) ? bridgeConfig.logMaxBytes : null,
+        statsSampleWindow           : Number.isFinite(bridgeConfig.statsSampleWindow) ? bridgeConfig.statsSampleWindow : null,
+        providerResidencyServiceKeys: Array.isArray(bridgeConfig.providerResidencyServiceKeys) ? [...bridgeConfig.providerResidencyServiceKeys] : []
+    };
+}
+
+function hasLookupFailure(service) {
+    return (service.errors || []).some(error => [
+        'compose-service-no-match',
+        'compose-service-ambiguous',
+        'docker-socket-forbidden',
+        'docker-socket-unavailable',
+        'docker-container-list-failed',
+        'docker-container-list-invalid-json',
+        'docker-container-list-invalid-shape',
+        'runtime-access-disabled',
+        'runtime-mechanism-unsupported',
+        'runtime-sidecar-unimplemented',
+        'runtime-service-not-allowlisted'
+    ].includes(error.reason));
+}
+
+function buildBridgeHints({reason, failureReasonCounts}) {
+    const hints = [];
+
+    if (reason === 'broad-service-lookup-failure') {
+        hints.push('All observed services failed runtime lookup; verify the orchestrator Docker socket mount and Compose project/service labels before investigating individual services.');
+    }
+
+    if (failureReasonCounts['compose-service-no-match']) {
+        hints.push('If the stack uses a non-default Compose project, set NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT to the project label shown by Docker Compose.');
+        hints.push('Ensure NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES and NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES name Docker com.docker.compose.service labels, not container names.');
+    }
+
+    if (failureReasonCounts['compose-service-ambiguous']) {
+        hints.push('Multiple containers matched a service label; configure NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT to disambiguate.');
+    }
+
+    if (failureReasonCounts['docker-socket-unavailable'] || failureReasonCounts['docker-socket-forbidden']) {
+        hints.push('Mount /var/run/docker.sock into the orchestrator with sufficient read permissions when B1 runtime diagnostics are intended, or disable runtime access explicitly.');
+    }
+
+    return unique(hints);
+}
+
+function countBy(values) {
+    return values.reduce((acc, value) => {
+        acc[value] = (acc[value] || 0) + 1;
+        return acc;
+    }, {});
+}
+
+function unique(values) {
+    return [...new Set(values)];
 }
 
 function isSafeServiceKey(value) {

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -295,11 +295,24 @@ export class DeploymentStateBridgeService extends Base {
             observedAt,
             status       : degradedServices.length > 0 ? 'degraded' : 'available',
             reason,
-            runtimeAccess: summarizeRuntimeAccessConfig(AiConfig.orchestrator.deploymentRuntimeAccess),
-            bridgeConfig : summarizeBridgeConfig({
-                bridgeConfig        : AiConfig.orchestrator.deploymentStateBridge,
-                effectiveServiceKeys: this.getServiceKeys()
-            }),
+            runtimeAccess: {
+                enabled            : AiConfig.orchestrator.deploymentRuntimeAccess.enabled,
+                mechanism          : AiConfig.orchestrator.deploymentRuntimeAccess.mechanism,
+                composeProject     : AiConfig.orchestrator.deploymentRuntimeAccess.composeProject,
+                allowedServices    : Array.isArray(AiConfig.orchestrator.deploymentRuntimeAccess.allowedServices) ? [...AiConfig.orchestrator.deploymentRuntimeAccess.allowedServices] : [],
+                readOperations     : Array.isArray(AiConfig.orchestrator.deploymentRuntimeAccess.readOperations) ? [...AiConfig.orchestrator.deploymentRuntimeAccess.readOperations] : [],
+                lifecycleOperations: Array.isArray(AiConfig.orchestrator.deploymentRuntimeAccess.lifecycleOperations) ? [...AiConfig.orchestrator.deploymentRuntimeAccess.lifecycleOperations] : [],
+                auditMode          : AiConfig.orchestrator.deploymentRuntimeAccess.auditMode
+            },
+            bridgeConfig: {
+                allowedServices             : Array.isArray(AiConfig.orchestrator.deploymentStateBridge.allowedServices) ? [...AiConfig.orchestrator.deploymentStateBridge.allowedServices] : [],
+                effectiveServiceKeys        : this.getServiceKeys(),
+                includeLogs                 : AiConfig.orchestrator.deploymentStateBridge.includeLogs,
+                logTail                     : Number.isFinite(AiConfig.orchestrator.deploymentStateBridge.logTail) ? AiConfig.orchestrator.deploymentStateBridge.logTail : null,
+                logMaxBytes                 : Number.isFinite(AiConfig.orchestrator.deploymentStateBridge.logMaxBytes) ? AiConfig.orchestrator.deploymentStateBridge.logMaxBytes : null,
+                statsSampleWindow           : Number.isFinite(AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow) ? AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow : null,
+                providerResidencyServiceKeys: Array.isArray(AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys) ? [...AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys] : []
+            },
             serviceResolution: {
                 serviceCount        : serviceList.length,
                 degradedServiceCount: degradedServices.length,
@@ -691,31 +704,6 @@ function sanitizeRuntimeAccessDetails(details) {
         filters             : details.filters || null,
         matchCount          : Number.isFinite(details.matchCount) ? details.matchCount : null,
         hints               : Array.isArray(details.hints) ? unique(details.hints.filter(Boolean)) : []
-    };
-}
-
-function summarizeRuntimeAccessConfig(config = {}) {
-    return {
-        enabled             : Boolean(config.enabled),
-        mechanism           : config.mechanism || null,
-        composeProject      : config.composeProject || null,
-        allowedServices     : Array.isArray(config.allowedServices) ? [...config.allowedServices] : [],
-        readOperations      : Array.isArray(config.readOperations) ? [...config.readOperations] : [],
-        lifecycleOperations : Array.isArray(config.lifecycleOperations) ? [...config.lifecycleOperations] : [],
-        auditMode           : config.auditMode || null,
-        socketPathConfigured: Boolean(config.socketPath)
-    };
-}
-
-function summarizeBridgeConfig({bridgeConfig = {}, effectiveServiceKeys = []} = {}) {
-    return {
-        allowedServices             : Array.isArray(bridgeConfig.allowedServices) ? [...bridgeConfig.allowedServices] : [],
-        effectiveServiceKeys        : Array.isArray(effectiveServiceKeys) ? [...effectiveServiceKeys] : [],
-        includeLogs                 : Boolean(bridgeConfig.includeLogs),
-        logTail                     : Number.isFinite(bridgeConfig.logTail) ? bridgeConfig.logTail : null,
-        logMaxBytes                 : Number.isFinite(bridgeConfig.logMaxBytes) ? bridgeConfig.logMaxBytes : null,
-        statsSampleWindow           : Number.isFinite(bridgeConfig.statsSampleWindow) ? bridgeConfig.statsSampleWindow : null,
-        providerResidencyServiceKeys: Array.isArray(bridgeConfig.providerResidencyServiceKeys) ? [...bridgeConfig.providerResidencyServiceKeys] : []
     };
 }
 

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -156,7 +156,9 @@ paths:
         or any public daemon/orchestrator route. It exists so MC-unhealthy / graph-unavailable
         incidents still have a KB-hosted current-state path when KB is healthy. The snapshot
         also includes redacted tenant-repo-sync scheduler/task/config state for pull-mode
-        ingestion diagnostics.
+        ingestion diagnostics. The snapshot can also include bridgeDiagnostics with redacted
+        runtime-access config, Compose label filter details, and stable lookup-failure reasons
+        for service-observation failures.
       tags: [Health]
       requestBody:
         required: false

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -202,7 +202,9 @@ paths:
         Reads the bounded deployment-state bridge snapshot written by the internal orchestrator.
         This is a read-only public MC surface: it does not expose Docker, shell, exec, restart,
         or any public daemon/orchestrator route. If the bridge is missing or stale, the response
-        reports that explicitly instead of falling back to graph-only proof.
+        reports that explicitly instead of falling back to graph-only proof. The snapshot can
+        include bridgeDiagnostics with redacted runtime-access config, Compose label filter
+        details, and stable lookup-failure reasons for service-observation failures.
       tags: [Diagnostics]
       requestBody:
         required: false

--- a/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
@@ -17,6 +17,7 @@ const DEFAULT_STALE_AFTER_MS     = 2 * 60 * 1000;
  * @param {Number} [options.generatedAt=Date.now()] Snapshot timestamp in epoch ms.
  * @param {String} [options.source='orchestrator-deployment-state-bridge'] Producer label.
  * @param {Object[]} [options.services=[]] Bounded per-service snapshots.
+ * @param {Object|null} [options.bridgeDiagnostics=null] Bounded bridge-level runtime-access diagnosis.
  * @param {Object|null} [options.recoveryRuns=null] Bounded recovery-run ledger snapshot.
  * @param {Object|null} [options.selfHeal=null] Bounded self-heal immune-system status (heal-ledger summary + recent events).
  * @param {Object|null} [options.tenantRepoSync=null] Bounded tenant-repo-sync scheduler/task/config snapshot.
@@ -26,6 +27,7 @@ export function createDeploymentStateSnapshot({
     generatedAt = Date.now(),
     source = 'orchestrator-deployment-state-bridge',
     services = [],
+    bridgeDiagnostics = null,
     recoveryRuns = null,
     selfHeal = null,
     tenantRepoSync = null
@@ -44,6 +46,7 @@ export function createDeploymentStateSnapshot({
         generatedAt,
         source,
         services,
+        bridgeDiagnostics,
         recoveryRuns,
         selfHeal,
         tenantRepoSync

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -130,6 +130,12 @@ Read `snapshot.bridgeDiagnostics` before changing service code:
   orchestrator cannot read the runtime socket. Mount `/var/run/docker.sock`
   into the orchestrator with suitable permissions, or disable runtime access
   explicitly when that deployment should not expose B1 diagnostics.
+- The default diagnostic set observes sibling services, not the orchestrator
+  container itself. When orchestrator logs/state are needed for a cloud
+  incident, add the Compose service label to both
+  `NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES` and
+  `NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES` (for the bundled compose file,
+  use `orchestrator`).
 
 The diagnostic intentionally exposes only non-secret config, service keys, and
 the label filter shape. It does not enumerate arbitrary containers or expose

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -104,6 +104,37 @@ docker compose -p <project> up -d --force-recreate kb-server mc-server orchestra
 
 This is an environment-only repair; no image rebuild is required.
 
+### `inspect_deployment` says `No Docker container found for compose service ...`
+
+**Layer:** the MCP server is reachable and the deployment-state bridge snapshot
+is fresh, but the orchestrator's runtime-access holder cannot resolve one or
+more allowlisted Compose services through Docker labels.
+
+Read `snapshot.bridgeDiagnostics` before changing service code:
+
+- `runtimeAccess.enabled: false` means the bridge is intentionally not using a
+  runtime handle. Set `NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED=true` only when
+  B1 runtime diagnostics/recovery are intended.
+- `reason: broad-service-lookup-failure` means most or all configured services
+  failed at the observation layer. Treat this as bridge configuration first,
+  not as four independent service outages.
+- `compose-service-no-match` means Docker returned no container for the label
+  filter shown in the error details. Align
+  `NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES` and
+  `NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES` with Docker
+  `com.docker.compose.service` labels, not container names.
+- `compose-service-ambiguous` means more than one container matched a service
+  label. Set `NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT=<project>` to the
+  Compose project label.
+- `docker-socket-unavailable` or `docker-socket-forbidden` means the
+  orchestrator cannot read the runtime socket. Mount `/var/run/docker.sock`
+  into the orchestrator with suitable permissions, or disable runtime access
+  explicitly when that deployment should not expose B1 diagnostics.
+
+The diagnostic intentionally exposes only non-secret config, service keys, and
+the label filter shape. It does not enumerate arbitrary containers or expose
+Docker, shell, restart, or daemon-control routes through public MCP tools.
+
 ## Test profile vs production auth profile
 
 Verify the wiring *before* real auth is enabled, but keep the two profiles distinct:

--- a/learn/agentos/tooling/KnowledgeBaseMcpApi.md
+++ b/learn/agentos/tooling/KnowledgeBaseMcpApi.md
@@ -50,6 +50,18 @@ task state, effective repo-config counts/tiers, redacted per-repo due state, and
 stable failure reason codes without exposing clone URLs, credentials, or raw
 logs.
 
+`inspect_deployment` and `get_deployment_state_snapshot` include a
+`bridgeDiagnostics` envelope when the orchestrator's deployment-state bridge
+can explain its own observation layer. That envelope reports non-secret
+runtime-access config such as the runtime mechanism, whether runtime access is
+enabled, the configured Compose project, allowlisted service keys, read
+operations, the bridge's effective service keys, and whether bounded logs are
+included. Per-service lookup failures also carry stable `reason` values and the
+Compose label filter used for the lookup, for example
+`compose-service-no-match` with
+`com.docker.compose.service=<service>`. This is diagnosis only: callers still
+receive no Docker socket, shell, restart, or arbitrary container enumeration.
+
 ## Admin Tools
 
 | Tool | Use |

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
@@ -33,11 +33,22 @@ function makeContainer(overrides = {}) {
     };
 }
 
-function createService({config = {}, containers = [makeContainer()], inspectData = {Name: '/neo-mc-server-1'}, statsData = {cpu_stats: {}}, logText = 'ready'} = {}) {
+function createService({
+    config = {},
+    containers = [makeContainer()],
+    inspectData = {Name: '/neo-mc-server-1'},
+    statsData = {cpu_stats: {}},
+    logText = 'ready',
+    requestError = null
+} = {}) {
     const calls = [];
 
     const dockerRequestFn = async request => {
         calls.push(request);
+
+        if (requestError) {
+            throw requestError;
+        }
 
         if (request.path.startsWith('/containers/json')) {
             return {statusCode: 200, headers: {}, body: JSON.stringify(containers)};
@@ -194,6 +205,39 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
         expect(sidecar.calls).toHaveLength(0);
     });
 
+    test('adds structured config and filter details when a compose service has no match', async () => {
+        const {service} = createService({
+            config    : {composeProject: 'prod'},
+            containers: []
+        });
+
+        const error = await service.readObserve({serviceKey: 'mc-server', operation: 'inspect'}).catch(e => e);
+
+        expect(error).toMatchObject({
+            reason : 'compose-service-no-match',
+            message: "No Docker container found for compose service 'mc-server'",
+            details: {
+                enabled             : true,
+                mechanism           : 'docker-socket',
+                composeProject      : 'prod',
+                allowedServices     : ['chroma', 'kb-server', 'mc-server', 'local-model'],
+                readOperations      : ['inspect', 'logs', 'stats'],
+                lifecycleOperations : ['restart'],
+                auditMode           : 'metadata',
+                socketPathConfigured: true,
+                serviceKey          : 'mc-server',
+                filters             : {
+                    label: [
+                        'com.docker.compose.service=mc-server',
+                        'com.docker.compose.project=prod'
+                    ]
+                },
+                matchCount: 0
+            }
+        });
+        expect(error.details.hints).toContain('Align NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES with Docker com.docker.compose.service labels.');
+    });
+
     test('requires composeProject when a service label resolves ambiguously', async () => {
         const {service} = createService({
             containers: [
@@ -202,7 +246,37 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
             ]
         });
 
-        await expect(service.readObserve({serviceKey: 'mc-server', operation: 'inspect'}))
-            .rejects.toThrow(/resolved to 2 containers/);
+        const error = await service.readObserve({serviceKey: 'mc-server', operation: 'inspect'}).catch(e => e);
+
+        expect(error).toMatchObject({
+            reason : 'compose-service-ambiguous',
+            message: "Compose service 'mc-server' resolved to 2 containers; configure composeProject to disambiguate",
+            details: {
+                serviceKey: 'mc-server',
+                matchCount: 2,
+                filters   : {
+                    label: ['com.docker.compose.service=mc-server']
+                }
+            }
+        });
+    });
+
+    test('classifies socket transport failures during compose lookup', async () => {
+        const requestError = Object.assign(new Error('connect ENOENT /var/run/docker.sock'), {code: 'ENOENT'});
+        const {service}    = createService({requestError});
+
+        const error = await service.readObserve({serviceKey: 'mc-server', operation: 'inspect'}).catch(e => e);
+
+        expect(error).toMatchObject({
+            reason : 'docker-socket-unavailable',
+            code   : 'ENOENT',
+            message: 'Docker socket is unavailable',
+            details: {
+                serviceKey: 'mc-server',
+                filters   : {
+                    label: ['com.docker.compose.service=mc-server']
+                }
+            }
+        });
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -152,6 +152,111 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             limit  : 10,
             entries: []
         });
+        expect(snapshot.bridgeDiagnostics).toMatchObject({
+            status       : 'available',
+            reason       : null,
+            runtimeAccess: {
+                enabled             : false,
+                mechanism           : 'docker-socket',
+                composeProject      : null,
+                allowedServices     : ['model'],
+                socketPathConfigured: true
+            },
+            bridgeConfig: {
+                effectiveServiceKeys: ['model'],
+                includeLogs         : true
+            },
+            serviceResolution: {
+                serviceCount        : 1,
+                degradedServiceCount: 0,
+                broadLookupFailure  : false
+            }
+        });
+    });
+
+    test('adds bridge-level diagnosis when every service lookup fails', async () => {
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
+            allowedServices: ['kb-server', 'mc-server'],
+            includeLogs    : false
+        });
+        Object.assign(AiConfig.orchestrator.deploymentRuntimeAccess, {
+            enabled        : true,
+            composeProject : null,
+            allowedServices: ['kb-server', 'mc-server'],
+            readOperations : ['inspect', 'stats', 'logs']
+        });
+
+        const runtimeAccessService = {
+            async readObserve({serviceKey}) {
+                const error = new Error(`No Docker container found for compose service '${serviceKey}'`);
+
+                error.reason  = 'compose-service-no-match';
+                error.details = {
+                    enabled             : true,
+                    mechanism           : 'docker-socket',
+                    composeProject      : null,
+                    allowedServices     : ['kb-server', 'mc-server'],
+                    readOperations      : ['inspect', 'stats', 'logs'],
+                    lifecycleOperations : ['restart'],
+                    auditMode           : 'metadata',
+                    socketPathConfigured: true,
+                    serviceKey,
+                    filters             : {
+                        label: [`com.docker.compose.service=${serviceKey}`]
+                    },
+                    matchCount: 0,
+                    hints     : ['Align NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES with Docker com.docker.compose.service labels.']
+                };
+
+                throw error;
+            }
+        };
+
+        const snapshot = await createService({runtimeAccessService}).collectSnapshot();
+
+        expect(snapshot.services).toHaveLength(2);
+        expect(snapshot.services[0].errors[0]).toMatchObject({
+            operation: 'inspect',
+            reason   : 'compose-service-no-match',
+            details  : {
+                socketPathConfigured: true,
+                filters             : {
+                    label: ['com.docker.compose.service=kb-server']
+                }
+            }
+        });
+        expect(JSON.stringify(snapshot.bridgeDiagnostics)).not.toContain('/var/run/docker.sock');
+        expect(snapshot.bridgeDiagnostics).toMatchObject({
+            status       : 'degraded',
+            reason       : 'broad-service-lookup-failure',
+            runtimeAccess: {
+                enabled             : true,
+                mechanism           : 'docker-socket',
+                composeProject      : null,
+                allowedServices     : ['kb-server', 'mc-server'],
+                readOperations      : ['inspect', 'stats', 'logs'],
+                lifecycleOperations : ['restart'],
+                socketPathConfigured: true
+            },
+            bridgeConfig: {
+                allowedServices     : ['kb-server', 'mc-server'],
+                effectiveServiceKeys: ['kb-server', 'mc-server'],
+                includeLogs         : false
+            },
+            serviceResolution: {
+                serviceCount          : 2,
+                degradedServiceCount  : 2,
+                allServicesDegraded   : true,
+                broadLookupFailure    : true,
+                lookupFailureCount    : 2,
+                failureReasonCounts   : {'compose-service-no-match': 4},
+                operationFailureCounts: {
+                    inspect: 2,
+                    stats  : 2
+                }
+            }
+        });
+        expect(snapshot.bridgeDiagnostics.hints).toContain('All observed services failed runtime lookup; verify the orchestrator Docker socket mount and Compose project/service labels before investigating individual services.');
     });
 
     test('collectSelfHealSnapshot folds the heal-ledger into an operator-facing immune-status (#14163 AC2)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -156,11 +156,10 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             status       : 'available',
             reason       : null,
             runtimeAccess: {
-                enabled             : false,
-                mechanism           : 'docker-socket',
-                composeProject      : null,
-                allowedServices     : ['model'],
-                socketPathConfigured: true
+                enabled        : false,
+                mechanism      : 'docker-socket',
+                composeProject : null,
+                allowedServices: ['model']
             },
             bridgeConfig: {
                 effectiveServiceKeys: ['model'],
@@ -230,13 +229,12 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             status       : 'degraded',
             reason       : 'broad-service-lookup-failure',
             runtimeAccess: {
-                enabled             : true,
-                mechanism           : 'docker-socket',
-                composeProject      : null,
-                allowedServices     : ['kb-server', 'mc-server'],
-                readOperations      : ['inspect', 'stats', 'logs'],
-                lifecycleOperations : ['restart'],
-                socketPathConfigured: true
+                enabled            : true,
+                mechanism          : 'docker-socket',
+                composeProject     : null,
+                allowedServices    : ['kb-server', 'mc-server'],
+                readOperations     : ['inspect', 'stats', 'logs'],
+                lifecycleOperations: ['restart']
             },
             bridgeConfig: {
                 allowedServices     : ['kb-server', 'mc-server'],

--- a/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
@@ -31,11 +31,14 @@ test.describe('deploymentStateBridgeStore', () => {
         });
     });
 
-    test('carries the self-heal immune-system status when provided, null by default (#14163 AC2)', () => {
-        const selfHeal = {status: 'available', summary: {total: 3, currentlyFrozen: ['c2']}, recentEvents: [{type: 'heal', at: 9}]},
-              snapshot = createDeploymentStateSnapshot({generatedAt: 1710000000000, selfHeal});
+    test('carries additive bridge diagnostics and self-heal status when provided, null by default (#14163 AC2)', () => {
+        const bridgeDiagnostics = {status: 'degraded', reason: 'broad-service-lookup-failure'},
+              selfHeal          = {status: 'available', summary: {total: 3, currentlyFrozen: ['c2']}, recentEvents: [{type: 'heal', at: 9}]},
+              snapshot          = createDeploymentStateSnapshot({generatedAt: 1710000000000, bridgeDiagnostics, selfHeal});
 
+        expect(snapshot.bridgeDiagnostics).toEqual(bridgeDiagnostics);
         expect(snapshot.selfHeal).toEqual(selfHeal);                       // passed through verbatim
+        expect(createDeploymentStateSnapshot({generatedAt: 1}).bridgeDiagnostics).toBeNull(); // additive + back-compat
         expect(createDeploymentStateSnapshot({generatedAt: 1}).selfHeal).toBeNull(); // additive + back-compat (omitted → null)
     });
 


### PR DESCRIPTION
Resolves #14397

Adds structured, redacted deployment-runtime diagnostics for compose-service lookup failures. The runtime holder now throws stable reason-coded errors with bounded effective config and Compose label filter context, and the deployment-state bridge folds broad observation failures into a top-level `bridgeDiagnostics` envelope for `inspect_deployment` / snapshot readers.

Evidence: L2 (focused unit specs cover no-match, ambiguous match, socket transport classification, bridge aggregate broad lookup failure, and snapshot-store passthrough) -> L2 required (public diagnostic contract plus docs; live cloud Docker socket proof is post-merge/deployment validation). No residuals.

## Deltas from ticket

- Kept the default diagnostic service set sibling-focused instead of adding `orchestrator` by default; documented the explicit `orchestrator` env override path for incidents that need it.
- Sanitized socket transport failures to stable reason/code messages so public snapshots do not leak host socket paths.
- KB synthesis had no narrow prior for this surface; source reads plus ADR-0026 were the active authority.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs` -> 27 passed (30.5s).
- `npm run ai:lint-guides` -> OK, 0 hard failures; existing repo-wide warnings remain.
- `npm run ai:lint-mcp-test-locations` -> OK.
- `git diff --cached --check` -> OK before commit.
- Pre-commit hooks passed for both commits; the code commit passed whitespace, shorthand, AiConfig test-mutation, JSDoc types, ticket archaeology, and block alignment.

## Post-Merge Validation

- [ ] In a cloud deployment with mismatched compose service labels, `inspect_deployment` reports `bridgeDiagnostics.reason: "broad-service-lookup-failure"` and per-service `compose-service-no-match` details.
- [ ] When orchestrator observation is needed, setting both runtime-access and bridge allowlists to include `orchestrator` surfaces the orchestrator compose service by label.

## Commits

- `18501de240` - structured runtime/bridge diagnostics.
- `c848d025ab` - documented orchestrator override.

Authored by Euclid (GPT-5, Codex Desktop). Session c0dfa949-22de-4daf-bbd2-1e093383fefc.
