### PR TITLE
fix(build): sync learn content and recursive portal data to pages (#14496)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -102,9 +102,21 @@ jobs:
 
           # Copy the data files
           cp apps/devindex/resources/data/users.jsonl temp_pages/node_modules/neo.mjs/apps/devindex/resources/data/
-          cp -f apps/portal/resources/data/*.json temp_pages/node_modules/neo.mjs/apps/portal/resources/data/ 2>/dev/null || true
+
+          # Portal data: deletion-synced recursive copy — the previous flat *.json glob missed the
+          # chunked subdirectory trees (tickets/v*/, pulls/latest/), which drifted between full
+          # deploys (#14496).
+          rm -rf temp_pages/node_modules/neo.mjs/apps/portal/resources/data
+          cp -r apps/portal/resources/data temp_pages/node_modules/neo.mjs/apps/portal/resources/
+
           cp -f apps/portal/sitemap.xml temp_pages/ 2>/dev/null || true
           cp -f apps/portal/llms.txt temp_pages/ 2>/dev/null || true
+
+          # learn/** content + nav index (learn/tree.json): sitemap.xml and llms.txt advertise these
+          # routes hourly — advertising them without syncing the content they point at produced the
+          # human-traffic 404 class (#14496). Deletion sync makes route renames propagate natively.
+          rm -rf temp_pages/node_modules/neo.mjs/learn
+          cp -r learn temp_pages/node_modules/neo.mjs/
 
           # Copy resources content (syncing deletions natively via git).
           # Per Epic #11187 7-bucket fan-out: support both legacy paths (issue-archive/,
@@ -123,15 +135,16 @@ jobs:
           cd temp_pages
 
           # Check for changes and push
-          if [[ -n $(git status -s node_modules/neo.mjs/apps/devindex/resources/data/users.jsonl node_modules/neo.mjs/apps/portal/resources/data/*.json sitemap.xml llms.txt node_modules/neo.mjs/resources/content/) ]]; then
+          if [[ -n $(git status -s node_modules/neo.mjs/apps/devindex/resources/data/users.jsonl node_modules/neo.mjs/apps/portal/resources/data/ sitemap.xml llms.txt node_modules/neo.mjs/resources/content/ node_modules/neo.mjs/learn/) ]]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
             git add node_modules/neo.mjs/apps/devindex/resources/data/users.jsonl
-            git add node_modules/neo.mjs/apps/portal/resources/data/*.json 2>/dev/null || true
+            git add -A node_modules/neo.mjs/apps/portal/resources/data/
             git add sitemap.xml 2>/dev/null || true
             git add llms.txt 2>/dev/null || true
             git add -A node_modules/neo.mjs/resources/content/
+            git add -A node_modules/neo.mjs/learn/
 
             # temp_pages is a clone of neomjs/pages (built output) — it carries no neo archaeology guard,
             # so NEO_SKIP_TICKET_ARCHAEOLOGY is intentionally absent here (only --no-verify, for whitespace).


### PR DESCRIPTION
Resolves #14496

Extends the hourly data-sync pipeline's pages-push step so the content that `sitemap.xml`/`llms.txt` advertise actually ships: `learn/**` (including the `learn/tree.json` nav index) now syncs with native deletion-sync, and `apps/portal/resources/data/**` switches from a flat top-level `*.json` glob to a deletion-synced recursive copy (the chunked subdirectory trees drifted between full deploys). Pages-side change-detection and the `git add` set are extended to match. This is the workflow-side half of today's operator-directed 404 investigation (the human-traffic dead-link class — pages' blog tree was frozen at the v10 era while the sitemap advanced hourly); the middleware-freeze half is `#14478` plus private-repo work.

Evidence: L2 (YAML parse + git-initialized shell simulation of the exact copy/detect/add block against the live repo tree) → L2 required (pre-merge ACs are static workflow logic). Residual: AC4 post-merge specimen check [#14496].

## Deltas from ticket

None substantive — the implementation matches the ticket's Fix section 1:1.

## Test Evidence

- Workflow YAML validity: `node -e "require('js-yaml').load(...)"` AND `npx js-yaml .github/workflows/data-sync-pipeline.yml` → valid.
- Git-initialized scratch simulation of the exact new block, with planted stale state:
  - **Deletion-sync proven:** planted `learn/WhatWasNeo.md`, `learn/blog/GONE-old-post.md`, and `data/tickets/old-release/stale.json` all removed by the sync.
  - **Fresh content lands:** `learn/tree.json` + `learn/blog/the-organism-already-existed.md` (today's live dead-link specimen, merged 11:52Z) present post-sync; portal chunk subtrees (`tickets/backlog`, `idMap.json`, `index.json`, …) present.
  - **Change detection:** the new dir-based `git status -s` pattern returns non-empty (`D` + `??` entries) on the delta; the `git add -A` set stages all of it.
- `npm run agent-preflight -- --no-fix` with this PR body: green (see PR checks for the CI-side lint).

## Post-Merge Validation

- [ ] After the next hourly run following a `learn/**` change on `dev`, the changed file exists in `neomjs/pages` under `node_modules/neo.mjs/learn/` — specimen: `learn/blog/the-organism-already-existed.md`.
- [ ] Route renames propagate via deletion-sync: after PR `#14470` merges, pages carries `learn/benefits/Introduction.md` (apex content) and drops `WhatIsNeo.md`.
- [ ] The hourly pages commit stays scoped/reviewable (no unintended tree growth beyond `learn/**` + portal data).

Authored by Clio (Claude Fable 5, Claude Code). Session 4ebdc396-4bd7-4dee-b16b-23baf188a622.
