### PR TITLE
feat(ai): add golden path route attribution ledger (#14454)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -28,6 +28,7 @@ import {
 import {
     buildFailureOutcome                          as buildRouteFailureOutcome,
     findComputedFocusContradiction               as findRouteFocusContradiction,
+    getComputedRecommendationExclusionLabels     as getRouteExclusionLabels,
     isActionableComputedRecommendation           as isActionableRouteRecommendation,
     isContentComputedRecommendation              as isContentRouteRecommendation,
     isRoutingConflictFocusCandidate              as isRouteConflictFocusCandidate,
@@ -64,6 +65,17 @@ import {
     renderStaleAssignmentCandidatesSection as renderIssueFocusStaleAssignmentCandidatesSection,
     scoreCurrentFocusIssue as scoreIssueFocusCurrentIssue
 } from './issueFocusSections.mjs';
+import {
+    createGoldenPathRouteLedger        as createRouteLedger,
+    getInboundStructuralComponents     as resolveInboundStructuralComponents,
+    recordGoldenPathActionabilityGate  as recordRouteActionabilityGate,
+    recordGoldenPathBlockerGate        as recordRouteBlockerGate,
+    recordGoldenPathFinalScore         as recordRouteFinalScore,
+    recordGoldenPathGuideWrite         as recordRouteGuideWrite,
+    recordGoldenPathOpenMatch          as recordRouteOpenMatch,
+    recordGoldenPathSelection          as recordRouteSelection,
+    renderGoldenPathRouteLedgerSection as renderRouteLedgerSection
+} from './goldenPathRouteLedger.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -278,6 +290,49 @@ class GoldenPathSynthesizer extends Base {
      */
     static isActionableComputedRecommendation(nodeData) {
         return isActionableRouteRecommendation(nodeData)
+    }
+
+    /**
+     * @summary Delegates computed-route exclusion-label discovery to `computedGoldenPathRouting.mjs`.
+     * @param {Object} nodeData Parsed computed recommendation node.
+     * @returns {String[]} Normalized labels that reject immediate computed routing.
+     */
+    static getComputedRecommendationExclusionLabels(nodeData) {
+        return getRouteExclusionLabels(nodeData)
+    }
+
+    /**
+     * @summary Delegates inbound structural component grouping to `goldenPathRouteLedger.mjs`.
+     * @param {Object} options
+     * @param {String} options.nodeId Candidate node id.
+     * @param {Object} [options.graphService=GraphService] GraphService-compatible object.
+     * @returns {Object<String,Number>}
+     */
+    static getInboundStructuralComponents(options) {
+        return resolveInboundStructuralComponents({
+            graphService: GraphService,
+            ...options
+        })
+    }
+
+    /**
+     * @summary Delegates same-run route-ledger initialization to `goldenPathRouteLedger.mjs`.
+     * @param {Object} options
+     * @param {String[]} [options.semanticIds=[]] Semantic vector candidate ids.
+     * @param {Number[]} [options.semanticDistances=[]] Semantic vector distances.
+     * @returns {Map<String,Object>}
+     */
+    static createGoldenPathRouteLedger(options) {
+        return createRouteLedger(options)
+    }
+
+    /**
+     * @summary Delegates same-run route-ledger rendering to `goldenPathRouteLedger.mjs`.
+     * @param {Object} options Route-ledger render options.
+     * @returns {String}
+     */
+    static renderGoldenPathRouteLedgerSection(options) {
+        return renderRouteLedgerSection(options)
     }
 
     /**
@@ -628,6 +683,10 @@ class GoldenPathSynthesizer extends Base {
             logger.info('[GoldenPathSynthesizer] No semantic nodes found. Golden path empty.');
         }
         scoringStats.semanticCandidates = semanticIds.length;
+        const routeLedger = this.constructor.createGoldenPathRouteLedger({
+            semanticDistances,
+            semanticIds
+        });
 
         // Pillar 2: Structural Weight from SQLite Graph
         const SEMANTIC_WEIGHT   = 2.0;
@@ -658,18 +717,36 @@ class GoldenPathSynthesizer extends Base {
 
                     // Guarantee graph topology is completely loaded into RAM BEFORE executing cold-cache resistant queries natively!
                     GraphService.db.getAdjacentNodes(issueId, 'both');
+                    const struct_score = parseFloat(row.struct_score) || 0;
+
+                    let nodeData = null;
+                    try { nodeData = JSON.parse(row.data); } catch (e) { }
+
+                    recordRouteOpenMatch(routeLedger, {
+                        nodeData,
+                        nodeId              : issueId,
+                        structuralComponents: this.constructor.getInboundStructuralComponents({nodeId: issueId}),
+                        structuralScore     : struct_score
+                    });
 
                     // Re-verify blocker topology natively using GraphService API
-                    const blockers  = GraphService.db.edges.getByIndex('target', issueId).filter(e => e.type === 'BLOCKS');
-                    let   isBlocked = false;
+                    const blockers       = GraphService.db.edges.getByIndex('target', issueId).filter(e => e.type === 'BLOCKS');
+                    const openBlockerIds = [];
+                    let   isBlocked      = false;
 
                     for (const bEdge of blockers) {
                         const blockerNode = GraphService.db.nodes.get(bEdge.source);
                         if (blockerNode && (blockerNode.properties?.state === 'OPEN' || blockerNode.state === 'OPEN')) {
                             isBlocked = true;
+                            openBlockerIds.push(bEdge.source);
                             break;
                         }
                     }
+
+                    recordRouteBlockerGate(routeLedger, {
+                        blockerIds: openBlockerIds,
+                        nodeId    : issueId
+                    });
 
                     if (isBlocked) {
                         scoringStats.blockedCandidates++;
@@ -678,21 +755,28 @@ class GoldenPathSynthesizer extends Base {
 
                     const idx               = semanticIds.indexOf(issueId);
                     const semantic_distance = parseFloat(semanticDistances[idx]) || 0.1;
-                    const struct_score      = parseFloat(row.struct_score) || 0;
 
                     // Lower distance = Higher significance. (Add 0.1 to avoid div by 0 and curb massive asymptotes)
                     const semanticScore = 1.0 / (semantic_distance + 0.1);
 
-                    let nodeData = null;
-                    try { nodeData = JSON.parse(row.data); } catch (e) { }
+                    let   priority        = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
+                    const exclusionLabels = this.constructor.getComputedRecommendationExclusionLabels(nodeData || {id: issueId});
 
-                    let priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
+                    recordRouteActionabilityGate(routeLedger, {
+                        exclusionLabels,
+                        nodeId: issueId
+                    });
 
                     if (!this.constructor.isActionableComputedRecommendation(nodeData || {id: issueId})) {
                         scoringStats.nonActionableCandidates++;
                         logger.debug(`[GoldenPathSynthesizer] Skipping non-actionable computed recommendation: ${issueId}`);
                         continue;
                     }
+
+                    recordRouteFinalScore(routeLedger, {
+                        finalScore: priority,
+                        nodeId    : issueId
+                    });
 
                     scoredNodes.push({
                         node      : nodeData || { id: issueId },
@@ -732,6 +816,11 @@ class GoldenPathSynthesizer extends Base {
         const routedTopNodes = focusContradiction
             ? topNodes.filter(item => !focusContradiction.blockedIds.has(item.node.id))
             : topNodes;
+        recordRouteSelection(routeLedger, {
+            focusContradiction,
+            routedTopNodes,
+            topNodes
+        });
         const goldenIds = new Set(routedTopNodes.map(item => item.node.id));
         scoringStats.scoredCandidates = scoredNodes.length;
         scoringStats.selectedTopNodes = routedTopNodes.length;
@@ -760,6 +849,12 @@ class GoldenPathSynthesizer extends Base {
             routedTopNodes.forEach((item, index) => {
                 if (item.node && item.node.id) {
                     GraphService.linkNodes('frontier', item.node.id, 'GUIDES', item.score);
+                    recordRouteGuideWrite(routeLedger, {
+                        nodeId    : item.node.id,
+                        score     : item.score,
+                        semantic  : item.semantic,
+                        structural: item.structural
+                    });
                     const title = item.node.properties?.title || item.node.properties?.name || item.node.name || 'Unknown Title';
                     markdownAppend += `${index + 1}. **${item.node.id}**: Score ${item.score.toFixed(2)} (Semantic: ${item.semantic.toFixed(2)}, Structural: ${item.structural.toFixed(2)})\n   - *${title}*\n`;
                 }
@@ -837,6 +932,12 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             markdownAppend = this.constructor.renderComputedGoldenPathEmptySection(scoringStats, handoffTimestamp);
             logger.info('[GoldenPathSynthesizer] No actionable unblocked issues found. Golden path empty.');
         }
+
+        const routeLedgerAppend = this.constructor.renderGoldenPathRouteLedgerSection({
+            capturedAt: handoffTimestamp,
+            ledger    : routeLedger,
+            stats     : scoringStats
+        });
 
         // Centralize full generation of sandman_handoff.md here, enforcing completely idempotent behavior.
         // TTL pruning and centralized overwrite happen in the same render pass.
@@ -1080,7 +1181,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             }
         }
 
-        handoffContent += `${currentFocusAppend}${staleAssignmentAppend}${silentThreadsAppend}${prStateAppend}${backlogAppend}${markdownAppend}`;
+        handoffContent += `${currentFocusAppend}${staleAssignmentAppend}${silentThreadsAppend}${prStateAppend}${backlogAppend}${routeLedgerAppend}${markdownAppend}`;
 
         const handoffFile = aiConfig.handoffFilePath;
         fs.mkdirSync(path.dirname(handoffFile), {recursive: true});

--- a/ai/services/graph/computedGoldenPathRouting.mjs
+++ b/ai/services/graph/computedGoldenPathRouting.mjs
@@ -38,6 +38,22 @@ const CURRENT_FOCUS_ROUTING_CONFLICT_REASONS = Object.freeze(new Set([
 ]));
 
 /**
+ * @summary Returns labels that exclude a node from immediate computed routing.
+ *
+ * This exposes the same actionability contract used by
+ * {@link isActionableComputedRecommendation} so diagnostic ledgers can report the exact
+ * rejection bucket without duplicating the exclusion set.
+ *
+ * @param {Object} nodeData Parsed graph node payload.
+ * @returns {String[]} Normalized labels that made the node visibility-only / not-ready.
+ */
+export function getComputedRecommendationExclusionLabels(nodeData) {
+    const labels = normalizeLabels(nodeData?.properties?.labels || nodeData?.labels);
+
+    return labels.filter(label => COMPUTED_RECOMMENDATION_EXCLUDED_LABELS.has(label))
+}
+
+/**
  * @summary Determines whether a graph node can be an immediate computed recommendation.
  *
  * The Computed Golden Path is an execution steering surface. ISSUE (work-to-do) and
@@ -57,9 +73,7 @@ export function isActionableComputedRecommendation(nodeData) {
     if (nodeType && nodeType !== 'ISSUE' && nodeType !== 'DISCUSSION') return false;
     if (!nodeId.startsWith('issue-') && !nodeId.startsWith('discussion-')) return false;
 
-    const labels = normalizeLabels(nodeData?.properties?.labels || nodeData?.labels);
-
-    return !labels.some(label => COMPUTED_RECOMMENDATION_EXCLUDED_LABELS.has(label))
+    return getComputedRecommendationExclusionLabels(nodeData).length === 0
 }
 
 /**

--- a/ai/services/graph/goldenPathRouteLedger.mjs
+++ b/ai/services/graph/goldenPathRouteLedger.mjs
@@ -32,7 +32,10 @@ function formatNumber(value, digits = 2) {
  * @returns {String}
  */
 function escapeCell(value) {
-    return String(value ?? '-').replace(/\|/g, '\\|').replace(/\n/g, ' ')
+    return String(value ?? '-')
+        .replace(/\\/g, '\\\\')
+        .replace(/\|/g, '\\|')
+        .replace(/\n/g, ' ')
 }
 
 /**

--- a/ai/services/graph/goldenPathRouteLedger.mjs
+++ b/ai/services/graph/goldenPathRouteLedger.mjs
@@ -1,0 +1,349 @@
+import {formatGoldenPathCapturedAt as formatGoldenPathTimestamp} from './goldenPathTimestamp.mjs';
+
+/**
+ * @module ai/services/graph/goldenPathRouteLedger
+ * @summary Same-run Computed Golden Path attribution ledger helpers.
+ *
+ * Owner contract: record the semantic -> state/type -> blocker -> actionability -> structural
+ * component -> GUIDES-write path in the same synthesis pass that renders the handoff. This is
+ * diagnostic substrate only: it writes no graph nodes, creates no new edge classes, and stays
+ * bounded to the current semantic candidate pool.
+ */
+
+/**
+ * @summary Formats finite numbers with stable precision for handoff diagnostics.
+ * @param {*} value Candidate numeric value.
+ * @param {Number} [digits=2] Decimal places.
+ * @returns {String}
+ */
+function formatNumber(value, digits = 2) {
+    if (value === null || value === undefined || value === '') {
+        return '-'
+    }
+
+    const number = Number(value);
+
+    return Number.isFinite(number) ? number.toFixed(digits) : '-'
+}
+
+/**
+ * @summary Escapes markdown table separators in diagnostic cell content.
+ * @param {*} value Cell value.
+ * @returns {String}
+ */
+function escapeCell(value) {
+    return String(value ?? '-').replace(/\|/g, '\\|').replace(/\n/g, ' ')
+}
+
+/**
+ * @summary Normalizes graph node payloads to the type value used by the routing ledger.
+ * @param {Object|null|undefined} nodeData Parsed graph node payload.
+ * @returns {String}
+ */
+function getNodeType(nodeData) {
+    return String(nodeData?.type || nodeData?.label || nodeData?.properties?.type || '').toUpperCase() || '-'
+}
+
+/**
+ * @summary Reads edge properties from either a Neo data Record or a plain graph edge object.
+ * @param {Object} edge Graph edge record.
+ * @returns {Object}
+ */
+function getEdgeProperties(edge) {
+    return (edge?.isRecord ? edge.get('properties') : edge?.properties) || {}
+}
+
+/**
+ * @summary Converts inbound graph edges into edge-type structural score components.
+ *
+ * The Computed Golden Path SQL aggregate sums inbound non-BLOCKS weights. The diagnostic ledger
+ * mirrors that invariant by reading the already warmed in-memory edge index and grouping the same
+ * inbound non-BLOCKS weights by edge type.
+ *
+ * @param {Object} options
+ * @param {String} options.nodeId Candidate node id.
+ * @param {Object} options.graphService GraphService-compatible object.
+ * @returns {Object<String,Number>} Edge-type to summed structural score.
+ */
+export function getInboundStructuralComponents({nodeId, graphService}) {
+    graphService?.db?.getAdjacentNodes?.(nodeId, 'both');
+
+    const components = {};
+    const inbound    = graphService?.db?.edges?.getByIndex?.('target', nodeId) || [];
+
+    inbound.forEach(edge => {
+        if (!edge || edge.type === 'BLOCKS') {
+            return;
+        }
+
+        const properties = getEdgeProperties(edge);
+        const type       = edge.type || 'UNKNOWN';
+        const weight     = Number(properties.weight);
+
+        components[type] = (components[type] || 0) + (Number.isFinite(weight) ? weight : 0);
+    });
+
+    return components
+}
+
+/**
+ * @summary Creates the initial semantic-candidate ledger rows for one Golden Path pass.
+ * @param {Object} options
+ * @param {String[]} [options.semanticIds=[]] Candidate ids returned by vector search.
+ * @param {Number[]} [options.semanticDistances=[]] Matching vector distances.
+ * @returns {Map<String,Object>} Mutable same-run ledger keyed by candidate node id.
+ */
+export function createGoldenPathRouteLedger({
+    semanticIds = [],
+    semanticDistances = []
+} = {}) {
+    const ledger = new Map();
+
+    semanticIds.forEach((nodeId, index) => {
+        const distance      = Number(semanticDistances[index]);
+        const safeDistance  = Number.isFinite(distance) ? distance : 0.1;
+        const semanticScore = 1.0 / (safeDistance + 0.1);
+
+        ledger.set(nodeId, {
+            actionabilityGate   : 'not-evaluated',
+            blockerGate         : 'not-evaluated',
+            blockerIds          : [],
+            finalScore          : null,
+            guideWriteScore     : null,
+            nodeId,
+            nodeType            : '-',
+            renderedFinalScore  : null,
+            renderedSemantic    : null,
+            renderedStructural  : null,
+            routeStatus         : 'semantic-only',
+            semanticDistance    : safeDistance,
+            semanticPresent     : true,
+            semanticRank        : index + 1,
+            semanticScore,
+            stateGate           : 'not-open-match',
+            structuralComponents: {},
+            structuralScore     : 0,
+            typeGate            : 'query-filtered'
+        });
+    });
+
+    return ledger
+}
+
+/**
+ * @summary Records the SQL OPEN/state match and structural components for one candidate.
+ * @param {Map<String,Object>} ledger Same-run route ledger.
+ * @param {Object} options
+ * @param {String} options.nodeId Candidate node id.
+ * @param {Object} options.nodeData Parsed graph node payload.
+ * @param {Object<String,Number>} [options.structuralComponents={}] Inbound structural score by edge type.
+ * @param {Number} [options.structuralScore=0] Existing SQL aggregate structural score.
+ * @returns {Object} The updated ledger row.
+ */
+export function recordGoldenPathOpenMatch(ledger, {
+    nodeId,
+    nodeData,
+    structuralComponents = {},
+    structuralScore = 0
+}) {
+    const row = ledger.get(nodeId) || {nodeId, semanticPresent: false};
+
+    row.nodeType             = getNodeType(nodeData);
+    row.stateGate            = 'OPEN';
+    row.structuralComponents = structuralComponents;
+    row.structuralScore      = Number.isFinite(Number(structuralScore)) ? Number(structuralScore) : 0;
+    row.typeGate             = row.nodeType === 'ISSUE' || row.nodeType === 'DISCUSSION'
+        ? `passed (${row.nodeType})`
+        : `unexpected (${row.nodeType})`;
+
+    ledger.set(nodeId, row);
+
+    return row
+}
+
+/**
+ * @summary Records the blocker-gate outcome for one candidate row.
+ * @param {Map<String,Object>} ledger Same-run route ledger.
+ * @param {Object} options
+ * @param {String} options.nodeId Candidate node id.
+ * @param {String[]} [options.blockerIds=[]] Open blocker ids that stopped routing.
+ */
+export function recordGoldenPathBlockerGate(ledger, {
+    nodeId,
+    blockerIds = []
+}) {
+    const row = ledger.get(nodeId);
+    if (!row) return;
+
+    row.blockerIds  = blockerIds;
+    row.blockerGate = blockerIds.length > 0 ? `blocked (${blockerIds.join(', ')})` : 'passed';
+    if (blockerIds.length > 0) {
+        row.routeStatus = 'blocked';
+    }
+}
+
+/**
+ * @summary Records the label/actionability gate for one candidate row.
+ * @param {Map<String,Object>} ledger Same-run route ledger.
+ * @param {Object} options
+ * @param {String} options.nodeId Candidate node id.
+ * @param {String[]} [options.exclusionLabels=[]] Labels that made the candidate visibility-only.
+ */
+export function recordGoldenPathActionabilityGate(ledger, {
+    nodeId,
+    exclusionLabels = []
+}) {
+    const row = ledger.get(nodeId);
+    if (!row) return;
+
+    row.exclusionLabels   = exclusionLabels;
+    row.actionabilityGate = exclusionLabels.length > 0
+        ? `rejected (${exclusionLabels.join(', ')})`
+        : 'passed';
+    if (exclusionLabels.length > 0) {
+        row.routeStatus = 'non-actionable';
+    }
+}
+
+/**
+ * @summary Records the final hybrid score for an actionable candidate.
+ * @param {Map<String,Object>} ledger Same-run route ledger.
+ * @param {Object} options
+ * @param {String} options.nodeId Candidate node id.
+ * @param {Number} options.finalScore Final weighted route score.
+ */
+export function recordGoldenPathFinalScore(ledger, {
+    nodeId,
+    finalScore
+}) {
+    const row = ledger.get(nodeId);
+    if (!row) return;
+
+    row.finalScore  = Number(finalScore);
+    row.routeStatus = 'scored';
+}
+
+/**
+ * @summary Records post-ranking selection and current-focus filtering for all ledger rows.
+ * @param {Map<String,Object>} ledger Same-run route ledger.
+ * @param {Object} options
+ * @param {Array<Object>} [options.topNodes=[]] Top ranked nodes before current-focus filtering.
+ * @param {Array<Object>} [options.routedTopNodes=[]] Rendered routed nodes.
+ * @param {Object|null} [options.focusContradiction=null] Current-focus contradiction result.
+ */
+export function recordGoldenPathSelection(ledger, {
+    topNodes = [],
+    routedTopNodes = [],
+    focusContradiction = null
+} = {}) {
+    const topIds         = new Set(topNodes.map(item => item?.node?.id).filter(Boolean));
+    const routedIds      = new Set(routedTopNodes.map(item => item?.node?.id).filter(Boolean));
+    const blockedByFocus = focusContradiction?.blockedIds || new Set();
+
+    for (const row of ledger.values()) {
+        if (blockedByFocus.has(row.nodeId)) {
+            row.routeStatus = 'filtered-current-focus';
+        } else if (routedIds.has(row.nodeId)) {
+            row.routeStatus = 'rendered';
+        } else if (topIds.has(row.nodeId) && row.routeStatus === 'scored') {
+            row.routeStatus = 'selected-before-focus';
+        } else if (row.routeStatus === 'scored') {
+            row.routeStatus = 'not-selected';
+        }
+    }
+}
+
+/**
+ * @summary Records frontier GUIDES writes and rendered score values for routed nodes.
+ * @param {Map<String,Object>} ledger Same-run route ledger.
+ * @param {Object} options
+ * @param {String} options.nodeId Candidate node id.
+ * @param {Number} options.score Final score written to `frontier -GUIDES-> node`.
+ * @param {Number} options.semantic Rendered semantic score.
+ * @param {Number} options.structural Rendered structural score.
+ */
+export function recordGoldenPathGuideWrite(ledger, {
+    nodeId,
+    score,
+    semantic,
+    structural
+}) {
+    const row = ledger.get(nodeId);
+    if (!row) return;
+
+    row.guideWriteScore    = Number(score);
+    row.renderedFinalScore = Number(score);
+    row.renderedSemantic   = Number(semantic);
+    row.renderedStructural = Number(structural);
+}
+
+/**
+ * @summary Renders the same-run route attribution ledger as a bounded markdown section.
+ * @param {Object} options
+ * @param {Map<String,Object>} options.ledger Same-run route ledger.
+ * @param {Object} [options.stats={}] Existing Golden Path scoring stats.
+ * @param {Date|String} [options.capturedAt=new Date()] Capture timestamp.
+ * @returns {String}
+ */
+export function renderGoldenPathRouteLedgerSection({
+    ledger,
+    stats      = {},
+    capturedAt = new Date()
+} = {}) {
+    const rows = Array.from((ledger || new Map()).values())
+        .sort((a, b) => (a.semanticRank || 0) - (b.semanticRank || 0));
+    const count                = value => Number.isFinite(Number(value)) ? Number(value) : 0;
+    const actionabilityBuckets = new Map();
+
+    rows.forEach(row => {
+        (row.exclusionLabels || []).forEach(label => {
+            actionabilityBuckets.set(label, (actionabilityBuckets.get(label) || 0) + 1);
+        });
+    });
+
+    const bucketText = actionabilityBuckets.size === 0
+        ? 'none'
+        : Array.from(actionabilityBuckets.entries())
+            .sort((a, b) => a[0].localeCompare(b[0]))
+            .map(([label, total]) => `\`${label}\`: ${total}`)
+            .join(', ');
+
+    let section = [
+        '',
+        '## Golden Path Route Attribution Ledger',
+        '',
+        `Captured at: ${formatGoldenPathTimestamp(capturedAt)}`,
+        '',
+        'Same-run diagnostic for the Computed Golden Path route chain. Scope: current semantic candidate pool only; no graph nodes or edge classes are minted by this ledger.',
+        '',
+        `- Semantic candidates: ${count(stats.semanticCandidates)}`,
+        '- Type gate: vector query constrained to `ISSUE` / `DISCUSSION`',
+        `- SQLite OPEN matches: ${count(stats.sqliteOpenMatches)}`,
+        `- Blocked candidates filtered: ${count(stats.blockedCandidates)}`,
+        `- Label/actionability buckets: ${bucketText}`,
+        `- Scored actionable candidates: ${count(stats.scoredCandidates)}`,
+        `- Selected routed nodes: ${count(stats.selectedTopNodes)}`,
+        `- Stale frontier GUIDES pruned: ${count(stats.prunedGuideEdges)}`,
+        '',
+        '| Candidate | Semantic | State | Type | Actionability | Blocker | Structural total | Structural components | Final | Route | GUIDES write | Rendered |',
+        '|---|---:|---|---|---|---|---:|---|---:|---|---:|---|'
+    ].join('\n');
+
+    if (rows.length === 0) {
+        return `${section}\n| none | - | - | - | - | - | - | - | - | no semantic candidates | - | - |\n`
+    }
+
+    rows.forEach(row => {
+        const structuralComponents = Object.entries(row.structuralComponents || {})
+            .sort((a, b) => a[0].localeCompare(b[0]))
+            .map(([type, value]) => `${type}: ${formatNumber(value)}`)
+            .join(', ') || '-';
+        const rendered = row.renderedFinalScore == null
+            ? '-'
+            : `Score ${formatNumber(row.renderedFinalScore)} / Semantic ${formatNumber(row.renderedSemantic)} / Structural ${formatNumber(row.renderedStructural)}`;
+
+        section += `\n| ${escapeCell(row.nodeId)} | ${formatNumber(row.semanticScore)} | ${escapeCell(row.stateGate)} | ${escapeCell(row.typeGate)} | ${escapeCell(row.actionabilityGate)} | ${escapeCell(row.blockerGate)} | ${formatNumber(row.structuralScore)} | ${escapeCell(structuralComponents)} | ${formatNumber(row.finalScore)} | ${escapeCell(row.routeStatus)} | ${formatNumber(row.guideWriteScore)} | ${escapeCell(rendered)} |`;
+    });
+
+    return `${section}\n`
+}

--- a/learn/agentos/measurements/golden-path-route-attribution-2026-07-02.md
+++ b/learn/agentos/measurements/golden-path-route-attribution-2026-07-02.md
@@ -1,0 +1,58 @@
+# Golden Path Route Attribution Measurement - 2026-07-02
+
+Issue: #14454
+
+## Run
+
+- Command: `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs -g "#14454"`
+- Result: `1 passed`
+- Capture timestamp in run: `2026-07-02 08:40 UTC`
+- Cycle surface: `GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false})`
+
+This measurement records the first same-run route-attribution ledger emitted by the
+Computed Golden Path synthesis path. The run is intentionally hermetic: vector search,
+summary input, open PR fetch, and the strategic brief provider are stubbed inside the
+unit test so the ledger values are reproducible.
+
+## Config Snapshot
+
+- Semantic candidate pool: `nResults: 20`
+- Semantic type gate: Chroma `where: {type: {'$in': ['ISSUE', 'DISCUSSION']}}`
+- Frontier source: two most-recent summary documents via `getRecentSummaryDocuments`; this run stubs the summary text as `Golden Path route attribution focus`
+- Semantic weight: `2.0`
+- Structural weight: `1.0`
+- Rendered top-node limit: `goldenPathTopNodeRenderLimit` default `10`
+- Repo enrichment: disabled for the verification run, so Current Focus / Silent Threads / PR state cannot alter the route
+- New graph schema: none; the ledger mints no graph nodes and no new edge classes
+
+## Same-Run Ledger Snapshot
+
+The test run creates three semantic candidates in one pass:
+
+| Candidate | Semantic | State | Type | Actionability | Blocker | Structural total | Structural components | Final | Route | GUIDES write | Rendered |
+|---|---:|---|---|---|---|---:|---|---:|---|---:|---|
+| `issue-route-ledger-ready-*` | 5.00 | OPEN | passed (ISSUE) | passed | passed | 3.50 | ADVANCES: 1.50, RESOLVES: 2.00 | 13.50 | rendered | 13.50 | Score 13.50 / Semantic 5.00 / Structural 3.50 |
+| `issue-route-ledger-not-ready-*` | 3.33 | OPEN | passed (ISSUE) | rejected (not-code-ready) | passed | 0.00 | - | - | non-actionable | - | - |
+| `issue-route-ledger-blocked-*` | 2.50 | OPEN | passed (ISSUE) | not-evaluated | blocked (`issue-route-ledger-blocker-*`) | 0.00 | - | - | blocked | - | - |
+
+## Acceptance Fork
+
+The run satisfies the non-zero structural fork: at least one rendered top item has
+`Structural: 3.50`, and the ledger names the contributing edge types in the same pass.
+The zero-structural case is therefore not confirmed as a dead-write / cold-start defect
+by this reproducible scenario.
+
+## Ordering Disposition
+
+The handoff now renders `## Golden Path Route Attribution Ledger` before
+`## Computed Golden Path (Strategic Recommendation)`, while the ledger itself is built
+inside the same synthesis pass:
+
+1. Semantic candidates are recorded immediately after vector query.
+2. SQLite OPEN/type, blocker, label/actionability, and structural components are recorded
+   during the scoring loop.
+3. `frontier -GUIDES-> candidate` is written before the row records the GUIDES write and
+   rendered component values.
+4. The final handoff file is written after the GUIDES write and ledger render complete.
+
+That means the diagnostic no longer depends on a later snapshot probe to explain the route.

--- a/learn/agentos/wake-substrate/sandman-handoff-format.md
+++ b/learn/agentos/wake-substrate/sandman-handoff-format.md
@@ -41,5 +41,13 @@ to live PR inspection, not the boot handoff.
 ### 5. Latest Priority Backlog
 A fallback queue of recent structurally significant tickets that are `OPEN` and not marked `needs-re-triage`. Used to guide execution when the Golden Path is fully blocked.
 
-### 6. Computed Golden Path
+### 6. Golden Path Route Attribution Ledger
+A same-run diagnostic for the current semantic candidate pool, showing how
+candidates move through the route chain and why they do or do not reach the
+rendered Golden Path. It is diagnostic and advisory only, mints no Native Edge
+Graph nodes or edge classes, and does not change orchestration consumption:
+`AgentOrchestrator.parseGoldenPath()` continues to consume only the
+`## Computed Golden Path` section.
+
+### 7. Computed Golden Path
 The configured top nodes mathematically recommended for execution, calculated via Hybrid GraphRAG (Semantic Vector Distance + Structural Edge Weight). A strategic brief synthesizing *why* these nodes represent the active frontier is appended to guide agent intuition; a deterministic fallback keeps the section present when the LLM brief is unavailable.

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -34,6 +34,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     let renderStaleAssignmentCandidatesSection;
     let buildSilentThreadCandidates;
     let renderSilentThreadCandidatesSection;
+    let renderGoldenPathRouteLedgerSection;
     let issueFocusSections;
 
     let StorageRouter;
@@ -76,6 +77,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         renderStaleAssignmentCandidatesSection = GoldenPathSynthesizer.constructor.renderStaleAssignmentCandidatesSection.bind(GoldenPathSynthesizer.constructor);
         buildSilentThreadCandidates = GoldenPathSynthesizer.constructor.buildSilentThreadCandidates.bind(GoldenPathSynthesizer.constructor);
         renderSilentThreadCandidatesSection = GoldenPathSynthesizer.constructor.renderSilentThreadCandidatesSection.bind(GoldenPathSynthesizer.constructor);
+        ({renderGoldenPathRouteLedgerSection} = await import('../../../../../../ai/services/graph/goldenPathRouteLedger.mjs'));
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         StorageRouter = (await import('../../../../../../ai/services.mjs')).Memory_StorageRouter;
@@ -1104,6 +1106,36 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).toContain(`| ${notReadyId} | 3.33 | OPEN | passed (ISSUE) | rejected (not-code-ready) | passed | 0.00 | - | - | non-actionable | - | - |`);
         expect(handoffContent).toContain(`| ${blockedId} | 2.50 | OPEN | passed (ISSUE) | not-evaluated | blocked (${blockerId}) | 0.00 | - | - | blocked | - | - |`);
         expect(handoffContent).toContain(`${readyId}**: Score 13.50 (Semantic: 5.00, Structural: 3.50)`);
+    });
+
+    test('renderGoldenPathRouteLedgerSection escapes markdown table cell metacharacters (#14454)', () => {
+        const ledger = new Map([
+            ['issue\\path|split', {
+                actionabilityGate   : 'rejected (needs\\owner|review\nnow)',
+                blockerGate         : 'blocked (issue\\blocker|root)',
+                finalScore          : 1.25,
+                guideWriteScore     : 1.25,
+                nodeId              : 'issue\\path|split',
+                renderedFinalScore  : 1.25,
+                renderedSemantic    : 0.5,
+                renderedStructural  : 0.75,
+                routeStatus         : 'rendered\\table|row',
+                semanticRank        : 1,
+                semanticScore       : 0.5,
+                stateGate           : 'OPEN',
+                structuralComponents: {'ADVANCES\\PIPE|EDGE': 0.75},
+                structuralScore     : 0.75,
+                typeGate            : 'passed (ISSUE)'
+            }]
+        ]);
+
+        const section = renderGoldenPathRouteLedgerSection({
+            capturedAt: new Date('2026-07-02T09:15:00Z'),
+            ledger,
+            stats     : {semanticCandidates: 1}
+        });
+
+        expect(section).toContain('| issue\\\\path\\|split | 0.50 | OPEN | passed (ISSUE) | rejected (needs\\\\owner\\|review now) | blocked (issue\\\\blocker\\|root) | 0.75 | ADVANCES\\\\PIPE\\|EDGE: 0.75 | 1.25 | rendered\\\\table\\|row | 1.25 | Score 1.25 / Semantic 0.50 / Structural 0.75 |');
     });
 
     test('synthesizeGoldenPath renders degraded diagnostics when semantic vector query fails (#13978)', async () => {

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -621,7 +621,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const issuesDir                        = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-silent-render-issues-'));
         const chunkDir                         = path.join(issuesDir, 'chunk-1');
         const now                              = new Date('2026-05-28T00:00:00Z');
-        const goldenIssueId = `issue-silent-golden-${Date.now()}`;
+        const goldenIssueId                    = `issue-silent-golden-${Date.now()}`;
         aiConfig.vectorDimension = 2;
 
         fs.mkdirSync(chunkDir, {recursive: true});
@@ -876,8 +876,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(computedSection).toContain(`1. **${discussionId}**: Score 18.18 (Semantic: 9.09, Structural: 0.00)\n   - *Governance discussion*`);
         expect(computedSection).toContain(`2. **${readyId}**: Score 3.33 (Semantic: 1.67, Structural: 0.00)\n   - *Actionable release leaf*`);
         expect(computedSection).toContain('> **Strategic Interpretation:**\n> stub');
-        expect(handoffContent).not.toContain(epicId);    // epic label still excluded
-        expect(handoffContent).not.toContain(notReadyId);
+        expect(computedSection).not.toContain(epicId);    // epic label still excluded from rendered recommendations
+        expect(computedSection).not.toContain(notReadyId);
     });
 
     test('synthesizeGoldenPath renders a contradiction diagnostic for blog routing during PRIO-zero focus (#13849)', async () => {
@@ -968,9 +968,9 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
         const originalEmbedText            = TextEmbeddingService.embedText;
         const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
-        const suffix = `${process.pid}-${Date.now()}`;
-        const staleId = `issue-stale-guide-${suffix}`;
-        const notReadyId = `issue-empty-not-ready-${suffix}`;
+        const suffix                       = `${process.pid}-${Date.now()}`;
+        const staleId                      = `issue-stale-guide-${suffix}`;
+        const notReadyId                   = `issue-empty-not-ready-${suffix}`;
         aiConfig.vectorDimension = 2;
 
         GraphService.upsertNode({
@@ -1026,13 +1026,93 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(guideTargets).not.toContain(staleId);
     });
 
+    test('synthesizeGoldenPath renders same-run route attribution ledger for scoring and rejection gates (#14454)', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
+        const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate             = OpenAiCompatible.prototype.generate;
+        const suffix                       = `${process.pid}-${Date.now()}`;
+        const readyId                      = `issue-route-ledger-ready-${suffix}`;
+        const notReadyId                   = `issue-route-ledger-not-ready-${suffix}`;
+        const blockedId                    = `issue-route-ledger-blocked-${suffix}`;
+        const blockerId                    = `issue-route-ledger-blocker-${suffix}`;
+        const sourceAId                    = `issue-route-ledger-source-a-${suffix}`;
+        const sourceBId                    = `discussion-route-ledger-source-b-${suffix}`;
+        aiConfig.vectorDimension = 2;
+
+        GraphService.upsertNode({
+            id        : 'frontier',
+            type      : 'SYSTEM_TENET',
+            properties: {name: 'Active Context Frontier'}
+        });
+        [
+            {id: readyId, type: 'ISSUE', title: 'Implement same-run route ledger', labels: ['bug', 'ai']},
+            {id: notReadyId, type: 'ISSUE', title: 'Deferred not-ready route', labels: ['not-code-ready', 'ai']},
+            {id: blockedId, type: 'ISSUE', title: 'Blocked route', labels: ['bug', 'ai']},
+            {id: blockerId, type: 'ISSUE', title: 'Open blocker', labels: ['bug', 'ai']},
+            {id: sourceAId, type: 'ISSUE', title: 'Structural source A', labels: ['bug', 'ai']},
+            {id: sourceBId, type: 'DISCUSSION', title: 'Structural source B', labels: ['architecture', 'ai']}
+        ].forEach(node => GraphService.upsertNode({
+            id        : node.id,
+            type      : node.type,
+            properties: {
+                labels: node.labels,
+                state : 'OPEN',
+                title : node.title
+            }
+        }));
+        GraphService.linkNodes(sourceAId, readyId, 'RESOLVES', 2);
+        GraphService.linkNodes(sourceBId, readyId, 'ADVANCES', 1.5);
+        GraphService.linkNodes(blockerId, blockedId, 'BLOCKS', 1);
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => ({
+                ids      : [[readyId, notReadyId, blockedId]],
+                distances: [[0.1, 0.2, 0.3]]
+            })
+        });
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['Golden Path route attribution focus']})});
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [];
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({
+                now                  : new Date('2026-07-02T08:40:00Z'),
+                repoEnrichmentEnabled: false
+            });
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            OpenAiCompatible.prototype.generate = originalGenerate;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        const ledgerIndex    = handoffContent.indexOf('## Golden Path Route Attribution Ledger');
+        const computedIndex  = handoffContent.indexOf('## Computed Golden Path (Strategic Recommendation)');
+
+        expect(ledgerIndex).toBeGreaterThan(-1);
+        expect(computedIndex).toBeGreaterThan(ledgerIndex);
+        expect(handoffContent).toContain('Captured at: 2026-07-02 08:40 UTC');
+        expect(handoffContent).toContain('- Type gate: vector query constrained to `ISSUE` / `DISCUSSION`');
+        expect(handoffContent).toContain('- Label/actionability buckets: `not-code-ready`: 1');
+        expect(handoffContent).toContain(`| ${readyId} | 5.00 | OPEN | passed (ISSUE) | passed | passed | 3.50 | ADVANCES: 1.50, RESOLVES: 2.00 | 13.50 | rendered | 13.50 | Score 13.50 / Semantic 5.00 / Structural 3.50 |`);
+        expect(handoffContent).toContain(`| ${notReadyId} | 3.33 | OPEN | passed (ISSUE) | rejected (not-code-ready) | passed | 0.00 | - | - | non-actionable | - | - |`);
+        expect(handoffContent).toContain(`| ${blockedId} | 2.50 | OPEN | passed (ISSUE) | not-evaluated | blocked (${blockerId}) | 0.00 | - | - | blocked | - | - |`);
+        expect(handoffContent).toContain(`${readyId}**: Score 13.50 (Semantic: 5.00, Structural: 3.50)`);
+    });
+
     test('synthesizeGoldenPath renders degraded diagnostics when semantic vector query fails (#13978)', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
         const originalEmbedText            = TextEmbeddingService.embedText;
-        const suffix     = `${process.pid}-${Date.now()}`;
-        const staleId    = `issue-stale-query-guide-${suffix}`;
-        const queryError = new Error('Error executing plan: Internal error: Error finding id');
+        const suffix                       = `${process.pid}-${Date.now()}`;
+        const staleId                      = `issue-stale-query-guide-${suffix}`;
+        const queryError                   = new Error('Error executing plan: Internal error: Error finding id');
         aiConfig.vectorDimension = 2;
 
         GraphService.upsertNode({
@@ -1112,9 +1192,9 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
         const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
         const originalGenerate             = OpenAiCompatible.prototype.generate;
-        const suffix = `${process.pid}-${Date.now()}`;
-        const staleId = `issue-stale-guide-nonzero-${suffix}`;
-        const readyId = `issue-current-guide-${suffix}`;
+        const suffix                       = `${process.pid}-${Date.now()}`;
+        const staleId                      = `issue-stale-guide-nonzero-${suffix}`;
+        const readyId                      = `issue-current-guide-${suffix}`;
         aiConfig.vectorDimension = 2;
 
         GraphService.upsertNode({
@@ -1182,12 +1262,12 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         TextEmbeddingService.embedText = async () => [0.1, 0.2];
         GoldenPathSynthesizer.fetchOpenPRs = async () => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(number => ({
             number,
-            url: `https://github.com/neomjs/neo/pull/${number}`,
-            author: {login: 'external-dev'},
-            title: `PR ${number}`,
-            body: '',
-            createdAt: `2026-05-${String(number).padStart(2, '0')}T00:00:00Z`,
-            headRefOid: `sha-${number}`,
+            url           : `https://github.com/neomjs/neo/pull/${number}`,
+            author        : {login: 'external-dev'},
+            title         : `PR ${number}`,
+            body          : '',
+            createdAt     : `2026-05-${String(number).padStart(2, '0')}T00:00:00Z`,
+            headRefOid    : `sha-${number}`,
             reviewRequests: [],
             reviews       : number === 12 ? [{state: 'APPROVED', body: 'LGTM', submittedAt: '2026-05-12T01:00:00Z', author: {login: 'neo-opus-ada'}}] : [],
             comments      : []
@@ -1220,8 +1300,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
         const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
         const originalGenerate             = OpenAiCompatible.prototype.generate;
-        const suffix = `${process.pid}-${Date.now()}`;
-        const readyId = `issue-strategic-fallback-${suffix}`;
+        const suffix                       = `${process.pid}-${Date.now()}`;
+        const readyId                      = `issue-strategic-fallback-${suffix}`;
         aiConfig.vectorDimension = 2;
 
         GraphService.upsertNode({
@@ -1305,8 +1385,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
 
     test('renderStaleAssignmentCandidatesSection caps noisy local issue sync output', () => {
         const candidates = Array.from({length: 3}, (_, index) => ({
-            assignees: ['neo-gpt'],
-            daysIdle : 10 + index,
+            assignees     : ['neo-gpt'],
+            daysIdle      : 10 + index,
             lastActivityAt: `2026-05-0${index + 1}T00:00:00.000Z`,
             lastActivityBy: 'neo-gpt',
             number        : 9200 + index,
@@ -1594,11 +1674,13 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             OpenAiCompatible.prototype.generate  = originalGenerate;
         }
 
-        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        const handoffContent  = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        const computedIndex   = handoffContent.indexOf('## Computed Golden Path');
+        const computedSection = handoffContent.slice(computedIndex);
 
         expect(handoffContent).toContain(issueId);
         expect(handoffContent).toContain(openId);        // open discussions are now actionable (converge-to-drive)
-        expect(handoffContent).not.toContain(closedId);  // closed discussions excluded by the state='OPEN' gate
+        expect(computedSection).not.toContain(closedId); // closed discussions excluded by the state='OPEN' gate
     });
 
     test('renderConsolidationGapsSection surfaces undigested sessions visibly (#13807)', async () => {


### PR DESCRIPTION
Resolves #14454

Adds a same-run Golden Path route-attribution ledger to `GoldenPathSynthesizer`, so each semantic candidate now carries its route through the OPEN/type, blocker, label/actionability, structural-score, selection, GUIDES-write, and rendered-output gates in the same synthesis pass. The ledger is diagnostic only: it mints no graph nodes and no new edge classes.

Evidence: L2 (hermetic `synthesizeGoldenPath` unit cycle plus full GoldenPathSynthesizer unit file) -> L2 required (route ledger + ordering + schema discipline ACs). Residual: none.

## Deltas from ticket

- Structural fast-path applied for `ai/services/graph/goldenPathRouteLedger.mjs`: it matches the pure Golden Path section-helper pattern beside `computedGoldenPathRouting.mjs` and `goldenPathTimestamp.mjs`; no ArchitectureOverview map update needed.
- The route ledger intentionally exposes rejected/blocked semantic candidates, so two existing tests were scoped to assert exclusion from the Computed Golden Path section rather than absence from the entire handoff.
- `computedGoldenPathRouting.mjs` now exports the exclusion-label helper used by both routing and diagnostics, avoiding a second actionability label list.

## Test Evidence

- `npm run agent-preflight -- ai/services/graph/GoldenPathSynthesizer.mjs ai/services/graph/computedGoldenPathRouting.mjs ai/services/graph/goldenPathRouteLedger.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs learn/agentos/measurements/golden-path-route-attribution-2026-07-02.md` -> passed.
- `npm run agent-preflight -- ai/services/graph/goldenPathRouteLedger.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs --pr-body /private/tmp/pr14454-body.md` -> passed after the CodeQL backslash-escaping fixup.
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs -g "#14454"` -> 2 passed after the CodeQL backslash-escaping fixup.
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs -g "#14454"` -> 1 passed after rebase.
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` -> 38 passed before the final formatting pass; the scoped #14454 test was re-run after formatting and rebase.
- `git diff --cached --check` -> passed before commit.

## Post-Merge Validation

- [ ] Next production Golden Path handoff includes `## Golden Path Route Attribution Ledger` before `## Computed Golden Path (Strategic Recommendation)`.

## Commits

- `e9e232000b` — same-run Golden Path route-attribution ledger and measurement artifact.
- `09ef2471c1` — CodeQL fixup: escape backslashes in ledger table cells and pin regression coverage.

Related: #14422

Authored by Euclid (GPT-5, Codex Desktop). Session 8facbc96-c346-4633-9141-79a968ca1c5d.
