### PR TITLE
feat(agentos): created-instance registry as first-class store records (#14656)

### DIFF
--- a/apps/agentos/view/create/model/CreatedInstance.mjs
+++ b/apps/agentos/view/create/model/CreatedInstance.mjs
@@ -1,0 +1,61 @@
+import Model from '../../../../../src/data/Model.mjs';
+
+/**
+ * @class AgentOS.view.create.model.CreatedInstance
+ * @extends Neo.data.Model
+ *
+ * @summary Record shape for one agent-created widget instance inside the creation module.
+ *
+ * A created widget is a first-class object the whole module reasons over — follow-up mutation
+ * targeting ("make THE GRID bigger"), lifecycle controls, and later serialization all read this
+ * shape instead of re-deriving "what exists" from the component tree. Disposed instances keep
+ * their record (state flips to `disposed`) so history and serialization stay complete.
+ */
+class CreatedInstance extends Model {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.create.model.CreatedInstance'
+         * @protected
+         */
+        className: 'AgentOS.view.create.model.CreatedInstance',
+        /**
+         * @member {String} keyProperty='instanceId'
+         */
+        keyProperty: 'instanceId',
+        /**
+         * @member {Object[]} fields
+         */
+        fields: [{
+            name: 'instanceId',
+            type: 'String'
+        }, {
+            // the registered blueprint schema id (e.g. 'grid@1') — the string key, never the schema object
+            name: 'blueprintSchema',
+            type: 'String'
+        }, {
+            name: 'title',
+            type: 'String'
+        }, {
+            // ISO timestamp; display/serialization surface, NOT the ordering authority (creationIndex is)
+            name: 'createdAt',
+            type: 'String'
+        }, {
+            // monotonic per-registry counter — deterministic "latest created" ordering without clock reads
+            name: 'creationIndex',
+            type: 'Int'
+        }, {
+            // 'live' | 'disposed'
+            name: 'state',
+            type: 'String'
+        }, {
+            // rendering pane reference; null until the pane chrome mounts the instance
+            name        : 'paneRef',
+            defaultValue: null
+        }, {
+            // the full accepted blueprint (untyped passthrough object) — the mutation/serialization source
+            name: 'blueprintSnapshot'
+        }]
+    }
+}
+
+export default Neo.setupClass(CreatedInstance);

