### PR TITLE
feat(examples): convergence-GP end-to-end demo + lane falsifier (#14648)

### DIFF
--- a/ai/examples/convergenceTerrainDemo.mjs
+++ b/ai/examples/convergenceTerrainDemo.mjs
@@ -1,0 +1,112 @@
+import {computeConvergenceSnapshots}                               from '../services/graph/convergenceCompute.mjs';
+import {buildConvergenceRenderLedger, renderConvergenceLedgerText} from '../services/graph/convergenceRenderLedger.mjs';
+
+/**
+ * @module ai/examples/convergenceTerrainDemo
+ * @summary Convergence-weighted Golden Path — end-to-end demo + lane falsifier (ticket-ref-ok: #14648 owning-leaf anchor; demo leaf of #14581).
+ *
+ * Runs the full convergence chain — snapshot schema → weighting compute → render-ledger — on a realistic,
+ * seeded goal→sub-goal lattice + N imagined futures, and proves the epic's lane-goal: convergence-weighting
+ * surfaces the sub-goals that lie on the most viable futures at once (cross-future-invariant — worth doing
+ * regardless of which future wins), while honestly discounting correlated futures.
+ *
+ * FALSIFIER (the reason a demo leaf exists — machinery is unproven until a run on real data is decision-useful):
+ *   1. A maximally-invariant sub-goal surfaces at the top of the terrain (on ALL futures).
+ *   2. A NON-TRIVIAL invariant surfaces too — high-invariance but NOT on every future (the non-obvious insight
+ *      convergence is for; a terrain that only re-finds the obvious endpoints proves nothing).
+ *   3. Correlated futures are visibly discounted: the OQ7 independence budget drops below 1 because two of the
+ *      seeded futures are deliberately identical (agreement among clones is not cross-future invariance).
+ *   4. OQ8 firewall preserved end-to-end: the demo consumes the `notAuthority` ledger surface, never an agent
+ *      boot-path.
+ *
+ * The seeded lattice is a startup's goal graph ("reach first revenue") across four strategy futures; `ship-mvp`
+ * and `first-revenue` lie on all four (trivially invariant endpoints), `find-pmf` on three (the non-obvious
+ * invariant), and `raise-seed` / `hire-sales` / `build-brand` are each future-specific. The lean-pivot future
+ * is intentionally identical to the bootstrap future so the independence budget must discount the agreement.
+ */
+
+/** @summary The seeded goal→sub-goal lattice (canonical ids — idempotent under normalizeConceptKey). @type {String[]} */
+export const SEED_LATTICE = Object.freeze(['ship-mvp', 'find-pmf', 'first-revenue', 'raise-seed', 'hire-sales', 'build-brand']);
+
+/** @summary Four imagined strategy futures over the lattice; the last is a deliberate clone of the first. @type {String[][]} */
+export const SEED_FUTURES = Object.freeze([
+    ['ship-mvp', 'find-pmf', 'first-revenue'],                   // bootstrap
+    ['ship-mvp', 'raise-seed', 'hire-sales', 'first-revenue'],  // venture-backed
+    ['ship-mvp', 'find-pmf', 'build-brand', 'first-revenue'],   // organic
+    ['ship-mvp', 'find-pmf', 'first-revenue']                   // lean pivot — identical to bootstrap (correlated)
+]);
+
+/**
+ * @summary Runs the convergence chain over the seeded lattice and returns the terrain artifact plus a
+ * structured falsifier verdict. Pure over its `now` injection — no I/O, no clock read — so the falsifier is
+ * CI-guarded, not a one-off console print.
+ * @param {Object} [options]
+ * @param {String} [options.now='2026-07-04T00:00:00.000Z'] ISO window anchor for deterministic output.
+ * @returns {{compute: Object, ledger: Object, text: String, falsifier: Object}} the run + its falsifier verdict.
+ */
+export function runConvergenceTerrainDemo({now = '2026-07-04T00:00:00.000Z'} = {}) {
+    const compute = computeConvergenceSnapshots({
+        latticeNodeIds: SEED_LATTICE,
+        futurePaths   : SEED_FUTURES,
+        provenance    : 'convergence-gp-demo:seeded-lattice',
+        manifest      : {futureSource: 'demo:4-imagined-strategy-futures'},
+        now
+    });
+
+    const ledger = buildConvergenceRenderLedger(compute, {now}),
+          text   = renderConvergenceLedgerText(ledger);
+
+    const maxFutures         = SEED_FUTURES.length,
+          rows               = ledger.rows,
+          topRow             = rows[0] || null,
+          invariantRows      = rows.filter(row => (row.convergenceWeight ?? 0) >= 3),
+          futureSpecificRows = rows.filter(row => (row.convergenceWeight ?? 0) <= 1),
+          // the insight: a high-invariance sub-goal that is NOT on every future (weight 3 of 4 here).
+          nonTrivialInvariant = rows.find(row => (row.convergenceWeight ?? 0) >= 3 && (row.convergenceWeight ?? 0) < maxFutures) || null,
+          budget              = ledger.independenceBudget?.value ?? null;
+
+    const falsifier = {
+        maxFutures,
+        topInvariant        : topRow && {id: topRow.canonicalId, weight: topRow.convergenceWeight},
+        surfacesMaxInvariant: !!topRow && topRow.convergenceWeight === maxFutures,
+        nonTrivialInvariant : nonTrivialInvariant && {id: nonTrivialInvariant.canonicalId, weight: nonTrivialInvariant.convergenceWeight},
+        invariantCount      : invariantRows.length,
+        futureSpecificCount : futureSpecificRows.length,
+        independenceBudget  : budget,
+        // two futures are identical → agreement is inflated → the budget must fall below a perfect 1.
+        discountVisible  : typeof budget === 'number' && budget < 1 && budget > 0,
+        firewallClean    : ledger.firewall?.clean === true,
+        firewallPreserved: ledger.notAuthority === true && ledger.agentBootConsumable === false
+    };
+
+    // The lane-goal is proven only if ALL of these hold together.
+    falsifier.passed = falsifier.surfacesMaxInvariant &&
+        !!falsifier.nonTrivialInvariant &&
+        falsifier.discountVisible &&
+        falsifier.firewallPreserved &&
+        falsifier.futureSpecificCount >= 1;   // the terrain SEPARATES invariant from future-specific structure
+
+    return {compute, ledger, text, falsifier};
+}
+
+/**
+ * @summary Runnable entry point: prints the shareable terrain artifact + the falsifier verdict, and exits
+ * non-zero if the lane-goal is not proven (so the demo doubles as an executable falsifier).
+ * @returns {void}
+ */
+function main() {
+    const {text, falsifier} = runConvergenceTerrainDemo();
+
+    console.log('\n================ Convergence Terrain (shareable, provisional / notAuthority) ================\n');
+    console.log(text);
+    console.log('\n================ Lane falsifier verdict ================\n');
+    console.log(JSON.stringify(falsifier, null, 2));
+    console.log(`\n${falsifier.passed ? '✅ PASSED' : '❌ FAILED'} — convergence-weighting ${falsifier.passed ? 'surfaced a non-obvious cross-future-invariant sub-goal and discounted correlated agreement.' : 'did NOT prove the lane-goal.'}\n`);
+
+    process.exit(falsifier.passed ? 0 : 1);
+}
+
+// Run only when executed directly (`node ai/examples/convergenceTerrainDemo.mjs`), not when imported by the spec.
+if (import.meta.url === `file://${process.argv[1]}`) {
+    main();
+}

--- a/test/playwright/unit/ai/examples/convergenceTerrainDemo.spec.mjs
+++ b/test/playwright/unit/ai/examples/convergenceTerrainDemo.spec.mjs
@@ -1,0 +1,51 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    SEED_FUTURES,
+    SEED_LATTICE,
+    runConvergenceTerrainDemo
+} from '../../../../../ai/examples/convergenceTerrainDemo.mjs';
+
+test.describe('convergenceTerrainDemo (#14648 — epic #14581 end-to-end falsifier)', () => {
+    const {ledger, text, falsifier} = runConvergenceTerrainDemo({now: '2026-07-04T00:00:00.000Z'});
+
+    test('AC1: runs the full chain (schema → compute → render) end-to-end into a terrain ledger', () => {
+        expect(ledger.kind).toBe('convergence-terrain-ledger');
+        expect(ledger.rowCount).toBe(SEED_LATTICE.length);   // every seeded sub-goal is placed on the terrain
+        expect(text).toContain('# Convergence Terrain Ledger');
+    });
+
+    test('AC2 (falsifier): surfaces a maximally-invariant AND a non-obvious sub-goal; discounts correlated futures', () => {
+        // A sub-goal on ALL futures tops the terrain (the trivially-invariant endpoint).
+        expect(falsifier.surfacesMaxInvariant).toBe(true);
+        expect(falsifier.topInvariant.weight).toBe(SEED_FUTURES.length);
+        // The insight convergence is FOR: high invariance but NOT on every future — `find-pmf` (3 of 4).
+        expect(falsifier.nonTrivialInvariant).toBeTruthy();
+        expect(falsifier.nonTrivialInvariant.id).toBe('find-pmf');
+        expect(falsifier.nonTrivialInvariant.weight).toBe(3);
+        // OQ7: two seeded futures are identical, so agreement is inflated — the budget must fall below a perfect 1.
+        expect(falsifier.discountVisible).toBe(true);
+        expect(falsifier.independenceBudget).toBeGreaterThan(0);
+        expect(falsifier.independenceBudget).toBeLessThan(1);
+        // The terrain SEPARATES invariant structure from future-specific noise.
+        expect(falsifier.futureSpecificCount).toBeGreaterThanOrEqual(1);
+    });
+
+    test('AC3 (reach artifact): the terrain is shareable, provisional / notAuthority-labeled, and shows the discount', () => {
+        expect(text).toContain('PROVISIONAL — notAuthority');
+        expect(text).toContain('find-pmf');                       // the non-obvious insight is visible in the artifact
+        expect(text).toMatch(/Independence budget \(OQ7\).*0\./); // the OQ7 discount is shown, not hidden
+        expect(text).toContain('convergence-gp-demo:seeded-lattice'); // provenance traceable (no authority-by-typography)
+    });
+
+    test('AC4 (firewall): the demo consumes the notAuthority ledger, never an agent boot-path (OQ8 end-to-end)', () => {
+        expect(falsifier.firewallPreserved).toBe(true);
+        expect(ledger.notAuthority).toBe(true);
+        expect(ledger.agentBootConsumable).toBe(false);
+        expect(falsifier.firewallClean).toBe(true);   // the compute run itself read neither peer futures nor prior convergence
+    });
+
+    test('the lane-goal is proven end-to-end (falsifier.passed)', () => {
+        expect(falsifier.passed).toBe(true);
+    });
+});


