### PR TITLE
fix(orchestrator): default wake delivery + swarm-heartbeat OFF (#14486)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -773,6 +773,9 @@ class Config extends ConfigProvider {
                  * without changing remote graph-backed A2A / Memory Core behavior.
                  * `null` means "use the deployment profile default" (`local` enables,
                  * `cloud` disables); set `true` only when explicitly opting a lane back in.
+                 * Exception: `bridgeDaemonEnabled` + `swarmHeartbeatEnabled` default `false`
+                 * (wake + heartbeat OFF) — the Stop hook makes them redundant flood; see their
+                 * inline notes. Both remain env-overridable to re-enable.
                  * @type {Object}
                  */
                 localOnly: {
@@ -782,7 +785,11 @@ class Config extends ConfigProvider {
                     // Local profile may supervise a child Chroma process; cloud profile
                     // reaches the compose-owned `chroma` peer container instead.
                     chromaDaemonEnabled    : leaf(null, 'NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED', 'boolean'),
-                    bridgeDaemonEnabled    : leaf(null, 'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED', 'boolean'),
+                    // Desktop wake-DELIVERY gate. Defaults OFF: the lane-state Stop hook forces turn
+                    // continuation, so wake interrupts are redundant duplicate-flood at multi-peer
+                    // scale (A2A messages still persist + surface on the next list_messages).
+                    // Set `true` (or `NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=true`) to restore delivery.
+                    bridgeDaemonEnabled    : leaf(false, 'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED', 'boolean'),
                     neuralLinkBridgeEnabled: leaf(null, 'NEO_ORCHESTRATOR_NL_BRIDGE_ENABLED', 'boolean'),
                     // The embed daemon durably drains the add_memory WAL into the content store
                     // (ai/daemons/embed/daemon.mjs). Local profile supervises it as a child
@@ -794,9 +801,14 @@ class Config extends ConfigProvider {
                     // messageWal.inProcessDrain host mode instead.
                     messageDaemonEnabled           : leaf(null, 'NEO_ORCHESTRATOR_MESSAGE_DAEMON_ENABLED', 'boolean'),
                     goldenPathRepoEnrichmentEnabled: leaf(null, 'NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED', 'boolean'),
-                    // `null` = use the deployment-profile default (local enables, cloud disables);
-                    // the swarm-heartbeat lane emits wake-substrate pulses through bridge delivery.
-                    swarmHeartbeatEnabled          : leaf(null, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED', 'boolean'),
+                    // Swarm-heartbeat lane: emits wake-substrate pulses + heartbeat-driven idle/swarm
+                    // wakes (`WakeDecisionService.decideWake` runs INSIDE `SwarmHeartbeatService.pulse()`).
+                    // Defaults OFF: the lane-state Stop hook covers turn continuation, so these pulses
+                    // are redundant duplicate-flood at multi-peer scale. Substrate maintenance
+                    // (GraphLog compaction, integrity sweep, embed/message daemons) runs via its own
+                    // separate task toggles and is unaffected. Set `true` (or
+                    // `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED=true`) to restore.
+                    swarmHeartbeatEnabled          : leaf(false, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED', 'boolean'),
                     // Reserved policy placeholder: no runtime consumer yet.
                     // `bridgeDaemonEnabled` is the active scheduler gate for desktop wake delivery.
                     wakeDispatchEnabled            : leaf(null)

--- a/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
+++ b/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
@@ -6,8 +6,8 @@
  * daemon under `NEO_AI_DEPLOYMENT_MODE=cloud` without crashing on missing Neo-team
  * substrate (identityRoots entries, operator-only config, pre-existing data dir).
  * Companion to the AC1-AC4 invariant tests in `Orchestrator.externalConfig.spec.mjs`;
- * this is the runtime proof for #11837 Sub-5 AC5 that PR #11946 deferred as too
- * heavy for unit-test scope.
+ * this is the runtime proof for the workspace-safety AC5 invariant that an earlier
+ * unit-scoped PR deferred as too heavy for unit-test scope.
  *
  * Two probes:
  *  1. Cloud-deployment-mode boot: confirms the daemon reaches the `[Orchestrator]
@@ -25,13 +25,13 @@
  * @see ai/daemons/orchestrator/daemon.mjs
  * @see ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
  */
-import {spawn}          from 'node:child_process';
-import fs               from 'node:fs/promises';
-import os               from 'node:os';
-import path             from 'node:path';
-import {fileURLToPath}  from 'node:url';
-import Database         from 'better-sqlite3';
-import {test, expect}   from '@playwright/test';
+import {spawn}         from 'node:child_process';
+import fs              from 'node:fs/promises';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import Database        from 'better-sqlite3';
+import {test, expect}  from '@playwright/test';
 
 const __filename   = fileURLToPath(import.meta.url);
 const __dirname    = path.dirname(__filename);
@@ -50,8 +50,8 @@ const SIGTERM_GRACE_MS = 5000;
  * @returns {Promise<String>} The matching content snapshot.
  */
 async function waitForLogContent(logPath, predicate, timeoutMs) {
-    const deadline = Date.now() + timeoutMs;
-    let lastContent = '';
+    const deadline    = Date.now() + timeoutMs;
+    let   lastContent = '';
 
     while (Date.now() < deadline) {
         try {
@@ -115,7 +115,7 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
         dataDir      = path.join(workspaceDir, 'orchestrator-daemon');
         logPath      = path.join(dataDir, 'orchestrator.log');
         dbPath       = path.join(workspaceDir, 'memory-core-graph.sqlite');
-        // Per #12012 — orchestrator now self-bootstraps its sqlite + schema on
+        // The orchestrator now self-bootstraps its sqlite + schema on
         // fresh-workspace boot (via `initializeDatabaseSelfBootstrap` →
         // `SQLite.mjs::initSchema`). The previous `initSqliteSchema()` fixture
         // helper that pre-created the schema here is deleted; the integration
@@ -183,7 +183,7 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
         // the graceful-degradation signal in this profile.
         expect(logContent).not.toMatch(/\[Orchestrator\] Swarm heartbeat init failed/i);
 
-        // AC1+AC2 (#12012) — orchestrator self-bootstrapped the sqlite file + schema
+        // AC1+AC2 — orchestrator self-bootstrapped the sqlite file + schema
         // even though the beforeEach hook no longer pre-creates them. Replaces the
         // deleted `initSqliteSchema(dbPath)` workaround fixture.
         const stats = await fs.stat(dbPath);
@@ -206,23 +206,25 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
     });
 
     test('AC4 — swarm-heartbeat target resolver degrades-with-log when selfIdentity is missing', async () => {
-        // Local deployment mode keeps the swarm-heartbeat lane enabled so the resolver
-        // fires. A short pulse interval forces a pulse cycle within the test window.
-        // Empty NEO_AGENT_IDENTITY + targetSource='self' triggers the documented
-        // disables-with-log path in `swarmHeartbeat.resolveTargets`.
+        // The swarm-heartbeat lane now defaults OFF, so this test explicitly enables it
+        // (NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED) to make the resolver fire, rather than
+        // relying on the old local-default. A short pulse interval forces a pulse cycle
+        // within the test window. Empty NEO_AGENT_IDENTITY + targetSource='self' triggers
+        // the documented disables-with-log path in `swarmHeartbeat.resolveTargets`.
         daemonProcess = spawn('node', [DAEMON_ENTRY], {
             cwd: workspaceDir,
             env: {
                 ...process.env,
-                NEO_AI_DEPLOYMENT_MODE                          : 'local',
-                NEO_AI_ORCHESTRATOR_DIR                         : dataDir,
-                NEO_AI_DB_PATH                                  : dbPath,
-                NEO_HEARTBEAT_ALIVE_PATH                        : path.join(workspaceDir, 'heartbeat.alive'),
-                NEO_BACKUP_PATH                                 : path.join(workspaceDir, 'backups'),
-                NEO_AGENT_IDENTITY                              : '',
-                NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE  : 'self',
-                NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS    : '1000',
-                NEO_ORCHESTRATOR_POLL_INTERVAL_MS               : '500',
+                NEO_AI_DEPLOYMENT_MODE                        : 'local',
+                NEO_AI_ORCHESTRATOR_DIR                       : dataDir,
+                NEO_AI_DB_PATH                                : dbPath,
+                NEO_HEARTBEAT_ALIVE_PATH                      : path.join(workspaceDir, 'heartbeat.alive'),
+                NEO_BACKUP_PATH                               : path.join(workspaceDir, 'backups'),
+                NEO_AGENT_IDENTITY                            : '',
+                NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED      : 'true',
+                NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE: 'self',
+                NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS  : '1000',
+                NEO_ORCHESTRATOR_POLL_INTERVAL_MS             : '500',
                 // NEO_DEBUG=true unlocks the memory-core logger's stderr forward
                 // (stderrMode: 'debug' gates stderr behind aiConfig.debug). Without it
                 // the resolver log goes to the file-sink only — which by default lives
@@ -230,9 +232,9 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
                 NEO_DEBUG                                       : 'true',
                 // Disable side-lanes that would spawn external binaries or touch other
                 // shared substrate during the test window.
-                NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED          : 'false',
-                NEO_ORCHESTRATOR_KB_SYNC_ENABLED                : 'false',
-                NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED       : 'false'
+                NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED   : 'false',
+                NEO_ORCHESTRATOR_KB_SYNC_ENABLED         : 'false',
+                NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED: 'false'
             },
             stdio: ['ignore', 'pipe', 'pipe']
         });
@@ -243,8 +245,8 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
         // Wait for the resolver disable-with-log surface. The exact phrase comes from
         // ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs line ~115.
         const combinedSignal = () => `${stdoutBuf}\n${stderrBuf}`;
-        const deadline = Date.now() + PULSE_TIMEOUT_MS;
-        let matched = false;
+        const deadline       = Date.now() + PULSE_TIMEOUT_MS;
+        let   matched        = false;
         while (Date.now() < deadline) {
             if (/\[resolveSwarmHeartbeatTargets\][^\n]*selfIdentity is null[^\n]*disabled/i.test(combinedSignal())) {
                 matched = true;

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -161,12 +161,12 @@ test.describe('Tier 1 Config Immutability', () => {
             kbSyncEnabled                  : null,
             githubWorkflowSyncEnabled      : null,
             chromaDaemonEnabled            : null,
-            bridgeDaemonEnabled            : null,
+            bridgeDaemonEnabled            : false,
             neuralLinkBridgeEnabled        : null,
             embedDaemonEnabled             : null,
             messageDaemonEnabled           : null,
             goldenPathRepoEnrichmentEnabled: null,
-            swarmHeartbeatEnabled          : null,
+            swarmHeartbeatEnabled          : false,
             wakeDispatchEnabled            : null
         });
         expect(Config.orchestrator.devServer).toEqual({


### PR DESCRIPTION
Resolves #14486

Defaults the wake-delivery + swarm-heartbeat lanes **OFF** so local deployments are quiet by default — no env vars. Operator-directed (@tobiu): *"we want no env vars locally. we want the DEFAULT value for both to be false."*

## The finding (V-B-A)

This ticket was originally scoped to *add* AiConfig toggles. Tracing the emission path first showed **the toggles already exist and are wired** — so this ships as a small default flip, not new config:

| Leaf | Was | Now | Gates |
|---|---|---|---|
| `orchestrator.localOnly.bridgeDaemonEnabled` | `leaf(null)` | `leaf(false)` | wake DELIVERY (`Orchestrator.mjs:952`) |
| `orchestrator.localOnly.swarmHeartbeatEnabled` | `leaf(null)` | `leaf(false)` | heartbeat pulses + the `decideWake` that rides inside `pulse()` (`Orchestrator.mjs:854`) |

`null` resolved to "local enables" via `resolveLocalDeploymentDefault`; an explicit `false` = OFF in both profiles (cloud was already OFF via the profile default, so **no cloud change**). Both stay env-overridable (`NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED` / `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED`) to re-enable.

**Why:** the lane-state Stop hook forces turn continuation, so wake-to-continue is redundant — the wake/heartbeat plumbing became a duplicate-flood at multi-peer scale (partly why a peer hit a rate limit). A2A messages still persist + surface on next `list_messages`; only the interrupt + pulses go quiet. Substrate maintenance (GraphLog compaction, integrity sweep, embed/message daemons) runs via its own separate toggles, unaffected.

Evidence: L2 (unit — config-default assertion + orchestrator gating verified).

## Deltas from ticket

Re-scoped from "add AiConfig toggles" (redundant — they already exist + are wired) to "flip the existing defaults to `false`" per the operator's decision. The discoverability runbook + any cloud-default question are separate follow-ups. See the ticket's V-B-A comment for the full trace.

## Test Evidence

- `node --check ai/config.template.mjs`
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs` → **9/9** (updated the `localOnly` default assertion: `bridgeDaemonEnabled` / `swarmHeartbeatEnabled` → `false`)
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` → **60/60** (no regression; its harness sets its own values via `?? true`)
- Re-materialized `config.mjs` from the template (`initServerConfigs.mjs`).

## Post-Merge Validation

- [ ] Operators re-materialize local `config.mjs` (`npm run prepare`) or restart the orchestrator to pick up the quiet defaults.
- [ ] Confirm no wake interrupts + no swarm-heartbeat pulses in a live local session; A2A still pollable via `list_messages`.

## Commits

- `369048399` — `fix(orchestrator): default wake delivery + swarm-heartbeat OFF (#14486)`

Authored by Grace (@neo-opus-grace, Claude Opus 4.8). Operator-directed (@tobiu). Parent epic #13652.
