### PR TITLE
fix(memory-core): repair mailbox graph projections from WAL (#14426)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -10,19 +10,23 @@ import {
     appendWalMessage,
     getMessageWalSegmentKey,
     getMissingMessageWalLeaves,
+    readWalMessages,
     readPendingMessageWalRecords
 } from './helpers/messageWalStore.mjs';
+import {IDENTITIES}                from '../../graph/identityRoots.mjs';
 import {getMissingMemoryWalLeaves} from './helpers/memoryWalStore.mjs';
 import {execFile}                  from 'child_process';
 import {promisify}                 from 'util';
 import crypto                      from 'crypto';
 
 const
-    execFileAsync                     = promisify(execFile),
-    RELATED_PULL_REQUEST_CACHE_TTL_MS = 30 * 1000,
-    RELATED_PULL_REQUEST_PATTERN      = /^#(\d+)$/,
-    relatedPullRequestStateCache      = new Map(),
-    WAKE_SUPPRESSION_ALLOWED_TAGS     = new Set(['sunset-protocol-handover', 'lead-role-baton']),
+    execFileAsync                        = promisify(execFile),
+    RELATED_PULL_REQUEST_CACHE_TTL_MS    = 30 * 1000,
+    RELATED_PULL_REQUEST_PATTERN         = /^#(\d+)$/,
+    relatedPullRequestStateCache         = new Map(),
+    WAKE_SUPPRESSION_ALLOWED_TAGS        = new Set(['sunset-protocol-handover', 'lead-role-baton']),
+    MESSAGE_GRAPH_REPAIR_LIMIT           = 250,
+    IDENTITY_ROOTS_BY_ID                 = new Map(IDENTITIES.map(identity => [identity.id, identity])),
     WAKE_SUPPRESSION_ACTIONABLE_SUBJECTS = [
         /^\[re-review/i,
         /^\[review/i,
@@ -317,6 +321,162 @@ function getMessageWalTimestamp(record, properties = {}) {
 
 function getMessageWalArray(value) {
     return Array.isArray(value) ? value : [];
+}
+
+/**
+ * @summary Returns a safe endpoint spec for replaying accepted mailbox WAL records after graph loss.
+ * @param {String} id Graph node id required by a delivery-critical mailbox edge.
+ * @returns {Object|null}
+ * @private
+ */
+function getMailboxEndpointRestoreSpec(id) {
+    if (typeof id !== 'string' || id.length === 0) return null;
+    if (IDENTITY_ROOTS_BY_ID.has(id)) return IDENTITY_ROOTS_BY_ID.get(id);
+
+    if (id === 'AGENT:*') {
+        return {
+            id,
+            type      : 'BroadcastSentinel',
+            name      : 'Broadcast',
+            properties: {
+                accountType               : 'sentinel',
+                restoredFromMessageWal    : true,
+                restoredFromMessageWalOnly: true
+            }
+        };
+    }
+
+    if (id.startsWith('@')) {
+        return {
+            id,
+            type       : 'AgentIdentity',
+            name       : id.slice(1) || id,
+            description: 'Mailbox endpoint restored from accepted message WAL so durable messages remain addressable after graph repair.',
+            properties : {
+                accountType               : 'wal-restored',
+                restoredFromMessageWal    : true,
+                restoredFromMessageWalOnly: true
+            }
+        };
+    }
+
+    if (id.startsWith('role:')) {
+        return {
+            id,
+            type      : 'ROLE',
+            name      : id,
+            properties: {restoredFromMessageWal: true}
+        };
+    }
+
+    if (id.startsWith('human:')) {
+        return {
+            id,
+            type      : 'HUMAN',
+            name      : id,
+            properties: {restoredFromMessageWal: true}
+        };
+    }
+
+    return null;
+}
+
+/**
+ * @summary Ensures a mailbox delivery edge endpoint exists before WAL replay relinks it.
+ * @param {String} id Endpoint graph node id.
+ * @private
+ */
+function ensureMailboxProjectionEndpoint(id) {
+    if (typeof id !== 'string' || id.length === 0) return;
+
+    const db = GraphService.requireDb('MailboxService.ensureMailboxProjectionEndpoint');
+    db.getAdjacentNodes(id, 'both');
+    if (db.nodes.has(id)) return;
+
+    const spec = getMailboxEndpointRestoreSpec(id);
+    if (spec) {
+        GraphService.upsertGlobalNode(spec);
+    }
+}
+
+function hasGraphEdge(source, target, type) {
+    return (GraphService.db?.edges?.items || []).some(edge =>
+        getRecordField(edge, 'source') === source &&
+        getRecordField(edge, 'target') === target &&
+        getRecordField(edge, 'type') === type
+    );
+}
+
+/**
+ * @summary Returns missing graph-projection pieces for an accepted mailbox WAL record.
+ * @param {Object} record Accepted message WAL record.
+ * @returns {String[]}
+ * @private
+ */
+function getMessageGraphProjectionIssues(record) {
+    const db       = GraphService.requireDb('MailboxService.getMessageGraphProjectionIssues'),
+        messageId  = record?.id || record?.message?.id,
+        message    = record?.message || {},
+        properties = message.properties || {},
+        routing    = record?.routing || {},
+        sentBy     = routing.sentBy || properties.from,
+        to         = routing.to || properties.to,
+        issues     = [];
+
+    if (typeof messageId !== 'string' || !messageId.startsWith('MESSAGE:')) {
+        return ['invalid-message-record'];
+    }
+
+    db.getAdjacentNodes(messageId, 'outbound');
+
+    const messageNode = db.nodes.get(messageId);
+    if (!messageNode || getRecordField(messageNode, 'label') !== 'MESSAGE') {
+        issues.push('missing-message-node');
+    }
+
+    if (!sentBy || !to) {
+        issues.push('missing-routing');
+        return issues;
+    }
+
+    if (!hasGraphEdge(messageId, sentBy, 'SENT_BY')) issues.push('missing-sent-by');
+    if (!hasGraphEdge(messageId, to, 'SENT_TO')) issues.push('missing-sent-to');
+
+    if (to === 'AGENT:*') {
+        for (const recipient of getMessageWalArray(routing.broadcastRecipients)) {
+            if (!hasGraphEdge(messageId, recipient, 'DELIVERED_TO')) {
+                issues.push(`missing-delivered-to:${recipient}`);
+            }
+        }
+    }
+
+    return issues;
+}
+
+/**
+ * @summary Checks whether a WAL record can affect the requested mailbox view.
+ * @param {Object} record Accepted message WAL record.
+ * @param {Object} options
+ * @param {String} [options.box='all'] Mailbox box being queried.
+ * @param {String} [options.target] Target identity being queried.
+ * @returns {Boolean}
+ * @private
+ */
+function messageWalRecordMatchesMailboxView(record, {box = 'all', target} = {}) {
+    if (!target) return true;
+
+    const properties = record?.message?.properties || {},
+        routing      = record?.routing || {},
+        sentBy       = routing.sentBy || properties.from,
+        to           = routing.to || properties.to,
+        recipients   = getMessageWalArray(routing.broadcastRecipients);
+
+    if (box === 'outbox') return sentBy === target;
+
+    const inboxMatch = to === target || to === 'AGENT:*' || recipients.includes(target);
+    if (box === 'inbox') return inboxMatch;
+
+    return sentBy === target || inboxMatch;
 }
 
 /**
@@ -815,6 +975,9 @@ class MailboxService extends Base {
             throw new Error(`[MailboxService] message WAL projection requires routing.sentBy and routing.to for ${messageId}`);
         }
 
+        ensureMailboxProjectionEndpoint(sentBy);
+        ensureMailboxProjectionEndpoint(to);
+
         GraphService.upsertNode({
             id        : messageId,
             type      : message.type || 'MESSAGE',
@@ -827,6 +990,7 @@ class MailboxService extends Base {
 
         if (to === 'AGENT:*') {
             for (const recipient of getMessageWalArray(routing.broadcastRecipients)) {
+                ensureMailboxProjectionEndpoint(recipient);
                 linkRequiredMailboxEdgeOrThrow(messageId, recipient, 'DELIVERED_TO', 1.0, {
                     deliveredAt : timestamp,
                     readAt      : null,
@@ -900,6 +1064,59 @@ class MailboxService extends Base {
     }
 
     /**
+     * @summary Repairs accepted mailbox WAL records whose graph projection was later deleted or damaged.
+     *
+     * `drainPendingMessageGraphProjections` handles records that never received a projection marker.
+     * This method covers the post-marker failure class: destructive graph clears, row loss, or FK
+     * cascade damage after the MESSAGE was already accepted and marked projected.
+     *
+     * @param {Object} [options]
+     * @param {String[]} [options.ids] Optional targeted message ids.
+     * @param {String} [options.target] Optional mailbox identity whose view is being queried.
+     * @param {String} [options.box='all'] Mailbox box being queried.
+     * @param {Number} [options.limit=250] Maximum matching accepted WAL records to inspect.
+     * @returns {Promise<{scanned: Number, intact: Number, repaired: Number, failed: Number, issues: Object}>}
+     */
+    async repairMessageGraphIntegrity({ids, target, box = 'all', limit = MESSAGE_GRAPH_REPAIR_LIMIT} = {}) {
+        const summary = {scanned: 0, intact: 0, repaired: 0, failed: 0, issues: {}};
+
+        if (getMissingMessageWalLeaves(aiConfig.messageWal, ['dir']).length > 0) {
+            return summary;
+        }
+
+        const idFilter      = Array.isArray(ids) ? new Set(ids) : null,
+            boundedLimit    = Number.isFinite(Number(limit)) && Number(limit) > 0 ? Number(limit) : MESSAGE_GRAPH_REPAIR_LIMIT,
+            acceptedRecords = await readWalMessages({dir: aiConfig.messageWal.dir});
+
+        for (const record of acceptedRecords) {
+            if (summary.scanned >= boundedLimit) break;
+            if (record?.graphProjectionVersion !== 1) continue;
+            if (idFilter && !idFilter.has(record.id)) continue;
+            if (!messageWalRecordMatchesMailboxView(record, {box, target})) continue;
+
+            summary.scanned++;
+
+            const issues = getMessageGraphProjectionIssues(record);
+            if (issues.length === 0) {
+                summary.intact++;
+                continue;
+            }
+
+            summary.issues[record.id] = issues;
+
+            try {
+                await this._projectMessageWalRecord(record, {pumpWake: false});
+                summary.repaired++;
+            } catch (error) {
+                summary.failed++;
+                logger.warn(`[MailboxService] message graph integrity repair failed for ${record.id}: ${error.message}`);
+            }
+        }
+
+        return summary;
+    }
+
+    /**
      * Lists messages in the mailbox.
      * @param {Object} args
      * @param {String} [args.box='inbox'] Which box to list ('inbox', 'outbox', 'all')
@@ -936,7 +1153,14 @@ class MailboxService extends Base {
             }
         }
 
-        const db = GraphService.requireDb('MailboxService.listMessages');
+        const db           = GraphService.requireDb('MailboxService.listMessages');
+        const numericLimit = Number(limit),
+            numericOffset   = Number(offset || 0),
+            repairScanLimit = Number.isFinite(numericLimit)
+                ? Math.max(MESSAGE_GRAPH_REPAIR_LIMIT, numericLimit + (Number.isFinite(numericOffset) ? numericOffset : 0))
+                : MESSAGE_GRAPH_REPAIR_LIMIT;
+
+        await this.repairMessageGraphIntegrity({target, box, limit: repairScanLimit});
 
         // Consume WAL delta AND re-populate vicinity from SQLite before iterating
         // in-memory edges. A bare `syncCache()` call invalidates cached
@@ -1102,6 +1326,7 @@ class MailboxService extends Base {
         }
 
         const db = GraphService.requireDb('MailboxService.getMessage');
+        await this.repairMessageGraphIntegrity({ids: [messageId], limit: 1});
 
         // Trigger syncCache + lazy-reload vicinity for this message node.
         // Ensures peer-process writes to this message's edges (e.g. late PART_OF_THREAD
@@ -1570,7 +1795,7 @@ class MailboxService extends Base {
 
         if (info.changes === 0) {
             // Lost the race or state changed asynchronously. Fetch fresh state directly from DB.
-            const row = db.storage.db.prepare(`SELECT json_extract(data, '$.properties.task.state') as state FROM Nodes WHERE id = ?`).get(taskId);
+            const row        = db.storage.db.prepare(`SELECT json_extract(data, '$.properties.task.state') as state FROM Nodes WHERE id = ?`).get(taskId);
             const freshState = row && row.state ? row.state : currentState;
             // Sync memory node to reality and trigger cache events
             if (messageNode && messageNode.properties && messageNode.properties.task) {
@@ -1750,6 +1975,8 @@ class MailboxService extends Base {
             }
         }
 
+        await this.repairMessageGraphIntegrity({target, box, limit: MESSAGE_GRAPH_REPAIR_LIMIT});
+
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite) return { count: 0 };
 
@@ -1872,8 +2099,8 @@ class MailboxService extends Base {
         }
 
         const { count: unreadCount } = await this.countMessages({ box: 'inbox', status: 'unread' });
-        const inboxResult  = await this.listMessages({ box: 'inbox',  limit: 3 });
-        const outboxResult = await this.listMessages({ box: 'outbox', limit: 3 });
+        const inboxResult            = await this.listMessages({ box: 'inbox',  limit: 3 });
+        const outboxResult           = await this.listMessages({ box: 'outbox', limit: 3 });
 
         const inboxPreview = inboxResult.messages.map(msg => ({
             id: msg.messageId,

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -8,9 +8,11 @@ import WakeSubscriptionService                  from './WakeSubscriptionService.
 import {
     appendMessageWalGraphProjectionMarker,
     appendWalMessage,
+    getMessageWalGraphProjectionStats,
     getMessageWalSegmentKey,
     getMissingMessageWalLeaves,
     readWalMessages,
+    readWalMessagesByIds,
     readPendingMessageWalRecords
 } from './helpers/messageWalStore.mjs';
 import {IDENTITIES}                from '../../graph/identityRoots.mjs';
@@ -405,6 +407,72 @@ function hasGraphEdge(source, target, type) {
         getRecordField(edge, 'target') === target &&
         getRecordField(edge, 'type') === type
     );
+}
+
+function hasGraphEdgeOfType(source, type) {
+    return (GraphService.db?.edges?.items || []).some(edge =>
+        getRecordField(edge, 'source') === source &&
+        getRecordField(edge, 'type') === type
+    );
+}
+
+/**
+ * @summary Returns missing graph pieces visible from the currently loaded cache for one message id.
+ * @param {String} messageId Message graph node id.
+ * @returns {String[]}
+ * @private
+ */
+function getCachedMessageProjectionIssues(messageId) {
+    const db = GraphService.requireDb('MailboxService.getCachedMessageProjectionIssues');
+
+    if (typeof messageId !== 'string' || !messageId.startsWith('MESSAGE:')) {
+        return ['invalid-message-id'];
+    }
+
+    db.getAdjacentNodes(messageId, 'outbound');
+
+    const messageNode = db.nodes.get(messageId);
+    const issues      = [];
+
+    if (!messageNode || getRecordField(messageNode, 'label') !== 'MESSAGE') {
+        issues.push('missing-message-node');
+    }
+
+    if (!hasGraphEdgeOfType(messageId, 'SENT_BY')) issues.push('missing-sent-by');
+    if (!hasGraphEdgeOfType(messageId, 'SENT_TO')) issues.push('missing-sent-to');
+
+    return issues;
+}
+
+/**
+ * @summary Checks whether projected WAL count exceeds required graph projection counts.
+ *
+ * This is the mailbox read-path guard: healthy reads use cheap SQLite counts plus the compact
+ * graph-marker index and avoid parsing accepted message WAL records. A mismatch means the graph
+ * projection may be damaged, so callers should run the full WAL-backed repair path.
+ *
+ * @returns {Promise<Boolean>}
+ * @private
+ */
+async function hasMailboxGraphProjectionGap() {
+    const sqlite = GraphService.db?.storage?.db;
+
+    if (!sqlite) return true;
+
+    const {projectedCount} = await getMessageWalGraphProjectionStats({dir: aiConfig.messageWal.dir});
+
+    if (projectedCount === 0) return false;
+
+    const row = sqlite.prepare(`
+        SELECT
+            (SELECT COUNT(*) FROM Nodes WHERE id LIKE 'MESSAGE:%' AND json_extract(data, '$.label') = 'MESSAGE') AS messageCount,
+            (SELECT COUNT(DISTINCT source) FROM Edges WHERE source LIKE 'MESSAGE:%' AND type = 'SENT_BY') AS sentByCount,
+            (SELECT COUNT(DISTINCT source) FROM Edges WHERE source LIKE 'MESSAGE:%' AND type = 'SENT_TO') AS sentToCount
+    `).get();
+
+    return (row?.messageCount ?? 0) < projectedCount ||
+        (row?.sentByCount ?? 0) < projectedCount ||
+        (row?.sentToCount ?? 0) < projectedCount;
 }
 
 /**
@@ -1084,9 +1152,16 @@ class MailboxService extends Base {
             return summary;
         }
 
-        const idFilter      = Array.isArray(ids) ? new Set(ids) : null,
-            boundedLimit    = Number.isFinite(Number(limit)) && Number(limit) > 0 ? Number(limit) : MESSAGE_GRAPH_REPAIR_LIMIT,
-            acceptedRecords = await readWalMessages({dir: aiConfig.messageWal.dir});
+        const idFilter   = Array.isArray(ids) ? new Set(ids) : null,
+            boundedLimit = Number.isFinite(Number(limit)) && Number(limit) > 0 ? Number(limit) : MESSAGE_GRAPH_REPAIR_LIMIT;
+
+        if (!idFilter && !await hasMailboxGraphProjectionGap()) {
+            return summary;
+        }
+
+        const acceptedRecords = idFilter
+            ? await readWalMessagesByIds({dir: aiConfig.messageWal.dir, ids: [...idFilter], limit: boundedLimit})
+            : await readWalMessages({dir: aiConfig.messageWal.dir});
 
         for (const record of acceptedRecords) {
             if (summary.scanned >= boundedLimit) break;
@@ -1326,13 +1401,17 @@ class MailboxService extends Base {
         }
 
         const db = GraphService.requireDb('MailboxService.getMessage');
-        await this.repairMessageGraphIntegrity({ids: [messageId], limit: 1});
 
         // Trigger syncCache + lazy-reload vicinity for this message node.
         // Ensures peer-process writes to this message's edges (e.g. late PART_OF_THREAD
         // additions, read-receipt annotations) are visible. See listMessages for the
         // full rationale on why bare `syncCache()` is insufficient for edge-type scans.
         db.getAdjacentNodes(messageId, 'both');
+
+        if (getCachedMessageProjectionIssues(messageId).length > 0) {
+            await this.repairMessageGraphIntegrity({ids: [messageId], limit: 1});
+            db.getAdjacentNodes(messageId, 'both');
+        }
 
         const messageNode = db.nodes.get(messageId);
         if (!messageNode || messageNode.label !== 'MESSAGE') {

--- a/ai/services/memory-core/helpers/messageWalStore.mjs
+++ b/ai/services/memory-core/helpers/messageWalStore.mjs
@@ -18,6 +18,7 @@ import {withAppendLock} from './walAppendLock.mjs';
  */
 
 const MESSAGE_WAL_SEGMENT_RE = /^message-wal-(\d{4}-\d{2}-\d{2})\.jsonl$/;
+const projectionStatsCache   = new Map();
 
 /**
  * @summary Names the `messageWal` config leaves missing from a config slice.
@@ -158,6 +159,35 @@ async function readJsonlEntries(filePath) {
 }
 
 /**
+ * @summary Builds a cacheable signature for graph-projection marker files.
+ * @param {String} dir Message WAL directory.
+ * @param {String[]} segmentKeys Segment keys newest first.
+ * @returns {Promise<Object[]>}
+ * @private
+ */
+async function getGraphMarkerFileStats(dir, segmentKeys) {
+    const stats = [];
+
+    for (const segmentKey of segmentKeys) {
+        const filePath = path.join(dir, getMessageWalGraphMarkersFileName(segmentKey));
+
+        try {
+            const stat = await fs.stat(filePath);
+            stats.push({
+                filePath,
+                segmentKey,
+                signature: `${segmentKey}:${stat.size}:${stat.mtimeMs}`
+            });
+        } catch (e) {
+            if (e?.code === 'ENOENT') continue;
+            throw e;
+        }
+    }
+
+    return stats;
+}
+
+/**
  * @summary Lists message WAL segment keys newest first.
  * @param {String} dir Message WAL directory.
  * @returns {Promise<String[]>}
@@ -194,6 +224,107 @@ export async function readWalMessages({dir} = {}) {
 
     for (const segmentKey of await listMessageWalSegmentKeys(dir)) {
         records.push(...await readJsonlEntries(path.join(dir, getMessageWalRecordsFileName(segmentKey))));
+    }
+
+    return records;
+}
+
+/**
+ * @summary Reads the graph-projection marker index for accepted message WAL records.
+ *
+ * The marker index is deliberately smaller than the accepted-message WAL and is safe to consult
+ * from read-path repair gates. It lets callers detect graph/WAL divergence or locate a targeted
+ * message id without parsing every accepted message record on the common path.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Message WAL directory.
+ * @returns {Promise<{projectedCount: Number, projectedIds: Set<String>, segmentById: Map<String,String>}>}
+ */
+export async function getMessageWalGraphProjectionStats({dir} = {}) {
+    if (!dir) {
+        throw new TypeError('getMessageWalGraphProjectionStats: dir is required');
+    }
+
+    const segmentKeys = await listMessageWalSegmentKeys(dir);
+    const markerStats = await getGraphMarkerFileStats(dir, segmentKeys);
+    const signature   = markerStats.map(item => item.signature).join('|');
+    const cached      = projectionStatsCache.get(dir);
+
+    if (cached?.signature === signature) {
+        return cached.stats;
+    }
+
+    const segmentById = new Map();
+
+    for (const {filePath, segmentKey} of markerStats) {
+        for (const entry of await readJsonlEntries(filePath)) {
+            const id = entry?.id;
+
+            if (typeof id === 'string' && id.startsWith('MESSAGE:') && !segmentById.has(id)) {
+                segmentById.set(id, segmentKey);
+            }
+        }
+    }
+
+    const stats = {
+        projectedCount: segmentById.size,
+        projectedIds  : new Set(segmentById.keys()),
+        segmentById
+    };
+
+    projectionStatsCache.set(dir, {signature, stats});
+
+    return stats;
+}
+
+/**
+ * @summary Reads accepted message WAL records for specific ids only.
+ *
+ * Targeted read-path repair uses graph-projection markers as the id -> segment index, then opens
+ * only the segment(s) containing the requested ids. This avoids pulling the full deployment-age
+ * WAL when `getMessage` needs to rebuild one damaged MESSAGE projection.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Message WAL directory.
+ * @param {String[]} options.ids Message ids to read.
+ * @param {Number} [options.limit] Maximum matching records to return.
+ * @returns {Promise<Object[]>}
+ */
+export async function readWalMessagesByIds({dir, ids, limit} = {}) {
+    if (!dir) {
+        throw new TypeError('readWalMessagesByIds: dir is required');
+    }
+
+    if (!Array.isArray(ids) || ids.length === 0) return [];
+
+    const idFilter  = new Set(ids.filter(id => typeof id === 'string' && id.startsWith('MESSAGE:')));
+    const bounded   = Number.isFinite(Number(limit)) && Number(limit) > 0 ? Number(limit) : Infinity;
+    const records   = [];
+    const {segmentById} = await getMessageWalGraphProjectionStats({dir});
+    const idsBySegment  = new Map();
+
+    for (const id of idFilter) {
+        const segmentKey = segmentById.get(id);
+
+        if (!segmentKey) continue;
+        if (!idsBySegment.has(segmentKey)) {
+            idsBySegment.set(segmentKey, new Set());
+        }
+        idsBySegment.get(segmentKey).add(id);
+    }
+
+    for (const [segmentKey, segmentIds] of idsBySegment) {
+        if (records.length >= bounded) break;
+
+        const segmentRecords = await readJsonlEntries(path.join(dir, getMessageWalRecordsFileName(segmentKey)));
+
+        for (const record of segmentRecords) {
+            if (records.length >= bounded) break;
+            if (record?.graphProjectionVersion !== 1) continue;
+            if (segmentIds.has(record.id)) {
+                records.push(record);
+            }
+        }
     }
 
     return records;

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -21,8 +21,9 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import                            '../../../../../../src/manager/Instance.mjs';
 import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 
+test.describe.configure({ mode: 'serial' });
+
 test.describe('Neo.ai.services.memory-core.MailboxService', () => {
-    test.describe.configure({ mode: 'serial' });
     let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, originalAutoSave, mailboxAiConfig, originalMailboxPolicy, readWalMessages, readPendingMessageWalRecords;
     let dbPath, messageWalDir;
 
@@ -116,6 +117,13 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         GraphService.db.storage.db.prepare(`
             UPDATE Nodes SET data = ? WHERE id = ?
         `).run(JSON.stringify(GraphService.db.nodes.get(messageId)), messageId);
+    }
+
+    function clearGraphCacheWithoutStorageMutation() {
+        GraphService.db.nodes.clear();
+        GraphService.db.edges.clear();
+        GraphService.db.vicinityLoadedNodes.clear();
+        GraphService.db.lastAccessMap.clear();
     }
 
     test('addMessage enforces identity and routes correctly', async () => {
@@ -260,6 +268,83 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         expect(sentTo).toBeDefined();
         expect(await readPendingMessageWalRecords({dir: messageWalDir, ids: [res.messageId]})).toHaveLength(0);
+    });
+
+    test('listMessages/getMessage repair projected direct messages after graph row loss (#14426)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            return await MailboxService.addMessage({
+                to     : '@bob',
+                subject: 'repair row loss',
+                body   : 'durable body'
+            });
+        });
+
+        expect(await readPendingMessageWalRecords({dir: messageWalDir, ids: [res.messageId]})).toHaveLength(0);
+
+        GraphService.db.storage.db.prepare('DELETE FROM Nodes WHERE id = ?').run(res.messageId);
+        clearGraphCacheWithoutStorageMutation();
+
+        const bobInbox = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.listMessages({status: 'all'});
+        });
+
+        expect(bobInbox.messages.map(message => message.messageId)).toContain(res.messageId);
+
+        const repairedMessage = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.getMessage({messageId: res.messageId});
+        });
+
+        expect(repairedMessage.subject).toBe('repair row loss');
+        expect(repairedMessage.body).toBe('durable body');
+        expect(repairedMessage.readAt).toBeNull();
+
+        const repairCheck = await MailboxService.repairMessageGraphIntegrity({ids: [res.messageId]});
+        expect(repairCheck).toMatchObject({scanned: 1, intact: 1, repaired: 0, failed: 0});
+    });
+
+    test('post-sync canary: accepted unread self-message survives destructive graph clear (#14426)', async () => {
+        const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            return await MailboxService.addMessage({
+                to     : '@me',
+                subject: 'post-sync canary',
+                body   : 'still here'
+            });
+        });
+
+        expect(await readPendingMessageWalRecords({dir: messageWalDir, ids: [res.messageId]})).toHaveLength(0);
+
+        await GraphService.db.storage.clear();
+        clearGraphCacheWithoutStorageMutation();
+
+        const count = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            return await MailboxService.countMessages({status: 'unread'});
+        });
+
+        expect(count.count).toBe(1);
+
+        const inbox = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            return await MailboxService.listMessages({status: 'unread'});
+        });
+
+        expect(inbox.messages).toHaveLength(1);
+        expect(inbox.messages[0]).toMatchObject({
+            messageId: res.messageId,
+            subject  : 'post-sync canary',
+            from     : '@alice',
+            to       : '@alice',
+            readAt   : null
+        });
+
+        const message = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            return await MailboxService.getMessage({messageId: res.messageId});
+        });
+
+        expect(message.body).toBe('still here');
+        expect(message.readAt).toBeNull();
     });
 
     test('drainPendingMessageGraphProjections leaves failed required-edge replay pending (#13892)', async () => {
@@ -2087,6 +2172,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
     });
 
     test('#13411 related PR state echo: getMessage/listMessages surface live state', async () => {
+        const threadId = 'thread-related-pr-live-state';
+        GraphService.upsertNode({ id: threadId, type: 'THREAD', name: 'Related PR live state', properties: {} });
+
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
         });
