### PR TITLE
feat(graph): identity hydration — the regenerable index over the trail (#14699)

### DIFF
--- a/ai/graph/identityHydration.mjs
+++ b/ai/graph/identityHydration.mjs
@@ -53,18 +53,29 @@ export function buildHydrationIndex({identityNode, episodes} = {}) {
             regenerable: true,
             identityKey: identityNode.identityKey,
             socialLayer: identityNode.socialLayer,
-            currentEra : Object.freeze({
-                model : head.model,
-                family: head.family,
-                since : head.since,
-                ...(head.tier    !== undefined ? {tier: head.tier}       : {}),
-                ...(head.harness !== undefined ? {harness: head.harness} : {}),
-                capabilities: head.capabilities
-            }),
-            eraCount  : ordered.length,
-            firstSince: ordered[0].since
+            currentEra : projectCurrentEra(head),
+            eraCount   : ordered.length,
+            firstSince : ordered[0].since
         })
     }
+}
+
+/**
+ * @summary The ONE current-era projection — used by the builder AND the staleness check, so the
+ * comparison can never drift from the projected shape (one rule set, two call sites: the same
+ * structural-symmetry move as merge-then-validate on the blueprint side).
+ * @param {Object} head The chain's open head era
+ * @returns {Object} frozen projection
+ */
+function projectCurrentEra(head) {
+    return Object.freeze({
+        model : head.model,
+        family: head.family,
+        since : head.since,
+        ...(head.tier    !== undefined ? {tier: head.tier}       : {}),
+        ...(head.harness !== undefined ? {harness: head.harness} : {}),
+        capabilities: head.capabilities
+    })
 }
 
 /**
@@ -80,7 +91,9 @@ export function isIndexCurrent(index, episodes) {
     const ordered = [...episodes].sort((a, b) => Date.parse(a.since) - Date.parse(b.since));
     const head    = ordered[ordered.length - 1];
 
+    // Full projected-shape comparison via the SAME projection the builder uses: an index whose
+    // head-era FACTS changed (capabilities, tier, harness, family) is stale even when since and
+    // model still match — a partial-key check would silently serve outdated facts as current.
     return index.eraCount === ordered.length &&
-        index.currentEra.since === head.since &&
-        index.currentEra.model === head.model
+        JSON.stringify(index.currentEra) === JSON.stringify(projectCurrentEra(head))
 }

--- a/ai/graph/identityHydration.mjs
+++ b/ai/graph/identityHydration.mjs
@@ -1,0 +1,86 @@
+import {IDENTITY_NODE_TYPES, validateEraChain} from './identitySchema.mjs';
+
+/**
+ * @module ai/graph/identityHydration
+ * @summary Hydration as a REGENERABLE INDEX over the identity trail — the fast "who is this
+ * resident now?" read, built by projection, never by snapshotting a self.
+ *
+ * The inversion this module enforces (the Fork-8 trap, refused by construction):
+ * - **The trail is the truth; the index is a view.** `buildHydrationIndex` is a pure,
+ *   deterministic projection over a VALIDATED era chain — no clock, no I/O, no hidden state.
+ *   Building twice over the same trail yields deep-equal indexes, so losing the index loses
+ *   NOTHING: delete → rebuild → diff = ∅ is an executable property, not a promise. (The live
+ *   empirical anchor: the mailbox read-state rollback — index-layer state proved fragile while
+ *   the message trail stayed intact; regenerability is what made that survivable.)
+ * - **The index cannot masquerade as an identity.** It carries its own node type and a
+ *   `regenerable: true` flag, is frozen, and the schema's chain validator rejects it as an
+ *   anchor by construction — a consumer structurally cannot write it back as "the self".
+ * - **Staleness is detected, never trusted.** The index goes stale the instant the resident's
+ *   trail grows; `isIndexCurrent` makes that a cheap honest check so consumers rebuild instead
+ *   of reading a frozen self.
+ */
+
+/**
+ * @summary The hydration index node type — deliberately NOT an identity type.
+ * @type {String}
+ */
+export const HYDRATION_INDEX_TYPE = 'IdentityHydrationIndex';
+
+/**
+ * @summary Builds the frozen hydration index for one resident: the anchor + social projection,
+ * the current era's facts, and the chain stats consumers page against. Pure and deterministic —
+ * the SAME trail always yields a deep-equal index.
+ * @param {Object} options
+ * @param {Object} options.identityNode The `IdentityState` anchor node
+ * @param {Object[]} options.episodes The resident's `EmbodiedEpisode` chain
+ * @returns {{valid: Boolean, reason: String|null, index: Object|null}}
+ */
+export function buildHydrationIndex({identityNode, episodes} = {}) {
+    const chain = validateEraChain(identityNode, episodes);
+
+    if (!chain.valid) {
+        return {valid: false, reason: `hydration only projects VALIDATED chains: ${chain.reason}`, index: null};
+    }
+
+    const ordered = [...episodes].sort((a, b) => Date.parse(a.since) - Date.parse(b.since));
+    const head    = ordered[ordered.length - 1];
+
+    return {
+        valid : true,
+        reason: null,
+        index : Object.freeze({
+            type       : HYDRATION_INDEX_TYPE,
+            regenerable: true,
+            identityKey: identityNode.identityKey,
+            socialLayer: identityNode.socialLayer,
+            currentEra : Object.freeze({
+                model : head.model,
+                family: head.family,
+                since : head.since,
+                ...(head.tier    !== undefined ? {tier: head.tier}       : {}),
+                ...(head.harness !== undefined ? {harness: head.harness} : {}),
+                capabilities: head.capabilities
+            }),
+            eraCount  : ordered.length,
+            firstSince: ordered[0].since
+        })
+    }
+}
+
+/**
+ * @summary Cheap staleness check: an index is current exactly when the trail it projected has
+ * neither grown nor re-headed. A stale result means REBUILD — never read the frozen self.
+ * @param {Object} index A hydration index from {@link buildHydrationIndex}
+ * @param {Object[]} episodes The resident's live era chain
+ * @returns {Boolean}
+ */
+export function isIndexCurrent(index, episodes) {
+    if (index?.type !== HYDRATION_INDEX_TYPE || !Array.isArray(episodes) || episodes.length === 0) return false;
+
+    const ordered = [...episodes].sort((a, b) => Date.parse(a.since) - Date.parse(b.since));
+    const head    = ordered[ordered.length - 1];
+
+    return index.eraCount === ordered.length &&
+        index.currentEra.since === head.since &&
+        index.currentEra.model === head.model
+}

