### PR TITLE
fix(ai): flag incomplete deployment snapshots (#14408)

### DIFF
--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -158,7 +158,8 @@ paths:
         also includes redacted tenant-repo-sync scheduler/task/config state for pull-mode
         ingestion diagnostics. The snapshot can also include bridgeDiagnostics with redacted
         runtime-access config, Compose label filter details, and stable lookup-failure reasons
-        for service-observation failures.
+        for service-observation failures. Fresh snapshots missing current-schema sections return
+        a degraded status with stable schemaDiagnostics reason codes.
       tags: [Health]
       requestBody:
         required: false
@@ -192,7 +193,9 @@ paths:
         This is a read-only public KB surface: it exposes allowlisted service state, bounded
         log tails, current diagnoses, recent recovery-run ledger entries, and redacted
         tenant-repo-sync scheduler/task/config state without exposing
-        Docker, shell, exec, restart, or any public daemon/orchestrator route.
+        Docker, shell, exec, restart, or any public daemon/orchestrator route. Fresh snapshots
+        missing current-schema sections return a degraded status with stable schemaDiagnostics
+        reason codes.
       tags: [Health]
       requestBody:
         required: false

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -204,7 +204,9 @@ paths:
         or any public daemon/orchestrator route. If the bridge is missing or stale, the response
         reports that explicitly instead of falling back to graph-only proof. The snapshot can
         include bridgeDiagnostics with redacted runtime-access config, Compose label filter
-        details, and stable lookup-failure reasons for service-observation failures.
+        details, and stable lookup-failure reasons for service-observation failures. Fresh
+        snapshots missing current-schema sections return a degraded status with stable
+        schemaDiagnostics reason codes.
       tags: [Diagnostics]
       requestBody:
         required: false
@@ -237,7 +239,9 @@ paths:
         Reads the bounded deployment inspection snapshot written by the internal orchestrator.
         This is a read-only public MC surface: it exposes allowlisted service state, bounded
         log tails, current diagnoses, and recent recovery-run ledger entries without exposing
-        Docker, shell, exec, restart, or any public daemon/orchestrator route.
+        Docker, shell, exec, restart, or any public daemon/orchestrator route. Fresh snapshots
+        missing current-schema sections return a degraded status with stable schemaDiagnostics
+        reason codes.
       tags: [Diagnostics]
       requestBody:
         required: false

--- a/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
@@ -6,6 +6,20 @@ export const DEPLOYMENT_STATE_BRIDGE_SCHEMA_VERSION = 1;
 const DEFAULT_MAX_SNAPSHOT_BYTES = 256 * 1024;
 const DEFAULT_STALE_AFTER_MS     = 2 * 60 * 1000;
 
+const CURRENT_SNAPSHOT_SECTIONS = [
+    'services',
+    'bridgeDiagnostics',
+    'recoveryRuns',
+    'selfHeal',
+    'tenantRepoSync'
+];
+
+const CURRENT_PRODUCER_METADATA = Object.freeze({
+    name         : 'orchestrator-deployment-state-bridge',
+    schemaVersion: DEPLOYMENT_STATE_BRIDGE_SCHEMA_VERSION,
+    sections     : CURRENT_SNAPSHOT_SECTIONS
+});
+
 /**
  * @summary Builds a bounded deployment-state snapshot envelope for KB/MC read tools.
  *
@@ -21,6 +35,7 @@ const DEFAULT_STALE_AFTER_MS     = 2 * 60 * 1000;
  * @param {Object|null} [options.recoveryRuns=null] Bounded recovery-run ledger snapshot.
  * @param {Object|null} [options.selfHeal=null] Bounded self-heal immune-system status (heal-ledger summary + recent events).
  * @param {Object|null} [options.tenantRepoSync=null] Bounded tenant-repo-sync scheduler/task/config snapshot.
+ * @param {Object} [options.producer=CURRENT_PRODUCER_METADATA] Bounded snapshot producer metadata.
  * @returns {Object}
  */
 export function createDeploymentStateSnapshot({
@@ -30,7 +45,8 @@ export function createDeploymentStateSnapshot({
     bridgeDiagnostics = null,
     recoveryRuns = null,
     selfHeal = null,
-    tenantRepoSync = null
+    tenantRepoSync = null,
+    producer = CURRENT_PRODUCER_METADATA
 } = {}) {
     if (!Number.isFinite(generatedAt)) {
         throw new TypeError('createDeploymentStateSnapshot: generatedAt must be finite');
@@ -45,6 +61,7 @@ export function createDeploymentStateSnapshot({
         recordType   : 'deployment-state-snapshot',
         generatedAt,
         source,
+        producer     : sanitizeProducerMetadata(producer),
         services,
         bridgeDiagnostics,
         recoveryRuns,
@@ -110,18 +127,47 @@ export async function readDeploymentStateSnapshot({
             return unavailable({filePath, reason: 'snapshot-too-large', details: {size: stat.size, maxBytes}});
         }
 
-        const snapshot = JSON.parse(await fs.readFile(filePath, 'utf8')),
-              ageMs    = Number.isFinite(snapshot.generatedAt) ? Math.max(0, now - snapshot.generatedAt) : null,
-              stale    = Number.isFinite(ageMs) && staleAfterMs > 0 && ageMs > staleAfterMs;
+        const snapshot          = JSON.parse(await fs.readFile(filePath, 'utf8')),
+              ageMs             = Number.isFinite(snapshot.generatedAt) ? Math.max(0, now - snapshot.generatedAt) : null,
+              stale             = Number.isFinite(ageMs) && staleAfterMs > 0 && ageMs > staleAfterMs,
+              schemaDiagnostics = inspectSnapshotSchema(snapshot);
+
+        if (stale) {
+            return {
+                ok    : false,
+                status: 'stale',
+                filePath,
+                ageMs,
+                staleAfterMs,
+                snapshot,
+                schemaDiagnostics,
+                reason: 'snapshot-stale'
+            };
+        }
+
+        if (schemaDiagnostics.status === 'degraded') {
+            return {
+                ok     : false,
+                status : 'degraded',
+                filePath,
+                ageMs,
+                staleAfterMs,
+                snapshot,
+                schemaDiagnostics,
+                reason : schemaDiagnostics.reason,
+                details: schemaDiagnostics
+            };
+        }
 
         return {
-            ok    : !stale,
-            status: stale ? 'stale' : 'available',
+            ok    : true,
+            status: 'available',
             filePath,
             ageMs,
             staleAfterMs,
             snapshot,
-            reason: stale ? 'snapshot-stale' : null
+            schemaDiagnostics,
+            reason: null
         };
     } catch (error) {
         if (error.code === 'ENOENT') {
@@ -166,6 +212,47 @@ function unavailable({filePath = null, reason, details = null}) {
         snapshot: null,
         reason,
         details
+    };
+}
+
+function inspectSnapshotSchema(snapshot) {
+    const
+        missingSections = CURRENT_SNAPSHOT_SECTIONS.filter(section => !Object.hasOwn(snapshot || {}, section)),
+        producer        = sanitizeProducerMetadata(snapshot?.producer),
+        producerMissing = !snapshot?.producer;
+
+    let status = 'available',
+        reason = null;
+
+    if (missingSections.length > 0) {
+        status = 'degraded';
+        reason = 'snapshot-section-missing';
+    } else if (producerMissing) {
+        status = 'degraded';
+        reason = 'snapshot-producer-metadata-missing';
+    }
+
+    return {
+        schemaVersion          : DEPLOYMENT_STATE_BRIDGE_SCHEMA_VERSION,
+        recordType             : 'deployment-state-schema-diagnostics',
+        status,
+        reason,
+        expectedSections       : CURRENT_SNAPSHOT_SECTIONS,
+        missingSections,
+        producerMetadataPresent: !producerMissing,
+        producer
+    };
+}
+
+function sanitizeProducerMetadata(producer) {
+    const source = producer && typeof producer === 'object' ? producer : CURRENT_PRODUCER_METADATA;
+
+    return {
+        name         : typeof source.name === 'string' ? source.name : CURRENT_PRODUCER_METADATA.name,
+        schemaVersion: Number.isFinite(source.schemaVersion) ? source.schemaVersion : DEPLOYMENT_STATE_BRIDGE_SCHEMA_VERSION,
+        sections     : Array.isArray(source.sections)
+            ? source.sections.filter(section => CURRENT_SNAPSHOT_SECTIONS.includes(section))
+            : [...CURRENT_SNAPSHOT_SECTIONS]
     };
 }
 

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -190,6 +190,16 @@ For push-mode deployments, trigger the deployment's ingestion entry point once, 
 
 For pull-mode deployments with configured `tenantRepos[]`, call `inspect_deployment` or `get_deployment_state_snapshot` and inspect the `tenantRepoSync` section before taking manual action. It distinguishes disabled, no configured repos, not-due, running, completed, failed, and degraded/unreadable state without exposing credentials or raw logs. If the task is configured but has not advanced, use the stable reason code and per-repo hashed state there to decide whether to wait for the next due sweep, fix credentials/config, or run `node ./ai/scripts/maintenance/syncTenantRepos.mjs` inside the orchestrator container. When `lastErrorCode` is `KB_TENANT_REPO_SYNC_SYNC_FAILED`, check `lastSourceErrorCode`: `KB_GITMIRROR_CREDENTIAL_REF_INVALID`, `KB_GITMIRROR_CLONE_FAILED`, or `KB_GITMIRROR_FETCH_FAILED` points to the credential/ref/upstream access path before generic ingestion debugging.
 
+If the deployment snapshot is fresh but the tool returns `status: degraded` with
+`reason: snapshot-section-missing` or `snapshot-producer-metadata-missing`, fix
+the bridge producer before debugging repo credentials or embeddings. Those
+reasons mean the public KB/MC server can read the snapshot file, but the
+orchestrator bridge that wrote it is older than the current diagnostic contract
+or omitted a required top-level section such as `tenantRepoSync`. Recreate the
+orchestrator with the current image/config, then re-run the public tool and only
+continue pull-mode ingestion debugging once `schemaDiagnostics.status` is
+`available`.
+
 ## See also
 
 - [Day-0 Tutorial](Day0Tutorial.md) — the first-deployment happy path.

--- a/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
@@ -24,10 +24,15 @@ test.describe('deploymentStateBridgeStore', () => {
 
         expect(written.ok).toBe(true);
         expect(read).toMatchObject({
-            ok    : true,
-            status: 'available',
-            ageMs : 100,
-            snapshot
+            ok               : true,
+            status           : 'available',
+            ageMs            : 100,
+            snapshot,
+            schemaDiagnostics: {
+                status                 : 'available',
+                producerMetadataPresent: true,
+                missingSections        : []
+            }
         });
     });
 
@@ -38,8 +43,70 @@ test.describe('deploymentStateBridgeStore', () => {
 
         expect(snapshot.bridgeDiagnostics).toEqual(bridgeDiagnostics);
         expect(snapshot.selfHeal).toEqual(selfHeal);                       // passed through verbatim
+        expect(snapshot.producer).toMatchObject({
+            name    : 'orchestrator-deployment-state-bridge',
+            sections: expect.arrayContaining(['bridgeDiagnostics', 'selfHeal', 'tenantRepoSync'])
+        });
         expect(createDeploymentStateSnapshot({generatedAt: 1}).bridgeDiagnostics).toBeNull(); // additive + back-compat
         expect(createDeploymentStateSnapshot({generatedAt: 1}).selfHeal).toBeNull(); // additive + back-compat (omitted → null)
+    });
+
+    test('degrades fresh legacy snapshots without producer metadata (#14408)', async () => {
+        const dir      = await fs.mkdtemp(path.join(os.tmpdir(), 'deployment-state-bridge-')),
+              filePath = path.join(dir, 'snapshot.json'),
+              snapshot = {
+                  schemaVersion    : 1,
+                  recordType       : 'deployment-state-snapshot',
+                  generatedAt      : 1710000000000,
+                  source           : 'orchestrator-deployment-state-bridge',
+                  services         : [],
+                  bridgeDiagnostics: null,
+                  recoveryRuns     : null,
+                  selfHeal         : null,
+                  tenantRepoSync   : null
+              };
+
+        await writeDeploymentStateSnapshot({filePath, snapshot});
+
+        await expect(readDeploymentStateSnapshot({filePath, now: 1710000000100})).resolves.toMatchObject({
+            ok               : false,
+            status           : 'degraded',
+            reason           : 'snapshot-producer-metadata-missing',
+            schemaDiagnostics: {
+                status                 : 'degraded',
+                producerMetadataPresent: false,
+                missingSections        : []
+            }
+        });
+    });
+
+    test('degrades fresh snapshots missing current top-level sections (#14408)', async () => {
+        const dir      = await fs.mkdtemp(path.join(os.tmpdir(), 'deployment-state-bridge-')),
+              filePath = path.join(dir, 'snapshot.json'),
+              snapshot = {
+                  schemaVersion: 1,
+                  recordType   : 'deployment-state-snapshot',
+                  generatedAt  : 1710000000000,
+                  source       : 'orchestrator-deployment-state-bridge',
+                  producer     : {
+                      name         : 'orchestrator-deployment-state-bridge',
+                      schemaVersion: 1,
+                      sections     : ['services']
+                  },
+                  services: []
+              };
+
+        await writeDeploymentStateSnapshot({filePath, snapshot});
+
+        await expect(readDeploymentStateSnapshot({filePath, now: 1710000000100})).resolves.toMatchObject({
+            ok               : false,
+            status           : 'degraded',
+            reason           : 'snapshot-section-missing',
+            schemaDiagnostics: {
+                status         : 'degraded',
+                missingSections: expect.arrayContaining(['bridgeDiagnostics', 'recoveryRuns', 'selfHeal', 'tenantRepoSync'])
+            }
+        });
     });
 
     test('reports missing and stale snapshots explicitly', async () => {


### PR DESCRIPTION
Resolves #14408

Fresh deployment-state snapshots now carry bounded producer/schema metadata, and the shared KB/MC read helper classifies fresh-but-incomplete snapshots as `degraded` instead of unqualified `available`. Missing current-schema sections report `snapshot-section-missing`; legacy snapshots without producer metadata report `snapshot-producer-metadata-missing`. The public tool descriptions and empty-KB troubleshooting path now tell operators to fix the bridge producer/schema mismatch before chasing repo credentials or embeddings.

Evidence: L2 (focused unit coverage + MCP OpenAPI validator + agent-preflight) -> L3 required only after deployment picks up the merged orchestrator image. Residual: rerun `inspect_deployment` against a cloud deployment after rollout to confirm `schemaDiagnostics.status: available`.

## Deltas from ticket

The implementation keeps the contract at the shared `deploymentStateBridgeStore` read path, so both KB and MC tools inherit the same classification. It treats absent top-level sections as the hard degraded case, while current snapshots can still contain present-but-null section values when the producer deliberately reports unavailable/degraded substate.

No always-loaded agent instruction substrate changed; the docs update is limited to the cloud deployment troubleshooting reference.

## Test Evidence

- `node --check ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs` -> 6 passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` -> 40 passed
- `npm run agent-preflight -- --no-fix ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs learn/agentos/cloud-deployment/Troubleshooting.md ai/mcp/server/knowledge-base/openapi.yaml ai/mcp/server/memory-core/openapi.yaml` -> passed
- `git diff --cached --check` -> passed

## Post-Merge Validation

- [ ] After the cloud deployment is rebuilt/recreated from a ref containing this PR, call `inspect_deployment(staleAfterMs: 600000)` and verify `schemaDiagnostics.status` is `available` once the orchestrator bridge writer is current.

## Commit

- `2d77aa88d6` - `fix(ai): flag incomplete deployment snapshots (#14408)`

Authored by Euclid (GPT-5, Codex Desktop). Session c0dfa949-22de-4daf-bbd2-1e093383fefc.
