### PR TITLE
feat(graph): add concept-touch measurement (#14506)

### DIFF
--- a/ai/services/graph/conceptTouchMeasurement.mjs
+++ b/ai/services/graph/conceptTouchMeasurement.mjs
@@ -289,6 +289,15 @@ function incrementCounter(bucket, key) {
 }
 
 /**
+ * @summary Maps reinforced graph weights to honest snapshot buckets.
+ * @param {Number|null} weight
+ * @returns {String}
+ */
+function resolveWeightBucket(weight) {
+    return Number(weight) === 1 ? 'weight-1.0' : 'weight-other';
+}
+
+/**
  * @summary Extracts profile-eligible concept-touch events from `TAGGED_CONCEPT` edges.
  * @param {Object} options
  * @param {Object[]} [options.nodes=[]] Graph node records.
@@ -348,7 +357,7 @@ export function extractConceptTouchEvents({nodes = [], edges = []} = {}) {
             touchedAt     : timestamp,
             depth         : 1,
             weight        : edge.properties.weight ?? rawEdge.weight ?? null,
-            provenance    : (edge.properties.weight ?? rawEdge.weight) === 1 ? 'curated' : 'inferred-or-unknown',
+            weightBucket  : resolveWeightBucket(edge.properties.weight ?? rawEdge.weight),
             visibilityTier: aggregate.visibilityTier,
             trustTier
         })
@@ -400,7 +409,7 @@ export function buildConceptTouchProfiles(events = []) {
             concepts     : new Set(),
             visibilityMix: {},
             trustTierMix : {},
-            provenanceMix: {},
+            weightBucketMix: {},
             depths       : [],
             events       : []
         };
@@ -411,7 +420,7 @@ export function buildConceptTouchProfiles(events = []) {
         profile.events.push(event);
         incrementCounter(profile.visibilityMix, event.visibilityTier);
         incrementCounter(profile.trustTierMix, event.trustTier);
-        incrementCounter(profile.provenanceMix, event.provenance);
+        incrementCounter(profile.weightBucketMix, event.weightBucket);
         byAgent.set(event.agentId, profile)
     }
 
@@ -430,7 +439,7 @@ export function buildConceptTouchProfiles(events = []) {
                 touchDepth           : Number(avgDepth.toFixed(2)),
                 visibilityMix        : profile.visibilityMix,
                 trustTierMix         : profile.trustTierMix,
-                provenanceMix        : profile.provenanceMix,
+                weightBucketMix      : profile.weightBucketMix,
                 revisitIntervals     : intervals,
                 revisitCount,
                 normalizedRevisitRate: Number((revisitCount / Math.max(1, profile.touchCount)).toFixed(4))
@@ -579,6 +588,9 @@ export function renderConceptTouchMeasurementMarkdown(report, {maxCandidateRows 
         'provenance. Elements with no resolvable visibility boundary are excluded, never defaulted',
         'into a public/team aggregate.',
         '',
+        'Weight bucket note: `weight-1.0` / `weight-other` are current edge-weight buckets, not',
+        'extractor provenance. TAGGED_CONCEPT reinforcement can change weights after extraction.',
+        '',
         '## Measurement Counts',
         '',
         '| Field | Count |',
@@ -591,16 +603,16 @@ export function renderConceptTouchMeasurementMarkdown(report, {maxCandidateRows 
         '',
         '## Per-Agent Concept-Touch Profiles',
         '',
-        '| Agent | Touches | Concepts | Avg depth | Revisit count | Normalized revisit rate | Visibility mix | Trust mix |',
-        '|---|---:|---:|---:|---:|---:|---|---|'
+        '| Agent | Touches | Concepts | Avg depth | Revisit count | Normalized revisit rate | Visibility mix | Trust mix | Weight bucket mix |',
+        '|---|---:|---:|---:|---:|---:|---|---|---|'
     ];
 
     for (const profile of report.profiles || []) {
-        lines.push(`| ${profile.agentId} | ${profile.touchCount} | ${profile.conceptsTouched} | ${profile.touchDepth} | ${profile.revisitCount} | ${profile.normalizedRevisitRate} | ${formatMix(profile.visibilityMix)} | ${formatMix(profile.trustTierMix)} |`)
+        lines.push(`| ${profile.agentId} | ${profile.touchCount} | ${profile.conceptsTouched} | ${profile.touchDepth} | ${profile.revisitCount} | ${profile.normalizedRevisitRate} | ${formatMix(profile.visibilityMix)} | ${formatMix(profile.trustTierMix)} | ${formatMix(profile.weightBucketMix)} |`)
     }
 
     if ((report.profiles || []).length === 0) {
-        lines.push('| none | 0 | 0 | 0 | 0 | 0 | - | - |')
+        lines.push('| none | 0 | 0 | 0 | 0 | 0 | - | - | - |')
     }
 
     lines.push(

--- a/ai/services/graph/conceptTouchMeasurement.mjs
+++ b/ai/services/graph/conceptTouchMeasurement.mjs
@@ -1,0 +1,649 @@
+import {IDENTITIES, TRUST_TIER_ORDER, TRUST_TIERS} from '../../graph/identityRoots.mjs';
+
+/**
+ * @module ai/services/graph/conceptTouchMeasurement
+ * @summary Read-only concept-touch profiles and history-slice re-derivation candidates.
+ *
+ * Owner contract: turn existing `TAGGED_CONCEPT` history into substrate diagnostics, never
+ * capability rankings. The helper consumes graph records/edges or a raw SQLite read projection
+ * and returns confidence-bearing measurements: per-agent concept-touch profiles and slice-1
+ * re-derivation candidates. It performs zero graph writes and does not mint new node/edge
+ * classes; the retrieval-event producer owns the later precision upgrade.
+ *
+ * Privacy / provenance contract: there is no live `privacyTier` field. The ticket's privacy
+ * obligation is enforced against current substrate fields: RLS visibility (`userId`,
+ * `sharedEntity`, `visibility`) plus most-restrictive provenance trust tiers. Elements with no
+ * resolvable visibility boundary are excluded from aggregate profiles rather than defaulted up.
+ */
+
+export const VISIBILITY_TIERS = Object.freeze({
+    PUBLIC : 'public',
+    TEAM   : 'team',
+    PRIVATE: 'private'
+});
+
+export const VISIBILITY_TIER_ORDER = Object.freeze([
+    VISIBILITY_TIERS.PUBLIC,
+    VISIBILITY_TIERS.TEAM,
+    VISIBILITY_TIERS.PRIVATE
+]);
+
+const VISIBILITY_RANK = new Map(VISIBILITY_TIER_ORDER.map((tier, index) => [tier, index]));
+const TRUST_RANK      = new Map(TRUST_TIER_ORDER.map((tier, index) => [tier, index]));
+const IDENTITY_TRUST  = new Map(IDENTITIES.flatMap(identity => {
+    const trustTier = identity.properties?.trustTier || TRUST_TIERS.UNCLASSIFIED,
+          login     = identity.properties?.githubLogin;
+
+    return [
+        [identity.id, trustTier],
+        [String(identity.id || '').replace(/^@/, ''), trustTier],
+        [login, trustTier],
+        [String(login || '').replace(/^@/, ''), trustTier]
+    ].filter(([key]) => key)
+}));
+
+/**
+ * @summary Normalizes graph node/edge records into the small shape this measurement consumes.
+ * @param {Object} record Graph node/edge record.
+ * @returns {{id: String, type: String, properties: Object}}
+ */
+export function normalizeGraphRecord(record = {}) {
+    return {
+        id        : String(record.id || ''),
+        type      : String(record.type || record.label || '').toUpperCase(),
+        properties: record.properties || {}
+    }
+}
+
+/**
+ * @summary Parses the JSON `data` column used by the SQLite graph store.
+ * @param {String|Object|null} data Raw SQLite JSON payload or already-parsed payload.
+ * @returns {{label: String, properties: Object}}
+ */
+export function parseGraphData(data) {
+    if (!data) return {label: '', properties: {}};
+    if (typeof data === 'object') {
+        return {
+            label     : data.label || data.type || '',
+            properties: data.properties || {}
+        }
+    }
+
+    try {
+        const parsed = JSON.parse(data);
+
+        return {
+            label     : parsed.label || parsed.type || '',
+            properties: parsed.properties || {}
+        }
+    } catch {
+        return {label: '', properties: {}}
+    }
+}
+
+/**
+ * @summary Reads raw `TAGGED_CONCEPT` edges plus endpoint nodes from GraphService's SQLite handle.
+ *
+ * The reader uses `SELECT` only. It is a convenience seam for diagnostics and scripts; the core
+ * measurement functions are pure and unit-tested against plain records.
+ *
+ * @param {Object} options
+ * @param {Object} options.graphService Bound GraphService instance.
+ * @param {Number} [options.limit=5000] Maximum tagged edges to read.
+ * @returns {{nodes: Object[], edges: Object[], readAt: String}}
+ */
+export function readTaggedConceptGraph({graphService, limit = 5000} = {}) {
+    const sqliteDb = graphService?.db?.storage?.db,
+          readAt   = new Date().toISOString();
+
+    if (!sqliteDb) {
+        return {nodes: [], edges: [], readAt}
+    }
+
+    const
+        max      = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 5000,
+        edgeRows = sqliteDb
+            .prepare('SELECT id, source, target, type, data, user_id FROM Edges WHERE type = ? ORDER BY id LIMIT ?')
+            .all('TAGGED_CONCEPT', max),
+        nodeIds  = [...new Set(edgeRows.flatMap(row => [row.source, row.target]).filter(Boolean))],
+        nodeStmt = sqliteDb.prepare('SELECT id, data, user_id FROM Nodes WHERE id = ?'),
+        nodes    = [],
+        edges    = edgeRows.map(row => {
+            const parsed = parseGraphData(row.data);
+
+            return {
+                id        : row.id,
+                source    : row.source,
+                target    : row.target,
+                type      : row.type,
+                properties: {
+                    ...(parsed.properties || {}),
+                    userId: parsed.properties?.userId ?? row.user_id ?? null
+                }
+            }
+        });
+
+    for (const id of nodeIds) {
+        const row = nodeStmt.get(id);
+        if (!row) continue;
+
+        const parsed = parseGraphData(row.data);
+        nodes.push({
+            id,
+            type      : parsed.label,
+            properties: {
+                ...(parsed.properties || {}),
+                userId: parsed.properties?.userId ?? row.user_id ?? null
+            }
+        })
+    }
+
+    return {nodes, edges, readAt}
+}
+
+/**
+ * @summary Resolves a graph element's current visibility boundary from live RLS fields.
+ * @param {Object} record Graph node or edge record.
+ * @returns {String|null} `private`, `team`, `public`, or null when no boundary is encoded.
+ */
+export function resolveVisibilityTier(record = {}) {
+    const properties = normalizeGraphRecord(record).properties;
+    const visibility = String(properties.visibility || '').toLowerCase();
+
+    if (VISIBILITY_RANK.has(visibility)) return visibility;
+    if (properties.sharedEntity === true || properties.sharedEntity === 1) return VISIBILITY_TIERS.TEAM;
+    if (typeof properties.userId === 'string' && properties.userId.length > 0) return VISIBILITY_TIERS.PRIVATE;
+    if (properties.userId === null) return VISIBILITY_TIERS.PUBLIC;
+
+    return null
+}
+
+/**
+ * @summary Applies most-restrictive visibility propagation across a source/edge/concept tuple.
+ * @param {Object[]} records Components of a candidate aggregate element.
+ * @returns {{visibilityTier: String|null, missing: String[]}}
+ */
+export function resolveAggregateVisibility(records = []) {
+    let   visibilityTier = null;
+    const missing        = [];
+
+    for (const record of records) {
+        const normalized = normalizeGraphRecord(record),
+              tier       = resolveVisibilityTier(normalized);
+
+        if (!tier) {
+            missing.push(normalized.id || '(anonymous)');
+            continue
+        }
+
+        if (!visibilityTier || VISIBILITY_RANK.get(tier) > VISIBILITY_RANK.get(visibilityTier)) {
+            visibilityTier = tier;
+        }
+    }
+
+    return {
+        visibilityTier: missing.length > 0 ? null : visibilityTier,
+        missing
+    }
+}
+
+function resolveRecordTrustTier(record = {}) {
+    const
+        normalized = normalizeGraphRecord(record),
+        properties = normalized.properties,
+        candidate  = properties.trustTier ||
+            properties.sourceTrustTier ||
+            properties.authorTrust ||
+            properties.sourceTier;
+
+    if (TRUST_RANK.has(candidate)) return candidate;
+
+    const identity = properties.agentIdentity || properties.from || properties.userId;
+
+    if (IDENTITY_TRUST.has(identity)) return IDENTITY_TRUST.get(identity);
+    if (IDENTITY_TRUST.has(String(identity || '').replace(/^@/, ''))) {
+        return IDENTITY_TRUST.get(String(identity).replace(/^@/, ''))
+    }
+
+    // Edges often carry only visibility / timestamp. With no explicit provenance, they are
+    // neutral connectors; node/source provenance drives the aggregate.
+    if (normalized.type && normalized.type !== 'TAGGED_CONCEPT') return TRUST_TIERS.UNCLASSIFIED;
+
+    return null
+}
+
+/**
+ * @summary Resolves the most-restrictive provenance trust tier across graph components.
+ * @param {Object[]} records Source records.
+ * @returns {String} Trust tier, falling to `unclassified` only when no component carries provenance.
+ */
+export function resolveAggregateTrustTier(records = []) {
+    let trustTier = null;
+
+    for (const record of records) {
+        const tier = resolveRecordTrustTier(record);
+
+        if (!tier) continue;
+
+        if (!trustTier || TRUST_RANK.get(tier) > TRUST_RANK.get(trustTier)) {
+            trustTier = tier;
+        }
+    }
+
+    return trustTier || TRUST_TIERS.UNCLASSIFIED
+}
+
+function normalizeTimestamp(value) {
+    const date = value ? new Date(value) : null;
+
+    return date && !Number.isNaN(date.getTime()) ? date.toISOString() : null
+}
+
+function resolveEventTimestamp(edge, source) {
+    const edgeProps   = normalizeGraphRecord(edge).properties,
+          sourceProps = normalizeGraphRecord(source).properties;
+
+    return normalizeTimestamp(
+        edgeProps.timestamp ||
+        edgeProps.createdAt ||
+        sourceProps.sentAt ||
+        sourceProps.timestamp ||
+        sourceProps.createdAt
+    )
+}
+
+function resolveAgentId(source, edge) {
+    const
+        sourceProps = normalizeGraphRecord(source).properties,
+        edgeProps   = normalizeGraphRecord(edge).properties;
+
+    return sourceProps.agentIdentity ||
+        sourceProps.from ||
+        sourceProps.userId ||
+        edgeProps.agentIdentity ||
+        edgeProps.userId ||
+        'unattributed'
+}
+
+function resolveSessionId(source, edge) {
+    const
+        sourceProps = normalizeGraphRecord(source).properties,
+        edgeProps   = normalizeGraphRecord(edge).properties;
+
+    return sourceProps.sessionId ||
+        sourceProps.originSessionId ||
+        sourceProps.partOfThread ||
+        edgeProps.sessionId ||
+        edgeProps.originSessionId ||
+        null
+}
+
+function isConceptRecord(record) {
+    const type = normalizeGraphRecord(record).type;
+
+    return type === 'CONCEPT' || type === 'CLASS'
+}
+
+function incrementCounter(bucket, key) {
+    bucket[key] = (bucket[key] || 0) + 1;
+}
+
+/**
+ * @summary Extracts profile-eligible concept-touch events from `TAGGED_CONCEPT` edges.
+ * @param {Object} options
+ * @param {Object[]} [options.nodes=[]] Graph node records.
+ * @param {Object[]} [options.edges=[]] Graph edge records.
+ * @returns {{events: Object[], excluded: Object[]}}
+ */
+export function extractConceptTouchEvents({nodes = [], edges = []} = {}) {
+    const
+        nodeMap  = new Map(nodes.map(record => {
+            const normalized = normalizeGraphRecord(record);
+            return [normalized.id, normalized]
+        })),
+        events   = [],
+        excluded = [];
+
+    for (const rawEdge of edges) {
+        const edge = normalizeGraphRecord(rawEdge);
+
+        if (edge.type !== 'TAGGED_CONCEPT') continue;
+
+        const
+            source       = nodeMap.get(rawEdge.source),
+            target       = nodeMap.get(rawEdge.target),
+            concept      = isConceptRecord(target) ? target : isConceptRecord(source) ? source : null,
+            sourceRecord = concept?.id === source?.id ? target : source,
+            timestamp    = resolveEventTimestamp(rawEdge, sourceRecord),
+            aggregate    = resolveAggregateVisibility([sourceRecord, rawEdge, concept].filter(Boolean)),
+            trustTier    = resolveAggregateTrustTier([sourceRecord, rawEdge, concept].filter(Boolean));
+
+        if (!concept || !sourceRecord) {
+            excluded.push({edgeId: edge.id, reason: 'missing-endpoint'});
+            continue
+        }
+
+        if (!timestamp) {
+            excluded.push({edgeId: edge.id, conceptId: concept.id, reason: 'missing-timestamp'});
+            continue
+        }
+
+        if (!aggregate.visibilityTier) {
+            excluded.push({
+                edgeId   : edge.id,
+                conceptId: concept.id,
+                reason   : 'missing-visibility-tier',
+                missing  : aggregate.missing
+            });
+            continue
+        }
+
+        events.push({
+            edgeId        : edge.id,
+            sourceId      : sourceRecord.id,
+            sourceType    : sourceRecord.type,
+            conceptId     : concept.id,
+            agentId       : resolveAgentId(sourceRecord, rawEdge),
+            sessionId     : resolveSessionId(sourceRecord, rawEdge),
+            touchedAt     : timestamp,
+            depth         : 1,
+            weight        : edge.properties.weight ?? rawEdge.weight ?? null,
+            provenance    : (edge.properties.weight ?? rawEdge.weight) === 1 ? 'curated' : 'inferred-or-unknown',
+            visibilityTier: aggregate.visibilityTier,
+            trustTier
+        })
+    }
+
+    events.sort((a, b) => a.touchedAt.localeCompare(b.touchedAt) || a.edgeId.localeCompare(b.edgeId));
+
+    return {events, excluded}
+}
+
+function computeRevisitIntervals(events) {
+    const byConcept = new Map();
+    const intervals = [];
+
+    for (const event of events) {
+        const list = byConcept.get(event.conceptId) || [];
+        list.push(event);
+        byConcept.set(event.conceptId, list)
+    }
+
+    for (const list of byConcept.values()) {
+        list.sort((a, b) => a.touchedAt.localeCompare(b.touchedAt));
+
+        for (let i = 1; i < list.length; i++) {
+            intervals.push({
+                conceptId: list[i].conceptId,
+                from     : list[i - 1].touchedAt,
+                to       : list[i].touchedAt,
+                ms       : new Date(list[i].touchedAt).getTime() - new Date(list[i - 1].touchedAt).getTime()
+            })
+        }
+    }
+
+    return intervals
+}
+
+/**
+ * @summary Builds per-agent concept-touch profiles from eligible touch events.
+ * @param {Object[]} events Concept-touch events.
+ * @returns {Object[]} Agent profiles sorted by agent id.
+ */
+export function buildConceptTouchProfiles(events = []) {
+    const byAgent = new Map();
+
+    for (const event of events) {
+        const profile = byAgent.get(event.agentId) || {
+            agentId      : event.agentId,
+            touchCount   : 0,
+            concepts     : new Set(),
+            visibilityMix: {},
+            trustTierMix : {},
+            provenanceMix: {},
+            depths       : [],
+            events       : []
+        };
+
+        profile.touchCount++;
+        profile.concepts.add(event.conceptId);
+        profile.depths.push(event.depth);
+        profile.events.push(event);
+        incrementCounter(profile.visibilityMix, event.visibilityTier);
+        incrementCounter(profile.trustTierMix, event.trustTier);
+        incrementCounter(profile.provenanceMix, event.provenance);
+        byAgent.set(event.agentId, profile)
+    }
+
+    return [...byAgent.values()]
+        .map(profile => {
+            const intervals    = computeRevisitIntervals(profile.events);
+            const revisitCount = intervals.length;
+            const avgDepth     = profile.depths.length
+                ? profile.depths.reduce((sum, value) => sum + value, 0) / profile.depths.length
+                : 0;
+
+            return {
+                agentId              : profile.agentId,
+                touchCount           : profile.touchCount,
+                conceptsTouched      : profile.concepts.size,
+                touchDepth           : Number(avgDepth.toFixed(2)),
+                visibilityMix        : profile.visibilityMix,
+                trustTierMix         : profile.trustTierMix,
+                provenanceMix        : profile.provenanceMix,
+                revisitIntervals     : intervals,
+                revisitCount,
+                normalizedRevisitRate: Number((revisitCount / Math.max(1, profile.touchCount)).toFixed(4))
+            }
+        })
+        .sort((a, b) => a.agentId.localeCompare(b.agentId))
+}
+
+function retrievalConcepts(retrieval = {}) {
+    return new Set([
+        ...(retrieval.resolvedConcepts || []),
+        ...(retrieval.conceptIds || []),
+        ...(retrieval.taggedConcepts || [])
+    ])
+}
+
+/**
+ * @summary Detects history-slice re-derivation candidates; never emits verdicts.
+ * @param {Object} options
+ * @param {Object[]} [options.events=[]] Concept-touch events.
+ * @param {Object[]} [options.retrievalEvents=[]] Optional retrieval events.
+ * @returns {Object[]} Candidate events with confidence and reason.
+ */
+export function detectRederivationCandidates({events = [], retrievalEvents = []} = {}) {
+    const byAgentConcept = new Map();
+
+    for (const event of events) {
+        const key  = `${event.agentId}\n${event.conceptId}`;
+        const list = byAgentConcept.get(key) || [];
+        list.push(event);
+        byAgentConcept.set(key, list)
+    }
+
+    const candidates = [];
+
+    for (const list of byAgentConcept.values()) {
+        list.sort((a, b) => a.touchedAt.localeCompare(b.touchedAt));
+
+        for (let i = 1; i < list.length; i++) {
+            const previous = list[i - 1],
+                  current  = list[i];
+
+            if (previous.sessionId && current.sessionId && previous.sessionId === current.sessionId) {
+                continue
+            }
+
+            const retrieved = retrievalEvents.some(retrieval => {
+                if (retrieval.agentId && retrieval.agentId !== current.agentId) return false;
+                if (retrieval.sessionId && current.sessionId && retrieval.sessionId !== current.sessionId) return false;
+                if (retrieval.occurredAt && new Date(retrieval.occurredAt) > new Date(current.touchedAt)) return false;
+
+                return retrievalConcepts(retrieval).has(current.conceptId)
+            });
+
+            if (retrieved) continue;
+
+            const missingSessionBoundary = !previous.sessionId || !current.sessionId;
+
+            candidates.push({
+                agentId          : current.agentId,
+                conceptId        : current.conceptId,
+                previousSessionId: previous.sessionId,
+                currentSessionId : current.sessionId,
+                previousTouchAt  : previous.touchedAt,
+                currentTouchAt   : current.touchedAt,
+                confidence       : missingSessionBoundary ? 0.35 : retrievalEvents.length > 0 ? 0.65 : 0.5,
+                reason           : missingSessionBoundary
+                    ? 'history-only-missing-session-boundary'
+                    : retrievalEvents.length > 0
+                    ? 'no-retrieval-event-for-concept-before-touch'
+                    : 'history-only-no-retrieval-log-yet'
+            })
+        }
+    }
+
+    return candidates
+}
+
+/**
+ * @summary Builds the complete measurement report from graph records.
+ * @param {Object} options
+ * @param {Object[]} [options.nodes=[]] Graph nodes.
+ * @param {Object[]} [options.edges=[]] Graph edges.
+ * @param {Object[]} [options.retrievalEvents=[]] Optional retrieval events.
+ * @param {String|Date} [options.generatedAt=new Date()] Report timestamp.
+ * @returns {Object} Measurement report.
+ */
+export function buildConceptTouchMeasurement({
+    nodes = [],
+    edges = [],
+    retrievalEvents = [],
+    generatedAt = new Date()
+} = {}) {
+    const {events, excluded} = extractConceptTouchEvents({nodes, edges});
+
+    return {
+        issue             : '#14506',
+        generatedAt       : normalizeTimestamp(generatedAt) || new Date().toISOString(),
+        coverageBound     : '~2 of 5 substrate-effect pressure classes mechanically catchable in slice 1',
+        normalization     : 'per-agent own-history denominator; no cross-agent ranking',
+        profiles          : buildConceptTouchProfiles(events),
+        rederivationEvents: detectRederivationCandidates({events, retrievalEvents}),
+        counts            : {
+            taggedConceptEdges : edges.filter(edge => normalizeGraphRecord(edge).type === 'TAGGED_CONCEPT').length,
+            eligibleEvents     : events.length,
+            eventsWithSessionId: events.filter(event => event.sessionId).length,
+            excludedEvents     : excluded.length,
+            retrievalEvents    : retrievalEvents.length
+        },
+        excluded
+    }
+}
+
+function formatMix(mix = {}) {
+    const entries = Object.entries(mix);
+
+    return entries.length ? entries.map(([key, count]) => `${key}:${count}`).join(', ') : '-'
+}
+
+/**
+ * @summary Renders the measurement report to the committed artifact shape.
+ * @param {Object} report Output from `buildConceptTouchMeasurement`.
+ * @param {Object} [options]
+ * @param {Number} [options.maxCandidateRows=25] Maximum candidate rows to render before summarizing the remainder.
+ * @returns {String} Markdown artifact.
+ */
+export function renderConceptTouchMeasurementMarkdown(report, {maxCandidateRows = 25} = {}) {
+    const
+        candidates     = report.rederivationEvents || [],
+        candidateLimit = Number.isFinite(maxCandidateRows) && maxCandidateRows > 0
+            ? Math.floor(maxCandidateRows)
+            : candidates.length;
+
+    const lines = [
+        '# Concept-Touch Measurement: Re-Derivation Slice 1',
+        '',
+        `Issue: ${report.issue || '#14506'} · Epic: #14472 · Generated: ${report.generatedAt}`,
+        '',
+        'Diagnostics-only measurement. This is not a capability ranking, not a leaderboard, and not',
+        'a merge gate. Metrics normalize by each agent\'s own eligible concept-touch history.',
+        '',
+        `Coverage bound: ${report.coverageBound}`,
+        '',
+        'Privacy/provenance note: current substrate has no `privacyTier` field. Aggregation uses',
+        'RLS visibility (`userId`, `sharedEntity`, `visibility`) plus most-restrictive trust-tier',
+        'provenance. Elements with no resolvable visibility boundary are excluded, never defaulted',
+        'into a public/team aggregate.',
+        '',
+        '## Measurement Counts',
+        '',
+        '| Field | Count |',
+        '|---|---:|',
+        `| TAGGED_CONCEPT edges scanned | ${report.counts?.taggedConceptEdges || 0} |`,
+        `| Eligible concept-touch events | ${report.counts?.eligibleEvents || 0} |`,
+        `| Eligible events with session id | ${report.counts?.eventsWithSessionId || 0} |`,
+        `| Excluded events (missing endpoint/timestamp/tier) | ${report.counts?.excludedEvents || 0} |`,
+        `| Retrieval events applied (slice-2 input) | ${report.counts?.retrievalEvents || 0} |`,
+        '',
+        '## Per-Agent Concept-Touch Profiles',
+        '',
+        '| Agent | Touches | Concepts | Avg depth | Revisit count | Normalized revisit rate | Visibility mix | Trust mix |',
+        '|---|---:|---:|---:|---:|---:|---|---|'
+    ];
+
+    for (const profile of report.profiles || []) {
+        lines.push(`| ${profile.agentId} | ${profile.touchCount} | ${profile.conceptsTouched} | ${profile.touchDepth} | ${profile.revisitCount} | ${profile.normalizedRevisitRate} | ${formatMix(profile.visibilityMix)} | ${formatMix(profile.trustTierMix)} |`)
+    }
+
+    if ((report.profiles || []).length === 0) {
+        lines.push('| none | 0 | 0 | 0 | 0 | 0 | - | - |')
+    }
+
+    lines.push(
+        '',
+        '## Candidate Re-Derivation Events',
+        '',
+        `Total candidates: ${candidates.length}. Showing first ${Math.min(candidateLimit, candidates.length)} by touch chronology.`,
+        '',
+        '| Agent | Concept | Previous session | Current session | Confidence | Reason |',
+        '|---|---|---|---|---:|---|'
+    );
+
+    for (const event of candidates.slice(0, candidateLimit)) {
+        lines.push(`| ${event.agentId} | ${event.conceptId} | ${event.previousSessionId || '-'} | ${event.currentSessionId || '-'} | ${event.confidence} | ${event.reason} |`)
+    }
+
+    if (candidates.length > candidateLimit) {
+        lines.push(`| omitted | ${candidates.length - candidateLimit} additional candidates | - | - | - | see helper output for full list |`)
+    }
+
+    if (candidates.length === 0) {
+        lines.push('| none | - | - | - | 0 | no candidate in this slice |')
+    }
+
+    lines.push(
+        '',
+        '## Study Codebook Mapping',
+        '',
+        '| Pressure class | Slice-1 computability | Note |',
+        '|---|---|---|',
+        '| repeated-concept re-entry | catchable | Same agent revisits a concept after prior memory exists. |',
+        '| retrieval miss before re-entry | partially catchable | Inferred until #14504 retrieval events supply the precision leg. |',
+        '| stale-state contradiction | not catchable | Belief-revision leaf #14507 owns claim-class conflict surfacing. |',
+        '| routing/cold-start bias | not catchable | Ranking-reach leaf #14503 / #14508 own routing disposition. |',
+        '| prose/frame drift | not catchable | Requires review/content evidence, not TAGGED_CONCEPT history. |',
+        '',
+        '## Slice-2 Upgrade Path',
+        '',
+        '#14504 retrieval events add `{query, resolvedConcepts, walkContributed}`. Once present,',
+        '`detectRederivationCandidates()` suppresses candidates when a matching retrieval event',
+        'surfaced the concept before the later touch; confidence rises only for no-retrieval matches.',
+        ''
+    );
+
+    return `${lines.join('\n')}\n`
+}

--- a/learn/agentos/measurements/concept-touch-measurement-2026-07-02.md
+++ b/learn/agentos/measurements/concept-touch-measurement-2026-07-02.md
@@ -12,30 +12,33 @@ RLS visibility (`userId`, `sharedEntity`, `visibility`) plus most-restrictive tr
 provenance. Elements with no resolvable visibility boundary are excluded, never defaulted
 into a public/team aggregate.
 
+Weight bucket note: `weight-1.0` / `weight-other` are current edge-weight buckets, not
+extractor provenance. TAGGED_CONCEPT reinforcement can change weights after extraction.
+
 ## Measurement Counts
 
 | Field | Count |
 |---|---:|
-| TAGGED_CONCEPT edges scanned | 162 |
-| Eligible concept-touch events | 137 |
+| TAGGED_CONCEPT edges scanned | 171 |
+| Eligible concept-touch events | 139 |
 | Eligible events with session id | 0 |
-| Excluded events (missing endpoint/timestamp/tier) | 25 |
+| Excluded events (missing endpoint/timestamp/tier) | 32 |
 | Retrieval events applied (slice-2 input) | 0 |
 
 ## Per-Agent Concept-Touch Profiles
 
-| Agent | Touches | Concepts | Avg depth | Revisit count | Normalized revisit rate | Visibility mix | Trust mix |
-|---|---:|---:|---:|---:|---:|---|---|
-| @neo-fable | 6 | 3 | 1 | 3 | 0.5 | team:6 | unclassified:6 |
-| @neo-fable-clio | 5 | 1 | 1 | 4 | 0.8 | team:5 | unclassified:5 |
-| @neo-gpt | 113 | 8 | 1 | 105 | 0.9292 | team:113 | unclassified:113 |
-| @neo-opus-ada | 5 | 1 | 1 | 4 | 0.8 | team:5 | unclassified:5 |
-| @neo-opus-grace | 3 | 2 | 1 | 1 | 0.3333 | team:3 | unclassified:3 |
-| @neo-opus-vega | 5 | 1 | 1 | 4 | 0.8 | team:5 | unclassified:5 |
+| Agent | Touches | Concepts | Avg depth | Revisit count | Normalized revisit rate | Visibility mix | Trust mix | Weight bucket mix |
+|---|---:|---:|---:|---:|---:|---|---|---|
+| @neo-fable | 6 | 3 | 1 | 3 | 0.5 | team:6 | unclassified:6 | weight-other:6 |
+| @neo-fable-clio | 5 | 1 | 1 | 4 | 0.8 | team:5 | unclassified:5 | weight-other:5 |
+| @neo-gpt | 114 | 8 | 1 | 106 | 0.9298 | team:114 | unclassified:114 | weight-other:113, weight-1.0:1 |
+| @neo-opus-ada | 5 | 1 | 1 | 4 | 0.8 | team:5 | unclassified:5 | weight-other:5 |
+| @neo-opus-grace | 3 | 2 | 1 | 1 | 0.3333 | team:3 | unclassified:3 | weight-other:3 |
+| @neo-opus-vega | 6 | 2 | 1 | 4 | 0.6667 | team:6 | unclassified:6 | weight-other:5, weight-1.0:1 |
 
 ## Candidate Re-Derivation Events
 
-Total candidates: 121. Showing first 25 by touch chronology.
+Total candidates: 122. Showing first 25 by touch chronology.
 
 | Agent | Concept | Previous session | Current session | Confidence | Reason |
 |---|---|---|---|---:|---|
@@ -53,6 +56,7 @@ Total candidates: 121. Showing first 25 by touch chronology.
 | @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
 | @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
 | @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
 | @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
 | @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
 | @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
@@ -63,8 +67,7 @@ Total candidates: 121. Showing first 25 by touch chronology.
 | @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
 | @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
 | @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
-| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
-| omitted | 96 additional candidates | - | - | - | see helper output for full list |
+| omitted | 97 additional candidates | - | - | - | see helper output for full list |
 
 ## Study Codebook Mapping
 

--- a/learn/agentos/measurements/concept-touch-measurement-2026-07-02.md
+++ b/learn/agentos/measurements/concept-touch-measurement-2026-07-02.md
@@ -1,0 +1,83 @@
+# Concept-Touch Measurement: Re-Derivation Slice 1
+
+Issue: #14506 · Epic: #14472 · Generated: 2026-07-02T22:50:00.000Z
+
+Diagnostics-only measurement. This is not a capability ranking, not a leaderboard, and not
+a merge gate. Metrics normalize by each agent's own eligible concept-touch history.
+
+Coverage bound: ~2 of 5 substrate-effect pressure classes mechanically catchable in slice 1
+
+Privacy/provenance note: current substrate has no `privacyTier` field. Aggregation uses
+RLS visibility (`userId`, `sharedEntity`, `visibility`) plus most-restrictive trust-tier
+provenance. Elements with no resolvable visibility boundary are excluded, never defaulted
+into a public/team aggregate.
+
+## Measurement Counts
+
+| Field | Count |
+|---|---:|
+| TAGGED_CONCEPT edges scanned | 162 |
+| Eligible concept-touch events | 137 |
+| Eligible events with session id | 0 |
+| Excluded events (missing endpoint/timestamp/tier) | 25 |
+| Retrieval events applied (slice-2 input) | 0 |
+
+## Per-Agent Concept-Touch Profiles
+
+| Agent | Touches | Concepts | Avg depth | Revisit count | Normalized revisit rate | Visibility mix | Trust mix |
+|---|---:|---:|---:|---:|---:|---|---|
+| @neo-fable | 6 | 3 | 1 | 3 | 0.5 | team:6 | unclassified:6 |
+| @neo-fable-clio | 5 | 1 | 1 | 4 | 0.8 | team:5 | unclassified:5 |
+| @neo-gpt | 113 | 8 | 1 | 105 | 0.9292 | team:113 | unclassified:113 |
+| @neo-opus-ada | 5 | 1 | 1 | 4 | 0.8 | team:5 | unclassified:5 |
+| @neo-opus-grace | 3 | 2 | 1 | 1 | 0.3333 | team:3 | unclassified:3 |
+| @neo-opus-vega | 5 | 1 | 1 | 4 | 0.8 | team:5 | unclassified:5 |
+
+## Candidate Re-Derivation Events
+
+Total candidates: 121. Showing first 25 by touch chronology.
+
+| Agent | Concept | Previous session | Current session | Confidence | Reason |
+|---|---|---|---|---:|---|
+| @neo-opus-ada | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-opus-ada | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-opus-ada | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-opus-ada | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | golden-path | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| @neo-gpt | lane-claim | - | - | 0.35 | history-only-missing-session-boundary |
+| omitted | 96 additional candidates | - | - | - | see helper output for full list |
+
+## Study Codebook Mapping
+
+| Pressure class | Slice-1 computability | Note |
+|---|---|---|
+| repeated-concept re-entry | catchable | Same agent revisits a concept after prior memory exists. |
+| retrieval miss before re-entry | partially catchable | Inferred until #14504 retrieval events supply the precision leg. |
+| stale-state contradiction | not catchable | Belief-revision leaf #14507 owns claim-class conflict surfacing. |
+| routing/cold-start bias | not catchable | Ranking-reach leaf #14503 / #14508 own routing disposition. |
+| prose/frame drift | not catchable | Requires review/content evidence, not TAGGED_CONCEPT history. |
+
+## Slice-2 Upgrade Path
+
+#14504 retrieval events add `{query, resolvedConcepts, walkContributed}`. Once present,
+`detectRederivationCandidates()` suppresses candidates when a matching retrieval event
+surfaced the concept before the later touch; confidence rises only for no-retrieval matches.

--- a/test/playwright/unit/ai/services/graph/conceptTouchMeasurement.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/conceptTouchMeasurement.spec.mjs
@@ -193,14 +193,14 @@ test.describe('Neo.ai.services.graph.conceptTouchMeasurement (#14506)', () => {
             sessionId     : 'session-1',
             visibilityTier: 'private',
             trustTier     : 'peer-trusted',
-            provenance    : 'curated'
+            weightBucket  : 'weight-1.0'
         });
 
         expect(events[2]).toMatchObject({
-            agentId   : '@neo-opus-vega',
-            conceptId : 'CONCEPT:DreamPipeline',
-            trustTier : 'external',
-            provenance: 'inferred-or-unknown'
+            agentId     : '@neo-opus-vega',
+            conceptId   : 'CONCEPT:DreamPipeline',
+            trustTier   : 'external',
+            weightBucket: 'weight-other'
         });
     });
 
