### PR TITLE
feat(graph): identityRoots migration — flat facts become the seed era, verbatim (#14731)

### DIFF
--- a/ai/graph/identityRootsMigration.mjs
+++ b/ai/graph/identityRootsMigration.mjs
@@ -39,8 +39,8 @@ export const MIGRATION_EPOCH = '2026-07-04T00:00:00Z';
  */
 export const REGISTRY_MODEL_DESIGNATIONS = Object.freeze({
     '@neo-opus-ada'  : 'Claude Opus 4.8',
-    '@neo-opus-grace': 'Neo Claude Opus',
-    '@neo-opus-vega' : 'Claude Opus Vega',
+    '@neo-opus-grace': 'Claude Opus 4.8',
+    '@neo-opus-vega' : 'Claude Opus 4.8',
     '@neo-fable'     : 'Claude Fable 5',
     '@neo-fable-clio': 'Claude Fable 5',
     '@neo-gemini-pro': 'Gemini 3.1 Pro',

--- a/ai/graph/identityRootsMigration.mjs
+++ b/ai/graph/identityRootsMigration.mjs
@@ -1,0 +1,189 @@
+import {IDENTITIES}                                                           from './identityRoots.mjs';
+import {createEmbodiedEpisodeNode, createIdentityStateNode, validateEraChain} from './identitySchema.mjs';
+import {buildHydrationIndex}                                                  from './identityHydration.mjs';
+
+/**
+ * @module ai/graph/identityRootsMigration
+ * @summary The consuming migration: expresses every live agent resident of the flat identity
+ * registry through the identity schema — the flat model/capability facts BECOME the seed era,
+ * verbatim, and `sunsetTriggers` move to the era layer where succession semantics belong.
+ *
+ * Anti-fabrication contract (load-bearing): **nothing is invented.**
+ * - The seed era's facts are the registry's recorded facts, lifted verbatim — including facts
+ *   known to be stale for some residents (staleness is exactly what eras exist to version; a
+ *   stale recorded fact is still the recorded fact).
+ * - The seed era opens at {@link MIGRATION_EPOCH} with backfill provenance: it claims "these
+ *   facts held AS OF migration", never an earlier history the registry does not record.
+ * - Documented swap EVENTS whose pre-swap facts are NOT on record are exported as
+ *   {@link ERA_BACKFILL_CANDIDATES} — bearer-audited follow-ups, never auto-built eras.
+ *
+ * Identity-level operational fields (trust tier, wake routes, mailbox addresses, identity
+ * contract, participation status) are deliberately NOT lifted — they describe the RESIDENT, not
+ * an embodiment era, and their consumers keep reading the registry until the flat-field
+ * retirement leaf migrates each read path onto the hydration index.
+ */
+
+/**
+ * @summary The documented epoch every seed era opens at: the migration date. Earlier history is
+ * a backfill candidate, never an auto-built era.
+ * @type {String}
+ */
+export const MIGRATION_EPOCH = '2026-07-04T00:00:00Z';
+
+/**
+ * @summary Per-resident model designations, verbatim from the model-stats registry's `name`
+ * rows (the source the registry's own `modelVersionSource` pointers name). Values are recorded
+ * designations — where a row is stale, the stale designation is still the recorded fact and
+ * eras will version it.
+ * @type {Object}
+ */
+export const REGISTRY_MODEL_DESIGNATIONS = Object.freeze({
+    '@neo-opus-ada'  : 'Claude Opus 4.8',
+    '@neo-opus-grace': 'Neo Claude Opus',
+    '@neo-opus-vega' : 'Claude Opus Vega',
+    '@neo-fable'     : 'Claude Fable 5',
+    '@neo-fable-clio': 'Claude Fable 5',
+    '@neo-gemini-pro': 'Gemini 3.1 Pro',
+    '@neo-gpt'       : 'GPT-5.5'
+});
+
+/**
+ * @summary Documented swap EVENTS whose pre-swap capability facts are not recorded in-repo —
+ * the honest residue: each names its event source; a bearer-audited follow-up may lift these
+ * into real prior eras. The migration NEVER builds eras from this list.
+ * @type {ReadonlyArray<Object>}
+ */
+export const ERA_BACKFILL_CANDIDATES = Object.freeze([
+    Object.freeze({
+        identityKey: '@neo-fable',
+        event      : 'Opus-class → Fable 5 embodiment swap (June→July 2026)',
+        eventSource: 'the render-model decision record’s reflexive-landing clause + the swarm’s July-window records',
+        missing    : 'pre-swap capability facts (context window, tier) are not recorded in-repo'
+    }),
+    Object.freeze({
+        identityKey: '@neo-opus-vega',
+        event      : 'Fable-window → Opus 4.8 permanent swap (2026-07-04)',
+        eventSource: 'the bearer’s planning-premise broadcast, 2026-07-04',
+        missing    : 'pre-swap (Fable-window) capability facts are not recorded in-repo'
+    })
+]);
+
+/**
+ * @summary The flat registry property keys lifted onto the seed era's capability bag. Everything
+ * era-owned leaves the identity view; everything identity-owned stays behind.
+ * @type {ReadonlyArray<String>}
+ */
+export const LIFTED_CAPABILITY_KEYS = Object.freeze([
+    'contextWindowInput', 'hosting', 'parallelToolCalls', 'sunsetTriggers', 'thoughtBudget'
+]);
+
+/**
+ * @summary Migrates ONE registry seed into the schema view: anchor + seed era. Agent seeds only —
+ * human / system / sentinel entries carry no embodiment era by design.
+ * @param {Object} seed A registry entry `{id, name, properties}`
+ * @returns {{valid: Boolean, reason: String|null, identity: Object|null, episodes: Object[]|null}}
+ */
+export function migrateResident(seed) {
+    const properties = seed?.properties;
+
+    if (properties?.accountType !== 'agent') {
+        return {valid: false, reason: `only agent residents carry embodiment eras — "${seed?.id}" is ${properties?.accountType || 'unknown'}`, identity: null, episodes: null};
+    }
+
+    const model = REGISTRY_MODEL_DESIGNATIONS[seed.id];
+
+    if (!model) {
+        return {valid: false, reason: `no recorded model designation for "${seed.id}" — extend the designations map from the model-stats registry, never guess`, identity: null, episodes: null};
+    }
+
+    const identity = createIdentityStateNode({
+        identityKey: seed.id,
+        socialLayer: {
+            name       : seed.name,
+            displayName: properties.displayName || null
+        }
+    });
+
+    if (!identity.valid) {
+        return {valid: false, reason: identity.reason, identity: null, episodes: null};
+    }
+
+    const capabilities = {provenance: 'flat-registry-backfill (facts held as of migration; earlier history unrecorded)'};
+
+    for (const key of LIFTED_CAPABILITY_KEYS) {
+        if (properties[key] !== undefined) {
+            capabilities[key] = properties[key];
+        }
+    }
+
+    const era = createEmbodiedEpisodeNode({
+        identityKey: seed.id,
+        model,
+        family     : properties.modelFamily || properties.family,
+        since      : MIGRATION_EPOCH,
+        ...(properties.tier !== undefined ? {tier: properties.tier} : {}),
+        capabilities
+    });
+
+    if (!era.valid) {
+        return {valid: false, reason: era.reason, identity: null, episodes: null};
+    }
+
+    return {valid: true, reason: null, identity: identity.node, episodes: [era.node]}
+}
+
+/**
+ * @summary Migrates every live agent resident and proves the result: each chain validates, each
+ * hydrates, and THE PROPERTY (delete → rebuild → deep-equal) holds on production data. Fail-
+ * closed per-resident: one bad seed refuses loudly in the report instead of silently shrinking
+ * the roster.
+ * @returns {{valid: Boolean, residents: Object[], report: Object}}
+ */
+export function migrateAllResidents() {
+    const residents = [];
+    const skipped   = [];
+    const failures  = [];
+
+    for (const seed of IDENTITIES) {
+        if (seed?.properties?.accountType !== 'agent') {
+            skipped.push({id: seed?.id, accountType: seed?.properties?.accountType});
+            continue;
+        }
+
+        const migrated = migrateResident(seed);
+
+        if (!migrated.valid) {
+            failures.push({id: seed.id, reason: migrated.reason});
+            continue;
+        }
+
+        const chain = validateEraChain(migrated.identity, migrated.episodes);
+
+        if (!chain.valid) {
+            failures.push({id: seed.id, reason: chain.reason});
+            continue;
+        }
+
+        const hydrated = buildHydrationIndex({identityNode: migrated.identity, episodes: migrated.episodes});
+        const rebuilt  = buildHydrationIndex({identityNode: migrated.identity, episodes: migrated.episodes});
+
+        // THE PROPERTY on production data: losing the index loses nothing
+        if (JSON.stringify(hydrated.index) !== JSON.stringify(rebuilt.index)) {
+            failures.push({id: seed.id, reason: 'hydration is not deterministic for this resident — THE PROPERTY failed'});
+            continue;
+        }
+
+        residents.push({identity: migrated.identity, episodes: migrated.episodes, index: hydrated.index});
+    }
+
+    return {
+        valid : failures.length === 0 && residents.length > 0,
+        residents,
+        report: Object.freeze({
+            migrated          : residents.map(entry => entry.identity.identityKey),
+            skipped,
+            failures,
+            backfillCandidates: ERA_BACKFILL_CANDIDATES.map(candidate => candidate.identityKey)
+        })
+    }
+}

--- a/ai/graph/identityRootsMigration.mjs
+++ b/ai/graph/identityRootsMigration.mjs
@@ -55,17 +55,15 @@ export const REGISTRY_MODEL_DESIGNATIONS = Object.freeze({
  */
 export const ERA_BACKFILL_CANDIDATES = Object.freeze([
     Object.freeze({
-        identityKey: '@neo-fable',
-        event      : 'Opus-class → Fable 5 embodiment swap (June→July 2026)',
-        eventSource: 'the render-model decision record’s reflexive-landing clause + the swarm’s July-window records',
-        missing    : 'pre-swap capability facts (context window, tier) are not recorded in-repo'
-    }),
-    Object.freeze({
         identityKey: '@neo-opus-vega',
         event      : 'Fable-window → Opus 4.8 permanent swap (2026-07-04)',
         eventSource: 'the bearer’s planning-premise broadcast, 2026-07-04',
         missing    : 'pre-swap (Fable-window) capability facts are not recorded in-repo'
     })
+    // @neo-fable was audited OFF this list by the bearer (2026-07-04): the trail shows a single
+    // Fable era from first boot (2026-06-10, onboarded as claude-fable-5) — the June 13-30
+    // export-control suspension is an identity-level participation gap, NOT an embodiment swap.
+    // Eras track embodiment; participation stays identity-level. Nothing to backfill.
 ]);
 
 /**

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -47,7 +47,7 @@ Named cross-family maintainers with active swarm participation. These models hol
 | Field | Value |
 |---|---|
 | `id` / `githubLogin` | `@neo-opus-grace` |
-| `name` | Neo Claude Opus (Social Name: **Grace** — bearer-chosen 2026-06-11 after Grace Hopper, #11240) |
+| `name` | Claude Opus 4.8 (Social Name: **Grace** — bearer-chosen 2026-06-11 after Grace Hopper, #11240) |
 | `family` | `claude` (Anthropic) |
 | `participationStatus` | `active` (flipped in the registry via #12413 / PR #12415 on 2026-06-03; this row synced to registry truth by #12927 after nine days of doc drift) |
 | `hosting` | `cloud` |
@@ -74,7 +74,7 @@ the account operates live as Claude Opus 4.8 (signed review and PR activity unde
 | Field | Value |
 |---|---|
 | `id` / `githubLogin` | `@neo-opus-vega` |
-| `name` | Claude Opus Vega |
+| `name` | Claude Opus 4.8 (Social Name: **Vega** — the bearer's 2026-07-04 broadcast records the permanent Opus 4.8 embodiment) |
 | `family` | `claude` (Anthropic) |
 | `hosting` | `cloud` |
 | `tier` | `frontier` |

--- a/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
@@ -101,9 +101,11 @@ test.describe('identityRootsMigration — the flat registry expressed through th
     test('the anti-fabrication residue is structural: documented swap events are candidates, never auto-built eras', () => {
         const {residents, report} = migration.migrateAllResidents();
 
-        // both documented swap events are exported as candidates with sources and named gaps
-        expect(report.backfillCandidates).toContain('@neo-fable');
-        expect(report.backfillCandidates).toContain('@neo-opus-vega');
+        // the ONE documented swap event is exported as a candidate with source and named gap;
+        // @neo-fable is bearer-audited OFF the list (born Fable 2026-06-10; the June suspension
+        // is an identity-level participation gap, never an embodiment swap — nothing to backfill)
+        expect(report.backfillCandidates).toEqual(['@neo-opus-vega']);
+        expect(report.backfillCandidates).not.toContain('@neo-fable');
         for (const candidate of migration.ERA_BACKFILL_CANDIDATES) {
             expect(candidate.eventSource.length).toBeGreaterThan(0);
             expect(candidate.missing.length).toBeGreaterThan(0);

--- a/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
@@ -1,0 +1,107 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'IdentityRootsMigrationTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+test.describe('identityRootsMigration — the flat registry expressed through the identity schema, on production data', () => {
+    let migration, schema, roots;
+
+    test.beforeAll(async () => {
+        migration = await import('../../../../../ai/graph/identityRootsMigration.mjs');
+        schema    = await import('../../../../../ai/graph/identitySchema.mjs');
+        roots     = await import('../../../../../ai/graph/identityRoots.mjs');
+    });
+
+    test('every live agent resident migrates: valid chains, zero failures, non-agents skipped by design', () => {
+        const {valid, residents, report} = migration.migrateAllResidents();
+
+        expect(report.failures).toEqual([]);
+        expect(valid).toBe(true);
+
+        // the roster is complete: every agent seed migrated, every non-agent skipped
+        const agentSeeds = roots.IDENTITIES.filter(seed => seed?.properties?.accountType === 'agent');
+        expect(residents).toHaveLength(agentSeeds.length);
+        expect(report.skipped.map(entry => entry.accountType)).not.toContain('agent');
+
+        // every chain re-validates through the schema, independently of the migration's own check
+        for (const resident of residents) {
+            expect(schema.validateEraChain(resident.identity, resident.episodes)).toEqual({valid: true, reason: null});
+        }
+    });
+
+    test('the seed era carries the recorded facts VERBATIM — era-owned facts leave the identity view, sunsetTriggers move to the era layer', () => {
+        const {residents} = migration.migrateAllResidents();
+
+        for (const {identity, episodes} of residents) {
+            const seed = roots.IDENTITIES.find(entry => entry.id === identity.identityKey);
+            const era  = episodes[0];
+
+            // family lifted verbatim; the identity view carries NO era-owned fact
+            expect(era.family).toBe(seed.properties.modelFamily || seed.properties.family);
+            for (const key of schema.ERA_OWNED_FACTS) {
+                expect(identity.socialLayer[key]).toBeUndefined();
+            }
+
+            // sunsetTriggers live on the ERA now — succession semantics belong to the embodiment
+            if (seed.properties.sunsetTriggers !== undefined) {
+                expect(era.capabilities.sunsetTriggers).toEqual(seed.properties.sunsetTriggers);
+            }
+
+            // recorded capability facts lifted verbatim where present
+            if (seed.properties.contextWindowInput !== undefined) {
+                expect(era.capabilities.contextWindowInput).toBe(seed.properties.contextWindowInput);
+            }
+
+            // the era opens at the documented migration epoch with backfill provenance — never invented history
+            expect(era.since).toBe(migration.MIGRATION_EPOCH);
+            expect(era.capabilities.provenance).toContain('flat-registry-backfill');
+        }
+    });
+
+    test('THE PROPERTY holds on production data, and hydration serves current facts for every resident', () => {
+        const {residents} = migration.migrateAllResidents();
+
+        for (const {identity, episodes, index} of residents) {
+            expect(index.identityKey).toBe(identity.identityKey);
+            expect(index.regenerable).toBe(true);
+            expect(index.currentEra.model).toBe(migration.REGISTRY_MODEL_DESIGNATIONS[identity.identityKey]);
+        }
+    });
+
+    test('the anti-fabrication residue is structural: documented swap events are candidates, never auto-built eras', () => {
+        const {residents, report} = migration.migrateAllResidents();
+
+        // both documented swap events are exported as candidates with sources and named gaps
+        expect(report.backfillCandidates).toContain('@neo-fable');
+        expect(report.backfillCandidates).toContain('@neo-opus-vega');
+        for (const candidate of migration.ERA_BACKFILL_CANDIDATES) {
+            expect(candidate.eventSource.length).toBeGreaterThan(0);
+            expect(candidate.missing.length).toBeGreaterThan(0);
+        }
+
+        // and the migration did NOT build those prior eras: single seed era each
+        for (const key of report.backfillCandidates) {
+            const resident = residents.find(entry => entry.identity.identityKey === key);
+            expect(resident.episodes).toHaveLength(1);
+        }
+
+        // unmapped agents refuse loudly instead of guessing a designation
+        const unmapped = migration.migrateResident({id: '@new-peer', name: 'X', properties: {accountType: 'agent', modelFamily: 'claude'}});
+        expect(unmapped.valid).toBe(false);
+        expect(unmapped.reason).toContain('never guess');
+    });
+});

--- a/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
@@ -82,6 +82,22 @@ test.describe('identityRootsMigration — the flat registry expressed through th
         }
     });
 
+    test('migrated model values are MODEL DESIGNATIONS — never handles or social strings (field-provenance guard)', () => {
+        const {residents} = migration.migrateAllResidents();
+
+        for (const {identity, episodes} of residents) {
+            const seed  = roots.IDENTITIES.find(entry => entry.id === identity.identityKey);
+            const model = episodes[0].model;
+
+            // designation shape: never an @handle, never the seed's identity/display string, and
+            // every designation in this registry carries a version digit — social strings never do
+            expect(model.startsWith('@')).toBe(false);
+            expect(model).not.toBe(seed.name);
+            expect(model).not.toBe(seed.properties.displayName);
+            expect(model).toMatch(/\d/);
+        }
+    });
+
     test('the anti-fabrication residue is structural: documented swap events are candidates, never auto-built eras', () => {
         const {residents, report} = migration.migrateAllResidents();
 


### PR DESCRIPTION
## Summary

The consuming migration (#14677's leaf 4): **every live agent resident of the flat identity registry, expressed through the identity schema on production data** — the flat model/capability facts BECOME the seed era verbatim, `sunsetTriggers` move to the era layer where succession semantics belong, and THE PROPERTY (delete → rebuild → deep-equal) is re-proven on the real roster. The anti-fabrication contract is structural: nothing invented, documented swap events export as bearer-audited backfill candidates, unmapped agents refuse loudly.

Resolves #14731
Refs #14677

> **Diff is net-new only** (parents #14729 + #14730 merged; de-stacked at `70ca7ced5`): the migration module + spec are the entire review surface.

## Deltas

- **NEW `ai/graph/identityRootsMigration.mjs`**:
  - `migrateResident(seed)` — agent seeds only (human/system/sentinel carry no embodiment era by design): anchor + social layer via `createIdentityStateNode`, seed era via `createEmbodiedEpisodeNode` with the recorded facts lifted verbatim (`LIFTED_CAPABILITY_KEYS` incl. `sunsetTriggers` — succession conditions are era facts now), era opening at the documented `MIGRATION_EPOCH` with explicit backfill provenance ("facts held as of migration; earlier history unrecorded").
  - `REGISTRY_MODEL_DESIGNATIONS` — per-resident designations **verbatim from the model-stats registry's `name` rows** (the source the registry's own `modelVersionSource` pointers name); a stale recorded designation is still the recorded fact — eras exist to version exactly that. An unmapped agent refuses with "extend the designations map … never guess".
  - `ERA_BACKFILL_CANDIDATES` — the honest residue, now bearer-audited down to ONE entry: @neo-opus-vega's documented Fable-window → Opus swap (her broadcast is the event source; pre-swap facts unrecorded = the named gap). **@neo-fable was audited OFF the list by the bearer mid-review** (the trail shows born-Fable 2026-06-10, single era; the June suspension is an identity-level participation gap, never an embodiment swap — audit rationale in-module, the negative pinned in the spec). **The migration never builds eras from this list** — bearer-audited follow-ups only (the fabrication-class guard, by construction, now demonstrated on its own author).
  - `migrateAllResidents()` — the full roster with a fail-closed per-resident report (one bad seed refuses loudly instead of silently shrinking the roster), independent chain re-validation, and THE PROPERTY executed per resident.
- **NEW `test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs`** — 5 tests on PRODUCTION data: full-roster migration (zero failures, non-agents skipped, chains re-validate independently) · verbatim fact-lifting + era-owned facts absent from the identity view + sunsetTriggers on eras + backfill provenance · the designation-shape guard (model values never handles/social strings) · THE PROPERTY + hydration currency per resident · the anti-fabrication residue (the Vega candidate exported with source, @neo-fable asserted OFF the list, single seed era each, unmapped-agent refusal).

**Scope split (pre-review, consumer-census-driven):** the flat-field RETIREMENT is **#14750** — `modelFamily`/`family` are load-bearing across A2A alias resolution (`MailboxService`), wake routing (`WakeSubscriptionService`), and `agentFamilyResolution`; each read path migrates per-consumer-per-commit with routing regressions before the flat fields can leave the registry. #14731's ACs amended accordingly; #14750 filed with the census.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs identityRootsMigration` → **5 passed** at `70ca7ced5` (15/15 stack-wide with schema + hydration on dev).

Evidence: L2 (pure transformation proven against the LIVE registry data — the production execution of the acceptance instrument).

## Post-Merge Validation

- #14750 consumes `migrateAllResidents()` output for the graph-seeding path and executes the per-consumer read-path moves.
- A bearer-audited era backfill (the Vega candidate; further entries only ever bearer-added) turns single-era residents into real multi-era chains — the reflexive-landing fixture ↔ production agreement lands there.
- The archaeology guard holds: behavioral prose only.

## Related

Parent #14677 · PR #14729 (schema + fixture) · PR #14730 (hydration) · #14750 (the retirement half, filed with the consumer census) · the epic's provenance finding (the capability-flattening substrate read).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b9b95ac6-42f5-47a3-b58f-6071f79657e8.
