### PR TITLE
feat(hooks): emit lifecycle state writer (#14466)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -2,6 +2,7 @@ import fs                                                      from 'fs';
 import path                                                    from 'path';
 import {fileURLToPath}                                         from 'url';
 import { Memory_Config as aiConfig }                           from '../../services.mjs';
+import { Memory_MailboxService as MailboxService }             from '../../services.mjs';
 import Base                                                    from '../../../src/core/Base.mjs';
 import { Memory_StorageRouter as StorageRouter }               from '../../services.mjs';
 import { Memory_TextEmbeddingService as TextEmbeddingService } from '../../services.mjs';
@@ -76,6 +77,10 @@ import {
     recordGoldenPathSelection          as recordRouteSelection,
     renderGoldenPathRouteLedgerSection as renderRouteLedgerSection
 } from './goldenPathRouteLedger.mjs';
+import {
+    buildLifecycleState     as buildHookLifecycleState,
+    writeLifecycleStateFile as writeHookLifecycleStateFile
+} from './lifecycleStateWriter.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -580,9 +585,31 @@ class GoldenPathSynthesizer extends Base {
         return renderConsolidationGaps(summaryColl, options)
     }
 
+    /**
+     * @summary Delegates hook lifecycle-state payload construction to the shared writer helper.
+     * @param {Object} options Lifecycle-state source payload.
+     * @returns {Promise<Object>}
+     */
+    static buildLifecycleState(options) {
+        return buildHookLifecycleState(options)
+    }
+
+    /**
+     * @summary Delegates atomic hook lifecycle-state writes to the shared writer helper.
+     * @param {Object} options Write target and state payload.
+     * @returns {String}
+     */
+    static writeLifecycleStateFile(options) {
+        return writeHookLifecycleStateFile(options)
+    }
+
     async synthesizeGoldenPath({
         repoEnrichmentEnabled = true,
         issuesDir = path.resolve(__dirname, '../../../resources/content/issues'),
+        lifecycleStateAgentIdentity = process.env.NEO_AGENT_IDENTITY,
+        lifecycleStateEnabled = repoEnrichmentEnabled,
+        lifecycleStateFile,
+        lifecycleStateMailboxService = MailboxService,
         now = new Date()
     } = {}) {
         logger.info('[GoldenPathSynthesizer] Initializing Hybrid GraphRAG Strategic Traversal...');
@@ -1120,7 +1147,8 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         }
 
         // --- Active PR Cycle State ---