@@ -274,7 +274,7 @@ test.describe('Neo.ai.services.graph.conceptTouchMeasurement (#14506)', () => {
 
         expect(md).toContain('Diagnostics-only measurement');
         expect(md).toContain('current substrate has no `privacyTier` field');
-        expect(md).toContain('| @neo-gpt | 2 | 1 | 1 | 1 | 0.5 | private:1, team:1 | peer-trusted:2 |');
+        expect(md).toContain('| @neo-gpt | 2 | 1 | 1 | 1 | 0.5 | private:1, team:1 | peer-trusted:2 | weight-1.0:2 |');
         expect(md).toContain('## Study Codebook Mapping');
         expect(md).toContain('#14504 retrieval events add');
     });

--- a/test/playwright/unit/ai/services/graph/conceptTouchMeasurement.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/conceptTouchMeasurement.spec.mjs
@@ -1,0 +1,333 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'ConceptTouchMeasurementTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+import {
+    VISIBILITY_TIERS,
+    buildConceptTouchMeasurement,
+    buildConceptTouchProfiles,
+    detectRederivationCandidates,
+    extractConceptTouchEvents,
+    readTaggedConceptGraph,
+    renderConceptTouchMeasurementMarkdown,
+    resolveAggregateTrustTier,
+    resolveAggregateVisibility,
+    resolveVisibilityTier
+} from '../../../../../../ai/services/graph/conceptTouchMeasurement.mjs';
+
+const NODES = [
+    {
+        id        : 'MESSAGE:1',
+        type      : 'MESSAGE',
+        properties: {
+            from     : '@neo-gpt',
+            sentAt   : '2026-07-02T10:00:00.000Z',
+            sessionId: 'session-1',
+            userId   : 'neo-gpt',
+            trustTier: 'peer-trusted'
+        }
+    },
+    {
+        id        : 'MESSAGE:2',
+        type      : 'MESSAGE',
+        properties: {
+            from        : '@neo-gpt',
+            sentAt      : '2026-07-02T12:00:00.000Z',
+            sessionId   : 'session-2',
+            visibility  : 'team',
+            sharedEntity: true,
+            trustTier   : 'peer-trusted'
+        }
+    },
+    {
+        id        : 'MESSAGE:3',
+        type      : 'MESSAGE',
+        properties: {
+            from      : '@neo-opus-vega',
+            sentAt    : '2026-07-02T13:00:00.000Z',
+            sessionId : 'session-3',
+            visibility: 'public',
+            trustTier : 'external'
+        }
+    },
+    {
+        id        : 'MESSAGE:missing-tier',
+        type      : 'MESSAGE',
+        properties: {
+            from     : '@neo-gpt',
+            sentAt   : '2026-07-02T14:00:00.000Z',
+            sessionId: 'session-4'
+        }
+    },
+    {
+        id        : 'CONCEPT:GoldenPath',
+        type      : 'CONCEPT',
+        properties: {
+            visibility: 'team',
+            trustTier : 'peer-trusted'
+        }
+    },
+    {
+        id        : 'CONCEPT:DreamPipeline',
+        type      : 'CONCEPT',
+        properties: {
+            visibility: 'public',
+            trustTier : 'peer-trusted'
+        }
+    }
+];
+
+const EDGES = [
+    {
+        id        : 'e1',
+        source    : 'MESSAGE:1',
+        target    : 'CONCEPT:GoldenPath',
+        type      : 'TAGGED_CONCEPT',
+        properties: {
+            timestamp: '2026-07-02T10:00:01.000Z',
+            userId   : 'neo-gpt',
+            weight   : 1.0
+        }
+    },
+    {
+        id        : 'e2',
+        source    : 'MESSAGE:2',
+        target    : 'CONCEPT:GoldenPath',
+        type      : 'TAGGED_CONCEPT',
+        properties: {
+            timestamp   : '2026-07-02T12:00:01.000Z',
+            sharedEntity: true,
+            weight      : 1.0
+        }
+    },
+    {
+        id        : 'e3',
+        source    : 'MESSAGE:3',
+        target    : 'CONCEPT:DreamPipeline',
+        type      : 'TAGGED_CONCEPT',
+        properties: {
+            timestamp : '2026-07-02T13:00:01.000Z',
+            visibility: 'public',
+            weight    : 0.8
+        }
+    },
+    {
+        id        : 'e4',
+        source    : 'MESSAGE:missing-tier',
+        target    : 'CONCEPT:DreamPipeline',
+        type      : 'TAGGED_CONCEPT',
+        properties: {
+            timestamp: '2026-07-02T14:00:01.000Z',
+            weight   : 1.0
+        }
+    }
+];
+
+test.describe('Neo.ai.services.graph.conceptTouchMeasurement (#14506)', () => {
+    test('resolveVisibilityTier maps live RLS fields instead of a phantom privacyTier', () => {
+        expect(resolveVisibilityTier({properties: {visibility: 'private'}})).toBe(VISIBILITY_TIERS.PRIVATE);
+        expect(resolveVisibilityTier({properties: {visibility: 'team'}})).toBe(VISIBILITY_TIERS.TEAM);
+        expect(resolveVisibilityTier({properties: {sharedEntity: true}})).toBe(VISIBILITY_TIERS.TEAM);
+        expect(resolveVisibilityTier({properties: {userId: 'neo-gpt'}})).toBe(VISIBILITY_TIERS.PRIVATE);
+        expect(resolveVisibilityTier({properties: {userId: null}})).toBe(VISIBILITY_TIERS.PUBLIC);
+        expect(resolveVisibilityTier({properties: {}})).toBeNull();
+    });
+
+    test('resolveAggregateVisibility excludes missing tiers and propagates the most restrictive boundary', () => {
+        const aggregate = resolveAggregateVisibility([
+            {id: 'public', properties: {visibility: 'public'}},
+            {id: 'team', properties: {visibility: 'team'}},
+            {id: 'private', properties: {userId: 'neo-gpt'}}
+        ]);
+
+        expect(aggregate.visibilityTier).toBe('private');
+        expect(aggregate.missing).toEqual([]);
+
+        const missing = resolveAggregateVisibility([
+            {id: 'known', properties: {visibility: 'team'}},
+            {id: 'unknown', properties: {}}
+        ]);
+
+        expect(missing.visibilityTier).toBeNull();
+        expect(missing.missing).toEqual(['unknown']);
+    });
+
+    test('resolveAggregateTrustTier uses most-restrictive-source semantics', () => {
+        expect(resolveAggregateTrustTier([
+            {properties: {trustTier: 'peer-trusted'}},
+            {properties: {sourceTrustTier: 'external'}}
+        ])).toBe('external');
+
+        expect(resolveAggregateTrustTier([{properties: {}}])).toBe('unclassified');
+    });
+
+    test('extractConceptTouchEvents builds eligible events and excludes missing visibility boundaries', () => {
+        const {events, excluded} = extractConceptTouchEvents({nodes: NODES, edges: EDGES});
+
+        expect(events).toHaveLength(3);
+        expect(excluded).toEqual([
+            {
+                edgeId   : 'e4',
+                conceptId: 'CONCEPT:DreamPipeline',
+                reason   : 'missing-visibility-tier',
+                missing  : ['MESSAGE:missing-tier', 'e4']
+            }
+        ]);
+
+        expect(events[0]).toMatchObject({
+            agentId       : '@neo-gpt',
+            conceptId     : 'CONCEPT:GoldenPath',
+            sessionId     : 'session-1',
+            visibilityTier: 'private',
+            trustTier     : 'peer-trusted',
+            provenance    : 'curated'
+        });
+
+        expect(events[2]).toMatchObject({
+            agentId   : '@neo-opus-vega',
+            conceptId : 'CONCEPT:DreamPipeline',
+            trustTier : 'external',
+            provenance: 'inferred-or-unknown'
+        });
+    });
+
+    test('buildConceptTouchProfiles normalizes by each agent own history', () => {
+        const {events} = extractConceptTouchEvents({nodes: NODES, edges: EDGES});
+        const profiles = buildConceptTouchProfiles(events);
+
+        const gpt = profiles.find(profile => profile.agentId === '@neo-gpt');
+
+        expect(gpt.touchCount).toBe(2);
+        expect(gpt.conceptsTouched).toBe(1);
+        expect(gpt.revisitCount).toBe(1);
+        expect(gpt.normalizedRevisitRate).toBe(0.5);
+        expect(gpt.visibilityMix).toEqual({private: 1, team: 1});
+    });
+
+    test('detectRederivationCandidates emits confidence-bearing candidates, not verdicts', () => {
+        const {events} = extractConceptTouchEvents({nodes: NODES, edges: EDGES});
+
+        expect(detectRederivationCandidates({events})).toEqual([
+            expect.objectContaining({
+                agentId         : '@neo-gpt',
+                conceptId       : 'CONCEPT:GoldenPath',
+                confidence      : 0.5,
+                reason          : 'history-only-no-retrieval-log-yet',
+                currentSessionId: 'session-2'
+            })
+        ]);
+
+        expect(detectRederivationCandidates({
+            events,
+            retrievalEvents: [{
+                agentId         : '@neo-gpt',
+                sessionId       : 'session-2',
+                occurredAt      : '2026-07-02T11:59:00.000Z',
+                resolvedConcepts: ['CONCEPT:GoldenPath'],
+                walkContributed : true
+            }]
+        })).toEqual([]);
+
+        expect(detectRederivationCandidates({
+            events: events
+                .filter(event => event.agentId === '@neo-gpt')
+                .map(event => ({...event, sessionId: null}))
+        })).toEqual([
+            expect.objectContaining({
+                confidence: 0.35,
+                reason    : 'history-only-missing-session-boundary'
+            })
+        ]);
+    });
+
+    test('buildConceptTouchMeasurement + renderConceptTouchMeasurementMarkdown produce the artifact shape', () => {
+        const report = buildConceptTouchMeasurement({
+            nodes      : NODES,
+            edges      : EDGES,
+            generatedAt: '2026-07-02T15:00:00.000Z'
+        });
+
+        expect(report.counts).toEqual({
+            taggedConceptEdges : 4,
+            eligibleEvents     : 3,
+            eventsWithSessionId: 3,
+            excludedEvents     : 1,
+            retrievalEvents    : 0
+        });
+        expect(report.profiles).toHaveLength(2);
+        expect(report.rederivationEvents).toHaveLength(1);
+
+        const md = renderConceptTouchMeasurementMarkdown(report);
+
+        expect(md).toContain('Diagnostics-only measurement');
+        expect(md).toContain('current substrate has no `privacyTier` field');
+        expect(md).toContain('| @neo-gpt | 2 | 1 | 1 | 1 | 0.5 | private:1, team:1 | peer-trusted:2 |');
+        expect(md).toContain('## Study Codebook Mapping');
+        expect(md).toContain('#14504 retrieval events add');
+    });
+
+    test('readTaggedConceptGraph reads SQLite rows and performs zero writes', () => {
+        let   wrote        = false;
+        const graphService = {
+            db: {
+                storage: {
+                    db: {
+                        prepare(sql) {
+                            if (/INSERT|UPDATE|DELETE/i.test(sql)) {
+                                wrote = true;
+                            }
+
+                            if (sql.startsWith('SELECT id, source, target, type, data, user_id FROM Edges')) {
+                                return {
+                                    all: () => [{
+                                        id     : 'edge-1',
+                                        source : 'MESSAGE:1',
+                                        target : 'CONCEPT:GoldenPath',
+                                        type   : 'TAGGED_CONCEPT',
+                                        data   : JSON.stringify({properties: {timestamp: '2026-07-02T10:00:00.000Z'}}),
+                                        user_id: 'neo-gpt'
+                                    }]
+                                }
+                            }
+
+                            if (sql.startsWith('SELECT id, data, user_id FROM Nodes')) {
+                                return {
+                                    get: id => ({
+                                        id,
+                                        data   : JSON.stringify({
+                                            label     : id.startsWith('CONCEPT:') ? 'CONCEPT' : 'MESSAGE',
+                                            properties: {visibility: 'team'}
+                                        }),
+                                        user_id: null
+                                    })
+                                }
+                            }
+
+                            throw new Error(`Unexpected SQL: ${sql}`)
+                        }
+                    }
+                }
+            }
+        };
+
+        const graph = readTaggedConceptGraph({graphService});
+
+        expect(wrote).toBe(false);
+        expect(graph.edges).toHaveLength(1);
+        expect(graph.nodes.map(node => node.id).sort()).toEqual(['CONCEPT:GoldenPath', 'MESSAGE:1']);
+        expect(typeof graph.readAt).toBe('string');
+    });
+});


