### PR TITLE
feat(fleet): setAvatar control verb (#14538)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -170,6 +170,17 @@ class FleetControlBridge extends Base {
     }
 
     /**
+     * @summary Set an agent's profile-avatar reference (`metadata.avatarUrl`) on its definition (fleet
+     * authority — the FM owns the registry, as with `defineAgent`). A single-`params` payload, so it is
+     * pane-reachable over the wire. Non-destructive to other metadata.
+     * @param {Object} payload `{id, avatarUrl?}` — the agent id + avatar reference.
+     * @returns {Object|null} the updated public definition, or `null` if the agent doesn't exist.
+     */
+    setAvatar(payload) {
+        return this.getManager().setAvatar(payload);
+    }
+
+    /**
      * @summary The *observe* half of the MVP loop: the per-agent repo-provisioning state across the
      * whole fleet, at the resolved managed root. Read-only.
      * @returns {Object[]} one status entry per registered agent.

--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -211,6 +211,24 @@ class FleetManager extends Base {
 
         return this.getLifecycleService().getRegistry().updateAgent(id, {metadata: {repo}});
     }
+
+    /**
+     * @summary Set the agent's profile-avatar reference on its registry definition
+     * (`metadata.avatarUrl`) — a fleet-authority presentation-field control, like `setRepo`. Single
+     * `{id, …}` payload (wire-compatible via {@link Neo.ai.services.fleet.dispatchFleetRequest}); a thin
+     * delegation to the registry's partial update, so other metadata keys survive the merge. A display
+     * reference only — not cross-agent-privileged, so fleet authority, not control-plane.
+     * @param {Object}  payload
+     * @param {String}  payload.id         Registry agent id.
+     * @param {String} [payload.avatarUrl] The avatar image URL / reference to record.
+     * @returns {Object|null} The updated public definition, or `null` if the agent doesn't exist.
+     */
+    setAvatar({id, avatarUrl} = {}) {
+        const metadata = {};
+        if (avatarUrl != null) metadata.avatarUrl = avatarUrl;
+
+        return this.getLifecycleService().getRegistry().updateAgent(id, {metadata});
+    }
 }
 
 export default Neo.setupClass(FleetManager);

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -16,6 +16,6 @@
  * @type {String[]}
  */
 export const FLEET_WIRE_METHODS = Object.freeze([
-    'defineAgent', 'setRepo', 'listAgents', 'getAgent',
+    'defineAgent', 'setRepo', 'setAvatar', 'listAgents', 'getAgent',
     'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus'
 ]);

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -43,7 +43,8 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
             restartAgent   : async id => { calls.push(['restartAgent', id]); return {id, state: 'running'}; },
             removeAgent    : async id => { calls.push(['removeAgent', id]);  return {success: true, id}; },
             fleetRepoStatus: ()       => { calls.push(['fleetRepoStatus']);  return [{id: 'alice', repo: 'clean'}]; },
-            setRepo        : payload  => { calls.push(['setRepo', payload]);   return {id: payload.id, metadata: {repo: payload}}; }
+            setRepo        : payload  => { calls.push(['setRepo', payload]);   return {id: payload.id, metadata: {repo: payload}}; },
+            setAvatar      : payload  => { calls.push(['setAvatar', payload]); return {id: payload.id, metadata: {avatarUrl: payload.avatarUrl}}; }
         };
 
         FleetControlBridge.registry = registryStub;
