### PR TITLE
feat(ai): temporal-summary substrate — collection, SUMMARY_* schema, MC maintenance registration (#14433)

### DIFF
--- a/ai/graph/temporalSummarySchema.mjs
+++ b/ai/graph/temporalSummarySchema.mjs
@@ -1,0 +1,194 @@
+import {slugifyIdPart} from './businessSchema.mjs';
+
+/**
+ * @summary Central schema definition for the temporal-pyramid summarization substrate
+ * (ADR 0028 — ticket-ref-ok: the Accepted decision record is this module's source of authority;
+ * the pointer is load-bearing, not archaeology — referred to below as "the pyramid contract").
+ *
+ * This module is the authoritative registry for the `temporal-summary` collection's metadata
+ * contract and the `SUMMARY_*` node-label family — the storage vocabulary the durable aggregation
+ * lane writes into and the dynamic synthesis path reads from. It carries schema only: no
+ * aggregation logic, no collection handles, no clock.
+ *
+ * The load-bearing disciplines, all from the pyramid contract:
+ *
+ * - **Durable/dynamic tier split (§2.1/§2.2):** L1 (session) and L2 (daily) are precomputed,
+ *   append-only durable facts; L3–L5 (weekly/monthly/quarterly) are synthesized on demand and
+ *   NEVER durably written — no LLM-compression cascade above the daily tier can exist, so the
+ *   photocopy-of-a-photocopy degradation is impossible by construction. The boundary is expressed
+ *   as data here (`durable` flags) so consumers enforce it by lookup, never by re-derivation.
+ * - **One collection, five-field metadata (§2.3):** a single `temporal-summary` collection inside
+ *   the `unified` store carries `{level, partition, windowStart, windowEnd, version}` — never
+ *   collection-per-level. The collection NAME is an `AiConfig.collections` leaf (the config
+ *   provider is the SSOT for names); this module deliberately does not duplicate it.
+ * - **Deterministic writes only (§2.3 anti-anchor):** `SUMMARY_*` labels are written exclusively
+ *   by the deterministic aggregation lane. They are NOT part of `SemanticGraphExtractor.VALID_TYPES`
+ *   and widening that prompt with summary labels is forbidden — summaries are aggregation output,
+ *   not LLM extraction.
+ * - **Per-agent + unified partitioning (§2.6):** every record names its track — one agent identity
+ *   or the single unified track with attribution. Partition is identity, not annotation: a
+ *   malformed partition fragments every downstream window query silently, so the validator
+ *   fail-closes on anything outside the two sanctioned forms.
+ * - **Append-only versioning (§2.4 / OQ8):** document ids embed the `version` field — a
+ *   re-aggregation mints NEW documents under the next version instead of rewriting history.
+ *   Retention policy within the version field is Leaf B's contract, not schema's.
+ */
+
+/**
+ * @summary The temporal-pyramid levels (the pyramid contract §2.1/§2.2), keyed by their semantic level name.
+ *
+ * `durable: true` levels (L1/L2) are precomputed facts the deterministic aggregation lane persists;
+ * `durable: false` levels (L3–L5) are reserved vocabulary for the on-demand synthesis path — their
+ * labels exist so nothing re-derives ad-hoc names, but no write path may persist them.
+ * @type {ReadonlyArray<Object>}
+ */
+export const TEMPORAL_SUMMARY_LEVELS = Object.freeze([
+    Object.freeze({key: 'session',   tier: 'L1', label: 'SUMMARY_SESSION',   durable: true}),
+    Object.freeze({key: 'daily',     tier: 'L2', label: 'SUMMARY_DAILY',     durable: true}),
+    Object.freeze({key: 'weekly',    tier: 'L3', label: 'SUMMARY_WEEKLY',    durable: false}),
+    Object.freeze({key: 'monthly',   tier: 'L4', label: 'SUMMARY_MONTHLY',   durable: false}),
+    Object.freeze({key: 'quarterly', tier: 'L5', label: 'SUMMARY_QUARTERLY', durable: false})
+]);
+
+/**
+ * @summary The level keys accepted in the `level` metadata field.
+ * @type {ReadonlyArray<String>}
+ */
+export const TEMPORAL_SUMMARY_LEVEL_KEYS = Object.freeze(TEMPORAL_SUMMARY_LEVELS.map(level => level.key));
+
+/**
+ * @summary Node labels the durable aggregation lane may write — the temporal family's rows in
+ * the Native Edge Graph node-type registry. ONLY the durable tiers appear here: a `SUMMARY_WEEKLY`
+ * graph node existing at all would mean the durable/dynamic boundary was breached.
+ * @type {ReadonlyArray<String>}
+ */
+export const DURABLE_SUMMARY_NODE_TYPES = Object.freeze(
+    TEMPORAL_SUMMARY_LEVELS.filter(level => level.durable).map(level => level.label)
+);
+
+/**
+ * @summary The five-field metadata contract every `temporal-summary` collection document carries
+ * (the pyramid contract §2.3). Exactly these fields — a document that cannot name its window,
+ * track, and version is invalid by construction.
+ * @type {ReadonlyArray<String>}
+ */
+export const TEMPORAL_SUMMARY_METADATA_FIELDS = Object.freeze([
+    'level', 'partition', 'windowStart', 'windowEnd', 'version'
+]);
+
+/**
+ * @summary The single unified partition track (the pyramid contract §2.6). Per-agent tracks use
+ * the agent's canonical `@<identity>` form.
+ * @type {String}
+ */
+export const UNIFIED_PARTITION = 'unified';
+
+/**
+ * @summary Resolves a level key to its level record, or null for unknown keys.
+ * @param {String} levelKey One of {@link TEMPORAL_SUMMARY_LEVEL_KEYS}
+ * @returns {Object|null}
+ */
+export function getTemporalSummaryLevel(levelKey) {
+    return TEMPORAL_SUMMARY_LEVELS.find(level => level.key === levelKey) ?? null
+}
+
+/**
+ * @summary Validates one partition value against the §2.6 sanctioned forms: the unified track or
+ * a per-agent `@<identity>` track.
+ * @param {String} partition
+ * @returns {Boolean}
+ */
+export function isValidPartition(partition) {
+    if (typeof partition !== 'string' || partition.trim() === '') {
+        return false
+    }
+
+    return partition === UNIFIED_PARTITION || (partition.startsWith('@') && partition.length > 1)
+}
+
+/**
+ * @summary Validates the five-field metadata contract for one `temporal-summary` document
+ * (the pyramid contract §2.3), fail-closed with every violation named.
+ *
+ * Window bounds are ISO 8601 UTC strings with `windowStart` strictly before `windowEnd`;
+ * `version` is a positive integer (append-only re-aggregation counter — retention within it is
+ * Leaf B's contract). Unknown extra fields are rejected: the contract is exactly five fields, and
+ * silently-carried extras become undocumented query surface.
+ * @param {Object} metadata The candidate metadata object
+ * @returns {{valid: Boolean, errors: String[]}}
+ */
+export function validateTemporalSummaryMetadata(metadata) {
+    const errors = [];
+
+    if (metadata == null || typeof metadata !== 'object' || Array.isArray(metadata)) {
+        return {valid: false, errors: ['metadata must be a plain object carrying the five-field contract']}
+    }
+
+    for (const field of TEMPORAL_SUMMARY_METADATA_FIELDS) {
+        if (!(field in metadata)) {
+            errors.push(`missing required metadata field: ${field}`)
+        }
+    }
+
+    for (const field of Object.keys(metadata)) {
+        if (!TEMPORAL_SUMMARY_METADATA_FIELDS.includes(field)) {
+            errors.push(`unknown metadata field: ${field} — the contract is exactly {${TEMPORAL_SUMMARY_METADATA_FIELDS.join(', ')}}`)
+        }
+    }
+
+    if ('level' in metadata && !TEMPORAL_SUMMARY_LEVEL_KEYS.includes(metadata.level)) {
+        errors.push(`unknown level: ${metadata.level} — expected one of {${TEMPORAL_SUMMARY_LEVEL_KEYS.join(', ')}}`)
+    }
+
+    if ('partition' in metadata && !isValidPartition(metadata.partition)) {
+        errors.push(`invalid partition: ${JSON.stringify(metadata.partition)} — expected '${UNIFIED_PARTITION}' or a per-agent '@<identity>' track`)
+    }
+
+    for (const bound of ['windowStart', 'windowEnd']) {
+        if (bound in metadata) {
+            const value = metadata[bound];
+
+            if (typeof value !== 'string' || Number.isNaN(Date.parse(value))) {
+                errors.push(`${bound} must be an ISO 8601 timestamp string, got: ${JSON.stringify(value)}`)
+            }
+        }
+    }
+
+    if (
+        typeof metadata.windowStart === 'string' && typeof metadata.windowEnd === 'string' &&
+        !Number.isNaN(Date.parse(metadata.windowStart)) && !Number.isNaN(Date.parse(metadata.windowEnd)) &&
+        Date.parse(metadata.windowStart) >= Date.parse(metadata.windowEnd)
+    ) {
+        errors.push('windowStart must be strictly before windowEnd — empty or inverted windows are invalid')
+    }
+
+    if ('version' in metadata && (!Number.isInteger(metadata.version) || metadata.version < 1)) {
+        errors.push(`version must be a positive integer, got: ${JSON.stringify(metadata.version)}`)
+    }
+
+    return {valid: errors.length === 0, errors}
+}
+
+/**
+ * @summary Mints the deterministic `temporal-summary` document id for one validated metadata
+ * record: same window + track + version → same id (idempotent re-runs), next version → a NEW id
+ * (append-only history per the pyramid contract §2.4 — re-aggregation never rewrites prior documents).
+ *
+ * The partition is slug-normalized through the shared id vocabulary (`businessSchema.mjs` — one
+ * slug convention across graph families, never a re-derived copy); the `@` identity marker is
+ * dropped in the id, the metadata keeps the canonical form.
+ * @param {Object} metadata A metadata object that passed {@link validateTemporalSummaryMetadata}
+ * @returns {String}
+ */
+export function createTemporalSummaryDocId(metadata) {
+    const {valid, errors} = validateTemporalSummaryMetadata(metadata);
+
+    if (!valid) {
+        throw new Error(`createTemporalSummaryDocId: invalid metadata — ${errors.join('; ')}`)
+    }
+
+    const partitionSlug = slugifyIdPart(metadata.partition.replace(/^@/, ''));
+    const windowSlug    = metadata.windowStart.replace(/[:.]/g, '-');
+
+    return `temporal-summary-${metadata.level}-${partitionSlug}-${windowSlug}-v${metadata.version}`
+}

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -33,8 +33,9 @@ const DAY_MS            = 24 * 60 * 60 * 1000;
 // separate process that re-evaluates this module → its own unique names, so fullyParallel workers
 // never collide on a shared collection. Generated here (not inside a `process.env` leaf default) so
 // the leaves stay declarative; selection is the `collections.useTestDatabase` toggle + formulas below.
-const testMemoryCollection  = `test-memory-${Date.now()}-${Math.random().toString(36).substring(7)}`;
-const testSessionCollection = `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+const testMemoryCollection          = `test-memory-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+const testSessionCollection         = `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+const testTemporalSummaryCollection = `test-temporal-summary-${Date.now()}-${Math.random().toString(36).substring(7)}`;
 
 // Per-worker-unique WAL test directory under the OS temp root (same isolation rationale as the
 // test collection names above): fullyParallel workers never share a write-ahead directory, and
@@ -252,19 +253,21 @@ class Config extends ConfigProvider {
              */
             collections: {
                 /**
-                 * `memory` / `session` (the active names consumers read) are formulas (below) resolving
-                 * `*Prod` / `*Test` by construction from `useTestDatabase` — no inline `process.env` in a
-                 * leaf default. The test names are per-worker-unique (module consts above) for fullyParallel
-                 * isolation; consumers (HealthService, ChromaManager, defragChromaDB) read `collections.memory`
-                 * / `session` unchanged.
+                 * `memory` / `session` / `temporalSummary` (the active names consumers read) are formulas
+                 * (below) resolving `*Prod` / `*Test` by construction from `useTestDatabase` — no inline
+                 * `process.env` in a leaf default. The test names are per-worker-unique (module consts above)
+                 * for fullyParallel isolation; consumers (HealthService, ChromaManager, defragChromaDB) read
+                 * `collections.memory` / `session` / `temporalSummary` unchanged.
                  * @type {string}
                  */
-                memoryProd     : leaf('neo-agent-memory', 'NEO_MEMORY_COLLECTION_NAME', 'string'),
-                memoryTest     : leaf(testMemoryCollection, 'NEO_MEMORY_COLLECTION_NAME_TEST', 'string'),
-                sessionProd    : leaf('neo-agent-sessions', 'NEO_SESSION_COLLECTION_NAME', 'string'),
-                sessionTest    : leaf(testSessionCollection, 'NEO_SESSION_COLLECTION_NAME_TEST', 'string'),
-                useTestDatabase: leaf(false, 'UNIT_TEST_MODE', 'boolean'),
-                graph          : leaf('neo-native-graph', 'NEO_GRAPH_COLLECTION_NAME', 'string')
+                memoryProd         : leaf('neo-agent-memory', 'NEO_MEMORY_COLLECTION_NAME', 'string'),
+                memoryTest         : leaf(testMemoryCollection, 'NEO_MEMORY_COLLECTION_NAME_TEST', 'string'),
+                sessionProd        : leaf('neo-agent-sessions', 'NEO_SESSION_COLLECTION_NAME', 'string'),
+                sessionTest        : leaf(testSessionCollection, 'NEO_SESSION_COLLECTION_NAME_TEST', 'string'),
+                temporalSummaryProd: leaf('neo-temporal-summary', 'NEO_TEMPORAL_SUMMARY_COLLECTION_NAME', 'string'),
+                temporalSummaryTest: leaf(testTemporalSummaryCollection, 'NEO_TEMPORAL_SUMMARY_COLLECTION_NAME_TEST', 'string'),
+                useTestDatabase    : leaf(false, 'UNIT_TEST_MODE', 'boolean'),
+                graph              : leaf('neo-native-graph', 'NEO_GRAPH_COLLECTION_NAME', 'string')
             },
             /**
              * Datasets Schema/Paths
@@ -758,15 +761,16 @@ class Config extends ConfigProvider {
          * Reactive computed config values (`Neo.state.Provider` formulas — recompute when a dependency changes).
          */
         formulas: {
-            // The active graph SQLite path + memory/session collection names, resolved BY CONSTRUCTION
-            // from the `useTestDatabase` toggle. Consumers read `AiConfig.storagePaths.graph` /
-            // `collections.memory` / `collections.session` unchanged — the single resolution point.
-            // Replaces the prior inline-`process.env` leaf ternaries.
-            'storagePaths.graph' : data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest  : data.storagePaths.graphProd,
-            'collections.memory' : data => data.collections.useTestDatabase  ? data.collections.memoryTest  : data.collections.memoryProd,
-            'collections.session': data => data.collections.useTestDatabase  ? data.collections.sessionTest : data.collections.sessionProd,
-            'memoryWal.dir'      : data => data.memoryWal.useTestDatabase    ? data.memoryWal.dirTest       : data.memoryWal.dirProd,
-            'messageWal.dir'     : data => {
+            // The active graph SQLite path + memory/session/temporal-summary collection names, resolved
+            // BY CONSTRUCTION from the `useTestDatabase` toggle. Consumers read `AiConfig.storagePaths.graph` /
+            // `collections.memory` / `collections.session` / `collections.temporalSummary` unchanged —
+            // the single resolution point. Replaces the prior inline-`process.env` leaf ternaries.
+            'storagePaths.graph'         : data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest           : data.storagePaths.graphProd,
+            'collections.memory'         : data => data.collections.useTestDatabase  ? data.collections.memoryTest           : data.collections.memoryProd,
+            'collections.session'        : data => data.collections.useTestDatabase  ? data.collections.sessionTest          : data.collections.sessionProd,
+            'collections.temporalSummary': data => data.collections.useTestDatabase  ? data.collections.temporalSummaryTest  : data.collections.temporalSummaryProd,
+            'memoryWal.dir'              : data => data.memoryWal.useTestDatabase    ? data.memoryWal.dirTest       : data.memoryWal.dirProd,
+            'messageWal.dir'             : data => {
                 const configuredDir = data.messageWal.useTestDatabase ? data.messageWal.dirTest : data.messageWal.dirProd;
                 if (configuredDir) return configuredDir;
 

--- a/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
+++ b/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
@@ -14,10 +14,11 @@ export const DESTRUCTIVE_PRODUCTION_CONFIRMATION = 'CONFIRM_PRODUCTION_DESTRUCTI
  * wrappers so the guard fires uniformly regardless of which subsystem's manager
  * a caller imports. The set is the union of all production canonical names:
  *
- * - `neo-agent-memory`   — Memory Core memories collection (`aiConfig.collections.memory`).
- * - `neo-agent-sessions` — Memory Core summaries collection (`aiConfig.collections.session`).
- * - `neo-native-graph`   — Memory Core graph collection (`aiConfig.collections.graph`).
- * - `neo-knowledge-base` — Knowledge Base canonical collection (`aiConfig.collectionName`).
+ * - `neo-agent-memory`     — Memory Core memories collection (`aiConfig.collections.memory`).
+ * - `neo-agent-sessions`   — Memory Core summaries collection (`aiConfig.collections.session`).
+ * - `neo-native-graph`     — Memory Core graph collection (`aiConfig.collections.graph`).
+ * - `neo-temporal-summary` — Memory Core temporal-summary collection (`aiConfig.collections.temporalSummary`).
+ * - `neo-knowledge-base`   — Knowledge Base canonical collection (`aiConfig.collectionName`).
  *
  * Names are hardcoded (not derived from config) so a caller that loads runtime config
  * without the unit-test isolation layer still gets the canonical name blocked. This
@@ -28,6 +29,7 @@ export const GUARDED_CANONICAL_COLLECTION_NAMES = Object.freeze(new Set([
     'neo-agent-memory',
     'neo-agent-sessions',
     'neo-native-graph',
+    'neo-temporal-summary',
     'neo-knowledge-base'
 ]));
 

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -1,11 +1,11 @@
-import aiConfig                  from '../../mcp/server/memory-core/config.mjs';
-import fs                        from 'fs-extra';
-import logger                    from '../../mcp/server/memory-core/logger.mjs';
-import path                      from 'path';
-import readline                  from 'readline';
-import Base                      from '../../../src/core/Base.mjs';
-import StorageRouter             from './managers/StorageRouter.mjs';
-import DestructiveOperationGuard from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+import aiConfig                                                   from '../../mcp/server/memory-core/config.mjs';
+import fs                                                         from 'fs-extra';
+import logger                                                     from '../../mcp/server/memory-core/logger.mjs';
+import path                                                       from 'path';
+import readline                                                   from 'readline';
+import Base                                                       from '../../../src/core/Base.mjs';
+import StorageRouter                                              from './managers/StorageRouter.mjs';
+import DestructiveOperationGuard                                  from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 import {partitionRowsByVectorValidity, summarizeVectorRejections} from './helpers/vectorWriteInvariant.mjs';
 
 /**
@@ -70,7 +70,7 @@ class DatabaseService extends Base {
         logger.log(`Found ${count} documents in ${collectionName} to export.`);
 
         await fs.ensureDir(backupPath);
-        const timestamp = new Date().toISOString().replace(/:/g, '-');
+        const timestamp   = new Date().toISOString().replace(/:/g, '-');
         const backupFile  = path.join(backupPath, `${filePrefix}-${timestamp}.jsonl`);
         const writeStream = fs.createWriteStream(backupFile);
         const stats       = {
@@ -203,7 +203,7 @@ class DatabaseService extends Base {
         const path = (await import('path')).default;
         await fs.ensureDir(backupPath);
 
-        const timestamp = new Date().toISOString().replace(/:/g, '-');
+        const timestamp   = new Date().toISOString().replace(/:/g, '-');
         const backupFile  = path.join(backupPath, `${filePrefix}-${timestamp}.jsonl`);
         const writeStream = fs.createWriteStream(backupFile);
 
@@ -286,8 +286,8 @@ class DatabaseService extends Base {
         //     still INSERT; live-only IDs untouched. This preserves live post-wipe re-ingestion
         //     while letting backups fill records that are genuinely missing.
         const conflictClause = mode === 'replace' ? 'OR REPLACE' : 'OR IGNORE';
-        const insertNode = db.prepare(`INSERT ${conflictClause} INTO Nodes (id, user_id, data) VALUES (?, ?, ?)`);
-        const insertEdge = db.prepare(`
+        const insertNode     = db.prepare(`INSERT ${conflictClause} INTO Nodes (id, user_id, data) VALUES (?, ?, ?)`);
+        const insertEdge     = db.prepare(`
             INSERT ${conflictClause} INTO Edges (id, user_id, source, target, type, data)
             VALUES (?, ?, ?, ?, ?, ?)
         `);
@@ -367,7 +367,7 @@ class DatabaseService extends Base {
     }
 
     /**
-     * Exports the memory database (memories, summaries, graph) to JSONL files.
+     * Exports the memory database (memories, summaries, temporal summaries, graph) to JSONL files.
      *
      * Accepts an optional `backupPath` so orchestrators (e.g. `ai/scripts/maintenance/backup.mjs`)
      * can direct artifacts into a subfolder of an atomic timestamped bundle without
@@ -375,14 +375,14 @@ class DatabaseService extends Base {
      * to `aiConfig.backupPath`).
      *
      * @param {Object}    options
-     * @param {String[]} [options.include=['memories','summaries','graph']] Array of collections to export.
+     * @param {String[]} [options.include=['memories','summaries','temporal-summaries','graph']] Array of collections to export.
      * @param {String}   [options.backupPath=aiConfig.backupPath]           Directory for the JSONL artifacts.
      * @returns {Promise<Object>}
      */
-    async exportDatabase({include=['memories', 'summaries', 'graph'], backupPath = aiConfig.backupPath} = {}) {
+    async exportDatabase({include=['memories', 'summaries', 'temporal-summaries', 'graph'], backupPath = aiConfig.backupPath} = {}) {
         try {
             logger.log('Starting agent memory export...');
-            let memoryStats = null, summaryStats = null, graphStats = null;
+            let memoryStats = null, summaryStats = null, temporalSummaryStats = null, graphStats = null;
 
             if (include.includes('memories')) {
                 const collection = await StorageRouter.getMemoryCollection();
@@ -394,21 +394,28 @@ class DatabaseService extends Base {
                 summaryStats     = await this.#exportCollection(collection, backupPath, 'summaries-backup', aiConfig.collections.session);
             }
 
+            if (include.includes('temporal-summaries')) {
+                const collection = await StorageRouter.getTemporalSummaryCollection();
+                temporalSummaryStats = await this.#exportCollection(collection, backupPath, 'temporal-summary-backup', aiConfig.collections.temporalSummary);
+            }
+
             if (include.includes('graph')) {
                 const graphCount = await this.#exportGraph(backupPath, 'graph-backup');
                 graphStats       = {expected: graphCount, exported: graphCount};
             }
 
-            const memoryCount  = memoryStats?.exported || 0,
-                  summaryCount = summaryStats?.exported || 0,
-                  graphCount   = graphStats?.exported || 0,
-                  result       = {
-                      message: `Export complete. Exported ${memoryCount} memories, ${summaryCount} summaries, and ${graphCount} graph elements.`,
-                      count  : memoryCount + summaryCount + graphCount
+            const memoryCount          = memoryStats?.exported || 0,
+                  summaryCount         = summaryStats?.exported || 0,
+                  temporalSummaryCount = temporalSummaryStats?.exported || 0,
+                  graphCount           = graphStats?.exported || 0,
+                  result               = {
+                      message: `Export complete. Exported ${memoryCount} memories, ${summaryCount} summaries, ${temporalSummaryCount} temporal summaries, and ${graphCount} graph elements.`,
+                      count  : memoryCount + summaryCount + temporalSummaryCount + graphCount
                   };
 
             if (memoryStats) result.memories = memoryStats;
             if (summaryStats) result.summaries = summaryStats;
+            if (temporalSummaryStats) result.temporalSummaries = temporalSummaryStats;
             if (graphStats) result.graph = graphStats;
 
             return result
@@ -480,9 +487,10 @@ class DatabaseService extends Base {
                 const subsystemsToWipe = new Set();
                 for (const filePath of filesToImport) {
                     const base = path.basename(filePath);
-                    if      (base.startsWith('graph-backup'))  subsystemsToWipe.add('graph');
-                    else if (base.startsWith('memory-backup')) subsystemsToWipe.add('memories');
-                    else                                       subsystemsToWipe.add('summaries');
+                    if      (base.startsWith('graph-backup'))            subsystemsToWipe.add('graph');
+                    else if (base.startsWith('memory-backup'))           subsystemsToWipe.add('memories');
+                    else if (base.startsWith('temporal-summary-backup')) subsystemsToWipe.add('temporal-summaries');
+                    else                                                 subsystemsToWipe.add('summaries');
                 }
 
                 if (subsystemsToWipe.size > 0) {
@@ -500,10 +508,11 @@ class DatabaseService extends Base {
             // mode runs `collection.upsert()` after subsystem truncate. `memoriesInserted` remains
             // as a backward-compatible aggregate of memories.inserted + summaries.inserted.
             const subsystemCounts = {
-                graph           : null,
-                memories        : {inserted: 0, skippedExisting: 0, failed: 0},
-                summaries       : {inserted: 0, skippedExisting: 0, failed: 0},
-                memoriesInserted: 0
+                graph            : null,
+                memories         : {inserted: 0, skippedExisting: 0, failed: 0},
+                summaries        : {inserted: 0, skippedExisting: 0, failed: 0},
+                temporalSummaries: {inserted: 0, skippedExisting: 0, failed: 0},
+                memoriesInserted : 0
             };
 
             // Atomic vector-write invariant: an explicit-embedding import must carry a valid same-dimension
@@ -525,16 +534,21 @@ class DatabaseService extends Base {
                 }
 
                 // Determine which collection to import into based on filename heuristics
-                const isMemoryBackup = path.basename(filePath).startsWith('memory-backup');
-                let   collection     = isMemoryBackup
+                const isMemoryBackup          = path.basename(filePath).startsWith('memory-backup');
+                const isTemporalSummaryBackup = path.basename(filePath).startsWith('temporal-summary-backup');
+                let   collection              = isMemoryBackup
                     ? await StorageRouter.getMemoryCollection()
-                    : await StorageRouter.getSummaryCollection();
+                    : isTemporalSummaryBackup
+                        ? await StorageRouter.getTemporalSummaryCollection()
+                        : await StorageRouter.getSummaryCollection();
 
                 targetCollectionName = collection.name; // roughly tracking target
 
                 // Route per-file counters into the right substrate bucket so memories vs summaries
-                // truthful counts stay separable across multi-file batches.
-                const chromaCounts = isMemoryBackup ? subsystemCounts.memories : subsystemCounts.summaries;
+                // vs temporal summaries truthful counts stay separable across multi-file batches.
+                const chromaCounts = isMemoryBackup
+                    ? subsystemCounts.memories
+                    : isTemporalSummaryBackup ? subsystemCounts.temporalSummaries : subsystemCounts.summaries;
 
                 const fileStream = fs.createReadStream(filePath);
                 const rl         = readline.createInterface({input: fileStream, crlfDelay: Infinity});
@@ -704,6 +718,12 @@ class DatabaseService extends Base {
                 const proxy = Neo.create('Neo.ai.services.memory-core.managers.CollectionProxy', { collectionType: 'session' });
                 await proxy.drop({confirmation});
                 truncated.push('summaries');
+            }
+
+            if (include.includes('temporal-summaries')) {
+                const proxy = Neo.create('Neo.ai.services.memory-core.managers.CollectionProxy', { collectionType: 'temporalSummary' });
+                await proxy.drop({confirmation});
+                truncated.push('temporal-summaries');
             }
 
             if (include.includes('graph')) {

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -1195,7 +1195,9 @@ class GraphService extends Base {
                 data = JSON.parse(row.data);
             } catch(e) { continue; }
 
-            if (data.label !== 'SYSTEM_ANCHOR' && data.label !== 'System' && data.label !== 'ADR' && data.label !== 'ISSUE' && data.label !== 'DISCUSSION' && data.label !== 'PULL_REQUEST' && data.label !== 'SESSION' && data.label !== 'MEMORY' && data.label !== 'AgentIdentity' && data.label !== 'BroadcastSentinel' && data.label !== 'WAKE_SUBSCRIPTION') {
+            // SUMMARY_SESSION / SUMMARY_DAILY: durable temporal-pyramid records (ai/graph/temporalSummarySchema.mjs)
+            // are irreplaceable aggregation facts — an edge-less window record is still substrate, never orphan-collectable.
+            if (data.label !== 'SYSTEM_ANCHOR' && data.label !== 'System' && data.label !== 'ADR' && data.label !== 'ISSUE' && data.label !== 'DISCUSSION' && data.label !== 'PULL_REQUEST' && data.label !== 'SESSION' && data.label !== 'MEMORY' && data.label !== 'AgentIdentity' && data.label !== 'BroadcastSentinel' && data.label !== 'WAKE_SUBSCRIPTION' && data.label !== 'SUMMARY_SESSION' && data.label !== 'SUMMARY_DAILY') {
                 orphaned.push(row.id);
             }
         }

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -979,8 +979,9 @@ class HealthService extends Base {
      */
     async #checkCollections(chromaProbeTimeoutMs) {
         const result = {
-            memories : null,
-            summaries: null
+            memories         : null,
+            summaries        : null,
+            temporalSummaries: null
         };
 
         try {
@@ -1002,7 +1003,16 @@ class HealthService extends Base {
                 chromaProbeTimeoutMs
             });
 
-            const errors = [result.memories?.error, result.summaries?.error].filter(Boolean);
+            result.temporalSummaries = await this.#checkCollectionCount({
+                collectionType : 'temporalSummary',
+                name           : aiConfig.collections.temporalSummary,
+                getCollection  : () => StorageRouter.getTemporalSummaryCollection(),
+                resolutionLabel: 'temporal-summary collection resolution health probe',
+                countLabel     : 'temporal-summary collection count health probe',
+                chromaProbeTimeoutMs
+            });
+
+            const errors = [result.memories?.error, result.summaries?.error, result.temporalSummaries?.error].filter(Boolean);
             if (errors.length) {
                 result.error = `Failed to access collections: ${errors.join('; ')}`;
             }

--- a/ai/services/memory-core/managers/AbstractVectorManager.mjs
+++ b/ai/services/memory-core/managers/AbstractVectorManager.mjs
@@ -46,6 +46,16 @@ class AbstractVectorManager extends Base {
     }
 
     /**
+     * @summary Resolves the temporal-summary collection abstraction from the Vector Storage Layer
+     * (the pyramid's durable L1/L2 window records — one collection, level-partitioned by metadata).
+     * @abstract
+     * @returns {Promise<Object>}
+     */
+    async getTemporalSummaryCollection() {
+        throw new Error('Abstract method: must be implemented by subclass');
+    }
+
+    /**
      * @summary Ingests data directly into the active Vector Storage Layer adapter.
      * @abstract
      * @param {Object} args

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -325,11 +325,11 @@ class ChromaManager extends AbstractVectorManager {
      * cached Chroma collection promises/objects, leaving service readiness and graph state
      * untouched so the next operation lazily re-resolves by canonical collection name.
      *
-     * @param {'memory'|'summary'|'graph'|'all'} [collectionType='all']
+     * @param {'memory'|'summary'|'temporalSummary'|'graph'|'all'} [collectionType='all']
      * @returns {void}
      */
     invalidateCollectionCache(collectionType = 'all') {
-        const types = collectionType === 'all' ? ['memory', 'summary', 'graph'] : [collectionType];
+        const types = collectionType === 'all' ? ['memory', 'summary', 'temporalSummary', 'graph'] : [collectionType];
 
         for (const type of types) {
             if (type === 'memory') {
@@ -338,6 +338,9 @@ class ChromaManager extends AbstractVectorManager {
             } else if (type === 'summary') {
                 this._summaryCollectionPromise = null;
                 this.summaryCollection         = null;
+            } else if (type === 'temporalSummary') {
+                this._temporalSummaryCollectionPromise = null;
+                this.temporalSummaryCollection         = null;
             } else if (type === 'graph') {
                 this._graphCollectionPromise = null;
                 this.graphCollection         = null;

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -269,6 +269,25 @@ class ChromaManager extends AbstractVectorManager {
     /**
      * @returns {Promise<Object>}
      */
+    async getTemporalSummaryCollection() {
+        if (!this._temporalSummaryCollectionPromise) {
+            const collectionName = aiConfig.collections.temporalSummary;
+            this.assertCollectionNotProdBleed({name: collectionName, database: this.resolveChromaClientConfig(aiConfig).database});
+            this._temporalSummaryCollectionPromise = this.#executeSilently(async () => {
+                return await this.client.getOrCreateCollection({
+                    name             : collectionName,
+                    embeddingFunction: this.#createEmbeddingFunction()
+                });
+            }, {filter: MC_WARN_FILTER});
+        }
+
+        this.temporalSummaryCollection = await this._temporalSummaryCollectionPromise;
+        return this.temporalSummaryCollection;
+    }
+
+    /**
+     * @returns {Promise<Object>}
+     */
     async getGraphCollection() {
         if (!this._graphCollectionPromise) {
             const collectionName = aiConfig.collections.graph;

--- a/ai/services/memory-core/managers/CollectionProxy.mjs
+++ b/ai/services/memory-core/managers/CollectionProxy.mjs
@@ -21,7 +21,7 @@ class CollectionProxy extends Base {
 
     async getManagers() {
         const architecture = aiConfig.engine;
-        const managers = [];
+        const managers     = [];
 
         // In Hybrid RAG, vectors exclusively live in ChromaDB
         if (architecture === 'chroma' || architecture === 'hybrid') {
@@ -36,7 +36,8 @@ class CollectionProxy extends Base {
     async getCollections() {
         const managers = await this.getManagers();
         return Promise.all(managers.map(m => {
-            if (this.collectionType === 'graph') return m.getGraphCollection();
+            if (this.collectionType === 'graph')           return m.getGraphCollection();
+            if (this.collectionType === 'temporalSummary') return m.getTemporalSummaryCollection();
             return this.collectionType === 'memory' ? m.getMemoryCollection() : m.getSummaryCollection();
         }));
     }
@@ -91,6 +92,8 @@ class CollectionProxy extends Base {
             let coll;
             if (this.collectionType === 'graph') {
                 coll = await manager.getGraphCollection();
+            } else if (this.collectionType === 'temporalSummary') {
+                coll = await manager.getTemporalSummaryCollection();
             } else {
                 coll = this.collectionType === 'memory' ?
                     await manager.getMemoryCollection() :

--- a/ai/services/memory-core/managers/StorageRouter.mjs
+++ b/ai/services/memory-core/managers/StorageRouter.mjs
@@ -57,6 +57,18 @@ class StorageRouter extends Base {
     }
 
     /**
+     * @summary Resolves the temporal-summary collection (the pyramid's durable L1/L2 window
+     * records). Semantic window queries ("what happened this week") ride the same re-ranker
+     * the session-summary path uses.
+     * @returns {Promise<CollectionProxy>} A proxy respecting aiConfig.engine
+     */
+    async getTemporalSummaryCollection() {
+        const proxy = Neo.create(CollectionProxy, { collectionType: 'temporalSummary' });
+        this.injectQueryReRanker(proxy, 'temporalSummary');
+        return proxy;
+    }
+
+    /**
      * @summary On-demand probe of each collection's vector-query (HNSW) path.
      *
      * A populated-but-corrupt collection passes `count()` but throws on `query()` (e.g. a desynced
@@ -149,11 +161,11 @@ class StorageRouter extends Base {
                 logger.error(`[StorageRouter] Pass 1 semantic retrieval failed on the '${collectionType}' collection${isCorruptionSignature ? ' (HNSW corruption signature "Error finding id")' : ''}: ${e.message}`);
 
                 return {
-                    ids: [[]], distances: [[]], metadatas: [[]], documents: undefined,
-                    _degraded         : true,
-                    _degradedReason   : e.message,
+                    ids                : [[]], distances: [[]], metadatas: [[]], documents: undefined,
+                    _degraded          : true,
+                    _degradedReason    : e.message,
                     _degradedCollection: collectionType,
-                    _degradedSignature: isCorruptionSignature ? 'chroma-error-finding-id' : 'chroma-query-error'
+                    _degradedSignature : isCorruptionSignature ? 'chroma-error-finding-id' : 'chroma-query-error'
                 };
             }
 
@@ -184,7 +196,7 @@ class StorageRouter extends Base {
 
             // Compute composite scores
             const rankedResults = pass1Ids.map((id, index) => {
-                const vectorDist    = Number(distances[index] ?? 0);
+                const vectorDist = Number(distances[index] ?? 0);
                 // Vector distance (lower is better, typically L2 in ChromaDB) -> score
                 const semanticScore = 1 / (1 + vectorDist);
 

--- a/learn/agentos/decisions/0024-native-edge-graph-model.md
+++ b/learn/agentos/decisions/0024-native-edge-graph-model.md
@@ -35,6 +35,7 @@ Core layers plus deterministic extensions. Source-of-truth in the right column (
 | **Work** | `SESSION`, `MEMORY`, `ARTIFACT_PLAN`, `ARTIFACT_TASK`, `ISSUE`, `STRATEGY`, `STALL_FINDING` | `VALID_TYPES` + GitHub / session sync; `STALL_FINDING` is deterministic work-graph inference output governed by ADR 0030 (never LLM-extracted) |
 | **System** | `SYSTEM_ANCHOR`, `[Frontier]`, `AgentIdentity`, `MESSAGE`, `WAKE_SUBSCRIPTION`, `NL_ACTION_SEQUENCE` | operational (`GraphService`, `MailboxService`, `IdentitySchema` — ADR 0018, `GapInferenceEngine` Neural Link evidence digest) |
 | **Business** | `BUSINESS_GOAL`, `METRIC` | `businessSchema.mjs` (`BUSINESS_NODE_TYPES` — deterministic validator-gated writes; never LLM-extracted; a `METRIC` without a `falsifyingQuery` is invalid by construction) |
+| **Temporal** | `SUMMARY_SESSION`, `SUMMARY_DAILY` | `temporalSummarySchema.mjs` (`DURABLE_SUMMARY_NODE_TYPES` — deterministic aggregation-lane writes only; never LLM-extracted; L3–L5 labels are reserved vocabulary with NO durable node class per ADR 0028 §2.2) |
 
 The LLM extractor's `VALID_TYPES` enum is **14** (`SemanticGraphExtractor:265`); an unrecognized extracted type defaults to `CONCEPT`. `ADR` is added **deterministically** by `AdrIngestor` (no LLM inference), so decision records are graph-queryable without widening the extractor enum (ADR 0006). `STALL_FINDING` is likewise deterministic work telemetry governed by ADR 0030, not LLM extraction. (`SYSTEM_ANCHOR` is grouped under System for its operational role but is itself one of the 14 `VALID_TYPES` — both LLM-extractable and operational.)
 
@@ -75,6 +76,16 @@ Four named enums (`CONCEPT_EDGE_TYPES`, `ADR_EDGE_TYPES`, `PROTECTED_EDGE_TYPES`
 > NODE-class disposition; `PROTECTED_EDGE_TYPES` (§2.3) governs EDGE facts, not node-class membership — the
 > two are orthogonal. Node writes + the post-sync integrity canary land with the compute leaf (#14634); this
 > leaf defines the schema only.
+
+> **Amended by #14433 (temporal-summary substrate, Leaf A of ADR 0028):** registers the durable
+> temporal-pyramid node classes `SUMMARY_SESSION` / `SUMMARY_DAILY` (`ai/graph/temporalSummarySchema.mjs`,
+> `DURABLE_SUMMARY_NODE_TYPES`) per ADR 0028 §2.7's pre-declared obligation. Written EXCLUSIVELY by the
+> deterministic aggregation lane (ADR 0028 §2.3 anti-anchor: never `SemanticGraphExtractor` — the extractor
+> enum stays 14); the dynamic tiers carry reserved label vocabulary but NO durable node class by construction
+> (no compression cascade above daily). Node-side disposition: **orphan-exempt** (an edge-less window record
+> is an aggregation fact, `GraphService.getOrphanedNodes` keep-list) and append-only under the `version`
+> metadata field — re-aggregation mints new documents, never rewrites. Graph-node writes land with the
+> L1/L2 lane leaf (Leaf B); this leaf registers schema + storage only.
 
 ### 2.4 Topology — how it connects
 

--- a/test/playwright/unit/ai/graph/temporalSummarySchema.spec.mjs
+++ b/test/playwright/unit/ai/graph/temporalSummarySchema.spec.mjs
@@ -1,0 +1,149 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'TemporalSummarySchemaTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+test.describe('temporalSummarySchema — the ADR 0028 storage contract mechanized (#14433)', () => {
+    let schema;
+
+    const validMetadata = () => ({
+        level      : 'daily',
+        partition  : 'unified',
+        windowStart: '2026-07-03T00:00:00.000Z',
+        windowEnd  : '2026-07-04T00:00:00.000Z',
+        version    : 1
+    });
+
+    test.beforeAll(async () => {
+        schema = await import('../../../../../ai/graph/temporalSummarySchema.mjs');
+    });
+
+    test.describe('level vocabulary + the durable/dynamic boundary', () => {
+        test('defines exactly the five pyramid levels with their SUMMARY_* labels', () => {
+            expect(schema.TEMPORAL_SUMMARY_LEVELS.map(({key, tier, label}) => ({key, tier, label}))).toEqual([
+                {key: 'session',   tier: 'L1', label: 'SUMMARY_SESSION'},
+                {key: 'daily',     tier: 'L2', label: 'SUMMARY_DAILY'},
+                {key: 'weekly',    tier: 'L3', label: 'SUMMARY_WEEKLY'},
+                {key: 'monthly',   tier: 'L4', label: 'SUMMARY_MONTHLY'},
+                {key: 'quarterly', tier: 'L5', label: 'SUMMARY_QUARTERLY'}
+            ]);
+        });
+
+        test('only the L1/L2 durable tiers are writable node types — no durable label exists above daily', () => {
+            expect(schema.DURABLE_SUMMARY_NODE_TYPES).toEqual(['SUMMARY_SESSION', 'SUMMARY_DAILY']);
+        });
+
+        test('resolves level records by key and fail-closes on unknown keys', () => {
+            expect(schema.getTemporalSummaryLevel('daily')).toMatchObject({tier: 'L2', durable: true});
+            expect(schema.getTemporalSummaryLevel('weekly')).toMatchObject({tier: 'L3', durable: false});
+            expect(schema.getTemporalSummaryLevel('hourly')).toBeNull();
+        });
+    });
+
+    test.describe('validateTemporalSummaryMetadata — the five-field contract', () => {
+        test('accepts a complete record for both sanctioned partition forms', () => {
+            expect(schema.validateTemporalSummaryMetadata(validMetadata())).toEqual({valid: true, errors: []});
+
+            expect(schema.validateTemporalSummaryMetadata({
+                ...validMetadata(),
+                level    : 'session',
+                partition: '@neo-fable-clio'
+            })).toEqual({valid: true, errors: []});
+        });
+
+        test('rejects non-object input and missing fields with every violation named', () => {
+            expect(schema.validateTemporalSummaryMetadata(null).valid).toBe(false);
+            expect(schema.validateTemporalSummaryMetadata([]).valid).toBe(false);
+
+            const {valid, errors} = schema.validateTemporalSummaryMetadata({level: 'daily'});
+
+            expect(valid).toBe(false);
+            expect(errors).toEqual(expect.arrayContaining([
+                'missing required metadata field: partition',
+                'missing required metadata field: windowStart',
+                'missing required metadata field: windowEnd',
+                'missing required metadata field: version'
+            ]));
+        });
+
+        test('rejects unknown extra fields — the contract is exactly five fields', () => {
+            const {valid, errors} = schema.validateTemporalSummaryMetadata({...validMetadata(), prose: 'summary text'});
+
+            expect(valid).toBe(false);
+            expect(errors.some(message => message.includes('unknown metadata field: prose'))).toBe(true);
+        });
+
+        test('rejects unknown levels and malformed partitions', () => {
+            expect(schema.validateTemporalSummaryMetadata({...validMetadata(), level: 'hourly'}).valid).toBe(false);
+            expect(schema.validateTemporalSummaryMetadata({...validMetadata(), partition: 'neo-fable-clio'}).valid).toBe(false);
+            expect(schema.validateTemporalSummaryMetadata({...validMetadata(), partition: '@'}).valid).toBe(false);
+            expect(schema.validateTemporalSummaryMetadata({...validMetadata(), partition: ''}).valid).toBe(false);
+        });
+
+        test('rejects non-ISO window bounds and empty or inverted windows', () => {
+            expect(schema.validateTemporalSummaryMetadata({...validMetadata(), windowStart: 1751500800000}).valid).toBe(false);
+            expect(schema.validateTemporalSummaryMetadata({...validMetadata(), windowEnd: 'not-a-date'}).valid).toBe(false);
+
+            const inverted = schema.validateTemporalSummaryMetadata({
+                ...validMetadata(),
+                windowStart: '2026-07-04T00:00:00.000Z',
+                windowEnd  : '2026-07-03T00:00:00.000Z'
+            });
+
+            expect(inverted.valid).toBe(false);
+            expect(inverted.errors.some(message => message.includes('strictly before'))).toBe(true);
+
+            const empty = schema.validateTemporalSummaryMetadata({
+                ...validMetadata(),
+                windowEnd: validMetadata().windowStart
+            });
+
+            expect(empty.valid).toBe(false);
+        });
+
+        test('rejects non-positive and non-integer versions', () => {
+            expect(schema.validateTemporalSummaryMetadata({...validMetadata(), version: 0}).valid).toBe(false);
+            expect(schema.validateTemporalSummaryMetadata({...validMetadata(), version: 1.5}).valid).toBe(false);
+            expect(schema.validateTemporalSummaryMetadata({...validMetadata(), version: '1'}).valid).toBe(false);
+        });
+    });
+
+    test.describe('createTemporalSummaryDocId — deterministic, append-only identity', () => {
+        test('same window + track + version mints the same id; the @ marker is slug-dropped', () => {
+            const metadata = {...validMetadata(), partition: '@neo-fable-clio'};
+
+            const first  = schema.createTemporalSummaryDocId(metadata);
+            const second = schema.createTemporalSummaryDocId({...metadata});
+
+            expect(first).toBe(second);
+            expect(first).toBe('temporal-summary-daily-neo-fable-clio-2026-07-03T00-00-00-000Z-v1');
+        });
+
+        test('the next version mints a NEW id — re-aggregation never rewrites history', () => {
+            const v1 = schema.createTemporalSummaryDocId(validMetadata());
+            const v2 = schema.createTemporalSummaryDocId({...validMetadata(), version: 2});
+
+            expect(v1).not.toBe(v2);
+            expect(v2.endsWith('-v2')).toBe(true);
+        });
+
+        test('fail-closes on invalid metadata instead of minting a partial id', () => {
+            expect(() => schema.createTemporalSummaryDocId({...validMetadata(), level: 'hourly'}))
+                .toThrow(/unknown level: hourly/);
+        });
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -311,6 +311,15 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.collections.graph).toBe('neo-native-graph');
     });
 
+    test('collections.temporalSummary resolves by construction from the *Prod/*Test leaves under the toggle (#14433)', () => {
+        // Same by-construction shape as memory/session above: the active name is a formula over
+        // `useTestDatabase`, the prod leaf is the canonical collection, the test leaf is the
+        // per-worker-unique module const — a unit run can never resolve the production name.
+        expect(config.collections.temporalSummaryProd).toBe('neo-temporal-summary');
+        expect(config.collections.temporalSummary).toMatch(/^test-temporal-summary-/);
+        expect(config.collections.temporalSummary).toBe(config.collections.temporalSummaryTest);
+    });
+
     test('remRunRetentionLimit defaults to 200 and parses NEO_REM_RUN_RETENTION_LIMIT as a number (#12123)', () => {
         expect(config.remRunRetentionLimit).toBe(200);
 

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
@@ -144,12 +144,14 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
     test('invalidateCollectionCache clears targeted and all collection handles', () => {
         const stalePromise = Promise.resolve({name: 'stale-collection'});
 
-        ChromaManager._memoryCollectionPromise  = stalePromise;
-        ChromaManager._summaryCollectionPromise = stalePromise;
-        ChromaManager._graphCollectionPromise   = stalePromise;
-        ChromaManager.memoryCollection  = {name: 'stale-memory'};
-        ChromaManager.summaryCollection = {name: 'stale-summary'};
-        ChromaManager.graphCollection   = {name: 'stale-graph'};
+        ChromaManager._memoryCollectionPromise          = stalePromise;
+        ChromaManager._summaryCollectionPromise         = stalePromise;
+        ChromaManager._temporalSummaryCollectionPromise = stalePromise;
+        ChromaManager._graphCollectionPromise           = stalePromise;
+        ChromaManager.memoryCollection          = {name: 'stale-memory'};
+        ChromaManager.summaryCollection         = {name: 'stale-summary'};
+        ChromaManager.temporalSummaryCollection = {name: 'stale-temporal-summary'};
+        ChromaManager.graphCollection           = {name: 'stale-graph'};
 
         ChromaManager.invalidateCollectionCache('summary');
 
@@ -157,16 +159,28 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
         expect(ChromaManager.memoryCollection).toEqual({name: 'stale-memory'});
         expect(ChromaManager._summaryCollectionPromise).toBeNull();
         expect(ChromaManager.summaryCollection).toBeNull();
+        // the name-adjacent temporalSummary handle must survive a targeted `summary` invalidation
+        expect(ChromaManager._temporalSummaryCollectionPromise).toBe(stalePromise);
+        expect(ChromaManager.temporalSummaryCollection).toEqual({name: 'stale-temporal-summary'});
         expect(ChromaManager._graphCollectionPromise).toBe(stalePromise);
         expect(ChromaManager.graphCollection).toEqual({name: 'stale-graph'});
+
+        ChromaManager.invalidateCollectionCache('temporalSummary');
+
+        expect(ChromaManager._temporalSummaryCollectionPromise).toBeNull();
+        expect(ChromaManager.temporalSummaryCollection).toBeNull();
+        expect(ChromaManager._memoryCollectionPromise).toBe(stalePromise);
+        expect(ChromaManager._graphCollectionPromise).toBe(stalePromise);
 
         ChromaManager.invalidateCollectionCache();
 
         expect(ChromaManager._memoryCollectionPromise).toBeNull();
         expect(ChromaManager._summaryCollectionPromise).toBeNull();
+        expect(ChromaManager._temporalSummaryCollectionPromise).toBeNull();
         expect(ChromaManager._graphCollectionPromise).toBeNull();
         expect(ChromaManager.memoryCollection).toBeNull();
         expect(ChromaManager.summaryCollection).toBeNull();
+        expect(ChromaManager.temporalSummaryCollection).toBeNull();
         expect(ChromaManager.graphCollection).toBeNull();
     });
 


### PR DESCRIPTION
## Summary

Leaf A of the ADR 0028 temporal-pyramid decomposition (Epic #12679): the **storage substrate** the durable aggregation lane (Leaf B, #14434) writes into and the dynamic synthesis path (Leaf C, #14435) reads from — the `temporal-summary` collection inside the `unified` store, the `SUMMARY_*` label schema as a pure module, and the Memory-Core-realm maintenance registration, with the ADR 0024 §2.2 node-type table updated in the same PR per ADR 0028 §2.7's pre-declared obligation. No aggregation logic, no data written beyond schema — sequencing exactly per the ticket.

**Merge gate state: OPEN** — ADR 0028 flipped to `Accepted` on PR #14428's merge (2026-07-02), so this leaf is merge-eligible per the epic's #11376 §6 contract.

Resolves #14433

Refs #12679

## Deltas

- **NEW `ai/graph/temporalSummarySchema.mjs`** (pure, no Neo import — mirrors `directionSchema.mjs`): the five-level vocabulary with the durable/dynamic boundary expressed as data (`SUMMARY_SESSION`/`SUMMARY_DAILY` durable; weekly/monthly/quarterly labels reserved, never durably written — the "no compression cascade above daily" invariant is lookup-able, not re-derivable); `DURABLE_SUMMARY_NODE_TYPES`; the five-field metadata contract validator (exact-field, fail-closed with every violation named: level enum, `unified`/`@identity` partition forms, ISO window bounds strictly ordered, positive-integer version); `createTemporalSummaryDocId` — deterministic and append-only (same window+track+version → same id; next version → new id).
- **`ai/mcp/server/memory-core/config.template.mjs`** — `temporalSummaryProd`/`temporalSummaryTest` leaves + the `collections.temporalSummary` by-construction formula, exactly the memory/session pattern (per-worker-unique test name; no inline env; consumers read the resolved leaf — the collection NAME lives only here, the schema module deliberately does not duplicate it).
- **`managers/`** — `AbstractVectorManager` abstract getter; `ChromaManager.getTemporalSummaryCollection()` (memoized promise + prod-bleed assert + silent executor, mirroring its siblings); `CollectionProxy` explicit `temporalSummary` branches in `getCollections()` + `drop()` (explicit — never the else-fallback); `StorageRouter.getTemporalSummaryCollection()` with the summary-path re-ranker (semantic window queries ride the same dual-pass).
- **`DatabaseService`** — export branch (`temporal-summary-backup` prefix) now in the DEFAULT export include; restore wipe-classifier + import dispatch branch BEFORE the else→summaries fallback; truncate branch (NOT in the default truncate include — see notes); per-substrate truthful counters extended.
- **`HealthService.#checkCollections`** — third probe (`temporalSummary`) with its error joined to the collection-health envelope.
- **`DestructiveOperationGuard`** — `neo-temporal-summary` joins `GUARDED_CANONICAL_COLLECTION_NAMES` (hardcoded-by-design canonical refusal).
- **`GraphService.getOrphanedNodes`** — `SUMMARY_SESSION`/`SUMMARY_DAILY` join the orphan keep-list: an edge-less window record is an aggregation fact, never orphan-collectable.
- **`learn/agentos/decisions/0024-native-edge-graph-model.md`** — §2.2 gains the **Temporal** layer row (source-of-truth: `temporalSummarySchema.mjs`) + the amendment block recording the deterministic-lane-only write discipline and the orphan-exempt / append-only node-side disposition.
- **NEW `test/playwright/unit/ai/graph/temporalSummarySchema.spec.mjs`** — 12 tests: level vocabulary + durable boundary, validator (per-field fail-closed incl. exact-field rejection, partition forms, inverted/empty windows, version shapes), doc-id determinism + append-only versioning + fail-closed minting.

## Deliberate boundaries (review anchors)

- **Export defaults widen, truncate defaults do not:** backups should automatically cover the new irreplaceable state (ADR 0017 MC-as-store recovery model), but the destructive default surface stays explicit — `temporal-summaries` truncates only when named (or via replace-mode restore classification of its own backup files).
- **`checkConnectivity` untouched:** its contract (memory+summary reachability) is a boot signal; the new collection's health rides the collection-count probe instead. Widening the connectivity contract is Leaf B's call if the lane needs it.
- **Observed adjacent hazard (out of scope, flagging):** `truncateDatabase`'s summaries branch passes `collectionType: 'session'` — a non-canonical type that resolves correctly only via `CollectionProxy`'s else-fallback. This leaf's new branches are explicit precisely to avoid that class; the `'session'` literal + the else-fallback tightening belong to a hygiene follow-up if wanted.

## Test Evidence

- `temporalSummarySchema` → **12 passed** (exact head).
- Full `test/playwright/unit/ai/services/memory-core/` + schema spec on an alternate Chroma test port (`NEO_CHROMA_PORT_TEST=18186`; 18180 occupied by a concurrent agent run) → **845 passed**.
- Managers-focused earlier gate: ChromaManager + StorageRouterDegraded + schema → **41 passed**.

Evidence: L2 (unit-pinned schema/config/registration; no runtime writer exists until Leaf B) → L2 required (Leaf A ACs are storage/schema contracts). Residual: none — every AC unit-coverable, covered.

## Post-Merge Validation

- Leaf B (#14434) binds the exact query/write contract into the deterministic lane; its records must validate through `validateTemporalSummaryMetadata` and mint ids through `createTemporalSummaryDocId` — any second vocabulary is the defect this leaf exists to prevent.
- The ADR-0033 `directionBreakdown` fields ride Leaf B's records on this substrate (ADR 0028 §2.4 amendment) → then #14568 ({v,s,r} composition) unblocks.

## Related

Parent Epic #12679 · authority ADR 0028 (Accepted; §2.3 storage / §2.6 partitioning / §2.7 obligation discharged here) · amends ADR 0024 §2.2 (this PR) · aligned-with ADR 0017 (within-posture collection add) · ADR 0019 (config leaves read at use site; read-gate honored) · consumed by #14434 → #14435 → #14568.

Authored by Clio (Claude Fable 5, Claude Code). Session fa2a6fd5-7488-4af6-a0d2-3855c86003e4.
