### PR TITLE
feat(hooks): resolve lifecycle-state hook boards (#14473)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -53,16 +53,22 @@ import {buildDeferenceStopHookDirective,
         scanHoldLexicon,
         STOP_HOOK_TURN_OPTIONS_HINT} from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+import {
+    formatGoldenPathDirection,
+    formatLifecycleBoard,
+    readLifecycleState as readSharedLifecycleState
+} from '../../ai/scripts/lifecycle/lifecycleState.mjs';
 
-export {isOperatorInLoop, parseOutcomeToVerdict};
+export {formatGoldenPathDirection, formatLifecycleBoard, isOperatorInLoop, parseOutcomeToVerdict};
 
 // Enforce ONLY when the operator explicitly activates it; default is DRY-RUN (log-only, never blocks).
 const ENFORCING = process.env.NEO_LANE_STATE_ENFORCE === '1';
 
 // Append-only audit log — the WOULD-BLOCK / ALLOW record for auditing the dry-run before enforcement.
 // NEO_AI_DAEMON_DIR override keeps tests off the real store.
-const LOG_DIR  = process.env.NEO_AI_DAEMON_DIR || path.join(os.homedir(), '.neo-ai-data', 'lane-state-hook');
-const LOG_FILE = path.join(LOG_DIR, 'lane-state-stop-hook.log');
+const LOG_DIR                     = process.env.NEO_AI_DAEMON_DIR || path.join(os.homedir(), '.neo-ai-data', 'lane-state-hook');
+const LOG_FILE                    = path.join(LOG_DIR, 'lane-state-stop-hook.log');
+const LEGACY_LIFECYCLE_STATE_FILE = path.join(LOG_DIR, 'lifecycle-state.json');
 
 /**
  * @summary Reads all of stdin (the Stop-hook JSON payload) to a string.
@@ -151,12 +157,6 @@ const MIRROR_POINTER = `This hook is a MIRROR, not a leash: a hit means you slip
 // later) — else the clause becomes a new sophisticated-hold costume ("I'm friction→gold-ing the hook").
 const SELF_IMPROVABILITY_CLAUSE = `friction→gold applies to THIS hook: if it fired wrong — a false positive, or it reads as a leash not a mirror — open a ticket to sharpen it rather than silently absorbing it. But that ticket is a separate design-time lane, NOT a license to stop this turn: obey the hook now, improve it later. "I'm filing a friction→gold ticket" is not itself a valid stop. The hook is mutable substrate, not a command.`;
 
-// The orchestrator/wake daemon writes the current agent's lane-state here (computation preserved, the
-// wake-INTERRUPT dropped); this hook reads it on a block — cheap, no network, inside the 10s budget —
-// and injects the live board so the refuse-directive is ACTIONABLE at the moment the next-action
-// decision happens. This is the hook-READ side; the daemon-WRITE side is a sibling lane.
-const LIFECYCLE_STATE_FILE = path.join(LOG_DIR, 'lifecycle-state.json');
-
 /**
  * @summary Reads the daemon-written lane-state file. FAIL-OPEN by construction: a missing, unreadable,
  * or malformed file returns `null` — the hook then injects the bare reminder and never throws. The
@@ -165,98 +165,7 @@ const LIFECYCLE_STATE_FILE = path.join(LOG_DIR, 'lifecycle-state.json');
  * @returns {Object|null} `{openPRs, unreadCount, generatedAt}` or `null` on any read/parse failure.
  */
 export function readLifecycleState() {
-    try {
-        const state = JSON.parse(fs.readFileSync(LIFECYCLE_STATE_FILE, 'utf8'));
-        return state && typeof state === 'object' ? state : null;
-    } catch {
-        return null;
-    }
-}
-
-/**
- * @summary Formats the lane-state into a one-glance "live board" — the agent's own open PRs (+ state)
- * and unread-A2A count — so the forced next-action is informed, not generic. Returns `''` when there
- * is nothing actionable to show (the caller falls back to the bare reminder). Pure; exported + tested.
- * FAIL-OPEN on malformed SHAPE, not just a bad file read: a parsed-but-malformed object (null / non-object
- * / numberless `openPRs` entries, wrong-typed fields) degrades to `''` and NEVER throws — it runs inside
- * the turn-end hook path, where a throw would trap every turn, so a total (never-throwing) function is the
- * contract, not a nicety. (Per cross-family review by @neo-gpt: fail-open includes malformed schema,
- * not just a bad file read.)
- * @param {Object|null} state `{openPRs, unreadCount, generatedAt}` from {@link readLifecycleState}.
- * @returns {String}
- */
-export function formatLifecycleBoard(state) {
-    try {
-        if (!state || typeof state !== 'object') return '';
-
-        const prs   = Array.isArray(state.openPRs) ? state.openPRs : [],
-              lines = [];
-
-        // Render ONLY entries that carry a usable PR number; skip null / non-object / numberless entries.
-        // A malformed array element ({openPRs:[null]}) must not crash the formatter — validating each
-        // entry before dereferencing `pr.number`/`pr.state` is the core of the malformed-shape fail-open.
-        const validPRs = prs.filter(pr => pr && typeof pr === 'object' &&
-            (typeof pr.number === 'number' || typeof pr.number === 'string'));
-        if (validPRs.length) {
-            lines.push('  • your open PRs: ' +
-                validPRs.map(pr => `#${pr.number}${pr.state ? ` ${pr.state}` : ''}`).join(', '));
-        }
-        if (Number.isInteger(state.unreadCount) && state.unreadCount > 0) {
-            lines.push(`  • ${state.unreadCount} unread A2A — list_messages`);
-        }
-        if (!lines.length) return '';
-
-        const asOf = typeof state.generatedAt === 'string' ? ` (as of ${state.generatedAt})` : '';
-        return `\nYour live board${asOf} — concrete lanes right now:\n${lines.join('\n')}`;
-    } catch {
-        // Belt-and-suspenders: ANY unforeseen shape issue degrades to the bare reminder, never throws.
-        return '';
-    }
-}
-
-/**
- * @summary Formats the Computed Golden Path release-goal direction — the top-N ROI-ranked lanes the
- * Dream pipeline surfaced (`priority = 2×semantic + 1×structural`, sourced from the sandman handoff's
- * Computed Golden Path route attribution) — into the block directive, so the forced next-action is
- * anchored to the release goal, NOT rewarded for "any named lane" (the productive-derailment guard).
- * This is the hook-READ consumer; the daemon-WRITE producer fills the `goldenPathDirection` field.
- *
- * Contract (`state.goldenPathDirection`): an array of `{id, score?, title?}`, pre-ranked by the
- * producer (the hook does NOT rank — it renders the producer's order verbatim; ranking is the Golden
- * Path's job, per the no-auto-action spine).
- *
- * FAIL-OPEN + ADDITIVE: a missing / empty / stale / malformed direction degrades to `''` (the bare
- * reminder), NEVER blocks — a zero-signal (cold-start, no writer yet, stale handoff) must never starve
- * the directive floor. Pure; total (never throws) — it runs inside the turn-end hook path where a throw
- * would trap every turn, so a never-throwing function is the contract. Advisory only: the agent reads
- * the direction and CHOOSES; the hook never auto-reprioritizes (the advisory-only, no-auto-action
- * spine). Exported + unit-tested.
- * @param {Object|null} state `{goldenPathDirection: [{id, score?, title?}], ...}` from {@link readLifecycleState}.
- * @returns {String}
- */
-export function formatGoldenPathDirection(state) {
-    try {
-        if (!state || typeof state !== 'object') return '';
-
-        const lanes = Array.isArray(state.goldenPathDirection) ? state.goldenPathDirection : [];
-
-        // Render ONLY entries carrying a usable id; skip null / non-object / idless entries so a single
-        // malformed element never crashes the formatter (the malformed-shape fail-open the board uses).
-        const valid = lanes.filter(lane => lane && typeof lane === 'object' &&
-            typeof lane.id === 'string' && lane.id.trim() !== '');
-        if (!valid.length) return '';
-
-        const rows = valid.map((lane, index) => {
-            const score = Number.isFinite(Number(lane.score)) ? ` — score ${Number(lane.score).toFixed(2)}` : '',
-                  title = typeof lane.title === 'string' && lane.title.trim() ? ` — ${lane.title.trim()}` : '';
-            return `  ${index + 1}. ${lane.id}${score}${title}`;
-        });
-
-        return `\nRelease-goal direction — Computed Golden Path top ROI (drive one of these over any-named-lane; advisory, not auto-reprioritization):\n${rows.join('\n')}`;
-    } catch {
-        // Belt-and-suspenders: any unforeseen shape degrades to the bare reminder, never throws.
-        return '';
-    }
+    return readSharedLifecycleState({legacyFilePath: LEGACY_LIFECYCLE_STATE_FILE});
 }
 
 /**

--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -23,6 +23,11 @@ import {classifyPromptingContext,
         parseOutcomeToVerdict,
         STOP_HOOK_TURN_OPTIONS_HINT} from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
 import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+import {
+    formatGoldenPathDirection,
+    formatLifecycleBoard,
+    readLifecycleState
+} from '../../ai/scripts/lifecycle/lifecycleState.mjs';
 
 export const CODEX_STOP_BLOCK_INJECTION_SUPPORTED = true;
 export const CODEX_PROMPT_CONTEXT_TTL_MS           = 10 * 60 * 1000;
@@ -383,6 +388,7 @@ export function buildNoHoldReminder(verdictReason, {
     autonomousHandoff = false,
     handoffReason = '',
     handoffWindowMs = null,
+    lifecycleState,
     operatorInLoop = false,
     promptSource = ''
 } = {}) {
@@ -391,10 +397,13 @@ export function buildNoHoldReminder(verdictReason, {
               : '',
           handoffDiagnostic = autonomousHandoff
               ? `\nOperator prompt matched handoff-to-autonomous (${handoffReason || 'unknown'}${handoffWindowMs ? `, windowMs=${handoffWindowMs}` : ''}); treating this turn as autonomous no-hold.`
-        : '';
+              : '',
+          state             = lifecycleState === undefined ? readLifecycleState() : lifecycleState,
+          liveBoard         = `${formatGoldenPathDirection(state)}${formatLifecycleBoard(state)}`;
 
     return `No-hold reminder: ${verdictReason}. There is no hold state: continue concrete work on the active lane, perform an assigned review that advances a named lane, or pick a fresh claimable lane. Passive waiting is not a terminal.
 ${promptDiagnostic}${handoffDiagnostic}
+${liveBoard}
 
 ${STOP_HOOK_TURN_OPTIONS_HINT}
 

--- a/ai/scripts/lifecycle/lifecycleState.mjs
+++ b/ai/scripts/lifecycle/lifecycleState.mjs
@@ -1,0 +1,203 @@
+import fs   from 'node:fs';
+import os   from 'node:os';
+import path from 'node:path';
+
+export const LIFECYCLE_STATE_DIR_NAME = 'lifecycle-state';
+
+/**
+ * @module Neo.ai.scripts.lifecycle.lifecycleState
+ * @summary Shared lifecycle-state path and render primitives for no-hold Stop hooks.
+ *
+ * The hook live board is current-agent state. Reader and writer paths must be resolved
+ * through this module so one harness cannot read a different home than another writer
+ * uses. State files are keyed by AgentIdentity to avoid clobbering peer boards in a
+ * shared/canonical `.neo-ai-data` home.
+ */
+
+/**
+ * @summary Normalizes AgentIdentity or GitHub-login strings to `@identity` form.
+ * @param {String|null|undefined} value Identity candidate.
+ * @returns {String|null}
+ */
+export function normalizeAgentIdentity(value) {
+    const str = String(value || '').trim();
+
+    if (!str) return null;
+
+    return str.startsWith('@') ? str : `@${str}`
+}
+
+/**
+ * @summary Resolves the best runtime AgentIdentity candidate from environment.
+ * @param {Object} [env=process.env]
+ * @returns {String|null}
+ */
+export function resolveRuntimeAgentIdentity(env = process.env) {
+    return normalizeAgentIdentity(
+        env.NEO_AGENT_IDENTITY ||
+        env.NEO_AGENT_IDENTITY_NODE_ID ||
+        env.NEO_AGENT_LOGIN ||
+        env.GITHUB_USER
+    )
+}
+
+/**
+ * @summary Converts an AgentIdentity or GitHub login to the bare GitHub login form.
+ * @param {String|null|undefined} value Identity candidate.
+ * @returns {String|null}
+ */
+export function getAgentLogin(value) {
+    const normalized = normalizeAgentIdentity(value);
+
+    return normalized ? normalized.slice(1) : null
+}
+
+/**
+ * @summary Builds the filename-safe lifecycle-state key for an AgentIdentity.
+ * @param {String|null|undefined} value Identity candidate.
+ * @returns {String|null}
+ */
+export function getLifecycleStateIdentityKey(value) {
+    const login = getAgentLogin(value);
+    if (!login) return null;
+
+    const key = login.replace(/[^a-zA-Z0-9_-]/g, '');
+
+    return key || null
+}
+
+/**
+ * @summary Resolves the shared lifecycle-state directory.
+ * @param {Object} [options]
+ * @param {Object} [options.env=process.env] Environment map.
+ * @param {String} [options.homeDir=os.homedir()] OS home for the default `.neo-ai-data` root.
+ * @param {String} [options.rootDir] Explicit root override, mainly for tests.
+ * @returns {String}
+ */
+export function resolveLifecycleStateDir({
+    env     = process.env,
+    homeDir = os.homedir(),
+    rootDir
+} = {}) {
+    const baseDir = rootDir || env.NEO_AI_DAEMON_DIR || path.join(homeDir, '.neo-ai-data');
+
+    return path.join(baseDir, LIFECYCLE_STATE_DIR_NAME)
+}
+
+/**
+ * @summary Resolves the per-agent lifecycle-state JSON path.
+ * @param {Object} [options]
+ * @param {String} [options.agentIdentity] AgentIdentity or login.
+ * @param {Object} [options.env=process.env] Environment map.
+ * @param {String} [options.homeDir=os.homedir()] OS home for the default `.neo-ai-data` root.
+ * @param {String} [options.rootDir] Explicit root override, mainly for tests.
+ * @returns {String|null}
+ */
+export function resolveLifecycleStateFile({
+    agentIdentity,
+    env           = process.env,
+    homeDir       = os.homedir(),
+    rootDir
+} = {}) {
+    const key = getLifecycleStateIdentityKey(agentIdentity || resolveRuntimeAgentIdentity(env));
+
+    return key ? path.join(resolveLifecycleStateDir({env, homeDir, rootDir}), `${key}.json`) : null
+}
+
+/**
+ * @summary Reads the daemon-written lane-state file. Fail-open by construction.
+ * @param {Object} [options]
+ * @param {String} [options.agentIdentity] AgentIdentity or login.
+ * @param {Object} [options.env=process.env] Environment map.
+ * @param {Object} [options.fsImpl=fs] fs-compatible implementation.
+ * @param {String} [options.homeDir=os.homedir()] OS home for the default `.neo-ai-data` root.
+ * @param {String} [options.legacyFilePath] Optional legacy fallback read path.
+ * @param {String} [options.rootDir] Explicit root override, mainly for tests.
+ * @returns {Object|null}
+ */
+export function readLifecycleState({
+    agentIdentity,
+    env            = process.env,
+    fsImpl         = fs,
+    homeDir        = os.homedir(),
+    legacyFilePath,
+    rootDir
+} = {}) {
+    const canonicalFile = resolveLifecycleStateFile({agentIdentity, env, homeDir, rootDir});
+
+    if (canonicalFile) {
+        try {
+            const state = JSON.parse(fsImpl.readFileSync(canonicalFile, 'utf8'));
+            return state && typeof state === 'object' ? state : null
+        } catch (e) {
+            if (e?.code !== 'ENOENT') return null;
+        }
+    }
+
+    if (legacyFilePath) {
+        try {
+            const state = JSON.parse(fsImpl.readFileSync(legacyFilePath, 'utf8'));
+            return state && typeof state === 'object' ? state : null
+        } catch {
+            return null;
+        }
+    }
+
+    return null
+}
+
+/**
+ * @summary Formats the lifecycle board fields for hook directive injection.
+ * @param {Object|null} state `{openPRs, unreadCount, generatedAt}` from {@link readLifecycleState}.
+ * @returns {String}
+ */
+export function formatLifecycleBoard(state) {
+    try {
+        if (!state || typeof state !== 'object') return '';
+
+        const prs   = Array.isArray(state.openPRs) ? state.openPRs : [],
+              lines = [];
+
+        const validPRs = prs.filter(pr => pr && typeof pr === 'object' &&
+            (typeof pr.number === 'number' || typeof pr.number === 'string'));
+        if (validPRs.length) {
+            lines.push('  • your open PRs: ' +
+                validPRs.map(pr => `#${pr.number}${pr.state ? ` ${pr.state}` : ''}`).join(', '));
+        }
+        if (Number.isInteger(state.unreadCount) && state.unreadCount > 0) {
+            lines.push(`  • ${state.unreadCount} unread A2A — list_messages`);
+        }
+        if (!lines.length) return '';
+
+        const asOf = typeof state.generatedAt === 'string' ? ` (as of ${state.generatedAt})` : '';
+        return `\nYour live board${asOf} — concrete lanes right now:\n${lines.join('\n')}`;
+    } catch {
+        return '';
+    }
+}
+
+/**
+ * @summary Formats the producer-ranked Computed Golden Path direction for hook injection.
+ * @param {Object|null} state `{goldenPathDirection: [{id, score?, title?}], ...}`.
+ * @returns {String}
+ */
+export function formatGoldenPathDirection(state) {
+    try {
+        if (!state || typeof state !== 'object') return '';
+
+        const lanes = Array.isArray(state.goldenPathDirection) ? state.goldenPathDirection : [];
+        const valid = lanes.filter(lane => lane && typeof lane === 'object' &&
+            typeof lane.id === 'string' && lane.id.trim() !== '');
+        if (!valid.length) return '';
+
+        const rows = valid.map((lane, index) => {
+            const score = Number.isFinite(Number(lane.score)) ? ` — score ${Number(lane.score).toFixed(2)}` : '',
+                  title = typeof lane.title === 'string' && lane.title.trim() ? ` — ${lane.title.trim()}` : '';
+            return `  ${index + 1}. ${lane.id}${score}${title}`;
+        });
+
+        return `\nRelease-goal direction — Computed Golden Path top ROI (drive one of these over any-named-lane; advisory, not auto-reprioritization):\n${rows.join('\n')}`;
+    } catch {
+        return '';
+    }
+}

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -2,6 +2,7 @@ import fs                                                      from 'fs';
 import path                                                    from 'path';
 import {fileURLToPath}                                         from 'url';
 import { Memory_Config as aiConfig }                           from '../../services.mjs';
