### PR TITLE
feat(hooks): inject release-goal Golden Path direction into the stop-hook block directive (#13751)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -215,20 +215,68 @@ export function formatLifecycleBoard(state) {
 }
 
 /**
+ * @summary Formats the Computed Golden Path release-goal direction — the top-N ROI-ranked lanes the
+ * Dream pipeline surfaced (`priority = 2×semantic + 1×structural`, sourced from the sandman handoff's
+ * Computed Golden Path route attribution) — into the block directive, so the forced next-action is
+ * anchored to the release goal, NOT rewarded for "any named lane" (the productive-derailment guard).
+ * This is the hook-READ consumer; the daemon-WRITE producer fills the `goldenPathDirection` field.
+ *
+ * Contract (`state.goldenPathDirection`): an array of `{id, score?, title?}`, pre-ranked by the
+ * producer (the hook does NOT rank — it renders the producer's order verbatim; ranking is the Golden
+ * Path's job, per the no-auto-action spine).
+ *
+ * FAIL-OPEN + ADDITIVE: a missing / empty / stale / malformed direction degrades to `''` (the bare
+ * reminder), NEVER blocks — a zero-signal (cold-start, no writer yet, stale handoff) must never starve
+ * the directive floor. Pure; total (never throws) — it runs inside the turn-end hook path where a throw
+ * would trap every turn, so a never-throwing function is the contract. Advisory only: the agent reads
+ * the direction and CHOOSES; the hook never auto-reprioritizes (the advisory-only, no-auto-action
+ * spine). Exported + unit-tested.
+ * @param {Object|null} state `{goldenPathDirection: [{id, score?, title?}], ...}` from {@link readLifecycleState}.
+ * @returns {String}
+ */
+export function formatGoldenPathDirection(state) {
+    try {
+        if (!state || typeof state !== 'object') return '';
+
+        const lanes = Array.isArray(state.goldenPathDirection) ? state.goldenPathDirection : [];
+
+        // Render ONLY entries carrying a usable id; skip null / non-object / idless entries so a single
+        // malformed element never crashes the formatter (the malformed-shape fail-open the board uses).
+        const valid = lanes.filter(lane => lane && typeof lane === 'object' &&
+            typeof lane.id === 'string' && lane.id.trim() !== '');
+        if (!valid.length) return '';
+
+        const rows = valid.map((lane, index) => {
+            const score = Number.isFinite(Number(lane.score)) ? ` — score ${Number(lane.score).toFixed(2)}` : '',
+                  title = typeof lane.title === 'string' && lane.title.trim() ? ` — ${lane.title.trim()}` : '';
+            return `  ${index + 1}. ${lane.id}${score}${title}`;
+        });
+
+        return `\nRelease-goal direction — Computed Golden Path top ROI (drive one of these over any-named-lane; advisory, not auto-reprioritization):\n${rows.join('\n')}`;
+    } catch {
+        // Belt-and-suspenders: any unforeseen shape degrades to the bare reminder, never throws.
+        return '';
+    }
+}
+
+/**
  * @summary Composes the directive injected on a block — the curated `IDLE_REMINDER` (lifecycle +
- * teeth-test) + the agent's live lane-state board (when the daemon-written file is present) + the
- * always-present mirror-pointer (discoverability) + the self-improvability clause (the floor is mutable
- * substrate) + the trigger `cause`. Reminder is WHAT-to-do, the board is WHAT'S-actionable-now, the
- * mirror-pointer is WHY-this-is-not-a-leash, the clause is HOW-to-fix-it-when-wrong, the cause is
- * WHY-blocked. Fail-open on the board (missing/bad file → bare reminder). One best-effort file read;
- * exported + unit-tested.
+ * teeth-test) + the Computed Golden Path release-goal direction (the release-goal anchor) + the agent's
+ * live lane-state board + the always-present mirror-pointer (discoverability) + the self-improvability
+ * clause (the floor is mutable substrate) + the trigger `cause`. Reminder is WHAT-to-do, the direction
+ * is WHICH-lane-serves-the-release-goal, the board is WHAT'S-actionable-now, the mirror-pointer is
+ * WHY-this-is-not-a-leash, the clause is HOW-to-fix-it-when-wrong, the cause is WHY-blocked. Fail-open
+ * on the direction + board (missing/bad file → bare reminder). ONE best-effort file read shared by both
+ * formatters; exported + unit-tested.
  * @param {String} cause The terminal-evidence violation that triggered the block (the verdict reason).
  * @returns {String}
  */
 export function composeBlockDirective(cause, holdMatches = []) {
-    const board   = formatLifecycleBoard(readLifecycleState()),
-          costume = formatHoldCostumeCallout(holdMatches);
-    return `${IDLE_REMINDER}${board}${costume}\n\n${MIRROR_POINTER}\n\n${SELF_IMPROVABILITY_CLAUSE}\n\n(Stop-hook trigger: ${cause})`;
+    const state     = readLifecycleState(),
+          direction = formatGoldenPathDirection(state),
+          board     = formatLifecycleBoard(state),
+          costume   = formatHoldCostumeCallout(holdMatches);
+    return `${IDLE_REMINDER}${direction}${board}${costume}\n\n${MIRROR_POINTER}\n\n${SELF_IMPROVABILITY_CLAUSE}\n\n(Stop-hook trigger: ${cause})`;
 }
 
 /**

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,7 +1,7 @@
 import {test, expect}                                                                              from '@playwright/test';
 import {composeBlockDirective, composeDeferenceDirective, decideHookAction, isOperatorInLoop, parseOutcomeToVerdict,
         extractFinalAssistantText, extractLastAssistantTextFromJsonl, extractLastUserTextFromJsonl,
-        formatLifecycleBoard, formatHoldCostumeCallout} from '../../../../.claude/hooks/laneStateStopHook.mjs';
+        formatLifecycleBoard, formatGoldenPathDirection, formatHoldCostumeCallout} from '../../../../.claude/hooks/laneStateStopHook.mjs';
 import {spawn} from 'node:child_process';
 import fs      from 'node:fs';
 import os      from 'node:os';
@@ -182,6 +182,43 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
             expect(board).not.toContain('undefined');
         });
     });
+
+    test.describe('formatGoldenPathDirection — the release-goal ROI anchor (#13751, fail-open)', () => {
+        test('renders the producer-ranked lanes (id + optional score/title) as a numbered release-goal direction', () => {
+            const dir = formatGoldenPathDirection({goldenPathDirection: [
+                {id: 'issue-14442', score: 13.5, title: 'Business engine'},
+                {id: 'discussion-14422', score: 9.09}
+            ]});
+            expect(dir).toContain('Release-goal direction');
+            expect(dir).toContain('drive one of these over any-named-lane');
+            expect(dir).toContain('1. issue-14442 — score 13.50 — Business engine');
+            expect(dir).toContain('2. discussion-14422 — score 9.09');
+        });
+
+        test('fail-open: null / non-object / empty / no-writer-yet → "" (never starves the directive floor)', () => {
+            expect(formatGoldenPathDirection(null)).toBe('');
+            expect(formatGoldenPathDirection('garbage')).toBe('');
+            expect(formatGoldenPathDirection({})).toBe('');                        // no field yet (no producer)
+            expect(formatGoldenPathDirection({goldenPathDirection: []})).toBe('');
+            expect(formatGoldenPathDirection({goldenPathDirection: 'not-an-array'})).toBe('');
+        });
+
+        test('fail-open on malformed SHAPE — skips idless/null entries, never throws', () => {
+            expect(() => formatGoldenPathDirection({goldenPathDirection: [null, {}, {id: ''}]})).not.toThrow();
+            expect(formatGoldenPathDirection({goldenPathDirection: [null, {}, {id: '   '}]})).toBe(''); // no valid entry
+            const dir = formatGoldenPathDirection({goldenPathDirection: [null, {id: 'issue-9'}, {}]});
+            expect(dir).toContain('1. issue-9');       // the one valid entry survives its malformed neighbors
+            expect(dir).not.toContain('undefined');
+        });
+
+        test('score is optional + a non-finite score is omitted cleanly (no "score NaN")', () => {
+            const dir = formatGoldenPathDirection({goldenPathDirection: [{id: 'issue-1', score: 'x'}, {id: 'issue-2'}]});
+            expect(dir).toContain('1. issue-1');
+            expect(dir).toContain('2. issue-2');
+            expect(dir).not.toContain('NaN');
+            expect(dir).not.toContain('score');        // neither entry carries a finite score
+        });
+    });
 });
 
 test.describe('laneStateStopHook — formatHoldCostumeCallout + composeBlockDirective wiring', () => {
@@ -270,12 +307,16 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
      * @param {{enforce: Boolean, promptingText: (String|null), stopHookActive: Boolean}} [opts]
      * @returns {Promise<{stdout: String, log: String}>}
      */