-        let prStateAppend = '';
+        let prStateAppend = '',
+            lifecyclePrs;
         if (repoEnrichmentEnabled) {
             try {
                 const Synthesizer = this.constructor,
@@ -1131,6 +1159,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                     throw new Error('fetchOpenPRs did not return an array');
                 }
 
+                lifecyclePrs  = prs;
                 prStateAppend = Synthesizer.renderActivePrCycleState({prs, capturedAt, now: capturedAt});
             } catch (e) {
                 logger.warn('[GoldenPathSynthesizer] Failed to generate Active PR Cycle State', e);
@@ -1187,6 +1216,25 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         fs.mkdirSync(path.dirname(handoffFile), {recursive: true});
         fs.writeFileSync(handoffFile, handoffContent.trim() + '\n', 'utf-8');
         logger.info(`[GoldenPathSynthesizer] sandman_handoff.md freshly generated via Centralized Pipeline. Golden Path integrated.`);
+
+        if (lifecycleStateEnabled) {
+            try {
+                const lifecycleState = await this.constructor.buildLifecycleState({
+                    agentIdentity : lifecycleStateAgentIdentity,
+                    generatedAt   : handoffTimestamp,
+                    mailboxService: lifecycleStateMailboxService,
+                    prs           : lifecyclePrs,
+                    routedTopNodes
+                });
+
+                this.constructor.writeLifecycleStateFile({
+                    filePath: lifecycleStateFile,
+                    state   : lifecycleState
+                });
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Failed to write lifecycle-state.json', e);
+            }
+        }
 
         logger.info(`[GoldenPathSynthesizer] Mathematical Golden Path established. Anchored ${topNodes.length} strategic nodes to frontier.`);
 

--- a/ai/services/graph/lifecycleStateWriter.mjs
+++ b/ai/services/graph/lifecycleStateWriter.mjs
@@ -1,0 +1,245 @@
+import fs                     from 'fs';
+import path                   from 'path';
+import {fileURLToPath}        from 'url';
+import RequestContextService  from '../../mcp/server/shared/services/RequestContextService.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+export const DEFAULT_LIFECYCLE_STATE_FILE = path.resolve(__dirname, '../../../.claude/logs/lifecycle-state.json');
+
+/**
+ * @module ai/services/graph/lifecycleStateWriter
+ * @summary Shared writer for the stop-hook lifecycle-state board.
+ *
+ * Owner contract: produce the single fail-open JSON file read by
+ * `.claude/hooks/laneStateStopHook.mjs`, using data already resolved by the Golden Path
+ * synthesis pass plus the bound-agent mailbox counter. The hook remains read-only; this
+ * helper owns the temp+rename write and degrades by omitting unverifiable fields rather
+ * than fabricating state.
+ */
+
+/**
+ * @summary Normalizes AgentIdentity or GitHub-login strings to `@identity` form.
+ * @param {String|null|undefined} value Identity candidate.
+ * @returns {String|null}
+ */
+export function normalizeAgentIdentity(value) {
+    const str = String(value || '').trim();
+
+    if (!str) return null;
+
+    return str.startsWith('@') ? str : `@${str}`
+}
+
+/**
+ * @summary Converts an AgentIdentity or GitHub login to the bare GitHub login form.
+ * @param {String|null|undefined} value Identity candidate.
+ * @returns {String|null}
+ */
+export function getAgentLogin(value) {
+    const normalized = normalizeAgentIdentity(value);
+
+    return normalized ? normalized.slice(1) : null
+}
+
+/**
+ * @summary Derives the compact hook-board state for an open PR.
+ *
+ * The hook renders only `#number state`, so this keeps the state intentionally coarse:
+ * active review changes beat outstanding review requests, then approval, then plain open.
+ *
+ * @param {Object} pr GitHub PR payload.
+ * @returns {String}
+ */
+export function getOpenPrBoardState(pr) {
+    const reviews = Array.isArray(pr?.reviews) ? pr.reviews : [];
+
+    if (reviews.some(review => review?.state === 'CHANGES_REQUESTED')) return 'CHANGES_REQUESTED';
+    if (Array.isArray(pr?.reviewRequests) && pr.reviewRequests.length > 0) return 'REVIEW_REQUESTED';
+    if (reviews.some(review => review?.state === 'APPROVED')) return 'APPROVED';
+
+    return 'OPEN'
+}
+
+/**
+ * @summary Projects current-agent open PR payloads into the hook's bounded board shape.
+ * @param {Object[]} prs GitHub PR payloads from `fetchOpenPRs`.
+ * @param {Object} [options]
+ * @param {String} [options.agentIdentity=process.env.NEO_AGENT_IDENTITY] Active AgentIdentity.
+ * @param {Number} [options.limit=10] Maximum board rows.
+ * @returns {Object[]}
+ */
+export function buildOpenPrBoard(prs = [], {
+    agentIdentity = process.env.NEO_AGENT_IDENTITY,
+    limit = 10
+} = {}) {
+    if (!Array.isArray(prs)) return [];
+
+    const agentLogin = getAgentLogin(agentIdentity);
+    if (!agentLogin) return [];
+
+    return prs
+        .filter(pr => pr?.author?.login === agentLogin)
+        .sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0))
+        .slice(0, limit)
+        .filter(pr => typeof pr.number === 'number' || typeof pr.number === 'string')
+        .map(pr => ({
+            number: pr.number,
+            state : getOpenPrBoardState(pr)
+        }))
+}
+
+/**
+ * @summary Projects routed Computed Golden Path nodes into the hook's advisory direction field.
+ * @param {Object[]} routedTopNodes Golden Path routed node entries.
+ * @param {Object} [options]
+ * @param {Number} [options.limit=5] Maximum direction rows.
+ * @returns {Object[]}
+ */
+export function buildGoldenPathDirection(routedTopNodes = [], {
+    limit = 5
+} = {}) {
+    if (!Array.isArray(routedTopNodes)) return [];
+
+    return routedTopNodes
+        .filter(item => item?.node?.id)
+        .slice(0, limit)
+        .map(item => {
+            const title = item.node.properties?.title || item.node.properties?.name || item.node.name;
+            const row   = {id: String(item.node.id)};
+
+            if (Number.isFinite(Number(item.score))) {
+                row.score = Number(item.score);
+            }
+            if (typeof title === 'string' && title.trim()) {
+                row.title = title.trim();
+            }
+
+            return row
+        })
+}
+
+/**
+ * @summary Counts unread inbox messages for the active agent, binding env identity when needed.
+ * @param {Object} options
+ * @param {Object} options.mailboxService MailboxService-compatible object.
+ * @param {Object} [options.requestContextService=RequestContextService] Context service.
+ * @param {String} [options.agentIdentity=process.env.NEO_AGENT_IDENTITY] Active AgentIdentity.
+ * @returns {Promise<Number|undefined>} Verified unread count, or `undefined` when unavailable.
+ */
+export async function resolveUnreadCount({
+    mailboxService,
+    requestContextService = RequestContextService,
+    agentIdentity = process.env.NEO_AGENT_IDENTITY
+} = {}) {
+    if (typeof mailboxService?.countMessages !== 'function') return undefined;
+
+    const readCount = async () => {
+        const result = await mailboxService.countMessages({box: 'inbox', status: 'unread'});
+        const count  = Number(result?.count);
+
+        return Number.isInteger(count) && count >= 0 ? count : undefined
+    };
+
+    let activeIdentity = null;
+
+    try {
+        activeIdentity = requestContextService?.getAgentIdentityNodeId?.();
+    } catch {
+        activeIdentity = null;
+    }
+
+    try {
+        if (activeIdentity) {
+            return await readCount()
+        }
+
+        const normalized = normalizeAgentIdentity(agentIdentity);
+        if (!normalized || typeof requestContextService?.run !== 'function') return undefined;
+
+        const userId = normalized.slice(1);
+
+        return await requestContextService.run({
+            agentIdentityNodeId: normalized,
+            source             : 'env-var',
+            userId,
+            username           : userId
+        }, readCount)
+    } catch {
+        return undefined
+    }
+}
+
+/**
+ * @summary Builds the lifecycle-state JSON payload from verified source data.
+ * @param {Object} options
+ * @param {Date|String} [options.generatedAt=new Date()] Capture time.
+ * @param {Object[]} [options.prs] Open PR payloads; omitted from output when unavailable.
+ * @param {Object[]} [options.routedTopNodes] Routed Golden Path entries; omitted when unavailable.
+ * @param {Object} [options.mailboxService] MailboxService-compatible object.
+ * @param {String} [options.agentIdentity=process.env.NEO_AGENT_IDENTITY] Active AgentIdentity.
+ * @param {Object} [options.requestContextService=RequestContextService] Context service.
+ * @returns {Promise<Object>} Lifecycle-state payload.
+ */
+export async function buildLifecycleState({
+    generatedAt = new Date(),
+    prs,
+    routedTopNodes,
+    mailboxService,
+    agentIdentity = process.env.NEO_AGENT_IDENTITY,
+    requestContextService = RequestContextService
+} = {}) {
+    const generatedDate = generatedAt instanceof Date ? generatedAt : new Date(generatedAt);
+    const state         = {
+        generatedAt: Number.isFinite(generatedDate.getTime())
+            ? generatedDate.toISOString()
+            : new Date().toISOString()
+    };
+
+    if (Array.isArray(prs)) {
+        state.openPRs = buildOpenPrBoard(prs, {agentIdentity});
+    }
+
+    if (Array.isArray(routedTopNodes)) {
+        state.goldenPathDirection = buildGoldenPathDirection(routedTopNodes);
+    }
+
+    const unreadCount = await resolveUnreadCount({
+        agentIdentity,
+        mailboxService,
+        requestContextService
+    });
+    if (Number.isInteger(unreadCount) && unreadCount >= 0) {
+        state.unreadCount = unreadCount;
+    }
+
+    return state
+}
+
+/**
+ * @summary Atomically writes the lifecycle-state payload for hook consumption.
+ * @param {Object} options
+ * @param {String} [options.filePath=DEFAULT_LIFECYCLE_STATE_FILE] Target JSON path.
+ * @param {Object} options.state Lifecycle-state payload.
+ * @param {Object} [options.fsImpl=fs] fs-compatible implementation for tests.
+ * @returns {String} Written target path.
+ */
+export function writeLifecycleStateFile({
+    filePath = DEFAULT_LIFECYCLE_STATE_FILE,
+    state,
+    fsImpl = fs
+} = {}) {
+    if (!state || typeof state !== 'object') {
+        throw new Error('Cannot write lifecycle-state: state object required');
+    }
+
+    const dir     = path.dirname(filePath);
+    const tmpPath = path.join(dir, `.lifecycle-state.${process.pid}.${Date.now()}.tmp`);
+
+    fsImpl.mkdirSync(dir, {recursive: true});
+    fsImpl.writeFileSync(tmpPath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+    fsImpl.renameSync(tmpPath, filePath);
+
+    return filePath
+}

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -36,6 +36,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     let renderSilentThreadCandidatesSection;
     let renderGoldenPathRouteLedgerSection;
     let issueFocusSections;
+    let defaultLifecycleStateFile;
 
     let StorageRouter;
     let TextEmbeddingService;
@@ -78,6 +79,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         buildSilentThreadCandidates = GoldenPathSynthesizer.constructor.buildSilentThreadCandidates.bind(GoldenPathSynthesizer.constructor);
         renderSilentThreadCandidatesSection = GoldenPathSynthesizer.constructor.renderSilentThreadCandidatesSection.bind(GoldenPathSynthesizer.constructor);
         ({renderGoldenPathRouteLedgerSection} = await import('../../../../../../ai/services/graph/goldenPathRouteLedger.mjs'));
+        ({DEFAULT_LIFECYCLE_STATE_FILE: defaultLifecycleStateFile} = await import('../../../../../../ai/services/graph/lifecycleStateWriter.mjs'));
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         StorageRouter = (await import('../../../../../../ai/services.mjs')).Memory_StorageRouter;
@@ -126,6 +128,9 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
 
         if (fs.existsSync(tmpHandoffFile)) {
             try { fs.unlinkSync(tmpHandoffFile); } catch(e) {}
+        }
+        if (defaultLifecycleStateFile && fs.existsSync(defaultLifecycleStateFile)) {
+            try { fs.unlinkSync(defaultLifecycleStateFile); } catch(e) {}
         }
     });
 
