### PR TITLE
fix(agentos): kindRegistry resolvers guard the closed set against prototype-shaped keys (#14728)

### DIFF
--- a/apps/agentos/view/fleet/kindRegistry.mjs
+++ b/apps/agentos/view/fleet/kindRegistry.mjs
@@ -53,20 +53,23 @@ const KIND_LABEL = {
 /**
  * Pure kind → color-token resolver — the single source of truth for chip color, on the --fm-kind-*
  * axis. Unknown kinds degrade to the neutral kind token, so the chip absorbs kind-set growth
- * without a broken color.
+ * without a broken color. Uses an `Object.hasOwn` check (not `MAP[k] ||`) so a prototype-shaped key
+ * (`toString`, `constructor`, `__proto__`) degrades to neutral instead of leaking an inherited value.
  * @param {String} kind
  * @returns {String} the color custom-property name (e.g. `--fm-kind-pr`)
  */
 export function kindToken(kind) {
-    return KIND_TOKEN[kind] || '--fm-kind-neutral'
+    return Object.hasOwn(KIND_TOKEN, kind) ? KIND_TOKEN[kind] : '--fm-kind-neutral'
 }
 
 /**
  * Pure kind → short-label resolver. Unknown kinds fall back to the kind string itself, so a new
- * kind still renders a readable (if verbose) chip until it earns a short label here.
+ * kind still renders a readable (if verbose) chip until it earns a short label here. Uses an
+ * `Object.hasOwn` check (not `MAP[k] ||`) so a prototype-shaped key (`toString`, `constructor`,
+ * `__proto__`) falls back to its literal string instead of leaking an inherited Object.prototype value.
  * @param {String} kind
  * @returns {String}
  */
 export function kindLabel(kind) {
-    return KIND_LABEL[kind] || (kind ?? 'event')
+    return Object.hasOwn(KIND_LABEL, kind) ? KIND_LABEL[kind] : (kind ?? 'event')
 }

--- a/test/playwright/unit/apps/agentos/view/fleet/kindRegistry.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/kindRegistry.spec.mjs
@@ -50,13 +50,21 @@ test.describe('Fleet event-kind registry — derived DTO coverage + --fm-kind-* 
         expect(kindToken('work-stall')).toBe('--fm-kind-alert');
         expect(kindToken('source-degraded')).toBe('--fm-kind-alert');
         expect(kindToken('some-brand-new-kind')).toBe('--fm-kind-neutral');
-        expect(kindToken(undefined)).toBe('--fm-kind-neutral')
+        expect(kindToken(undefined)).toBe('--fm-kind-neutral');
+        // prototype-shaped keys must not leak an inherited Object.prototype value past the closed set
+        expect(kindToken('toString')).toBe('--fm-kind-neutral');
+        expect(kindToken('constructor')).toBe('--fm-kind-neutral');
+        expect(kindToken('__proto__')).toBe('--fm-kind-neutral')
     });
 
     test('kindLabel gives short labels and falls back to the kind string for unknown kinds', () => {
         expect(kindLabel('lifecycle-request')).toBe('request');
         expect(kindLabel('work-stall')).toBe('stall');
         expect(kindLabel('pr-activity')).toBe('pr');
-        expect(kindLabel('a-new-kind')).toBe('a-new-kind')
+        expect(kindLabel('a-new-kind')).toBe('a-new-kind');
+        // prototype-shaped keys fall back to the literal kind string, never an inherited value
+        expect(kindLabel('toString')).toBe('toString');
+        expect(kindLabel('constructor')).toBe('constructor');
+        expect(kindLabel('__proto__')).toBe('__proto__')
     });
 });


### PR DESCRIPTION
Resolves #14728

**Depends-on #14726** (merge that first — it carries #14728's state-axis half; see Deltas). Refs #14560 (parent epic) · Refs #14701 (kindRegistry, merged — the file this hardens) · Refs #14722 (sibling resolver on the same pattern).

Closes the **kind-axis** half of the systemic `MAP[k] || fallback` prototype-leak: `kindToken` and `kindLabel` returned an inherited `Object.prototype` member for a prototype-shaped key.

Evidence: L2 (unit-tested; 3/3 green at `1fa0d955f`; rebased content-identical onto dev-with-#14744 at `05344dac5`, CI re-running).

## What it fixes

`kindToken('toString')` / `kindLabel('constructor')` etc. previously resolved to an inherited `Object.prototype` function (truthy → `||` short-circuits), leaking a function into the `--fm-chip` binding and the chip label. Both resolvers now use `Object.hasOwn(MAP, kind)` so a prototype-shaped key degrades to the neutral token (`kindToken`) / its literal string (`kindLabel`) — the same guard `familyToken`, `stateToken`, and `stateLabel` carry.

## Systemic close

The pattern spanned four resolvers across two PRs:
- `familyToken` — FamilyRail #14722
- `stateToken` + `stateLabel` — HealthSwatch #14726 (fix-at-source)
- `kindToken` + `kindLabel` — **this PR**

## Test Evidence

`npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/kindRegistry.spec.mjs` → **3 passed** (at `1fa0d955f`; the rebase to `05344dac5` touches only the base, not the kindRegistry files — CI re-confirms). Prototype-key regression (`toString` / `constructor` / `__proto__`) added to both the `kindToken` (→ `--fm-kind-neutral`) and `kindLabel` (→ literal string) tests.

## Post-Merge Validation

- [ ] None beyond CI — pure resolver hardening, no render-surface change. Merged EventChip consumer (#14594) resolves known kinds identically.

## Deltas from ticket

**Close-target correction** (per @neo-gpt's #14737 RC): #14728 named all four resolvers; its scope is delivered across **two** PRs — the state-axis pair (`stateToken`/`stateLabel`) folded into #14726 fix-at-source, and this PR's kind-axis pair. So **#14728 is fully delivered only when BOTH #14726 and this PR are on dev** — hence `Depends-on #14726` and the merge-order (land #14726 first). `Resolves #14728` is retained on that ordering: once #14726 is on dev, this PR's merge completes the ticket accurately. If merge-order can't be guaranteed, downgrade this to `Refs` and I'll close #14728 once both land.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
