### PR TITLE
feat(graph): render work-graph stall findings (#14462)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -536,6 +536,17 @@ class Config extends ConfigProvider {
              */
             goldenPathSilentThreadRenderLimit: leaf(5, 'NEO_GOLDEN_PATH_SILENT_THREAD_RENDER_LIMIT', 'number'),
             /**
+             * Render switch for the visibility-only Work-Graph Stall Inference handoff section.
+             * Detection remains data-only; disabling this leaf only removes the pull-surface.
+             * @type {boolean}
+             */
+            goldenPathStallFindingRenderEnabled: leaf(true, 'NEO_GOLDEN_PATH_STALL_FINDING_RENDER_ENABLED', 'boolean'),
+            /**
+             * Maximum verified/advisory stall findings rendered into the Sandman handoff.
+             * @type {number}
+             */
+            goldenPathStallFindingRenderLimit: leaf(5, 'NEO_GOLDEN_PATH_STALL_FINDING_RENDER_LIMIT', 'number'),
+            /**
              * Maximum recent open PR rows rendered inside `Active PR Cycle State`.
              * @type {number}
              */

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -51,6 +51,7 @@ import {
     buildCurrentFocusCandidates as buildIssueFocusCurrentFocusCandidates,
     buildSilentThreadCandidates as buildIssueFocusSilentThreadCandidates,
     buildStaleAssignmentCandidates as buildIssueFocusStaleAssignmentCandidates,
+    buildWorkGraphStallFindings as buildIssueFocusWorkGraphStallFindings,
     collectIssueMarkdownFiles as collectIssueFocusMarkdownFiles,
     extractAssignmentEvents as extractIssueFocusAssignmentEvents,
     extractIssueCommentBlocks as extractIssueFocusCommentBlocks,
@@ -63,6 +64,7 @@ import {
     renderCurrentFocusCandidatesSection as renderIssueFocusCurrentFocusCandidatesSection,
     renderSilentThreadCandidatesSection as renderIssueFocusSilentThreadCandidatesSection,
     renderStaleAssignmentCandidatesSection as renderIssueFocusStaleAssignmentCandidatesSection,
+    renderWorkGraphStallFindingsSection as renderIssueFocusWorkGraphStallFindingsSection,
     scoreCurrentFocusIssue as scoreIssueFocusCurrentIssue
 } from './issueFocusSections.mjs';
 import {
@@ -272,6 +274,25 @@ class GoldenPathSynthesizer extends Base {
      */
     static renderSilentThreadCandidatesSection(candidates, options = {}) {
         return renderIssueFocusSilentThreadCandidatesSection(candidates, options)
+    }
+
+    /**
+     * @summary Delegates deterministic work-graph stall finding construction to the issue-focus helper.
+     * @param {Object} options See `issueFocusSections.buildWorkGraphStallFindings`.
+     * @returns {Object[]} Work-graph stall finding payloads.
+     */
+    static buildWorkGraphStallFindings(options = {}) {
+        return buildIssueFocusWorkGraphStallFindings(options)
+    }
+
+    /**
+     * @summary Delegates visibility-only stall finding handoff rendering to the issue-focus helper.
+     * @param {Object[]} findings Stall finding payloads.
+     * @param {Object} options See `issueFocusSections.renderWorkGraphStallFindingsSection`.
+     * @returns {String}
+     */
+    static renderWorkGraphStallFindingsSection(findings, options = {}) {
+        return renderIssueFocusWorkGraphStallFindingsSection(findings, options)
     }
 
     /**
@@ -555,7 +576,7 @@ class GoldenPathSynthesizer extends Base {
      */
     async fetchOpenPRs() {
         const { execSync } = await import('child_process');
-        const rawPrData    = execSync('gh pr list --state open --json number,url,author,title,body,headRefOid,reviewRequests,reviews,comments,createdAt', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
+        const rawPrData    = execSync('gh pr list --state open --json number,url,author,title,body,headRefOid,reviewRequests,reviews,comments,createdAt,updatedAt,isDraft', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
         return JSON.parse(rawPrData);
     }
 
@@ -1120,6 +1141,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         }
 
         // --- Active PR Cycle State ---
+        let openPrs       = [];
         let prStateAppend = '';
         if (repoEnrichmentEnabled) {
             try {
@@ -1131,6 +1153,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                     throw new Error('fetchOpenPRs did not return an array');
                 }
 
+                openPrs       = prs;
                 prStateAppend = Synthesizer.renderActivePrCycleState({prs, capturedAt, now: capturedAt});
             } catch (e) {
                 logger.warn('[GoldenPathSynthesizer] Failed to generate Active PR Cycle State', e);
@@ -1139,6 +1162,24 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                     error     : e,
                     now       : now instanceof Date ? now : new Date(now)
                 });
+            }
+        }
+
+        // --- Work-Graph Stall Inference ---
+        let stallFindingsAppend = '';
+        if (repoEnrichmentEnabled) {
+            try {
+                const Synthesizer = this.constructor,
+                      capturedAt  = now instanceof Date ? now : new Date(now),
+                      findings    = Synthesizer.buildWorkGraphStallFindings({
+                          issuesDir,
+                          now: capturedAt,
+                          prs: openPrs
+                      });
+
+                stallFindingsAppend = Synthesizer.renderWorkGraphStallFindingsSection(findings, {capturedAt});
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Failed to generate Work-Graph Stall Inference', e);
             }
         }
 
@@ -1181,7 +1222,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             }
         }
 
-        handoffContent += `${currentFocusAppend}${staleAssignmentAppend}${silentThreadsAppend}${prStateAppend}${backlogAppend}${routeLedgerAppend}${markdownAppend}`;
+        handoffContent += `${currentFocusAppend}${staleAssignmentAppend}${silentThreadsAppend}${prStateAppend}${stallFindingsAppend}${backlogAppend}${routeLedgerAppend}${markdownAppend}`;
 
         const handoffFile = aiConfig.handoffFilePath;
         fs.mkdirSync(path.dirname(handoffFile), {recursive: true});

