### PR TITLE
feat(fleet): add cockpit status DTO (#14562)

### DIFF
--- a/src/ai/fleet/fleetCockpitStatus.mjs
+++ b/src/ai/fleet/fleetCockpitStatus.mjs
@@ -1,0 +1,157 @@
+const WIRE_SOURCES = Object.freeze({
+        activity  : 'fleet:activity-adapters',
+        repoStatus: 'fleet:fleetStatus',
+        roster    : 'fleet:listAgents',
+        runtime   : 'fleet:runtimeStatus',
+        lifecycle : 'fleet:lifecycle'
+    })
+
+export const FLEET_COCKPIT_EVENT_TYPES = Object.freeze([
+    'lifecycle-request',
+    'lifecycle-success',
+    'lifecycle-failure',
+    'bridge-unavailable',
+    'bridge-gated'
+])
+
+/**
+ * @summary Source labels for the Fleet Manager cockpit DTO. These labels are deliberately stable and
+ * transport-agnostic: the Body-side cockpit can explain which live substrate produced each row or
+ * event without importing the Node-only FleetControlBridge / registry / lifecycle service chain.
+ * @type {Object}
+ */
+export const FLEET_COCKPIT_SOURCES = Object.freeze({...WIRE_SOURCES})
+
+/**
+ * @summary Build the first Fleet Manager cockpit snapshot from the already-shipped bridge reads:
+ * `listAgents()` for the redacted roster and `fleetStatus()` for repo-provisioning state. Runtime
+ * process truth and A2A/PR/lane activity are explicit capability slots, not guessed browser state; an
+ * unwired adapter is rendered as `not-wired` so Lane 1 never mistakes placeholder data for fact.
+ *
+ * @param {Object}   options={}
+ * @param {Object[]} options.agents      Public agent definitions from `registryBridge.listAgents()`.
+ * @param {Object[]} options.fleetStatus Repo-status entries from `registryBridge.fleetStatus()`.
+ * @param {Object[]} options.events      Optional already-normalized cockpit events.
+ * @returns {Object} serializable cockpit DTO `{sources, capabilities, rows, events}`.
+ */
+export function createFleetCockpitStatus({agents = [], fleetStatus = [], events = []} = {}) {
+    const statusByAgentId = new Map(
+        fleetStatus.map(status => [status.agentId || status.id, sanitizePayload(status)])
+    )
+
+    return {
+        sources     : FLEET_COCKPIT_SOURCES,
+        capabilities: {
+            activity: createNotWiredCapability(FLEET_COCKPIT_SOURCES.activity, 'A2A / PR / lane activity adapter not wired'),
+            runtime : createNotWiredCapability(FLEET_COCKPIT_SOURCES.runtime, 'runtime process status is pending the Fleet runtime-status wire method')
+        },
+        rows: agents.map(agent => {
+            const publicAgent = sanitizePayload(agent),
+                  agentId     = publicAgent.id,
+                  repoStatus  = statusByAgentId.get(agentId) || null
+
+            return {
+                id            : agentId,
+                githubUsername: publicAgent.githubUsername ?? null,
+                harnessType   : publicAgent.harnessType ?? null,
+                displayName   : publicAgent.displayName ?? publicAgent.name ?? publicAgent.githubUsername ?? agentId ?? null,
+                agent         : publicAgent,
+                repoStatus,
+                lifecycle     : {
+                    source    : FLEET_COCKPIT_SOURCES.runtime,
+                    state     : 'not-wired',
+                    confidence: 'none'
+                },
+                sources: {
+                    roster: {
+                        source    : FLEET_COCKPIT_SOURCES.roster,
+                        state     : 'wired',
+                        confidence: 'observed'
+                    },
+                    repoStatus: {
+                        source    : FLEET_COCKPIT_SOURCES.repoStatus,
+                        state     : repoStatus ? 'wired' : 'missing',
+                        confidence: repoStatus ? 'observed' : 'none'
+                    },
+                    runtime: {
+                        source    : FLEET_COCKPIT_SOURCES.runtime,
+                        state     : 'not-wired',
+                        confidence: 'none'
+                    }
+                }
+            }
+        }),
+        events: events.map(event => createFleetCockpitEvent(event))
+    }
+}
+
+/**
+ * @summary Normalize a bounded fleet cockpit activity event. The type set is intentionally narrow so
+ * UI and whitebox tests can prove lifecycle request/success/failure and bridge unavailable/gated
+ * states without inventing opaque free-form activity.
+ * @param {Object} event
+ * @returns {Object}
+ */
+export function createFleetCockpitEvent({type, source, agentId = null, confidence = 'observed', payload = null, occurredAt = null} = {}) {
+    if (!FLEET_COCKPIT_EVENT_TYPES.includes(type)) {
+        throw new Error(`createFleetCockpitEvent: unsupported event type '${type}'`)
+    }
+    if (!source) {
+        throw new Error('createFleetCockpitEvent: source is required')
+    }
+
+    return {
+        type,
+        source,
+        agentId,
+        confidence,
+        occurredAt,
+        payload: sanitizePayload(payload)
+    }
+}
+
+/**
+ * @summary Capability placeholder for adapters that are planned but not wired. A missing adapter is a
+ * first-class fact, not sample data.
+ * @param {String} source
+ * @param {String} reason
+ * @returns {Object}
+ */
+export function createNotWiredCapability(source, reason) {
+    return {
+        source,
+        state     : 'not-wired',
+        confidence: 'none',
+        reason
+    }
+}
+
+function sanitizePayload(value) {
+    if (Array.isArray(value)) {
+        return value.map(item => sanitizePayload(item))
+    }
+
+    if (!value || typeof value !== 'object') {
+        return value
+    }
+
+    return Object.fromEntries(
+        Object.entries(value)
+            .filter(([key]) => !isSecretKey(key))
+            .map(([key, item]) => [key, sanitizePayload(item)])
+    )
+}
+
+function isSecretKey(key) {
+    const normalized = key.toLowerCase().replace(/[_-]/g, '')
+
+    return normalized === 'credential' ||
+        normalized.endsWith('credential') ||
+        normalized === 'pat' ||
+        normalized.endsWith('pat') ||
+        normalized.includes('token') ||
+        normalized.includes('secret') ||
+        normalized.includes('password') ||
+        normalized.includes('signingkey') ||
+        normalized.includes('privatekey')
+}

--- a/test/playwright/unit/ai/buildScripts/docs/index/PortalContentIndexes.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/docs/index/PortalContentIndexes.spec.mjs
@@ -35,12 +35,15 @@ function getChunkNumber(record) {
  * @param {Object[]} records
  * @param {String} parentId
  */
-function expectChunkFoldersDescending(records, parentId) {
+function expectChunkFoldersDescending(records, parentId, {requireMultiple = true} = {}) {
     const chunkNumbers = records
         .filter(record => record.parentId === parentId && getChunkNumber(record) !== null)
         .map(getChunkNumber);
 
-    expect(chunkNumbers.length).toBeGreaterThan(1);
+    if (requireMultiple) {
+        expect(chunkNumbers.length).toBeGreaterThan(1);
+    }
+
     expect(chunkNumbers).toEqual([...chunkNumbers].sort((a, b) => b - a))
 }
 
@@ -183,7 +186,7 @@ test.describe('Portal content index generators (#12210)', () => {
     test('committed pull-request index keeps active chunk folders in chunk-number order', async () => {
         const index = await fs.readJson(path.join(process.cwd(), 'apps/portal/resources/data/pulls/index.json'));
 
-        expectChunkFoldersDescending(index, 'Latest')
+        expectChunkFoldersDescending(index, 'Latest', {requireMultiple: false})
     });
 
     test('createDiscussionIndex groups by frontmatter category for active and archive files', async () => {

--- a/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
@@ -1,0 +1,153 @@
+import {setup} from '../../../../setup.mjs'
+
+const appName = 'FleetCockpitStatusTest'
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+})
+
+import {test, expect} from '@playwright/test'
+import Neo            from '../../../../../../src/Neo.mjs'
+import * as core      from '../../../../../../src/core/_export.mjs'
+
+import {
+    createFleetCockpitEvent,
+    createFleetCockpitStatus,
+    FLEET_COCKPIT_EVENT_TYPES,
+    FLEET_COCKPIT_SOURCES
+} from '../../../../../../src/ai/fleet/fleetCockpitStatus.mjs'
+
+test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
+    test('composes roster and repo status with explicit source labels', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents: [{
+                id            : 'alice',
+                githubUsername: 'alice-gh',
+                harnessType   : 'codex',
+                metadata      : {
+                    repo: {repoSlug: 'neomjs/neo'}
+                }
+            }],
+            fleetStatus: [{
+                agentId           : 'alice',
+                configured        : true,
+                repoSlug          : 'neomjs/neo',
+                state             : 'checkout',
+                provisioningAction: 'reuse'
+            }]
+        })
+
+        expect(snapshot.sources).toEqual(FLEET_COCKPIT_SOURCES)
+        expect(snapshot.rows).toHaveLength(1)
+        expect(snapshot.rows[0]).toMatchObject({
+            id            : 'alice',
+            githubUsername: 'alice-gh',
+            harnessType   : 'codex',
+            repoStatus    : {
+                agentId : 'alice',
+                repoSlug: 'neomjs/neo',
+                state   : 'checkout'
+            },
+            sources: {
+                roster: {
+                    source: FLEET_COCKPIT_SOURCES.roster,
+                    state : 'wired'
+                },
+                repoStatus: {
+                    source: FLEET_COCKPIT_SOURCES.repoStatus,
+                    state : 'wired'
+                }
+            }
+        })
+    })
+
+    test('marks runtime and activity adapters as not wired instead of inventing state', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents     : [{id: 'alice', githubUsername: 'alice-gh'}],
+            fleetStatus: []
+        })
+
+        expect(snapshot.capabilities.activity).toMatchObject({
+            source: FLEET_COCKPIT_SOURCES.activity,
+            state : 'not-wired'
+        })
+        expect(snapshot.capabilities.runtime).toMatchObject({
+            source: FLEET_COCKPIT_SOURCES.runtime,
+            state : 'not-wired'
+        })
+        expect(snapshot.rows[0].repoStatus).toBeNull()
+        expect(snapshot.rows[0].sources.repoStatus).toMatchObject({
+            source: FLEET_COCKPIT_SOURCES.repoStatus,
+            state : 'missing'
+        })
+        expect(snapshot.rows[0].lifecycle).toMatchObject({
+            source: FLEET_COCKPIT_SOURCES.runtime,
+            state : 'not-wired'
+        })
+    })
+
+    test('strips secret-shaped fields from rows and events recursively', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents: [{
+                id             : 'alice',
+                credential     : 'ghp_secret',
+                credentialState: 'stored',
+                metadata       : {
+                    repo        : {repoSlug: 'neomjs/neo'},
+                    privateToken: 'secret'
+                }
+            }],
+            fleetStatus: [{
+                agentId   : 'alice',
+                repoPath  : '/tmp/fleet/alice',
+                state     : 'checkout',
+                signingKey: 'secret'
+            }],
+            events: [{
+                type   : 'lifecycle-request',
+                source : FLEET_COCKPIT_SOURCES.lifecycle,
+                agentId: 'alice',
+                payload: {
+                    id       : 'alice',
+                    bridgePAT: 'ghp_secret',
+                    nested   : {
+                        password: 'secret'
+                    }
+                }
+            }]
+        })
+
+        const serialized = JSON.stringify(snapshot)
+
+        expect(serialized).toContain('alice')
+        expect(serialized).toContain('credentialState')
+        expect(serialized).toContain('repoPath')
+        expect(serialized).not.toContain('ghp_secret')
+        expect(serialized).not.toContain('signingKey')
+        expect(serialized).not.toContain('privateToken')
+        expect(serialized).not.toContain('bridgePAT')
+        expect(serialized).not.toContain('password')
+    })
+
+    test('normalizes only the bounded lifecycle and bridge event classes', () => {
+        const events = FLEET_COCKPIT_EVENT_TYPES.map(type => createFleetCockpitEvent({
+            type,
+            source : type.startsWith('bridge') ? FLEET_COCKPIT_SOURCES.roster : FLEET_COCKPIT_SOURCES.lifecycle,
+            agentId: 'alice'
+        }))
+
+        expect(events.map(event => event.type)).toEqual([...FLEET_COCKPIT_EVENT_TYPES])
+    })
+
+    test('rejects source-less or unsupported events', () => {
+        expect(() => createFleetCockpitEvent({type: 'lifecycle-request'})).toThrow('source is required')
+        expect(() => createFleetCockpitEvent({type: 'free-form', source: FLEET_COCKPIT_SOURCES.lifecycle})).toThrow('unsupported event type')
+    })
+})


