### PR TITLE
fix(ai): ADR-19 remediation — assertConfigFresh crash fix + promote ADR-0019 read-gate to gate 10 (#14523)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ This file contains behavioral rules and protocols that must be enforced on every
 > *"Compaction taxonomy is substrate-authoring guidance; before modifying turn-loaded or skill-loaded instruction substrate, load `learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md`."*
 
 ## §critical_gates
-These nine rules are mechanically verifiable and have **no conditional exceptions** under any approval state, cross-family signal, or contextual nuance. Approval signals ("LGTM", "approved", "ready for merge", "no required actions") are **NOT** authorization to bypass any of them.
+These ten rules have **no conditional exceptions** under any approval state, cross-family signal, or contextual nuance. Approval signals ("LGTM", "approved", "ready for merge", "no required actions") are **NOT** authorization to bypass any of them.
 1. **No `gh pr merge` (Human-Only execution).**
     - **trigger:** agent considers executing a PR merge
     - **must:** hand off to @tobiu (human operator); cross-family approval = eligibility, not authority
@@ -61,6 +61,7 @@ These nine rules are mechanically verifiable and have **no conditional exception
 7. **No tracked file modification without a self-assigned ticket.** Self-assign + broadcast `[lane-claim]` to `AGENT:*` before any git-tracked edit; if the operator explicitly suppresses `AGENT:*` broadcasts, use the documented direct-DM fallback in peer-role/post-review-pickup instead; suppression is not a halt-state. Enforcement: `pull-request-workflow.md §1.2`, `ticket-create-workflow.md §10`. Reviewers executing the Maintainer Polish Fast Path (`pull-request-workflow.md §10`) operate under the PR's ticket authority and satisfy this invariant by fulfilling its strict gates: the Review-Loop Cost Circuit Breaker is active, the edit is strictly mechanical/metadata, Verification Evidence is documented, and an FYI A2A is broadcast.
 8. **No agent-authored PRs targeting `main`.** Agent-authored pull requests target `dev`. `main` is release-only; `main`-targeted PRs require explicit operator release direction. The normal release-line mutation is `buildScripts/release/publish.mjs`, whose low-level git plumbing creates the atomic release commit from `dev` onto `main`.
 9. **No client names in public-facing artifacts.** Never mention a client by name in any public artifact (public-repo issues/PRs/discussions/docs/comments); client specifics live only in private repos.
+10. **No AiConfig work without reading ADR-0019 first.** Before authoring OR reviewing ANY `ai/` config touch, read `learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md` — no exception, no approval signal, no CI-green substitute (diligence is empirically insufficient: #12420 missed 4/4; #14499 shipped ≥2 violations past 2 reviews). The ADR §3 catalog is the forbidden-pattern list (pass-along/thread, re-derive/env-read, defensive `?.`, hidden defaults, runtime mutation, non-entrypoint `import AiConfig`/C1).
 
 ## §pre_commit_gates
 For any actionable request modifying the repository, you **MUST** pass two critical gating protocols *before* executing `git commit`.
@@ -182,7 +183,6 @@ Before triggering a lifecycle skill, state in your reasoning: *"I will read the 
 - **Visual Verification (§visual_verification_protocol):** Debugging frontend UI/layout.
 - **Authoring Discipline:** Read 1-2 sibling files to lift patterns before writing new classes.
 - **Ticket Creation Freshness:** Before any `create_issue` path, invoke `ticket-create`; its Content Sweep requires live latest-open issue queue evidence in addition to KB/local duplicate checks.
-- **AiConfig / ADR-0019 (`ai/` config touch):** STOP before code/review: read `learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md`. `AiConfig` is the reactive Provider SSOT; local subtree refs are OK. Forbidden unless an ADR-19 boundary is named: config pass-through across methods/modules, re-derive/env-read, hidden defaults/type casts, defensive `?.`, runtime mutation.
 - **File Reading Efficiently:** Reading modified files; efficiency patterns.
 - **Verify-Before-Assert (§verify_before_assert):** core-value epistemic-prerequisite; before asserting any factual claim in a public artifact, run the falsifying tool. Tool inventory + empirical anchors (including #11089 self-Drop+Supersede recursion): §anti_hallucination_policy.
 - **Wake/Heartbeat → run the cycle (`/post-review-pickup`):** drain the lifecycle queue (own-PR changes/review → own-PR-green→request-review) before a new lane; there is no holding terminal (§identity_prompt_firewall L3_No_Hold_State). Three heartbeats with no forward artifact = critical failure → `/post-review-pickup` + `NightShiftLeasedDriver.md`.

--- a/ai/daemons/kb-alerting/daemon.mjs
+++ b/ai/daemons/kb-alerting/daemon.mjs
@@ -45,10 +45,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
     process.on('SIGINT',  () => cleanShutdown('SIGINT'));
 
+    const {findings} = AiConfig.validateRequiredEnv({entrypoint: 'kb-alerting-daemon'});
     assertConfigFresh({
-        aiConfig  : AiConfig,
-        entrypoint: 'kb-alerting-daemon',
-        serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
+        requiredFindings: findings,
+        serverPath      : fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
     })
         .then(() => KbAlertingService.start())
         .catch(err => {

--- a/ai/daemons/kb-gc/daemon.mjs
+++ b/ai/daemons/kb-gc/daemon.mjs
@@ -47,10 +47,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
     process.on('SIGINT',  () => cleanShutdown('SIGINT'));
 
+    const {findings} = AiConfig.validateRequiredEnv({entrypoint: 'kb-gc-daemon'});
     assertConfigFresh({
-        aiConfig  : AiConfig,
-        entrypoint: 'kb-gc-daemon',
-        serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
+        requiredFindings: findings,
+        serverPath      : fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
     })
         .then(() => KbGarbageCollectionService.start())
         .catch(err => {

--- a/ai/daemons/kb-reconciliation/daemon.mjs
+++ b/ai/daemons/kb-reconciliation/daemon.mjs
@@ -47,10 +47,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
     process.on('SIGINT',  () => cleanShutdown('SIGINT'));
 
+    const {findings} = AiConfig.validateRequiredEnv({entrypoint: 'kb-reconciliation-daemon'});
     assertConfigFresh({
-        aiConfig  : AiConfig,
-        entrypoint: 'kb-reconciliation-daemon',
-        serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
+        requiredFindings: findings,
+        serverPath      : fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
     })
         .then(() => KbReconciliationService.start())
         .catch(err => {

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -198,7 +198,8 @@ export async function startOrchestrator(options = {}) {
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
     // Boot guard: fail fast on a stale config overlay (missing a leaf its template added) with an
     // actionable --migrate-config message, rather than letting the orchestrator crash cryptically.
-    assertConfigFresh({aiConfig: AiConfig, entrypoint: 'orchestrator-daemon'})
+    const {findings} = AiConfig.validateRequiredEnv({entrypoint: 'orchestrator-daemon'});
+    assertConfigFresh({requiredFindings: findings})
         .then(() => startOrchestrator())
         .catch(err => {
             console.error(`[Orchestrator] Failed to start: ${err && err.stack ? err.stack : err}`);

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -1754,10 +1754,10 @@ function initConfigDerivedState() {
 async function main() {
     // Fail-fast on a stale memory-core config overlay with the actionable --migrate-config message,
     // BEFORE initConfigDerivedState() derefs memoryCoreConfig.
+    const {findings} = memoryCoreConfig.validateRequiredEnv({entrypoint: 'wake-daemon'});
     await assertConfigFresh({
-        aiConfig  : memoryCoreConfig,
-        entrypoint: 'wake-daemon',
-        serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
+        requiredFindings: findings,
+        serverPath      : fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
     });
 
     initConfigDerivedState();

--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -1,3 +1,7 @@
+// Load the Tier-1 realm root so getParent() inheritance resolves `auth.*` and other shared leaves via
+// the SSOT chain — matches memory-core/knowledge-base. This server reads no Tier-1 leaf
+// directly; they resolve through the parent chain, not a binding.
+import '../../../config.template.mjs';
 import path                                        from 'path';
 import {fileURLToPath}                             from 'url';
 import ConfigProvider, { createConfigProxy, leaf } from '../../../ConfigProvider.mjs';

--- a/ai/mcp/server/github-workflow/mcp-server.mjs
+++ b/ai/mcp/server/github-workflow/mcp-server.mjs
@@ -27,9 +27,11 @@ if (options.debug) {
 }
 
 try {
-    // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
-    // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-    await assertConfigFresh({aiConfig, entrypoint: 'github-workflow-mcp', serverPath: fileURLToPath(new URL('.', import.meta.url))});
+    // Boot guard: read this server's required-env findings at the use site (the entrypoint reads the
+    // SSOT; assertConfigFresh is a non-entrypoint that never does), then fail fast on a
+    // stale overlay or a missing required leaf instead of crashing cryptically on an undefined leaf.
+    const {findings} = aiConfig.validateRequiredEnv({entrypoint: 'github-workflow-mcp'});
+    await assertConfigFresh({requiredFindings: findings, serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
     await Neo.create(Server, {
         configFile: options.config

--- a/ai/mcp/server/gitlab-workflow/config.template.mjs
+++ b/ai/mcp/server/gitlab-workflow/config.template.mjs
@@ -1,3 +1,7 @@
+// Load the Tier-1 realm root so getParent() inheritance resolves `auth.*` and other shared leaves via
+// the SSOT chain — matches memory-core/knowledge-base. This server reads no Tier-1 leaf
+// directly; they resolve through the parent chain, not a binding.
+import '../../../config.template.mjs';
 import path                                      from 'path';
 import {fileURLToPath}                           from 'url';
 import ConfigProvider, {createConfigProxy, leaf} from '../../../ConfigProvider.mjs';

--- a/ai/mcp/server/gitlab-workflow/mcp-server.mjs
+++ b/ai/mcp/server/gitlab-workflow/mcp-server.mjs
@@ -26,9 +26,11 @@ if (options.debug) {
 }
 
 try {
-    // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
-    // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-    await assertConfigFresh({aiConfig, entrypoint: 'gitlab-workflow-mcp', serverPath: fileURLToPath(new URL('.', import.meta.url))});
+    // Boot guard: read this server's required-env findings at the use site (the entrypoint reads the
+    // SSOT; assertConfigFresh is a non-entrypoint that never does), then fail fast on a
+    // stale overlay or a missing required leaf instead of crashing cryptically on an undefined leaf.
+    const {findings} = aiConfig.validateRequiredEnv({entrypoint: 'gitlab-workflow-mcp'});
+    await assertConfigFresh({requiredFindings: findings, serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
     await Neo.create(Server, {
         configFile: options.config

--- a/ai/mcp/server/knowledge-base/mcp-server.mjs
+++ b/ai/mcp/server/knowledge-base/mcp-server.mjs
@@ -27,9 +27,11 @@ if (options.debug) {
 }
 
 try {
-    // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
-    // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-    await assertConfigFresh({aiConfig, entrypoint: 'knowledge-base-mcp', serverPath: fileURLToPath(new URL('.', import.meta.url))});
+    // Boot guard: read this server's required-env findings at the use site (the entrypoint reads the
+    // SSOT; assertConfigFresh is a non-entrypoint that never does), then fail fast on a
+    // stale overlay or a missing required leaf instead of crashing cryptically on an undefined leaf.
+    const {findings} = aiConfig.validateRequiredEnv({entrypoint: 'knowledge-base-mcp'});
+    await assertConfigFresh({requiredFindings: findings, serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
     await Neo.create(Server, {
         configFile: options.config

--- a/ai/mcp/server/memory-core/mcp-server.mjs
+++ b/ai/mcp/server/memory-core/mcp-server.mjs
@@ -27,9 +27,11 @@ if (options.debug) {
 }
 
 try {
-    // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
-    // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-    await assertConfigFresh({aiConfig, entrypoint: 'memory-core-mcp', serverPath: fileURLToPath(new URL('.', import.meta.url))});
+    // Boot guard: read this server's required-env findings at the use site (the entrypoint reads the
+    // SSOT; assertConfigFresh is a non-entrypoint that never does), then fail fast on a
+    // stale overlay or a missing required leaf instead of crashing cryptically on an undefined leaf.
+    const {findings} = aiConfig.validateRequiredEnv({entrypoint: 'memory-core-mcp'});
+    await assertConfigFresh({requiredFindings: findings, serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
     await Neo.create(Server, {
         configFile: options.config

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -1,3 +1,7 @@
+// Load the Tier-1 realm root so getParent() inheritance resolves `auth.*` and other shared leaves via
+// the SSOT chain — matches memory-core/knowledge-base. This server reads no Tier-1 leaf
+// directly; they resolve through the parent chain, not a binding.
+import '../../../config.template.mjs';
 import os              from 'os';
 import path            from 'path';
 import {fileURLToPath} from 'url';

--- a/ai/mcp/server/neural-link/mcp-server.mjs
+++ b/ai/mcp/server/neural-link/mcp-server.mjs
@@ -29,9 +29,11 @@ if (options.debug) {
 }
 
 try {
-    // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
-    // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-    await assertConfigFresh({aiConfig, entrypoint: 'neural-link-mcp', serverPath: fileURLToPath(new URL('.', import.meta.url))});
+    // Boot guard: read this server's required-env findings at the use site (the entrypoint reads the
+    // SSOT; assertConfigFresh is a non-entrypoint that never does), then fail fast on a
+    // stale overlay or a missing required leaf instead of crashing cryptically on an undefined leaf.
+    const {findings} = aiConfig.validateRequiredEnv({entrypoint: 'neural-link-mcp'});
+    await assertConfigFresh({requiredFindings: findings, serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
     await Neo.create(Server, {
         configFile        : options.config,

--- a/ai/mcp/server/neural-link/run-bridge.mjs
+++ b/ai/mcp/server/neural-link/run-bridge.mjs
@@ -25,9 +25,11 @@ if (options.debug) {
 
 (async () => {
     try {
-        // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
-        // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
-        await assertConfigFresh({aiConfig, entrypoint: 'neural-link-bridge', serverPath: fileURLToPath(new URL('.', import.meta.url))});
+        // Boot guard: read this bridge's required-env findings at the use site (the entrypoint reads the
+        // SSOT; assertConfigFresh is a non-entrypoint that never does), then fail fast on
+        // a stale overlay or a missing required leaf instead of crashing cryptically on an undefined leaf.
+        const {findings} = aiConfig.validateRequiredEnv({entrypoint: 'neural-link-bridge'});
+        await assertConfigFresh({requiredFindings: findings, serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
         if (options.config) {
             await aiConfig.load(options.config);

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -389,6 +389,14 @@ export function projectSourceShape(src) {
         }
     }
 
+    // Bare side-effect imports (`import '<source>';` — no `from` clause): e.g. the Tier-1 realm-root load
+    // that makes a server config participate in the hierarchy. Track them so a template that ADDS a
+    // participation import registers as drift a config.mjs must materialize — the detection gap that let
+    // non-participating server overlays boot with getParent() unable to resolve the realm root.
+    for (const bare of src.matchAll(/^import\s+['"]([^'"]+)['"]/gm)) {
+        imports.push(bare[1]);
+    }
+
     imports.sort();
 
     const exports = [...src.matchAll(/^export\s+\{([^}]+)\}/gm)]
@@ -672,12 +680,10 @@ export async function initTier1Config({argv = process.argv, logger = console, ai
  * leaves + the `--migrate-config` fix instead of crashing every consumer cryptically.
  *
  * @param {Object}   [options]
- * @param {Object}   [options.aiConfig] ConfigProvider instance/proxy whose required-env leaf metadata
- *   should be validated for this entrypoint. Omit only for legacy callers without a live config.
- * @param {String}   [options.consumerClaim='readiness'] The claim this guard certifies.
- * @param {String}   [options.entrypoint='boot'] The entrypoint name for requiredness matching.
- * @param {String}   [options.mode] Active mode for requiredness matching; defaults to
- *   `aiConfig.auth.mode` when omitted.
+ * @param {Object[]} [options.requiredFindings=[]] Required-env findings the ENTRYPOINT already computed by
+ *   reading `AiConfig` / its own server config at its use site (`config.validateRequiredEnv(...)`) and
+ *   passed in as a value. This guard is a non-entrypoint, so it never reads the SSOT itself — the
+ *   entrypoint injects the computed findings (a narrow bootstrap boundary), never the config object.
  * @param {String}   [options.serverPath] An `ai/mcp/server/<name>/` dir whose `config.mjs` overlay to
  *   additionally check; its Tier-1 import is materialized before the shape-compare (matching
  *   {@link initConfigs}) so the template-vs-overlay import path is not read as false drift.
@@ -687,16 +693,12 @@ export async function initTier1Config({argv = process.argv, logger = console, ai
  * @throws {Error} on crash-causing overlay drift or missing required env state, naming the fix.
  */
 export async function assertConfigFresh({
-    aiConfig,
     aiRoot = aiDir,
-    consumerClaim = 'readiness',
-    entrypoint = 'boot',
     logger = console,
-    mode,
+    requiredFindings = [],
     serverPath
 } = {}) {
-    const stale            = [],
-          requiredFindings = [];
+    const stale = [];
 
     const record = (label, drift) => {
         const crashCausing = [
@@ -732,17 +734,6 @@ export async function assertConfigFresh({
 
             record(`${path.basename(serverPath)}/config.mjs`, detectDrift(templateShape, activeShape));
         }
-    }
-
-    if (aiConfig !== undefined) {
-        // `validateRequiredEnv` resolves the active mode itself (`mode ?? getData('auth.mode')`) through
-        // the provider hierarchy — re-deriving it here as `aiConfig.auth.mode` both duplicates the
-        // Provider's own resolution AND crashes on a config whose chain has no resolvable `auth` leaf (a
-        // server config that does not import the Tier-1 root, e.g. the neural-link bridge). Pass `mode`
-        // through and let the Provider resolve it.
-        const result = aiConfig.validateRequiredEnv({consumerClaim, entrypoint, mode});
-
-        requiredFindings.push(...result.findings);
     }
 
     if (stale.length > 0) {

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -735,11 +735,12 @@ export async function assertConfigFresh({
     }
 
     if (aiConfig !== undefined) {
-        const result = aiConfig.validateRequiredEnv({
-            consumerClaim,
-            entrypoint,
-            mode: mode ?? aiConfig.auth.mode
-        });
+        // `validateRequiredEnv` resolves the active mode itself (`mode ?? getData('auth.mode')`) through
+        // the provider hierarchy — re-deriving it here as `aiConfig.auth.mode` both duplicates the
+        // Provider's own resolution AND crashes on a config whose chain has no resolvable `auth` leaf (a
+        // server config that does not import the Tier-1 root, e.g. the neural-link bridge). Pass `mode`
+        // through and let the Provider resolve it.
+        const result = aiConfig.validateRequiredEnv({consumerClaim, entrypoint, mode});
 
         requiredFindings.push(...result.findings);
     }

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -582,6 +582,18 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
         ]);
     });
 
+    test('bare side-effect imports are tracked so a missing participation import is drift (#14499)', () => {
+        // A server config participates in the Tier-1 hierarchy by loading the realm root via a bare
+        // side-effect import (`import '../../../config.mjs';`). The detector MUST see it — else a template
+        // that ADDS participation is invisible drift and the overlay boots non-participating — getParent()
+        // has no root, so `auth.*` is unresolvable.
+        const templateShape = projectSourceShape(`import '../../../config.mjs';\nimport os from 'os';\nexport default {};\n`);
+        const configShape   = projectSourceShape(`import os from 'os';\nexport default {};\n`);
+
+        expect(templateShape.imports).toContain('../../../config.mjs');
+        expect(detectDrift(templateShape, configShape).missingImports).toContain('../../../config.mjs');
+    });
+
     test('detectDrift reports same-env leaf default changes (#12767)', () => {
         const templateShape = projectSourceShape([
             `export default {`,
@@ -910,35 +922,21 @@ test.describe('assertConfigFresh — boot freshness guard (#13560)', () => {
             configContents  : TEMPLATE_WITH_LEAF
         });
 
-        const aiConfig = {
-            auth: {mode: 'gitlab-pat'},
-            validateRequiredEnv({consumerClaim, entrypoint, mode}) {
-                // Mirror the real ConfigProvider.validateRequiredEnv: it resolves the active mode
-                // internally (`mode ?? this.getData('auth.mode')`) and reports the RESOLVED mode. The guard
-                // must NOT pre-resolve `auth.mode` for it — that re-implements the Provider's resolution and
-                // crashes on a config whose chain has no resolvable `auth` leaf.
-                const activeMode = mode ?? this.auth.mode;
-                return {
-                    ok      : false,
-                    findings: [{
-                        consumerClaim,
-                        entrypoint,
-                        env        : 'NEO_AUTH_GITLAB_API_BASE_URL',
-                        leafPath   : 'auth.gitlabApiBaseUrl',
-                        mode       : activeMode,
-                        reason     : 'PAT validation cannot certify readiness without a GitLab API base URL.',
-                        valueState : 'absent',
-                        disposition: 'fail-closed'
-                    }]
-                }
-            }
-        };
-
+        // The ENTRYPOINT computes findings by reading its config at its use site (config.validateRequiredEnv);
+        // the guard is a non-entrypoint that never reads the SSOT — it throws on the injected value.
         const error = await callGuard({
-            aiConfig,
-            aiRoot    : root,
-            entrypoint: 'memory-core-mcp',
-            logger    : recordingLogger()
+            aiRoot          : root,
+            logger          : recordingLogger(),
+            requiredFindings: [{
+                consumerClaim: 'readiness',
+                entrypoint   : 'memory-core-mcp',
+                env          : 'NEO_AUTH_GITLAB_API_BASE_URL',
+                leafPath     : 'auth.gitlabApiBaseUrl',
+                mode         : 'gitlab-pat',
+                reason       : 'PAT validation cannot certify readiness without a GitLab API base URL.',
+                valueState   : 'absent',
+                disposition  : 'fail-closed'
+            }]
         });
 
         expect(error).not.toBeNull();
@@ -947,23 +945,6 @@ test.describe('assertConfigFresh — boot freshness guard (#13560)', () => {
         expect(error.message).toContain('memory-core-mcp/gitlab-pat/readiness');
     });
 
-    test('a supplied config without validateRequiredEnv fails loud instead of skipping readiness validation (#13432)', async () => {
-        const root = buildTier1({
-            name            : 'malformed-ai-config',
-            templateContents: TEMPLATE_WITH_LEAF,
-            configContents  : TEMPLATE_WITH_LEAF
-        });
-
-        const error = await callGuard({
-            aiConfig  : {auth: {mode: 'gitlab-pat'}},
-            aiRoot    : root,
-            entrypoint: 'memory-core-mcp',
-            logger    : recordingLogger()
-        });
-
-        expect(error).not.toBeNull();
-        expect(error.message).toContain('validateRequiredEnv');
-    });
 });
 
 test.describe('initClaudeSettings — Claude Stop-hook auto-wire (#13641)', () => {

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -913,6 +913,11 @@ test.describe('assertConfigFresh — boot freshness guard (#13560)', () => {
         const aiConfig = {
             auth: {mode: 'gitlab-pat'},
             validateRequiredEnv({consumerClaim, entrypoint, mode}) {
+                // Mirror the real ConfigProvider.validateRequiredEnv: it resolves the active mode
+                // internally (`mode ?? this.getData('auth.mode')`) and reports the RESOLVED mode. The guard
+                // must NOT pre-resolve `auth.mode` for it — that re-implements the Provider's resolution and
+                // crashes on a config whose chain has no resolvable `auth` leaf.
+                const activeMode = mode ?? this.auth.mode;
                 return {
                     ok      : false,
                     findings: [{
@@ -920,7 +925,7 @@ test.describe('assertConfigFresh — boot freshness guard (#13560)', () => {
                         entrypoint,
                         env        : 'NEO_AUTH_GITLAB_API_BASE_URL',
                         leafPath   : 'auth.gitlabApiBaseUrl',
-                        mode,
+                        mode       : activeMode,
                         reason     : 'PAT validation cannot certify readiness without a GitLab API base URL.',
                         valueState : 'absent',
                         disposition: 'fail-closed'


### PR DESCRIPTION
## Summary

The complete ADR-19 remediation of the #14499 config regression that crashed the Neural Link bridge on boot (`TypeError: Cannot read properties of undefined (reading 'mode')`). Root cause: #14499 shipped ADR-19 violations approved past two reviews (@neo-opus-grace flip + @neo-opus-ada re-approve — the rubber-stamp ADR-19 §3 D/E documents).

Resolves #14523.

## The fix (four parts)

1. **Participation (§2.1 / SSOT).** `neural-link`, `github-workflow`, `gitlab-workflow` `config.template.mjs` now load the Tier-1 realm root (`import '../../../config.template.mjs'`, materialized to `../../../config.mjs`) like `memory-core`/`knowledge-base`, so `getParent()` resolves `auth.*` + shared leaves through the SSOT chain. Without it `aiConfig.auth.mode` had no root → the boot crash.
2. **Drift-detection gap — the reason it shipped stale.** `projectSourceShape` only tracked `import … from '…'`; bare side-effect imports were invisible, so a template *adding* a participation import was not flagged as drift and the overlay booted non-participating. Now tracked → `--migrate-config` materializes the import into the gitignored `config.mjs`.
3. **No pass-along (§2/§3, B5, C1).** `assertConfigFresh` is a non-entrypoint, so it no longer takes `aiConfig` / reads the SSOT. Each of the 11 boot guards (orchestrator + kb-gc/kb-alerting/kb-reconciliation/wake daemons, 5 `mcp-server.mjs`, `run-bridge.mjs`) reads its own config at the use site (`config.validateRequiredEnv(...)`) and injects the computed `requiredFindings` value.
4. **ADR-19 read-gate → critical gate 10** in `AGENTS.md` (soft edge-case trigger → hard gate), under the 24 KiB cap.

## Test Evidence

Evidence: L1 unit 42/42; L2 boot-guard passes with no `auth.mode` crash after `--migrate-config`; L3 `node --check` clean across all 16 changed files.

- `npm run test-unit -- test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs` → **42/42** (incl. the new `bare side-effect imports are tracked …` drift test).
- **Boot-verified by running** (the owed check): after `node ai/scripts/setup/initServerConfigs.mjs --migrate-config`, the NL bridge boot-guard path (`validateRequiredEnv` → `assertConfigFresh`) passes with **no `auth.mode` crash**; the migration now detects + materializes the participation import into `neural-link`/`github-workflow`/`gitlab-workflow` `config.mjs`.
- `node --check` clean across all 16 changed files.

## Post-Merge Validation

- After merge + `git pull` + `npm run prepare -- --migrate-config`, restart the orchestrator: every server/daemon boot guard passes; the NL bridge starts (no `auth.mode` TypeError).
- Confirm no `assertConfigFresh({aiConfig …})` remains anywhere (`grep`), i.e. the B5 pass-along is gone repo-wide.

## Deltas

- `ai/mcp/server/{neural-link,github-workflow,gitlab-workflow}/config.template.mjs`: add the Tier-1 realm-root side-effect import (participation).
- `ai/scripts/setup/initServerConfigs.mjs`: `projectSourceShape` tracks bare imports; `assertConfigFresh` drops `aiConfig`/`consumerClaim`/`mode`, takes `requiredFindings`.
- `ai/mcp/server/*/mcp-server.mjs` + `run-bridge.mjs` + `ai/daemons/{orchestrator,kb-gc,kb-alerting,kb-reconciliation,wake}/daemon.mjs`: read config + inject findings at the use site.
- `test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs`: Shape-2 required-env test + the bare-import drift regression test.
- `AGENTS.md`: critical gate 10.

## Graph Ingestion Notes

ADR-0019 (#12457) reactive-Provider-SSOT: participation via realm-root import; read-at-use-site (no pass-along/B5); non-entrypoint C1 boundary. Complements #14500 (the B3/A5/A1 SSOT lint) — this closes the bare-import-participation detection gap specifically. Grace's held §2.1 (`fix/14521-adr19-config-participation`) is superseded by part 1 here.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8).
