### PR TITLE
feat(agentos): creation-flow state machine — the five keeper states as a pure spine (#14711)

### DIFF
--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -3,13 +3,16 @@
  * @summary The keeper creation flow's transition TABLE — the five SSOT states and which
  * transitions between them are legal, as pure data-plane logic with zero DOM.
  *
- * Consumption contract (neo-core idiom, load-bearing): the flow state itself LIVES as a
- * reactive config on the view layer — a `flowState_` config whose `beforeSetFlowState` hook
- * consults {@link nextCreationState} to admit or refuse the transition, with `afterSetFlowState`
- * driving the render side effects. That keeps the state visible to bindings, effects, state
- * providers, and Neural Link introspection for free. This module is the hook's ORACLE (which
- * transitions are legal — domain knowledge the class system does not provide); it is never a
- * parallel state store, and the view must not re-derive "which state" from a bag of booleans.
+ * Consumption contract (neo-core idiom, load-bearing): the flow state itself LIVES on the
+ * create-module's `state.Provider` — provider `data` (e.g. `flowState`, `flowReason`) that
+ * views consume via bindings, with the transition admitted or refused by consulting
+ * {@link nextCreationState} at the ONE place that writes it. A provider — not component-local
+ * state — because the wedge's promote step moves the created panel into its own OS window BY
+ * DESIGN: a provider on the app-worker heap stays reachable from component trees in different
+ * browser windows, and it can expose the created-instances store via its `stores_` config for
+ * the same cross-window reach. This module is that writer's ORACLE (which transitions are legal
+ * — domain knowledge the class system does not provide); it is never a parallel state store,
+ * and the view must not re-derive "which state" from a bag of booleans.
  *
  * The oracle mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
  * illegal transition returns the CURRENT state plus a reason, so the hook cancels the update