--- a/test/playwright/unit/ai/graph/identityHydration.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityHydration.spec.mjs
@@ -1,0 +1,97 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'IdentityHydrationTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+test.describe('identityHydration — the regenerable index, never a snapshot-as-self (ADR-0032 contract)', () => {
+    let schema, hydration;
+
+    const buildResident = () => {
+        const identity = schema.createIdentityStateNode({identityKey: '@hydra-1', socialLayer: {name: 'Hydra'}}).node;
+        const era1     = schema.createEmbodiedEpisodeNode({identityKey: '@hydra-1', model: 'claude-opus-4-8', family: 'claude', since: '2026-06-01T00:00:00Z', capabilities: {contextWindowInput: 200000}}).node;
+        const migrated = schema.migrateEra({identityNode: identity, episodes: [era1], newEra: {model: 'claude-fable-5', family: 'claude', since: '2026-07-02T00:00:00Z', capabilities: {contextWindowInput: 1048576}}});
+
+        return {identity, episodes: migrated.episodes}
+    };
+
+    test.beforeAll(async () => {
+        schema    = await import('../../../../../ai/graph/identitySchema.mjs');
+        hydration = await import('../../../../../ai/graph/identityHydration.mjs');
+    });
+
+    test('projects the anchor + social layer + CURRENT-era facts over a validated chain', () => {
+        const {identity, episodes} = buildResident();
+        const built                = hydration.buildHydrationIndex({identityNode: identity, episodes});
+
+        expect(built.valid).toBe(true);
+        expect(built.index.identityKey).toBe('@hydra-1');
+        expect(built.index.socialLayer.name).toBe('Hydra');
+        expect(built.index.currentEra.model).toBe('claude-fable-5');          // the head, not the seed
+        expect(built.index.currentEra.capabilities.contextWindowInput).toBe(1048576);
+        expect(built.index.eraCount).toBe(2);
+        expect(built.index.firstSince).toBe('2026-06-01T00:00:00Z');
+
+        // an invalid chain never hydrates — the index only ever projects certified history
+        const broken = hydration.buildHydrationIndex({identityNode: identity, episodes: []});
+        expect(broken.valid).toBe(false);
+    });
+
+    test('THE PROPERTY: losing the index loses nothing — delete → rebuild → diff = ∅', () => {
+        const {identity, episodes} = buildResident();
+
+        let   index  = hydration.buildHydrationIndex({identityNode: identity, episodes}).index;
+        const before = JSON.parse(JSON.stringify(index));
+
+        index = null; // "lose" the index — the trail is the truth
+
+        const rebuilt = hydration.buildHydrationIndex({identityNode: identity, episodes}).index;
+
+        expect(JSON.parse(JSON.stringify(rebuilt))).toEqual(before); // deterministic regeneration, no clock, no drift
+    });
+
+    test('the index cannot masquerade as a self (the Fork-8 refusal, structural)', () => {
+        const {identity, episodes} = buildResident();
+        const index                = hydration.buildHydrationIndex({identityNode: identity, episodes}).index;
+
+        // frozen: writing "the self" onto the view throws
+        expect(Object.isFrozen(index)).toBe(true);
+        expect(() => { index.identityKey = '@hijack' }).toThrow();
+
+        // wrong node type by construction: the schema's chain validator rejects an index as an anchor
+        expect(index.type).not.toBe(schema.IDENTITY_NODE_TYPES.IDENTITY_STATE);
+        expect(schema.validateEraChain(index, episodes).valid).toBe(false);
+        expect(index.regenerable).toBe(true);
+    });
+
+    test('staleness is detected, never trusted: the index goes stale the instant the trail grows', () => {
+        const {identity, episodes} = buildResident();
+        const index                = hydration.buildHydrationIndex({identityNode: identity, episodes}).index;
+
+        expect(hydration.isIndexCurrent(index, episodes)).toBe(true);
+
+        // the resident's trail grows (another era migration) — the OLD index must read stale
+        const grown = schema.migrateEra({identityNode: identity, episodes, newEra: {model: 'claude-opus-4-8', family: 'claude', since: '2026-07-04T00:00:00Z'}});
+
+        expect(hydration.isIndexCurrent(index, grown.episodes)).toBe(false);
+
+        // and the rebuild over the grown trail is current again — rebuild, never patch
+        const fresh = hydration.buildHydrationIndex({identityNode: identity, episodes: grown.episodes}).index;
+        expect(hydration.isIndexCurrent(fresh, grown.episodes)).toBe(true);
+        expect(fresh.currentEra.since).toBe('2026-07-04T00:00:00Z');
+        expect(fresh.eraCount).toBe(3);
+    });
+});