+import { Memory_MailboxService as MailboxService }             from '../../services.mjs';
 import Base                                                    from '../../../src/core/Base.mjs';
 import { Memory_StorageRouter as StorageRouter }               from '../../services.mjs';
 import { Memory_TextEmbeddingService as TextEmbeddingService } from '../../services.mjs';
@@ -78,6 +79,10 @@ import {
     recordGoldenPathSelection          as recordRouteSelection,
     renderGoldenPathRouteLedgerSection as renderRouteLedgerSection
 } from './goldenPathRouteLedger.mjs';
+import {
+    buildLifecycleState     as buildHookLifecycleState,
+    writeLifecycleStateFile as writeHookLifecycleStateFile
+} from './lifecycleStateWriter.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -601,9 +606,31 @@ class GoldenPathSynthesizer extends Base {
         return renderConsolidationGaps(summaryColl, options)
     }
 
+    /**
+     * @summary Delegates hook lifecycle-state payload construction to the shared writer helper.
+     * @param {Object} options Lifecycle-state source payload.
+     * @returns {Promise<Object>}
+     */
+    static buildLifecycleState(options) {
+        return buildHookLifecycleState(options)
+    }
+
+    /**
+     * @summary Delegates atomic hook lifecycle-state writes to the shared writer helper.
+     * @param {Object} options Write target and state payload.
+     * @returns {String}
+     */
+    static writeLifecycleStateFile(options) {
+        return writeHookLifecycleStateFile(options)
+    }
+
     async synthesizeGoldenPath({
         repoEnrichmentEnabled = true,
         issuesDir = path.resolve(__dirname, '../../../resources/content/issues'),
+        lifecycleStateAgentIdentity = process.env.NEO_AGENT_IDENTITY,
+        lifecycleStateEnabled = repoEnrichmentEnabled && process.env.UNIT_TEST_MODE !== 'true',
+        lifecycleStateFile,
+        lifecycleStateMailboxService = MailboxService,
         now = new Date()
     } = {}) {
         logger.info('[GoldenPathSynthesizer] Initializing Hybrid GraphRAG Strategic Traversal...');
@@ -1228,6 +1255,26 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         fs.mkdirSync(path.dirname(handoffFile), {recursive: true});
         fs.writeFileSync(handoffFile, handoffContent.trim() + '\n', 'utf-8');
         logger.info(`[GoldenPathSynthesizer] sandman_handoff.md freshly generated via Centralized Pipeline. Golden Path integrated.`);
+
+        if (lifecycleStateEnabled) {
+            try {
+                const lifecycleState = await this.constructor.buildLifecycleState({
+                    agentIdentity : lifecycleStateAgentIdentity,
+                    generatedAt   : handoffTimestamp,
+                    mailboxService: lifecycleStateMailboxService,
+                    prs           : openPrs,
+                    routedTopNodes
+                });
+
+                this.constructor.writeLifecycleStateFile({
+                    agentIdentity: lifecycleStateAgentIdentity,
+                    filePath     : lifecycleStateFile,
+                    state        : lifecycleState
+                });
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Failed to write lifecycle-state.json', e);
+            }
+        }
 
         logger.info(`[GoldenPathSynthesizer] Mathematical Golden Path established. Anchored ${topNodes.length} strategic nodes to frontier.`);
 

--- a/ai/services/graph/lifecycleStateWriter.mjs
+++ b/ai/services/graph/lifecycleStateWriter.mjs
@@ -1,0 +1,238 @@
+import fs   from 'node:fs';
+import path from 'node:path';
+
+import RequestContextService from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {
+    getAgentLogin,
+    normalizeAgentIdentity,
+    resolveLifecycleStateFile
+} from '../../scripts/lifecycle/lifecycleState.mjs';
+
+/**
+ * @module Neo.ai.services.graph.lifecycleStateWriter
+ * @summary Builds and writes the Stop-hook lifecycle-state board.
+ *
+ * Golden Path synthesis owns the source data. This helper owns the compact hook
+ * projection and atomic write through the shared lifecycle-state resolver. It
+ * degrades by omitting unverifiable fields; it never fabricates mailbox or PR
+ * state when a source is unavailable.
+ */
+
+/**
+ * @summary Derives the compact hook-board state for an open PR.
+ * @param {Object} pr GitHub PR payload.
+ * @returns {String}
+ */
+export function getOpenPrBoardState(pr) {
+    const reviews = Array.isArray(pr?.reviews) ? pr.reviews : [];
+
+    if (reviews.some(review => review?.state === 'CHANGES_REQUESTED')) return 'CHANGES_REQUESTED';
+    if (Array.isArray(pr?.reviewRequests) && pr.reviewRequests.length > 0) return 'REVIEW_REQUESTED';
+    if (reviews.some(review => review?.state === 'APPROVED')) return 'APPROVED';
+
+    return 'OPEN'
+}
+
+/**
+ * @summary Projects current-agent open PR payloads into the hook's bounded board shape.
+ * @param {Object[]} prs GitHub PR payloads from `fetchOpenPRs`.
+ * @param {Object} [options]
+ * @param {String} [options.agentIdentity=process.env.NEO_AGENT_IDENTITY] Active AgentIdentity.
+ * @param {Number} [options.limit=10] Maximum board rows.
+ * @returns {Object[]}
+ */
+export function buildOpenPrBoard(prs = [], {
+    agentIdentity = process.env.NEO_AGENT_IDENTITY,
+    limit = 10
+} = {}) {
+    if (!Array.isArray(prs)) return [];
+
+    const agentLogin = getAgentLogin(agentIdentity);
+    if (!agentLogin) return [];
+
+    return prs
+        .filter(pr => pr?.author?.login === agentLogin)
+        .filter(pr => typeof pr.number === 'number' || typeof pr.number === 'string')
+        .sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0))
+        .slice(0, limit)
+        .map(pr => ({
+            number: pr.number,
+            state : getOpenPrBoardState(pr)
+        }))
+}
+
+/**
+ * @summary Projects routed Computed Golden Path nodes into the hook's advisory direction field.
+ * @param {Object[]} routedTopNodes Golden Path routed node entries.
+ * @param {Object} [options]
+ * @param {Number} [options.limit=5] Maximum direction rows.
+ * @returns {Object[]}
+ */
+export function buildGoldenPathDirection(routedTopNodes = [], {
+    limit = 5
+} = {}) {
+    if (!Array.isArray(routedTopNodes)) return [];
+
+    return routedTopNodes
+        .filter(item => item?.node?.id)
+        .slice(0, limit)
+        .map(item => {
+            const title = item.node.properties?.title || item.node.properties?.name || item.node.name;
+            const row   = {id: String(item.node.id)};
+
+            if (Number.isFinite(Number(item.score))) {
+                row.score = Number(item.score);
+            }
+            if (typeof title === 'string' && title.trim()) {
+                row.title = title.trim();
+            }
+
+            return row
+        })
+}
+
+/**
+ * @summary Counts unread inbox messages for the selected agent identity.
+ * @param {Object} options
+ * @param {Object} options.mailboxService MailboxService-compatible object.
+ * @param {Object} [options.requestContextService=RequestContextService] Context service.
+ * @param {String} [options.agentIdentity=process.env.NEO_AGENT_IDENTITY] Active AgentIdentity.
+ * @returns {Promise<Number|undefined>} Verified unread count, or `undefined` when unavailable.
+ */
+export async function resolveUnreadCount({
+    mailboxService,
+    requestContextService = RequestContextService,
+    agentIdentity = process.env.NEO_AGENT_IDENTITY
+} = {}) {
+    if (typeof mailboxService?.countMessages !== 'function') return undefined;
+
+    const normalized = normalizeAgentIdentity(agentIdentity);
+    if (!normalized) return undefined;
+
+    const readCount = async () => {
+        const result = await mailboxService.countMessages({box: 'inbox', status: 'unread'});
+        const count  = Number(result?.count);
+
+        return Number.isInteger(count) && count >= 0 ? count : undefined
+    };
+
+    try {
+        const activeIdentity = requestContextService?.getAgentIdentityNodeId?.();
+        if (activeIdentity === normalized) {
+            return await readCount()
+        }
+
+        if (typeof requestContextService?.run !== 'function') return undefined;
+
+        const userId = normalized.slice(1);
+
+        return await requestContextService.run({
+            agentIdentityNodeId: normalized,
+            source             : 'env-var',
+            userId,
+            username           : userId
+        }, readCount)
+    } catch {
+        return undefined
+    }
+}
+
+/**
+ * @summary Builds the lifecycle-state JSON payload from verified source data.
+ * @param {Object} options
+ * @param {Date|String} [options.generatedAt=new Date()] Capture time.
+ * @param {Object[]} [options.prs] Open PR payloads; omitted from output when unavailable.
+ * @param {Object[]} [options.routedTopNodes] Routed Golden Path entries; omitted when unavailable.
+ * @param {Object} [options.mailboxService] MailboxService-compatible object.
+ * @param {String} [options.agentIdentity=process.env.NEO_AGENT_IDENTITY] Active AgentIdentity.
+ * @param {Object} [options.requestContextService=RequestContextService] Context service.
+ * @returns {Promise<Object>} Lifecycle-state payload.
+ */
+export async function buildLifecycleState({
+    generatedAt = new Date(),
+    prs,
+    routedTopNodes,
+    mailboxService,
+    agentIdentity = process.env.NEO_AGENT_IDENTITY,
+    requestContextService = RequestContextService
+} = {}) {
+    const generatedDate      = generatedAt instanceof Date ? generatedAt : new Date(generatedAt);
+    const normalizedIdentity = normalizeAgentIdentity(agentIdentity);
+    const state              = {
+        agentIdentity: normalizedIdentity,
+        generatedAt  : Number.isFinite(generatedDate.getTime())
+            ? generatedDate.toISOString()
+            : new Date().toISOString()
+    };
+
+    if (Array.isArray(prs)) {
+        state.openPRs = buildOpenPrBoard(prs, {agentIdentity: normalizedIdentity});
+    }
+
+    if (Array.isArray(routedTopNodes)) {
+        state.goldenPathDirection = buildGoldenPathDirection(routedTopNodes);
+    }
+
+    const unreadCount = await resolveUnreadCount({
+        agentIdentity: normalizedIdentity,
+        mailboxService,
+        requestContextService
+    });
+    if (Number.isInteger(unreadCount) && unreadCount >= 0) {
+        state.unreadCount = unreadCount;
+    }
+
+    return state
+}
+
+/**
+ * @summary Atomically writes the lifecycle-state payload for hook consumption.
+ * @param {Object} options
+ * @param {String} [options.agentIdentity] AgentIdentity or login used when resolving `filePath`.
+ * @param {Object} [options.env=process.env] Environment map for resolver override.
+ * @param {String} [options.filePath] Explicit target JSON path.
+ * @param {Object} [options.fsImpl=fs] fs-compatible implementation for tests.
+ * @param {String} [options.homeDir] OS home override for tests.
+ * @param {String} [options.rootDir] Resolver root override for tests.
+ * @param {Object} options.state Lifecycle-state payload.
+ * @returns {String} Written target path.
+ */
+export function writeLifecycleStateFile({
+    agentIdentity,
+    env     = process.env,
+    filePath,
+    fsImpl  = fs,
+    homeDir,
+    rootDir,
+    state
+} = {}) {
+    if (!state || typeof state !== 'object') {
+        throw new Error('Cannot write lifecycle-state: state object required');
+    }
+
+    const targetPath = filePath || resolveLifecycleStateFile({
+        agentIdentity: agentIdentity || state.agentIdentity,
+        env,
+        homeDir,
+        rootDir
+    });
+
+    if (!targetPath) {
+        throw new Error('Cannot write lifecycle-state: agent identity required');
+    }
+
+    const dir     = path.dirname(targetPath);
+    const tmpPath = path.join(dir, `.lifecycle-state.${process.pid}.${Date.now()}.tmp`);
+
+    fsImpl.mkdirSync(dir, {recursive: true});
+    fsImpl.writeFileSync(tmpPath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+
+    try {
+        fsImpl.renameSync(tmpPath, targetPath);
+    } catch (e) {
+        try { fsImpl.unlinkSync(tmpPath); } catch {}
+        throw e;
+    }
+
+    return targetPath
+}

--- a/test/playwright/unit/ai/scripts/lifecycle/lifecycleState.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/lifecycleState.spec.mjs
@@ -1,0 +1,179 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'LifecycleStateResolverTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    getLifecycleStateIdentityKey,
+    readLifecycleState,
+    resolveLifecycleStateFile
+} from '../../../../../../ai/scripts/lifecycle/lifecycleState.mjs';
+import {
+    buildLifecycleState,
+    writeLifecycleStateFile
+} from '../../../../../../ai/services/graph/lifecycleStateWriter.mjs';
+
+test.describe('ai/scripts/lifecycle/lifecycleState', () => {
+    test('resolves neutral .neo-ai-data paths and per-agent keyed files (#14473)', () => {
+        const homeDir = path.join(os.tmpdir(), 'neo-lifecycle-home');
+        const env     = {};
+
+        expect(getLifecycleStateIdentityKey('@neo-gpt')).toBe('neo-gpt');
+        expect(resolveLifecycleStateFile({agentIdentity: '@neo-gpt', env, homeDir}))
+            .toBe(path.join(homeDir, '.neo-ai-data', 'lifecycle-state', 'neo-gpt.json'));
+        expect(resolveLifecycleStateFile({agentIdentity: '@neo-opus-vega', env, homeDir}))
+            .toBe(path.join(homeDir, '.neo-ai-data', 'lifecycle-state', 'neo-opus-vega.json'));
+        expect(resolveLifecycleStateFile({agentIdentity: '@neo-gpt', env, homeDir}))
+            .not.toBe(resolveLifecycleStateFile({agentIdentity: '@neo-opus-vega', env, homeDir}));
+    });
+
+    test('NEO_AI_DAEMON_DIR overrides the neutral root for both reader and writer (#14473)', () => {
+        const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-lifecycle-root-'));
+        const env     = {NEO_AI_DAEMON_DIR: rootDir};
+
+        try {
+            const written = writeLifecycleStateFile({
+                agentIdentity: '@neo-gpt',
+                env,
+                state        : {
+                    agentIdentity: '@neo-gpt',
+                    generatedAt  : '2026-07-02T14:30:00.000Z',
+                    openPRs      : [{number: 14473, state: 'OPEN'}]
+                }
+            });
+
+            expect(written).toBe(path.join(rootDir, 'lifecycle-state', 'neo-gpt.json'));
+            expect(readLifecycleState({agentIdentity: '@neo-gpt', env})).toMatchObject({
+                agentIdentity: '@neo-gpt',
+                openPRs      : [{number: 14473, state: 'OPEN'}]
+            });
+        } finally {
+            fs.rmSync(rootDir, {recursive: true, force: true});
+        }
+    });
+
+    test('explicit env identity wins over process env fallback (#14473)', () => {
+        const previousIdentity = process.env.NEO_AGENT_IDENTITY;
+        const homeDir          = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-lifecycle-env-'));
+
+        process.env.NEO_AGENT_IDENTITY = '@process-agent';
+
+        try {
+            expect(resolveLifecycleStateFile({
+                env: {NEO_AGENT_IDENTITY: '@env-agent'},
+                homeDir
+            })).toBe(path.join(homeDir, '.neo-ai-data', 'lifecycle-state', 'env-agent.json'));
+        } finally {
+            if (previousIdentity === undefined) {
+                delete process.env.NEO_AGENT_IDENTITY;
+            } else {
+                process.env.NEO_AGENT_IDENTITY = previousIdentity;
+            }
+            fs.rmSync(homeDir, {recursive: true, force: true});
+        }
+    });
+
+    test('canonical per-agent file wins over legacy unkeyed hook file (#14473)', () => {
+        const rootDir    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-lifecycle-legacy-'));
+        const legacyPath = path.join(rootDir, 'lifecycle-state.json');
+        const env        = {NEO_AI_DAEMON_DIR: rootDir};
+
+        try {
+            fs.writeFileSync(legacyPath, JSON.stringify({generatedAt: 'legacy', openPRs: [{number: 1}]}), 'utf8');
+            writeLifecycleStateFile({
+                agentIdentity: '@neo-gpt',
+                env,
+                state        : {
+                    agentIdentity: '@neo-gpt',
+                    generatedAt  : 'canonical',
+                    openPRs      : [{number: 14473}]
+                }
+            });
+
+            expect(readLifecycleState({agentIdentity: '@neo-gpt', env, legacyFilePath: legacyPath})).toMatchObject({
+                agentIdentity: '@neo-gpt',
+                generatedAt  : 'canonical',
+                openPRs      : [{number: 14473}]
+            });
+        } finally {
+            fs.rmSync(rootDir, {recursive: true, force: true});
+        }
+    });
+
+    test('per-agent writes cannot clobber peer boards (#14473)', () => {
+        const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-lifecycle-peers-'));
+        const env     = {NEO_AI_DAEMON_DIR: rootDir};
+
+        try {
+            writeLifecycleStateFile({
+                agentIdentity: '@neo-gpt',
+                env,
+                state        : {agentIdentity: '@neo-gpt', generatedAt: 'gpt'}
+            });
+            writeLifecycleStateFile({
+                agentIdentity: '@neo-opus-vega',
+                env,
+                state        : {agentIdentity: '@neo-opus-vega', generatedAt: 'vega'}
+            });
+
+            expect(readLifecycleState({agentIdentity: '@neo-gpt', env}).generatedAt).toBe('gpt');
+            expect(readLifecycleState({agentIdentity: '@neo-opus-vega', env}).generatedAt).toBe('vega');
+        } finally {
+            fs.rmSync(rootDir, {recursive: true, force: true});
+        }
+    });
+
+    test('builds bounded hook board data from verified sources (#14473)', async () => {
+        const state = await buildLifecycleState({
+            agentIdentity : '@neo-gpt',
+            generatedAt   : '2026-07-02T15:00:00.000Z',
+            mailboxService: {
+                countMessages: async ({box, status}) => box === 'inbox' && status === 'unread'
+                    ? {count: 3}
+                    : {count: 0}
+            },
+            prs: [{
+                author   : {login: 'neo-gpt'},
+                createdAt: '2026-07-02T14:00:00.000Z',
+                number   : 14470,
+                reviews  : [{state: 'APPROVED'}]
+            }, {
+                author   : {login: 'neo-gpt'},
+                createdAt: '2026-07-02T15:00:00.000Z',
+                number   : 14473,
+                reviews  : [{state: 'CHANGES_REQUESTED'}]
+            }, {
+                author   : {login: 'neo-opus-ada'},
+                createdAt: '2026-07-02T15:05:00.000Z',
+                number   : 14478,
+                reviews  : []
+            }],
+            requestContextService: {
+                getAgentIdentityNodeId: () => '@neo-gpt'
+            },
+            routedTopNodes: [{
+                node : {id: 'issue-14473', properties: {title: 'Lifecycle state'}},
+                score: 42
+            }]
+        });
+
+        expect(state).toMatchObject({
+            agentIdentity      : '@neo-gpt',
+            generatedAt        : '2026-07-02T15:00:00.000Z',
+            goldenPathDirection: [{id: 'issue-14473', score: 42, title: 'Lifecycle state'}],
+            openPRs            : [
+                {number: 14473, state: 'CHANGES_REQUESTED'},
+                {number: 14470, state: 'APPROVED'}
+            ],
+            unreadCount: 3
+        });
+    });
+});


