### PR TITLE
fix(lifecycle): suppress reported deference mentions (#14436)

### DIFF
--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -48,6 +48,48 @@ function stripMarkdownCode(text) {
 }
 
 /**
+ * @summary Replaces quoted prose spans that report a phrase instead of using it.
+ * @param {String} text Assistant final-turn text with code spans already removed.
+ * @returns {String}
+ */
+function stripQuotedMentions(text) {
+    return text
+        .replace(/"[^"\n]*"/g, ' ')
+        .replace(/(^|[^a-zA-Z0-9_])'[^'\n]*'(?=$|[^a-zA-Z0-9_])/g, '$1 ');
+}
+
+/**
+ * @summary Checks whether a local match is a reported phrase rather than deference.
+ * @param {String} text Searchable assistant final-turn text.
+ * @param {Number} startIndex Match start index.
+ * @returns {Boolean}
+ */
+function isReportedMentionContext(text, startIndex) {
+    const prefix = text.slice(Math.max(0, startIndex - 80), startIndex).toLowerCase();
+
+    return /\b(?:the|this|that)\s+(?:literal\s+)?(?:phrase|text|string|trigger|matched\s+text|wording)\s*$/.test(prefix) ||
+           /\b(?:quoted|reported|mention(?:ed|ing)?|document(?:ed|ing)?)\s*$/.test(prefix);
+}
+
+/**
+ * @summary Checks whether a local "your call" match cites a prior operator decision.
+ * @param {String} phrase Matched deference phrase.
+ * @param {String} text Searchable assistant final-turn text.
+ * @param {Number} startIndex Match start index.
+ * @returns {Boolean}
+ */
+function isAttributiveCitationContext(phrase, text, startIndex) {
+    if (phrase.toLowerCase() !== 'your call') {
+        return false;
+    }
+
+    const prefix = text.slice(Math.max(0, startIndex - 80), startIndex).toLowerCase();
+
+    return /\bper\s+$/.test(prefix) ||
+           /\bas\s+you\s+(?:said|directed|called)\W*$/.test(prefix);
+}
+
+/**
  * @summary Returns the first deference phrase found in text, using case-insensitive boundary match.
  * @param {String} text Assistant final-turn text.
  * @param {String[]} [phrases=DEFERENCE_PHRASES]
@@ -58,13 +100,21 @@ export function matchDeferencePhrase(text = '', phrases = DEFERENCE_PHRASES) {
         return null;
     }
 
-    const searchableText = stripMarkdownCode(text);
+    const searchableText = stripQuotedMentions(stripMarkdownCode(text));
 
     return phrases.find(phrase => {
         const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+'),
               matcher = new RegExp(`(^|[^a-z0-9_])${escaped}(?=$|[^a-z0-9_])`, 'i');
+        const match = matcher.exec(searchableText);
 
-        return matcher.test(searchableText);
+        if (!match) {
+            return false;
+        }
+
+        const startIndex = match.index + match[1].length;
+
+        return !isReportedMentionContext(searchableText, startIndex) &&
+               !isAttributiveCitationContext(phrase, searchableText, startIndex);
     }) || null;
 }
 

--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -104,17 +104,19 @@ export function matchDeferencePhrase(text = '', phrases = DEFERENCE_PHRASES) {
 
     return phrases.find(phrase => {
         const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+'),
-              matcher = new RegExp(`(^|[^a-z0-9_])${escaped}(?=$|[^a-z0-9_])`, 'i');
-        const match = matcher.exec(searchableText);
+              matcher = new RegExp(`(^|[^a-z0-9_])${escaped}(?=$|[^a-z0-9_])`, 'ig');
+        let match;
 
-        if (!match) {
-            return false;
+        while ((match = matcher.exec(searchableText)) !== null) {
+            const startIndex = match.index + match[1].length;
+
+            if (!isReportedMentionContext(searchableText, startIndex) &&
+                !isAttributiveCitationContext(phrase, searchableText, startIndex)) {
+                return true;
+            }
         }
 
-        const startIndex = match.index + match[1].length;
-
-        return !isReportedMentionContext(searchableText, startIndex) &&
-               !isAttributiveCitationContext(phrase, searchableText, startIndex);
+        return false;
     }) || null;
 }
 

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -47,6 +47,25 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase('```text\nYour steer on the next lane.\n```')).toBeNull();
     });
 
+    test('does not match quoted or reported phrase mentions', () => {
+        expect(matchDeferencePhrase('The "your call" firing was a demonstrable false positive.')).toBeNull();
+        expect(matchDeferencePhrase("The 'per your call' firing was a demonstrable false positive.")).toBeNull();
+        expect(matchDeferencePhrase('The phrase your call is mentioned in the #14420 corpus.')).toBeNull();
+        expect(matchDeferencePhrase("The phrase if you'd rather is part of the deference register.")).toBeNull();
+    });
+
+    test('does not match attributive citations of an operator decision', () => {
+        expect(matchDeferencePhrase('Clio owns it, per your call.')).toBeNull();
+        expect(matchDeferencePhrase('The ownership route stands as you directed: your call is the source.'))
+            .toBeNull();
+    });
+
+    test('still matches live deference uses of your call', () => {
+        expect(matchDeferencePhrase('Your call on the branch cut.')).toBe('your call');
+        expect(matchDeferencePhrase("It's your call whether I pick this up.")).toBe('your call');
+        expect(matchDeferencePhrase('Your call?')).toBe('your call');
+    });
+
     test('operator-dialogue carve skips the phrase match', () => {
         expect(detectDeferencePhrase('Your call on the exact color.', {operatorInLoop: true})).toBeNull();
         expect(detectDeferencePhrase('Your call on the exact color.', {operatorInLoop: false})).toBe('your call');

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -66,6 +66,11 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase('Your call?')).toBe('your call');
     });
 
+    test('still fires when a live use follows a carved mention of the same phrase', () => {
+        expect(matchDeferencePhrase('The phrase your call recurs. Your call on the merge?')).toBe('your call');
+        expect(matchDeferencePhrase('Clio owns it per your call, but honestly, your call?')).toBe('your call');
+    });
+
     test('operator-dialogue carve skips the phrase match', () => {
         expect(detectDeferencePhrase('Your call on the exact color.', {operatorInLoop: true})).toBeNull();
         expect(detectDeferencePhrase('Your call on the exact color.', {operatorInLoop: false})).toBe('your call');


### PR DESCRIPTION
Resolves #14436

Related: #14420

This narrows the pure deference phrase matcher so quoted/reported phrase mentions and attributive citations of an already-made operator decision do not fire the autonomous deference hook, while live deference uses of `your call` still match.

Evidence: L2 (focused unit coverage + shared hook consumer suites) -> L2 required (pure matcher behavior). Residual: #14420 remains open for operator-prompt visibility, terminal-shape re-fire, sunset, and declining-yield hook-level axes.

## Deltas from ticket

The implementation began under the parent #14420 claim before #14436 was filed as the honest close target for this narrow PR. The pushed commit therefore references #14420; this PR resolves only #14436 and deliberately does not close the parent.

The fix stays inside `ai/scripts/lifecycle/deferencePhraseMatch.mjs` and its direct unit spec. It does not change L3 no-hold policy, operator-dialogue handling, Codex/Claude adapter payload parsing, or the remaining hook-level #14420 axes.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs` passed: 11/11.
- `npm run test-unit -- test/playwright/unit/hooks/stopHookDecision.spec.mjs` passed: 31/31.
- `NEO_AI_DAEMON_DIR=/private/tmp/neo-codex-hook-test-14420 npm run test-unit -- test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs` passed: 76/76.
- `npm run agent-preflight -- ai/scripts/lifecycle/deferencePhraseMatch.mjs test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs` passed.
- `git diff --check` passed.

## Post-Merge Validation

- [ ] Future #14420 re-fire/sunset/operator-prompt PRs can build on the narrower matcher without reopening Defect A.

## Commits

- `1c4d55a65e` - `fix(lifecycle): suppress reported deference mentions (#14420)`

Authored by Euclid (GPT-5, Codex Desktop). Session 8facbc96-c346-4633-9141-79a968ca1c5d.
