### PR TITLE
fix(release): neutralize analyzer cutoff label (#14531)

### DIFF
--- a/buildScripts/release/analyzeClosedSinceRelease.mjs
+++ b/buildScripts/release/analyzeClosedSinceRelease.mjs
@@ -15,8 +15,8 @@ import {fileURLToPath} from 'url';
  *
  * Usage:
  *   node buildScripts/release/analyzeClosedSinceRelease.mjs [cutoff-date-ISO]
- *   # defaults to v12.1 release (2026-03-27)
- *   node buildScripts/release/analyzeClosedSinceRelease.mjs 2026-03-27 --format markdown --include-items --output /tmp/v13-appendix.md
+ *   # defaults to cutoff 2026-03-27; pass an explicit previous-release cutoff for later releases
+ *   node buildScripts/release/analyzeClosedSinceRelease.mjs 2026-03-27 --format markdown --include-items --output /tmp/release-appendix.md
  *
  * Output:
  *   - Merged PR and closed issue counts
@@ -311,13 +311,13 @@ function renderText(report, options) {
 function renderMarkdown(report, options) {
     const {closedIssues, mergedPulls, labelCounts, parentCounts, epicIssues, authorCounts, scopeCounts} = report;
     const lines = [
-        '# v13 Release Appendix Report',
+        '# Release Appendix Report',
         '',
         `Generated from local recursive content mirrors on ${new Date().toISOString()}.`,
         '',
         '## Source Boundary',
         '',
-        `- Cutoff: \`${options.cutoff}\` (v12.1.0 release boundary).`,
+        `- Cutoff: \`${options.cutoff}\` (explicit previous-release boundary).`,
         '- PR source: `resources/content/pulls/**/*.md` with `state: MERGED` and `mergedAt >= cutoff`.',
         '- Issue source: `resources/content/issues/**/*.md` with `state: CLOSED` and `closedAt >= cutoff`.',
         '- Freshness: local mirror only. Run `sync_all` or live GitHub count checks immediately before release cut.',
@@ -387,7 +387,7 @@ function renderMarkdown(report, options) {
             'Run this command immediately before release cut to produce the full PR and issue tables:',
             '',
             '```bash',
-            `node buildScripts/release/analyzeClosedSinceRelease.mjs ${options.cutoff} --format markdown --include-items --output /tmp/v13-release-appendix.md`,
+            `node buildScripts/release/analyzeClosedSinceRelease.mjs ${options.cutoff} --format markdown --include-items --output /tmp/release-appendix.md`,
             '```'
         )
     }


### PR DESCRIPTION
Resolves #14531

Neutralizes stale release-boundary wording in `buildScripts/release/analyzeClosedSinceRelease.mjs` so explicit v13.0 cutoff runs no longer print `v12.1.0 release boundary` or v13-specific output filenames. The script still counts the same local mirror data; only the generated labels/help prose now describe the cutoff as an explicit previous-release boundary.

Evidence: L1 (syntax check + sample CLI output in sandbox) -> L1 required (build-script text output). Residual: none.

## Deltas from ticket

Chose the smallest durable shape: neutral cutoff language instead of adding release-name inference. This avoids teaching the script to infer version labels from dates without a source of truth.

## Test Evidence

- `node --check buildScripts/release/analyzeClosedSinceRelease.mjs` -> passed.
- `node buildScripts/release/analyzeClosedSinceRelease.mjs --help` -> passed; no stale v12.1 wording.
- `node buildScripts/release/analyzeClosedSinceRelease.mjs 2026-06-12 --format markdown` -> passed; output now says `explicit previous-release boundary`.
- `rg "v12\\.1" buildScripts/release/analyzeClosedSinceRelease.mjs` -> no matches.
- `npm run agent-preflight -- --no-fix buildScripts/release/analyzeClosedSinceRelease.mjs` -> passed.

## Post-Merge Validation

- [ ] Re-run the #14475 release appendix command before the v13.1 cut and confirm no manual boundary-label caveat is needed.

Authored by Euclid (GPT-5, Codex Desktop). Session 7186fa08-ba22-48eb-bc1e-84325fa26e40.
