### PR TITLE
feat(fleet): add PR/lane activity adapter (#14573)

### DIFF
--- a/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
+++ b/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
@@ -1,0 +1,342 @@
+import {
+    createFleetCockpitEvent,
+    FLEET_COCKPIT_SOURCES
+} from '../../../src/ai/fleet/fleetCockpitStatus.mjs'
+import {
+    extractIssueCommentBlocks,
+    getPrDeferDisposition,
+    getPrHumanGateState
+} from '../graph/issueFocusSections.mjs'
+
+/**
+ * @module ai/services/fleet/fleetPrLaneActivityAdapter
+ * @summary Maps GitHub Workflow / work-graph facts into the bounded Fleet cockpit activity DTO.
+ *
+ * This adapter is deliberately source-specific: GitHub PR/issue/lane-state and graph stall facts
+ * become small, source-labeled cockpit events. It does not add a FleetControlBridge wire method and
+ * does not stream full comment bodies into the Body-side DTO; bodies are only pattern input for
+ * deriving ids, timestamps, and event class.
+ */
+
+export const DEFAULT_FLEET_ACTIVITY_EVENT_LIMIT = 50
+
+const LANE_CLAIM_PATTERN = /\[(?:lane-claim|claiming)\]|\blane-state:\s*next-lane\b|\b(?:taking|claiming)\s+#\d+\b/i
+
+/**
+ * @summary Build one cockpit activity snapshot from already-read GitHub / graph facts.
+ *
+ * @param {Object} options={}
+ * @param {Object[]} options.prs Open or recent PR payloads from GitHub Workflow.
+ * @param {Object[]} options.issues Open or recent issue payloads from GitHub Workflow / local sync.
+ * @param {Object[]} options.stallFindings Work-graph stall findings from `issueFocusSections`.
+ * @param {Error|String|null} options.error Source-read failure; returns degraded capability.
+ * @param {Date|String} options.capturedAt Capture timestamp.
+ * @param {Number} options.limit Maximum events to return.
+ * @returns {{capability: Object, events: Object[]}}
+ */
+export function createFleetPrLaneActivitySnapshot({
+    prs = [],
+    issues = [],
+    stallFindings = [],
+    error = null,
+    capturedAt = new Date(),
+    limit = DEFAULT_FLEET_ACTIVITY_EVENT_LIMIT
+} = {}) {
+    const observedAt = toIsoString(capturedAt)
+
+    if (error) {
+        return {
+            capability: createActivityCapability({
+                capturedAt: observedAt,
+                confidence: 'none',
+                reason    : normalizeError(error),
+                state     : 'degraded'
+            }),
+            events: [createFleetCockpitEvent({
+                type      : 'source-degraded',
+                source    : FLEET_COCKPIT_SOURCES.activity,
+                confidence: 'none',
+                occurredAt: observedAt,
+                payload   : {
+                    kind  : 'source-degraded',
+                    reason: normalizeError(error)
+                }
+            })]
+        }
+    }
+
+    const events = [
+        ...createPrActivityEvents(prs, {capturedAt: observedAt}),
+        ...createIssueActivityEvents(issues, {capturedAt: observedAt}),
+        ...createStallActivityEvents(stallFindings, {capturedAt: observedAt})
+    ]
+        .sort((a, b) => new Date(b.occurredAt || 0) - new Date(a.occurredAt || 0))
+        .slice(0, Math.max(0, limit))
+
+    return {
+        capability: createActivityCapability({
+            capturedAt: observedAt,
+            confidence: 'observed',
+            state     : 'wired'
+        }),
+        events
+    }
+}
+
+/**
+ * @summary Convert PR payloads into bounded Fleet cockpit activity events.
+ * @param {Object[]} prs GitHub PR payloads.
+ * @param {Object} options
+ * @param {Date|String} options.capturedAt Fallback timestamp.
+ * @returns {Object[]}
+ */
+export function createPrActivityEvents(prs = [], {capturedAt = new Date()} = {}) {
+    return asArray(prs)
+        .filter(Boolean)
+        .map(pr => {
+            const number = getNumber(pr.number),
+                  author = getLogin(pr.author),
+                  relatedTickets = extractRefs(`${pr.title || ''} ${pr.body || ''}`)
+
+            const humanGateState = getPrHumanGateState(pr)
+
+            return createFleetCockpitEvent({
+                type      : 'pr-activity',
+                source    : FLEET_COCKPIT_SOURCES.githubPr,
+                agentId   : author,
+                confidence: 'observed',
+                occurredAt: toIsoString(pr.updatedAt || pr.mergedAt || pr.closedAt || pr.createdAt, capturedAt),
+                payload   : {
+                    kind            : 'pull-request',
+                    number,
+                    title           : pr.title || null,
+                    url             : pr.url || null,
+                    state           : pr.state || null,
+                    author,
+                    reviewDecision  : pr.reviewDecision || null,
+                    isDraft         : Boolean(pr.isDraft),
+                    relatedPrs      : number ? [number] : [],
+                    relatedTickets,
+                    deferDisposition: normalizeDeferDisposition(getPrDeferDisposition(pr, new Date(capturedAt))),
+                    humanGateState  : {
+                        ...humanGateState,
+                        changedRequested: Boolean(humanGateState.changedRequested)
+                    }
+                }
+            })
+        })
+}
+
+/**
+ * @summary Convert issue and lane-claim facts into bounded Fleet cockpit events.
+ * @param {Object[]} issues GitHub issue or local-sync issue payloads.
+ * @param {Object} options
+ * @param {Date|String} options.capturedAt Fallback timestamp.
+ * @returns {Object[]}
+ */
+export function createIssueActivityEvents(issues = [], {capturedAt = new Date()} = {}) {
+    const events = []
+
+    for (const issue of asArray(issues).filter(Boolean)) {
+        const normalized = normalizeIssue(issue, capturedAt)
+
+        events.push(createFleetCockpitEvent({
+            type      : 'issue-activity',
+            source    : FLEET_COCKPIT_SOURCES.githubIssue,
+            agentId   : normalized.assignees[0] || null,
+            confidence: 'observed',
+            occurredAt: normalized.updatedAt || normalized.createdAt,
+            payload   : {
+                kind          : 'issue',
+                number        : normalized.number,
+                title         : normalized.title,
+                url           : normalized.url,
+                state         : normalized.state,
+                assignees     : normalized.assignees,
+                labels        : normalized.labels,
+                relatedTickets: normalized.relatedTickets
+            }
+        }))
+
+        for (const comment of normalized.comments) {
+            if (!LANE_CLAIM_PATTERN.test(comment.body || '')) continue;
+
+            events.push(createFleetCockpitEvent({
+                type      : 'lane-claim',
+                source    : FLEET_COCKPIT_SOURCES.graphLane,
+                agentId   : comment.author || null,
+                confidence: 'observed',
+                occurredAt: toIsoString(comment.createdAt, normalized.updatedAt || capturedAt),
+                payload   : {
+                    kind          : 'lane-claim',
+                    issueNumber   : normalized.number,
+                    issueTitle    : normalized.title,
+                    issueUrl      : normalized.url,
+                    commentId     : comment.id || null,
+                    author        : comment.author || null,
+                    relatedTickets: [...new Set([
+                        ...normalized.relatedTickets,
+                        ...extractRefs(comment.body || '')
+                    ])]
+                }
+            }))
+        }
+    }
+
+    return events
+}
+
+/**
+ * @summary Convert work-graph stall findings into cockpit activity events.
+ * @param {Object[]} stallFindings Findings from `buildWorkGraphStallFindings`.
+ * @param {Object} options
+ * @param {Date|String} options.capturedAt Fallback timestamp.
+ * @returns {Object[]}
+ */
+export function createStallActivityEvents(stallFindings = [], {capturedAt = new Date()} = {}) {
+    return asArray(stallFindings)
+        .filter(Boolean)
+        .map(finding => createFleetCockpitEvent({
+            type      : 'work-stall',
+            source    : FLEET_COCKPIT_SOURCES.graphStall,
+            agentId   : finding.subject?.owner || null,
+            confidence: finding.sourceFidelity === 'candidate' || finding.grade === 'candidate-stall' ? 'inferred' : 'observed',
+            occurredAt: toIsoString(finding.observedAt || finding.lastVerifiedAt || finding.waitingSince, capturedAt),
+            payload   : {
+                kind              : 'work-stall',
+                findingClass      : finding.findingClass || null,
+                grade             : finding.grade || null,
+                motionPredicate   : finding.motionPredicate || null,
+                evidenceRefs      : asArray(finding.evidenceRefs),
+                verificationSource: finding.verificationSource || null,
+                waitingSince      : finding.waitingSince || null,
+                subject           : normalizeSubject(finding.subject)
+            }
+        }))
+}
+
+function createActivityCapability({capturedAt, confidence, reason = null, state}) {
+    return {
+        source: FLEET_COCKPIT_SOURCES.activity,
+        state,
+        confidence,
+        capturedAt,
+        reason
+    }
+}
+
+function normalizeIssue(issue, capturedAt) {
+    const meta = issue.meta || issue,
+          number = getNumber(issue.number || meta.number || meta.id),
+          title = issue.title || meta.title || null,
+          content = issue.content || issue.body || '',
+          comments = normalizeComments(issue, content)
+
+    return {
+        number,
+        title,
+        url           : issue.url || meta.githubUrl || meta.url || null,
+        state         : issue.state || meta.state || null,
+        createdAt     : toIsoString(issue.createdAt || meta.createdAt, capturedAt),
+        updatedAt     : toIsoString(issue.updatedAt || meta.updatedAt || issue.createdAt || meta.createdAt, capturedAt),
+        assignees     : normalizeLogins(issue.assignees || meta.assignees),
+        labels        : normalizeLabels(issue.labels || meta.labels),
+        relatedTickets: extractRefs(`${title || ''} ${content}`),
+        comments
+    }
+}
+
+function normalizeComments(issue, content = '') {
+    const commentNodes = issue.comments?.nodes || issue.comments || []
+
+    if (Array.isArray(commentNodes) && commentNodes.length > 0) {
+        return commentNodes.map(comment => ({
+            id       : comment.id || comment.node_id || null,
+            author   : getLogin(comment.author || comment.user),
+            body     : comment.body || '',
+            createdAt: comment.createdAt || comment.created_at || comment.submittedAt || null
+        }))
+    }
+
+    return extractIssueCommentBlocks(content)
+}
+
+function normalizeSubject(subject = {}) {
+    if (!subject || typeof subject !== 'object') return null
+
+    return {
+        id    : subject.id || null,
+        number: getNumber(subject.number),
+        owner : subject.owner || null,
+        title : subject.title || null,
+        type  : subject.type || null,
+        url   : subject.url || null
+    }
+}
+
+function normalizeDeferDisposition(disposition = {}) {
+    return {
+        anchorArtifact: disposition.anchorArtifact || null,
+        authority     : disposition.authority || null,
+        deferredAt    : disposition.deferredAt || null,
+        evidenceRefs  : asArray(disposition.evidenceRefs),
+        state         : disposition.state || 'none'
+    }
+}
+
+function normalizeLabels(labels = []) {
+    return asArray(labels)
+        .map(label => typeof label === 'string' ? label : label?.name)
+        .filter(Boolean)
+}
+
+function normalizeLogins(values = []) {
+    return asArray(values)
+        .map(getLogin)
+        .filter(Boolean)
+}
+
+function getLogin(value) {
+    if (!value) return null
+    if (typeof value === 'string') return value.replace(/^@/, '')
+
+    return value.login || value.name || null
+}
+
+function getNumber(value) {
+    const number = Number(value)
+
+    return Number.isFinite(number) ? number : null
+}
+
+function extractRefs(text = '') {
+    const refs = new Set()
+
+    for (const match of String(text).matchAll(/#(\d+)/g)) {
+        refs.add(Number(match[1]))
+    }
+
+    return [...refs].sort((a, b) => a - b)
+}
+
+function normalizeError(error) {
+    return redactSecretText(String(error?.message || error || 'source unavailable')).replace(/\s+/g, ' ').slice(0, 240)
+}
+
+function redactSecretText(text) {
+    return text
+        .replace(/\b(token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
+        .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
+}
+
+function toIsoString(value, fallback = new Date()) {
+    const date = value instanceof Date ? value : new Date(value)
+    if (!Number.isNaN(date.getTime())) return date.toISOString()
+
+    const fallbackDate = fallback instanceof Date ? fallback : new Date(fallback)
+    return fallbackDate.toISOString()
+}
+
+function asArray(value) {
+    return Array.isArray(value) ? value : []
+}

--- a/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
+++ b/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
@@ -13,9 +13,10 @@ import {
  * @summary Maps GitHub Workflow / work-graph facts into the bounded Fleet cockpit activity DTO.
  *
  * This adapter is deliberately source-specific: GitHub PR/issue/lane-state and graph stall facts
- * become small, source-labeled cockpit events. It does not add a FleetControlBridge wire method and
- * does not stream full comment bodies into the Body-side DTO; bodies are only pattern input for
- * deriving ids, timestamps, and event class.
+ * become small, source-labeled cockpit events. Comment-derived lane claims are heuristic issue
+ * comment matches, not authoritative graph lane-state facts. It does not add a FleetControlBridge
+ * wire method and does not stream full comment bodies into the Body-side DTO; bodies are only
+ * pattern input for deriving ids, timestamps, and event class.
  */
 
 export const DEFAULT_FLEET_ACTIVITY_EVENT_LIMIT = 50
@@ -163,7 +164,7 @@ export function createIssueActivityEvents(issues = [], {capturedAt = new Date()}
 
             events.push(createFleetCockpitEvent({
                 type      : 'lane-claim',
-                source    : FLEET_COCKPIT_SOURCES.graphLane,
+                source    : FLEET_COCKPIT_SOURCES.commentLane,
                 agentId   : comment.author || null,
                 confidence: 'observed',
                 occurredAt: toIsoString(comment.createdAt, normalized.updatedAt || capturedAt),

--- a/src/ai/fleet/fleetCockpitStatus.mjs
+++ b/src/ai/fleet/fleetCockpitStatus.mjs
@@ -2,6 +2,7 @@ const WIRE_SOURCES = Object.freeze({
         activity  : 'fleet:activity-adapters',
         githubPr  : 'github-workflow:pull-requests',
         githubIssue: 'github-workflow:issues',
+        commentLane: 'github-workflow:issue-comments',
         graphLane : 'graph:lane-state',
         graphStall: 'graph:work-stall',
         repoStatus: 'fleet:fleetStatus',

--- a/src/ai/fleet/fleetCockpitStatus.mjs
+++ b/src/ai/fleet/fleetCockpitStatus.mjs
@@ -1,5 +1,9 @@
 const WIRE_SOURCES = Object.freeze({
         activity  : 'fleet:activity-adapters',
+        githubPr  : 'github-workflow:pull-requests',
+        githubIssue: 'github-workflow:issues',
+        graphLane : 'graph:lane-state',
+        graphStall: 'graph:work-stall',
         repoStatus: 'fleet:fleetStatus',
         roster    : 'fleet:listAgents',
         runtime   : 'fleet:runtimeStatus',
@@ -11,7 +15,12 @@ export const FLEET_COCKPIT_EVENT_TYPES = Object.freeze([
     'lifecycle-success',
     'lifecycle-failure',
     'bridge-unavailable',
-    'bridge-gated'
+    'bridge-gated',
+    'pr-activity',
+    'issue-activity',
+    'lane-claim',
+    'work-stall',
+    'source-degraded'
 ])
 
 /**
@@ -32,9 +41,12 @@ export const FLEET_COCKPIT_SOURCES = Object.freeze({...WIRE_SOURCES})
  * @param {Object[]} options.agents      Public agent definitions from `registryBridge.listAgents()`.
  * @param {Object[]} options.fleetStatus Repo-status entries from `registryBridge.fleetStatus()`.
  * @param {Object[]} options.events      Optional already-normalized cockpit events.
+ * @param {Object}   options.capabilities Optional source-capability overrides from wired adapters.
  * @returns {Object} serializable cockpit DTO `{sources, capabilities, rows, events}`.
  */
-export function createFleetCockpitStatus({agents = [], fleetStatus = [], events = []} = {}) {
+export function createFleetCockpitStatus({agents = [], fleetStatus = [], events = [], capabilities = {}} = {}) {
+    const suppliedCapabilities = capabilities || {}
+
     const statusByAgentId = new Map(
         fleetStatus.map(status => [status.agentId || status.id, sanitizePayload(status)])
     )
@@ -42,8 +54,8 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], events 
     return {
         sources     : FLEET_COCKPIT_SOURCES,
         capabilities: {
-            activity: createNotWiredCapability(FLEET_COCKPIT_SOURCES.activity, 'A2A / PR / lane activity adapter not wired'),
-            runtime : createNotWiredCapability(FLEET_COCKPIT_SOURCES.runtime, 'runtime process status is pending the Fleet runtime-status wire method')
+            activity: suppliedCapabilities.activity || createNotWiredCapability(FLEET_COCKPIT_SOURCES.activity, 'A2A / PR / lane activity adapter not wired'),
+            runtime : suppliedCapabilities.runtime || createNotWiredCapability(FLEET_COCKPIT_SOURCES.runtime, 'runtime process status is pending the Fleet runtime-status wire method')
         },
         rows: agents.map(agent => {
             const publicAgent = sanitizePayload(agent),

--- a/test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs
@@ -1,0 +1,192 @@
+import {setup} from '../../../../setup.mjs'
+
+const appName = 'FleetPrLaneActivityAdapterTest'
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+})
+
+import {test, expect} from '@playwright/test'
+import Neo            from '../../../../../../src/Neo.mjs'
+import * as core      from '../../../../../../src/core/_export.mjs'
+
+import {
+    createFleetPrLaneActivitySnapshot,
+    createIssueActivityEvents,
+    createPrActivityEvents,
+    createStallActivityEvents
+} from '../../../../../../ai/services/fleet/fleetPrLaneActivityAdapter.mjs'
+import {FLEET_COCKPIT_SOURCES} from '../../../../../../src/ai/fleet/fleetCockpitStatus.mjs'
+
+test.describe('fleetPrLaneActivityAdapter - PR/lane activity mapping', () => {
+    test('maps PR facts without exposing the PR body', () => {
+        const [event] = createPrActivityEvents([{
+            number        : 14625,
+            title         : 'feat(ai): Neural Link dock tools (#14587)',
+            body          : 'Parked-on: #14587 [blocked] - ghp_secret body text must not reach the cockpit',
+            state         : 'OPEN',
+            url           : 'https://github.com/neomjs/neo/pull/14625',
+            author        : {login: 'neo-fable-clio'},
+            createdAt     : '2026-07-04T03:00:00Z',
+            updatedAt     : '2026-07-04T03:05:00Z',
+            reviewDecision: 'APPROVED',
+            reviews       : [{author: {login: 'neo-opus-grace'}, state: 'APPROVED', submittedAt: '2026-07-04T03:04:00Z'}]
+        }])
+
+        expect(event).toMatchObject({
+            type     : 'pr-activity',
+            source   : FLEET_COCKPIT_SOURCES.githubPr,
+            agentId  : 'neo-fable-clio',
+            occurredAt: '2026-07-04T03:05:00.000Z',
+            payload  : {
+                kind          : 'pull-request',
+                number        : 14625,
+                relatedPrs    : [14625],
+                relatedTickets: [14587],
+                humanGateState: {
+                    approved        : true,
+                    changedRequested: false
+                },
+                deferDisposition: {
+                    state         : 'deferred',
+                    anchorArtifact: '#14587'
+                }
+            }
+        })
+
+        const serialized = JSON.stringify(event)
+
+        expect(serialized).not.toContain('body text must not reach')
+        expect(serialized).not.toContain('ghp_secret')
+    })
+
+    test('maps issue and lane-claim facts while omitting comment bodies', () => {
+        const events = createIssueActivityEvents([{
+            number   : 14573,
+            title    : 'Fleet cockpit PR and lane activity adapter',
+            state    : 'OPEN',
+            url      : 'https://github.com/neomjs/neo/issues/14573',
+            labels   : [{name: 'enhancement'}, {name: 'ai'}],
+            assignees: [{login: 'neo-gpt'}],
+            updatedAt: '2026-07-04T03:10:00Z',
+            comments : {
+                nodes: [{
+                    id       : 'IC_lane',
+                    author   : {login: 'neo-gpt'},
+                    createdAt: '2026-07-04T03:12:00Z',
+                    body     : '[lane-claim] taking #14573 — ghp_secret must not leak'
+                }]
+            }
+        }])
+
+        expect(events).toHaveLength(2)
+        expect(events[0]).toMatchObject({
+            type   : 'issue-activity',
+            source : FLEET_COCKPIT_SOURCES.githubIssue,
+            agentId: 'neo-gpt',
+            payload: {
+                kind          : 'issue',
+                number        : 14573,
+                labels        : ['enhancement', 'ai'],
+                assignees     : ['neo-gpt'],
+                relatedTickets: []
+            }
+        })
+        expect(events[1]).toMatchObject({
+            type   : 'lane-claim',
+            source : FLEET_COCKPIT_SOURCES.graphLane,
+            agentId: 'neo-gpt',
+            payload: {
+                kind          : 'lane-claim',
+                issueNumber   : 14573,
+                commentId     : 'IC_lane',
+                relatedTickets: [14573]
+            }
+        })
+
+        const serialized = JSON.stringify(events)
+
+        expect(serialized).not.toContain('ghp_secret')
+        expect(serialized).not.toContain('[lane-claim]')
+    })
+
+    test('maps work-graph stall findings as bounded cockpit events', () => {
+        const [event] = createStallActivityEvents([{
+            observedAt          : '2026-07-04T03:08:00Z',
+            findingClass        : 'DECISION_STARVED',
+            grade               : 'verified-stall',
+            motionPredicate     : 'PR merges or receives changes requested',
+            evidenceRefs        : ['PR #14585', 'approvedAt:2026-07-04T03:00:00Z'],
+            verificationSource  : 'GitHub PR list reviews',
+            waitingSince        : '2026-07-04T03:00:00Z',
+            sourceFidelity      : 'verified',
+            subject             : {type: 'PR', number: 14585, owner: 'human-merge-gate', title: 'ADR 0033', url: 'https://github.com/neomjs/neo/pull/14585'}
+        }])
+
+        expect(event).toMatchObject({
+            type      : 'work-stall',
+            source    : FLEET_COCKPIT_SOURCES.graphStall,
+            agentId   : 'human-merge-gate',
+            confidence: 'observed',
+            payload   : {
+                kind        : 'work-stall',
+                findingClass: 'DECISION_STARVED',
+                subject     : {
+                    type  : 'PR',
+                    number: 14585
+                }
+            }
+        })
+    })
+
+    test('returns degraded capability when GitHub or graph reads fail', () => {
+        const snapshot = createFleetPrLaneActivitySnapshot({
+            error     : new Error('GitHub 502 token=secret should stay bounded'),
+            capturedAt: '2026-07-04T03:15:00Z'
+        })
+
+        expect(snapshot.capability).toMatchObject({
+            source    : FLEET_COCKPIT_SOURCES.activity,
+            state     : 'degraded',
+            confidence: 'none'
+        })
+        expect(snapshot.events).toHaveLength(1)
+        expect(snapshot.events[0]).toMatchObject({
+            type      : 'source-degraded',
+            source    : FLEET_COCKPIT_SOURCES.activity,
+            confidence: 'none'
+        })
+        expect(JSON.stringify(snapshot)).not.toContain('token=secret')
+    })
+
+    test('sorts newest first and bounds event count', () => {
+        const snapshot = createFleetPrLaneActivitySnapshot({
+            capturedAt: '2026-07-04T03:20:00Z',
+            limit     : 2,
+            prs       : [
+                {number: 1, title: 'old', author: {login: 'neo-gpt'}, updatedAt: '2026-07-04T03:01:00Z'},
+                {number: 2, title: 'new', author: {login: 'neo-gpt'}, updatedAt: '2026-07-04T03:03:00Z'}
+            ],
+            issues: [{
+                number   : 3,
+                title    : 'middle',
+                assignees: ['neo-gpt'],
+                updatedAt: '2026-07-04T03:02:00Z'
+            }]
+        })
+
+        expect(snapshot.capability).toMatchObject({
+            source    : FLEET_COCKPIT_SOURCES.activity,
+            state     : 'wired',
+            confidence: 'observed'
+        })
+        expect(snapshot.events.map(event => event.payload.number || event.payload.issueNumber)).toEqual([2, 3])
+    })
+})

--- a/test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs
@@ -101,7 +101,7 @@ test.describe('fleetPrLaneActivityAdapter - PR/lane activity mapping', () => {
         })
         expect(events[1]).toMatchObject({
             type   : 'lane-claim',
-            source : FLEET_COCKPIT_SOURCES.graphLane,
+            source : FLEET_COCKPIT_SOURCES.commentLane,
             agentId: 'neo-gpt',
             payload: {
                 kind          : 'lane-claim',


### PR DESCRIPTION
Resolves #14573

Adds a Brain-side Fleet cockpit PR/lane activity adapter that maps existing GitHub Workflow and work-graph facts into bounded `createFleetCockpitEvent()` payloads. The DTO now has explicit source labels for PRs, issues, lane-state, and stall findings, plus a capability override so a wired adapter can replace the existing `not-wired` activity slot without adding a FleetControlBridge wire method.

Evidence: L2 (focused unit and static contract validation) -> L2 required (adapter mapping, bounds, redaction, and fail-closed behavior). Residual: downstream render consumption remains in the #14560 activity-stream leaf.

## Deltas from ticket

The adapter intentionally strips free-form PR defer exit text and comment bodies from cockpit payloads. It uses those fields only as source input for deriving structured event class, ids, timestamps, evidence refs, and related ticket ids.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs` -> 10 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/` -> 61 passed.
- `git diff --check` -> passed.
- `npm run agent-preflight -- --no-fix src/ai/fleet/fleetCockpitStatus.mjs ai/services/fleet/fleetPrLaneActivityAdapter.mjs test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs` -> passed; 3 files scanned, 0 ticket-archaeology violations.

## Post-Merge Validation

- [ ] Activity-stream consumer wires this adapter's capability/events instead of sample activity rows.
- [ ] The sibling A2A adapter (#14572) composes with the same activity capability surface without replacing PR/lane source labels.
- [ ] Product surfaces continue to render bounded ids/titles/states only, not full PR bodies or comment bodies.

## Commits

- `4516ef80e9` - `feat(fleet): add PR/lane activity adapter (#14573)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019f2a7a-94c2-7de1-901a-966c21a5d604.
