### PR TITLE
feat(graph): canonicalize concept spine aliases (#14502)

### DIFF
--- a/ai/scripts/maintenance/auditConceptSpineAliases.mjs
+++ b/ai/scripts/maintenance/auditConceptSpineAliases.mjs
@@ -2,6 +2,14 @@ import {Command}       from 'commander';
 import fs              from 'fs-extra';
 import path            from 'path';
 import {fileURLToPath} from 'url';
+import {
+    SEMANTIC_SPINE_NODE_TYPE_SET,
+    chooseCanonicalConceptId,
+    getConceptAliasKeys,
+    normalizeConceptKey
+} from '../../services/graph/conceptSpineCanonicalization.mjs';
+
+export {normalizeConceptKey};
 
 const __filename   = fileURLToPath(import.meta.url);
 const __dirname    = path.dirname(__filename);
@@ -9,7 +17,7 @@ const PROJECT_ROOT = path.resolve(__dirname, '../../..');
 
 export const DEFAULT_OUTPUT_DIR = path.join(PROJECT_ROOT, 'learn', 'agentos', 'measurements');
 
-const SEMANTIC_NODE_LABELS = new Set(['CONCEPT', 'CLASS', 'PROCESS']);
+const SEMANTIC_NODE_LABELS = SEMANTIC_SPINE_NODE_TYPE_SET;
 const SEMANTIC_ID_PREFIXES = /^(CONCEPT|CLASS|PROCESS):/i;
 
 /**
@@ -50,27 +58,6 @@ export function parseArgs(argv, env = process.env) {
         json     : opts.json === true,
         help     : opts.help === true
     };
-}
-
-/**
- * @summary Normalizes a concept-ish id/name/alias into the detection key used for alias clustering.
- * @param {String} value Raw graph id, name, or alias.
- * @returns {String} Lowercase kebab-case key with known semantic prefixes stripped.
- */
-export function normalizeConceptKey(value) {
-    if (typeof value !== 'string') return '';
-
-    return value
-        .trim()
-        .replace(SEMANTIC_ID_PREFIXES, '')
-        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
-        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-        .normalize('NFKD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .replace(/&/g, ' and ')
-        .replace(/[^A-Za-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '')
-        .toLowerCase();
 }
 
 /**
@@ -137,7 +124,7 @@ export function createConceptSpineAliasReport({
         keyNodes      = new Map();
 
     for (const node of semanticNodes) {
-        const keys = getNodeAliasKeys(node);
+        const keys = getConceptAliasKeys(node);
         if (keys.length === 0) continue;
 
         nodeKeys.set(node.id, keys);
@@ -320,23 +307,13 @@ function isSemanticSpineNode(node) {
     return SEMANTIC_NODE_LABELS.has(node.label) || SEMANTIC_ID_PREFIXES.test(node.id);
 }
 
-function getNodeAliasKeys(node) {
-    const values = [
-        node.id,
-        node.name,
-        ...(Array.isArray(node.aliases) ? node.aliases : [])
-    ];
-
-    return [...new Set(values.map(normalizeConceptKey).filter(Boolean))];
-}
-
 function buildCluster(group, nodesById, nodeKeys, edges) {
     const
         nodeIds      = [...group.nodeIds].sort(),
         nodes        = nodeIds.map(id => nodesById.get(id)).filter(Boolean),
         keys         = [...group.keys].sort(),
         keySet       = new Set(keys),
-        canonical    = chooseCanonicalCandidate(nodeIds, keySet),
+        canonical    = chooseCanonicalConceptId(nodeIds, keySet),
         neighborhood = summarizeNeighborhood(nodeIds, edges);
 
     return {
@@ -352,19 +329,6 @@ function buildCluster(group, nodesById, nodeKeys, edges) {
         })),
         neighborhood
     };
-}
-
-function chooseCanonicalCandidate(nodeIds, keySet) {
-    const bareExact = nodeIds.find(id => !id.includes(':') && keySet.has(id) && normalizeConceptKey(id) === id);
-    if (bareExact) return bareExact;
-
-    const sorted = [...nodeIds].sort((a, b) => {
-        const aPrefix = a.includes(':') ? 1 : 0;
-        const bPrefix = b.includes(':') ? 1 : 0;
-        return aPrefix - bPrefix || a.length - b.length || a.localeCompare(b);
-    });
-
-    return normalizeConceptKey(sorted[0] || '');
 }
 
 function summarizeNeighborhood(nodeIds, edges) {

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -15,6 +15,10 @@ import {
 } from '../../services/memory-core/helpers/remRunStateStore.mjs';
 import Json                                            from '../../../src/util/Json.mjs';
 import logger                                          from '../../mcp/server/memory-core/logger.mjs';
+import {
+    canonicalizeSemanticGraphNodeId,
+    canonicalizeTaggedConceptIds
+} from './conceptSpineCanonicalization.mjs';
 import {buildGraphProvider, resolveGraphModelProvider} from './providerDispatch.mjs';
 import {chunkSession}                                  from './sessionChunker.mjs';
 
@@ -829,6 +833,7 @@ class SemanticGraphExtractor extends Base {
                 nodeId = `${nodeType}:${cleanName}`;
             }
             nodeId = this.normalizeMemorySessionGraphNodeId(nodeId);
+            nodeId = canonicalizeSemanticGraphNodeId({id: nodeId, type: nodeType, name: node.name});
 
             GraphService.upsertNode({
                 id              : nodeId,
@@ -864,6 +869,8 @@ class SemanticGraphExtractor extends Base {
 
             resolvedSource = this.normalizeMemorySessionGraphNodeId(resolvedSource);
             resolvedTarget = this.normalizeMemorySessionGraphNodeId(resolvedTarget);
+            resolvedSource = canonicalizeSemanticGraphNodeId({id: resolvedSource});
+            resolvedTarget = canonicalizeSemanticGraphNodeId({id: resolvedTarget});
 
             const sourceExists = validNodeRefs.has(resolvedSource) || GraphService.db.nodes.has(resolvedSource);
             const targetExists = validNodeRefs.has(resolvedTarget) || GraphService.db.nodes.has(resolvedTarget);
@@ -1211,7 +1218,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 return [];
             }
 
-            const validConcepts = payload.concepts.filter(c => typeof c === 'string' && c.includes(':'));
+            const validConcepts = canonicalizeTaggedConceptIds(payload.concepts.filter(c => typeof c === 'string' && c.includes(':')));
             logger.info(`[SemanticGraphExtractor] Extracted ${validConcepts.length} concepts from message.`);
             return validConcepts;
 

--- a/ai/services/graph/conceptNeighborhoodProbe.mjs
+++ b/ai/services/graph/conceptNeighborhoodProbe.mjs
@@ -1,3 +1,5 @@
+import {normalizeConceptKey} from './conceptSpineCanonicalization.mjs';
+
 /**
  * @module ai/services/graph/conceptNeighborhoodProbe
  * @summary Read-only concept-neighborhood reachability probe with provenance/tier output (#14474; ticket-ref-ok: owning-leaf anchor).
@@ -38,13 +40,7 @@ export const CONTRACT_AXES = Object.freeze({
  * @returns {String} Cluster key, e.g. `CONCEPT:Golden Path Synthesis` → `golden-path-synthesis`.
  */
 export function conceptClusterKey(id) {
-    return String(id || '')
-        .replace(/^CONCEPT:/i, '')
-        .replace(/^CLASS:/i, '')
-        .trim()
-        .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
-        .replace(/[\s_]+/g, '-')
-        .toLowerCase()
+    return normalizeConceptKey(id)
 }
 
 /**

--- a/ai/services/graph/conceptSpineCanonicalization.mjs
+++ b/ai/services/graph/conceptSpineCanonicalization.mjs
@@ -1,0 +1,526 @@
+const SEMANTIC_ID_PREFIXES = /^(CONCEPT|CLASS|PROCESS):/i;
+
+export const SEMANTIC_SPINE_NODE_TYPES = Object.freeze(['CONCEPT', 'CLASS', 'PROCESS']);
+export const SEMANTIC_SPINE_NODE_TYPE_SET = new Set(SEMANTIC_SPINE_NODE_TYPES);
+
+/**
+ * @summary Canonical concept-spine id policy: semantic concept ids are bare lower-kebab keys.
+ *
+ * The policy intentionally strips legacy semantic prefixes (`CONCEPT:`, `CLASS:`, `PROCESS:`)
+ * and normalizes case/punctuation before any new concept-spine edge is minted. Historical alias
+ * nodes remain addressable through tombstone metadata; new writes converge on one id.
+ *
+ * @param {String} value Raw concept name, alias, or id.
+ * @returns {String} Bare lower-kebab canonical concept id.
+ */
+export function normalizeConceptKey(value) {
+    if (typeof value !== 'string') return '';
+
+    return value
+        .trim()
+        .replace(SEMANTIC_ID_PREFIXES, '')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/&/g, ' and ')
+        .replace(/[^A-Za-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .toLowerCase();
+}
+
+/**
+ * @summary Tests whether a node type participates in the concept spine.
+ * @param {String} type Graph node label/type.
+ * @returns {Boolean}
+ */
+export function isSemanticSpineNodeType(type) {
+    return SEMANTIC_SPINE_NODE_TYPE_SET.has(String(type || '').toUpperCase());
+}
+
+/**
+ * @summary Tests whether a graph id uses a legacy semantic concept prefix.
+ * @param {String} id Graph node id.
+ * @returns {Boolean}
+ */
+export function hasSemanticSpinePrefix(id) {
+    return typeof id === 'string' && SEMANTIC_ID_PREFIXES.test(id);
+}
+
+/**
+ * @summary Canonicalizes one semantic concept id to the bare lower-kebab convention.
+ * @param {String} value Raw concept id, name, or alias.
+ * @returns {String}
+ */
+export function canonicalizeConceptId(value) {
+    return normalizeConceptKey(value);
+}
+
+/**
+ * @summary Canonicalizes a graph node id when the node belongs to the semantic spine.
+ * @param {Object} node Graph node-ish record.
+ * @param {String} node.id Raw node id.
+ * @param {String} [node.type] Raw node type/label.
+ * @param {String} [node.name] Raw node name.
+ * @returns {String}
+ */
+export function canonicalizeSemanticGraphNodeId({id, type, name} = {}) {
+    if (!isSemanticSpineNodeType(type) && !hasSemanticSpinePrefix(id)) {
+        return id;
+    }
+
+    return canonicalizeConceptId(id || name);
+}
+
+/**
+ * @summary Canonicalizes message/search tagged concepts while preserving caller order.
+ * @param {String[]} values Raw concept tags.
+ * @returns {String[]} Unique canonical concept ids.
+ */
+export function canonicalizeTaggedConceptIds(values = []) {
+    const seen   = new Set();
+    const result = [];
+
+    for (const value of Array.isArray(values) ? values : []) {
+        const canonical = canonicalizeConceptId(value);
+        if (!canonical || seen.has(canonical)) continue;
+
+        seen.add(canonical);
+        result.push(canonical);
+    }
+
+    return result;
+}
+
+/**
+ * @summary Returns all deterministic alias keys for one concept-spine node.
+ * @param {Object} node Graph node-ish record.
+ * @returns {String[]}
+ */
+export function getConceptAliasKeys(node = {}) {
+    const properties = node.properties || {};
+    const values     = [
+        node.id,
+        node.name || properties.name,
+        ...(Array.isArray(node.aliases) ? node.aliases : []),
+        ...(Array.isArray(properties.aliases) ? properties.aliases : [])
+    ];
+
+    return [...new Set(values.map(normalizeConceptKey).filter(Boolean))];
+}
+
+/**
+ * @summary Selects the canonical id for an alias cluster.
+ * @param {String[]} nodeIds Cluster node ids.
+ * @param {Set<String>} [keySet] Alias keys found in the cluster.
+ * @returns {String}
+ */
+export function chooseCanonicalConceptId(nodeIds = [], keySet = new Set()) {
+    const bareExact = nodeIds.find(id => !String(id).includes(':') && keySet.has(id) && normalizeConceptKey(id) === id);
+    if (bareExact) return bareExact;
+
+    const sorted = [...nodeIds].sort((a, b) => {
+        const aPrefix = String(a).includes(':') ? 1 : 0,
+              bPrefix = String(b).includes(':') ? 1 : 0;
+
+        return aPrefix - bPrefix || String(a).length - String(b).length || String(a).localeCompare(String(b));
+    });
+
+    return normalizeConceptKey(sorted[0] || '');
+}
+
+/**
+ * @summary Builds a deterministic merge plan for concept-spine alias clusters.
+ * @param {Object} options
+ * @param {Object[]} options.nodes Graph node records.
+ * @param {Object[]} options.edges Graph edge records.
+ * @param {String} [options.generatedAt] ISO timestamp for tombstone metadata.
+ * @returns {Object}
+ */
+export function buildConceptSpineMergePlan({nodes = [], edges = [], generatedAt = new Date().toISOString()} = {}) {
+    const
+        semanticNodes = nodes.filter(isSemanticSpineNode),
+        uf            = new UnionFind(),
+        nodeKeys      = new Map(),
+        keyNodes      = new Map();
+
+    for (const node of semanticNodes) {
+        const keys = getConceptAliasKeys(node);
+        if (keys.length === 0) continue;
+
+        nodeKeys.set(node.id, keys);
+        for (const key of keys) {
+            uf.add(key);
+            if (!keyNodes.has(key)) keyNodes.set(key, new Set());
+            keyNodes.get(key).add(node.id);
+        }
+        for (const key of keys.slice(1)) {
+            uf.union(keys[0], key);
+        }
+    }
+
+    const groups = new Map();
+    for (const [key, nodeIds] of keyNodes) {
+        const root = uf.find(key);
+        if (!groups.has(root)) {
+            groups.set(root, {keys: new Set(), nodeIds: new Set()});
+        }
+        const group = groups.get(root);
+        group.keys.add(key);
+        for (const nodeId of nodeIds) {
+            group.nodeIds.add(nodeId);
+        }
+    }
+
+    const clusters = [...groups.values()]
+        .map(group => buildMergeCluster(group, nodeKeys, edges, generatedAt))
+        .filter(cluster => cluster.aliases.length > 0)
+        .sort((a, b) => b.nodeIds.length - a.nodeIds.length || a.canonicalId.localeCompare(b.canonicalId));
+
+    return {
+        generatedAt,
+        policy  : 'bare lower-kebab canonical id; aliases tombstoned with aliasOf pointer; edge collisions keep MAX weight',
+        clusters
+    };
+}
+
+/**
+ * @summary Applies a merge plan to plain graph records for hermetic verification and script seams.
+ * @param {Object} options
+ * @param {Object[]} options.nodes Graph node records.
+ * @param {Object[]} options.edges Graph edge records.
+ * @param {Object} options.plan Plan from `buildConceptSpineMergePlan`.
+ * @returns {{nodes: Object[], edges: Object[], applied: Object}}
+ */
+export function applyConceptSpineMergePlan({nodes = [], edges = [], plan} = {}) {
+    const
+        nodeMap = new Map(nodes.map(node => [node.id, cloneRecord(node)])),
+        edgeMap = new Map(edges.map(edge => [edge.id, cloneRecord(edge)])),
+        applied = {clusters: 0, tombstonedAliases: 0, rewiredEdges: 0, removedDuplicateEdges: 0};
+
+    for (const cluster of plan?.clusters || []) {
+        applied.clusters++;
+
+        const canonicalNode = nodeMap.get(cluster.canonicalId) || cloneRecord(nodeMap.get(cluster.nodeIds[0]) || {
+            id        : cluster.canonicalId,
+            type      : 'CONCEPT',
+            properties: {}
+        });
+
+        canonicalNode.id         = cluster.canonicalId;
+        canonicalNode.properties = {
+            ...(canonicalNode.properties || {}),
+            canonicalConceptId: cluster.canonicalId,
+            conceptAliases    : cluster.aliases
+        };
+        nodeMap.set(cluster.canonicalId, canonicalNode);
+
+        for (const alias of cluster.aliases) {
+            const aliasNode = nodeMap.get(alias);
+            if (!aliasNode) continue;
+
+            aliasNode.properties = {
+                ...(aliasNode.properties || {}),
+                aliasOf                 : cluster.canonicalId,
+                canonicalConceptId      : cluster.canonicalId,
+                conceptSpineTombstonedAt: cluster.generatedAt,
+                conceptSpineTombstoneBy : 'concept-spine-alias-merge'
+            };
+            applied.tombstonedAliases++;
+        }
+
+        for (const rewrite of cluster.edgeRewrites) {
+            const primary = edgeMap.get(rewrite.primaryEdgeId);
+            if (!primary) continue;
+
+            primary.source     = rewrite.source;
+            primary.target     = rewrite.target;
+            primary.type       = rewrite.type;
+            primary.properties = {
+                ...(primary.properties || {}),
+                weight                    : rewrite.weight,
+                conceptSpineMergedEdgeIds : rewrite.edgeIds.filter(id => id !== rewrite.primaryEdgeId),
+                conceptSpineMergedAt      : cluster.generatedAt,
+                conceptSpineMergeCollision: rewrite.edgeIds.length > 1
+            };
+            applied.rewiredEdges++;
+
+            for (const duplicateId of rewrite.edgeIds.filter(id => id !== rewrite.primaryEdgeId)) {
+                if (edgeMap.delete(duplicateId)) {
+                    applied.removedDuplicateEdges++;
+                }
+            }
+        }
+    }
+
+    return {
+        nodes: [...nodeMap.values()],
+        edges: [...edgeMap.values()],
+        applied
+    };
+}
+
+/**
+ * @summary Executes a concept-spine merge plan against a mounted GraphService instance.
+ *
+ * This executor intentionally updates selected primary edges directly instead of routing
+ * through `GraphService.linkNodes()`: the normal link path reinforces existing edge scent,
+ * while alias collision repair must preserve edge-decay semantics by keeping MAX weight.
+ *
+ * @param {Object} options
+ * @param {Object} options.graphService Mounted GraphService-like instance.
+ * @param {Object} options.plan Plan from `buildConceptSpineMergePlan`.
+ * @returns {Object} Applied mutation counts.
+ */
+export function executeConceptSpineMergePlan({graphService, plan} = {}) {
+    const db = graphService?.db;
+    if (!db) {
+        throw new Error('executeConceptSpineMergePlan requires graphService.db');
+    }
+
+    const applied = {clusters: 0, tombstonedAliases: 0, rewiredEdges: 0, removedDuplicateEdges: 0};
+
+    runGraphTransaction(db, () => {
+        for (const cluster of plan?.clusters || []) {
+            applied.clusters++;
+
+            upsertCanonicalConceptNode({graphService, db, cluster});
+
+            for (const alias of cluster.aliases) {
+                if (tombstoneAliasNode({graphService, db, cluster, alias})) {
+                    applied.tombstonedAliases++;
+                }
+            }
+
+            for (const rewrite of cluster.edgeRewrites) {
+                const primary = getEdgeRecord(db, rewrite.primaryEdgeId);
+                if (!primary) continue;
+
+                setRecordField(primary, 'source', rewrite.source);
+                setRecordField(primary, 'target', rewrite.target);
+                setRecordField(primary, 'type', rewrite.type);
+                setRecordProperties(primary, {
+                    ...getRecordProperties(primary),
+                    weight                    : rewrite.weight,
+                    conceptSpineMergedEdgeIds : rewrite.edgeIds.filter(id => id !== rewrite.primaryEdgeId),
+                    conceptSpineMergedAt      : cluster.generatedAt,
+                    conceptSpineMergeCollision: rewrite.edgeIds.length > 1
+                });
+                persistEdges(db, [primary]);
+                applied.rewiredEdges++;
+
+                for (const duplicateId of rewrite.edgeIds.filter(id => id !== rewrite.primaryEdgeId)) {
+                    if (removeEdgeRecord(db, duplicateId)) {
+                        applied.removedDuplicateEdges++;
+                    }
+                }
+            }
+        }
+    });
+
+    acknowledgeGraphMutations(db);
+    return applied;
+}
+
+function isSemanticSpineNode(node) {
+    return isSemanticSpineNodeType(node.type || node.label) || hasSemanticSpinePrefix(node.id);
+}
+
+function buildMergeCluster(group, nodeKeys, edges, generatedAt) {
+    const
+        nodeIds      = [...group.nodeIds].sort(),
+        keys         = [...group.keys].sort(),
+        keySet       = new Set(keys),
+        canonicalId  = chooseCanonicalConceptId(nodeIds, keySet),
+        aliases      = nodeIds.filter(id => id !== canonicalId),
+        edgeRewrites = buildEdgeRewrites({nodeIds, canonicalId, edges});
+
+    return {
+        canonicalId,
+        generatedAt,
+        nodeIds,
+        aliases,
+        keys,
+        nodeKeys: Object.fromEntries(nodeIds.map(id => [id, nodeKeys.get(id) || []])),
+        edgeRewrites
+    };
+}
+
+function buildEdgeRewrites({nodeIds, canonicalId, edges}) {
+    const
+        clusterIds = new Set(nodeIds),
+        grouped    = new Map();
+
+    for (const edge of edges) {
+        const sourceIn = clusterIds.has(edge.source),
+              targetIn = clusterIds.has(edge.target);
+
+        if (!sourceIn && !targetIn) continue;
+
+        const
+            source = sourceIn ? canonicalId : edge.source,
+            target = targetIn ? canonicalId : edge.target;
+
+        if (source === target) continue;
+
+        const signature = `${source}\u0000${target}\u0000${edge.type}`;
+        if (!grouped.has(signature)) {
+            grouped.set(signature, {
+                source,
+                target,
+                type         : edge.type,
+                weight       : 0,
+                edgeIds      : [],
+                primaryEdgeId: null
+            });
+        }
+
+        const group = grouped.get(signature);
+        group.weight = Math.max(group.weight, getEdgeWeight(edge));
+        group.edgeIds.push(edge.id);
+        if (!group.primaryEdgeId || (edge.source === source && edge.target === target)) {
+            group.primaryEdgeId = edge.id;
+        }
+    }
+
+    return [...grouped.values()].sort((a, b) => a.primaryEdgeId.localeCompare(b.primaryEdgeId));
+}
+
+function getEdgeWeight(edge) {
+    const weight = Number(edge?.properties?.weight ?? edge?.weight ?? 1);
+    return Number.isFinite(weight) ? weight : 1;
+}
+
+function cloneRecord(record = {}) {
+    return {
+        ...record,
+        properties: {...(record.properties || {})}
+    };
+}
+
+function upsertCanonicalConceptNode({graphService, db, cluster}) {
+    const sourceNode     = getNodeRecord(db, cluster.canonicalId) || getNodeRecord(db, cluster.nodeIds[0]),
+          sourceProps    = getRecordProperties(sourceNode),
+          canonicalProps = {
+              ...sourceProps,
+              canonicalConceptId: cluster.canonicalId,
+              conceptAliases    : cluster.aliases
+          };
+
+    graphService.upsertNode({
+        id         : cluster.canonicalId,
+        type       : getRecordField(sourceNode, 'label') || getRecordField(sourceNode, 'type') || 'CONCEPT',
+        name       : sourceProps.name || cluster.canonicalId,
+        description: sourceProps.description,
+        properties : canonicalProps
+    });
+}
+
+function tombstoneAliasNode({graphService, db, cluster, alias}) {
+    const aliasNode = getNodeRecord(db, alias);
+    if (!aliasNode) return false;
+
+    const aliasProps = getRecordProperties(aliasNode);
+    graphService.upsertNode({
+        id         : alias,
+        type       : getRecordField(aliasNode, 'label') || getRecordField(aliasNode, 'type') || 'CONCEPT',
+        name       : aliasProps.name || alias,
+        description: aliasProps.description,
+        properties : {
+            ...aliasProps,
+            aliasOf                 : cluster.canonicalId,
+            canonicalConceptId      : cluster.canonicalId,
+            conceptSpineTombstonedAt: cluster.generatedAt,
+            conceptSpineTombstoneBy : 'concept-spine-alias-merge'
+        }
+    });
+
+    return true;
+}
+
+function runGraphTransaction(db, fn) {
+    if (db.isExecutingTransaction || typeof db.transaction !== 'function') {
+        return fn();
+    }
+
+    return db.transaction(fn);
+}
+
+function getNodeRecord(db, id) {
+    return db?.nodes?.get?.(id) || null;
+}
+
+function getEdgeRecord(db, id) {
+    return db?.edges?.get?.(id) || db?.edges?.items?.find(edge => edge.id === id) || null;
+}
+
+function removeEdgeRecord(db, id) {
+    const existing = getEdgeRecord(db, id);
+    if (!existing) return false;
+
+    db.removeEdge(id);
+    return true;
+}
+
+function persistEdges(db, edges) {
+    if (db?.autoSave !== false && db?.storage?.addEdges) {
+        db.storage.addEdges(edges);
+    }
+}
+
+function acknowledgeGraphMutations(db) {
+    if (typeof db?.acknowledgeLocalMutations === 'function') {
+        db.acknowledgeLocalMutations();
+    }
+}
+
+function getRecordField(record, field) {
+    if (!record) return undefined;
+    return record.isRecord ? record.get(field) : record[field];
+}
+
+function setRecordField(record, field, value) {
+    if (record.isRecord) {
+        record.set(field, value);
+    } else {
+        record[field] = value;
+    }
+}
+
+function getRecordProperties(record) {
+    return {...(getRecordField(record, 'properties') || {})};
+}
+
+function setRecordProperties(record, properties) {
+    setRecordField(record, 'properties', properties);
+}
+
+class UnionFind {
+    parent = new Map()
+
+    add(value) {
+        if (!this.parent.has(value)) {
+            this.parent.set(value, value);
+        }
+    }
+
+    find(value) {
+        this.add(value);
+
+        const parent = this.parent.get(value);
+        if (parent === value) return value;
+
+        const root = this.find(parent);
+        this.parent.set(value, root);
+        return root;
+    }
+
+    union(a, b) {
+        const rootA = this.find(a),
+              rootB = this.find(b);
+
+        if (rootA !== rootB) {
+            this.parent.set(rootB, rootA);
+        }
+    }
+}

--- a/ai/services/graph/conceptSpineCanonicalization.mjs
+++ b/ai/services/graph/conceptSpineCanonicalization.mjs
@@ -69,7 +69,7 @@ export function canonicalizeSemanticGraphNodeId({id, type, name} = {}) {
         return id;
     }
 
-    return canonicalizeConceptId(id || name);
+    return canonicalizeConceptId(id || name) || id;
 }
 
 /**

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -427,6 +427,8 @@ function ensureTaggedConceptNode(id) {
 
     try {
         const db = GraphService.requireDb('MailboxService.ensureTaggedConceptNode');
+        // Cache-warm before checking existence so persisted rich nodes are not
+        // overwritten by a cold in-memory miss; mirrors GraphService.upsertNode.
         db.getAdjacentNodes(id, 'both');
         if (db.nodes.has(id)) return;
 

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -2,6 +2,7 @@ import Base                                     from '../../../src/core/Base.mjs
 import aiConfig                                 from '../../mcp/server/memory-core/config.mjs';
 import logger                                   from '../../mcp/server/memory-core/logger.mjs';
 import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {canonicalizeTaggedConceptIds}           from '../graph/conceptSpineCanonicalization.mjs';
 import GraphService                             from './GraphService.mjs';
 import PermissionService                        from './PermissionService.mjs';
 import WakeSubscriptionService                  from './WakeSubscriptionService.mjs';
@@ -325,6 +326,26 @@ function getMessageWalArray(value) {
     return Array.isArray(value) ? value : [];
 }
 
+function buildTaggedConceptFilterGroups(values = []) {
+    if (!Array.isArray(values)) return [];
+
+    const groups = new Map();
+
+    for (const value of values) {
+        const
+            raw       = typeof value === 'string' ? value.trim() : '',
+            canonical = canonicalizeTaggedConceptIds([value])[0] || '',
+            key       = canonical || raw;
+
+        if (!key) continue;
+        if (!groups.has(key)) groups.set(key, new Set());
+        if (canonical) groups.get(key).add(canonical);
+        if (raw) groups.get(key).add(raw);
+    }
+
+    return [...groups.values()].map(group => [...group]);
+}
+
 /**
  * @summary Returns a safe endpoint spec for replaying accepted mailbox WAL records after graph loss.
  * @param {String} id Graph node id required by a delivery-critical mailbox edge.
@@ -398,6 +419,27 @@ function ensureMailboxProjectionEndpoint(id) {
     const spec = getMailboxEndpointRestoreSpec(id);
     if (spec) {
         GraphService.upsertGlobalNode(spec);
+    }
+}
+
+function ensureTaggedConceptNode(id) {
+    if (typeof id !== 'string' || id.length === 0) return;
+
+    try {
+        const db = GraphService.requireDb('MailboxService.ensureTaggedConceptNode');
+        db.getAdjacentNodes(id, 'both');
+        if (db.nodes.has(id)) return;
+
+        GraphService.upsertGlobalNode({
+            id,
+            type      : 'CONCEPT',
+            name      : id,
+            properties: {
+                canonicalConceptId: id
+            }
+        });
+    } catch (e) {
+        logger.warn(`[MailboxService] tagged concept node restore skipped for ${id}: ${e.message}`);
     }
 }
 
@@ -923,6 +965,8 @@ class MailboxService extends Base {
             throw new Error(`Invalid task state: ${task.state}. Must be one of: ${MailboxService.VALID_TASK_STATES.join(', ')}`);
         }
 
+        taggedConcepts = canonicalizeTaggedConceptIds(taggedConcepts);
+
         const wakeSuppressionRisk = getWakeSuppressionRisk({wakeSuppressed, to, subject, priority, taggedConcepts, task});
 
         if (wakeSuppressionRisk) {
@@ -1086,6 +1130,7 @@ class MailboxService extends Base {
             linkOptionalMailboxEdge(messageId, t, 'REFERENCES_TICKET', 1.0, edgeProperties);
         }
         for (const c of getMessageWalArray(optionalEdges.taggedConcepts)) {
+            ensureTaggedConceptNode(c);
             linkOptionalMailboxEdge(messageId, c, 'TAGGED_CONCEPT', 1.0, edgeProperties);
         }
 
@@ -1220,7 +1265,9 @@ class MailboxService extends Base {
             throw RequestContextService.unboundIdentityError('list messages');
         }
 
-        const target = to || me;
+        const
+            target                       = to || me,
+            requestedTaggedConceptGroups = buildTaggedConceptFilterGroups(taggedConcepts);
 
         if (target !== me && target !== 'AGENT:*') {
             if (!PermissionService.hasPermission(me, target, 'CAN_READ_INBOX_OF')) {
@@ -1342,10 +1389,10 @@ class MailboxService extends Base {
                     if (fromIdentity && sentByNodeId !== fromIdentity) continue;
                     if (threadId && foundThreadId !== threadId) continue;
 
-                    if (taggedConcepts && taggedConcepts.length > 0) {
+                    if (requestedTaggedConceptGroups.length > 0) {
                         let hasAllConcepts = true;
-                        for (const concept of taggedConcepts) {
-                            if (!messageTaggedConcepts.includes(concept)) {
+                        for (const conceptGroup of requestedTaggedConceptGroups) {
+                            if (!conceptGroup.some(concept => messageTaggedConcepts.includes(concept))) {
                                 hasAllConcepts = false;
                                 break;
                             }

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -222,7 +222,7 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
 
             // Check if RELATES_TO edge was added to the GraphService (since frontier exists)
             const edges = GraphService.db.edges.items;
-            expect(edges.some(e => e.type === 'RELATES_TO' && e.source === 'CONCEPT:TestConcept')).toBe(true);
+            expect(edges.some(e => e.type === 'RELATES_TO' && e.source === 'test-concept')).toBe(true);
 
             // MENTIONED_IN shouldn't be in the DB directly because it targets a non-existent node
             expect(edges.some(e => e.type === 'MENTIONED_IN')).toBe(false);
@@ -257,9 +257,9 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
             expect(result).not.toBeNull();
             expect(Array.isArray(result)).toBe(true);
             expect(result.length).toBe(3);
-            expect(result).toContain("CONCEPT:mailbox-service");
-            expect(result).toContain("CLASS:Neo.ai.services.memory-core.MailboxService");
-            expect(result).toContain("CONCEPT:auto-emit");
+            expect(result).toContain("mailbox-service");
+            expect(result).toContain("neo-ai-services-memory-core-mailbox-service");
+            expect(result).toContain("auto-emit");
             expect(result).not.toContain("invalid-concept"); // properly filtered
         } finally {
             // Restore global function
@@ -1002,8 +1002,8 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
             expect(result.session_artifact.human_readable_summary).toContain('summary-0');
             expect(result.session_artifact.human_readable_summary).toContain('summary-1');
             expect(result.session_artifact.roadmap_impact).toBe('second chunk impact');
-            expect(GraphService.db.nodes.get('CLASS:Shared0')).toBeTruthy();
-            expect(GraphService.db.nodes.get('CLASS:Shared1')).toBeFalsy();
+            expect(GraphService.db.nodes.get('shared0')).toBeTruthy();
+            expect(GraphService.db.nodes.get('shared1')).toBeFalsy();
         } finally {
             OpenAiCompatible.prototype.generate = baseGenerate;
             setConfigOverrides(originalOverrides);

--- a/test/playwright/unit/ai/services/graph/conceptSpineCanonicalization.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/conceptSpineCanonicalization.spec.mjs
@@ -1,0 +1,255 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    applyConceptSpineMergePlan,
+    buildConceptSpineMergePlan,
+    canonicalizeSemanticGraphNodeId,
+    canonicalizeTaggedConceptIds,
+    chooseCanonicalConceptId,
+    executeConceptSpineMergePlan,
+    normalizeConceptKey
+} from '../../../../../../ai/services/graph/conceptSpineCanonicalization.mjs';
+
+test.describe('conceptSpineCanonicalization', () => {
+    test('normalizes legacy semantic prefixes to bare lower-kebab ids', () => {
+        expect(normalizeConceptKey('CONCEPT:GoldenPath')).toBe('golden-path');
+        expect(normalizeConceptKey('CLASS:Neo.ai.services.memory-core.MailboxService')).toBe('neo-ai-services-memory-core-mailbox-service');
+        expect(normalizeConceptKey('PROCESS:Dream Pipeline')).toBe('dream-pipeline');
+        expect(canonicalizeSemanticGraphNodeId({
+            id  : 'CONCEPT:Golden Path Synthesis',
+            type: 'CONCEPT'
+        })).toBe('golden-path-synthesis');
+        expect(canonicalizeSemanticGraphNodeId({
+            id  : 'file:learn/agentos/DreamPipeline.md',
+            type: 'FILE'
+        })).toBe('file:learn/agentos/DreamPipeline.md');
+    });
+
+    test('canonicalizes tagged concept filters while preserving first-seen order', () => {
+        expect(canonicalizeTaggedConceptIds([
+            'CONCEPT:GoldenPath',
+            'golden-path',
+            'v13.1',
+            'ADR-0019'
+        ])).toEqual([
+            'golden-path',
+            'v13-1',
+            'adr-0019'
+        ]);
+    });
+
+    test('prefers existing bare canonical ids before deriving from prefixed aliases', () => {
+        expect(chooseCanonicalConceptId(
+            ['CONCEPT:GoldenPath', 'golden-path', 'CONCEPT:Golden Path Synthesis'],
+            new Set(['golden-path', 'golden-path-synthesis'])
+        )).toBe('golden-path');
+    });
+
+    test('plans and applies alias merges with MAX-weight edge collision handling', () => {
+        const nodes = [
+            {
+                id        : 'golden-path',
+                type      : 'CONCEPT',
+                properties: {name: 'Golden Path'}
+            },
+            {
+                id        : 'CONCEPT:GoldenPath',
+                type      : 'CONCEPT',
+                properties: {name: 'Golden Path'}
+            },
+            {
+                id        : 'CONCEPT:Golden Path Synthesis',
+                type      : 'CONCEPT',
+                properties: {
+                    name   : 'Golden Path Synthesis',
+                    aliases: ['Golden Path']
+                }
+            },
+            {
+                id        : 'file:learn/agentos/DreamPipeline.md',
+                type      : 'FILE',
+                properties: {}
+            }
+        ];
+
+        const edges = [
+            {
+                id        : 'edge-canonical',
+                source    : 'golden-path',
+                target    : 'file:learn/agentos/DreamPipeline.md',
+                type      : 'EXPLAINED_BY',
+                properties: {weight: 0.4}
+            },
+            {
+                id        : 'edge-alias',
+                source    : 'CONCEPT:GoldenPath',
+                target    : 'file:learn/agentos/DreamPipeline.md',
+                type      : 'EXPLAINED_BY',
+                properties: {weight: 0.9}
+            },
+            {
+                id        : 'edge-other-alias',
+                source    : 'CONCEPT:Golden Path Synthesis',
+                target    : 'file:learn/agentos/DreamPipeline.md',
+                type      : 'IMPLEMENTED_BY',
+                properties: {weight: 0.7}
+            }
+        ];
+
+        const plan = buildConceptSpineMergePlan({
+            nodes,
+            edges,
+            generatedAt: '2026-07-03T00:00:00.000Z'
+        });
+
+        expect(plan.clusters).toHaveLength(1);
+        expect(plan.clusters[0].canonicalId).toBe('golden-path');
+        expect(plan.clusters[0].aliases).toEqual([
+            'CONCEPT:Golden Path Synthesis',
+            'CONCEPT:GoldenPath'
+        ]);
+
+        const result        = applyConceptSpineMergePlan({nodes, edges, plan});
+        const explainedBy   = result.edges.find(edge => edge.id === 'edge-canonical');
+        const implementedBy = result.edges.find(edge => edge.type === 'IMPLEMENTED_BY');
+
+        expect(explainedBy.source).toBe('golden-path');
+        expect(explainedBy.properties.weight).toBe(0.9);
+        expect(explainedBy.properties.conceptSpineMergeCollision).toBe(true);
+        expect(result.edges.some(edge => edge.id === 'edge-alias')).toBe(false);
+        expect(implementedBy.source).toBe('golden-path');
+
+        const aliasNode = result.nodes.find(node => node.id === 'CONCEPT:GoldenPath');
+        expect(aliasNode.properties.aliasOf).toBe('golden-path');
+        expect(aliasNode.properties.conceptSpineTombstonedAt).toBe('2026-07-03T00:00:00.000Z');
+        expect(result.applied.removedDuplicateEdges).toBe(1);
+    });
+
+    test('executes merge plans against a GraphService-like mutation seam', () => {
+        const nodes = [
+            {
+                id        : 'golden-path',
+                label     : 'CONCEPT',
+                properties: {name: 'Golden Path'}
+            },
+            {
+                id        : 'CONCEPT:GoldenPath',
+                label     : 'CONCEPT',
+                properties: {name: 'Golden Path'}
+            },
+            {
+                id        : 'file:learn/agentos/DreamPipeline.md',
+                label     : 'FILE',
+                properties: {}
+            }
+        ];
+
+        const edges = [
+            {
+                id        : 'edge-canonical',
+                source    : 'golden-path',
+                target    : 'file:learn/agentos/DreamPipeline.md',
+                type      : 'EXPLAINED_BY',
+                properties: {weight: 0.4}
+            },
+            {
+                id        : 'edge-alias',
+                source    : 'CONCEPT:GoldenPath',
+                target    : 'file:learn/agentos/DreamPipeline.md',
+                type      : 'EXPLAINED_BY',
+                properties: {weight: 0.9}
+            }
+        ];
+
+        const plan = buildConceptSpineMergePlan({
+            nodes,
+            edges,
+            generatedAt: '2026-07-03T00:00:00.000Z'
+        });
+
+        const graphService = createFakeGraphService({nodes, edges});
+        const applied      = executeConceptSpineMergePlan({graphService, plan});
+
+        expect(applied).toEqual({
+            clusters             : 1,
+            tombstonedAliases    : 1,
+            rewiredEdges         : 1,
+            removedDuplicateEdges: 1
+        });
+
+        const edge = graphService.db.edges.get('edge-canonical');
+        expect(edge.source).toBe('golden-path');
+        expect(edge.properties.weight).toBe(0.9);
+        expect(edge.properties.conceptSpineMergeCollision).toBe(true);
+        expect(graphService.db.edges.get('edge-alias')).toBeNull();
+
+        const aliasNode = graphService.db.nodes.get('CONCEPT:GoldenPath');
+        expect(aliasNode.properties.aliasOf).toBe('golden-path');
+        expect(graphService.acknowledged).toBe(true);
+    });
+});
+
+function createFakeGraphService({nodes, edges}) {
+    const
+        nodeMap = new Map(nodes.map(node => [node.id, cloneFixtureRecord(node)])),
+        edgeMap = new Map(edges.map(edge => [edge.id, cloneFixtureRecord(edge)]));
+
+    const graphService = {
+        acknowledged: false,
+        db          : null,
+        upsertNode(node) {
+            const existing = nodeMap.get(node.id) || {
+                id        : node.id,
+                label     : node.type,
+                properties: {}
+            };
+
+            existing.label      = node.type || existing.label;
+            existing.properties = {
+                ...(existing.properties || {}),
+                ...(node.properties || {})
+            };
+            nodeMap.set(node.id, existing);
+        }
+    };
+
+    graphService.db = {
+        get autoSave() {
+            return true;
+        },
+        nodes: {
+            get: id => nodeMap.get(id) || null
+        },
+        edges: {
+            get  : id => edgeMap.get(id) || null,
+            items: [...edgeMap.values()]
+        },
+        storage: {
+            addEdges(updatedEdges) {
+                for (const edge of updatedEdges) {
+                    edgeMap.set(edge.id, edge);
+                }
+                graphService.db.edges.items = [...edgeMap.values()];
+            }
+        },
+        removeEdge(id) {
+            edgeMap.delete(id);
+            this.edges.items = [...edgeMap.values()];
+        },
+        transaction(fn) {
+            return fn();
+        },
+        acknowledgeLocalMutations() {
+            graphService.acknowledged = true;
+        }
+    };
+
+    return graphService;
+}
+
+function cloneFixtureRecord(record) {
+    return {
+        ...record,
+        properties: {...(record.properties || {})}
+    };
+}

--- a/test/playwright/unit/ai/services/graph/conceptSpineCanonicalization.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/conceptSpineCanonicalization.spec.mjs
@@ -38,6 +38,19 @@ test.describe('conceptSpineCanonicalization', () => {
         ]);
     });
 
+    test('falls back to raw semantic ids when canonicalization would empty the key', () => {
+        expect(canonicalizeSemanticGraphNodeId({
+            id  : 'CONCEPT:日本語',
+            type: 'CONCEPT',
+            name: '日本語'
+        })).toBe('CONCEPT:日本語');
+
+        expect(canonicalizeSemanticGraphNodeId({
+            id  : 'CONCEPT:★★★',
+            type: 'CONCEPT'
+        })).toBe('CONCEPT:★★★');
+    });
+
     test('prefers existing bare canonical ids before deriving from prefixed aliases', () => {
         expect(chooseCanonicalConceptId(
             ['CONCEPT:GoldenPath', 'golden-path', 'CONCEPT:Golden Path Synthesis'],

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -744,7 +744,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(node.properties.to).toBe('@bob');
         expect(node.properties.inReplyTo).toBe('MESSAGE:abc');
         expect(node.properties.partOfThread).toBe('THREAD:xyz');
-        expect(node.properties.taggedConcepts).toEqual(['CONCEPT:test']);
+        expect(node.properties.taggedConcepts).toEqual(['test']);
         expect(node.properties.wakeSuppressed).toBe(false);
 
         let edges = GraphService.db.edges.items.filter(e => e.source === msgId);
@@ -753,7 +753,17 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(edges.find(e => e.type === 'REFERENCES_TICKET' && e.target === 'ISSUE:10168')).toBeDefined();
         expect(edges.find(e => e.type === 'IN_REPLY_TO' && e.target === 'MESSAGE:abc')).toBeDefined();
         expect(edges.find(e => e.type === 'PART_OF_THREAD' && e.target === 'THREAD:xyz')).toBeDefined();
-        expect(edges.find(e => e.type === 'TAGGED_CONCEPT' && e.target === 'CONCEPT:test')).toBeDefined();
+        expect(edges.find(e => e.type === 'TAGGED_CONCEPT' && e.target === 'test')).toBeDefined();
+        expect(GraphService.db.nodes.get('test').properties.canonicalConceptId).toBe('test');
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            const byLegacyFilter = await MailboxService.listMessages({
+                status        : 'all',
+                taggedConcepts: ['CONCEPT:test']
+            });
+
+            expect(byLegacyFilter.messages.map(message => message.messageId)).toContain(msgId);
+        });
     });
 
     test('addMessage persists wakeSuppressed mailbox-only messages as unread inbox items', async () => {


### PR DESCRIPTION
Resolves #14502
Related: #14472

Implements the residual concept-spine canonicalization slice after the detector/report and concept-touch measurement children landed. The PR introduces one shared concept-spine policy/helper, reuses it from the detector/probe surfaces, adds a merge executor with tombstoned alias nodes and MAX-weight edge collision handling, and routes both mint sites (`SemanticGraphExtractor` and `MailboxService`) through canonical bare kebab ids before writing.

Evidence: L2 achieved with hermetic merge-executor coverage, mint-path unit coverage, detector/probe regression coverage, and no-fix preflight; L3 remains required for executing the merge against the deployment graph and rerunning the live probe. Residual: post-merge live validation checklist below.

## Deltas from ticket
The previously merged child PRs cover the full-spine detector/report and concept-touch measurement evidence; this PR deliberately scopes to the residual merge executor plus mint-time guard. Mailbox reads preserve compatibility by accepting legacy prefixed tag filters while storing new tags canonically. Ambiguous aliases still require an explicit metadata bridge; the helper does not force broad suffix synonym merges.

Review response delta: Vega/Fable caught that kebab-emptying semantic ids could make `canonicalizeSemanticGraphNodeId()` return `''`, violating the ticket's never-block write fallback. The helper now falls back to the raw semantic id when canonicalization empties the key, preserving `SemanticGraphExtractor` writes for pathological concept names while keeping the value visible as a legacy-form outlier. The cache-warm comment in `MailboxService.ensureTaggedConceptNode()` now mirrors the existing `GraphService.upsertNode()` discipline.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/graph/conceptSpineCanonicalization.spec.mjs` — 6 passed
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/auditConceptSpineAliases.spec.mjs test/playwright/unit/ai/services/graph/conceptNeighborhoodProbe.spec.mjs` — 10 passed
- `npm run test-unit -- test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs` — 16 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — 80 passed
- `npm run test-unit -- test/playwright/unit/ai/services/graph/conceptSpineCanonicalization.spec.mjs test/playwright/unit/ai/scripts/maintenance/auditConceptSpineAliases.spec.mjs test/playwright/unit/ai/services/graph/conceptNeighborhoodProbe.spec.mjs test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — 112 passed
- `npm run agent-preflight -- --no-fix ai/services/graph/conceptSpineCanonicalization.mjs ai/services/memory-core/MailboxService.mjs test/playwright/unit/ai/services/graph/conceptSpineCanonicalization.spec.mjs` — passed
- `git diff --cached --check` — passed before commit

## Post-Merge Validation
- [ ] Execute the concept-spine merge plan against the live graph and verify alias nodes are tombstoned, duplicate edges are removed, and no orphaned edges remain.
- [ ] Report any surviving intra-cluster tombstone-to-tombstone edge residue separately from orphaned edges.
- [ ] Verify a canonical `golden-path` filter matches a pre-migration legacy-tagged message after the live merge rewires `TAGGED_CONCEPT` edges.
- [ ] Rerun the concept-neighborhood probe over Golden Path and Dream Pipeline and verify single-neighborhood resolution.

## Commits
- `d87223065a` — `feat(graph): canonicalize concept spine aliases (#14502)`
- `3e9802bd5d` — `fix(graph): preserve concept write fallback (#14502)`

Authored by Euclid (GPT-5, Codex Desktop). Session 7186fa08-ba22-48eb-bc1e-84325fa26e40.
