### PR TITLE
test(agentos): prove fleet lifecycle bridge via NL (#14563)

### DIFF
--- a/test/playwright/e2e/FleetCockpitLifecycleNL.spec.mjs
+++ b/test/playwright/e2e/FleetCockpitLifecycleNL.spec.mjs
@@ -1,0 +1,204 @@
+import {test, expect} from '../fixtures.mjs';
+import {
+    NeuralLink_ComponentService,
+    NeuralLink_ConnectionService,
+    NeuralLink_DataService,
+    NeuralLink_InstanceService
+} from '../../../ai/services.mjs';
+import {FLEET_WIRE_METHODS} from '../../../src/ai/fleet/fleetWireMethods.mjs';
+
+const TEST_AGENT_ID = 'nl-proof-agent';
+
+/**
+ * @summary Start a recording loopback Fleet bridge on the same URL `apps/agentos` installs at boot.
+ * The app still uses the production `installFleetBridge` / `createFleetRegistryBridge` client; this
+ * server only replaces the Brain-side transport target for deterministic e2e assertions.
+ * @param {Object} [options]
+ * @param {Boolean} [options.rejectStart=false]
+ * @returns {Promise<{close: Function, requests: Object[]}>}
+ */
+async function startRecordingFleetBridge({rejectStart = false} = {}) {
+    const {startFleetBridgeServer} = await import('../../../ai/services/fleet/fleetBridgeServer.mjs'),
+          requests                 = [],
+          server                   = await startFleetBridgeServer({
+              port    : 8083,
+              dispatch: async request => {
+                  requests.push(request);
+
+                  if (request.method === 'startAgent') {
+                      return rejectStart
+                          ? {ok: false, error: 'fleet: start rejected by test bridge'}
+                          : {ok: true, result: {id: request.params, state: 'running'}}
+                  }
+
+                  if (request.method === 'stopAgent') {
+                      return {ok: true, result: {id: request.params, state: 'stopped'}}
+                  }
+
+                  if (request.method === 'restartAgent') {
+                      return {ok: true, result: {id: request.params, state: 'running'}}
+                  }
+
+                  if (request.method === 'listAgents' || request.method === 'fleetStatus' || request.method === 'fleetRuntimeStatus') {
+                      return {ok: true, result: []}
+                  }
+
+                  return {ok: false, error: `fleet: unexpected test method '${request.method}'`}
+              }
+          });
+
+    return {
+        requests,
+        close: () => new Promise(resolve => server.close(resolve))
+    }
+}
+
+/**
+ * @summary Resolve the AgentOS roster store by semantic model, never by generated runtime id.
+ * @param {String} sessionId
+ * @returns {Promise<String>}
+ */
+async function getAgentDefinitionsStoreId(sessionId) {
+    const stores = await NeuralLink_DataService.listStores({sessionId}),
+          store  = stores.stores.find(candidate => candidate.model === 'AgentOS.model.AgentDefinition');
+
+    expect(store, 'AgentDefinitions store should be registered in the App Worker').toBeTruthy();
+
+    return store.id
+}
+
+/**
+ * @summary Read a public fleet roster row from the App Worker store.
+ * @param {String} sessionId
+ * @param {String} storeId
+ * @param {String} agentId
+ * @returns {Promise<Object|undefined>}
+ */
+async function getAgentRow(sessionId, storeId, agentId) {
+    const store = await NeuralLink_DataService.inspectStore({sessionId, storeId, limit: 10});
+
+    return store.items.find(item => item.id === agentId)
+}
+
+/**
+ * @summary Seed the public Body-side roster through Neural Link without ever crossing a credential.
+ * @param {String} sessionId
+ * @param {String} storeId
+ * @returns {Promise<void>}
+ */
+async function seedPublicAgentRow(sessionId, storeId) {
+    await NeuralLink_InstanceService.callMethod({
+        sessionId,
+        id    : storeId,
+        method: 'add',
+        args  : [{
+            id             : TEST_AGENT_ID,
+            githubUsername : TEST_AGENT_ID,
+            harnessType    : 'codex',
+            credentialState: 'stored-node-side',
+            lifecycleState : 'defined',
+            statusText     : 'Seeded public roster row for NL proof; no credential field.',
+            updatedAt      : '2026-07-04T00:00:00.000Z'
+        }]
+    })
+}
+
+/**
+ * @summary Assert the lifecycle click crossed the fleet wire as the minimal agent-id operation.
+ * @param {Object} request The recorded loopback fleet request.
+ */
+function expectMinimalLifecyclePayload(request) {
+    expect(FLEET_WIRE_METHODS).toContain(request.method);
+    expect(request).toEqual({
+        method: 'startAgent',
+        params: TEST_AGENT_ID
+    });
+    expect(typeof request.params).toBe('string');
+    expect(JSON.stringify(request.params)).not.toMatch(/credential|pat|token/i)
+}
+
+test.describe('AgentOS Fleet cockpit lifecycle controls (Neural Link)', () => {
+    test.setTimeout(90000);
+
+    test('drives Start through the UI and verifies App Worker state + minimal bridge payload', async ({page, neuralLink}) => {
+        const fleet = await startRecordingFleetBridge();
+
+        try {
+            await page.goto('/apps/agentos/index.html');
+            await expect(page.locator('.agent-panel-settings')).toBeVisible({timeout: 30000});
+
+            // Use the fixture to own bridge startup, then bind by app name: AgentOS SharedWorker
+            // exposes a page-local app id via getWorkerId(), while the bridge registers `agentos`.
+            expect(neuralLink.bridgePort).toBeGreaterThan(0);
+
+            const sessionId = await NeuralLink_ConnectionService.waitForSession('agentos', 30000),
+                  panels    = await NeuralLink_ComponentService.queryComponent({
+                      sessionId,
+                      selector        : {className: 'AgentOS.view.FleetSettingsPanel'},
+                      returnProperties: ['id', 'className', 'reference', 'windowId']
+                  }),
+                  buttons   = await NeuralLink_ComponentService.queryComponent({
+                      sessionId,
+                      selector        : {ntype: 'button'},
+                      returnProperties: ['id', 'text', 'handler']
+                  }),
+                  storeId   = await getAgentDefinitionsStoreId(sessionId);
+
+            expect(panels.components).toHaveLength(1);
+            expect(buttons.components.map(button => button.properties.text)).toEqual(expect.arrayContaining([
+                'Start',
+                'Stop',
+                'Restart'
+            ]));
+
+            await seedPublicAgentRow(sessionId, storeId);
+
+            const seeded = await getAgentRow(sessionId, storeId, TEST_AGENT_ID);
+            expect(seeded.credential).toBeUndefined();
+            expect(seeded.pat).toBeUndefined();
+            expect(seeded.token).toBeUndefined();
+
+            await page.getByRole('button', {name: 'Start', exact: true}).click();
+
+            await expect.poll(
+                () => getAgentRow(sessionId, storeId, TEST_AGENT_ID).then(row => row?.lifecycleState),
+                {message: 'Start should update the App Worker roster row through the Fleet bridge', timeout: 15000}
+            ).toBe('running');
+
+            const row = await getAgentRow(sessionId, storeId, TEST_AGENT_ID);
+            expect(row.statusText).toBe(`Agent ${TEST_AGENT_ID} → running.`);
+            expect(fleet.requests).toHaveLength(1);
+            expectMinimalLifecyclePayload(fleet.requests[0])
+        } finally {
+            await fleet.close()
+        }
+    });
+
+    test('reflects a rejected bridge call as an error without sending credentials', async ({page, neuralLink}) => {
+        const fleet = await startRecordingFleetBridge({rejectStart: true});
+
+        try {
+            await page.goto('/apps/agentos/index.html');
+            await expect(page.locator('.agent-panel-settings')).toBeVisible({timeout: 30000});
+            expect(neuralLink.bridgePort).toBeGreaterThan(0);
+
+            const sessionId = await NeuralLink_ConnectionService.waitForSession('agentos', 30000),
+                  storeId   = await getAgentDefinitionsStoreId(sessionId);
+
+            await seedPublicAgentRow(sessionId, storeId);
+            await page.getByRole('button', {name: 'Start', exact: true}).click();
+
+            await expect.poll(
+                () => getAgentRow(sessionId, storeId, TEST_AGENT_ID).then(row => row?.lifecycleState),
+                {message: 'Rejected bridge calls should surface as App Worker error state', timeout: 15000}
+            ).toBe('error');
+
+            const row = await getAgentRow(sessionId, storeId, TEST_AGENT_ID);
+            expect(row.statusText).toBe('fleet: start rejected by test bridge');
+            expect(fleet.requests).toHaveLength(1);
+            expectMinimalLifecyclePayload(fleet.requests[0])
+        } finally {
+            await fleet.close()
+        }
+    })
+});


### PR DESCRIPTION
Resolves #14563

Adds `test/playwright/e2e/FleetCockpitLifecycleNL.spec.mjs`, a Neural Link whitebox e2e that mounts AgentOS, runs the real App-Worker `installFleetBridge` client against a recording loopback fleet transport, seeds only the public roster row via Neural Link, clicks the visible Start control, and verifies both App Worker state and the exact fleet wire request. It also covers a rejected start response and asserts the Body-side control payload remains the minimal agent id string, never PAT/credential/token data.

Evidence: L3 (local Chromium + live Neural Link App Worker e2e with loopback fleet transport) -> L3 required (close-target ACs require live AgentOS/NL cockpit proof). No residuals.

## Deltas from ticket
Implemented the rejected-bridge branch rather than the missing-bridge branch because `apps/agentos/app.mjs` now installs the production dev-server bridge on boot; the honest fail path at this layer is a rejected `{ok:false,error}` envelope from the loopback transport.

The test binds the AgentOS SharedWorker by bridge app name `agentos` because the page-local `getWorkerId()` returns `neo-app-*`, while the Neural Link bridge session id is the App Worker UUID. No production code was changed.

## Test Evidence
- `npm run test-e2e -- test/playwright/e2e/FleetCockpitLifecycleNL.spec.mjs` -> 2 passed (local Chrome, Neural Link bridge, AgentOS app).
- `git diff --cached --check` -> passed.

## Post-Merge Validation
- [ ] CI e2e lane or a maintainer rerun of the focused command passes on the merge candidate.

Authored by Euclid (GPT-5, Codex Desktop). Session 33403f62-0332-411a-bda3-0f4ab10cd1e6.