### PR TITLE
fix(ai): GP contradiction guard — drop the stale v13.1 literal (#14588)

### DIFF
--- a/ai/services/graph/computedGoldenPathRouting.mjs
+++ b/ai/services/graph/computedGoldenPathRouting.mjs
@@ -31,10 +31,16 @@ const COMPUTED_CONTENT_CONTRADICTION_LABELS = Object.freeze(new Set([
     'content'
 ]));
 
+/**
+ * Focus reasons strong enough to pause contradictory content routing. Deliberately
+ * limited to release-INDEPENDENT classes: a release-version literal in this set outlives
+ * its release and arms the guard forever — post-ship, every pass renders zero routes
+ * while the release tail stays open. Release-window guarding, if reintroduced, must ride
+ * a config/SSOT leaf with a publish-cleared lifecycle — never a hardcoded literal.
+ */
 const CURRENT_FOCUS_ROUTING_CONFLICT_REASONS = Object.freeze(new Set([
     'incident',
-    'prio-zero',
-    'v13.1'
+    'prio-zero'
 ]));
 
 /**

--- a/test/playwright/unit/ai/services/graph/computedGoldenPathRouting.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/computedGoldenPathRouting.spec.mjs
@@ -1,0 +1,92 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'ComputedGoldenPathRoutingTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('computedGoldenPathRouting — the contradiction guard (routing-decision surface, #14588)', () => {
+    let findComputedFocusContradiction, isRoutingConflictFocusCandidate;
+
+    const contentNode = id => ({
+        node: {
+            id,
+            type      : 'ISSUE',
+            properties: {labels: ['documentation', 'ai'], title: 'release cut: notes + version bump'}
+        },
+        score: 1, semantic: 1, structural: 0
+    });
+
+    const codeNode = id => ({
+        node: {
+            id,
+            type      : 'ISSUE',
+            properties: {labels: ['bug', 'ai'], title: 'router collapses to zero routes'}
+        },
+        score: 1, semantic: 1, structural: 0
+    });
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/graph/computedGoldenPathRouting.mjs');
+        findComputedFocusContradiction  = mod.findComputedFocusContradiction;
+        isRoutingConflictFocusCandidate = mod.isRoutingConflictFocusCandidate;
+    });
+
+    test('a release-version reason does NOT arm the routing guard (the stale-boundary class, #14588 / #14531 sibling)', () => {
+        // The 2026-07-04 live reproducer: post-release focus tail carrying the shipped
+        // release's reason zeroed every routing pass. Release literals are banned from
+        // the conflict set; the candidate stays visibility-only.
+        expect(isRoutingConflictFocusCandidate({number: 14475, reasons: ['v13.1', 'fresh-updated']})).toBe(false);
+
+        const result = findComputedFocusContradiction({
+            currentFocusCandidates: [{number: 14310, reasons: ['v13.1']}],
+            topNodes              : [contentNode('issue-14475')]
+        });
+
+        expect(result).toBeNull();
+    });
+
+    test('incident and prio-zero reasons still arm the guard', () => {
+        expect(isRoutingConflictFocusCandidate({number: 1, reasons: ['incident']})).toBe(true);
+        expect(isRoutingConflictFocusCandidate({number: 2, reasons: ['prio-zero']})).toBe(true);
+        expect(isRoutingConflictFocusCandidate({number: 3, reasons: ['agent-os', 'fresh-created']})).toBe(false);
+    });
+
+    test('under live incident focus, content candidates are blocked while non-content candidates survive (fallback-to-next stays routable)', () => {
+        const result = findComputedFocusContradiction({
+            currentFocusCandidates: [{number: 100, reasons: ['incident']}],
+            topNodes              : [contentNode('issue-200'), codeNode('issue-201')]
+        });
+
+        expect(result).not.toBeNull();
+        expect([...result.blockedIds]).toEqual(['issue-200']);
+
+        // The synthesizer routes topNodes minus blockedIds — the non-content candidate remains.
+        const routed = [contentNode('issue-200'), codeNode('issue-201')]
+            .filter(item => !result.blockedIds.has(item.node.id));
+
+        expect(routed).toHaveLength(1);
+        expect(routed[0].node.id).toBe('issue-201');
+    });
+
+    test('a focus MEMBER is never blocked, even when content-classified', () => {
+        const result = findComputedFocusContradiction({
+            currentFocusCandidates: [{number: 300, reasons: ['incident']}],
+            topNodes              : [contentNode('issue-300')]
+        });
+
+        expect(result).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

Fixes the operator-reported live failure (2026-07-04 01:50Z handoff): **the Computed Golden Path rendered `Selected routed nodes: 0` on every pass post-v13.1**, starving autonomous ticket/sandbox pickup. Root cause: `CURRENT_FOCUS_ROUTING_CONFLICT_REASONS` hardcoded the literal `'v13.1'` — so after the release shipped, every still-open release-tail focus candidate (#14575/#14310/#13448) kept arming the contradiction guard forever, and with the pass's single actionable candidate (#14475, blocked via its `documentation` label) filtered, the route surface zeroed. Same stale-release-boundary class as the release-analyzer literal fixed in #14531.

Resolves #14588
Refs #14565

## Deltas

- `ai/services/graph/computedGoldenPathRouting.mjs` — `'v13.1'` removed from the conflict-reason set; the set is now deliberately release-INDEPENDENT (`incident`, `prio-zero`), with the class-lesson recorded behaviorally in the constant's JSDoc (release-window guarding, if reintroduced, rides a config/SSOT leaf with a publish-cleared lifecycle — never a literal).
- **NEW:** `test/playwright/unit/ai/services/graph/computedGoldenPathRouting.spec.mjs` — 4 tests pinning the guard semantics: release-version reasons never arm the guard (the live reproducer's shape); `incident`/`prio-zero` still do; under genuine incident focus, content candidates block while non-content candidates survive (the fallback-to-next path, now test-pinned); focus MEMBERS are never blocked.

**Deliberately NOT in this PR (scope fence, recorded on #14588):**
- The emitter-side release literals (`issueFocusSections.mjs` — `V13_1_PATTERN`, milestone gate): visibility-only surface, unaffected by this fix, and the durable class-fix ("current release" as a config/SSOT leaf cleared by `publish.mjs`) is follow-up scope with config-template blast radius.
- The single-actionable-candidate narrowness (20 semantic → 5 open → 1 actionable) — that reach problem is #14503's lane (type-gate/cold-start disposition).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs computedGoldenPathRouting` → **4 passed (35.3s)**. Behavioral proof of the live fix: with the literal removed, tonight's reproducer state (focus tail carrying only `v13.1` reasons, one content-classified actionable candidate) yields `findComputedFocusContradiction → null` → the candidate routes; `Selected routed nodes ≥ 1`.

Evidence: L2 (unit fixtures pinning the routing-decision surface; the live handoff re-render lands with the next Golden Path pass post-merge).

## Post-Merge Validation

- Next Golden Path pass renders a numbered recommendation (operator-visible in `sandman_handoff.md`) instead of the routing-paused diagnostic — falsifiable in one pass.
- The #14454 route-attribution ledger shows routed nodes non-zero on the first post-merge emission.
- `incident`/`prio-zero` guard behavior unchanged (spec-pinned).

## Related

#14588 (this fix; layers 2–3 investigation recorded there) · #14531 (the sibling stale-boundary literal, release analyzer) · #14503 (ranking reach — the narrowness half) · #14565/ADR 0033 (the fail-open route-surface principle this enforces guard-side) · D#14561 Lane-4 lane-goal ("GP never empty post-release").

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session a5af7cf6-45a3-42db-8a30-f04f4241a55c.