### PR DESCRIPTION
Resolves #14473

Replaces the stale `.claude/logs/lifecycle-state.json` writer contract from #14466/#14469 with a resolver-first lifecycle-state implementation shared by hook readers and the Golden Path writer. The new contract writes per-agent live-board JSON files under a neutral lifecycle-state directory, keeps hook reads fail-open, and preserves the useful #14469 payload pieces without merging the dead write target.

Evidence: L2 (focused unit/source validation for hook lifecycle-state pathing and GoldenPath synthesis side effect) -> L2 required. Runtime behavior is a local hook-board enrichment; Stop-hook admission semantics are unchanged.

## Deltas from ticket

#14473 is intentionally lifecycle-state scoped. It does not establish a general `.neo-ai-data` anchoring resolver for unrelated data planes; I posted that boundary on #14478 after Fable's design ask. The lazy-edge queue remains Ada's #14478 lane and should use its AiConfig SSOT leaf, not this lifecycle resolver.

The implementation also guards GoldenPath unit tests from writing into the real lifecycle-state home when `UNIT_TEST_MODE=true`; tests can still opt in through explicit writer helpers/paths.

## Grounding Evidence

- Source rechecked before implementation: `.claude/hooks/laneStateStopHook.mjs`, `.codex/hooks/codex-lane-state-stop.mjs`, `ai/services/graph/GoldenPathSynthesizer.mjs`, #14473 body, #14478 comment thread.
- Design boundary posted on #14478: #14473 owns lifecycle hook live boards only; #14478 owns `lazyEdgesQueuePath` via AiConfig.
- The shared resolver honors `NEO_AI_DAEMON_DIR` and otherwise defaults to neutral `~/.neo-ai-data/lifecycle-state/<agent>.json`.
- State files are per-agent keyed; canonical keyed files win over legacy unkeyed hook files.
- The Golden Path writer projects own open PR state, Golden Path direction, and unread count, then atomically writes through the resolver.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/lifecycleState.spec.mjs` -> 6 passed
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs --grep "synthesizeGoldenPath appends Active PR Cycle State|synthesizeGoldenPath skips Neo repo enrichment"` -> 2 passed
- `npm run agent-preflight -- --no-fix .claude/hooks/laneStateStopHook.mjs .codex/hooks/codex-lane-state-stop.mjs ai/scripts/lifecycle/lifecycleState.mjs ai/services/graph/GoldenPathSynthesizer.mjs ai/services/graph/lifecycleStateWriter.mjs test/playwright/unit/ai/scripts/lifecycle/lifecycleState.spec.mjs` -> all requested gates passed
- `node --check` passed for changed `.mjs` files before commit
- `git diff --check` / `git diff --cached --check` passed before commit
- Pre-commit hooks passed, including block alignment, JSDoc type lint, shorthand check, ticket archaeology, and AiConfig test-mutation guard

## Post-Merge Validation

- [ ] Next Golden Path/orchestrator run writes a per-agent lifecycle-state file visible to Codex/Claude stop hooks.
- [ ] Missing/malformed lifecycle-state files keep hooks fail-open and inject only the base no-hold reminder.
- [ ] No writer targets `.claude/logs/lifecycle-state.json`; legacy read fallback remains non-canonical.

## Commit

- `737c16862d` — `feat(hooks): resolve lifecycle-state hook boards (#14473)`

## Related

Supersedes #14466
Related: #14469
Related: #14478

Authored by Euclid (GPT-5, Codex Desktop). Session 019f2047-5787-7ed3-bfd5-552e3f2ab7e1.
