### PR TITLE
chore(settings): scope force-push denies to dev/main (#14623)

### DIFF
--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -26,12 +26,15 @@
       "Bash(gh pr checks *)",
       "Bash(gh pr list *)",
       "Bash(gh issue view *)",
-      "Bash(gh issue list *)"
+      "Bash(gh issue list *)",
+      "Bash(git push --force-with-lease origin agent/*)"
     ],
     "deny": [
       "Bash(gh pr merge *)",
-      "Bash(git push* --force*)",
-      "Bash(git push* -f *)",
+      "Bash(git push* --force* origin dev*)",
+      "Bash(git push* --force* origin main*)",
+      "Bash(git push* -f * origin dev*)",
+      "Bash(git push* -f * origin main*)",
       "Bash(git push* *:*)",
       "Bash(git push origin dev*)",
       "Bash(git push origin main*)",


### PR DESCRIPTION
## Summary

Operator-directed (2026-07-04): the blanket force-push deny in the settings template was agent-authored over-caution (#14415 design), not an operator rule — and under squash-merge-to-dev it protects nothing on feature branches while blocking the NORMAL rebase-based PR conflict-resolution path. Scopes the denies to the branches that actually need them (`dev`, `main`) and allow-lists the safe lease form on `agent/*` branches.

Resolves #14623

## Deltas

- `.claude/settings.template.json` — **deny:** the two blanket rules (`git push* --force*`, `git push* -f *`) replaced by four branch-scoped rules (`--force*`/`-f` × `origin dev*`/`origin main*`). **allow:** `git push --force-with-lease origin agent/*` added — lease-form ONLY (bare `--force` still prompts; lease refuses to clobber a peer's concurrent push), `agent/*` only. Untouched by design: the refspec colon-deny (`git push* *:*`, the #14419 hazard), the plain dev/main push denies, the `--no-verify` denies, and the guidance prose (never push dev/main directly — still correct, still enforced).

## Test Evidence

`JSON.parse` validation green post-edit (1 file, +6/−3). Behavioral proof of the gap this closes: PR #14585's one-hunk seam-table conflict had a lint-verified rebase resolution ready on the author's branch tonight and the blanket rule blocked delivery — the operator had to be pulled into a conflict any agent could clear in seconds.

Evidence: L1 (config-template change; the runtime consumer is each instance's gitignored `settings.json` overlay, updated per-instance post-merge — the operator's stated follow-up).

## Post-Merge Validation

- Each agent instance applies the same edit to its live `.claude/settings.json` (gitignored, per-instance) — the template is the tracked source new copies inherit.
- Falsifying probe: on an `agent/*` branch with a rebased head, `git push --force-with-lease origin agent/<branch>` executes without a permission denial; `git push --force origin dev` remains denied.

## Related

#14623 (this fix) · #14415 (the original allowlist design this narrows) · #14419 (the refspec deny, untouched) · PR #14585 (the empirical anchor).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session a5af7cf6-45a3-42db-8a30-f04f4241a55c.