--- a/apps/agentos/view/create/store/CreatedInstances.mjs
+++ b/apps/agentos/view/create/store/CreatedInstances.mjs
@@ -1,0 +1,193 @@
+import CreatedInstanceModel from '../model/CreatedInstance.mjs';
+import Store                from '../../../../../src/data/Store.mjs';
+
+/**
+ * @class AgentOS.view.create.store.CreatedInstances
+ * @extends Neo.data.Store
+ *
+ * @summary The ONE authoritative registry of agent-created widget instances — every surface that
+ * needs "what exists" (mutation targeting, lifecycle controls, serialization) reads THIS store
+ * instead of reaching around into the component tree.
+ *
+ * Exposed as a **singleton**: the accept path writes on instantiate, the mutation path updates
+ * snapshots, dispose flips state — one shared instance, explicit-import consumption only.
+ *
+ * Lifecycle methods mirror the creation pipeline's refusal vocabulary: fail-closed, never throw,
+ * always `{accepted, reason, record}` so callers branch on `accepted` exactly as they do on the
+ * blueprint validators. Disposed records are kept (state `disposed`), never removed — the registry
+ * is history-complete for serialization; only `live` records participate in target resolution.
+ */
+class CreatedInstances extends Store {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.create.store.CreatedInstances'
+         * @protected
+         */
+        className: 'AgentOS.view.create.store.CreatedInstances',
+        /**
+         * @member {Boolean} singleton=true
+         */
+        singleton: true,
+        /**
+         * @member {String} keyProperty='instanceId'
+         */
+        keyProperty: 'instanceId',
+        /**
+         * @member {Neo.data.Model} model=CreatedInstanceModel
+         * @reactive
+         */
+        model: CreatedInstanceModel
+    }
+
+    /**
+     * Registers a freshly instantiated widget as a live record. Refuses on missing identity
+     * fields or a duplicate instanceId — one record per instance is the registry's authority.
+     * @param {Object} data
+     * @param {String} data.instanceId
+     * @param {String} data.blueprintSchema The registered schema id string (e.g. 'grid@1')
+     * @param {String} data.title
+     * @param {Object} data.blueprintSnapshot The full accepted blueprint
+     * @param {String|null} [data.paneRef=null]
+     * @returns {{accepted: Boolean, reason: String|null, record: Object|null}}
+     */
+    registerCreated({instanceId, blueprintSchema, title, blueprintSnapshot, paneRef=null}) {
+        for (const [name, value] of [['instanceId', instanceId], ['blueprintSchema', blueprintSchema], ['title', title]]) {
+            if (typeof value !== 'string' || value.trim() === '') {
+                return {accepted: false, reason: `registration requires a non-empty string ${name}`, record: null}
+            }
+        }
+
+        if (blueprintSnapshot == null || typeof blueprintSnapshot !== 'object' || Array.isArray(blueprintSnapshot)) {
+            return {accepted: false, reason: 'registration requires the accepted blueprint as blueprintSnapshot', record: null}
+        }
+
+        if (this.get(instanceId)) {
+            return {accepted: false, reason: `instanceId "${instanceId}" is already registered — one record per instance`, record: null}
+        }
+
+        const record = this.add({
+            instanceId,
+            blueprintSchema,
+            title,
+            blueprintSnapshot,
+            paneRef,
+            createdAt    : new Date().toISOString(),
+            creationIndex: this.nextCreationIndex(),
+            state        : 'live'
+        })[0];
+
+        return {accepted: true, reason: null, record}
+    }
+
+    /**
+     * Applies an accepted mutation to a live record: only `title` and/or `blueprintSnapshot` may
+     * change — identity, ordering and lifecycle fields are immutable here. Mutation VALIDATION is
+     * the shared blueprint validator's job on the accept path; this method records its outcome.
+     * @param {String} instanceId
+     * @param {Object} changes
+     * @param {String} [changes.title]
+     * @param {Object} [changes.blueprintSnapshot]
+     * @returns {{accepted: Boolean, reason: String|null, record: Object|null}}
+     */
+    markMutated(instanceId, changes) {
+        const record = this.get(instanceId);
+
+        if (!record) {
+            return {accepted: false, reason: `no record for instanceId "${instanceId}"`, record: null}
+        }
+
+        if (record.state !== 'live') {
+            return {accepted: false, reason: `instanceId "${instanceId}" is disposed — disposed instances never mutate`, record: null}
+        }
+
+        if (changes == null || typeof changes !== 'object' || Array.isArray(changes)) {
+            return {accepted: false, reason: 'mutation changes must be a plain object', record: null}
+        }
+
+        const unknownKeys = Object.keys(changes).filter(key => !['title', 'blueprintSnapshot'].includes(key));
+
+        if (unknownKeys.length > 0) {
+            return {accepted: false, reason: `only title/blueprintSnapshot may change — unexpected: ${unknownKeys.join(', ')}`, record: null}
+        }
+
+        if ('title' in changes) {
+            record.title = changes.title
+        }
+
+        if ('blueprintSnapshot' in changes) {
+            record.blueprintSnapshot = changes.blueprintSnapshot
+        }
+
+        return {accepted: true, reason: null, record}
+    }
+
+    /**
+     * Flips a live record to `disposed`. The record is kept — the registry stays history-complete;
+     * resolution simply stops seeing it. Double-dispose is refused so callers learn true state.
+     * @param {String} instanceId
+     * @returns {{accepted: Boolean, reason: String|null, record: Object|null}}
+     */
+    markDisposed(instanceId) {
+        const record = this.get(instanceId);
+
+        if (!record) {
+            return {accepted: false, reason: `no record for instanceId "${instanceId}"`, record: null}
+        }
+
+        if (record.state !== 'live') {
+            return {accepted: false, reason: `instanceId "${instanceId}" is already disposed`, record: null}
+        }
+
+        record.state = 'disposed';
+
+        return {accepted: true, reason: null, record}
+    }
+
+    /**
+     * Next monotonic creation index, derived from the current maximum so it survives store
+     * clears and needs no hidden counter state.
+     * @returns {Number}
+     */
+    nextCreationIndex() {
+        let max = 0;
+
+        this.items.forEach(record => {
+            if (record.creationIndex > max) {
+                max = record.creationIndex
+            }
+        });
+
+        return max + 1
+    }
+
+    /**
+     * Resolves a follow-up target ("make THE GRID bigger"):
+     * - `instanceId` wins and returns the record in ANY state (callers see `disposed` honestly);
+     * - `title` returns the latest LIVE record with that exact title;
+     * - no selector returns the latest LIVE record overall.
+     * @param {Object} [selector={}]
+     * @param {String} [selector.instanceId]
+     * @param {String} [selector.title]
+     * @returns {Object|null} the resolved record, or null
+     */
+    resolveTarget({instanceId, title}={}) {
+        if (instanceId) {
+            return this.get(instanceId) || null
+        }
+
+        let candidate = null;
+
+        this.items.forEach(record => {
+            if (record.state === 'live'
+                && (title === undefined || record.title === title)
+                && (!candidate || record.creationIndex > candidate.creationIndex)
+            ) {
+                candidate = record
+            }
+        });
+
+        return candidate
+    }
+}
+
+export default Neo.setupClass(CreatedInstances);

