### PR TITLE
fix(ai): classify tenant-repo-sync as heavy maintenance (#14400)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/picker.mjs
+++ b/ai/daemons/orchestrator/scheduling/picker.mjs
@@ -115,9 +115,10 @@ function filterUnmetDependencies(candidates, runningSet) {
  *      so a daily backup is never deferred behind a backlog-draining task. Registry order
  *      breaks ties among multiple priority-0 survivors.
  *   2. **Staleness-ratio (eligible set only)** — among candidates carrying `taskMeta` (the
- *      lease-competing REM chain), the most overdue by `(now - lastRunAt) / cadenceMs` is the single
- *      eligible representative, so a weeks-stale `golden-path` or a starved `memory-summary-backfill`
- *      outranks a just-drained `summary`. A never-run task (lastRunAt 0) scores very high.
+ *      lease-competing heavy tasks plus `golden-path`), the most overdue by `(now - lastRunAt) /
+ *      cadenceMs` is the single eligible representative, so a weeks-stale `golden-path` or a
+ *      starved `memory-summary-backfill` outranks a just-drained `summary`. A never-run task
+ *      (lastRunAt 0) scores very high.
  *   3. **Registry order across the class boundary** — NON-eligible candidates (no `taskMeta`:
  *      lightweight / health / continuous) keep their registry slot; the winner is the first in
  *      registry order among the non-eligible candidates plus the one eligible representative, so a
@@ -146,11 +147,11 @@ function selectByPriority(candidates, policyContext = {}) {
         if (priorityZeroWinner) return priorityZeroWinner;
     }
 
-    // Staleness reorders ONLY the eligible set (candidates carrying `taskMeta` — the lease-competing
-    // REM chain). The most-overdue eligible candidate is the single eligible representative; every
-    // NON-eligible candidate keeps its registry slot, so the cross-class boundary is unchanged
-    // (a registry-earlier non-heavy task still wins over a later overdue heavy one). Strict `>`
-    // keeps the earlier eligible candidate on equal ratios (registry-order tiebreak).
+    // Staleness reorders ONLY the eligible set (candidates carrying `taskMeta` — the
+    // lease-competing heavy tasks plus `golden-path`). The most-overdue eligible candidate is the
+    // single eligible representative; every NON-eligible candidate keeps its registry slot, so the
+    // cross-class boundary is unchanged (a registry-earlier non-heavy task still wins over a later
+    // overdue heavy one). Strict `>` keeps the earlier eligible candidate on equal ratios.
     let topEligible = null;
     let topRatio    = -Infinity;
 

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -14,13 +14,13 @@ export const PRIORITY_ZERO_TASKS = Object.freeze(['backup']);
 /**
  * Maps a staleness-eligible task to the `context.intervals` cadence key the picker normalizes its
  * overdue-ness against. DELIBERATELY scoped to the lease-competing heavy tasks plus the
- * graph-dependent `golden-path` (the REM chain), and EXCLUDES the lightweight / health / continuous
- * tasks (`swarm-heartbeat`, `embed-drain-liveness-watchdog`, `tenant-repo-sync`): those keep
- * registry-order (a neutral staleness score of 0) so a frequently-due light task can never out-rank a
- * heavy one and starve the heavy pipeline — the inverse of the bug this ticket fixes. Backlog-driven
- * tasks (`summary`, `memory-summary-backfill`) have no real interval, so they share the summary-sweep
- * cadence as a nominal denominator; that reduces their comparison to least-recently-run, which is the
- * intended ordering (a starved backfill out-ages a constantly-running summary).
+ * graph-dependent `golden-path`, and EXCLUDES lightweight / health / continuous tasks
+ * (`swarm-heartbeat`, `embed-drain-liveness-watchdog`): those keep registry-order (a neutral
+ * staleness score of 0) so a frequently-due light task can never out-rank a heavy one and starve the
+ * heavy pipeline — the inverse of the bug this ticket fixes. Backlog-driven tasks (`summary`,
+ * `memory-summary-backfill`) have no real interval, so they share the summary-sweep cadence as a
+ * nominal denominator; that reduces their comparison to least-recently-run, which is the intended
+ * ordering (a starved backfill out-ages a constantly-running summary).
  * @type {Readonly<Object>}
  */
 export const TASK_STALENESS_CADENCE_KEY = Object.freeze({
@@ -31,6 +31,7 @@ export const TASK_STALENESS_CADENCE_KEY = Object.freeze({
     backup                   : 'backup',
     'graphlog-compaction'    : 'graphLogCompaction',
     'primary-dev-sync'       : 'primaryDevSync',
+    'tenant-repo-sync'       : 'tenantRepoSync',
     dream                    : 'dream',
     'message-concept-harvest': 'messageConceptHarvest',
     'golden-path'            : 'goldenPath'

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -170,8 +170,8 @@ export const TASK_REGISTRY = Object.freeze([
     {
         taskName        : 'tenant-repo-sync',
         executionKind   : 'service-runner',
-        maintenanceClass: 'continuous',
-        backpressure    : 'none',
+        maintenanceClass: 'heavy',
+        backpressure    : 'exclusive-heavy',
         dependencies    : [],
         getDueTask({state, now, intervals, enables, hooks}) {
             return (hooks.tenantRepoSyncGetDueTask || getTenantRepoSyncDueTask)({

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -24,6 +24,7 @@ export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
     'backup',
     'graphlog-compaction',
     'primary-dev-sync',
+    'tenant-repo-sync',
     'dream',
     'message-concept-harvest'
 ]);

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1386,6 +1386,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             'memory-summary-backfill',
             'message-concept-harvest',
             'primary-dev-sync',
+            'tenant-repo-sync',
             'dream',
             'summary'
         ].sort());

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs
@@ -23,20 +23,20 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
 
     test('returns the first candidate when none are running and no conflicts', () => {
         const candidates = [makeCandidate('summary'), makeCandidate('backup')];
-        const winner = pickNextCandidate({candidates, runningTasks: []});
+        const winner     = pickNextCandidate({candidates, runningTasks: []});
         expect(winner.taskName).toBe('summary');
     });
 
     test('filterAlreadyRunning: drops candidates whose task is already running', () => {
         const candidates = [makeCandidate('summary'), makeCandidate('backup')];
-        const winner = pickNextCandidate({candidates, runningTasks: ['summary']});
+        const winner     = pickNextCandidate({candidates, runningTasks: ['summary']});
         expect(winner.taskName).toBe('backup');
     });
 
     test('filterAlreadyRunning: handles Set or Array for runningTasks', () => {
         const candidates = [makeCandidate('summary'), makeCandidate('backup')];
-        const winnerArr = pickNextCandidate({candidates, runningTasks: ['summary']});
-        const winnerSet = pickNextCandidate({candidates, runningTasks: new Set(['summary'])});
+        const winnerArr  = pickNextCandidate({candidates, runningTasks: ['summary']});
+        const winnerSet  = pickNextCandidate({candidates, runningTasks: new Set(['summary'])});
         expect(winnerArr.taskName).toBe('backup');
         expect(winnerSet.taskName).toBe('backup');
     });
@@ -138,10 +138,10 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
 
     test('NEGATIVE: picker causes no state mutation', () => {
         // Picker reads candidates + runningTasks; it must not mutate either.
-        const candidates = [makeCandidate('summary'), makeCandidate('backup')];
+        const candidates         = [makeCandidate('summary'), makeCandidate('backup')];
         const candidatesSnapshot = JSON.stringify(candidates);
-        const runningTasks = ['some-task'];
-        const runningSnapshot = JSON.stringify(runningTasks);
+        const runningTasks       = ['some-task'];
+        const runningSnapshot    = JSON.stringify(runningTasks);
 
         pickNextCandidate({candidates, runningTasks});
 
@@ -162,7 +162,7 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
     // --- priority-0 (backup) + staleness-ratio selector ---
 
     test('#13586 priority-0: backup wins unconditionally over a registry-earlier, fresher task', () => {
-        const now = 1_000_000;
+        const now        = 1_000_000;
         const candidates = [
             makeCandidate('summary', {maintenanceClass: 'heavy'}),
             makeCandidate('backup',  {maintenanceClass: 'heavy'})
@@ -183,7 +183,7 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
     });
 
     test('#13586 priority-0 beats a hugely-stale non-prio-zero task', () => {
-        const now = 1_000_000_000;
+        const now        = 1_000_000_000;
         const candidates = [
             makeCandidate('memory-summary-backfill', {maintenanceClass: 'heavy'}),
             makeCandidate('backup',                   {maintenanceClass: 'heavy'})
@@ -204,8 +204,8 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
     });
 
     test('#13586 staleness-ratio: a weeks-stale golden-path outranks a just-drained summary', () => {
-        const WEEK = 7 * 24 * 60 * 60 * 1000;
-        const now  = 10 * WEEK;
+        const WEEK       = 7 * 24 * 60 * 60 * 1000;
+        const now        = 10 * WEEK;
         const candidates = [
             makeCandidate('summary',     {maintenanceClass: 'heavy'}),
             makeCandidate('golden-path', {maintenanceClass: 'graph-dependent'})
@@ -226,7 +226,7 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
     });
 
     test('#13586 staleness-ratio: a starved (never-run) backfill outranks a just-drained summary', () => {
-        const now = 1_000_000_000;
+        const now        = 1_000_000_000;
         const candidates = [
             makeCandidate('summary',                  {maintenanceClass: 'heavy'}),
             makeCandidate('memory-summary-backfill',  {maintenanceClass: 'heavy'})
@@ -247,7 +247,7 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
     });
 
     test('#13586 staleness-ratio: registry order breaks ties on equal ratios (strict-greater)', () => {
-        const now = 1_000_000;
+        const now        = 1_000_000;
         const candidates = [
             makeCandidate('alpha', {maintenanceClass: 'heavy'}),
             makeCandidate('beta',  {maintenanceClass: 'heavy'})
@@ -280,10 +280,10 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
     test('#13586 cross-class: a registry-earlier non-heavy candidate beats an overdue heavy one', () => {
         // Review falsifier: a continuous task registry-earlier than an overdue heavy one keeps its
         // slot — non-heavy behavior is unchanged (staleness reorders only the eligible/heavy set).
-        const now = 1_000_000;
+        const now        = 1_000_000;
         const candidates = [
-            makeCandidate('tenant-repo-sync', {maintenanceClass: 'continuous'}),
-            makeCandidate('dream',            {maintenanceClass: 'heavy'})
+            makeCandidate('swarm-heartbeat', {maintenanceClass: 'continuous'}),
+            makeCandidate('dream',           {maintenanceClass: 'heavy'})
         ];
         const winner = pickNextCandidate({
             candidates,
@@ -294,17 +294,19 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
                 taskMeta         : {dream: {lastRunAt: 0, cadenceMs: 600_000}}  // only dream eligible + overdue
             }
         });
-        expect(winner.taskName).toBe('tenant-repo-sync');
+        expect(winner.taskName).toBe('swarm-heartbeat');
     });
 
-    test('#13586 cross-class: heavy still reorders among heavy with a registry-later non-heavy present', () => {
-        // summary + dream (both eligible) reorder; tenant-repo-sync (non-eligible) is registry-later,
+    test('#13586 cross-class: tenant-repo-sync now reorders among heavy with a registry-later non-heavy present (#14400)', () => {
+        // summary + tenant-repo-sync + dream (all eligible heavy tasks) reorder; swarm-heartbeat
+        // (non-eligible) is registry-later,
         // so the eligible representative (the staler dream) still wins.
-        const now = 1_000_000;
+        const now        = 1_000_000;
         const candidates = [
             makeCandidate('summary',          {maintenanceClass: 'heavy'}),
+            makeCandidate('tenant-repo-sync', {maintenanceClass: 'heavy'}),
             makeCandidate('dream',            {maintenanceClass: 'heavy'}),
-            makeCandidate('tenant-repo-sync', {maintenanceClass: 'continuous'})
+            makeCandidate('swarm-heartbeat',  {maintenanceClass: 'continuous'})
         ];
         const winner = pickNextCandidate({
             candidates,
@@ -313,8 +315,9 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
                 now,
                 priorityZeroTasks: ['backup'],
                 taskMeta         : {
-                    summary: {lastRunAt: now - 60_000, cadenceMs: 600_000},  // fresh
-                    dream  : {lastRunAt: 0,            cadenceMs: 600_000}    // stale → eligible rep
+                    summary           : {lastRunAt: now - 60_000,  cadenceMs: 600_000}, // fresh
+                    'tenant-repo-sync': {lastRunAt: now - 120_000, cadenceMs: 60_000},  // due
+                    dream             : {lastRunAt: 0,             cadenceMs: 60_000}   // stale → eligible rep
                 }
             }
         });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -328,7 +328,7 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
                 makeCandidateDescriptor({
                     taskName        : 'tenant-repo-sync',
                     executionKind   : 'service-runner',
-                    maintenanceClass: 'continuous'
+                    maintenanceClass: 'heavy'
                 })
             ],
             context : makeContext(),
@@ -811,6 +811,7 @@ test.describe('orchestrator/scheduling/pipeline staleness selector (#13586)', ()
     test('buildTaskStalenessMeta: builds {lastRunAt, cadenceMs} only for staleness-eligible candidates', () => {
         const candidates = [
             {taskName: 'summary'},
+            {taskName: 'tenant-repo-sync'},
             {taskName: 'golden-path'},
             {taskName: 'message-concept-harvest'},
             {taskName: 'swarm-heartbeat'},               // light → omitted
@@ -818,11 +819,13 @@ test.describe('orchestrator/scheduling/pipeline staleness selector (#13586)', ()
         ];
         const state = {
             summary                  : {lastRunAt: 5_000},
+            'tenant-repo-sync'       : {lastRunAt: 3_000},
             'golden-path'            : {lastRunAt: 1_000},
             'message-concept-harvest': {lastRunAt: 2_000}
         };
         const intervals = {
             summarySweep         : 600_000,
+            tenantRepoSync       : 60_000,
             goldenPath           : 3_600_000,
             messageConceptHarvest: 21_600_000
         };
@@ -831,6 +834,7 @@ test.describe('orchestrator/scheduling/pipeline staleness selector (#13586)', ()
 
         expect(meta).toEqual({
             summary                  : {lastRunAt: 5_000, cadenceMs: 600_000},
+            'tenant-repo-sync'       : {lastRunAt: 3_000, cadenceMs: 60_000},
             'golden-path'            : {lastRunAt: 1_000, cadenceMs: 3_600_000},
             'message-concept-harvest': {lastRunAt: 2_000, cadenceMs: 21_600_000}
         });
@@ -848,11 +852,11 @@ test.describe('orchestrator/scheduling/pipeline staleness selector (#13586)', ()
         expect(meta['memory-summary-backfill']).toEqual({lastRunAt: 0, cadenceMs: 600_000});
     });
 
-    test('TASK_STALENESS_CADENCE_KEY: excludes lightweight / health / continuous tasks', () => {
+    test('TASK_STALENESS_CADENCE_KEY: excludes lightweight / health tasks and includes tenant-repo-sync heavy work', () => {
         expect(TASK_STALENESS_CADENCE_KEY['swarm-heartbeat']).toBeUndefined();
         expect(TASK_STALENESS_CADENCE_KEY['embed-drain-liveness-watchdog']).toBeUndefined();
         expect(TASK_STALENESS_CADENCE_KEY['rem-consolidation-liveness-watchdog']).toBeUndefined();
-        expect(TASK_STALENESS_CADENCE_KEY['tenant-repo-sync']).toBeUndefined();
+        expect(TASK_STALENESS_CADENCE_KEY['tenant-repo-sync']).toBe('tenantRepoSync');
         expect(TASK_STALENESS_CADENCE_KEY['message-concept-harvest']).toBe('messageConceptHarvest');
         expect(TASK_STALENESS_CADENCE_KEY['golden-path']).toBe('goldenPath');
         expect(TASK_STALENESS_CADENCE_KEY.summary).toBe('summarySweep');

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -66,6 +66,29 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
         })).toBeNull();
     });
 
+    test('tenant-repo-sync is registered as an exclusive-heavy cloud-ingestion lane (#14400)', () => {
+        const descriptor = TASK_REGISTRY.find(d => d.taskName === 'tenant-repo-sync');
+        expect(descriptor, 'tenant-repo-sync is registered').toBeTruthy();
+        expect(descriptor.executionKind).toBe('service-runner');
+        expect(descriptor.maintenanceClass).toBe('heavy');
+        expect(descriptor.backpressure).toBe('exclusive-heavy');
+        expect(descriptor.dependencies).toEqual([]);
+        expect(descriptor.getDueTask({
+            state    : {'tenant-repo-sync': {lastRunAt: 0}},
+            now      : 6000,
+            intervals: {tenantRepoSync: 5000},
+            enables  : {tenantRepoSync: true},
+            hooks    : {}
+        })).toMatchObject({taskName: 'tenant-repo-sync'});
+        expect(descriptor.getDueTask({
+            state    : {'tenant-repo-sync': {lastRunAt: 2000}},
+            now      : 6000,
+            intervals: {tenantRepoSync: 5000},
+            enables  : {tenantRepoSync: true},
+            hooks    : {}
+        })).toBeNull();
+    });
+
     test('embed-drain-liveness-watchdog is registered as a read-only, no-backpressure health-check (#13551)', () => {
         const descriptor = TASK_REGISTRY.find(d => d.taskName === 'embed-drain-liveness-watchdog');
         expect(descriptor, 'embed-drain-liveness-watchdog is registered').toBeTruthy();

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -75,6 +75,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
             'memory-summary-backfill',
             'message-concept-harvest',
             'primary-dev-sync',
+            'tenant-repo-sync',
             'summary'
         ].sort());
         expect(Object.isFrozen(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES)).toBe(true);
@@ -105,6 +106,10 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
     test('isHeavyMaintenanceTask returns membership in heavy set', () => {
         expect(isHeavyMaintenanceTask({
             taskName                 : 'summary',
+            heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
+        })).toBe(true);
+        expect(isHeavyMaintenanceTask({
+            taskName                 : 'tenant-repo-sync',
             heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
         })).toBe(true);
         expect(isHeavyMaintenanceTask({
@@ -425,6 +430,39 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(executions).toEqual([{taskName: NON_HEAVY_TASK_NAME, reason: 'periodic-heartbeat'}]);
         expect(result).toBe(true);
         expect(activeHeavyTask.name).toBeNull();
+    });
+
+    test('acquireLeaseAndExecute runs tenant-repo-sync through the heavy lease', () => {
+        const acquireCalls = [];
+        const releaseCalls = [];
+        const executions   = [];
+        const service      = buildService({
+            taskStateService: buildTaskStateService({}),
+            acquireLeaseFn  : opts => { acquireCalls.push(opts); return {acquired: true, lease: {token: 'tenant-token'}}; },
+            releaseLeaseFn  : opts => releaseCalls.push(opts)
+        });
+
+        const activeHeavyTask = {name: null};
+        const result          = service.acquireLeaseAndExecute({
+            taskName : 'tenant-repo-sync',
+            executeFn: (taskName, reason, onSuccess, taskOptions) => {
+                executions.push({taskName, reason, env: taskOptions.env});
+                taskOptions.onComplete?.();
+                return true;
+            },
+            reason: 'periodic-tenant-repo-sync',
+            activeHeavyTask
+        });
+
+        expect(result).toBe(true);
+        expect(acquireCalls).toHaveLength(1);
+        expect(executions).toEqual([{
+            taskName: 'tenant-repo-sync',
+            reason  : 'periodic-tenant-repo-sync',
+            env     : {NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: 'tenant-token'}
+        }]);
+        expect(releaseCalls).toHaveLength(1);
+        expect(activeHeavyTask.name).toBe('tenant-repo-sync');
     });
 
     test('Sub 9 hypothesis 4: acquireLeaseAndExecute records intra-process backpressure as skipped (#12617)', () => {


### PR DESCRIPTION
Resolves #14400

Classifies `tenant-repo-sync` as lease-competing heavy maintenance across the scheduler registry, backpressure SSOT, and staleness selector so cloud pull-mode repo ingestion no longer runs as an off-lease continuous lane. The change reuses the existing heavy-maintenance lease and picker path; it does not add a new scheduler mechanism.

Evidence: L2 (focused unit specs cover registry classification, heavy-set parity, lease admission, staleness metadata, picker ordering, and the tenant sync no-config guard) -> L2 required (scheduler/backpressure contract and unit-observable runtime dispatch). No residuals.

## Deltas from ticket

- Chose the ADR-0014 / ADR-0022 classification already documented in the codebase: `tenant-repo-sync` is periodic heavy/resource-mutex work.
- Left public docs unchanged because the ADRs and cloud ingestion docs already describe `tenant-repo-sync` as heavy and credential-bound; the drift was in runtime code and tests.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` -> 187 passed (32.5s).
- `git diff --check` -> OK.
- `git diff --cached --check` -> OK before commit.
- Pre-commit hooks passed: whitespace, shorthand, AiConfig test-mutation, JSDoc types, ticket archaeology, and block alignment.

## Post-Merge Validation

- [ ] In a cloud deployment with configured pull-mode tenant repos, verify `tenant-repo-sync` defers behind an active heavy-maintenance lease and appears in task-state/outcome diagnostics as a heavy scheduled lane.

## Commits

- `a85f15e7c0` - classify `tenant-repo-sync` as heavy maintenance.

Authored by Euclid (GPT-5, Codex Desktop). Session c0dfa949-22de-4daf-bbd2-1e093383fefc.
