### PR TITLE
feat(agentos): CreationStateProvider — oracle-guarded flow state + registry exposure (#14718)

### DIFF
--- a/apps/agentos/view/create/CreationStateProvider.mjs
+++ b/apps/agentos/view/create/CreationStateProvider.mjs
@@ -1,0 +1,100 @@
+import Provider                                                from '../../../../src/state/Provider.mjs';
+import CreatedInstances                                        from './store/CreatedInstances.mjs';
+import {CREATION_STATES, nextCreationState, applyRouteOutcome} from './util/creationFlowState.mjs';
+
+/**
+ * @class AgentOS.view.create.CreationStateProvider
+ * @extends Neo.state.Provider
+ *
+ * @summary The create-module's shared state surface — the five keeper-flow states and the
+ * created-instances registry as ONE declarative binding target for every consumer.
+ *
+ * Why a provider and not a config on some component: the flow state has MANY consumers (the
+ * chat surface, the blueprint preview, the pane chrome, the promote affordance) spread across
+ * the module's component tree — a provider in the hierarchy gives each of them a `bind` to the
+ * same truth, where component-local configs would force consumers to locate and reach into one
+ * specific component. Since the whole tree lives in the shared app worker, ALL of this state —
+ * provider data and component configs alike — is naturally window-agnostic (windows are render
+ * targets, instances never move); the provider's contribution is the declarative shared-binding
+ * surface, and the promote step working across windows comes with it for free.
+ *
+ * Views bind `data.flowState` / `data.flowReason` and the exposed `stores.createdInstances`;
+ * they never re-derive "which state" from booleans and never write flow state directly —
+ * {@link CreationStateProvider#applyFlowEvent} is the ONE writer, guarded by the pure transition
+ * oracle. Illegal transitions mutate nothing and return the oracle's bounded refusal, mirroring
+ * the pipeline's `{accepted, reason}` vocabulary end to end.
+ */
+class CreationStateProvider extends Provider {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.create.CreationStateProvider'
+         * @protected
+         */
+        className: 'AgentOS.view.create.CreationStateProvider',
+        /**
+         * The five SSOT flow states live here, beside the follow-up target the mutation path
+         * defaults to. `flowReason` carries the ERROR state's "always a reason" render text.
+         * @member {Object} data
+         */
+        data: {
+            activeInstanceId: null,
+            flowReason      : null,
+            flowState       : CREATION_STATES.EMPTY
+        },
+        /**
+         * The created-instances registry, exposed to bindings — grids/panes in ANY window read
+         * the same singleton reactively instead of reaching into the component tree.
+         * @member {Object} stores
+         */
+        stores: {
+            createdInstances: CreatedInstances
+        }
+    }
+
+    /**
+     * The ONE flow-state writer: consults the transition oracle and applies ONLY legal
+     * transitions to the provider data (one batched `setData`). Illegal or unknown events leave
+     * the data untouched and return the oracle's bounded result, so callers branch exactly as
+     * they do on the pipeline's `{accepted, reason}` shapes — nothing throws.
+     * @param {String} event One of the oracle's CREATION_EVENTS
+     * @param {Object} [options]
+     * @param {String} [options.reason] Refusal reason carried on a `refused` transition
+     * @returns {{state: String, reason: String|null, changed: Boolean}} the oracle result
+     */
+    applyFlowEvent(event, {reason} = {}) {
+        const result = nextCreationState(this.getData('flowState'), event, {reason});
+
+        // the oracle's illegal shape: unchanged state + a reason. Everything else (including
+        // legal same-state transitions and the reason-carrying `refused` arc) applies.
+        if (result.changed || result.reason === null) {
+            this.setData({
+                flowReason: result.reason,
+                flowState : result.state
+            })
+        }
+
+        return result
+    }
+
+    /**
+     * Maps an accept-path / route outcome to the generating→terminal fork through the same
+     * guarded writer — the ERROR state receives the pipeline's refusal reason for the SSOT's
+     * "always a reason" render.
+     * @param {{accepted: Boolean, reason: String|null}} outcome The route/accept-path result
+     * @returns {{state: String, reason: String|null, changed: Boolean}}
+     */
+    applyCreationRouteOutcome(outcome) {
+        const result = applyRouteOutcome(this.getData('flowState'), outcome);
+
+        if (result.changed || result.reason === null) {
+            this.setData({
+                flowReason: result.reason,
+                flowState : result.state
+            })
+        }
+
+        return result
+    }
+}
+
+export default Neo.setupClass(CreationStateProvider);