-    function runHook(finalText, {enforce = false, promptingText = null, stopHookActive = false} = {}) {
+    function runHook(finalText, {enforce = false, promptingText = null, stopHookActive = false, lifecycleState = null} = {}) {
         return new Promise((resolve, reject) => {
             const dir            = fs.mkdtempSync(path.join(os.tmpdir(), 'lane-hook-e2e-')),
                   transcriptPath = path.join(dir, 'transcript.jsonl'),
                   env            = {...process.env, NEO_AI_DAEMON_DIR: dir},
                   payload        = {stop_hook_active: stopHookActive, session_id: 'e2e'};
+
+            if (lifecycleState !== null) {
+                fs.writeFileSync(path.join(dir, 'lifecycle-state.json'), JSON.stringify(lifecycleState), 'utf8');
+            }
 
             if (promptingText !== null) {
                 fs.writeFileSync(transcriptPath, [
@@ -389,5 +430,18 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         const {stdout, log} = await runHook(validTerminal, {enforce: true, promptingText: 'please do X', stopHookActive: true});
         expect(log).toContain('BLOCK');
         expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('ENFORCE block injects the Golden Path release-goal direction from lifecycle-state (#13751)', async () => {
+        const {stdout, log} = await runHook(block('{"laneContinuation":"verified-no-lane"}'), {
+            enforce       : true,
+            promptingText : '[WAKE] 1 event',
+            lifecycleState: {goldenPathDirection: [{id: 'issue-14442', score: 13.5, title: 'Business engine'}]}
+        });
+        expect(log).toContain('BLOCK');
+        const decision = JSON.parse(stdout);
+        expect(decision.decision).toBe('block');
+        expect(decision.reason).toContain('Release-goal direction');
+        expect(decision.reason).toContain('issue-14442 — score 13.50 — Business engine');
     });
 });


### PR DESCRIPTION
Resolves #13751 — the stop-hook hook-READ consumer for the Computed Golden Path release-goal direction (#13751's full scope).

`formatGoldenPathDirection(state)` injects the top-N ROI-ranked lanes into `composeBlockDirective`, so the stop-hook's forced next-action is anchored to the release goal — the productive-derailment guard ("not rewarded for *any* named lane", the ticket's thesis).

## Consumer / producer split (#13751 = the consumer; the producer is a separate, unscoped writer)

Verified by reading the live hook (design resolution: https://github.com/neomjs/neo/issues/13751#issuecomment-4864311278):
- **This PR — consumer (#13751, its full scope):** the hook reads a `goldenPathDirection` field from `lifecycle-state.json` (fail-open) and renders it. **L1/L2 input-quality** — it enriches the injected block *reason*; the **L3 block decision (`decideHookAction`) is untouched** (not a Tier-4 teeth change). Reads `lifecycle-state.json` once, shared by the direction + board formatters.
- **Producer — writer (not yet scoped):** a `lifecycle-state.json` writer extracts the top-N from the sandman handoff's Computed Golden Path (sourced by the route-attribution ledger, PR #14458) → writes the `goldenPathDirection` field. **No writer for `lifecycle-state.json` exists yet** (the closed board consumer `#13678` shipped dormant for the same reason); this producer is a separate lane still to be filed/coordinated. *(Correction: earlier drafts + A2As named #13623 as the producer — that is wrong. #13623 is the no-hold-state L-collab ratio-observability ticket, currently `not-code-ready`; it is not this writer.)*
- The consumer is **fail-open** (renders the bare reminder) until a producer writes the field — mirroring the closed `#13678` board consumer, which shipped + closed while its writer was still absent. `Resolves #13751` on that precedent: **the hook-read consumer is #13751's full scope and is delivered here.** The producer is a separate lane; this PR does **not** leave #13751 partially open — the remaining producer work is that separate lane's deliverable, not a #13751 residual.

**Contract** (`state.goldenPathDirection`): an array of `{id, score?, title?}`, **pre-ranked by the producer** — the hook renders the producer's order verbatim (ranking is the Golden Path's job; the advisory / no-auto-action spine, per #14447 / #14453). This contract is the stable target the future `lifecycle-state.json` writer fills.

Evidence: L2 (hermetic unit — 4 `formatGoldenPathDirection` cases + an e2e case proving `composeBlockDirective` injects the direction from a written `lifecycle-state.json`; 47/47 green). No live-store dependence.

## Deltas from ticket

- **Scope is the CONSUMER half only** — a fail-open-consumer-before-producer increment. #13751 (the consumer) is delivered here; the producer (the still-unscoped `lifecycle-state.json` writer) is a separate lane.
- **Stale labels cleared:** removed `not-code-ready` + `needs-design` from #13751 — the consumer is code-ready and delivered (per @neo-gpt's #14463 review path (a): #13751 is the delivered consumer leaf, precedent `#13678`).
- **Design entanglement resolved by reading the live hook** (not designed from priors): #13751 ⊆ the closed `#13678` hook-read enrichment; the missing piece is a `lifecycle-state.json` writer (unscoped); source = the #14458 route-attribution ledger. Full resolution on the ticket (issue-4864311278).
- **Additive / fail-open**: an absent (no writer yet) / empty / stale / malformed field degrades to the bare reminder, never blocks — a zero-signal never starves the directive floor.

## Test Evidence

- `UNIT_TEST_MODE=true npm run test-unit -- test/playwright/unit/hooks/laneStateStopHook.spec.mjs` → **47/47 green** (independently re-run by @neo-gpt at head `7d1bbfd01`).
- New: 4 `formatGoldenPathDirection` cases (render with score/title; fail-open on null / non-object / empty / `not-an-array` / no-writer-yet; skip idless/null entries without throwing; optional/non-finite score omitted cleanly) + 1 e2e (`runHook` writes `lifecycle-state.json` with `goldenPathDirection` → asserts the blocked directive injects `Release-goal direction — … issue-14442 — score 13.50 — Business engine`).
- `node --check` on the hook: OK (never ship a broken parse on the live-enforcing hook). agent-preflight + all pre-commit gates (whitespace / shorthand / aiconfig-test-mutation / jsdoc-types / ticket-archaeology 0-violations / block-alignment): pass.
- Consumed-format-SSOT sweep: the block-directive has **no enumerating format-SSOT** (unlike the handoff's `sandman-handoff-format.md`); its components are self-documented in the `composeBlockDirective` JSDoc (updated here). A *verified* negative.

## Post-Merge Validation

- [ ] N/A for the consumer — it is fail-open and dormant until a producer exists (unit + e2e covered; no live behavior to validate at merge). The end-to-end direction-rendering is validated under the separate producer lane (the `lifecycle-state.json` writer) when it lands — not a #13751 residual.

## Boundary carried

- No allow-path, no weakening of the block decision (L3 teeth = operator / Tier-4-owned; this is L1/L2 input-quality only).
- Advisory-only: the direction is DATA the agent reads and chooses from; the hook never auto-reprioritizes.

Authored by Grace (@neo-opus-grace, Claude Opus 4.8).
