### PR TITLE
feat(ai): retrospective assembler + synthesizer wiring — the section goes live (#14706)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -36,6 +36,8 @@ import {
     renderComputedGoldenPathEmptySection         as renderRouteEmptySection,
     renderComputedGoldenPathFailureSection       as renderRouteFailureSection
 } from './computedGoldenPathRouting.mjs';
+import {RETROSPECTIVE_GRAINS, renderHandoffRetrospectiveSection} from './handoffRetrospective.mjs';
+import {assembleRetrospectiveStats}                              from './handoffRetrospectiveAssembler.mjs';
 import {
     getActivePrCycleStatus                      as resolveActivePrCycleStatus,
     renderActivePrCycleState                    as renderActivePrCycleStateSection,
@@ -538,6 +540,36 @@ class GoldenPathSynthesizer extends Base {
         const { execSync } = await import('child_process');
         const rawPrData    = execSync('gh pr list --state open --json number,url,author,title,body,headRefOid,reviewRequests,reviews,comments,createdAt,updatedAt,isDraft', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
         return JSON.parse(rawPrData);
+    }
+
+    /**
+     * @summary Fetches PRs merged within a window — the highest-signal "what happened" fact class
+     * for the handoff retrospective. Bounded by a `merged:>ISO` search so the query stays small.
+     * @param {Date} since Lower window bound.
+     * @returns {Promise<Array<{number: Number, title: String, mergedAt: String}>>}
+     */
+    async fetchRecentMergedPRs(since) {
+        const { execSync } = await import('child_process');
+        const sinceDate    = since.toISOString().slice(0, 10); // gh search granularity is day-level
+        const raw          = execSync(`gh pr list --state merged --search "merged:>=${sinceDate}" --json number,title,mergedAt --limit 50`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
+        return JSON.parse(raw);
+    }
+
+    /**
+     * @summary Assembles + renders the handoff retrospective section (the history leg) from window
+     * facts. Static + pure over its inputs: the assembler folds, the render emits — this shim is
+     * the synthesizer's stable seam to both, mirroring the computed-GP render shims.
+     * @param {Object} options
+     * @param {Object} options.facts `{mergedPrs, openedPrs, closedIssues, openedIssues, graduations, sessions}`
+     * @param {Object} [options.grain=RETROSPECTIVE_GRAINS.THREE_DAY] Retrospective grain
+     * @param {Date|String} [options.now=new Date()] Window anchor
+     * @param {String|String[]} [options.filterSets=[]] Declared filter set(s) the facts were gathered under
+     * @returns {String} Markdown section
+     */
+    static renderHandoffRetrospectiveSection({facts, grain = RETROSPECTIVE_GRAINS.THREE_DAY, now = new Date(), filterSets = []} = {}) {
+        const stats = assembleRetrospectiveStats({facts, grain, now, filterSets});
+
+        return renderHandoffRetrospectiveSection({grain, stats, capturedAt: now})
     }
 
     /**
@@ -1113,6 +1145,34 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             }
         }
 
+        // --- Handoff Retrospective (the history leg: "what happened since I last looked") ---
+        // Best-effort, like every enrichment block: a failure renders nothing, never crashes the
+        // handoff. Grain fixed to 3-day here — the batch file is not per-reader; staleness-adaptive
+        // grain selection is the interactive boot flow's concern (selectRetrospectiveGrain).
+        let retrospectiveAppend = '';
+        if (repoEnrichmentEnabled) {
+            try {
+                const capturedAt = now instanceof Date ? now : new Date(now),
+                      windowMs   = RETROSPECTIVE_GRAINS.THREE_DAY.windowHours * 3600 * 1000,
+                      mergedPrs  = (await this.fetchRecentMergedPRs(new Date(capturedAt.getTime() - windowMs)))
+                          .map(pr => ({ref: `PR #${pr.number}`, headline: pr.title, at: pr.mergedAt})),
+                      // opened-PRs-in-window come free from the already-fetched open-PR list
+                      openedPrs  = (Array.isArray(openPrs) ? openPrs : [])
+                          .map(pr => ({ref: `PR #${pr.number}`, headline: pr.title, at: pr.createdAt}));
+
+                retrospectiveAppend = this.constructor.renderHandoffRetrospectiveSection({
+                    facts: {mergedPrs, openedPrs},
+                    grain: RETROSPECTIVE_GRAINS.THREE_DAY,
+                    now  : capturedAt,
+                    // declared honestly: only the PR classes are wired so far — the filter set names
+                    // exactly what these counts cover, so the render never overstates the window
+                    filterSets: 'merged+opened PRs, all authors'
+                })
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Failed to generate Handoff Retrospective', e);
+            }
+        }
+
         // --- Work-Graph Stall Inference ---
         let stallFindingsAppend = '';
         if (repoEnrichmentEnabled) {
@@ -1170,7 +1230,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             }
         }
 
-        handoffContent += `${currentFocusAppend}${staleAssignmentAppend}${silentThreadsAppend}${prStateAppend}${stallFindingsAppend}${backlogAppend}${markdownAppend}`;
+        handoffContent += `${currentFocusAppend}${staleAssignmentAppend}${silentThreadsAppend}${prStateAppend}${stallFindingsAppend}${backlogAppend}${retrospectiveAppend}${markdownAppend}`;
 
         const handoffFile = aiConfig.handoffFilePath;
         fs.mkdirSync(path.dirname(handoffFile), {recursive: true});

--- a/ai/services/graph/handoffRetrospectiveAssembler.mjs
+++ b/ai/services/graph/handoffRetrospectiveAssembler.mjs
@@ -1,0 +1,120 @@
+import {RETROSPECTIVE_GRAINS} from './handoffRetrospective.mjs';
+
+/**
+ * @module ai/services/graph/handoffRetrospectiveAssembler
+ * @summary The retrospective ASSEMBLER — folds raw window facts into the stats contract that
+ * {@link module:ai/services/graph/handoffRetrospective.renderHandoffRetrospectiveSection}
+ * renders. The pure half of the history leg: no I/O, no clock of its own (the window anchor is
+ * an argument), so it is exhaustively unit-testable and replayable, exactly as the direction
+ * attribution pass is pure beneath its writer.
+ *
+ * Fact contract (each array holds `{ref, headline, at}`; `at` is an ISO string or Date):
+ * `{mergedPrs, openedPrs, closedIssues, openedIssues, graduations, sessions}`. The assembler
+ * windows each array by `at` against the grain, counts the survivors, and merges them into one
+ * recency-ranked `topEvents` list — the render caps the display, so the assembler hands over a
+ * bounded-but-generous slice rather than pre-truncating a single class.
+ *
+ * Filter-set honesty is preserved end to end: `filterSets` passes through to the render, which
+ * refuses to show naked counts without it. The assembler NEVER invents a filter set — an
+ * assembler that folds unfiltered facts must say so, or the render withholds.
+ */
+
+/**
+ * @summary How many merged events to hand the render — a generous multiple of the render's own
+ * display cap, so recency ranking happens over the real set, not a per-class pre-truncation.
+ * @type {Number}
+ */
+export const TOP_EVENT_ASSEMBLY_LIMIT = 20;
+
+/**
+ * @summary The fact classes the assembler folds, paired with the count key the render expects
+ * and the event-kind tag used in the merged top-events list.
+ * @type {Array<{source: String, countKey: String, kind: String}>}
+ */
+const FACT_CLASSES = Object.freeze([
+    {source: 'mergedPrs',    countKey: 'mergedPrs',    kind: 'merged-pr'},
+    {source: 'openedPrs',    countKey: 'openedPrs',    kind: 'opened-pr'},
+    {source: 'closedIssues', countKey: 'closedIssues', kind: 'closed-issue'},
+    {source: 'openedIssues', countKey: 'openedIssues', kind: 'opened-issue'},
+    {source: 'graduations',  countKey: 'graduations',  kind: 'graduation'},
+    {source: 'sessions',     countKey: 'sessions',     kind: 'session'}
+]);
+
+/**
+ * @summary Parses an event timestamp to epoch millis; unparseable / missing → NaN (excluded
+ * from the window, never crashing the fold).
+ * @param {String|Date|Number} at
+ * @returns {Number}
+ */
+function toEpoch(at) {
+    if (at instanceof Date) return at.getTime();
+    if (typeof at === 'number') return Number.isFinite(at) ? at : NaN;
+    if (typeof at === 'string') {
+        const parsed = Date.parse(at);
+        return Number.isNaN(parsed) ? NaN : parsed
+    }
+    return NaN
+}
+
+/**
+ * @summary Folds raw window facts into the render's stats contract for one grain.
+ *
+ * Windowing rule: an event is in-window when its `at` is within `grain.windowHours` before
+ * `now` (inclusive) and not in the future relative to `now`. Events with no parseable `at` are
+ * excluded from counts AND top-events — an undateable fact cannot be placed in a window
+ * honestly. When NO `filterSets` is supplied the contract still returns `filterSets: []`, which
+ * the render turns into the withheld state — the assembler never fabricates a filter declaration.
+ *
+ * @param {Object} options
+ * @param {Object} [options.facts={}] `{mergedPrs, openedPrs, closedIssues, openedIssues, graduations, sessions}`
+ * @param {Object} [options.grain=RETROSPECTIVE_GRAINS.DAILY] One of the render's grains
+ * @param {Date|String|Number} [options.now=new Date()] The window anchor (argument, never a clock read)
+ * @param {String|String[]} [options.filterSets=[]] The declared filter set(s) the facts were gathered under
+ * @returns {{filterSets: String[], computedAt: String, counts: Object, topEvents: Array<{ref, headline, at, kind}>}}
+ */
+export function assembleRetrospectiveStats({
+    facts      = {},
+    grain      = RETROSPECTIVE_GRAINS.DAILY,
+    now        = new Date(),
+    filterSets = []
+} = {}) {
+    const
+        nowEpoch    = toEpoch(now),
+        anchorEpoch = Number.isNaN(nowEpoch) ? Date.now() : nowEpoch,
+        windowMs    = (grain?.windowHours || RETROSPECTIVE_GRAINS.DAILY.windowHours) * 3600 * 1000,
+        lowerBound  = anchorEpoch - windowMs,
+        counts      = {},
+        allEvents   = [];
+
+    for (const {source, countKey, kind} of FACT_CLASSES) {
+        const raw = Array.isArray(facts?.[source]) ? facts[source] : [];
+
+        const inWindow = raw.filter(event => {
+            const epoch = toEpoch(event?.at);
+
+            return !Number.isNaN(epoch) && epoch >= lowerBound && epoch <= anchorEpoch
+        });
+
+        counts[countKey] = inWindow.length;
+
+        for (const event of inWindow) {
+            allEvents.push({
+                ref     : event.ref || '',
+                headline: event.headline || event.title || '',
+                at      : event.at,
+                kind
+            })
+        }
+    }
+
+    const topEvents = allEvents
+        .sort((a, b) => toEpoch(b.at) - toEpoch(a.at))
+        .slice(0, TOP_EVENT_ASSEMBLY_LIMIT);
+
+    return {
+        filterSets: [].concat(filterSets).filter(entry => typeof entry === 'string' && entry.trim() !== ''),
+        computedAt: (Number.isNaN(nowEpoch) ? new Date() : new Date(anchorEpoch)).toISOString(),
+        counts,
+        topEvents
+    }
+}

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -356,6 +356,54 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).not.toContain('- **Head SHA**:');
     });
 
