### PR TITLE
feat(fleet): setRepo control verb + registry updateAgent (#14535)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -157,11 +157,12 @@ class FleetControlBridge extends Base {
     }
 
     /**
-     * @summary Set an agent's target repo / data-dir override on its definition (fleet authority — the
-     * FM owns the registry, as with `defineAgent`). Non-destructive to the existing on-disk checkout;
-     * provisioning honoring the override is a separate follow-up leaf.
+     * @summary Set an agent's working-repo coordinates (`metadata.repo = {cloneUrl, repoSlug}`) on its
+     * definition (fleet authority — the FM owns the registry, as with `defineAgent`). Functional
+     * end-to-end: the provisioner already honors `metadata.repo`, so the next start launches the agent
+     * in the set repo. Non-destructive to the existing on-disk checkout.
      * @param {String} id Registry agent id.
-     * @param {Object} repo `{repoUrl?, dataDir?}` — the override facets to record.
+     * @param {Object} repo `{cloneUrl?, repoSlug?}` — the working-repo coordinates.
      * @returns {Object|null} the updated public definition, or `null` if the agent doesn't exist.
      */
     setRepo(id, repo) {

--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -157,6 +157,18 @@ class FleetControlBridge extends Base {
     }
 
     /**
+     * @summary Set an agent's target repo / data-dir override on its definition (fleet authority — the
+     * FM owns the registry, as with `defineAgent`). Non-destructive to the existing on-disk checkout;
+     * provisioning honoring the override is a separate follow-up leaf.
+     * @param {String} id Registry agent id.
+     * @param {Object} repo `{repoUrl?, dataDir?}` — the override facets to record.
+     * @returns {Object|null} the updated public definition, or `null` if the agent doesn't exist.
+     */
+    setRepo(id, repo) {
+        return this.getManager().setRepo(id, repo);
+    }
+
+    /**
      * @summary The *observe* half of the MVP loop: the per-agent repo-provisioning state across the
      * whole fleet, at the resolved managed root. Read-only.
      * @returns {Object[]} one status entry per registered agent.

--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -159,14 +159,14 @@ class FleetControlBridge extends Base {
     /**
      * @summary Set an agent's working-repo coordinates (`metadata.repo = {cloneUrl, repoSlug}`) on its
      * definition (fleet authority — the FM owns the registry, as with `defineAgent`). Functional
-     * end-to-end: the provisioner already honors `metadata.repo`, so the next start launches the agent
-     * in the set repo. Non-destructive to the existing on-disk checkout.
-     * @param {String} id Registry agent id.
-     * @param {Object} repo `{cloneUrl?, repoSlug?}` — the working-repo coordinates.
+     * end-to-end: the provisioner already honors `metadata.repo`, so the next start launches the agent in
+     * the set repo. A single-`params` payload, so it is pane-reachable over the wire. Non-destructive to
+     * the existing on-disk checkout.
+     * @param {Object} payload `{id, cloneUrl?, repoSlug?}` — the agent id + working-repo coordinates.
      * @returns {Object|null} the updated public definition, or `null` if the agent doesn't exist.
      */
-    setRepo(id, repo) {
-        return this.getManager().setRepo(id, repo);
+    setRepo(payload) {
+        return this.getManager().setRepo(payload);
     }
 
     /**

--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -185,27 +185,29 @@ class FleetManager extends Base {
     }
 
     /**
-     * @summary Turnkey per-agent repo/data-dir override: record the agent's target repo + data-dir on
-     * its registry definition (under `metadata`) via the registry's partial update, so a later
-     * provisioned start can honor it. **Non-destructive to disk**, mirroring {@link removeAgent}: it
-     * does NOT move or delete the agent's existing checkout or its checkout-path-keyed auto-memory —
-     * that physical reconciliation is a Memory-Core policy that must land WITH the move, never orphan
-     * it here. Provisioning honoring the override is a separate follow-up leaf. A thin delegation:
-     * setting a definition facet needs no `managedRoot` / provisioning, so it forwards straight to the
-     * registry's `updateAgent` (fleet authority — the FM owns the definition registry, like
-     * `defineAgent`), not a cross-agent control-plane op.
-     * @param {String}  agentId Registry agent id.
+     * @summary Set the agent's working-repo coordinates on its registry definition — `metadata.repo =
+     * {cloneUrl, repoSlug}`, the EXACT convention {@link Neo.ai.services.fleet.startAgentProvisioned}
+     * already honors (it clones/reuses that repo and pins the harness `cwd` to the checkout). So this is
+     * functional end-to-end: the next provisioned start launches the agent in the newly-set repo. A thin
+     * fleet-authority delegation to the registry's partial update (the FM owns the definition registry,
+     * like `defineAgent`) — NOT a cross-agent control-plane op. **Non-destructive to disk**, mirroring
+     * {@link removeAgent}: it does not move or delete the agent's EXISTING checkout or its
+     * checkout-path-keyed auto-memory; the next provisioned start ensures the new checkout (clone-or-
+     * reuse, never clobber), and reconciling a now-stale old checkout is a Memory-Core policy, not
+     * orphaned here. Replaces `metadata.repo` wholesale (a repo is set as a unit); other metadata keys
+     * survive the merge.
+     * @param {String}  agentId  Registry agent id.
      * @param {Object}  repo
-     * @param {String} [repo.repoUrl] Target repository URL / override.
-     * @param {String} [repo.dataDir] Target data-dir override.
+     * @param {String} [repo.cloneUrl] The clone URL the provisioner clones from.
+     * @param {String} [repo.repoSlug] The repo slug (checkout-dir naming under the managed root).
      * @returns {Object|null} The updated public definition, or `null` if the agent doesn't exist.
      */
-    setRepo(agentId, {repoUrl, dataDir} = {}) {
-        const metadata = {};
-        if (repoUrl != null) metadata.repoUrl = repoUrl;
-        if (dataDir != null) metadata.dataDir = dataDir;
+    setRepo(agentId, {cloneUrl, repoSlug} = {}) {
+        const repo = {};
+        if (cloneUrl != null) repo.cloneUrl = cloneUrl;
+        if (repoSlug != null) repo.repoSlug = repoSlug;
 
-        return this.getLifecycleService().getRegistry().updateAgent(agentId, {metadata});
+        return this.getLifecycleService().getRegistry().updateAgent(agentId, {metadata: {repo}});
     }
 }
 

--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -188,26 +188,28 @@ class FleetManager extends Base {
      * @summary Set the agent's working-repo coordinates on its registry definition — `metadata.repo =
      * {cloneUrl, repoSlug}`, the EXACT convention {@link Neo.ai.services.fleet.startAgentProvisioned}
      * already honors (it clones/reuses that repo and pins the harness `cwd` to the checkout). So this is
-     * functional end-to-end: the next provisioned start launches the agent in the newly-set repo. A thin
-     * fleet-authority delegation to the registry's partial update (the FM owns the definition registry,
-     * like `defineAgent`) — NOT a cross-agent control-plane op. **Non-destructive to disk**, mirroring
+     * functional end-to-end: the next provisioned start launches the agent in the newly-set repo. Takes
+     * a SINGLE payload object (`{id, …}`) — mirroring `defineAgent` and the app↔fleet wire's single-
+     * `params` contract ({@link Neo.ai.services.fleet.dispatchFleetRequest}), so it is pane-reachable
+     * over the wire. A thin fleet-authority delegation to the registry's partial update (the FM owns the
+     * definition registry) — NOT a cross-agent control-plane op. **Non-destructive to disk**, mirroring
      * {@link removeAgent}: it does not move or delete the agent's EXISTING checkout or its
      * checkout-path-keyed auto-memory; the next provisioned start ensures the new checkout (clone-or-
      * reuse, never clobber), and reconciling a now-stale old checkout is a Memory-Core policy, not
      * orphaned here. Replaces `metadata.repo` wholesale (a repo is set as a unit); other metadata keys
      * survive the merge.
-     * @param {String}  agentId  Registry agent id.
-     * @param {Object}  repo
-     * @param {String} [repo.cloneUrl] The clone URL the provisioner clones from.
-     * @param {String} [repo.repoSlug] The repo slug (checkout-dir naming under the managed root).
+     * @param {Object}  payload
+     * @param {String}  payload.id        Registry agent id.
+     * @param {String} [payload.cloneUrl] The clone URL the provisioner clones from.
+     * @param {String} [payload.repoSlug] The repo slug (checkout-dir naming under the managed root).
      * @returns {Object|null} The updated public definition, or `null` if the agent doesn't exist.
      */
-    setRepo(agentId, {cloneUrl, repoSlug} = {}) {
+    setRepo({id, cloneUrl, repoSlug} = {}) {
         const repo = {};
         if (cloneUrl != null) repo.cloneUrl = cloneUrl;
         if (repoSlug != null) repo.repoSlug = repoSlug;
 
-        return this.getLifecycleService().getRegistry().updateAgent(agentId, {metadata: {repo}});
+        return this.getLifecycleService().getRegistry().updateAgent(id, {metadata: {repo}});
     }
 }
 

--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -183,6 +183,30 @@ class FleetManager extends Base {
         await this.stopAgent(agentId);
         return this.getLifecycleService().getRegistry().removeAgent(agentId);
     }
+
+    /**
+     * @summary Turnkey per-agent repo/data-dir override: record the agent's target repo + data-dir on
+     * its registry definition (under `metadata`) via the registry's partial update, so a later
+     * provisioned start can honor it. **Non-destructive to disk**, mirroring {@link removeAgent}: it
+     * does NOT move or delete the agent's existing checkout or its checkout-path-keyed auto-memory —
+     * that physical reconciliation is a Memory-Core policy that must land WITH the move, never orphan
+     * it here. Provisioning honoring the override is a separate follow-up leaf. A thin delegation:
+     * setting a definition facet needs no `managedRoot` / provisioning, so it forwards straight to the
+     * registry's `updateAgent` (fleet authority — the FM owns the definition registry, like
+     * `defineAgent`), not a cross-agent control-plane op.
+     * @param {String}  agentId Registry agent id.
+     * @param {Object}  repo
+     * @param {String} [repo.repoUrl] Target repository URL / override.
+     * @param {String} [repo.dataDir] Target data-dir override.
+     * @returns {Object|null} The updated public definition, or `null` if the agent doesn't exist.
+     */
+    setRepo(agentId, {repoUrl, dataDir} = {}) {
+        const metadata = {};
+        if (repoUrl != null) metadata.repoUrl = repoUrl;
+        if (dataDir != null) metadata.dataDir = dataDir;
+
+        return this.getLifecycleService().getRegistry().updateAgent(agentId, {metadata});
+    }
 }
 
 export default Neo.setupClass(FleetManager);

--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -153,6 +153,39 @@ class FleetRegistryService extends Base {
     }
 
     /**
+     * Partially update an existing agent definition: merge `metadata` (does NOT replace it) and
+     * override `modelProvider` if given, preserving every other field, `createdAt`, and the stored
+     * credential. The narrow patch path distinct from {@link defineAgent}'s full create-or-replace
+     * upsert — control verbs (e.g. `FleetManager.setRepo`) mutate one facet without re-supplying the
+     * whole definition (which would demand `githubUsername`/`harnessType` and wipe unspecified
+     * metadata). Non-destructive to on-disk checkout and credential. No-op-safe: an unknown id
+     * returns `null` rather than creating a partial definition.
+     * @param {String}  id
+     * @param {Object}  patch
+     * @param {Object} [patch.metadata]      Metadata keys merged into the existing metadata.
+     * @param {String} [patch.modelProvider] New model-provider login.
+     * @returns {Object|null} The updated public definition, or `null` when the agent doesn't exist.
+     */
+    updateAgent(id, {metadata, modelProvider} = {}) {
+        this.ensureLoaded();
+
+        const existing = this.agents.get(id);
+        if (!existing) return null;
+
+        const def = {
+            ...existing,
+            metadata     : metadata ? {...existing.metadata, ...metadata} : existing.metadata,
+            modelProvider: modelProvider || existing.modelProvider,
+            updatedAt    : new Date().toISOString()
+        };
+
+        this.agents.set(id, def);
+        this.writeRegistry();
+
+        return this.toPublic(def);
+    }
+
+    /**
      * List all agent definitions (no credentials).
      * @returns {Object[]}
      */

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -16,6 +16,6 @@
  * @type {String[]}
  */
 export const FLEET_WIRE_METHODS = Object.freeze([
-    'defineAgent', 'listAgents', 'getAgent',
+    'defineAgent', 'setRepo', 'listAgents', 'getAgent',
     'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus'
 ]);

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -100,7 +100,7 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
     });
 
     test('setRepo delegates to the manager definition-update (fleet authority, non-secret facet)', () => {
-        const repo = {repoUrl: 'https://github.com/x/y', dataDir: '/tmp/y'};
+        const repo = {cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'};
         expect(FleetControlBridge.setRepo('alice', repo)).toEqual({id: 'alice', metadata: repo});
         expect(calls).toEqual([['setRepo', 'alice', repo]]);
     });

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -42,7 +42,8 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
             stopAgent      : async id => { calls.push(['stopAgent', id]);    return {success: true, id, state: 'stopped'}; },
             restartAgent   : async id => { calls.push(['restartAgent', id]); return {id, state: 'running'}; },
             removeAgent    : async id => { calls.push(['removeAgent', id]);  return {success: true, id}; },
-            fleetRepoStatus: ()       => { calls.push(['fleetRepoStatus']);  return [{id: 'alice', repo: 'clean'}]; }
+            fleetRepoStatus: ()       => { calls.push(['fleetRepoStatus']);  return [{id: 'alice', repo: 'clean'}]; },
+            setRepo        : (id, repo) => { calls.push(['setRepo', id, repo]); return {id, metadata: repo}; }
         };
 
         FleetControlBridge.registry = registryStub;
@@ -96,6 +97,12 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
     test('removeAgent delegates to the manager compose (stop + deregister)', async () => {
         await expect(FleetControlBridge.removeAgent('alice')).resolves.toEqual({success: true, id: 'alice'});
         expect(calls).toEqual([['removeAgent', 'alice']]);
+    });
+
+    test('setRepo delegates to the manager definition-update (fleet authority, non-secret facet)', () => {
+        const repo = {repoUrl: 'https://github.com/x/y', dataDir: '/tmp/y'};
+        expect(FleetControlBridge.setRepo('alice', repo)).toEqual({id: 'alice', metadata: repo});
+        expect(calls).toEqual([['setRepo', 'alice', repo]]);
     });
 
     test('fleetStatus delegates to the manager repo-status aggregator', () => {

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -43,7 +43,7 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
             restartAgent   : async id => { calls.push(['restartAgent', id]); return {id, state: 'running'}; },
             removeAgent    : async id => { calls.push(['removeAgent', id]);  return {success: true, id}; },
             fleetRepoStatus: ()       => { calls.push(['fleetRepoStatus']);  return [{id: 'alice', repo: 'clean'}]; },
-            setRepo        : (id, repo) => { calls.push(['setRepo', id, repo]); return {id, metadata: repo}; }
+            setRepo        : payload  => { calls.push(['setRepo', payload]);   return {id: payload.id, metadata: {repo: payload}}; }
         };
 
         FleetControlBridge.registry = registryStub;
@@ -99,10 +99,10 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         expect(calls).toEqual([['removeAgent', 'alice']]);
     });
 
-    test('setRepo delegates to the manager definition-update (fleet authority, non-secret facet)', () => {
-        const repo = {cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'};
-        expect(FleetControlBridge.setRepo('alice', repo)).toEqual({id: 'alice', metadata: repo});
-        expect(calls).toEqual([['setRepo', 'alice', repo]]);
+    test('setRepo delegates the single payload to the manager definition-update (fleet authority)', () => {
+        const payload = {id: 'alice', cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'};
+        expect(FleetControlBridge.setRepo(payload)).toEqual({id: 'alice', metadata: {repo: payload}});
+        expect(calls).toEqual([['setRepo', payload]]);
     });
 
     test('fleetStatus delegates to the manager repo-status aggregator', () => {

--- a/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
@@ -1,0 +1,67 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'FleetManagerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import FleetManager   from '../../../../../../ai/services/fleet/FleetManager.mjs';
+
+// FleetManager is a singleton; `lifecycleService` is a plain injectable seam (default =
+// FleetLifecycleService). Each test swaps in a stub whose getRegistry() returns a recording registry
+// stub, so setRepo's fleet-authority delegation + its metadata construction are proven without
+// touching disk / spawning processes; afterEach resets the seam so no state leaks between tests.
+
+test.describe('Neo.ai.services.fleet.FleetManager.setRepo — fleet-authority definition-update delegation', () => {
+    let calls, registryStub;
+
+    test.beforeEach(() => {
+        calls = [];
+
+        registryStub = {
+            updateAgent: (id, patch) => { calls.push(['updateAgent', id, patch]); return {id, ...patch}; }
+        };
+
+        FleetManager.lifecycleService = {getRegistry: () => registryStub};
+    });
+
+    test.afterEach(() => {
+        FleetManager.lifecycleService = null;
+    });
+
+    test('records repoUrl + dataDir under metadata via the registry partial-update', () => {
+        const result = FleetManager.setRepo('alice', {repoUrl: 'https://github.com/x/y', dataDir: '/data/y'});
+
+        expect(calls).toEqual([['updateAgent', 'alice', {metadata: {repoUrl: 'https://github.com/x/y', dataDir: '/data/y'}}]]);
+        expect(result.metadata).toEqual({repoUrl: 'https://github.com/x/y', dataDir: '/data/y'});
+    });
+
+    test('omits an unset facet — no null/undefined leaks into the merged metadata', () => {
+        FleetManager.setRepo('alice', {repoUrl: 'https://github.com/x/y'});
+
+        expect(calls).toEqual([['updateAgent', 'alice', {metadata: {repoUrl: 'https://github.com/x/y'}}]]);
+    });
+
+    test('with no facets passes an empty metadata patch (a safe no-op merge, not a wipe)', () => {
+        FleetManager.setRepo('alice', {});
+
+        expect(calls).toEqual([['updateAgent', 'alice', {metadata: {}}]]);
+    });
+
+    test('forwards the registry null (unknown agent) verbatim — no partial definition invented', () => {
+        registryStub.updateAgent = (id, patch) => { calls.push(['updateAgent', id, patch]); return null; };
+
+        expect(FleetManager.setRepo('ghost', {repoUrl: 'https://github.com/x/y'})).toBeNull();
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
@@ -40,28 +40,28 @@ test.describe('Neo.ai.services.fleet.FleetManager.setRepo — fleet-authority de
         FleetManager.lifecycleService = null;
     });
 
-    test('records repoUrl + dataDir under metadata via the registry partial-update', () => {
-        const result = FleetManager.setRepo('alice', {repoUrl: 'https://github.com/x/y', dataDir: '/data/y'});
+    test('sets metadata.repo = {cloneUrl, repoSlug} — the convention the provisioner honors', () => {
+        const result = FleetManager.setRepo('alice', {cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'});
 
-        expect(calls).toEqual([['updateAgent', 'alice', {metadata: {repoUrl: 'https://github.com/x/y', dataDir: '/data/y'}}]]);
-        expect(result.metadata).toEqual({repoUrl: 'https://github.com/x/y', dataDir: '/data/y'});
+        expect(calls).toEqual([['updateAgent', 'alice', {metadata: {repo: {cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'}}}]]);
+        expect(result.metadata.repo).toEqual({cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'});
     });
 
-    test('omits an unset facet — no null/undefined leaks into the merged metadata', () => {
-        FleetManager.setRepo('alice', {repoUrl: 'https://github.com/x/y'});
+    test('omits an unset coordinate — no null/undefined leaks into metadata.repo', () => {
+        FleetManager.setRepo('alice', {cloneUrl: 'https://github.com/x/y.git'});
 
-        expect(calls).toEqual([['updateAgent', 'alice', {metadata: {repoUrl: 'https://github.com/x/y'}}]]);
+        expect(calls).toEqual([['updateAgent', 'alice', {metadata: {repo: {cloneUrl: 'https://github.com/x/y.git'}}}]]);
     });
 
-    test('with no facets passes an empty metadata patch (a safe no-op merge, not a wipe)', () => {
+    test('with no coordinates sets an empty metadata.repo (a safe no-op, not a wipe of other metadata)', () => {
         FleetManager.setRepo('alice', {});
 
-        expect(calls).toEqual([['updateAgent', 'alice', {metadata: {}}]]);
+        expect(calls).toEqual([['updateAgent', 'alice', {metadata: {repo: {}}}]]);
     });
 
     test('forwards the registry null (unknown agent) verbatim — no partial definition invented', () => {
         registryStub.updateAgent = (id, patch) => { calls.push(['updateAgent', id, patch]); return null; };
 
-        expect(FleetManager.setRepo('ghost', {repoUrl: 'https://github.com/x/y'})).toBeNull();
+        expect(FleetManager.setRepo('ghost', {cloneUrl: 'https://github.com/x/y.git'})).toBeNull();
     });
 });

--- a/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
@@ -40,21 +40,21 @@ test.describe('Neo.ai.services.fleet.FleetManager.setRepo — fleet-authority de
         FleetManager.lifecycleService = null;
     });
 
-    test('sets metadata.repo = {cloneUrl, repoSlug} — the convention the provisioner honors', () => {
-        const result = FleetManager.setRepo('alice', {cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'});
+    test('sets metadata.repo = {cloneUrl, repoSlug} from the single payload — the convention the provisioner honors', () => {
+        const result = FleetManager.setRepo({id: 'alice', cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'});
 
         expect(calls).toEqual([['updateAgent', 'alice', {metadata: {repo: {cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'}}}]]);
         expect(result.metadata.repo).toEqual({cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'});
     });
 
     test('omits an unset coordinate — no null/undefined leaks into metadata.repo', () => {
-        FleetManager.setRepo('alice', {cloneUrl: 'https://github.com/x/y.git'});
+        FleetManager.setRepo({id: 'alice', cloneUrl: 'https://github.com/x/y.git'});
 
         expect(calls).toEqual([['updateAgent', 'alice', {metadata: {repo: {cloneUrl: 'https://github.com/x/y.git'}}}]]);
     });
 
     test('with no coordinates sets an empty metadata.repo (a safe no-op, not a wipe of other metadata)', () => {
-        FleetManager.setRepo('alice', {});
+        FleetManager.setRepo({id: 'alice'});
 
         expect(calls).toEqual([['updateAgent', 'alice', {metadata: {repo: {}}}]]);
     });
@@ -62,6 +62,6 @@ test.describe('Neo.ai.services.fleet.FleetManager.setRepo — fleet-authority de
     test('forwards the registry null (unknown agent) verbatim — no partial definition invented', () => {
         registryStub.updateAgent = (id, patch) => { calls.push(['updateAgent', id, patch]); return null; };
 
-        expect(FleetManager.setRepo('ghost', {cloneUrl: 'https://github.com/x/y.git'})).toBeNull();
+        expect(FleetManager.setRepo({id: 'ghost', cloneUrl: 'https://github.com/x/y.git'})).toBeNull();
     });
 });

--- a/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
@@ -1,0 +1,63 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'FleetRegistryServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}       from '@playwright/test';
+import Neo                  from '../../../../../../src/Neo.mjs';
+import * as core            from '../../../../../../src/core/_export.mjs';
+import FleetRegistryService from '../../../../../../ai/services/fleet/FleetRegistryService.mjs';
+import fs                   from 'fs';
+import os                   from 'os';
+import path                 from 'path';
+
+// FleetRegistryService is a singleton. Pointing `dataDir` at a fresh temp dir per test makes
+// ensureLoaded reload an empty registry (isolation) and keeps every write off the real
+// ~/.neo-ai-data. No credential is passed, so the crypto/storeCredential path is never exercised.
+
+test.describe('Neo.ai.services.fleet.FleetRegistryService.updateAgent — narrow partial-merge patch', () => {
+    let tmpDir;
+
+    test.beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-fleet-reg-'));
+        FleetRegistryService.dataDir = tmpDir;
+    });
+
+    test.afterEach(() => {
+        FleetRegistryService.dataDir = null;
+        fs.rmSync(tmpDir, {recursive: true, force: true});
+    });
+
+    test('merges the metadata patch into the existing definition, preserving every other field', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'alice', harnessType: 'codex', metadata: {tier: 'A', keep: 1}});
+
+        const updated = FleetRegistryService.updateAgent('alice', {metadata: {tier: 'B', repoUrl: 'https://github.com/x/y'}});
+
+        // merged (not replaced): the untouched `keep` survives, `tier` overrides, `repoUrl` is added
+        expect(updated.metadata).toEqual({tier: 'B', keep: 1, repoUrl: 'https://github.com/x/y'});
+        expect(updated.githubUsername).toBe('alice');
+        expect(updated.harnessType).toBe('codex');
+    });
+
+    test('returns null for an unknown agent — invents no partial definition', () => {
+        expect(FleetRegistryService.updateAgent('ghost', {metadata: {x: 1}})).toBeNull();
+    });
+
+    test('a patch without metadata leaves the existing metadata intact (no accidental wipe)', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'bob', harnessType: 'codex', metadata: {a: 1}});
+
+        const updated = FleetRegistryService.updateAgent('bob', {});
+
+        expect(updated.metadata).toEqual({a: 1});
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -37,6 +37,7 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
             restartAgent: async id => { calls.push(['restartAgent', id]); return {id, state: 'running'}; },
             removeAgent : async id => { calls.push(['removeAgent', id]);  return {success: true, id}; },
             fleetStatus : () => { calls.push(['fleetStatus']); return [{id: 'a'}]; },
+            setRepo     : payload => { calls.push(['setRepo', payload]); return {id: payload.id, metadata: {repo: payload}}; },
             // resolver seams that MUST be unreachable over the wire (they return lifecycle-powerful singletons):
             getManager : () => { calls.push(['getManager']);  return {DANGER: 'lifecycle'}; },
             getRegistry: () => { calls.push(['getRegistry']); return {DANGER: 'registry'}; }
@@ -53,6 +54,14 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
         const res = await dispatchFleetRequest({method: 'startAgent', params: 'alice'}, bridge);
         expect(res).toEqual({ok: true, result: {id: 'alice', state: 'running'}});
         expect(calls).toEqual([['startAgent', 'alice']]);
+    });
+
+    test('routes setRepo, forwarding the single payload to the bridge (wire-compatible single-params)', async () => {
+        const payload = {id: 'alice', cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'},
+              res     = await dispatchFleetRequest({method: 'setRepo', params: payload}, bridge);
+
+        expect(res).toEqual({ok: true, result: {id: 'alice', metadata: {repo: payload}}});
+        expect(calls).toEqual([['setRepo', payload]]);
     });
 
     test('rejects a method NOT on the wire allowlist without ever calling the bridge', async () => {

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -82,7 +82,7 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
 
     test('the wire allowlist is exactly the pane operations — no resolver seams', () => {
         expect([...FLEET_WIRE_METHODS].sort()).toEqual(
-            ['defineAgent', 'fleetStatus', 'getAgent', 'listAgents', 'removeAgent', 'restartAgent', 'startAgent', 'stopAgent'].sort()
+            ['defineAgent', 'fleetStatus', 'getAgent', 'listAgents', 'removeAgent', 'restartAgent', 'setRepo', 'startAgent', 'stopAgent'].sort()
         );
         expect(FLEET_WIRE_METHODS).not.toContain('getManager');
         expect(FLEET_WIRE_METHODS).not.toContain('getRegistry');


### PR DESCRIPTION
Resolves #14535

Delivers the first FM control verb beyond read/define — `setRepo` — plus the registry primitive it needs. Per the operator's cockpit-as-control-surface reframe (#13448 Lane B consumes it): the FM cockpit gains a per-agent repo control that sets the agent's working-repo coordinates. **Functional end-to-end** — it writes the exact `metadata.repo` convention the provisioner already honors.

## The change (4 files + 3 specs)

- `FleetRegistryService.updateAgent(id, patch)` — the narrow partial-merge the registry lacked (`defineAgent` is a full create-or-replace upsert): merges `metadata`, preserves every other field + `createdAt` + the stored credential, returns `null` on an unknown id. Non-destructive to disk.
- `FleetManager.setRepo({id, cloneUrl, repoSlug})` — a **single-payload** (wire-compatible) fleet-authority delegate to `updateAgent`, setting `metadata.repo = {cloneUrl, repoSlug}` — the **exact convention `startAgentProvisioned` already reads** (`ai/services/fleet/startAgentProvisioned.mjs:54`: clone-or-reuse + pin the harness `cwd` to the checkout). So the next provisioned start launches the agent in the newly-set repo. Non-destructive, mirroring `removeAgent`.
- `FleetControlBridge.setRepo(payload)` — the pane-reachable capability-allowlist entry.
- `FLEET_WIRE_METHODS` += `setRepo` — the app↔fleet wire SSOT; both ends updated — the browser bridge (`createFleetRegistryBridge`, SSOT-generated) AND the Node choke-point (`dispatchFleetRequest`, which enforces the exact list).

Evidence: L1 (unit) achieved → L1 required (pure service delegation + merge + wire routing; the provisioning consumer is pre-existing + already covered). Residual: none for this verb.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/` → **44 passed** (the full fleet dir): updateAgent merge/preserve/null · setRepo single-payload → `metadata.repo` + omit-unset + null passthrough · FleetControlBridge allowlist delegation + secret-omission boundary · **dispatchFleetRequest exact-allowlist + `setRepo` routing (single-`params` wire-compat)** · createFleetRegistryBridge + the real-server transport integration.
- Pre-commit hooks green on all commits: block-alignment, ticket-archaeology, jsdoc-types, whitespace, shorthand, aiconfig-test-mutation.

## Post-Merge Validation

- [ ] `setWakeEnabled` (the OTHER control verb) lands via #14537 — **control-plane-authorized** (cross-agent privilege boundary via `WakeSubscriptionService`'s owner-scoping), so #14537 is `blocked_by` #14477 (the #14501 control-plane authority).
- [ ] #13448 (Lane B cockpit) wires the repo control to `registryBridge.setRepo`.

## Deltas

- **Scope refined + #14535 synced.** #14535 was filed for `setWakeEnabled` + `setRepo`; V-B-A split `setWakeEnabled` to #14537 (`blocked_by` #14477). #14535's body/Contract-Ledger/ACs are now synchronized to the shipped `setRepo({id, cloneUrl, repoSlug})` contract (per @neo-gpt RA2).
- **Field convention corrected mid-PR (self-caught).** The first commit invented `metadata.repoUrl`/`dataDir`; V-B-A'ing the consumer showed `startAgentProvisioned` already honors `metadata.repo = {cloneUrl, repoSlug}`. Commit `8bccd15d` writes that existing convention — functional end-to-end, obsoleting a planned "provisioning" follow-up.
- **Wire-arity corrected (per @neo-gpt RA1).** `dispatchFleetRequest` forwards a single `params`; the initial `setRepo(id, repo)` was 2-arg (wire-broken). Commit `fb45cca5` makes it a single `{id, …}` payload (mirroring `defineAgent`) + adds the dispatch allowlist + routing tests that prove the choke-point routes it.

## Graph Ingestion Notes

FM Lane C (#13015): the client-facing FM control verbs split by authority — **fleet authority** (own-registry ops: `defineAgent`, `setRepo`) vs **control-plane authority** (cross-agent ops: `setWakeEnabled` → #14477/#14501). `updateAgent` is the reusable partial-update primitive. Two consumer-verification lessons: (1) verify the CONSUMER (`startAgentProvisioned`) before minting a field convention; (2) a new `FLEET_WIRE_METHODS` verb must be single-`params` (the dispatch choke-point forwards one arg) AND update `dispatchFleetRequest`'s exact-allowlist assertion, not just the SSOT-generated client bridge.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8).