--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -3,13 +3,16 @@
  * @summary The keeper creation flow's transition TABLE — the five SSOT states and which
  * transitions between them are legal, as pure data-plane logic with zero DOM.
  *
- * Consumption contract (neo-core idiom, load-bearing): the flow state itself LIVES as a
- * reactive config on the view layer — a `flowState_` config whose `beforeSetFlowState` hook
- * consults {@link nextCreationState} to admit or refuse the transition, with `afterSetFlowState`
- * driving the render side effects. That keeps the state visible to bindings, effects, state
- * providers, and Neural Link introspection for free. This module is the hook's ORACLE (which
- * transitions are legal — domain knowledge the class system does not provide); it is never a
- * parallel state store, and the view must not re-derive "which state" from a bag of booleans.
+ * Consumption contract (neo-core idiom, load-bearing): the flow state itself LIVES on the
+ * create-module's `state.Provider` — provider `data` (e.g. `flowState`, `flowReason`) that
+ * views consume via bindings, with the transition admitted or refused by consulting
+ * {@link nextCreationState} at the ONE place that writes it. A provider — not component-local
+ * state — because the wedge's promote step moves the created panel into its own OS window BY
+ * DESIGN: a provider on the app-worker heap stays reachable from component trees in different
+ * browser windows, and it can expose the created-instances store via its `stores_` config for
+ * the same cross-window reach. This module is that writer's ORACLE (which transitions are legal
+ * — domain knowledge the class system does not provide); it is never a parallel state store,
+ * and the view must not re-derive "which state" from a bag of booleans.
  *
  * The oracle mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
  * illegal transition returns the CURRENT state plus a reason, so the hook cancels the update

