### PR TITLE
fix(ai): NL/github/gitlab MCP configs participate in the Tier-1 hierarchy (ADR-19 §2.1)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -1,3 +1,7 @@
+// Loads the Tier-1 realm root (Neo.ai.Config) so getParent() resolves inherited leaves (auth.*)
+// through the provider chain — the same participation the memory-core and knowledge-base configs
+// use. Without it, any inherited-leaf read on this config throws at boot.
+import '../../../config.template.mjs';
 import path                                        from 'path';
 import {fileURLToPath}                             from 'url';
 import ConfigProvider, { createConfigProxy, leaf } from '../../../ConfigProvider.mjs';

--- a/ai/mcp/server/gitlab-workflow/config.template.mjs
+++ b/ai/mcp/server/gitlab-workflow/config.template.mjs
@@ -1,3 +1,7 @@
+// Loads the Tier-1 realm root (Neo.ai.Config) so getParent() resolves inherited leaves (auth.*)
+// through the provider chain — the same participation the memory-core and knowledge-base configs
+// use. Without it, any inherited-leaf read on this config throws at boot.
+import '../../../config.template.mjs';
 import path                                      from 'path';
 import {fileURLToPath}                           from 'url';
 import ConfigProvider, {createConfigProxy, leaf} from '../../../ConfigProvider.mjs';

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -1,3 +1,7 @@
+// Loads the Tier-1 realm root (Neo.ai.Config) so getParent() resolves inherited leaves (auth.*)
+// through the provider chain — the same participation the memory-core and knowledge-base configs
+// use. Without it, any inherited-leaf read on this config throws at boot.
+import '../../../config.template.mjs';
 import os              from 'os';
 import path            from 'path';
 import {fileURLToPath} from 'url';

--- a/test/playwright/unit/ai/mcp/server/config-participation.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/config-participation.spec.mjs
@@ -1,0 +1,43 @@
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs/promises';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+const __dirname  = path.dirname(fileURLToPath(import.meta.url));
+const serverRoot = path.resolve(__dirname, '../../../../../../ai/mcp/server');
+
+/*
+ * Contract: every MCP server config participates in the Tier-1 realm hierarchy by loading the root
+ * config module, so getParent() resolves inherited Tier-1 leaves (auth.*, engines.*) through the
+ * provider chain. A server config that skips this import has no resolvable parent — the moment any
+ * consumer reads an inherited leaf on it (AuthService / TransportService under sse transport, or the
+ * boot freshness guard) it throws "Cannot read properties of undefined (reading 'mode')", the live
+ * NL-bridge boot crash. This test fails red for any standalone server config, so a new server cannot
+ * ship without participating. It accepts both the side-effect import form and the named-import form.
+ */
+const ROOT_IMPORT = /^import\s+(?:[^'"\n]*\bfrom\s+)?['"]\.\.\/\.\.\/\.\.\/config\.template\.mjs['"]/m;
+
+test.describe('MCP server config Tier-1 hierarchy participation', () => {
+    test('every ai/mcp/server/*/config.template.mjs loads the Tier-1 realm root', async () => {
+        const entries   = await fs.readdir(serverRoot, {withFileTypes: true});
+        const templates = [];
+
+        for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+
+            const templatePath = path.join(serverRoot, entry.name, 'config.template.mjs');
+
+            try {
+                templates.push({name: entry.name, src: await fs.readFile(templatePath, 'utf8')});
+            } catch {
+                // a server dir without a config.template.mjs (e.g. shared/) is not a server config
+            }
+        }
+
+        expect(templates.length, 'expected at least one server config.template.mjs').toBeGreaterThan(0);
+
+        const standalone = templates.filter(entry => !ROOT_IMPORT.test(entry.src)).map(entry => entry.name).sort();
+
+        expect(standalone, 'server configs missing the Tier-1 realm-root import — they will crash on any inherited-leaf read').toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

Three MCP server configs — `neural-link`, `github-workflow`, `gitlab-workflow` — did not load the Tier-1 realm root, so their provider chain had no resolvable parent. Any read of an inherited Tier-1 leaf on them (`auth.mode` in the boot freshness guard; `AuthService` / `TransportService` under sse transport) threw `Cannot read properties of undefined (reading 'mode')` — the live NL-bridge boot crash behind #14499. This makes all five server configs participate uniformly (`memory-core` + `knowledge-base` already do) and adds a contract test so a new server config cannot ship standalone.

This is the **§2.1 (hierarchy participation)** half of the #14499 remediation. @neo-opus-ada's #14524 is the §3 crash-fix + AGENTS.md read-gate, and her §2/§3 Option B (own-config `validateRequiredEnv`) builds on this participation. Fix-forward, not a revert.

Resolves #14521
Refs #14523

## The fix

Each of the three `config.template.mjs` gains one side-effect import of the Tier-1 root (`import '../../../config.template.mjs'`, materialized to `import '../../../config.mjs'`) — the `memory-core` form. These configs consume Tier-1 leaves via shared services but do not bind `AiConfig` themselves, so a named import (the `knowledge-base` form) would be an unused binding.

## Test Evidence

New contract test `test/playwright/unit/ai/mcp/server/config-participation.spec.mjs` asserts every `ai/mcp/server/*/config.template.mjs` loads the Tier-1 root (accepts both side-effect and named-import forms).

Evidence: proven as a true falsifier (red-before / green-after), not asserted —
- **RED on dev (pre-fix):** failed listing exactly `["github-workflow", "gitlab-workflow", "neural-link"]` (MC + KB correctly absent).
- **GREEN post-fix:** `1 passed (30.7s)`.
- **Functional:** force-regenerated the three `config.mjs` from the fixed templates and loaded each in a Neo boot context — all three resolve `auth.mode = "oidc"` via the chain, no crash.

## Deltas

- `ai/mcp/server/neural-link/config.template.mjs`: + Tier-1 root import + behavior comment.
- `ai/mcp/server/github-workflow/config.template.mjs`: + Tier-1 root import + behavior comment.
- `ai/mcp/server/gitlab-workflow/config.template.mjs`: + Tier-1 root import + behavior comment.
- `test/playwright/unit/ai/mcp/server/config-participation.spec.mjs`: new contract test (the standalone-config falsifier).

## Post-Merge Validation

- [ ] Cloud rebuild (build-time `initServerConfigs` regenerates `config.mjs` from templates) — the three servers boot with `auth.*` resolving under sse + gitlab-pat.
- [ ] `config-participation.spec.mjs` green in the CI unit suite.
- [ ] Honest bound (out of scope, flagged for follow-up): `npm run prepare --migrate-config` does not propagate a newly-added side-effect import to an **existing** `config.mjs` (the drift-detector doesn't flag it); fresh materialization (cloud build / `rm` + regenerate) does. Non-urgent — NL/gh/gitlab are stdio locally with no auth path — but it belongs in the ADR-19 lint convergence (#14500).

Authored by Grace (Claude Opus 4.8, Claude Code).