@@ -2109,6 +2197,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
                     to            : '@bob',
                     subject       : 'Review request',
                     body          : 'Please review the PR.',
+                    partOfThread  : threadId,
                     relatedTickets: ['#13411', '#13412']
                 });
                 msgId = res.messageId;
@@ -2123,7 +2212,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
             ]);
 
             const bobList = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
-                return await MailboxService.listMessages({ status: 'all' });
+                return await MailboxService.listMessages({ status: 'all', threadId });
             });
             const found = bobList.messages.find(m => m.messageId === msgId);
             expect(found.relatedTickets).toEqual(['#13411', '#13412']);
@@ -2137,6 +2226,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
     });
 
     test('#13411 related PR state echo: fetch failure omits echo but keeps message', async () => {
+        const threadId = 'thread-related-pr-fetch-failure';
+        GraphService.upsertNode({ id: threadId, type: 'THREAD', name: 'Related PR fetch failure', properties: {} });
+
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
         });
@@ -2155,6 +2247,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
                     to            : '@bob',
                     subject       : 'Review request',
                     body          : 'Please review the PR.',
+                    partOfThread  : threadId,
                     relatedTickets: ['#13411']
                 });
                 msgId = res.messageId;
@@ -2168,7 +2261,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
             expect(bobRead.body).toBe('Please review the PR.');
 
             const bobList = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
