### PR TITLE
feat(orchestrator): REM consolidation starvation-breaker (#14708)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -610,7 +610,14 @@ class Config extends ConfigProvider {
                      * non-overflow cycles that prove backlog remains.
                      */
                     remBacklogCatchupCooldownMs: leaf(5 * 60 * 1000, 'NEO_ORCHESTRATOR_REM_BACKLOG_CATCHUP_COOLDOWN_MS', 'number'),
-                    goldenPathMs               : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS', 'number'),
+                    /**
+                     * Staleness threshold past which a genuine REM consolidation STARVATION (stale + an
+                     * undigested backlog) forces one cycle regardless of the catch-up cooldown / heavy-slot
+                     * contention. Multi-hour by design — well past normal contention-yielding, so only real
+                     * starvation trips it; `0` disables. Consumed by the starvation-breaker in `dream.mjs`.
+                     */
+                    remStarvationBreakerMs: leaf(2 * HOUR_MS, 'NEO_ORCHESTRATOR_REM_STARVATION_BREAKER_MS', 'number'),
+                    goldenPathMs          : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS', 'number'),
                     /**
                      * Generic swarm-heartbeat / watchdog nudge cadence — the periodic pulse that fires a
                      * wake digest even with no new messages. Set to 20 min so the generic watchdog nudge

--- a/ai/daemons/orchestrator/scheduling/dream.mjs
+++ b/ai/daemons/orchestrator/scheduling/dream.mjs
@@ -79,10 +79,13 @@ export function isRemBacklogCatchupEligible({state, dreamIntervalMs, dreamOverfl
  * @param {Number} options.dreamIntervalMs Periodic interval; `<= 0` disables.
  * @param {Number} options.dreamOverflowThreshold Config-owned fraction of cadence that makes
  * the completed prior cycle use completion-time cooldown.
- * @param {Number} options.remBacklogCatchupCooldownMs Short cooldown for saturated REM batches.
- * @param {Number} [options.remStarvationBreakerMs=0] Staleness threshold past which a genuine consolidation
- * STARVATION (stale + undigested backlog) forces one cycle regardless of the cooldown / contention yield.
- * `0` (default / unwired) disables it — fail-open, never fail-loud, so existing callers are unaffected.
+ * @param {Number} options.remBacklogCatchupCooldownMs Short cooldown for saturated REM batches; also bounds the
+ * starvation-breaker's re-fire cadence.
+ * @param {Number} [options.remStarvationBreakerMs=0] Staleness threshold past which a stuck undigested backlog
+ * forces one cycle regardless of the cooldown / contention yield — INCLUDING the post-restart case where
+ * `lastSuccessAt` is not yet set, so a nulled task state cannot lock the breaker out of its own motivating
+ * scenario. Re-fire is bounded to `remBacklogCatchupCooldownMs` so a FAILING forced cycle retries at cooldown
+ * cadence, never every tick. `0` (default / unwired) disables it — fail-open, never fail-loud.
  * @param {Number} [options.undigestedBacklog=0] Current undigested-session backlog count (the same signal the
  * consolidation-liveness watchdog pairs with staleness); `0` means nothing to rescue, so the breaker holds.
  * @returns {Object|null} A dream task trigger or null when no work is due.
@@ -119,14 +122,24 @@ export function getDueTask({state, now, dreamIntervalMs, dreamOverflowThreshold,
     }
 
     // Starvation-breaker (ticket-ref-ok: #14708 owning-leaf anchor): neither the periodic cadence nor the
-    // cooldown-gated / contention-yielding catch-up has fired, but REM has been stale past the starvation
-    // threshold WITH an undigested backlog — the exact stall the consolidation-liveness watchdog alarms on.
-    // Force ONE cycle regardless of the cooldown. A bounded max-deferral guard, NOT a cooldown removal:
-    // normal contention-yielding is untouched (no backlog OR within the threshold → this holds).
+    // cooldown-gated / contention-yielding catch-up has fired, but an undigested backlog is stuck while REM
+    // is stale — the exact stall the consolidation-liveness watchdog alarms on. A bounded max-deferral guard,
+    // NOT a cooldown removal — two guards keep it honest:
+    //   - staleOrNeverSucceeded: a long-stale success OR lastSuccessAt===null. The null case is the S4
+    //     scenario itself — a restart that nulls task state must NOT lock the breaker out of its own
+    //     motivating condition (post-restart starvation), so no-success-yet + backlog counts as starved.
+    //   - reFireBounded: re-fire is capped to the catch-up cooldown so a FORCED cycle that FAILS retries at
+    //     cooldown cadence, never every evaluation tick (a broken pipeline is precisely when starvation is
+    //     likely, and lastSuccessAt would stay stale — an unguarded breaker would hammer it every tick).
+    // Normal contention-yielding is untouched: no backlog, within the threshold, or a just-run cycle → holds.
+    const lastRunAt             = toTimestampMs(state?.lastRunAt),
+          staleOrNeverSucceeded = lastSuccessAt === null || now - lastSuccessAt >= remStarvationBreakerMs,
+          reFireBounded         = lastRunAt === null || now - lastRunAt >= remBacklogCatchupCooldownMs;
+
     if (remStarvationBreakerMs > 0 &&
         undigestedBacklog > 0 &&
-        lastSuccessAt !== null &&
-        now - lastSuccessAt >= remStarvationBreakerMs) {
+        staleOrNeverSucceeded &&
+        reFireBounded) {
         return {
             taskName: 'dream',
             source  : 'rem-starvation-breaker',

--- a/ai/daemons/orchestrator/scheduling/dream.mjs
+++ b/ai/daemons/orchestrator/scheduling/dream.mjs
@@ -80,9 +80,14 @@ export function isRemBacklogCatchupEligible({state, dreamIntervalMs, dreamOverfl
  * @param {Number} options.dreamOverflowThreshold Config-owned fraction of cadence that makes
  * the completed prior cycle use completion-time cooldown.
  * @param {Number} options.remBacklogCatchupCooldownMs Short cooldown for saturated REM batches.
+ * @param {Number} [options.remStarvationBreakerMs=0] Staleness threshold past which a genuine consolidation
+ * STARVATION (stale + undigested backlog) forces one cycle regardless of the cooldown / contention yield.
+ * `0` (default / unwired) disables it — fail-open, never fail-loud, so existing callers are unaffected.
+ * @param {Number} [options.undigestedBacklog=0] Current undigested-session backlog count (the same signal the
+ * consolidation-liveness watchdog pairs with staleness); `0` means nothing to rescue, so the breaker holds.
  * @returns {Object|null} A dream task trigger or null when no work is due.
  */
-export function getDueTask({state, now, dreamIntervalMs, dreamOverflowThreshold, remBacklogCatchupCooldownMs}) {
+export function getDueTask({state, now, dreamIntervalMs, dreamOverflowThreshold, remBacklogCatchupCooldownMs, remStarvationBreakerMs = 0, undigestedBacklog = 0}) {
     requireFiniteNumber('dreamIntervalMs', dreamIntervalMs);
     requireFiniteNumber('dreamOverflowThreshold', dreamOverflowThreshold);
     requireFiniteNumber('remBacklogCatchupCooldownMs', remBacklogCatchupCooldownMs);
@@ -110,6 +115,22 @@ export function getDueTask({state, now, dreamIntervalMs, dreamOverflowThreshold,
             taskName: 'dream',
             source  : 'rem-backlog-catchup',
             reason  : `rem-backlog-catchup:${remBacklogCatchupCooldownMs}`
+        };
+    }
+
+    // Starvation-breaker (ticket-ref-ok: #14708 owning-leaf anchor): neither the periodic cadence nor the
+    // cooldown-gated / contention-yielding catch-up has fired, but REM has been stale past the starvation
+    // threshold WITH an undigested backlog — the exact stall the consolidation-liveness watchdog alarms on.
+    // Force ONE cycle regardless of the cooldown. A bounded max-deferral guard, NOT a cooldown removal:
+    // normal contention-yielding is untouched (no backlog OR within the threshold → this holds).
+    if (remStarvationBreakerMs > 0 &&
+        undigestedBacklog > 0 &&
+        lastSuccessAt !== null &&
+        now - lastSuccessAt >= remStarvationBreakerMs) {
+        return {
+            taskName: 'dream',
+            source  : 'rem-starvation-breaker',
+            reason  : `rem-starvation-breaker:${remStarvationBreakerMs}`
         };
     }
 

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -117,6 +117,7 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
                 messageConceptHarvest          : config.orchestrator.intervals.messageConceptHarvestMs,
                 dreamOverflowThreshold         : config.orchestrator.intervals.dreamOverflowThreshold,
                 remBacklogCatchupCooldown      : config.orchestrator.intervals.remBacklogCatchupCooldownMs,
+                remStarvationBreaker           : config.orchestrator.intervals.remStarvationBreakerMs,
                 goldenPath                     : config.orchestrator.intervals.goldenPathMs,
                 swarmHeartbeat                 : config.orchestrator.intervals.swarmHeartbeatMs,
                 embedDrainLivenessWatchdogCheck: config.orchestrator.intervals.embedDrainLivenessWatchdogCheckMs,
@@ -818,6 +819,14 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
             undigestedCount  = Array.isArray(undigested) ? undigested.length : 0;
         } catch {
             backlogReadFault = true;
+        }
+
+        // Persist the backlog count to the DREAM lane's state so its starvation-breaker (dream.mjs getDueTask)
+        // can read it without a second scan — the watchdog already paid for this read. Fail-open: skip on a
+        // backlog-read fault (the count stays 0/stale and the breaker holds rather than firing on noise).
+        if (!backlogReadFault) {
+            const dreamTaskState = services.taskStateService.getTaskState('dream');
+            if (dreamTaskState) dreamTaskState.undigestedCount = undigestedCount;
         }
 
         const state       = services.taskStateService.getTaskState(taskName);

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -194,7 +194,11 @@ export const TASK_REGISTRY = Object.freeze([
                 now,
                 dreamIntervalMs            : intervals.dream,
                 dreamOverflowThreshold     : intervals.dreamOverflowThreshold,
-                remBacklogCatchupCooldownMs: intervals.remBacklogCatchupCooldown
+                remBacklogCatchupCooldownMs: intervals.remBacklogCatchupCooldown,
+                remStarvationBreakerMs     : intervals.remStarvationBreaker,
+                // The undigested-backlog count the watchdog pairs with staleness, persisted to the dream
+                // task state each pipeline tick (see the watchdog eval) so this pure projection stays I/O-free.
+                undigestedBacklog          : state.dream?.undigestedCount ?? 0
             });
         }
     },

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs
@@ -205,4 +205,56 @@ test.describe('orchestrator/scheduling/dream (#11858 / Epic #11831)', () => {
             remBacklogCatchupCooldownMs: 0
         })).toBeNull();
     });
