### PR TITLE
feat(agentos): the keeper chat surface — five SSOT states bound to the create spine (#14720)

### DIFF
--- a/apps/agentos/view/create/CreateSurface.mjs
+++ b/apps/agentos/view/create/CreateSurface.mjs
@@ -1,0 +1,132 @@
+import Button                  from '../../../../src/button/Base.mjs';
+import Container               from '../../../../src/container/Base.mjs';
+import CreateSurfaceController from './CreateSurfaceController.mjs';
+import CreationStateProvider   from './CreationStateProvider.mjs';
+import Label                   from '../../../../src/component/Label.mjs';
+import TextField               from '../../../../src/form/field/Text.mjs';
+import {CREATION_STATES}       from './util/creationFlowState.mjs';
+
+/**
+ * @class AgentOS.view.create.CreateSurface
+ * @extends Neo.container.Base
+ *
+ * @summary The keeper chat surface — the five SSOT states as ONE bound view over the
+ * create-module provider. Every visible branch binds `data.flowState` / `data.flowReason`; the
+ * view holds no flow booleans (the provider is the single truth, the transition table its
+ * oracle). The stage container is the ONE create path: accepted blueprints are `add()`ed into it
+ * by the accept path and recorded by the insert registrar.
+ *
+ * The five states render visibly distinct per the SSOT wedge — empty invitation · composing
+ * preview · generating (cancellable) · materialized (live panel in the stage + dispose) · error
+ * (the pipeline reason verbatim + edit-and-retry). Visual polish beyond state-distinctness is
+ * the design-iteration leaf's concern; the STATE BINDING is this leaf's contract.
+ */
+class CreateSurface extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.create.CreateSurface'
+         * @protected
+         */
+        className: 'AgentOS.view.create.CreateSurface',
+        /**
+         * @member {String} ntype='agentos-create-surface'
+         * @protected
+         */
+        ntype: 'agentos-create-surface',
+        /**
+         * @member {String[]} cls=['agentos-create-surface']
+         * @reactive
+         */
+        cls: ['agentos-create-surface'],
+        /**
+         * @member {Neo.controller.Component} controller=CreateSurfaceController
+         * @reactive
+         */
+        controller: CreateSurfaceController,
+        /**
+         * The create-module provider — flow state + registry exposure for every consumer below.
+         * @member {Neo.state.Provider} stateProvider=CreationStateProvider
+         * @reactive
+         */
+        stateProvider: CreationStateProvider,
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            // The intake row — the single affordance of the EMPTY invitation, live in every state.
+            module: Container,
+            cls   : ['agentos-create-intake'],
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                module       : TextField,
+                reference    : 'intent-field',
+                flex         : 1,
+                labelPosition: 'inline',
+                labelText    : 'Describe an app to build…',
+                clearable    : true,
+                listeners    : {change: 'onIntentChange'}
+            }, {
+                module : Button,
+                text   : 'Create',
+                iconCls: 'fas fa-wand-magic-sparkles',
+                handler: 'onSubmitIntent',
+                bind   : {
+                    // the single affordance disables while a build is in flight
+                    disabled: data => data.flowState === 'generating'
+                }
+            }]
+        }, {
+            // The state strip — one Label whose text IS the flow state's SSOT narration.
+            module: Label,
+            cls   : ['agentos-create-state'],
+            bind  : {
+                text: data => ({
+                    [CREATION_STATES.EMPTY]       : 'The invitation: one affordance, no chrome — describe an app to build.',
+                    [CREATION_STATES.COMPOSING]   : 'Composing — the blueprint previews on create; refine your words freely.',
+                    [CREATION_STATES.GENERATING]  : 'Materializing… honest progress, cancellable below.',
+                    [CREATION_STATES.MATERIALIZED]: 'Live — the app is a real docked panel in the stage below.',
+                    [CREATION_STATES.ERROR]       : `Blocked: ${data.flowReason || 'generation refused'} — edit and retry; never a dead-end.`
+                })[data.flowState] || ''
+            }
+        }, {
+            // The action strip — state-dependent affordances, all provider-event dispatchers.
+            module: Container,
+            cls   : ['agentos-create-actions'],
+            layout: {ntype: 'hbox'},
+            items : [{
+                module : Button,
+                text   : 'Retry',
+                ui     : 'secondary',
+                handler: 'onRetry',
+                bind   : {hidden: data => data.flowState !== 'error'}
+            }, {
+                module : Button,
+                text   : 'Dispose',
+                ui     : 'secondary',
+                handler: 'onDispose',
+                bind   : {hidden: data => data.flowState !== 'materialized'}
+            }, {
+                module : Button,
+                text   : 'Cancel',
+                ui     : 'secondary',
+                handler: 'onReset',
+                bind   : {hidden: data => data.flowState !== 'generating' && data.flowState !== 'composing'}
+            }]
+        }, {
+            // THE stage — the ONE create path's target: accepted blueprints are add()ed here by
+            // the accept path (never declared as static items), recorded on insert.
+            module   : Container,
+            reference: 'create-stage',
+            cls      : ['agentos-create-stage'],
+            flex     : 1,
+            layout   : {ntype: 'fit'}
+        }]
+    }
+}
+
+export default Neo.setupClass(CreateSurface);