@@ -103,6 +104,12 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         const payload = {id: 'alice', cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'};
         expect(FleetControlBridge.setRepo(payload)).toEqual({id: 'alice', metadata: {repo: payload}});
         expect(calls).toEqual([['setRepo', payload]]);
+    });
+
+    test('setAvatar delegates the single payload to the manager definition-update (fleet authority)', () => {
+        const payload = {id: 'alice', avatarUrl: 'https://cdn/x.png'};
+        expect(FleetControlBridge.setAvatar(payload)).toEqual({id: 'alice', metadata: {avatarUrl: 'https://cdn/x.png'}});
+        expect(calls).toEqual([['setAvatar', payload]]);
     });
 
     test('fleetStatus delegates to the manager repo-status aggregator', () => {

--- a/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
@@ -23,7 +23,7 @@ import FleetManager   from '../../../../../../ai/services/fleet/FleetManager.mjs
 // stub, so setRepo's fleet-authority delegation + its metadata construction are proven without
 // touching disk / spawning processes; afterEach resets the seam so no state leaks between tests.
 
-test.describe('Neo.ai.services.fleet.FleetManager.setRepo — fleet-authority definition-update delegation', () => {
+test.describe('Neo.ai.services.fleet.FleetManager — fleet-authority definition-update verbs (setRepo / setAvatar)', () => {
     let calls, registryStub;
 
     test.beforeEach(() => {
@@ -63,5 +63,18 @@ test.describe('Neo.ai.services.fleet.FleetManager.setRepo — fleet-authority de
         registryStub.updateAgent = (id, patch) => { calls.push(['updateAgent', id, patch]); return null; };
 
         expect(FleetManager.setRepo({id: 'ghost', cloneUrl: 'https://github.com/x/y.git'})).toBeNull();
+    });
+
+    test('setAvatar sets metadata.avatarUrl from the single payload (sibling fleet-authority verb)', () => {
+        const result = FleetManager.setAvatar({id: 'alice', avatarUrl: 'https://cdn/x.png'});
+
+        expect(calls).toEqual([['updateAgent', 'alice', {metadata: {avatarUrl: 'https://cdn/x.png'}}]]);
+        expect(result.metadata.avatarUrl).toBe('https://cdn/x.png');
+    });
+
+    test('setAvatar with no avatarUrl sends an empty metadata patch (safe no-op, not a wipe)', () => {
+        FleetManager.setAvatar({id: 'alice'});
+
+        expect(calls).toEqual([['updateAgent', 'alice', {metadata: {}}]]);
     });
 });

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -38,6 +38,7 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
             removeAgent : async id => { calls.push(['removeAgent', id]);  return {success: true, id}; },
             fleetStatus : () => { calls.push(['fleetStatus']); return [{id: 'a'}]; },
             setRepo     : payload => { calls.push(['setRepo', payload]); return {id: payload.id, metadata: {repo: payload}}; },
+            setAvatar   : payload => { calls.push(['setAvatar', payload]); return {id: payload.id, metadata: {avatarUrl: payload.avatarUrl}}; },
             // resolver seams that MUST be unreachable over the wire (they return lifecycle-powerful singletons):
             getManager : () => { calls.push(['getManager']);  return {DANGER: 'lifecycle'}; },
             getRegistry: () => { calls.push(['getRegistry']); return {DANGER: 'registry'}; }
@@ -62,6 +63,14 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
 
         expect(res).toEqual({ok: true, result: {id: 'alice', metadata: {repo: payload}}});
         expect(calls).toEqual([['setRepo', payload]]);
+    });
+
+    test('routes setAvatar, forwarding the single payload to the bridge', async () => {
+        const payload = {id: 'alice', avatarUrl: 'https://cdn/x.png'},
+              res     = await dispatchFleetRequest({method: 'setAvatar', params: payload}, bridge);
+
+        expect(res).toEqual({ok: true, result: {id: 'alice', metadata: {avatarUrl: 'https://cdn/x.png'}}});
+        expect(calls).toEqual([['setAvatar', payload]]);
     });
 
     test('rejects a method NOT on the wire allowlist without ever calling the bridge', async () => {
@@ -91,7 +100,7 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
 
     test('the wire allowlist is exactly the pane operations — no resolver seams', () => {
         expect([...FLEET_WIRE_METHODS].sort()).toEqual(
-            ['defineAgent', 'fleetStatus', 'getAgent', 'listAgents', 'removeAgent', 'restartAgent', 'setRepo', 'startAgent', 'stopAgent'].sort()
+            ['defineAgent', 'fleetStatus', 'getAgent', 'listAgents', 'removeAgent', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
         );
         expect(FLEET_WIRE_METHODS).not.toContain('getManager');
         expect(FLEET_WIRE_METHODS).not.toContain('getRegistry');


### PR DESCRIPTION
Resolves #14538

Adds the `setAvatar` FM control verb — a per-agent profile-avatar reference on the agent definition (`metadata.avatarUrl`), one of the operator's cockpit controls. The third fleet-authority definition-mutating verb (`defineAgent`, `setRepo`, `setAvatar`) over the reusable `updateAgent` primitive.

> **Rebased onto dev after #14536 (setRepo) merged** — now a clean single commit (`220f631fc8`), no stack. The four setRepo commits dropped (they're in dev via #14536's squash); `FLEET_WIRE_METHODS` correctly carries both `setRepo` and `setAvatar`.

## The change (2 files + 3 specs)

- `FleetManager.setAvatar({id, avatarUrl})` — single-payload (wire-compatible), fleet-authority delegate to `updateAgent` setting `metadata.avatarUrl`; non-destructive to other metadata; `null` on unknown id.
- `FleetControlBridge.setAvatar(payload)` — pane-reachable capability-allowlist entry.
- `FLEET_WIRE_METHODS` += `setAvatar` — both wire ends + the `dispatchFleetRequest` choke-point (exact-allowlist assertion + routing test).

A **display reference only** — not cross-agent-privileged, so fleet authority (like `defineAgent`/`setRepo`), NOT control-plane.

Evidence: L1 (unit) achieved → L1 required (pure service delegation + wire routing). Residual: none.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/` → **48 passed** (full fleet dir, rebased on dev's setRepo): the setAvatar service + bridge + the `dispatchFleetRequest` allowlist (now `defineAgent · setRepo · setAvatar · …`) + single-payload routing.
- Pre-commit hooks green (validated at the original commit; content byte-identical after the clean rebase).

## Post-Merge Validation

- [ ] #13448 (Lane B cockpit) wires the avatar control to `registryBridge.setAvatar`.

## Deltas

- Rebased `--onto origin/dev` after #14536's squash-merge to drop the already-merged setRepo commits; the diff is now exactly the 6 setAvatar files (verified diff-vs-dev before force-push).
- Built directly on #14536's proven pattern: single-`params` payload (the wire forwards one arg), FleetControlBridge allowlist, `FLEET_WIRE_METHODS` + the `dispatchFleetRequest` exact-allowlist assertion + a routing test. No new registry primitive (reuses `updateAgent`).

## Graph Ingestion Notes

FM Lane C (#13015): `setAvatar` is the third fleet-authority definition-mutating verb over the reusable `updateAgent` primitive. Presentation fields (avatar) are fleet authority; cross-agent lifecycle (wake) is control-plane (#14537). The verb checklist (single-`params` + both wire ends + dispatch allowlist assertion + routing test) is a repeatable FM-control-verb template.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8).