--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -1,13 +1,19 @@
 /**
  * @module AgentOS.view.create.util.creationFlowState
- * @summary The keeper creation flow as a pure state machine — the five SSOT states and the legal
- * transitions between them, with zero DOM. The view Controller binds this; it never re-derives
- * "which state" from a bag of booleans (the multi-flag incoherence the object-permanent registry
- * avoids for instances, applied to flow state).
+ * @summary The keeper creation flow's transition TABLE — the five SSOT states and which
+ * transitions between them are legal, as pure data-plane logic with zero DOM.
  *
- * The machine mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
- * illegal transition returns the CURRENT state plus a reason, so the Controller logs or ignores
- * rather than corrupting state, exactly as every create surface branches on `{accepted, reason}`.
+ * Consumption contract (framework-idiom, load-bearing): the flow state itself LIVES as a
+ * reactive config on the view layer — a `flowState_` config whose `beforeSetFlowState` hook
+ * consults {@link nextCreationState} to admit or refuse the transition, with `afterSetFlowState`
+ * driving the render side effects. That keeps the state visible to bindings, effects, state
+ * providers, and Neural Link introspection for free. This module is the hook's ORACLE (which
+ * transitions are legal — domain knowledge the framework does not provide); it is never a
+ * parallel state store, and the view must not re-derive "which state" from a bag of booleans.
+ *
+ * The oracle mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
+ * illegal transition returns the CURRENT state plus a reason, so the hook cancels the update
+ * (the framework's return-`undefined`-from-beforeSet idiom) rather than corrupting state.
  *
  * The accept-path outcome drives the generating→terminal fork: an accepted route result advances
  * to MATERIALIZED; a refused one advances to ERROR carrying the refusal reason to the SSOT's

--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -1,0 +1,130 @@
+/**
+ * @module AgentOS.view.create.util.creationFlowState
+ * @summary The keeper creation flow as a pure state machine — the five SSOT states and the legal
+ * transitions between them, with zero DOM. The view Controller binds this; it never re-derives
+ * "which state" from a bag of booleans (the multi-flag incoherence the object-permanent registry
+ * avoids for instances, applied to flow state).
+ *
+ * The machine mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
+ * illegal transition returns the CURRENT state plus a reason, so the Controller logs or ignores
+ * rather than corrupting state, exactly as every create surface branches on `{accepted, reason}`.
+ *
+ * The accept-path outcome drives the generating→terminal fork: an accepted route result advances
+ * to MATERIALIZED; a refused one advances to ERROR carrying the refusal reason to the SSOT's
+ * "always a reason" error render.
+ */
+
+/**
+ * @summary The five keeper-flow states (SSOT §"the five states").
+ * @type {Object}
+ */
+export const CREATION_STATES = Object.freeze({
+    EMPTY       : 'empty',        // the invitation — one affordance, no chrome
+    COMPOSING   : 'composing',    // intent typed; blueprint previewed, not committed
+    GENERATING  : 'generating',   // the blueprint runs the route; cancellable
+    MATERIALIZED: 'materialized', // the app is a live docked panel; promotable
+    ERROR       : 'error'         // generation failed / safety gate refused; always recoverable
+});
+
+/**
+ * @summary The transition triggers. `accepted` / `refused` are the accept-path outcome fork;
+ * the rest are user/lifecycle actions from the SSOT wedge flow.
+ * @type {Object}
+ */
+export const CREATION_EVENTS = Object.freeze({
+    COMPOSE : 'compose',  // the user starts typing an intent
+    SUBMIT  : 'submit',   // the previewed blueprint is sent to the route
+    ACCEPTED: 'accepted', // the route returned a validated blueprint
+    REFUSED : 'refused',  // the route/validator refused (carries a reason)
+    EDIT    : 'edit',     // back to composing to refine words/blueprint
+    RETRY   : 'retry',    // from ERROR, edit-and-retry
+    RESET   : 'reset',    // clear back to the empty invitation
+    DISPOSE : 'dispose'   // the materialized panel is disposed
+});
+
+/**
+ * @summary The legal transition table: `state → {event → nextState}`. Any (state, event) pair
+ * absent here is an illegal transition and leaves the state unchanged with a reason.
+ * @type {Object}
+ */
+const TRANSITIONS = Object.freeze({
+    [CREATION_STATES.EMPTY]: Object.freeze({
+        [CREATION_EVENTS.COMPOSE]: CREATION_STATES.COMPOSING
+    }),
+    [CREATION_STATES.COMPOSING]: Object.freeze({
+        [CREATION_EVENTS.SUBMIT]: CREATION_STATES.GENERATING,
+        [CREATION_EVENTS.EDIT]  : CREATION_STATES.COMPOSING, // refine in place
+        [CREATION_EVENTS.RESET] : CREATION_STATES.EMPTY
+    }),
+    [CREATION_STATES.GENERATING]: Object.freeze({
+        [CREATION_EVENTS.ACCEPTED]: CREATION_STATES.MATERIALIZED,
+        [CREATION_EVENTS.REFUSED] : CREATION_STATES.ERROR,
+        [CREATION_EVENTS.RESET]   : CREATION_STATES.EMPTY   // the cancellable path
+    }),
+    [CREATION_STATES.MATERIALIZED]: Object.freeze({
+        [CREATION_EVENTS.EDIT]   : CREATION_STATES.COMPOSING, // mutate the live app via a follow-up
+        [CREATION_EVENTS.DISPOSE]: CREATION_STATES.EMPTY,
+        [CREATION_EVENTS.RESET]  : CREATION_STATES.EMPTY
+    }),
+    [CREATION_STATES.ERROR]: Object.freeze({
+        [CREATION_EVENTS.RETRY]: CREATION_STATES.COMPOSING, // edit-and-retry — never a dead-end
+        [CREATION_EVENTS.RESET]: CREATION_STATES.EMPTY
+    })
+});
+
+const STATE_VALUES = Object.freeze(new Set(Object.values(CREATION_STATES)));
+const EVENT_VALUES = Object.freeze(new Set(Object.values(CREATION_EVENTS)));
+
+/**
+ * @summary Pure transition: returns the next flow state for `(current, event)`, or the current
+ * state plus a reason for an illegal / unknown transition. Never throws.
+ *
+ * When the event is `refused`, the caller's `reason` (the pipeline's refusal reason) is carried
+ * through to the result so the ERROR render can show "always a reason"; on any legal transition
+ * `reason` is null.
+ *
+ * @param {String} current One of {@link CREATION_STATES}
+ * @param {String} event One of {@link CREATION_EVENTS}
+ * @param {Object} [options]
+ * @param {String} [options.reason] The refusal reason to carry on a `refused` transition
+ * @returns {{state: String, reason: String|null, changed: Boolean}}
+ */
+export function nextCreationState(current, event, {reason} = {}) {
+    if (!STATE_VALUES.has(current)) {
+        return {state: CREATION_STATES.EMPTY, reason: `unknown state "${current}" — resetting to empty`, changed: true};
+    }
+
+    if (!EVENT_VALUES.has(event)) {
+        return {state: current, reason: `unknown event "${event}"`, changed: false};
+    }
+
+    const target = TRANSITIONS[current][event];
+
+    if (target === undefined) {
+        return {state: current, reason: `"${event}" is not legal from "${current}"`, changed: false};
+    }
+
+    if (event === CREATION_EVENTS.REFUSED) {
+        return {state: target, reason: reason || 'generation refused', changed: target !== current};
+    }
+
+    return {state: target, reason: null, changed: target !== current};
+}
+
+/**
+ * @summary Maps an accept-path / route outcome (`{accepted, reason}`) to the terminal transition
+ * from GENERATING — the single fork the flow's whole safety story hinges on. A convenience over
+ * `nextCreationState` so the Controller never re-implements the accepted/refused branch.
+ * @param {String} current Should be GENERATING; any other state returns unchanged with a reason
+ * @param {{accepted: Boolean, reason: String|null}} outcome The route/accept-path result
+ * @returns {{state: String, reason: String|null, changed: Boolean}}
+ */
+export function applyRouteOutcome(current, outcome) {
+    if (current !== CREATION_STATES.GENERATING) {
+        return {state: current, reason: `route outcome only resolves from generating, not "${current}"`, changed: false};
+    }
+
+    return outcome?.accepted
+        ? nextCreationState(current, CREATION_EVENTS.ACCEPTED)
+        : nextCreationState(current, CREATION_EVENTS.REFUSED, {reason: outcome?.reason});
+}

