### PR TITLE
docs(roadmap): "the framework" → "the tech" — binding vocabulary (#14741)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ The roadmap holds the **next-release scope only** — what ships next and why. E
 
 v13.1 made the institution safe to leave running; **v13.2 makes it real to a stranger.** The release gate is a compound, honest bar:
 
-> **A stranger downloads the harness and it self-configures to first persistence in minutes; the operator starts an agent from the cockpit UI instead of a terminal; the docking demos are public and animated; and every flagship demo reports its measured reach — whether anyone outside our developer circle actually cares.** The stranger never evaluates the framework; we count the people who never read a line of Neo code.
+> **A stranger downloads the harness and it self-configures to first persistence in minutes; the operator starts an agent from the cockpit UI instead of a terminal; the docking demos are public and animated; and every flagship demo reports its measured reach — whether anyone outside our developer circle actually cares.** The stranger never evaluates the tech; we count the people who never read a line of Neo code.
 
 The scope was converged by a six-voice team weighting round — the full consensus record with per-entry disclosures lives at [D#14561's fold](https://github.com/neomjs/neo/discussions/14561#discussioncomment-17528678); this section names the gate and the load-bearing path, not a frozen checklist. [Milestone #9](https://github.com/neomjs/neo/milestone/9) is the v13.2 tracking milestone — the cornerstone epics anchor into it as the scope opens.
 


### PR DESCRIPTION
Resolves #14741

Refs @neo-fable's binding-vocabulary broadcast (neo is never "a framework").

One-word docs-hygiene fix: ROADMAP.md line 13's "the framework" → "the tech". My residual from the v13.2 fold (`59fb062a0`) — @neo-fable's "all durable surfaces fixed" sweep predated this line, so this is mine to clean, not a miss on their part.

Evidence: L0 (docs-only; single-word prose change, no code or test surface).

## What it changes

Line 13: *"…The stranger never evaluates ~~the framework~~ **the tech**; we count the people who never read a line of Neo code."*

"the tech" preserves the sentence's contrast — a developer would evaluate the underlying stack; a stranger outside the developer circle just experiences the products, and reach is what we measure — without the banned "framework" framing.

## Test Evidence

N/A — docs-only prose change, no executable surface.

## Post-Merge Validation

- [ ] None — single-word markdown edit; no runtime or build surface.

## Deltas from ticket

None, and honestly so: both #14741 ACs are fully met (line 13 no longer uses "framework"; the meaning is preserved) with **no deferred clause** — unlike the NL-row residuals on the sibling primitive PRs, this docs fix has nothing left to verify post-merge. The friction→gold mechanization idea (a guard against vocab drift) is routed to @neo-fable on the ticket, not built here — "framework" is legitimate in many contexts, so it's their vocab lane's call whether/how to mechanize.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
