### PR TITLE
feat(ai): validate required deployment config (#13432)

### DIFF
--- a/ai/ConfigProvider.mjs
+++ b/ai/ConfigProvider.mjs
@@ -193,16 +193,19 @@ class ConfigProvider extends Provider {
      * state cannot be checked fails closed for readiness-certifying consumers.
      * @param {Object} [options]
      * @param {String} [options.entrypoint='unknown'] Entry point performing the check.
-     * @param {String} [options.mode='unknown'] Active deployment/auth mode.
+     * @param {String} [options.mode] Active deployment/auth mode. Defaults to the resolved
+     *        `auth.mode` leaf so readiness checks do not carry a hidden fallback mode.
      * @param {String} [options.consumerClaim='readiness'] Claim made by the consumer.
      * @returns {{ok:Boolean, findings:Array<Object>}}
      */
-    validateRequiredEnv({entrypoint = 'unknown', mode = 'unknown', consumerClaim = 'readiness'} = {}) {
+    validateRequiredEnv({entrypoint = 'unknown', mode, consumerClaim = 'readiness'} = {}) {
         const
-            findings  = [],
-            providers = [];
+            findings             = [],
+            activeMode           = mode ?? this.getData('auth.mode'),
+            providers            = [],
+            shadowedRequiredness = new Set();
 
-        for (let provider = this; provider instanceof ConfigProvider; provider = provider.getParent?.()) {
+        for (let provider = this; provider instanceof ConfigProvider; provider = provider.getParent()) {
             if (providers.includes(provider)) {
                 break
             }
@@ -212,21 +215,29 @@ class ConfigProvider extends Provider {
 
         for (const provider of providers) {
             for (const [leafPath, meta] of provider.#leafMetadataRegistry) {
+                if (shadowedRequiredness.has(leafPath)) {
+                    continue
+                }
+
                 const requirements = Array.isArray(meta.requiredFor)
                     ? meta.requiredFor
                     : (meta.requiredFor ? [meta.requiredFor] : []);
 
+                if (requirements.length > 0) {
+                    shadowedRequiredness.add(leafPath)
+                }
+
                 for (const requirement of requirements) {
                     if (
-                        !matchesContext(requirement.entrypoints, entrypoint) ||
-                        !matchesContext(requirement.modes,       mode)       ||
+                        !matchesContext(requirement.entrypoints, entrypoint)  ||
+                        !matchesContext(requirement.modes,       activeMode)  ||
                         !matchesContext(requirement.consumerClaims, consumerClaim)
                     ) {
                         continue
                     }
 
                     const
-                        value     = provider.getData(leafPath),
+                        value     = this.getData(leafPath),
                         validator = meta.type ? typeValidators[meta.type] : null;
 
                     let valueState = 'present-valid';
@@ -243,7 +254,7 @@ class ConfigProvider extends Provider {
                             entrypoint,
                             env        : meta.env,
                             leafPath,
-                            mode,
+                            mode       : activeMode,
                             reason     : requirement.reason ?? null,
                             valueState,
                             disposition: requirement.disposition ?? 'fail-closed'

--- a/ai/ConfigProvider.mjs
+++ b/ai/ConfigProvider.mjs
@@ -47,9 +47,11 @@ const typeValidators = {
  * @param {String|null} [env=null] Env var name, or null for a non-env leaf.
  * @param {String|null} [type=null] One of `typeParsers` / `typeValidators` keys. Inferred from
  *        `defaultValue` via `Neo.typeOf` (lower-cased) when omitted and the default is non-null.
+ * @param {Object|null} [metadata=null] Additional declarative leaf metadata. Used for readiness
+ *        contracts such as mode/entrypoint requiredness; never for parallel env defaults.
  * @returns {{default:*, env:(String|null), type:(String|null), parse:(Function|null)}}
  */
-export function leaf(defaultValue, env = null, type = null) {
+export function leaf(defaultValue, env = null, type = null, metadata = null) {
     // Neo.typeOf returns undefined for objects carrying an own `constructor` key (e.g. the
     // dummy embedding fn's anti-legacy duck-type), so guard the inference. Such object leaves
     // simply resolve to a null type (no validator) — pass an explicit `type` to override.
@@ -60,9 +62,28 @@ export function leaf(defaultValue, env = null, type = null) {
     return {
         default: defaultValue,
         env,
-        type   : resolvedType,
-        parse  : env ? (typeParsers[resolvedType] ?? Env.parseString) : null
+        ...(metadata || {}),
+        type : resolvedType,
+        parse: env ? (typeParsers[resolvedType] ?? Env.parseString) : null
     }
+}
+
+function normalizeList(value) {
+    if (value === undefined || value === null || value === '*') {
+        return null
+    }
+
+    return Array.isArray(value) ? value : [value]
+}
+
+function matchesContext(value, actual) {
+    const list = normalizeList(value);
+
+    return !list || list.includes(actual)
+}
+
+function isEmptyRequiredValue(value) {
+    return value === undefined || value === null || (typeof value === 'string' && value.trim() === '')
 }
 
 /**
@@ -147,8 +168,9 @@ class ConfigProvider extends Provider {
 
                     Neo.assignToNs(path, value.default, plainData);
                     registry.set(dotted, {
-                        env  : value.env   ?? null,
-                        parse: value.parse ?? null,
+                        env        : value.env         ?? null,
+                        parse      : value.parse       ?? null,
+                        requiredFor: value.requiredFor ?? null,
                         // Guard inference: Neo.typeOf is undefined for objects with an own `constructor` key.
                         type : value.type  ?? (value.default == null
                             ? null
@@ -162,6 +184,79 @@ class ConfigProvider extends Provider {
 
         walk(tree, []);
         return {plainData, registry}
+    }
+
+    /**
+     * Classifies declarative required-env leaf state for one entrypoint/mode/consumer claim.
+     * The contract reads the existing leaf metadata registry; it never re-reads env vars or keeps
+     * a parallel required-var list. A required leaf whose value is invalid, absent, empty, or whose
+     * state cannot be checked fails closed for readiness-certifying consumers.
+     * @param {Object} [options]
+     * @param {String} [options.entrypoint='unknown'] Entry point performing the check.
+     * @param {String} [options.mode='unknown'] Active deployment/auth mode.
+     * @param {String} [options.consumerClaim='readiness'] Claim made by the consumer.
+     * @returns {{ok:Boolean, findings:Array<Object>}}
+     */
+    validateRequiredEnv({entrypoint = 'unknown', mode = 'unknown', consumerClaim = 'readiness'} = {}) {
+        const
+            findings  = [],
+            providers = [];
+
+        for (let provider = this; provider instanceof ConfigProvider; provider = provider.getParent?.()) {
+            if (providers.includes(provider)) {
+                break
+            }
+
+            providers.push(provider);
+        }
+
+        for (const provider of providers) {
+            for (const [leafPath, meta] of provider.#leafMetadataRegistry) {
+                const requirements = Array.isArray(meta.requiredFor)
+                    ? meta.requiredFor
+                    : (meta.requiredFor ? [meta.requiredFor] : []);
+
+                for (const requirement of requirements) {
+                    if (
+                        !matchesContext(requirement.entrypoints, entrypoint) ||
+                        !matchesContext(requirement.modes,       mode)       ||
+                        !matchesContext(requirement.consumerClaims, consumerClaim)
+                    ) {
+                        continue
+                    }
+
+                    const
+                        value     = provider.getData(leafPath),
+                        validator = meta.type ? typeValidators[meta.type] : null;
+
+                    let valueState = 'present-valid';
+
+                    if (isEmptyRequiredValue(value)) {
+                        valueState = 'absent'
+                    } else if (validator && !validator(value)) {
+                        valueState = 'present-invalid'
+                    }
+
+                    if (valueState !== 'present-valid') {
+                        findings.push({
+                            consumerClaim,
+                            entrypoint,
+                            env        : meta.env,
+                            leafPath,
+                            mode,
+                            reason     : requirement.reason ?? null,
+                            valueState,
+                            disposition: requirement.disposition ?? 'fail-closed'
+                        })
+                    }
+                }
+            }
+        }
+
+        return {
+            findings,
+            ok: findings.length === 0
+        }
     }
 
     /**

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -109,7 +109,14 @@ class Config extends ConfigProvider {
                 // Authorization strategy selector: 'oidc' (default) | 'gitlab-pat'. See block doc above.
                 mode              : leaf('oidc', 'NEO_AUTH_MODE', 'string'),
                 // GitLab API base URL used by 'gitlab-pat' mode for token validation (self-managed configurable).
-                gitlabApiBaseUrl  : leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string'),
+                gitlabApiBaseUrl  : leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string', {
+                    requiredFor: [{
+                        entrypoints   : '*',
+                        modes         : ['gitlab-pat'],
+                        consumerClaims: ['readiness'],
+                        reason        : 'PAT validation cannot certify readiness without a GitLab API base URL.'
+                    }]
+                }),
                 // Bounded TTL (seconds) for the per-token PAT validation cache → a revoked PAT clears within this window.
                 patCacheTtlSeconds: leaf(300, 'NEO_AUTH_PAT_CACHE_TTL_SECONDS', 'number'),
                 // Optional GitLab OAuth app binding for 'gitlab-pat' mode. Empty means no app gate.

--- a/ai/daemons/kb-alerting/daemon.mjs
+++ b/ai/daemons/kb-alerting/daemon.mjs
@@ -29,6 +29,7 @@ import logger                         from '../../mcp/server/knowledge-base/logg
 import KbAlertingService              from './KbAlertingService.mjs';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import {assertConfigFresh}            from '../../scripts/setup/initServerConfigs.mjs';
+import AiConfig                       from '../../config.mjs';
 
 const cleanShutdown = signal => {
     logger.info(`[KbAlertingService] Received ${signal}; stopping.`);
@@ -44,7 +45,11 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
     process.on('SIGINT',  () => cleanShutdown('SIGINT'));
 
-    assertConfigFresh({serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))})
+    assertConfigFresh({
+        aiConfig  : AiConfig,
+        entrypoint: 'kb-alerting-daemon',
+        serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
+    })
         .then(() => KbAlertingService.start())
         .catch(err => {
             logger.error('[KbAlertingService] Daemon start failed:', err);

--- a/ai/daemons/kb-gc/daemon.mjs
+++ b/ai/daemons/kb-gc/daemon.mjs
@@ -31,6 +31,7 @@ import logger                         from '../../mcp/server/knowledge-base/logg
 import KbGarbageCollectionService     from './KbGarbageCollectionService.mjs';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import {assertConfigFresh}            from '../../scripts/setup/initServerConfigs.mjs';
+import AiConfig                       from '../../config.mjs';
 
 const cleanShutdown = signal => {
     logger.info(`[KbGarbageCollectionService] Received ${signal}; stopping.`);
@@ -46,7 +47,11 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
     process.on('SIGINT',  () => cleanShutdown('SIGINT'));
 
-    assertConfigFresh({serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))})
+    assertConfigFresh({
+        aiConfig  : AiConfig,
+        entrypoint: 'kb-gc-daemon',
+        serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
+    })
         .then(() => KbGarbageCollectionService.start())
         .catch(err => {
             logger.error('[KbGarbageCollectionService] Daemon start failed:', err);

--- a/ai/daemons/kb-reconciliation/daemon.mjs
+++ b/ai/daemons/kb-reconciliation/daemon.mjs
@@ -31,6 +31,7 @@ import logger                         from '../../mcp/server/knowledge-base/logg
 import KbReconciliationService        from './KbReconciliationService.mjs';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import {assertConfigFresh}            from '../../scripts/setup/initServerConfigs.mjs';
+import AiConfig                       from '../../config.mjs';
 
 const cleanShutdown = signal => {
     logger.info(`[KbReconciliationService] Received ${signal}; stopping.`);
@@ -46,7 +47,11 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
     process.on('SIGINT',  () => cleanShutdown('SIGINT'));
 
-    assertConfigFresh({serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))})
+    assertConfigFresh({
+        aiConfig  : AiConfig,
+        entrypoint: 'kb-reconciliation-daemon',
+        serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
+    })
         .then(() => KbReconciliationService.start())
         .catch(err => {
             logger.error('[KbReconciliationService] Daemon start failed:', err);

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -26,17 +26,17 @@ import Neo             from '../../../src/Neo.mjs';
 import * as core       from '../../../src/core/_export.mjs';
 import InstanceManager from '../../../src/manager/Instance.mjs';
 
-import {fileURLToPath, pathToFileURL} from 'url';
-import fs                             from 'fs-extra';
-import path                           from 'path';
-import {execSync}                     from 'child_process';
-import AiConfig                       from '../../config.mjs';
+import {fileURLToPath, pathToFileURL}        from 'url';
+import fs                                    from 'fs-extra';
+import path                                  from 'path';
+import {execSync}                            from 'child_process';
+import AiConfig                              from '../../config.mjs';
 import Orchestrator, {rotateLogFileIfNewDay} from './Orchestrator.mjs';
-import {assertConfigFresh}            from '../../scripts/setup/initServerConfigs.mjs';
+import {assertConfigFresh}                   from '../../scripts/setup/initServerConfigs.mjs';
 
-const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
-const PID_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
-const LOG_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator.log');
+const DAEMON_DATA_DIR               = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
+const PID_FILE                      = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
+const LOG_FILE                      = path.join(DAEMON_DATA_DIR, 'orchestrator.log');
 const ORCHESTRATOR_DAEMON_PATH_TAIL = 'ai/daemons/orchestrator/daemon.mjs';
 export const LOCAL_AI_CONFIG_FILE = fileURLToPath(new URL('../../config.mjs', import.meta.url));
 
@@ -189,7 +189,7 @@ export async function startOrchestrator(options = {}) {
     await loadLocalAiConfig();
 
     return Orchestrator.start({
-        dataDir: DAEMON_DATA_DIR,
+        dataDir                  : DAEMON_DATA_DIR,
         primaryDevSyncRootsConfig: AiConfig.orchestrator.devSyncRoots,
         ...options
     });
@@ -198,7 +198,7 @@ export async function startOrchestrator(options = {}) {
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
     // Boot guard: fail fast on a stale config overlay (missing a leaf its template added) with an
     // actionable --migrate-config message, rather than letting the orchestrator crash cryptically.
-    assertConfigFresh()
+    assertConfigFresh({aiConfig: AiConfig, entrypoint: 'orchestrator-daemon'})
         .then(() => startOrchestrator())
         .catch(err => {
             console.error(`[Orchestrator] Failed to start: ${err && err.stack ? err.stack : err}`);

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -42,7 +42,7 @@ import { constants as fsConstants }     from 'fs';
 import { spawn, execSync }              from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname  = path.dirname(__filename);
 import {
     initializeDatabase,
     getLastSyncId,
@@ -80,15 +80,15 @@ let DAEMON_DATA_DIR;
 let STATE_FILE;
 let LOG_FILE;
 let WOKEN_WATERMARK_FILE;
-const LOG_RETENTION_DAYS       = 30;
-const POLL_INTERVAL_MS         = 3000;
-const DEFAULT_COALESCE_WINDOW_MS = 30000; // 30 seconds
-const CODEX_APP_SERVER_ADAPTER   = 'codex-app-server';
-const DEFAULT_CODEX_DESKTOP_CLI_PATH = '/Applications/Codex.app/Contents/Resources/codex';
+const LOG_RETENTION_DAYS                = 30;
+const POLL_INTERVAL_MS                  = 3000;
+const DEFAULT_COALESCE_WINDOW_MS        = 30000; // 30 seconds
+const CODEX_APP_SERVER_ADAPTER          = 'codex-app-server';
+const DEFAULT_CODEX_DESKTOP_CLI_PATH    = '/Applications/Codex.app/Contents/Resources/codex';
 const CODEX_TURN_START_PROOF_TIMEOUT_MS = Number(process.env.WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS) || 45000;
 const CODEX_TURN_START_PROOF_POLL_MS    = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
 const CODEX_WAKE_SUBMIT_NONCE_PREFIX    = 'NEO_WAKE_SUBMIT_NONCE:';
-const WAKE_PRIORITY_RANKS      = {
+const WAKE_PRIORITY_RANKS               = {
     low   : 0,
     normal: 1,
     high  : 2
@@ -302,8 +302,8 @@ async function enforceSingleton() {
     }
 
     // Cleanup on exit
-    let cleanedUp = false;
-    const cleanup = () => {
+    let   cleanedUp = false;
+    const cleanup   = () => {
         if (cleanedUp) return;
         cleanedUp = true;
         try {
@@ -358,10 +358,10 @@ async function pollLoop() {
         }
 
         if (logs.length > 0) {
-            const invalidNodes = new Set();
-            const invalidEdges = new Set();
+            const invalidNodes    = new Set();
+            const invalidEdges    = new Set();
             const batchBaseSyncId = lastSyncId;
-            let maxId = lastSyncId;
+            let   maxId           = lastSyncId;
 
             for (const trace of logs) {
                 maxId = Math.max(maxId, trace.log_id);
@@ -763,8 +763,8 @@ async function flushSubscription(subId) {
  */
 function spawnAsync(command, args) {
     return new Promise((resolve, reject) => {
-        const child = spawn(command, args, { stdio: ['ignore', 'ignore', 'pipe'] });
-        let stderrData = '';
+        const child      = spawn(command, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+        let   stderrData = '';
         child.stderr.on('data', (data) => {
             stderrData += data.toString();
         });
@@ -914,7 +914,7 @@ function buildWakeDeliveryEvidence({messages = [], tasks = [], permissions = [],
     };
 
     const actionableCount = counts.messages + counts.tasks + counts.permissions;
-    const correlation = {
+    const correlation     = {
         messageIds   : messages.map(message => message.messageId).filter(Boolean),
         taskIds      : tasks.map(task => task.taskId).filter(Boolean),
         permissionIds: permissions.map(permission => permission.logId).filter(Boolean),
@@ -1027,8 +1027,8 @@ function appendCodexWakeSubmitNonce(digest, wakeSubmitNonce) {
  * @returns {Object|null}
  */
 function findTurnPresenceAfter(sqlite, agentIdentity, sinceIso, {wakeSubmitNonce} = {}) {
-    const params = [agentIdentity, sinceIso];
-    let nonceFilter = '';
+    const params      = [agentIdentity, sinceIso];
+    let   nonceFilter = '';
 
     if (wakeSubmitNonce) {
         nonceFilter = `AND json_extract(data, '$.properties.wakeSubmitNonce') = ?`;
@@ -1077,10 +1077,10 @@ function scheduleCodexTurnStartProof(subscription, submitAttemptedAt, deliveryEv
 
     if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return;
 
-    const agentIdentity = subscription.properties?.agentIdentity,
-          submitIso     = submitAttemptedAt.toISOString(),
-          deadlineAt    = Date.now() + timeoutMs,
-          correlation   = formatWakeCorrelationEvidence(deliveryEvidence),
+    const agentIdentity   = subscription.properties?.agentIdentity,
+          submitIso       = submitAttemptedAt.toISOString(),
+          deadlineAt      = Date.now() + timeoutMs,
+          correlation     = formatWakeCorrelationEvidence(deliveryEvidence),
           wakeSubmitNonce = deliveryEvidence.wakeSubmitNonce;
 
     if (!agentIdentity) {
@@ -1180,12 +1180,12 @@ const pendingDeliveryRetries = new Map(); // subscriptionId -> {subscription, id
  * @returns {Promise<String|undefined>}
  */
 async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
-    const meta = subscription.properties?.harnessTargetMetadata || {};
+    const meta                           = subscription.properties?.harnessTargetMetadata || {};
     const {instanceAddress, addressType} = resolveInstanceAddress(meta);
     // Fall back to osascript on macOS by default, tmux otherwise
-    const defaultAdapter = process.platform === 'darwin' ? 'osascript' : 'tmux';
-    const adapter       = meta.adapter || defaultAdapter;
-    const adapterSource = meta.adapter ? 'metadata' : 'platform-default';
+    const defaultAdapter  = process.platform === 'darwin' ? 'osascript' : 'tmux';
+    const adapter         = meta.adapter || defaultAdapter;
+    const adapterSource   = meta.adapter ? 'metadata' : 'platform-default';
     const wakeSubmitNonce = isCodexSubmitProofAdapter({adapter, appName: meta.appName}) ? crypto.randomUUID() : null;
     const dispatchDigest  = wakeSubmitNonce ? appendCodexWakeSubmitNonce(digest, wakeSubmitNonce) : digest;
     const proofEvidence   = wakeSubmitNonce ? {...deliveryEvidence, wakeSubmitNonce} : deliveryEvidence;
@@ -1236,9 +1236,9 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
                 return;
             }
             const metadataWithDefaults = applyHarnessMetadataDefaults(meta);
-            let tabShortcut            = metadataWithDefaults.tabShortcut;
-            let focusSeedKey           = metadataWithDefaults.focusSeedKey;
-            let focusSeedSequence      = metadataWithDefaults.focusSeedSequence;
+            let   tabShortcut          = metadataWithDefaults.tabShortcut;
+            let   focusSeedKey         = metadataWithDefaults.focusSeedKey;
+            let   focusSeedSequence    = metadataWithDefaults.focusSeedSequence;
 
             // Codex Desktop fail-closed guard. The wake daemon must not drive the destructive
             // Cmd+A/Cmd+X clear path unless subscription metadata provides a verified,
@@ -1754,7 +1754,11 @@ function initConfigDerivedState() {
 async function main() {
     // Fail-fast on a stale memory-core config overlay with the actionable --migrate-config message,
     // BEFORE initConfigDerivedState() derefs memoryCoreConfig.
-    await assertConfigFresh({serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))});
+    await assertConfigFresh({
+        aiConfig  : memoryCoreConfig,
+        entrypoint: 'wake-daemon',
+        serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
+    });
 
     initConfigDerivedState();
 

--- a/ai/mcp/server/github-workflow/mcp-server.mjs
+++ b/ai/mcp/server/github-workflow/mcp-server.mjs
@@ -29,7 +29,7 @@ if (options.debug) {
 try {
     // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
     // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-    await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+    await assertConfigFresh({aiConfig, entrypoint: 'github-workflow-mcp', serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
     await Neo.create(Server, {
         configFile: options.config

--- a/ai/mcp/server/gitlab-workflow/mcp-server.mjs
+++ b/ai/mcp/server/gitlab-workflow/mcp-server.mjs
@@ -28,7 +28,7 @@ if (options.debug) {
 try {
     // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
     // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-    await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+    await assertConfigFresh({aiConfig, entrypoint: 'gitlab-workflow-mcp', serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
     await Neo.create(Server, {
         configFile: options.config

--- a/ai/mcp/server/knowledge-base/mcp-server.mjs
+++ b/ai/mcp/server/knowledge-base/mcp-server.mjs
@@ -29,7 +29,7 @@ if (options.debug) {
 try {
     // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
     // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-    await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+    await assertConfigFresh({aiConfig, entrypoint: 'knowledge-base-mcp', serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
     await Neo.create(Server, {
         configFile: options.config

--- a/ai/mcp/server/memory-core/mcp-server.mjs
+++ b/ai/mcp/server/memory-core/mcp-server.mjs
@@ -29,7 +29,7 @@ if (options.debug) {
 try {
     // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
     // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-    await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+    await assertConfigFresh({aiConfig, entrypoint: 'memory-core-mcp', serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
     await Neo.create(Server, {
         configFile: options.config

--- a/ai/mcp/server/neural-link/mcp-server.mjs
+++ b/ai/mcp/server/neural-link/mcp-server.mjs
@@ -31,7 +31,7 @@ if (options.debug) {
 try {
     // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
     // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-    await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+    await assertConfigFresh({aiConfig, entrypoint: 'neural-link-mcp', serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
     await Neo.create(Server, {
         configFile        : options.config,

--- a/ai/mcp/server/neural-link/run-bridge.mjs
+++ b/ai/mcp/server/neural-link/run-bridge.mjs
@@ -27,7 +27,7 @@ if (options.debug) {
     try {
         // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
         // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-        await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+        await assertConfigFresh({aiConfig, entrypoint: 'neural-link-bridge', serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
         if (options.config) {
             await aiConfig.load(options.config);

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -677,7 +677,7 @@ export async function initTier1Config({argv = process.argv, logger = console, ai
  * @param {String}   [options.consumerClaim='readiness'] The claim this guard certifies.
  * @param {String}   [options.entrypoint='boot'] The entrypoint name for requiredness matching.
  * @param {String}   [options.mode] Active mode for requiredness matching; defaults to
- *   `aiConfig.auth.mode` when present.
+ *   `aiConfig.auth.mode` when omitted.
  * @param {String}   [options.serverPath] An `ai/mcp/server/<name>/` dir whose `config.mjs` overlay to
  *   additionally check; its Tier-1 import is materialized before the shape-compare (matching
  *   {@link initConfigs}) so the template-vs-overlay import path is not read as false drift.
@@ -734,11 +734,11 @@ export async function assertConfigFresh({
         }
     }
 
-    if (aiConfig?.validateRequiredEnv) {
+    if (aiConfig !== undefined) {
         const result = aiConfig.validateRequiredEnv({
             consumerClaim,
             entrypoint,
-            mode: mode ?? aiConfig.auth?.mode ?? 'unknown'
+            mode: mode ?? aiConfig.auth.mode
         });
 
         requiredFindings.push(...result.findings);

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -35,7 +35,7 @@ const cwd        = path.resolve(__dirname, '../../../');
 const serversDir = path.join(cwd, 'ai', 'mcp', 'server');
 const aiDir      = path.join(cwd, 'ai');
 
-const MIGRATE_FLAG = '--migrate-config';
+const MIGRATE_FLAG                = '--migrate-config';
 const MATERIALIZED_SERVER_IMPORTS = new Set([
     '../../../config.mjs',
     '../../../config.mjs:default'
@@ -84,8 +84,8 @@ export function listServersWithTemplates(serversRoot = serversDir) {
  * @returns {Number}
  */
 function findClosingParen(src, openIndex) {
-    let quote = null;
-    let depth = 0;
+    let quote  = null;
+    let depth  = 0;
     let escape = false;
 
     for (let i = openIndex; i < src.length; i++) {
@@ -127,11 +127,11 @@ function findClosingParen(src, openIndex) {
  * @returns {String[]}
  */
 function splitTopLevelArgs(src) {
-    const args = [];
-    let quote = null;
-    let depth = 0;
-    let start = 0;
-    let escape = false;
+    const args   = [];
+    let   quote  = null;
+    let   depth  = 0;
+    let   start  = 0;
+    let   escape = false;
 
     for (let i = 0; i < src.length; i++) {
         const char = src[i];
@@ -211,6 +211,16 @@ function leafDefaultIdentity(leaf) {
 }
 
 /**
+ * Builds the stable identity for requiredness metadata attached to an env-bound leaf.
+ *
+ * @param {{key: String, env: String, type: String, metadata: String}} leaf Leaf-requiredness descriptor.
+ * @returns {String}
+ */
+function leafRequirednessIdentity(leaf) {
+    return `${leaf.key} (${leaf.env}, ${leaf.type}): ${leaf.metadata}`
+}
+
+/**
  * Builds a stable sort key for projected leaf-default descriptors.
  *
  * @param {{key: String, env: String, type: String, default: String}} leaf Leaf-default descriptor.
@@ -253,6 +263,45 @@ function projectLeafDefaults(src) {
     }
 
     return leafDefaults.sort((a, b) => leafDefaultSortKey(a).localeCompare(leafDefaultSortKey(b)))
+}
+
+/**
+ * Projects `requiredFor` metadata on env-bound `leaf(...)` calls.
+ *
+ * A metadata-only addition to an existing leaf changes runtime readiness semantics while leaving
+ * imports and env-var literals unchanged. This projection makes stale gitignored overlays visible
+ * when a template adds the fourth-argument requiredness contract to an existing leaf.
+ *
+ * @param {String} src Source text.
+ * @returns {String[]} Stable requiredness descriptors.
+ */
+function projectRequiredLeaves(src) {
+    const requiredLeaves = [];
+    const leafPattern    = /([A-Za-z_$][\w$]*)\s*:\s*leaf\s*\(/g;
+
+    for (const match of src.matchAll(leafPattern)) {
+        const openIndex  = match.index + match[0].lastIndexOf('(');
+        const closeIndex = findClosingParen(src, openIndex);
+
+        if (closeIndex === -1) continue;
+
+        const args = splitTopLevelArgs(src.slice(openIndex + 1, closeIndex));
+        if (args.length < 4 || !/\brequiredFor\s*:/.test(args[3])) continue;
+
+        const env  = stringLiteralValue(args[1]);
+        const type = stringLiteralValue(args[2]);
+
+        if (!env || !type || !/^[A-Z][A-Z0-9_]+$/.test(env)) continue;
+
+        requiredLeaves.push(leafRequirednessIdentity({
+            key     : match[1],
+            env,
+            type,
+            metadata: normalizeLeafDefault(args[3])
+        }))
+    }
+
+    return requiredLeaves.sort()
 }
 
 /**
@@ -302,9 +351,11 @@ function formatChangedLeafDefault(leaf) {
  *   calls. Same-env default flips are semantic AiConfig drift; env-var projection alone treats
  *   `leaf('gemini', 'NEO_MODEL_PROVIDER', 'string')` and
  *   `leaf('openAiCompatible', 'NEO_MODEL_PROVIDER', 'string')` as equal.
+ * - **Required leaves**: stable descriptors for fourth-argument `requiredFor` metadata. This catches
+ *   a readiness-contract addition to an existing leaf, where imports/env vars/defaults are unchanged.
  *
  * @param {String} src Source text to project.
- * @returns {{imports: String[], exports: String[], envVars: String[], leafDefaults: Object[]}}
+ * @returns {{imports: String[], exports: String[], envVars: String[], leafDefaults: Object[], requiredLeaves: String[]}}
  */
 export function projectSourceShape(src) {
     const imports = [];
@@ -318,7 +369,7 @@ export function projectSourceShape(src) {
         const namedBlock = body.match(/\{([^}]+)\}/);
         if (namedBlock) {
             for (const raw of namedBlock[1].split(',')) {
-                const cleaned  = raw.trim();
+                const cleaned = raw.trim();
                 if (!cleaned) continue;
                 const imported = cleaned.split(/\s+as\s+/)[0].trim();
                 if (imported) {
@@ -355,9 +406,11 @@ export function projectSourceShape(src) {
         [...src.matchAll(/['"]([A-Z][A-Z0-9_]+)['"]/g)].map(m => m[1])
     )].sort();
 
-    const leafDefaults = projectLeafDefaults(src);
+    const
+        leafDefaults   = projectLeafDefaults(src),
+        requiredLeaves = projectRequiredLeaves(src);
 
-    return {imports, exports, envVars, leafDefaults}
+    return {imports, exports, envVars, leafDefaults, requiredLeaves}
 }
 
 export async function projectShape(filePath) {
@@ -390,7 +443,7 @@ export function materializeServerConfigTemplate(src) {
  * Detects the narrow drift shape where an existing per-server `config.mjs`
  * only needs its Tier-1 import materialized, not a full template overwrite.
  *
- * @param {{missingImports: String[], missingExports: String[], missingEnvVars: String[], changedLeafDefaults: Object[], hasDrift: Boolean}} drift Drift shape (`missingEnvVars` / `changedLeafDefaults` optional on hand-built fixtures).
+ * @param {{missingImports: String[], missingExports: String[], missingEnvVars: String[], missingRequiredLeaves: String[], changedLeafDefaults: Object[], hasDrift: Boolean}} drift Drift shape (`missingEnvVars` / `missingRequiredLeaves` / `changedLeafDefaults` optional on hand-built fixtures).
  * @returns {Boolean}
  */
 export function isOnlyServerMaterializationDrift(drift) {
@@ -400,6 +453,7 @@ export function isOnlyServerMaterializationDrift(drift) {
         // A new env-bound leaf (data-tree drift) needs the full template refresh, not an
         // import-only patch — so env-var drift disqualifies the materialize-only fast path.
         (drift.missingEnvVars?.length ?? 0) === 0 &&
+        (drift.missingRequiredLeaves?.length ?? 0) === 0 &&
         (drift.changedLeafDefaults?.length ?? 0) === 0 &&
         drift.missingImports.length > 0 &&
         drift.missingImports.every(i => MATERIALIZED_SERVER_IMPORTS.has(i))
@@ -412,17 +466,18 @@ export function isOnlyServerMaterializationDrift(drift) {
  * config but not in template — operator-removed paths) is intentionally NOT
  * reported, since this is a one-way "template advanced, config stale" detector.
  *
- * @param {{imports: String[], exports: String[], envVars: String[], leafDefaults: Object[]}} templateShape Projected template shape (`envVars` / `leafDefaults` optional on hand-built fixtures).
- * @param {{imports: String[], exports: String[], envVars: String[], leafDefaults: Object[]}} configShape Projected config shape (same optionality).
- * @returns {{missingImports: String[], missingExports: String[], missingEnvVars: String[], changedLeafDefaults: Object[], hasDrift: Boolean}}
+ * @param {{imports: String[], exports: String[], envVars: String[], leafDefaults: Object[], requiredLeaves: String[]}} templateShape Projected template shape (`envVars` / `leafDefaults` / `requiredLeaves` optional on hand-built fixtures).
+ * @param {{imports: String[], exports: String[], envVars: String[], leafDefaults: Object[], requiredLeaves: String[]}} configShape Projected config shape (same optionality).
+ * @returns {{missingImports: String[], missingExports: String[], missingEnvVars: String[], missingRequiredLeaves: String[], changedLeafDefaults: Object[], hasDrift: Boolean}}
  */
 export function detectDrift(templateShape, configShape) {
     const missingImports = templateShape.imports.filter(i => !configShape.imports.includes(i));
     const missingExports = templateShape.exports.filter(e => !configShape.exports.includes(e));
     // `envVars` is optional on hand-built shapes (e.g. unit fixtures) → default to empty.
-    const missingEnvVars = (templateShape.envVars || []).filter(e => !(configShape.envVars || []).includes(e));
-    const configLeafDefaults = new Map((configShape.leafDefaults || []).map(leaf => [leafDefaultIdentity(leaf), leaf]));
-    const changedLeafDefaults = (templateShape.leafDefaults || [])
+    const missingEnvVars        = (templateShape.envVars || []).filter(e => !(configShape.envVars || []).includes(e));
+    const missingRequiredLeaves = (templateShape.requiredLeaves || []).filter(e => !(configShape.requiredLeaves || []).includes(e));
+    const configLeafDefaults    = new Map((configShape.leafDefaults || []).map(leaf => [leafDefaultIdentity(leaf), leaf]));
+    const changedLeafDefaults   = (templateShape.leafDefaults || [])
         .map(templateLeaf => {
             const configLeaf = configLeafDefaults.get(leafDefaultIdentity(templateLeaf));
 
@@ -444,8 +499,9 @@ export function detectDrift(templateShape, configShape) {
         missingImports,
         missingExports,
         missingEnvVars,
+        missingRequiredLeaves,
         changedLeafDefaults,
-        hasDrift: missingImports.length + missingExports.length + missingEnvVars.length + changedLeafDefaults.length > 0
+        hasDrift: missingImports.length + missingExports.length + missingEnvVars.length + missingRequiredLeaves.length + changedLeafDefaults.length > 0
     }
 }
 
@@ -501,7 +557,7 @@ export async function initConfigs({argv = process.argv, logger = console, server
         }
 
         const activeSrc = await fs.readFile(activePath, 'utf-8');
-        const drift = detectDrift(
+        const drift     = detectDrift(
             projectSourceShape(activeTemplateSrc),
             projectSourceShape(activeSrc)
         );
@@ -529,6 +585,7 @@ export async function initConfigs({argv = process.argv, logger = console, server
             drift.missingImports.forEach(i => logger.warn(`  + import: ${i}`));
             drift.missingExports.forEach(e => logger.warn(`  + export: ${e}`));
             drift.missingEnvVars.forEach(e => logger.warn(`  + env: ${e}`));
+            drift.missingRequiredLeaves.forEach(e => logger.warn(`  + required-leaf: ${e}`));
             drift.changedLeafDefaults.forEach(leaf => logger.warn(`  + leaf-default: ${formatChangedLeafDefault(leaf)}`));
             logger.warn(`  Run \`npm run prepare -- ${MIGRATE_FLAG}\` to refresh (gitignored; safe).`);
             processed.push({serverName, action: 'warn', drift});
@@ -595,6 +652,7 @@ export async function initTier1Config({argv = process.argv, logger = console, ai
     drift.missingImports.forEach(i => logger.warn(`  + import: ${i}`));
     drift.missingExports.forEach(e => logger.warn(`  + export: ${e}`));
     drift.missingEnvVars.forEach(e => logger.warn(`  + env: ${e}`));
+    drift.missingRequiredLeaves.forEach(e => logger.warn(`  + required-leaf: ${e}`));
     drift.changedLeafDefaults.forEach(leaf => logger.warn(`  + leaf-default: ${formatChangedLeafDefault(leaf)}`));
     logger.warn(`  Run \`npm run prepare -- ${MIGRATE_FLAG}\` to refresh (gitignored; safe).`);
 
@@ -614,19 +672,39 @@ export async function initTier1Config({argv = process.argv, logger = console, ai
  * leaves + the `--migrate-config` fix instead of crashing every consumer cryptically.
  *
  * @param {Object}   [options]
+ * @param {Object}   [options.aiConfig] ConfigProvider instance/proxy whose required-env leaf metadata
+ *   should be validated for this entrypoint. Omit only for legacy callers without a live config.
+ * @param {String}   [options.consumerClaim='readiness'] The claim this guard certifies.
+ * @param {String}   [options.entrypoint='boot'] The entrypoint name for requiredness matching.
+ * @param {String}   [options.mode] Active mode for requiredness matching; defaults to
+ *   `aiConfig.auth.mode` when present.
  * @param {String}   [options.serverPath] An `ai/mcp/server/<name>/` dir whose `config.mjs` overlay to
  *   additionally check; its Tier-1 import is materialized before the shape-compare (matching
  *   {@link initConfigs}) so the template-vs-overlay import path is not read as false drift.
  * @param {String}   [options.aiRoot=aiDir]  Tier-1 root; `ai/config.mjs` is always checked.
  * @param {Object}   [options.logger=console] Log sink; injectable for tests.
  * @returns {Promise<void>}
- * @throws {Error} on crash-causing overlay drift, naming the missing leaves + the `--migrate-config` fix.
+ * @throws {Error} on crash-causing overlay drift or missing required env state, naming the fix.
  */
-export async function assertConfigFresh({serverPath, aiRoot = aiDir, logger = console} = {}) {
-    const stale = [];
+export async function assertConfigFresh({
+    aiConfig,
+    aiRoot = aiDir,
+    consumerClaim = 'readiness',
+    entrypoint = 'boot',
+    logger = console,
+    mode,
+    serverPath
+} = {}) {
+    const stale            = [],
+          requiredFindings = [];
 
     const record = (label, drift) => {
-        const crashCausing = [...drift.missingImports, ...drift.missingExports, ...drift.missingEnvVars];
+        const crashCausing = [
+            ...drift.missingImports,
+            ...drift.missingExports,
+            ...drift.missingEnvVars,
+            ...(drift.missingRequiredLeaves ?? [])
+        ];
 
         if (crashCausing.length > 0) {
             stale.push({label, missing: crashCausing});
@@ -656,12 +734,34 @@ export async function assertConfigFresh({serverPath, aiRoot = aiDir, logger = co
         }
     }
 
+    if (aiConfig?.validateRequiredEnv) {
+        const result = aiConfig.validateRequiredEnv({
+            consumerClaim,
+            entrypoint,
+            mode: mode ?? aiConfig.auth?.mode ?? 'unknown'
+        });
+
+        requiredFindings.push(...result.findings);
+    }
+
     if (stale.length > 0) {
         const detail = stale.map(item => `  - ${item.label}: missing ${item.missing.join(', ')}`).join('\n');
 
         throw new Error(
-            `[Neo AI] Stale config overlay — a materialized config.mjs is missing leaves its template added:\n${detail}\n` +
-            `This will crash at runtime on an undefined config leaf. Refresh: \`npm run prepare -- ${MIGRATE_FLAG}\` (gitignored; safe), then restart.`
+            `[Neo AI] Stale config overlay — a materialized config.mjs is missing template-owned config shape:\n${detail}\n` +
+            `This can crash at runtime or skip readiness requiredness. Refresh: \`npm run prepare -- ${MIGRATE_FLAG}\` (gitignored; safe), then restart.`
+        );
+    }
+
+    if (requiredFindings.length > 0) {
+        const detail = requiredFindings.map(item => {
+            const target = item.env ? `${item.env} (${item.leafPath})` : item.leafPath;
+            return `  - ${target}: ${item.valueState}; needed for ${item.entrypoint}/${item.mode}/${item.consumerClaim}${item.reason ? ` — ${item.reason}` : ''}`
+        }).join('\n');
+
+        throw new Error(
+            `[Neo AI] Required deployment configuration is missing or invalid:\n${detail}\n` +
+            'Set the named env var or update the active config before certifying readiness.'
         );
     }
 }

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -4,7 +4,7 @@ import os               from 'os';
 import path             from 'path';
 import Neo              from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
-import ConfigProvider         from '../../../../ai/ConfigProvider.mjs';
+import ConfigProvider, {leaf} from '../../../../ai/ConfigProvider.mjs';
 import {TIER1_DEFAULTS}       from '../../fixtures/aiConfigDefaults.mjs';
 import {CHROMA_TEST_DATABASE} from '../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
 
@@ -57,6 +57,118 @@ test.describe('Tier 1 Config Immutability', () => {
 
     test('ships a machine-neutral orchestrator dev-sync root default', async () => {
         expect(Config.orchestrator.devSyncRoots).toEqual([]);
+    });
+
+    test('leaf-owned requiredness classifies entrypoint/mode readiness state (#13432)', () => {
+        const envName          = 'NEO_UNIT_REQUIRED_ENV_VALIDATION_URL';
+        const originalEnvValue = process.env[envName];
+        delete process.env[envName];
+
+        const requiredConfig = Neo.create(ConfigProvider, {
+            data: {
+                auth: {
+                    gitlabApiBaseUrl: leaf('', envName, 'string', {
+                        requiredFor: [{
+                            entrypoints   : ['memory-core-mcp'],
+                            modes         : ['gitlab-pat'],
+                            consumerClaims: ['readiness'],
+                            reason        : 'unit readiness requirement'
+                        }]
+                    })
+                }
+            }
+        });
+
+        try {
+            const missing = requiredConfig.validateRequiredEnv({
+                consumerClaim: 'readiness',
+                entrypoint   : 'memory-core-mcp',
+                mode         : 'gitlab-pat'
+            });
+
+            expect(missing.ok).toBe(false);
+            expect(missing.findings).toEqual([{
+                consumerClaim: 'readiness',
+                entrypoint   : 'memory-core-mcp',
+                env          : envName,
+                leafPath     : 'auth.gitlabApiBaseUrl',
+                mode         : 'gitlab-pat',
+                reason       : 'unit readiness requirement',
+                valueState   : 'absent',
+                disposition  : 'fail-closed'
+            }]);
+
+            expect(requiredConfig.validateRequiredEnv({
+                consumerClaim: 'readiness',
+                entrypoint   : 'github-workflow-mcp',
+                mode         : 'gitlab-pat'
+            })).toEqual({findings: [], ok: true});
+        } finally {
+            if (originalEnvValue === undefined) {
+                delete process.env[envName];
+            } else {
+                process.env[envName] = originalEnvValue;
+            }
+            requiredConfig.destroy();
+        }
+    });
+
+    test('child configs validate inherited Tier-1 requiredness metadata (#13432)', () => {
+        const
+            envName          = 'NEO_UNIT_REQUIRED_ENV_VALIDATION_PARENT_URL',
+            originalEnvValue = process.env[envName],
+            previousRoot     = Neo.ai?.Config;
+
+        delete process.env[envName];
+
+        const rootConfig = Neo.create(ConfigProvider, {
+            data: {
+                auth: {
+                    mode            : leaf('gitlab-pat', null, 'string'),
+                    gitlabApiBaseUrl: leaf('', envName, 'string', {
+                        requiredFor: [{
+                            entrypoints   : ['wake-daemon'],
+                            modes         : ['gitlab-pat'],
+                            consumerClaims: ['readiness']
+                        }]
+                    })
+                }
+            }
+        });
+        const childConfig = Neo.create(ConfigProvider, {
+            data: {
+                wakeDaemon: {
+                    enabled: leaf(true, null, 'boolean')
+                }
+            }
+        });
+
+        Neo.ai.Config = rootConfig;
+
+        try {
+            const result = childConfig.validateRequiredEnv({
+                consumerClaim: 'readiness',
+                entrypoint   : 'wake-daemon',
+                mode         : 'gitlab-pat'
+            });
+
+            expect(result.ok).toBe(false);
+            expect(result.findings).toHaveLength(1);
+            expect(result.findings[0]).toMatchObject({
+                env       : envName,
+                leafPath  : 'auth.gitlabApiBaseUrl',
+                valueState: 'absent'
+            });
+        } finally {
+            Neo.ai.Config = previousRoot;
+            if (originalEnvValue === undefined) {
+                delete process.env[envName];
+            } else {
+                process.env[envName] = originalEnvValue;
+            }
+            rootConfig.destroy();
+            childConfig.destroy();
+        }
     });
 
     test('ships Tier-1 provider and unified Chroma defaults', async () => {

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -171,6 +171,48 @@ test.describe('Tier 1 Config Immutability', () => {
         }
     });
 
+    test('child configs validate requiredness against resolved child overrides (#13432)', () => {
+        const
+            envName      = 'NEO_UNIT_REQUIRED_ENV_VALIDATION_OVERRIDE_URL',
+            previousRoot = Neo.ai?.Config;
+
+        const rootConfig = Neo.create(ConfigProvider, {
+            data: {
+                auth: {
+                    mode            : leaf('gitlab-pat', null, 'string'),
+                    gitlabApiBaseUrl: leaf('', envName, 'string', {
+                        requiredFor: [{
+                            entrypoints   : ['memory-core-mcp'],
+                            modes         : ['gitlab-pat'],
+                            consumerClaims: ['readiness']
+                        }]
+                    })
+                }
+            }
+        });
+        const childConfig = Neo.create(ConfigProvider, {
+            data: {
+                auth: {
+                    gitlabApiBaseUrl: leaf('https://override.example.test', null, 'string')
+                }
+            }
+        });
+
+        Neo.ai.Config = rootConfig;
+
+        try {
+            expect(childConfig.validateRequiredEnv({
+                consumerClaim: 'readiness',
+                entrypoint   : 'memory-core-mcp',
+                mode         : 'gitlab-pat'
+            })).toEqual({findings: [], ok: true});
+        } finally {
+            Neo.ai.Config = previousRoot;
+            rootConfig.destroy();
+            childConfig.destroy();
+        }
+    });
+
     test('ships Tier-1 provider and unified Chroma defaults', async () => {
         expect(Config.chatProvider).toBe(process.env.NEO_MODEL_PROVIDER || 'openAiCompatible');
         expect(Config.modelProvider).toBe(Config.chatProvider);

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -941,6 +941,24 @@ test.describe('assertConfigFresh — boot freshness guard (#13560)', () => {
         expect(error.message).toContain('NEO_AUTH_GITLAB_API_BASE_URL (auth.gitlabApiBaseUrl): absent');
         expect(error.message).toContain('memory-core-mcp/gitlab-pat/readiness');
     });
+
+    test('a supplied config without validateRequiredEnv fails loud instead of skipping readiness validation (#13432)', async () => {
+        const root = buildTier1({
+            name            : 'malformed-ai-config',
+            templateContents: TEMPLATE_WITH_LEAF,
+            configContents  : TEMPLATE_WITH_LEAF
+        });
+
+        const error = await callGuard({
+            aiConfig  : {auth: {mode: 'gitlab-pat'}},
+            aiRoot    : root,
+            entrypoint: 'memory-core-mcp',
+            logger    : recordingLogger()
+        });
+
+        expect(error).not.toBeNull();
+        expect(error.message).toContain('validateRequiredEnv');
+    });
 });
 
 test.describe('initClaudeSettings — Claude Stop-hook auto-wire (#13641)', () => {

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -564,6 +564,24 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
         ]);
     });
 
+    test('requiredness projection captures fourth-argument leaf contracts (#13432)', () => {
+        const src = [
+            `export default {auth: {`,
+            `    gitlabApiBaseUrl: leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string', {`,
+            `        requiredFor: [{entrypoints: '*', modes: ['gitlab-pat'], consumerClaims: ['readiness']}]`,
+            `    }),`,
+            `    mode: leaf('oidc', 'NEO_AUTH_MODE', 'string')`,
+            `}};`,
+            ``
+        ].join('\n');
+
+        const shape = projectSourceShape(src);
+
+        expect(shape.requiredLeaves).toEqual([
+            `gitlabApiBaseUrl (NEO_AUTH_GITLAB_API_BASE_URL, string): { requiredFor: [{entrypoints: '*', modes: ['gitlab-pat'], consumerClaims: ['readiness']}] }`
+        ]);
+    });
+
     test('detectDrift reports same-env leaf default changes (#12767)', () => {
         const templateShape = projectSourceShape([
             `export default {`,
@@ -639,6 +657,32 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
         expect(drift.missingExports).toEqual([]);
     });
 
+    test('detectDrift reports missing requiredness metadata for an existing env leaf (#13432)', () => {
+        const templateShape = projectSourceShape([
+            `export default {auth: {`,
+            `    gitlabApiBaseUrl: leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string', {requiredFor: [{modes: ['gitlab-pat']}]})`,
+            `}};`,
+            ``
+        ].join('\n'));
+        const configShape = projectSourceShape([
+            `export default {auth: {`,
+            `    gitlabApiBaseUrl: leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string')`,
+            `}};`,
+            ``
+        ].join('\n'));
+
+        const drift = detectDrift(templateShape, configShape);
+
+        expect(drift.hasDrift).toBe(true);
+        expect(drift.missingImports).toEqual([]);
+        expect(drift.missingExports).toEqual([]);
+        expect(drift.missingEnvVars).toEqual([]);
+        expect(drift.changedLeafDefaults).toEqual([]);
+        expect(drift.missingRequiredLeaves).toEqual([
+            `gitlabApiBaseUrl (NEO_AUTH_GITLAB_API_BASE_URL, string): {requiredFor: [{modes: ['gitlab-pat']}]}`
+        ]);
+    });
+
     test('a template that adds an env-bound config leaf warns the existing config (env drift)', async () => {
         // Identical imports/exports — only a NEW leaf carrying NEO_AUTH_MODE is added. The
         // import/export projection alone is blind to this; env-var projection catches it.
@@ -699,6 +743,35 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
         const onDisk = fs.readFileSync(path.join(root, 'memory-core', 'config.mjs'), 'utf-8');
         expect(onDisk).toBe(materializeServerConfigTemplate(templateSrc));
         expect(onDisk).toContain('NEO_AUTH_MODE');
+    });
+
+    test('requiredness metadata drift forces a full migrate (NOT the materialize-only fast path)', async () => {
+        const templateSrc = [
+            `import AiConfig from '../../../config.template.mjs';`,
+            `export default {auth: {gitlabApiBaseUrl: leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string', {requiredFor: [{modes: ['gitlab-pat']}]})}};`,
+            ``
+        ].join('\n');
+        const configSrc = [
+            `import AiConfig from '../../../config.template.mjs';`,
+            `export default {auth: {gitlabApiBaseUrl: leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string')}};`,
+            ``
+        ].join('\n');
+        const root = buildServerSandbox({
+            sandboxName     : 'requiredness-drift-migrate',
+            templateContents: templateSrc,
+            configContents  : configSrc
+        });
+
+        const logger = recordingLogger();
+        const result = await initConfigs({argv: ['node', 'initServerConfigs.mjs', '--migrate-config'], logger, serversRoot: root});
+
+        const action = result.processed.find(p => p.serverName === 'memory-core');
+        expect(action.action).toBe('migrate');
+        expect(action.migration).toBeUndefined();
+
+        const onDisk = fs.readFileSync(path.join(root, 'memory-core', 'config.mjs'), 'utf-8');
+        expect(onDisk).toBe(materializeServerConfigTemplate(templateSrc));
+        expect(onDisk).toContain('requiredFor');
     });
 
     test.describe('listServersWithTemplates / hasConfigTemplate (shared enumeration)', () => {
@@ -777,7 +850,13 @@ test.describe('assertConfigFresh — boot freshness guard (#13560)', () => {
     });
 
     // The template adds an env-bound leaf; a stale overlay missing it is the crash-causing class.
-    const TEMPLATE_WITH_LEAF = `export default {section: {enabled: leaf(true, 'NEO_SECTION_ENABLED', 'bool')}};\n`;
+    const TEMPLATE_WITH_LEAF          = `export default {section: {enabled: leaf(true, 'NEO_SECTION_ENABLED', 'bool')}};\n`;
+    const TEMPLATE_WITH_REQUIRED_LEAF = [
+        `export default {auth: {`,
+        `    gitlabApiBaseUrl: leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string', {requiredFor: [{modes: ['gitlab-pat']}]})`,
+        `}};`,
+        ``
+    ].join('\n');
 
     test('fails fast (throws) when the overlay is missing a leaf the template added', async () => {
         const root  = buildTier1({name: 'stale', templateContents: TEMPLATE_WITH_LEAF, configContents: 'export default {};\n'});
@@ -807,6 +886,60 @@ test.describe('assertConfigFresh — boot freshness guard (#13560)', () => {
 
         expect(error).toBeNull();
         expect(logger.entries.warn.some(w => w.includes('benign config drift'))).toBe(true);
+    });
+
+    test('fails fast when a stale overlay lacks requiredness metadata the template added', async () => {
+        const root = buildTier1({
+            name            : 'missing-requiredness',
+            templateContents: TEMPLATE_WITH_REQUIRED_LEAF,
+            configContents  : `export default {auth: {gitlabApiBaseUrl: leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string')}};\n`
+        });
+        const error = await callGuard({aiRoot: root, logger: recordingLogger()});
+
+        expect(error).not.toBeNull();
+        expect(error.message).toMatch(/Stale config overlay/);
+        expect(error.message).toContain('NEO_AUTH_GITLAB_API_BASE_URL');
+        expect(error.message).toContain('requiredFor');
+        expect(error.message).toContain('--migrate-config');
+    });
+
+    test('required-env findings are fatal for readiness-certifying guards (#13432)', async () => {
+        const root = buildTier1({
+            name            : 'required-env-finding',
+            templateContents: TEMPLATE_WITH_LEAF,
+            configContents  : TEMPLATE_WITH_LEAF
+        });
+
+        const aiConfig = {
+            auth: {mode: 'gitlab-pat'},
+            validateRequiredEnv({consumerClaim, entrypoint, mode}) {
+                return {
+                    ok      : false,
+                    findings: [{
+                        consumerClaim,
+                        entrypoint,
+                        env        : 'NEO_AUTH_GITLAB_API_BASE_URL',
+                        leafPath   : 'auth.gitlabApiBaseUrl',
+                        mode,
+                        reason     : 'PAT validation cannot certify readiness without a GitLab API base URL.',
+                        valueState : 'absent',
+                        disposition: 'fail-closed'
+                    }]
+                }
+            }
+        };
+
+        const error = await callGuard({
+            aiConfig,
+            aiRoot    : root,
+            entrypoint: 'memory-core-mcp',
+            logger    : recordingLogger()
+        });
+
+        expect(error).not.toBeNull();
+        expect(error.message).toContain('Required deployment configuration is missing or invalid');
+        expect(error.message).toContain('NEO_AUTH_GITLAB_API_BASE_URL (auth.gitlabApiBaseUrl): absent');
+        expect(error.message).toContain('memory-core-mcp/gitlab-pat/readiness');
     });
 });
 


### PR DESCRIPTION
Resolves #13432

Adds leaf-owned required deployment configuration validation for AiConfig and wires the boot guard through MCP servers plus daemon entrypoints. Requiredness now lives on the config leaf via `requiredFor`, stale generated overlays fail loud when that metadata is missing, and readiness-certifying boots throw a concrete missing/invalid config error instead of silently proceeding with lazy defaults.

Evidence: L2 focused unit + local preflight evidence -> L2 required for the config/boot-guard contract. Residual: none for #13432.

## Deltas from ticket
The implementation also extends the existing config-shape drift detector so a template that adds `requiredFor` metadata to an existing `leaf(...)` forces overlay migration. Existing ignored `ai/config.mjs` overlays may need `npm run prepare -- --migrate-config` after pull; that is intentional fail-loud behavior for the new metadata contract.

## Test Evidence
- `npm run agent-preflight -- --no-fix ai/ConfigProvider.mjs ai/config.template.mjs ai/daemons/kb-alerting/daemon.mjs ai/daemons/kb-gc/daemon.mjs ai/daemons/kb-reconciliation/daemon.mjs ai/daemons/orchestrator/daemon.mjs ai/daemons/wake/daemon.mjs ai/mcp/server/github-workflow/mcp-server.mjs ai/mcp/server/gitlab-workflow/mcp-server.mjs ai/mcp/server/knowledge-base/mcp-server.mjs ai/mcp/server/memory-core/mcp-server.mjs ai/mcp/server/neural-link/mcp-server.mjs ai/mcp/server/neural-link/run-bridge.mjs ai/scripts/setup/initServerConfigs.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs` -> 52 passed
- `git diff --cached --check`
- Freshness: `git merge-base HEAD origin/dev == git rev-parse origin/dev` before push

## Post-Merge Validation
- [ ] Start one MCP server from a checkout with a migrated config overlay and verify default `oidc` mode does not trigger the `gitlab-pat` requiredness rule.
- [ ] In a stale local overlay, verify the boot guard names the missing `requiredFor` shape and instructs `npm run prepare -- --migrate-config`.

## Commits
- `77a94da0b9` — `feat(ai): validate required deployment config (#13432)`

Authored by GPT (GPT-5, Codex Desktop). Session 019f231a-ae83-71e1-8d52-c34508826872.