### PR DESCRIPTION
Resolves #14506
Refs #14472
Refs #14504

Adds a read-only concept-touch measurement helper, focused unit coverage, and the first live measurement artifact for Golden Path v2 consumer 4. The implementation uses current graph visibility fields instead of inventing `privacyTier`, applies most-restrictive visibility/trust propagation, emits confidence-bearing slice-1 candidates, and keeps the output explicitly diagnostics-only rather than ranking-shaped.

Evidence: L3 (focused unit coverage plus live non-destructive GraphService SELECT probe generated the committed measurement artifact) → L3 required (read-only profile/detector behavior plus live history artifact). No residuals.

## Deltas from ticket

- Corrected the ticket's `privacyTier` wording to the live fields: `userId`, `sharedEntity`, `visibility`, and provenance trust tiers.
- The live graph currently has 137 eligible touch events but 0 eligible events with session IDs, so candidate rows use `history-only-missing-session-boundary` at 0.35 confidence instead of overstating the session leg.
- The renderer caps candidate rows in the committed artifact while preserving the true candidate count.
- Retrieval-event precision remains the slice-2 upgrade path owned by `#14504`.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/graph/conceptTouchMeasurement.spec.mjs --reporter=line` → 8 passed after the rebase onto `origin/dev`.
- Live non-destructive measurement probe against `GraphService` generated: 162 `TAGGED_CONCEPT` edges scanned, 137 eligible events, 25 excluded missing endpoints, 6 per-agent profiles, 121 low-confidence history-only candidates, 0 retrieval events.
- `git diff --cached --check` passed before commit.
- `node buildScripts/util/check-block-alignment.mjs --staged` passed before commit.
- Pre-commit hooks passed: whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, block alignment.

## Post-Merge Validation

- [ ] Re-run the live measurement after `#14504` retrieval events are available and confirm matched retrieval events suppress candidates instead of requiring re-architecture.

## Commits

- `54f53426ec` — `feat(graph): add concept-touch measurement (#14506)`

Authored by GPT (GPT-5, Codex Desktop). Session c5938a7c-42e6-4f94-ac19-1a874529dfb4.
