### PR TITLE
feat(agentos): accept path — blueprint to live instance via the one create path (#14689)

### DIFF
--- a/apps/agentos/view/create/util/acceptPath.mjs
+++ b/apps/agentos/view/create/util/acceptPath.mjs
@@ -1,0 +1,220 @@
+import {validateBlueprint, validateMutation} from './blueprintSchema.mjs';
+
+/**
+ * @module AgentOS.view.create.util.acceptPath
+ * @summary The accept path: carries an ACCEPTED blueprint into a live component through the ONE
+ * create path, and keeps the created-instance registry truthful over the create → mutate →
+ * dispose lifecycle.
+ *
+ * Join, never fork: widgets enter the stage via the container `add → insert` seam — the same
+ * seam a Neural-Link `create_component` drives — so provenance projection works identically for
+ * in-app and external creations. This module therefore never instantiates directly; it builds a
+ * stage-insertable config (`ntype`, wire-safe — module references cannot cross the Neural Link)
+ * and calls the injected stage's `add()`.
+ *
+ * Accept-side validation runs the SAME imported `validateBlueprint` the emit side runs — the
+ * fail-closed-both-sides contract as two call sites of ONE validator, never a second rule set.
+ * Every failure returns the pipeline's bounded refusal shape `{accepted, reason, stage}`; nothing
+ * in this module throws into a render path.
+ */
+
+/**
+ * @summary The accept path's failure stages, extending the route's vocabulary.
+ * @type {Object}
+ */
+export const ACCEPT_STAGES = Object.freeze({
+    ACCEPT  : 'accept',
+    MUTATION: 'mutation',
+    DISPOSE : 'dispose'
+});
+
+/**
+ * @summary Schema-keyed materializers — the render half of the schema registry: `materialize`
+ * builds the stage-insertable component config from an accepted blueprint; `apply` writes an
+ * accepted MERGED blueprint onto the live component. Adding a widget type here is ONE entry,
+ * keyed by the exact same schema id the validator registry uses; a schema present in one
+ * registry and absent here is a coverage defect the accept path refuses loudly.
+ * @type {Object}
+ */
+export const SCHEMA_MATERIALIZERS = Object.freeze({
+    'grid@1': Object.freeze({
+        /**
+         * Generalizes the shipped first-widget grid mapping: wire-safe `ntype`, columns from the
+         * blueprint's `{field, text}` pairs, an inline store with string fields derived from the
+         * same columns, data as the blueprint rows.
+         * @param {Object} blueprint Accepted `grid@1` blueprint
+         * @param {Object} identity
+         * @param {String} identity.instanceId
+         * @returns {Object} stage-insertable component config
+         */
+        materialize(blueprint, {instanceId}) {
+            const columns = blueprint.config.columns.map(column => ({dataField: column.field, text: column.text}));
+
+            return {
+                ntype    : 'grid-container',
+                reference: instanceId,
+                title    : blueprint.title,
+                flex     : 1,
+                columns,
+                ...(blueprint.config.height !== undefined ? {height: blueprint.config.height} : {}),
+                ...(blueprint.config.width  !== undefined ? {width : blueprint.config.width}  : {}),
+                store: {
+                    model: {fields: columns.map(column => ({name: column.dataField, type: 'String'}))},
+                    data : blueprint.data
+                },
+                // provenance stamp: the insert-side registrar reads this to write the registry
+                // record at the same moment the provenance projection fires; external
+                // create_component inserts carry no stamp and are untouched by the registrar
+                blueprintMeta: {instanceId, schema: blueprint.schema, title: blueprint.title, blueprintSnapshot: blueprint}
+            }
+        },
+        /**
+         * @param {Object} component The live grid (title / store.data / dimension configs)
+         * @param {Object} merged The validator's merged blueprint
+         */
+        apply(component, merged) {
+            component.title = merged.title;
+
+            if (merged.config.height !== undefined) {
+                component.height = merged.config.height
+            }
+
+            if (merged.config.width !== undefined) {
+                component.width = merged.config.width
+            }
+
+            component.store.data = merged.data
+        }
+    })
+});
+
+/**
+ * @summary Accepts a blueprint into the stage: validates it on the accept side (same validator,
+ * second call site), materializes the wire-safe config, and routes it through the injected
+ * stage's `add()` — the ONE create path. Registration happens on the stage's `insert` event via
+ * {@link createInsertRegistrar}, never here — the registry becomes truthful at the same moment
+ * the provenance projection fires.
+ * @param {Object} options
+ * @param {Object} options.blueprint The route-accepted blueprint
+ * @param {String} options.instanceId Caller-assigned unique instance id
+ * @param {Object} options.stage The live stage container (must expose `add`)
+ * @returns {{accepted: Boolean, config: Object|null, reason: String|null, stage: String|null}}
+ */
+export function acceptBlueprint({blueprint, instanceId, stage} = {}) {
+    if (typeof instanceId !== 'string' || instanceId.trim() === '') {
+        return {accepted: false, config: null, reason: 'accept requires a non-empty string instanceId', stage: ACCEPT_STAGES.ACCEPT};
+    }
+
+    if (!stage || typeof stage.add !== 'function') {
+        return {accepted: false, config: null, reason: 'no live stage injected — the accept path never creates outside the stage seam', stage: ACCEPT_STAGES.ACCEPT};
+    }
+
+    const validation = validateBlueprint(blueprint);
+
+    if (!validation.accepted) {
+        return {accepted: false, config: null, reason: validation.reason, stage: ACCEPT_STAGES.ACCEPT};
+    }
+
+    const materializer = SCHEMA_MATERIALIZERS[blueprint.schema];
+
+    if (!materializer) {
+        return {accepted: false, config: null, reason: `schema "${blueprint.schema}" validates but has no registered materializer — registry coverage defect`, stage: ACCEPT_STAGES.ACCEPT};
+    }
+
+    const config = materializer.materialize(blueprint, {instanceId});
+
+    stage.add(config);
+
+    return {accepted: true, config, reason: null, stage: null}
+}
+
+/**
+ * @summary Builds the stage `insert` observer that writes the registry record for
+ * blueprint-created components. Inserts without a provenance stamp (external
+ * `create_component`, static items) are ignored — the registrar only records what the accept
+ * path materialized.
+ * @param {Object} options
+ * @param {Object} options.registry The CreatedInstances singleton (or a double in tests)
+ * @returns {Function} `({item}) => {accepted, reason, record}|null`
+ */
+export function createInsertRegistrar({registry}) {
+    return function onStageInsert({item} = {}) {
+        const meta = item?.blueprintMeta;
+
+        if (!meta) return null;
+
+        return registry.registerCreated({
+            instanceId       : meta.instanceId,
+            blueprintSchema  : meta.schema,
+            title            : meta.title,
+            blueprintSnapshot: meta.blueprintSnapshot,
+            paneRef          : item.reference || null
+        })
+    }
+}
+
+/**
+ * @summary Routes a follow-up mutation: pulls the current snapshot from the registry, runs the
+ * shared merge-then-validate contract, applies the MERGED blueprint to the live component via
+ * the schema's applier, then records the outcome. The registry snapshot is the current-blueprint
+ * argument — no surface ever hand-merges.
+ * @param {Object} options
+ * @param {String} options.instanceId
+ * @param {Object} options.mutation Partial `{title?, config?, data?}`
+ * @param {Object} options.registry The CreatedInstances singleton
+ * @param {Function} options.resolveComponent `(instanceId) => live component|null`
+ * @returns {{accepted: Boolean, reason: String|null, stage: String|null, blueprint: Object|null}}
+ */
+export function mutateInstance({instanceId, mutation, registry, resolveComponent} = {}) {
+    const record = registry?.resolveTarget?.({instanceId});
+
+    if (!record) {
+        return {accepted: false, reason: `no registry record for instanceId "${instanceId}"`, stage: ACCEPT_STAGES.MUTATION, blueprint: null};
+    }
+
+    if (record.state !== 'live') {
+        return {accepted: false, reason: `instanceId "${instanceId}" is disposed — disposed instances never mutate`, stage: ACCEPT_STAGES.MUTATION, blueprint: null};
+    }
+
+    const validation = validateMutation(record.blueprintSnapshot, mutation);
+
+    if (!validation.accepted) {
+        return {accepted: false, reason: validation.reason, stage: ACCEPT_STAGES.MUTATION, blueprint: null};
+    }
+
+    const component = typeof resolveComponent === 'function' ? resolveComponent(instanceId) : null;
+
+    if (!component) {
+        return {accepted: false, reason: `no live component resolvable for "${instanceId}" — registry and stage disagree`, stage: ACCEPT_STAGES.MUTATION, blueprint: null};
+    }
+
+    SCHEMA_MATERIALIZERS[validation.blueprint.schema].apply(component, validation.blueprint);
+
+    registry.markMutated(instanceId, {title: validation.blueprint.title, blueprintSnapshot: validation.blueprint});
+
+    return {accepted: true, reason: null, stage: null, blueprint: validation.blueprint}
+}
+
+/**
+ * @summary Disposes a created instance: destroys the live component when resolvable, then flips
+ * the registry record (kept, state `disposed`). A missing component does not block the registry
+ * flip — a half-dead instance must still leave truthful state.
+ * @param {Object} options
+ * @param {String} options.instanceId
+ * @param {Object} options.registry The CreatedInstances singleton
+ * @param {Function} [options.resolveComponent] `(instanceId) => live component|null`
+ * @returns {{accepted: Boolean, reason: String|null, stage: String|null}}
+ */
+export function disposeInstance({instanceId, registry, resolveComponent} = {}) {
+    const flipped = registry?.markDisposed?.(instanceId);
+
+    if (!flipped?.accepted) {
+        return {accepted: false, reason: flipped?.reason || 'registry unavailable', stage: ACCEPT_STAGES.DISPOSE};
+    }
+
+    const component = typeof resolveComponent === 'function' ? resolveComponent(instanceId) : null;
+
+    component?.destroy?.();
+
+    return {accepted: true, reason: null, stage: null}
+}

--- a/apps/agentos/view/create/util/acceptPath.mjs
+++ b/apps/agentos/view/create/util/acceptPath.mjs
@@ -98,9 +98,13 @@ export const SCHEMA_MATERIALIZERS = Object.freeze({
  * @param {Object} options.blueprint The route-accepted blueprint
  * @param {String} options.instanceId Caller-assigned unique instance id
  * @param {Object} options.stage The live stage container (must expose `add`)
+ * @param {Object} [options.registry] The CreatedInstances singleton. When provided, the id is
+ *   pre-checked for uniqueness BEFORE insertion so the insert-side registrar cannot refuse after
+ *   the component is already in the stage — closing the stage-truth vs registry-truth gap. Omit
+ *   only when the caller otherwise guarantees id uniqueness.
  * @returns {{accepted: Boolean, config: Object|null, reason: String|null, stage: String|null}}
  */
-export function acceptBlueprint({blueprint, instanceId, stage} = {}) {
+export function acceptBlueprint({blueprint, instanceId, stage, registry} = {}) {
     if (typeof instanceId !== 'string' || instanceId.trim() === '') {
         return {accepted: false, config: null, reason: 'accept requires a non-empty string instanceId', stage: ACCEPT_STAGES.ACCEPT};
     }
@@ -119,6 +123,15 @@ export function acceptBlueprint({blueprint, instanceId, stage} = {}) {
 
     if (!materializer) {
         return {accepted: false, config: null, reason: `schema "${blueprint.schema}" validates but has no registered materializer — registry coverage defect`, stage: ACCEPT_STAGES.ACCEPT};
+    }
+
+    // Refuse a duplicate id BEFORE touching the stage: the insert-side registrar would refuse
+    // registration for an already-known id, but only after the component is already inserted —
+    // leaving stage truth and registry truth diverged while the caller saw success. Pre-checking
+    // here makes registration-blocking refusal part of the accept outcome, so a truthful insert is
+    // the only insert that happens.
+    if (registry?.resolveTarget?.({instanceId})) {
+        return {accepted: false, config: null, reason: `instanceId "${instanceId}" is already registered — one record per instance`, stage: ACCEPT_STAGES.ACCEPT};
     }
 
     const config = materializer.materialize(blueprint, {instanceId});
@@ -188,7 +201,15 @@ export function mutateInstance({instanceId, mutation, registry, resolveComponent
         return {accepted: false, reason: `no live component resolvable for "${instanceId}" — registry and stage disagree`, stage: ACCEPT_STAGES.MUTATION, blueprint: null};
     }
 
-    SCHEMA_MATERIALIZERS[validation.blueprint.schema].apply(component, validation.blueprint);
+    // Apply the merged blueprint to the live component. A wrong-shaped or stale component (e.g.
+    // one missing the store the schema writes) is the same registry/stage-disagreement class as a
+    // missing one: fail closed with a bounded refusal and DO NOT record the mutation — a thrown
+    // applier must never leave the registry claiming a change the component never took.
+    try {
+        SCHEMA_MATERIALIZERS[validation.blueprint.schema].apply(component, validation.blueprint);
+    } catch (error) {
+        return {accepted: false, reason: `live component for "${instanceId}" could not take the mutation (registry/stage disagree): ${error instanceof Error ? error.message : String(error)}`, stage: ACCEPT_STAGES.MUTATION, blueprint: null};
+    }
 
     registry.markMutated(instanceId, {title: validation.blueprint.title, blueprintSnapshot: validation.blueprint});
 

--- a/apps/agentos/view/create/util/acceptPath.mjs
+++ b/apps/agentos/view/create/util/acceptPath.mjs
@@ -29,6 +29,20 @@ export const ACCEPT_STAGES = Object.freeze({
 });
 
 /**
+ * @summary The DEFAULT component resolution: the framework instance manager. Every created
+ * component self-registers by id (`afterSetId` → `Neo.manager.Instance`), and the materializer
+ * stamps `id: instanceId`, so `Neo.get(instanceId)` returns the live `Neo.core.Base` instance or
+ * null — instance shape is a framework guarantee on this path, never a hope. Passing a custom
+ * `resolveComponent` remains supported as a TEST seam only; production callers should not
+ * override it.
+ * @param {String} instanceId
+ * @returns {Neo.core.Base|null}
+ */
+function resolveViaInstanceManager(instanceId) {
+    return (typeof Neo !== 'undefined' && typeof Neo.get === 'function') ? (Neo.get(instanceId) || null) : null
+}
+
+/**
  * @summary Schema-keyed materializers — the render half of the schema registry: `materialize`
  * builds the stage-insertable component config from an accepted blueprint; `apply` writes an
  * accepted MERGED blueprint onto the live component. Adding a widget type here is ONE entry,
@@ -51,6 +65,10 @@ export const SCHEMA_MATERIALIZERS = Object.freeze({
             const columns = blueprint.config.columns.map(column => ({dataField: column.field, text: column.text}));
 
             return {
+                // id + reference both set to the instanceId (the shipped first-widget parity):
+                // the id makes the instance resolvable via the framework instance manager
+                // (Neo.get); the reference keeps container-scoped getReference() lookups working
+                id       : instanceId,
                 ntype    : 'grid-container',
                 reference: instanceId,
                 title    : blueprint.title,
@@ -69,19 +87,20 @@ export const SCHEMA_MATERIALIZERS = Object.freeze({
             }
         },
         /**
-         * @param {Object} component The live grid (title / store.data / dimension configs)
+         * Applies the merged blueprint through the framework's batched mutation path: ONE
+         * `component.set()` call for the component-level configs (the EffectManager pauses,
+         * every beforeSet/afterSet hook sees the complete new value set, bindings/effects
+         * cascade once), then a single store-level data assignment. Never a chain of direct
+         * property writes — each of those fires its own reactive cascade.
+         * @param {Neo.core.Base} component The live grid instance
          * @param {Object} merged The validator's merged blueprint
          */
         apply(component, merged) {
-            component.title = merged.title;
-
-            if (merged.config.height !== undefined) {
-                component.height = merged.config.height
-            }
-
-            if (merged.config.width !== undefined) {
-                component.width = merged.config.width
-            }
+            component.set({
+                title: merged.title,
+                ...(merged.config.height !== undefined ? {height: merged.config.height} : {}),
+                ...(merged.config.width  !== undefined ? {width : merged.config.width}  : {})
+            });
 
             component.store.data = merged.data
         }
@@ -175,10 +194,11 @@ export function createInsertRegistrar({registry}) {
  * @param {String} options.instanceId
  * @param {Object} options.mutation Partial `{title?, config?, data?}`
  * @param {Object} options.registry The CreatedInstances singleton
- * @param {Function} options.resolveComponent `(instanceId) => live component|null`
+ * @param {Function} [options.resolveComponent] `(instanceId) => live component|null`; defaults to
+ *   the framework instance manager (`Neo.get`) — override only as a test seam
  * @returns {{accepted: Boolean, reason: String|null, stage: String|null, blueprint: Object|null}}
  */
-export function mutateInstance({instanceId, mutation, registry, resolveComponent} = {}) {
+export function mutateInstance({instanceId, mutation, registry, resolveComponent = resolveViaInstanceManager} = {}) {
     const record = registry?.resolveTarget?.({instanceId});
 
     if (!record) {
@@ -201,10 +221,11 @@ export function mutateInstance({instanceId, mutation, registry, resolveComponent
         return {accepted: false, reason: `no live component resolvable for "${instanceId}" — registry and stage disagree`, stage: ACCEPT_STAGES.MUTATION, blueprint: null};
     }
 
-    // Apply the merged blueprint to the live component. A wrong-shaped or stale component (e.g.
-    // one missing the store the schema writes) is the same registry/stage-disagreement class as a
-    // missing one: fail closed with a bounded refusal and DO NOT record the mutation — a thrown
-    // applier must never leave the registry claiming a change the component never took.
+    // Apply the merged blueprint through the framework's batched path. On the default
+    // (instance-manager) resolution the component shape is a framework guarantee; this guard is
+    // belt-and-suspenders for ANY applier/set failure (a hook throwing, an injected test double):
+    // fail closed with a bounded refusal and DO NOT record the mutation — a thrown applier must
+    // never leave the registry claiming a change the component never took.
     try {
         SCHEMA_MATERIALIZERS[validation.blueprint.schema].apply(component, validation.blueprint);
     } catch (error) {
@@ -223,10 +244,11 @@ export function mutateInstance({instanceId, mutation, registry, resolveComponent
  * @param {Object} options
  * @param {String} options.instanceId
  * @param {Object} options.registry The CreatedInstances singleton
- * @param {Function} [options.resolveComponent] `(instanceId) => live component|null`
+ * @param {Function} [options.resolveComponent] `(instanceId) => live component|null`; defaults to
+ *   the framework instance manager (`Neo.get`) — override only as a test seam
  * @returns {{accepted: Boolean, reason: String|null, stage: String|null}}
  */
-export function disposeInstance({instanceId, registry, resolveComponent} = {}) {
+export function disposeInstance({instanceId, registry, resolveComponent = resolveViaInstanceManager} = {}) {
     const flipped = registry?.markDisposed?.(instanceId);
 
     if (!flipped?.accepted) {

--- a/apps/agentos/view/create/util/acceptPath.mjs
+++ b/apps/agentos/view/create/util/acceptPath.mjs
@@ -29,10 +29,10 @@ export const ACCEPT_STAGES = Object.freeze({
 });
 
 /**
- * @summary The DEFAULT component resolution: the framework instance manager. Every created
+ * @summary The DEFAULT component resolution: the neo core instance manager. Every created
  * component self-registers by id (`afterSetId` → `Neo.manager.Instance`), and the materializer
  * stamps `id: instanceId`, so `Neo.get(instanceId)` returns the live `Neo.core.Base` instance or
- * null — instance shape is a framework guarantee on this path, never a hope. Passing a custom
+ * null — instance shape is a core-contract guarantee on this path, never a hope. Passing a custom
  * `resolveComponent` remains supported as a TEST seam only; production callers should not
  * override it.
  * @param {String} instanceId
@@ -66,7 +66,7 @@ export const SCHEMA_MATERIALIZERS = Object.freeze({
 
             return {
                 // id + reference both set to the instanceId (the shipped first-widget parity):
-                // the id makes the instance resolvable via the framework instance manager
+                // the id makes the instance resolvable via the core instance manager
                 // (Neo.get); the reference keeps container-scoped getReference() lookups working
                 id       : instanceId,
                 ntype    : 'grid-container',
@@ -87,7 +87,7 @@ export const SCHEMA_MATERIALIZERS = Object.freeze({
             }
         },
         /**
-         * Applies the merged blueprint through the framework's batched mutation path: ONE
+         * Applies the merged blueprint through neo core's batched mutation path: ONE
          * `component.set()` call for the component-level configs (the EffectManager pauses,
          * every beforeSet/afterSet hook sees the complete new value set, bindings/effects
          * cascade once), then a single store-level data assignment. Never a chain of direct
@@ -195,7 +195,7 @@ export function createInsertRegistrar({registry}) {
  * @param {Object} options.mutation Partial `{title?, config?, data?}`
  * @param {Object} options.registry The CreatedInstances singleton
  * @param {Function} [options.resolveComponent] `(instanceId) => live component|null`; defaults to
- *   the framework instance manager (`Neo.get`) — override only as a test seam
+ *   the core instance manager (`Neo.get`) — override only as a test seam
  * @returns {{accepted: Boolean, reason: String|null, stage: String|null, blueprint: Object|null}}
  */
 export function mutateInstance({instanceId, mutation, registry, resolveComponent = resolveViaInstanceManager} = {}) {
@@ -221,8 +221,8 @@ export function mutateInstance({instanceId, mutation, registry, resolveComponent
         return {accepted: false, reason: `no live component resolvable for "${instanceId}" — registry and stage disagree`, stage: ACCEPT_STAGES.MUTATION, blueprint: null};
     }
 
-    // Apply the merged blueprint through the framework's batched path. On the default
-    // (instance-manager) resolution the component shape is a framework guarantee; this guard is
+    // Apply the merged blueprint through the core's batched path. On the default
+    // (instance-manager) resolution the component shape is a core-contract guarantee; this guard is
     // belt-and-suspenders for ANY applier/set failure (a hook throwing, an injected test double):
     // fail closed with a bounded refusal and DO NOT record the mutation — a thrown applier must
     // never leave the registry claiming a change the component never took.
@@ -245,7 +245,7 @@ export function mutateInstance({instanceId, mutation, registry, resolveComponent
  * @param {String} options.instanceId
  * @param {Object} options.registry The CreatedInstances singleton
  * @param {Function} [options.resolveComponent] `(instanceId) => live component|null`; defaults to
- *   the framework instance manager (`Neo.get`) — override only as a test seam
+ *   the core instance manager (`Neo.get`) — override only as a test seam
  * @returns {{accepted: Boolean, reason: String|null, stage: String|null}}
  */
 export function disposeInstance({instanceId, registry, resolveComponent = resolveViaInstanceManager} = {}) {

--- a/test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs
@@ -63,6 +63,7 @@ test.describe('acceptPath — blueprint → live instance via the ONE create pat
 
         expect(result.accepted).toBe(true);
         expect(result.config.ntype).toBe('grid-container');           // wire-safe, never a module ref
+        expect(result.config.id).toBe('ap-1');                        // instance-manager resolvable (Neo.get)
         expect(result.config.reference).toBe('ap-1');
         expect(result.config.columns).toEqual([{dataField: 'name', text: 'Name'}, {dataField: 'city', text: 'City'}]);
         expect(stage.added).toHaveLength(1);                          // the ONE create path was used
@@ -110,7 +111,13 @@ test.describe('acceptPath — blueprint → live instance via the ONE create pat
         stage.on('insert', registrar);
         accept.acceptBlueprint({blueprint: validGrid('Mutate Grid'), instanceId: 'ap-m1', stage});
 
-        const component        = {title: 'Mutate Grid', store: {data: []}};
+        // a framework-shaped double: the applier goes through set() (the batched mutation path),
+        // so the double must honor that contract — a bare property bag correctly REFUSES now
+        const component = {
+            title: 'Mutate Grid',
+            store: {data: []},
+            set(values) { Object.assign(this, values) }
+        };
         const resolveComponent = id => id === 'ap-m1' ? component : null;
 
         const grown = accept.mutateInstance({

--- a/test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs
@@ -136,9 +136,46 @@ test.describe('acceptPath — blueprint → live instance via the ONE create pat
         expect(attack).toMatchObject({accepted: false, stage: accept.ACCEPT_STAGES.MUTATION});
         expect(CreatedInstances.resolveTarget({instanceId: 'ap-m1'}).blueprintSnapshot.config.height).toBe(500);
 
-        // registry/stage disagreement fails closed
+        // registry/stage disagreement fails closed — MISSING component
         expect(accept.mutateInstance({instanceId: 'ap-m1', mutation: {config: {width: 300}}, registry: CreatedInstances, resolveComponent: () => null}).reason)
             .toContain('disagree');
+
+        // registry/stage disagreement fails closed — WRONG-SHAPED component (no store the applier writes):
+        // the applier throws, but the result is a bounded refusal and the registry is NOT updated
+        const wrongShaped = accept.mutateInstance({
+            instanceId      : 'ap-m1',
+            mutation        : {config: {width: 300}},
+            registry        : CreatedInstances,
+            resolveComponent: () => ({}) // missing .store
+        });
+        expect(wrongShaped).toMatchObject({accepted: false, stage: accept.ACCEPT_STAGES.MUTATION});
+        expect(wrongShaped.reason).toContain('disagree');
+        // the registry still reflects the last GOOD mutation (height 500), never the failed width
+        const snapshot = CreatedInstances.resolveTarget({instanceId: 'ap-m1'}).blueprintSnapshot;
+        expect(snapshot.config.height).toBe(500);
+        expect(snapshot.config.width).toBeUndefined();
+    });
+
+    test('accept fails closed on a duplicate id BEFORE insertion — stage and registry truth never diverge', () => {
+        const stage     = createStageDouble();
+        const registrar = accept.createInsertRegistrar({registry: CreatedInstances});
+
+        stage.on('insert', registrar);
+
+        // first accept registers cleanly
+        const first = accept.acceptBlueprint({blueprint: validGrid('Dup Grid'), instanceId: 'ap-dup', stage, registry: CreatedInstances});
+        expect(first.accepted).toBe(true);
+        expect(stage.added).toHaveLength(1);
+
+        // second accept with the SAME id: refused at accept-stage, and crucially NOTHING new reaches
+        // the stage — the pre-registration gap (insert succeeds, registration refuses) cannot open
+        const second = accept.acceptBlueprint({blueprint: validGrid('Dup Grid 2'), instanceId: 'ap-dup', stage, registry: CreatedInstances});
+        expect(second).toMatchObject({accepted: false, stage: accept.ACCEPT_STAGES.ACCEPT});
+        expect(second.reason).toContain('already registered');
+        expect(stage.added).toHaveLength(1); // still just the first — no orphaned insert
+
+        // the registry still holds exactly the first record, unperturbed
+        expect(CreatedInstances.resolveTarget({instanceId: 'ap-dup'}).blueprintSnapshot.title).toBe('Dup Grid');
     });
 
     test('dispose destroys the component when resolvable and always flips the registry', () => {

--- a/test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs
@@ -1,0 +1,171 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'AcceptPathTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}      from '@playwright/test';
+import Neo                 from '../../../../../../src/Neo.mjs';
+import * as core           from '../../../../../../src/core/_export.mjs';
+import InstanceManager     from '../../../../../../src/manager/Instance.mjs';
+import CreatedInstances    from '../../../../../../apps/agentos/view/create/store/CreatedInstances.mjs';
+import {BLUEPRINT_SCHEMAS} from '../../../../../../apps/agentos/view/create/util/blueprintSchema.mjs';
+import * as accept         from '../../../../../../apps/agentos/view/create/util/acceptPath.mjs';
+
+const validGrid = title => ({
+    schema: 'grid@1',
+    title,
+    config: {columns: [{field: 'name', text: 'Name'}, {field: 'city', text: 'City'}]},
+    data  : [{name: 'A', city: 'B'}]
+});
+
+// a stage double honoring the seam contract: add() fires the insert observers with the item,
+// exactly as the container add → insert path does for the observing controller
+const createStageDouble = () => {
+    const observers = [];
+
+    return {
+        added: [],
+        on(event, handler) { event === 'insert' && observers.push(handler) },
+        add(config) {
+            this.added.push(config);
+            // the inserted "component" carries the config's provenance stamp + reference
+            const item = {...config};
+            observers.forEach(handler => handler({item}));
+            return item
+        }
+    }
+};
+
+test.describe('acceptPath — blueprint → live instance via the ONE create path + registry lifecycle', () => {
+    test('every validator schema has a registered materializer (coverage contract)', () => {
+        for (const schemaId of Object.keys(BLUEPRINT_SCHEMAS)) {
+            expect(accept.SCHEMA_MATERIALIZERS[schemaId], `materializer missing for ${schemaId}`).toBeTruthy();
+        }
+    });
+
+    test('accept → stage add → insert → registry record, end to end on the real registry', () => {
+        const stage     = createStageDouble();
+        const registrar = accept.createInsertRegistrar({registry: CreatedInstances});
+
+        stage.on('insert', registrar);
+
+        const result = accept.acceptBlueprint({blueprint: validGrid('Accept Grid'), instanceId: 'ap-1', stage});
+
+        expect(result.accepted).toBe(true);
+        expect(result.config.ntype).toBe('grid-container');           // wire-safe, never a module ref
+        expect(result.config.reference).toBe('ap-1');
+        expect(result.config.columns).toEqual([{dataField: 'name', text: 'Name'}, {dataField: 'city', text: 'City'}]);
+        expect(stage.added).toHaveLength(1);                          // the ONE create path was used
+
+        // the insert event wrote the registry record with the provenance stamp
+        const record = CreatedInstances.resolveTarget({instanceId: 'ap-1'});
+
+        expect(record.state).toBe('live');
+        expect(record.blueprintSchema).toBe('grid@1');
+        expect(record.paneRef).toBe('ap-1');
+        expect(record.blueprintSnapshot.title).toBe('Accept Grid');
+    });
+
+    test('accept refusals are staged data: bad blueprint, dead stage, missing id, unstamped inserts', () => {
+        const stage = createStageDouble();
+
+        expect(accept.acceptBlueprint({blueprint: validGrid('X'), instanceId: '', stage}))
+            .toMatchObject({accepted: false, stage: accept.ACCEPT_STAGES.ACCEPT});
+
+        expect(accept.acceptBlueprint({blueprint: validGrid('X'), instanceId: 'ap-2'}))
+            .toMatchObject({accepted: false, stage: accept.ACCEPT_STAGES.ACCEPT});
+
+        // accept-side validation is the SAME validator: an html-key attack refuses here too
+        const attack = accept.acceptBlueprint({
+            blueprint : {...validGrid('X'), config: {columns: [{field: 'a', text: 'A', html: '<img onerror=1>'}]}},
+            instanceId: 'ap-2',
+            stage
+        });
+
+        expect(attack.accepted).toBe(false);
+        expect(attack.reason).toContain('forbidden key');
+        expect(stage.added).toHaveLength(0);                          // nothing reached the stage
+
+        // external create_component inserts carry no provenance stamp — the registrar ignores them
+        const registrar = accept.createInsertRegistrar({registry: CreatedInstances});
+
+        expect(registrar({item: {ntype: 'grid-container', reference: 'external-1'}})).toBeNull();
+        expect(CreatedInstances.resolveTarget({instanceId: 'external-1'})).toBeNull();
+    });
+
+    test('mutation pulls the registry snapshot, applies the MERGED blueprint, and records it', () => {
+        const stage     = createStageDouble();
+        const registrar = accept.createInsertRegistrar({registry: CreatedInstances});
+
+        stage.on('insert', registrar);
+        accept.acceptBlueprint({blueprint: validGrid('Mutate Grid'), instanceId: 'ap-m1', stage});
+
+        const component        = {title: 'Mutate Grid', store: {data: []}};
+        const resolveComponent = id => id === 'ap-m1' ? component : null;
+
+        const grown = accept.mutateInstance({
+            instanceId: 'ap-m1',
+            mutation  : {config: {height: 500}},
+            registry  : CreatedInstances,
+            resolveComponent
+        });
+
+        expect(grown.accepted).toBe(true);
+        expect(component.height).toBe(500);
+        expect(grown.blueprint.config.columns).toHaveLength(2);       // merge preserved columns
+        expect(CreatedInstances.resolveTarget({instanceId: 'ap-m1'}).blueprintSnapshot.config.height).toBe(500);
+
+        // the same contract refuses what creation could not reach — and the component stays untouched
+        const attack = accept.mutateInstance({
+            instanceId: 'ap-m1',
+            mutation  : {data: 'not rows'},
+            registry  : CreatedInstances,
+            resolveComponent
+        });
+
+        expect(attack).toMatchObject({accepted: false, stage: accept.ACCEPT_STAGES.MUTATION});
+        expect(CreatedInstances.resolveTarget({instanceId: 'ap-m1'}).blueprintSnapshot.config.height).toBe(500);
+
+        // registry/stage disagreement fails closed
+        expect(accept.mutateInstance({instanceId: 'ap-m1', mutation: {config: {width: 300}}, registry: CreatedInstances, resolveComponent: () => null}).reason)
+            .toContain('disagree');
+    });
+
+    test('dispose destroys the component when resolvable and always flips the registry', () => {
+        const stage     = createStageDouble();
+        const registrar = accept.createInsertRegistrar({registry: CreatedInstances});
+
+        stage.on('insert', registrar);
+        accept.acceptBlueprint({blueprint: validGrid('Dispose Grid'), instanceId: 'ap-d1', stage});
+
+        let   destroyed = false;
+        const result    = accept.disposeInstance({
+            instanceId      : 'ap-d1',
+            registry        : CreatedInstances,
+            resolveComponent: () => ({destroy() { destroyed = true }})
+        });
+
+        expect(result.accepted).toBe(true);
+        expect(destroyed).toBe(true);
+        expect(CreatedInstances.resolveTarget({instanceId: 'ap-d1'}).state).toBe('disposed');
+
+        // disposed instances refuse mutation through the accept path too
+        expect(accept.mutateInstance({instanceId: 'ap-d1', mutation: {title: 'late'}, registry: CreatedInstances, resolveComponent: () => ({})}).reason)
+            .toContain('disposed');
+
+        // double dispose refuses; unknown id refuses — staged, never thrown
+        expect(accept.disposeInstance({instanceId: 'ap-d1', registry: CreatedInstances}))
+            .toMatchObject({accepted: false, stage: accept.ACCEPT_STAGES.DISPOSE});
+        expect(accept.disposeInstance({instanceId: 'ap-missing', registry: CreatedInstances}).accepted).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

T2.10 of the harness pillar (Epic #13349): the **accept path** — carries an accepted blueprint into a live component through the childapp's ONE create path, and keeps the created-instance registry truthful over the create → mutate → dispose lifecycle. This is the leaf that joins the two now-merged spines (#14655 route + validator, #14656 registry) into a working create flow.

Resolves #14689
Refs #13349

Both dependencies are on `dev`: #14678 (#14655 route + `validateBlueprint`/`validateMutation`) and #14682 (#14656 `CreatedInstances`). This PR is a clean single-commit diff against them.

## Deltas

- **NEW `apps/agentos/view/create/util/acceptPath.mjs`** — join, never fork:
  - `acceptBlueprint({blueprint, instanceId, stage})` — runs the **same imported `validateBlueprint`** the emit side runs (the fail-closed-both-sides contract as two call sites of ONE validator), materializes a **wire-safe** config (`ntype`, never a module ref — Neural-Link parity), and routes it through the injected stage's `add()` — the childapp's ONE-create-path invariant (`ViewportController`'s `add → insert` seam a `create_component` also drives), joined not forked.
  - `SCHEMA_MATERIALIZERS` — the render half of the schema registry, keyed by the SAME schema ids the validator uses (`grid@1`: `materialize` → stage-insertable config with a provenance `blueprintMeta` stamp; `apply` → writes a merged blueprint onto the live component). A coverage-contract test asserts every validator schema has a materializer.
  - `createInsertRegistrar({registry})` — writes `registerCreated` on the stage `insert` event via the provenance stamp; external `create_component` inserts (no stamp) are ignored, so the registry records only what the accept path materialized.
  - `mutateInstance(...)` — pulls the current snapshot FROM the registry, runs merge-then-validate, applies the merged blueprint via the schema applier, records `markMutated`. No surface hand-merges.
  - `disposeInstance(...)` — destroys the live component when resolvable, always flips the registry (a half-dead instance still leaves truthful state).
  - Every failure returns the pipeline's bounded `{accepted, reason, stage}` — nothing throws into a render path.
- **NEW `test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs`** — 5 tests against the **real** `CreatedInstances` singleton + **real** validator (the first true integration proof of the whole T1 stack: route → validator → stage seam → registry): materializer coverage · accept→stage→insert→registry round-trip · accept refusals (bad blueprint via the shared validator, dead stage, missing id, unstamped external inserts) · mutation pulls-snapshot/applies-merged/records + refuses what creation can't reach + registry-stage-disagreement fail-closed · dispose destroys + flips + refuses double-dispose.

**Deliberately NOT in this PR:** pane chrome / chat surface (SSOT-gated views, #14692) · live NL wiring (the injected `generate` leaf) · T4 persistence · retiring the childapp's v1 `parseEditRequest`/`validateRequest` (a follow-up once this path is proven).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs acceptPath` → **5 passed (14.8s)** against the merged-to-dev deps.

Evidence: L2 (unit-pinned, exercised against the real registry + real validator — this is the integration proof, not an isolated leaf).

## Post-Merge Validation

- The first VIEW leaf (chat-creation state-machine binding, SSOT #14692) consumes `acceptBlueprint` + `createInsertRegistrar` + `mutateInstance` — no parallel create path anywhere in the module is the check.
- Registering a second widget schema touches ONLY `BLUEPRINT_SCHEMAS` (validator) + `SCHEMA_MATERIALIZERS` (render) — if it needs any other change, the plugin seam failed.

## Related

Epic #13349 (T2.10) · #14655 / #14678 (route + validator, merged) · #14656 / #14682 (registry, merged) · #14644 (safety contract, two-sided) · #14642 (module convention) · #14692 (the SSOT the view leaf implements) · `apps/agentos/childapps/widget/view/ViewportController.mjs` (the ONE-create-path invariant this generalizes).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b9b95ac6-42f5-47a3-b58f-6071f79657e8.
