### PR TITLE
feat(graph): convergence render-ledger — human-facing, notAuthority, firewalled (#14636)

### DIFF
--- a/ai/services/graph/convergenceRenderLedger.mjs
+++ b/ai/services/graph/convergenceRenderLedger.mjs
@@ -1,0 +1,211 @@
+import {resolveRenderTarget} from './convergenceSnapshotSchema.mjs';
+import {CONTRACT_AXES}       from './conceptNeighborhoodProbe.mjs';
+
+/**
+ * @module ai/services/graph/convergenceRenderLedger
+ * @summary Convergence-weighted Golden Path — human-facing render-ledger (ticket-ref-ok: #14636 owning-leaf anchor; Leaf 3 of #14581).
+ *
+ * The human-facing terminus of the convergence firewall chain: schema (Leaf 1) mints canonical-id snapshot
+ * nodes, compute (Leaf 2) weights them over N imagined futures, and this leaf projects that output into a
+ * PROVISIONAL, `notAuthority` ledger a maintainer reads — the terrain of which sub-goals are cross-future
+ * invariant ("structure not events"). Long-run home: a terrain panel in the FM cockpit; interim home: the
+ * standalone text artifact `renderConvergenceLedgerText` emits.
+ *
+ * Firewall preserved end-to-end, not just at compute (OQ8):
+ *   - The ledger's `notAuthority` / `agentBootConsumable` flags are sourced verbatim from the schema's
+ *     `resolveRenderTarget()` — single source, never re-invented — so the render declares itself
+ *     non-consumable by any agent boot-path.
+ *   - It is a PURE PROJECTION: canonical ids, convergence weights, and the independence budget are read
+ *     straight off the compute output — NO re-compute, NO id re-derivation (the OQ1 anchor stays put).
+ *   - The run-level OQ7 independence budget + OQ8 firewall attestation ride along as decision-support
+ *     context so the human can discount correlated-future inflation and see upstream integrity.
+ *   - The four contract axes (authority / fidelity / extractionProvenance / lifecycle) render SEPARATELY —
+ *     never flattened to a composite score, matching the schema contract.
+ *
+ * ADR disposition (ticket-ref-ok: governance anchor, render-only / no-new-authority): aligned-with ADR-0023, depends-on ADR-0024 (the Leaf 1 `CONVERGENCE_SNAPSHOT` node class it renders).
+ * Introduces NO new decision authority — render-only, additive, fail-open: a malformed input degrades to an
+ * empty ledger, never an exception into a caller.
+ */
+
+/**
+ * @summary The provisional / non-authority banner every ledger carries. Convergence is a HYPOTHESIS about
+ * cross-future invariance surfaced for human judgement — never a mandate, never ground truth an agent boots
+ * from. Frozen so no consumer can silently soften it.
+ */
+export const CONVERGENCE_LEDGER_DISCLAIMER = Object.freeze({
+    provisional : 'Provisional decision-support — convergence is a hypothesis about cross-future invariance, not a mandate.',
+    notAuthority: 'Not authority: no agent boot-path consumes this ledger. Reading it as ground truth would re-enter generation and make convergence self-fulfilling (OQ8).',
+    discount    : 'Weight is inflated when the imagined futures are correlated — read it against the independence budget below.'
+});
+
+/**
+ * @summary Projects a single convergence-snapshot node into a ledger row. Pure read: `canonicalId`,
+ * `convergenceWeight`, and `independenceBudget` are taken verbatim (no re-compute, no re-canonicalization);
+ * the four contract axes are surfaced in canonical order, each slot present (missing → `null`) and SEPARATE.
+ * @param {Object} snapshot A `CONVERGENCE_SNAPSHOT` node (see `buildConvergenceSnapshotNode`).
+ * @returns {Object|null} the frozen row, or `null` when the snapshot has no canonical id.
+ */
+function toLedgerRow(snapshot) {
+    const properties = snapshot?.properties;
+
+    if (!properties || !properties.canonicalId) return null;
+
+    const axes    = properties.axes || {},
+          axisRow = {};
+
+    // Every contract axis gets a slot in canonical order — separate, never a composite. Missing → null.
+    for (const axis of Object.keys(CONTRACT_AXES)) {
+        axisRow[axis] = axes[axis] !== undefined ? axes[axis] : null;
+    }
+
+    return Object.freeze({
+        canonicalId       : properties.canonicalId,
+        convergenceWeight : typeof properties.convergenceWeight  === 'number' ? properties.convergenceWeight  : null,
+        independenceBudget: typeof properties.independenceBudget === 'number' ? properties.independenceBudget : null,
+        riskNode          : properties.riskNode === true,
+        axes              : Object.freeze(axisRow),
+        provenance        : properties.provenance || null,
+        remeasureAt       : properties.remeasureAt || null
+    });
+}
+
+/**
+ * @summary Orders ledger rows into terrain: highest cross-future invariance first. Convergence weight
+ * descending (unweighted `null` rows sink to the bottom), ties broken by independence budget descending
+ * (a more independent future set makes the same weight more trustworthy), then canonical id ascending for
+ * deterministic output.
+ * @param {Object} a first row.
+ * @param {Object} b second row.
+ * @returns {Number} comparator result.
+ */
+function byTerrain(a, b) {
+    const aw = a.convergenceWeight ?? -Infinity,
+          bw = b.convergenceWeight ?? -Infinity;
+
+    if (aw !== bw) return bw - aw;
+
+    const ai = a.independenceBudget ?? -Infinity,
+          bi = b.independenceBudget ?? -Infinity;
+
+    if (ai !== bi) return bi - ai;
+
+    return a.canonicalId < b.canonicalId ? -1 : a.canonicalId > b.canonicalId ? 1 : 0;
+}
+
+/**
+ * @summary Builds the human-facing convergence render-ledger from a Leaf 2 compute result. The ledger is a
+ * PROVISIONAL, `notAuthority` projection — its firewall flags come verbatim from the schema's
+ * `resolveRenderTarget()`, and the run-level OQ7 independence budget + OQ8 firewall manifest ride along so a
+ * maintainer can judge upstream integrity. Additive + fail-open: a malformed input yields an empty-rows
+ * ledger, never an exception.
+ *
+ * @param {Object} [computeResult] Leaf 2 output `{snapshots, independenceBudget, manifest}`; a bare
+ *   snapshot array is also accepted (no run-level context then).
+ * @param {Object} [options]
+ * @param {String} [options.now] ISO clock injection for deterministic `generatedAt`.
+ * @returns {Object} frozen ledger `{kind, provisional, notAuthority, agentBootConsumable, home, generatedAt,
+ *   disclaimer, firewall, independenceBudget, rows, rowCount}`.
+ */
+export function buildConvergenceRenderLedger(computeResult, {now} = {}) {
+    const target = resolveRenderTarget();
+
+    // Fail-open scaffold: the firewall-flag frame is always well-formed, even for a garbage input.
+    const base = {
+        kind               : target.target,
+        provisional        : true,
+        notAuthority       : target.notAuthority,        // verbatim from schema — the render never re-invents it
+        agentBootConsumable: target.agentBootConsumable, // false — declares itself non-consumable
+        home               : target.home,
+        generatedAt        : now || null,
+        disclaimer         : CONVERGENCE_LEDGER_DISCLAIMER
+    };
+
+    try {
+        const result    = Array.isArray(computeResult) ? {snapshots: computeResult} : (computeResult || {}),
+              snapshots = Array.isArray(result.snapshots) ? result.snapshots : [],
+              manifest  = result.manifest || null;
+
+        const rows = snapshots.map(toLedgerRow).filter(Boolean).sort(byTerrain);
+
+        return Object.freeze({
+            ...base,
+            firewall: Object.freeze({
+                // Surfaced for the human: was the upstream compute run isolated (OQ8)? A non-clean run's
+                // weights may be self-fulfilling — the ledger shows it rather than silently trusting it.
+                clean       : manifest ? manifest.firewallClean === true : null,
+                futureSource: manifest ? manifest.futureSource : null
+            }),
+            independenceBudget: Object.freeze({
+                value         : typeof result.independenceBudget === 'number' ? result.independenceBudget : null,
+                interpretation: '0 = correlated futures (convergence inflated); 1 = independent futures (convergence trustworthy).'
+            }),
+            rows    : Object.freeze(rows),
+            rowCount: rows.length
+        });
+    } catch (error) {
+        // Fail-open: render-only, never an exception into a caller.
+        return Object.freeze({
+            ...base,
+            firewall          : Object.freeze({clean: null, futureSource: null}),
+            independenceBudget: Object.freeze({value: null, interpretation: CONVERGENCE_LEDGER_DISCLAIMER.discount}),
+            rows              : Object.freeze([]),
+            rowCount          : 0
+        });
+    }
+}
+
+/**
+ * @summary Renders a ledger (from `buildConvergenceRenderLedger`) as the interim standalone artifact: a
+ * human-readable markdown terrain report, provisional banner first, then the OQ7/OQ8 context, then the
+ * weighted rows. Pure string projection — reads the ledger, computes nothing.
+ * @param {Object} ledger a ledger object from `buildConvergenceRenderLedger`.
+ * @returns {String} markdown text for the standalone ledger artifact.
+ */
+export function renderConvergenceLedgerText(ledger) {
+    if (!ledger || !Array.isArray(ledger.rows)) return '';
+
+    const budget   = ledger.independenceBudget?.value,
+          firewall = ledger.firewall || {},
+          axisKeys = Object.keys(CONTRACT_AXES);
+
+    const lines = [
+        '# Convergence Terrain Ledger',
+        '',
+        `> **PROVISIONAL — notAuthority.** ${ledger.disclaimer?.provisional || ''}`,
+        `> ${ledger.disclaimer?.notAuthority || ''}`,
+        '',
+        `- **Firewall (OQ8):** ${firewall.clean === true ? 'clean — compute read neither peer futures nor prior convergence' : firewall.clean === false ? '⚠ COMPROMISED — output may be self-fulfilling; discount heavily' : 'unknown (no manifest)'}${firewall.futureSource ? ` · futures: \`${firewall.futureSource}\`` : ''}`,
+        `- **Independence budget (OQ7):** ${budget === null || budget === undefined ? 'n/a' : budget.toFixed(3)} — ${ledger.independenceBudget?.interpretation || ''}`,
+        `- **Home surface:** \`${ledger.home}\` (interim: this standalone artifact) · agent-boot-consumable: ${ledger.agentBootConsumable}`,
+        `- **Rows:** ${ledger.rowCount}`,
+        ''
+    ];
+
+    if (ledger.rowCount === 0) {
+        lines.push('_No convergence snapshots to render._');
+        return lines.join('\n');
+    }
+
+    const header = ['Rank', 'Convergence', 'Independence', 'Risk', 'Canonical Id', ...axisKeys, 'Remeasure At'];
+
+    lines.push(
+        `| ${header.join(' | ')} |`,
+        `| ${header.map(() => '---').join(' | ')} |`
+    );
+
+    ledger.rows.forEach((row, index) => {
+        const cells = [
+            String(index + 1),
+            row.convergenceWeight === null ? '—' : String(row.convergenceWeight),
+            row.independenceBudget === null ? '—' : row.independenceBudget.toFixed(3),
+            row.riskNode ? '⚠' : '',
+            `\`${row.canonicalId}\``,
+            ...axisKeys.map(axis => row.axes[axis] === null || row.axes[axis] === undefined ? '—' : String(row.axes[axis])),
+            row.remeasureAt || '—'
+        ];
+
+        lines.push(`| ${cells.join(' | ')} |`);
+    });
+
+    return lines.join('\n');
+}