--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -1,13 +1,19 @@
 /**
  * @module AgentOS.view.create.util.creationFlowState
- * @summary The keeper creation flow as a pure state machine — the five SSOT states and the legal
- * transitions between them, with zero DOM. The view Controller binds this; it never re-derives
- * "which state" from a bag of booleans (the multi-flag incoherence the object-permanent registry
- * avoids for instances, applied to flow state).
+ * @summary The keeper creation flow's transition TABLE — the five SSOT states and which
+ * transitions between them are legal, as pure data-plane logic with zero DOM.
  *
- * The machine mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
- * illegal transition returns the CURRENT state plus a reason, so the Controller logs or ignores
- * rather than corrupting state, exactly as every create surface branches on `{accepted, reason}`.
+ * Consumption contract (framework-idiom, load-bearing): the flow state itself LIVES as a
+ * reactive config on the view layer — a `flowState_` config whose `beforeSetFlowState` hook
+ * consults {@link nextCreationState} to admit or refuse the transition, with `afterSetFlowState`
+ * driving the render side effects. That keeps the state visible to bindings, effects, state
+ * providers, and Neural Link introspection for free. This module is the hook's ORACLE (which
+ * transitions are legal — domain knowledge the framework does not provide); it is never a
+ * parallel state store, and the view must not re-derive "which state" from a bag of booleans.
+ *
+ * The oracle mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
+ * illegal transition returns the CURRENT state plus a reason, so the hook cancels the update
+ * (the framework's return-`undefined`-from-beforeSet idiom) rather than corrupting state.
  *
  * The accept-path outcome drives the generating→terminal fork: an accepted route result advances
  * to MATERIALIZED; a refused one advances to ERROR carrying the refusal reason to the SSOT's

--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -1,0 +1,130 @@
+/**
+ * @module AgentOS.view.create.util.creationFlowState
+ * @summary The keeper creation flow as a pure state machine — the five SSOT states and the legal
+ * transitions between them, with zero DOM. The view Controller binds this; it never re-derives
+ * "which state" from a bag of booleans (the multi-flag incoherence the object-permanent registry
+ * avoids for instances, applied to flow state).
+ *
+ * The machine mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
+ * illegal transition returns the CURRENT state plus a reason, so the Controller logs or ignores
+ * rather than corrupting state, exactly as every create surface branches on `{accepted, reason}`.
+ *
+ * The accept-path outcome drives the generating→terminal fork: an accepted route result advances
+ * to MATERIALIZED; a refused one advances to ERROR carrying the refusal reason to the SSOT's
+ * "always a reason" error render.
+ */
+
+/**
+ * @summary The five keeper-flow states (SSOT §"the five states").
+ * @type {Object}
+ */
+export const CREATION_STATES = Object.freeze({
+    EMPTY       : 'empty',        // the invitation — one affordance, no chrome
+    COMPOSING   : 'composing',    // intent typed; blueprint previewed, not committed
+    GENERATING  : 'generating',   // the blueprint runs the route; cancellable
+    MATERIALIZED: 'materialized', // the app is a live docked panel; promotable
+    ERROR       : 'error'         // generation failed / safety gate refused; always recoverable
+});
+
+/**
+ * @summary The transition triggers. `accepted` / `refused` are the accept-path outcome fork;
+ * the rest are user/lifecycle actions from the SSOT wedge flow.
+ * @type {Object}
+ */
+export const CREATION_EVENTS = Object.freeze({
+    COMPOSE : 'compose',  // the user starts typing an intent
+    SUBMIT  : 'submit',   // the previewed blueprint is sent to the route
+    ACCEPTED: 'accepted', // the route returned a validated blueprint
+    REFUSED : 'refused',  // the route/validator refused (carries a reason)
+    EDIT    : 'edit',     // back to composing to refine words/blueprint
+    RETRY   : 'retry',    // from ERROR, edit-and-retry
+    RESET   : 'reset',    // clear back to the empty invitation
+    DISPOSE : 'dispose'   // the materialized panel is disposed
+});
+
+/**
+ * @summary The legal transition table: `state → {event → nextState}`. Any (state, event) pair
+ * absent here is an illegal transition and leaves the state unchanged with a reason.
+ * @type {Object}
+ */
+const TRANSITIONS = Object.freeze({
+    [CREATION_STATES.EMPTY]: Object.freeze({
+        [CREATION_EVENTS.COMPOSE]: CREATION_STATES.COMPOSING
+    }),
+    [CREATION_STATES.COMPOSING]: Object.freeze({
+        [CREATION_EVENTS.SUBMIT]: CREATION_STATES.GENERATING,
+        [CREATION_EVENTS.EDIT]  : CREATION_STATES.COMPOSING, // refine in place
+        [CREATION_EVENTS.RESET] : CREATION_STATES.EMPTY
+    }),
+    [CREATION_STATES.GENERATING]: Object.freeze({
+        [CREATION_EVENTS.ACCEPTED]: CREATION_STATES.MATERIALIZED,
+        [CREATION_EVENTS.REFUSED] : CREATION_STATES.ERROR,
+        [CREATION_EVENTS.RESET]   : CREATION_STATES.EMPTY   // the cancellable path
+    }),
+    [CREATION_STATES.MATERIALIZED]: Object.freeze({
+        [CREATION_EVENTS.EDIT]   : CREATION_STATES.COMPOSING, // mutate the live app via a follow-up
+        [CREATION_EVENTS.DISPOSE]: CREATION_STATES.EMPTY,
+        [CREATION_EVENTS.RESET]  : CREATION_STATES.EMPTY
+    }),
+    [CREATION_STATES.ERROR]: Object.freeze({
+        [CREATION_EVENTS.RETRY]: CREATION_STATES.COMPOSING, // edit-and-retry — never a dead-end
+        [CREATION_EVENTS.RESET]: CREATION_STATES.EMPTY
+    })
+});
+
+const STATE_VALUES = Object.freeze(new Set(Object.values(CREATION_STATES)));
+const EVENT_VALUES = Object.freeze(new Set(Object.values(CREATION_EVENTS)));
+
+/**
+ * @summary Pure transition: returns the next flow state for `(current, event)`, or the current
+ * state plus a reason for an illegal / unknown transition. Never throws.
+ *
+ * When the event is `refused`, the caller's `reason` (the pipeline's refusal reason) is carried
+ * through to the result so the ERROR render can show "always a reason"; on any legal transition
+ * `reason` is null.
+ *
+ * @param {String} current One of {@link CREATION_STATES}
+ * @param {String} event One of {@link CREATION_EVENTS}
+ * @param {Object} [options]
+ * @param {String} [options.reason] The refusal reason to carry on a `refused` transition
+ * @returns {{state: String, reason: String|null, changed: Boolean}}
+ */
+export function nextCreationState(current, event, {reason} = {}) {
+    if (!STATE_VALUES.has(current)) {
+        return {state: CREATION_STATES.EMPTY, reason: `unknown state "${current}" — resetting to empty`, changed: true};
+    }
+
+    if (!EVENT_VALUES.has(event)) {
+        return {state: current, reason: `unknown event "${event}"`, changed: false};
+    }
+
+    const target = TRANSITIONS[current][event];
+
+    if (target === undefined) {
+        return {state: current, reason: `"${event}" is not legal from "${current}"`, changed: false};
+    }
+
+    if (event === CREATION_EVENTS.REFUSED) {
+        return {state: target, reason: reason || 'generation refused', changed: target !== current};
+    }
+
+    return {state: target, reason: null, changed: target !== current};
+}
+
+/**
+ * @summary Maps an accept-path / route outcome (`{accepted, reason}`) to the terminal transition
+ * from GENERATING — the single fork the flow's whole safety story hinges on. A convenience over
+ * `nextCreationState` so the Controller never re-implements the accepted/refused branch.
+ * @param {String} current Should be GENERATING; any other state returns unchanged with a reason
+ * @param {{accepted: Boolean, reason: String|null}} outcome The route/accept-path result
+ * @returns {{state: String, reason: String|null, changed: Boolean}}
+ */
+export function applyRouteOutcome(current, outcome) {
+    if (current !== CREATION_STATES.GENERATING) {
+        return {state: current, reason: `route outcome only resolves from generating, not "${current}"`, changed: false};
+    }
+
+    return outcome?.accepted
+        ? nextCreationState(current, CREATION_EVENTS.ACCEPTED)
+        : nextCreationState(current, CREATION_EVENTS.REFUSED, {reason: outcome?.reason});
+}