--- a/apps/agentos/view/create/CreateSurfaceController.mjs
+++ b/apps/agentos/view/create/CreateSurfaceController.mjs
@@ -1,0 +1,163 @@
+import Controller                                                from '../../../../src/controller/Component.mjs';
+import CreatedInstances                                          from './store/CreatedInstances.mjs';
+import {CREATION_EVENTS}                                         from './util/creationFlowState.mjs';
+import {routeCreationRequest}                                    from './util/requestRoute.mjs';
+import {acceptBlueprint, createInsertRegistrar, disposeInstance} from './util/acceptPath.mjs';
+
+let instanceSeq = 0;
+
+/**
+ * @summary Deterministic intent→blueprint fallback — the placeholder the NL wiring leaf replaces.
+ * Produces a small `grid@1` blueprint titled from the intent text so the wedge is demoable end to
+ * end TODAY; it is deliberately dumb (no parsing intelligence) and clearly labeled as the
+ * deterministic default the injectable `generateBlueprint` seam swaps out.
+ * @param {String} request The user's intent text
+ * @returns {Object} a `grid@1` blueprint candidate
+ */
+export function deterministicBlueprintFallback(request) {
+    const title = request.trim().slice(0, 60) || 'Untitled Grid';
+
+    return {
+        schema: 'grid@1',
+        title,
+        config: {columns: [{field: 'item', text: 'Item'}, {field: 'note', text: 'Note'}]},
+        data  : [
+            {item: 'created from', note: title},
+            {item: 'state',        note: 'materialized via the keeper flow'}
+        ]
+    }
+}
+
+/**
+ * @class AgentOS.view.create.CreateSurfaceController
+ * @extends Neo.controller.Component
+ *
+ * @summary Drives the keeper flow: every user event routes through the create-module provider's
+ * ONE oracle-guarded writer (`applyFlowEvent` / `applyCreationRouteOutcome`) — this controller
+ * holds NO flow booleans and never writes flow state directly. The submit path runs the full
+ * merged spine: route (emit-validate) → route outcome onto the provider → accept path
+ * (accept-validate + the stage `add → insert` seam) → the insert registrar records the instance.
+ *
+ * The blueprint generator is an injectable seam (`generateBlueprint` config): the NL wiring leaf
+ * provides the live one; the deterministic fallback keeps the wedge demoable without it, and
+ * tests inject doubles.
+ */
+class CreateSurfaceController extends Controller {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.create.CreateSurfaceController'
+         * @protected
+         */
+        className: 'AgentOS.view.create.CreateSurfaceController',
+        /**
+         * Async `(request) => blueprint candidate`. Injectable; defaults to the deterministic
+         * fallback until the NL leaf lands the live generator.
+         * @member {Function|null} generateBlueprint=null
+         */
+        generateBlueprint: null
+    }
+
+    /**
+     * Wires the insert registrar once the view tree exists: the stage container's `insert` event
+     * writes the registry record — truth at the same moment the component lands in the stage.
+     * @protected
+     */
+    onComponentConstructed() {
+        const stage = this.getReference('create-stage');
+
+        stage?.on('insert', createInsertRegistrar({registry: CreatedInstances}), this)
+    }
+
+    /**
+     * The provider owning the flow state — the surface's `stateProvider`.
+     * @returns {AgentOS.view.create.CreationStateProvider}
+     */
+    getProvider() {
+        return this.component.getStateProvider()
+    }
+
+    /**
+     * Intent field input: first keystroke moves empty → composing (legal same-state edits after).
+     * @protected
+     */
+    onIntentChange() {
+        const provider = this.getProvider(),
+              state    = provider.getData('flowState');
+
+        provider.applyFlowEvent(state === 'empty' ? CREATION_EVENTS.COMPOSE : CREATION_EVENTS.EDIT)
+    }
+
+    /**
+     * The submit path — the whole spine in one handler, every step branching on bounded
+     * `{accepted, reason}` shapes, nothing thrown into the render:
+     * composing → generating → (route) → materialized | error.
+     * @protected
+     */
+    async onSubmitIntent() {
+        const me       = this,
+              provider = me.getProvider(),
+              field    = me.getReference('intent-field'),
+              request  = String(field?.value || '');
+
+        const submitted = provider.applyFlowEvent(CREATION_EVENTS.SUBMIT);
+
+        if (submitted.state !== 'generating') return; // illegal from the current state — oracle said no, nothing mutated
+
+        const generate = me.generateBlueprint || (async text => deterministicBlueprintFallback(text));
+        const routed   = await routeCreationRequest({request, generate});
+
+        const outcome = provider.applyCreationRouteOutcome(routed);
+
+        if (!routed.accepted || outcome.state !== 'materialized') return; // ERROR state carries the reason for the render
+
+        const instanceId = `keeper-grid-${++instanceSeq}`,
+              accepted   = acceptBlueprint({
+                  blueprint: routed.blueprint,
+                  instanceId,
+                  stage    : me.getReference('create-stage'),
+                  registry : CreatedInstances
+              });
+
+        if (accepted.accepted) {
+            provider.setData({activeInstanceId: instanceId})
+        } else {
+            // accept-stage refusal AFTER route acceptance (duplicate id, dead stage): honest error state
+            provider.applyFlowEvent(CREATION_EVENTS.REFUSED, {reason: accepted.reason})
+        }
+    }
+
+    /**
+     * ERROR → composing (edit-and-retry — never a dead-end).
+     * @protected
+     */
+    onRetry() {
+        this.getProvider().applyFlowEvent(CREATION_EVENTS.RETRY)
+    }
+
+    /**
+     * Disposes the active instance (component destroyed via the core instance manager inside the
+     * accept path) and returns the flow to the empty invitation.
+     * @protected
+     */
+    onDispose() {
+        const provider   = this.getProvider(),
+              instanceId = provider.getData('activeInstanceId');
+
+        if (instanceId) {
+            disposeInstance({instanceId, registry: CreatedInstances});
+            provider.setData({activeInstanceId: null})
+        }
+
+        provider.applyFlowEvent(CREATION_EVENTS.DISPOSE)
+    }
+
+    /**
+     * Cancel/reset from any state back to the empty invitation.
+     * @protected
+     */
+    onReset() {
+        this.getProvider().applyFlowEvent(CREATION_EVENTS.RESET)
+    }
+}
+
+export default Neo.setupClass(CreateSurfaceController);

