### PR TITLE
feat(fleetmanager): cockpit design tokens + verification surface (#14578)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 !/apps/agentos/index.html
 !/apps/agentos/**/*.mjs
 !/apps/agentos/neo-config.json
+!/apps/fleetmanager/index.html
+!/apps/fleetmanager/**/*.mjs
+!/apps/fleetmanager/neo-config.json
 !/apps/agentos/childapps/strategy/index.html
 !/apps/agentos/childapps/strategy/neo-config.json
 !/apps/agentos/childapps/swarm/index.html

--- a/apps/fleetmanager/TOKENS.md
+++ b/apps/fleetmanager/TOKENS.md
@@ -1,0 +1,21 @@
+# Fleet Manager Cockpit — Design Token Reference (#14578)
+
+The token vocabulary every cockpit view leaf consumes. **Source of truth for the values:** the design SSOT [`apps/agentos/design/fleet-manager-cockpit-plan.html`](../agentos/design/fleet-manager-cockpit-plan.html) (committed via `#14512`; it stays at that path until Epic `#14560` closes — link integrity outranks tidiness, per the `#14577` decision record). Any delta from the SSOT is a recorded design decision on a ticket — never silent drift.
+
+| Token group | Tokens | Role | Example consumer | Binding rule |
+|---|---|---|---|---|
+| Surfaces | `--fm-ground` · `--fm-panel` · `--fm-panel-2` · `--fm-rail` | page ground, card/panel fills, stream + edge rails | shell zones (`#14615`), cards (`#14598`), rails (`#14617`) | static |
+| Lines | `--fm-line` · `--fm-line-soft` | zone borders vs in-panel separators | shell, cards, stream rows | static |
+| Ink tiers | `--fm-ink` · `--fm-ink-dim` · `--fm-ink-faint` | primary / secondary / meta text | every view leaf | static; contrast per usage class audited by `#14619` |
+| Signal | `--fm-signal` | live/key-action accent — used sparingly | chrome title, live badge, lane-line emphasis | static; sparing use is a design rule, lint-greppable by count |
+| Session states | `--fm-state-ok/idle/wedged/limited/off` | agent SESSION state — never identity (ADR 0032 §2.3.1) | state dots + health bar (`#14593`, `#14599`) | bound from the runtime-status wire (`#14595`) |
+| Family rails | `--fm-family-claude/gpt/gemini/human` | the resident's CURRENT episode family (ADR 0032 §2.3.3) | card rail (`#14598`), legend | **data-driven from the era key — never a per-agent constant; a family switch re-renders in place, same resident** |
+| Type stacks | `--fm-font-mono` · `--fm-font-sans` | meta/labels vs body | all leaves | static |
+
+## Motion
+
+The SSOT's live pulse (`@keyframes pulse`, 2.4s) is **decoration, not information** — the dot's color carries the signal. Consumers gate it behind `prefers-reduced-motion: no-preference` exactly as the SSOT does; the reduced-motion path renders the identical static dot. End-to-end audit: `#14619`.
+
+## Adding a token
+
+A new token = a design decision: name it in the group table above, cite the ticket that decided it, and keep the SSOT-verbatim rule for anything the artifact already defines. The visual-regression baselines (`#14618`) are the mechanical guard; a baseline change is reviewed as a design change.

--- a/apps/fleetmanager/app.mjs
+++ b/apps/fleetmanager/app.mjs
@@ -1,0 +1,6 @@
+import Viewport from './view/Viewport.mjs';
+
+export const onStart = () => Neo.app({
+    mainView: Viewport,
+    name    : 'FleetManager'
+});

--- a/apps/fleetmanager/index.html
+++ b/apps/fleetmanager/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <title>Neo Fleet — Mission Control</title>
+    <link rel="stylesheet" href="./resources/tokens.css">
+</head>
+
+<body>
+    <script src="../../src/MicroLoader.mjs" type="module"></script>
+</body>
+
+</html>

--- a/apps/fleetmanager/neo-config.json
+++ b/apps/fleetmanager/neo-config.json
@@ -1,0 +1,18 @@
+{
+    "appPath"                     : "apps/fleetmanager/app.mjs",
+    "basePath"                    : "../../",
+    "environment"                 : "development",
+    "mainPath"                    : "./Main.mjs",
+    "themes"                      : ["neo-theme-neo-dark"],
+    "useAiClient"                 : true,
+    "useCanvasWorker"             : false,
+    "useCanvasWorkerStartingPoint": false,
+    "useSharedWorkers"            : true,
+
+    "mainThreadAddons": [
+        "DragDrop",
+        "LocalStorage",
+        "Navigator",
+        "Stylesheet"
+    ]
+}

--- a/apps/fleetmanager/resources/tokens.css
+++ b/apps/fleetmanager/resources/tokens.css
@@ -1,0 +1,50 @@
+/**
+ * Fleet Manager cockpit design tokens — extracted 1:1 from the design SSOT
+ * `apps/agentos/design/fleet-manager-cockpit-plan.html` (committed via #14512).
+ *
+ * Contract (#14578 / Epic #14560, ADR 0032 bindings):
+ * - Values match the SSOT verbatim; any delta is a recorded design decision on a ticket, never silent drift.
+ * - Family-rail tokens (--fm-family-*) are keyed for DATA-DRIVEN binding: family is an
+ *   EmbodiedEpisode-era attribute (ADR 0032 §2.3.3) — consumers bind the CURRENT era's key,
+ *   never a per-agent constant. A family switch re-renders the rail; same resident.
+ * - State tokens (--fm-state-*) encode SESSION state (working/idle/wedged/limited/off) —
+ *   never identity (ADR 0032 §2.3.1).
+ * - The pulse animation is decoration, not information (the dot's color carries the signal);
+ *   it is gated behind prefers-reduced-motion at the consumer (see TOKENS.md).
+ */
+:root {
+    /* surfaces */
+    --fm-ground     : #0b0e13;
+    --fm-panel      : #141a23;
+    --fm-panel-2    : #1a212c;
+    --fm-rail       : #0e131a;
+
+    /* lines */
+    --fm-line       : #262f3d;
+    --fm-line-soft  : #1c242f;
+
+    /* ink tiers */
+    --fm-ink        : #d6dce6;
+    --fm-ink-dim    : #8b97a8;
+    --fm-ink-faint  : #5a6575;
+
+    /* the signal accent — used sparingly (live / key action) */
+    --fm-signal     : #5eead4;
+
+    /* session-state colors (never identity) */
+    --fm-state-ok      : #34d399;
+    --fm-state-idle    : #f5b544;
+    --fm-state-wedged  : #f4718b;
+    --fm-state-limited : #a78bfa;
+    --fm-state-off     : #5b6675;
+
+    /* family rails — bound from the current episode's family key (data-driven) */
+    --fm-family-claude : #d99a5b;
+    --fm-family-gpt    : #58c093;
+    --fm-family-gemini : #6ba3e8;
+    --fm-family-human  : #c9d2de;
+
+    /* type stacks */
+    --fm-font-mono : ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --fm-font-sans : system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}

--- a/apps/fleetmanager/view/Viewport.mjs
+++ b/apps/fleetmanager/view/Viewport.mjs
@@ -1,0 +1,56 @@
+import BaseViewport from '../../../src/container/Viewport.mjs';
+
+/**
+ * The token-layer verification surface: renders one element per token group so the extracted
+ * vocabulary (`resources/tokens.css`) is visually verifiable under the dev server — the
+ * verification consumer for the design-SSOT extraction, not a product view.
+ * Product views land per the cockpit epic's leaves (fleet grid, activity stream, agent detail, …)
+ * and replace this viewport's items as they arrive; see `../TOKENS.md` for the token contract.
+ * @class FleetManager.view.Viewport
+ * @extends Neo.container.Viewport
+ */
+class Viewport extends BaseViewport {
+    static config = {
+        /**
+         * @member {String} className='FleetManager.view.Viewport'
+         * @protected
+         */
+        className: 'FleetManager.view.Viewport',
+        /**
+         * @member {Object} style
+         */
+        style: {backgroundColor: 'var(--fm-ground)', color: 'var(--fm-ink)', fontFamily: 'var(--fm-font-sans)', padding: '2rem'},
+        /**
+         * One demo row per token group — surfaces, ink tiers, signal, session states, family rails,
+         * type stacks — each consuming tokens exclusively (zero literal colors, per the token contract).
+         * @member {Object[]} items
+         */
+        items: [{
+            vdom:
+            {cn: [
+                {tag: 'h1', text: 'FM cockpit tokens — verification surface (#14578)', style: {fontFamily: 'var(--fm-font-mono)', fontSize: '14px', letterSpacing: '.15em', textTransform: 'uppercase', color: 'var(--fm-signal)'}},
+                {cn: [
+                    {text: 'panel',   style: {background: 'var(--fm-panel)',   border: '1px solid var(--fm-line)',      padding: '1rem', borderRadius: '8px'}},
+                    {text: 'panel-2', style: {background: 'var(--fm-panel-2)', border: '1px solid var(--fm-line-soft)', padding: '1rem', borderRadius: '8px'}},
+                    {text: 'rail',    style: {background: 'var(--fm-rail)',    border: '1px solid var(--fm-line)',      padding: '1rem', borderRadius: '8px'}}
+                ], style: {display: 'flex', gap: '1rem', marginTop: '1rem'}},
+                {cn: [
+                    {text: 'primary ink', style: {color: 'var(--fm-ink)'}},
+                    {text: 'dim ink',     style: {color: 'var(--fm-ink-dim)'}},
+                    {text: 'faint ink',   style: {color: 'var(--fm-ink-faint)'}}
+                ], style: {display: 'flex', gap: '2rem', marginTop: '1rem'}},
+                {cn: ['ok', 'idle', 'wedged', 'limited', 'off'].map(state => (
+                    {cn: [
+                        {style: {background: `var(--fm-state-${state})`, width: '10px', height: '10px', borderRadius: '50%'}},
+                        {text: state, style: {fontFamily: 'var(--fm-font-mono)', fontSize: '12px', color: 'var(--fm-ink-dim)'}}
+                    ], style: {display: 'flex', alignItems: 'center', gap: '.5rem'}}
+                )), style: {display: 'flex', gap: '1.5rem', marginTop: '1rem'}},
+                {cn: ['claude', 'gpt', 'gemini', 'human'].map(family => (
+                    {text: family, style: {borderLeft: `3px solid var(--fm-family-${family})`, paddingLeft: '.6rem', fontFamily: 'var(--fm-font-mono)', fontSize: '12px', color: 'var(--fm-ink-dim)'}}
+                )), style: {display: 'flex', gap: '1.5rem', marginTop: '1rem'}}
+            ]}
+        }]
+    }
+}
+
+export default Neo.setupClass(Viewport);


### PR DESCRIPTION
Resolves #14578

Refs #14560 (parent epic — never a close-target).

The T1 design-floor leaf, delivered as the full triplet: (1) `apps/fleetmanager/resources/tokens.css` — the 1:1 SSOT extraction (`--fm-*` namespaced; surfaces/lines/ink/signal/session-states/family-rails/type-stacks) with the ADR 0032 bindings encoded in the contract header (family tokens = era-attribute data-driven, never per-agent constants; state tokens = session-never-identity; pulse = decoration-not-information); (2) `TOKENS.md` — the reference table (group × role × consumer × binding rule) + the add-a-token ritual wired to the #14618 baseline guard; (3) the minimal app scaffold + token verification surface (`view/Viewport.mjs`) rendering one element per group with zero literal colors, per the target-app decision (#14577: fresh `apps/fleetmanager`, design-authority signed).

Evidence: L3 (live render verified — see Test Evidence) → L2/L3 required (the AC's dev-server render + doc legs). Residual: none — all five ACs delivered.

## Deltas from ticket

- **`.gitignore` whitelist added** (`!/apps/fleetmanager/...` ×3): apps are ignored by default and every real app carries explicit negations — without them the scaffold writes into the void (empirically hit: the first scaffold commit staged zero files; `git check-ignore -v` was the diagnosis). Sibling pattern followed exactly (the agentos block).
- The app scaffold shipped in THIS leaf rather than a separate one: the #14577 decision landed fresh-app minutes before, making the namespace's first files this leaf's natural placement executor. `neo-config.json` carries `useAiClient: true` + `useSharedWorkers: true` per the epic's NL-e2e spine + multi-window story.
- JSDoc reworded to prose (no bare ticket refs in code comments — the archaeology gate; string literals unaffected).

## Test Evidence

- `npm run agent-preflight -- --no-fix apps/fleetmanager/app.mjs apps/fleetmanager/view/Viewport.mjs` → **all gates passed** (check-ticket-archaeology: 2 files scanned, 0 violations).
- **Live render verified** (webpack dev-server + browser preview, 2026-07-04 02:52Z): all token groups render — 3 surface panels with line borders, 3 stepped ink tiers, all 5 state dots (ok/idle/wedged/limited/off), all 4 family rails (claude/gpt/gemini/human), signal-accented mono heading — matching the SSOT palette on the ground background. **Console: zero errors, zero warnings.**

## Post-Merge Validation

- [ ] Downstream T1/T2 leaves (#14593/#14594/#14598…) consume `--fm-*` tokens exclusively (lint-greppable: zero literal colors in cockpit views).
- [ ] #14618 baselines this verification surface as its first fixture.

## Commits

- f200cfa2f — tokens.css + TOKENS.md (extraction + reference legs)
- 4825ff9bc — app scaffold + verification surface + gitignore whitelist

Authored by Vega (Claude Fable 5, Claude Code). Session a28f1415-37a4-4a5a-a3e4-b56adf6274ec.