### PR TITLE
docs(readme): replace dead Quickstart links with portal learning URLs (#14493)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,10 @@ npx neo-app@latest
 
 This sets up a new app workspace, a pre-configured app shell, a local development server, and launches your app in a new browser window — all in one go.
 
-* :book: **[Getting Started Guide](./.github/GETTING_STARTED.md)**
-* :student: **[Learning Section](https://neomjs.com/dist/production/apps/portal/#/learn/gettingstarted.Setup)**
-* :star: **[Examples Portal](https://neomjs.com/dist/production/apps/portal/#/examples)**
-* :robot: **[AI Quick Start Guide](./.github/AI_QUICK_START.md)**
-* :blue_book: **[Blog](https://neomjs.com/dist/production/apps/portal/#/blog)**
+* :book: **[Getting Started](https://neomjs.com/#/learn/gettingstarted/Setup)** — build your first app, step by step
+* :student: **[Learning Section](https://neomjs.com/#/learn)** — the guided curriculum, with the nav tree and live component previews
+* :sparkles: **[What Is Neo?](https://neomjs.com/#/learn/benefits/WhatIsNeo)** — the two-hemisphere organism, in five minutes
+* :robot: **[Run Your Own Agent Team](https://neomjs.com/#/learn/agentos/OwnAgentTeam)** — point the Agent OS at your own fork
 
 </br></br>
 ## Who This Is For


### PR DESCRIPTION
Resolves #14493

Fixes the README **Quickstart** — every CTA pointed at a dead target (`.github/` files or `dist/production` portal URLs whose deploy path is gone). Operator-flagged (@tobiu): *"every user that uses those links is a lost one forever."*

Replaces the 5 dead links with **4 verified portal learning-section links**. Per the operator's rule, README learning links target ONLY `learn/` markdown OR the portal learning section (`neomjs.com/#/learn/<id>` — nav tree + live component previews + prev/next, superior for humans). The invariant: every `learn/**.md` registered in `learn/tree.json` *is* a live portal page, so tree.json membership = a guaranteed-live route.

| Was (dead) | Now (verified) | tree.json id |
|---|---|---|
| `.github/GETTING_STARTED.md` | `neomjs.com/#/learn/gettingstarted/Setup` | `gettingstarted/Setup` ✓ |
| `dist/production/…/#/learn/gettingstarted.Setup` (stale `.` sep) | `neomjs.com/#/learn` | hub route ✓ |
| `.github/AI_QUICK_START.md` | `neomjs.com/#/learn/agentos/OwnAgentTeam` | `agentos/OwnAgentTeam` ✓ |
| _(added front-door)_ | `neomjs.com/#/learn/benefits/WhatIsNeo` | `benefits/WhatIsNeo` ✓ |

Evidence: L1 (static — each portal id V-B-A'd against `learn/tree.json`; docs-only, no runtime AC).

## Deltas from ticket

**Examples + Blog dropped** from the original 5-link list: neither is in `learn/tree.json` and their old `#/examples` / `#/blog` routes no longer exist in portal source — linking them would mint new dead links. Re-add once live routes are confirmed (flagged to operator). Read Next VISION/STORY `.github/` links are a separate, out-of-scope finding (those files physically live in `.github/`, so relocating them is its own decision).

## Test Evidence

- Docs-only change; no unit tests apply.
- Each of the 3 deep-link ids verified present in `learn/tree.json` (`gettingstarted/Setup`, `benefits/WhatIsNeo`, `agentos/OwnAgentTeam`); the `#/learn` hub route confirmed in `apps/portal` source.
- `git diff --check` clean.

## Post-Merge Validation

- [ ] Confirm all 4 portal links resolve on the live neomjs.com site.
- [ ] Follow-up: confirm Examples/Blog live routes + re-add; run the codebase-wide portal-URL consistency sweep (`dist/esm` / `apps/portal/#/` / `#/` all drift across `learn/blog/*` + guides) as a #14310 / #14327 leaf.

## Commits

- `d9b735578` — `docs(readme): replace dead Quickstart links with portal learning URLs (#14493)`

Authored by Grace (@neo-opus-grace, Claude Opus 4.8). Operator-flagged (@tobiu). Parent epic #14310.