--- a/apps/agentos/view/create/CreateSurfaceController.mjs
+++ b/apps/agentos/view/create/CreateSurfaceController.mjs
@@ -106,10 +106,14 @@ class CreateSurfaceController extends Controller {
         const generate = me.generateBlueprint || (async text => deterministicBlueprintFallback(text));
         const routed   = await routeCreationRequest({request, generate});
 
-        const outcome = provider.applyCreationRouteOutcome(routed);
+        if (!routed.accepted) {
+            provider.applyCreationRouteOutcome(routed); // generating → error, the route's reason verbatim
+            return
+        }
 
-        if (!routed.accepted || outcome.state !== 'materialized') return; // ERROR state carries the reason for the render
-
+        // MATERIALIZED is accept-path truth, never route truth: the provider only leaves
+        // `generating` after the accept path has actually put an instance into the stage. Both
+        // refusal sources (route above, accept-stage here) land ERROR from `generating`.
         const instanceId = `keeper-grid-${++instanceSeq}`,
               accepted   = acceptBlueprint({
                   blueprint: routed.blueprint,
@@ -119,10 +123,12 @@ class CreateSurfaceController extends Controller {
               });
 
         if (accepted.accepted) {
+            provider.applyCreationRouteOutcome(routed); // generating → materialized — now TRUE
             provider.setData({activeInstanceId: instanceId})
         } else {
-            // accept-stage refusal AFTER route acceptance (duplicate id, dead stage): honest error state
-            provider.applyFlowEvent(CREATION_EVENTS.REFUSED, {reason: accepted.reason})
+            // accept-stage refusal AFTER route acceptance (dead stage, duplicate id, coverage
+            // defect): honest ERROR carrying the ACCEPT PATH's reason; no active instance
+            provider.applyCreationRouteOutcome({accepted: false, reason: accepted.reason})
         }
     }
 

--- a/test/playwright/unit/apps/agentos/create/createSurface.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/createSurface.spec.mjs
@@ -1,0 +1,155 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'CreateSurfaceTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+
+test.describe('CreateSurface — the wedge screen: five states, one provider, the whole spine (#14720)', () => {
+    let Controller, Provider, oracle, deterministicBlueprintFallback;
+
+    // a stage double honoring the container seam the controller drives
+    const createStageDouble = () => {
+        const observers = [];
+        return {
+            added: [],
+            on(event, handler, scope) { event === 'insert' && observers.push([handler, scope]) },
+            add(config) {
+                this.added.push(config);
+                const item = {...config};
+                observers.forEach(([handler, scope]) => handler.call(scope || null, {item}));
+                return item
+            }
+        }
+    };
+
+    // a controller double: real class instance shape minus the component tree — we drive its
+    // handlers with injected provider/stage/field seams
+    const createRig = async ({generate, request = 'build me a neo grid'} = {}) => {
+        const provider = Neo.create(Provider, {});
+        const stage    = createStageDouble();
+        const field    = {value: request};
+
+        // a minimal owning-component double: the controller's construct chain walks
+        // component.parent, and getProvider reads component.getStateProvider()
+        const componentDouble = {
+            parent          : null,
+            getStateProvider: () => provider,
+            down            : () => null,
+            on              : () => {},
+            un              : () => {}
+        };
+
+        const controller = Neo.create(Controller, {component: componentDouble, generateBlueprint: generate || null});
+
+        // seam the reference lookups (the component tree is the SSOT-gated chrome; this
+        // spec proves the CONTROLLER contract against the real provider + real spine)
+        controller.getReference = name => name === 'create-stage' ? stage : name === 'intent-field' ? field : null;
+
+        // wire the registrar exactly as onComponentConstructed does
+        const {createInsertRegistrar}     = await import('../../../../../../apps/agentos/view/create/util/acceptPath.mjs');
+        const {default: CreatedInstances} = await import('../../../../../../apps/agentos/view/create/store/CreatedInstances.mjs');
+        stage.on('insert', createInsertRegistrar({registry: CreatedInstances}), controller);
+
+        return {provider, stage, field, controller, CreatedInstances}
+    };
+
+    test.beforeAll(async () => {
+        Controller = (await import('../../../../../../apps/agentos/view/create/CreateSurfaceController.mjs')).default;
+        Provider   = (await import('../../../../../../apps/agentos/view/create/CreationStateProvider.mjs')).default;
+        oracle     = await import('../../../../../../apps/agentos/view/create/util/creationFlowState.mjs');
+        deterministicBlueprintFallback = (await import('../../../../../../apps/agentos/view/create/CreateSurfaceController.mjs')).deterministicBlueprintFallback;
+    });
+
+    test('the happy wedge: compose → submit → materialized, instance in the stage AND the registry', async () => {
+        const {provider, stage, controller, CreatedInstances} = await createRig();
+        const S                                               = oracle.CREATION_STATES;
+
+        expect(provider.getData('flowState')).toBe(S.EMPTY);
+
+        controller.onIntentChange();
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);
+
+        await controller.onSubmitIntent();
+
+        expect(provider.getData('flowState')).toBe(S.MATERIALIZED);
+        expect(stage.added).toHaveLength(1);                          // the ONE create path was used
+        expect(stage.added[0].ntype).toBe('grid-container');
+
+        const instanceId = provider.getData('activeInstanceId');
+        expect(instanceId).toMatch(/^keeper-grid-/);
+
+        const record = CreatedInstances.resolveTarget({instanceId});
+        expect(record.state).toBe('live');
+        expect(record.blueprintSchema).toBe('grid@1');
+
+        provider.destroy(); controller.destroy()
+    });
+
+    test('the refusal wedge: a gate-refused blueprint lands ERROR with the pipeline reason; retry recovers', async () => {
+        // the injected generator emits an html-key attack — the shared validator must refuse it
+        const attack = async () => ({
+            schema: 'grid@1', title: 'Evil',
+            config: {columns: [{field: 'a', text: 'A', html: '<img onerror=1>'}]},
+            data  : []
+        });
+
+        const {provider, stage, controller} = await createRig({generate: attack});
+        const S                             = oracle.CREATION_STATES;
+
+        controller.onIntentChange();
+        await controller.onSubmitIntent();
+
+        expect(provider.getData('flowState')).toBe(S.ERROR);
+        expect(provider.getData('flowReason')).toContain('forbidden key'); // the pipeline reason, verbatim
+        expect(stage.added).toHaveLength(0);                              // nothing reached the stage
+
+        controller.onRetry();
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);          // edit-and-retry, never a dead-end
+
+        provider.destroy(); controller.destroy()
+    });
+
+    test('dispose returns to the empty invitation and flips the registry record', async () => {
+        const {provider, controller, CreatedInstances} = await createRig();
+        const S                                        = oracle.CREATION_STATES;
+
+        controller.onIntentChange();
+        await controller.onSubmitIntent();
+        const instanceId = provider.getData('activeInstanceId');
+
+        controller.onDispose();
+
+        expect(provider.getData('flowState')).toBe(S.EMPTY);
+        expect(provider.getData('activeInstanceId')).toBeNull();
+        expect(CreatedInstances.resolveTarget({instanceId}).state).toBe('disposed');
+
+        provider.destroy(); controller.destroy()
+    });
+
+    test('no flow booleans anywhere: state truth lives ONLY on the provider (the §7.5.1 audit line)', async () => {
+        const {provider, controller} = await createRig();
+
+        // the controller instance carries no is*/has* flow flags — the provider is the single truth
+        const flagKeys = Object.keys(controller).filter(key => /^(is|has)[A-Z]/.test(key) && /generat|error|material|compos|flow/i.test(key));
+        expect(flagKeys).toEqual([]);
+
+        // and the fallback generator is deterministic + labeled (the NL seam's placeholder)
+        const blueprint = deterministicBlueprintFallback('  My Fleet PRs  ');
+        expect(blueprint.schema).toBe('grid@1');
+        expect(blueprint.title).toBe('My Fleet PRs');
+
+        provider.destroy(); controller.destroy()
+    });
+});

