### PR TITLE
feat(dashboard): topology capture — windowDocuments slot-map + composed fingerprint (#14667)

### DIFF
--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -893,8 +893,10 @@ class DockZoneModel extends Base {
      * Slot ORDER is meaning: the reconciliation of a restored topology maps captured slots onto
      * live windows positionally-by-shape, so the composed term preserves input order verbatim.
      * Envelope-agnostic by design — whichever record shape the topology capture persists,
-     * it carries this composition. Fails closed on an empty list or any entry that is not a
-     * window-shape fingerprint record.
+     * it carries this composition. Fails closed on an empty list, any entry that is not a
+     * window-shape fingerprint record, and any INCOMPLETE record: the composition consumes
+     * `itemCount`, and a window fingerprint always emits an integer count ≥ 0, so a missing or
+     * malformed count is rejected — never defaulted into a fake zero.
      * @param {Object[]} windowFingerprints Ordered per-window records from {@link #computeShapeFingerprint}.
      * @returns {{fingerprint:(Object|null), errors:String[]}}
      * @static
@@ -909,6 +911,8 @@ class DockZoneModel extends Base {
         windowFingerprints.forEach((entry, index) => {
             if (entry?.schema !== 'neo.harness.dockShape.v1' || typeof entry.shape !== 'string') {
                 errors.push(`entry ${index} is not a window shape fingerprint record`)
+            } else if (!Number.isInteger(entry.itemCount) || entry.itemCount < 0) {
+                errors.push(`entry ${index} is an incomplete window fingerprint record: itemCount must be an integer >= 0`)
             }
         });
 
@@ -921,7 +925,7 @@ class DockZoneModel extends Base {
                 schema     : 'neo.harness.dockTopologyShape.v1',
                 windowCount: windowFingerprints.length,
                 shape      : `w[${windowFingerprints.map(entry => entry.shape).join('|')}]`,
-                totalItems : windowFingerprints.reduce((sum, entry) => sum + (entry.itemCount || 0), 0)
+                totalItems : windowFingerprints.reduce((sum, entry) => sum + entry.itemCount, 0)
             },
             errors
         }

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -750,6 +750,12 @@ class DockZoneModel extends Base {
      * the composed topology term — so a single-document topology capture is structurally
      * identical to a window-scope capture apart from its declared scope and composed
      * fingerprint schema (the degenerate-case identity, asserted in the unit specs).
+     *
+     * Fingerprint-coherence by construction (same rule as {@link #capturePerspective}): raw
+     * inputs are fingerprint-PROBED first purely as the cycle/shape gate (results discarded —
+     * the writer's normalize pass must never see a cyclic graph), then the composed fingerprint
+     * derives exclusively from the PERSISTED trees, so it can never describe shapes the record
+     * does not contain.
      * @param {Object[]} documents Ordered committed dock-zone documents, primary first.
      * @param {Object} [metadata={}] {layoutId, title, revision, metadata, perspectiveName}
      * @returns {{layout:(Object|null), errors:String[]}}
@@ -760,13 +766,37 @@ class DockZoneModel extends Base {
             return {layout: null, errors: ['topology capture requires a non-empty ordered array of documents']}
         }
 
-        const fingerprints = [];
-
+        // probe every raw input first — the cycle/shape gate before any recursion-bearing pass
         for (let i = 0; i < documents.length; i++) {
-            const {fingerprint, errors} = DockZoneModel.computeShapeFingerprint(documents[i]);
+            const probe = DockZoneModel.computeShapeFingerprint(documents[i]);
+
+            if (probe.errors.length) {
+                return {layout: null, errors: probe.errors.map(error => `documents[${i}]: ${error}`)}
+            }
+        }
+
+        const written = DockZoneModel.createSavedLayout(documents[0], {
+            ...metadata,
+            captureScope     : 'topology',
+            windowFingerprint: null,
+            ...(documents.length > 1 && {
+                windowDocuments: documents.slice(1).map(DockZoneModel.normalizeTree)
+            })
+        });
+
+        if (written.errors.length) {
+            return written
+        }
+
+        // compose from the PERSISTED trees — the primary + the stored slots — never the raw inputs
+        const persisted    = [written.layout.dockZone, ...(written.layout.windowDocuments || [])],
+              fingerprints = [];
+
+        for (let i = 0; i < persisted.length; i++) {
+            const {fingerprint, errors} = DockZoneModel.computeShapeFingerprint(persisted[i]);
 
             if (errors.length) {
-                return {layout: null, errors: errors.map(error => `documents[${i}]: ${error}`)}
+                return {layout: null, errors: errors.map(error => `persisted[${i}]: ${error}`)}
             }
 
             fingerprints.push(fingerprint)
@@ -778,14 +808,9 @@ class DockZoneModel extends Base {
             return {layout: null, errors: composed.errors}
         }
 
-        return DockZoneModel.createSavedLayout(documents[0], {
-            ...metadata,
-            captureScope     : 'topology',
-            windowFingerprint: composed.fingerprint,
-            ...(documents.length > 1 && {
-                windowDocuments: documents.slice(1).map(DockZoneModel.normalizeTree)
-            })
-        })
+        written.layout.windowFingerprint = composed.fingerprint;
+
+        return written
     }
 
     /**

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -797,6 +797,46 @@ class DockZoneModel extends Base {
     }
 
     /**
+     * @summary Composes per-window shape fingerprints into one whole-topology fingerprint.
+     *
+     * Slot ORDER is meaning: the reconciliation of a restored topology maps captured slots onto
+     * live windows positionally-by-shape, so the composed term preserves input order verbatim.
+     * Envelope-agnostic by design — whichever record shape the topology capture persists,
+     * it carries this composition. Fails closed on an empty list or any entry that is not a
+     * window-shape fingerprint record.
+     * @param {Object[]} windowFingerprints Ordered per-window records from {@link #computeShapeFingerprint}.
+     * @returns {{fingerprint:(Object|null), errors:String[]}}
+     * @static
+     */
+    static composeTopologyFingerprint(windowFingerprints) {
+        let errors = [];
+
+        if (!Array.isArray(windowFingerprints) || windowFingerprints.length < 1) {
+            return {fingerprint: null, errors: ['topology fingerprint requires a non-empty ordered array of window fingerprints']}
+        }
+
+        windowFingerprints.forEach((entry, index) => {
+            if (entry?.schema !== 'neo.harness.dockShape.v1' || typeof entry.shape !== 'string') {
+                errors.push(`entry ${index} is not a window shape fingerprint record`)
+            }
+        });
+
+        if (errors.length) {
+            return {fingerprint: null, errors}
+        }
+
+        return {
+            fingerprint: {
+                schema     : 'neo.harness.dockTopologyShape.v1',
+                windowCount: windowFingerprints.length,
+                shape      : `w[${windowFingerprints.map(entry => entry.shape).join('|')}]`,
+                totalItems : windowFingerprints.reduce((sum, entry) => sum + (entry.itemCount || 0), 0)
+            },
+            errors
+        }
+    }
+
+    /**
      * @summary Captures the current window's dock document as a v2 saved-layout perspective.
      *
      * The single-window capture scope: layout truth only enters the record — the committed

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -75,7 +75,7 @@ class DockZoneModel extends Base {
      */
     static savedLayoutKeys = new Set([
         'schema', 'layoutId', 'title', 'dockZone', 'metadata', 'revision',
-        'captureScope', 'windowFingerprint', 'perspectiveName'
+        'captureScope', 'windowFingerprint', 'perspectiveName', 'windowDocuments'
     ])
 
     /**
@@ -719,7 +719,73 @@ class DockZoneModel extends Base {
             errors.push('perspectiveName must be a non-empty string when present')
         }
 
+        // windowDocuments carries the ADDITIONAL windows' trees (slots 1..N; slot 0 stays
+        // `dockZone`, so the degenerate single-window topology record equals a window-scope
+        // capture by construction). Topology-scope-only: a window-scope record carrying it
+        // fails closed; every slot tree passes the full dock-zone validation, offender indexed.
+        if (Object.hasOwn(layout, 'windowDocuments')) {
+            if (layout.captureScope !== 'topology') {
+                errors.push('windowDocuments is only valid on captureScope "topology" records')
+            } else if (!Array.isArray(layout.windowDocuments)) {
+                errors.push('windowDocuments must be an array of dock-zone documents')
+            } else {
+                layout.windowDocuments.forEach((tree, index) => {
+                    const treeErrors = DockZoneModel.validate(tree);
+
+                    if (treeErrors.length) {
+                        errors.push(`windowDocuments[${index}] is not a valid dock-zone document: ${treeErrors[0]}`)
+                    }
+                })
+            }
+        }
+
         return errors
+    }
+
+    /**
+     * @summary Captures a whole multi-window topology as ONE v2 saved-layout perspective.
+     *
+     * Slot order is meaning: `documents[0]` becomes the primary `dockZone`, the remaining
+     * slots persist as `windowDocuments` (topology-scope-only), and `windowFingerprint` holds
+     * the composed topology term — so a single-document topology capture is structurally
+     * identical to a window-scope capture apart from its declared scope and composed
+     * fingerprint schema (the degenerate-case identity, asserted in the unit specs).
+     * @param {Object[]} documents Ordered committed dock-zone documents, primary first.
+     * @param {Object} [metadata={}] {layoutId, title, revision, metadata, perspectiveName}
+     * @returns {{layout:(Object|null), errors:String[]}}
+     * @static
+     */
+    static captureTopologyPerspective(documents, metadata={}) {
+        if (!Array.isArray(documents) || documents.length < 1) {
+            return {layout: null, errors: ['topology capture requires a non-empty ordered array of documents']}
+        }
+
+        const fingerprints = [];
+
+        for (let i = 0; i < documents.length; i++) {
+            const {fingerprint, errors} = DockZoneModel.computeShapeFingerprint(documents[i]);
+
+            if (errors.length) {
+                return {layout: null, errors: errors.map(error => `documents[${i}]: ${error}`)}
+            }
+
+            fingerprints.push(fingerprint)
+        }
+
+        const composed = DockZoneModel.composeTopologyFingerprint(fingerprints);
+
+        if (composed.errors.length) {
+            return {layout: null, errors: composed.errors}
+        }
+
+        return DockZoneModel.createSavedLayout(documents[0], {
+            ...metadata,
+            captureScope     : 'topology',
+            windowFingerprint: composed.fingerprint,
+            ...(documents.length > 1 && {
+                windowDocuments: documents.slice(1).map(DockZoneModel.normalizeTree)
+            })
+        })
     }
 
     /**
@@ -934,6 +1000,10 @@ class DockZoneModel extends Base {
 
         if (Object.hasOwn(metadata, 'perspectiveName')) {
             layout.perspectiveName = metadata.perspectiveName
+        }
+
+        if (Object.hasOwn(metadata, 'windowDocuments')) {
+            layout.windowDocuments = metadata.windowDocuments
         }
 
         if (typeof layout.layoutId !== 'string' || !layout.layoutId.trim()) {

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -312,6 +312,50 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(bad.errors.join(' ')).toContain('entry 1')
         });
 
+        test('captureTopologyPerspective: multi-window round-trip with slot-ordered windowDocuments', () => {
+            const second = doc();
+            second.nodes['main-tabs'].items.push('inspector');
+
+            const {layout, errors} = DockZoneModel.captureTopologyPerspective([doc(), second], {
+                layoutId       : 'fleet',
+                title          : 'Fleet',
+                perspectiveName: 'Fleet View'
+            });
+
+            expect(errors).toEqual([]);
+            expect(layout.captureScope).toBe('topology');
+            expect(layout.windowFingerprint.schema).toBe('neo.harness.dockTopologyShape.v1');
+            expect(layout.windowFingerprint.windowCount).toBe(2);
+            expect(layout.windowDocuments.length).toBe(1);
+            expect(DockZoneModel.validate(layout.windowDocuments[0])).toEqual([]);
+            expect(DockZoneModel.restoreSavedLayout(layout).errors).toEqual([])
+        });
+
+        test('degenerate single-document topology capture equals a window-scope capture modulo scope + fingerprint schema', () => {
+            const topo = DockZoneModel.captureTopologyPerspective([doc()], {layoutId: 'solo', title: 'Solo'}).layout,
+                  win  = DockZoneModel.capturePerspective(doc(), {layoutId: 'solo', title: 'Solo'}).layout;
+
+            expect('windowDocuments' in topo).toBe(false);
+            expect(topo.dockZone).toEqual(win.dockZone);
+            expect(topo.windowFingerprint.shape).toBe(`w[${win.windowFingerprint.shape}]`);
+            expect(topo.captureScope).toBe('topology');
+            expect(win.captureScope).toBe('window')
+        });
+
+        test('windowDocuments fails closed on window-scope records and on invalid slot trees', () => {
+            const base = DockZoneModel.capturePerspective(doc(), {layoutId: 'x', title: 'X'}).layout;
+
+            const smuggled = {...base, windowDocuments: [doc()]};
+            expect(DockZoneModel.restoreSavedLayout(smuggled).errors.join(' '))
+                .toContain('only valid on captureScope "topology"');
+
+            const badTree = doc();
+            badTree.root = 'ghost';
+            const {layout, errors} = DockZoneModel.captureTopologyPerspective([doc(), badTree], {layoutId: 'x', title: 'X'});
+            expect(layout).toBe(null);
+            expect(errors.join(' ')).toContain('documents[1]')
+        });
+
         test('fingerprint walk fails closed on dangling node refs', () => {
             const broken = doc();
             broken.root = 'missing-node';

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -342,6 +342,24 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(win.captureScope).toBe('window')
         });
 
+        test('topology fingerprint derives from the PERSISTED slot trees (collapsing-slot coherence)', () => {
+            // second window: a single-child split that normalizeTree collapses — the stored slot
+            // is the collapsed tree, and the composed fingerprint must describe THAT, not the input
+            const collapsing = splitDoc();
+            collapsing.nodes['main-split'].children = ['main-tabs'];
+            collapsing.nodes['main-split'].sizes    = [1];
+            delete collapsing.nodes['side-tabs'];
+            delete collapsing.items.terminal;
+
+            const {layout, errors} = DockZoneModel.captureTopologyPerspective([doc(), collapsing], {layoutId: 't', title: 'T'});
+
+            expect(errors).toEqual([]);
+            const slotTerm = DockZoneModel.computeShapeFingerprint(layout.windowDocuments[0]).fingerprint.shape;
+            expect(layout.windowFingerprint.shape).toContain(slotTerm);
+            expect(layout.windowFingerprint.shape).not.toContain('h(');
+            expect(slotTerm.startsWith('h(')).toBe(false)
+        });
+
         test('windowDocuments fails closed on window-scope records and on invalid slot trees', () => {
             const base = DockZoneModel.capturePerspective(doc(), {layoutId: 'x', title: 'X'}).layout;
 

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -285,6 +285,33 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(DockZoneModel.computeShapeFingerprint(mutated).fingerprint.shape).not.toBe(a.fingerprint.shape)
         });
 
+        test('topology fingerprints compose per-window terms in slot order and fail closed on bad input', () => {
+            const single = DockZoneModel.computeShapeFingerprint(doc()).fingerprint;
+
+            const two = DockZoneModel.composeTopologyFingerprint([single, single]);
+            expect(two.errors).toEqual([]);
+            expect(two.fingerprint.schema).toBe('neo.harness.dockTopologyShape.v1');
+            expect(two.fingerprint.windowCount).toBe(2);
+            expect(two.fingerprint.shape).toBe(`w[${single.shape}|${single.shape}]`);
+            expect(two.fingerprint.totalItems).toBe(single.itemCount * 2);
+
+            // slot order IS meaning: reversed input must produce a different term when shapes differ
+            const mutated = doc();
+            mutated.nodes['main-tabs'].items.push('extra-item');
+            const other = DockZoneModel.computeShapeFingerprint(mutated).fingerprint;
+            expect(DockZoneModel.composeTopologyFingerprint([single, other]).fingerprint.shape)
+                .not.toBe(DockZoneModel.composeTopologyFingerprint([other, single]).fingerprint.shape);
+
+            // degenerate single-window composition wraps the same term
+            expect(DockZoneModel.composeTopologyFingerprint([single]).fingerprint.shape).toBe(`w[${single.shape}]`);
+
+            // fail-closed: empty list + non-fingerprint entry
+            expect(DockZoneModel.composeTopologyFingerprint([]).fingerprint).toBe(null);
+            const bad = DockZoneModel.composeTopologyFingerprint([single, {shape: 42}]);
+            expect(bad.fingerprint).toBe(null);
+            expect(bad.errors.join(' ')).toContain('entry 1')
+        });
+
         test('fingerprint walk fails closed on dangling node refs', () => {
             const broken = doc();
             broken.root = 'missing-node';

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -312,6 +312,23 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(bad.errors.join(' ')).toContain('entry 1')
         });
 
+        test('topology composition rejects incomplete window fingerprints — a missing itemCount never fakes a zero', () => {
+            // right schema, right shape, NO itemCount: must fail closed, never compose totalItems: 0
+            const incomplete = DockZoneModel.composeTopologyFingerprint([{schema: 'neo.harness.dockShape.v1', shape: 't1'}]);
+            expect(incomplete.fingerprint).toBe(null);
+            expect(incomplete.errors.join(' ')).toContain('entry 0');
+            expect(incomplete.errors.join(' ')).toContain('incomplete');
+
+            // malformed counts are rejected the same way, with the offending slot indexed
+            const single = DockZoneModel.computeShapeFingerprint(doc()).fingerprint;
+
+            for (const itemCount of [NaN, -1, 1.5, '3']) {
+                const malformed = DockZoneModel.composeTopologyFingerprint([single, {...single, itemCount}]);
+                expect(malformed.fingerprint).toBe(null);
+                expect(malformed.errors.join(' ')).toContain('entry 1')
+            }
+        });
+
         test('captureTopologyPerspective: multi-window round-trip with slot-ordered windowDocuments', () => {
             const second = doc();
             second.nodes['main-tabs'].items.push('inspector');


### PR DESCRIPTION
## Summary

Tree line **B3** of the #13158 docking lane, now WHOLE (stacked on #14697; base auto-retargets as the stack merges): whole-topology perspective capture per ADR 0029 §2.2 and the **fork resolution recorded on the ticket** — `captureScope:'topology'` records carry an ordered `windowDocuments` slot-map (slots 1..N; slot 0 stays `dockZone`), `captureTopologyPerspective()` composes per-window shape fingerprints into the `dockTopologyShape.v1` term, and the **degenerate single-document capture is structurally identical to a window-scope capture by construction** — asserted, not hoped.

Resolves #14667
Refs #13158

## Deltas

- **`src/dashboard/DockZoneModel.mjs`** — `composeTopologyFingerprint()` (slot-ORDER-preserving composition; order is meaning for B5's positional-by-shape reconciliation; fail-closed with the entry indexed) · `windowDocuments` on the v2 envelope (additive — no version bump, v1 migration untouched since legacy records can never be topology-scope; topology-scope-only with window-scope smuggling failing closed; every slot tree passes full dock-zone validation, offender indexed) · `captureTopologyPerspective(documents, metadata)` (primary-first ordered docs → fingerprint-compose → delegate to the writer; per-document errors indexed).
- **`test/playwright/unit/dashboard/DockZoneModel.spec.mjs`** — composition spec (order-sensitivity, degenerate wrap, two failure modes) + multi-window round-trip (restorable, slot validated) + **the degenerate-case identity spec** (single-doc topology ≡ window capture modulo scope + fingerprint schema) + the fail-closed pair (smuggled `windowDocuments` on window-scope; invalid slot tree indexed).

**Fork resolution provenance:** the build-start comment on #14667 recorded the three-option fork (the #14695 falsifier firing as designed); the resolution comment records the decision, rejections, and the reversibility bound (per-slot metadata → parallel `windowMeta`, never a reshape). This PR implements exactly that record.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs DockZoneModel` → **70 passed** at this head.

Evidence: L2 (pure model logic; the live multi-window capture shell rides the NL-tools leaf #14649 where the service boundary lives).

## Post-Merge Validation

- B5's reconciler consumes the slot-map positionally — if it needs per-slot metadata beyond the trees, the envelope gains the bounded `windowMeta` array per the resolution's reversibility clause (the falsifier).
- #14667's degenerate-identity guarantee is the regression tripwire: any future envelope change breaking `topo(doc) ≡ win(doc)` fails the identity spec.

## Related

Epic #13158 (`Refs` only — tree line B3) · stacked on #14697 (#14652) → merged #14695 (#14651) · fork record: the two #14667 comments · consumed by #14668/B5, #14649, #14590.

Authored by Clio (Claude Fable 5, Claude Code). Session fa2a6fd5-7488-4af6-a0d2-3855c86003e4.