-                return await MailboxService.listMessages({ status: 'all' });
+                return await MailboxService.listMessages({ status: 'all', threadId });
             });
             const found = bobList.messages.find(m => m.messageId === msgId);
             expect(found.relatedPullRequests).toBeUndefined();

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -306,6 +306,47 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(repairCheck).toMatchObject({scanned: 1, intact: 1, repaired: 0, failed: 0});
     });
 
+    test('healthy reads and targeted getMessage repair do not open unrelated WAL segments (#14426)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            return await MailboxService.addMessage({
+                to     : '@bob',
+                subject: 'bounded repair',
+                body   : 'target body'
+            });
+        });
+
+        const unrelatedSegment = path.join(messageWalDir, 'message-wal-2001-01-01.jsonl');
+        fs.ensureDirSync(unrelatedSegment);
+
+        try {
+            const healthyInbox = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+                return await MailboxService.listMessages({status: 'all'});
+            });
+            expect(healthyInbox.messages.map(message => message.messageId)).toContain(res.messageId);
+
+            const healthyCount = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+                return await MailboxService.countMessages({status: 'all'});
+            });
+            expect(healthyCount.count).toBe(1);
+
+            GraphService.db.storage.db.prepare('DELETE FROM Nodes WHERE id = ?').run(res.messageId);
+            clearGraphCacheWithoutStorageMutation();
+
+            const repairedMessage = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+                return await MailboxService.getMessage({messageId: res.messageId});
+            });
+
+            expect(repairedMessage.subject).toBe('bounded repair');
+            expect(repairedMessage.body).toBe('target body');
+        } finally {
+            fs.removeSync(unrelatedSegment);
+        }
+    });
+
     test('post-sync canary: accepted unread self-message survives destructive graph clear (#14426)', async () => {
         const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
             return await MailboxService.addMessage({


### PR DESCRIPTION
Resolves #14426

Repairs A2A mailbox reads when accepted message WAL records still exist but their Native Edge Graph projection has been deleted or damaged after the projection marker was written. `listMessages`, `getMessage`, and `countMessages` now detect missing MESSAGE / delivery-edge projection pieces from accepted WAL records and replay only damaged records, restoring required sender/recipient endpoints before relinking so FK-safe replay also survives full graph clears.

Evidence: L2 (MailboxService unit regressions for post-marker MESSAGE row loss, destructive graph-clear canary, bounded hot-path read regression, plus full MailboxService unit suite) -> L2 required (internal Memory Core graph/WAL repair contract). No residuals.

## Deltas from ticket

- Uses the accepted message WAL as the repair authority for already-marked records instead of extending the pending-marker drain semantics.
- Restores canonical first-party endpoints from `identityRoots`; unknown accepted endpoints are restored as WAL-only endpoints so historical messages remain addressable without entering the active broadcast audience.
- Bounds hot-path repair cost: healthy mailbox reads use graph-marker stats plus SQLite projection counts and skip accepted-WAL parsing; targeted `getMessage` repair locates one id through projection markers and reads only the containing WAL segment.
- Moves the MailboxService unit suite's serial configuration to file scope because the new repair path legitimately reads shared message WAL, exposing the previous fully-parallel singleton race.
- Scopes the related-PR echo list assertions by thread so unrelated repaired messages cannot affect their cache-call counters.

## Test Evidence

- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` -> 80 passed (34.1s)
- `git diff --check`

## Post-Merge Validation

- [ ] On a live Memory Core deployment, send an unread self-message, run the sync/import path that previously cleared mailbox graph projections, then confirm `countMessages`, `list_messages`, and `get_message` return the same unread message with `readAt: null`.

## Commits

- `10149ba041` — repair mailbox graph projections from accepted WAL
- `1693f7d1bb` — bound mailbox WAL repair reads

Authored by Euclid (GPT-5.5, Codex Desktop). Session 019f2047-5787-7ed3-bfd5-552e3f2ab7e1.