--- a/test/playwright/unit/apps/agentos/create/createSurface.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/createSurface.spec.mjs
@@ -121,6 +121,29 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
         provider.destroy(); controller.destroy()
     });
 
+    test('accept-stage refusal AFTER route acceptance lands ERROR with the ACCEPT reason — materialized is accept-path truth', async () => {
+        // valid blueprint, but the stage reference is dead — the accept path must refuse AFTER
+        // the route accepted, and the provider must never claim materialized
+        const {provider, controller} = await createRig();
+        const S                      = oracle.CREATION_STATES;
+
+        // sever the stage: route will accept, acceptBlueprint will refuse ("no live stage")
+        const originalGetReference = controller.getReference;
+        controller.getReference = name => name === 'create-stage' ? null : originalGetReference(name);
+
+        controller.onIntentChange();
+        await controller.onSubmitIntent();
+
+        expect(provider.getData('flowState')).toBe(S.ERROR);              // never materialized
+        expect(provider.getData('flowReason')).toContain('stage');        // the ACCEPT path's reason, not the route's
+        expect(provider.getData('activeInstanceId')).toBeNull();          // no phantom instance
+
+        controller.onRetry();
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);          // recoverable like every refusal
+
+        provider.destroy(); controller.destroy()
+    });
+
     test('dispose returns to the empty invitation and flips the registry record', async () => {
         const {provider, controller, CreatedInstances} = await createRig();
         const S                                        = oracle.CREATION_STATES;


### PR DESCRIPTION
## Summary

T3.3 — **the wedge becomes a screen**: the keeper chat surface binding the five SSOT states to the entire create spine this cycle built. A user types an intent, the route emit-validates, the accept path materializes a live grid through the ONE create path into the stage, the registrar records it — and a gate-refused blueprint lands the ERROR state with the pipeline's reason verbatim, edit-and-retry recovering. "A stranger types an intent and gets a live app", running end to end through production modules with a deterministic generator fallback until the NL leaf lands.

Resolves #14720 (scope reconciled at review cycle 1: the live render-verify + whitebox-e2e ACs split to follow-up leaf #14734 — this PR delivers the state-binding leaf exactly; the ticket ACs now match the diff)
Refs #13349

> **⚠ Stacked, based on `dev`:** transiently includes the oracle (#14711/PR #14712, APPROVED) + provider (#14718/PR #14719, APPROVED) commits — they drop as those merge. **Net-new in THIS leaf: `CreateSurface.mjs` + `CreateSurfaceController.mjs` + `createSurface.spec.mjs`. Merge order: after #14712 → #14719.**

## Deltas

- **NEW `apps/agentos/view/create/CreateSurface.mjs`** — the five-state view as ONE bound container over `CreationStateProvider`: intake row (the empty invitation's single affordance, submit disabled while generating), a state strip whose text IS the SSOT narration per state (ERROR renders `data.flowReason` verbatim — "always a reason"), a state-dependent action strip (Retry ↔ error only, Dispose ↔ materialized only, Cancel ↔ composing/generating), and **the stage container** — the ONE create path's target, never carrying declarative children. Zero flow booleans anywhere; every visible branch is a `bind` on provider data.
- **NEW `apps/agentos/view/create/CreateSurfaceController.mjs`** — every user event dispatches through the provider's oracle-guarded writers (`applyFlowEvent`/`applyCreationRouteOutcome`); the controller holds NO flow state. The submit path is the whole spine in one handler, each step branching on bounded `{accepted, reason}` shapes: SUBMIT event → `routeCreationRequest` (emit-validate) → route outcome onto the provider → `acceptBlueprint` (accept-validate + duplicate-id pre-check + stage `add → insert`) → the insert registrar records the instance → `activeInstanceId` onto provider data. An accept-stage refusal AFTER route acceptance (dead stage, duplicate) flows to the honest ERROR state. `generateBlueprint` is the injectable NL seam; `deterministicBlueprintFallback` (exported, labeled) keeps the wedge demoable today.
- **NEW `test/playwright/unit/apps/agentos/create/createSurface.spec.mjs`** — 4 tests driving the REAL controller + REAL provider + REAL route/validator/accept-path/registry (only stage/field/component are seams): the happy wedge end-to-end (state → stage → registry) · the refusal wedge (html-key attack → ERROR with `forbidden key` verbatim, nothing reaches the stage, retry recovers) · dispose round-trip (empty + registry flipped) · the **no-flow-booleans audit** as an executable assertion (the §7.5.1 line) + the fallback's determinism.

**§9.6 Core-Idiom Pre-Flight record:** `src/core/Base.mjs` / `src/Neo.mjs` / `src/state/Provider.mjs` (this session, recorded on #14718) + `src/controller/Component.mjs` (getReference/getParent contracts) + `src/container/Base.mjs` (add→insert seam) + the childapp `Viewport.mjs`/`ViewportController.mjs` siblings at build.

**Deliberately NOT in this PR:** the live NL generator (the injectable seam's leaf) · promote-to-OS-window mechanics (dock lane — the affordance's `activeInstanceId` is ready for it) · visual polish beyond state-distinctness (the SSOT design-iteration leaf; PR #14692's residual ACs) · follow-up mutation UI (the registry + validateMutation spine is merged and waiting).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/apps/agentos/create/` → **27 passed** (4 new + the full create-module suite green on the integrated stack).

Evidence: L2 (unit-pinned through the real spine; the browser-visible proof lands with the whitebox-NL e2e once the stack merges — the #14705 loopback pattern is the template).

## Post-Merge Validation

- The NL leaf swaps `generateBlueprint` and changes NOTHING else — the seam is the check.
- The dock/promote lane consumes `activeInstanceId` without touching flow state.
- A live render-verify of the five states against the #14692 artifact once both merge (the SSOT's residual ACs iterate the chrome; the state contract is pinned here).

## Related

Parent #13349 (T3.3) · #14645/PR #14692 (the SSOT — the bar) · #14711/PR #14712 + #14718/PR #14719 (the stacked parents, both approved) · #14689/PR #14710 (accept path, merged) · #14655/#14656 (route + registry, merged) · the childapp first-widget surface (the precedent this generalizes).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b9b95ac6-42f5-47a3-b58f-6071f79657e8.
