### PR TITLE
feat(fleet): runtime-status wire method — fleetRuntimeStatus (#14595)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -188,6 +188,18 @@ class FleetControlBridge extends Base {
     fleetStatus() {
         return this.getManager().fleetRepoStatus();
     }
+
+    /**
+     * @summary The live-process half of the *observe* MVP loop: per-agent process-runtime state across
+     * the whole fleet (running / stopped / exited), complementing {@link #fleetStatus}'s repo view.
+     * Read-only; carries no secret (the lifecycle status holds none). Richer idle / wedged / rate-limited
+     * states are a watchdog-gated follow-up — this returns what the lifecycle records observe, never
+     * an invented state.
+     * @returns {Object[]} one `{agentId, state, running, confidence, source}` entry per registered agent.
+     */
+    fleetRuntimeStatus() {
+        return this.getManager().fleetRuntimeStatus();
+    }
 }
 
 export default Neo.setupClass(FleetControlBridge);

--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -191,7 +191,7 @@ class FleetControlBridge extends Base {
 
     /**
      * @summary The live-process half of the *observe* MVP loop: per-agent process-runtime state across
-     * the whole fleet (running / stopped / exited), complementing {@link #fleetStatus}'s repo view.
+     * the whole fleet (running / stopped), complementing {@link #fleetStatus}'s repo view.
      * Read-only; carries no secret (the lifecycle status holds none). Richer idle / wedged / rate-limited
      * states are a watchdog-gated follow-up — this returns what the lifecycle records observe, never
      * an invented state.

--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -141,6 +141,37 @@ class FleetManager extends Base {
     }
 
     /**
+     * @summary Turnkey fleet runtime observability: the per-agent process-runtime state across the whole
+     * fleet — the live-process view complementing {@link fleetRepoStatus}'s repo view. Composes the
+     * registry roster with the lifecycle service's per-agent {@link
+     * Neo.ai.services.fleet.FleetLifecycleService#status} read, so every *registered* agent gets a row (an
+     * agent with no live process reads `state:'stopped'`) and the cockpit renders the whole fleet, not
+     * only running processes. Read-only; never carries a secret (`status` holds none — `stderrBytes` is a
+     * count). Lifecycle records expose running / stopped / exited directly; richer idle / wedged /
+     * rate-limited states need watchdog signals this service does not yet surface (a separate
+     * watchdog-signals follow-up), so a row is `observed` when a process record backs it and `inferred`
+     * otherwise — the
+     * state is never invented.
+     * @returns {Object[]} one `{agentId, state, running, confidence, source}` entry per registered agent.
+     */
+    fleetRuntimeStatus() {
+        const lifecycle = this.getLifecycleService();
+
+        return lifecycle.getRegistry().listAgents().map(agent => {
+            const status   = lifecycle.status(agent.id),
+                  observed = status.pid != null || status.startedAt != null || status.exitCode != null;
+
+            return {
+                agentId   : agent.id,
+                state     : status.state,
+                running   : status.running,
+                confidence: observed ? 'observed' : 'inferred',
+                source    : 'fleet:runtimeStatus'
+            };
+        });
+    }
+
+    /**
      * @summary Turnkey stop: gracefully stop an agent's harness process (`SIGTERM`, then `SIGKILL` after
      * the timeout) via the lifecycle collaborator. A thin delegation — stopping a process needs no
      * `managedRoot` / provisioning, so it forwards straight to `FleetLifecycleService.stop`, mirroring how

--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -147,7 +147,7 @@ class FleetManager extends Base {
      * Neo.ai.services.fleet.FleetLifecycleService#status} read, so every *registered* agent gets a row (an
      * agent with no live process reads `state:'stopped'`) and the cockpit renders the whole fleet, not
      * only running processes. Read-only; never carries a secret (`status` holds none — `stderrBytes` is a
-     * count). Lifecycle records expose running / stopped / exited directly; richer idle / wedged /
+     * count). Lifecycle records expose running / stopped directly; richer idle / wedged /
      * rate-limited states need watchdog signals this service does not yet surface (a separate
      * watchdog-signals follow-up), so a row is `observed` when a process record backs it and `inferred`
      * otherwise — the

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -17,5 +17,5 @@
  */
 export const FLEET_WIRE_METHODS = Object.freeze([
     'defineAgent', 'setRepo', 'setAvatar', 'listAgents', 'getAgent',
-    'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus'
+    'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus', 'fleetRuntimeStatus'
 ]);

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -117,6 +117,12 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         expect(calls).toEqual([['fleetRepoStatus']]);
     });
 
