### PR TITLE
feat(ai): boot-identity fact AC-1 discriminator + live watchdog classification (#14514)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -2,6 +2,7 @@ import {collectDueCandidates}                                  from './collector
 import {pickNextCandidate}                                     from './picker.mjs';
 import {evaluateStallAlarm, getEmbedDrainPendingAge}           from './embedDrainLivenessWatchdog.mjs';
 import {evaluateConsolidationStallAlarm, getRemCycleStaleness} from './remConsolidationLivenessWatchdog.mjs';
+import {classifyBootFreshness}                                 from '../services/bootIdentityFreshness.mjs';
 
 /**
  * Tasks that win the per-poll pick unconditionally when due. `backup` is data-safety:
@@ -828,13 +829,26 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
         };
 
         if (stalled) {
+            // Advisory boot-identity classification: when a stall fires, distinguish a restart-lost
+            // scheduler (this process booted after the last recorded cycle) from an as-yet-unexplained
+            // gap, so the alarm carries its likely disposition rather than triggering a forensic hunt.
+            // Advisory only — it never changes WHETHER the stall alarms, only its recorded reason.
+            const bootFreshness = classifyBootFreshness({
+                bootAt        : now - Math.round(process.uptime() * 1000),
+                lastCycleAt   : lastCompletedAt,
+                now,
+                deferralReason: null
+            }, {designedCadenceMs: thresholdMs, marginMs: 0});
+
             services.healthService?.recordTaskOutcome?.(taskName, 'failed', {
                 ...details,
-                stalledSince: stalledSince === null ? null : new Date(stalledSince).toISOString()
+                stalledSince       : stalledSince === null ? null : new Date(stalledSince).toISOString(),
+                bootFreshness      : bootFreshness.classification,
+                bootFreshnessReason: bootFreshness.reason
             });
 
             if (shouldAlarm) {
-                runtime.writeLog?.('WARN', `[Orchestrator] rem-consolidation-liveness-watchdog: REM consolidation STALLED (hasCycle=${hasCycle}, stalenessMs=${stalenessMs}, thresholdMs=${thresholdMs}) — the dream stopped laying trails; the graph is rotting while the forecast looks fresh.`);
+                runtime.writeLog?.('WARN', `[Orchestrator] rem-consolidation-liveness-watchdog: REM consolidation STALLED (hasCycle=${hasCycle}, stalenessMs=${stalenessMs}, thresholdMs=${thresholdMs}, bootFreshness=${bootFreshness.classification}) — the dream stopped laying trails; the graph is rotting while the forecast looks fresh.`);
                 if (runtime.remConsolidationWatchdogAlarmEnabled) {
                     await dispatchRemConsolidationStallAlarm({
                         dispatcher     : services.remConsolidationLivenessAlarmDispatcher,

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -39,6 +39,23 @@ export const TASK_STALENESS_CADENCE_KEY = Object.freeze({
 });
 
 /**
+ * The maintenance-backpressure deferral `reasonCode`s that `MaintenanceBackpressureService.recordDeferral`
+ * emits onto a deferred task's `skipped` outcome. The REM-consolidation watchdog re-labels a recent
+ * `dream` (REM producer) skip as a `designed-deferral` boot-freshness disposition ONLY when its
+ * `reasonCode` is one of these AND it carries a recency-bounded deferral-specific `deferredAt` — so a
+ * generic or unrecognized skip is NOT a designed deferral and can never mask a genuine stall. Keep in
+ * lockstep with the `recordDeferral` emitters in `MaintenanceBackpressureService`.
+ * @type {ReadonlyArray<String>}
+ */
+export const RECOGNIZED_DEFERRAL_REASON_CODES = Object.freeze([
+    'heavy-maintenance-shed-window',
+    'heavy-maintenance-backpressure',
+    'heavy-maintenance-lease-acquire-error',
+    'heavy-maintenance-lease-held',
+    'golden-path-dependency-backpressure'
+]);
+
+/**
  * @summary Builds the picker's per-candidate `{lastRunAt, cadenceMs}` staleness map.
  *
  * Only staleness-eligible candidates (keys of `TASK_STALENESS_CADENCE_KEY`) get an entry; the rest
@@ -838,12 +855,18 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
             // HealthService task-outcome surface, recency-bounded to the staleness window so a stale
             // prior deferral can't mask a genuine gap. Advisory only — a present reason re-labels the
             // disposition, never whether the stall alarms.
-            const dreamOutcome   = services.healthService?.getTaskOutcome?.('dream');
-            const deferralReason = (
-                dreamOutcome?.status === 'skipped' &&
-                Number.isFinite(Date.parse(dreamOutcome.recordedAt)) &&
-                (now - Date.parse(dreamOutcome.recordedAt)) <= thresholdMs
-            ) ? (dreamOutcome.details?.reason ?? dreamOutcome.details?.reasonCode ?? null) : null;
+            const dreamOutcome = services.healthService?.getTaskOutcome?.('dream');
+            // A recent `dream` skip re-labels the stall as a DESIGNED deferral ONLY when it is a
+            // RECOGNIZED maintenance-backpressure deferral carrying a recency-bounded deferral-specific
+            // `deferredAt` — so a generic / unrecognized skip can never mask a genuine gap.
+            const deferralDetails = dreamOutcome?.status === 'skipped' ? dreamOutcome.details : null;
+            const deferredAtMs    = Date.parse(deferralDetails?.deferredAt);
+            const deferralReason  = (
+                deferralDetails &&
+                RECOGNIZED_DEFERRAL_REASON_CODES.includes(deferralDetails.reasonCode) &&
+                Number.isFinite(deferredAtMs) &&
+                (now - deferredAtMs) <= thresholdMs
+            ) ? (deferralDetails.reason ?? deferralDetails.reasonCode) : null;
 
             const bootFreshness = classifyBootFreshness({
                 bootAt     : now - Math.round(process.uptime() * 1000),

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -833,11 +833,23 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
             // scheduler (this process booted after the last recorded cycle) from an as-yet-unexplained
             // gap, so the alarm carries its likely disposition rather than triggering a forensic hunt.
             // Advisory only — it never changes WHETHER the stall alarms, only its recorded reason.
+            // A recent maintenance-deferral of the REM producer ('dream') explains the gap as a
+            // designed deferral, not a restart-lost scheduler: read its reason from the shared
+            // HealthService task-outcome surface, recency-bounded to the staleness window so a stale
+            // prior deferral can't mask a genuine gap. Advisory only — a present reason re-labels the
+            // disposition, never whether the stall alarms.
+            const dreamOutcome   = services.healthService?.getTaskOutcome?.('dream');
+            const deferralReason = (
+                dreamOutcome?.status === 'skipped' &&
+                Number.isFinite(Date.parse(dreamOutcome.recordedAt)) &&
+                (now - Date.parse(dreamOutcome.recordedAt)) <= thresholdMs
+            ) ? (dreamOutcome.details?.reason ?? dreamOutcome.details?.reasonCode ?? null) : null;
+
             const bootFreshness = classifyBootFreshness({
-                bootAt        : now - Math.round(process.uptime() * 1000),
-                lastCycleAt   : lastCompletedAt,
+                bootAt     : now - Math.round(process.uptime() * 1000),
+                lastCycleAt: lastCompletedAt,
                 now,
-                deferralReason: null
+                deferralReason
             }, {designedCadenceMs: thresholdMs, marginMs: 0});
 
             services.healthService?.recordTaskOutcome?.(taskName, 'failed', {

--- a/ai/daemons/orchestrator/services/BootIdentityHealthService.mjs
+++ b/ai/daemons/orchestrator/services/BootIdentityHealthService.mjs
@@ -1,0 +1,85 @@
+import Base                                            from '../../../../src/core/Base.mjs';
+import {classifyBootFreshness, SCHEDULER_RESUME_STATE} from './bootIdentityFreshness.mjs';
+
+/**
+ * @summary Read-only advisory boot-identity health surface for long-lived Agent-OS processes.
+ *
+ * Produces the boot-identity fact `{bootAt, sourceRef, schedulerResumeState, lastCycleRef, lastCycleAt}`
+ * and delegates to the pure `classifyBootFreshness` discriminator ({@link ./bootIdentityFreshness.mjs}),
+ * so a stale-wake alarm is answered by a fact-compare instead of a forensic probe.
+ *
+ * **Read-only + advisory only:** this producer never emits a definitive `stale` verdict and never carries
+ * a restart command. Restart authority lives in a separate control-plane actuator, not here. It is
+ * orthogonal to config/schema-digest freshness tracking (`RuntimeFreshnessService`) and to wake/heartbeat
+ * emission control — this surface answers "which source is this long-lived process actually running".
+ *
+ * The raw-fact gathering (process boot time, source ref, scheduler resume state, last scheduler cycle) is
+ * an injected collaborator, so the discriminator stays testable without the live scheduler/boot surfaces.
+ *
+ * @class Neo.ai.daemons.services.BootIdentityHealthService
+ * @extends Neo.core.Base
+ */
+export class BootIdentityHealthService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.BootIdentityHealthService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.BootIdentityHealthService',
+        /**
+         * Injected async collaborator returning the raw boot-identity facts for this process:
+         * `async () => {bootAt, sourceRef, schedulerResumeState, lastCycleAt, lastCycleRef, deferralReason}`.
+         * Injected (not read here) so the discriminator is testable without the live boot/scheduler surfaces.
+         * @member {Function|null} factGatherer_=null
+         * @protected
+         * @reactive
+         */
+        factGatherer_: null,
+        /**
+         * Freshness thresholds `{designedCadenceMs, marginMs}`, read at the use site (never re-derived).
+         * @member {Object|null} freshnessConfig_=null
+         * @protected
+         * @reactive
+         */
+        freshnessConfig_: null,
+        /**
+         * Injected epoch-ms clock; keeps the classify path free of an ambient `Date.now`.
+         * @member {Function|null} nowFn_=null
+         * @protected
+         * @reactive
+         */
+        nowFn_: null
+    }
+
+    /**
+     * Gathers the current boot-identity fact and classifies its freshness. Read-only + advisory:
+     * returns `{fact, classification, advisory:true, reason}`, never a restart command. An absent
+     * gatherer or absent facts yield an `unknown` advisory, never a definitive `stale` verdict.
+     * @returns {Promise<Object>}
+     */
+    async produceBootIdentityFact() {
+        const gather = this.factGatherer;
+
+        if (!gather) {
+            return {fact: null, classification: 'unknown', advisory: true, reason: 'no-fact-gatherer'};
+        }
+
+        const
+            raw = await gather() || {},
+            now = (this.nowFn || Date.now)(),
+            cfg = this.freshnessConfig || {};
+
+        return {
+            fact: {
+                bootAt              : Number.isFinite(raw.bootAt) ? raw.bootAt : null,
+                sourceRef           : raw.sourceRef ?? null,
+                schedulerResumeState: raw.schedulerResumeState ?? SCHEDULER_RESUME_STATE.none,
+                lastCycleRef        : raw.lastCycleRef ?? null,
+                lastCycleAt         : Number.isFinite(raw.lastCycleAt) ? raw.lastCycleAt : null
+            },
+            ...classifyBootFreshness({...raw, now}, cfg)
+        };
+    }
+}
+
+export default Neo.setupClass(BootIdentityHealthService);

