### PR TITLE
fix(test): kill clock-brittle handoffRetrospective red poisoning every PR (#14743)

### DIFF
--- a/test/playwright/unit/ai/services/graph/handoffRetrospectiveAssembler.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/handoffRetrospectiveAssembler.spec.mjs
@@ -89,10 +89,15 @@ test.describe('handoffRetrospectiveAssembler — the pure fold beneath the rende
         const undeclared = assemble({facts, grain: grains.DAILY, now: NOW});
         expect(undeclared.filterSets).toEqual([]);
 
-        // the assembler's output feeds the render directly: undeclared → withheld, not naked counts
-        const section = render({grain: grains.DAILY, stats: undeclared});
+        // the assembler's output feeds the render directly: undeclared → withheld, not naked counts.
+        // capturedAt is pinned so the render is deterministic — the default new Date() made this
+        // clock-dependent (the header's Captured-at timestamp), the root of the intermittent red.
+        const section = render({grain: grains.DAILY, stats: undeclared, capturedAt: NOW});
         expect(section).toContain('Counts withheld');
-        expect(section).not.toContain('1');
+        // honesty contract: withholding renders NO naked count line and NO event ref. Assert those
+        // shapes, not a bare '1' — a bare digit also matched the header timestamp, not just a leak.
+        expect(section).not.toContain('Merged PRs:');
+        expect(section).not.toContain('PR #1');
     });
 
     test('assembler output renders end-to-end through the real render module', () => {


### PR DESCRIPTION
Resolves #14743

**EMERGENCY: dev-level unit-red poisoning every open PR** (@tobiu flagged; @neo-gpt confirmed the "unrelated full-unit red gate").

Root: `handoffRetrospectiveAssembler.spec.mjs:95` asserted `.not.toContain('1')` on the withhold render — a blunt proxy for "no naked count / no PR-ref leaks." But `render()` defaults `capturedAt` to `new Date()`, and the header's `Captured at: YYYY-MM-DD HH:MM UTC` line carries the wall-clock hour, which contains `'1'` for the **entire 10:00–19:59 UTC block** → fails every run in that window → reddens every open PR's `unit` gate. It merged green during a no-'1' window; the brittleness is clock-dependent.

Evidence: L2. The render is correct (the withhold path omits all counts/refs — verified); the test assertion was clock-brittle. 6/6 green, verified **inside** the previously-failing 10:xx UTC window.

## What it changes (test-only)

- Pin `capturedAt` to the spec's fixed `NOW` — the render is now deterministic (removes the `new Date()` dependency, the actual root).
- Replace `.not.toContain('1')` with contract-precise assertions: the withhold render carries no count line (`Merged PRs:`) and no event ref (`PR #1`) — testing the honesty contract, not a bare digit that also matched the header timestamp.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/graph/handoffRetrospectiveAssembler.spec.mjs` → **6 passed** at head `40c3d0ed9`, run at 10:31 UTC (a window that deterministically failed before the fix).

## Post-Merge Validation

- [ ] The `unit` gate goes green on dev; the stuck open-PR backlog (mine #14722/#14726/#14737/#14742 + the convergence set #14725/#14732) clears with a re-run / fresh commit.

## Deltas from ticket

None — matches #14743's ACs (clock-independent, contract-precise assertion, unit gate unblocked), no deferred clause. The render code is untouched (it was correct); this is purely the brittle-assertion fix.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462. Emergency pickup while the Fable family / Grace / Ada are rate-limited; the render was authored under #14694/#14709.
