### PR TITLE
feat(agentos): fleet cockpit HealthSwatch primitive — legend + count-bar unit (#14637)

### DIFF
--- a/apps/agentos/resources/fleet-components.css
+++ b/apps/agentos/resources/fleet-components.css
@@ -50,6 +50,30 @@
     );
 }
 
+/* Health-summary swatch: a legend row (dot + label) or a count-bar unit (dot + count + label).
+   The dot reuses the state token via --fm-dot; the count reads as the emphasis tier. */
+.fm-health-swatch {
+    display    : inline-flex;
+    align-items: center;
+    gap        : 6px;
+    font-family: var(--fm-font-mono);
+    font-size  : 11px;
+    color      : var(--fm-ink-dim);
+}
+
+.fm-health-swatch .fm-sw-dot {
+    width        : 9px;
+    height       : 9px;
+    flex         : none;
+    border-radius: 50%;
+    background   : var(--fm-dot, var(--fm-state-off));
+}
+
+.fm-health-swatch .fm-sw-count {
+    color      : var(--fm-ink);
+    font-weight: 600;
+}
+
 /* Pulse: decoration only, gated behind reduced-motion. The color already carries the signal. */
 @media (prefers-reduced-motion: no-preference) {
     .fm-state-dot.fm-live {

--- a/apps/agentos/view/fleet/HealthSwatch.mjs
+++ b/apps/agentos/view/fleet/HealthSwatch.mjs
@@ -1,0 +1,73 @@
+import {defineComponent} from '../../../../src/functional/_export.mjs';
+import {stateToken}      from './StateDot.mjs';
+
+/**
+ * Canonical legend label per session-state category. Kept beside the state→token map so the fleet
+ * health summary reads one vocabulary.
+ * @type {Object}
+ */
+const STATE_LABEL = {
+    ok     : 'working',
+    idle   : 'idle',
+    wedged : 'wedged',
+    limited: 'rate-limited',
+    off    : 'benched / offline'
+};
+
+/**
+ * Pure state → label resolver. A known category → its canonical label; an unknown category →
+ * the LITERAL category string (never invisible, never silently re-labelled as `off`), so a new
+ * runtime state still renders a readable swatch until it earns a canonical label here.
+ * @param {String} state
+ * @returns {String}
+ */
+export function stateLabel(state) {
+    return STATE_LABEL[state] || String(state ?? 'unknown')
+}
+
+/**
+ * A single entry in the fleet health-summary legend / bar: a swatch dot (colored from the same
+ * `--fm-state-*` token as {@link StateDot} via the shared `stateToken` — one source of truth on the
+ * agent-health axis), an optional count, and the category label. Composable BOTH ways: a plain
+ * legend row (no count) and the count-carrying bar unit the health summary consumes (set `count`).
+ * An unknown category renders off-toned with its literal text — never invisible.
+ *
+ * @summary Health-summary swatch — legend row + count-bar unit, agent-health axis.
+ */
+export default defineComponent({
+    config: {
+        className: 'AgentOS.view.fleet.HealthSwatch',
+        ntype    : 'fm-health-swatch',
+        /**
+         * The session-state category this swatch legends — `ok` · `idle` · `wedged` · `limited` · `off`.
+         * An unknown category renders off-toned with its literal text.
+         * @member {String} state_='ok'
+         */
+        state_: 'ok',
+        /**
+         * Optional count for the bar-unit shape (the health-summary consumer). `null` renders a plain
+         * legend row; a number renders a count beside the label (e.g. "3 working").
+         * @member {Number|null} count_=null
+         */
+        count_: null,
+        /**
+         * Optional label override. Defaults to the canonical category label for `state`.
+         * @member {String|null} label_=null
+         */
+        label_: null
+    },
+
+    createVdom(config) {
+        const cn = [
+            {cls: ['fm-sw-dot'], style: {'--fm-dot': `var(${stateToken(config.state)})`}}
+        ];
+
+        if (config.count != null) {
+            cn.push({tag: 'span', cls: ['fm-sw-count'], text: String(config.count)})
+        }
+
+        cn.push({tag: 'span', cls: ['fm-sw-label'], text: config.label ?? stateLabel(config.state)});
+
+        return {cls: ['fm-health-swatch'], cn}
+    }
+});

--- a/apps/agentos/view/fleet/HealthSwatch.mjs
+++ b/apps/agentos/view/fleet/HealthSwatch.mjs
@@ -17,12 +17,14 @@ const STATE_LABEL = {
 /**
  * Pure state → label resolver. A known category → its canonical label; an unknown category →
  * the LITERAL category string (never invisible, never silently re-labelled as `off`), so a new
- * runtime state still renders a readable swatch until it earns a canonical label here.
+ * runtime state still renders a readable swatch until it earns a canonical label here. Uses an
+ * `Object.hasOwn` check (not `MAP[k] ||`) so a prototype-shaped key (`toString`, `constructor`,
+ * `__proto__`) resolves to its literal text instead of leaking an inherited Object.prototype value.
  * @param {String} state
  * @returns {String}
  */
 export function stateLabel(state) {
-    return STATE_LABEL[state] || String(state ?? 'unknown')
+    return Object.hasOwn(STATE_LABEL, state) ? STATE_LABEL[state] : String(state ?? 'unknown')
 }
 
 /**

--- a/apps/agentos/view/fleet/StateDot.mjs
+++ b/apps/agentos/view/fleet/StateDot.mjs
@@ -17,12 +17,14 @@ const STATE_TOKEN = {
 
 /**
  * Pure state → token mapping, exported so it is the single source of truth for the fleet
- * primitives (HealthSwatch reuses it) and is directly unit-testable without a render.
+ * primitives (HealthSwatch reuses it) and is directly unit-testable without a render. Uses an
+ * `Object.hasOwn` check (not `MAP[k] ||`) so a prototype-shaped key (`toString`, `constructor`,
+ * `__proto__`) degrades to the neutral `off` token instead of leaking an inherited value.
  * @param {String} state
  * @returns {String} the `--fm-state-*` custom-property name
  */
 export function stateToken(state) {
-    return STATE_TOKEN[state] || STATE_TOKEN.off
+    return Object.hasOwn(STATE_TOKEN, state) ? STATE_TOKEN[state] : STATE_TOKEN.off
 }
 
 /**

--- a/test/playwright/unit/apps/agentos/view/fleet/healthSwatch.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/healthSwatch.spec.mjs
@@ -1,0 +1,88 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FleetHealthSwatchTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+test.describe('Fleet cockpit HealthSwatch — state-axis legend + count-bar unit (#14637)', () => {
+    let HealthSwatch, stateLabel;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../apps/agentos/view/fleet/HealthSwatch.mjs');
+
+        HealthSwatch = mod.default;
+        stateLabel   = mod.stateLabel
+    });
+
+    test('stateLabel gives canonical labels; an unknown category → its LITERAL text (never off, never invisible)', () => {
+        expect(stateLabel('ok')).toBe('working');
+        expect(stateLabel('limited')).toBe('rate-limited');
+        expect(stateLabel('off')).toBe('benched / offline');
+        expect(stateLabel('some-new-state')).toBe('some-new-state');
+        expect(stateLabel(undefined)).toBe('unknown')
+    });
+
+    test('renders a legend row (no count) — state dot + label, no count element', async () => {
+        const sw = Neo.create(HealthSwatch, {appName, state: 'wedged'});
+        await sw.initVnode();
+
+        const dot   = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-dot')),
+              label = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-label')),
+              count = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-count'));
+
+        expect(dot.style['--fm-dot']).toBe('var(--fm-state-wedged)');
+        expect(label.text).toBe('wedged');
+        expect(count).toBeUndefined();
+
+        sw.destroy()
+    });
+
+    test('renders the count-bar unit when count is set (#14599 consumer shape), incl a zero count', async () => {
+        const sw = Neo.create(HealthSwatch, {appName, state: 'ok', count: 3});
+        await sw.initVnode();
+
+        expect(sw.vdom.cn.find(n => n.cls?.includes('fm-sw-count'))?.text).toBe('3');
+        expect(sw.vdom.cn.find(n => n.cls?.includes('fm-sw-label')).text).toBe('working');
+
+        // a zero count still renders (a health bar shows "0 wedged" to confirm none) — not falsy-dropped
+        sw.count = 0;
+        expect(sw.vdom.cn.find(n => n.cls?.includes('fm-sw-count'))?.text).toBe('0');
+
+        sw.destroy()
+    });
+
+    test('renders an unknown category off-toned with its literal text (never invisible)', async () => {
+        const sw = Neo.create(HealthSwatch, {appName, state: 'mystery'});
+        await sw.initVnode();
+
+        const dot   = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-dot')),
+              label = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-label'));
+
+        expect(dot.style['--fm-dot']).toBe('var(--fm-state-off)');
+        expect(label.text).toBe('mystery');
+
+        sw.destroy()
+    });
+
+    test('honors a label override', async () => {
+        const sw = Neo.create(HealthSwatch, {appName, state: 'idle', label: 'napping'});
+        await sw.initVnode();
+
+        expect(sw.vdom.cn.find(n => n.cls?.includes('fm-sw-label')).text).toBe('napping');
+
+        sw.destroy()
+    });
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/healthSwatch.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/healthSwatch.spec.mjs
@@ -32,7 +32,11 @@ test.describe('Fleet cockpit HealthSwatch — state-axis legend + count-bar unit
         expect(stateLabel('limited')).toBe('rate-limited');
         expect(stateLabel('off')).toBe('benched / offline');
         expect(stateLabel('some-new-state')).toBe('some-new-state');
-        expect(stateLabel(undefined)).toBe('unknown')
+        expect(stateLabel(undefined)).toBe('unknown');
+        // prototype-shaped keys resolve to their literal text, never an inherited Object.prototype value
+        expect(stateLabel('toString')).toBe('toString');
+        expect(stateLabel('constructor')).toBe('constructor');
+        expect(stateLabel('__proto__')).toBe('__proto__')
     });
 
     test('renders a legend row (no count) — state dot + label, no count element', async () => {
@@ -73,6 +77,20 @@ test.describe('Fleet cockpit HealthSwatch — state-axis legend + count-bar unit
 
         expect(dot.style['--fm-dot']).toBe('var(--fm-state-off)');
         expect(label.text).toBe('mystery');
+
+        sw.destroy()
+    });
+
+    test('a prototype-shaped unknown state renders off-toned with its literal text (no inherited leak on either axis)', async () => {
+        const sw = Neo.create(HealthSwatch, {appName, state: 'toString'});
+        await sw.initVnode();
+
+        const dot   = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-dot')),
+              label = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-label'));
+
+        // both the dot token (via stateToken) and the label (via stateLabel) must be closed-set-safe
+        expect(dot.style['--fm-dot']).toBe('var(--fm-state-off)');
+        expect(label.text).toBe('toString');
 
         sw.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/statePrimitives.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/statePrimitives.spec.mjs
@@ -35,7 +35,11 @@ test.describe('Fleet cockpit StateDot — session-state token mapping + reduced-
         expect(stateToken('off')).toBe('--fm-state-off');
         // unknown / undefined falls back to off — never throws, never a hand-rolled color
         expect(stateToken('nonsense')).toBe('--fm-state-off');
-        expect(stateToken(undefined)).toBe('--fm-state-off')
+        expect(stateToken(undefined)).toBe('--fm-state-off');
+        // prototype-shaped keys must not leak an inherited Object.prototype value past the closed set
+        expect(stateToken('toString')).toBe('--fm-state-off');
+        expect(stateToken('constructor')).toBe('--fm-state-off');
+        expect(stateToken('__proto__')).toBe('--fm-state-off')
     });
 
     test('StateDot binds the token via --fm-dot and gates the pulse behind the live config', async () => {


### PR DESCRIPTION
Resolves #14637

Refs #14560 (parent epic — never a close-target) · Refs #14593 (the triplet it split from) · Refs #14578 (token layer) · Refs #14599 (the health-bar consumer + NL-verification mount).

The health-summary swatch — the **last** split from the #14593 triplet per @neo-gpt's review, built to #14637's **code + unit-spec ACs**. AC#3's NL-verified legend row is a documented residual deferred to the #14599 health-bar mount — see Deltas.

Evidence: L2 (unit-tested; 6/6 HealthSwatch + 3/3 StateDot resolver regression = 9/9, green at head `5f945c8b6`, post-rebase onto dev). The NL legend row is deferred to the #14599 consumer mount — the same pattern the merged StateDot #14700 used for its in-app verification (residual documented below).

## What it adds

- **HealthSwatch** — state → `--fm-state-*` dot + label via the merged StateDot's shared `stateToken` (one SSOT on the **agent-health axis**, distinct from EventChip's `--fm-kind-*` axis).
- **Unknown category → off-toned + its LITERAL text** (never silently re-labelled `off`, never invisible) — a new runtime state still reads.
- **Composable both ways**: a plain legend row (no count) AND the count-carrying bar unit the health summary (#14599) consumes — a `count` slot; a **zero count still renders** ("0 wedged" confirms none), not falsy-dropped.
- **Closed-set hardening** (folds @neo-gpt's RC + the state-axis half of the #14728 follow-up): both `stateLabel` (HealthSwatch) and the reused `stateToken` (StateDot) now use `Object.hasOwn` instead of `MAP[k] ||`, so a prototype-shaped state (`toString`/`constructor`/`__proto__`) degrades to the neutral `off` token + literal text instead of leaking an inherited Object.prototype value on either axis.

## Test Evidence

`npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/healthSwatch.spec.mjs test/playwright/unit/apps/agentos/view/fleet/statePrimitives.spec.mjs` → **9 passed** (6 HealthSwatch + 3 StateDot) at head `5f945c8b6`. Adds resolver-level prototype-key regression to both `stateLabel` and `stateToken`, plus a HealthSwatch render case proving both axes (dot token via `stateToken`, label via `stateLabel`) are closed-set-safe.

## Post-Merge Validation

- [ ] **NL-verified legend row (AC#3 clause 3 — deferred):** the primitive has no standalone mount and the NL bridge currently has no live session for it (`healthcheck` → `connected:false`). The in-app NL render verification lands when the #14599 health bar composes HealthSwatch as its count-carrying unit (its natural mount) — the same deferral the merged StateDot #14700 declared.

## Deltas from ticket

**One residual, made explicit** (folding @neo-gpt's evidence RA): #14637 AC#3 is *"tokens only; unit specs + NL-verified row."* The tokens-only and unit-spec clauses are **met** (9/9 green, zero hand-rolled colors); the **NL-verified legend row is deferred** to the #14599 consumer mount. A mount-less primitive can't be NL-rendered standalone without duplicating the consumer's mount, so this render proof lands post-merge at composition — exactly how the merged StateDot #14700 handled its in-app verification. `Resolves #14637` is retained on that precedent: built + unit-verified code, with the render proof as a post-merge validation item (above), not unbuilt scope. The residual is annotated on #14637 itself. **Prior body corrected:** dropped the "matches full ACs / Deltas: None" overstatement per @neo-gpt's RC.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