+    test('fleetRuntimeStatus delegates to the manager runtime aggregator', () => {
+        managerStub.fleetRuntimeStatus = () => { calls.push(['fleetRuntimeStatus']); return [{agentId: 'alice', state: 'running', running: true, confidence: 'observed', source: 'fleet:runtimeStatus'}]; };
+        expect(FleetControlBridge.fleetRuntimeStatus()).toEqual([{agentId: 'alice', state: 'running', running: true, confidence: 'observed', source: 'fleet:runtimeStatus'}]);
+        expect(calls).toEqual([['fleetRuntimeStatus']]);
+    });
+
     // ---- the security boundary: the allowlist OMITS the Brain-internal secret paths ----
 
     test('the surface exposes NO Brain-internal secret accessor (the capability allowlist)', () => {

--- a/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
@@ -78,3 +78,38 @@ test.describe('Neo.ai.services.fleet.FleetManager — fleet-authority definition
         expect(calls).toEqual([['updateAgent', 'alice', {metadata: {}}]]);
     });
 });
+
+test.describe('Neo.ai.services.fleet.FleetManager — fleetRuntimeStatus (roster × lifecycle status)', () => {
+    test.afterEach(() => {
+        FleetManager.lifecycleService = null;
+    });
+
+    test('composes the roster with per-agent lifecycle status — every registered agent gets a row', () => {
+        const registryStub = {listAgents: () => [{id: 'alice'}, {id: 'bob'}]};
+
+        FleetManager.lifecycleService = {
+            getRegistry: () => registryStub,
+            status     : id => id === 'alice'
+                ? {id, state: 'running', running: true,  pid: 4242, startedAt: '2026-07-04T00:00:00Z', exitCode: null}
+                : {id, state: 'stopped', running: false, pid: null, startedAt: null,                    exitCode: null}
+        };
+
+        expect(FleetManager.fleetRuntimeStatus()).toEqual([
+            {agentId: 'alice', state: 'running', running: true,  confidence: 'observed', source: 'fleet:runtimeStatus'},
+            {agentId: 'bob',   state: 'stopped', running: false, confidence: 'inferred', source: 'fleet:runtimeStatus'}
+        ]);
+    });
+
+    test('a tracked-but-exited agent reads observed (a process record backs it) — state never invented', () => {
+        const registryStub = {listAgents: () => [{id: 'alice'}]};
+
+        FleetManager.lifecycleService = {
+            getRegistry: () => registryStub,
+            status     : id => ({id, state: 'exited', running: false, pid: null, startedAt: null, exitCode: 1})
+        };
+
+        expect(FleetManager.fleetRuntimeStatus()).toEqual([
+            {agentId: 'alice', state: 'exited', running: false, confidence: 'observed', source: 'fleet:runtimeStatus'}
+        ]);
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
@@ -100,16 +100,16 @@ test.describe('Neo.ai.services.fleet.FleetManager — fleetRuntimeStatus (roster
         ]);
     });
 
-    test('a tracked-but-exited agent reads observed (a process record backs it) — state never invented', () => {
+    test('a tracked-but-stopped agent reads observed (a process record backs it) — state never invented', () => {
         const registryStub = {listAgents: () => [{id: 'alice'}]};
 
         FleetManager.lifecycleService = {
             getRegistry: () => registryStub,
-            status     : id => ({id, state: 'exited', running: false, pid: null, startedAt: null, exitCode: 1})
+            status     : id => ({id, state: 'stopped', running: false, pid: null, startedAt: '2026-07-04T00:00:00Z', exitCode: 1})
         };
 
         expect(FleetManager.fleetRuntimeStatus()).toEqual([
-            {agentId: 'alice', state: 'exited', running: false, confidence: 'observed', source: 'fleet:runtimeStatus'}
+            {agentId: 'alice', state: 'stopped', running: false, confidence: 'observed', source: 'fleet:runtimeStatus'}
         ]);
     });
 });

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -100,7 +100,7 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
 
     test('the wire allowlist is exactly the pane operations — no resolver seams', () => {
         expect([...FLEET_WIRE_METHODS].sort()).toEqual(
-            ['defineAgent', 'fleetStatus', 'getAgent', 'listAgents', 'removeAgent', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
+            ['defineAgent', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'listAgents', 'removeAgent', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
         );
         expect(FLEET_WIRE_METHODS).not.toContain('getManager');
         expect(FLEET_WIRE_METHODS).not.toContain('getRegistry');


### PR DESCRIPTION
Resolves #14595

Adds a fail-closed wire method exposing per-agent process-runtime state to the FM cockpit: `FleetManager#fleetRuntimeStatus` composes the registry roster with per-agent `FleetLifecycleService.status()`, `FleetControlBridge` delegates it, and `'fleetRuntimeStatus'` joins `FLEET_WIRE_METHODS`. This ships the **provider** that the #14562 cockpit DTO (PR #14571) will consume to flip its `runtime` slot from `not-wired` to wired — that consumer flip lands **post-merge** in a separate DTO update; this PR does not itself modify the DTO.

Evidence: L2 (unit — composition / delegation / allowlist / secret-boundary) → L2 required (the wire-method ACs are fully unit-covered). Residual: the #14562 DTO `not-wired → wired` flip is a separate consumer change, post-merge.

## Deltas from ticket
Narrowed to the actually-shipped wire-method leaf (per @neo-gpt review on this PR):
- **Output shape** is `{agentId, state, running, confidence, source}` from `FleetLifecycleService.status()` per agent over the roster — not `listRunning + watchdog`. The #14595 Contract Ledger is updated to this exact shape.
- **States** are the real lifecycle ones: `running` / `stopped` (a terminated child reads `stopped` with `exitCode` / `exitedAt`). Richer `idle` / `wedged` / `rate-limited` need watchdog signals this service does not surface — an explicit **follow-up**, out of scope for this leaf (removed from the #14595 close-target).
- **No DTO flip here** — this PR ships the provider only; the #14562 consumer update is post-merge.
- A row is `confidence:'observed'` only when a process record backs it (`pid` / `startedAt` / `exitCode`), `'inferred'` otherwise — never invented.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/services/fleet/` → **51 passed (31.2s)**:
- FleetManager composition (roster × status; running→observed, untracked-stopped→inferred, tracked-stopped→observed) + FleetControlBridge delegation.
- Updated the `dispatchFleetRequest` allowlist assertion (+`fleetRuntimeStatus`); the browser-bridge specs auto-include it.
- No regressions; the full-chain `fleetTransport` integration spec stays green.

## Post-Merge Validation
- [ ] A separate #14562 DTO update flips `capabilities.runtime` + per-row `sources.runtime` from `not-wired → wired` against `fleetRuntimeStatus` (consumer change, not this PR).
- [ ] The cockpit fleet-grid state-dots (Vega's L1 #14598 / #14599) render live runtime state over the wire once the DTO consumes it.

## Commits
- 88ed5a9fe7 — `fleetRuntimeStatus` (FleetManager + FleetControlBridge) + `FLEET_WIRE_METHODS` verb + specs
- 04b75567d6 — correct the `exited → stopped` state overclaim (JSDoc + test) per review

Related: #13015 (FM MVP parent) · #14562 / PR #14571 (future consumer) · #14561 (L2 lane).

Cross-family review requested — @neo-gpt (Euclid).

Authored by Ada (Claude Opus 4.8, Claude Code). Session a5ffd401-b3ed-4aa2-aedd-6ca8ea0d6867.