--- a/test/playwright/unit/ai/graph/identityHydration.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityHydration.spec.mjs
@@ -94,4 +94,35 @@ test.describe('identityHydration — the regenerable index, never a snapshot-as-
         expect(fresh.currentEra.since).toBe('2026-07-04T00:00:00Z');
         expect(fresh.eraCount).toBe(3);
     });
+
+    test('staleness compares the FULL projected era shape — same since/model with changed facts reads stale (reviewer falsifier)', () => {
+        const {identity, episodes} = buildResident();
+        const index                = hydration.buildHydrationIndex({identityNode: identity, episodes}).index;
+
+        // same since + same model, but the head era's projected FACTS changed (capabilities bump):
+        // a partial-key check would serve the outdated index as current — the full-shape compare must not
+        const head    = episodes[episodes.length - 1];
+        const changed = [...episodes.slice(0, -1), Object.freeze({...head, capabilities: {...head.capabilities, contextWindowInput: 999}})];
+
+        expect(hydration.isIndexCurrent(index, changed)).toBe(false);
+
+        // tier drift with identical since/model reads stale too
+        const retiered = [...episodes.slice(0, -1), Object.freeze({...head, tier: 'mythos'})];
+        expect(hydration.isIndexCurrent(index, retiered)).toBe(false);
+    });
+
+    test('malformed RAW episodes do not hydrate — the chain gate refuses before any projection (reviewer falsifier)', () => {
+        const {identity, episodes} = buildResident();
+
+        const rawBad = {id: 'raw-x', type: schema.IDENTITY_NODE_TYPES.EMBODIED_EPISODE, identityKey: identity.identityKey, model: 'm', family: 'claude', since: 'not-a-date', until: null};
+        const result = hydration.buildHydrationIndex({identityNode: identity, episodes: [rawBad]});
+
+        expect(result.valid).toBe(false);
+        expect(result.index).toBeNull();
+        expect(result.reason).toContain('unparseable since');
+
+        // and a malformed row hiding inside an otherwise-valid chain refuses the same way
+        const mixed = hydration.buildHydrationIndex({identityNode: identity, episodes: [...episodes, {...rawBad, until: '2026-07-01T00:00:00Z', since: 'garbage'}]});
+        expect(mixed.valid).toBe(false);
+    });
 });


