### PR TITLE
fix(hooks): isolate codex stop-hook prompt store tests (#14449)

### DIFF
--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -343,9 +343,11 @@ export function extractFinalAssistantText(input = {}) {
  * @summary Resolves the best available text that prompted this Codex turn. This is the external
  * operator-vs-wake signal; missing text fails closed to autonomous in `isOperatorInLoop`.
  * @param {Object} [input={}]
+ * @param {Object} [options]
+ * @param {String} [options.logDir]
  * @returns {{text: String, source: String}}
  */
-export function extractPromptingText(input = {}) {
+export function extractPromptingText(input = {}, {logDir} = {}) {
     const direct = input.last_user_message ?? input.lastUserMessage ?? input.prompting_message ?? input.promptingMessage;
     if (direct) {
         const text = extractTextFromMessage(direct);
@@ -364,7 +366,9 @@ export function extractPromptingText(input = {}) {
         if (text.trim()) return {text, source: 'transcript_path'};
     }
 
-    const promptContext = readPromptContext();
+    const promptContext = readPromptContext({
+        promptContextPath: getCodexPromptContextPath({logDir})
+    });
     if (promptContext) return {text: promptContext.text, source: 'prompt_context'};
 
     return {text: '', source: 'none'};
@@ -468,12 +472,13 @@ export function summarizePayloadShape(payload = {}) {
  * @param {Object} input
  * @param {Object} [options]
  * @param {Boolean} [options.enforcing=false]
+ * @param {String} [options.logDir]
  * @returns {{action: ('allow'|'block'|'would-block'), reason: String, source: String, promptSource: String, verdict: Object, phrase: (String|undefined)}}
  */
-export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
+export function classifyCodexStopPayload(input = {}, {enforcing = false, logDir} = {}) {
     const stopHookActive                                                      = !!(input.stop_hook_active || input.stopHookActive),
           {text, source}                                                      = extractFinalAssistantText(input),
-          {text: promptingText, source: promptSource}                         = extractPromptingText(input),
+          {text: promptingText, source: promptSource}                         = extractPromptingText(input, {logDir}),
           promptContext                                                       = classifyPromptingContext({stopHookActive, promptingText}),
           {autonomousHandoff, handoffReason, handoffWindowMs, operatorInLoop} = promptContext;
 

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -25,12 +25,22 @@ const block       = body => '```lane-state\n' + body + '\n```',
       fixture     = JSON.parse(fs.readFileSync(fixturePath, 'utf8')),
       codexRecord = (role, text) => JSON.stringify({
           type   : 'response_item',
-          payload: {
-              type   : 'message',
-              role,
-              content: [{type: role === 'assistant' ? 'output_text' : 'input_text', text}]
+	          payload: {
+	              type   : 'message',
+	              role,
+	              content: [{type: role === 'assistant' ? 'output_text' : 'input_text', text}]
           }
       });
+
+function classifyWithIsolatedPromptContext(input, options = {}) {
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-lane-direct-'));
+
+    try {
+        return classifyCodexStopPayload(input, {...options, logDir});
+    } finally {
+        fs.rmSync(logDir, {recursive: true, force: true});
+    }
+}
 
 test.describe('codex-lane-state-stop - contract boundary', () => {
     test('Codex block/inject is active, so enforced invalid terminals block', () => {
@@ -203,7 +213,7 @@ test.describe('codex-lane-state-stop - input resolution', () => {
 
 test.describe('codex-lane-state-stop - lane-state classification', () => {
     test('valid representative payload without an operator prompt would-blocks', () => {
-        const result = classifyCodexStopPayload(fixture);
+        const result = classifyWithIsolatedPromptContext(fixture);
 
         expect(result.action).toBe('would-block');
         expect(result.reason).toContain('valid lane-state terminal');
@@ -212,6 +222,29 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
         expect(result.source).toBe('last_assistant_message');
         expect(result.promptSource).toBe('none');
         expect(result.operatorInLoop).toBe(false);
+    });
+
+    test('direct classification can isolate itself from prompt-context store pollution', () => {
+        const logDir            = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-lane-polluted-')),
+              promptContextPath = getCodexPromptContextPath({logDir});
+
+        try {
+            fs.writeFileSync(promptContextPath, JSON.stringify({
+                createdAt    : new Date().toISOString(),
+                promptingText: 'operator dialogue from another live Codex session',
+                source       : 'codex-user-prompt-submit'
+            }), 'utf8');
+
+            const polluted = classifyCodexStopPayload(fixture, {logDir});
+            expect(polluted.action).toBe('allow');
+            expect(polluted.promptSource).toBe('prompt_context');
+
+            const isolated = classifyWithIsolatedPromptContext(fixture);
+            expect(isolated.action).toBe('would-block');
+            expect(isolated.promptSource).toBe('none');
+        } finally {
+            fs.rmSync(logDir, {recursive: true, force: true});
+        }
     });
 
     test('live operator prompt is the only valid voluntary allow', () => {
@@ -300,7 +333,7 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
     });
 
     test('absent lane-state would-block with no-hold reminder', () => {
-        const result = classifyCodexStopPayload({
+        const result = classifyWithIsolatedPromptContext({
             session_id            : 'absent',
             last_assistant_message: 'Final prose without the structured block.'
         });
@@ -312,7 +345,7 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
     });
 
     test('malformed lane-state is distinct from absent', () => {
-        const result = classifyCodexStopPayload({
+        const result = classifyWithIsolatedPromptContext({
             session_id            : 'malformed',
             last_assistant_message: block('{laneContinuation: nope}')
         });


### PR DESCRIPTION
Resolves #14449

Adds an explicit `logDir` test seam to the Codex Stop hook's in-process classification path, then uses it in direct fixture tests so they cannot read a live Codex prompt-context record from another session. Live/spawned hook behavior stays unchanged: omitted `logDir` still uses the module-level store, and spawned tests continue to isolate through `NEO_AI_DAEMON_DIR`.

Evidence: L2 (focused Codex hook spec, polluted-store falsifier, full hook unit directory) -> L2 required (#14449 unit-test isolation contract). Residual: none.

Related: #14420, #14439

## Deltas from ticket

None. The ticket was split from #14420 during implementation because #14420 remains a broader stop-hook detection-quality parent and must not be closed by this narrow test-isolation leaf.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs` -> 35 passed.
- `NEO_AI_DAEMON_DIR=<polluted temp prompt-context store> npm run test-unit -- test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs` -> 35 passed.
- `npm run test-unit -- test/playwright/unit/hooks/` -> 134 passed.
- `npm run agent-preflight -- --no-fix` -> passed.
- `node --check .codex/hooks/codex-lane-state-stop.mjs` -> passed.
- `git diff --check` and `git diff --cached --check` -> passed.

## Post-Merge Validation

- [ ] None required; the defect is covered by the polluted-store unit falsifier.

## Commit

- `75d299bb39` — `fix(hooks): isolate codex stop-hook prompt store tests (#14449)`

Authored by Euclid (GPT-5, Codex Desktop). Session 8facbc96-c346-4633-9141-79a968ca1c5d.
