### PR TITLE
feat(agentos): fleet cockpit FamilyRail primitive — data-driven, unclassified-safe (#14635)

### DIFF
--- a/apps/agentos/resources/fleet-components.css
+++ b/apps/agentos/resources/fleet-components.css
@@ -1,7 +1,7 @@
 /*
  * Fleet cockpit component primitives — geometry + motion over the --fm-* token layer.
  *
- * COLOR is never declared here: each component reads a --fm-* custom property (--fm-dot, --fm-chip)
+ * COLOR is never declared here: each component reads a --fm-* custom property (--fm-dot, --fm-chip, --fm-rail)
  * that it binds from the token layer (tokens.css). These rules carry only shape and the
  * reduced-motion-gated pulse. The pulse is decoration — the dot's COLOR carries the signal, so
  * reduced-motion users lose nothing informational.
@@ -31,6 +31,23 @@
     color         : var(--fm-chip, var(--fm-state-off));
     background    : color-mix(in srgb, var(--fm-chip, var(--fm-state-off)) 14%, transparent);
     border        : 1px solid color-mix(in srgb, var(--fm-chip, var(--fm-state-off)) 34%, transparent);
+}
+
+.fm-family-rail {
+    width        : 3px;
+    align-self   : stretch;
+    border-radius: 3px 0 0 3px;
+    background   : var(--fm-rail, var(--fm-state-off));
+}
+
+/* Unclassified family: a hatched neutral rail — the render marks "no recognized family" rather
+   than guessing one, so an unknown/absent family is visibly distinct from any real family color. */
+.fm-family-rail.fm-family-unclassified {
+    background: repeating-linear-gradient(
+        135deg,
+        var(--fm-state-off), var(--fm-state-off) 2px,
+        transparent 2px, transparent 4px
+    );
 }
 
 /* Pulse: decoration only, gated behind reduced-motion. The color already carries the signal. */

--- a/apps/agentos/view/fleet/FamilyRail.mjs
+++ b/apps/agentos/view/fleet/FamilyRail.mjs
@@ -16,12 +16,14 @@ const FAMILY_TOKEN = {
 };
 
 /**
- * Pure family → rail-token resolver. Unknown / absent family → the neutral token.
+ * Pure family → rail-token resolver. Unknown / absent family → the neutral token. Uses the
+ * `isKnownFamily` hasOwn check (not `MAP[k] ||`) so a prototype-shaped key (`toString`,
+ * `constructor`, `__proto__`) can't leak an inherited value past the closed set.
  * @param {String} family
  * @returns {String} a `--fm-family-*` name for a known family, else `--fm-state-off`
  */
 export function familyToken(family) {
-    return FAMILY_TOKEN[family] || '--fm-state-off'
+    return isKnownFamily(family) ? FAMILY_TOKEN[family] : '--fm-state-off'
 }
 
 /**

--- a/apps/agentos/view/fleet/FamilyRail.mjs
+++ b/apps/agentos/view/fleet/FamilyRail.mjs
@@ -1,0 +1,69 @@
+import {defineComponent} from '../../../../src/functional/_export.mjs';
+
+/**
+ * Maps a model-family key to its rail token (see `apps/agentos/resources/tokens.css`).
+ * Family is an attribute of the resident's CURRENT EmbodiedEpisode era — NOT a per-agent
+ * constant and NOT identity. A KNOWN family maps to its --fm-family-* token; anything else
+ * degrades to the NEUTRAL --fm-state-off token (never silently to `human`), so an unrecognized
+ * or absent family reads as genuinely unclassified rather than being mis-attributed.
+ * @type {Object}
+ */
+const FAMILY_TOKEN = {
+    claude: '--fm-family-claude',
+    gpt   : '--fm-family-gpt',
+    gemini: '--fm-family-gemini',
+    human : '--fm-family-human'
+};
+
+/**
+ * Pure family → rail-token resolver. Unknown / absent family → the neutral token.
+ * @param {String} family
+ * @returns {String} a `--fm-family-*` name for a known family, else `--fm-state-off`
+ */
+export function familyToken(family) {
+    return FAMILY_TOKEN[family] || '--fm-state-off'
+}
+
+/**
+ * Whether `family` is a recognized family key — drives the `unclassified` render marker.
+ * @param {String} family
+ * @returns {Boolean}
+ */
+export function isKnownFamily(family) {
+    return Object.hasOwn(FAMILY_TOKEN, family)
+}
+
+/**
+ * The family-accent rail on the leading edge of a resident's card. Its color binds DATA-DRIVEN
+ * from the resident's CURRENT-era family key — so a family swap (e.g. Opus→Fable) re-renders the
+ * rail in place for the SAME resident, never forks a new self (the anti-lock-in binding enforced
+ * here once instead of re-derived per consumer). An unknown or absent family renders NEUTRAL with
+ * an `unclassified` marker rather than guessing a family.
+ *
+ * The family key is a `harnessType`-derived proxy, declared as such until the identity-state
+ * schema lands the first-class era attribute — the binding surface is stable; only the source of
+ * the key changes.
+ *
+ * @summary Family-accent rail primitive — data-driven era attribute, unclassified-safe.
+ */
+export default defineComponent({
+    config: {
+        className: 'AgentOS.view.fleet.FamilyRail',
+        ntype    : 'fm-family-rail',
+        /**
+         * The current-era family — `claude` · `gpt` · `gemini` · `human`. A data-driven episode
+         * attribute, never a per-agent constant. Unknown / absent renders neutral + `unclassified`.
+         * @member {String|null} family_=null
+         */
+        family_: null
+    },
+
+    createVdom(config) {
+        const known = isKnownFamily(config.family);
+
+        return {
+            cls  : ['fm-family-rail', !known && 'fm-family-unclassified'].filter(Boolean),
+            style: {'--fm-rail': `var(${familyToken(config.family)})`}
+        }
+    }
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/familyRail.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/familyRail.spec.mjs
@@ -36,14 +36,20 @@ test.describe('Fleet cockpit FamilyRail — data-driven era attribute, unclassif
         // the key rule: unknown does NOT silently become human — it degrades to neutral
         expect(familyToken('some-new-family')).toBe('--fm-state-off');
         expect(familyToken(null)).toBe('--fm-state-off');
-        expect(familyToken(undefined)).toBe('--fm-state-off')
+        expect(familyToken(undefined)).toBe('--fm-state-off');
+        // prototype-shaped keys must not leak an inherited value past the closed set
+        expect(familyToken('toString')).toBe('--fm-state-off');
+        expect(familyToken('constructor')).toBe('--fm-state-off');
+        expect(familyToken('__proto__')).toBe('--fm-state-off')
     });
 
     test('isKnownFamily gates the unclassified marker', () => {
         expect(isKnownFamily('claude')).toBe(true);
         expect(isKnownFamily('human')).toBe(true);
         expect(isKnownFamily('mystery')).toBe(false);
-        expect(isKnownFamily(null)).toBe(false)
+        expect(isKnownFamily(null)).toBe(false);
+        expect(isKnownFamily('toString')).toBe(false);
+        expect(isKnownFamily('__proto__')).toBe(false)
     });
 
     test('FamilyRail binds --fm-rail from the family and marks unknown/absent as unclassified', async () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/familyRail.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/familyRail.spec.mjs
@@ -1,0 +1,78 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FleetFamilyRailTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+test.describe('Fleet cockpit FamilyRail — data-driven era attribute, unclassified-safe (#14635)', () => {
+    let FamilyRail, familyToken, isKnownFamily;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../apps/agentos/view/fleet/FamilyRail.mjs');
+
+        FamilyRail    = mod.default;
+        familyToken   = mod.familyToken;
+        isKnownFamily = mod.isKnownFamily
+    });
+
+    test('familyToken maps known families to --fm-family-*, unknown/absent to the NEUTRAL token (never human)', () => {
+        expect(familyToken('claude')).toBe('--fm-family-claude');
+        expect(familyToken('gpt')).toBe('--fm-family-gpt');
+        expect(familyToken('gemini')).toBe('--fm-family-gemini');
+        expect(familyToken('human')).toBe('--fm-family-human');
+        // the key rule: unknown does NOT silently become human — it degrades to neutral
+        expect(familyToken('some-new-family')).toBe('--fm-state-off');
+        expect(familyToken(null)).toBe('--fm-state-off');
+        expect(familyToken(undefined)).toBe('--fm-state-off')
+    });
+
+    test('isKnownFamily gates the unclassified marker', () => {
+        expect(isKnownFamily('claude')).toBe(true);
+        expect(isKnownFamily('human')).toBe(true);
+        expect(isKnownFamily('mystery')).toBe(false);
+        expect(isKnownFamily(null)).toBe(false)
+    });
+
+    test('FamilyRail binds --fm-rail from the family and marks unknown/absent as unclassified', async () => {
+        const rail = Neo.create(FamilyRail, {appName, family: 'claude'});
+        await rail.initVnode();
+
+        expect(rail.vdom.cls).toContain('fm-family-rail');
+        expect(rail.vdom.cls).not.toContain('fm-family-unclassified');
+        expect(rail.vdom.style['--fm-rail']).toBe('var(--fm-family-claude)');
+
+        // an unknown/absent family renders neutral + the unclassified marker — never a guessed family
+        rail.family = 'mystery';
+        expect(rail.vdom.style['--fm-rail']).toBe('var(--fm-state-off)');
+        expect(rail.vdom.cls).toContain('fm-family-unclassified');
+
+        rail.destroy()
+    });
+
+    test('a family swap re-renders the SAME resident in place (anti-lock-in episode binding)', async () => {
+        const rail = Neo.create(FamilyRail, {appName, family: 'claude'});
+        await rail.initVnode();
+
+        const before = rail.id;
+        // Opus→Fable is still Claude-family; a cross-family swap (Claude→GPT) is the harder case
+        rail.family = 'gpt';
+        expect(rail.vdom.style['--fm-rail']).toBe('var(--fm-family-gpt)');
+        expect(rail.id).toBe(before);
+        expect(rail.vdom.cls).not.toContain('fm-family-unclassified');
+
+        rail.destroy()
+    });
+});


### PR DESCRIPTION
Resolves #14635

Refs #14560 (parent epic — never a close-target) · Refs #14578 (token layer).

The family-accent rail — split out of the #14593 triplet per @neo-gpt's review, and built to #14635's **code + unit-spec ACs** (the version bundled in the narrowed #14700 under-satisfied them: it fell back unknown→`human`). AC#3's NL-verified render row is a **documented residual** deferred to composition — see Deltas.

Evidence: L2 (unit-tested; 4/4 green at head `17db2a4a7`, post-rebase onto dev). The NL render row is deferred to the #14598 composer mount — the same pattern the merged StateDot #14700 used for its in-app verification (residual documented below).

## What it adds

- **FamilyRail** — family binds **data-driven** from the current-era key via a pure `familyToken()` resolver; a family swap re-renders the rail in place for the **same resident** (rebind-same-instance fixture), never forks a new self.
- **Unknown / absent family → NEUTRAL** (`--fm-state-off`, never silently `human`) **+ an `fm-family-unclassified` marker** (a hatched neutral rail) — the render marks "no recognized family" rather than guessing one. The closed-set resolver guards against prototype-shaped keys (`toString`/`constructor`/`__proto__`) via `Object.hasOwn`, so an inherited value can't leak past the set.
- The family key is a `harnessType`-derived proxy, declared as such until the identity-state schema (#11318 / epic #14677) lands the first-class era attribute — the binding surface is stable, only the source of the key changes.

## Test Evidence

`npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/familyRail.spec.mjs` → **4 passed** (green at head `17db2a4a7`, post-rebase onto dev). Covers `familyToken` (known → `--fm-family-*`; unknown/absent → `--fm-state-off` **not** human, incl. prototype-shaped keys), `isKnownFamily`, the `--fm-rail` binding + `unclassified` marker, and the rebind-same-instance family swap.

## Post-Merge Validation

- [ ] **NL-verified render row (AC#3 clause 3 — deferred):** the primitive has no standalone mount and the NL bridge currently has no live session for it (`healthcheck` → `connected:false`). The in-app NL render verification lands when AgentCard #14598 composes FamilyRail (its natural mount) — the same deferral the merged StateDot #14700 declared.

## Deltas from ticket

**One residual, made explicit** (folding @neo-gpt's evidence RA on the prior head `5c3b234`): #14635 AC#3 is *"tokens only (zero literal colors); unit specs + NL-verified row."* The tokens-only and unit-spec clauses are **met** (4/4 green, zero hand-rolled colors); the **NL-verified row is deferred** to the #14598 composer mount. A mount-less primitive can't be NL-rendered standalone without duplicating the composer's mount, so this render proof lands post-merge at composition — exactly how the merged StateDot #14700 handled its in-app verification. `Resolves #14635` is retained on that precedent: this is built + unit-verified code, and the render proof is a post-merge validation item (above), not unbuilt scope. The residual is annotated on #14635 itself.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
