### PR TITLE
fix(memory-core): record_turn_presence omits terminalState off the terminal path (#14582)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2433,8 +2433,8 @@ components:
           format: date-time
         terminalState:
           type: string
-          nullable: true
           enum: [completed, blocked, aborted, stale]
+          description: Present only on a `terminal` close; omitted for `start` / `progress` responses.
         source:
           type: string
         note:

--- a/ai/services/memory-core/TurnPresenceService.mjs
+++ b/ai/services/memory-core/TurnPresenceService.mjs
@@ -136,12 +136,22 @@ class TurnPresenceService extends Base {
             properties
         });
 
-        return {
+        const response = {
             ...properties,
             status: 'recorded',
             action,
             id    : nodeId
         };
+
+        // `terminalState` is meaningful only on a `terminal` close. The declared output schema's enum
+        // carries no null member (the MCP structured-content validator does not honor OpenAPI
+        // `nullable: true`), so returning a non-terminal `terminalState: null` fails client-side
+        // validation — every `start` / `progress` call would error. Omit it off the terminal path.
+        if (action !== 'terminal') {
+            delete response.terminalState;
+        }
+
+        return response;
     }
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs
@@ -109,7 +109,7 @@ test.describe('Neo.ai.services.memory-core.TurnPresenceService', () => {
         expect(result.lastProgressAt).toBe('2026-06-19T00:00:00.000Z');
         expect(result.freshUntil).toBe('2026-06-19T00:30:00.000Z');
         expect(result.expiresAt).toBe('2026-06-19T01:00:00.000Z');
-        expect(result.terminalState).toBe(null);
+        expect(result.terminalState).toBeUndefined();
         expect(result.status).toBe('recorded');
 
         const node = getNode('turn-start');
@@ -198,5 +198,20 @@ test.describe('Neo.ai.services.memory-core.TurnPresenceService', () => {
         expect(node.properties.status).toBe('terminal');
         expect(node.properties.terminalState).toBe('completed');
         expect(node.properties.source).toBe('add_memory');
+    });
+
+    // Regression guard (schema↔handler drift): `terminalState` must be OMITTED — not null — on
+    // non-terminal responses. The declared output schema's enum has no null member, so a
+    // `terminalState: null` on a `start` / `progress` response fails the MCP structured-content
+    // validator and every such call errors. It is present only on a `terminal` close.
+    test('omits terminalState on non-terminal responses; present only on terminal', async () => {
+        const started = await asAgent(() => TurnPresenceService.recordTurnPresence({action: 'start', turnId: 'drift-turn', source: 'spec'}));
+        expect('terminalState' in started).toBe(false);
+
+        const progressed = await asAgent(() => TurnPresenceService.recordTurnPresence({action: 'progress', turnId: 'drift-turn'}));
+        expect('terminalState' in progressed).toBe(false);
+
+        const terminated = await asAgent(() => TurnPresenceService.recordTurnPresence({action: 'terminal', turnId: 'drift-turn', terminalState: 'aborted'}));
+        expect(terminated.terminalState).toBe('aborted');
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs
@@ -17,10 +17,25 @@ import {test, expect}        from '@playwright/test';
 import Neo                   from '../../../../../../src/Neo.mjs';
 import * as core             from '../../../../../../src/core/_export.mjs';
 import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+import fs                     from 'fs';
+import path                   from 'path';
+import * as yaml              from 'js-yaml';
+import {fileURLToPath}        from 'url';
+import {buildOutputZodSchema} from '../../../../../../ai/mcp/validation/openApiValidator.mjs';
 
 // Stub Neo.get to keep data-record boot behavior from masking turn-presence coverage.
 // The setup regression is outside this spec's delivery contract.
 if (!Neo.get) Neo.get = () => null;
+
+// The tool's DECLARED output schema (memory-core openapi.yaml), built with the SAME validator the MCP
+// server applies to structured content (`buildOutputZodSchema` — the locus of the client-side -32602).
+// A prior version of this spec validated a hand-written response shape, never the declared schema, so a
+// buggy `terminalState: null` on `start` passed CI while the live tool errored. Parsing every action's
+// real response against this schema is the drift guard that catches that class of divergence.
+const repoRoot                 = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..'),
+      memoryCoreOpenApi        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/memory-core/openapi.yaml'), 'utf8')),
+      recordTurnPresenceOp     = Object.values(memoryCoreOpenApi.paths['/turn-presence/record']).find(op => op?.operationId === 'record_turn_presence'),
+      turnPresenceOutputSchema = buildOutputZodSchema(memoryCoreOpenApi, recordTurnPresenceOp);
 
 /**
  * @summary Unit coverage for the turn-started presence writer substrate.
@@ -200,18 +215,38 @@ test.describe('Neo.ai.services.memory-core.TurnPresenceService', () => {
         expect(node.properties.source).toBe('add_memory');
     });
 
-    // Regression guard (schema↔handler drift): `terminalState` must be OMITTED — not null — on
-    // non-terminal responses. The declared output schema's enum has no null member, so a
-    // `terminalState: null` on a `start` / `progress` response fails the MCP structured-content
-    // validator and every such call errors. It is present only on a `terminal` close.
-    test('omits terminalState on non-terminal responses; present only on terminal', async () => {
-        const started = await asAgent(() => TurnPresenceService.recordTurnPresence({action: 'start', turnId: 'drift-turn', source: 'spec'}));
-        expect('terminalState' in started).toBe(false);
+    // Schema↔handler drift guard — validates every action's REAL emitted response against the tool's
+    // DECLARED output schema (not a hand-written shape). `terminalState` is a terminal-only enum with no
+    // null member, so a non-terminal `terminalState: null` fails the MCP structured-content validator and
+    // errors every call. start/progress must OMIT it; terminal must carry it for all four states.
+    test('every action response parses against the DECLARED output schema — start/progress omit terminalState, terminal carries all four states; the pre-fix null shape is rejected (#14582 AC3/AC4)', async () => {
+        const start = await asAgent(() => TurnPresenceService.recordTurnPresence({
+            action: 'start', turnId: 'schema-turn', source: 'spec', now: '2026-06-19T00:00:00.000Z'
+        }));
+        expect(() => turnPresenceOutputSchema.parse(start), 'start response must satisfy the declared output schema').not.toThrow();
+        expect('terminalState' in start).toBe(false);
 
-        const progressed = await asAgent(() => TurnPresenceService.recordTurnPresence({action: 'progress', turnId: 'drift-turn'}));
-        expect('terminalState' in progressed).toBe(false);
+        const progress = await asAgent(() => TurnPresenceService.recordTurnPresence({
+            action: 'progress', turnId: 'schema-turn', now: '2026-06-19T00:05:00.000Z'
+        }));
+        expect(() => turnPresenceOutputSchema.parse(progress), 'progress response must satisfy the declared output schema').not.toThrow();
+        expect('terminalState' in progress).toBe(false);
 
-        const terminated = await asAgent(() => TurnPresenceService.recordTurnPresence({action: 'terminal', turnId: 'drift-turn', terminalState: 'aborted'}));
-        expect(terminated.terminalState).toBe('aborted');
+        // The full terminal enum — the ticket's AC3 ("terminal verified for all four terminal states").
+        for (const terminalState of ['completed', 'blocked', 'aborted', 'stale']) {
+            await asAgent(() => TurnPresenceService.recordTurnPresence({
+                action: 'start', turnId: `term-${terminalState}`, now: '2026-06-19T00:00:00.000Z'
+            }));
+            const terminal = await asAgent(() => TurnPresenceService.recordTurnPresence({
+                action: 'terminal', turnId: `term-${terminalState}`, terminalState, now: '2026-06-19T00:01:00.000Z'
+            }));
+            expect(() => turnPresenceOutputSchema.parse(terminal), `terminal:${terminalState} must satisfy the declared output schema`).not.toThrow();
+            expect(terminal.terminalState).toBe(terminalState);
+        }
+
+        // The exact pre-fix shape: a non-terminal response carrying `terminalState: null` is what the live
+        // MCP client rejected with -32602. The declared schema MUST reject it here — proving this fixture
+        // catches the drift the old hand-written `toBe(null)` assertion silently encoded.
+        expect(() => turnPresenceOutputSchema.parse({...start, terminalState: null})).toThrow();
     });
 });


### PR DESCRIPTION
Resolves #14582

`record_turn_presence` returned `terminalState: null` for non-terminal actions (`start` / `progress`), which the MCP structured-content validator rejects against the output schema's terminal-only enum — so **every `action:'start'` call errored `-32602`**, blinding presence / `who_is_online` liveness telemetry from the Claude Code harness since ≤2026-07-02 (two reproductions, two sessions). **Reproduced live again this session** (byte-identical `-32602 ... data/terminalState must be equal to one of the allowed values`) against the still-unpatched deployed server.

Evidence: L2 (unit) — every action's **real emitted response now parses against the tool's DECLARED output schema** (built with `buildOutputZodSchema`, the same validator the MCP server applies to structured content): `start` / `progress` omit `terminalState`; `terminal` carries it for **all four** states (`completed` / `blocked` / `aborted` / `stale`); and the exact pre-fix `terminalState: null` shape is **negative-asserted** to be rejected. Residual: live-harness re-verification against the *running* server is post-deploy (the deployed server picks up the change only on restart, unreachable from the sandbox) — see Post-Merge Validation.

## Deltas from ticket
- **`Resolves` kept, with post-deploy residuals annotated** (per cross-family review, option b): 3 of 5 ACs are met + CI-proven at merge; AC2/AC5 are live-verification that can only run post-deploy — recorded below as **post-deploy smoke-checks with a reopen trigger**, not a claim they're done. #14582 is annotated with this ledger.
  - **AC1 (forensic fork)** — answered from code, no query needed: `GraphService.upsertNode` runs **before** the response is built + validated, so the client-side `-32602` is post-write — presence nodes **did** persist; cosmetic-but-blinding, **no data backfill**. ✅
  - **AC3 (all four terminal states)** — covered by the declared-schema fixture. ✅
  - **AC4 (all actions validated against the declared output schema)** — the fixture parses each action's real response against `buildOutputZodSchema`; drift now fails in CI, not in a live harness. ✅
  - **AC2 (live `start` / `progress` schema-valid from a running harness)** — post-deploy. ⏳
  - **AC5 (`who_is_online` freshness sanity post-fix)** — post-deploy. ⏳
- **Fix layer**: took the ticket's preferred option 1 (handler omits `terminalState` off the terminal path) over widening the schema — the field is semantically terminal-only. Also dropped the now-vestigial `nullable: true` from the output schema.
- **Corrected the buggy spec assertion** (`result.terminalState).toBe(null)`) that **encoded the buggy shape** — which is exactly why the unit suite stayed green while the live tool failed: it validated a hand-written shape, never the declared schema.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs` → **6 passed (45.8s)**:
- **Declared-schema fixture** (new, replaces the prior behavioral-only omission guard): builds the `record_turn_presence` output schema via `buildOutputZodSchema` and `.parse()`s each action's **real** response — `start` / `progress` (terminalState omitted), `terminal` × all four states; negative-asserts the `terminalState: null` shape throws (the exact `-32602`).
- Corrected the `start` assertion: `terminalState` is **absent** (`toBeUndefined`), not `null`.
- The existing progress / terminal-close / noop / add_memory-terminalizes tests are unchanged and green.

## Post-Merge Validation
- [ ] A live `record_turn_presence({action:'start'})` from a harness returns a schema-valid payload (no `-32602`) once the deployed server restarts onto this change — **AC2**. (Live repro of the failure captured this session; this is the post-fix falsifier.)
- [ ] `who_is_online` freshness reflects active turns again — **AC5** (downstream consumer, #13498).
- If **either** check fails post-deploy, **reopen #14582** — the code fix + CI drift guard are the mergeable, verifiable surface; these two are the live smoke-checks that follow the deploy.

## Commits
- 903e19fc62 — omit `terminalState` off the terminal path + output-schema `nullable` drop + spec fix
- 7d10d08dec — declared-output-schema fixture (all actions × all four terminal states + negative null-guard)

Related: #13499 / #13498 (the shipped presence substrate this regressed on) · #14537 / #14576 (consumers whose idle-detection accuracy this gates).

Cross-family review — @neo-gpt (Euclid, the named forensic-holder for this ticket class). RAs addressed at 7d10d08dec.

Authored by Ada (Claude Opus 4.8, Claude Code). Session a5ffd401-b3ed-4aa2-aedd-6ca8ea0d6867.
