### PR TITLE
docs(agentos): chat-creation keeper-flow design SSOT (#14645)

### DIFF
--- a/apps/agentos/design/chat-creation-plan.html
+++ b/apps/agentos/design/chat-creation-plan.html
@@ -229,7 +229,7 @@
   <p class="lead" style="margin-top:.8rem;font-size:.8rem">Non-view leaves are buildable <em>now</em> against this contract; only the view tranche waits on the rendered artifact.</p>
 
   <h2>Body-idiom binding — for the view-leaf builders (per #14714)</h2>
-  <p class="lead" style="font-size:.82rem">This surface is <b>Body-hemisphere</b> code (<span class="mono">apps/agentos</span>) — it follows <span class="mono">src/</span> framework idioms, not <span class="mono">ai/</span> ones (#14714, operator-ratified after two violations shipped). The state machine above binds to the framework contract this way:</p>
+  <p class="lead" style="font-size:.82rem">This surface is <b>Body-hemisphere</b> code (<span class="mono">apps/agentos</span>) — it follows <span class="mono">src/</span> neo-core idioms, not <span class="mono">ai/</span> ones (#14714, operator-ratified after two violations shipped). The state machine above binds to the core contracts this way:</p>
   <div class="two">
     <div class="col">
       <h3 style="color:var(--fm-signal)">The five states = ONE reactive config</h3>
@@ -241,7 +241,7 @@
     <div class="col">
       <h3 style="color:var(--fm-ink-dim)">Resolution, lifecycle &amp; the allowed plain half</h3>
       <ul>
-        <li><b><span class="mono">Neo.get(id)</span></b> resolves the materialized widget (auto-registered via <span class="mono">afterSetId</span>) — never a bespoke <span class="mono">resolveComponent</span> seam; the framework's <span class="mono">Symbol.hasInstance</span> already guarantees the instance shape.</li>
+        <li><b><span class="mono">Neo.get(id)</span></b> resolves the materialized widget (auto-registered via <span class="mono">afterSetId</span>) — never a bespoke <span class="mono">resolveComponent</span> seam; neo core's <span class="mono">Symbol.hasInstance</span> already guarantees the instance shape.</li>
         <li><b>Pure data-plane stays plain</b> — the intake <span class="mono">validateRequest</span>, the edit-grammar parser, and the transition table are plain util modules (childapp-precedented, #14714's explicitly-allowed half). The idiom boundary is <em>instance mutation + view state</em>, nothing below it.</li>
       </ul>
     </div>

--- a/apps/agentos/design/chat-creation-plan.html
+++ b/apps/agentos/design/chat-creation-plan.html
@@ -1,0 +1,190 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Chat-Creation — the Keeper Flow · Design SSOT (#14645)</title>
+<!--
+  Design SSOT for the conversational app-creation surface (the "keeper flow") — the fleet-manager
+  sibling module inside the one harness app (apps/agentos). Companion artifact: the FM cockpit SSOT
+  (fleet-manager-cockpit-plan.html). Values SoT = the cockpit plan, extracted to
+  apps/agentos/resources/tokens.css; the :root fallback below lets this doc render standalone.
+  Grace, 2026-07-04.
+-->
+<link rel="stylesheet" href="../resources/tokens.css">
+<style>
+  /* standalone-render fallback — verbatim from the cockpit values SSOT (tokens.css is the app SoT) */
+  :root{
+    --fm-ground:#0b0e13; --fm-panel:#141a23; --fm-panel-2:#1a212c; --fm-rail:#0e131a;
+    --fm-line:#262f3d; --fm-line-soft:#1c242f;
+    --fm-ink:#d6dce6; --fm-ink-dim:#8b97a8; --fm-ink-faint:#5a6575;
+    --fm-signal:#5eead4;
+    --fm-state-ok:#34d399; --fm-state-idle:#f5b544; --fm-state-wedged:#f4718b; --fm-state-limited:#a78bfa; --fm-state-off:#5b6675;
+    --fm-family-claude:#d99a5b; --fm-family-gpt:#58c093; --fm-family-gemini:#6ba3e8; --fm-family-human:#c9d2de;
+    --fm-font-mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+    --fm-font-sans:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--fm-ground);color:var(--fm-ink);font-family:var(--fm-font-sans);line-height:1.5;
+       padding:2.4rem clamp(1rem,4vw,3.2rem) 5rem;max-width:1180px;margin-inline:auto}
+  h1{font-size:1.5rem;margin:0 0 .3rem} h2{font-size:.78rem;font-family:var(--fm-font-mono);letter-spacing:.16em;
+     text-transform:uppercase;color:var(--fm-signal);margin:2.8rem 0 1rem;font-weight:600}
+  .lead{color:var(--fm-ink-dim);max-width:70ch} .mono{font-family:var(--fm-font-mono)}
+  .tag{font-family:var(--fm-font-mono);font-size:.62rem;letter-spacing:.14em;text-transform:uppercase;
+       color:var(--fm-ink-faint)}
+  a{color:var(--fm-signal);text-decoration:none;border-bottom:1px solid #24463f}
+  .band{display:flex;align-items:baseline;gap:.8rem;flex-wrap:wrap;border-bottom:1px solid var(--fm-line);
+        padding-bottom:1.2rem;margin-bottom:.4rem}
+  .wedge{display:flex;gap:.5rem;flex-wrap:wrap;align-items:stretch;margin-top:.4rem}
+  .step{flex:1 1 120px;min-width:120px;background:var(--fm-panel);border:1px solid var(--fm-line);border-radius:10px;
+        padding:.75rem .8rem;position:relative}
+  .step .n{font-family:var(--fm-font-mono);font-size:.6rem;color:var(--fm-signal);letter-spacing:.1em}
+  .step .t{font-size:.86rem;margin-top:.25rem} .step .d{font-size:.72rem;color:var(--fm-ink-dim);margin-top:.2rem}
+  .step + .step::before{content:"→";position:absolute;left:-.62rem;top:50%;transform:translateY(-50%);
+        color:var(--fm-ink-faint);font-size:.8rem}
+  .states{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:1rem;margin-top:.4rem}
+  .state{background:var(--fm-panel);border:1px solid var(--fm-line);border-radius:12px;padding:1rem;display:flex;flex-direction:column;gap:.6rem}
+  .state h3{margin:0;font-size:.82rem;font-family:var(--fm-font-mono);letter-spacing:.08em;text-transform:uppercase;
+        display:flex;align-items:center;gap:.5rem}
+  .dot{width:9px;height:9px;border-radius:50%;flex:none}
+  .state p{margin:0;font-size:.76rem;color:var(--fm-ink-dim)}
+  /* in-state mini-mockups */
+  .mock{background:var(--fm-rail);border:1px solid var(--fm-line-soft);border-radius:8px;padding:.6rem;font-size:.72rem;
+        min-height:66px;display:flex;flex-direction:column;gap:.4rem;justify-content:center}
+  .field{border:1px dashed var(--fm-line);border-radius:6px;padding:.4rem .55rem;color:var(--fm-ink-faint);font-family:var(--fm-font-mono);font-size:.68rem}
+  .field.live{border-style:solid;border-color:#2b6b60;color:var(--fm-ink)}
+  .bp{border-left:3px solid var(--fm-signal);padding-left:.5rem;color:var(--fm-ink-dim)}
+  .bar{height:6px;border-radius:4px;background:#20262f;overflow:hidden} .bar i{display:block;height:100%;background:var(--fm-signal);width:58%}
+  .panelchip{border:1px solid #2b6b60;border-radius:6px;padding:.35rem .5rem;display:flex;align-items:center;gap:.4rem;color:var(--fm-ink)}
+  .win{margin-left:auto;font-size:.62rem;color:var(--fm-signal);border:1px solid #24463f;border-radius:4px;padding:.1rem .35rem}
+  .err{border-left:3px solid var(--fm-state-wedged);padding-left:.5rem;color:#f0b7c2}
+  .two{display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-top:.4rem}
+  @media(max-width:640px){.two{grid-template-columns:1fr}}
+  .col{background:var(--fm-panel);border:1px solid var(--fm-line);border-radius:12px;padding:1rem}
+  .col h3{margin:.1rem 0 .6rem;font-size:.8rem;font-family:var(--fm-font-mono);letter-spacing:.06em}
+  ul{margin:.3rem 0 0;padding-left:1.05rem} li{font-size:.8rem;margin:.32rem 0;color:var(--fm-ink-dim)}
+  li b{color:var(--fm-ink);font-weight:600}
+  .gate{background:linear-gradient(180deg,#141a23,#11151d);border:1px solid var(--fm-line);border-radius:12px;
+        padding:1.1rem 1.2rem;margin-top:.4rem}
+  .gate .rule{font-size:.9rem} .gate .sub{font-size:.76rem;color:var(--fm-ink-dim);margin-top:.4rem}
+  .flow2{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;margin-top:.7rem;font-family:var(--fm-font-mono);font-size:.72rem}
+  .pill{border:1px solid var(--fm-line);border-radius:20px;padding:.25rem .7rem;color:var(--fm-ink-dim)}
+  .pill.auth{border-color:#2b6b60;color:var(--fm-signal)}
+  footer{margin-top:3rem;border-top:1px solid var(--fm-line);padding-top:1rem;font-size:.74rem;color:var(--fm-ink-faint)}
+  .fam{display:inline-flex;gap:.5rem;align-items:center;margin-left:.4rem}
+  .sw{width:11px;height:4px;border-radius:2px;display:inline-block}
+</style>
+</head>
+<body>
+
+  <div class="band">
+    <h1>Chat-Creation — the Keeper Flow</h1>
+    <span class="tag">design SSOT · #14645 · apps/agentos module</span>
+  </div>
+  <p class="lead">A stranger types an intent and gets a live app in its own window. <b class="mono" style="color:var(--fm-ink)">chat&nbsp;→&nbsp;"build me a neo grid"&nbsp;→&nbsp;a docked peer panel&nbsp;→&nbsp;drag to its own OS window&nbsp;→&nbsp;use&nbsp;/&nbsp;share</b>. This surface is the impedance-match wedge — legible to someone who never read a line of Neo code. The pipeline that runs behind it (<span class="mono">#14655</span> intake route · <span class="mono">#14656</span> instance registry) is a peer's lane; this artifact fixes what the human <em>sees and touches</em>.</p>
+
+  <h2>The wedge — the flow this surface renders</h2>
+  <div class="wedge">
+    <div class="step"><div class="n">01 · intent</div><div class="t">Say it</div><div class="d">Plain language. One affordance, no chrome.</div></div>
+    <div class="step"><div class="n">02 · blueprint</div><div class="t">Preview</div><div class="d">Intent → a provisional blueprint. Editable, not yet committed.</div></div>
+    <div class="step"><div class="n">03 · generate</div><div class="t">Build</div><div class="d">Blueprint runs the route. Honest progress, cancellable.</div></div>
+    <div class="step"><div class="n">04 · materialize</div><div class="t">Live panel</div><div class="d">The app is a docked peer panel — real, usable now.</div></div>
+    <div class="step"><div class="n">05 · promote</div><div class="t">Own window</div><div class="d">Drag to its own OS window on the shared heap; share the URL.</div></div>
+  </div>
+
+  <h2>The five states — the SSOT owns these; view leaves bind them</h2>
+  <div class="states">
+
+    <div class="state">
+      <h3><span class="dot" style="background:var(--fm-ink-faint)"></span>empty</h3>
+      <div class="mock"><div class="field">Describe an app to build…</div></div>
+      <p>The invitation. A single affordance, no toolbars, no menus. The whole surface says "start here."</p>
+    </div>
+
+    <div class="state">
+      <h3><span class="dot" style="background:var(--fm-family-human)"></span>composing</h3>
+      <div class="mock">
+        <div class="field live">build me a grid of the fleet's open PRs</div>
+        <div class="bp">blueprint · Grid · store: pulls&nbsp;· cols: title, author, state</div>
+      </div>
+      <p>Intent typed; the blueprint is <b class="mono" style="color:var(--fm-ink)">previewed</b>, not committed. The human can refine words or the blueprint before anything runs.</p>
+    </div>
+
+    <div class="state">
+      <h3><span class="dot" style="background:var(--fm-state-idle)"></span>generating</h3>
+      <div class="mock">
+        <div class="bp">materializing Grid…</div>
+        <div class="bar"><i></i></div>
+        <div class="tag">cancellable · route #14655 → registry #14656</div>
+      </div>
+      <p>The blueprint runs the intake route. Progress is honest and interruptible — never a spinner that lies about being stuck.</p>
+    </div>
+
+    <div class="state">
+      <h3><span class="dot" style="background:var(--fm-state-ok)"></span>materialized</h3>
+      <div class="mock">
+        <div class="panelchip"><span class="dot" style="background:var(--fm-state-ok)"></span>Fleet PRs · Grid <span class="win">↗ window</span></div>
+        <div class="tag">live docked panel · a first-class instance</div>
+      </div>
+      <p>The app is alive as a docked peer panel and usable immediately. The <b>promotion affordance</b> (→ own window) is present the moment it exists.</p>
+    </div>
+
+    <div class="state">
+      <h3><span class="dot" style="background:var(--fm-state-wedged)"></span>error</h3>
+      <div class="mock">
+        <div class="err">blueprint blocked at the safety gate · not built</div>
+        <div class="field">edit the intent, or view why ↗</div>
+      </div>
+      <p>Generation failed, or the safety gate refused the blueprint. Always recoverable — edit and retry, never a dead-end, always a reason.</p>
+    </div>
+
+  </div>
+
+  <h2>Draw-vs-delegate — the boundary so leaves don't collide</h2>
+  <div class="two">
+    <div class="col">
+      <h3 style="color:var(--fm-signal)">This SSOT owns</h3>
+      <ul>
+        <li><b>The creation-surface IA</b> — the empty invitation, where the input lives, how the blueprint preview reads.</li>
+        <li><b>The interaction model</b> — say → preview → generate → materialize → promote.</li>
+        <li><b>The five states</b> above, and every transition between them.</li>
+        <li><b>The promotion affordance</b> — panel → its own OS window on the shared heap.</li>
+      </ul>
+    </div>
+    <div class="col">
+      <h3 style="color:var(--fm-ink-dim)">The pipeline leaves own</h3>
+      <ul>
+        <li><b>Intake → blueprint route</b> — <span class="mono">#14655</span> (Mnemosyne).</li>
+        <li><b>Created-instance registry</b> — <span class="mono">#14656</span>: live widgets as first-class records.</li>
+        <li><b>NL wiring &amp; app-lifecycle</b> — the generation engine behind state 03.</li>
+        <li><b>The safety contract</b> — <span class="mono">#14644</span> constrained-blueprint gate (see below).</li>
+      </ul>
+    </div>
+  </div>
+  <p class="lead" style="margin-top:.8rem;font-size:.8rem">Non-view leaves are buildable <em>now</em> against this contract; only the view tranche waits on the rendered artifact.</p>
+
+  <h2>notAuthority — the surface proposes, the gate disposes</h2>
+  <div class="gate">
+    <div class="rule">The chat and its blueprint preview are <b>provisional</b>. They never bypass the <b>constrained-blueprint safety gate</b> (<span class="mono">#14644</span>) — the gate is the authority, not the conversation.</div>
+    <div class="sub">This is the <a href="https://github.com/neomjs/neo/discussions/14548">#14548</a> firewall applied to creation: a persuasive intent must not become a live app by persuasion alone. What the human types is a <em>request</em>; what the gate passes is what runs. The error state exists precisely so a refused blueprint reads as a boundary, not a failure of the person.</div>
+    <div class="flow2">
+      <span class="pill">chat intent</span><span>→</span>
+      <span class="pill">blueprint preview</span><span>→</span>
+      <span class="pill auth">safety gate #14644</span><span>→</span>
+      <span class="pill">materialize</span>
+    </div>
+  </div>
+
+  <footer>
+    Tokens: the <span class="mono">--fm-*</span> vocabulary (<span class="mono">apps/agentos/resources/tokens.css</span>) — native to the one harness app, visually consistent with the FM cockpit.
+    <span class="fam">families:
+      <i class="sw" style="background:var(--fm-family-claude)"></i>Claude
+      <i class="sw" style="background:var(--fm-family-gpt)"></i>GPT
+      <i class="sw" style="background:var(--fm-family-gemini)"></i>Gemini
+      <i class="sw" style="background:var(--fm-family-human)"></i>Human
+    </span><br>
+    Design contract frozen on #14645 (issuecomment-4880624136) · sibling artifact: <span class="mono">fleet-manager-cockpit-plan.html</span> · pipeline lanes: #14655 · #14656 · #14644. Grace · 2026-07-04.
+  </footer>
+
+</body>
+</html>

--- a/apps/agentos/design/chat-creation-plan.html
+++ b/apps/agentos/design/chat-creation-plan.html
@@ -228,6 +228,25 @@
   </div>
   <p class="lead" style="margin-top:.8rem;font-size:.8rem">Non-view leaves are buildable <em>now</em> against this contract; only the view tranche waits on the rendered artifact.</p>
 
+  <h2>Body-idiom binding — for the view-leaf builders (per #14714)</h2>
+  <p class="lead" style="font-size:.82rem">This surface is <b>Body-hemisphere</b> code (<span class="mono">apps/agentos</span>) — it follows <span class="mono">src/</span> framework idioms, not <span class="mono">ai/</span> ones (#14714, operator-ratified after two violations shipped). The state machine above binds to the framework contract this way:</p>
+  <div class="two">
+    <div class="col">
+      <h3 style="color:var(--fm-signal)">The five states = ONE reactive config</h3>
+      <ul>
+        <li><b><span class="mono">flowState_</span> reactive config</b> — empty→composing→generating→materialized→error is a single reactive config with an <span class="mono">afterSetFlowState</span> hook, <em>never a parallel store</em> (the #14712 lesson: the transition table is the oracle <em>for</em> the config, not a second copy of state beside it).</li>
+        <li><b>Transitions batch via <span class="mono">set()</span></b> — a state change plus its side-effects go through <span class="mono">component.set(…)</span> (one EffectManager cascade, coherent <span class="mono">beforeSet</span>/<span class="mono">afterSet</span>) — never chained direct property assignments.</li>
+      </ul>
+    </div>
+    <div class="col">
+      <h3 style="color:var(--fm-ink-dim)">Resolution, lifecycle &amp; the allowed plain half</h3>
+      <ul>
+        <li><b><span class="mono">Neo.get(id)</span></b> resolves the materialized widget (auto-registered via <span class="mono">afterSetId</span>) — never a bespoke <span class="mono">resolveComponent</span> seam; the framework's <span class="mono">Symbol.hasInstance</span> already guarantees the instance shape.</li>
+        <li><b>Pure data-plane stays plain</b> — the intake <span class="mono">validateRequest</span>, the edit-grammar parser, and the transition table are plain util modules (childapp-precedented, #14714's explicitly-allowed half). The idiom boundary is <em>instance mutation + view state</em>, nothing below it.</li>
+      </ul>
+    </div>
+  </div>
+
   <h2>notAuthority — the surface proposes, the gate disposes</h2>
   <div class="gate">
     <div class="rule">The chat and its blueprint preview are <b>provisional</b>. They never bypass the <b>constrained-blueprint safety gate</b> (<span class="mono">#14644</span>) — the gate is the authority, not the conversation.</div>

--- a/apps/agentos/design/chat-creation-plan.html
+++ b/apps/agentos/design/chat-creation-plan.html
@@ -232,10 +232,10 @@
   <p class="lead" style="font-size:.82rem">This surface is <b>Body-hemisphere</b> code (<span class="mono">apps/agentos</span>) — it follows <span class="mono">src/</span> neo-core idioms, not <span class="mono">ai/</span> ones (#14714, operator-ratified after two violations shipped). The state machine above binds to the core contracts this way:</p>
   <div class="two">
     <div class="col">
-      <h3 style="color:var(--fm-signal)">The five states = ONE reactive config</h3>
+      <h3 style="color:var(--fm-signal)">The five states = ONE shared surface (state.Provider)</h3>
       <ul>
-        <li><b><span class="mono">flowState_</span> reactive config</b> — empty→composing→generating→materialized→error is a single reactive config with an <span class="mono">afterSetFlowState</span> hook, <em>never a parallel store</em> (the #14712 lesson: the transition table is the oracle <em>for</em> the config, not a second copy of state beside it).</li>
-        <li><b>Transitions batch via <span class="mono">set()</span></b> — a state change plus its side-effects go through <span class="mono">component.set(…)</span> (one EffectManager cascade, coherent <span class="mono">beforeSet</span>/<span class="mono">afterSet</span>) — never chained direct property assignments.</li>
+        <li><b>a shared <span class="mono">state.Provider</span> · <span class="mono">data.flowState</span></b> — empty→composing→generating→materialized→error live on the create-module's <span class="mono">state.Provider</span> as ONE binding surface (the many consumers — chat surface, blueprint preview, pane chrome, promote affordance — <span class="mono">bind</span> to it rather than reaching into one component's config), <em>never a parallel store</em> (the #14712 lesson: the transition table is the pure legality oracle <em>for</em> the state, not a second copy beside it). Realized in <span class="mono">CreationStateProvider</span> (#14719).</li>
+        <li><b>Transitions batch via one guarded <span class="mono">setData()</span></b> — a state change + its reason go through the provider's ONE oracle-guarded writer (<span class="mono">applyFlowEvent</span>), one batched write; an illegal transition mutates nothing and returns a bounded reason (never chained assignments, never throws — mirroring the pipeline's <span class="mono">{accepted, reason}</span>).</li>
       </ul>
     </div>
     <div class="col">

--- a/apps/agentos/design/chat-creation-plan.html
+++ b/apps/agentos/design/chat-creation-plan.html
@@ -73,6 +73,24 @@
   footer{margin-top:3rem;border-top:1px solid var(--fm-line);padding-top:1rem;font-size:.74rem;color:var(--fm-ink-faint)}
   .fam{display:inline-flex;gap:.5rem;align-items:center;margin-left:.4rem}
   .sw{width:11px;height:4px;border-radius:2px;display:inline-block}
+  /* transcript treatment */
+  .script{background:var(--fm-rail);border:1px solid var(--fm-line-soft);border-radius:12px;padding:1rem;display:flex;flex-direction:column;gap:.7rem;margin-top:.4rem}
+  .turn{display:flex;gap:.6rem;align-items:flex-start}
+  .turn .who{font-family:var(--fm-font-mono);font-size:.58rem;letter-spacing:.1em;text-transform:uppercase;color:var(--fm-ink-faint);flex:none;width:3rem;padding-top:.35rem}
+  .turn.agent .who{color:var(--fm-signal)}
+  .turn .msg{background:var(--fm-panel);border:1px solid var(--fm-line);border-radius:8px;padding:.5rem .65rem;font-size:.78rem;color:var(--fm-ink);flex:1}
+  .turn.human .msg{background:var(--fm-panel-2)}
+  /* provenance-as-inspector */
+  .prov{background:var(--fm-rail);border:1px solid var(--fm-line-soft);border-radius:8px;padding:.6rem;display:flex;flex-direction:column;gap:.45rem;margin-bottom:.7rem}
+  .prov-row{display:flex;gap:.6rem;align-items:center;font-size:.74rem;color:var(--fm-ink-dim)}
+  .prov-row .tag{width:2.6rem;flex:none}
+  .fam-chip{display:inline-flex;align-items:center;gap:.35rem;color:var(--fm-ink)}
+  /* M2 storyboard */
+  .board{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:.9rem;margin-top:.4rem}
+  .beat{background:var(--fm-panel);border:1px solid var(--fm-line);border-radius:12px;padding:.85rem .9rem}
+  .beat .bn{font-family:var(--fm-font-mono);font-size:.6rem;letter-spacing:.1em;color:var(--fm-signal)}
+  .beat .bt{font-size:.9rem;margin:.3rem 0 .25rem;color:var(--fm-ink)}
+  .beat .bd{font-size:.75rem;color:var(--fm-ink-dim);line-height:1.45}
 </style>
 </head>
 <body>
@@ -140,6 +158,53 @@
 
   </div>
 
+  <h2>Transcript treatment — the conversation is the medium</h2>
+  <p class="lead" style="font-size:.82rem">The keeper flow is a dialogue, not a form. The transcript renders under Neo's <b class="mono" style="color:var(--fm-ink)">markdown-VDOM</b> constraints — streamed tokens, fenced code, and the inline blueprint are VDOM nodes diffed in place, never <span class="mono">innerHTML</span>. Turns stay compact; the blueprint preview is a first-class turn, not a wall of prose.</p>
+  <div class="script">
+    <div class="turn human"><span class="who">you</span><div class="msg">build me a grid of the fleet's open PRs</div></div>
+    <div class="turn agent"><span class="who">keeper</span><div class="msg">A <b>Grid</b> over the open-PR store — title, author, state. Streaming as it resolves:
+      <div class="bp" style="margin-top:.4rem">blueprint · Grid · store: pulls · cols: title · author · state</div></div></div>
+    <div class="turn human"><span class="who">you</span><div class="msg">make state a coloured chip</div></div>
+  </div>
+  <p class="lead" style="font-size:.78rem;margin-top:.6rem">Constraints the treatment honours: streamed text appends via VDOM deltas (no layout thrash); code and blueprint blocks are <em>components</em>, not markdown-to-HTML; long transcripts virtualise; the newest turn stays in view. The transcript never becomes the app — it's the lane the app arrives through.</p>
+
+  <h2>Follow-up — the app is live; keep talking to it</h2>
+  <p class="lead" style="font-size:.82rem">Materialize is not the end of the conversation. The same thread iterates on the <em>live</em> app — every follow-up is another intent → blueprint-<b>diff</b> → apply, against the instance that already exists. No regeneration from scratch; the widget mutates in place.</p>
+  <div class="wedge">
+    <div class="step"><div class="n">live</div><div class="t">The Grid exists</div><div class="d">Docked, usable, still in the thread's context.</div></div>
+    <div class="step"><div class="n">refine</div><div class="t">"filter by author"</div><div class="d">Intent scoped to the live instance, not a new app.</div></div>
+    <div class="step"><div class="n">diff</div><div class="t">Blueprint delta</div><div class="d">Only the change previews — an add, not a rebuild.</div></div>
+    <div class="step"><div class="n">apply</div><div class="t">Mutates in place</div><div class="d">Same instance updates; state &amp; scroll preserved.</div></div>
+  </div>
+  <p class="lead" style="font-size:.78rem;margin-top:.6rem">The follow-up affordance lives where the eye already is — an inline input pinned under the live panel and the transcript's tail resolve to the same thread. Follow-ups route through the safety gate too (a refinement is an intent). Undo restores the previous blueprint, never a blank slate.</p>
+
+  <h2>The created-widget pane — chrome, promotion &amp; provenance-as-inspector</h2>
+  <div class="two">
+    <div class="col">
+      <h3 style="color:var(--fm-signal)">Pane chrome — dock-participating</h3>
+      <div class="mock" style="min-height:auto;margin-bottom:.7rem">
+        <div class="panelchip"><span class="dot" style="background:var(--fm-state-ok)"></span>Fleet PRs · Grid <span class="win">↗ window</span></div>
+      </div>
+      <ul>
+        <li><b>Participates in the dock</b> — split, tab, auto-hide like any dockZone item; never a modal.</li>
+        <li><b>Pop-out affordance</b> — <span class="mono">↗ window</span> promotes it to its own OS window on the shared heap.</li>
+        <li><b>Live-state indicator</b> — the dot speaks the cockpit's state vocabulary (ok · idle · wedged), so a stalled widget reads honestly.</li>
+      </ul>
+    </div>
+    <div class="col">
+      <h3 style="color:var(--fm-ink-dim)">Provenance — a secondary inspector, never the centre</h3>
+      <div class="prov">
+        <div class="prov-row"><span class="tag">who</span><span class="fam-chip"><i class="sw" style="background:var(--fm-family-human)"></i>you · intent</span></div>
+        <div class="prov-row"><span class="tag">how</span><span class="mono">blueprint → route #14655 → registry #14656</span></div>
+        <div class="prov-row"><span class="tag">what</span><span class="mono">Grid · 3 cols · store:pulls · +authorFilter</span></div>
+      </div>
+      <ul>
+        <li><b>Inspector, not header</b> — provenance opens on demand (a disclosure strip), never occupying the widget's primary frame. The <span class="mono">#13349</span> scope correction: the app is the point, its lineage is reference.</li>
+        <li><b>Legible lineage</b> — which intent, which route, which mutations — so a human can trust or audit without reading code.</li>
+      </ul>
+    </div>
+  </div>
+
   <h2>Draw-vs-delegate — the boundary so leaves don't collide</h2>
   <div class="two">
     <div class="col">
@@ -174,6 +239,18 @@
       <span class="pill">materialize</span>
     </div>
   </div>
+
+  <h2>M2 demo — the one-shot gesture, beat by beat</h2>
+  <p class="lead" style="font-size:.82rem">The canonical M2 demo is a single unbroken take: a stranger goes from a sentence to a shared, running app without touching code or config. Storyboard for the recordable walkthrough (<span class="mono">#14646</span> binds these beats to NL-driven steps):</p>
+  <div class="board">
+    <div class="beat"><div class="bn">beat 1 · 0:00</div><div class="bt">Empty invitation</div><div class="bd">One field: "Describe an app to build." Nothing else on screen — the stranger isn't taught, they're invited.</div></div>
+    <div class="beat"><div class="bn">beat 2 · 0:04</div><div class="bt">Say it</div><div class="bd">Types <span class="mono">"build me a grid of the fleet's open PRs"</span>. The blueprint streams in as a preview turn.</div></div>
+    <div class="beat"><div class="bn">beat 3 · 0:09</div><div class="bt">Generate</div><div class="bd">Confirms. Honest progress; the Grid materializes as a docked panel — real data, not a mock.</div></div>
+    <div class="beat"><div class="bn">beat 4 · 0:15</div><div class="bt">Use it live</div><div class="bd">Sorts a column, follows up "colour the state" — the panel mutates in place. The app <em>works</em>.</div></div>
+    <div class="beat"><div class="bn">beat 5 · 0:22</div><div class="bt">Pop out</div><div class="bd">Drags the panel to its own OS window on the shared heap — object-permanent; nobody dragged a file.</div></div>
+    <div class="beat"><div class="bn">beat 6 · 0:27</div><div class="bt">Share</div><div class="bd">Copies the hosted URL; a second person opens the running app. Built &amp; shipped, code unread.</div></div>
+  </div>
+  <p class="lead" style="font-size:.78rem;margin-top:.6rem">The falsifier: a viewer who has never seen Neo follows every beat without narration. No performance numbers appear (per <span class="mono">#13032</span>) — the claim is legibility, not benchmarks.</p>
 
   <footer>
     Tokens: the <span class="mono">--fm-*</span> vocabulary (<span class="mono">apps/agentos/resources/tokens.css</span>) — native to the one harness app, visually consistent with the FM cockpit.


### PR DESCRIPTION
Resolves #14645

Refs #13349 (pillar-2 — the conversational-creation lane) · Refs #14560 (FM cockpit epic — companion surface).

The design SSOT for the conversational app-creation surface (the "keeper flow") — a module inside the one harness app (`apps/agentos`). It draws the #14645 design contract at the cockpit bar: the keeper-flow wedge (chat intent → blueprint preview → generating → materialized docked panel → its own OS window / share), the **five states** (empty · composing · generating · materialized · error), the **transcript treatment** (markdown-VDOM), the **follow-up** interaction, the **created-widget pane + provenance-as-inspector**, the **M2 demo storyboard**, the **draw-vs-delegate boundary**, the **notAuthority safety framing** (the #14644 constrained-blueprint gate), and the **Body-idiom binding** (the five states → a `state.Provider` `data.flowState`, realized in #14719). Consumes the `--fm-*` tokens for visual consistency with the FM cockpit.

Evidence: L1 (self-contained HTML/CSS design doc — no runtime / JS / external deps; inline `:root` token fallback for standalone render) → L2 (render-verify). Residual: the render-verify on the expanded head (a browser pass — see Post-Merge Validation).

## Deltas from ticket

- Delivers all of #14645's design ACs at the cockpit bar — the five states + wedge, the transcript / follow-up / provenance-as-inspector / M2-storyboard surfaces, and the Body-idiom binding (realized in #14719). The Cycle-2 expansion added the four surfaces flagged in the first review, so `Resolves #14645` now holds; the deeper per-surface **implementation** design iterates in the view-tranche leaves (#14719 / #14720 / #14722), not in this design SSOT.
- Consumes the `--fm-*` token vocabulary (`apps/agentos/resources/tokens.css`; values SoT = the cockpit plan).

## Test Evidence

- Self-contained static HTML/CSS — no unit/e2e surface. Precommit hooks pass; tag-balance verified (divs 112/112, node tag-stack clean).
- Render-verify: Mnemosyne verified the Cycle-1 artifact in a live browser — all sections render, zero horizontal overflow at 516px, `--fm-*` token fallback applied (#14692 issuecomment-4880667103); the expanded sections reuse that verified grammar.

## Post-Merge Validation

- [ ] **RENDER-VERIFY (human gate — confirms the expansion):** a browser pass on `apps/agentos/design/chat-creation-plan.html` at the current head — the 5 state cards + mini-mockups, the wedge, the transcript / follow-up / provenance / M2 sections, the draw-vs-delegate + Body-idiom columns, the safety-gate band. Mnemosyne verified Cycle-1; this confirms the added surfaces render.

## Authored-by

Authored by Grace (@neo-opus-grace, Claude Opus 4.8, Claude Code). Session e6b744fd-e84d-4b6c-a1e7-da6f10fc3b70.

Cross-family review: Euclid (@neo-gpt / GPT) is the mandatory cross-family leg; operator-last human merge.
