### PR TITLE
refactor(agentos): StateDot → class-based component (functional→idiomatic) (#14745)

### DIFF
--- a/apps/agentos/view/fleet/StateDot.mjs
+++ b/apps/agentos/view/fleet/StateDot.mjs
@@ -1,4 +1,5 @@
-import {defineComponent} from '../../../../src/functional/_export.mjs';
+import Component from '../../../../src/component/Base.mjs';
+import NeoArray  from '../../../../src/util/Array.mjs';
 
 /**
  * Maps a session-state key to its design token (see `apps/agentos/resources/tokens.css`).
@@ -30,33 +31,69 @@ export function stateToken(state) {
 /**
  * The atomic session-state indicator: a colored dot whose color is driven entirely by the
  * `--fm-state-*` token layer, with an optional live-pulse gated behind `prefers-reduced-motion`
- * in `fleet-components.css`. The color — not the motion — carries the signal, so the
- * primitive degrades cleanly for reduced-motion users. Composed by every fleet surface.
+ * in `fleet-components.css`. The color — not the motion — carries the signal, so the primitive
+ * degrades cleanly for reduced-motion users. Composed by every fleet surface.
  *
- * @summary Session-state dot primitive — token-driven, reduced-motion-honored.
+ * @class AgentOS.view.fleet.StateDot
+ * @extends Neo.component.Base
  */
-export default defineComponent({
-    config: {
-        className: 'AgentOS.view.fleet.StateDot',
-        ntype    : 'fm-state-dot',
+class StateDot extends Component {
+    static config = {
         /**
-         * The session state — one of `ok` · `idle` · `wedged` · `limited` · `off`.
-         * Encodes SESSION state, never identity. Unknown values render as `off`.
+         * @member {String} className='AgentOS.view.fleet.StateDot'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.StateDot',
+        /**
+         * @member {String} ntype='fm-state-dot'
+         * @protected
+         */
+        ntype: 'fm-state-dot',
+        /**
+         * @member {String[]} baseCls=['fm-state-dot']
+         */
+        baseCls: ['fm-state-dot'],
+        /**
+         * The session state — one of `ok` · `idle` · `wedged` · `limited` · `off`. Encodes SESSION
+         * state, never identity. Unknown values render as `off`.
          * @member {String} state_='off'
+         * @reactive
          */
         state_: 'off',
         /**
          * When true, adds the `fm-live` class that carries the pulse animation. The pulse is
-         * decoration and is gated behind `prefers-reduced-motion: no-preference` at the CSS layer.
+         * decoration, gated behind `prefers-reduced-motion: no-preference` at the CSS layer.
          * @member {Boolean} live_=false
+         * @reactive
          */
         live_: false
-    },
-
-    createVdom(config) {
-        return {
-            cls  : ['fm-state-dot', config.live && 'fm-live'].filter(Boolean),
-            style: {'--fm-dot': `var(${stateToken(config.state)})`}
-        }
     }
-});
+
+    /**
+     * Triggered after the state config changed — rebinds the `--fm-dot` color token from the
+     * closed-set resolver. State is session-state, never identity.
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetState(value, oldValue) {
+        let style = this.style || {};
+        style['--fm-dot'] = `var(${stateToken(value)})`;
+        this.style = style
+    }
+
+    /**
+     * Triggered after the live config changed — toggles the reduced-motion-gated pulse class.
+     * The color already carries the signal, so the class is decoration only.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetLive(value, oldValue) {
+        let cls = this.cls;
+        NeoArray[value ? 'add' : 'remove'](cls, 'fm-live');
+        this.cls = cls
+    }
+}
+
+export default Neo.setupClass(StateDot);


### PR DESCRIPTION
Resolves #14748 · Refs #14745 (epic — FM primitive layer functional→class; StateDot is the pattern-setter leaf)

Refs #14560 (FM epic) · Refs #14598 (AgentCard, built class-based after) · operator veto 2026-07-04.

@tobiu vetoed functional FM components (*"vastly inferior to class-based counterparts. VBA"*). VBA confirmed: apps/ is **320:9 class-vs-functional**; `defineComponent` thinly wraps the model while the mature idiom (`extends Component.Base`, reactive `x_` configs + `afterSetX()` render, `Neo.setupClass` — see `src/component/Chip.mjs`) is the production component. My FM primitive layer was built functional — this converts it, **StateDot first** (the foundational primitive others reuse via `stateToken`).

Evidence: L2 — `statePrimitives.spec.mjs` 3/3 green, **unchanged** (behavior-identical conversion).

## What it changes

- StateDot: `defineComponent(...)` → `class StateDot extends Neo.component.Base` with `baseCls: ['fm-state-dot']`, reactive `state_`/`live_` configs, `afterSetState` (rebinds `--fm-dot` from `stateToken`), `afterSetLive` (toggles the reduced-motion-gated `fm-live` cls), `Neo.setupClass`.
- **Public surface preserved:** the exported (hardened) `stateToken` resolver + the `--fm-*` token binding contract are unchanged, so HealthSwatch (reuses `stateToken`) and the CSS layer are unaffected.

## Test Evidence

`npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/statePrimitives.spec.mjs` → **3 passed**, spec unchanged (`Neo.create` + `initVnode` + `vdom.style['--fm-dot']` + `vdom.cls` all hold for the class version — the conversion is behavior-identical).

## Post-Merge Validation

- [ ] The layer conversion continues under #14745: FamilyRail → EventChip → HealthSwatch → class; then AgentCard #14598 builds class-based composing them. This PR is the pattern-setter.

## Deltas from ticket

None for the StateDot leaf — class-based, public surface preserved, spec green. The remaining primitives are follow-up PRs under the same ticket (per-primitive, right-sized).

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