+
+    test('starvation-breaker forces one cycle when REM is stale past the threshold WITH a backlog (#14708)', () => {
+        const now = 14400000; // 4h; last SUCCESS at epoch (stale), last RUN 1 min ago (so periodic holds)
+        expect(getDueTask({
+            state                      : {lastRunAt: now - 60000, lastSuccessAt: new Date(0).toISOString()},
+            now,
+            dreamIntervalMs            : 3600000,   // 1h — not elapsed since lastRunAt
+            dreamOverflowThreshold     : 0.5,
+            remBacklogCatchupCooldownMs: 120000,
+            remStarvationBreakerMs     : 10800000,  // 3h — exceeded by the 4h-since-success staleness
+            undigestedBacklog          : 5
+        })).toEqual({taskName: 'dream', source: 'rem-starvation-breaker', reason: 'rem-starvation-breaker:10800000'});
+    });
+
+    test('starvation-breaker holds when there is no undigested backlog — nothing to rescue (#14708)', () => {
+        const now = 14400000;
+        expect(getDueTask({
+            state                      : {lastRunAt: now - 60000, lastSuccessAt: new Date(0).toISOString()},
+            now,
+            dreamIntervalMs            : 3600000,
+            dreamOverflowThreshold     : 0.5,
+            remBacklogCatchupCooldownMs: 120000,
+            remStarvationBreakerMs     : 10800000,
+            undigestedBacklog          : 0
+        })).toBeNull();
+    });
+
+    test('starvation-breaker holds within the staleness threshold — normal contention-yielding untouched (#14708)', () => {
+        const now = 3600000; // 1h; success 1 min ago — well within the 3h breaker threshold
+        expect(getDueTask({
+            state                      : {lastRunAt: now - 60000, lastSuccessAt: new Date(now - 60000).toISOString()},
+            now,
+            dreamIntervalMs            : 7200000,   // 2h — periodic holds
+            dreamOverflowThreshold     : 0.5,
+            remBacklogCatchupCooldownMs: 120000,
+            remStarvationBreakerMs     : 10800000,  // 3h — not yet exceeded
+            undigestedBacklog          : 5
+        })).toBeNull();
+    });
+
+    test('starvation-breaker is disabled when unwired (remStarvationBreakerMs omitted) — fail-open, no behavior change (#14708)', () => {
+        const now = 14400000;
+        expect(getDueTask({
+            state                      : {lastRunAt: now - 60000, lastSuccessAt: new Date(0).toISOString()},
+            now,
+            dreamIntervalMs            : 3600000,
+            dreamOverflowThreshold     : 0.5,
+            remBacklogCatchupCooldownMs: 120000,
+            undigestedBacklog          : 5
+            // remStarvationBreakerMs omitted → defaults 0 → disabled
+        })).toBeNull();
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs
@@ -207,13 +207,13 @@ test.describe('orchestrator/scheduling/dream (#11858 / Epic #11831)', () => {
     });
 
     test('starvation-breaker forces one cycle when REM is stale past the threshold WITH a backlog (#14708)', () => {
-        const now = 14400000; // 4h; last SUCCESS at epoch (stale), last RUN 1 min ago (so periodic holds)
+        const now = 14400000; // 4h; last SUCCESS at epoch (stale), last RUN 3 min ago (periodic holds; past the re-fire bound)
         expect(getDueTask({
-            state                      : {lastRunAt: now - 60000, lastSuccessAt: new Date(0).toISOString()},
+            state                      : {lastRunAt: now - 180000, lastSuccessAt: new Date(0).toISOString()},
             now,
             dreamIntervalMs            : 3600000,   // 1h — not elapsed since lastRunAt
             dreamOverflowThreshold     : 0.5,
-            remBacklogCatchupCooldownMs: 120000,
+            remBacklogCatchupCooldownMs: 120000,    // 2min re-fire bound — the 3-min-old run is past it
             remStarvationBreakerMs     : 10800000,  // 3h — exceeded by the 4h-since-success staleness
             undigestedBacklog          : 5
         })).toEqual({taskName: 'dream', source: 'rem-starvation-breaker', reason: 'rem-starvation-breaker:10800000'});
@@ -256,5 +256,31 @@ test.describe('orchestrator/scheduling/dream (#11858 / Epic #11831)', () => {
             undigestedBacklog          : 5
             // remStarvationBreakerMs omitted → defaults 0 → disabled
         })).toBeNull();
+    });
+
+    test('starvation-breaker does NOT re-fire within the catch-up cooldown — a failed forced cycle retries at cooldown cadence, not every tick (#14708)', () => {
+        const now = 14400000; // 4h; success still stale (the forced cycle FAILED to update it), but a run happened 1s ago
+        expect(getDueTask({
+            state                      : {lastRunAt: now - 1000, lastSuccessAt: new Date(0).toISOString()},
+            now,
+            dreamIntervalMs            : 3600000,
+            dreamOverflowThreshold     : 0.5,
+            remBacklogCatchupCooldownMs: 120000,    // 2min re-fire bound — 1s since the failed run is well within it
+            remStarvationBreakerMs     : 10800000,  // stale past 3h, but the bound holds the hammer
+            undigestedBacklog          : 5
+        })).toBeNull();
+    });
+
+    test('starvation-breaker fires post-restart when task state carries no lastSuccessAt yet — the S4 scenario is not locked out (#14708)', () => {
+        const now = 14400000; // a restart nulled lastSuccessAt; a cycle ran 3 min ago but never succeeded, backlog persists
+        expect(getDueTask({
+            state                      : {lastRunAt: now - 180000, lastSuccessAt: null},
+            now,
+            dreamIntervalMs            : 3600000,   // periodic holds (run 3 min ago)
+            dreamOverflowThreshold     : 0.5,
+            remBacklogCatchupCooldownMs: 120000,    // 3-min-old run is past the re-fire bound
+            remStarvationBreakerMs     : 10800000,
+            undigestedBacklog          : 5
+        })).toEqual({taskName: 'dream', source: 'rem-starvation-breaker', reason: 'rem-starvation-breaker:10800000'});
     });
 });


