### PR TITLE
feat(ai): retrospective enrichment — issues + sessions join the coverage label (#14721)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -657,6 +657,33 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Reads sessions recorded within a window from the summary collection already in
+     * scope — metadata-only (no document bodies), using the same multi-key timestamp resolution
+     * as the recency-ordered summary reads. Returns retrospective fact shapes.
+     * @param {Object} collection Summary Chroma collection (exposes async `.get`).
+     * @param {Date} since Lower window bound.
+     * @returns {Promise<Array<{ref: String, headline: String, at: String}>>}
+     */
+    static async fetchRecentSessions(collection, since) {
+        const meta      = await collection.get({include: ['metadatas']});
+        const resolveTs = m => {
+            const raw = m?.timestamp ?? m?.lastActivity ?? m?.updatedAt ?? m?.createdAt;
+            return Number.isFinite(Number(raw)) ? Number(raw) : (Date.parse(raw) || 0);
+        };
+        const sinceMs = since.getTime();
+
+        return (meta?.ids || [])
+            .map((id, idx) => ({id, ts: resolveTs(meta.metadatas?.[idx]), agent: meta.metadatas?.[idx]?.agent}))
+            .filter(entry => entry.ts >= sinceMs)
+            .sort((a, b) => b.ts - a.ts)
+            .map(entry => ({
+                ref     : `session ${String(entry.id).slice(0, 8)}`,
+                headline: entry.agent ? `session (${entry.agent})` : 'session recorded',
+                at      : new Date(entry.ts).toISOString()
+            }));
+    }
+
+    /**
      * @summary Assembles + renders the handoff retrospective section (the history leg) from window
      * facts. Static + pure over its inputs: the assembler folds, the render emits — this shim is
      * the synthesizer's stable seam to both, mirroring the computed-GP render shims.
@@ -1283,9 +1310,10 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                       openedPrs   = (Array.isArray(openPrs) ? openPrs : [])
                           .map(pr => ({ref: `PR #${pr.number}`, headline: pr.title, at: pr.createdAt}));
 
-                // the issue pair is per-class best-effort: a failing reader drops ITS class and
-                // narrows the declared label, so coverage is never overstated
-                let closedIssues = [], openedIssues = [], issueClassesLive = false;
+                // per-class best-effort: a failing reader drops ITS classes and narrows the
+                // declared label, so coverage is never overstated
+                let closedIssues = [], openedIssues = [], issueClassesLive = false,
+                    sessions     = [], sessionClassLive = false;
 
                 try {
                     closedIssues = (await this.fetchRecentClosedIssues(windowStart))
@@ -1297,15 +1325,26 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                     logger.warn('[GoldenPathSynthesizer] Retrospective issue readers failed — dropping the issue classes', issueError);
                 }
 
+                try {
+                    sessions         = await this.constructor.fetchRecentSessions(summaryColl, windowStart);
+                    sessionClassLive = true;
+                } catch (sessionError) {
+                    logger.warn('[GoldenPathSynthesizer] Retrospective session reader failed — dropping the session class', sessionError);
+                }
+
+                const coveredClasses = [
+                    'merged+opened PRs',
+                    ...(issueClassesLive  ? ['closed+opened issues'] : []),
+                    ...(sessionClassLive  ? ['sessions']             : [])
+                ];
+
                 retrospectiveAppend = this.constructor.renderHandoffRetrospectiveSection({
-                    facts: {mergedPrs, openedPrs, closedIssues, openedIssues},
+                    facts: {mergedPrs, openedPrs, closedIssues, openedIssues, sessions},
                     grain: RETROSPECTIVE_GRAINS.THREE_DAY,
                     now  : capturedAt,
                     // the label names exactly what these counts cover, per class, so the render
                     // never overstates the window's coverage
-                    filterSets: issueClassesLive
-                        ? 'merged+opened PRs · closed+opened issues, all authors'
-                        : 'merged+opened PRs, all authors'
+                    filterSets: `${coveredClasses.join(' · ')}, all authors`
                 })
             } catch (e) {
                 logger.warn('[GoldenPathSynthesizer] Failed to generate Handoff Retrospective', e);

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -664,7 +664,7 @@ class GoldenPathSynthesizer extends Base {
      * @param {Date} since Lower window bound.
      * @returns {Promise<Array<{ref: String, headline: String, at: String}>>}
      */
-    static async fetchRecentSessions(collection, since) {
+    async fetchRecentSessions(collection, since) {
         const meta      = await collection.get({include: ['metadatas']});
         const resolveTs = m => {
             const raw = m?.timestamp ?? m?.lastActivity ?? m?.updatedAt ?? m?.createdAt;
@@ -1326,7 +1326,9 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 }
 
                 try {
-                    sessions         = await this.constructor.fetchRecentSessions(summaryColl, windowStart);
+                    // instance seam like every sibling reader — the singleton export IS the
+                    // patchable surface; a static here silently bypasses test doubles
+                    sessions         = await this.fetchRecentSessions(summaryColl, windowStart);
                     sessionClassLive = true;
                 } catch (sessionError) {
                     logger.warn('[GoldenPathSynthesizer] Retrospective session reader failed — dropping the session class', sessionError);

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -632,6 +632,31 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Fetches issues closed within a window — the same bounded day-granularity search
+     * pattern as the merged-PR reader; one fact class of the retrospective's declared coverage.
+     * @param {Date} since Lower window bound.
+     * @returns {Promise<Array<{number: Number, title: String, closedAt: String}>>}
+     */
+    async fetchRecentClosedIssues(since) {
+        const { execSync } = await import('child_process');
+        const sinceDate    = since.toISOString().slice(0, 10);
+        const raw          = execSync(`gh issue list --state closed --search "closed:>=${sinceDate}" --json number,title,closedAt --limit 50`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
+        return JSON.parse(raw);
+    }
+
+    /**
+     * @summary Fetches issues opened within a window — the opened-side sibling of the closed reader.
+     * @param {Date} since Lower window bound.
+     * @returns {Promise<Array<{number: Number, title: String, createdAt: String}>>}
+     */
+    async fetchRecentOpenedIssues(since) {
+        const { execSync } = await import('child_process');
+        const sinceDate    = since.toISOString().slice(0, 10);
+        const raw          = execSync(`gh issue list --state all --search "created:>=${sinceDate}" --json number,title,createdAt --limit 50`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
+        return JSON.parse(raw);
+    }
+
+    /**
      * @summary Assembles + renders the handoff retrospective section (the history leg) from window
      * facts. Static + pure over its inputs: the assembler folds, the render emits — this shim is
      * the synthesizer's stable seam to both, mirroring the computed-GP render shims.
@@ -1249,21 +1274,38 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         let retrospectiveAppend = '';
         if (repoEnrichmentEnabled) {
             try {
-                const capturedAt = now instanceof Date ? now : new Date(now),
-                      windowMs   = RETROSPECTIVE_GRAINS.THREE_DAY.windowHours * 3600 * 1000,
-                      mergedPrs  = (await this.fetchRecentMergedPRs(new Date(capturedAt.getTime() - windowMs)))
+                const capturedAt  = now instanceof Date ? now : new Date(now),
+                      windowMs    = RETROSPECTIVE_GRAINS.THREE_DAY.windowHours * 3600 * 1000,
+                      windowStart = new Date(capturedAt.getTime() - windowMs),
+                      mergedPrs   = (await this.fetchRecentMergedPRs(windowStart))
                           .map(pr => ({ref: `PR #${pr.number}`, headline: pr.title, at: pr.mergedAt})),
                       // opened-PRs-in-window come free from the already-fetched open-PR list
-                      openedPrs  = (Array.isArray(openPrs) ? openPrs : [])
+                      openedPrs   = (Array.isArray(openPrs) ? openPrs : [])
                           .map(pr => ({ref: `PR #${pr.number}`, headline: pr.title, at: pr.createdAt}));
 
+                // the issue pair is per-class best-effort: a failing reader drops ITS class and
+                // narrows the declared label, so coverage is never overstated
+                let closedIssues = [], openedIssues = [], issueClassesLive = false;
+
+                try {
+                    closedIssues = (await this.fetchRecentClosedIssues(windowStart))
+                        .map(issue => ({ref: `#${issue.number}`, headline: issue.title, at: issue.closedAt}));
+                    openedIssues = (await this.fetchRecentOpenedIssues(windowStart))
+                        .map(issue => ({ref: `#${issue.number}`, headline: issue.title, at: issue.createdAt}));
+                    issueClassesLive = true;
+                } catch (issueError) {
+                    logger.warn('[GoldenPathSynthesizer] Retrospective issue readers failed — dropping the issue classes', issueError);
+                }
+
                 retrospectiveAppend = this.constructor.renderHandoffRetrospectiveSection({
-                    facts: {mergedPrs, openedPrs},
+                    facts: {mergedPrs, openedPrs, closedIssues, openedIssues},
                     grain: RETROSPECTIVE_GRAINS.THREE_DAY,
                     now  : capturedAt,
-                    // declared honestly: only the PR classes are wired so far — the filter set names
-                    // exactly what these counts cover, so the render never overstates the window
-                    filterSets: 'merged+opened PRs, all authors'
+                    // the label names exactly what these counts cover, per class, so the render
+                    // never overstates the window's coverage
+                    filterSets: issueClassesLive
+                        ? 'merged+opened PRs · closed+opened issues, all authors'
+                        : 'merged+opened PRs, all authors'
                 })
             } catch (e) {
                 logger.warn('[GoldenPathSynthesizer] Failed to generate Handoff Retrospective', e);

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -362,12 +362,26 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalEmbedText            = TextEmbeddingService.embedText;
         aiConfig.vectorDimension = 2;
 
-        StorageRouter.getGraphCollection   = async () => ({ query: async () => ({ ids: [['mock-id']], distances: [[0.1]] }) });
-        StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
-        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
-
         const now      = new Date();
         const hoursAgo = h => new Date(now.getTime() - h * 3600 * 1000).toISOString();
+
+        StorageRouter.getGraphCollection   = async () => ({ query: async () => ({ ids: [['mock-id']], distances: [[0.1]] }) });
+        // ONE collection double serving both consumers: document reads (semantic context) AND the
+        // session reader's metadata scope — real metadata path: one in-window session, one
+        // out-of-window, one undateable (no timestamp keys at all)
+        StorageRouter.getSummaryCollection = async () => ({
+            get: async ({include} = {}) => include?.includes('metadatas')
+                ? {
+                    ids      : ['abcdef1234567890', 'stale-session-id', 'undateable-id'],
+                    metadatas: [
+                        {timestamp: now.getTime() - 2 * 3600 * 1000, agent: '@neo-fable'},
+                        {timestamp: now.getTime() - 500 * 3600 * 1000, agent: '@neo-gpt'},
+                        {note: 'no timestamp keys'}
+                    ]
+                }
+                : {documents: ['mock document']}
+        });
+        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
 
         const originalFetchOpenPRs            = GoldenPathSynthesizer.fetchOpenPRs;
         const originalFetchRecentMergedPRs    = GoldenPathSynthesizer.fetchRecentMergedPRs;
@@ -410,7 +424,15 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).toContain('- Opened PRs: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
         expect(handoffContent).toContain('- Closed issues: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
         expect(handoffContent).toContain('- Opened issues: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
-        expect(handoffContent).toContain('- Sessions: 0 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`'); // the mock summary collection has no ids — class live, honestly zero
+        // the real metadata path: exactly the in-window session counts; the rendered ref carries
+        // the 8-char id + agent headline; stale + undateable rows are excluded FROM THE SECTION
+        // (other handoff sections legitimately consume the same summary metadata — scope the
+        // exclusion to the retrospective slice)
+        const retroSection = handoffContent.split('## Handoff Retrospective')[1].split('\n## ')[0];
+        expect(handoffContent).toContain('- Sessions: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
+        expect(retroSection).toContain('session abcdef12 — session (@neo-fable)');
+        expect(retroSection).not.toContain('stale-se');
+        expect(retroSection).not.toContain('undateab');
         expect(handoffContent).toContain('PR #14678 — keeper request route');
         expect(handoffContent).toContain('PR #14682 — registry snapshot clone');
         expect(handoffContent).toContain('#14588 — GP zero-routes collapse');
@@ -420,6 +442,60 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).not.toContain('ancient close outside the window');
         // firewall: the retrospective introduces no numbered route entries into the handoff
         expect(handoffContent).not.toMatch(/\d+\.\s\*\*issue-\d+\*\*:[^\n]*\n\s+-\s\*.*?\*/);
+    });
+
+    test('session reader failure drops ONLY the session class — handoff renders, label omits sessions (#14721)', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        aiConfig.vectorDimension = 2;
+
+        const now      = new Date();
+        const hoursAgo = h => new Date(now.getTime() - h * 3600 * 1000).toISOString();
+
+        StorageRouter.getGraphCollection   = async () => ({ query: async () => ({ ids: [['mock-id']], distances: [[0.1]] }) });
+        StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
+        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+
+        const originalFetchOpenPRs            = GoldenPathSynthesizer.fetchOpenPRs;
+        const originalFetchRecentMergedPRs    = GoldenPathSynthesizer.fetchRecentMergedPRs;
+        const originalFetchRecentClosedIssues = GoldenPathSynthesizer.fetchRecentClosedIssues;
+        const originalFetchRecentOpenedIssues = GoldenPathSynthesizer.fetchRecentOpenedIssues;
+        const originalFetchRecentSessions     = GoldenPathSynthesizer.fetchRecentSessions;
+
+        GoldenPathSynthesizer.fetchOpenPRs            = async () => [];
+        GoldenPathSynthesizer.fetchRecentMergedPRs    = async () => [
+            {number: 14678, title: 'keeper request route', mergedAt: hoursAgo(3)}
+        ];
+        GoldenPathSynthesizer.fetchRecentClosedIssues = async () => [];
+        GoldenPathSynthesizer.fetchRecentOpenedIssues = async () => [];
+        // the session READER fails (the enrichment try/catch seam — same class as a Chroma outage)
+        GoldenPathSynthesizer.fetchRecentSessions = async () => {
+            throw new Error('summary metadata read unavailable');
+        };
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({now});
+        } finally {
+            GoldenPathSynthesizer.fetchOpenPRs            = originalFetchOpenPRs;
+            GoldenPathSynthesizer.fetchRecentMergedPRs    = originalFetchRecentMergedPRs;
+            GoldenPathSynthesizer.fetchRecentClosedIssues = originalFetchRecentClosedIssues;
+            GoldenPathSynthesizer.fetchRecentOpenedIssues = originalFetchRecentOpenedIssues;
+            GoldenPathSynthesizer.fetchRecentSessions     = originalFetchRecentSessions;
+            StorageRouter.getGraphCollection              = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection            = originalGetSummaryCollection;
+            TextEmbeddingService.embedText                = originalEmbedText;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+
+        // the handoff still renders with the surviving classes; the coverage label OMITS sessions
+        expect(handoffContent).toContain('## Handoff Retrospective (3-Day');
+        expect(handoffContent).toContain('- Merged PRs: 1 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
+        expect(handoffContent).not.toContain('· sessions,');
+        // the sessions COUNT line still renders (honest 0 under the declared label) — the class
+        // is absent from coverage, not silently faked
+        expect(handoffContent).toContain('- Sessions: 0 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
     });
 
     test('synthesizeGoldenPath overwrites stale author sections when semantic candidates are empty', async () => {

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -406,10 +406,11 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
 
         expect(handoffContent).toContain('## Handoff Retrospective (3-Day');
-        expect(handoffContent).toContain('- Merged PRs: 1 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
-        expect(handoffContent).toContain('- Opened PRs: 1 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
-        expect(handoffContent).toContain('- Closed issues: 1 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
-        expect(handoffContent).toContain('- Opened issues: 1 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
+        expect(handoffContent).toContain('- Merged PRs: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
+        expect(handoffContent).toContain('- Opened PRs: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
+        expect(handoffContent).toContain('- Closed issues: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
+        expect(handoffContent).toContain('- Opened issues: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
+        expect(handoffContent).toContain('- Sessions: 0 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`'); // the mock summary collection has no ids — class live, honestly zero
         expect(handoffContent).toContain('PR #14678 — keeper request route');
         expect(handoffContent).toContain('PR #14682 — registry snapshot clone');
         expect(handoffContent).toContain('#14588 — GP zero-routes collapse');

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -369,8 +369,10 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const now      = new Date();
         const hoursAgo = h => new Date(now.getTime() - h * 3600 * 1000).toISOString();
 
-        const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
-        const originalFetchRecentMergedPRs = GoldenPathSynthesizer.fetchRecentMergedPRs;
+        const originalFetchOpenPRs            = GoldenPathSynthesizer.fetchOpenPRs;
+        const originalFetchRecentMergedPRs    = GoldenPathSynthesizer.fetchRecentMergedPRs;
+        const originalFetchRecentClosedIssues = GoldenPathSynthesizer.fetchRecentClosedIssues;
+        const originalFetchRecentOpenedIssues = GoldenPathSynthesizer.fetchRecentOpenedIssues;
 
         // opened-PRs come from the open-PR list (in-window); merged-PRs from the bounded merged query
         GoldenPathSynthesizer.fetchOpenPRs = async () => [
@@ -380,26 +382,41 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             {number: 14678, title: 'keeper request route', mergedAt: hoursAgo(3)},
             {number: 99999, title: 'ancient merge outside the window', mergedAt: hoursAgo(500)}
         ];
+        // the issue pair — one in-window each, plus an out-of-window closed issue the fold excludes
+        GoldenPathSynthesizer.fetchRecentClosedIssues = async () => [
+            {number: 14588, title: 'GP zero-routes collapse', closedAt: hoursAgo(6)},
+            {number: 88888, title: 'ancient close outside the window', closedAt: hoursAgo(400)}
+        ];
+        GoldenPathSynthesizer.fetchRecentOpenedIssues = async () => [
+            {number: 14731, title: 'identityRoots migration', createdAt: hoursAgo(1)}
+        ];
 
         try {
             await GoldenPathSynthesizer.synthesizeGoldenPath({now});
         } finally {
-            GoldenPathSynthesizer.fetchOpenPRs         = originalFetchOpenPRs;
-            GoldenPathSynthesizer.fetchRecentMergedPRs = originalFetchRecentMergedPRs;
-            StorageRouter.getGraphCollection           = originalGetGraphCollection;
-            StorageRouter.getSummaryCollection         = originalGetSummaryCollection;
-            TextEmbeddingService.embedText             = originalEmbedText;
+            GoldenPathSynthesizer.fetchOpenPRs            = originalFetchOpenPRs;
+            GoldenPathSynthesizer.fetchRecentMergedPRs    = originalFetchRecentMergedPRs;
+            GoldenPathSynthesizer.fetchRecentClosedIssues = originalFetchRecentClosedIssues;
+            GoldenPathSynthesizer.fetchRecentOpenedIssues = originalFetchRecentOpenedIssues;
+            StorageRouter.getGraphCollection              = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection            = originalGetSummaryCollection;
+            TextEmbeddingService.embedText                = originalEmbedText;
         }
 
         const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
 
         expect(handoffContent).toContain('## Handoff Retrospective (3-Day');
-        expect(handoffContent).toContain('- Merged PRs: 1 `[filters: merged+opened PRs, all authors]`');
-        expect(handoffContent).toContain('- Opened PRs: 1 `[filters: merged+opened PRs, all authors]`');
+        expect(handoffContent).toContain('- Merged PRs: 1 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
+        expect(handoffContent).toContain('- Opened PRs: 1 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
+        expect(handoffContent).toContain('- Closed issues: 1 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
+        expect(handoffContent).toContain('- Opened issues: 1 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
         expect(handoffContent).toContain('PR #14678 — keeper request route');
         expect(handoffContent).toContain('PR #14682 — registry snapshot clone');
-        // the 500h-old merge is outside the 3-day window — count stays 1, it never renders
+        expect(handoffContent).toContain('#14588 — GP zero-routes collapse');
+        expect(handoffContent).toContain('#14731 — identityRoots migration');
+        // out-of-window facts never render — counts stay honest per class
         expect(handoffContent).not.toContain('ancient merge outside the window');
+        expect(handoffContent).not.toContain('ancient close outside the window');
         // firewall: the retrospective introduces no numbered route entries into the handoff
         expect(handoffContent).not.toMatch(/\d+\.\s\*\*issue-\d+\*\*:[^\n]*\n\s+-\s\*.*?\*/);
     });


### PR DESCRIPTION
## Summary

The retrospective enrichment family goes from two live fact classes to **five**: closed + opened issues (bounded day-granularity readers mirroring the merged-PR pattern) and sessions (a metadata-only window count over the summary collection already in scope) join the live handoff's "what happened" section — behind a **per-class best-effort guard with a compositional coverage label**: each reader's health adds or drops exactly its own classes from the declared `filterSets` string, so the render can never overstate what a count covers.

Resolves #14721 (the graduations reader — a different query surface — split to #14738 at PR time; this ticket's ACs match this diff exactly)
Refs #14603

## Deltas

- **`ai/services/graph/GoldenPathSynthesizer.mjs`**:
  - `fetchRecentClosedIssues(since)` / `fetchRecentOpenedIssues(since)` — exact `fetchRecentMergedPRs` mirrors (bounded `gh` searches, 50-cap, day granularity).
  - static `fetchRecentSessions(collection, since)` — metadata-only read reusing the recency reads' multi-key timestamp resolution, windowed client-side; no document bodies fetched.
  - The call-site folds all classes **per-class best-effort**: the issue pair and the session class each fail independently (warn + drop), and the declared label is compositional — `coveredClasses.join(' · ')` — so declared coverage is reader-health-adaptive by construction.
- **`test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs`** — the wiring integration test now mocks all four gh-backed readers and asserts from the WRITTEN handoff: four class counts under the full label, per-class out-of-window exclusion (an ancient close never renders), `Sessions: 0` honestly under the label when the summary mock carries no ids, and the route-parser firewall re-asserted.

## Test Evidence

`NEO_CHROMA_PORT_TEST=18195 npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` → **45 passed** at `c13a636f`.

Evidence: L2 (unit + synthesizer integration against the written handoff file).

## Post-Merge Validation

- The graduations reader (#14738) slots in with ONE `coveredClasses` array entry — if it needs call-site surgery beyond that, the compositional design failed.
- A live dream cycle emits the five-class section; the coverage label in production names exactly the healthy readers.

## Related

#14721 (resolved) · #14738 (the split graduations reader) · #14603/#14706 (render + assembler contracts, merged) · #11375 (the operator seed this family serves).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b9b95ac6-42f5-47a3-b58f-6071f79657e8.