--- a/ai/services/graph/issueFocusSections.mjs
+++ b/ai/services/graph/issueFocusSections.mjs
@@ -14,6 +14,8 @@ const DAY_MS                  = 24 * 60 * 60 * 1000;
 const CURRENT_FOCUS_WINDOW_MS = 3 * DAY_MS;
 const EPIC_LABEL              = 'epic';
 const V13_1_PATTERN           = /\bv13\.1\b/i;
+const STALL_FINDING_TTL_MS    = 7 * DAY_MS;
+const PR_PARKED_ON_PATTERN    = /^Parked-on:\s*(#[0-9]+|https?:\/\/\S+)(?:\s+\[([^\]]+)\])?\s+[-\u2013\u2014]\s+(.+)$/im;
 
 const CURRENT_FOCUS_EXCLUDED_LABELS = Object.freeze(new Set([
     'deferred-by-design',
@@ -32,6 +34,19 @@ const EPIC_CURRENT_FOCUS_REASONS = Object.freeze(new Set([
     'incident',
     'prio-zero',
     'v13.1'
+]));
+
+const DEFER_LABELS = Object.freeze(new Set([
+    'deferred-by-design',
+    'needs-design',
+    'needs-re-triage',
+    'not-code-ready',
+    'not code ready'
+]));
+
+const INACTIVE_PARTICIPATION_STATUSES = Object.freeze(new Set([
+    'operator_benched',
+    'temporarily_unreachable'
 ]));
 
 const MAINTAINER_PROGRESS_PATTERN = /\b(?:in[-\s]?progress|picking up|taking|claim(?:ed|ing)?|lane-claim|lane-state:\s*next-lane|working|implement(?:ing)?|opened\s+(?:PR|pull request)|PR\s*#\d+)\b/i;
@@ -68,6 +83,74 @@ export function getStaleAssignmentMaintainers() {
             .map(identity => getIdentityGithubLogin(identity))
             .filter(Boolean)
     )]
+}
+
+/**
+ * @summary Returns AgentIdentity participation state keyed by GitHub login.
+ *
+ * Stall inference consumes the same structured participation ledger as
+ * family-keyed quorum. It does not infer absence from message recency or raw
+ * issue timestamps.
+ *
+ * @param {Object[]} identities AgentIdentity roots.
+ * @returns {Map<String, Object>} Login without leading `@` to identity metadata.
+ */
+export function getParticipationStatusByLogin(identities = IDENTITIES) {
+    const statusByLogin = new Map();
+
+    for (const identity of identities) {
+        const login = getIdentityGithubLogin(identity);
+        if (!login) continue;
+
+        statusByLogin.set(login, {
+            authority          : identity.properties?.authority || null,
+            identityId         : identity.id,
+            login,
+            participationStatus: identity.properties?.participationStatus || 'unknown',
+            reactivationTrigger: identity.properties?.reactivationTrigger || null,
+            since              : identity.properties?.since || null,
+            statusReason       : identity.properties?.statusReason || null
+        });
+    }
+
+    return statusByLogin
+}
+
+/**
+ * @summary Converts arbitrary dates into stable ISO strings for finding payloads.
+ * @param {*} value Candidate date.
+ * @param {Date} fallback Fallback date.
+ * @returns {String}
+ */
+function toIsoString(value, fallback = new Date()) {
+    const date = value instanceof Date ? value : new Date(value);
+    if (!Number.isNaN(date.getTime())) return date.toISOString();
+
+    const fallbackDate = fallback instanceof Date ? fallback : new Date(fallback);
+    return fallbackDate.toISOString()
+}
+
+/**
+ * @summary Extracts a canonical issue id from synced issue frontmatter.
+ * @param {Object} meta Parsed frontmatter.
+ * @param {String} filePath Markdown source path.
+ * @returns {String}
+ */
+function getIssueId(meta = {}, filePath = '') {
+    const rawId = meta.id || meta.number || path.basename(filePath, '.md').replace(/^issue-/, '');
+
+    return String(rawId).startsWith('issue-') ? String(rawId) : `issue-${rawId}`
+}
+
+/**
+ * @summary Extracts the numeric issue number where possible.
+ * @param {Object} meta Parsed frontmatter.
+ * @param {String} issueId Canonical issue id.
+ * @returns {Number|String}
+ */
+function getIssueNumber(meta = {}, issueId = '') {
+    const raw = meta.id || meta.number || String(issueId).replace(/^issue-/, '');
+    return Number(raw) || raw
 }
 
 /**
@@ -554,6 +637,439 @@ export function renderSilentThreadCandidatesSection(candidates, {
             `last activity ${candidate.lastActivityAt} by @${candidate.lastActivityBy}; ` +
             `structural weight ${candidate.structuralWeight.toFixed(2)}; ` +
             `silence score ${candidate.silenceScore.toFixed(2)} (${candidate.reason})\n`;
+    }
+
+    return section
+}
+
+/**
+ * @summary Reads synced issue markdown into deterministic work-item records.
+ *
+ * @param {String} issuesDir Local synced issue directory.
+ * @returns {Array<Object>} Parsed issue work records.
+ */
+export function readWorkGraphIssueRecords(issuesDir) {
+    const records = [];
+
+    for (const filePath of collectIssueMarkdownFiles(issuesDir)) {
+        let parsed;
+        try {
+            parsed = matter(fs.readFileSync(filePath, 'utf-8'));
+        } catch (error) {
+            logger.warn(`[GoldenPathSynthesizer] Failed to parse issue markdown for Stall Inference: ${filePath}`, error);
+            continue;
+        }
+
+        const meta    = parsed.data || {},
+              issueId = getIssueId(meta, filePath);
+
+        records.push({
+            assignees: Array.isArray(meta.assignees) ? meta.assignees.filter(Boolean) : [],
+            content  : parsed.content || '',
+            filePath,
+            issueId,
+            labels   : normalizeLabels(meta.labels),
+            meta,
+            number   : getIssueNumber(meta, issueId),
+            title    : meta.title || '(no title)',
+            url      : meta.githubUrl
+        });
+    }
+
+    return records
+}
+
+/**
+ * @summary Detects deliberate-defer state for an issue work item.
+ *
+ * @param {Object} issue Parsed issue work record.
+ * @param {Date} now Capture timestamp.
+ * @param {Object} graphService Graph service or test double.
+ * @returns {Object} Normalized defer disposition.
+ */
+export function getIssueDeferDisposition(issue, now = new Date(), graphService = GraphService) {
+    const deferredLabels = issue.labels.filter(label => DEFER_LABELS.has(label));
+    const observedAt     = toIsoString(now);
+
+    if (deferredLabels.length > 0) {
+        return {
+            anchorArtifact: `#${issue.number}`,
+            authority     : `issue-label:${deferredLabels[0]}`,
+            deferredAt    : toIsoString(issue.meta.updatedAt || issue.meta.createdAt, now),
+            evidenceRefs  : [`#${issue.number}`, `label:${deferredLabels[0]}`],
+            exitCondition : `remove ${deferredLabels[0]} or replace it with a narrower ready-state signal`,
+            state         : 'deferred'
+        }
+    }
+
+    const blockedBy = Array.isArray(issue.meta.blockedBy) ? issue.meta.blockedBy.filter(Boolean) : [];
+    if (blockedBy.length > 0) {
+        const hasOpenBlocker = hasOpenIssueBlocker({
+            issueId: issue.issueId,
+            issue  : issue.meta,
+            graphService
+        });
+
+        return {
+            anchorArtifact: `#${issue.number}`,
+            authority     : 'issue-blocker-edge',
+            deferredAt    : toIsoString(issue.meta.updatedAt || issue.meta.createdAt, now),
+            evidenceRefs  : [`#${issue.number}`, `blockedBy:${blockedBy.join(',')}`],
+            exitCondition : `close blocker ${blockedBy.map(id => `#${String(id).replace(/^issue-/, '')}`).join(', ')}`,
+            lastVerifiedAt: observedAt,
+            state         : hasOpenBlocker ? 'deferred' : 'stale-defer'
+        }
+    }
+
+    const marker = /DEFERRED-ON:\s*(.+)$/im.exec(issue.content || '');
+    if (marker) {
+        return {
+            anchorArtifact: `#${issue.number}`,
+            authority     : 'doc-marker',
+            deferredAt    : toIsoString(issue.meta.updatedAt || issue.meta.createdAt, now),
+            evidenceRefs  : [`#${issue.number}`, 'DEFERRED-ON marker'],
+            exitCondition : marker[1].trim(),
+            state         : marker[1].trim() ? 'deferred' : 'candidate-defer'
+        }
+    }
+
+    return {state: 'none'}
+}
+
+/**
+ * @summary Detects deliberate PR parking from the canonical `Parked-on:` adapter.
+ *
+ * @param {Object} pr GitHub PR payload.
+ * @param {Date} now Capture timestamp.
+ * @returns {Object} Normalized defer disposition.
+ */
+export function getPrDeferDisposition(pr, now = new Date()) {
+    const body = String(pr?.body || '');
+    if (!/\bParked-on:/i.test(body)) return {state: 'none'};
+
+    const match = PR_PARKED_ON_PATTERN.exec(body);
+    if (!match) {
+        return {
+            anchorArtifact: `PR #${pr.number}`,
+            authority     : 'pr-body',
+            deferredAt    : toIsoString(pr.updatedAt || pr.createdAt, now),
+            evidenceRefs  : [`PR #${pr.number}`, 'Parked-on line'],
+            exitCondition : null,
+            state         : 'candidate-defer'
+        }
+    }
+
+    return {
+        anchorArtifact: match[1],
+        authority     : 'pr-body',
+        deferredAt    : toIsoString(pr.updatedAt || pr.createdAt, now),
+        evidenceRefs  : [`PR #${pr.number}`, match[1], match[2] ? `[${match[2]}]` : null].filter(Boolean),
+        exitCondition : match[3].trim(),
+        state         : 'deferred'
+    }
+}
+
+/**
+ * @summary Resolves the latest per-reviewer state for a PR.
+ * @param {Object[]} reviews GitHub PR review payloads.
+ * @returns {Object[]} Latest review per author.
+ */
+function getLatestReviewsByAuthor(reviews = []) {
+    const latestByAuthor = new Map();
+
+    for (const review of Array.isArray(reviews) ? reviews : []) {
+        const author = review.author?.login || review.author || 'unknown';
+        const submittedAt = new Date(review.submittedAt || review.createdAt || 0);
+        const existing = latestByAuthor.get(author);
+
+        if (!existing || submittedAt > new Date(existing.submittedAt || existing.createdAt || 0)) {
+            latestByAuthor.set(author, review);
+        }
+    }
+
+    return [...latestByAuthor.values()]
+}
+
+/**
+ * @summary Returns approval-readiness derived from structured PR reviews.
+ *
+ * `updatedAt` is deliberately not a motion predicate. A PR leaves
+ * `DECISION_STARVED` only through merge/close, required changes, or loss of
+ * approval.
+ *
+ * @param {Object} pr GitHub PR payload.
+ * @returns {{approved: Boolean, approvedAt: String|null, changedRequested: Boolean}}
+ */
+export function getPrHumanGateState(pr) {
+    if (pr.reviewDecision === 'CHANGES_REQUESTED') {
+        return {approved: false, approvedAt: null, changedRequested: true}
+    }
+
+    const latestReviews    = getLatestReviewsByAuthor(pr.reviews);
+    const changedRequested = latestReviews.some(review => review.state === 'CHANGES_REQUESTED');
+    const approvals        = latestReviews.filter(review => review.state === 'APPROVED');
+
+    if (changedRequested || approvals.length === 0) {
+        return {approved: false, approvedAt: null, changedRequested}
+    }
+
+    approvals.sort((a, b) => new Date(b.submittedAt || b.createdAt || 0) - new Date(a.submittedAt || a.createdAt || 0));
+
+    return {
+        approved : true,
+        approvedAt: toIsoString(approvals[0].submittedAt || approvals[0].createdAt || pr.createdAt)
+    }
+}
+
+/**
+ * @summary Builds one durable stall finding object.
+ *
+ * @param {Object} options Finding fields.
+ * @returns {Object}
+ */
+function buildStallFinding({
+    capturedAt,
+    deferDisposition = {state: 'none'},
+    evidenceRefs = [],
+    findingClass,
+    grade = 'verified-stall',
+    motionPredicate,
+    presenceSource,
+    sourceFidelity = 'verified',
+    subject,
+    verificationSource,
+    waitingSince
+}) {
+    const observedAt = toIsoString(capturedAt);
+
+    return {
+        deferDisposition,
+        evidenceRefs: evidenceRefs.filter(Boolean),
+        findingClass,
+        firstSeen       : observedAt,
+        grade,
+        lastSeen        : observedAt,
+        lastVerifiedAt  : observedAt,
+        motionPredicate,
+        observedAt,
+        presenceSource,
+        sourceFidelity,
+        subject,
+        ttlExpiresAt    : new Date(new Date(observedAt).getTime() + STALL_FINDING_TTL_MS).toISOString(),
+        verificationSource,
+        waitingSince    : waitingSince ? toIsoString(waitingSince, capturedAt) : observedAt
+    }
+}
+
+/**
+ * @summary Builds deterministic work-graph stall findings for the handoff surface.
+ *
+ * This pass is visibility-only: it emits data for `sandman_handoff.md` and does
+ * not reassign work, file tickets, wake peers, or mutate Golden Path routing
+ * weights.
+ *
+ * @param {Object} options
+ * @param {String} options.issuesDir Local synced issue directory.
+ * @param {Object[]} [options.prs=[]] Open PR payloads from GitHub.
+ * @param {Date} [options.now=new Date()] Capture timestamp.
+ * @param {Object[]} [options.identities=IDENTITIES] AgentIdentity roots.
+ * @param {Object} [options.graphService=GraphService] Graph service or test double.
+ * @returns {Object[]} Stall findings.
+ */
+export function buildWorkGraphStallFindings({
+    issuesDir,
+    prs = [],
+    now = new Date(),
+    identities = IDENTITIES,
+    graphService = GraphService
+}) {
+    if (!issuesDir) return [];
+
+    const
+        findings      = [],
+        issueRecords  = readWorkGraphIssueRecords(issuesDir),
+        statusByLogin = getParticipationStatusByLogin(identities);
+
+    for (const issue of issueRecords) {
+        if (issue.meta.state !== 'OPEN') continue;
+
+        const deferDisposition = getIssueDeferDisposition(issue, now, graphService);
+        if (deferDisposition.state === 'deferred' || deferDisposition.state === 'candidate-defer') continue;
+
+        if (deferDisposition.state === 'stale-defer') {
+            findings.push(buildStallFinding({
+                capturedAt: now,
+                deferDisposition,
+                evidenceRefs: deferDisposition.evidenceRefs,
+                findingClass: 'STALE_DEFER',
+                grade       : 'candidate-stall',
+                motionPredicate: 'defer exit condition is satisfied and no class-specific motion has been recorded after the defer',
+                presenceSource : 'issue blocker/defer adapter',
+                sourceFidelity : 'candidate',
+                subject: {
+                    id    : issue.issueId,
+                    number: issue.number,
+                    title : issue.title,
+                    type  : 'ISSUE',
+                    url   : issue.url
+                },
+                verificationSource: 'local issue sync + graph blocker state',
+                waitingSince      : deferDisposition.deferredAt
+            }));
+        }
+
+        const inactiveAssignees = issue.assignees
+            .map(login => statusByLogin.get(String(login).replace(/^@/, '')))
+            .filter(status => status && INACTIVE_PARTICIPATION_STATUSES.has(status.participationStatus));
+
+        if (inactiveAssignees.length > 0) {
+            const assignee = inactiveAssignees[0];
+            findings.push(buildStallFinding({
+                capturedAt: now,
+                evidenceRefs: [`#${issue.number}`, `ai/graph/identityRoots.mjs:${assignee.login}:${assignee.participationStatus}`],
+                findingClass: 'OWNER_BENCHED_LANE',
+                motionPredicate: 'owned open work moves when AgentIdentity.participationStatus returns active, the lane is reassigned, or linked work advances under an active owner',
+                presenceSource : 'AgentIdentity.participationStatus',
+                subject: {
+                    id    : issue.issueId,
+                    number: issue.number,
+                    owner : assignee.login,
+                    title : issue.title,
+                    type  : 'ISSUE',
+                    url   : issue.url
+                },
+                verificationSource: 'identityRoots.mjs + local issue sync',
+                waitingSince      : assignee.since || issue.meta.createdAt
+            }));
+        }
+
+        if (issue.labels.includes(EPIC_LABEL)) {
+            const
+                total     = Number(issue.meta.subIssuesTotal),
+                completed = Number(issue.meta.subIssuesCompleted),
+                allSubsClosed = Number.isFinite(total) && total > 0 && Number.isFinite(completed) && completed >= total,
+                hasActiveAssignee = issue.assignees.some(login => {
+                    const status = statusByLogin.get(String(login).replace(/^@/, ''));
+                    return status?.participationStatus === 'active'
+                });
+
+            if (allSubsClosed && !hasActiveAssignee) {
+                findings.push(buildStallFinding({
+                    capturedAt: now,
+                    evidenceRefs: [`#${issue.number}`, `subIssuesCompleted:${completed}`, `subIssuesTotal:${total}`],
+                    findingClass: 'RESOLUTION_PENDING',
+                    motionPredicate: 'parent epic closes, /epic-resolution posts a verdict, or a required sub reopens',
+                    presenceSource : issue.assignees.length > 0 ? 'AgentIdentity.participationStatus' : 'issue assignee state',
+                    sourceFidelity : issue.assignees.length > 0 ? 'verified' : 'candidate',
+                    grade          : issue.assignees.length > 0 ? 'verified-stall' : 'candidate-stall',
+                    subject: {
+                        id    : issue.issueId,
+                        number: issue.number,
+                        title : issue.title,
+                        type  : 'ISSUE',
+                        url   : issue.url
+                    },
+                    verificationSource: 'local issue sync sub-issue counters',
+                    waitingSince      : issue.meta.updatedAt || issue.meta.createdAt
+                }));
+            }
+        }
+    }
+
+    for (const pr of Array.isArray(prs) ? prs : []) {
+        if (pr.state && pr.state !== 'OPEN') continue;
+        if (pr.isDraft) continue;
+        if (pr.mergedAt || pr.closedAt) continue;
+
+        const deferDisposition = getPrDeferDisposition(pr, now);
+        if (deferDisposition.state === 'deferred' || deferDisposition.state === 'candidate-defer') continue;
+
+        const gateState = getPrHumanGateState(pr);
+        if (!gateState.approved) continue;
+
+        findings.push(buildStallFinding({
+            capturedAt: now,
+            deferDisposition,
+            evidenceRefs: [`PR #${pr.number}`, pr.url, gateState.approvedAt ? `approvedAt:${gateState.approvedAt}` : null],
+            findingClass: 'DECISION_STARVED',
+            motionPredicate: 'PR merges, closes, receives a new required-change state, or loses approval/merge readiness',
+            presenceSource : 'GitHub PR review state',
+            subject: {
+                id    : `pr-${pr.number}`,
+                number: pr.number,
+                owner : 'human-merge-gate',
+                title : pr.title || '(no title)',
+                type  : 'PR',
+                url   : pr.url
+            },
+            verificationSource: 'GitHub PR list reviews',
+            waitingSince      : gateState.approvedAt || pr.createdAt
+        }));
+    }
+
+    findings.sort((a, b) =>
+        (a.grade === 'verified-stall' ? 0 : 1) - (b.grade === 'verified-stall' ? 0 : 1) ||
+        String(a.findingClass).localeCompare(String(b.findingClass)) ||
+        String(a.subject?.type).localeCompare(String(b.subject?.type)) ||
+        Number(a.subject?.number || 0) - Number(b.subject?.number || 0)
+    );
+
+    return findings
+}
+
+/**
+ * @summary Renders bounded work-graph stall findings into the Sandman handoff.
+ *
+ * @param {Object[]} findings Stall finding payloads.
+ * @param {Object} options
+ * @param {Date} [options.capturedAt=new Date()] Capture timestamp.
+ * @param {Number} [options.limit=aiConfig.goldenPathStallFindingRenderLimit] Maximum verified findings to render.
+ * @param {Boolean} [options.renderEnabled=aiConfig.goldenPathStallFindingRenderEnabled] Render flag.
+ * @returns {String}
+ */
+export function renderWorkGraphStallFindingsSection(findings = [], {
+    capturedAt = new Date(),
+    limit = aiConfig.goldenPathStallFindingRenderLimit,
+    renderEnabled = aiConfig.goldenPathStallFindingRenderEnabled
+} = {}) {
+    if (renderEnabled === false) return '';
+
+    let section = `\n## Work-Graph Stall Inference\n\n`;
+    section += `*Captured at: ${capturedAt.toISOString()} (Source: local issue sync + GitHub PR state; visibility-only, no wakes, no reassignment, no routing-weight changes)*\n\n`;
+
+    if (findings.length === 0) {
+        section += `No verified stall findings detected.\n`;
+        return section
+    }
+
+    const verified = findings.filter(finding => finding.grade === 'verified-stall');
+    const advisory = findings.filter(finding => finding.grade !== 'verified-stall');
+    const visibleVerified = verified.slice(0, limit);
+
+    section += `### Verified Stalls (\`${visibleVerified.length}\` of \`${verified.length}\` items)\n`;
+
+    for (const finding of visibleVerified) {
+        const subjectRef = finding.subject?.type === 'PR'
+            ? `PR #${finding.subject.number}`
+            : `#${finding.subject?.number}`;
+        const title = finding.subject?.title || '(no title)';
+
+        section += `- **${subjectRef}** — ${title} — \`${finding.findingClass}\`\n`;
+        section += `  - Motion predicate: ${finding.motionPredicate}\n`;
+        section += `  - waitingSince: ${finding.waitingSince}; grade: ${finding.grade}; fidelity: ${finding.sourceFidelity}\n`;
+        section += `  - Evidence: ${finding.evidenceRefs.join(' · ')}\n`;
+        section += `  - Unblock leverage: one stalled lane returns to motion when the predicate clears; detector takes no action.\n`;
+    }
+
+    if (advisory.length > 0) {
+        section += `\n<details><summary>Candidate / source-degraded findings (${advisory.length})</summary>\n\n`;
+        advisory.slice(0, limit).forEach(finding => {
+            const subjectRef = finding.subject?.type === 'PR'
+                ? `PR #${finding.subject.number}`
+                : `#${finding.subject?.number}`;
+            section += `- **${subjectRef}** — ${finding.subject?.title || '(no title)'} — \`${finding.findingClass}\` — ${finding.grade}; evidence: ${finding.evidenceRefs.join(' · ')}\n`;
+        });
+        section += `\n</details>\n`;
     }
 
     return section

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -34,6 +34,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     let renderStaleAssignmentCandidatesSection;
     let buildSilentThreadCandidates;
     let renderSilentThreadCandidatesSection;
+    let buildWorkGraphStallFindings;
+    let renderWorkGraphStallFindingsSection;
     let renderGoldenPathRouteLedgerSection;
     let issueFocusSections;
 
@@ -50,6 +52,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     let originalGoldenPathSilentThreadMinScore;
     let originalGoldenPathSilentThreadRenderLimit;
     let originalGoldenPathSilentThreadThresholdMs;
+    let originalGoldenPathStallFindingRenderEnabled;
+    let originalGoldenPathStallFindingRenderLimit;
     let originalVectorDimension;
     let originalWarn;
 
@@ -77,6 +81,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         renderStaleAssignmentCandidatesSection = GoldenPathSynthesizer.constructor.renderStaleAssignmentCandidatesSection.bind(GoldenPathSynthesizer.constructor);
         buildSilentThreadCandidates = GoldenPathSynthesizer.constructor.buildSilentThreadCandidates.bind(GoldenPathSynthesizer.constructor);
         renderSilentThreadCandidatesSection = GoldenPathSynthesizer.constructor.renderSilentThreadCandidatesSection.bind(GoldenPathSynthesizer.constructor);
+        buildWorkGraphStallFindings = GoldenPathSynthesizer.constructor.buildWorkGraphStallFindings.bind(GoldenPathSynthesizer.constructor);
+        renderWorkGraphStallFindingsSection = GoldenPathSynthesizer.constructor.renderWorkGraphStallFindingsSection.bind(GoldenPathSynthesizer.constructor);
         ({renderGoldenPathRouteLedgerSection} = await import('../../../../../../ai/services/graph/goldenPathRouteLedger.mjs'));
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
@@ -98,6 +104,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         originalGoldenPathSilentThreadMinScore          = aiConfig.goldenPathSilentThreadMinScore;
         originalGoldenPathSilentThreadRenderLimit       = aiConfig.goldenPathSilentThreadRenderLimit;
         originalGoldenPathSilentThreadThresholdMs       = aiConfig.goldenPathSilentThreadThresholdMs;
+        originalGoldenPathStallFindingRenderEnabled     = aiConfig.goldenPathStallFindingRenderEnabled;
+        originalGoldenPathStallFindingRenderLimit       = aiConfig.goldenPathStallFindingRenderLimit;
         originalVectorDimension   = aiConfig.vectorDimension;
         originalWarn              = logger.warn;
 
@@ -108,6 +116,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         aiConfig.goldenPathSilentThreadMinScore          = 14;
         aiConfig.goldenPathSilentThreadRenderLimit       = 10;
         aiConfig.goldenPathSilentThreadThresholdMs       = 14 * 24 * 60 * 60 * 1000;
+        aiConfig.goldenPathStallFindingRenderEnabled     = true;
+        aiConfig.goldenPathStallFindingRenderLimit       = 10;
     });
 
     test.afterEach(() => {
@@ -120,6 +130,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         aiConfig.goldenPathSilentThreadMinScore          = originalGoldenPathSilentThreadMinScore;
         aiConfig.goldenPathSilentThreadRenderLimit       = originalGoldenPathSilentThreadRenderLimit;
         aiConfig.goldenPathSilentThreadThresholdMs       = originalGoldenPathSilentThreadThresholdMs;
+        aiConfig.goldenPathStallFindingRenderEnabled     = originalGoldenPathStallFindingRenderEnabled;
+        aiConfig.goldenPathStallFindingRenderLimit       = originalGoldenPathStallFindingRenderLimit;
         aiConfig.vectorDimension   = originalVectorDimension;
         child_process.execSync     = originalExecSync;
         logger.warn                = originalWarn;
@@ -1600,6 +1612,277 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(capped).toContain('Silent Candidate 1');
         expect(capped).toContain('Silent Candidate 2');
         expect(capped).not.toContain('Silent Candidate 3');
+    });
+
+    test('buildWorkGraphStallFindings emits deterministic ADR-0030 findings and suppresses deliberate defers', () => {
+        const issuesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-stall-findings-'));
+        const chunkDir  = path.join(issuesDir, 'chunk-1');
+        const now       = new Date('2026-07-02T12:00:00Z');
+        fs.mkdirSync(chunkDir, {recursive: true});
+
+        function writeIssue(number, lines) {
+            fs.writeFileSync(path.join(chunkDir, `issue-${number}.md`), lines.join('\n'));
+        }
+
+        writeIssue(9501, [
+            '---',
+            'id: 9501',
+            "title: 'Benched owner lane with fresh comments'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees:',
+            '  - neo-gemini-pro',
+            "createdAt: '2026-06-01T00:00:00Z'",
+            "updatedAt: '2026-07-02T11:00:00Z'",
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9501'",
+            '---',
+            '# Benched owner lane'
+        ]);
+        writeIssue(9502, [
+            '---',
+            'id: 9502',
+            "title: 'Deliberately deferred benched lane'",
+            'state: OPEN',
+            'labels:',
+            '  - not-code-ready',
+            'assignees:',
+            '  - neo-gemini-pro',
+            "createdAt: '2026-06-01T00:00:00Z'",
+            "updatedAt: '2026-07-02T11:00:00Z'",
+            '---',
+            '# Deferred benched owner lane'
+        ]);
+        writeIssue(9503, [
+            '---',
+            'id: 9503',
+            "title: 'Closed-sub epic awaiting closure'",
+            'state: OPEN',
+            'labels:',
+            '  - epic',
+            'assignees:',
+            '  - neo-gemini-pro',
+            "createdAt: '2026-05-01T00:00:00Z'",
+            "updatedAt: '2026-06-20T00:00:00Z'",
+            'subIssuesCompleted: 3',
+            'subIssuesTotal: 3',
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9503'",
+            '---',
+            '# Closed-sub epic'
+        ]);
+        writeIssue(9504, [
+            '---',
+            'id: 9504',
+            "title: 'Active-owner closed-sub epic'",
+            'state: OPEN',
+            'labels:',
+            '  - epic',
+            'assignees:',
+            '  - neo-gpt',
+            "createdAt: '2026-05-01T00:00:00Z'",
+            "updatedAt: '2026-06-20T00:00:00Z'",
+            'subIssuesCompleted: 2',
+            'subIssuesTotal: 2',
+            '---',
+            '# Active-owner epic'
+        ]);
+        writeIssue(9505, [
+            '---',
+            'id: 9505',
+            "title: 'Resolved blocker defer with no motion'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees: []',
+            'blockedBy:',
+            '  - 9506',
+            "createdAt: '2026-05-01T00:00:00Z'",
+            "updatedAt: '2026-05-15T00:00:00Z'",
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9505'",
+            '---',
+            '# Resolved blocker defer'
+        ]);
+
+        const graphService = {
+            db: {
+                edges: {
+                    getByIndex(index, target) {
+                        return index === 'target' && target === 'issue-9505'
+                            ? [{type: 'BLOCKS', source: 'issue-9506'}]
+                            : []
+                    }
+                },
+                getAdjacentNodes() {},
+                nodes: {
+                    get(id) {
+                        return id === 'issue-9506' ? {properties: {state: 'CLOSED'}} : null
+                    }
+                }
+            }
+        };
+
+        const prs = [
+            {
+                number   : 9601,
+                title    : 'Approved PR at human gate',
+                url      : 'https://github.com/neomjs/neo/pull/9601',
+                createdAt: '2026-07-01T00:00:00Z',
+                reviews  : [{author: {login: 'neo-opus-ada'}, state: 'APPROVED', submittedAt: '2026-07-01T01:00:00Z'}]
+            },
+            {
+                number   : 9602,
+                title    : 'Parked approved PR',
+                body     : 'Parked-on: #14441 [OQ5] - governance hold',
+                createdAt: '2026-07-01T00:00:00Z',
+                reviews  : [{author: {login: 'neo-gpt'}, state: 'APPROVED', submittedAt: '2026-07-01T01:00:00Z'}]
+            },
+            {
+                number   : 9603,
+                title    : 'Required-change PR',
+                createdAt: '2026-07-01T00:00:00Z',
+                reviews  : [
+                    {author: {login: 'neo-gpt'}, state: 'APPROVED', submittedAt: '2026-07-01T01:00:00Z'},
+                    {author: {login: 'neo-gpt'}, state: 'CHANGES_REQUESTED', submittedAt: '2026-07-01T02:00:00Z'}
+                ]
+            }
+        ];
+
+        try {
+            const findings = buildWorkGraphStallFindings({issuesDir, now, prs, graphService});
+            const classes  = findings.map(finding => `${finding.findingClass}:${finding.subject.number}`);
+
+            expect(classes).toEqual([
+                'DECISION_STARVED:9601',
+                'OWNER_BENCHED_LANE:9501',
+                'OWNER_BENCHED_LANE:9503',
+                'RESOLUTION_PENDING:9503',
+                'STALE_DEFER:9505'
+            ]);
+
+            const ownerFinding = findings.find(finding => finding.findingClass === 'OWNER_BENCHED_LANE' && finding.subject.number === 9501);
+            expect(ownerFinding).toMatchObject({
+                grade             : 'verified-stall',
+                sourceFidelity    : 'verified',
+                verificationSource: 'identityRoots.mjs + local issue sync'
+            });
+            expect(ownerFinding.motionPredicate).toContain('participationStatus');
+            expect(ownerFinding.evidenceRefs).toContain('ai/graph/identityRoots.mjs:neo-gemini-pro:operator_benched');
+            expect(ownerFinding.waitingSince).toBe('2026-05-18T00:00:00.000Z');
+            expect(ownerFinding.lastSeen).toBe('2026-07-02T12:00:00.000Z');
+
+            expect(findings.some(finding => finding.subject.number === 9502)).toBe(false);
+            expect(findings.some(finding => finding.subject.number === 9504)).toBe(false);
+            expect(findings.some(finding => finding.subject.number === 9602)).toBe(false);
+            expect(findings.some(finding => finding.subject.number === 9603)).toBe(false);
+
+            const staleDefer = findings.find(finding => finding.findingClass === 'STALE_DEFER');
+            expect(staleDefer.grade).toBe('candidate-stall');
+            expect(staleDefer.deferDisposition.state).toBe('stale-defer');
+            expect(staleDefer.evidenceRefs).toContain('blockedBy:9506');
+            expect(staleDefer).toHaveProperty('ttlExpiresAt');
+        } finally {
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+    });
+
+    test('renderWorkGraphStallFindingsSection is bounded, visibility-only, and honors render-off', () => {
+        const findings = [
+            {
+                evidenceRefs      : ['#9601', 'approvedAt:2026-07-01T01:00:00.000Z'],
+                findingClass      : 'DECISION_STARVED',
+                grade             : 'verified-stall',
+                motionPredicate   : 'PR merges or loses approval',
+                sourceFidelity    : 'verified',
+                subject           : {number: 9601, title: 'Approved PR', type: 'PR'},
+                waitingSince      : '2026-07-01T01:00:00.000Z'
+            },
+            {
+                evidenceRefs      : ['#9505', 'blockedBy:9506'],
+                findingClass      : 'STALE_DEFER',
+                grade             : 'candidate-stall',
+                motionPredicate   : 'defer exit satisfied',
+                sourceFidelity    : 'candidate',
+                subject           : {number: 9505, title: 'Resolved blocker defer', type: 'ISSUE'},
+                waitingSince      : '2026-05-15T00:00:00.000Z'
+            }
+        ];
+
+        const hidden = renderWorkGraphStallFindingsSection(findings, {renderEnabled: false});
+        expect(hidden).toBe('');
+
+        const section = renderWorkGraphStallFindingsSection(findings, {
+            capturedAt: new Date('2026-07-02T12:00:00Z'),
+            limit     : 1
+        });
+
+        expect(section).toContain('## Work-Graph Stall Inference');
+        expect(section).toContain('visibility-only, no wakes, no reassignment, no routing-weight changes');
+        expect(section).toContain('Verified Stalls (`1` of `1` items)');
+        expect(section).toContain('PR #9601');
+        expect(section).toContain('waitingSince: 2026-07-01T01:00:00.000Z');
+        expect(section).toContain('<details><summary>Candidate / source-degraded findings (1)</summary>');
+        expect(section).toContain('STALE_DEFER');
+    });
+
+    test('synthesizeGoldenPath renders Work-Graph Stall Inference from issue sync and PR state', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
+        const issuesDir                    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-stall-render-issues-'));
+        const chunkDir                     = path.join(issuesDir, 'chunk-1');
+        aiConfig.vectorDimension = 2;
+        fs.mkdirSync(chunkDir, {recursive: true});
+
+        fs.writeFileSync(path.join(chunkDir, 'issue-9701.md'), [
+            '---',
+            'id: 9701',
+            "title: 'Benched owner render lane'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees:',
+            '  - neo-gemini-pro',
+            "createdAt: '2026-06-01T00:00:00Z'",
+            "updatedAt: '2026-07-02T11:00:00Z'",
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9701'",
+            '---',
+            '# Benched owner render lane'
+        ].join('\n'));
+
+        StorageRouter.getGraphCollection = async () => ({query: async () => ({ids: [[]], distances: [[]]})});
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['mock document']})});
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [{
+            number   : 9702,
+            title    : 'Approved PR render lane',
+            url      : 'https://github.com/neomjs/neo/pull/9702',
+            createdAt: '2026-07-01T00:00:00Z',
+            reviews  : [{author: {login: 'neo-opus-ada'}, state: 'APPROVED', submittedAt: '2026-07-01T01:00:00Z'}]
+        }];
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({
+                issuesDir,
+                now: new Date('2026-07-02T12:00:00Z')
+            });
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+
+        expect(handoffContent).toContain('## Active PR Cycle State');
+        expect(handoffContent).toContain('## Work-Graph Stall Inference');
+        expect(handoffContent).toContain('Benched owner render lane');
+        expect(handoffContent).toContain('OWNER_BENCHED_LANE');
+        expect(handoffContent).toContain('Approved PR render lane');
+        expect(handoffContent).toContain('DECISION_STARVED');
+        expect(handoffContent.indexOf('## Active PR Cycle State')).toBeLessThan(handoffContent.indexOf('## Work-Graph Stall Inference'));
     });
 
     test('synthesizeGoldenPath does not compose KB tenant telemetry into the handoff', () => {


### PR DESCRIPTION
Resolves #14462

Related: #14461

Adds a visibility-only Work-Graph Stall Inference section to Golden Path synthesis. The detector now emits deterministic stall findings for benched-owner lanes, resolution-pending epics, stale defers whose blocker has cleared, and approved PRs waiting at the human merge gate, while explicitly suppressing deliberate defers and parked PRs.

Evidence: L2 (unit-level detector/render/composition coverage over local issue sync + PR fixtures) -> L2 required (deterministic Dream-cycle handoff surface; no live routing or mutation ACs). No residuals.

## Deltas from ticket

The v1 delivery renders findings into the Sandman handoff instead of persisting finding nodes. The payload still carries the required durable shape (`findingClass`, `motionPredicate`, `presenceSource`, `grade`, `firstSeen`, `lastSeen`, `lastVerifiedAt`, `ttlExpiresAt`, `deferDisposition`, `evidenceRefs`) so persistence can be added later without changing the detector contract.

The detector is intentionally pull-only: no wakes, no reassignment, no ticket filing, and no Golden Path routing-weight changes.

## Config Template Sync

Changed keys:

- `goldenPathStallFindingRenderEnabled`
- `goldenPathStallFindingRenderLimit`

Local `ai/mcp/server/memory-core/config.mjs` files in active clones should be regenerated or manually given these keys after merge to keep clone-local config shape aligned. Long-running Memory Core / Sandman processes should be restarted if operators want the new local values without waiting for the next process start; one-shot test processes need no restart.

## Test Evidence

- `node --check ai/services/graph/issueFocusSections.mjs`
- `node --check ai/services/graph/GoldenPathSynthesizer.mjs`
- `node --check ai/mcp/server/memory-core/config.template.mjs`
- `node --check test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs`
- `npm run agent-preflight -- --no-fix ai/services/graph/issueFocusSections.mjs ai/services/graph/GoldenPathSynthesizer.mjs ai/mcp/server/memory-core/config.template.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` (42/42)
- `git diff --check`
- `git diff --cached --check`

## Post-Merge Validation

- [ ] Regenerate or sync local Memory Core config files in active clones.
- [ ] Confirm the next Sandman handoff includes `## Work-Graph Stall Inference` when findings exist, and stays quiet when none exist.

## Commits

- `586ab10984` - `feat(graph): render work-graph stall findings (#14462)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019f2047-5787-7ed3-bfd5-552e3f2ab7e1.
