### PR TITLE
feat(goal-scoping): encode graduation bar (#14579)

### DIFF
--- a/.agents/skills/epic-create/references/epic-create-workflow.md
+++ b/.agents/skills/epic-create/references/epic-create-workflow.md
@@ -52,7 +52,7 @@ Each sub the decomposition creates MUST be a **leaf that a single PR can FULLY d
 3. **Graduation gate (if from a Discussion).** High-blast Epics require the §6.2 family-keyed quorum + the §5.1 divergence matrix in the source Discussion before filing (per `ideation-sandbox-workflow.md` + `ideation-sandbox/audits/double-diamond-divergence-guard.md`). Carry the `Signal Ledger` / dissent / liveness / criteria-mapping sections into the body.
 4. **Author the body** = problem-scope + intended-solution (+ ledger if graduated). NO ACs, NO sub-list.
 5. **Label `epic`** + apply title hygiene (per `ticket-create`).
-6. **Create subs separately** (via `ticket-create` — each with its own ACs + Contract Ledger) and **link each via `update_issue_relationship`** (parent = the Epic). Add subs incrementally as the decomposition clarifies — never block Epic creation on a complete sub-list.
+6. **Create subs separately** (via `ticket-create` — each with its own ACs + Contract Ledger) and **link each via `update_issue_relationship`** (parent = the Epic). Add subs incrementally as decomposition clarifies; that governs Epic life. Goal-scoping graduation is stricter: full v1 leaves are filed/native-linked, while the Epic body stays sub-list-free.
 7. **Verify** (pre-flight, before `create_issue`):
    - [ ] Body contains **no** `## Acceptance Criteria` block.
    - [ ] Body contains **no** hardcoded sub-registry (subs discoverable via parent-child relationship instead).

--- a/.agents/skills/goal-scoping/references/goal-scoping-workflow.md
+++ b/.agents/skills/goal-scoping/references/goal-scoping-workflow.md
@@ -25,7 +25,9 @@ Carve the goal into a **few** (≈2–6) coherent streams — by subsystem / dae
 **The lane test:** would one accountable owner carry this whole stream in their head and drive it to a goal? If it is too small to warrant an owner, it is a *sub* of a lane, not a lane. If it spans unrelated concerns, split it.
 
 ### 3. Each lane → an epic
-Author each lane as an epic via **`/epic-create`** (problem-scope + intended-solution; subs linked, added reasonably by the owner). The lane-epic is the **durable, context-wipe-proof ownership anchor**: an owner who wakes disoriented asks "what do I own?" → "the X lane / epic #N" → reads the epic body + linked subs → rebuilt. (Contrast: self-assigned scattered micro-tickets evaporate across a context-wipe → ownership-amnesia → grabbing stale tickets.)
+Author each lane as an epic via **`/epic-create`**; linked subs, not prose, are its durable ownership anchor across context wipes.
+
+**Graduation bar:** epic exists; full v1 one-PR leaves are filed/native-linked (`blocked-by` if ordered); source Discussion is closed RESOLVED; peers can claim leaves without hidden context. #14565/#14564 are the 2026-07-04 precedent; epic shells with "subs to follow" repeat the June failure. Epic bodies stay sub-list-free.
 
 ### 4. Ownership = SELF-SELECT
 The planner **defines** the goal + the lanes (the planning artifact) and **facilitates**. Peers **self-select** the lane they own. The planner **never assigns** a peer to a lane — that is micro-management and violates self-assignment. Surface the lanes; let peers claim them. Each lane needs exactly one accountable owner; if two claim, the earlier claim wins (the later contributes into it).
@@ -50,5 +52,6 @@ The owner is accountable for the **lane's goal** (close-by-goal, never sub-count
 | Lead assigns peers to lanes | micro-management; violates self-assignment + flat-peer agency |
 | Scrap-ticket explosion (goal → N micro-tickets) | per-unit overhead × N; ownership-amnesia across context-wipes |
 | A "lane" that is really a sliver | too small to own; it is a sub, not a lane |
+| Epic shell with leaves to follow | not delegatable; hidden planner context |
 | Lanes listed in prose, never owned | a backlog dump is not a plan; lanes have accountable owners |
 | The planner owns every lane | that is a solo project, not planning; the point is distributed ownership |


### PR DESCRIPTION
Resolves #14579

Adds the goal-scoping graduation bar as a compact skill-payload rule: a lane is graduated only after the epic exists, full v1 leaf tickets are filed/native-linked, the source Discussion is closed RESOLVED, and peers can claim leaves without hidden planner context. It also clarifies epic-create step 6 so ordinary epic lifecycle decomposition can remain incremental without weakening goal-scoping graduation.

Evidence: L1 (static skill-payload contract validation: agent-preflight, skill-manifest lint, diff check) -> L1 required (documentation/substrate payload ACs only). No residuals.

## Deltas from ticket
None substantive. The implementation compresses the requested language to stay within the skill-manifest net-growth cap. The source-ticket Contract Ledger was posted on #14579 before PR creation.

## Test Evidence
- npm run agent-preflight -- --no-fix .agents/skills/goal-scoping/references/goal-scoping-workflow.md .agents/skills/epic-create/references/epic-create-workflow.md
- node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev
- git diff --check
- Contract Ledger posted on #14579: https://github.com/neomjs/neo/issues/14579#issuecomment-4880240281

## Substrate Slot Rationale
Modified sections: conditional skill reference payloads under .agents/skills/goal-scoping/references/ and .agents/skills/epic-create/references/.

Disposition delta: compress-to-trigger. SKILL.md router text is unchanged, so always-loaded map delta is +0 bytes; the rule body lives in conditional World-Atlas payloads.

Net loaded-byte delta: always-loaded +0 bytes; conditional skill Markdown +156 bytes (+71 goal-scoping, +85 epic-create). lint-skill-manifest passed under the +250-byte gate.

## Post-Merge Validation
- [ ] A future goal-scoping graduation uses the bar to file and native-link the full v1 leaf set before marking the lane delegatable.

## Commits
- 7489bb732d - feat(goal-scoping): encode graduation bar (#14579)

Authored by Euclid (GPT-5, Codex Desktop). Session 33403f62-0332-411a-bda3-0f4ab10cd1e6.