### PR TITLE
fix(ai): preserve tenant repo source error code (#14402)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -863,6 +863,7 @@ function summarizeTenantRepoOutcome(outcome) {
         status              : outcome.status || null,
         lastIngestedRev     : shortRevision(outcome.lastIngestedRev || outcome.headRevision),
         lastErrorCode       : outcome.lastErrorCode || outcome.code || null,
+        lastSourceErrorCode : safeKnowledgeBaseErrorCode(outcome.lastSourceErrorCode || outcome.sourceErrorCode),
         lastSyncDeletedCount: numberOrNull(outcome.lastSyncDeletedCount ?? outcome.deleted),
         consecutiveFailures : numberOrNull(outcome.consecutiveFailures)
     };
@@ -988,6 +989,10 @@ function hashValue(value) {
 
 function shortRevision(value) {
     return value ? String(value).slice(0, 12) : null;
+}
+
+function safeKnowledgeBaseErrorCode(value) {
+    return (typeof value === 'string' && /^KB_[A-Z0-9_]{1,120}$/.test(value)) ? value : null;
 }
 
 function isTenantRepoDisabled(repo) {

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1,11 +1,11 @@
-import fs from 'fs-extra';
-import path from 'node:path';
-import Base from '../../../../src/core/Base.mjs';
-import AiConfig from '../../../config.mjs';
-import {DEFAULT_DATA_DIR} from '../taskDefinitions.mjs';
-import GitMirror from '../../../services/knowledge-base/helpers/gitMirror.mjs';
+import fs                    from 'fs-extra';
+import path                  from 'node:path';
+import Base                  from '../../../../src/core/Base.mjs';
+import AiConfig              from '../../../config.mjs';
+import {DEFAULT_DATA_DIR}    from '../taskDefinitions.mjs';
+import GitMirror             from '../../../services/knowledge-base/helpers/gitMirror.mjs';
 import {buildIngestEnvelope} from '../../../services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
-import {isRepoDue} from '../scheduling/tenantRepoSync.mjs';
+import {isRepoDue}           from '../scheduling/tenantRepoSync.mjs';
 import {
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
@@ -36,7 +36,7 @@ const PERSISTED_REVISIONS_FILE_NAME = 'tenant-repo-sync-revisions.json';
  * @returns {{acquire: Function, release: Function}}
  */
 function createConcurrencySemaphore({limit, timeoutMs = 0}) {
-    let active = 0;
+    let   active  = 0;
     const waiters = [];
 
     const handoffSlot = () => {
@@ -77,6 +77,16 @@ function createConcurrencySemaphore({limit, timeoutMs = 0}) {
             handoffSlot();
         }
     };
+}
+
+function getSourceErrorCode(error, outerCode) {
+    const sourceCode = error?.code;
+
+    if (typeof sourceCode !== 'string' || sourceCode === outerCode) {
+        return null;
+    }
+
+    return /^KB_[A-Z0-9_]{1,120}$/.test(sourceCode) ? sourceCode : null;
 }
 
 /**
@@ -180,11 +190,16 @@ class TenantRepoSyncService extends Base {
      * Runs the tenant-repo-sync task under orchestrator state + health envelopes.
      *
      * Error code taxonomy (see `./TenantRepoSyncErrors.mjs`). Operators branch on
-     * `details.repos[i].lastErrorCode` for per-repo failures and `details.reasonCode`
-     * for outer-task structural failures. Underlying transport errors
+     * `details.repos[i].lastErrorCode` for per-repo failures,
+     * `details.repos[i].lastSourceErrorCode` for redacted sibling-subsystem
+     * provenance, and `details.reasonCode` for outer-task structural failures.
+     * Underlying transport errors
      * (GitMirror auth, ChromaDB write, etc.) are wrapped as
      * `KB_TENANT_REPO_SYNC_SYNC_FAILED` so callers can rely on the stable prefix
-     * without parsing message prose.
+     * without parsing message prose. When the underlying error already carried a
+     * stable `KB_*` code (for example `KB_GITMIRROR_FETCH_FAILED`), that code is
+     * preserved as `lastSourceErrorCode` without copying raw stderr, URLs, or
+     * credential material.
      *
      * | Code | Surface | Trigger |
      * |---|---|---|
@@ -241,7 +256,7 @@ class TenantRepoSyncService extends Base {
                 taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder,
                 globalCadenceMs, jitterRatio, seedBootstrap
             });
-            const status = result.status;
+            const status         = result.status;
             const lastCompletion = {
                 status,
                 reason,
@@ -262,9 +277,9 @@ class TenantRepoSyncService extends Base {
             // Propagate stable error code + meta when the throw is a TenantRepoSyncError;
             // otherwise wrap as the unspecific KB_TENANT_REPO_SYNC_SYNC_FAILED so operators
             // can branch on `error.code` instead of message prose.
-            const code      = isTenantRepoSyncErrorCode(e.code) ? e.code : KB_TENANT_REPO_SYNC_SYNC_FAILED;
-            const meta      = (e instanceof TenantRepoSyncError) ? e.meta : undefined;
-            const details   = {
+            const code    = isTenantRepoSyncErrorCode(e.code) ? e.code : KB_TENANT_REPO_SYNC_SYNC_FAILED;
+            const meta    = (e instanceof TenantRepoSyncError) ? e.meta : undefined;
+            const details = {
                 reason,
                 phase     : 'tenant-repo-sync',
                 error     : e.message,
@@ -304,11 +319,11 @@ class TenantRepoSyncService extends Base {
         if (repos.length === 0 && onlyRepoSlugs?.length > 0) {
             const knownSlugs   = allRepos.map(r => r.repoSlug);
             const unknownSlugs = onlyRepoSlugs.filter(s => !knownSlugs.includes(s));
-            const details = {
-                reason     : 'repo-not-configured',
-                reasonCode : KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
-                repoCount  : 0,
-                requestedSlugs: onlyRepoSlugs,
+            const details      = {
+                reason         : 'repo-not-configured',
+                reasonCode     : KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
+                repoCount      : 0,
+                requestedSlugs : onlyRepoSlugs,
                 unknownSlugs,
                 configuredSlugs: knownSlugs
             };
@@ -325,9 +340,9 @@ class TenantRepoSyncService extends Base {
         const resolvedRevisionsPath = revisionsFilePath || this.defaultRevisionsFilePath();
         const ingestionService      = knowledgeBaseIngestionService || await this.resolveIngestionService();
         const persistedRevisions    = await this.readPersistedRevisions({filePath: resolvedRevisionsPath});
-        const repoStates = [];
-        let   completedCount     = 0;
-        let   failedCount        = 0;
+        const repoStates            = [];
+        let   completedCount        = 0;
+        let   failedCount           = 0;
 
         // Per-runTask concurrency gate caps simultaneous git/ingest work.
         // Fresh instance per call so live `concurrencyLimit` / `concurrencyGateTimeoutMs`
@@ -374,9 +389,9 @@ class TenantRepoSyncService extends Base {
         }
 
         await Promise.all(repos.map(async (repo) => {
-            const repoLabel    = `${repo.tenantId}/${repo.repoSlug}`;
-            const priorState   = persistedRevisions[repoLabel] || null;
-            const startedMs    = Date.now();
+            const repoLabel  = `${repo.tenantId}/${repo.repoSlug}`;
+            const priorState = persistedRevisions[repoLabel] || null;
+            const startedMs  = Date.now();
 
             // Per-repo due check applies deterministic jitter + exponential backoff on
             // top of configured cadence. Manual CLI runs (onlyRepoSlugs filter)
@@ -416,28 +431,28 @@ class TenantRepoSyncService extends Base {
                 writeLog?.('INFO', `[TenantRepoSync] Refreshing ${repoLabel}.`);
 
                 await gitMirror.cloneIfMissing({
-                    tenantId      : repo.tenantId,
-                    repoSlug      : repo.repoSlug,
-                    mirrorRoot    : repo.mirrorRoot,
-                    cloneUrl      : repo.cloneUrl,
-                    credentialRef : repo.credentialRef
+                    tenantId     : repo.tenantId,
+                    repoSlug     : repo.repoSlug,
+                    mirrorRoot   : repo.mirrorRoot,
+                    cloneUrl     : repo.cloneUrl,
+                    credentialRef: repo.credentialRef
                 });
                 await gitMirror.fetch({
-                    tenantId      : repo.tenantId,
-                    repoSlug      : repo.repoSlug,
-                    mirrorRoot    : repo.mirrorRoot,
-                    credentialRef : repo.credentialRef
+                    tenantId     : repo.tenantId,
+                    repoSlug     : repo.repoSlug,
+                    mirrorRoot   : repo.mirrorRoot,
+                    credentialRef: repo.credentialRef
                 });
 
                 const envelope = await envelopeBuilder({
-                    tenantId        : repo.tenantId,
-                    repoSlug        : repo.repoSlug,
-                    mirrorRoot      : repo.mirrorRoot,
-                    lastIngestedRev : priorState?.lastIngestedRev || null,
-                    newHead         : repo.branchRef || 'HEAD',
-                    rootKind        : repo.rootKind || 'external-source',
-                    parserId        : repo.parserId,
-                    parserVersion   : repo.parserVersion,
+                    tenantId       : repo.tenantId,
+                    repoSlug       : repo.repoSlug,
+                    mirrorRoot     : repo.mirrorRoot,
+                    lastIngestedRev: priorState?.lastIngestedRev || null,
+                    newHead        : repo.branchRef || 'HEAD',
+                    rootKind       : repo.rootKind || 'external-source',
+                    parserId       : repo.parserId,
+                    parserVersion  : repo.parserVersion,
                     gitMirror
                 });
 
@@ -473,17 +488,19 @@ class TenantRepoSyncService extends Base {
                 });
                 completedCount++;
                 healthService?.recordTaskOutcome?.(taskName, 'completed', {
-                    repo            : repoLabel,
-                    tenantId        : repo.tenantId,
-                    repoSlug        : repo.repoSlug,
+                    repo        : repoLabel,
+                    tenantId    : repo.tenantId,
+                    repoSlug    : repo.repoSlug,
                     ingested,
                     deleted,
-                    headRevision    : shortHead,
+                    headRevision: shortHead,
                     durationMs
                 });
             } catch (e) {
-                const code = isTenantRepoSyncErrorCode(e.code) ? e.code : KB_TENANT_REPO_SYNC_SYNC_FAILED;
-                writeLog?.('ERROR', `[TenantRepoSync] ${repoLabel} failed: ${code} (${e.message})`);
+                const code            = isTenantRepoSyncErrorCode(e.code) ? e.code : KB_TENANT_REPO_SYNC_SYNC_FAILED;
+                const sourceErrorCode = getSourceErrorCode(e, code);
+                const sourceSuffix    = sourceErrorCode ? ` source=${sourceErrorCode}` : '';
+                writeLog?.('ERROR', `[TenantRepoSync] ${repoLabel} failed: ${code}${sourceSuffix} (${e.message})`);
 
                 // Increment consecutiveFailures on failure; preserve last good
                 // ingested revision so the next successful run starts from the correct base.
@@ -496,7 +513,7 @@ class TenantRepoSyncService extends Base {
                     consecutiveFailures: nextFailureCount
                 };
 
-                repoStates.push({
+                const failedRepoState = {
                     tenantId           : repo.tenantId,
                     repoSlug           : repo.repoSlug,
                     lastIngestedRev    : priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : null,
@@ -504,14 +521,21 @@ class TenantRepoSyncService extends Base {
                     status             : 'degraded',
                     lastErrorCode      : code,
                     consecutiveFailures: nextFailureCount
-                });
+                };
+
+                if (sourceErrorCode) {
+                    failedRepoState.lastSourceErrorCode = sourceErrorCode;
+                }
+
+                repoStates.push(failedRepoState);
                 failedCount++;
                 healthService?.recordTaskOutcome?.(taskName, 'failed', {
-                    repo               : repoLabel,
-                    tenantId           : repo.tenantId,
-                    repoSlug           : repo.repoSlug,
-                    error              : e.message,
+                    repo    : repoLabel,
+                    tenantId: repo.tenantId,
+                    repoSlug: repo.repoSlug,
+                    error   : e.message,
                     code,
+                    ...(sourceErrorCode ? {sourceErrorCode} : {}),
                     consecutiveFailures: nextFailureCount
                 });
                 // Continue with remaining repos — per-repo failure isolation is the
@@ -528,7 +552,7 @@ class TenantRepoSyncService extends Base {
         // each repo's decision was honored). 'failed' only when actual work failed and no
         // actual work succeeded.
         const attemptedCount = completedCount + failedCount;
-        const status = attemptedCount === 0
+        const status         = attemptedCount === 0
             ? 'completed' // all repos were not-due; cycle ran cleanly
             : (failedCount === 0 ? 'completed' : (completedCount > 0 ? 'completed' : 'failed'));
 
@@ -537,11 +561,11 @@ class TenantRepoSyncService extends Base {
         return {
             status,
             details: {
-                repoCount   : repos.length,
+                repoCount: repos.length,
                 completedCount,
                 failedCount,
                 notDueCount,
-                repos       : repoStates
+                repos    : repoStates
             }
         };
     }
@@ -585,8 +609,8 @@ class TenantRepoSyncService extends Base {
             ?? orchestratorConfig?.tenantRepoMirrorRoot
             ?? env.NEO_TENANT_REPO_MIRROR_ROOT
             ?? '/app/.neo-ai-data';
-        const kbService    = ingestionService || await this.resolveIngestionService();
-        const normalized   = await kbService.listConfiguredTenantRepos();
+        const kbService  = ingestionService || await this.resolveIngestionService();
+        const normalized = await kbService.listConfiguredTenantRepos();
 
         normalized.tenantRepos = normalized.tenantRepos.map(entry =>
             entry.mirrorRoot ? entry : {...entry, mirrorRoot: tier1Default}

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -275,7 +275,8 @@ Per-repo freshness is surfaced through the existing Memory Core healthcheck orch
             lastSyncAt           : '2026-05-25T05:30:00.000Z',
             status               : 'active',      // 'active' | 'degraded' | 'quarantined' | 'disabled'
             lastSyncDeletedCount : 0,
-            lastErrorCode        : null           // present only when status !== 'active'
+            lastErrorCode        : null,          // present only when status !== 'active'
+            lastSourceErrorCode  : null           // optional bounded source code, e.g. KB_GITMIRROR_FETCH_FAILED
         }
     ]
 }
@@ -302,7 +303,7 @@ Status is computed from per-repo `lastIngestedRev` + recent-failure-count state;
 
 ### Stable Error Code Taxonomy
 
-Per-repo failures carry a stable `lastErrorCode` field on the health payload; operators branch on `error.code`, not message prose. Codes live in [`TenantRepoSyncErrors.mjs`](../../../ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs).
+Per-repo failures carry a stable `lastErrorCode` field on the health payload; operators branch on `error.code`, not message prose. Codes live in [`TenantRepoSyncErrors.mjs`](../../../ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs). When a sibling subsystem such as `GitMirror` already produced a stable, redacted `KB_*` code, the health payload and deployment bridge also expose `lastSourceErrorCode` so operators can distinguish credential/clone/fetch failures from generic ingest failures without raw stderr or credentials.
 
 | Code | Where it surfaces | Trigger |
 |---|---|---|
@@ -313,15 +314,17 @@ Per-repo failures carry a stable `lastErrorCode` field on the health payload; op
 | `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT` | reserved | Future concurrency-limit gate (tracked in [#11942](https://github.com/neomjs/neo/issues/11942) AC2); no current emitter. |
 
 The `KB_TENANT_REPO_SYNC_*` prefix distinguishes these codes from sibling-subsystem error families (`KB_GITMIRROR_*`, `KB_INGEST_*`, `KB_TENANT_REPO_ACCESS_*`).
+`lastSourceErrorCode` is optional and bounded to stable `KB_*` codes only; it never carries clone URLs, credential references, tokens, raw repository identities, or git stderr.
 
 ### Quarantine Runbook
 
 When a repo enters `quarantined`, the lane stops attempting it on periodic cycles until the operator acts. Steps:
 
 1. Read the per-repo `lastErrorCode` from the health payload. Stable codes follow the `KB_TENANT_REPO_SYNC_*` prefix (e.g., `KB_TENANT_REPO_SYNC_SYNC_FAILED`, `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED`).
-2. Inspect operator logs filtered to `[TenantRepoSync] <tenantId>/<repoSlug>` for the redacted error message.
+2. If present, read `lastSourceErrorCode` to identify the failing subsystem before falling back to logs.
 3. Common cases:
-   - `KB_TENANT_REPO_SYNC_SYNC_FAILED` with git stderr indicating auth failure → rotate the `credentialRef` target; re-check the secret store.
+   - `lastSourceErrorCode: KB_GITMIRROR_CREDENTIAL_REF_INVALID` → confirm the env var or secret file named by `credentialRef` exists and is non-empty.
+   - `lastSourceErrorCode: KB_GITMIRROR_CLONE_FAILED` / `KB_GITMIRROR_FETCH_FAILED` → verify upstream access, token read scope, repo path, and network egress.
    - Persistent network/DNS error → the deployment can't reach the upstream remote; verify network egress.
    - Repository deleted / renamed upstream → update the `tenantRepos[]` config or remove the entry.
 4. Once the underlying issue is resolved, force a manual sync via `node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <slug>`. A successful run returns the repo to `active`.

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -188,7 +188,7 @@ A freshly deployed Knowledge Base can be **healthy but empty**: `healthcheck` re
 
 For push-mode deployments, trigger the deployment's ingestion entry point once, then query again.
 
-For pull-mode deployments with configured `tenantRepos[]`, call `inspect_deployment` or `get_deployment_state_snapshot` and inspect the `tenantRepoSync` section before taking manual action. It distinguishes disabled, no configured repos, not-due, running, completed, failed, and degraded/unreadable state without exposing credentials or raw logs. If the task is configured but has not advanced, use the stable reason code and per-repo hashed state there to decide whether to wait for the next due sweep, fix credentials/config, or run `node ./ai/scripts/maintenance/syncTenantRepos.mjs` inside the orchestrator container.
+For pull-mode deployments with configured `tenantRepos[]`, call `inspect_deployment` or `get_deployment_state_snapshot` and inspect the `tenantRepoSync` section before taking manual action. It distinguishes disabled, no configured repos, not-due, running, completed, failed, and degraded/unreadable state without exposing credentials or raw logs. If the task is configured but has not advanced, use the stable reason code and per-repo hashed state there to decide whether to wait for the next due sweep, fix credentials/config, or run `node ./ai/scripts/maintenance/syncTenantRepos.mjs` inside the orchestrator container. When `lastErrorCode` is `KB_TENANT_REPO_SYNC_SYNC_FAILED`, check `lastSourceErrorCode`: `KB_GITMIRROR_CREDENTIAL_REF_INVALID`, `KB_GITMIRROR_CLONE_FAILED`, or `KB_GITMIRROR_FETCH_FAILED` points to the credential/ref/upstream access path before generic ingestion debugging.
 
 ## See also
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -594,6 +594,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                                 repoSlug           : 'private/repo',
                                 status             : 'degraded',
                                 lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+                                lastSourceErrorCode: 'KB_GITMIRROR_FETCH_FAILED',
                                 consecutiveFailures: 2
                             }]
                         }
@@ -641,10 +642,12 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             status             : 'degraded',
             consecutiveFailures: 2,
             lastOutcome        : {
-                status       : 'degraded',
-                lastErrorCode: 'KB_TENANT_REPO_SYNC_SYNC_FAILED'
+                status             : 'degraded',
+                lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+                lastSourceErrorCode: 'KB_GITMIRROR_FETCH_FAILED'
             }
         });
+        expect(JSON.stringify(tenantRepoSync)).not.toContain('env:TOKEN');
     });
 
     test('collectTenantRepoSyncSnapshot degrades when revision state is unreadable', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -24,7 +24,7 @@ import os              from 'os';
 import path            from 'path';
 import {fileURLToPath} from 'url';
 
-import TenantRepoSyncService from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
+import TenantRepoSyncService        from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
 import {deriveTenantRepoMirrorPath} from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -78,12 +78,12 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             async ingestSourceFiles(payload) {
                 captureCalls.push({op: 'ingestSourceFiles', payload});
                 return {
-                    ingested: payload.files?.length || 0,
-                    deleted : payload.deleted?.length || 0,
+                    ingested           : payload.files?.length || 0,
+                    deleted            : payload.deleted?.length || 0,
                     embeddingsGenerated: 0,
-                    errors  : [],
-                    tenantId: payload.tenantId,
-                    durationMs: 1
+                    errors             : [],
+                    tenantId           : payload.tenantId,
+                    durationMs         : 1
                 };
             }
         };
@@ -111,7 +111,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
     test.afterEach(async () => {
         await fs.remove(tmpDir);
-        // Restore the singleton's reactive config to default values so #11942-AC2
+        // Restore the singleton's reactive config to default values so
         // concurrency tests cannot leak short timeouts / serial-limit to siblings.
         TenantRepoSyncService.concurrencyLimit         = 2;
         TenantRepoSyncService.concurrencyGateTimeoutMs = 30000;
@@ -121,7 +121,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         const taskStateService = createInMemoryTaskStateService();
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'manual-test',
+            reason           : 'manual-test',
             taskStateService,
             tenantReposConfig: {tenantRepos: []},
             revisionsFilePath: revisionsFile
@@ -138,7 +138,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         taskStateService.taskState['tenant-repo-sync'] = {running: true, pid: 12345};
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic',
+            reason           : 'periodic',
             taskStateService,
             tenantReposConfig: {tenantRepos: [{tenantId: 't1', repoSlug: 'org/repo', mirrorRoot: '/tmp/mirror', cloneUrl: 'https://github.com/neomjs/repo.git'}]},
             revisionsFilePath: revisionsFile
@@ -158,7 +158,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo-b'});
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:60000',
+            reason           : 'periodic-sweep:60000',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/repo-a', mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git'},
@@ -168,7 +168,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService({captureCalls: ingestCalls}),
             revisionsFilePath            : revisionsFile,
-            // Bootstrap-seeding (#11942 AC1 cycle-2) defers fresh repos to a later sweep
+            // Bootstrap seeding defers fresh repos to a later sweep
             // within the jitter window; this test simulates the in-loop iteration path
             // and opts out so it can assert "first call processes all repos".
             seedBootstrap                : false
@@ -218,7 +218,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         };
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic',
+            reason           : 'periodic',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/good',   mirrorRoot, cloneUrl: 'https://github.com/neomjs/good.git'},
@@ -245,9 +245,10 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         const failed = result.details.repos.find(r => r.status === 'degraded');
         expect(failed.tenantId).toBe('t1');
         expect(failed.repoSlug).toBe('org/broken');
-        // Service wraps non-prefixed errors as the stable KB_TENANT_REPO_SYNC_SYNC_FAILED code
-        // so test assertion uses the lastErrorCode the operator would actually see.
+        // Service wraps sibling-subsystem errors as the stable KB_TENANT_REPO_SYNC_SYNC_FAILED code
+        // and preserves the source code in a bounded non-secret field for diagnostics.
         expect(failed.lastErrorCode).toBe('KB_TENANT_REPO_SYNC_SYNC_FAILED');
+        expect(failed.lastSourceErrorCode).toBe('KB_GITMIRROR_FETCH_FAILED');
     });
 
     test('onlyRepoSlugs scoping: subset filtering for manual CLI path', async () => {
@@ -259,7 +260,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/c'});
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'manual',
+            reason           : 'manual',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/a', mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git'},
@@ -288,7 +289,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await fs.ensureDir(path.dirname(revisionsFile));
         await fs.writeJson(revisionsFile, {revisions: {'t1/org/seeded': 'sha-prior-run'}});
 
-        let capturedLastIngestedRev = null;
+        let   capturedLastIngestedRev   = null;
         const envelopeWatchingGitMirror = {
             async cloneIfMissing() {},
             async fetch() {},
@@ -306,10 +307,10 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         };
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic',
+            reason           : 'periodic',
             taskStateService,
             tenantReposConfig: {tenantRepos: [{tenantId: 't1', repoSlug: 'org/seeded', mirrorRoot, cloneUrl: 'https://github.com/neomjs/seeded.git'}]},
-            gitMirror                    : envelopeWatchingGitMirror,
+            gitMirror        : envelopeWatchingGitMirror,
             // For the persistence test, use a real-shape envelope-builder fake that
             // calls gitMirror.resolveHead twice — once for HEAD, once for prior sha —
             // so the test can verify lastIngestedRev flows through.
@@ -317,9 +318,9 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 await args.gitMirror.resolveHead({...args, ref: args.newHead || 'HEAD'});
                 if (args.lastIngestedRev) await args.gitMirror.resolveHead({...args, ref: args.lastIngestedRev});
                 return {
-                    tenantId: args.tenantId,
-                    repoSlug: args.repoSlug,
-                    files: [], deleted: [],
+                    tenantId    : args.tenantId,
+                    repoSlug    : args.repoSlug,
+                    files       : [], deleted: [],
                     headRevision: 'sha-new-head'
                 };
             },
@@ -336,7 +337,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo-a'});
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:60000',
+            reason           : 'periodic-sweep:60000',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/repo-a', mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git'}
@@ -379,7 +380,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         };
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:60000',
+            reason           : 'periodic-sweep:60000',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/broken', mirrorRoot, cloneUrl: 'https://github.com/neomjs/broken.git'}
@@ -397,10 +398,57 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(repoState.status).toBe('degraded');
         // Underlying error code (KB_GITMIRROR_FETCH_FAILED) does NOT carry the
         // KB_TENANT_REPO_SYNC_ prefix, so the service wraps it as the stable
-        // KB_TENANT_REPO_SYNC_SYNC_FAILED code that operators branch on.
+        // KB_TENANT_REPO_SYNC_SYNC_FAILED code that operators branch on while
+        // preserving bounded source provenance.
         expect(repoState.lastErrorCode).toBe('KB_TENANT_REPO_SYNC_SYNC_FAILED');
+        expect(repoState.lastSourceErrorCode).toBe('KB_GITMIRROR_FETCH_FAILED');
         expect(repoState.tenantId).toBe('t1');
         expect(repoState.repoSlug).toBe('org/broken');
+    });
+
+    test('health payload: unresolved credentialRef preserves GitMirror source code', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+
+        const failingMirror = {
+            async cloneIfMissing() {
+                const err = new Error('GitMirror env credentialRef could not be resolved');
+                err.code = 'KB_GITMIRROR_CREDENTIAL_REF_INVALID';
+                throw err;
+            },
+            async fetch() {},
+            async resolveHead() { return 'sha-current'; },
+            async isAncestor() { return true; },
+            async diffRevisions() { return {addedOrChanged: [], deleted: []}; }
+        };
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {
+                    tenantId     : 't1',
+                    repoSlug     : 'org/private',
+                    mirrorRoot,
+                    cloneUrl     : 'https://github.com/neomjs/private.git',
+                    credentialRef: 'env:MISSING_TOKEN'
+                }
+            ]},
+            gitMirror                    : failingMirror,
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
+        });
+
+        expect(result.status).toBe('failed');
+
+        const repoState = result.details.repos[0];
+        expect(repoState).toMatchObject({
+            status             : 'degraded',
+            lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+            lastSourceErrorCode: 'KB_GITMIRROR_CREDENTIAL_REF_INVALID'
+        });
+        expect(JSON.stringify(repoState)).not.toContain('MISSING_TOKEN');
     });
 
     test('operator log: emits per-repo completed line + cycle summary in expected shape', async () => {
@@ -409,9 +457,9 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo-a'});
 
         await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:60000',
+            reason           : 'periodic-sweep:60000',
             taskStateService,
-            writeLog        : (level, msg) => logLines.push({level, msg}),
+            writeLog         : (level, msg) => logLines.push({level, msg}),
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/repo-a', mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git'}
             ]},
@@ -422,9 +470,9 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             seedBootstrap                : false
         });
 
-        const refreshLine = logLines.find(l => l.msg.includes('Refreshing t1/org/repo-a'));
+        const refreshLine   = logLines.find(l => l.msg.includes('Refreshing t1/org/repo-a'));
         const completedLine = logLines.find(l => l.msg.includes('t1/org/repo-a completed'));
-        const summaryLine = logLines.find(l => l.msg.includes('Cycle summary'));
+        const summaryLine   = logLines.find(l => l.msg.includes('Cycle summary'));
 
         expect(refreshLine).toBeDefined();
         expect(completedLine).toBeDefined();
@@ -442,9 +490,9 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/known'});
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'manual',
+            reason           : 'manual',
             taskStateService,
-            writeLog        : (level, msg) => logLines.push({level, msg}),
+            writeLog         : (level, msg) => logLines.push({level, msg}),
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/known', mirrorRoot, cloneUrl: 'https://github.com/neomjs/known.git'}
             ]},
@@ -503,9 +551,9 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         try {
             const result = await TenantRepoSyncService.runTask({
-                reason          : 'periodic-sweep:60000',
+                reason           : 'periodic-sweep:60000',
                 taskStateService,
-                writeLog        : (level, msg) => logLines.push({level, msg}),
+                writeLog         : (level, msg) => logLines.push({level, msg}),
                 tenantReposConfig: {tenantRepos: [
                     {tenantId: 't1', repoSlug: 'org/repo-a', mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git'}
                 ]},
@@ -530,7 +578,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         TenantRepoSyncService.concurrencyLimit = 1;
 
         const inFlightLog = [];
-        let inFlight      = 0;
+        let   inFlight    = 0;
 
         const trackingMirror = {
             async cloneIfMissing() {
@@ -550,8 +598,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         }
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic',
-            taskStateService: createInMemoryTaskStateService(),
+            reason           : 'periodic',
+            taskStateService : createInMemoryTaskStateService(),
             tenantReposConfig: {tenantRepos: ['org/r1', 'org/r2', 'org/r3'].map(s => ({
                 tenantId: 't1', repoSlug: s, mirrorRoot, cloneUrl: `https://github.com/neomjs/${s.split('/')[1]}.git`
             }))},
@@ -573,7 +621,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         TenantRepoSyncService.concurrencyLimit = 2;
 
         const inFlightLog = [];
-        let inFlight      = 0;
+        let   inFlight    = 0;
 
         const trackingMirror = {
             async cloneIfMissing() {
@@ -593,8 +641,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         }
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic',
-            taskStateService: createInMemoryTaskStateService(),
+            reason           : 'periodic',
+            taskStateService : createInMemoryTaskStateService(),
             tenantReposConfig: {tenantRepos: ['org/r1', 'org/r2', 'org/r3', 'org/r4'].map(s => ({
                 tenantId: 't1', repoSlug: s, mirrorRoot, cloneUrl: `https://github.com/neomjs/${s.split('/')[1]}.git`
             }))},
@@ -669,7 +717,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'neomjs/recent-repo'});
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:1800000',
+            reason           : 'periodic-sweep:1800000',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'neomjs/recent-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/recent-repo.git'}
@@ -697,8 +745,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
     test('jitter+backoff: persists consecutiveFailures increment on failure (#11942 AC1)', async () => {
         const taskStateService = createInMemoryTaskStateService();
 
-        // Opts out of #11942 AC1 cycle-2 (#11962) bootstrap seeding so the
-        // simulated failure path actually fires this sweep (instead of being
+        // Opts out of bootstrap seeding so the simulated failure path
+        // actually fires this sweep (instead of being
         // deferred-as-seeded). Test verifies failure-increment semantics, not
         // bootstrap-spread behavior.
         const failingMirror = {
@@ -712,7 +760,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'neomjs/failing-repo'});
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:1800000',
+            reason           : 'periodic-sweep:1800000',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'neomjs/failing-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/failing-repo.git'}
@@ -755,7 +803,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'neomjs/recovering-repo'});
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:1800000',
+            reason           : 'periodic-sweep:1800000',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'neomjs/recovering-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/recovering-repo.git'}
@@ -788,7 +836,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'neomjs/legacy-repo'});
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:1800000',
+            reason           : 'periodic-sweep:1800000',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'neomjs/legacy-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/legacy-repo.git'}
@@ -830,7 +878,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'neomjs/manual-repo'});
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'manual',
+            reason           : 'manual',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'neomjs/manual-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/manual-repo.git'}
@@ -852,7 +900,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
     });
 
     // ─────────────────────────────────────────────────────────────────────────
-    // #11942 AC1 cycle-2 (#11962): bootstrap-spread seeding + decoupled-sweep
+    // Bootstrap-spread seeding + decoupled-sweep
     // composition + orchestrator-resolved cadence pass-through.
     // ─────────────────────────────────────────────────────────────────────────
 
@@ -864,8 +912,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         const baseCadenceMs = 1800000; // 30min — matches AiConfig default
 
         const sweepStart = Date.now();
-        const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:60000',
+        const result     = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/repo-a', mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git'},
@@ -888,8 +936,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         // Persisted state shows seeded `lastRunAttemptAt = sweepStart - baseCadenceMs`.
         const persisted = await fs.readJson(revisionsFile);
-        const stateA = persisted.revisions['t1/org/repo-a'];
-        const stateB = persisted.revisions['t1/org/repo-b'];
+        const stateA    = persisted.revisions['t1/org/repo-a'];
+        const stateB    = persisted.revisions['t1/org/repo-b'];
 
         expect(stateA).toBeTruthy();
         expect(stateA.lastIngestedRev).toBeNull();
@@ -910,7 +958,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         const baseCadenceMs = 100; // tiny so test can advance via real Date.now
 
         // Pre-write seeded state: lastRunAttemptAt = (now - baseCadence) → due at now + jitter
-        const seedTime  = Date.now() - baseCadenceMs;
+        const seedTime = Date.now() - baseCadenceMs;
         await fs.writeJson(revisionsFile, {
             revisions: {
                 't1/org/short-jitter': {lastIngestedRev: null, lastRunAttemptAt: seedTime, consecutiveFailures: 0},
@@ -928,8 +976,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await new Promise(r => setTimeout(r, 60));
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:1000',
-            taskStateService: createInMemoryTaskStateService(),
+            reason           : 'periodic-sweep:1000',
+            taskStateService : createInMemoryTaskStateService(),
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/short-jitter', mirrorRoot, cloneUrl: 'https://github.com/neomjs/short.git'},
                 {tenantId: 't1', repoSlug: 'org/long-jitter',  mirrorRoot, cloneUrl: 'https://github.com/neomjs/long.git'}
@@ -969,8 +1017,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // is NOT due. Without explicit pass, the service would fall back to
         // AiConfig.data.orchestrator.intervals.tenantRepoSyncMs default.
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:60000',
-            taskStateService: createInMemoryTaskStateService(),
+            reason           : 'periodic-sweep:60000',
+            taskStateService : createInMemoryTaskStateService(),
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/repo.git'}
             ]},
@@ -991,7 +1039,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
     test('orchestrator-resolved jitterRatio flows through to isRepoDue (#11942 AC1 cycle-2 RA3)', async () => {
         // Pre-populate priorState with lastRunAttemptAt exactly at cadence-boundary
         // so jitterRatio=0 → due (cadence elapsed), jitterRatio=0.50 with large jitter → not-due.
-        const baseCadenceMs = 1000;
+        const baseCadenceMs            = 1000;
         const exactlyAtCadenceBoundary = Date.now() - baseCadenceMs;
         await fs.writeJson(revisionsFile, {
             revisions: {
@@ -1004,8 +1052,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // jitterRatio=0.50 + tenantId/repoSlug → jitter > 0 → effectiveCadence > baseCadence → not-due
         // (because (now - lastRunAttemptAt) = baseCadenceMs < baseCadenceMs + jitter).
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:60000',
-            taskStateService: createInMemoryTaskStateService(),
+            reason           : 'periodic-sweep:60000',
+            taskStateService : createInMemoryTaskStateService(),
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/repo.git'}
             ]},
@@ -1031,7 +1079,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/manual-target'});
 
         const result = await TenantRepoSyncService.runTask({
-            reason          : 'manual',
+            reason           : 'manual',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/manual-target', mirrorRoot, cloneUrl: 'https://github.com/neomjs/manual.git'}
@@ -1055,8 +1103,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         TenantRepoSyncService.concurrencyGateTimeoutMs = 50;
 
         let releaseFirstRepo;
-        const firstRepoGate = new Promise(resolve => { releaseFirstRepo = resolve; });
-        let cloneCallCount  = 0;
+        const firstRepoGate  = new Promise(resolve => { releaseFirstRepo = resolve; });
+        let   cloneCallCount = 0;
 
         const slowMirror = {
             async cloneIfMissing() {
@@ -1076,8 +1124,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/queued'});
 
         const resultPromise = TenantRepoSyncService.runTask({
-            reason          : 'periodic',
-            taskStateService: createInMemoryTaskStateService(),
+            reason           : 'periodic',
+            taskStateService : createInMemoryTaskStateService(),
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/slow',   mirrorRoot, cloneUrl: 'https://github.com/neomjs/slow.git'},
                 {tenantId: 't1', repoSlug: 'org/queued', mirrorRoot, cloneUrl: 'https://github.com/neomjs/queued.git'}
@@ -1118,7 +1166,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo-default'});
 
         await TenantRepoSyncService.runTask({
-            reason          : 'periodic-sweep:60000',
+            reason           : 'periodic-sweep:60000',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/repo-with-branch', mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git', branchRef: 'dev'},
@@ -1146,7 +1194,7 @@ test.describe('TenantRepoSyncService.resolveIngestionService — export-drift gu
     /*
      * Other tests in this file inject `knowledgeBaseIngestionService` directly via
      * `runTask` arguments, bypassing `resolveIngestionService` entirely. That's how
-     * the export-drift bug fixed in PR #12037 (lookup of the non-existent
+     * the historical export-drift bug where the resolver looked up non-existent
      * `KB_KnowledgeBaseIngestionService` / `KnowledgeBaseIngestionService` names)
      * escaped unit-test detection. This block covers all three drift classes:
      *
@@ -1166,8 +1214,8 @@ test.describe('TenantRepoSyncService.resolveIngestionService — export-drift gu
      * bootstrap on fresh clone, so this is the green path. Operator checkouts whose
      * per-server `config.mjs` was generated before the materialization logic landed
      * will hit the collision until they re-run `npm run prepare -- --migrate-config`
-     * OR manually update the import path. Documented in #12047 (open) for the
-     * materialization-migration substrate work.
+     * OR manually update the import path. Keep this note until the
+     * materialization-migration substrate is retired.
      */
     const repoRoot     = path.resolve(__dirname, '../../../../../../../');
     const servicesPath = path.join(repoRoot, 'ai/services.mjs');
@@ -1236,7 +1284,7 @@ test.describe('TenantRepoSyncService.resolveTenantReposConfig — Tier-1 mirrorR
             ]})
         };
 