--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -3,17 +3,17 @@
  * @summary The keeper creation flow's transition TABLE — the five SSOT states and which
  * transitions between them are legal, as pure data-plane logic with zero DOM.
  *
- * Consumption contract (framework-idiom, load-bearing): the flow state itself LIVES as a
+ * Consumption contract (neo-core idiom, load-bearing): the flow state itself LIVES as a
  * reactive config on the view layer — a `flowState_` config whose `beforeSetFlowState` hook
  * consults {@link nextCreationState} to admit or refuse the transition, with `afterSetFlowState`
  * driving the render side effects. That keeps the state visible to bindings, effects, state
  * providers, and Neural Link introspection for free. This module is the hook's ORACLE (which
- * transitions are legal — domain knowledge the framework does not provide); it is never a
+ * transitions are legal — domain knowledge the class system does not provide); it is never a
  * parallel state store, and the view must not re-derive "which state" from a bag of booleans.
  *
  * The oracle mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
  * illegal transition returns the CURRENT state plus a reason, so the hook cancels the update
- * (the framework's return-`undefined`-from-beforeSet idiom) rather than corrupting state.
+ * (neo core's return-`undefined`-from-beforeSet idiom) rather than corrupting state.
  *
  * The accept-path outcome drives the generating→terminal fork: an accepted route result advances
  * to MATERIALIZED; a refused one advances to ERROR carrying the refusal reason to the SSOT's

--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -6,13 +6,16 @@
  * Consumption contract (neo-core idiom, load-bearing): the flow state itself LIVES on the
  * create-module's `state.Provider` — provider `data` (e.g. `flowState`, `flowReason`) that
  * views consume via bindings, with the transition admitted or refused by consulting
- * {@link nextCreationState} at the ONE place that writes it. A provider — not component-local
- * state — because the wedge's promote step moves the created panel into its own OS window BY
- * DESIGN: a provider on the app-worker heap stays reachable from component trees in different
- * browser windows, and it can expose the created-instances store via its `stores_` config for
- * the same cross-window reach. This module is that writer's ORACLE (which transitions are legal
- * — domain knowledge the class system does not provide); it is never a parallel state store,
- * and the view must not re-derive "which state" from a bag of booleans.
+ * {@link nextCreationState} at the ONE place that writes it. A provider — rather than a config
+ * on one component — because the flow state has MANY consumers across the module's tree (chat
+ * surface, blueprint preview, pane chrome, promote affordance): each gets a declarative `bind`
+ * to the same truth instead of locating and reaching into a specific component. All of this
+ * state lives in the shared app worker either way (windows are render targets — instances and
+ * their configs are naturally window-agnostic), so the promote step works across windows for
+ * free; the provider's contribution is the shared-binding surface, plus `stores_` exposure of
+ * the created-instances registry. This module is that writer's ORACLE (which transitions are
+ * legal — domain knowledge the class system does not provide); it is never a parallel state
+ * store, and the view must not re-derive "which state" from a bag of booleans.
  *
  * The oracle mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
  * illegal transition returns the CURRENT state plus a reason, so the hook cancels the update