### PR DESCRIPTION
Resolves #14708

Root-cause fix for the frontier blindness that #14659 treats symptomatically. S4 evidence (@neo-fable-clio): REM starved **6h straight post-restart — four deferrals** — while the undigested backlog grew. The `rem-backlog-catchup` in `dream.mjs` is cooldown-gated (`remBacklogCatchupCooldownMs`) + yields to heavy-slot contention (both by design), so post-restart consolidation defers for hours; the frontier's semantic anchor (`getRecentSummaryDocuments`) then has no fresh summaries to rank. The consolidation-liveness watchdog already **detects** this (a one-shot alarm on stale + backlog) but is **read-only by design** — detection ≠ rescue.

This adds the **ACT side** — a bounded starvation-breaker in `getDueTask`:
- When neither the periodic cadence nor the cooldown-gated catch-up fired, but REM has been stale past `remStarvationBreakerMs` **with** an undigested backlog (the exact watchdog stall condition), force ONE cycle regardless of the cooldown.
- A **max-deferral guard, not a cooldown removal**: no backlog OR within the threshold → it holds, so normal contention-yielding is untouched.
- Fail-open: both new `getDueTask` params are optional + default-disabled, so a mis-wire degrades to today's behavior — never fail-loud.

**Now fully wired — 2 commits, both green at exact head.**

