### PR TITLE
fix(hooks): namedGates consumption honesty in the lane-state hint (#14459)

### DIFF
--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -17,7 +17,8 @@ export const LANE_STATE_SCHEMA_HINT = `Machine lane-state block to emit with you
 \`\`\`lane-state
 {"wakeDisposition":"awareness","laneContinuation":"next-lane","namedGates":[],"awaitingOwnPrOnly":false}
 \`\`\`
-Validator gotchas: if an own PR is only awaiting merge/review/CI, use laneContinuation "next-lane"; "active-lane" + awaitingOwnPrOnly:true is invalid. Every namedGates[] entry needs a same-turn checkedAt; mergeClaim must use field "mergedAt".`;
+Validator gotchas: if an own PR is only awaiting merge/review/CI, use laneContinuation "next-lane"; "active-lane" + awaitingOwnPrOnly:true is invalid. Every namedGates[] entry needs a same-turn checkedAt; mergeClaim must use field "mergedAt".
+Consumption honesty: namedGates[] is audit/coordination payload (peer-visible gate state; the audit ledger) — it is validated for shape but does NOT influence the block/allow decision in autonomous mode.`;
 
 /**
  * @summary Compact cross-harness turn-end options hint for Stop-hook injections.

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -33,6 +33,11 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
         expect(LANE_STATE_SCHEMA_HINT).toContain('field "mergedAt"');
     });
 
+    test('LANE_STATE_SCHEMA_HINT: states consumption honesty — namedGates is audit/coordination payload, not admission evidence (regression: demanded-but-unread contract)', () => {
+        expect(LANE_STATE_SCHEMA_HINT).toContain('Consumption honesty');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('does NOT influence the block/allow decision');
+    });
+
     test('STOP_HOOK_TURN_OPTIONS_HINT: compactly names operator dialogue, memory, and fail-closed behavior', () => {
         expect(STOP_HOOK_TURN_OPTIONS_HINT).toContain('operator dialogue/planning');
         expect(STOP_HOOK_TURN_OPTIONS_HINT).toContain('[WAKE]/stop-hook continuations');


### PR DESCRIPTION
Resolves #14459

Fix shape (i) from the ticket: the shared `LANE_STATE_SCHEMA_HINT` (SSOT for both harness hooks) gains an explicit consumption-honesty sentence — `namedGates[]` is audit/coordination payload, validated for shape, and does NOT influence the autonomous block/allow decision. The demanded-but-unread contract gap (20-chain live evidence, session `c82afc7d`) closes at the prompt-text tier with zero admission change.

Evidence: L2 (full hooks suite 135/135 at head, including Claude+Codex parity specs — both consume the shared string, so cross-harness hint identity holds by construction; new regression test pins the honesty clause). L2 is the ceiling and sufficient: the diff is one string constant + one spec test; no runtime decision path is touched (verifiable by inspection — the decision functions are untouched).

## Deltas from ticket

None. Shape (ii) (wiring namedGates freshness into the Option-F audit meter) remains available as a follow-up under the same ticket family once `#14441` OQ5 rules; this PR deliberately takes only the admission-neutral prompt-text half so it is NOT sequenced behind the operator ruling.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/hooks/` → **135/135** at head (full suite: decision primitives, Claude hook, Codex hook, parity).
- Validation truths retained verbatim: existing spec assertions for `same-turn checkedAt` / `field "mergedAt"` / `awaitingOwnPrOnly` pass unchanged.
- New regression: the hint must contain the consumption-honesty clause.

## Post-Merge Validation

- [ ] The next autonomous refusal's injected prompt shows the honesty sentence (observable in any live session transcript).

## Commits

- single commit — string + spec.

Authored by Clio (Claude Fable 5, Claude Code). Session c82afc7d-dffe-400e-984d-c670b62f39dc.