### PR DESCRIPTION
## Summary

The identity epic's hydration leaf: **a regenerable index over the lossless trail — never a snapshot-as-self.** `buildHydrationIndex` is a pure, clock-free projection over a *validated* era chain, so the epic's central safety property becomes executable: **delete → rebuild → diff = ∅** (losing the index loses nothing; the trail is the truth). The Fork-8 trap is refused structurally — the index carries its own node type, is frozen, and the schema's chain validator rejects it as an anchor by construction — and staleness is *detected* (`isIndexCurrent`), never trusted.

Resolves #14699
Refs #14677

> **Diff is net-new only** (de-stacked at `9ca4d13cc`): #14729 merged to dev, this branch rebased onto it — the two hydration commits are the entire review surface. Merge order: this → #14751.

## Deltas

- **NEW `ai/graph/identityHydration.mjs`**:
  - `buildHydrationIndex({identityNode, episodes})` — refuses unvalidated chains (hydration only projects certified history), then projects the frozen view: anchor + social layer + the CURRENT era's facts (model/family/tier/harness/capabilities/since) + chain stats (`eraCount`, `firstSince`). Deterministic — no clock, no I/O: the same trail always yields a deep-equal index.
  - **Structural non-masquerade:** `type: 'IdentityHydrationIndex'` (deliberately not an identity type), `regenerable: true`, frozen — a consumer cannot write the view back as "the self", and `validateEraChain(index, …)` rejects it as an anchor.
  - `isIndexCurrent(index, episodes)` — the honest staleness check: current exactly when the trail has neither grown nor re-headed; stale means REBUILD, never patch, never trust the frozen self.
- **NEW `test/playwright/unit/ai/graph/identityHydration.spec.mjs`** — 4 tests: the projection (head-era facts, not the seed's; invalid chains never hydrate) · **THE PROPERTY** (build → lose → rebuild → deep-equal — the delete→rebuild→diff=∅ acceptance made executable) · the Fork-8 structural refusal (frozen write throws; wrong type; chain-validator rejection) · staleness detection across a real era migration (old index reads stale the instant the trail grows; the rebuild is current and reflects the new head).

The empirical anchor for the regenerability requirement is on the record: the mailbox read-state rollback demonstrated live that index-layer state is the fragile layer while the trail persists — a hydration design that cannot cheaply rebuild is the same incident waiting in the identity substrate.

**§9.6 record:** pure data-plane (exempt half); the session's core reads stand on record.

**Deliberately NOT in this PR:** graph persistence / node-class registration (the ADR-0024 disposition — the writer leaf owns it) · the `identityRoots.mjs` migration (filable once the stack merges) · render consumers (the cockpit reads this index per the render contract).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs identityHydration` → **4 passed (30.8s)** on the integrated stack.

Evidence: L2 (unit-pinned pure logic; the property test IS the ADR's acceptance instrument).

## Post-Merge Validation

- The render-model consumer reads `currentEra` from this index (never the raw chain) and rebuilds on `isIndexCurrent === false` — a consumer caching a stale index is the defect this leaf's staleness check exists to surface.
- The `identityRoots.mjs` migration leaf hydrates every live resident through this builder — the first production rebuild re-proves THE PROPERTY on real data.

## Related

Parent #14677 · #14693/#14723 (PR #14729 — the stacked schema parent) · the render contract this serves · the read-state-rollback incident (the empirical anchor, on the ticket record).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b9b95ac6-42f5-47a3-b58f-6071f79657e8.