--- a/test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs
@@ -1,0 +1,92 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'CreationFlowStateTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('creationFlowState — the five keeper-flow states as a pure machine (#14711)', () => {
+    let S, E, next, applyRouteOutcome;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../apps/agentos/view/create/util/creationFlowState.mjs');
+        S = mod.CREATION_STATES;
+        E = mod.CREATION_EVENTS;
+        next = mod.nextCreationState;
+        applyRouteOutcome = mod.applyRouteOutcome;
+    });
+
+    test('the SSOT wedge flow runs end to end through legal transitions', () => {
+        // empty → composing → generating → materialized, then dispose back to empty
+        expect(next(S.EMPTY, E.COMPOSE)).toEqual({state: S.COMPOSING, reason: null, changed: true});
+        expect(next(S.COMPOSING, E.SUBMIT).state).toBe(S.GENERATING);
+        expect(next(S.GENERATING, E.ACCEPTED).state).toBe(S.MATERIALIZED);
+        expect(next(S.MATERIALIZED, E.DISPOSE).state).toBe(S.EMPTY);
+
+        // the error arm and its recovery: generating → error → (retry) composing
+        expect(next(S.GENERATING, E.REFUSED).state).toBe(S.ERROR);
+        expect(next(S.ERROR, E.RETRY).state).toBe(S.COMPOSING);
+
+        // reset is legal from every non-empty state (never a dead-end)
+        for (const from of [S.COMPOSING, S.GENERATING, S.MATERIALIZED, S.ERROR]) {
+            expect(next(from, E.RESET).state).toBe(S.EMPTY);
+        }
+    });
+
+    test('refused carries the pipeline reason to the ERROR render; legal transitions carry none', () => {
+        const refused = next(S.GENERATING, E.REFUSED, {reason: 'blueprint blocked at the safety gate'});
+        expect(refused).toEqual({state: S.ERROR, reason: 'blueprint blocked at the safety gate', changed: true});
+
+        // refused with no reason still lands in ERROR with a default (the render always shows a reason)
+        expect(next(S.GENERATING, E.REFUSED).reason).toBe('generation refused');
+
+        // a legal non-refused transition carries no reason
+        expect(next(S.EMPTY, E.COMPOSE).reason).toBeNull();
+    });
+
+    test('illegal transitions leave state unchanged with a reason, never throw', () => {
+        // cannot submit from empty, cannot accept from composing, cannot dispose from empty
+        const illegal = [
+            [S.EMPTY, E.SUBMIT],
+            [S.COMPOSING, E.ACCEPTED],
+            [S.EMPTY, E.DISPOSE],
+            [S.MATERIALIZED, E.SUBMIT],
+            [S.ERROR, E.ACCEPTED]
+        ];
+
+        for (const [state, event] of illegal) {
+            const result = next(state, event);
+            expect(result.state).toBe(state);
+            expect(result.changed).toBe(false);
+            expect(result.reason).toContain('not legal');
+        }
+
+        // unknown event → unchanged + reason; unknown state → reset to empty
+        expect(next(S.COMPOSING, 'teleport')).toMatchObject({state: S.COMPOSING, changed: false});
+        expect(next('nirvana', E.COMPOSE)).toMatchObject({state: S.EMPTY, changed: true});
+    });
+
+    test('applyRouteOutcome maps a real-shaped route result to the terminal fork', () => {
+        // accepted → materialized
+        expect(applyRouteOutcome(S.GENERATING, {accepted: true, reason: null}).state).toBe(S.MATERIALIZED);
+
+        // refused → error, reason carried from the pipeline
+        const refused = applyRouteOutcome(S.GENERATING, {accepted: false, reason: 'unregistered blueprint schema "iframe@1"'});
+        expect(refused.state).toBe(S.ERROR);
+        expect(refused.reason).toContain('iframe@1');
+
+        // only resolves from generating — a stray outcome elsewhere is a no-op with a reason
+        expect(applyRouteOutcome(S.COMPOSING, {accepted: true}).changed).toBe(false);
+        expect(applyRouteOutcome(S.MATERIALIZED, {accepted: false, reason: 'x'}).state).toBe(S.MATERIALIZED);
+    });
+});