--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -3,17 +3,17 @@
  * @summary The keeper creation flow's transition TABLE — the five SSOT states and which
  * transitions between them are legal, as pure data-plane logic with zero DOM.
  *
- * Consumption contract (framework-idiom, load-bearing): the flow state itself LIVES as a
+ * Consumption contract (neo-core idiom, load-bearing): the flow state itself LIVES as a
  * reactive config on the view layer — a `flowState_` config whose `beforeSetFlowState` hook
  * consults {@link nextCreationState} to admit or refuse the transition, with `afterSetFlowState`
  * driving the render side effects. That keeps the state visible to bindings, effects, state
  * providers, and Neural Link introspection for free. This module is the hook's ORACLE (which
- * transitions are legal — domain knowledge the framework does not provide); it is never a
+ * transitions are legal — domain knowledge the class system does not provide); it is never a
  * parallel state store, and the view must not re-derive "which state" from a bag of booleans.
  *
  * The oracle mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
  * illegal transition returns the CURRENT state plus a reason, so the hook cancels the update
- * (the framework's return-`undefined`-from-beforeSet idiom) rather than corrupting state.
+ * (neo core's return-`undefined`-from-beforeSet idiom) rather than corrupting state.
  *
  * The accept-path outcome drives the generating→terminal fork: an accepted route result advances
  * to MATERIALIZED; a refused one advances to ERROR carrying the refusal reason to the SSOT's

--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -6,13 +6,16 @@
  * Consumption contract (neo-core idiom, load-bearing): the flow state itself LIVES on the
  * create-module's `state.Provider` — provider `data` (e.g. `flowState`, `flowReason`) that
  * views consume via bindings, with the transition admitted or refused by consulting
- * {@link nextCreationState} at the ONE place that writes it. A provider — not component-local
- * state — because the wedge's promote step moves the created panel into its own OS window BY
- * DESIGN: a provider on the app-worker heap stays reachable from component trees in different
- * browser windows, and it can expose the created-instances store via its `stores_` config for
- * the same cross-window reach. This module is that writer's ORACLE (which transitions are legal
- * — domain knowledge the class system does not provide); it is never a parallel state store,
- * and the view must not re-derive "which state" from a bag of booleans.
+ * {@link nextCreationState} at the ONE place that writes it. A provider — rather than a config
+ * on one component — because the flow state has MANY consumers across the module's tree (chat
+ * surface, blueprint preview, pane chrome, promote affordance): each gets a declarative `bind`
+ * to the same truth instead of locating and reaching into a specific component. All of this
+ * state lives in the shared app worker either way (windows are render targets — instances and
+ * their configs are naturally window-agnostic), so the promote step works across windows for
+ * free; the provider's contribution is the shared-binding surface, plus `stores_` exposure of
+ * the created-instances registry. This module is that writer's ORACLE (which transitions are
+ * legal — domain knowledge the class system does not provide); it is never a parallel state
+ * store, and the view must not re-derive "which state" from a bag of booleans.
  *
  * The oracle mirrors the pipeline's refusal vocabulary: `nextCreationState` never throws — an
  * illegal transition returns the CURRENT state plus a reason, so the hook cancels the update

