### PR TITLE
feat(agentos): keeper request route + the shared blueprint validator (#14655)

### DIFF
--- a/apps/agentos/view/create/util/blueprintSchema.mjs
+++ b/apps/agentos/view/create/util/blueprintSchema.mjs
@@ -1,0 +1,215 @@
+/**
+ * @module AgentOS.view.create.util.blueprintSchema
+ * @summary The ONE blueprint validator for the keeper creation flow — emit-side and accept-side
+ * share this module (one vocabulary per contract; two call sites, zero re-derivation).
+ *
+ * Mechanizes the constrained-blueprint safety contract v2: a creation request never produces
+ * arbitrary code — it produces a **versioned, schema-registered, allowlist-validated blueprint**
+ * (`{schema, title, config, data}`), and anything outside the allowlists fails CLOSED to a bounded
+ * `{accepted: false, reason}` the caller renders as an honest refusal. The pattern generalizes the
+ * shipped `blueprintEvidence.mjs` projection (allowlist, not denylist: an unexpected or executable
+ * field can never slip through) from evidence display to the full create/mutate path.
+ *
+ * Hard exclusions enforced by construction, everywhere in the payload (deep scan):
+ * function values · `html`/`innerHTML`-class keys · event-handler configs (`listeners`,
+ * `handler(s)`, `on*`) · unregistered schemas · non-allowlisted config keys. Mutations are partial
+ * blueprints under the SAME validator — a follow-up can never introduce a key creation couldn't.
+ */
+
+/**
+ * @summary Key names that are forbidden ANYWHERE in a blueprint payload (deep scan) — the
+ * executable/injection surface. Checked case-insensitively for the html class; `on*` matches the
+ * DOM-handler convention (`onClick`, `onchange`, …).
+ * @type {RegExp[]}
+ */
+const FORBIDDEN_KEY_PATTERNS = Object.freeze([
+    /^html$/i,
+    /^innerhtml$/i,
+    /^listeners$/,
+    /^handlers?$/,
+    /^on[A-Z]/,
+    /^on[a-z]/
+]);
+
+/**
+ * @summary The only top-level keys a blueprint may carry.
+ * @type {ReadonlyArray<String>}
+ */
+export const BLUEPRINT_TOP_LEVEL_KEYS = Object.freeze(['schema', 'title', 'config', 'data']);
+
+/**
+ * @summary The registered blueprint schemas — the T5 plugin contract's substrate: adding a widget
+ * type is ONE registration here, never a validator fork. `grid@1` is the canonical first type
+ * (the birds-eye demo widget).
+ *
+ * Per schema: `configAllowlist` = the ONLY keys `config` may carry; `validate` = the per-schema
+ * structural check run after the generic gates.
+ * @type {Object}
+ */
+export const BLUEPRINT_SCHEMAS = Object.freeze({
+    'grid@1': Object.freeze({
+        configAllowlist: Object.freeze(['columns', 'height', 'width']),
+        /**
+         * @param {Object} blueprint
+         * @returns {String|null} a rejection reason, or null when structurally valid
+         */
+        validate(blueprint) {
+            const columns = blueprint.config?.columns;
+
+            if (!Array.isArray(columns) || columns.length === 0) {
+                return 'grid@1 requires config.columns as a non-empty array';
+            }
+
+            for (const column of columns) {
+                if (column == null || typeof column !== 'object' || typeof column.field !== 'string' || typeof column.text !== 'string') {
+                    return 'grid@1 columns must be objects with string "field" + "text"';
+                }
+            }
+
+            if (!Array.isArray(blueprint.data)) {
+                return 'grid@1 requires data as an array of row objects';
+            }
+
+            for (const row of blueprint.data) {
+                if (row == null || typeof row !== 'object' || Array.isArray(row)) {
+                    return 'grid@1 data rows must be plain objects';
+                }
+            }
+
+            return null;
+        }
+    })
+});
+
+/**
+ * @summary Deep-scans a value for forbidden keys and function values — the executable surface a
+ * blueprint may never carry, at any nesting depth.
+ * @param {*} value
+ * @param {String} path Human-readable location for the rejection reason
+ * @returns {String|null} a rejection reason, or null when clean
+ */
+function findExecutableSurface(value, path) {
+    if (typeof value === 'function') {
+        return `function value at "${path}" — blueprints are data, never code`;
+    }
+
+    if (value == null || typeof value !== 'object') {
+        return null;
+    }
+
+    const entries = Array.isArray(value)
+        ? value.map((item, index) => [String(index), item])
+        : Object.entries(value);
+
+    for (const [key, child] of entries) {
+        if (!Array.isArray(value) && FORBIDDEN_KEY_PATTERNS.some(pattern => pattern.test(key))) {
+            return `forbidden key "${key}" at "${path}" — html/handler-class fields never enter a blueprint`;
+        }
+
+        const nested = findExecutableSurface(child, `${path}.${key}`);
+
+        if (nested) {
+            return nested;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * @summary Validates a full creation blueprint against the v2 contract. Fail-closed, never throws:
+ * every caller (emit-side route, accept-side instantiation) branches on `accepted`.
+ * @param {Object} blueprint Candidate `{schema, title, config, data}`
+ * @returns {{accepted: Boolean, reason: String|null}}
+ */
+export function validateBlueprint(blueprint) {
+    if (blueprint == null || typeof blueprint !== 'object' || Array.isArray(blueprint)) {
+        return {accepted: false, reason: 'blueprint must be a plain object'};
+    }
+
+    const unknownKeys = Object.keys(blueprint).filter(key => !BLUEPRINT_TOP_LEVEL_KEYS.includes(key));
+
+    if (unknownKeys.length > 0) {
+        return {accepted: false, reason: `unexpected top-level keys: ${unknownKeys.join(', ')}`};
+    }
+
+    const schemaDef = BLUEPRINT_SCHEMAS[blueprint.schema];
+
+    if (!schemaDef) {
+        return {accepted: false, reason: `unregistered blueprint schema "${blueprint.schema}" — registration is a reviewed change, not a write`};
+    }
+
+    if (typeof blueprint.title !== 'string' || blueprint.title.trim() === '') {
+        return {accepted: false, reason: 'blueprint requires a non-empty string title'};
+    }
+
+    if (blueprint.config == null || typeof blueprint.config !== 'object' || Array.isArray(blueprint.config)) {
+        return {accepted: false, reason: 'blueprint requires a config object'};
+    }
+
+    const configViolations = Object.keys(blueprint.config).filter(key => !schemaDef.configAllowlist.includes(key));
+
+    if (configViolations.length > 0) {
+        return {accepted: false, reason: `config keys outside the ${blueprint.schema} allowlist: ${configViolations.join(', ')}`};
+    }
+
+    const executable = findExecutableSurface(blueprint, 'blueprint');
+
+    if (executable) {
+        return {accepted: false, reason: executable};
+    }
+
+    const structural = schemaDef.validate(blueprint);
+
+    if (structural) {
+        return {accepted: false, reason: structural};
+    }
+
+    return {accepted: true, reason: null};
+}
+
+/**
+ * @summary Validates a follow-up MUTATION as a partial blueprint under the same contract: only
+ * allowlisted config keys and/or data may change; schema and executable-surface rules apply
+ * unchanged (a mutation can never introduce what creation couldn't).
+ * @param {String} schema The live instance's registered schema id
+ * @param {Object} mutation Partial `{title?, config?, data?}`
+ * @returns {{accepted: Boolean, reason: String|null}}
+ */
+export function validateMutation(schema, mutation) {
+    const schemaDef = BLUEPRINT_SCHEMAS[schema];
+
+    if (!schemaDef) {
+        return {accepted: false, reason: `unregistered blueprint schema "${schema}"`};
+    }
+
+    if (mutation == null || typeof mutation !== 'object' || Array.isArray(mutation)) {
+        return {accepted: false, reason: 'mutation must be a plain object'};
+    }
+
+    const unknownKeys = Object.keys(mutation).filter(key => !['title', 'config', 'data'].includes(key));
+
+    if (unknownKeys.length > 0) {
+        return {accepted: false, reason: `mutations may only touch title/config/data — unexpected: ${unknownKeys.join(', ')}`};
+    }
+
+    if ('config' in mutation) {
+        if (mutation.config == null || typeof mutation.config !== 'object' || Array.isArray(mutation.config)) {
+            return {accepted: false, reason: 'mutation config must be a plain object'};
+        }
+
+        const violations = Object.keys(mutation.config).filter(key => !schemaDef.configAllowlist.includes(key));
+
+        if (violations.length > 0) {
+            return {accepted: false, reason: `mutation config keys outside the ${schema} allowlist: ${violations.join(', ')}`};
+        }
+    }
+
+    const executable = findExecutableSurface(mutation, 'mutation');
+
+    if (executable) {
+        return {accepted: false, reason: executable};
+    }
+
+    return {accepted: true, reason: null};
+}

--- a/apps/agentos/view/create/util/blueprintSchema.mjs
+++ b/apps/agentos/view/create/util/blueprintSchema.mjs
@@ -12,8 +12,9 @@
  *
  * Hard exclusions enforced by construction, everywhere in the payload (deep scan):
  * function values · `html`/`innerHTML`-class keys · event-handler configs (`listeners`,
- * `handler(s)`, `on*`) · unregistered schemas · non-allowlisted config keys. Mutations are partial
- * blueprints under the SAME validator — a follow-up can never introduce a key creation couldn't.
+ * `handler(s)`, `on*`) · unregistered schemas · non-allowlisted config keys. Mutations run
+ * merge-then-validate: the partial merges into the current blueprint and the merged result must
+ * pass the FULL creation validator — a follow-up can never reach a state creation couldn't.
  */
 
 /**
@@ -169,47 +170,52 @@ export function validateBlueprint(blueprint) {
 }
 
 /**
- * @summary Validates a follow-up MUTATION as a partial blueprint under the same contract: only
- * allowlisted config keys and/or data may change; schema and executable-surface rules apply
- * unchanged (a mutation can never introduce what creation couldn't).
- * @param {String} schema The live instance's registered schema id
+ * @summary Validates a follow-up MUTATION by merge-then-validate: the partial `{title?, config?,
+ * data?}` is merged into the CURRENT blueprint (title/data replace, config shallow-merges so
+ * "make it taller" preserves columns) and the merged result runs the FULL creation validator.
+ * A mutation is valid exactly when the merged result would be creation-valid — the symmetry is
+ * structural, not a second rule set that could drift from the first.
+ *
+ * On acceptance the merged blueprint is returned: the validator owns the merge semantics, so
+ * consumers never hand-merge (a second merge implementation is the same drift risk twice).
+ * @param {Object} currentBlueprint The live instance's current full blueprint
  * @param {Object} mutation Partial `{title?, config?, data?}`
- * @returns {{accepted: Boolean, reason: String|null}}
+ * @returns {{accepted: Boolean, reason: String|null, blueprint: Object|null}} `blueprint` is the
+ * merged result when accepted, null when refused
  */
-export function validateMutation(schema, mutation) {
-    const schemaDef = BLUEPRINT_SCHEMAS[schema];
+export function validateMutation(currentBlueprint, mutation) {
+    const current = validateBlueprint(currentBlueprint);
 
-    if (!schemaDef) {
-        return {accepted: false, reason: `unregistered blueprint schema "${schema}"`};
+    if (!current.accepted) {
+        return {accepted: false, reason: `current blueprint is not valid: ${current.reason}`, blueprint: null};
     }
 
     if (mutation == null || typeof mutation !== 'object' || Array.isArray(mutation)) {
-        return {accepted: false, reason: 'mutation must be a plain object'};
+        return {accepted: false, reason: 'mutation must be a plain object', blueprint: null};
     }
 
     const unknownKeys = Object.keys(mutation).filter(key => !['title', 'config', 'data'].includes(key));
 
     if (unknownKeys.length > 0) {
-        return {accepted: false, reason: `mutations may only touch title/config/data — unexpected: ${unknownKeys.join(', ')}`};
+        return {accepted: false, reason: `mutations may only touch title/config/data — unexpected: ${unknownKeys.join(', ')}`, blueprint: null};
     }
 
-    if ('config' in mutation) {
-        if (mutation.config == null || typeof mutation.config !== 'object' || Array.isArray(mutation.config)) {
-            return {accepted: false, reason: 'mutation config must be a plain object'};
-        }
-
-        const violations = Object.keys(mutation.config).filter(key => !schemaDef.configAllowlist.includes(key));
-
-        if (violations.length > 0) {
-            return {accepted: false, reason: `mutation config keys outside the ${schema} allowlist: ${violations.join(', ')}`};
-        }
+    if ('config' in mutation && (mutation.config == null || typeof mutation.config !== 'object' || Array.isArray(mutation.config))) {
+        return {accepted: false, reason: 'mutation config must be a plain object', blueprint: null};
     }
 
-    const executable = findExecutableSurface(mutation, 'mutation');
+    const merged = {
+        ...currentBlueprint,
+        ...('title'  in mutation ? {title: mutation.title} : {}),
+        ...('data'   in mutation ? {data: mutation.data}   : {}),
+        ...('config' in mutation ? {config: {...currentBlueprint.config, ...mutation.config}} : {})
+    };
 
-    if (executable) {
-        return {accepted: false, reason: executable};
+    const result = validateBlueprint(merged);
+
+    if (!result.accepted) {
+        return {accepted: false, reason: result.reason, blueprint: null};
     }
 
-    return {accepted: true, reason: null};
+    return {accepted: true, reason: null, blueprint: merged};
 }

--- a/apps/agentos/view/create/util/requestRoute.mjs
+++ b/apps/agentos/view/create/util/requestRoute.mjs
@@ -1,0 +1,79 @@
+import {validateBlueprint} from './blueprintSchema.mjs';
+
+/**
+ * @module AgentOS.view.create.util.requestRoute
+ * @summary The keeper request→blueprint route — the creation pipeline's spine, view-free.
+ *
+ * Accepts a natural-language creation request, calls the INJECTED agent boundary to produce a
+ * candidate blueprint, and emit-validates it through the one shared validator before anything
+ * reaches instantiation. The agent boundary is a parameter (not an import) so the route is fully
+ * testable without a live agent and the NL/provider wiring stays a separate leaf's concern.
+ *
+ * Refusals are data, never exceptions: every failure path — empty request, over-long request,
+ * boundary error, invalid blueprint — returns a bounded `{accepted: false, reason, stage}` the
+ * chat surface renders as the honest-refusal state. The agent sees the same reason and can
+ * self-correct on the next attempt (the emit-side half of the fail-closed-both-sides contract).
+ */
+
+/**
+ * @summary Upper bound on accepted request length — a creation request is a sentence or a
+ * paragraph, never a document; oversized input is refused, not truncated (truncation silently
+ * changes intent).
+ * @type {Number}
+ */
+export const MAX_REQUEST_LENGTH = 2000;
+
+/**
+ * @summary The route's failure stages, so callers and tests can assert WHERE a refusal happened
+ * without parsing prose.
+ * @type {Object}
+ */
+export const ROUTE_STAGES = Object.freeze({
+    BOUNDARY  : 'boundary',
+    REQUEST   : 'request',
+    VALIDATION: 'validation'
+});
+
+/**
+ * @summary Routes one creation request to a validated blueprint via the injected agent boundary.
+ *
+ * @param {Object}   options
+ * @param {String}   options.request  The user's natural-language creation request
+ * @param {Function} options.generate Async agent boundary: `(request) => candidate blueprint`.
+ *   Injected by the caller (the NL wiring leaf provides the live one; tests provide doubles).
+ * @returns {Promise<{accepted: Boolean, blueprint: Object|null, reason: String|null, stage: String|null}>}
+ */
+export async function routeCreationRequest({request, generate}) {
+    if (typeof request !== 'string' || request.trim() === '') {
+        return {accepted: false, blueprint: null, reason: 'creation request must be a non-empty string', stage: ROUTE_STAGES.REQUEST};
+    }
+
+    if (request.length > MAX_REQUEST_LENGTH) {
+        return {accepted: false, blueprint: null, reason: `creation request exceeds ${MAX_REQUEST_LENGTH} characters — refused, not truncated`, stage: ROUTE_STAGES.REQUEST};
+    }
+
+    if (typeof generate !== 'function') {
+        return {accepted: false, blueprint: null, reason: 'no agent boundary injected — the route never imports a provider directly', stage: ROUTE_STAGES.BOUNDARY};
+    }
+
+    let candidate;
+
+    try {
+        candidate = await generate(request.trim());
+    } catch (error) {
+        return {
+            accepted : false,
+            blueprint: null,
+            reason   : `agent boundary failed: ${error instanceof Error ? error.message : String(error)}`,
+            stage    : ROUTE_STAGES.BOUNDARY
+        };
+    }
+
+    const {accepted, reason} = validateBlueprint(candidate);
+
+    if (!accepted) {
+        return {accepted: false, blueprint: null, reason, stage: ROUTE_STAGES.VALIDATION};
+    }
+
+    return {accepted: true, blueprint: candidate, reason: null, stage: null};
+}

--- a/test/playwright/unit/apps/agentos/create/requestRoute.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/requestRoute.spec.mjs
@@ -1,0 +1,88 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KeeperRequestRouteTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('keeper request→blueprint route + the ONE shared validator (constrained-blueprint safety contract v2)', () => {
+    let schema, route;
+
+    const validGrid = () => ({
+        schema: 'grid@1',
+        title : 'People',
+        config: {columns: [{field: 'name', text: 'Name'}, {field: 'city', text: 'City'}]},
+        data  : [{name: 'A', city: 'B'}, {name: 'C', city: 'D'}]
+    });
+
+    test.beforeAll(async () => {
+        schema = await import('../../../../../../apps/agentos/view/create/util/blueprintSchema.mjs');
+        route  = await import('../../../../../../apps/agentos/view/create/util/requestRoute.mjs');
+    });
+
+    test('a well-formed grid@1 blueprint validates and routes end-to-end', async () => {
+        expect(schema.validateBlueprint(validGrid())).toEqual({accepted: true, reason: null});
+
+        const result = await route.routeCreationRequest({request: 'build me a neo grid', generate: async () => validGrid()});
+
+        expect(result.accepted).toBe(true);
+        expect(result.blueprint.schema).toBe('grid@1');
+        expect(result.stage).toBeNull();
+    });
+
+    test('the attack suite is refused on the shared validator (contract §5)', () => {
+        const cases = [
+            [{...validGrid(), config: {columns: [{field: 'x', text: 'X'}], renderer: () => {}}}, 'allowlist'],          // (a) function via non-allowlisted key
+            [{...validGrid(), config: {columns: [{field: 'x', text: 'X', html: '<img onerror=1>'}]}}, 'forbidden key'], // (b) html key injection, nested
+            [{...validGrid(), schema: 'iframe@1'}, 'unregistered'],                                                     // (c) unknown schema
+            [{...validGrid(), vdom: {}}, 'unexpected top-level'],                                                       // (d) unknown top-level key
+            [{...validGrid(), config: {columns: [{field: 'x', text: 'X', listeners: {}}]}}, 'forbidden key'],           // (e) handler smuggling, nested
+            [{...validGrid(), data: [{name: () => {}}]}, 'function value']                                              // (f) deep function value
+        ];
+
+        for (const [payload, reasonFragment] of cases) {
+            const result = schema.validateBlueprint(payload);
+
+            expect(result.accepted).toBe(false);
+            expect(result.reason.toLowerCase()).toContain(reasonFragment.toLowerCase());
+        }
+    });
+
+    test('mutations run the same contract — no key creation could not add (§4)', () => {
+        expect(schema.validateMutation('grid@1', {config: {height: 400}})).toEqual({accepted: true, reason: null});
+        expect(schema.validateMutation('grid@1', {config: {renderer: 'x'}}).accepted).toBe(false);
+        expect(schema.validateMutation('grid@1', {vdom: {}}).accepted).toBe(false);
+        expect(schema.validateMutation('grid@1', {data: [{f: () => {}}]}).accepted).toBe(false);
+        expect(schema.validateMutation('nope@9', {config: {}}).accepted).toBe(false);
+    });
+
+    test('route refusals are staged data, never exceptions', async () => {
+        const empty = await route.routeCreationRequest({request: '  ', generate: async () => validGrid()});
+        expect(empty).toMatchObject({accepted: false, stage: route.ROUTE_STAGES.REQUEST});
+
+        const oversized = await route.routeCreationRequest({request: 'x'.repeat(2001), generate: async () => validGrid()});
+        expect(oversized.reason).toContain('refused, not truncated');
+
+        const noBoundary = await route.routeCreationRequest({request: 'build me a grid'});
+        expect(noBoundary).toMatchObject({accepted: false, stage: route.ROUTE_STAGES.BOUNDARY});
+
+        const boundaryThrows = await route.routeCreationRequest({request: 'build me a grid', generate: async () => { throw new Error('provider down'); }});
+        expect(boundaryThrows).toMatchObject({accepted: false, stage: route.ROUTE_STAGES.BOUNDARY});
+        expect(boundaryThrows.reason).toContain('provider down');
+
+        const badBlueprint = await route.routeCreationRequest({request: 'build me a grid', generate: async () => ({schema: 'grid@1', title: '', config: {}, data: []})});
+        expect(badBlueprint).toMatchObject({accepted: false, stage: route.ROUTE_STAGES.VALIDATION});
+    });
+});

--- a/test/playwright/unit/apps/agentos/create/requestRoute.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/requestRoute.spec.mjs
@@ -60,12 +60,28 @@ test.describe('keeper request→blueprint route + the ONE shared validator (cons
         }
     });
 
-    test('mutations run the same contract — no key creation could not add (§4)', () => {
-        expect(schema.validateMutation('grid@1', {config: {height: 400}})).toEqual({accepted: true, reason: null});
-        expect(schema.validateMutation('grid@1', {config: {renderer: 'x'}}).accepted).toBe(false);
-        expect(schema.validateMutation('grid@1', {vdom: {}}).accepted).toBe(false);
-        expect(schema.validateMutation('grid@1', {data: [{f: () => {}}]}).accepted).toBe(false);
-        expect(schema.validateMutation('nope@9', {config: {}}).accepted).toBe(false);
+    test('mutations run merge-then-validate — no state creation could not reach (§4)', () => {
+        const current = validGrid();
+
+        // config shallow-merges: "make it taller" preserves columns; the validator returns the merged result
+        const taller = schema.validateMutation(current, {config: {height: 400}});
+        expect(taller.accepted).toBe(true);
+        expect(taller.blueprint.config.height).toBe(400);
+        expect(taller.blueprint.config.columns).toEqual(current.config.columns);
+
+        // key-level refusals, unchanged
+        expect(schema.validateMutation(current, {config: {renderer: 'x'}}).accepted).toBe(false);
+        expect(schema.validateMutation(current, {vdom: {}}).accepted).toBe(false);
+        expect(schema.validateMutation(current, {data: [{f: () => {}}]}).accepted).toBe(false);
+
+        // schema-owned SHAPE symmetry: partials that would reach a creation-invalid state are refused
+        expect(schema.validateMutation(current, {title: 42}).accepted).toBe(false);
+        expect(schema.validateMutation(current, {data: 'not rows'}).accepted).toBe(false);
+        expect(schema.validateMutation(current, {data: ['not object']}).accepted).toBe(false);
+        expect(schema.validateMutation(current, {config: {columns: ['bad']}}).accepted).toBe(false);
+
+        // a corrupted current blueprint fails closed before any merge
+        expect(schema.validateMutation({schema: 'nope@9', title: 'x', config: {}, data: []}, {config: {}}).accepted).toBe(false);
     });
 
     test('route refusals are staged data, never exceptions', async () => {


### PR DESCRIPTION
## Summary

First creation-flow leaf of the harness pillar (Epic #13349, module convention per #14642, safety contract per #14644): **the keeper request→blueprint route and the ONE shared validator**, view-free and agent-boundary-injected. A natural-language creation request can now only ever become a versioned, schema-registered, allowlist-validated blueprint — or a bounded, staged refusal. Nothing executable can transit the pipe, by construction, and the emit side and accept side will share this exact module (one vocabulary per contract; two call sites, zero re-derivation).

Resolves #14655
Refs #13349

## Deltas

- **NEW `apps/agentos/view/create/util/blueprintSchema.mjs`** — the contract mechanized: `BLUEPRINT_SCHEMAS` registry (`grid@1` first: `configAllowlist: ['columns','height','width']` + structural validate), `BLUEPRINT_TOP_LEVEL_KEYS` (`schema/title/config/data`, nothing else), `FORBIDDEN_KEY_PATTERNS` (html/innerHTML class, `listeners`, `handler(s)`, `on*` DOM-handler convention) enforced by `findExecutableSurface` — a **deep scan of every key and value at any nesting depth**, functions included. `validateBlueprint` + `validateMutation` are both fail-closed and never throw. Mutations run **merge-then-validate** (review cycle 1): the partial `{title?, config?, data?}` merges into the current blueprint (title/data replace; config shallow-merges so "make it taller" preserves columns) and the merged result must pass the FULL creation validator — mutation-valid ⇔ merged-result-creation-valid, symmetric by construction with no second rule set to drift; the accepted merged blueprint is returned so consumers never hand-merge. Adding a widget type is ONE registration here, never a validator fork (the plugin seam for later tranches).
- **NEW `apps/agentos/view/create/util/requestRoute.mjs`** — `routeCreationRequest({request, generate})`: the async agent boundary is a **parameter, not an import**, so the route is fully testable without a live agent and NL/provider wiring stays a separate leaf's concern. Refusals are data with a machine-checkable `stage` (`request` / `boundary` / `validation`); oversized input is refused, not truncated (truncation silently changes intent); a throwing boundary becomes a staged refusal carrying the provider error.
- **NEW `test/playwright/unit/apps/agentos/create/requestRoute.spec.mjs`** — 4 tests: the happy grid path end-to-end · the six-shape attack suite refused on the shared validator (function config, nested `html` injection, unregistered schema, unknown top-level key, nested `listeners` smuggling, deep function value in data) · merge-then-validate mutations incl. the four reviewer-falsifier regressions (`{title: 42}`, `{data: 'not rows'}`, `{data: ['not object']}`, `{config: {columns: ['bad']}}` all refused), the columns-preserving shallow config merge, and corrupted-current fail-closed · staged refusal semantics (empty, oversized, missing boundary, throwing boundary, invalid candidate — all data, never exceptions).

**Deliberately NOT in this PR (scope honesty):** the live NL wiring (the injected `generate` of a later leaf), the created-instance registry (#14656, filed, next lane), and any view/chat-surface code — this leaf is the pure spine those consume.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs requestRoute` → **4 passed (30.5s)**.

Evidence: L2 (unit-pinned pure logic; the live agent-boundary proof lands with the NL wiring leaf per the scope note).

## Post-Merge Validation

- The accept-side instantiation leaf (#14656 registry + mount path) imports `validateBlueprint` from this module instead of re-deriving — the two-sided fail-closed contract's second call site is the check.
- Registering a second schema (e.g. a chart widget) touches ONLY `BLUEPRINT_SCHEMAS` — if it needs validator-code changes, the plugin seam failed and that's a defect.
- The archaeology guard holds: behavioral prose only in durable comments.

## Related

Epic #13349 (harness pillar, `Refs` only) · #14642 (module convention: `view/create/`, closed with Vega's path concurrence) · #14644 (the recorded v2 safety contract this mechanizes) · #14656 (created-instance registry, next leaf) · `apps/agentos/view/evidence/util/blueprintEvidence.mjs` (the shipped allowlist-projection pattern this generalizes).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b9b95ac6-42f5-47a3-b58f-6071f79657e8.
