### PR TITLE
feat(fleet): add A2A cockpit activity adapter (#14572)

### DIFF
--- a/ai/services/fleet/fleetA2AActivityAdapter.mjs
+++ b/ai/services/fleet/fleetA2AActivityAdapter.mjs
@@ -1,0 +1,292 @@
+import {
+    createFleetCockpitEvent,
+    FLEET_COCKPIT_SOURCES
+} from '../../../src/ai/fleet/fleetCockpitStatus.mjs'
+
+/**
+ * @module ai/services/fleet/fleetA2AActivityAdapter
+ * @summary Maps Memory Core A2A mailbox summaries into bounded Fleet cockpit activity DTO rows.
+ *
+ * The adapter consumes MailboxService-compatible `listMessages()` output instead of importing the
+ * singleton directly, so callers keep ownership of identity binding and read permissions. It never
+ * copies full message bodies into the cockpit DTO; the operator surface gets sender, recipient class,
+ * subject/status metadata, related ticket ids, timestamps, and a source label only.
+ */
+
+export const DEFAULT_FLEET_A2A_ACTIVITY_EVENT_LIMIT = 50
+
+const LANE_CLAIM_SUBJECT = /^\s*\[lane-claim\]/i
+
+/**
+ * @summary Read recent A2A mailbox summaries through a Memory Core-owned read path and map them into
+ * Fleet cockpit activity events.
+ * @param {Object} options={}
+ * @param {Object} [options.mailboxService] Service exposing `listMessages(args)`.
+ * @param {Function} [options.listMessages] Direct `listMessages(args)` override for tests/callers.
+ * @param {Object} [options.listArgs] Explicit MailboxService query bounds.
+ * @param {Date|String} [options.capturedAt] Capture timestamp.
+ * @param {Number} [options.limit] Maximum events to return and default mailbox read bound.
+ * @param {Date|String|null} [options.since] Lower timestamp bound for mapped events.
+ * @param {Date|String|null} [options.until] Upper timestamp bound for mapped events.
+ * @returns {Promise<{capability: Object, events: Object[]}>}
+ */
+export async function readFleetA2AActivitySnapshot({
+    mailboxService = null,
+    listMessages = null,
+    listArgs = {},
+    capturedAt = new Date(),
+    limit = DEFAULT_FLEET_A2A_ACTIVITY_EVENT_LIMIT,
+    since = null,
+    until = null
+} = {}) {
+    const readMessages = listMessages || mailboxService?.listMessages?.bind(mailboxService)
+
+    if (!readMessages) {
+        return createFleetA2AActivitySnapshot({
+            capturedAt,
+            error: 'Memory Core mailbox read path unavailable',
+            limit
+        })
+    }
+
+    try {
+        const result = await readMessages({
+            box   : 'all',
+            status: 'all',
+            limit : normalizeLimit(limit),
+            ...listArgs
+        })
+
+        return createFleetA2AActivitySnapshot({
+            capturedAt,
+            limit,
+            messages: result?.messages || [],
+            since,
+            until
+        })
+    } catch (error) {
+        return createFleetA2AActivitySnapshot({
+            capturedAt,
+            error,
+            limit
+        })
+    }
+}
+
+/**
+ * @summary Build a cockpit activity snapshot from already-read Memory Core mailbox summaries.
+ * @param {Object} options={}
+ * @param {Object[]} options.messages Message summaries from `MailboxService.listMessages()`.
+ * @param {Error|String|null} options.error Source-read failure; returns degraded capability.
+ * @param {Date|String} options.capturedAt Capture timestamp.
+ * @param {Number} options.limit Maximum events to return.
+ * @param {Date|String|null} options.since Lower timestamp bound for mapped events.
+ * @param {Date|String|null} options.until Upper timestamp bound for mapped events.
+ * @returns {{capability: Object, events: Object[]}}
+ */
+export function createFleetA2AActivitySnapshot({
+    messages = [],
+    error = null,
+    capturedAt = new Date(),
+    limit = DEFAULT_FLEET_A2A_ACTIVITY_EVENT_LIMIT,
+    since = null,
+    until = null
+} = {}) {
+    const observedAt = toIsoString(capturedAt)
+
+    if (error) {
+        const reason = normalizeError(error)
+
+        return {
+            capability: createA2AActivityCapability({
+                capturedAt: observedAt,
+                confidence: 'none',
+                reason,
+                state     : 'degraded'
+            }),
+            events: [createFleetCockpitEvent({
+                type      : 'source-degraded',
+                source    : FLEET_COCKPIT_SOURCES.a2a,
+                confidence: 'none',
+                occurredAt: observedAt,
+                payload   : {
+                    adapter: 'a2a-mailbox',
+                    kind   : 'source-degraded',
+                    reason
+                }
+            })]
+        }
+    }
+
+    const events = createA2AMessageActivityEvents(messages, {capturedAt, since, until})
+        .sort((a, b) => new Date(b.occurredAt || 0) - new Date(a.occurredAt || 0))
+        .slice(0, normalizeLimit(limit))
+
+    return {
+        capability: createA2AActivityCapability({
+            capturedAt: observedAt,
+            confidence: 'observed',
+            state     : 'wired'
+        }),
+        events
+    }
+}
+
+/**
+ * @summary Convert Memory Core mailbox summaries into bounded Fleet cockpit activity events.
+ * @param {Object[]} messages Message summaries from `MailboxService.listMessages()`.
+ * @param {Object} options
+ * @param {Date|String} options.capturedAt Fallback timestamp.
+ * @param {Date|String|null} options.since Lower timestamp bound.
+ * @param {Date|String|null} options.until Upper timestamp bound.
+ * @returns {Object[]}
+ */
+export function createA2AMessageActivityEvents(messages = [], {capturedAt = new Date(), since = null, until = null} = {}) {
+    const
+        sinceTime = toTime(since),
+        untilTime = toTime(until)
+
+    return asArray(messages)
+        .filter(Boolean)
+        .map(message => normalizeA2AMessage(message, capturedAt))
+        .filter(message => isWithinBounds(message.occurredAt, sinceTime, untilTime))
+        .map(message => createFleetCockpitEvent({
+            type      : message.isLaneClaim ? 'lane-claim' : 'a2a-activity',
+            source    : FLEET_COCKPIT_SOURCES.a2a,
+            agentId   : message.from,
+            confidence: 'observed',
+            occurredAt: message.occurredAt,
+            payload   : {
+                kind              : message.isLaneClaim ? 'a2a-lane-claim' : 'a2a-message',
+                messageId         : message.messageId,
+                subject           : message.subject,
+                from              : message.from,
+                priority          : message.priority,
+                recipientClass    : message.recipientClass,
+                relatedTickets    : message.relatedTickets,
+                relatedPullRequests: message.relatedPullRequests,
+                status            : message.status,
+                taskState         : message.taskState,
+                wakeSuppressed    : message.wakeSuppressed
+            }
+        }))
+}
+
+function normalizeA2AMessage(message, capturedAt) {
+    const subject = normalizeSubject(message.subject)
+
+    return {
+        messageId         : typeof message.messageId === 'string' ? message.messageId : null,
+        subject,
+        from              : normalizeAgentId(message.from),
+        priority          : message.priority || null,
+        recipientClass    : getRecipientClass(message.to),
+        relatedTickets    : normalizeRelatedTickets(message.relatedTickets),
+        relatedPullRequests: normalizeRelatedPullRequests(message.relatedPullRequests),
+        status            : getMessageStatus(message),
+        taskState         : message.task?.state || null,
+        wakeSuppressed    : Boolean(message.wakeSuppressed),
+        occurredAt        : toIsoString(message.sentAt || message.createdAt, capturedAt),
+        isLaneClaim       : LANE_CLAIM_SUBJECT.test(subject || '')
+    }
+}
+
+function createA2AActivityCapability({capturedAt, confidence, reason = null, state}) {
+    return {
+        source: FLEET_COCKPIT_SOURCES.activity,
+        state,
+        confidence,
+        capturedAt,
+        reason
+    }
+}
+
+function getMessageStatus(message) {
+    if (message.retracted) return 'retracted'
+    if (message.archivedAt) return 'archived'
+    if (message.readAt) return 'read'
+
+    return 'unread'
+}
+
+function getRecipientClass(to) {
+    if (!to) return 'unknown'
+    if (to === 'AGENT:*') return 'broadcast'
+    if (String(to).startsWith('@')) return 'agent'
+    if (String(to).startsWith('role:')) return 'role'
+    if (String(to).startsWith('human:')) return 'human'
+
+    return 'other'
+}
+
+function normalizeAgentId(value) {
+    if (!value) return null
+    if (typeof value === 'string') return value.replace(/^@/, '')
+
+    return value.login || value.name || null
+}
+
+function normalizeSubject(subject) {
+    if (!subject) return null
+
+    return redactSecretText(String(subject).replace(/\s+/g, ' ').trim()).slice(0, 180)
+}
+
+function normalizeRelatedTickets(values = []) {
+    return asArray(values)
+        .map(value => Number(String(value).replace(/^#/, '')))
+        .filter(value => Number.isSafeInteger(value) && value > 0)
+        .sort((a, b) => a - b)
+}
+
+function normalizeRelatedPullRequests(values = []) {
+    return asArray(values)
+        .map(value => typeof value === 'number' ? value : Number(value?.number || value?.ticket?.replace?.(/^#/, '')))
+        .filter(value => Number.isSafeInteger(value) && value > 0)
+        .sort((a, b) => a - b)
+}
+
+function isWithinBounds(value, sinceTime, untilTime) {
+    const time = toTime(value)
+
+    if (sinceTime !== null && time < sinceTime) return false
+    if (untilTime !== null && time > untilTime) return false
+
+    return true
+}
+
+function normalizeLimit(value) {
+    const limit = Number(value)
+
+    return Number.isFinite(limit) ? Math.max(0, limit) : DEFAULT_FLEET_A2A_ACTIVITY_EVENT_LIMIT
+}
+
+function normalizeError(error) {
+    return redactSecretText(String(error?.message || error || 'source unavailable')).replace(/\s+/g, ' ').slice(0, 240)
+}
+
+function redactSecretText(text) {
+    return text
+        .replace(/\b(token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
+        .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
+}
+
+function toIsoString(value, fallback = new Date()) {
+    const date = value instanceof Date ? value : new Date(value)
+    if (!Number.isNaN(date.getTime())) return date.toISOString()
+
+    const fallbackDate = fallback instanceof Date ? fallback : new Date(fallback)
+    return fallbackDate.toISOString()
+}
+
+function toTime(value) {
+    if (!value) return null
+
+    const date = value instanceof Date ? value : new Date(value)
+
+    return Number.isNaN(date.getTime()) ? null : date.getTime()
+}
+
+function asArray(value) {
+    return Array.isArray(value) ? value : []
+}

--- a/src/ai/fleet/fleetCockpitStatus.mjs
+++ b/src/ai/fleet/fleetCockpitStatus.mjs
@@ -1,5 +1,6 @@
 const WIRE_SOURCES = Object.freeze({
         activity  : 'fleet:activity-adapters',
+        a2a       : 'memory-core:mailbox',
         githubPr  : 'github-workflow:pull-requests',
         githubIssue: 'github-workflow:issues',
         commentLane: 'github-workflow:issue-comments',
@@ -17,6 +18,7 @@ export const FLEET_COCKPIT_EVENT_TYPES = Object.freeze([
     'lifecycle-failure',
     'bridge-unavailable',
     'bridge-gated',
+    'a2a-activity',
     'pr-activity',
     'issue-activity',
     'lane-claim',

--- a/test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs
@@ -1,0 +1,189 @@
+import {setup} from '../../../../setup.mjs'
+
+const appName = 'FleetA2AActivityAdapterTest'
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+})
+
+import {test, expect} from '@playwright/test'
+import Neo            from '../../../../../../src/Neo.mjs'
+import * as core      from '../../../../../../src/core/_export.mjs'
+
+import {
+    createA2AMessageActivityEvents,
+    createFleetA2AActivitySnapshot,
+    readFleetA2AActivitySnapshot
+} from '../../../../../../ai/services/fleet/fleetA2AActivityAdapter.mjs'
+import {FLEET_COCKPIT_SOURCES} from '../../../../../../src/ai/fleet/fleetCockpitStatus.mjs'
+
+test.describe('fleetA2AActivityAdapter - Memory Core A2A activity mapping', () => {
+    test('maps mailbox summaries without exposing bodies or exact recipient ids', () => {
+        const [event] = createA2AMessageActivityEvents([{
+            messageId     : 'MESSAGE:123',
+            subject       : '[review-request] PR #14703 token=secret',
+            body          : 'full body ghp_secret must not reach the cockpit',
+            bodyText      : 'full body ghp_secret must not reach the cockpit',
+            from          : '@neo-opus-ada',
+            to            : '@neo-gpt',
+            priority      : 'normal',
+            sentAt        : '2026-07-04T06:00:00Z',
+            relatedTickets: ['#14572', '#14703'],
+            relatedPullRequests: [{number: 14703}],
+            task          : {state: 'Submitted', input: 'secret=hidden'},
+            wakeSuppressed: true
+        }])
+
+        expect(event).toMatchObject({
+            type      : 'a2a-activity',
+            source    : FLEET_COCKPIT_SOURCES.a2a,
+            agentId   : 'neo-opus-ada',
+            confidence: 'observed',
+            occurredAt: '2026-07-04T06:00:00.000Z',
+            payload   : {
+                kind              : 'a2a-message',
+                messageId         : 'MESSAGE:123',
+                from              : 'neo-opus-ada',
+                recipientClass    : 'agent',
+                relatedTickets    : [14572, 14703],
+                relatedPullRequests: [14703],
+                status            : 'unread',
+                taskState         : 'Submitted',
+                wakeSuppressed    : true
+            }
+        })
+
+        const serialized = JSON.stringify(event)
+
+        expect(serialized).toContain('token=[redacted]')
+        expect(serialized).not.toContain('ghp_secret')
+        expect(serialized).not.toContain('full body')
+        expect(serialized).not.toContain('neo-gpt')
+        expect(serialized).not.toContain('secret=hidden')
+    })
+
+    test('maps lane-claim broadcasts as bounded lane-claim events', () => {
+        const [event] = createA2AMessageActivityEvents([{
+            messageId: 'MESSAGE:lane',
+            subject  : '[lane-claim][#14572] Fleet cockpit A2A activity adapter',
+            from     : '@neo-gpt',
+            to       : 'AGENT:*',
+            sentAt   : '2026-07-04T06:02:00Z'
+        }])
+
+        expect(event).toMatchObject({
+            type   : 'lane-claim',
+            source : FLEET_COCKPIT_SOURCES.a2a,
+            agentId: 'neo-gpt',
+            payload: {
+                kind          : 'a2a-lane-claim',
+                recipientClass: 'broadcast',
+                status        : 'unread'
+            }
+        })
+    })
+
+    test('sorts newest first, applies timestamp bounds, and limits events', () => {
+        const snapshot = createFleetA2AActivitySnapshot({
+            capturedAt: '2026-07-04T06:10:00Z',
+            since     : '2026-07-04T06:02:00Z',
+            until     : '2026-07-04T06:04:00Z',
+            limit     : 1,
+            messages  : [{
+                messageId: 'MESSAGE:old',
+                subject  : 'old',
+                from     : '@neo-gpt',
+                to       : '@neo-opus-ada',
+                sentAt   : '2026-07-04T06:01:00Z'
+            }, {
+                messageId: 'MESSAGE:middle',
+                subject  : 'middle',
+                from     : '@neo-gpt',
+                to       : '@neo-opus-ada',
+                sentAt   : '2026-07-04T06:03:00Z'
+            }, {
+                messageId: 'MESSAGE:new',
+                subject  : 'new',
+                from     : '@neo-gpt',
+                to       : '@neo-opus-ada',
+                sentAt   : '2026-07-04T06:05:00Z'
+            }]
+        })
+
+        expect(snapshot.capability).toMatchObject({
+            source    : FLEET_COCKPIT_SOURCES.activity,
+            state     : 'wired',
+            confidence: 'observed'
+        })
+        expect(snapshot.events).toHaveLength(1)
+        expect(snapshot.events[0].payload.messageId).toBe('MESSAGE:middle')
+    })
+
+    test('reads through a MailboxService-compatible function with explicit bounds', async() => {
+        const seenArgs = []
+
+        const snapshot = await readFleetA2AActivitySnapshot({
+            capturedAt : '2026-07-04T06:12:00Z',
+            limit      : 2,
+            listArgs   : {box: 'inbox', status: 'unread', includeArchived: false},
+            listMessages: async(args) => {
+                seenArgs.push(args)
+
+                return {
+                    messages: [{
+                        messageId: 'MESSAGE:reader',
+                        subject  : 'reader path',
+                        from     : '@neo-opus-vega',
+                        to       : '@neo-gpt',
+                        sentAt   : '2026-07-04T06:11:00Z'
+                    }]
+                }
+            }
+        })
+
+        expect(seenArgs).toEqual([{
+            box            : 'inbox',
+            status         : 'unread',
+            limit          : 2,
+            includeArchived: false
+        }])
+        expect(snapshot.events).toHaveLength(1)
+        expect(snapshot.events[0].payload.messageId).toBe('MESSAGE:reader')
+    })
+
+    test('returns degraded capability when Memory Core is missing or errors', async() => {
+        const missing = await readFleetA2AActivitySnapshot({
+            capturedAt: '2026-07-04T06:12:00Z'
+        })
+        const failed = await readFleetA2AActivitySnapshot({
+            capturedAt : '2026-07-04T06:12:00Z',
+            listMessages: async() => {
+                throw new Error('Memory Core token=secret unavailable')
+            }
+        })
+
+        for (const snapshot of [missing, failed]) {
+            expect(snapshot.capability).toMatchObject({
+                source    : FLEET_COCKPIT_SOURCES.activity,
+                state     : 'degraded',
+                confidence: 'none'
+            })
+            expect(snapshot.events).toHaveLength(1)
+            expect(snapshot.events[0]).toMatchObject({
+                type      : 'source-degraded',
+                source    : FLEET_COCKPIT_SOURCES.a2a,
+                confidence: 'none'
+            })
+        }
+
+        expect(JSON.stringify(failed)).toContain('token=[redacted]')
+        expect(JSON.stringify(failed)).not.toContain('token=secret')
+    })
+})


### PR DESCRIPTION
Resolves #14572

Adds the Memory Core A2A half of the Fleet cockpit activity contract. The new pure adapter reads through a MailboxService-compatible `listMessages()` function with explicit bounds, maps summary metadata into bounded cockpit events, adds a `memory-core:mailbox` source label plus `a2a-activity` event type, and fail-closes missing/erroring Memory Core as degraded capability instead of fake quietness. Full message bodies and exact recipient ids stay out of the cockpit DTO.

Evidence: L2 (pure adapter unit coverage + DTO regression coverage + local preflight validation) -> L2 required (#14572 adapter/mapping/redaction/fail-closed ACs). No residuals.

## Deltas from ticket

- Added `FLEET_COCKPIT_SOURCES.a2a` and `a2a-activity` to the shared DTO source/type vocabulary so Lane 1 can distinguish Memory Core mailbox activity from GitHub/graph activity.
- Kept the adapter pure and injectable: callers pass `mailboxService` or `listMessages`; the module does not import the live Memory Core singleton, avoiding unit-test side effects and preserving the owning service boundary.
- Mapped recipient identity to `recipientClass` only (`agent`, `broadcast`, `role`, `human`, etc.) to keep direct targets out of the product DTO while still explaining delivery shape.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs` -> 10 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs` -> 15 passed.
- `npm run agent-preflight -- --no-fix src/ai/fleet/fleetCockpitStatus.mjs ai/services/fleet/fleetA2AActivityAdapter.mjs test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs` -> passed.
- `git diff --check` and `git diff --cached --check` -> passed.

## Post-Merge Validation

- [ ] Lane 1 cockpit consumption can combine #14572 A2A events with #14573 PR/lane events without re-implementing either adapter.
- [ ] Optional live smoke: call the adapter with the real Memory Core `MailboxService.listMessages()` surface and verify recent A2A summaries render as `memory-core:mailbox` events.

## Commits

- `9f93d3b808` - `feat(fleet): add A2A cockpit activity adapter (#14572)`

Authored by Euclid (GPT-5 Codex, Codex Desktop). Session 33403f62-0332-411a-bda3-0f4ab10cd1e6.