--- a/ai/daemons/orchestrator/services/bootIdentityFactGatherer.mjs
+++ b/ai/daemons/orchestrator/services/bootIdentityFactGatherer.mjs
@@ -1,0 +1,61 @@
+import {SCHEDULER_RESUME_STATE} from './bootIdentityFreshness.mjs';
+
+/**
+ * Live fact-gatherer factory for the boot-identity health surface — the integration layer the
+ * advisory service injects. Reads the last scheduler cycle from the REM run-state store (the same
+ * source the consolidation liveness watchdog reads) and pairs it with the process boot time so the
+ * pure discriminator can classify a stale-wake.
+ *
+ * Conservative first cut: `schedulerResumeState` defaults to `'none'` (no scheduler re-arm signal
+ * surface exists yet, so a boot-after-last-cycle conservatively reads as restart-explains), and
+ * `deferralReason` / `sourceRef` are read best-effort (null when unavailable). Each is behind an
+ * optional injected resolver, so the domain-specific derivations refine in place without restructuring.
+ *
+ * @param {Object}   options
+ * @param {Number}   options.bootAt                          Epoch-ms captured at process/service construction.
+ * @param {Function} options.readRecentRemRunStates          Async `({dir, limit}) => Promise<Object[]>` reader.
+ * @param {String}   options.remRunStateDir                  Directory holding the REM run-state JSONL artifacts.
+ * @param {Function} [options.resolveSourceRef]              `() => (String|null)` advisory source ref (never gitHead-primary).
+ * @param {Function} [options.resolveDeferralReason]         `async () => (String|null)` why the scheduler deferred.
+ * @param {Function} [options.resolveSchedulerResumeState]   `() => String` refines the conservative `'none'` default.
+ * @returns {Function} async `() => {bootAt, sourceRef, schedulerResumeState, lastCycleAt, lastCycleRef, deferralReason}`
+ */
+export function createBootIdentityFactGatherer({
+    bootAt,
+    readRecentRemRunStates,
+    remRunStateDir,
+    resolveSourceRef            = null,
+    resolveDeferralReason       = null,
+    resolveSchedulerResumeState = null
+} = {}) {
+    return async function gatherBootIdentityFacts() {
+        let lastCycleAt  = null,
+            lastCycleRef = null;
+
+        // Read the most-recent REM cycle from the same store the liveness watchdog reads. Fail soft:
+        // a read fault leaves the cycle facts null -> the discriminator returns `unknown`, never a
+        // definitive stale.
+        try {
+            const entries = typeof readRecentRemRunStates === 'function'
+                ? await readRecentRemRunStates({dir: remRunStateDir, limit: 1})
+                : null;
+            const latest = Array.isArray(entries) && entries.length > 0 ? entries[0] : null;
+
+            if (latest) {
+                lastCycleAt  = Number.isFinite(Number(latest.completedAt)) ? Number(latest.completedAt) : null;
+                lastCycleRef = latest.runId ?? null;
+            }
+        } catch {
+            // fail soft — cycle facts stay null
+        }
+
+        return {
+            bootAt              : Number.isFinite(bootAt) ? bootAt : null,
+            sourceRef           : resolveSourceRef            ? resolveSourceRef()            : null,
+            schedulerResumeState: resolveSchedulerResumeState ? resolveSchedulerResumeState() : SCHEDULER_RESUME_STATE.none,
+            lastCycleAt,
+            lastCycleRef,
+            deferralReason      : resolveDeferralReason       ? await resolveDeferralReason() : null
+        };
+    };
+}