--- a/test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs
@@ -1,0 +1,92 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'CreationFlowStateTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('creationFlowState — the five keeper-flow states as a pure machine (#14711)', () => {
+    let S, E, next, applyRouteOutcome;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../apps/agentos/view/create/util/creationFlowState.mjs');
+        S = mod.CREATION_STATES;
+        E = mod.CREATION_EVENTS;
+        next = mod.nextCreationState;
+        applyRouteOutcome = mod.applyRouteOutcome;
+    });
+
+    test('the SSOT wedge flow runs end to end through legal transitions', () => {
+        // empty → composing → generating → materialized, then dispose back to empty
+        expect(next(S.EMPTY, E.COMPOSE)).toEqual({state: S.COMPOSING, reason: null, changed: true});
+        expect(next(S.COMPOSING, E.SUBMIT).state).toBe(S.GENERATING);
+        expect(next(S.GENERATING, E.ACCEPTED).state).toBe(S.MATERIALIZED);
+        expect(next(S.MATERIALIZED, E.DISPOSE).state).toBe(S.EMPTY);
+
+        // the error arm and its recovery: generating → error → (retry) composing
+        expect(next(S.GENERATING, E.REFUSED).state).toBe(S.ERROR);
+        expect(next(S.ERROR, E.RETRY).state).toBe(S.COMPOSING);
+
+        // reset is legal from every non-empty state (never a dead-end)
+        for (const from of [S.COMPOSING, S.GENERATING, S.MATERIALIZED, S.ERROR]) {
+            expect(next(from, E.RESET).state).toBe(S.EMPTY);
+        }
+    });
+
+    test('refused carries the pipeline reason to the ERROR render; legal transitions carry none', () => {
+        const refused = next(S.GENERATING, E.REFUSED, {reason: 'blueprint blocked at the safety gate'});
+        expect(refused).toEqual({state: S.ERROR, reason: 'blueprint blocked at the safety gate', changed: true});
+
+        // refused with no reason still lands in ERROR with a default (the render always shows a reason)
+        expect(next(S.GENERATING, E.REFUSED).reason).toBe('generation refused');
+
+        // a legal non-refused transition carries no reason
+        expect(next(S.EMPTY, E.COMPOSE).reason).toBeNull();
+    });
+
+    test('illegal transitions leave state unchanged with a reason, never throw', () => {
+        // cannot submit from empty, cannot accept from composing, cannot dispose from empty
+        const illegal = [
+            [S.EMPTY, E.SUBMIT],
+            [S.COMPOSING, E.ACCEPTED],
+            [S.EMPTY, E.DISPOSE],
+            [S.MATERIALIZED, E.SUBMIT],
+            [S.ERROR, E.ACCEPTED]
+        ];
+
+        for (const [state, event] of illegal) {
+            const result = next(state, event);
+            expect(result.state).toBe(state);
+            expect(result.changed).toBe(false);
+            expect(result.reason).toContain('not legal');
+        }
+
+        // unknown event → unchanged + reason; unknown state → reset to empty
+        expect(next(S.COMPOSING, 'teleport')).toMatchObject({state: S.COMPOSING, changed: false});
+        expect(next('nirvana', E.COMPOSE)).toMatchObject({state: S.EMPTY, changed: true});
+    });
+
+    test('applyRouteOutcome maps a real-shaped route result to the terminal fork', () => {
+        // accepted → materialized
+        expect(applyRouteOutcome(S.GENERATING, {accepted: true, reason: null}).state).toBe(S.MATERIALIZED);
+
+        // refused → error, reason carried from the pipeline
+        const refused = applyRouteOutcome(S.GENERATING, {accepted: false, reason: 'unregistered blueprint schema "iframe@1"'});
+        expect(refused.state).toBe(S.ERROR);
+        expect(refused.reason).toContain('iframe@1');
+
+        // only resolves from generating — a stray outcome elsewhere is a no-op with a reason
+        expect(applyRouteOutcome(S.COMPOSING, {accepted: true}).changed).toBe(false);
+        expect(applyRouteOutcome(S.MATERIALIZED, {accepted: false, reason: 'x'}).state).toBe(S.MATERIALIZED);
+    });
+});

