### PR TITLE
fix(focus): walk component tree for focus moves (#6129)

### DIFF
--- a/src/manager/Focus.mjs
+++ b/src/manager/Focus.mjs
@@ -107,21 +107,19 @@ class Focus extends CoreBase {
         if (commonId) {
             component = Neo.getComponent(commonId);
 
-            if (!component) {
-                return
+            if (component) {
+                data = {
+                    component,
+                    path   : opts.data.path,
+                    oldPath: history[0].data.path
+                };
+
+                component.onFocusMove?.(data);
+                component.fire('focusMove', data);
+
+                component.onFocusChange?.(data);
+                component.fire('focusChange', data)
             }
-
-            data = {
-                component,
-                path   : opts.data.path,
-                oldPath: history[0].data.path
-            };
-
-            component.onFocusMove?.(data);
-            component.fire('focusMove', data);
-
-            component.onFocusChange?.(data);
-            component.fire('focusChange', data)
         }
 
         me.addToHistory(opts)

--- a/src/manager/Focus.mjs
+++ b/src/manager/Focus.mjs
@@ -1,5 +1,4 @@
 import CoreBase from '../core/Base.mjs';
-import NeoArray from '../util/Array.mjs';
 
 /**
  * @class Neo.manager.Focus
@@ -95,33 +94,51 @@ class Focus extends CoreBase {
             {history}        = me,
             newComponentPath = opts.componentPath,
             oldComponentPath = history[0].componentPath,
-            focusEnter       = NeoArray.difference(newComponentPath, oldComponentPath),
-            focusLeave       = NeoArray.difference(oldComponentPath, newComponentPath),
-            focusMove        = NeoArray.intersection(newComponentPath, oldComponentPath),
+            commonId         = me.getClosestCommonComponentId(oldComponentPath, newComponentPath),
+            oldCommonIndex   = oldComponentPath.indexOf(commonId),
+            newCommonIndex   = newComponentPath.indexOf(commonId),
+            focusLeave       = oldCommonIndex === -1 ? oldComponentPath : oldComponentPath.slice(0, oldCommonIndex),
+            focusEnter       = newCommonIndex === -1 ? newComponentPath : newComponentPath.slice(0, newCommonIndex),
             component, data;
 
         me.setComponentFocus({componentPath: focusLeave, data: opts.data}, false);
         me.setComponentFocus({componentPath: focusEnter, data: opts.data}, true);
 
-        focusMove.forEach(id => {
-            component = Neo.getComponent(id);
+        if (commonId) {
+            component = Neo.getComponent(commonId);
 
-            if (component) {
-                data = {
-                    component,
-                    path   : opts.data.path,
-                    oldPath: history[0].data.path
-                };
-
-                component.onFocusMove?.(data);
-                component.fire('focusMove', data);
-
-                component.onFocusChange?.(data);
-                component.fire('focusChange', data)
+            if (!component) {
+                return
             }
-        });
+
+            data = {
+                component,
+                path   : opts.data.path,
+                oldPath: history[0].data.path
+            };
+
+            component.onFocusMove?.(data);
+            component.fire('focusMove', data);
+
+            component.onFocusChange?.(data);
+            component.fire('focusChange', data)
+        }
 
         me.addToHistory(opts)
+    }
+
+    /**
+     * Finds the nearest shared component between two upward component paths.
+     * Both paths are ordered from the focused component toward the root.
+     * @param {String[]} oldComponentPath Previous component path
+     * @param {String[]} newComponentPath New component path
+     * @returns {String|null} closest common component id
+     * @protected
+     */
+    getClosestCommonComponentId(oldComponentPath, newComponentPath) {
+        const oldIds = new Set(oldComponentPath);
+
+        return newComponentPath.find(id => oldIds.has(id)) || null
     }
 
     /**

--- a/test/playwright/unit/manager/Focus.spec.mjs
+++ b/test/playwright/unit/manager/Focus.spec.mjs
@@ -81,4 +81,122 @@ test.describe('Neo.manager.Focus', () => {
         expect(root.containsFocus).toBe(true);
         expect(FocusManager.history[0].componentPath).toEqual(['focus-new-child', 'focus-parent', 'focus-root']);
     });
+
+    test('handles disjoint component paths without firing focusMove', () => {
+        const log = [];
+
+        components = [
+            createFocusComponent('focus-old-root',  'document.body',  log),
+            createFocusComponent('focus-old-child', 'focus-old-root', log),
+            createFocusComponent('focus-new-root',  'document.body',  log),
+            createFocusComponent('focus-new-child', 'focus-new-root', log)
+        ];
+
+        const [oldRoot, oldChild, newRoot, newChild] = components;
+
+        oldRoot.containsFocus = true;
+        oldChild.containsFocus = true;
+
+        FocusManager.history = [{
+            componentPath: ['focus-old-child', 'focus-old-root'],
+            data         : {path: ['old-dom-node']}
+        }];
+
+        FocusManager.focusMove({
+            componentPath: ['focus-new-child', 'focus-new-root'],
+            data         : {
+                path         : ['new-dom-node'],
+                relatedTarget: null
+            }
+        });
+
+        expect(log).toEqual([
+            ['leave', 'focus-old-child', 'focus-old-child'],
+            ['leave', 'focus-old-root',  'focus-old-root'],
+            ['enter', 'focus-new-child', 'focus-new-child'],
+            ['enter', 'focus-new-root',  'focus-new-root']
+        ]);
+
+        expect(oldChild.containsFocus).toBe(false);
+        expect(oldRoot.containsFocus).toBe(false);
+        expect(newChild.containsFocus).toBe(true);
+        expect(newRoot.containsFocus).toBe(true);
+        expect(FocusManager.history[0].componentPath).toEqual(['focus-new-child', 'focus-new-root']);
+    });
+
+    test('records history when the closest common component no longer exists', () => {
+        const log = [];
+
+        components = [
+            createFocusComponent('focus-old-child', 'document.body', log),
+            createFocusComponent('focus-new-child', 'document.body', log)
+        ];
+
+        const [oldChild, newChild] = components;
+
+        oldChild.containsFocus = true;
+
+        FocusManager.history = [{
+            componentPath: ['focus-old-child', 'focus-missing-common', 'focus-root'],
+            data         : {path: ['old-dom-node']}
+        }];
+
+        FocusManager.focusMove({
+            componentPath: ['focus-new-child', 'focus-missing-common', 'focus-root'],
+            data         : {
+                path         : ['new-dom-node'],
+                relatedTarget: null
+            }
+        });
+
+        expect(log).toEqual([
+            ['leave', 'focus-old-child', 'focus-old-child'],
+            ['enter', 'focus-new-child', 'focus-new-child']
+        ]);
+
+        expect(oldChild.containsFocus).toBe(false);
+        expect(newChild.containsFocus).toBe(true);
+        expect(FocusManager.history[0].componentPath).toEqual(['focus-new-child', 'focus-missing-common', 'focus-root']);
+        expect(FocusManager.history[0].data.path).toEqual(['new-dom-node']);
+    });
+
+    test('notifies only the nearest common component for focusChange consumers', () => {
+        const log = [];
+
+        components = [
+            createFocusComponent('focus-root',      'document.body', log),
+            createFocusComponent('focus-parent',    'focus-root',    log),
+            createFocusComponent('focus-old-child', 'focus-parent',  log),
+            createFocusComponent('focus-new-child', 'focus-parent',  log)
+        ];
+
+        const [root, parent, oldChild] = components;
+
+        root.onFocusChange   = data => log.push(['change', 'root',   data.component.id, data.oldPath, data.path]);
+        parent.onFocusChange = data => log.push(['change', 'parent', data.component.id, data.oldPath, data.path]);
+
+        root.containsFocus = true;
+        parent.containsFocus = true;
+        oldChild.containsFocus = true;
+
+        FocusManager.history = [{
+            componentPath: ['focus-old-child', 'focus-parent', 'focus-root'],
+            data         : {path: ['old-event-node']}
+        }];
+
+        FocusManager.focusMove({
+            componentPath: ['focus-new-child', 'focus-parent', 'focus-root'],
+            data         : {
+                path         : ['new-event-node'],
+                relatedTarget: null
+            }
+        });
+
+        expect(log).toEqual([
+            ['leave',  'focus-old-child', 'focus-old-child'],
+            ['enter',  'focus-new-child', 'focus-new-child'],
+            ['move',   'focus-parent',    'focus-parent', ['old-event-node'], ['new-event-node']],
+            ['change', 'parent',          'focus-parent', ['old-event-node'], ['new-event-node']]
+        ]);
+    });
 });

--- a/test/playwright/unit/manager/Focus.spec.mjs
+++ b/test/playwright/unit/manager/Focus.spec.mjs
@@ -1,0 +1,84 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'ManagerFocusTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import FocusManager   from '../../../../src/manager/Focus.mjs';
+
+test.describe('Neo.manager.Focus', () => {
+    let components;
+
+    test.afterEach(() => {
+        components?.forEach(component => component.destroy());
+        components = null;
+
+        FocusManager.history = [];
+        FocusManager.lastFocusInDate = null;
+        FocusManager.lastFocusOutDate = null;
+    });
+
+    function createFocusComponent(id, parentId, log) {
+        const component = Neo.create(Component, {
+            appName,
+            id,
+            parentId
+        });
+
+        component.onFocusEnter = data => log.push(['enter', id, data.component.id]);
+        component.onFocusLeave = data => log.push(['leave', id, data.component.id]);
+        component.onFocusMove  = data => log.push(['move',  id, data.component.id, data.oldPath, data.path]);
+
+        return component
+    }
+
+    test('fires focusMove only on the closest common component', () => {
+        const log = [];
+
+        components = [
+            createFocusComponent('focus-root',       'document.body', log),
+            createFocusComponent('focus-parent',     'focus-root',    log),
+            createFocusComponent('focus-old-child',  'focus-parent',  log),
+            createFocusComponent('focus-new-child',  'focus-parent',  log)
+        ];
+
+        const [root, parent, oldChild, newChild] = components;
+
+        root.containsFocus = true;
+        parent.containsFocus = true;
+        oldChild.containsFocus = true;
+
+        FocusManager.history = [{
+            componentPath: ['focus-old-child', 'focus-parent', 'focus-root'],
+            data         : {path: ['old-dom-node']}
+        }];
+
+        FocusManager.focusMove({
+            componentPath: ['focus-new-child', 'focus-parent', 'focus-root'],
+            data         : {
+                path         : ['new-dom-node'],
+                relatedTarget: null
+            }
+        });
+
+        expect(log).toEqual([
+            ['leave', 'focus-old-child', 'focus-old-child'],
+            ['enter', 'focus-new-child', 'focus-new-child'],
+            ['move',  'focus-parent',    'focus-parent', ['old-dom-node'], ['new-dom-node']]
+        ]);
+
+        expect(oldChild.containsFocus).toBe(false);
+        expect(newChild.containsFocus).toBe(true);
+        expect(parent.containsFocus).toBe(true);
+        expect(root.containsFocus).toBe(true);
+        expect(FocusManager.history[0].componentPath).toEqual(['focus-new-child', 'focus-parent', 'focus-root']);
+    });
+});


### PR DESCRIPTION
Resolves #6129

FocusManager now walks the component-tree path by the closest common component instead of set-diffing the full path. A sibling focus transfer leaves only the old divergent branch, enters only the new divergent branch, and fires `focusMove` / `focusChange` once on the closest common ancestor.

Review-response update: commit `7bd6990723` keeps `addToHistory(opts)` unconditional when the closest common component is no longer live, adds regression coverage for that destroyed-common-ancestor branch, adds disjoint no-common coverage, and pins the nearest-only `focusChange` consumer semantics that calendar week/month rely on.

Evidence: L2 (Playwright unit/browser harness validates the FocusManager component-tree event sequence, destroyed-common history preservation, disjoint-path fallback, nearest-only consumer event data, and adjacent DomEvent manager regression) -> L2 required (component-tree focus event routing). No residuals.

## Deltas from ticket
The upstream `DomEvent` manager already converts DOM paths into component-tree paths before calling `FocusManager`. This PR keeps the fix in `FocusManager`: it replaces order-agnostic intersection/difference math with nearest-common-ancestor slicing, which is the remaining behavior gap.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/manager/Focus.spec.mjs` passed: 4/4.
- `npm run test-unit -- test/playwright/unit/manager/Focus.spec.mjs test/playwright/unit/manager/domEvent/Fire.spec.mjs` passed: 9/9.
- `npm run test-unit -- test/playwright/unit/vdom/Calendar.spec.mjs` passed: 10/10.
- `npm run agent-preflight -- --no-fix src/manager/Focus.mjs test/playwright/unit/manager/Focus.spec.mjs` passed.
- `git diff --check`, `git diff --cached --check`, and `git diff --check HEAD~1..HEAD` passed.
- GitHub CI at `7bd6990723`: Agent PR Body Lint, AiConfig Test-Mutation Lint, CodeQL, JSDoc Type Lint, Ticket Archaeology Lint, Tests `unit`, and Tests `integration-unified` passed.

## Post-Merge Validation
- [ ] Human merge gate only after current-head CI is green and one cross-family Approved review is recorded.

Authored by Euclid (GPT-5.5, Codex Desktop). Session c5938a7c-42e6-4f94-ac19-1a874529dfb4.