### PR DESCRIPTION
## Summary

T3.1 of the harness pillar (#13349): the keeper creation flow as a **pure state machine** — the five SSOT states (`empty · composing · generating · materialized · error`) and their legal transitions, with zero DOM. This is the non-view spine the chat-creation view Controller will bind (the view chrome stays SSOT-gated on #14692); it's the same pure-first split used across the whole create stack.

Resolves #14711
Refs #13349 · #14645 (the SSOT fixing the five states)

## Deltas

- **NEW `apps/agentos/view/create/util/creationFlowState.mjs`**:
  - `CREATION_STATES` (the SSOT's five) + `CREATION_EVENTS` (the transition triggers: `compose/submit/accepted/refused/edit/retry/reset/dispose`), frozen enums.
  - `nextCreationState(current, event, {reason})` — a pure transition over a declared table. Never throws: an illegal `(state, event)` returns the CURRENT state + a reason (`changed: false`); an unknown state resets to `empty`. Mirrors the pipeline's `{accepted, reason}` vocabulary so the Controller branches identically everywhere.
  - The `refused` transition carries the pipeline's refusal reason to the ERROR state — the SSOT's "always a reason, never a dead-end" error render made literal; `reset` is legal from every non-empty state; `error → retry → composing` is the recovery arm.
  - `applyRouteOutcome(current, {accepted, reason})` — maps an accept-path / route result to the single terminal fork (`generating → materialized` on accept, `generating → error` carrying the reason on refuse), so the Controller never re-implements that branch. It's a no-op with a reason from any non-`generating` state.
- **NEW `test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs`** — 4 tests: the full SSOT wedge flow end-to-end + reset-from-everywhere · reason-carrying on refused (incl. the default) · illegal transitions unchanged-with-reason + unknown state/event handling · `applyRouteOutcome` against real-shaped route results.

**Deliberately NOT in this PR:** the view chrome (SSOT-gated tranche, post-#14692) · the Controller wiring that drives these transitions from user events + the accept-path · animation/choreography (dock lane) · the promotion-to-OS-window action.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs creationFlowState` → **4 passed (1.3s)** — pure logic, no fixtures.

Evidence: L1 (pure state-transition logic; the view binding lands with the SSOT-gated tranche).

## Post-Merge Validation

- The chat-creation view Controller imports `nextCreationState` / `applyRouteOutcome` instead of tracking `isGenerating`/`hasError`/`hasWidget` booleans — a boolean bag anywhere in the create view is the incoherence this leaf exists to prevent.
- Every state the SSOT renders has exactly one machine state; a render branch with no matching state (or vice-versa) is a defect the tranche review catches.

## Related

Parent #13349 (T3.1) · #14645 / #14692 (the SSOT — render-verified) · #14689 (accept-path, whose `{accepted, reason, stage}` drives `applyRouteOutcome`) · #14656 (registry — the object-permanence sibling this mirrors for flow state).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b9b95ac6-42f5-47a3-b58f-6071f79657e8.