--- a/test/playwright/unit/apps/agentos/create/creationStateProvider.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/creationStateProvider.spec.mjs
@@ -1,0 +1,102 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'CreationStateProviderTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+
+test.describe('CreationStateProvider — the shared flow-state surface, oracle-guarded (#14718)', () => {
+    let ProviderClass, S, E;
+
+    test.beforeAll(async () => {
+        ProviderClass = (await import('../../../../../../apps/agentos/view/create/CreationStateProvider.mjs')).default;
+        const oracle = await import('../../../../../../apps/agentos/view/create/util/creationFlowState.mjs');
+        S = oracle.CREATION_STATES;
+        E = oracle.CREATION_EVENTS;
+    });
+
+    test('the legal wedge run mutates provider data through the ONE writer', () => {
+        const provider = Neo.create(ProviderClass, {});
+
+        expect(provider.getData('flowState')).toBe(S.EMPTY);
+
+        provider.applyFlowEvent(E.COMPOSE);
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);
+
+        provider.applyFlowEvent(E.SUBMIT);
+        expect(provider.getData('flowState')).toBe(S.GENERATING);
+
+        const accepted = provider.applyCreationRouteOutcome({accepted: true, reason: null});
+        expect(accepted.state).toBe(S.MATERIALIZED);
+        expect(provider.getData('flowState')).toBe(S.MATERIALIZED);
+        expect(provider.getData('flowReason')).toBeNull();
+
+        provider.destroy()
+    });
+
+    test('illegal events leave provider data untouched and return the bounded refusal', () => {
+        const provider = Neo.create(ProviderClass, {});
+
+        const illegal = provider.applyFlowEvent(E.ACCEPTED); // cannot accept from empty
+        expect(illegal.changed).toBe(false);
+        expect(illegal.reason).toContain('not legal');
+        expect(provider.getData('flowState')).toBe(S.EMPTY);
+        expect(provider.getData('flowReason')).toBeNull();
+
+        const unknown = provider.applyFlowEvent('teleport');
+        expect(unknown.changed).toBe(false);
+        expect(provider.getData('flowState')).toBe(S.EMPTY);
+
+        provider.destroy()
+    });
+
+    test('a refused route outcome lands the pipeline reason in flowReason for the ERROR render', () => {
+        const provider = Neo.create(ProviderClass, {});
+
+        provider.applyFlowEvent(E.COMPOSE);
+        provider.applyFlowEvent(E.SUBMIT);
+
+        const refused = provider.applyCreationRouteOutcome({accepted: false, reason: 'unregistered blueprint schema "iframe@1"'});
+
+        expect(refused.state).toBe(S.ERROR);
+        expect(provider.getData('flowState')).toBe(S.ERROR);
+        expect(provider.getData('flowReason')).toContain('iframe@1');
+
+        // recovery arc: retry returns to composing and clears the reason
+        provider.applyFlowEvent(E.RETRY);
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);
+        expect(provider.getData('flowReason')).toBeNull();
+
+        // a stray outcome outside generating is a no-op with a reason
+        expect(provider.applyCreationRouteOutcome({accepted: true}).changed).toBe(false);
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);
+
+        provider.destroy()
+    });
+
+    test('the registry is exposed to bindings via stores', () => {
+        const provider = Neo.create(ProviderClass, {});
+
+        const store = provider.getStore('createdInstances');
+
+        expect(store).toBeTruthy();
+        expect(store.className).toBe('AgentOS.view.create.store.CreatedInstances');
+        // the exposed store IS the singleton — one truth across every window's bindings
+        expect(typeof store.registerCreated).toBe('function');
+
+        provider.destroy()
+    });
+});


