### PR TITLE
fix(release): scope orphan guard to post-publish duplicates (#14484)

### DIFF
--- a/test/playwright/unit/ai/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs
@@ -1,17 +1,37 @@
 import {test, expect} from '@playwright/test';
 import fs             from 'fs';
+import os             from 'os';
 import path           from 'path';
 
 /**
  * Regression coverage for the release-note orphan.
  *
- * The release pipeline authors a top-level `resources/content/release-notes/v{version}.md` as the
- * GitHub-release body; the content sync later buckets the published release into `chunk-N/` with
- * frontmatter. Without an explicit cleanup the top-level staging copy lingers as a duplicate of the
- * chunked record, double-listing the version in the release index and the sitemap.
+ * The staging-window lifecycle: `buildScripts/release/publish.mjs` REQUIRES a top-level
+ * `resources/content/release-notes/v{version}.md` before the cut (pre-flight errors without it),
+ * appends the atomic-hash line to it, creates the GitHub release from it, and removes it itself
+ * afterwards; the content sync then buckets the published release into `chunk-N/` with frontmatter.
+ * A top-level note for a not-yet-published version is therefore the DESIGNED staging state —
+ * authored and iterated on dev ahead of the cut. The defect class is narrower: a top-level copy
+ * that lingers ALONGSIDE its chunked mirror after publish, double-listing the version in the
+ * release index and the sitemap.
  */
 
 const root = process.cwd();
+
+/**
+ * @summary Returns top-level release-note files that duplicate an already-chunked (published) version.
+ * @param {String} dir Release-notes directory containing chunk-N buckets.
+ * @returns {String[]} Orphaned file names (post-publish duplicates only; staging files pass).
+ */
+function findOrphanedTopLevelNotes(dir) {
+    const
+        entries       = fs.readdirSync(dir),
+        topLevelNotes = entries.filter(entry => /^v.*\.md$/.test(entry)),
+        chunkDirs     = entries.filter(entry => /^chunk-\d+$/.test(entry)),
+        mirrored      = new Set(chunkDirs.flatMap(chunk => fs.readdirSync(path.join(dir, chunk))));
+
+    return topLevelNotes.filter(name => mirrored.has(name))
+}
 
 test.describe('Release-note orphan prevention', () => {
     test('publish.mjs deletes the top-level staging release note after the GitHub release is created', () => {
@@ -25,13 +45,27 @@ test.describe('Release-note orphan prevention', () => {
         expect(cleanupIdx).toBeGreaterThan(releaseIdx);
     });
 
-    test('no top-level release-notes/v*.md orphan exists alongside the chunk-N buckets', () => {
-        const
-            dir           = path.join(root, 'resources/content/release-notes'),
-            entries       = fs.readdirSync(dir),
-            topLevelNotes = entries.filter(entry => /^v.*\.md$/.test(entry));
+    test('no top-level release-notes/v*.md lingers alongside its chunk-N mirror', () => {
+        expect(findOrphanedTopLevelNotes(path.join(root, 'resources/content/release-notes'))).toEqual([]);
+    });
 
-        expect(topLevelNotes).toEqual([]);
+    test('a pre-publish staging note passes; a post-publish duplicate is flagged', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-orphan-guard-'));
+
+        try {
+            fs.mkdirSync(path.join(tmp, 'chunk-1'));
+            fs.writeFileSync(path.join(tmp, 'chunk-1', 'v99.0.0.md'), '# v99.0.0');
+
+            // The designed staging state: a top-level note for a version with no chunk mirror yet.
+            fs.writeFileSync(path.join(tmp, 'v99.1.0.md'), '# staging draft');
+            expect(findOrphanedTopLevelNotes(tmp)).toEqual([]);
+
+            // The defect class: a top-level copy of a version the sync already chunked.
+            fs.writeFileSync(path.join(tmp, 'v99.0.0.md'), '# lingering duplicate');
+            expect(findOrphanedTopLevelNotes(tmp)).toEqual(['v99.0.0.md']);
+        } finally {
+            fs.rmSync(tmp, {recursive: true, force: true});
+        }
     });
 
     test('the release index lists each release leaf exactly once', () => {


### PR DESCRIPTION
Resolves #14484
Refs #14483

Narrows the release-note orphan guard to its actual defect class. `publish.mjs` REQUIRES a top-level `resources/content/release-notes/v{version}.md` before the cut (pre-flight errors without it, `:83-87`), appends the atomic-hash line to it, creates the GitHub Release from it, and removes it itself post-release (`:223-226`) — so a top-level note for a not-yet-published version is the pipeline's DESIGNED staging state, authored and iterated on dev ahead of the cut (the v13.0 lineage did exactly this across #12695→#12924). The guard's second test asserted the flat root is ALWAYS empty, outlawing that mandatory state and blocking any notes PR from green CI (live demonstration: PR #14480's first head failed `unit` solely here). The refined predicate flags a top-level file **only when its chunk-N mirror already exists** — the post-publish lingering duplicate that #13273 was actually about — via a shared `findOrphanedTopLevelNotes()` helper. Tests 1 (publish cleanup ordering) and 3 (release-index uniqueness) are unchanged, and a new fixture test pins both sides of the contract in a temp directory (staging note passes; mirrored duplicate flagged) so the narrowing itself is regression-proof.

Evidence: L2 (unit spec, 4/4 passed locally; the change surface is the spec itself) — fully covers the close-target ACs.

## Deltas from ticket

- The ticket offered `_index.json` keys with a chunk-scan fallback for mirror detection; the implementation uses the chunk-directory scan directly — it is the physical source of truth the index derives from, needs no JSON parse, and degrades identically (no chunks → nothing mirrored → nothing flagged).
- Recorded observation carried from the ticket (explicitly out of scope here): `buildScripts/docs/index/release.mjs` scans flat files recursively, so a committed staging note surfaces its version in `releases.json` when the docs index regenerates pre-cut; whether the index builder should skip flat staging files is an editorial/product call for the epic.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/buildScripts/release/PublishReleaseNoteOrphan.spec.mjs` → **4 passed** (was 3 tests; test 2 refined + 1 fixture test added)
- `npm run agent-preflight -- --no-fix <spec>` → all gates passed (ticket-archaeology 0 violations)
- Contract proof in-suite: the fixture test asserts a staging `v99.1.0.md` passes while a `v99.0.0.md` duplicating `chunk-1/v99.0.0.md` is flagged

## Post-Merge Validation

- [ ] PR #14480 (iteration-1 notes at the flat root, version unmirrored) re-runs `unit` green against dev containing this change
- [ ] The next release cut exercises the full staging lifecycle: file present pre-flight → publish consumes + removes → sync chunks it → guard stays green throughout

Authored by Vega (Claude Fable 5 — temporary boost on the Opus 4.8 identity, Claude Code). Session 8cf234b7-e698-47ca-99e2-bf865196b6aa.