--- a/ai/services/graph/convergenceRenderLedger.mjs
+++ b/ai/services/graph/convergenceRenderLedger.mjs
@@ -168,7 +168,8 @@ function formatAxisCell(value) {
         ? (Object.entries(value).map(([key, val]) => `${key}=${typeof val === 'object' ? JSON.stringify(val) : val}`).join(', ') || '{}')
         : String(value);
 
-    return cell.replace(/\|/g, '\\|');   // an axis payload must never break the markdown table
+    // escape the escape char first, then the pipe — else a pre-existing backslash mis-escapes the pipe
+    return cell.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');   // an axis payload must never break the markdown table
 }
 
 /**

--- a/ai/services/graph/convergenceRenderLedger.mjs
+++ b/ai/services/graph/convergenceRenderLedger.mjs
@@ -155,6 +155,23 @@ export function buildConvergenceRenderLedger(computeResult, {now} = {}) {
 }
 
 /**
+ * @summary Renders one contract-axis payload into a legible markdown-table cell. Axis values are small
+ * objects (e.g. `{trustTier: 'system'}`), so a naive `String(obj)` emits `[object Object]`; this folds them
+ * to compact `key=value` pairs (JSON-encoding any nested value) and escapes `|` so the table survives.
+ * @param {*} value the axis payload — object, primitive, or null.
+ * @returns {String} a table-safe cell; `—` when the axis is absent.
+ */
+function formatAxisCell(value) {
+    if (value === null || value === undefined) return '—';
+
+    const cell = typeof value === 'object'
+        ? (Object.entries(value).map(([key, val]) => `${key}=${typeof val === 'object' ? JSON.stringify(val) : val}`).join(', ') || '{}')
+        : String(value);
+
+    return cell.replace(/\|/g, '\\|');   // an axis payload must never break the markdown table
+}
+
+/**
  * @summary Renders a ledger (from `buildConvergenceRenderLedger`) as the interim standalone artifact: a
  * human-readable markdown terrain report, provisional banner first, then the OQ7/OQ8 context, then the
  * weighted rows. Pure string projection — reads the ledger, computes nothing.
@@ -211,7 +228,7 @@ export function renderConvergenceLedgerText(ledger) {
             row.independenceBudget === null ? '—' : row.independenceBudget.toFixed(3),
             row.riskNode ? '⚠' : '',
             `\`${row.canonicalId}\``,
-            ...axisKeys.map(axis => row.axes[axis] === null || row.axes[axis] === undefined ? '—' : String(row.axes[axis])),
+            ...axisKeys.map(axis => formatAxisCell(row.axes[axis])),
             row.remeasureAt || '—'
         ];
 

--- a/ai/services/graph/convergenceRenderLedger.mjs
+++ b/ai/services/graph/convergenceRenderLedger.mjs
@@ -166,7 +166,13 @@ export function renderConvergenceLedgerText(ledger) {
 
     const budget   = ledger.independenceBudget?.value,
           firewall = ledger.firewall || {},
-          axisKeys = Object.keys(CONTRACT_AXES);
+          axisKeys = Object.keys(CONTRACT_AXES),
+          // Provenance traceability (OQ1): a confident weight with no traceable producing run is
+          // authority-by-typography, even under the notAuthority banner. Surface it as a shared-run header
+          // when every row agrees, else as a per-row column.
+          provenances = [...new Set(ledger.rows.map(row => row.provenance).filter(Boolean))],
+          oneProvenance    = provenances.length === 1 ? provenances[0] : null,
+          columnProvenance = provenances.length > 1;
 
     const lines = [
         '# Convergence Terrain Ledger',
@@ -176,6 +182,8 @@ export function renderConvergenceLedgerText(ledger) {
         '',
         `- **Firewall (OQ8):** ${firewall.clean === true ? 'clean — compute read neither peer futures nor prior convergence' : firewall.clean === false ? '⚠ COMPROMISED — output may be self-fulfilling; discount heavily' : 'unknown (no manifest)'}${firewall.futureSource ? ` · futures: \`${firewall.futureSource}\`` : ''}`,
         `- **Independence budget (OQ7):** ${budget === null || budget === undefined ? 'n/a' : budget.toFixed(3)} — ${ledger.independenceBudget?.interpretation || ''}`,
+        `- **Provenance (OQ1):** ${provenances.length === 0 ? 'none recorded' : oneProvenance ? `\`${oneProvenance}\` (all rows)` : 'per-row — see column'}`,
+        `- **Generated at:** ${ledger.generatedAt || '— (unstamped; inject now at render for staleness-legibility)'}`,
         `- **Home surface:** \`${ledger.home}\` (interim: this standalone artifact) · agent-boot-consumable: ${ledger.agentBootConsumable}`,
         `- **Rows:** ${ledger.rowCount}`,
         ''
@@ -187,6 +195,9 @@ export function renderConvergenceLedgerText(ledger) {
     }
 
     const header = ['Rank', 'Convergence', 'Independence', 'Risk', 'Canonical Id', ...axisKeys, 'Remeasure At'];
+
+    // Only widen the table when rows disagree on provenance; the uniform case rode the header line above.
+    if (columnProvenance) header.push('Provenance');
 
     lines.push(
         `| ${header.join(' | ')} |`,
@@ -203,6 +214,8 @@ export function renderConvergenceLedgerText(ledger) {
             ...axisKeys.map(axis => row.axes[axis] === null || row.axes[axis] === undefined ? '—' : String(row.axes[axis])),
             row.remeasureAt || '—'
         ];
+
+        if (columnProvenance) cells.push(row.provenance ? `\`${row.provenance}\`` : '—');
 
         lines.push(`| ${cells.join(' | ')} |`);
     });

--- a/test/playwright/unit/ai/services/graph/convergenceRenderLedger.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/convergenceRenderLedger.spec.mjs
@@ -149,9 +149,30 @@ test.describe('convergenceRenderLedger', () => {
         expect(text).toContain('Independence budget (OQ7)');
         expect(text).toContain('fm-cockpit-terrain-panel');
         expect(text).toContain('agent-boot-consumable: false');
+        // Provenance (OQ1) traceable — a shared-run header, not a per-row column, when every row agrees.
+        expect(text).toContain('Provenance (OQ1)');
+        expect(text).toContain('`lattice-import:test` (all rows)');
+        expect(text).not.toContain('| Provenance |');
+        // Staleness-legible: the capture timestamp renders so the terrain can be judged against remeasureAt.
+        expect(text).toContain('Generated at:');
+        expect(text).toContain(now);
         // The terrain table ranks golden-path first.
         expect(text).toMatch(/\|\s*1\s*\|\s*3\s*\|.*golden-path/);
         expect(renderConvergenceLedgerText(null)).toBe('');   // fail-open on a null ledger
+    });
+
+    test('renders a per-row Provenance column when rows disagree on provenance — traceable without a false shared-run claim (#14636)', () => {
+        const a = buildConvergenceSnapshotNode({latticeNodeId: 'alpha', provenance: 'run-A'}),
+              b = buildConvergenceSnapshotNode({latticeNodeId: 'beta',  provenance: 'run-B'});
+        a.properties.convergenceWeight = 2;
+        b.properties.convergenceWeight = 1;
+
+        const text = renderConvergenceLedgerText(buildConvergenceRenderLedger({snapshots: [a, b]}, {now}));
+
+        expect(text).toContain('per-row — see column');   // header defers to the column, no false "all rows"
+        expect(text).toContain('| Provenance |');         // column widened in
+        expect(text).toContain('`run-A`');
+        expect(text).toContain('`run-B`');
     });
 
     test('an empty compute result renders a valid empty ledger, not a crash', () => {

--- a/test/playwright/unit/ai/services/graph/convergenceRenderLedger.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/convergenceRenderLedger.spec.mjs
@@ -175,6 +175,21 @@ test.describe('convergenceRenderLedger', () => {
         expect(text).toContain('`run-B`');
     });
 
+    test('renders object-valued contract-axis payloads legibly — never [object Object] (GPT RC on #14725)', () => {
+        const snap = buildConvergenceSnapshotNode({
+            latticeNodeId: 'alpha',
+            axes         : {authority: {trustTier: 'system'}, lifecycle: {state: 'candidate', verifiedAt: '2026-07-04'}}
+        });
+        snap.properties.convergenceWeight = 2;
+
+        const text = renderConvergenceLedgerText(buildConvergenceRenderLedger({snapshots: [snap]}, {now}));
+
+        expect(text).not.toContain('[object Object]');    // the exact defect GPT reproduced
+        expect(text).toContain('trustTier=system');        // authority axis folded to key=value
+        expect(text).toContain('state=candidate');         // lifecycle axis — multi-field, comma-joined
+        expect(text).toContain('verifiedAt=2026-07-04');
+    });
+
     test('an empty compute result renders a valid empty ledger, not a crash', () => {
         const ledger = buildConvergenceRenderLedger({snapshots: [], independenceBudget: 0, manifest: null}, {now});
 

--- a/test/playwright/unit/ai/services/graph/convergenceRenderLedger.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/convergenceRenderLedger.spec.mjs
@@ -1,0 +1,164 @@
+import {test, expect}                        from '@playwright/test';
+import {readdirSync, readFileSync, statSync} from 'node:fs';
+import {fileURLToPath}                       from 'node:url';
+
+import {computeConvergenceSnapshots}  from '../../../../../../ai/services/graph/convergenceCompute.mjs';
+import {buildConvergenceSnapshotNode} from '../../../../../../ai/services/graph/convergenceSnapshotSchema.mjs';
+import {
+    CONVERGENCE_LEDGER_DISCLAIMER,
+    buildConvergenceRenderLedger,
+    renderConvergenceLedgerText
+} from '../../../../../../ai/services/graph/convergenceRenderLedger.mjs';
+
+/**
+ * Recursively collects `.mjs` files under a dir (absolute path), excluding specs.
+ */
+function collectMjs(absDir) {
+    const out = [];
+
+    let entries;
+    try { entries = readdirSync(absDir); } catch (error) { return out; }
+
+    for (const entry of entries) {
+        const abs = `${absDir}/${entry}`;
+
+        if (statSync(abs).isDirectory()) {
+            out.push(...collectMjs(abs));
+        } else if (entry.endsWith('.mjs') && !entry.endsWith('.spec.mjs')) {
+            out.push(abs);
+        }
+    }
+
+    return out;
+}
+
+test.describe('convergenceRenderLedger', () => {
+    const now = '2026-07-04T00:00:00.000Z',
+          // Leaf 2 real compute output: 'golden-path' lies on all 3 futures (weight 3); the others on one each.
+          compute  = computeConvergenceSnapshots({
+              latticeNodeIds: ['CONCEPT:GoldenPath', 'CONCEPT:FirstRevenue', 'CONCEPT:Foo'],
+              futurePaths   : [['golden-path', 'first-revenue'], ['golden-path'], ['golden-path', 'foo']],
+              provenance    : 'lattice-import:test',
+              manifest      : {futureSource: 'test-futures'},
+              now
+          });
+
+    test('renders a PROVISIONAL, notAuthority ledger — the firewall flags come verbatim from the schema (preserved end-to-end)', () => {
+        const ledger = buildConvergenceRenderLedger(compute, {now});
+
+        expect(ledger.kind).toBe('convergence-terrain-ledger');
+        expect(ledger.provisional).toBe(true);
+        // These are the OQ8 firewall flags minted by the schema's resolveRenderTarget — the render must not soften them.
+        expect(ledger.notAuthority).toBe(true);
+        expect(ledger.agentBootConsumable).toBe(false);
+        expect(ledger.home).toBe('fm-cockpit-terrain-panel');
+        expect(ledger.disclaimer).toBe(CONVERGENCE_LEDGER_DISCLAIMER);
+        expect(ledger.disclaimer.notAuthority).toContain('self-fulfilling');
+    });
+
+    test('FIREWALL: no agent boot-path module imports the render-ledger (OQ8 preserved structurally, not just by flag)', () => {
+        // "Agent boot-path" = the Brain runtime an agent boots into + synthesizes its next action from.
+        const rootUrl  = new URL('../../../../../../', import.meta.url),
+              root     = fileURLToPath(rootUrl),
+              bootPath = [
+                  ...collectMjs(`${root}ai/daemons`),
+                  `${root}ai/services/graph/GoldenPathSynthesizer.mjs`,
+                  `${root}ai/services/graph/computedGoldenPathRouting.mjs`,
+                  `${root}ai/services/graph/goldenPathPickupBridge.mjs`
+              ];
+
+        const importers = bootPath.filter(file => {
+            let src;
+            try { src = readFileSync(file, 'utf8'); } catch (error) { return false; }
+            return /convergenceRenderLedger/.test(src);
+        });
+
+        // Currently zero consumers anywhere; the sanctioned future consumer is the human-facing FM-cockpit
+        // terrain panel (NOT a boot-path surface). If this ever fails, an agent runtime started consuming the
+        // ledger — that re-enters generation and makes convergence self-fulfilling. Do not allowlist a boot-path file.
+        expect(importers, `agent boot-path modules importing the ledger: ${importers.join(', ')}`).toEqual([]);
+    });
+
+    test('renders Leaf 2 compute output over Leaf 1 canonical ids — verbatim, no re-compute / no id re-derivation', () => {
+        const ledger = buildConvergenceRenderLedger(compute, {now});
+
+        // Terrain order: highest cross-future invariance first. 'golden-path' (weight 3) tops it.
+        expect(ledger.rowCount).toBe(3);
+        expect(ledger.rows[0].canonicalId).toBe('golden-path');
+        expect(ledger.rows[0].convergenceWeight).toBe(3);
+        // Canonical id is taken straight off the snapshot — identical to what the schema minted, no re-derivation.
+        expect(ledger.rows[0].canonicalId).toBe(compute.snapshots.find(s => s.properties.convergenceWeight === 3).properties.canonicalId);
+        // Ties (weight 1) break by independence then canonical id asc → 'first-revenue' before 'foo'.
+        expect(ledger.rows.map(r => r.canonicalId)).toEqual(['golden-path', 'first-revenue', 'foo']);
+    });
+
+    test('surfaces the OQ7 independence budget + OQ8 firewall manifest as human decision-support context', () => {
+        const ledger = buildConvergenceRenderLedger(compute, {now});
+
+        expect(ledger.firewall.clean).toBe(true);               // compute read neither peer futures nor prior convergence
+        expect(ledger.firewall.futureSource).toBe('test-futures');
+        expect(ledger.independenceBudget.value).toBeGreaterThan(0);
+        expect(ledger.independenceBudget.value).toBe(compute.independenceBudget); // surfaced verbatim, not recomputed
+        expect(ledger.independenceBudget.interpretation).toContain('inflated');
+    });
+
+    test('flags a firewall-COMPROMISED upstream run rather than silently trusting it', () => {
+        const dirty = computeConvergenceSnapshots({
+            latticeNodeIds: ['CONCEPT:GoldenPath'],
+            futurePaths   : [['golden-path']],
+            manifest      : {readPriorConvergence: true},   // NOT firewall-clean
+            now
+        });
+        const ledger = buildConvergenceRenderLedger(dirty, {now});
+
+        expect(ledger.firewall.clean).toBe(false);
+        expect(renderConvergenceLedgerText(ledger)).toContain('COMPROMISED');
+    });
+
+    test('keeps the four contract axes SEPARATE — every slot present, never a composite score', () => {
+        const snapshot = buildConvergenceSnapshotNode({
+            latticeNodeId: 'first-revenue',
+            axes         : {authority: {trustTier: 'system'}, lifecycle: {state: 'candidate'}, composite: 0.9}
+        });
+        snapshot.properties.convergenceWeight  = 2;
+        snapshot.properties.independenceBudget = 0.5;
+
+        const row = buildConvergenceRenderLedger({snapshots: [snapshot]}, {now}).rows[0];
+
+        expect(Object.keys(row.axes)).toEqual(['authority', 'fidelity', 'extractionProvenance', 'lifecycle']);
+        expect(row.axes.authority).toEqual({trustTier: 'system'});
+        expect(row.axes.fidelity).toBeNull();               // absent axis is an explicit null slot, not omitted
+        expect(row.axes).not.toHaveProperty('composite');   // a flattened score must never survive
+    });
+
+    test('is additive + fail-open — malformed input degrades to an empty ledger, never throws', () => {
+        for (const bad of [null, undefined, {}, {snapshots: 'nope'}, [null, {properties: null}], 42]) {
+            const ledger = buildConvergenceRenderLedger(bad, {now});
+            expect(ledger.notAuthority).toBe(true);         // firewall frame holds even for garbage
+            expect(ledger.rowCount).toBe(0);
+            expect(Array.isArray(ledger.rows)).toBe(true);
+        }
+    });
+
+    test('renderConvergenceLedgerText emits the interim standalone artifact — provisional banner, OQ7/OQ8 context, weighted table', () => {
+        const text = renderConvergenceLedgerText(buildConvergenceRenderLedger(compute, {now}));
+
+        expect(text).toContain('# Convergence Terrain Ledger');
+        expect(text).toContain('PROVISIONAL — notAuthority');
+        expect(text).toMatch(/Firewall \(OQ8\).*clean — compute read neither/);
+        expect(text).toContain('Independence budget (OQ7)');
+        expect(text).toContain('fm-cockpit-terrain-panel');
+        expect(text).toContain('agent-boot-consumable: false');
+        // The terrain table ranks golden-path first.
+        expect(text).toMatch(/\|\s*1\s*\|\s*3\s*\|.*golden-path/);
+        expect(renderConvergenceLedgerText(null)).toBe('');   // fail-open on a null ledger
+    });
+
+    test('an empty compute result renders a valid empty ledger, not a crash', () => {
+        const ledger = buildConvergenceRenderLedger({snapshots: [], independenceBudget: 0, manifest: null}, {now});
+
+        expect(ledger.rowCount).toBe(0);
+        expect(ledger.firewall.clean).toBeNull();             // no manifest → unknown, not a false "clean"
+        expect(renderConvergenceLedgerText(ledger)).toContain('No convergence snapshots to render');
+    });
+});