-        const result      = await TenantRepoSyncService.resolveTenantReposConfig({
+        const result = await TenantRepoSyncService.resolveTenantReposConfig({
             ingestionService: ingestionStub,
             tier1MirrorRoot : '/app/.neo-ai-data'
         });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop).

Resolves #14402

Preserves the tenant-repo-sync compatibility code while carrying a bounded underlying source code through the diagnostic path. A private-repo GitMirror failure now still surfaces as `KB_TENANT_REPO_SYNC_SYNC_FAILED` for existing consumers, plus `lastSourceErrorCode` for the non-secret `KB_GITMIRROR_*` provenance that tells operators whether to inspect credentials, clone/fetch access, or generic ingestion.

## Deltas
- Adds `lastSourceErrorCode` to failed per-repo tenant-repo-sync outcomes when the caught error carries a stable `KB_*` source code distinct from the outer tenant-sync code.
- Projects that bounded source code through `DeploymentStateBridgeService` into `tenantRepoSync.repos[].lastOutcome`.
- Updates cloud troubleshooting docs to make `lastSourceErrorCode` the first branch before container logs.

Evidence:
- Source V-B-A: `GitMirror` emits redacted `KB_GITMIRROR_*` codes; `TenantRepoSyncService` previously collapsed them before the bridge snapshot could expose them.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs` -> 53 passed.
- `git diff --check`

## Post-Merge Validation
- [ ] In a pull-mode cloud deployment with a deliberately invalid `credentialRef`, `inspect_deployment` or `get_deployment_state_snapshot` reports `lastErrorCode: KB_TENANT_REPO_SYNC_SYNC_FAILED` plus `lastSourceErrorCode: KB_GITMIRROR_CREDENTIAL_REF_INVALID`, without clone URLs, credential refs, tokens, or raw stderr.