@@ -272,6 +277,41 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(await Synthesizer.getRecentSummaryDocuments(collection, 2)).toEqual({documents: []});
     });
 
+    test('buildLifecycleState omits unavailable source fields instead of fabricating hook-board data (#14466)', async () => {
+        const Synthesizer = GoldenPathSynthesizer.constructor;
+        const contexts    = [];
+        const state       = await Synthesizer.buildLifecycleState({
+            agentIdentity       : 'neo-gpt',
+            generatedAt         : '2026-07-02T11:00:00.000Z',
+            mailboxService      : {
+                countMessages: async () => {
+                    throw new Error('mailbox unavailable')
+                }
+            },
+            prs                 : null,
+            requestContextService: {
+                getAgentIdentityNodeId: () => {
+                    throw new Error('unbound context')
+                },
+                run: async (context, callback) => {
+                    contexts.push(context);
+                    return callback()
+                }
+            },
+            routedTopNodes      : undefined
+        });
+
+        expect(state).toEqual({
+            generatedAt: '2026-07-02T11:00:00.000Z'
+        });
+        expect(contexts[0]).toMatchObject({
+            agentIdentityNodeId: '@neo-gpt',
+            source             : 'env-var',
+            userId             : 'neo-gpt',
+            username           : 'neo-gpt'
+        });
+    });
+
     test('findLastQualifyingAssignmentActivity treats owner identity comments as maintainer progress acknowledgements', () => {
         const Synthesizer = GoldenPathSynthesizer.constructor;
         const activity    = Synthesizer.findLastQualifyingAssignmentActivity({
@@ -344,6 +384,121 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).not.toContain('- **Reviewers**:');
         expect(handoffContent).not.toContain('- **Status**:');
         expect(handoffContent).not.toContain('- **Head SHA**:');
+    });
+
+    test('synthesizeGoldenPath writes the shared lifecycle-state hook board from resolved sources (#14466)', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
+        const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate             = OpenAiCompatible.prototype.generate;
+        const tempDir                      = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-lifecycle-state-'));
+        const issuesDir                    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-lifecycle-issues-'));
+        const lifecycleStateFile           = path.join(tempDir, 'lifecycle-state.json');
+        const now                          = new Date('2026-07-02T11:15:00.000Z');
+        const suffix                       = `${process.pid}-${Date.now()}`;
+        const readyId                      = `issue-lifecycle-${suffix}`;
+        let   countCalls                   = 0;
+        aiConfig.vectorDimension = 2;
+
+        GraphService.upsertNode({
+            id        : readyId,
+            type      : 'ISSUE',
+            state     : 'OPEN',
+            properties: {
+                labels: ['enhancement', 'ai'],
+                state : 'OPEN',
+                title : 'Emit lifecycle state writer'
+            }
+        });
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => ({
+                ids      : [[readyId]],
+                distances: [[0.1]]
+            })
+        });
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['lifecycle writer context']})});
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [
+            {
+                number        : 14466,
+                url           : 'https://github.com/neomjs/neo/pull/14466',
+                author        : {login: 'neo-gpt'},
+                title         : 'feat(hooks): emit lifecycle state writer',
+                body          : '',
+                createdAt     : '2026-07-02T10:41:08Z',
+                headRefOid    : 'abcdef1234567890',
+                reviewRequests: [{login: 'neo-opus-grace'}],
+                reviews       : [
+                    {state: 'CHANGES_REQUESTED', submittedAt: '2026-07-02T10:55:00Z', author: {login: 'neo-opus-grace'}}
+                ],
+                comments      : []
+            },
+            {
+                number        : 14465,
+                url           : 'https://github.com/neomjs/neo/pull/14465',
+                author        : {login: 'neo-fable'},
+                title         : 'docs(blog): publish time capsule',
+                body          : '',
+                createdAt     : '2026-07-02T10:00:00Z',
+                headRefOid    : 'fedcba0987654321',
+                reviewRequests: [],
+                reviews       : [],
+                comments      : []
+            }
+        ];
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"Lifecycle state writer is the immediate route."}'});
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({
+                issuesDir,
+                lifecycleStateAgentIdentity: '@neo-gpt',
+                lifecycleStateFile,
+                lifecycleStateMailboxService: {
+                    countMessages: async ({box, status}) => {
+                        countCalls++;
+                        expect({box, status}).toEqual({box: 'inbox', status: 'unread'});
+                        return {count: 3}
+                    }
+                },
+                now
+            });
+        } finally {
+            GoldenPathSynthesizer.fetchOpenPRs  = originalFetchOpenPRs;
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            OpenAiCompatible.prototype.generate = originalGenerate;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+
+        try {
+            const lifecycleState = JSON.parse(fs.readFileSync(lifecycleStateFile, 'utf-8'));
+
+            expect(countCalls).toBe(1);
+            expect(lifecycleState).toMatchObject({
+                generatedAt        : '2026-07-02T11:15:00.000Z',
+                goldenPathDirection: [
+                    {
+                        id   : readyId,
+                        title: 'Emit lifecycle state writer'
+                    }
+                ],
+                openPRs: [
+                    {
+                        number: 14466,
+                        state : 'CHANGES_REQUESTED'
+                    }
+                ],
+                unreadCount: 3
+            });
+            expect(lifecycleState.goldenPathDirection[0].score).toBeCloseTo(10, 5);
+            expect(fs.readdirSync(tempDir).filter(name => name.startsWith('.lifecycle-state.'))).toEqual([]);
+        } finally {
+            fs.rmSync(tempDir, {recursive: true, force: true});
+        }
     });
 
     test('synthesizeGoldenPath overwrites stale author sections when semantic candidates are empty', async () => {


### PR DESCRIPTION
Resolves #14466

Adds the shared Phase-1 lifecycle-state producer that writes the single hook-board file consumed by `.claude/hooks/laneStateStopHook.mjs`: `.claude/logs/lifecycle-state.json`. The writer lives under the Golden Path graph service boundary, reuses the existing open-PR enrichment pass, binds unread A2A counting to the active agent identity, projects the current Golden Path route into `goldenPathDirection`, and writes via temp-file + rename so the stop hook never sees a normal partial write.

Evidence: L2 (focused unit/static coverage in the sandbox: producer payload, atomic write, Golden Path integration, existing hook fail-open consumer tests) -> L3 required (post-merge real Golden Path/orchestrator cadence writes the file and a real stop-hook block reads it). Residual: post-merge hook/orchestrator smoke validation below.

## Deltas from ticket

The implementation keeps the CLI runner passive and invokes the writer from `GoldenPathSynthesizer.synthesizeGoldenPath()`, immediately after the handoff render succeeds. Source failures degrade by omitting unverifiable fields: failed PR fetch omits `openPRs`; failed mailbox identity/count omits `unreadCount`; unavailable route data omits `goldenPathDirection`. No #13623 AC4 ratio/re-tread/operator-scope fields were added.

## Test Evidence

- `node --check ai/services/graph/lifecycleStateWriter.mjs` -> pass
- `node --check ai/services/graph/GoldenPathSynthesizer.mjs` -> pass
- `npm run agent-preflight -- --no-fix ai/services/graph/lifecycleStateWriter.mjs ai/services/graph/GoldenPathSynthesizer.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` -> all requested gates passed
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` -> 41 passed
- `npm run test-unit -- test/playwright/unit/hooks/laneStateStopHook.spec.mjs` -> 47 passed

## Post-Merge Validation

- [ ] Run the real Golden Path/orchestrator cadence and verify `.claude/logs/lifecycle-state.json` is generated with `generatedAt`, `openPRs`, `unreadCount`, and `goldenPathDirection` when sources are available.
- [ ] Trigger a real stop-hook block and verify the generated lifecycle-state file enriches the no-hold directive without changing fail-open behavior.

## Commits

- `886e8a53e3` — `feat(hooks): emit lifecycle state writer (#14466)`

## Review routing

CI is expected to run on PR open. Per the PR routing contract, I will request exactly one cross-family primary reviewer after current-head CI is green.

Authored by Euclid (GPT-5, Codex Desktop). Session 019f2047-5787-7ed3-bfd5-552e3f2ab7e1.
