### PR TITLE
feat(build): add refspec-safe agent push wrapper (#14419)

### DIFF
--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -5,6 +5,7 @@
       "mcp__neo-mjs-memory-core__*",
       "mcp__neo-mjs-knowledge-base__*",
       "Bash(npm run agent-preflight*)",
+      "Bash(npm run agent-push*)",
       "Bash(git add *)",
       "Bash(git commit *)",
       "Bash(git checkout -b agent/*)",

--- a/buildScripts/util/agent-push.mjs
+++ b/buildScripts/util/agent-push.mjs
@@ -1,0 +1,201 @@
+import {execFileSync, spawnSync} from 'node:child_process';
+import process                   from 'node:process';
+import {fileURLToPath}           from 'node:url';
+import path                      from 'node:path';
+
+const
+    __filename           = fileURLToPath(import.meta.url),
+    AGENT_BRANCH_PATTERN = /^agent\/[A-Za-z0-9][A-Za-z0-9._/-]*$/u,
+    FORBIDDEN_FLAGS      = new Set([
+        '-f',
+        '--all',
+        '--delete',
+        '--force',
+        '--force-if-includes',
+        '--force-with-lease',
+        '--mirror',
+        '--tags'
+    ]);
+
+/**
+ * @summary Parses the narrow agent-push argv surface without trusting git's full push grammar.
+ * @param {String[]} argv Raw wrapper arguments, excluding `node` and script path.
+ * @returns {{remote: String, refspec: String|null, setUpstream: Boolean}}
+ */
+export function parseArgs(argv = []) {
+    const positional  = [];
+    let   setUpstream = false;
+
+    for (const arg of argv) {
+        if (arg === '-u') {
+            if (setUpstream) {
+                throw new Error('duplicate -u option')
+            }
+
+            setUpstream = true;
+            continue
+        }
+
+        if (arg.startsWith('-')) {
+            if (FORBIDDEN_FLAGS.has(arg)) {
+                throw new Error(`refusing unsafe git push option: ${arg}`)
+            }
+
+            throw new Error(`unsupported git push option: ${arg}`)
+        }
+
+        positional.push(arg)
+    }
+
+    if (positional.length > 2) {
+        throw new Error('refusing multiple refspecs; pass at most one branch refspec')
+    }
+
+    const
+        remote  = positional[0] || 'origin',
+        refspec = positional.length === 2 ? positional[1] : null;
+
+    if (remote !== 'origin') {
+        throw new Error(`remote must be origin, received: ${remote}`)
+    }
+
+    assertSafeRefspec(refspec);
+
+    return {remote, refspec, setUpstream}
+}
+
+/**
+ * @summary Rejects refspec forms whose source/destination grammar cannot be prefix-proved safely.
+ * @param {String|null} refspec
+ * @returns {void}
+ */
+export function assertSafeRefspec(refspec) {
+    if (!refspec) {
+        return
+    }
+
+    if (refspec.startsWith('+')) {
+        throw new Error('refusing force refspec prefix')
+    }
+
+    if (refspec.includes(':')) {
+        throw new Error('refusing colon refspec; destination must be implicit and agent-scoped')
+    }
+
+    if (refspec.includes('*')) {
+        throw new Error('refusing wildcard refspec')
+    }
+}
+
+/**
+ * @summary Reads the current git branch for implicit or HEAD refspec destinations.
+ * @param {Object} options
+ * @param {String} options.cwd
+ * @param {Function} options.execFileSyncImpl
+ * @returns {String}
+ */
+export function getCurrentBranch({cwd = process.cwd(), execFileSyncImpl = execFileSync} = {}) {
+    const branch = String(execFileSyncImpl('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+        cwd,
+        encoding: 'utf8',
+        stdio   : 'pipe'
+    })).trim();
+
+    if (!branch || branch === 'HEAD') {
+        throw new Error('cannot infer destination from detached HEAD')
+    }
+
+    return branch
+}
+
+/**
+ * @summary Normalizes a branch-like ref to the remote branch destination the wrapper will permit.
+ * @param {String} ref
+ * @returns {String}
+ */
+export function normalizeDestination(ref) {
+    return ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+}
+
+/**
+ * @summary Proves the effective push destination is an allowed agent branch.
+ * @param {Object} options
+ * @param {String|null} options.refspec
+ * @param {String} options.currentBranch
+ * @returns {String}
+ */
+export function resolveDestination({currentBranch, refspec = null} = {}) {
+    const destination = normalizeDestination(!refspec || refspec === 'HEAD' ? currentBranch : refspec);
+
+    if (!AGENT_BRANCH_PATTERN.test(destination)) {
+        throw new Error(`destination must be an agent/* branch, resolved: ${destination}`)
+    }
+
+    return destination
+}
+
+/**
+ * @summary Builds the validated `git push` argv that the wrapper will execute.
+ * @param {Object} options
+ * @param {String|null} options.refspec
+ * @param {String} options.remote
+ * @param {Boolean} options.setUpstream
+ * @param {String} options.destination
+ * @returns {String[]}
+ */
+export function buildGitPushArgs({destination, refspec = null, remote = 'origin', setUpstream = false} = {}) {
+    return [
+        'push',
+        ...(setUpstream ? ['-u'] : []),
+        remote,
+        refspec || destination
+    ]
+}
+
+function writeLine(stream, line = '') {
+    stream.write(line + '\n')
+}
+
+/**
+ * @summary Runs the refspec-validated agent push wrapper and returns a process-style status code.
+ * @param {Object} options
+ * @returns {Number}
+ */
+export function runAgentPush({
+    argv             = process.argv.slice(2),
+    cwd              = process.cwd(),
+    execFileSyncImpl = execFileSync,
+    spawnSyncImpl    = spawnSync,
+    stderr           = process.stderr
+} = {}) {
+    let parsed, currentBranch, destination;
+
+    try {
+        parsed = parseArgs(argv);
+        currentBranch = getCurrentBranch({cwd, execFileSyncImpl});
+        destination = resolveDestination({currentBranch, refspec: parsed.refspec})
+    } catch (error) {
+        writeLine(stderr, `agent-push: ${error.message}`);
+        return 1
+    }
+
+    const result = spawnSyncImpl('git', buildGitPushArgs({
+        destination,
+        refspec    : parsed.refspec,
+        remote     : parsed.remote,
+        setUpstream: parsed.setUpstream
+    }), {
+        cwd,
+        stdio: 'inherit'
+    });
+
+    if (typeof result.status === 'number') {
+        return result.status
+    }
+
+    return result.error ? 1 : 0
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    process.exitCode = runAgentPush()
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "scripts"        : {
         "add-config"                   : "node ./buildScripts/create/addConfig.mjs",
         "agent-preflight"              : "node ./buildScripts/util/agent-preflight.mjs",
+        "agent-push"                   : "node ./buildScripts/util/agent-push.mjs",
         "add-reactive-tags"            : "node ./buildScripts/helpers/addReactiveTags.mjs",
         "ai:agent"                     : "node ./ai/scripts/runners/runAgent.mjs",
         "ai:analyze-nl-telemetry"      : "node ./ai/scripts/diagnostics/analyzeNlTelemetry.mjs",

--- a/test/playwright/unit/ai/buildScripts/util/agent-push.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-push.spec.mjs
@@ -1,0 +1,157 @@
+import {test, expect} from '@playwright/test';
+import {
+    assertSafeRefspec,
+    buildGitPushArgs,
+    getCurrentBranch,
+    normalizeDestination,
+    parseArgs,
+    resolveDestination,
+    runAgentPush
+} from '../../../../../../buildScripts/util/agent-push.mjs';
+
+test.describe('agent-push utility (#14419)', () => {
+    test('parses the narrow accepted argv surface', () => {
+        expect(parseArgs([])).toEqual({remote: 'origin', refspec: null, setUpstream: false});
+        expect(parseArgs(['-u'])).toEqual({remote: 'origin', refspec: null, setUpstream: true});
+        expect(parseArgs(['origin'])).toEqual({remote: 'origin', refspec: null, setUpstream: false});
+        expect(parseArgs(['-u', 'origin', 'agent/14419-agent-push'])).toEqual({
+            remote     : 'origin',
+            refspec    : 'agent/14419-agent-push',
+            setUpstream: true
+        })
+    });
+
+    test('refuses unsafe or widening push grammar before destination resolution', () => {
+        const rejected = [
+            ['upstream', 'agent/demo'],
+            ['origin', 'agent/demo:dev'],
+            ['origin', 'HEAD:refs/heads/dev'],
+            ['origin', 'agent/demo', 'agent/extra'],
+            ['origin', '+agent/demo'],
+            ['origin', 'agent/*'],
+            ['--tags'],
+            ['--all'],
+            ['--mirror'],
+            ['--delete'],
+            ['--force'],
+            ['--force-with-lease'],
+            ['--force-if-includes'],
+            ['-f'],
+            ['--porcelain']
+        ];
+
+        for (const argv of rejected) {
+            expect(() => parseArgs(argv), argv.join(' ')).toThrow()
+        }
+    });
+
+    test('refspec validation rejects source-destination and wildcard forms', () => {
+        expect(() => assertSafeRefspec('agent/demo:dev')).toThrow(/colon refspec/u);
+        expect(() => assertSafeRefspec('HEAD:refs/heads/dev')).toThrow(/colon refspec/u);
+        expect(() => assertSafeRefspec('+agent/demo')).toThrow(/force refspec/u);
+        expect(() => assertSafeRefspec('agent/*')).toThrow(/wildcard/u);
+        expect(() => assertSafeRefspec('agent/demo')).not.toThrow()
+    });
+
+    test('normalizes refs/heads prefixes without accepting unsafe destinations', () => {
+        expect(normalizeDestination('refs/heads/agent/demo')).toBe('agent/demo');
+        expect(normalizeDestination('agent/demo')).toBe('agent/demo')
+    });
+
+    test('resolves the effective destination from explicit, HEAD, and implicit forms', () => {
+        expect(resolveDestination({
+            currentBranch: 'agent/current',
+            refspec      : 'agent/explicit'
+        })).toBe('agent/explicit');
+
+        expect(resolveDestination({
+            currentBranch: 'agent/current',
+            refspec      : 'refs/heads/agent/full-ref'
+        })).toBe('agent/full-ref');
+
+        expect(resolveDestination({
+            currentBranch: 'agent/current',
+            refspec      : 'HEAD'
+        })).toBe('agent/current');
+
+        expect(resolveDestination({
+            currentBranch: 'agent/current',
+            refspec      : null
+        })).toBe('agent/current')
+    });
+
+    test('refuses destinations outside agent branches', () => {
+        expect(() => resolveDestination({
+            currentBranch: 'dev',
+            refspec      : null
+        })).toThrow(/agent\/\*/u);
+
+        expect(() => resolveDestination({
+            currentBranch: 'agent/current',
+            refspec      : 'main'
+        })).toThrow(/agent\/\*/u)
+    });
+
+    test('reads the current branch through git and rejects detached HEAD', () => {
+        const execFileSyncImpl = () => 'agent/current\n';
+
+        expect(getCurrentBranch({execFileSyncImpl})).toBe('agent/current');
+        expect(() => getCurrentBranch({execFileSyncImpl: () => 'HEAD\n'})).toThrow(/detached HEAD/u)
+    });
+
+    test('builds deterministic git push argv with the resolved destination', () => {
+        expect(buildGitPushArgs({
+            destination: 'agent/current',
+            remote     : 'origin'
+        })).toEqual(['push', 'origin', 'agent/current']);
+
+        expect(buildGitPushArgs({
+            destination: 'agent/current',
+            remote     : 'origin',
+            setUpstream: true
+        })).toEqual(['push', '-u', 'origin', 'agent/current']);
+
+        expect(buildGitPushArgs({
+            destination: 'agent/current',
+            refspec    : 'agent/explicit',
+            remote     : 'origin'
+        })).toEqual(['push', 'origin', 'agent/explicit'])
+    });
+
+    test('executes git push only after validation and propagates the git status', () => {
+        const calls  = [];
+        const status = runAgentPush({
+            argv            : ['-u'],
+            cwd             : '/repo',
+            execFileSyncImpl: () => 'agent/current\n',
+            spawnSyncImpl   : (cmd, args, options) => {
+                calls.push({cmd, args, options});
+                return {status: 7}
+            },
+            stderr: {write: () => {}}
+        });
+
+        expect(status).toBe(7);
+        expect(calls).toEqual([{
+            cmd    : 'git',
+            args   : ['push', '-u', 'origin', 'agent/current'],
+            options: {cwd: '/repo', stdio: 'inherit'}
+        }])
+    });
+
+    test('does not invoke git when validation fails', () => {
+        let   stderr = '';
+        const calls  = [];
+
+        const status = runAgentPush({
+            argv            : ['origin', 'agent/current:dev'],
+            execFileSyncImpl: () => 'agent/current\n',
+            spawnSyncImpl   : (...args) => calls.push(args),
+            stderr          : {write: value => { stderr += value }}
+        });
+
+        expect(status).toBe(1);
+        expect(calls).toEqual([]);
+        expect(stderr).toContain('agent-push:')
+    })
+});


### PR DESCRIPTION
Resolves #14419

Adds a refspec-aware `agent-push` wrapper for routine agent branch publication. The wrapper parses a deliberately tiny `git push` grammar, proves the effective destination is an `agent/*` branch, refuses the bypass forms from the #14417 review, and only then delegates to `git push`. It also adds the npm script and the Claude template allow entry for `Bash(npm run agent-push*)`; raw `git push` remains classified and the existing deny rules stay in place.

Evidence: L2 (focused unit matrix + local agent preflight) -> L2 required (#14419 wrapper grammar and template ACs). Residual: post-merge lifecycle smoke [#14419].

## Deltas from ticket

- Added the intake Contract Ledger supplement on #14419 before implementation: https://github.com/neomjs/neo/issues/14419#issuecomment-4863156328
- Kept the wrapper scoped to `agent/*` destinations as written in #14419. Codex command-policy parity was already tracked separately by #14421 and is closed; this PR does not widen the wrapper to raw Codex push policy.
- The wrapper supports no explicit refspec by resolving the current branch and executing a deterministic `git push origin <current-agent-branch>`, with `-u` adding upstream setup for first push.

## Contract Ledger

| Surface | Signature / command | Consumer | Behavior | Evidence |
|---|---|---|---|---|
| `buildScripts/util/agent-push.mjs` parser | `parseArgs(argv)` | `npm run agent-push` wrapper + unit tests | Accepts only optional `-u`, remote `origin`, and at most one non-colon refspec. | Unit refusal matrix covers unknown flags, force/delete/mirror/tags/all, non-origin remotes, colon refspecs, multi-refspecs, force-prefix refspecs, and wildcard refspecs. |
| Destination proof | `resolveDestination({currentBranch, refspec})` | Wrapper before exec | Normalizes `refs/heads/*`, resolves implicit/`HEAD` pushes to the current branch, and requires `agent/*`. | Unit tests cover explicit, full-ref, `HEAD`, implicit current branch, and `dev`/`main` refusal. |
| Executable wrapper | `runAgentPush(...)` / `npm run agent-push` | Agent PR lifecycle | Builds deterministic `git push` argv only after validation and propagates git's exit code. | Unit tests prove validation blocks execution and successful validation delegates with expected argv/status. |
| Claude permission template | `Bash(npm run agent-push*)` | Claude harness | Allows the wrapper command while raw `git push` remains classified and denied unsafe forms remain defense-in-depth. | Template diff + grep audit. |

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/agent-push.spec.mjs` -> 10 passed.
- `npm run agent-preflight` -> passed; applied block alignment to the new `.mjs` files.
- `npm run agent-preflight -- --no-fix` -> passed.
- `node --check buildScripts/util/agent-push.mjs` -> passed.
- `git diff --cached --check` -> passed before commit.
- Safety grep confirmed `.claude/settings.template.json` adds only `Bash(npm run agent-push*)` while existing raw `git push` deny entries remain.

## Post-Merge Validation

- [ ] From an `agent/*` branch, run `npm run agent-push -- -u` and confirm it pushes the current branch without classifier dependency.
- [ ] Confirm raw `git push origin dev`, raw `git push origin main`, force push, and colon-refspec push forms remain classified/denied by the harness policy.

Authored by Euclid (GPT-5, Codex Desktop). Session Codex Desktop active thread, 2026-07-02.