+    test('synthesizeGoldenPath appends the Handoff Retrospective from merged + opened PR facts (#14706)', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        aiConfig.vectorDimension = 2;
+
+        StorageRouter.getGraphCollection   = async () => ({ query: async () => ({ ids: [['mock-id']], distances: [[0.1]] }) });
+        StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
+        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+
+        const now      = new Date();
+        const hoursAgo = h => new Date(now.getTime() - h * 3600 * 1000).toISOString();
+
+        const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
+        const originalFetchRecentMergedPRs = GoldenPathSynthesizer.fetchRecentMergedPRs;
+
+        // opened-PRs come from the open-PR list (in-window); merged-PRs from the bounded merged query
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [
+            {number: 14682, url: 'https://github.com/neomjs/neo/pull/14682', author: {login: 'neo-fable'}, title: 'registry snapshot clone', createdAt: hoursAgo(5), reviewRequests: [], reviews: [], comments: []}
+        ];
+        GoldenPathSynthesizer.fetchRecentMergedPRs = async () => [
+            {number: 14678, title: 'keeper request route', mergedAt: hoursAgo(3)},
+            {number: 99999, title: 'ancient merge outside the window', mergedAt: hoursAgo(500)}
+        ];
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({now});
+        } finally {
+            GoldenPathSynthesizer.fetchOpenPRs         = originalFetchOpenPRs;
+            GoldenPathSynthesizer.fetchRecentMergedPRs = originalFetchRecentMergedPRs;
+            StorageRouter.getGraphCollection           = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection         = originalGetSummaryCollection;
+            TextEmbeddingService.embedText             = originalEmbedText;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+
+        expect(handoffContent).toContain('## Handoff Retrospective (3-Day');
+        expect(handoffContent).toContain('- Merged PRs: 1 `[filters: merged+opened PRs, all authors]`');
+        expect(handoffContent).toContain('- Opened PRs: 1 `[filters: merged+opened PRs, all authors]`');
+        expect(handoffContent).toContain('PR #14678 — keeper request route');
+        expect(handoffContent).toContain('PR #14682 — registry snapshot clone');
+        // the 500h-old merge is outside the 3-day window — count stays 1, it never renders
+        expect(handoffContent).not.toContain('ancient merge outside the window');
+        // firewall: the retrospective introduces no numbered route entries into the handoff
+        expect(handoffContent).not.toMatch(/\d+\.\s\*\*issue-\d+\*\*:[^\n]*\n\s+-\s\*.*?\*/);
+    });
+
     test('synthesizeGoldenPath overwrites stale author sections when semantic candidates are empty', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
@@ -1751,22 +1799,22 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     test('renderWorkGraphStallFindingsSection is bounded, visibility-only, and honors render-off', () => {
         const findings = [
             {
-                evidenceRefs      : ['#9601', 'approvedAt:2026-07-01T01:00:00.000Z'],
-                findingClass      : 'DECISION_STARVED',
-                grade             : 'verified-stall',
-                motionPredicate   : 'PR merges or loses approval',
-                sourceFidelity    : 'verified',
-                subject           : {number: 9601, title: 'Approved PR', type: 'PR'},
-                waitingSince      : '2026-07-01T01:00:00.000Z'
+                evidenceRefs   : ['#9601', 'approvedAt:2026-07-01T01:00:00.000Z'],
+                findingClass   : 'DECISION_STARVED',
+                grade          : 'verified-stall',
+                motionPredicate: 'PR merges or loses approval',
+                sourceFidelity : 'verified',
+                subject        : {number: 9601, title: 'Approved PR', type: 'PR'},
+                waitingSince   : '2026-07-01T01:00:00.000Z'
             },
             {
-                evidenceRefs      : ['#9505', 'blockedBy:9506'],
-                findingClass      : 'STALE_DEFER',
-                grade             : 'candidate-stall',
-                motionPredicate   : 'defer exit satisfied',
-                sourceFidelity    : 'candidate',
-                subject           : {number: 9505, title: 'Resolved blocker defer', type: 'ISSUE'},
-                waitingSince      : '2026-05-15T00:00:00.000Z'
+                evidenceRefs   : ['#9505', 'blockedBy:9506'],
+                findingClass   : 'STALE_DEFER',
+                grade          : 'candidate-stall',
+                motionPredicate: 'defer exit satisfied',
+                sourceFidelity : 'candidate',
+                subject        : {number: 9505, title: 'Resolved blocker defer', type: 'ISSUE'},
+                waitingSince   : '2026-05-15T00:00:00.000Z'
             }
         ];
 

--- a/test/playwright/unit/ai/services/graph/handoffRetrospectiveAssembler.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/handoffRetrospectiveAssembler.spec.mjs
@@ -1,0 +1,121 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'HandoffRetrospectiveAssemblerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('handoffRetrospectiveAssembler — the pure fold beneath the render', () => {
+    let assemble, render, grains;
+
+    const NOW      = '2026-07-04T12:00:00Z';
+    const hoursAgo = h => new Date(Date.parse(NOW) - h * 3600 * 1000).toISOString();
+
+    test.beforeAll(async () => {
+        const asm = await import('../../../../../../ai/services/graph/handoffRetrospectiveAssembler.mjs');
+        const rnd = await import('../../../../../../ai/services/graph/handoffRetrospective.mjs');
+        assemble = asm.assembleRetrospectiveStats;
+        render   = rnd.renderHandoffRetrospectiveSection;
+        grains   = rnd.RETROSPECTIVE_GRAINS;
+    });
+
+    test('windows facts by the grain and counts survivors per class', () => {
+        const facts = {
+            mergedPrs   : [{ref: 'PR #1', headline: 'in',  at: hoursAgo(10)}, {ref: 'PR #2', headline: 'out', at: hoursAgo(50)}],
+            openedPrs   : [{ref: 'PR #3', headline: 'in',  at: hoursAgo(5)}],
+            closedIssues: [{ref: '#4', headline: 'in', at: hoursAgo(1)}, {ref: '#5', headline: 'in', at: hoursAgo(23)}],
+            graduations : [{ref: '#6', headline: 'grad', at: hoursAgo(2)}],
+            sessions    : [{ref: 's1', headline: 'sess', at: hoursAgo(200)}] // outside even a daily window
+        };
+
+        const daily = assemble({facts, grain: grains.DAILY, now: NOW, filterSets: 'non-chore'});
+
+        // daily window = 24h: the 50h PR and 200h session fall out; everything else counts
+        expect(daily.counts).toEqual({mergedPrs: 1, openedPrs: 1, closedIssues: 2, openedIssues: 0, graduations: 1, sessions: 0});
+        expect(daily.filterSets).toEqual(['non-chore']);
+        expect(daily.computedAt).toBe(new Date(NOW).toISOString()); // canonical ISO (…000Z)
+
+        // widening to weekly pulls the 50h PR back in but the 200h session stays out (168h window)
+        const weekly = assemble({facts, grain: grains.WEEKLY, now: NOW, filterSets: 'non-chore'});
+        expect(weekly.counts.mergedPrs).toBe(2);
+        expect(weekly.counts.sessions).toBe(0);
+    });
+
+    test('top events merge all classes and rank by recency, tagged by kind', () => {
+        const facts = {
+            mergedPrs   : [{ref: 'PR #9', headline: 'oldest', at: hoursAgo(20)}],
+            graduations : [{ref: '#10', headline: 'newest', at: hoursAgo(1)}],
+            closedIssues: [{ref: '#11', headline: 'middle', at: hoursAgo(10)}]
+        };
+
+        const stats = assemble({facts, grain: grains.DAILY, now: NOW, filterSets: 'non-chore'});
+
+        expect(stats.topEvents.map(e => e.headline)).toEqual(['newest', 'middle', 'oldest']);
+        expect(stats.topEvents.map(e => e.kind)).toEqual(['graduation', 'closed-issue', 'merged-pr']);
+    });
+
+    test('undateable and future events are excluded, never crashing the fold', () => {
+        const facts = {
+            mergedPrs: [
+                {ref: 'PR #1', headline: 'no date'},
+                {ref: 'PR #2', headline: 'bad date', at: 'not-a-date'},
+                {ref: 'PR #3', headline: 'future',   at: hoursAgo(-5)}, // 5h AFTER now
+                {ref: 'PR #4', headline: 'valid',    at: hoursAgo(3)}
+            ]
+        };
+
+        const stats = assemble({facts, grain: grains.DAILY, now: NOW, filterSets: 'non-chore'});
+
+        expect(stats.counts.mergedPrs).toBe(1);
+        expect(stats.topEvents).toHaveLength(1);
+        expect(stats.topEvents[0].headline).toBe('valid');
+    });
+
+    test('no filter set → empty filterSets → the render withholds (honesty round-trip)', () => {
+        const facts = {mergedPrs: [{ref: 'PR #1', headline: 'x', at: hoursAgo(1)}]};
+
+        const undeclared = assemble({facts, grain: grains.DAILY, now: NOW});
+        expect(undeclared.filterSets).toEqual([]);
+
+        // the assembler's output feeds the render directly: undeclared → withheld, not naked counts
+        const section = render({grain: grains.DAILY, stats: undeclared});
+        expect(section).toContain('Counts withheld');
+        expect(section).not.toContain('1');
+    });
+
+    test('assembler output renders end-to-end through the real render module', () => {
+        const facts = {
+            mergedPrs  : [{ref: 'PR #14678', headline: 'keeper route merged', at: hoursAgo(2)}],
+            graduations: [{ref: '#14565', headline: 'direction GP epic', at: hoursAgo(6)}]
+        };
+
+        const stats   = assemble({facts, grain: grains.THREE_DAY, now: NOW, filterSets: ['non-chore', 'agent-authored']});
+        const section = render({grain: grains.THREE_DAY, stats, capturedAt: NOW});
+
+        expect(section).toContain('Handoff Retrospective (3-Day');
+        expect(section).toContain('- Merged PRs: 1 `[filters: non-chore + agent-authored]`');
+        expect(section).toContain('PR #14678 — keeper route merged');
+        expect(section).not.toMatch(/\*\*issue-\d+\*\*:/); // firewall holds on real assembled data
+    });
+
+    test('empty facts yield an all-zero contract the render turns into the quiet state', () => {
+        const stats   = assemble({facts: {}, grain: grains.DAILY, now: NOW, filterSets: 'non-chore'});
+        const section = render({grain: grains.DAILY, stats});
+
+        expect(Object.values(stats.counts).every(c => c === 0)).toBe(true);
+        expect(stats.topEvents).toHaveLength(0);
+        expect(section).toContain('Quiet window');
+    });
+});


### PR DESCRIPTION
## Summary

The follow-up to the render leaf (#14603 / PR #14694): the **assembler + synthesizer wiring** that makes the "what happened since I last looked" section appear in the **live handoff**, beside the Computed Golden Path — the operator's #11375 catch-up seed, delivered. Pure-fold first, live-wired second: same sequencing as the direction-attribution chain.

Resolves #14706
Refs #14603 · #11375

> **#14603 (PR #14694) is MERGED** — this PR is now a clean 4-file diff against `dev`: `ai/services/graph/handoffRetrospectiveAssembler.mjs` (new) + the `GoldenPathSynthesizer.mjs` wiring + `handoffRetrospectiveAssembler.spec.mjs` (new) + the `GoldenPathSynthesizer.spec.mjs` +1 integration test.

## Deltas

- **NEW `ai/services/graph/handoffRetrospectiveAssembler.mjs`** — pure `assembleRetrospectiveStats({facts, grain, now, filterSets})`: windows each fact class (`mergedPrs/openedPrs/closedIssues/openedIssues/graduations/sessions`) by `at` against the grain, counts survivors, merges into one recency-ranked `topEvents` list tagged by kind. No I/O, no clock of its own (the anchor is an argument) — exhaustively unit-testable and replayable, exactly like the direction-attribution pass beneath its writer. Filter-set honesty is preserved end to end: it never fabricates a `filterSets`, so an unfiltered fold renders as withheld downstream.
- **`ai/services/graph/GoldenPathSynthesizer.mjs`** — the live wiring:
  - `fetchRecentMergedPRs(since)` — a bounded `gh pr list --state merged --search "merged:>=…"` for the highest-signal "what happened" class.
  - static `renderHandoffRetrospectiveSection(...)` shim (assemble → render), mirroring the computed-GP render shims.
  - the call-site block (best-effort, try/caught like every enrichment block — a failure renders nothing, never crashes the handoff): folds **merged PRs** (bounded query) + **opened PRs** (free, from the already-fetched open-PR list) into the section, declares its filter set **honestly** (`merged+opened PRs, all authors` — it names exactly what's covered so the render never overstates the window), appends it before the computed-GP section. Grain fixed to 3-day (the batch file is not per-reader; staleness-adaptive selection is the interactive boot flow's concern via `selectRetrospectiveGrain`).
- **NEW `test/playwright/unit/ai/services/graph/handoffRetrospectiveAssembler.spec.mjs`** — 6 tests: windowing per class + grain-widening · recency-ranked kind-tagged top-events · undateable/future exclusion · the no-filter→withheld honesty round-trip through the real render · end-to-end render + firewall-holds-on-assembled-data · empty→quiet-state.
- **`test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs`** — +1 integration test: mocks both PR fetches, runs `synthesizeGoldenPath`, and asserts the **written handoff file** contains the retrospective section with the right counts + declared filters, that an out-of-window merge never renders, and that the section introduces no parseable route entry (the #14603 firewall holding in the real file).

## Scope honesty — the enrichment boundary (AC-tracked on #14706)

Two of six fact classes are wired live (merged + opened PRs — the highest-signal, zero-new-heavy-query pair). The remaining four — **closed/opened issues, graduations, sessions** — are honest enrichment ACs on #14706: each needs its own bounded reader (issue timestamps, graduation-comment detection, summary-collection counts). The section is live and non-empty today; it grows fact classes without any assembler or render change (they already support all six). This is the same "ship the proven spine, name the enrichment" discipline as the render leaf's assembler split.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs handoffRetrospectiveAssembler` → **6 passed**. `… GoldenPathSynthesizer` → **42 passed** (was 41; +1 the live-wiring integration test). Combined retrospective suite → 11 passed.

Evidence: L2 (unit + synthesizer-integration with mocked gh; the assembler fold is pure and exhaustively pinned, the wiring is proven against the written handoff file).

## Post-Merge Validation

- The FM cockpit catch-up view (#14560 T7.26) consumes `assembleRetrospectiveStats` instead of re-deriving window folds — the second consumer this pure module exists for.
- The enrichment leaves (issues/graduations/sessions readers) add fact classes with zero change to the assembler or render.
- A live dream cycle emits the section into `sandman_handoff.md`; the orchestrator's `parseGoldenPath()` still routes only real computed lanes with it present.

## Related

#14603 / PR #14694 (the render leaf this wires — parent of the stack) · #11375 (operator seed) · #14570 (the forecast sibling, opposite temporal direction) · #14560 T7.26 (the cockpit consumer) · ADR 0028 (substrate) · ADR 0033 (filter-set discipline).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b9b95ac6-42f5-47a3-b58f-6071f79657e8.
