### PR TITLE
feat(ai): direction attribution — EVOLUTION_GOAL schema + the pure pass (#14567)

### DIFF
--- a/ai/graph/directionAttribution.mjs
+++ b/ai/graph/directionAttribution.mjs
@@ -1,0 +1,171 @@
+import {
+    UNATTRIBUTED_DIRECTION_KEY,
+    composeBreakdownKey,
+    createAttributionFactId,
+    createClusterDirectionKey,
+    validateAttributionFact,
+    validateConservation
+} from './directionSchema.mjs';
+
+/**
+ * @summary The direction-attribution pass (the direction contract §2.2, attribute-then-aggregate) — pure logic.
+ *
+ * Attributes each motion event to direction keys FIRST, then aggregates per direction: the
+ * substrate-owner-disposed composition under which per-direction velocity stays exact per period
+ * and history is append-only under mapping version. This module is deliberately pure (no graph
+ * reads/writes, no clock): the Dream-pipeline writer supplies motion events, declared goals, and
+ * the versioned cluster mapping; this module returns validated facts, the durable-record
+ * `directionBreakdown`, the conservation verdict, and the derived alignment states. Purity is what
+ * makes the hindcast protocol possible — replaying window W with only-in-W inputs is just calling
+ * these functions with historical arguments.
+ *
+ * The hybrid representation (the direction contract's OQ1 shape): motion matches DECLARED anchors
+ * via each goal's canonical concept matchers, and EMERGENT clusters via the versioned
+ * `conceptId → clusterId` mapping. THE MAPPING IS THE SIGNAL — three derived states per unit of
+ * motion: aligned (a declared goal it serves), unattributed (innovation-or-drift, human judges),
+ * and starved (`INTENT_STARVED`: a declared active goal NO motion serves — the June-2026 failure
+ * class, machine-detectable). Multi-match splits the event's measure equally across its matched
+ * directions (measure-preserving: splitting a goal splits its measure; no event ever counts twice).
+ */
+
+/**
+ * @summary Attributes one window's motion events to direction keys and aggregates the breakdown.
+ *
+ * Every motion event carries measure 1, distributed over its matched directions. Events matching
+ * nothing land WHOLLY in the first-class UNATTRIBUTED pool. Matching is deterministic: canonical
+ * concept ids only (callers canonicalize through the concept-spine SSOT before invoking — this
+ * module never sees aliases).
+ *
+ * @param {Object}   options
+ * @param {Object[]} options.motionEvents Window motion facts, each `{id, conceptIds?: String[]}`
+ * @param {Object[]} options.declaredGoals `EVOLUTION_GOAL` records, each
+ *   `{id, lifecycle, matchers?: String[]}` — `matchers` are canonical concept ids/slugs the goal declares
+ * @param {Object}   [options.clusterMapping={}] Versioned emergent mapping `conceptId → clusterId`
+ * @param {Number}   options.mappingVersion Positive integer version of `clusterMapping`
+ * @param {String}   options.filterSet The declared motion-class filter set this window was built under
+ * @param {String}   options.falsifyingQuery The window-level falsifying query (carries the SAME
+ *   filter set + version pin — the direction contract §2.4 falsifier symmetry); stamped onto every fact
+ * @returns {{facts: Object[], breakdown: Object, conservation: Object, states: Object, errors: String[]}}
+ */
+export function attributeMotion({
+    motionEvents = [],
+    declaredGoals = [],
+    clusterMapping = {},
+    mappingVersion,
+    filterSet,
+    falsifyingQuery
+}) {
+    const errors      = [];
+    const facts       = [];
+    const shareByKey  = new Map([[UNATTRIBUTED_DIRECTION_KEY, 0]]);
+    const activeGoals = (Array.isArray(declaredGoals) ? declaredGoals : [])
+        .filter(goal => goal != null && goal.lifecycle === 'active' && typeof goal.id === 'string');
+
+    for (const event of Array.isArray(motionEvents) ? motionEvents : []) {
+        if (event == null || typeof event.id !== 'string' || event.id.trim() === '') {
+            errors.push('motion event without a valid id skipped — motion identity is required');
+            continue;
+        }
+
+        const conceptIds  = Array.isArray(event.conceptIds) ? event.conceptIds : [];
+        const matchedKeys = new Set();
+
+        for (const goal of activeGoals) {
+            const matchers = Array.isArray(goal.matchers) ? goal.matchers : [];
+
+            if (matchers.some(matcher => conceptIds.includes(matcher))) {
+                matchedKeys.add(goal.id);
+            }
+        }
+
+        for (const conceptId of conceptIds) {
+            const clusterId = clusterMapping?.[conceptId];
+
+            if (clusterId != null && clusterId !== '') {
+                matchedKeys.add(createClusterDirectionKey(clusterId));
+            }
+        }
+
+        if (matchedKeys.size === 0) {
+            // Whole measure to the pool — visible, never faked into a split (the direction contract §2.3).
+            shareByKey.set(UNATTRIBUTED_DIRECTION_KEY, shareByKey.get(UNATTRIBUTED_DIRECTION_KEY) + 1);
+            continue;
+        }
+
+        const share = 1 / matchedKeys.size;
+
+        for (const directionKey of matchedKeys) {
+            const fact = {
+                factId  : createAttributionFactId({motionId: event.id, directionKey, mappingVersion}),
+                motionId: event.id,
+                directionKey,
+                mappingVersion,
+                share,
+                filterSet,
+                falsifyingQuery
+            };
+
+            const {valid, errors: factErrors} = validateAttributionFact(fact);
+
+            if (!valid) {
+                errors.push(...factErrors.map(message => `${event.id} → ${directionKey}: ${message}`));
+                continue;
+            }
+
+            facts.push(fact);
+
+            const breakdownKey = composeBreakdownKey(directionKey, mappingVersion);
+            shareByKey.set(breakdownKey, (shareByKey.get(breakdownKey) ?? 0) + share);
+        }
+    }
+
+    const eventCount = (Array.isArray(motionEvents) ? motionEvents : [])
+        .filter(event => event != null && typeof event.id === 'string' && event.id.trim() !== '')
+        .length;
+
+    // Normalize absolute measures to shares-of-window so the conservation identity checks against 1.
+    const breakdown = {};
+
+    for (const [key, measure] of shareByKey) {
+        breakdown[key] = eventCount === 0 ? (key === UNATTRIBUTED_DIRECTION_KEY ? 1 : 0) : measure / eventCount;
+    }
+
+    const conservation = validateConservation(breakdown);
+    const states       = deriveAlignmentStates({activeGoals, facts, breakdown});
+
+    if (!conservation.valid) {
+        errors.push(...conservation.errors);
+    }
+
+    return {facts, breakdown, conservation, states, errors};
+}
+
+/**
+ * @summary Derives the three alignment states from one window's attribution (the mapping IS the
+ * signal): `aligned` goals (motion served them), `starved` goals (`INTENT_STARVED` — declared
+ * ACTIVE intent that NO motion served this window; the June-2026 planning-failure class rendered
+ * machine-detectable), and the `unattributedShare` (innovation-or-drift; a human judges).
+ *
+ * Advisory-only by contract: these states annotate, they never gate — a starved goal raises an
+ * alarm for humans, it must not re-rank or suppress routes (the direction contract §2.6).
+ * @param {Object}   options
+ * @param {Object[]} options.activeGoals Active `EVOLUTION_GOAL` records `{id, ...}`
+ * @param {Object[]} options.facts Validated attribution facts from the same window
+ * @param {Object}   options.breakdown The normalized share breakdown (for the pool share)
+ * @returns {{aligned: String[], starved: String[], unattributedShare: Number}}
+ */
+export function deriveAlignmentStates({activeGoals = [], facts = [], breakdown = {}}) {
+    const servedKeys = new Set(facts.map(fact => fact.directionKey));
+    const aligned    = [];
+    const starved    = [];
+
+    for (const goal of activeGoals) {
+        (servedKeys.has(goal.id) ? aligned : starved).push(goal.id);
+    }
+
+    return {
+        aligned,
+        starved,
+        unattributedShare: breakdown[UNATTRIBUTED_DIRECTION_KEY] ?? 0
+    };
+}

--- a/ai/graph/directionSchema.mjs
+++ b/ai/graph/directionSchema.mjs
@@ -1,0 +1,369 @@
+import {slugifyIdPart, validateBusinessProperties} from './businessSchema.mjs';
+
+/**
+ * @summary Central schema definition for the Direction layer of the Native Edge Graph, mechanizing
+ * the accepted direction contract (ADR 0033 — ticket-ref-ok: the Accepted decision record is this
+ * module's source of authority; the pointer is load-bearing, not archaeology).
+ *
+ * This module is the authoritative family registry for the `EVOLUTION_GOAL` node label and the
+ * `ATTRIBUTED_TO` edge type — the layer that makes evolution DIRECTION a first-class computed
+ * object (Epic: direction-weighted Golden Path). It GENERALIZES the business family: an
+ * `EVOLUTION_GOAL` carries the same five-field honesty contract as `BUSINESS_GOAL`/`METRIC`
+ * (imported from `businessSchema.mjs` — one vocabulary per contract, never a re-derived copy),
+ * plus direction-specific identity and intent fields. The two families stay SEPARATE node classes
+ * on a shared schema shape: composable siblings, never merged.
+ *
+ * The load-bearing disciplines, all from the direction contract:
+ *
+ * - **Deterministic identity (§2.1):** a direction is identified by a deterministic key — a
+ *   declared `EVOLUTION_GOAL` id or an emergent `cluster-` key — never an LLM label or mutable
+ *   cluster name. Attribution facts are `{directionKey, mappingVersion}` pairs with APPEND-ONLY
+ *   history: fact ids embed the mapping version, so a re-clustering mints NEW facts under the next
+ *   version instead of rewriting prior ones.
+ * - **Conservation (§2.3):** per window, per declared filter set, attributed shares plus the
+ *   UNATTRIBUTED share must sum to the whole. The pool is first-class, not residue — below any
+ *   coverage floor the correct behavior is to render the pool, never to fake a split.
+ * - **Falsifier symmetry (§2.4):** every attribution fact names the filter set it was computed
+ *   under and the query that would falsify it; a fact that cannot name its falsifier is invalid
+ *   by construction (the `businessSchema.mjs` discipline, applied to attribution).
+ * - **Operator-owned intent (§2.5):** `intentWeight` is Tier-4-set by the operator, never
+ *   computed. Validators enforce shape; write paths MUST NOT derive or auto-adjust it.
+ * - **Fail-open boundary (§2.6):** nothing in this layer gates the computed route. Direction data
+ *   is additive annotation; consumers that zero a route on missing/low alignment violate the
+ *   contract this schema serves.
+ */
+
+/**
+ * @summary Node labels owned by the direction family (Native Edge Graph node-type registry).
+ * @type {ReadonlyArray<String>}
+ */
+export const DIRECTION_NODE_TYPES = Object.freeze(['EVOLUTION_GOAL']);
+
+/**
+ * @summary Edge types owned by the direction family.
+ *
+ * `ATTRIBUTED_TO` connects a motion fact (session / PR / commit / ticket node) to the direction it
+ * served. Family disposition: attribution is a durable structural FACT — "motion X served
+ * direction D under mapping vN" stays historically true — so the type is cross-listed in
+ * `PROTECTED_EDGE_TYPES` (GraphService decay shield). A velocity number built on decaying edges
+ * rots invisibly; measurement substrate is fact-class, not scent (the direction contract §2.5).
+ * @type {ReadonlyArray<String>}
+ */
+export const DIRECTION_EDGE_TYPES = Object.freeze(['ATTRIBUTED_TO']);
+
+/**
+ * @summary `EVOLUTION_GOAL` lifecycle states (mirror of the business-goal lifecycle — retirement
+ * is not deletion; the anchor and its attribution history persist).
+ * @type {ReadonlyArray<String>}
+ */
+export const EVOLUTION_GOAL_LIFECYCLE = Object.freeze(['active', 'achieved', 'retired']);
+
+/**
+ * @summary Seed classes for declared anchors. `operator` anchors count against the small-N cap;
+ * `release-train` seeds (the vX.Y → vX.Y+1 arc) are free per the direction contract §2.5.
+ * @type {ReadonlyArray<String>}
+ */
+export const EVOLUTION_GOAL_SEED_CLASSES = Object.freeze(['operator', 'release-train']);
+
+/**
+ * @summary The small-N cap on operator-declared anchors (the direction contract §2.5: "small-N capped").
+ *
+ * Direction is a strategic vocabulary, not a tag cloud — past this count, declared intent stops
+ * being legible as strategy. Raising the cap is a decision-record amendment, not a config tweak.
+ * @type {Number}
+ */
+export const DECLARED_ANCHOR_CAP = 12;
+
+/**
+ * @summary The first-class UNATTRIBUTED pool key (the direction contract §2.3).
+ *
+ * Motion no mapping explains lands here VISIBLY — it is the innovation-or-drift signal a human
+ * judges, and the fail-open floor: attribution absence degrades to unweighted-but-visible, never
+ * to fail-closed, never to a faked split.
+ * @type {String}
+ */
+export const UNATTRIBUTED_DIRECTION_KEY = 'unattributed';
+
+/**
+ * @summary Node-id / key prefixes for the direction family (kebab convention shared with the
+ * business family's `business-goal-` / `metric-` prefixes).
+ * @type {Object}
+ */
+export const DIRECTION_ID_PREFIXES = Object.freeze({
+    ATTRIBUTION   : 'attribution-',
+    CLUSTER_KEY   : 'cluster-',
+    EVOLUTION_GOAL: 'evolution-goal-'
+});
+
+/**
+ * @summary Default tolerance for the conservation identity on float shares.
+ * @type {Number}
+ */
+export const CONSERVATION_EPSILON = 1e-9;
+
+/**
+ * @summary Derives the `EVOLUTION_GOAL` node id from its stable operator slug.
+ *
+ * Goals are operator-named: the slug is the durable identity (display titles rename freely without
+ * re-minting). Where a slug names a CONCEPT, callers canonicalize it through the concept-spine SSOT
+ * (`conceptSpineCanonicalization.canonicalizeConceptId`) BEFORE minting — the 2,705-alias-cluster
+ * hazard makes canonical ids a correctness gate, not polish (the direction contract §2.5). This module stays
+ * dependency-light and pure; the canonicalization routing is the writer's obligation.
+ * @param {String} slug Stable operator slug (e.g. `outward-traction`, `release-train-v13-2`)
+ * @returns {String}
+ */
+export function createEvolutionGoalId(slug) {
+    const normalized = slugifyIdPart(slug);
+
+    if (normalized === '') {
+        throw new Error('createEvolutionGoalId: slug is missing or empty — EVOLUTION_GOAL identity is a stable operator slug');
+    }
+
+    return DIRECTION_ID_PREFIXES.EVOLUTION_GOAL + normalized;
+}
+
+/**
+ * @summary Derives an emergent-cluster direction key from a deterministic cluster id.
+ *
+ * The cluster KEY is stable per cluster id; which mapping version produced the cluster travels on
+ * the attribution fact (and composes into breakdown keys), never inside this key — so version
+ * churn re-attributes without re-keying (the direction contract §2.1).
+ * @param {String} clusterId Deterministic cluster identifier from the mapping artifact
+ * @returns {String}
+ */
+export function createClusterDirectionKey(clusterId) {
+    const normalized = slugifyIdPart(clusterId);
+
+    if (normalized === '') {
+        throw new Error('createClusterDirectionKey: clusterId is missing or empty');
+    }
+
+    return DIRECTION_ID_PREFIXES.CLUSTER_KEY + normalized;
+}
+
+/**
+ * @summary Returns true for any valid direction key: a declared goal id, an emergent cluster key,
+ * or the first-class UNATTRIBUTED pool.
+ * @param {String} directionKey
+ * @returns {Boolean}
+ */
+export function isDirectionKey(directionKey) {
+    return directionKey === UNATTRIBUTED_DIRECTION_KEY ||
+        (typeof directionKey === 'string' && (
+            directionKey.startsWith(DIRECTION_ID_PREFIXES.EVOLUTION_GOAL) ||
+            directionKey.startsWith(DIRECTION_ID_PREFIXES.CLUSTER_KEY)
+        ) && directionKey.length > Math.max(
+            DIRECTION_ID_PREFIXES.EVOLUTION_GOAL.length,
+            DIRECTION_ID_PREFIXES.CLUSTER_KEY.length
+        ) - 1);
+}
+
+/**
+ * @summary Composes the durable-record breakdown key `"<directionKey>@<mappingVersion>"`
+ * (the direction contract §2.2 — the `directionBreakdown` map key on L1/L2 records).
+ * @param {String} directionKey
+ * @param {Number} mappingVersion Positive integer mapping version
+ * @returns {String}
+ */
+export function composeBreakdownKey(directionKey, mappingVersion) {
+    if (!isDirectionKey(directionKey)) {
+        throw new Error(`composeBreakdownKey: "${directionKey}" is not a valid direction key`);
+    }
+
+    if (!Number.isInteger(mappingVersion) || mappingVersion < 1) {
+        throw new Error('composeBreakdownKey: mappingVersion must be a positive integer');
+    }
+
+    return `${directionKey}@${mappingVersion}`;
+}
+
+/**
+ * @summary Parses a breakdown key back into `{directionKey, mappingVersion}` — the falsifier-side
+ * inverse of `composeBreakdownKey`, so a shipped falsifying query can pin the SAME version the
+ * measurement carried (the direction contract §2.4 falsifier symmetry).
+ * @param {String} breakdownKey
+ * @returns {{directionKey: String, mappingVersion: Number}}
+ */
+export function parseBreakdownKey(breakdownKey) {
+    const at = String(breakdownKey ?? '').lastIndexOf('@');
+
+    if (at < 1) {
+        throw new Error(`parseBreakdownKey: "${breakdownKey}" is not a "<directionKey>@<mappingVersion>" key`);
+    }
+
+    const directionKey   = breakdownKey.slice(0, at);
+    const mappingVersion = Number(breakdownKey.slice(at + 1));
+
+    if (!isDirectionKey(directionKey) || !Number.isInteger(mappingVersion) || mappingVersion < 1) {
+        throw new Error(`parseBreakdownKey: "${breakdownKey}" failed key/version validation`);
+    }
+
+    return {directionKey, mappingVersion};
+}
+
+/**
+ * @summary Derives the deterministic attribution-fact id.
+ *
+ * Identity contract: `(motionId, directionKey, mappingVersion)` → the same id on every
+ * recomputation UNDER THE SAME VERSION (idempotent re-runs), while a new mapping version yields a
+ * NEW id — the append-only-under-version contract mechanized at the id layer (the direction contract §2.1: a
+ * re-clustering writes new facts, never rewrites old ones). `--` join is injective because
+ * `slugifyIdPart` output can never contain `--` (the `businessSchema.mjs` collision argument).
+ * @param {Object} identity
+ * @param {String} identity.motionId       Graph node id of the motion fact (e.g. `issue-14567`)
+ * @param {String} identity.directionKey   Declared goal id, cluster key, or the UNATTRIBUTED pool
+ * @param {Number} identity.mappingVersion Positive integer mapping version
+ * @returns {String}
+ */
+export function createAttributionFactId({motionId, directionKey, mappingVersion}) {
+    if (slugifyIdPart(motionId) === '') {
+        throw new Error('createAttributionFactId: motionId is missing or empty');
+    }
+
+    // Validates key + version in one place; the composed suffix keeps version in the identity.
+    const versionedKey = composeBreakdownKey(directionKey, mappingVersion);
+
+    return DIRECTION_ID_PREFIXES.ATTRIBUTION + [slugifyIdPart(motionId), slugifyIdPart(versionedKey)].join('--');
+}
+
+/**
+ * @summary Validates a full `EVOLUTION_GOAL` node's properties: the shared five-field business
+ * contract (imported — one vocabulary per contract) plus the direction-specific fields.
+ *
+ * `intentWeight` is OPERATOR-OWNED (the direction contract §2.5): validators enforce shape and range; no write
+ * path may compute, derive, or auto-adjust it. Fail-closed: returns every violation.
+ * @param {Object} properties
+ * @returns {{valid: Boolean, errors: String[]}}
+ */
+export function validateEvolutionGoalProperties(properties) {
+    const props    = properties ?? {};
+    const {errors} = validateBusinessProperties(props);
+
+    if (slugifyIdPart(props.slug) === '') {
+        errors.push('missing EVOLUTION_GOAL identity property "slug" (stable operator slug)');
+    }
+
+    if (!EVOLUTION_GOAL_LIFECYCLE.includes(props.lifecycle)) {
+        errors.push(`"lifecycle" must be one of [${EVOLUTION_GOAL_LIFECYCLE.join(', ')}]`);
+    }
+
+    if (typeof props.intentWeight !== 'number' || !Number.isFinite(props.intentWeight) || props.intentWeight <= 0 || props.intentWeight > 1) {
+        errors.push('"intentWeight" must be a finite number in (0, 1] — operator-set (Tier-4), never computed');
+    }
+
+    if (!EVOLUTION_GOAL_SEED_CLASSES.includes(props.seedClass)) {
+        errors.push(`"seedClass" must be one of [${EVOLUTION_GOAL_SEED_CLASSES.join(', ')}] — operator anchors count against the cap; release-train seeds are free`);
+    }
+
+    return {valid: errors.length === 0, errors};
+}
+
+/**
+ * @summary Enforces the small-N declared-anchor cap (the direction contract §2.5) at plan time.
+ *
+ * Counts only `operator`-class ACTIVE goals — release-train seeds and retired/achieved goals are
+ * exempt. Pure check: the writer calls this before minting a new operator anchor.
+ * @param {Object[]} existingGoals Current `EVOLUTION_GOAL` property records
+ * @returns {{atCap: Boolean, operatorActiveCount: Number, cap: Number}}
+ */
+export function checkDeclaredAnchorCap(existingGoals) {
+    const operatorActiveCount = (Array.isArray(existingGoals) ? existingGoals : [])
+        .filter(goal => goal != null && goal.seedClass === 'operator' && goal.lifecycle === 'active')
+        .length;
+
+    return {atCap: operatorActiveCount >= DECLARED_ANCHOR_CAP, operatorActiveCount, cap: DECLARED_ANCHOR_CAP};
+}
+
+/**
+ * @summary Validates one attribution fact against the direction contract.
+ *
+ * Every fact must name: its motion source, a valid direction key, the mapping version that
+ * produced it, its share of the motion unit, the declared filter set it was computed under
+ * (the direction contract §2.4 — filters are never implicit), and the query that would falsify it (§2.4
+ * falsifier symmetry; the `falsifyingQuery` MUST apply the same filter set and version pin).
+ * @param {Object} fact
+ * @returns {{valid: Boolean, errors: String[]}}
+ */
+export function validateAttributionFact(fact) {
+    const errors = [];
+    const f      = fact ?? {};
+
+    if (slugifyIdPart(f.motionId) === '') {
+        errors.push('missing attribution property "motionId" (the motion fact\'s graph node id)');
+    }
+
+    if (!isDirectionKey(f.directionKey)) {
+        errors.push(`"directionKey" must be a declared goal id ("${DIRECTION_ID_PREFIXES.EVOLUTION_GOAL}…"), a cluster key ("${DIRECTION_ID_PREFIXES.CLUSTER_KEY}…"), or "${UNATTRIBUTED_DIRECTION_KEY}"`);
+    }
+
+    if (!Number.isInteger(f.mappingVersion) || f.mappingVersion < 1) {
+        errors.push('"mappingVersion" must be a positive integer — attribution history is append-only under version');
+    }
+
+    if (typeof f.share !== 'number' || !Number.isFinite(f.share) || f.share <= 0 || f.share > 1) {
+        errors.push('"share" must be a finite number in (0, 1] — a motion unit\'s measure distributes over its directions');
+    }
+
+    if (typeof f.filterSet !== 'string' || f.filterSet.trim() === '') {
+        errors.push('"filterSet" must be a non-empty string — motion inputs are class-filtered by construction, never implicitly (the direction contract §2.4)');
+    }
+
+    if (typeof f.falsifyingQuery !== 'string' || f.falsifyingQuery.trim() === '') {
+        errors.push('"falsifyingQuery" must be a non-empty string — an attribution that cannot name its falsifier is invalid by construction');
+    }
+
+    return {valid: errors.length === 0, errors};
+}
+
+/**
+ * @summary Machine-checks the conservation identity for one window under one filter set
+ * (the direction contract §2.3): the attributed shares plus the UNATTRIBUTED pool must sum to 1.
+ *
+ * A failed identity is a BUILD DEFECT, never noise — the caller (the L1 aggregation lane) must
+ * refuse the window, not clamp it. The UNATTRIBUTED entry is required even at share 0: the pool's
+ * visibility is the fail-open floor.
+ * @param {Object} breakdown Map of breakdown key (or the UNATTRIBUTED key) → share
+ * @param {Number} [epsilon=CONSERVATION_EPSILON] Float tolerance
+ * @returns {{valid: Boolean, total: Number, unattributedShare: Number|null, errors: String[]}}
+ */
+export function validateConservation(breakdown, epsilon = CONSERVATION_EPSILON) {
+    const errors  = [];
+    const entries = Object.entries(breakdown ?? {});
+
+    if (entries.length === 0) {
+        return {valid: false, total: 0, unattributedShare: null, errors: ['conservation check requires at least the UNATTRIBUTED pool entry']};
+    }
+
+    let total             = 0;
+    let unattributedShare = null;
+
+    for (const [key, share] of entries) {
+        if (typeof share !== 'number' || !Number.isFinite(share) || share < 0) {
+            errors.push(`share for "${key}" must be a finite number >= 0`);
+            continue;
+        }
+
+        total += share;
+
+        if (key === UNATTRIBUTED_DIRECTION_KEY) {
+            unattributedShare = share;
+        } else {
+            // Throws on malformed keys — a breakdown with an unparseable key is itself a defect.
+            try {
+                parseBreakdownKey(key);
+            } catch (e) {
+                errors.push(e.message);
+            }
+        }
+    }
+
+    if (unattributedShare === null) {
+        errors.push(`missing "${UNATTRIBUTED_DIRECTION_KEY}" entry — the pool is first-class, present even at share 0`);
+    }
+
+    if (Math.abs(total - 1) > epsilon) {
+        errors.push(`conservation violated: shares sum to ${total}, expected 1 (±${epsilon}) — Σ attributed + unattributed = total is a build invariant, not a target`);
+    }
+
+    return {valid: errors.length === 0, total, unattributedShare, errors};
+}

--- a/ai/graph/directionSchema.mjs
+++ b/ai/graph/directionSchema.mjs
@@ -148,14 +148,19 @@ export function createClusterDirectionKey(clusterId) {
  * @returns {Boolean}
  */
 export function isDirectionKey(directionKey) {
-    return directionKey === UNATTRIBUTED_DIRECTION_KEY ||
-        (typeof directionKey === 'string' && (
-            directionKey.startsWith(DIRECTION_ID_PREFIXES.EVOLUTION_GOAL) ||
-            directionKey.startsWith(DIRECTION_ID_PREFIXES.CLUSTER_KEY)
-        ) && directionKey.length > Math.max(
-            DIRECTION_ID_PREFIXES.EVOLUTION_GOAL.length,
-            DIRECTION_ID_PREFIXES.CLUSTER_KEY.length
-        ) - 1);
+    if (directionKey === UNATTRIBUTED_DIRECTION_KEY) return true;
+    if (typeof directionKey !== 'string') return false;
+
+    // Per-prefix suffix check: a key is valid iff it carries a NON-EMPTY id after ITS OWN
+    // prefix — a shared length bound would tie short cluster keys to the longer goal prefix
+    // and admit empty declared-goal suffixes (the exact identity-contract drift class).
+    for (const prefix of [DIRECTION_ID_PREFIXES.EVOLUTION_GOAL, DIRECTION_ID_PREFIXES.CLUSTER_KEY]) {
+        if (directionKey.startsWith(prefix)) {
+            return directionKey.length > prefix.length;
+        }
+    }
+
+    return false;
 }
 
 /**

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -71,7 +71,8 @@ function isValidGraphNodeId(id) {
 }
 
 const PROTECTED_EDGE_TYPES = Object.freeze([
-    'ADVANCED_BY', // business layer: goal→work advancement is history, never scent; zombie-priority is handled by explicit retirement reweight (ai/graph/businessSchema.mjs), not decay
+    'ADVANCED_BY',   // business layer: goal→work advancement is history, never scent; zombie-priority is handled by explicit retirement reweight (ai/graph/businessSchema.mjs), not decay
+    'ATTRIBUTED_TO', // direction layer: motion→direction attribution is measurement substrate — a velocity number built on decaying edges rots invisibly; fact-class per the direction contract (ai/graph/directionSchema.mjs)
     'IMPLEMENTS',
     'EXTENDS',
     'SYSTEM_TENET',

--- a/test/playwright/unit/ai/graph/directionSchema.spec.mjs
+++ b/test/playwright/unit/ai/graph/directionSchema.spec.mjs
@@ -41,6 +41,30 @@ test.describe('directionSchema + directionAttribution — the direction contract
         expect(() => schema.createAttributionFactId({motionId: 'issue-1', directionKey: 'not-a-direction', mappingVersion: 1})).toThrow();
     });
 
+    test('minimal-key regressions: short cluster keys valid, empty suffixes invalid (review cycle-1 identity-contract fix)', () => {
+        // The drift class: a shared length bound tied cluster validity to the longer goal prefix.
+        expect(schema.isDirectionKey('cluster-x')).toBe(true);
+        expect(schema.isDirectionKey(schema.createClusterDirectionKey('x'))).toBe(true);
+
+        // Empty suffixes are never identities — for EITHER prefix.
+        expect(schema.isDirectionKey('evolution-goal-')).toBe(false);
+        expect(schema.isDirectionKey('cluster-')).toBe(false);
+        expect(() => schema.parseBreakdownKey('evolution-goal-@1')).toThrow();
+
+        // End-to-end: a 1-char cluster id attributes cleanly (the throw path the review caught).
+        const result = attribution.attributeMotion({
+            motionEvents   : [{id: 'issue-1', conceptIds: ['c']}],
+            declaredGoals  : [],
+            clusterMapping : {c: 'x'},
+            mappingVersion : 1,
+            filterSet      : 'excludeClasses:[chore]',
+            falsifyingQuery: 'replay'
+        });
+
+        expect(result.errors).toEqual([]);
+        expect(result.breakdown['cluster-x@1']).toBe(1);
+    });
+
     test('breakdown keys compose and parse symmetrically — the falsifier can pin the measured version (§2.4)', () => {
         const key = schema.composeBreakdownKey('cluster-memory-substrate', 3);
 

--- a/test/playwright/unit/ai/graph/directionSchema.spec.mjs
+++ b/test/playwright/unit/ai/graph/directionSchema.spec.mjs
@@ -1,0 +1,161 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'DirectionSchemaTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+test.describe('directionSchema + directionAttribution — the direction contract mechanized (ADR 0033, #14567)', () => {
+    let schema, attribution;
+
+    test.beforeAll(async () => {
+        schema      = await import('../../../../../ai/graph/directionSchema.mjs');
+        attribution = await import('../../../../../ai/graph/directionAttribution.mjs');
+    });
+
+    test('deterministic identity: goal ids, cluster keys, and append-only-under-version fact ids (§2.1)', () => {
+        expect(schema.createEvolutionGoalId('Outward Traction!')).toBe('evolution-goal-outward-traction');
+        expect(schema.createClusterDirectionKey('memory substrate')).toBe('cluster-memory-substrate');
+
+        // Same (motion, direction, version) → same id: re-runs are idempotent.
+        const idV1 = schema.createAttributionFactId({motionId: 'issue-14567', directionKey: 'evolution-goal-outward-traction', mappingVersion: 1});
+        expect(schema.createAttributionFactId({motionId: 'issue-14567', directionKey: 'evolution-goal-outward-traction', mappingVersion: 1})).toBe(idV1);
+
+        // A new mapping version mints a NEW fact id — history is append-only under version.
+        const idV2 = schema.createAttributionFactId({motionId: 'issue-14567', directionKey: 'evolution-goal-outward-traction', mappingVersion: 2});
+        expect(idV2).not.toBe(idV1);
+
+        expect(() => schema.createEvolutionGoalId('')).toThrow();
+        expect(() => schema.createAttributionFactId({motionId: 'issue-1', directionKey: 'not-a-direction', mappingVersion: 1})).toThrow();
+    });
+
+    test('breakdown keys compose and parse symmetrically — the falsifier can pin the measured version (§2.4)', () => {
+        const key = schema.composeBreakdownKey('cluster-memory-substrate', 3);
+
+        expect(key).toBe('cluster-memory-substrate@3');
+        expect(schema.parseBreakdownKey(key)).toEqual({directionKey: 'cluster-memory-substrate', mappingVersion: 3});
+        expect(() => schema.composeBreakdownKey('evolution-goal-x', 0)).toThrow();
+        expect(() => schema.parseBreakdownKey('no-version-here')).toThrow();
+    });
+
+    test('EVOLUTION_GOAL validation: shared five-field contract + operator-owned intent + seed classes', () => {
+        const valid = schema.validateEvolutionGoalProperties({
+            claimClass        : 'measured',
+            falsifyingQuery   : 'attribution facts for this goal in window W, same filter set',
+            windowSemantics   : 'week:iso',
+            confoundDisclaimer: 'cannot isolate operator steering from organic drift',
+            publicFlag        : false,
+            slug              : 'outward-traction',
+            lifecycle         : 'active',
+            intentWeight      : 0.6,
+            seedClass         : 'operator'
+        });
+
+        expect(valid.valid).toBe(true);
+
+        const invalid = schema.validateEvolutionGoalProperties({slug: 'x', lifecycle: 'active', intentWeight: 2, seedClass: 'vibes'});
+
+        expect(invalid.valid).toBe(false);
+        expect(invalid.errors.join(' ')).toContain('falsifyingQuery');
+        expect(invalid.errors.join(' ')).toContain('intentWeight');
+        expect(invalid.errors.join(' ')).toContain('seedClass');
+    });
+
+    test('the declared-anchor cap counts only active operator anchors — release-train seeds are free (§2.5)', () => {
+        const goals = [
+            ...Array.from({length: 12}, (_, i) => ({seedClass: 'operator', lifecycle: 'active', id: `evolution-goal-g${i}`})),
+            {seedClass: 'release-train', lifecycle: 'active', id: 'evolution-goal-release-train-v13-2'},
+            {seedClass: 'operator', lifecycle: 'retired', id: 'evolution-goal-old'}
+        ];
+
+        const check = schema.checkDeclaredAnchorCap(goals);
+
+        expect(check).toEqual({atCap: true, operatorActiveCount: 12, cap: 12});
+        expect(schema.checkDeclaredAnchorCap(goals.slice(1)).atCap).toBe(false);
+    });
+
+    test('conservation: the identity holds, the pool is mandatory, malformed keys are defects (§2.3)', () => {
+        const ok = schema.validateConservation({
+            'evolution-goal-outward-traction@1': 0.5,
+            'cluster-memory-substrate@1'       : 0.25,
+            [schema.UNATTRIBUTED_DIRECTION_KEY]: 0.25
+        });
+
+        expect(ok.valid).toBe(true);
+        expect(ok.unattributedShare).toBe(0.25);
+
+        const missingPool = schema.validateConservation({'evolution-goal-x@1': 1});
+        expect(missingPool.valid).toBe(false);
+        expect(missingPool.errors.join(' ')).toContain('unattributed');
+
+        const leaky = schema.validateConservation({
+            'evolution-goal-x@1'               : 0.5,
+            [schema.UNATTRIBUTED_DIRECTION_KEY]: 0.1
+        });
+        expect(leaky.valid).toBe(false);
+        expect(leaky.errors.join(' ')).toContain('conservation violated');
+    });
+
+    test('attributeMotion: hybrid matching, equal-split measure, first-class pool, conservation-by-construction (§2.2/§2.3)', () => {
+        const result = attribution.attributeMotion({
+            motionEvents: [
+                {id: 'issue-100', conceptIds: ['golden-path']},                       // declared match
+                {id: 'issue-101', conceptIds: ['docking-layout']},                    // cluster match
+                {id: 'issue-102', conceptIds: ['golden-path', 'docking-layout']},     // both → split 0.5/0.5
+                {id: 'issue-103', conceptIds: ['something-new']}                      // unattributed
+            ],
+            declaredGoals: [
+                {id: 'evolution-goal-gp-direction', lifecycle: 'active', matchers: ['golden-path']},
+                {id: 'evolution-goal-starved-one', lifecycle: 'active', matchers: ['nobody-works-this']},
+                {id: 'evolution-goal-retired-one', lifecycle: 'retired', matchers: ['golden-path']}
+            ],
+            clusterMapping : {'docking-layout': 'body engine'},
+            mappingVersion : 1,
+            filterSet      : 'excludeClasses:[chore]',
+            falsifyingQuery: 'replay window W under filterSet excludeClasses:[chore] @ mapping v1'
+        });
+
+        expect(result.errors).toEqual([]);
+        expect(result.conservation.valid).toBe(true);
+
+        // issue-100 → goal (1.0) · issue-101 → cluster (1.0) · issue-102 → 0.5 + 0.5 · issue-103 → pool.
+        expect(result.breakdown['evolution-goal-gp-direction@1']).toBeCloseTo(0.375, 10); // (1 + 0.5) / 4
+        expect(result.breakdown['cluster-body-engine@1']).toBeCloseTo(0.375, 10);
+        expect(result.breakdown[schema.UNATTRIBUTED_DIRECTION_KEY]).toBeCloseTo(0.25, 10);
+
+        // Every fact is validated, version-pinned, filter-stamped.
+        expect(result.facts).toHaveLength(4);
+        expect(result.facts.every(fact => fact.mappingVersion === 1 && fact.filterSet === 'excludeClasses:[chore]')).toBe(true);
+
+        // The retired goal never matches; the unserved ACTIVE goal is INTENT_STARVED — the June-class alarm.
+        expect(result.states.aligned).toEqual(['evolution-goal-gp-direction']);
+        expect(result.states.starved).toEqual(['evolution-goal-starved-one']);
+        expect(result.states.unattributedShare).toBeCloseTo(0.25, 10);
+    });
+
+    test('empty window: the pool carries the whole measure — never a faked split, never a crash', () => {
+        const result = attribution.attributeMotion({
+            motionEvents   : [],
+            declaredGoals  : [{id: 'evolution-goal-x', lifecycle: 'active', matchers: ['x']}],
+            mappingVersion : 1,
+            filterSet      : 'excludeClasses:[chore]',
+            falsifyingQuery: 'replay empty window'
+        });
+
+        expect(result.breakdown[schema.UNATTRIBUTED_DIRECTION_KEY]).toBe(1);
+        expect(result.conservation.valid).toBe(true);
+        expect(result.states.starved).toEqual(['evolution-goal-x']);
+    });
+});


### PR DESCRIPTION
## Summary

First implementation leaf of the direction-weighted Golden Path (Epic #14565), consuming the freshly-Accepted ADR 0033 as its frozen spec: **evolution direction becomes computable.** Two new pure modules in the graph family plus the protected-edge registration — the schema/validators/planners for `EVOLUTION_GOAL` anchors and the attribute-then-aggregate pass that turns a window's motion into validated, version-pinned attribution facts with a machine-checked conservation identity and the three derived alignment states (including `INTENT_STARVED` — the June-2026 planning-failure class, now machine-detectable).

Resolves #14567
Refs #14565

## Deltas

- **NEW `ai/graph/directionSchema.mjs`** — the direction family registry, sibling and generalization of `businessSchema.mjs` (imports its `slugifyIdPart` + five-field validator — one vocabulary per contract, never a re-derived copy): `EVOLUTION_GOAL` node type + `ATTRIBUTED_TO` edge type · deterministic ids/keys (`evolution-goal-<slug>`, `cluster-<id>`, breakdown keys `<key>@<version>` with symmetric compose/parse) · **append-only-under-version fact ids** (same `(motion, direction, version)` → same id; new mapping version → new fact — history can never be rewritten, mechanized at the id layer) · operator-owned `intentWeight` validation (Tier-4-set, never computed) · the small-N declared-anchor cap with release-train seeds exempt · the first-class `UNATTRIBUTED` pool constant · the **conservation validator** (`Σ attributed + unattributed = 1`, pool entry mandatory even at 0, malformed keys are defects).
- **NEW `ai/graph/directionAttribution.mjs`** — the pure attribute-then-aggregate pass: hybrid matching (declared-goal canonical matchers × versioned emergent cluster mapping), equal-split measure preservation on multi-match (no event counts twice), whole-measure-to-pool on no-match (never a faked split), per-fact validation with filter-set + falsifying-query stamping, normalized `directionBreakdown`, conservation verdict, and `deriveAlignmentStates` (aligned / starved / unattributed-share). Deliberately pure — no graph I/O, no clock — which is what makes the hindcast leaf (#14569) a replay of these functions over historical inputs.
- **`ai/services/memory-core/GraphService.mjs`** — `ATTRIBUTED_TO` joins `PROTECTED_EDGE_TYPES` with inline rationale (measurement substrate is fact-class; a velocity number built on decaying edges rots invisibly) — the same-PR protected-set disposition ADR 0033 §2.5 mandates.
- **NEW `test/playwright/unit/ai/graph/directionSchema.spec.mjs`** — 7 tests pinning: deterministic identity + append-only-under-version · breakdown-key compose/parse symmetry (falsifier version-pinning) · goal validation incl. operator-owned intent + seed classes · the anchor cap (operator-active-only counting) · conservation (identity, mandatory pool, malformed-key defects) · the full pass (hybrid match, 0.5/0.5 split, pool, `INTENT_STARVED` derivation, retired-goal exclusion) · the empty window (pool carries 1, no crash).

**Deliberately NOT in this PR (scope honesty):** the Dream-pipeline WRITER (wiring motion events from session/PR sync into this pass and persisting facts/breakdowns onto ADR 0028's durable records) — that is the integration seam shared with the velocity leaf (#14568, Clio's first-claim on the temporal substrate); landing pure logic first keeps her lane's write-path decisions hers. The #14426 post-sync canary registration rides the writer (no node class is written by this PR). Both carried per the epic's boundary rule.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs directionSchema` → **7 passed (30.6s)**. The spec's attribution fixture is the worked example of the contract: 4 motion events → declared match / cluster match / split match / pool, conservation green, the starved active goal flagged while the retired one stays silent.

Evidence: L2 (unit-pinned pure logic; the live-emission proof lands with the writer integration per the scope note).

## Post-Merge Validation

- #14568 (velocity composition, Clio) consumes `composeBreakdownKey`/`validateConservation` instead of re-deriving — the re-derivation-prevention this leaf chain exists for; her intake citing this module is the check.
- The archaeology guard holds: one marked load-bearing authority pointer (module head), behavioral prose elsewhere.
- `ATTRIBUTED_TO` visible in the decay-shield enum; no decay events on attribution edges after the writer lands.

## Related

Epic #14565 (parent, `Refs` only) · ADR 0033 (the Accepted spec — merged this session as PR #14585) · #14568 (next leaf, first-claim @neo-fable-clio — the writer seam is yours to shape) · #14569/#14570 (downstream, blocked-by chain) · `ai/graph/businessSchema.mjs` (the generalized sibling) · #14581 (composable sibling epic sharing the `EVOLUTION_GOAL` schema family).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session a5af7cf6-45a3-42db-8a30-f04f4241a55c.