### PR DESCRIPTION
Resolves #14648

This demo/falsifier leaf for the Convergence-weighted Golden Path epic (#14581) runs the full chain — snapshot schema (merged) → weighting compute (merged) → render-ledger (merged via PR #14725) — on a seeded startup goal-lattice across four imagined strategy futures, proving the lane-goal rather than leaving the schema/compute/render leaves as unfalsified machinery. Epic closeout remains pending until #14732 clears the merge gate and epic-resolution verifies the parent ACs.

> **Stack resolved.** This branch was originally stacked on #14725 to reach `convergenceRenderLedger.mjs` pre-merge. #14725 has now merged to `dev`; the live #14732 diff is exactly the 2 demo files — `ai/examples/convergenceTerrainDemo.mjs` + its spec.

## What it proves (the falsifier)
The seeded lattice is a startup's "reach first revenue" goal graph across four futures (bootstrap · venture-backed · organic · lean-pivot). The lean-pivot future is **deliberately identical** to bootstrap so the OQ7 discount must engage. The falsifier asserts:
1. A **maximally-invariant** sub-goal tops the terrain (`ship-mvp` / `first-revenue`, on all 4 futures).
2. A **non-trivial** invariant surfaces — `find-pmf`, on 3 of 4 futures: the non-obvious insight convergence exists for (a terrain that only re-finds the obvious endpoints proves nothing).
3. **Correlated futures are discounted**: the OQ7 independence budget falls to **0.394** (< 1) because two futures are clones — agreement among clones is not cross-future invariance.
4. **OQ8 firewall preserved end-to-end**: the demo consumes the `notAuthority` ledger, never an agent boot-path.

`runConvergenceTerrainDemo()` is pure over a `now`-injection (CI-guarded), and `main()` prints the shareable terrain + exits non-zero if the lane-goal is unproven — an **executable** falsifier.

Evidence: L2 (unit — 5 falsifier specs + the runnable demo exits 0 locally) → L2 required (the AC is a deterministic end-to-end assertion over the pure chain; no live substrate). No residual.

## Deltas from ticket
- The demo is a **harness** (`ai/examples/` — the repo's demo convention), not an `example/` app: the AC allows either, and a harness makes the falsifier CI-guarded (the app form would not).
- Scope kept to the **core falsifier + reach artifact**; the FM-cockpit terrain-panel presentation (needs @neo-opus-grace's view-tranche SSOT) stays out of scope per the ticket — the render module already emits the shareable artifact.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/examples/convergenceTerrainDemo.spec.mjs` → **5 passed** (AC1 full-chain render · AC2 falsifier: max + non-trivial invariant + OQ7 discount · AC3 reach artifact · AC4 OQ8 firewall · lane-goal proven). `node ai/examples/convergenceTerrainDemo.mjs` → exits 0, prints the terrain + verdict (`find-pmf` weight 3, independence budget 0.394).

## Post-Merge Validation
- [x] After #14725 merged to `dev`, confirmed this diff reduces to the 2 demo files and full CI is green on the merge candidate.

## Commits
- e9487005ec — the demo harness + 5-spec falsifier

Related: epic #14581 (closeout pending after #14732 clears the merge gate and epic-resolution verifies the parent ACs) · #14633 (schema, merged) · #14707 (compute, merged) · #14636 / PR #14725 (render-ledger, merged) · demo-leaf-per-epic rule (D#14561).

Authored by Ada (Claude Opus 4.8, Claude Code). Session 9a6b25ba-1dd8-4269-8fbf-57a461fd0978.
