### PR TITLE
docs(skills): mark PR-body Deltas heading as unconditional lint anchor (#14467)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -302,7 +302,7 @@ Resolves #N
 Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target ACs requiring it>). Residual: AC<N> [#<close-target>].
 
 ## Deltas from ticket
-<scope additions, better solutions, discovered edge cases — state "None substantive" when empty; this heading is a CI lint anchor and MUST be present>
+<scope additions, better solutions, edge cases — "None substantive" when empty; heading is a lint anchor>
 
 ## Test Evidence
 <commands run, results, coverage>
@@ -317,7 +317,7 @@ Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target 
 <one compressed paragraph per pivot — why direction changed, not the old text>
 ```
 
-The `agent-pr-body-lint` workflow enforces these headings as **unconditional substring anchors** — visible: `Evidence:`, `## Test Evidence`, `## Post-Merge Validation`; invisible: `## Deltas`, `Authored by `. Prose conditionality never applies to heading presence (sync-by-convention with `.github/workflows/agent-pr-body-lint.yml`; empirical anchor: PR #14465's post-open red check).
+`agent-pr-body-lint.yml` enforces `Evidence:`, `## Test Evidence`, `## Post-Merge Validation`, `## Deltas`, `Authored by ` as **unconditional** anchors — presence is never prose-conditional (PR #14465).
 
 **Evidence declaration discipline (`#10698` graduation artifact):**
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -301,8 +301,8 @@ Resolves #N
 
 Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target ACs requiring it>). Residual: AC<N> [#<close-target>].
 
-## Deltas from ticket (if any)
-<scope additions, better solutions, discovered edge cases>
+## Deltas from ticket
+<scope additions, better solutions, discovered edge cases — state "None substantive" when empty; this heading is a CI lint anchor and MUST be present>
 
 ## Test Evidence
 <commands run, results, coverage>
@@ -316,6 +316,8 @@ Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target 
 ## Evolution (optional, only if pivots occurred during implementation)
 <one compressed paragraph per pivot — why direction changed, not the old text>
 ```
+
+The `agent-pr-body-lint` workflow enforces these headings as **unconditional substring anchors** — visible: `Evidence:`, `## Test Evidence`, `## Post-Merge Validation`; invisible: `## Deltas`, `Authored by `. Prose conditionality never applies to heading presence (sync-by-convention with `.github/workflows/agent-pr-body-lint.yml`; empirical anchor: PR #14465's post-open red check).
 
 **Evidence declaration discipline (`#10698` graduation artifact):**
 


### PR DESCRIPTION
Resolves #14467

Aligns `pull-request-workflow.md` §9 with the `agent-pr-body-lint` enforcement reality: the `## Deltas from ticket` heading loses its misleading "(if any)" (the validator requires the anchor unconditionally), gains state-"None substantive"-when-empty guidance in the placeholder, and a sync-by-convention sentence under the template block now names all five lint anchors with a pointer at the workflow file. Authoring source and enforcement source no longer disagree.

Evidence: L1 (docs-only — skill reference prose; no runtime surface). Empirical anchor: PR #14465 failed run 28583491232 for exactly this omission, passed run 28583620814 after the body edit.

## Deltas from ticket
None substantive — implements the ticket's Fix section verbatim (both ACs; the third AC is the no-change boundary, held).

## Test Evidence
- `npm run agent-preflight -- --no-fix <file>` → all requested gates passed
- Anchor cross-check: the five names in the new sentence match `VISIBLE_PR_BODY_ANCHORS` + `INVISIBLE_PR_BODY_ANCHORS` in `.github/workflows/agent-pr-body-lint.yml` (lines ~55–64) verbatim.

## Post-Merge Validation
- [ ] Next agent-authored PR that reads §9 ships the `## Deltas` section on first open (no post-open body-edit round-trip).

## Slot rationale (substrate-mutation pre-flight, §1.1)
- Modified section: §9 minimum-viable structure — disposition `rewrite` (2-line prose alignment + 1 sync sentence). Loaded only on `pull-request` skill invocation (not always-loaded); net +2 lines against a documented recurring failure-class (post-open red check + body-edit round-trip per occurrence). Trigger-frequency: every agent PR; failure-severity: CI red on otherwise-green PRs; enforceability: CI-mechanical (the anchor check itself).

Related: #11501, #11502, #14465

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 1d4262a2-a001-4387-9372-3923f024be8e.