--- a/ai/daemons/orchestrator/services/bootIdentityFreshness.mjs
+++ b/ai/daemons/orchestrator/services/bootIdentityFreshness.mjs
@@ -1,0 +1,84 @@
+/**
+ * Pure boot-identity freshness discriminator for the boot-identity health surface.
+ *
+ * Standalone + Neo-free so it stays hermetically unit-testable (no `Neo.setupClass`, no socket,
+ * no live scheduler/boot surface). `BootIdentityHealthService` delegates to `classifyBootFreshness`;
+ * the raw-fact gathering is that service's injected integration layer.
+ */
+
+/**
+ * Boot-identity health fact classifications. Advisory-only — never a definitive `stale` verdict and
+ * never a restart command; the restart cure belongs to a separate control-plane actuator.
+ * @type {Object}
+ */
+export const BOOT_FRESHNESS_CLASS = Object.freeze({
+    designedDeferral: 'designed-deferral',    // gap is a designed-cadence deferral -> close/recalibrate the alarm
+    restartExplains : 'restart-explains-gap', // gap explained by a stale/restart-lost scheduler -> a restart cures it
+    unknown         : 'unknown'               // insufficient/absent facts -> advisory, never a definitive stale
+});
+
+/**
+ * Scheduler resume states carried by the boot-identity fact.
+ * @type {Object}
+ */
+export const SCHEDULER_RESUME_STATE = Object.freeze({
+    reArmed: 're-armed', // scheduler re-armed its timers after boot/restart
+    fresh  : 'fresh',    // fresh boot, timers armed from scratch
+    none   : 'none'      // no scheduler resume observed
+});
+
+/**
+ * @summary Classifies a long-lived process's boot-identity fact against its last scheduler cycle,
+ * collapsing the "stale-wake" question to a single deterministic, advisory fact-compare.
+ *
+ * Pure — no I/O, no ambient clock, no restart authority. Gathering the input facts (bootAt, sourceRef,
+ * schedulerResumeState, lastCycleAt) is the injected integration layer; this is the discriminator.
+ * Worked example: a scheduler gap larger than the cadence classifies as `designed-deferral` when a
+ * deferral reason is present (e.g. deferred behind heavy maintenance), but as `restart-explains-gap`
+ * when the same gap follows a fresh boot with an un-re-armed scheduler.
+ *
+ * @param {Object}      facts
+ * @param {Number|null} facts.bootAt                Epoch-ms the process booted.
+ * @param {Number|null} facts.lastCycleAt           Epoch-ms of the last completed scheduler cycle.
+ * @param {String|null} facts.schedulerResumeState  One of {@link SCHEDULER_RESUME_STATE}.
+ * @param {String|null} [facts.deferralReason=null] Present when the scheduler deliberately deferred.
+ * @param {Number}      facts.now                   Epoch-ms now (injected; no ambient clock).
+ * @param {Object}      config
+ * @param {Number}      config.designedCadenceMs    The scheduler's designed cadence, ms.
+ * @param {Number}      [config.marginMs=0]         Tolerance added to the cadence before a gap is suspicious.
+ * @returns {{classification:String, advisory:Boolean, reason:String}}
+ */
+export function classifyBootFreshness(facts, config) {
+    const
+        {bootAt                      = null, lastCycleAt = null, schedulerResumeState = null, deferralReason = null, now} = facts  || {},
+        {designedCadenceMs, marginMs = 0}                                                            = config || {};
+
+    // Insufficient facts to compare -> `unknown`. Absent facts NEVER assert a definitive stale.
+    if (!Number.isFinite(now) || !Number.isFinite(lastCycleAt) || !Number.isFinite(designedCadenceMs)) {
+        return {classification: BOOT_FRESHNESS_CLASS.unknown, advisory: true, reason: 'insufficient-facts'};
+    }
+
+    // Designed-deferral: within cadence+margin, or the scheduler deliberately deferred (e.g. behind
+    // heavy maintenance). Close the alarm + recalibrate its threshold to cadence+margin.
+    if (deferralReason || now - lastCycleAt < designedCadenceMs + marginMs) {
+        return {
+            classification: BOOT_FRESHNESS_CLASS.designedDeferral,
+            advisory      : true,
+            reason        : deferralReason ? 'deferral-reason-present' : 'within-cadence-margin'
+        };
+    }
+
+    // Restart-explains-gap: the process booted AFTER the last cycle AND the scheduler did not re-arm
+    // its timers -> a stale / restart-lost scheduler. The cure is a separate restart actuator, never
+    // triggered here (this is a read-only advisory producer).
+    if (Number.isFinite(bootAt) && bootAt > lastCycleAt && schedulerResumeState !== SCHEDULER_RESUME_STATE.reArmed) {
+        return {
+            classification: BOOT_FRESHNESS_CLASS.restartExplains,
+            advisory      : true,
+            reason        : 'boot-after-last-cycle-and-not-re-armed'
+        };
+    }
+
+    // Gap exceeds cadence+margin but the boot-identity does not explain it -> `unknown` (advisory).
+    return {classification: BOOT_FRESHNESS_CLASS.unknown, advisory: true, reason: 'gap-unexplained-by-boot-identity'};
+}

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1,15 +1,15 @@
-import fs                       from 'fs/promises';
-import fsExtra                  from 'fs-extra';
-import path                     from 'path';
-import {fileURLToPath}          from 'url';
-import aiConfig                 from '../../mcp/server/memory-core/config.mjs';
-import Base                     from '../../../src/core/Base.mjs';
-import RuntimeFreshnessService  from '../../mcp/server/shared/services/RuntimeFreshnessService.mjs';
-import ChromaManager            from './managers/ChromaManager.mjs';
-import StorageRouter            from './managers/StorageRouter.mjs';
-import ChromaLifecycleService   from './lifecycle/ChromaLifecycleService.mjs';
-import logger                   from '../../mcp/server/memory-core/logger.mjs';
-import {readGateState}          from '../../scripts/lifecycle/wakeSafetyGate.mjs';
+import fs                      from 'fs/promises';
+import fsExtra                 from 'fs-extra';
+import path                    from 'path';
+import {fileURLToPath}         from 'url';
+import aiConfig                from '../../mcp/server/memory-core/config.mjs';
+import Base                    from '../../../src/core/Base.mjs';
+import RuntimeFreshnessService from '../../mcp/server/shared/services/RuntimeFreshnessService.mjs';
+import ChromaManager           from './managers/ChromaManager.mjs';
+import StorageRouter           from './managers/StorageRouter.mjs';
+import ChromaLifecycleService  from './lifecycle/ChromaLifecycleService.mjs';
+import logger                  from '../../mcp/server/memory-core/logger.mjs';
+import {readGateState}         from '../../scripts/lifecycle/wakeSafetyGate.mjs';
 import {
     SHARED_USER_ID,
     hasCoreSwarmParticipant,
@@ -22,8 +22,8 @@ import {withTimeout}                  from './helpers/withTimeout.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const
-    configPath  = path.resolve(__dirname, '../../config.mjs'),
-    openApiPath = path.resolve(__dirname, '../../mcp/server/memory-core/openapi.yaml'),
+    configPath              = path.resolve(__dirname, '../../config.mjs'),
+    openApiPath             = path.resolve(__dirname, '../../mcp/server/memory-core/openapi.yaml'),
     runtimeFreshnessTracker = RuntimeFreshnessService.createTracker({
         files  : [{
             key       : 'configDigest',
@@ -114,9 +114,9 @@ export function buildIdentityBlock(stdioIdentityState) {
     }
 
     const {agentIdentityNodeId, source, userId} = stdioIdentityState,
-          resolvedSource = source || 'unresolved',
-          isEnvPinnedUnbound = resolvedSource === 'env-var' && !agentIdentityNodeId,
-          warning = isEnvPinnedUnbound
+          resolvedSource                        = source || 'unresolved',
+          isEnvPinnedUnbound                    = resolvedSource === 'env-var' && !agentIdentityNodeId,
+          warning                               = isEnvPinnedUnbound
               ? `NEO_AGENT_IDENTITY is pinned to '${userId || 'unknown'}' but resolved to no ` +
                 `AgentIdentity graph node (bound:false). Check for a stale checkout, run ` +
                 `ai/scripts/setup/seedAgentIdentities.mjs, or confirm the identity exists in ` +
@@ -124,9 +124,9 @@ export function buildIdentityBlock(stdioIdentityState) {
               : null;
 
     return {
-        source : resolvedSource,
-        bound  : !!agentIdentityNodeId,
-        nodeId : agentIdentityNodeId || null,
+        source: resolvedSource,
+        bound : !!agentIdentityNodeId,
+        nodeId: agentIdentityNodeId || null,
         warning
     };
 }
@@ -259,31 +259,31 @@ function buildSingleEmbeddingProviderBlock(cfg, active, configName) {
         case 'openAiCompatible':
             return {
                 active,
-                host      : cfg.openAiCompatible?.host || null,
-                model     : cfg.openAiCompatible?.embeddingModel || null,
+                host : cfg.openAiCompatible?.host || null,
+                model: cfg.openAiCompatible?.embeddingModel || null,
                 dimensions
             };
         case 'ollama':
             return {
                 active,
-                host      : cfg.ollama?.host || null,
-                model     : cfg.ollama?.embeddingModel || null,
+                host : cfg.ollama?.host || null,
+                model: cfg.ollama?.embeddingModel || null,
                 dimensions
             };
         case 'gemini':
             return {
                 active,
-                host      : null,
-                model     : cfg.embeddingModel || null,
+                host : null,
+                model: cfg.embeddingModel || null,
                 dimensions
             };
         default:
             return {
                 active,
-                host      : null,
-                model     : null,
+                host : null,
+                model: null,
                 dimensions,
-                error     : `Unrecognized ${configName}: '${active}'. Expected 'gemini' | 'openAiCompatible' | 'ollama'.`
+                error: `Unrecognized ${configName}: '${active}'. Expected 'gemini' | 'openAiCompatible' | 'ollama'.`
             };
     }
 }
@@ -389,7 +389,7 @@ export function buildProviderPrerequisiteBlock(cfg, env = process.env) {
           details = [summary.detail, embedding.detail].filter(Boolean);
 
     return {
-        ready: summary.ready && embedding.ready,
+        ready  : summary.ready && embedding.ready,
         summary: {
             provider: summaryProvider,
             ready   : summary.ready
@@ -481,9 +481,9 @@ export async function buildWakeFeaturesBlock(now = Date.now()) {
     };
 
     try {
-        const stat       = await fs.stat(heartbeatAlivePath());
-        const mtimeMs    = stat.mtime.getTime();
-        const ageMs      = Math.max(0, nowMs - mtimeMs);
+        const stat    = await fs.stat(heartbeatAlivePath());
+        const mtimeMs = stat.mtime.getTime();
+        const ageMs   = Math.max(0, nowMs - mtimeMs);
         livenessBlock = {
             daemonRunning        : ageMs < heartbeatLivenessStaleMs(),
             lastPulseAt          : stat.mtime.toISOString(),
@@ -566,13 +566,13 @@ export async function buildBackupStateBlock(backupPath, fs, path) {
 
         return {
             lastSuccessful: timestamp,
-            count: backupDirs.length
+            count         : backupDirs.length
         };
     } catch (e) {
         return {
             lastSuccessful: null,
-            count: 0,
-            error: e.message
+            count         : 0,
+            error         : e.message
         };
     }
 }
@@ -607,10 +607,10 @@ export function buildChromaMigrationStats(metadatas, {summaryCollection = false}
     (metadatas || []).forEach(metadata => {
         stats.totalRecords++;
 
-        const rawUserId = metadata?.userId;
+        const rawUserId     = metadata?.userId;
         const missingUserId = rawUserId === undefined || rawUserId === null || rawUserId === '';
-        const userId = normalizeUserId(rawUserId);
-        const hasCorePeer = summaryCollection && hasCoreSwarmParticipant(metadata?.participatingAgents);
+        const userId        = normalizeUserId(rawUserId);
+        const hasCorePeer   = summaryCollection && hasCoreSwarmParticipant(metadata?.participatingAgents);
 
         if (missingUserId) {
             stats.missingUserId++;
@@ -716,7 +716,7 @@ export async function buildRemPipelineState({sessionId, axisTimeoutMs = aiConfig
     ]);
 
     const [undigested, digested, sessionNodes, topologyConflicts] = axisEntries.map(entry => entry.value),
-          axisErrors = Object.fromEntries(
+          axisErrors                                              = Object.fromEntries(
               ['undigested', 'digested', 'sessionNodes', 'topologyConflicts']
                   .map((key, index) => [key, axisEntries[index].error])
                   .filter(([, error]) => error)
@@ -937,7 +937,7 @@ class HealthService extends Base {
      */
     async #checkDatabaseConnections(chromaProbeTimeoutMs) {
         try {
-            const engine = aiConfig.engine;
+            const engine  = aiConfig.engine;
             const engines = { chroma: false };
 
             // 2. Vector Chroma DB (Hybrid & Standalone Chroma)
@@ -1200,7 +1200,7 @@ class HealthService extends Base {
             // Dynamic import to avoid circular dependency with GraphService (GraphService
             // itself imports HealthService indirectly via other service chains).
             const {default: GraphService} = await import('./GraphService.mjs');
-            const sqliteDb = GraphService.db?.storage?.db;
+            const sqliteDb                = GraphService.db?.storage?.db;
 
             if (!sqliteDb) {
                 return {memory: 0, session: 0, total: 0, available: false};
@@ -1316,8 +1316,8 @@ class HealthService extends Base {
      */
     async #scanChromaMetadata(collection, options = {}) {
         const batchSize = 2000;
-        let metadatas   = [];
-        let offset      = 0;
+        let   metadatas = [];
+        let   offset    = 0;
 
         while (true) {
             const batch = await collection.get({limit: batchSize, offset, include: ['metadatas']});
@@ -1416,8 +1416,8 @@ class HealthService extends Base {
      * @private
      */
     async #getEmbeddingWriteCanary(embeddingWriteCanaryTimeoutMs) {
-        const now = Date.now(),
-              key = `${aiConfig.embeddingProvider}:${aiConfig.vectorDimension}:${embeddingWriteCanaryTimeoutMs}`,
+        const now    = Date.now(),
+              key    = `${aiConfig.embeddingProvider}:${aiConfig.vectorDimension}:${embeddingWriteCanaryTimeoutMs}`,
               cached = this.#embeddingWriteCanaryCache;
 
         if (cached &&
@@ -1496,10 +1496,10 @@ class HealthService extends Base {
             startup : {
                 dependencies: this.getStartupDependencyState()
             },
-            backup   : await buildBackupStateBlock(aiConfig.backupPath, fsExtra, path),
-            details  : [],
-            version  : process.env.npm_package_version || '1.0.0',
-            uptime   : process.uptime()
+            backup : await buildBackupStateBlock(aiConfig.backupPath, fsExtra, path),
+            details: [],
+            version: process.env.npm_package_version || '1.0.0',
+            uptime : process.uptime()
         };
 
         // Step 1: Check Database connectivity
@@ -1764,6 +1764,17 @@ class HealthService extends Base {
 
         // Clear the cache to ensure next healthcheck returns updated info
         this.clearCache();
+    }
+
+    /**
+     * Reads the most-recently recorded outcome for a task, or `null` when none is recorded.
+     * Read-only accessor over the internal per-task outcome map; the returned shape is
+     * `{status, details, recordedAt}` exactly as written by {@link recordTaskOutcome}.
+     * @param {String} taskName
+     * @returns {{status:String, details:(Object|null), recordedAt:String}|null}
+     */
+    getTaskOutcome(taskName) {
+        return this.#taskOutcomes[taskName] || null;
     }
 
     /**

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1768,13 +1768,15 @@ class HealthService extends Base {
 
     /**
      * Reads the most-recently recorded outcome for a task, or `null` when none is recorded.
-     * Read-only accessor over the internal per-task outcome map; the returned shape is
-     * `{status, details, recordedAt}` exactly as written by {@link recordTaskOutcome}.
+     * Returns a **defensive deep clone** of `{status, details, recordedAt}` (via `structuredClone`),
+     * so a caller mutating the result — including its nested `details` — can never corrupt the
+     * internal per-task outcome map. Read-only accessor over that map.
      * @param {String} taskName
      * @returns {{status:String, details:(Object|null), recordedAt:String}|null}
      */
     getTaskOutcome(taskName) {
-        return this.#taskOutcomes[taskName] || null;
+        const outcome = this.#taskOutcomes[taskName];
+        return outcome ? structuredClone(outcome) : null;
     }
 
     /**

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
@@ -13,7 +13,8 @@ import {
     buildSchedulingContext,
     runSchedulingPipeline
 }                                     from '../../../../../../../ai/daemons/orchestrator/scheduling/pipeline.mjs';
-import {TASK_REGISTRY}               from '../../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
+import {TASK_REGISTRY}        from '../../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
+import {BOOT_FRESHNESS_CLASS} from '../../../../../../../ai/daemons/orchestrator/services/bootIdentityFreshness.mjs';
 
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -138,13 +139,14 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
         };
     }
 
-    function makeServices({taskStateService, outcomes, dispatcher, undigestedCount = 5}) {
+    function makeServices({taskStateService, outcomes, dispatcher, undigestedCount = 5, taskOutcomes = {}}) {
         return {
             dreamService: {
                 findUndigestedSessions: async () => Array.from({length: undigestedCount}, (_, index) => ({id: `s-${index}`}))
             },
             healthService: {
-                recordTaskOutcome(taskName, status, details) { outcomes.push({taskName, status, details}); }
+                recordTaskOutcome(taskName, status, details) { outcomes.push({taskName, status, details}); },
+                getTaskOutcome(taskName) { return taskOutcomes[taskName] || null; }
             },
             maintenanceBackpressureService: {
                 getActiveHeavyMaintenanceTask() { return null; },
@@ -167,7 +169,7 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
         };
     }
 
-    async function runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime, undigestedCount = 5}) {
+    async function runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime, undigestedCount = 5, taskOutcomes = {}}) {
         const context = buildSchedulingContext({
             db       : {},
             state    : taskStateService.getState(),
@@ -180,19 +182,44 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
         runSchedulingPipeline({
             registry: [TASK_REGISTRY.find(d => d.taskName === 'rem-consolidation-liveness-watchdog')],
             context,
-            services: makeServices({taskStateService, outcomes, dispatcher, undigestedCount}),
+            services: makeServices({taskStateService, outcomes, dispatcher, undigestedCount, taskOutcomes}),
             runtime
         });
 
         await new Promise(resolve => setTimeout(resolve, 20));
     }
 
-    test('fires the active alarm once on stall-onset and latches subsequent stalled checks', async () => {
-        const outcomes = [];
-        const alarmCalls = [];
-        const dispatcher = async payload => { alarmCalls.push(payload); };
+    test('a recent dream deferral labels the stall designed-deferral WITHOUT suppressing the alarm (#14490)', async () => {
+        const now              = Date.now();
+        const outcomes         = [];
+        const alarmCalls       = [];
+        const dispatcher       = async payload => { alarmCalls.push(payload); };
         const taskStateService = makeTaskStateService();
-        const runtime = makeRuntime();
+        const runtime          = makeRuntime();
+        // A finite but STALE cycle (7h ago, beyond the 6h threshold) → the watchdog stalls; absent a
+        // deferral this gap would read as unexplained / restart-explains, not designed.
+        await appendRemRunState({runId: 'stale', completedAt: now - 7 * HOUR_MS}, {dir: remRunStateDir});
+        // A RECENT 'dream' maintenance-deferral sits on the shared health task-outcome surface.
+        const taskOutcomes = {
+            dream: {status: 'skipped', details: {reason: 'heavy-maintenance-backpressure'}, recordedAt: new Date().toISOString()}
+        };
+
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime, taskOutcomes});
+
+        const failed = outcomes.find(outcome => outcome.status === 'failed');
+        expect(failed).toBeTruthy();
+        // The recent deferral re-labels the disposition as designed-deferral...
+        expect(failed.details.bootFreshness).toBe(BOOT_FRESHNESS_CLASS.designedDeferral);
+        // ...but ADVISORY-ONLY: the stall alarm still fires (OQ4 — a deferral never suppresses it).
+        expect(alarmCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('fires the active alarm once on stall-onset and latches subsequent stalled checks', async () => {
+        const outcomes         = [];
+        const alarmCalls       = [];
+        const dispatcher       = async payload => { alarmCalls.push(payload); };
+        const taskStateService = makeTaskStateService();
+        const runtime          = makeRuntime();
 
         await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime});
         await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime});
@@ -211,9 +238,9 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
     });
 
     test('suppresses the active alarm when the local dream lane is not owned here', async () => {
-        const outcomes = [];
-        const alarmCalls = [];
-        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const outcomes         = [];
+        const alarmCalls       = [];
+        const dispatcher       = async payload => { alarmCalls.push(payload); };
         const taskStateService = makeTaskStateService();
 
         await runWatchdogOnce({
@@ -226,8 +253,8 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
     });
 
     test('dispatcher failures are logged and swallowed after the passive failed outcome', async () => {
-        const outcomes = [];
-        const logs = [];
+        const outcomes         = [];
+        const logs             = [];
         const taskStateService = makeTaskStateService();
 
         await runWatchdogOnce({
@@ -250,8 +277,8 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
         const now = Date.now();
         await appendRemRunState({runId: 'healthy', completedAt: now - HOUR_MS}, {dir: remRunStateDir});
 
-        const outcomes = [];
-        const alarmCalls = [];
+        const outcomes         = [];
+        const alarmCalls       = [];
         const taskStateService = makeTaskStateService();
         taskStateService.getTaskState('rem-consolidation-liveness-watchdog').remConsolidationAlarm = {
             alarmed     : true,

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
@@ -199,9 +199,15 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
         // A finite but STALE cycle (7h ago, beyond the 6h threshold) → the watchdog stalls; absent a
         // deferral this gap would read as unexplained / restart-explains, not designed.
         await appendRemRunState({runId: 'stale', completedAt: now - 7 * HOUR_MS}, {dir: remRunStateDir});
-        // A RECENT 'dream' maintenance-deferral sits on the shared health task-outcome surface.
+        // A RECENT, RECOGNIZED 'dream' maintenance-deferral sits on the shared health task-outcome
+        // surface — the exact shape MaintenanceBackpressureService.recordDeferral emits (recognized
+        // reasonCode + deferral-specific deferredAt).
         const taskOutcomes = {
-            dream: {status: 'skipped', details: {reason: 'heavy-maintenance-backpressure'}, recordedAt: new Date().toISOString()}
+            dream: {
+                status    : 'skipped',
+                details   : {reason: 'heavy maintenance task backup is active', reasonCode: 'heavy-maintenance-backpressure', deferredAt: new Date(now).toISOString(), blockingTaskName: 'backup'},
+                recordedAt: new Date(now).toISOString()
+            }
         };
 
         await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime, taskOutcomes});
@@ -212,6 +218,37 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
         expect(failed.details.bootFreshness).toBe(BOOT_FRESHNESS_CLASS.designedDeferral);
         // ...but ADVISORY-ONLY: the stall alarm still fires (OQ4 — a deferral never suppresses it).
         expect(alarmCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('a dream skip that is NOT a recognized recent deferral does NOT become designed-deferral (#14492 review)', async () => {
+        const runtime = makeRuntime();
+
+        // Two ways a skip fails the narrowed gate: (1) a generic / unrecognized reasonCode (not a
+        // maintenance-backpressure deferral); (2) a recognized reasonCode but NO deferral-specific
+        // deferredAt (not a real recordDeferral outcome). Neither may masquerade as a designed deferral.
+        const negativeDetails = [
+            {reason: 'ad-hoc skip',      reasonCode: 'some-unrecognized-reason', deferredAt: new Date(Date.now()).toISOString()},
+            {reason: 'no deferredAt',    reasonCode: 'heavy-maintenance-backpressure'}
+        ];
+
+        for (const details of negativeDetails) {
+            const now              = Date.now();
+            const outcomes         = [];
+            const alarmCalls       = [];
+            const dispatcher       = async payload => { alarmCalls.push(payload); };
+            const taskStateService = makeTaskStateService();
+            await appendRemRunState({runId: 'stale', completedAt: now - 7 * HOUR_MS}, {dir: remRunStateDir});
+            const taskOutcomes = {dream: {status: 'skipped', details, recordedAt: new Date(now).toISOString()}};
+
+            await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime, taskOutcomes});
+
+            const failed = outcomes.find(outcome => outcome.status === 'failed');
+            expect(failed).toBeTruthy();
+            // The unrecognized / non-deferral skip is rejected — NOT a designed deferral.
+            expect(failed.details.bootFreshness).not.toBe(BOOT_FRESHNESS_CLASS.designedDeferral);
+            // ...and the alarm still fires regardless (advisory-only classification).
+            expect(alarmCalls.length).toBeGreaterThanOrEqual(1);
+        }
     });
 
     test('fires the active alarm once on stall-onset and latches subsequent stalled checks', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityFactGatherer.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityFactGatherer.spec.mjs
@@ -1,0 +1,71 @@
+import {test, expect}                   from '@playwright/test';
+import {createBootIdentityFactGatherer} from '../../../../../../../ai/daemons/orchestrator/services/bootIdentityFactGatherer.mjs';
+import {SCHEDULER_RESUME_STATE}         from '../../../../../../../ai/daemons/orchestrator/services/bootIdentityFreshness.mjs';
+
+test.describe('ai/daemons/orchestrator/services/bootIdentityFactGatherer — #14490 slice 2', () => {
+    const bootAt = 1_000_000_000_000;
+
+    test('maps the latest REM run-state entry to lastCycleAt/lastCycleRef + carries bootAt', async () => {
+        const gather = createBootIdentityFactGatherer({
+            bootAt,
+            remRunStateDir        : '/tmp/rem',
+            readRecentRemRunStates: async ({dir, limit}) => {
+                expect(dir).toBe('/tmp/rem');
+                expect(limit).toBe(1);
+                return [{runId: 'cycle-abc', completedAt: bootAt - 3_600_000}];
+            }
+        });
+
+        const facts = await gather();
+
+        expect(facts.bootAt).toBe(bootAt);
+        expect(facts.lastCycleAt).toBe(bootAt - 3_600_000);
+        expect(facts.lastCycleRef).toBe('cycle-abc');
+        expect(facts.schedulerResumeState).toBe(SCHEDULER_RESUME_STATE.none); // conservative default
+        expect(facts.deferralReason).toBeNull();
+    });
+
+    test('read fault fails soft -> null cycle facts (discriminator returns unknown, never a definitive stale)', async () => {
+        const gather = createBootIdentityFactGatherer({
+            bootAt,
+            remRunStateDir        : '/tmp/rem',
+            readRecentRemRunStates: async () => { throw new Error('read fault'); }
+        });
+
+        const facts = await gather();
+
+        expect(facts.lastCycleAt).toBeNull();
+        expect(facts.lastCycleRef).toBeNull();
+        expect(facts.bootAt).toBe(bootAt); // the boot fact is still present
+    });
+
+    test('empty store -> null cycle facts', async () => {
+        const gather = createBootIdentityFactGatherer({
+            bootAt,
+            remRunStateDir        : '/tmp/rem',
+            readRecentRemRunStates: async () => []
+        });
+
+        const facts = await gather();
+
+        expect(facts.lastCycleAt).toBeNull();
+        expect(facts.lastCycleRef).toBeNull();
+    });
+
+    test('injected resolvers refine the conservative defaults in place', async () => {
+        const gather = createBootIdentityFactGatherer({
+            bootAt,
+            remRunStateDir             : '/tmp/rem',
+            readRecentRemRunStates     : async () => [{runId: 'c1', completedAt: bootAt - 100}],
+            resolveSchedulerResumeState: () => SCHEDULER_RESUME_STATE.reArmed,
+            resolveDeferralReason      : async () => 'heavy-maintenance',
+            resolveSourceRef           : () => 'runtime-digest-xyz'
+        });
+
+        const facts = await gather();
+
+        expect(facts.schedulerResumeState).toBe(SCHEDULER_RESUME_STATE.reArmed);
+        expect(facts.deferralReason).toBe('heavy-maintenance');
+        expect(facts.sourceRef).toBe('runtime-digest-xyz');
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityFreshness.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityFreshness.spec.mjs
@@ -1,0 +1,105 @@
+import {test, expect} from '@playwright/test';
+import {
+    BOOT_FRESHNESS_CLASS,
+    SCHEDULER_RESUME_STATE,
+    classifyBootFreshness
+} from '../../../../../../../ai/daemons/orchestrator/services/bootIdentityFreshness.mjs';
+
+const HOUR = 60 * 60 * 1000;
+
+test.describe('ai/daemons/orchestrator/services/bootIdentityFreshness — #14490 (#14477 Leaf 1)', () => {
+    const config = {designedCadenceMs: HOUR, marginMs: 30 * 60 * 1000}; // 1h cadence + 30min margin
+    const now    = 1_000_000_000_000;
+
+    test.describe('the 2026-07-02 7.2h->9.3h REM-stall alarm pair (worked example)', () => {
+        test('designed-deferral when the scheduler deferred behind heavy maintenance', () => {
+            // @neo-gpt live probe: REM deferred behind heavy maintenance, scheduler re-armed, MC healthy.
+            const result = classifyBootFreshness({
+                now,
+                lastCycleAt         : now - 9.3 * HOUR,
+                bootAt              : now - 40 * HOUR, // booted long BEFORE the last cycle -> not a restart gap
+                schedulerResumeState: SCHEDULER_RESUME_STATE.reArmed,
+                deferralReason      : 'heavy-maintenance'
+            }, config);
+
+            expect(result.classification).toBe(BOOT_FRESHNESS_CLASS.designedDeferral);
+            expect(result.advisory).toBe(true);
+            expect(result.classification).not.toBe('stale'); // OQ4: never certainty-class stale
+        });
+
+        test('restart-explains-gap when the same gap follows a fresh boot with an un-re-armed scheduler', () => {
+            // Counterfactual: the process booted AFTER the last cycle and the scheduler never re-armed.
+            const result = classifyBootFreshness({
+                now,
+                lastCycleAt         : now - 9.3 * HOUR,
+                bootAt              : now - 2 * HOUR, // booted AFTER the last cycle -> restart-lost scheduler
+                schedulerResumeState: SCHEDULER_RESUME_STATE.none,
+                deferralReason      : null
+            }, config);
+
+            expect(result.classification).toBe(BOOT_FRESHNESS_CLASS.restartExplains);
+            expect(result.advisory).toBe(true);
+        });
+    });
+
+    test.describe('discriminator branches', () => {
+        test('within cadence+margin -> designed-deferral (no restart implied)', () => {
+            const result = classifyBootFreshness({
+                now,
+                lastCycleAt         : now - (HOUR + 10 * 60 * 1000), // 70min < 90min (cadence+margin)
+                bootAt              : now - 5 * HOUR,
+                schedulerResumeState: SCHEDULER_RESUME_STATE.reArmed
+            }, config);
+
+            expect(result.classification).toBe(BOOT_FRESHNESS_CLASS.designedDeferral);
+        });
+
+        test('boot-after-last-cycle AND re-armed -> not restart-explains (scheduler recovered its timers)', () => {
+            const result = classifyBootFreshness({
+                now,
+                lastCycleAt         : now - 9.3 * HOUR,
+                bootAt              : now - 2 * HOUR,
+                schedulerResumeState: SCHEDULER_RESUME_STATE.reArmed
+            }, config);
+
+            expect(result.classification).not.toBe(BOOT_FRESHNESS_CLASS.restartExplains);
+            expect(result.classification).toBe(BOOT_FRESHNESS_CLASS.unknown); // gap unexplained by boot-identity
+        });
+
+        test('gap beyond cadence+margin but boot PRECEDES the last cycle -> unknown (not restart-explained)', () => {
+            const result = classifyBootFreshness({
+                now,
+                lastCycleAt         : now - 9.3 * HOUR,
+                bootAt              : now - 40 * HOUR,
+                schedulerResumeState: SCHEDULER_RESUME_STATE.none
+            }, config);
+
+            expect(result.classification).toBe(BOOT_FRESHNESS_CLASS.unknown);
+        });
+    });
+
+    test.describe('OQ4 invariant — absent facts never assert a certainty-class stale', () => {
+        test('missing now -> unknown (advisory)', () => {
+            const result = classifyBootFreshness({lastCycleAt: now - HOUR}, config);
+            expect(result.classification).toBe(BOOT_FRESHNESS_CLASS.unknown);
+            expect(result.advisory).toBe(true);
+        });
+
+        test('missing lastCycleAt -> unknown (advisory)', () => {
+            const result = classifyBootFreshness({now, bootAt: now - HOUR}, config);
+            expect(result.classification).toBe(BOOT_FRESHNESS_CLASS.unknown);
+        });
+
+        test('missing config cadence -> unknown, never stale', () => {
+            const result = classifyBootFreshness({now, lastCycleAt: now - 9.3 * HOUR}, {});
+            expect(result.classification).toBe(BOOT_FRESHNESS_CLASS.unknown);
+            expect(result.classification).not.toBe('stale');
+        });
+
+        test('no fact-class in the codebook is a certainty-class stale', () => {
+            for (const cls of Object.values(BOOT_FRESHNESS_CLASS)) {
+                expect(cls).not.toBe('stale');
+            }
+        });
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -1320,7 +1320,7 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
     });
 
     test('heartbeatAlivePath() reads the resolved AiConfig leaf (#12438)', async () => {
-        const path = await import('path');
+        const path         = await import('path');
         const overridePath = path.join(tmpDir, `alive-helper-${Date.now()}`);
 
         AiConfig.setEnvOverride('NEO_HEARTBEAT_ALIVE_PATH', overridePath);
@@ -1516,5 +1516,37 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
                 delete process.env.POLL_INTERVAL;
             }
         }
+    });
+});
+
+test.describe('HealthService — getTaskOutcome mutation boundary (#14492 review)', () => {
+    let healthService;
+
+    test.beforeAll(async () => {
+        healthService = (await import('../../../../../../ai/services/memory-core/HealthService.mjs')).default;
+    });
+
+    test('getTaskOutcome returns a deep clone — mutating the result cannot corrupt the stored outcome', () => {
+        healthService.recordTaskOutcome('mutation-boundary-probe', 'skipped', {
+            reason    : 'r',
+            reasonCode: 'heavy-maintenance-backpressure',
+            nested    : {count: 1}
+        });
+
+        const first = healthService.getTaskOutcome('mutation-boundary-probe');
+        expect(first.details.nested.count).toBe(1);
+
+        // A careless / hostile caller mutates the returned object AND its nested details.
+        first.status               = 'HACKED';
+        first.details.reasonCode   = 'tampered';
+        first.details.nested.count = 999;
+
+        const second = healthService.getTaskOutcome('mutation-boundary-probe');
+        expect(second.status).toBe('skipped');
+        expect(second.details.reasonCode).toBe('heavy-maintenance-backpressure');
+        expect(second.details.nested.count).toBe(1);
+        // fresh clone each call — distinct object graphs, never the stored reference
+        expect(second).not.toBe(first);
+        expect(second.details).not.toBe(first.details);
     });
 });


### PR DESCRIPTION
Resolves #14514

> **Boot-identity fact AC-1:** the `classifyBootFreshness` discriminator + advisory-fact contract + fact-gatherer + the **live REM-consolidation watchdog integration**. **Part of `#14490`** — its **AC-2** (authenticated control-plane exposure, R3-safe) stays open on `#14490`, gated on the #14501 substrate decision, and is deliberately NOT auto-closed by this PR. Review fixes applied at `ba7090fa62` (see Deltas).

## Summary

A read-only, advisory boot-identity health surface that collapses the stale-wake question — *is a long-lived process running current source, or a stale / restart-lost scheduler?* — into a deterministic fact-compare instead of a multi-agent forensic probe.

**Delivered:** the pure `classifyBootFreshness` discriminator + codebooks, the `BootIdentityHealthService` advisory scaffold, the live fact-gatherer, and the **REM-consolidation liveness watchdog integration** — a stall now carries its boot-freshness disposition (`restart-explains` / `designed-deferral` / `unknown`), reading a **recognized, recency-bounded** `'dream'` maintenance-deferral to label a designed deferral without ever suppressing the alarm.

Resolves #14514

Part of `#14490` (AC-2 control-plane exposure remains open, gated on #14501)

## Changes

- **`ai/daemons/orchestrator/services/bootIdentityFreshness.mjs`** — the pure `classifyBootFreshness(facts, config)` discriminator + `BOOT_FRESHNESS_CLASS` / `SCHEDULER_RESUME_STATE` codebooks. Neo-free, hermetically unit-testable. Advisory-only (never a certainty-class `stale`).
- **`ai/daemons/orchestrator/services/BootIdentityHealthService.mjs`** — the `Neo.core.Base` advisory service producing the fact, delegating to the discriminator via an injected gatherer.
- **`ai/daemons/orchestrator/services/bootIdentityFactGatherer.mjs`** — the live fact-gatherer factory (reads the last REM cycle; conservative `schedulerResumeState: 'none'` + best-effort resolvers).
- **`ai/daemons/orchestrator/scheduling/pipeline.mjs`** — the REM-consolidation watchdog classifies boot-freshness, reading only a **recognized recent `dream` deferral** (`RECOGNIZED_DEFERRAL_REASON_CODES` + a recency-bounded deferral-specific `deferredAt`) — a generic skip can never mask a genuine stall.
- **`ai/services/memory-core/HealthService.mjs`** — new read-only `getTaskOutcome(taskName)` getter, returning a **defensive deep clone** (the deferral read-surface).

## Deltas from ticket

- **Split for a truthful close-target (review):** this PR resolves the AC-1 slice #14514 (the fact + live watchdog classification); it does NOT auto-close `#14490`, whose **AC-2** (authenticated control-plane exposure) is still residual — gated on the #14501 substrate decision.
- **AC-1 complete** (both derivation halves): `schedulerResumeState` stays conservative `'none'` (V-B-A'd with @neo-gpt — no durable re-arm surface exists); the deferral read is wired live from the shared `HealthService` task-outcome surface.
- **Review fixes** (@neo-gpt REQUEST_CHANGES): (1) the watchdog now requires a RECOGNIZED maintenance-backpressure `reasonCode` + a deferral-specific `deferredAt` — a generic skip can't become `designed-deferral` (+ a negative spec); (2) `getTaskOutcome` returns a `structuredClone` so a caller can't corrupt internal state (+ a mutation-boundary spec).
- **Placement** — the files sit in `daemons/orchestrator/services/`; their domain-first home (`daemons/diagnostics/`) is @neo-opus-grace's #14304 sequencing call.

## Test Evidence

- Boot-identity + watchdog + HealthService + pipeline specs **green** at `ba7090fa62`, including the two review specs: the negative deferral case (generic skip → NOT `designed-deferral`) and the `getTaskOutcome` mutation-boundary (deep-clone, internal state uncorrupted). `npx playwright test .../remConsolidationLivenessWatchdog.spec.mjs .../HealthService.spec.mjs .../pipeline.spec.mjs` → **104 passed**.
- Pre-commit hooks (jsdoc-types / ticket-archaeology / block-alignment) pass at `ba7090fa62`.

## Evidence

Evidence: L2 (unit — the discriminator + the live watchdog integration + the narrowing + the read-surface clone, fully covered) → L2 required (AC-1 = the fact-compare classifies from live facts). AC-2 control-plane exposure (L3-adjacent, gated on #14501) is out of this PR's scope; it lands + is verified on `#14490` when #14501 graduates.

## Post-Merge Validation

- [ ] AC-2 (on `#14490`, post-#14501): construct `BootIdentityHealthService` in the Orchestrator + expose the fact on the authenticated control-plane surface #14501 resolves + the R3 boundary test (client Bridge RPC exposes no restart-affecting command).
- [ ] Placement: re-home to the `diagnostics/` domain per @neo-opus-grace's #14304 call.

## Related

- Parent leaf: `#14490` (AC-2 residual). Epic: #14477. Control-plane substrate ideation: #14501 (the AC-2 blocker). `remConsolidationLivenessWatchdog` (the consumer). #14304 (@neo-opus-grace — placement).

Authored by Ada (Claude Opus 4.8, Claude Code). Session 2c2efa1e-7a1b-42c2-b923-3109cbc36a3a.