### PR TITLE
feat(dashboard): dockLayout v2 envelope — perspective fields + pure v1 migration (#14651)

### DIFF
--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -35,18 +35,37 @@ class DockZoneModel extends Base {
     static SCHEMA = 'neo.harness.dockZone.v1'
 
     /**
-     * The saved layout wrapper schema around a normalized dock-zone document.
-     * @member {String} LAYOUT_SCHEMA='neo.harness.dockLayout.v1'
+     * The saved layout wrapper schema around a normalized dock-zone document. v2 adds the
+     * perspective fields (`captureScope`, `windowFingerprint`, `perspectiveName`); writes always
+     * emit v2, while v1 records stay readable through {@link #migrateSavedLayout} (fail-open read
+     * with honest defaults — a legacy record never errors, and never silently re-persists as v1).
+     * @member {String} LAYOUT_SCHEMA='neo.harness.dockLayout.v2'
      * @static
      */
-    static LAYOUT_SCHEMA = 'neo.harness.dockLayout.v1'
+    static LAYOUT_SCHEMA = 'neo.harness.dockLayout.v2'
 
     /**
-     * The saved layout collection schema for named layout perspectives.
+     * The legacy saved-layout wrapper schema, accepted on read via {@link #migrateSavedLayout}.
+     * @member {String} LAYOUT_SCHEMA_V1='neo.harness.dockLayout.v1'
+     * @static
+     */
+    static LAYOUT_SCHEMA_V1 = 'neo.harness.dockLayout.v1'
+
+    /**
+     * The saved layout collection schema for named layout perspectives. The collection envelope
+     * stays v1: its `layouts` values migrate individually at restore time.
      * @member {String} LAYOUT_COLLECTION_SCHEMA='neo.harness.dockLayoutCollection.v1'
      * @static
      */
     static LAYOUT_COLLECTION_SCHEMA = 'neo.harness.dockLayoutCollection.v1'
+
+    /**
+     * The capture scopes a saved layout may declare: one window's dock document, or the whole
+     * multi-window topology.
+     * @member {String[]} CAPTURE_SCOPES
+     * @static
+     */
+    static CAPTURE_SCOPES = ['window', 'topology']
 
     /**
      * Top-level fields allowed in a saved-layout wrapper.
@@ -54,7 +73,10 @@ class DockZoneModel extends Base {
      * @protected
      * @static
      */
-    static savedLayoutKeys = new Set(['schema', 'layoutId', 'title', 'dockZone', 'metadata', 'revision'])
+    static savedLayoutKeys = new Set([
+        'schema', 'layoutId', 'title', 'dockZone', 'metadata', 'revision',
+        'captureScope', 'windowFingerprint', 'perspectiveName'
+    ])
 
     /**
      * Top-level fields allowed in a named saved-layout collection.
@@ -645,13 +667,69 @@ class DockZoneModel extends Base {
     }
 
     /**
+     * @summary Migrates a saved-layout record to the current wrapper schema, read-side and pure.
+     *
+     * A legacy v1 record gains the perspective fields with honest defaults (`captureScope:
+     * 'window'` — v1 could only ever capture one window's document — and `windowFingerprint:
+     * null`, since no fingerprint was recorded at capture time); `perspectiveName` stays absent
+     * because it is optional by contract. Idempotent: current-schema records pass through
+     * untouched, and unknown schemas pass through for the caller's validation to reject, so this
+     * never masks a genuinely foreign envelope. Writers never emit v1 again.
+     * @param {Object} savedLayout A saved-layout record of any known schema revision.
+     * @returns {Object} The record at the current schema revision (a shallow-cloned upgrade for v1).
+     * @static
+     */
+    static migrateSavedLayout(savedLayout) {
+        if (savedLayout?.schema !== DockZoneModel.LAYOUT_SCHEMA_V1) {
+            return savedLayout
+        }
+
+        return {
+            ...savedLayout,
+            schema           : DockZoneModel.LAYOUT_SCHEMA,
+            captureScope     : 'window',
+            windowFingerprint: null
+        }
+    }
+
+    /**
+     * @summary Validates the perspective fields shared by the create and restore paths.
+     *
+     * `captureScope` must be one of {@link #CAPTURE_SCOPES}; `windowFingerprint` describes
+     * topology SHAPE only and must be a JSON object or null (never window ids or coordinates —
+     * the persistence guardrail); `perspectiveName`, when present, must be a non-empty string.
+     * @param {Object} layout The saved-layout record carrying the perspective fields.
+     * @returns {String[]} Validation errors, empty when the fields are contract-clean.
+     * @static
+     */
+    static validatePerspectiveFields(layout) {
+        let errors = [];
+
+        if (!DockZoneModel.CAPTURE_SCOPES.includes(layout.captureScope)) {
+            errors.push(`captureScope must be one of: ${DockZoneModel.CAPTURE_SCOPES.join(', ')}`)
+        }
+
+        if (layout.windowFingerprint !== null && !DockZoneModel.isJsonRecord(layout.windowFingerprint)) {
+            errors.push('windowFingerprint must be a JSON object or null')
+        }
+
+        if (Object.hasOwn(layout, 'perspectiveName') &&
+            (typeof layout.perspectiveName !== 'string' || !layout.perspectiveName.trim())
+        ) {
+            errors.push('perspectiveName must be a non-empty string when present')
+        }
+
+        return errors
+    }
+
+    /**
      * @summary Wraps a valid committed dock-zone document in a JSON-only saved-layout envelope.
      *
      * The wrapper and dock-zone tree are finite-schema: unknown fields fail closed. The explicit
      * `metadata` field is an opaque JSON-only non-secret annotation channel; callers must not place
      * credentials or runtime authority inside it.
      * @param {Object} document The committed dock-zone document to normalize and wrap.
-     * @param {Object} [metadata={}] {layoutId, title, revision, metadata}
+     * @param {Object} [metadata={}] {layoutId, title, revision, metadata, captureScope, windowFingerprint, perspectiveName}
      * @returns {{layout:(Object|null), errors:String[]}}
      * @static
      */
@@ -679,15 +757,21 @@ class DockZoneModel extends Base {
             layoutId   = Object.hasOwn(metadata, 'layoutId') ? metadata.layoutId : 'default',
             title      = Object.hasOwn(metadata, 'title') ? metadata.title : layoutId,
             layout     = {
-                schema  : DockZoneModel.LAYOUT_SCHEMA,
+                schema           : DockZoneModel.LAYOUT_SCHEMA,
                 layoutId,
                 title,
-                dockZone: normalized,
-                metadata: Object.hasOwn(metadata, 'metadata') ? metadata.metadata : {}
+                dockZone         : normalized,
+                metadata         : Object.hasOwn(metadata, 'metadata') ? metadata.metadata : {},
+                captureScope     : Object.hasOwn(metadata, 'captureScope') ? metadata.captureScope : 'window',
+                windowFingerprint: Object.hasOwn(metadata, 'windowFingerprint') ? metadata.windowFingerprint : null
             };
 
         if (Object.hasOwn(metadata, 'revision')) {
             layout.revision = metadata.revision
+        }
+
+        if (Object.hasOwn(metadata, 'perspectiveName')) {
+            layout.perspectiveName = metadata.perspectiveName
         }
 
         if (typeof layout.layoutId !== 'string' || !layout.layoutId.trim()) {
@@ -697,6 +781,8 @@ class DockZoneModel extends Base {
         if (typeof layout.title !== 'string' || !layout.title.trim()) {
             errors.push('title must be a non-empty string')
         }
+
+        errors.push(...DockZoneModel.validatePerspectiveFields(layout))
 
         if (!DockZoneModel.isJsonRecord(layout.metadata)) {
             errors.push('metadata must be a JSON object')
@@ -741,9 +827,13 @@ class DockZoneModel extends Base {
             return {document: null, errors: ['saved layout must be a JSON object']}
         }
 
+        savedLayout = DockZoneModel.migrateSavedLayout(savedLayout);
+
         if (savedLayout.schema !== DockZoneModel.LAYOUT_SCHEMA) {
             errors.push(`schema must be ${DockZoneModel.LAYOUT_SCHEMA}`)
         }
+
+        errors.push(...DockZoneModel.validatePerspectiveFields(savedLayout));
 
         if (typeof savedLayout.layoutId !== 'string' || !savedLayout.layoutId.trim()) {
             errors.push('layoutId must be a non-empty string')

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -161,12 +161,74 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
                 title   : 'Operator Default'
             });
 
-            layout.schema = 'neo.harness.dockLayout.v2';
+            layout.schema = 'neo.harness.dockLayout.v3';
 
             const {document, errors} = DockZoneModel.restoreSavedLayout(layout);
 
             expect(document).toBe(null);
             expect(errors.join(' ')).toContain(DockZoneModel.LAYOUT_SCHEMA)
+        });
+
+        test('reads a legacy v1 record fail-open with honest perspective defaults', () => {
+            const {layout} = DockZoneModel.createSavedLayout(doc(), {
+                layoutId: 'legacy',
+                title   : 'Legacy Layout'
+            });
+
+            // shape a stored-era v1 record: old schema tag, no perspective fields
+            const v1 = {...layout, schema: DockZoneModel.LAYOUT_SCHEMA_V1};
+            delete v1.captureScope;
+            delete v1.windowFingerprint;
+
+            const restored = DockZoneModel.restoreSavedLayout(v1);
+
+            expect(restored.errors).toEqual([]);
+            expect(restored.document).toEqual(layout.dockZone);
+            // the input record is never mutated (pure migration)
+            expect(v1.schema).toBe(DockZoneModel.LAYOUT_SCHEMA_V1);
+            expect('captureScope' in v1).toBe(false)
+        });
+
+        test('migrateSavedLayout upgrades v1 with defaults and is idempotent on v2', () => {
+            const v1 = {schema: DockZoneModel.LAYOUT_SCHEMA_V1, layoutId: 'a', title: 'A', dockZone: {}};
+
+            const migrated = DockZoneModel.migrateSavedLayout(v1);
+
+            expect(migrated.schema).toBe(DockZoneModel.LAYOUT_SCHEMA);
+            expect(migrated.captureScope).toBe('window');
+            expect(migrated.windowFingerprint).toBe(null);
+            expect('perspectiveName' in migrated).toBe(false);
+            expect(DockZoneModel.migrateSavedLayout(migrated)).toBe(migrated)
+        });
+
+        test('round-trips the v2 perspective fields (topology scope, fingerprint, name)', () => {
+            const {layout, errors} = DockZoneModel.createSavedLayout(doc(), {
+                layoutId         : 'focus',
+                title            : 'Focus',
+                captureScope     : 'topology',
+                windowFingerprint: {windows: 2, splits: [2, 1]},
+                perspectiveName  : 'Focus Mode'
+            });
+
+            expect(errors).toEqual([]);
+            expect(layout.captureScope).toBe('topology');
+            expect(layout.windowFingerprint).toEqual({windows: 2, splits: [2, 1]});
+            expect(layout.perspectiveName).toBe('Focus Mode');
+            expect(DockZoneModel.restoreSavedLayout(layout).errors).toEqual([])
+        });
+
+        test('fails closed on perspective-field contract violations', () => {
+            const badScope = DockZoneModel.createSavedLayout(doc(), {layoutId: 'x', title: 'X', captureScope: 'galaxy'});
+            expect(badScope.layout).toBe(null);
+            expect(badScope.errors.join(' ')).toContain('captureScope');
+
+            const badPrint = DockZoneModel.createSavedLayout(doc(), {layoutId: 'x', title: 'X', windowFingerprint: 'w1'});
+            expect(badPrint.layout).toBe(null);
+            expect(badPrint.errors.join(' ')).toContain('windowFingerprint');
+
+            const badName = DockZoneModel.createSavedLayout(doc(), {layoutId: 'x', title: 'X', perspectiveName: '  '});
+            expect(badName.layout).toBe(null);
+            expect(badName.errors.join(' ')).toContain('perspectiveName')
         });
 
         test('fails closed for malformed wrapper identity fields', () => {

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -395,11 +395,13 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(saved.errors.join(' ')).toContain('autoHidden');
 
             const savedLayout = {
-                schema  : DockZoneModel.LAYOUT_SCHEMA,
-                layoutId: 'operator-default',
-                title   : 'Operator Default',
-                dockZone: doc(),
-                metadata: {}
+                schema           : DockZoneModel.LAYOUT_SCHEMA,
+                layoutId         : 'operator-default',
+                title            : 'Operator Default',
+                dockZone         : doc(),
+                metadata         : {},
+                captureScope     : 'window',
+                windowFingerprint: null
             };
 
             savedLayout.dockZone.items.strategy.pinned = 'yes';
@@ -427,11 +429,13 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(saved.errors.join(' ')).toContain('cannot be pinned and autoHidden');
 
             const savedLayout = {
-                schema  : DockZoneModel.LAYOUT_SCHEMA,
-                layoutId: 'operator-default',
-                title   : 'Operator Default',
-                dockZone: doc(),
-                metadata: {}
+                schema           : DockZoneModel.LAYOUT_SCHEMA,
+                layoutId         : 'operator-default',
+                title            : 'Operator Default',
+                dockZone         : doc(),
+                metadata         : {},
+                captureScope     : 'window',
+                windowFingerprint: null
             };
 
             savedLayout.dockZone.items.terminal.pinned = true;


### PR DESCRIPTION
## Summary

Tree line **B1** of the #13158 docking lane — the T-B tranche's substrate gate: the saved-layout envelope advances to **`neo.harness.dockLayout.v2`**, gaining the perspective fields ADR 0029 §2.2's whole behavior set needs schema room for (`captureScope`, `windowFingerprint`, `perspectiveName`), with a **pure, idempotent v1 read-migration** so every stored legacy record keeps loading with honest defaults — and writes never emit v1 again. The migration path exists BEFORE the first perspective persists, so v1 never becomes a legacy problem.

Resolves #14651
Refs #13158

## Deltas

- **`src/dashboard/DockZoneModel.mjs`** — `LAYOUT_SCHEMA` → v2 with `LAYOUT_SCHEMA_V1` kept as the accepted-on-read legacy constant; `CAPTURE_SCOPES = ['window','topology']`; `savedLayoutKeys` extended (fail-closed unknown-key discipline preserved). NEW `migrateSavedLayout()` — pure shallow-clone upgrade for v1 (defaults: `captureScope:'window'` — v1 could only ever capture one window's document; `windowFingerprint:null` — none was recorded; `perspectiveName` stays absent, optional by contract), pass-through for v2 AND for foreign schemas (migration never masks a genuinely alien envelope — the caller's validation rejects it). NEW `validatePerspectiveFields()` shared by both paths: scope enum-checked; fingerprint is **shape-only JSON-or-null** (the no-window-ids/no-coordinates persistence guardrail stated in the JSDoc); name non-empty-string-when-present. `createSavedLayout` stamps the v2 fields; `restoreSavedLayout` migrates first, then validates — the fail-open read.
- **`test/playwright/unit/dashboard/DockZoneModel.spec.mjs`** — the unsupported-schema probe advances to `.v3` (its literal `.v2` string is now the real schema; intent preserved). Four new tests: legacy v1 record restores fail-open with defaults AND without input mutation (pure migration asserted); `migrateSavedLayout` upgrade + idempotence; full v2 field round-trip (topology scope + fingerprint + name); the three contract violations fail closed (`galaxy` scope, string fingerprint, blank name).

**Scope honesty:** capture/restore BEHAVIOR (B2–B5 leaves), the named store (B6), and the NL tools (#14649) all build on this envelope and are deliberately absent.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs DockZoneModel DockService` → **63 passed at head** (61 prior + the 2 hand-built negative-path fixtures recovered by carrying valid perspective fields — they now reach the deep validation they test; RA-1).

Evidence: L2 (unit-pinned pure schema/migration logic — the envelope has no runtime surface until B2+ consume it).

## Post-Merge Validation

- B2 (single-window capture) stamps these fields through `createSavedLayout` — if it needs envelope changes, this leaf under-specified (the falsifier).
- The `examples/dashboard/dock` seeded perspectives regenerate as v2 on next build via `createSavedLayout`; any stored v1 collection loads through the migration (asserted by the fail-open test).

## Related

Epic #13158 (`Refs` only — tree line B1) · authority ADR 0029 §2.2 · gates #14652/#14667/#14668/#14669 + #14649 · sibling PR #14625 (the read-accessor contract this envelope round-trips through).

Authored by Clio (Claude Fable 5, Claude Code). Session fa2a6fd5-7488-4af6-a0d2-3855c86003e4.