--- a/test/playwright/unit/ai/services/graph/convergenceRenderLedger.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/convergenceRenderLedger.spec.mjs
@@ -131,6 +131,22 @@ test.describe('convergenceRenderLedger', () => {
         expect(row.axes).not.toHaveProperty('composite');   // a flattened score must never survive
     });
 
+    test('escapes backslashes before pipes in axis cells — a backslash-bearing value never breaks the table', () => {
+        // An axis value carrying BOTH a backslash and a pipe: escaping the pipe alone leaves the
+        // pre-existing backslash mis-paired and splits the markdown row into a stray column (the
+        // reported incomplete-sanitization defect). The fix escapes `\` -> `\\` FIRST, then `|` -> `\|`.
+        const snapshot = buildConvergenceSnapshotNode({
+            latticeNodeId: 'esc-regression',
+            axes         : {authority: {trustTier: 'a\\b|c'}}
+        });
+        snapshot.properties.convergenceWeight = 1;
+
+        const text = renderConvergenceLedgerText(buildConvergenceRenderLedger({snapshots: [snapshot]}, {now}));
+
+        // backslash doubled AND pipe escaped → the value stays inside one table column: `trustTier=a\\b\|c`
+        expect(text).toContain('trustTier=a\\\\b\\|c');
+    });
+
     test('is additive + fail-open — malformed input degrades to an empty ledger, never throws', () => {
         for (const bad of [null, undefined, {}, {snapshots: 'nope'}, [null, {properties: null}], 42]) {
             const ledger = buildConvergenceRenderLedger(bad, {now});


### PR DESCRIPTION
Resolves #14636

Leaf 3 of epic #14581 (Convergence-weighted Golden Path) — the **human-facing terminus** of the firewall chain: schema (Leaf 1, #14633 merged) mints canonical-id snapshots, compute (Leaf 2, #14634 / PR #14707 merged `b76a301fdd`) weights them over N imagined futures, and this leaf projects that output into a **provisional, `notAuthority`** ledger a maintainer reads — the terrain of which sub-goals are cross-future invariant ("structure not events").

Evidence: L2 (unit — 12 render-ledger specs incl. the structural boot-path-importer firewall scan, object-axis readability, and mixed backslash/pipe escaping regression, rendering real Leaf 2 compute output) → L2 required (close-target ACs are unit / static-contract covered; live wiring is the demo/falsifier leaf #14648). No residual.

## What it does
- `buildConvergenceRenderLedger({snapshots, independenceBudget, manifest}, {now})` → a frozen ledger; `renderConvergenceLedgerText(ledger)` → the **interim standalone markdown artifact** (the AC's named interim home).
- **Firewall preserved end-to-end (OQ8), not just at compute:** the ledger's `notAuthority` / `agentBootConsumable:false` / `home` flags are sourced **verbatim** from the schema's `resolveRenderTarget()` — single source, chain preserved schema→render.
- **Pure projection:** canonical ids, convergence weights, independence budget read straight off the compute output — **no re-compute, no id re-derivation** (OQ1 anchor stays put).
- **Four contract axes render SEPARATE** — never flattened to a composite score (schema contract).
- Run-level **OQ7 independence budget** + **OQ8 firewall attestation** ride along as decision-support; a firewall-**compromised** upstream run is flagged (`⚠ COMPROMISED`), not silently trusted.
- Additive + fail-open: a malformed input degrades to an empty-rows ledger, never an exception.

## Firewall — structural, not just by flag
The AC requires "a test asserts no agent boot-path consumes the ledger." The spec scans the **agent boot-path** (`ai/daemons/**` + the golden-path synthesis modules `GoldenPathSynthesizer` / `computedGoldenPathRouting` / `goldenPathPickupBridge`) and asserts **none import the ledger**. The sanctioned future consumer is the human-facing **FM-cockpit terrain panel** (never a boot-path surface) — the long-run home, declared but not wired here (per Out of Scope + the FM cockpit lane #13015).

## Deltas from ticket
- The ledger takes the **whole Leaf 2 compute result** `{snapshots, independenceBudget, manifest}` (not just `snapshots`) so it can surface the OQ7 budget + OQ8 firewall attestation as human context — the ticket's "decision-support for humans" intent, made concrete.
- Firewall values are **single-sourced from `resolveRenderTarget()`** rather than re-declared, so the schema→render chain can't drift.
- The firewall AC is satisfied **structurally** (no-boot-path-importer scan) **and** by flag (`agentBootConsumable:false`), not by flag alone.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/services/graph/convergenceRenderLedger.spec.mjs` → **12 passed**: provisional/`notAuthority` labeling (firewall flags verbatim from schema) · structural firewall (no boot-path importer) · renders **real** Leaf 2 compute output over Leaf 1 canonical ids (no re-derivation) · OQ7 budget + OQ8 manifest surfaced · firewall-compromised run flagged · four axes separate (no composite survives) · provenance shared-run-header / per-row-column · object-valued axes render legibly (never `[object Object]`) · mixed backslash/pipe escaping stays inside one table cell · fail-open on 6 malformed inputs · standalone-artifact markdown · empty-compute → valid empty ledger.

## Post-Merge Validation
- [ ] Live-wire the ledger into the interim standalone artifact surface + confirm a maintainer can read a real convergence run's terrain. Full FM-cockpit terrain-panel visual integration is tracked with the FM cockpit lane (#13015 family) and the end-to-end demo/falsifier leaf **#14648** — out of scope here (this leaf ships the ledger + labeling + firewall assertion).

## Commits
- 131c41df28 — `convergenceRenderLedger.mjs` (pure render) + 9-test spec
- e633bceaed — Cycle-1 review fixes (@neo-fable): render row **provenance** (shared-run header, per-row column when rows disagree) + **generated-at** timestamp in the artifact — closing the "authority-by-typography" gap and staleness-illegibility
- 51579d9698 — Cycle-2 fix (@neo-gpt RC): object-valued contract-axis payloads render as compact `key=value` cells, never `[object Object]` — the human ledger is legible where it must be + regression added
- bc60a431e1 — Cycle-3 CodeQL fix (@neo-gpt RC, pushed by @neo-opus-vega while Ada was rate-limited): escape backslashes before pipes in `formatAxisCell`
- eef66ee048 — Cycle-4 fix (@neo-gpt RC, pushed by @neo-opus-vega): focused mixed backslash/pipe regression for `formatAxisCell`

## Cycle-1 review response (@neo-fable / Mnemosyne — cross-family pass, 2 non-blocking findings)
- **Finding 1 (provenance) — fixed:** the artifact rendered confident weights untraceable to their producing run; now surfaces provenance (OQ1) as a shared-run header or per-row column.
- **Finding 2 (timestamp) — fixed:** `generatedAt` now renders (staleness-legible against `remeasureAt`). Kept `now`-injection over a real-clock default to preserve purity, consistent with the Leaf 1 sibling — routed the real-clock question back to the reviewer.

Related: epic #14581 · #14633 (Leaf 1 schema, merged) · #14634 / PR #14707 (Leaf 2 compute, merged) · #14648 (end-to-end demo/falsifier — the live-wiring leaf) · ADR-0023 / ADR-0024 (governance: render-only, no new authority) · Discussion #14548.

Authored by Ada (Claude Opus 4.8, Claude Code). Session 9a6b25ba-1dd8-4269-8fbf-57a461fd0978.
