### PR TITLE
fix(ai): make empty KB guidance cloud-aware (#14410)

### DIFF
--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -1,14 +1,17 @@
-import aiConfig             from '../../mcp/server/knowledge-base/config.mjs';
-import Base                 from '../../../src/core/Base.mjs';
-import {buildChatModel}     from '../../provider/buildChatModel.mjs';
-import {PROVIDER_TIMEOUT_CODE} from '../../provider/createTimeoutError.mjs';
-import ChromaManager        from './ChromaManager.mjs';
-import fs                   from 'fs-extra';
-import logger               from '../../mcp/server/knowledge-base/logger.mjs';
-import path                 from 'path';
-import QueryService         from './QueryService.mjs';
-import {checkAskRateLimit}  from './helpers/askRateLimit.mjs';
+import aiConfig                       from '../../mcp/server/knowledge-base/config.mjs';
+import Base                           from '../../../src/core/Base.mjs';
+import {buildChatModel}               from '../../provider/buildChatModel.mjs';
+import {PROVIDER_TIMEOUT_CODE}        from '../../provider/createTimeoutError.mjs';
+import ChromaManager                  from './ChromaManager.mjs';
+import fs                             from 'fs-extra';
+import logger                         from '../../mcp/server/knowledge-base/logger.mjs';
+import path                           from 'path';
+import QueryService                   from './QueryService.mjs';
+import {checkAskRateLimit}            from './helpers/askRateLimit.mjs';
 import {getMissingAskSynthesisLeaves} from './helpers/askSynthesisGuard.mjs';
+
+const LOCAL_EMPTY_COLLECTION_ANSWER  = "The knowledge base collection is empty. Populate it with the release artifact via 'npm run ai:download-kb' (or build locally with 'npm run ai:sync-kb').";
+const REMOTE_EMPTY_COLLECTION_ANSWER = "The knowledge base collection is empty. In a cloud or remote tenant-ingestion deployment, inspect ingestion state first: call get_ingestion_progress(), then inspect_deployment or get_deployment_state_snapshot for tenantRepoSync / deployment-state details. For push-mode tenants, run the configured ingest_source_files or bulk tenant-ingest path before retrying the query.";
 
 /**
  * @summary Orchestrates Retrieval-Augmented Generation (RAG) by combining semantic search with LLM synthesis.
@@ -101,11 +104,11 @@ class SearchService extends Base {
         const ask = aiConfig.askSynthesis;
 
         this.model = buildChatModel({
-            modelProvider          : ask.provider,
-            openAiCompatibleConfig : {...aiConfig.openAiCompatible, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
-            ollamaConfig           : {...aiConfig.ollama, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
-            geminiApiKey           : ask.apiKey,
-            geminiModelName        : ask.model
+            modelProvider         : ask.provider,
+            openAiCompatibleConfig: {...aiConfig.openAiCompatible, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
+            ollamaConfig          : {...aiConfig.ollama, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
+            geminiApiKey          : ask.apiKey,
+            geminiModelName       : ask.model
         });
     }
 
@@ -148,6 +151,20 @@ class SearchService extends Base {
         }
 
         return metadata.tenantId !== defaultTenantId;
+    }
+
+    /**
+     * Returns the operator-facing answer for a healthy but empty KB collection.
+     *
+     * Local stdio deployments need the curated Neo corpus download/sync hint. Remote SSE deployments
+     * expose tenant-ingestion tools, so an empty collection is first an ingestion-state diagnostic.
+     *
+     * @returns {String} The empty-collection remediation message.
+     */
+    getEmptyCollectionAnswer() {
+        return aiConfig.transport === 'sse'
+            ? REMOTE_EMPTY_COLLECTION_ANSWER
+            : LOCAL_EMPTY_COLLECTION_ANSWER;
     }
 
     /**
@@ -224,7 +241,7 @@ class SearchService extends Base {
         const degradedCode = code || (isTimeout ? 'synthesis_timeout' : 'synthesis_failed');
 
         return {
-            answer: `Knowledge-base retrieval succeeded, but answer synthesis is currently unavailable (${reason}). Use the references directly while the synthesis provider recovers.`,
+            answer  : `Knowledge-base retrieval succeeded, but answer synthesis is currently unavailable (${reason}). Use the references directly while the synthesis provider recovers.`,
             references,
             degraded: true,
             degradedCode,
@@ -273,7 +290,7 @@ class SearchService extends Base {
 
             return {
                 answer: count === 0
-                    ? "The knowledge base collection is empty. Populate it with the release artifact via 'npm run ai:download-kb' (or build locally with 'npm run ai:sync-kb')."
+                    ? this.getEmptyCollectionAnswer()
                     : "No relevant documents found in the knowledge base.",
                 references: []
             };
@@ -351,7 +368,7 @@ Instructions:
         // Interactive use sits far below the cap; a scripted runaway (the incident class) trips it and we
         // return the degraded references instead of issuing the (costly) remote call. State lives on the
         // singleton; the rate check is a pure helper (`checkAskRateLimit`) for isolated, mutation-free testing.
-        const nowMs = Date.now();
+        const nowMs           = Date.now();
         const {limited, kept} = checkAskRateLimit(this.askCallTimestamps, nowMs, aiConfig.askSynthesis.maxCallsPerMinute);
         this.askCallTimestamps = kept;
         if (limited) {

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -13,12 +13,12 @@ setup({
     }
 });
 
-import {test, expect}  from '@playwright/test';
-import Neo             from '../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../../../src/manager/Instance.mjs';
-import fs              from 'fs-extra';
-import path            from 'path';
+import {test, expect}          from '@playwright/test';
+import Neo                     from '../../../../../../src/Neo.mjs';
+import * as core               from '../../../../../../src/core/_export.mjs';
+import InstanceManager         from '../../../../../../src/manager/Instance.mjs';
+import fs                      from 'fs-extra';
+import path                    from 'path';
 import {PROVIDER_TIMEOUT_CODE} from '../../../../../../ai/provider/createTimeoutError.mjs';
 
 /**
@@ -37,6 +37,7 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
     let aiConfig;
     let originalQueryDocuments;
     let originalModel;
+    let originalTransport;
     let tmpFilePath;
     let tmpFileRelativeToRoot;
     const tmpFileContents = 'MOCK_FILE_CONTENT_abc123 — the SearchService should read this verbatim';
@@ -55,11 +56,13 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
 
         originalQueryDocuments = QueryService.queryDocuments.bind(QueryService);
         originalModel          = SearchService.model;
+        originalTransport      = aiConfig.transport;
     });
 
     test.afterAll(async () => {
         QueryService.queryDocuments = originalQueryDocuments;
         SearchService.model         = originalModel;
+        aiConfig.transport          = originalTransport;
         if (tmpFilePath) await fs.remove(path.dirname(tmpFilePath)).catch(() => {});
     });
 
@@ -333,7 +336,7 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
     });
 
     test('ask names the download/sync one-liners when the collection is EMPTY (post npm-prepare decouple cold-start)', async () => {
-        const ChromaManager = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        const ChromaManager         = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
         const originalGetCollection = ChromaManager.getKnowledgeBaseCollection;
 
         QueryService.queryDocuments = async () => ({results: []});
@@ -350,8 +353,32 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
         }
     });
 
+    test('ask points remote empty collections at tenant-ingestion diagnostics', async () => {
+        const ChromaManager         = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        const originalGetCollection = ChromaManager.getKnowledgeBaseCollection;
+
+        QueryService.queryDocuments = async () => ({results: []});
+        ChromaManager.getKnowledgeBaseCollection = async () => ({count: async () => 0});
+        aiConfig.transport = 'sse';
+
+        try {
+            const result = await SearchService.ask({query: 'anything'});
+
+            expect(result.answer).toContain('get_ingestion_progress()');
+            expect(result.answer).toContain('inspect_deployment');
+            expect(result.answer).toContain('get_deployment_state_snapshot');
+            expect(result.answer).toContain('tenantRepoSync');
+            expect(result.answer).toContain('ingest_source_files');
+            expect(result.answer).not.toContain('npm run ai:download-kb');
+            expect(result.references).toEqual([]);
+        } finally {
+            ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
+            aiConfig.transport = originalTransport;
+        }
+    });
+
     test('ask falls back to the generic no-documents answer when the count probe errors', async () => {
-        const ChromaManager = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        const ChromaManager         = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
         const originalGetCollection = ChromaManager.getKnowledgeBaseCollection;
 
         QueryService.queryDocuments = async () => ({results: []});
@@ -368,7 +395,7 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
     });
 
     test('ask keeps the generic no-documents answer when the collection has documents but none match', async () => {
-        const ChromaManager = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        const ChromaManager         = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
         const originalGetCollection = ChromaManager.getKnowledgeBaseCollection;
 
         QueryService.queryDocuments = async () => ({results: []});


### PR DESCRIPTION
Resolves #14410

`ask_knowledge_base()` now distinguishes local cold-start empty KBs from remote/cloud tenant-ingestion empty KBs. Local `stdio` deployments keep the existing `npm run ai:download-kb` / `npm run ai:sync-kb` remediation, while remote `sse` deployments point operators first at `get_ingestion_progress()`, `inspect_deployment`, `get_deployment_state_snapshot`, `tenantRepoSync`, and tenant ingest paths.

Evidence: L2 focused unit coverage (`SearchService.spec.mjs`, `SearchService.noModel.spec.mjs`) -> required close-target ACs for local empty response, cloud/remote empty response, answer-shape stability, and no-model guard. Residual: post-merge deployed-server smoke remains deployment-environment validation.

## Deltas from ticket

Used `aiConfig.transport === 'sse'` as the cloud/remote discriminator. That matches the existing KB server transport contract for remote tenant ingestion and avoids guessing from tenant repo config that may live in graph or YAML state instead of the KB config module.

Cloud troubleshooting docs were checked and already describe healthy-but-empty cloud KBs as ingestion-state diagnostics, so no doc wording change was needed.

## Test Evidence

- `npm run agent-preflight -- ai/services/knowledge-base/SearchService.mjs test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs` passed: 18 tests.
- `git diff --check` passed.

## Post-Merge Validation

- [ ] After deployment refresh, call `ask_knowledge_base()` against an empty remote KB and verify the answer points to ingestion diagnostics rather than local curated-KB seed commands.

Authored by Euclid (GPT-5, Codex Desktop). Session c0dfa949-22de-4daf-bbd2-1e093383fefc.