### PR DESCRIPTION
## Summary

T3.2 of the harness pillar (#13349), operator-seeded (`src/state/Provider.mjs`): **the create-module's shared state surface** — the five keeper-flow states and the created-instances registry as ONE declarative binding target. The flow state has many consumers across the module tree (chat surface, blueprint preview, pane chrome, promote affordance); a provider gives each a `bind` to the same truth instead of locating and reaching into a specific component's configs. Topology stated correctly (operator-corrected same day): the whole component tree lives in the shared app worker — windows are render targets — so ALL worker-side state is naturally window-agnostic; the provider's contribution is the shared-binding surface, and promote-across-windows comes free with the architecture.

Resolves #14718
Refs #13349

> **⚠ Stacked on #14711 (PR #14712), based on `dev`.** The diff transiently includes the oracle's two commits (`creationFlowState.mjs` + its spec — under review on PR #14712); they drop on that merge + rebase. **Net-new in THIS leaf: `CreationStateProvider.mjs` + `creationStateProvider.spec.mjs`. Do not merge before #14712.**

## Deltas

- **NEW `apps/agentos/view/create/CreationStateProvider.mjs`** — extends `Neo.state.Provider`:
  - `data: {flowState: 'empty', flowReason: null, activeInstanceId: null}` — the five SSOT states live here; views bind, never re-derive from booleans.
  - `stores: {createdInstances: CreatedInstances}` — the merged registry singleton exposed to bindings (`stores_` is the core idiom for this); grids/panes anywhere in the tree read one truth reactively.
  - `applyFlowEvent(event, {reason})` — **the ONE flow-state writer**, guarded by the #14711 transition oracle: legal transitions apply via a single batched `setData({flowState, flowReason})`; illegal/unknown events mutate NOTHING and return the oracle's bounded `{state, reason, changed:false}` — callers branch exactly as they do on the pipeline's `{accepted, reason}` shapes, nothing throws.
  - `applyCreationRouteOutcome(outcome)` — the generating→terminal fork through the same guarded writer; a refusal lands its pipeline reason in `data.flowReason` for the SSOT's "always a reason" ERROR render.
- **NEW `test/playwright/unit/apps/agentos/create/creationStateProvider.spec.mjs`** — 4 tests on real `Neo.create`d providers: the legal wedge run mutates provider data through the writer · illegal/unknown events leave data untouched + bounded refusal · refused route outcome lands `flowReason` + the retry recovery arc clears it + stray outcomes outside `generating` are no-ops · `getStore('createdInstances')` resolves the registry singleton.

**§9.6 Core-Idiom Pre-Flight record (the gate's first live execution):** contracts read this session — `src/core/Base.mjs` (reactive configs, `set()` batching, destroy), `src/Neo.mjs` (`setupClass`/`Neo.get`), `src/state/Provider.mjs` (data proxy, `setData` batching, `stores_`, `getStore` parent-chain walk — verified at src/state/Provider.mjs:560), unit pattern from `test/playwright/unit/state/Provider.spec.mjs`.

**Deliberately NOT in this PR:** the view chrome binding it (SSOT #14692 merged — the view tranche files against it next) · NL wiring · dock/promote mechanics (that affordance consumes this provider; wiring is the dock lane).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs creationStateProvider creationFlowState` → **8 passed** (4 new + the oracle's 4 on the same stack).

Evidence: L2 (unit-pinned on real provider instances; the binding proof lands with the view tranche).

## Post-Merge Validation

- The view tranche binds `data.flowState`/`data.flowReason` + `stores.createdInstances` and calls `applyFlowEvent`/`applyCreationRouteOutcome` — any view writing flow state directly, or tracking `isGenerating`-style booleans, is the defect this leaf exists to prevent.
- The dock/promote lane consumes `activeInstanceId` for follow-up targeting.

## Related

Parent #13349 (T3.2) · #14711 / PR #14712 (the oracle — merge-order parent) · #14656 (the exposed registry, merged) · #14692 (the SSOT, merged — five states carried here) · `src/state/Provider.mjs` (the operator-seeded core contract).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b9b95ac6-42f5-47a3-b58f-6071f79657e8.
