### PR TITLE
feat(build): clarify agent-preflight check-only mode (#14406)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -15,9 +15,11 @@ The act of opening a PR is an irreversible state transition in the Agent OS. Bef
 *If and only if* you pass this reflection phase, proceed to the Git execution sequence.
 
 Before the first commit or PR-body attempt on an agent-authored PR, run
-`npm run agent-preflight -- [files...]`; when a local PR body draft exists,
-include `-- --pr-body <draft-body.md>` so local source and PR-body gate failures
-surface before CI.
+`npm run agent-preflight -- [files...]` when you want the repair-capable pass
+that may run `check-block-alignment --fix`. For final validation without file
+mutation, run `npm run agent-preflight -- --no-fix [files...]`; when a local PR
+body draft exists, include `-- --pr-body <draft-body.md>` so local source and
+PR-body gate failures surface before CI.
 
 ### 1.1 The Substrate-Mutation Pre-Flight Gate
 

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -34,10 +34,10 @@ const
 export function createProgram() {
     return new Command()
         .name('agent-preflight')
-        .description('Runs the agent commit/PR preflight gates in one pass.')
+        .description('Runs the agent commit/PR preflight gates in one pass; default mode may repair block alignment.')
         .usage('[options] [files...]')
         .option('--pr-body <file>', 'Run local PR-body template lint against the given markdown file.')
-        .option('--no-fix', 'Skip the check-block-alignment --fix pass.')
+        .option('--no-fix', 'Check-only mode: skip the check-block-alignment --fix repair pass.')
         .argument('[files...]', 'Optional file paths. When omitted, staged ACMR files are read from git.')
 }
 
@@ -343,6 +343,12 @@ export function runAgentPreflight({
     if (mjsFiles.length === 0) {
         writeLine(stdout, 'agent-preflight: 0 .mjs files in scope; skipped source gates.');
     } else {
+        if (options.fix) {
+            writeLine(stdout, 'agent-preflight: repair mode enabled; running check-block-alignment --fix before staged checks. Use --no-fix for check-only validation.');
+        } else {
+            writeLine(stdout, 'agent-preflight: check-only mode; skipped check-block-alignment --fix.');
+        }
+
         const gateRuns = [
             runNodeGate({
                 args: [path.join(scriptDir, 'check-ticket-archaeology.mjs'), ...mjsFiles],

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -32,10 +32,14 @@ const validBody = [
 test.describe('agent-preflight utility', () => {
     test('builds the Commander program with the expected option surface', () => {
         const program = createProgram();
+        const help    = program.helpInformation();
 
-        expect(program.helpInformation()).toContain('Usage: agent-preflight [options] [files...]');
-        expect(program.helpInformation()).toContain('--pr-body <file>');
-        expect(program.helpInformation()).toContain('--no-fix')
+        expect(help).toContain('Usage: agent-preflight [options] [files...]');
+        expect(help).toContain('default mode may repair');
+        expect(help).toContain('block alignment');
+        expect(help).toContain('--pr-body <file>');
+        expect(help).toContain('--no-fix');
+        expect(help).toContain('Check-only mode')
     });
 
     test('parses files, optional PR body, and fix mode through Commander', () => {
@@ -114,7 +118,43 @@ test.describe('agent-preflight utility', () => {
         ]);
         expect(calls[2].args).toContain('--fix');
         expect(calls[3].args).toContain('--staged');
+        expect(stdout).toContain('agent-preflight: repair mode enabled; running check-block-alignment --fix');
         expect(stdout).toContain('agent-preflight: no --pr-body provided; skipped PR-body lint.');
+        expect(stdout).toContain('agent-preflight: all requested gates passed.')
+    });
+
+    test('--no-fix skips the block-alignment repair gate but keeps staged checks', () => {
+        const calls = [];
+
+        const execFileSyncImpl = (cmd, args) => {
+            calls.push({cmd, args});
+
+            return `${path.basename(args[0])} ok\n`
+        };
+
+        let stdout = '';
+        let stderr = '';
+
+        const status = runAgentPreflight({
+            argv            : ['--no-fix', 'src/a.mjs'],
+            cwd             : '/repo',
+            execFileSyncImpl,
+            existsSyncImpl  : () => false,
+            readFileSyncImpl: () => '',
+            scriptDir       : '/repo/buildScripts/util',
+            stderr          : {write: value => { stderr += value }},
+            stdout          : {write: value => { stdout += value }}
+        });
+
+        expect(status).toBe(0);
+        expect(stderr).toBe('');
+        expect(calls.map(call => path.basename(call.args[0]))).toEqual([
+            'check-ticket-archaeology.mjs',
+            'check-block-alignment.mjs'
+        ]);
+        expect(calls.some(call => call.args.includes('--fix'))).toBe(false);
+        expect(calls[1].args).toContain('--staged');
+        expect(stdout).toContain('agent-preflight: check-only mode; skipped check-block-alignment --fix.');
         expect(stdout).toContain('agent-preflight: all requested gates passed.')
     });
 


### PR DESCRIPTION
Resolves #14406

`agent-preflight` now names its two modes directly: the default repair-capable path announces that it may run `check-block-alignment --fix`, while `--no-fix` announces check-only validation. The PR workflow now tells authors which mode to use, and the existing unit spec proves both default repair orchestration and `--no-fix` skipping the repair gate.

Evidence: L2 (focused unit coverage + local CLI/preflight gates) -> L2 required (build-script workflow clarity and skill payload guidance). No residuals.

## Deltas from ticket

The implementation keeps the existing default repair behavior intact. It only makes the contract visible in CLI help/output and documents the existing `--no-fix` validation path.

## Substrate Load-Effect

Modified substrate: `.agents/skills/pull-request/references/pull-request-workflow.md`.

Slot rationale: `rewrite` of an existing workflow-map paragraph. The always-loaded `pull-request/SKILL.md` router is unchanged; no new skill, trigger, or top-level rule was added. The change lives in the already-triggered PR workflow payload and clarifies an existing command contract at the point where authors are already required to read the payload.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs` -> 23 passed.
- `npm run agent-preflight -- --no-fix buildScripts/util/agent-preflight.mjs test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs .agents/skills/pull-request/references/pull-request-workflow.md` -> passed.
- `npm run agent-preflight -- --no-fix` -> passed on staged files.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> passed.
- `node --check buildScripts/util/agent-preflight.mjs` -> passed.
- `git diff --check` and `git diff --cached --check` -> passed.

## Post-Merge Validation

- [ ] Authors running `npm run agent-preflight -- --no-fix <files>` see check-only mode text and no repair gate is invoked.

## Commits

- `12928c61a2` - `feat(build): clarify agent-preflight check-only mode (#14406)`

Authored by Euclid (GPT-5, Codex Desktop). Session c0dfa949-22de-4daf-bbd2-1e093383fefc.