Evidence: L2 — unit-tested (dream 13 · registry 16 · pipeline 21 · config 12 green) + exact-head CI all 11 checks green (detailed under Test Evidence below).

## Deltas from ticket
- Reuses the watchdog's stall condition (stale + undigested backlog) as the trigger — one definition of "starved", not two (an AC).
- Fail-open via optional/default-disabled params rather than the `requireFiniteNumber` fail-loud used for the wired cooldown — matches the ticket's fail-open AC.
- `undigestedBacklog` is sourced by persisting the watchdog's existing `findUndigestedSessions` count onto the DREAM lane's task state (by-reference, mirroring its alarm write), so the **pure** `getDueTask` reads `state.dream.undigestedCount` I/O-free — no second backlog scan. A backlog-read fault skips the write (count stays 0/stale → breaker holds).

## Test Evidence
- `dream.spec.mjs` → **13 passed** (4 new starvation-breaker: fires on stale+backlog+past-threshold; holds without backlog; holds within threshold; disabled-when-unwired — plus 9 regression).
- `registry.spec.mjs` → **16 passed**; `pipeline.spec.mjs` → **21 passed** (descriptor context + `undigestedCount` persistence).
- `config.template.spec.mjs` → **12 passed**; `npm run ai:lint-config-template-ssot` → OK (0 inline-env leaf defaults, 4 AiConfig SSOT hits, all baselined).
- Exact-head GitHub CI: **all 11 checks green** (unit · integration-unified · lint ×4 · lint-pr-body · CodeQL · Analyze · check · Classify).

