### PR TITLE
docs(portal): 6 Agent OS boxes on the landing page + README link fix (#14545)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ This sets up a new app workspace, a pre-configured app shell, a local developmen
 
 * :book: **[Getting Started](https://neomjs.com/#/learn/gettingstarted/Setup)** — build your first app, step by step
 * :student: **[Learning Section](https://neomjs.com/#/learn)** — the guided curriculum, with the nav tree and live component previews
-* :sparkles: **[What Is Neo?](https://neomjs.com/#/learn/benefits/WhatIsNeo)** — the two-hemisphere organism, in five minutes
+* :sparkles: **[What Is Neo?](https://neomjs.com/#/learn/benefits/Introduction)** — the two-hemisphere organism, with receipts
 * :robot: **[Run Your Own Agent Team](https://neomjs.com/#/learn/agentos/OwnAgentTeam)** — point the Agent OS at your own fork
 
 </br></br>

--- a/apps/portal/view/home/parts/AiToolchain.mjs
+++ b/apps/portal/view/home/parts/AiToolchain.mjs
@@ -86,9 +86,9 @@ class AiToolchain extends BaseContainer {
                     route  : '#/learn/agentos/SwarmIntelligence',
                     content: [
                         'Peers wake peers through the night.',
-                        '10-20 pull requests merged with no operator awake.',
+                        '10-20 pull requests carried to approval, no operator awake.',
                         'Every change gated by cross-family quorum.',
-                        'Autonomy by construction, not a babysat loop.'
+                        'The human holds the merge gate - by governance, not limit.'
                     ]
                 }, {
                     module : ContentBox,

--- a/apps/portal/view/home/parts/AiToolchain.mjs
+++ b/apps/portal/view/home/parts/AiToolchain.mjs
@@ -80,55 +80,37 @@ class AiToolchain extends BaseContainer {
                         'Friction becomes tickets and skills.',
                         'The system evolves by predicting its own evolution.'
                     ]
-                }]
-            }, {
-                ntype: 'component',
-                cls  : ['agent-os-faq'],
-                flex : 'none',
-                vdom : {tag: 'section', cn: [{
-                    tag : 'h2',
-                    text: 'Agent OS FAQ'
                 }, {
-                    tag: 'div',
-                    cls: ['faq-list'],
-                    cn : [{
-                        tag: 'article',
-                        cn : [{
-                            tag : 'h3',
-                            text: 'What is the Neural Link?'
-                        }, {
-                            tag : 'p',
-                            text: 'The Neural Link is a bi-directional bridge that connects AI agents directly to the Neo.mjs runtime. It lets agents inspect the Scene Graph, component state, event listeners, computed styles, and DOM rectangles, and mutate the running application in real time.'
-                        }]
-                    }, {
-                        tag: 'article',
-                        cn : [{
-                            tag : 'h3',
-                            text: 'Why is Neo.mjs called an Application Engine instead of a framework?'
-                        }, {
-                            tag : 'p',
-                            text: 'Neo.mjs maintains persistent application objects in a worker-backed Scene Graph instead of compiling application state away into ephemeral DOM nodes. That architecture enables multi-window orchestration, runtime permutation, and deep AI introspection.'
-                        }]
-                    }, {
-                        tag: 'article',
-                        cn : [{
-                            tag : 'h3',
-                            text: 'What is Context Engineering?'
-                        }, {
-                            tag : 'p',
-                            text: 'Context Engineering shapes the information and tool environment around AI agents. Neo.mjs implements it through Knowledge Base, Memory Core, GitHub Workflow, and Neural Link MCP servers for frontier harnesses, plus a File System MCP server for internal Neo.ai.Agent local loops.'
-                        }]
-                    }, {
-                        tag: 'article',
-                        cn : [{
-                            tag : 'h3',
-                            text: 'What is the Neo.mjs Agent OS?'
-                        }, {
-                            tag : 'p',
-                            text: 'The Neo.mjs Agent OS is the repository Brain: source code and services for Memory Core, Knowledge Base, Active Hybrid GraphRAG, DreamService, Golden Path synthesis, A2A coordination, and Neural Link tooling.'
-                        }]
-                    }]
-                }]}
+                    module : ContentBox,
+                    header : 'The Night Shift',
+                    route  : '#/learn/agentos/SwarmIntelligence',
+                    content: [
+                        'Peers wake peers through the night.',
+                        '10-20 pull requests merged with no operator awake.',
+                        'Every change gated by cross-family quorum.',
+                        'Autonomy by construction, not a babysat loop.'
+                    ]
+                }, {
+                    module : ContentBox,
+                    header : 'Self-Healing',
+                    route  : '#/learn/agentos/SelfHealing',
+                    content: [
+                        'Detects its own data-integrity faults.',
+                        'Diagnoses the corruption mode, then heals it.',
+                        'Runs unattended, with no human to escalate to.',
+                        'Stops trusting a green health check blindly.'
+                    ]
+                }, {
+                    module : ContentBox,
+                    header : 'The Cross-Family Institution',
+                    route  : '#/learn/agentos/FlatPeerInstitution',
+                    content: [
+                        'Named maintainers from rival labs: Claude, Gemini, GPT.',
+                        'Each reviews the others across families.',
+                        'Transparent A2A introspection, not just messaging.',
+                        'Correlated blind spots caught by construction.'
+                    ]
+                }]
             }]
         }, {
             module: FooterContainer,


### PR DESCRIPTION
Resolves #14545

Operator-directed front-door polish, release-minimal. Surfaces the moat on the landing page — the Agent OS Brain earns equal billing next to the engine showcase — and fixes a dead README front-door link.

## Changes
- **`apps/portal/view/home/parts/AiToolchain.mjs`** — expanded the Agent OS section from 3 to 6 `ContentBox` items. The existing three are the *tools* (Neural Link · GraphRAG · Dream Pipeline); the new three are the *wow they produce*:
  - **The Night Shift** → `#/learn/agentos/SwarmIntelligence`
  - **Self-Healing** → `#/learn/agentos/SelfHealing`
  - **The Cross-Family Institution** → `#/learn/agentos/FlatPeerInstitution`

  Each route verified against a live `learn/agentos/*.md`. Removed the `agent-os-faq` block. `columns:3` kept (6 boxes = 2 rows).
- **`README.md`** — front-door link `benefits/WhatIsNeo` → `benefits/Introduction`. The `WhatIsNeo` route is **dead** — the file was authored in #14313 and removed by #14470; the "What Is Neo?" content now lives at `benefits/Introduction`. Also dropped the false "in five minutes" descriptor (the doc is a 46KB narrative).

## Deltas from ticket
None — matches #14545 as scoped.

## Evidence
Evidence: L2 (static — `node --check` syntax pass; the 3 new routes verified against live `learn/agentos/` files; `git diff --check` clean; pre-commit jsdoc / ticket-archaeology / block-alignment passed) → L2 required (portal-content / docs; no runtime AC). Residual: portal render is a visual confirmation at the human merge gate. Minor: the now-unused `.agent-os-faq` SCSS rule is harmless dead CSS — optional follow-up, left out of this release-minimal scope.

## Test Evidence
- `node --check apps/portal/view/home/parts/AiToolchain.mjs` — syntax OK.
- Routes exist: `learn/agentos/{SwarmIntelligence,SelfHealing,FlatPeerInstitution}.md`.
- Box count = 6 `ContentBox`; `agent-os-faq` removed.
- `git diff --check` clean; pre-commit hooks green.

## Post-Merge Validation
- [ ] Human merge gate only after current-head CI is green and one cross-family Approved review is recorded.
- [ ] Visual: portal home renders 6 Agent OS boxes (2 rows), no FAQ.
- [ ] Sequence behind #14544 (also edits `README.md`) to avoid a README merge conflict.

Authored by Grace (@neo-opus-grace, Claude Opus 4.8).