### PR DESCRIPTION
Resolves #14562
Resolves #14575

Adds a dependency-light Body-side Fleet cockpit status adapter for Lane 2/C. The new DTO composes the already-shipped `listAgents()` roster and `fleetStatus()` repo-provisioning read, labels every source, keeps runtime/activity adapters explicit as `not-wired`, normalizes bounded lifecycle/bridge events, and strips secret-shaped payload fields without dropping public `credentialState` or `repoPath` facts.

Also fixes the unrelated red full-unit failure exposed by the v13.1 archive: the committed Portal pull-request index can legitimately have zero active `Latest` chunks immediately after release, while the synthetic generator test still proves multi-chunk descending order.

Evidence: L2 (focused unit + fleet-unit contract coverage + exact red-CI spec reproduction) -> L2 required for the DTO/source-label/redaction/fail-closed ACs and for the #14575 test-contract correction. Residual: runtime process truth remains behind Ada's runtime-status wire delta; #14563 covers the Neural Link/live cockpit proof layer.

## Deltas from ticket

- No new `FLEET_WIRE_METHODS` verb was added for this slice. Runtime state is intentionally represented as a `not-wired` capability until Ada lands the runtime-status method.
- A2A/PR/lane activity adapters are modeled as explicit future capability state rather than fake events.
- The sanitizer was narrowed after self-review so public non-secret fields such as `credentialState` and `repoPath` survive.
- #14575 was added as a second commit after CI proved `origin/dev` already had zero active Portal PR chunks post-release.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs` -> 5 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/fleet` -> 53 passed.
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/docs/index/PortalContentIndexes.spec.mjs` -> 4 passed.
- `npm run agent-preflight -- --no-fix src/ai/fleet/fleetCockpitStatus.mjs test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs test/playwright/unit/ai/buildScripts/docs/index/PortalContentIndexes.spec.mjs` -> passed.
- `git diff --check` -> passed before the #14575 commit.
- Note: one parallel test attempt collided on the shared Chroma unit-test port while another focused spec was running; the affected specs were rerun serially and passed.

## Post-Merge Validation

- [ ] Lane 1 cockpit UI can consume `createFleetCockpitStatus()` instead of sample/inferred status when #14560 wires rows.
- [ ] Ada's runtime-status wire method can replace the runtime `not-wired` capability when it lands.
- [ ] The next full `unit` run stays green with a post-release empty `Latest` PR chunk set.

Authored by Euclid (GPT-5, Codex Desktop). Session 019f2a7a-94c2-7de1-901a-966c21a5d604.