### PR TITLE
refactor(kb): centralize remote deployment predicate (#14424)

### DIFF
--- a/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
+++ b/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
@@ -1,5 +1,6 @@
 import aiConfig         from './config.mjs';
 import IngestionService from '../../../services/knowledge-base/IngestionService.mjs';
+import {isRemoteKnowledgeBaseDeployment} from '../../../services/knowledge-base/helpers/deploymentMode.mjs';
 
 const ingestToolName = 'ingest_source_files';
 
@@ -17,23 +18,23 @@ const getEffectiveToolName = toolName => {
 };
 
 /**
- * @summary Returns true when the KB MCP server is in its remote StreamableHTTP profile.
+ * @summary Returns true when the KB MCP server is in its remote tenant-ingestion deployment profile.
  * @returns {Boolean} True when remote tenant push clients may call `ingest_source_files`.
  */
-const isRemoteIngestTransport = () => aiConfig.transport === 'sse';
+const isRemoteIngestDeployment = () => isRemoteKnowledgeBaseDeployment(aiConfig);
 
 /**
  * @summary Returns true when the ingest tool should appear in MCP tools/list.
  * @returns {Boolean} True when the current transport exposes `ingest_source_files`.
  */
-const isIngestSourceFilesToolVisible = () => isRemoteIngestTransport();
+const isIngestSourceFilesToolVisible = () => isRemoteIngestDeployment();
 
 /**
  * @summary Fails closed when a local stdio client tries to invoke the remote push facade.
  * @param {String} toolName The requested MCP tool name.
  */
 const assertToolTransportAllowed = toolName => {
-    if (getEffectiveToolName(toolName) === ingestToolName && !isRemoteIngestTransport()) {
+    if (getEffectiveToolName(toolName) === ingestToolName && !isRemoteIngestDeployment()) {
         throw new Error(
             '`ingest_source_files` is only exposed when the Knowledge Base MCP server runs ' +
             'with `transport: "sse"` (StreamableHTTP). Use `npm run ai:ingest-tenant` or ' +

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -8,6 +8,7 @@ import logger                         from '../../mcp/server/knowledge-base/logg
 import path                           from 'path';
 import QueryService                   from './QueryService.mjs';
 import {checkAskRateLimit}            from './helpers/askRateLimit.mjs';
+import {isRemoteKnowledgeBaseDeployment} from './helpers/deploymentMode.mjs';
 import {getMissingAskSynthesisLeaves} from './helpers/askSynthesisGuard.mjs';
 
 const LOCAL_EMPTY_COLLECTION_ANSWER  = "The knowledge base collection is empty. Populate it with the release artifact via 'npm run ai:download-kb' (or build locally with 'npm run ai:sync-kb').";
@@ -162,7 +163,7 @@ class SearchService extends Base {
      * @returns {String} The empty-collection remediation message.
      */
     getEmptyCollectionAnswer() {
-        return aiConfig.transport === 'sse'
+        return isRemoteKnowledgeBaseDeployment(aiConfig)
             ? REMOTE_EMPTY_COLLECTION_ANSWER
             : LOCAL_EMPTY_COLLECTION_ANSWER;
     }

--- a/ai/services/knowledge-base/helpers/deploymentMode.mjs
+++ b/ai/services/knowledge-base/helpers/deploymentMode.mjs
@@ -1,0 +1,13 @@
+/**
+ * @summary Returns true when the Knowledge Base server is running in a remote tenant-ingestion profile.
+ *
+ * Remote deployments expose the push-based `ingest_source_files` facade and need remote
+ * ingestion-state diagnostics for empty collections. The transport spelling is an implementation
+ * detail; call sites depend on this semantic deployment predicate.
+ *
+ * @param {Object} aiConfig Resolved Knowledge Base MCP config.
+ * @returns {Boolean} True when remote tenant-ingestion behavior should be enabled.
+ */
+export function isRemoteKnowledgeBaseDeployment(aiConfig) {
+    return aiConfig.transport === 'sse'
+}


### PR DESCRIPTION
Resolves #14424

Centralizes the KB remote deployment decision behind `isRemoteKnowledgeBaseDeployment(aiConfig)` and uses that semantic predicate for both empty-collection remediation and the `ingest_source_files` MCP facade. This keeps the current `transport: "sse"` behavior intact while removing duplicate transport literals from the call sites.

Evidence: L2 (focused unit coverage for SearchService remote/local empty guidance and IngestSourceFilesTool remote/local facade gating plus static preflight) -> L2 required (internal predicate refactor with behavior covered by unit tests). No residuals.

## Deltas from ticket
None substantive. The helper is placed under `ai/services/knowledge-base/helpers/` beside existing KB service helpers and keeps the transport spelling local to the predicate.

## Test Evidence
- `node --check ai/services/knowledge-base/helpers/deploymentMode.mjs`
- `node --check ai/services/knowledge-base/SearchService.mjs`
- `node --check ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs`
- `git diff --check`
- `git diff --cached --check`
- `npm run agent-preflight -- --no-fix ai/services/knowledge-base/helpers/deploymentMode.mjs ai/services/knowledge-base/SearchService.mjs ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs` (20 passed)

## Post-Merge Validation
- [ ] Confirm `ask_knowledge_base` still reports remote tenant-ingestion diagnostics for an empty remote collection.
- [ ] Confirm local `stdio` KB MCP tools/list still hides `ingest_source_files`.

Authored by Euclid (GPT-5, Codex Desktop). Session c5938a7c-42e6-4f94-ac19-1a874529dfb4.
