### PR TITLE
refactor(agentos): FamilyRail/EventChip/HealthSwatch → class-based (#14745)

### DIFF
--- a/apps/agentos/view/fleet/EventChip.mjs
+++ b/apps/agentos/view/fleet/EventChip.mjs
@@ -1,4 +1,4 @@
-import {defineComponent}      from '../../../../src/functional/_export.mjs';
+import Component              from '../../../../src/component/Base.mjs';
 import {kindToken, kindLabel} from './kindRegistry.mjs';
 
 /**
@@ -7,31 +7,78 @@ import {kindToken, kindLabel} from './kindRegistry.mjs';
  * with the neutral unknown fallback — lives in {@link kindRegistry} (one owner), so this component
  * only renders; a growing kind set never forces a chip edit or a per-view edit.
  *
- * @summary Event-kind chip primitive — renders a kind via the shared registry.
+ * @class AgentOS.view.fleet.EventChip
+ * @extends Neo.component.Base
  */
-export default defineComponent({
-    config: {
+class EventChip extends Component {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.EventChip'
+         * @protected
+         */
         className: 'AgentOS.view.fleet.EventChip',
-        ntype    : 'fm-event-chip',
+        /**
+         * @member {String} ntype='fm-event-chip'
+         * @protected
+         */
+        ntype: 'fm-event-chip',
+        /**
+         * @member {String[]} baseCls=['fm-event-chip']
+         */
+        baseCls: ['fm-event-chip'],
+        /**
+         * @member {String} tag='span'
+         * @protected
+         * @reactive
+         */
+        tag: 'span',
         /**
          * The event kind — e.g. `pr` · `a2a` · `review` · `alert` · `lane-claim` · `work-stall`
          * · `source-degraded` · `lifecycle-request`. Unknown kinds render neutral, never broken.
          * @member {String} kind_='a2a'
+         * @reactive
          */
         kind_: 'a2a',
         /**
          * Optional label override. Defaults to the canonical short label for `kind`.
          * @member {String|null} label_=null
+         * @reactive
          */
         label_: null
-    },
-
-    createVdom(config) {
-        return {
-            tag  : 'span',
-            cls  : ['fm-event-chip'],
-            style: {'--fm-chip': `var(${kindToken(config.kind)})`},
-            text : config.label ?? kindLabel(config.kind)
-        }
     }
-});
+
+    /**
+     * Triggered after the kind config changed — rebinds the `--fm-chip` color token from the
+     * shared registry and refreshes the text (when no label override is set).
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetKind(value, oldValue) {
+        let style = this.style || {};
+        style['--fm-chip'] = `var(${kindToken(value)})`;
+        this.style = style;
+        this.updateChipText()
+    }
+
+    /**
+     * Triggered after the label override changed — refreshes the text.
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetLabel(value, oldValue) {
+        this.updateChipText()
+    }
+
+    /**
+     * The chip text is the label override, else the canonical short label for the kind.
+     * @protected
+     */
+    updateChipText() {
+        this.vdom.text = this.label ?? kindLabel(this.kind);
+        this.update()
+    }
+}
+
+export default Neo.setupClass(EventChip);

--- a/apps/agentos/view/fleet/FamilyRail.mjs
+++ b/apps/agentos/view/fleet/FamilyRail.mjs
@@ -1,4 +1,5 @@
-import {defineComponent} from '../../../../src/functional/_export.mjs';
+import Component from '../../../../src/component/Base.mjs';
+import NeoArray  from '../../../../src/util/Array.mjs';
 
 /**
  * Maps a model-family key to its rail token (see `apps/agentos/resources/tokens.css`).
@@ -46,26 +47,53 @@ export function isKnownFamily(family) {
  * schema lands the first-class era attribute — the binding surface is stable; only the source of
  * the key changes.
  *
- * @summary Family-accent rail primitive — data-driven era attribute, unclassified-safe.
+ * @class AgentOS.view.fleet.FamilyRail
+ * @extends Neo.component.Base
  */
-export default defineComponent({
-    config: {
+class FamilyRail extends Component {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.FamilyRail'
+         * @protected
+         */
         className: 'AgentOS.view.fleet.FamilyRail',
-        ntype    : 'fm-family-rail',
+        /**
+         * @member {String} ntype='fm-family-rail'
+         * @protected
+         */
+        ntype: 'fm-family-rail',
+        /**
+         * @member {String[]} baseCls=['fm-family-rail']
+         */
+        baseCls: ['fm-family-rail'],
         /**
          * The current-era family — `claude` · `gpt` · `gemini` · `human`. A data-driven episode
          * attribute, never a per-agent constant. Unknown / absent renders neutral + `unclassified`.
          * @member {String|null} family_=null
+         * @reactive
          */
         family_: null
-    },
-
-    createVdom(config) {
-        const known = isKnownFamily(config.family);
-
-        return {
-            cls  : ['fm-family-rail', !known && 'fm-family-unclassified'].filter(Boolean),
-            style: {'--fm-rail': `var(${familyToken(config.family)})`}
-        }
     }
-});
+
+    /**
+     * Triggered after the family config changed — data-driven rebind. A family swap re-renders the
+     * rail in place for the SAME resident (anti-lock-in). Known → its --fm-family-* token; unknown
+     * or absent → the neutral token + the `unclassified` marker (never a guessed family).
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetFamily(value, oldValue) {
+        let me    = this,
+            cls   = me.cls,
+            style = me.style || {};
+
+        NeoArray[isKnownFamily(value) ? 'remove' : 'add'](cls, 'fm-family-unclassified');
+        me.cls = cls;
+
+        style['--fm-rail'] = `var(${familyToken(value)})`;
+        me.style = style
+    }
+}
+
+export default Neo.setupClass(FamilyRail);

--- a/apps/agentos/view/fleet/HealthSwatch.mjs
+++ b/apps/agentos/view/fleet/HealthSwatch.mjs
@@ -1,5 +1,5 @@
-import {defineComponent} from '../../../../src/functional/_export.mjs';
-import {stateToken}      from './StateDot.mjs';
+import Component    from '../../../../src/component/Base.mjs';
+import {stateToken} from './StateDot.mjs';
 
 /**
  * Canonical legend label per session-state category. Kept beside the state→token map so the fleet
@@ -34,42 +34,109 @@ export function stateLabel(state) {
  * legend row (no count) and the count-carrying bar unit the health summary consumes (set `count`).
  * An unknown category renders off-toned with its literal text — never invisible.
  *
- * @summary Health-summary swatch — legend row + count-bar unit, agent-health axis.
+ * @class AgentOS.view.fleet.HealthSwatch
+ * @extends Neo.component.Base
  */
-export default defineComponent({
-    config: {
+class HealthSwatch extends Component {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.HealthSwatch'
+         * @protected
+         */
         className: 'AgentOS.view.fleet.HealthSwatch',
-        ntype    : 'fm-health-swatch',
+        /**
+         * @member {String} ntype='fm-health-swatch'
+         * @protected
+         */
+        ntype: 'fm-health-swatch',
+        /**
+         * @member {String[]} baseCls=['fm-health-swatch']
+         */
+        baseCls: ['fm-health-swatch'],
         /**
          * The session-state category this swatch legends — `ok` · `idle` · `wedged` · `limited` · `off`.
          * An unknown category renders off-toned with its literal text.
          * @member {String} state_='ok'
+         * @reactive
          */
         state_: 'ok',
         /**
          * Optional count for the bar-unit shape (the health-summary consumer). `null` renders a plain
-         * legend row; a number renders a count beside the label (e.g. "3 working").
+         * legend row; a number renders a count beside the label (e.g. "3 working"). A zero still renders.
          * @member {Number|null} count_=null
+         * @reactive
          */
         count_: null,
         /**
          * Optional label override. Defaults to the canonical category label for `state`.
          * @member {String|null} label_=null
+         * @reactive
          */
-        label_: null
-    },
+        label_: null,
+        /**
+         * The dot (colored via the shared state token), an optional count (bar-unit shape), and the
+         * category label. The count node is `removeDom`-toggled so a plain legend row omits it.
+         * @member {Object} _vdom
+         */
+        _vdom:
+        {cn: [
+            {cls: ['fm-sw-dot']},
+            {tag: 'span', cls: ['fm-sw-count'], removeDom: true},
+            {tag: 'span', cls: ['fm-sw-label']}
+        ]}
+    }
 
-    createVdom(config) {
-        const cn = [
-            {cls: ['fm-sw-dot'], style: {'--fm-dot': `var(${stateToken(config.state)})`}}
-        ];
+    /**
+     * Triggered after the state config changed — rebinds the dot's `--fm-dot` token (shared with
+     * StateDot on the agent-health axis) and refreshes the label (when no override is set).
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetState(value, oldValue) {
+        this.vdom.cn[0].style = {'--fm-dot': `var(${stateToken(value)})`};
+        this.applyLabel();
+        this.update()
+    }
 
-        if (config.count != null) {
-            cn.push({tag: 'span', cls: ['fm-sw-count'], text: String(config.count)})
+    /**
+     * Triggered after the count config changed — a number renders the count node (a zero still
+     * renders, to confirm "none"); `null` removes it so the swatch is a plain legend row.
+     * @param {Number|null} value
+     * @param {Number|null} oldValue
+     * @protected
+     */
+    afterSetCount(value, oldValue) {
+        let countNode = this.vdom.cn[1];
+
+        if (value == null) {
+            countNode.removeDom = true
+        } else {
+            countNode.removeDom = false;
+            countNode.text      = String(value)
         }
 
-        cn.push({tag: 'span', cls: ['fm-sw-label'], text: config.label ?? stateLabel(config.state)});
-
-        return {cls: ['fm-health-swatch'], cn}
+        this.update()
     }
-});
+
+    /**
+     * Triggered after the label override changed — refreshes the label text.
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetLabel(value, oldValue) {
+        this.applyLabel();
+        this.update()
+    }
+
+    /**
+     * The label is the override, else the canonical category label (unknown → its literal text).
+     * @protected
+     */
+    applyLabel() {
+        this.vdom.cn[2].text = this.label ?? stateLabel(this.state)
+    }
+}
+
+export default Neo.setupClass(HealthSwatch);

--- a/test/playwright/unit/apps/agentos/view/fleet/healthSwatch.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/healthSwatch.spec.mjs
@@ -49,7 +49,9 @@ test.describe('Fleet cockpit HealthSwatch — state-axis legend + count-bar unit
 
         expect(dot.style['--fm-dot']).toBe('var(--fm-state-wedged)');
         expect(label.text).toBe('wedged');
-        expect(count).toBeUndefined();
+        // class-idiom: the count node stays in cn, removeDom-toggled (not omitted) — so a plain
+        // legend row renders no count element in the DOM.
+        expect(count.removeDom).toBe(true);
 
         sw.destroy()
     });


### PR DESCRIPTION
Resolves #14749 · Refs #14745 (epic — FM primitive layer functional→class; StateDot leaf = #14748/PR #14746) · Refs #14560 · Refs #14598 (AgentCard builds class-based composing these).

@tobiu vetoed functional FM components (*"vastly inferior to class-based. VBA"*); VBA confirmed apps/ is **320:9 class**. StateDot's conversion (#14746) set the pattern; this converts the remaining three.

Evidence: L2 — familyRail 4/4 + eventChip 3/3 + healthSwatch 6/6 = **13/13 green**.

## What it changes (all `defineComponent` → `extends Neo.component.Base`, the src/component/Chip.mjs idiom)

- **FamilyRail** — `family_` reactive config; `afterSetFamily` rebinds `--fm-rail` from `familyToken` + toggles the `fm-family-unclassified` cls (data-driven rebind, anti-lock-in, unclassified-safe — preserved).
- **EventChip** — `kind_`/`label_` configs; `afterSetKind` rebinds `--fm-chip`, `afterSetKind`/`afterSetLabel` set the text (`label ?? kindLabel(kind)`).
- **HealthSwatch** — `state_`/`count_`/`label_` over a `_vdom` with dot/count/label child nodes; `afterSetState` → dot `--fm-dot`, `afterSetCount` toggles the count node's `removeDom` (a zero still renders), label = `label ?? stateLabel(state)`.
- **Public surface preserved** — exported `familyToken`/`isKnownFamily`/`stateLabel` resolvers + the `--fm-*` binding contract unchanged.

## Test Evidence

`npm run test-unit -- .../familyRail.spec.mjs .../eventChip.spec.mjs .../healthSwatch.spec.mjs` → **13 passed**. One healthSwatch assertion updated to the class idiom: the count node is `removeDom`-toggled (present in `cn`) rather than omitted — same rendered DOM, idiomatic conditional rendering per Chip.

## Post-Merge Validation

- [ ] With StateDot #14746 + this on dev, the FM primitive layer is fully class-based (no `defineComponent` left in `apps/agentos/view/fleet/`); AgentCard #14598 then builds class-based composing them.

## Deltas from ticket

This PR converts the **three remaining** primitives — it does **not** complete the FM layer on its own (StateDot is #14748 / PR #14746; exact-head this branch still has functional StateDot from dev). #14745 (epic) closes only once **both** #14746 and this land on dev. Independent files, so no strict merge order between them — but "class-complete" is a two-PR state, not this branch alone. No code deltas from #14749 (class-based, public surface + `--fm-*` contract preserved, specs 13/13).

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
