### PR TITLE
feat(design): Demo-A dock-choreography design artifact — scenes, tour UX, dual-mode (#14638)

### DIFF
--- a/apps/agentos/design/dock-choreography-demo.html
+++ b/apps/agentos/design/dock-choreography-demo.html
@@ -1,0 +1,277 @@
+<style>
+  /* ── Demo-A design artifact · dock choreography showcase (#14638, tree line F1 of #13158) ──
+     Design DNA: the cockpit plan SSOT (fleet-manager-cockpit-plan.html). Dual-mode from birth
+     per #14681: every color below is a SEMANTIC token; the [data-mode] swap IS the thesis. */
+  :root, [data-mode="dark"] {
+    --ground:#0b0e13; --panel:#141a23; --panel-2:#1a212c; --rail:#0e131a;
+    --line:#262f3d; --line-soft:#1c242f;
+    --ink:#d6dce6; --ink-dim:#8b97a8; --ink-faint:#5a6575;
+    --signal:#5eead4; --ok:#34d399; --warn:#f5b544; --hot:#f4718b;
+    --pane-a:#22485f; --pane-b:#3b3560; --pane-c:#2e5243; --pane-d:#5b3d49;
+    --shadow:0 24px 60px -30px #000;
+  }
+  [data-mode="light"] {
+    --ground:#f5f7fa; --panel:#ffffff; --panel-2:#eef1f6; --rail:#e8ecf2;
+    --line:#c9d2de; --line-soft:#dde3ec;
+    --ink:#1c2430; --ink-dim:#4a5568; --ink-faint:#8a94a6;
+    --signal:#0d9488; --ok:#059669; --warn:#b45309; --hot:#be123c;
+    --pane-a:#bfdbef; --pane-b:#d4cff0; --pane-c:#c3e6d4; --pane-d:#eccdd6;
+    --shadow:0 24px 60px -30px #94a3b8;
+  }
+  --mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+  *{box-sizing:border-box}
+  body{background:var(--ground);transition:background .3s}
+  .wrap{max-width:1180px;margin:0 auto;padding:0 24px 96px;color:var(--ink);
+    font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;line-height:1.6}
+  .eyebrow{font-family:ui-monospace,Menlo,monospace;font-size:11.5px;letter-spacing:.22em;
+    text-transform:uppercase;color:var(--signal);margin:0}
+  h1{font-size:clamp(30px,4.4vw,46px);line-height:1.08;letter-spacing:-.02em;margin:14px 0 0;font-weight:640}
+  h2{font-size:24px;letter-spacing:-.01em;margin:0 0 4px;font-weight:620}
+  h3{font-size:15px;margin:0;font-weight:620}
+  .lede{font-size:19px;color:var(--ink-dim);max-width:66ch;margin:18px 0 0}
+  .sec{margin-top:72px}
+  .sec-head{display:flex;align-items:baseline;gap:14px;border-bottom:1px solid var(--line);
+    padding-bottom:12px;margin-bottom:26px}
+  .sec-num{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:var(--ink-faint);letter-spacing:.1em}
+  .muted{color:var(--ink-dim)} .faint{color:var(--ink-faint)}
+  .mono{font-family:ui-monospace,Menlo,monospace}
+  p{margin:12px 0 0}
+
+  header{padding-top:56px;position:relative}
+  .mode-toggle{position:absolute;top:56px;right:0;font-family:ui-monospace,Menlo,monospace;
+    font-size:11.5px;color:var(--ink-dim);background:var(--panel);border:1px solid var(--line);
+    border-radius:7px;padding:7px 12px;cursor:pointer}
+  .mode-toggle:hover{color:var(--signal);border-color:var(--signal)}
+  .kicker-row{display:flex;flex-wrap:wrap;gap:10px 22px;align-items:center;margin-top:22px;
+    font-family:ui-monospace,Menlo,monospace;font-size:12px;color:var(--ink-faint)}
+  .kicker-row b{color:var(--ink-dim);font-weight:500}
+
+  /* thumbnail moment */
+  .thumb{margin-top:26px;border:1px solid var(--line);border-radius:12px;overflow:hidden;
+    background:var(--panel);box-shadow:var(--shadow);padding:22px}
+  .thumb-line{font-size:15px;color:var(--ink-dim)} .thumb-line b{color:var(--ink)}
+
+  /* storyboard */
+  .scene{border:1px solid var(--line);border-radius:11px;overflow:hidden;background:var(--panel);margin-top:20px}
+  .scene-head{display:flex;align-items:center;gap:13px;padding:14px 18px;background:var(--panel-2);
+    border-bottom:1px solid var(--line-soft)}
+  .scene-id{font-family:ui-monospace,Menlo,monospace;font-size:12px;font-weight:700;
+    color:var(--ground);background:var(--signal);padding:3px 9px;border-radius:6px}
+  .scene-dur{margin-left:auto;font-family:ui-monospace,Menlo,monospace;font-size:11.5px;color:var(--ink-faint)}
+  .scene-body{padding:16px 18px;display:grid;grid-template-columns:1fr 1fr;gap:18px}
+  .board{background:var(--rail);border:1px solid var(--line-soft);border-radius:9px;padding:12px}
+  .board-label{font-family:ui-monospace,Menlo,monospace;font-size:10.5px;letter-spacing:.12em;
+    text-transform:uppercase;color:var(--ink-faint);margin-bottom:10px}
+  .stage{display:grid;gap:4px;height:150px}
+  .pane{border-radius:5px;display:grid;place-items:center;font-family:ui-monospace,Menlo,monospace;
+    font-size:10.5px;color:var(--ink);opacity:.92;min-height:0;min-width:0}
+  .tabbar{display:flex;gap:3px;height:16px;margin-bottom:3px}
+  .tab{flex:1;border-radius:3px 3px 0 0;opacity:.6} .tab.active{opacity:1}
+  .rail-edge{width:14px;border-radius:4px;display:grid;place-items:center;
+    font-size:8.5px;writing-mode:vertical-rl;color:var(--ink-dim);background:var(--panel-2);border:1px dashed var(--line)}
+  .scene-notes{padding:0 18px 16px;display:grid;grid-template-columns:1fr 1fr;gap:18px}
+  .note h4{font-family:ui-monospace,Menlo,monospace;font-size:10.5px;letter-spacing:.12em;
+    text-transform:uppercase;color:var(--signal);margin:0 0 6px;font-weight:600}
+  .note ol,.note ul{margin:0;padding-left:18px;font-size:13px;color:var(--ink-dim)}
+  .note li{margin-top:4px} .note li b{color:var(--ink);font-weight:600}
+  .op{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:var(--signal)}
+
+  /* tour UX */
+  .tourbar{border:1px solid var(--line);border-radius:11px;background:var(--panel);padding:14px 18px;
+    display:flex;align-items:center;gap:16px;margin-top:8px}
+  .tour-btn{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:var(--ground);
+    background:var(--signal);border:0;border-radius:6px;padding:7px 13px;font-weight:600}
+  .tour-caption{font-size:13.5px;color:var(--ink-dim);flex:1}
+  .tour-caption b{color:var(--ink)}
+  .tour-progress{display:flex;gap:5px}
+  .tp{width:26px;height:5px;border-radius:3px;background:var(--line)}
+  .tp.done{background:var(--signal)}
+
+  .tokens{width:100%;border-collapse:collapse;font-size:13px;margin-top:8px}
+  .tokens th,.tokens td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line-soft)}
+  .tokens th{font-family:ui-monospace,Menlo,monospace;font-size:10.5px;letter-spacing:.1em;
+    text-transform:uppercase;color:var(--ink-faint);font-weight:600}
+  .tokens td:first-child{font-family:ui-monospace,Menlo,monospace;color:var(--signal);font-size:12px}
+  .swatch{display:inline-block;width:12px;height:12px;border-radius:3px;vertical-align:-1px;
+    border:1px solid var(--line);margin-right:7px}
+
+  .honest{background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--warn);
+    border-radius:9px;padding:16px 18px;margin-top:8px;font-size:14px;color:var(--ink-dim)}
+  .honest b{color:var(--ink)}
+  @media (max-width:820px){.scene-body,.scene-notes{grid-template-columns:1fr}}
+</style>
+
+<div class="wrap" id="artifact-root" data-mode="dark">
+  <header>
+    <p class="eyebrow">Demo A · Design Artifact · #14638 (tree F1 of #13158)</p>
+    <button class="mode-toggle" onclick="var r=document.getElementById('artifact-root');r.dataset.mode=r.dataset.mode==='dark'?'light':'dark';this.textContent=r.dataset.mode==='dark'?'☾ dark — toggle':'☀ light — toggle'">☾ dark — toggle</button>
+    <h1>Layouts that rebuild themselves — smoothly, on command, while everything keeps running.</h1>
+    <p class="lede">The 30-second stranger test: within one scene they must SEE panes split, regroup, and tuck away as <b style="color:var(--ink)">continuous animated motion</b> — and understand no pane ever reloaded. Within three scenes they must notice nobody is dragging: <b style="color:var(--ink)">an agent is driving the layout through the Neural Link.</b></p>
+    <div class="kicker-row">
+      <span>Consumes <b>#14625 NL tools</b></span><span>Script <b>#14661 (tour)</b></span>
+      <span>Player <b>#14640 (runner)</b></span><span>Proof <b>#14591 (e2e replay)</b></span>
+      <span>Modes <b>light + dark (#14681)</b> — toggle ↗</span>
+    </div>
+  </header>
+
+  <!-- 01 · THE FRAMING -->
+  <section class="sec">
+    <div class="sec-head"><span class="sec-num">01</span><h2>The thumbnail moment</h2></div>
+    <div class="thumb">
+      <p class="thumb-line"><b>The video freeze-frame that earns the click:</b> a four-pane workspace mid-morph — two panes visibly gliding into a shared tab group while a third slides to the edge as a labeled rail tab — with the caption <span class="mono" style="color:var(--signal)">"an agent is re-docking this workspace, live."</span> Motion IS the message: every transition is animated re-parenting, never a flicker of remount. A ticking clock pane stays visibly ticking through every scene as the object-permanence witness.</p>
+    </div>
+  </section>
+
+  <!-- 02 · SCENES -->
+  <section class="sec">
+    <div class="sec-head"><span class="sec-num">02</span><h2>Three scenes, storyboarded</h2>
+      <span class="faint mono" style="margin-left:auto;font-size:12px">ops = shipped dockZone.v1 vocabulary only · exact JSON descriptors bind in the tour script (#14661) against the live schema — never invented here</span></div>
+
+    <!-- scene 1 -->
+    <div class="scene">
+      <div class="scene-head"><span class="scene-id">S1</span><h3>Split choreography — one pane becomes a studio</h3><span class="scene-dur">~25s · 4 ops</span></div>
+      <div class="scene-body">
+        <div class="board"><div class="board-label">Before — single pane</div>
+          <div class="stage" style="grid-template:1fr / 1fr">
+            <div class="pane" style="background:var(--pane-a)">EDITOR <span style="opacity:.6">· clock 09:41:07 ⟳</span></div>
+          </div>
+        </div>
+        <div class="board"><div class="board-label">After — three-way studio</div>
+          <div class="stage" style="grid-template:2fr 1fr / 2fr 1fr">
+            <div class="pane" style="background:var(--pane-a)">EDITOR ⟳</div>
+            <div class="pane" style="background:var(--pane-b);grid-row:1/3">PREVIEW</div>
+            <div class="pane" style="background:var(--pane-c)">TERMINAL</div>
+          </div>
+        </div>
+      </div>
+      <div class="scene-notes">
+        <div class="note"><h4>Operation beats</h4>
+          <ol>
+            <li><span class="op">split</span> editor → <b>right</b> (preview enters, 50/50)</li>
+            <li><span class="op">resizeSplit</span> → editor takes 2/3 (the golden-ratio settle)</li>
+            <li><span class="op">split</span> editor → <b>bottom</b> (terminal enters low)</li>
+            <li><span class="op">resizeSplit</span> → terminal to 1/3 height</li>
+          </ol>
+        </div>
+        <div class="note"><h4>Motion + camera</h4>
+          <ul>
+            <li><b>FLIP re-parent:</b> entering pane grows from its drop edge (280ms, standard-decelerate); siblings yield with the SAME easing — one choreography, not two animations.</li>
+            <li><b>Splitter settle:</b> resize eases 180ms; no scroll-jank in the yielding pane (observe_motion assertable).</li>
+            <li><b>Camera:</b> full workspace, static; the clock ticks through all 4 beats.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- scene 2 -->
+    <div class="scene">
+      <div class="scene-head"><span class="scene-id">S2</span><h3>Tab dance — density without loss</h3><span class="scene-dur">~20s · 3 ops</span></div>
+      <div class="scene-body">
+        <div class="board"><div class="board-label">Before — the S1 studio</div>
+          <div class="stage" style="grid-template:2fr 1fr / 2fr 1fr">
+            <div class="pane" style="background:var(--pane-a)">EDITOR ⟳</div>
+            <div class="pane" style="background:var(--pane-b);grid-row:1/3">PREVIEW</div>
+            <div class="pane" style="background:var(--pane-c)">TERMINAL</div>
+          </div>
+        </div>
+        <div class="board"><div class="board-label">After — tabbed right column + fourth arrival</div>
+          <div class="stage" style="grid-template:2fr 1fr / 2fr 1fr">
+            <div class="pane" style="background:var(--pane-a)">EDITOR ⟳</div>
+            <div style="grid-row:1/3;display:flex;flex-direction:column">
+              <div class="tabbar"><div class="tab active" style="background:var(--pane-b)"></div><div class="tab" style="background:var(--pane-c)"></div><div class="tab" style="background:var(--pane-d)"></div></div>
+              <div class="pane" style="background:var(--pane-b);flex:1">PREVIEW <span style="opacity:.6">(3 tabs)</span></div>
+            </div>
+            <div class="pane" style="background:var(--pane-d)">LOGS</div>
+          </div>
+        </div>
+      </div>
+      <div class="scene-notes">
+        <div class="note"><h4>Operation beats</h4>
+          <ol>
+            <li><span class="op">moveItem→tab</span> terminal INTO preview (tab group forms)</li>
+            <li><span class="op">split</span> editor → bottom: <b>logs</b> arrives (fourth resident)</li>
+            <li><span class="op">moveItem→tab</span> logs into the right group; active-tab handoff visible</li>
+          </ol>
+        </div>
+        <div class="note"><h4>Motion + camera</h4>
+          <ul>
+            <li><b>Tab-fold:</b> the folding pane shrinks toward the target tab-strip slot while its tab fades in (240ms) — the tab IS the pane, relocated, and the motion says so.</li>
+            <li><b>Active-tab pulse:</b> one subtle signal-color pulse on handoff; never a blink.</li>
+            <li><b>Camera:</b> slow push-in on the right column for beat 3; clock still ticking top-left.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- scene 3 -->
+    <div class="scene">
+      <div class="scene-head"><span class="scene-id">S3</span><h3>Auto-hide wave — the workspace breathes</h3><span class="scene-dur">~25s · 4 ops</span></div>
+      <div class="scene-body">
+        <div class="board"><div class="board-label">Before — the S2 den</div>
+          <div class="stage" style="grid-template:2fr 1fr / 2fr 1fr">
+            <div class="pane" style="background:var(--pane-a)">EDITOR ⟳</div>
+            <div class="pane" style="background:var(--pane-b);grid-row:1/3">PREVIEW +2</div>
+            <div class="pane" style="background:var(--pane-d)">LOGS</div>
+          </div>
+        </div>
+        <div class="board"><div class="board-label">After — focus mode, rails armed</div>
+          <div class="stage" style="grid-template:1fr / 14px 1fr 14px">
+            <div class="rail-edge">LOGS</div>
+            <div class="pane" style="background:var(--pane-a)">EDITOR — full stage ⟳</div>
+            <div class="rail-edge">PREVIEW</div>
+          </div>
+        </div>
+      </div>
+      <div class="scene-notes">
+        <div class="note"><h4>Operation beats</h4>
+          <ol>
+            <li><span class="op">setItemAutoHidden</span> logs → true (tucks to left rail, #14654's affordance)</li>
+            <li><span class="op">setItemAutoHidden</span> preview-group → true (right rail; editor floods the stage)</li>
+            <li>hover-reveal moment: preview slides over as overlay, releases (#14660's contract — shown, not persisted)</li>
+            <li><span class="op">setItemAutoHidden</span> ×2 → false: the wave rolls back, layout restores</li>
+          </ol>
+        </div>
+        <div class="note"><h4>Motion + camera</h4>
+          <ul>
+            <li><b>Tuck:</b> pane collapses toward its edge into the labeled rail tab (260ms); the editor's expansion is the SAME transaction — one breath, not two events.</li>
+            <li><b>Reveal:</b> overlay slides 200ms, dismiss 160ms with grace delay — the D2 state machine rendered honestly.</li>
+            <li><b>Camera:</b> static full stage; the finale is the reverse wave — a layout remembering itself.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 03 · TOUR MODE UX -->
+  <section class="sec">
+    <div class="sec-head"><span class="sec-num">03</span><h2>Tour mode — the screenplay surface</h2>
+      <span class="faint mono" style="margin-left:auto;font-size:12px">one script (#14661) = the demo · the e2e spec · the video take</span></div>
+    <div class="tourbar">
+      <button class="tour-btn">▶ tour</button>
+      <span class="tour-caption"><b>S2 · beat 1/3</b> — the agent folds the terminal into a tab group: <span class="mono">moveItem→tab(terminal → preview)</span></span>
+      <span class="tour-progress"><i class="tp done"></i><i class="tp done"></i><i class="tp done"></i><i class="tp done"></i><i class="tp done"></i><i class="tp"></i><i class="tp"></i><i class="tp"></i><i class="tp"></i><i class="tp"></i><i class="tp"></i></span>
+    </div>
+    <p class="muted" style="font-size:14px;max-width:74ch">The tour bar is the only demo chrome: play/pause, the current beat's caption (scene · beat · the operation in vocabulary terms — the caption teaches the API by narrating it), and beat-progress pips. Manual-drive stays available the whole time (grab any splitter, drag any tab — the tour yields, a <span class="mono">⟲ resume tour</span> affordance appears). Recording profile (#14589-F7): tour mode, captions on, reduced-motion OFF asserted, mode per take — the same run twice is the same video.</p>
+  </section>
+
+  <!-- 04 · VISUAL IDENTITY -->
+  <section class="sec">
+    <div class="sec-head"><span class="sec-num">04</span><h2>Visual identity — semantic tokens, two modes</h2></div>
+    <table class="tokens">
+      <tr><th>token</th><th>role</th><th>dark</th><th>light</th></tr>
+      <tr><td>--ground / --panel / --rail</td><td>stage depths (page · card · well)</td><td><span class="swatch" style="background:#0b0e13"></span>near-black blues</td><td><span class="swatch" style="background:#f5f7fa"></span>cool paper</td></tr>
+      <tr><td>--signal</td><td>the one accent: live action, tour chrome, active tab pulse</td><td><span class="swatch" style="background:#5eead4"></span>teal-mint</td><td><span class="swatch" style="background:#0d9488"></span>deep teal (AA on paper)</td></tr>
+      <tr><td>--pane-a…d</td><td>pane identities — muted, content-like, never candy</td><td>4 dusk hues</td><td>4 chalk hues</td></tr>
+      <tr><td>--ink / -dim / -faint</td><td>type ramp (3 steps, no more)</td><td>cool grays ↑</td><td>slate grays ↓</td></tr>
+    </table>
+    <p class="muted" style="font-size:14px;max-width:74ch">This artifact's own toggle (top right) demonstrates the #14681 thesis: mode = a token-set swap, zero component knowledge. Reconciliation with the FM module floor happens at build time (F2): where the relocated <span class="mono">tokens.css</span> already names an equivalent, the demo consumes the module token and this table records the mapping — the demo and the cockpit must read as one family (post-veto: one app, one design DNA).</p>
+  </section>
+
+  <!-- 05 · HONEST STATE -->
+  <section class="sec">
+    <div class="sec-head"><span class="sec-num">05</span><h2>Honest state — what this mock promises vs what ships today</h2></div>
+    <div class="honest">
+      <b>Real today (shipped dockZone.v1 + landed #14625 tools):</b> every S1–S3 operation class — split, resizeSplit, moveItem→tab, setItemAutoHidden — executes semantically with animated transitions, agent-drivable end-to-end. <b>Designed here, building in the tree:</b> the edge-rail affordance (#14654) and reveal/dismiss timing (#14660) for S3's beats 1–3; the tour runner (#14640) and this screenplay as its script (#14661). <b>Deliberately absent:</b> perspectives and multi-window pop-out — that is Demo B (#14590, spec-gated), and blending the two would blur both stories. No performance numbers appear anywhere in the demo (#13032 guardrail; the motion must simply LOOK effortless — a claim the viewer verifies with their own eyes).
+    </div>
+  </section>
+</div>


### PR DESCRIPTION
## Summary

Tree line **F1** of the #13158 docking lane — the Demo-A design artifact at the cockpit-plan bar: the gate leaf the whole demo tranche (F2–F8), the tour script (#14661), the e2e replay (#14591) and the recording pipeline build against. One self-contained HTML mock: the 30-second-stranger framing, three storyboarded scenes with exact shipped-vocabulary operation beats, the tour-mode UX (the screenplay surface where one script = demo = spec = video take), the semantic token identity — **with a working light/dark toggle demonstrating the #14681 dual-mode thesis inside the artifact itself** — and an honest-state section separating what ships today from what the tree is building.

Resolves #14638
Refs #13158

## Deltas

- **NEW `apps/agentos/design/dock-choreography-demo.html`** — sibling of the committed cockpit-plan SSOT, same design DNA and section grammar (eyebrow → thumbnail moment → numbered secs). Content per the ticket's five ACs: **§01** the video freeze-frame thesis (a ticking clock pane as the object-permanence witness through every scene); **§02** scenes S1–S3 (split choreography · tab dance · auto-hide wave) each with before/after CSS storyboards, numbered operation beats in shipped dockZone.v1 vocabulary (`split`, `resizeSplit`, `moveItem→tab`, `setItemAutoHidden` — exact JSON descriptors deliberately bind at tour-script time against the live schema, never invented in a design doc), motion notes (FLIP re-parent 280ms standard-decelerate; tab-fold 240ms; tuck/reveal 260/200/160ms with grace) and camera framing; **§03** the tour bar UX (play/pause · teaching captions that narrate the API · beat pips · manual-drive yield with resume affordance · the F7 recording profile); **§04** the token table (3-step ink ramp, one signal accent, four muted pane identities) with both mode values and the F2 reconciliation rule against the relocated FM module floor (post-veto: one app, one design family); **§05** honest state incl. the #13032 no-perf-claims guardrail.
- Dual-mode is LIVE in the mock: `[data-mode]` token-set swap + toggle button — zero component knowledge, the #14681 mechanism demonstrated before it ships.
- Tracked via `git add -f` following the cockpit plan's own precedent (`/apps/**/*.html` gitignore rule; the SSOT precedent is force-tracked — a `!apps/agentos/design/*.html` negation would spare the next design author the trip, noted for whoever touches `.gitignore` next).

## Test Evidence

Static self-contained design artifact — no runtime code paths. Render-verified in the harness preview panel (file is live in the operator's Launch preview as of authoring); whitespace pre-commit hook green.

Evidence: L1 (design artifact; the AC's gate is human design review — this PR is that review surface) → L1 required (all #14638 ACs are review-class). Residual: none.

## Post-Merge Validation

- #14661 (tour script) transcribes S1–S3's operation beats into runner-schema JSON — if any beat can't be expressed in the shipped vocabulary, the storyboard was wrong and comes back here (the falsifier).
- F2 records the token mapping against the FM module floor; divergence between demo and module families is a defect per §04's rule.
- The "stunning" bar stays human-falsifiable: operator + design-review eyes on the rendered mock, not on this diff.

## Related

Epic #13158 (`Refs` only — tree line F1) · consumed by #14589/#14661/#14640/#14591 · #14681 (dual-mode thesis, demonstrated) · #14654/#14660 (S3's affordances, building) · the cockpit-plan SSOT (the bar).

Authored by Clio (Claude Fable 5, Claude Code). Session fa2a6fd5-7488-4af6-a0d2-3855c86003e4.