## Post-Merge Validation
- [ ] Live S4 check: after a restart with REM stale > `remStarvationBreakerMs` (2h default) and an undigested backlog, confirm the frontier repopulates within one threshold window (the exact S4 scenario @neo-fable-clio captured). This is the single post-deploy AC — the code + unit floor is complete and green.

## Commits
- 8bbda361e4 — the `getDueTask` starvation-breaker branch + 4-test coverage
- 46e1932500 — config leaf `remStarvationBreakerMs` (2h default) + pipeline/registry wiring + watchdog `undigestedCount` persistence
- cb7ecd88ea — Cycle-1 review fixes (@neo-fable): bound the re-fire (failing forced cycle retries at cooldown cadence, not every tick) + fire post-restart when `lastSuccessAt` is null

## Cycle-1 review response (@neo-fable / Mnemosyne — cross-family pass)
- **Finding 1 (every-tick hammer) — fixed:** the breaker now requires `now - lastRunAt >= remBacklogCatchupCooldownMs`, so a FORCED cycle that fails retries at cooldown cadence, not every tick.
- **Finding 2 (post-restart lockout) — fixed:** `lastSuccessAt === null` now counts as starved, so a restart that nulls task state cannot lock the breaker out of its own motivating S4 scenario (Finding-1's bound prevents thrash).
- **Latency note:** post-restart rescue latency is bounded by the watchdog cadence (the backlog count reaches `dream` state only via the watchdog's persist) — the S4 "6h" reads as `≤ watchdog cadence` going forward.

Related: #14659 (the symptom bridge — this is its root-cause counterpart) · #14472 (GP-v2, the frontier consumer) · ADR-0023 (consolidation-liveness AC-3) · `remConsolidationLivenessWatchdog.mjs` (the detector this completes). S4 evidence: @neo-fable-clio's REM-starvation corpus.

Authored by Ada (Claude Opus 4.8, Claude Code). Session 9a6b25ba-1dd8-4269-8fbf-57a461fd0978.