--- a/apps/agentos/view/create/store/CreatedInstances.mjs
+++ b/apps/agentos/view/create/store/CreatedInstances.mjs
@@ -16,6 +16,9 @@ import Store                from '../../../../../src/data/Store.mjs';
  * always `{accepted, reason, record}` so callers branch on `accepted` exactly as they do on the
  * blueprint validators. Disposed records are kept (state `disposed`), never removed — the registry
  * is history-complete for serialization; only `live` records participate in target resolution.
+ *
+ * Snapshot ownership: `blueprintSnapshot` is REGISTRY-OWNED — cloned on registration and on
+ * mutation, never aliased to caller state; consumers treat resolved records as read-only.
  */
 class CreatedInstances extends Store {
     static config = {
@@ -65,11 +68,17 @@ class CreatedInstances extends Store {
             return {accepted: false, reason: `instanceId "${instanceId}" is already registered — one record per instance`, record: null}
         }
 
+        const snapshot = this.cloneSnapshot(blueprintSnapshot);
+
+        if (!snapshot.accepted) {
+            return {accepted: false, reason: snapshot.reason, record: null}
+        }
+
         const record = this.add({
             instanceId,
             blueprintSchema,
             title,
-            blueprintSnapshot,
+            blueprintSnapshot: snapshot.value,
             paneRef,
             createdAt    : new Date().toISOString(),
             creationIndex: this.nextCreationIndex(),
@@ -110,12 +119,22 @@ class CreatedInstances extends Store {
             return {accepted: false, reason: `only title/blueprintSnapshot may change — unexpected: ${unknownKeys.join(', ')}`, record: null}
         }
 
+        let snapshot = null;
+
+        if ('blueprintSnapshot' in changes) {
+            snapshot = this.cloneSnapshot(changes.blueprintSnapshot);
+
+            if (!snapshot.accepted) {
+                return {accepted: false, reason: snapshot.reason, record: null}
+            }
+        }
+
         if ('title' in changes) {
             record.title = changes.title
         }
 
-        if ('blueprintSnapshot' in changes) {
-            record.blueprintSnapshot = changes.blueprintSnapshot
+        if (snapshot) {
+            record.blueprintSnapshot = snapshot.value
         }
 
         return {accepted: true, reason: null, record}
@@ -141,6 +160,22 @@ class CreatedInstances extends Store {
         record.state = 'disposed';
 
         return {accepted: true, reason: null, record}
+    }
+
+    /**
+     * Snapshot ownership enforcement: the registry stores a structured clone, never a caller
+     * reference — a caller mutating their original after the call can never rewrite recorded
+     * history. Content a structured clone rejects (functions, DOM nodes — the executable-surface
+     * class) becomes a bounded refusal, so such values cannot even be STORED here.
+     * @param {Object} blueprintSnapshot
+     * @returns {{accepted: Boolean, reason: String|null, value: Object|null}}
+     */
+    cloneSnapshot(blueprintSnapshot) {
+        try {
+            return {accepted: true, reason: null, value: structuredClone(blueprintSnapshot)}
+        } catch (error) {
+            return {accepted: false, reason: `blueprintSnapshot is not snapshot-safe data: ${error.message}`, value: null}
+        }
     }
 
     /**

--- a/test/playwright/unit/apps/agentos/create/createdInstances.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/createdInstances.spec.mjs
@@ -92,6 +92,43 @@ test.describe('created-instance registry: live widgets as first-class store reco
         expect(CreatedInstances.markDisposed('lc-grid-1').accepted).toBe(false);
     });
 
+    test('snapshots are registry-owned: caller mutations never rewrite recorded history', () => {
+        const original = gridSnapshot('Ownership Grid');
+
+        CreatedInstances.registerCreated({
+            instanceId       : 'own-1',
+            blueprintSchema  : 'grid@1',
+            title            : 'Ownership Grid',
+            blueprintSnapshot: original
+        });
+
+        // caller mutates their original AFTER registration — deep and shallow
+        original.title             = 'HIJACKED';
+        original.config.columns[0] = {field: 'evil', text: 'Evil'};
+        original.data.push({name: 'injected'});
+
+        const afterRegister = CreatedInstances.resolveTarget({instanceId: 'own-1'}).blueprintSnapshot;
+
+        expect(afterRegister.title).toBe('Ownership Grid');
+        expect(afterRegister.config.columns[0].field).toBe('name');
+        expect(afterRegister.data).toHaveLength(1);
+
+        // same rule on mutation: the caller's merged object stays theirs
+        const mutated = gridSnapshot('Ownership Grid v2');
+
+        CreatedInstances.markMutated('own-1', {blueprintSnapshot: mutated});
+        mutated.config.columns[0].field = 'evil-again';
+
+        expect(CreatedInstances.resolveTarget({instanceId: 'own-1'}).blueprintSnapshot.config.columns[0].field).toBe('name');
+
+        // non-snapshot-safe content (the executable class) refuses instead of throwing — it cannot even be stored
+        const withFunction = {...gridSnapshot('Fn Grid'), data: [{name: () => {}}]};
+
+        expect(CreatedInstances.registerCreated({instanceId: 'own-2', blueprintSchema: 'grid@1', title: 'Fn Grid', blueprintSnapshot: withFunction}).accepted).toBe(false);
+        expect(CreatedInstances.markMutated('own-1', {blueprintSnapshot: withFunction}).accepted).toBe(false);
+        expect(CreatedInstances.resolveTarget({instanceId: 'own-1'}).blueprintSnapshot.title).toBe('Ownership Grid v2');
+    });
+
     test('target resolution: by id, by title (latest live wins), latest-created fallback', () => {
         const register = (instanceId, title) => CreatedInstances.registerCreated({
             instanceId,

--- a/test/playwright/unit/apps/agentos/create/createdInstances.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/createdInstances.spec.mjs
@@ -1,0 +1,126 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AgentOSCreatedInstancesTest'
+    }
+});
+
+import {test, expect}   from '@playwright/test';
+import Neo              from '../../../../../../src/Neo.mjs';
+import * as core        from '../../../../../../src/core/_export.mjs';
+import InstanceManager  from '../../../../../../src/manager/Instance.mjs';
+import CreatedInstances from '../../../../../../apps/agentos/view/create/store/CreatedInstances.mjs';
+
+// Each test uses its own instanceIds: the store is a singleton, so tests must never
+// assert on ids they did not register themselves.
+const gridSnapshot = title => ({
+    schema: 'grid@1',
+    title,
+    config: {columns: [{field: 'name', text: 'Name'}]},
+    data  : [{name: 'row-1'}]
+});
+
+test.describe('created-instance registry: live widgets as first-class store records', () => {
+    test('full lifecycle round-trip: register → mutate → dispose, with the record kept', () => {
+        const registered = CreatedInstances.registerCreated({
+            instanceId       : 'rt-grid-1',
+            blueprintSchema  : 'grid@1',
+            title            : 'Roundtrip Grid',
+            blueprintSnapshot: gridSnapshot('Roundtrip Grid')
+        });
+
+        expect(registered.accepted).toBe(true);
+        expect(registered.record.state).toBe('live');
+        expect(registered.record.paneRef).toBeNull();
+        expect(registered.record.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(registered.record.creationIndex).toBeGreaterThan(0);
+
+        const mutated = CreatedInstances.markMutated('rt-grid-1', {
+            title            : 'Roundtrip Grid XL',
+            blueprintSnapshot: {...gridSnapshot('Roundtrip Grid XL'), config: {columns: [{field: 'name', text: 'Name'}], height: 600}}
+        });
+
+        expect(mutated.accepted).toBe(true);
+        expect(mutated.record.title).toBe('Roundtrip Grid XL');
+        expect(mutated.record.blueprintSnapshot.config.height).toBe(600);
+
+        const disposed = CreatedInstances.markDisposed('rt-grid-1');
+
+        expect(disposed.accepted).toBe(true);
+        expect(disposed.record.state).toBe('disposed');
+
+        // history-complete: the record survives dispose, resolvable by id in any state
+        expect(CreatedInstances.resolveTarget({instanceId: 'rt-grid-1'}).state).toBe('disposed');
+    });
+
+    test('registration refuses bad identity, missing snapshot, and duplicate ids', () => {
+        const base = {blueprintSchema: 'grid@1', title: 'Refusals', blueprintSnapshot: gridSnapshot('Refusals')};
+
+        expect(CreatedInstances.registerCreated({...base, instanceId: ''}).accepted).toBe(false);
+        expect(CreatedInstances.registerCreated({...base, instanceId: 'ref-1', blueprintSchema: '  '}).accepted).toBe(false);
+        expect(CreatedInstances.registerCreated({...base, instanceId: 'ref-1', blueprintSnapshot: null}).accepted).toBe(false);
+        expect(CreatedInstances.registerCreated({...base, instanceId: 'ref-1', blueprintSnapshot: []}).accepted).toBe(false);
+
+        expect(CreatedInstances.registerCreated({...base, instanceId: 'ref-1'}).accepted).toBe(true);
+
+        const duplicate = CreatedInstances.registerCreated({...base, instanceId: 'ref-1'});
+
+        expect(duplicate.accepted).toBe(false);
+        expect(duplicate.reason).toContain('already registered');
+    });
+
+    test('lifecycle refusals: unknown ids, disposed mutation, double dispose, foreign keys', () => {
+        CreatedInstances.registerCreated({
+            instanceId       : 'lc-grid-1',
+            blueprintSchema  : 'grid@1',
+            title            : 'Lifecycle Grid',
+            blueprintSnapshot: gridSnapshot('Lifecycle Grid')
+        });
+
+        expect(CreatedInstances.markMutated('lc-missing', {title: 'x'}).accepted).toBe(false);
+        expect(CreatedInstances.markDisposed('lc-missing').accepted).toBe(false);
+
+        // only title/blueprintSnapshot may change — identity and lifecycle fields are immutable here
+        const foreign = CreatedInstances.markMutated('lc-grid-1', {state: 'disposed'});
+        expect(foreign.accepted).toBe(false);
+        expect(foreign.reason).toContain('unexpected');
+        expect(CreatedInstances.markMutated('lc-grid-1', null).accepted).toBe(false);
+
+        expect(CreatedInstances.markDisposed('lc-grid-1').accepted).toBe(true);
+        expect(CreatedInstances.markMutated('lc-grid-1', {title: 'too late'}).accepted).toBe(false);
+        expect(CreatedInstances.markDisposed('lc-grid-1').accepted).toBe(false);
+    });
+
+    test('target resolution: by id, by title (latest live wins), latest-created fallback', () => {
+        const register = (instanceId, title) => CreatedInstances.registerCreated({
+            instanceId,
+            blueprintSchema  : 'grid@1',
+            title,
+            blueprintSnapshot: gridSnapshot(title)
+        });
+
+        register('res-a', 'Sales Grid');
+        register('res-b', 'Sales Grid');
+        register('res-c', 'People Grid');
+
+        // by id: exact, any state
+        expect(CreatedInstances.resolveTarget({instanceId: 'res-a'}).instanceId).toBe('res-a');
+        expect(CreatedInstances.resolveTarget({instanceId: 'res-nope'})).toBeNull();
+
+        // by title: the LATEST live record with that title
+        expect(CreatedInstances.resolveTarget({title: 'Sales Grid'}).instanceId).toBe('res-b');
+        expect(CreatedInstances.resolveTarget({title: 'No Such Grid'})).toBeNull();
+
+        // no selector: latest live overall (res-c is this worker's newest registration)
+        expect(CreatedInstances.resolveTarget().instanceId).toBe('res-c');
+
+        // dispose shifts resolution to the previous live record — disposed never resolves by title/latest
+        CreatedInstances.markDisposed('res-c');
+        CreatedInstances.markDisposed('res-b');
+
+        expect(CreatedInstances.resolveTarget().instanceId).toBe('res-a');
+        expect(CreatedInstances.resolveTarget({title: 'Sales Grid'}).instanceId).toBe('res-a');
+        expect(CreatedInstances.resolveTarget({title: 'People Grid'})).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

T2.9 of the harness pillar (Epic #13349): **the created-instance registry** — agent-created widgets become first-class store records the whole creation module reasons over. Follow-up mutation targeting ("make THE GRID bigger"), lifecycle controls, and later serialization all read ONE authoritative singleton store instead of re-deriving "what exists" from the component tree — the reach-around the module-boundary contract (#14642) bans.

Resolves #14656
Refs #13349

## Deltas

- **NEW `apps/agentos/view/create/model/CreatedInstance.mjs`** — the record shape: `{instanceId (key), blueprintSchema (the string id, e.g. 'grid@1'), title, createdAt (ISO, display-only), creationIndex (monotonic Int — the ordering authority, deterministic without clock reads), state (live|disposed), paneRef (null until pane chrome mounts), blueprintSnapshot (the full accepted blueprint, untyped passthrough)}`.
- **NEW `apps/agentos/view/create/store/CreatedInstances.mjs`** — singleton store keyed on `instanceId` with the lifecycle API, mirroring the creation pipeline's refusal vocabulary (fail-closed, never throws, `{accepted, reason, record}`):
  - `registerCreated(...)` — refuses missing identity fields, non-object snapshots, duplicate ids (one record per instance is the registry's authority); stamps `createdAt` + `creationIndex` + `state: 'live'`.
  - `markMutated(id, {title?, blueprintSnapshot?})` — ONLY those two fields may change (identity/ordering/lifecycle fields immutable here); disposed records never mutate. Mutation *validation* stays the shared blueprint validator's job on the accept path — this method records its outcome.
  - `markDisposed(id)` — flips to `disposed`, KEEPS the record (history-complete for serialization); double-dispose refused so callers learn true state.
  - `resolveTarget({instanceId?, title?})` — by-id returns any state (callers see `disposed` honestly); by-title returns the latest LIVE match; no selector returns the latest live overall.
- **NEW `test/playwright/unit/apps/agentos/create/createdInstances.spec.mjs`** — 4 tests: full lifecycle round-trip (register → mutate → dispose with record kept + resolvable) · registration refusals (identity, snapshot shape, duplicates) · lifecycle refusals (unknown ids, disposed mutation, double dispose, foreign-key mutation attempts) · target resolution incl. dispose shifting latest/title resolution to the previous live record. Tests are singleton-safe: unique ids per test, ordering assertions robust under fullyParallel worker distribution.

**Deliberately NOT in this PR (scope honesty):** T4 persistence to disk/git, pane chrome (SSOT-gated views), the dock wiring (T2.7), and the create/mutate/dispose *hook wiring* into the instantiation mechanism — those leaves consume this store by explicit import.

Deliberately independent of PR #14678's files (no stacking): the registry stores the schema id string + snapshot; validation stays in the route/accept path.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs createdInstances` → **4 passed (30.4s)**.

Two environment findings baked into the spec (prior-art: tree unit specs): the store must set `keyProperty` itself (the collection default `'id'` wins over the model's key via `getKeyProperty`'s fallback order), and record writes require `src/manager/Instance.mjs` imported for `Neo.get` in the unit env.

Evidence: L2 (unit-pinned store logic; live wiring lands with the instantiation-hook leaf per the scope note).

## Post-Merge Validation

- The instantiation/mutation/dispose hook leaves import THIS store and call the lifecycle API instead of tracking instances locally — a second "what exists" source anywhere in the module is a defect.
- The pane-chrome tranche fills `paneRef` on mount; `resolveTarget` behavior unchanged by it.
- The archaeology guard holds: behavioral prose only in durable comments.

## Related

Epic #13349 (T2.9, `Refs` only) · #14642 (module convention + boundary contract) · #14655 / PR #14678 (the emit-side route this registry complements on the accept side) · #13361 (the mutation mechanism whose product face consumes this) · `apps/agentos/store/AgentDefinitions.mjs` (the singleton-store sibling pattern).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b9b95ac6-42f5-47a3-b58f-6071f79657e8.
