### PR TITLE
feat(ai): nightly whitebox-e2e runner + red-only A2A digest (#14685)

### DIFF
--- a/ai/scripts/lifecycle/nightly-e2e/README.md
+++ b/ai/scripts/lifecycle/nightly-e2e/README.md
@@ -1,0 +1,68 @@
+# Nightly whitebox-e2e runner — activation (#14685)
+
+The unattended quality heartbeat. Neo's whitebox-e2e suites live **outside CI by design** (the failing-honest
+discipline — a whitebox proof may be legitimately red without blocking a merge), but nothing runs them on a
+schedule, so red states sit undiscovered. This LaunchAgent runs the declared e2e configs nightly and, on **any**
+red, pushes **one** normal-priority (mailbox-drain, never a wake storm) A2A digest naming the failing specs +
+first-error lines + the run-log path. Green runs are **silent**.
+
+- Runner: [`../nightlyE2eRunner.mjs`](../nightlyE2eRunner.mjs) (I/O: lockfile, spawn playwright, read the json report, send the A2A digest).
+- Pure parse/format core (unit-tested): [`../nightlyE2eDigest.mjs`](../nightlyE2eDigest.mjs).
+- Plist template: [`com.neomjs.nightly-e2e.plist`](./com.neomjs.nightly-e2e.plist).
+
+## Why staged, not auto-installed
+
+The plist is a **template**, not an installed agent: it carries a machine-specific absolute repo path and a
+schedule the operator owns. Auto-installing a LaunchAgent from a checkout would be a surprising side effect on
+every clone. Activation is a deliberate, per-machine operator step — deployments that do not want a nightly run
+simply never install it.
+
+## Activate (macOS, per-user LaunchAgent)
+
+```sh
+# 1. Render the template with your absolute repo root.
+REPO="$(git rev-parse --show-toplevel)"
+mkdir -p "$REPO/.neo-ai-data/nightly-e2e/logs" ~/Library/LaunchAgents
+sed "s#__NEO_REPO_ROOT__#$REPO#g" \
+  "$REPO/ai/scripts/lifecycle/nightly-e2e/com.neomjs.nightly-e2e.plist" \
+  > ~/Library/LaunchAgents/com.neomjs.nightly-e2e.plist
+
+# 2. Load it (fires only on schedule — RunAtLoad is false).
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.neomjs.nightly-e2e.plist
+launchctl print "gui/$(id -u)/com.neomjs.nightly-e2e" | head    # verify it's loaded
+```
+
+Default schedule: **03:17 local**, nightly. Edit `StartCalendarInterval` in your installed copy to change it.
+
+## Verify / read results
+
+```sh
+# Trigger one run immediately (bypasses the schedule) to smoke-test:
+launchctl kickstart -k "gui/$(id -u)/com.neomjs.nightly-e2e"
+
+cat .neo-ai-data/nightly-e2e/last-run.json          # {at, red, configs:[{config, failing, ran, note}], logPath}
+ls  .neo-ai-data/nightly-e2e/logs/                  # per-run logs + launchd.{out,err}.log
+```
+
+On a **red** run the digest arrives in the A2A mailbox from `@system` (subject `[nightly-e2e][RED] …`), naming
+the failing specs. On a **green** run nothing is sent — silence is the signal.
+
+## Add a suite
+
+Append to `E2E_CONFIGS` in the runner header ([`../nightlyE2eRunner.mjs`](../nightlyE2eRunner.mjs)) — one
+`{config, results}` entry per playwright config (its own `json` reporter `outputFile` is read back). The list is
+deliberately additive as dock e2e, FM NL-proofs, and tour-replay suites land. **Custom configs only** — every
+run passes `-c <config>`, never the default `npx playwright test`.
+
+## Disable / uninstall
+
+```sh
+launchctl bootout "gui/$(id -u)/com.neomjs.nightly-e2e"
+rm ~/Library/LaunchAgents/com.neomjs.nightly-e2e.plist
+```
+
+## Scope
+
+Out of scope (per #14685): CI integration (the outside-CI discipline stands) · fixing the reds (the digest
+points; owners fix) · unit / integration suites (CI owns those). A Linux `systemd --user` timer equivalent is a
+follow-up if/when a non-macOS runner host is provisioned.

--- a/ai/scripts/lifecycle/nightly-e2e/com.neomjs.nightly-e2e.plist
+++ b/ai/scripts/lifecycle/nightly-e2e/com.neomjs.nightly-e2e.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  STAGED, NOT auto-installed (#14685). This is a template: substitute __NEO_REPO_ROOT__ with the absolute
+  repo path, then follow ai/scripts/lifecycle/nightly-e2e/README.md to install it as a per-user LaunchAgent.
+  The runner keeps e2e OUTSIDE CI (failing-honest discipline) but runs it nightly + pushes a RED-ONLY A2A
+  digest. RunAtLoad is false: it fires only on the schedule, never at load/boot.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.neomjs.nightly-e2e</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>node</string>
+        <string>ai/scripts/lifecycle/nightlyE2eRunner.mjs</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__NEO_REPO_ROOT__</string>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>17</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>__NEO_REPO_ROOT__/.neo-ai-data/nightly-e2e/logs/launchd.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__NEO_REPO_ROOT__/.neo-ai-data/nightly-e2e/logs/launchd.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/ai/scripts/lifecycle/nightlyE2eDigest.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eDigest.mjs
@@ -72,3 +72,24 @@ export function formatDigest(outcomes, logPath) {
     lines.push(`Run log: \`${logPath}\``);
     return lines.join('\n');
 }
+
+/**
+ * @summary Assembles the per-run log body from each config's captured runner output — the concrete file the
+ * digest's `Run log:` pointer resolves to. Pure (outcomes → string); the runner writes the returned body and
+ * creates the log dir. Backed by real captured output so a red/infra-red digest can never point at a phantom
+ * file — the failure mode this closes.
+ * @param {Object[]} outcomes per-config outcomes, each optionally carrying `{config, note, output}`.
+ * @param {String} [at=''] ISO timestamp of the run, headlined at the top of the log.
+ * @returns {String} the run-log body.
+ */
+export function buildRunLog(outcomes, at = '') {
+    const sections = [`# Nightly whitebox-e2e run ${at}`.trimEnd(), ''];
+
+    for (const outcome of (outcomes || [])) {
+        sections.push(`## ${outcome.config}${outcome.note ? ` — ${outcome.note}` : ''}`);
+        sections.push(outcome.output ? String(outcome.output).trimEnd() : '(no captured output)');
+        sections.push('');
+    }
+
+    return sections.join('\n');
+}

--- a/ai/scripts/lifecycle/nightlyE2eDigest.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eDigest.mjs
@@ -1,0 +1,74 @@
+/**
+ * @module ai/scripts/lifecycle/nightlyE2eDigest
+ * @summary Pure parse/format core for the nightly whitebox-e2e runner (ticket-ref-ok: #14685 owning-leaf anchor).
+ *
+ * Service-free by design: the runner (`nightlyE2eRunner.mjs`) owns the I/O — spawn playwright, read the json
+ * report, send the A2A digest — while this module is the pure projection it delegates to: walk a Playwright json
+ * report into actionable failure pointers, and format the red digest. Keeping it free of the memory-core service
+ * imports is what lets the digest logic unit-test in isolation (no GraphService / LifecycleService boot).
+ */
+
+/**
+ * @summary Walks a Playwright json report and collects every failed spec as an actionable pointer. A spec is
+ * failing when it is not `ok` (Playwright sets `ok:false` for unexpected outcomes). Returns the spec title, its
+ * `file:line`, and the FIRST error line (no full stack — the digest points, the owner opens the log).
+ * @param {Object} report Parsed Playwright `json` reporter output.
+ * @returns {Object[]} failing specs — each `{title, location, firstError}`.
+ */
+export function collectFailures(report) {
+    const failures = [];
+
+    const walk = suite => {
+        for (const spec of suite.specs || []) {
+            if (spec.ok === false) {
+                const result    = spec.tests?.[0]?.results?.find(r => r.status !== 'passed' && r.status !== 'skipped') || spec.tests?.[0]?.results?.[0],
+                      rawError  = result?.errors?.[0]?.message || result?.error?.message || 'no error message captured',
+                      firstLine = String(rawError).split('\n').find(line => line.trim().length > 0)?.trim() || 'no error message captured';
+
+                failures.push({
+                    title     : spec.title,
+                    location  : `${spec.file || suite.file || '?'}:${spec.line ?? '?'}`,
+                    firstError: firstLine.length > 240 ? `${firstLine.slice(0, 240)}…` : firstLine
+                });
+            }
+        }
+        for (const child of suite.suites || []) walk(child);
+    };
+
+    for (const suite of (report?.suites || [])) walk(suite);
+    return failures;
+}
+
+/**
+ * @summary Reduces per-config outcomes to the red/green verdict: red when any config has a failing spec OR did
+ * not cleanly run (an infra/boot failure with no report is a red, never swallowed as green).
+ * @param {Object[]} outcomes per-config outcomes, each `{config, failures, ran, note}`.
+ * @returns {Boolean} `true` when the run must digest.
+ */
+export function isRed(outcomes) {
+    return (outcomes || []).some(outcome => (outcome.failures?.length || 0) > 0 || outcome.ran === false);
+}
+
+/**
+ * @summary Formats the red digest markdown: per-config failing specs + first errors + the run-log path, so it is
+ * actionable without thread archaeology. Only red/non-clean configs are listed; clean-green configs stay silent.
+ * @param {Object[]} outcomes per-config outcomes, each `{config, failures, ran, note}`.
+ * @param {String} logPath the run-log path.
+ * @returns {String} digest body.
+ */
+export function formatDigest(outcomes, logPath) {
+    const lines = ['Nightly whitebox-e2e run surfaced RED. Red-as-pointer — owners fix, this digest only points.', ''];
+
+    for (const outcome of (outcomes || [])) {
+        if ((outcome.failures?.length || 0) === 0 && outcome.ran !== false && !outcome.note) continue;
+
+        lines.push(`**\`${outcome.config}\`** — ${outcome.failures?.length || 0} failing${outcome.note ? ` · ${outcome.note}` : ''}`);
+        for (const failure of (outcome.failures || [])) {
+            lines.push(`- \`${failure.location}\` — ${failure.title}: ${failure.firstError}`);
+        }
+        lines.push('');
+    }
+
+    lines.push(`Run log: \`${logPath}\``);
+    return lines.join('\n');
+}

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -16,15 +16,15 @@
  * Out of scope (per the ticket): CI integration (the outside-CI discipline stands), fixing the reds (the digest
  * points; owners fix), and unit/integration suites (CI owns those).
  */
-import {spawnSync}                            from 'node:child_process';
-import path                                   from 'node:path';
-import {fileURLToPath}                        from 'node:url';
-import fs                                     from 'fs-extra';
-import GraphService                           from '../../services/memory-core/GraphService.mjs';
-import LifecycleService                       from '../../services/memory-core/lifecycle/SystemLifecycleService.mjs';
-import MailboxService                         from '../../services/memory-core/MailboxService.mjs';
-import RequestContextService                  from '../../mcp/server/shared/services/RequestContextService.mjs';
-import {collectFailures, formatDigest, isRed} from './nightlyE2eDigest.mjs';
+import {spawnSync}                                         from 'node:child_process';
+import path                                                from 'node:path';
+import {fileURLToPath}                                     from 'node:url';
+import fs                                                  from 'fs-extra';
+import GraphService                                        from '../../services/memory-core/GraphService.mjs';
+import LifecycleService                                    from '../../services/memory-core/lifecycle/SystemLifecycleService.mjs';
+import MailboxService                                      from '../../services/memory-core/MailboxService.mjs';
+import RequestContextService                               from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {buildRunLog, collectFailures, formatDigest, isRed} from './nightlyE2eDigest.mjs';
 
 /**
  * The whitebox-e2e configs the nightly run executes. ADDITIVE: append a config here as a suite lands
@@ -74,8 +74,13 @@ async function acquireLock(nowIso) {
  */
 function runConfig(entry) {
     console.error(`[nightlyE2eRunner] Running ${entry.config} …`);
-    // Custom config ONLY — never the default `npx playwright test`.
-    const run = spawnSync('npx', ['playwright', 'test', '-c', entry.config], {encoding: 'utf8', stdio: ['ignore', 'inherit', 'inherit']});
+    // Custom config ONLY — never the default `npx playwright test`. Capture (pipe) rather than inherit so the
+    // output backs the per-run log the digest points at; echo it through so an attended run still sees it live.
+    const run = spawnSync('npx', ['playwright', 'test', '-c', entry.config], {encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']});
+
+    if (run.stdout) process.stdout.write(run.stdout);
+    if (run.stderr) process.stderr.write(run.stderr);
+    const output = `$ npx playwright test -c ${entry.config}\n${run.stdout ?? ''}${run.stderr ?? ''}`;
 
     let report = null;
     try {
@@ -87,10 +92,10 @@ function runConfig(entry) {
     if (!report) {
         // No parseable report + non-zero exit = infra/boot red. Surface it explicitly rather than reporting green.
         const ran = run.status === 0;
-        return {config: entry.config, failures: [], ran, note: ran ? 'ran; no report emitted' : `runner exited ${run.status ?? 'signal'} with no report (infra/boot failure)`};
+        return {config: entry.config, failures: [], ran, note: ran ? 'ran; no report emitted' : `runner exited ${run.status ?? 'signal'} with no report (infra/boot failure)`, output};
     }
 
-    return {config: entry.config, failures: collectFailures(report), ran: true, note: ''};
+    return {config: entry.config, failures: collectFailures(report), ran: true, note: '', output};
 }
 
 /**
@@ -109,6 +114,11 @@ export async function runNightlyE2e() {
     try {
         const outcomes = E2E_CONFIGS.map(runConfig),
               red      = isRed(outcomes);
+
+        // Back the digest's `Run log:` pointer with a real file: ensure the logs dir, write the captured
+        // per-config output. Without this the logPath in last-run.json / the digest would be a phantom.
+        fs.ensureDirSync(path.dirname(logPath));
+        fs.writeFileSync(logPath, buildRunLog(outcomes, nowIso), 'utf8');
 
         await fs.writeJson(STATE_PATH, {
             at     : nowIso,

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * @summary Unattended nightly whitebox-e2e run with a RED-ONLY A2A digest (ticket-ref-ok: #14685 owning-leaf anchor).
+ *
+ * e2e lives OUTSIDE CI by design (failing-honest discipline — a whitebox proof may be legitimately red without
+ * blocking a merge), but nothing runs it on a schedule, so red states sit undiscovered (the 3-week middleware
+ * staleness failure mode). This is the unattended quality heartbeat: run the declared e2e configs, and on ANY
+ * red, push ONE mailbox-drain-class A2A digest naming the failing specs + first-error lines + the run-log path.
+ * Green runs are SILENT — red-as-pointer made push, not pull.
+ *
+ * Hardening (the middleware-scheduler LaunchAgent precedent): an exclusive PID lockfile with stale-steal, a run log,
+ * structured stderr, and finally-hygiene that always releases the lock. LaunchAgent-staged (not auto-installed);
+ * see ai/scripts/lifecycle/nightly-e2e/README for activation. CRITICAL inherited rule: custom playwright configs
+ * only — every run passes `-c <config>`, never the default `npx playwright test`.
+ *
+ * Out of scope (per the ticket): CI integration (the outside-CI discipline stands), fixing the reds (the digest
+ * points; owners fix), and unit/integration suites (CI owns those).
+ */
+import {spawnSync}           from 'node:child_process';
+import path                  from 'node:path';
+import {fileURLToPath}       from 'node:url';
+import fs                    from 'fs-extra';
+import GraphService          from '../../services/memory-core/GraphService.mjs';
+import LifecycleService      from '../../services/memory-core/lifecycle/SystemLifecycleService.mjs';
+import MailboxService        from '../../services/memory-core/MailboxService.mjs';
+import RequestContextService from '../../mcp/server/shared/services/RequestContextService.mjs';
+
+/**
+ * The whitebox-e2e configs the nightly run executes. ADDITIVE: append a config here as a suite lands
+ * (dock e2e, FM NL-proofs, tour-replay suites). Each entry is a repo-relative playwright config;
+ * its own `json` reporter `outputFile` is read back for the digest. Unit/integration configs are CI-owned and
+ * deliberately absent.
+ */
+const E2E_CONFIGS = [
+    {config: 'test/playwright/playwright.config.e2e.mjs', results: 'test-results/e2e/results.json'}
+];
+
+const STATE_DIR     = '.neo-ai-data/nightly-e2e',
+      LOCK_PATH     = `${STATE_DIR}/runner.lock`,
+      STATE_PATH    = `${STATE_DIR}/last-run.json`,
+      LOCK_STALE_MS = 6 * 60 * 60 * 1000;   // 6h — a nightly run that outlives this is a hung process; steal the lock
+
+/**
+ * @summary Acquires the exclusive runner lock, stealing it only when the holder is provably stale (> 6h). A
+ * fresh lock means another nightly run is in flight — abort rather than double-run the suite.
+ * @param {String} nowIso ISO timestamp for the lock stamp.
+ * @returns {Promise<Boolean>} `true` when the lock is held by this process, `false` when a fresh run owns it.
+ */
+async function acquireLock(nowIso) {
+    await fs.ensureDir(STATE_DIR);
+
+    if (await fs.pathExists(LOCK_PATH)) {
+        const held    = await fs.readJson(LOCK_PATH).catch(() => null),
+              heldAt  = held?.at ? new Date(held.at).getTime() : 0,
+              staleMs = Date.now() - heldAt;
+
+        if (held && staleMs < LOCK_STALE_MS) {
+            console.error(`[nightlyE2eRunner] Abort: a run started ${held.at} (pid ${held.pid}) still holds the lock.`);
+            return false;
+        }
+        console.error(`[nightlyE2eRunner] Stealing stale lock (held ${held?.at ?? 'unknown'}, > ${LOCK_STALE_MS}ms).`);
+    }
+
+    await fs.writeJson(LOCK_PATH, {pid: process.pid, at: nowIso}, {spaces: 2});
+    return true;
+}
+
+/**
+ * @summary Walks a Playwright JSON report and collects every failed spec as an actionable pointer.
+ * A spec is failing when it is not `ok` (Playwright sets `ok:false` for unexpected outcomes). Returns the
+ * spec title, its `file:line`, and the FIRST error line (no full stack — the digest points, the owner opens).
+ * @param {Object} report Parsed Playwright `json` reporter output.
+ * @returns {Object[]} failing specs — each `{title, location, firstError}`.
+ */
+function collectFailures(report) {
+    const failures = [];
+
+    const walk = suite => {
+        for (const spec of suite.specs || []) {
+            if (spec.ok === false) {
+                const result    = spec.tests?.[0]?.results?.find(r => r.status !== 'passed' && r.status !== 'skipped') || spec.tests?.[0]?.results?.[0],
+                      rawError  = result?.errors?.[0]?.message || result?.error?.message || 'no error message captured',
+                      firstLine = String(rawError).split('\n').find(line => line.trim().length > 0)?.trim() || 'no error message captured';
+
+                failures.push({
+                    title     : spec.title,
+                    location  : `${spec.file || suite.file || '?'}:${spec.line ?? '?'}`,
+                    firstError: firstLine.length > 240 ? `${firstLine.slice(0, 240)}…` : firstLine
+                });
+            }
+        }
+        for (const child of suite.suites || []) walk(child);
+    };
+
+    for (const suite of report.suites || []) walk(suite);
+    return failures;
+}
+
+/**
+ * @summary Runs one e2e config to completion and reads back its JSON reporter output. A non-zero exit with no
+ * parseable results is itself a red (an infra/boot failure the digest must surface, not swallow).
+ * @param {Object} entry declared config `{config, results}` — the config path + its reporter output path.
+ * @returns {Object} per-config outcome `{config, failures, ran, note}`.
+ */
+function runConfig(entry) {
+    console.error(`[nightlyE2eRunner] Running ${entry.config} …`);
+    // Custom config ONLY — never the default `npx playwright test`.
+    const run = spawnSync('npx', ['playwright', 'test', '-c', entry.config], {encoding: 'utf8', stdio: ['ignore', 'inherit', 'inherit']});
+
+    let report = null;
+    try {
+        if (fs.pathExistsSync(entry.results)) report = fs.readJsonSync(entry.results);
+    } catch (error) {
+        console.error(`[nightlyE2eRunner] Could not parse ${entry.results}: ${error.message}`);
+    }
+
+    if (!report) {
+        // No parseable report + non-zero exit = infra/boot red. Surface it explicitly rather than reporting green.
+        const ran = run.status === 0;
+        return {config: entry.config, failures: [], ran, note: ran ? 'ran; no report emitted' : `runner exited ${run.status ?? 'signal'} with no report (infra/boot failure)`};
+    }
+
+    return {config: entry.config, failures: collectFailures(report), ran: true, note: ''};
+}
+
+/**
+ * @summary Formats the red digest markdown: per-config failing specs + first errors + the run-log path, so it
+ * is actionable without thread archaeology.
+ * @param {Array} outcomes per-config outcomes.
+ * @param {String} logPath the run-log path.
+ * @returns {String} digest body.
+ */
+function formatDigest(outcomes, logPath) {
+    const lines = ['Nightly whitebox-e2e run surfaced RED. Red-as-pointer — owners fix, this digest only points.', ''];
+
+    for (const outcome of outcomes) {
+        if (outcome.failures.length === 0 && outcome.ran && !outcome.note) continue;
+
+        lines.push(`**\`${outcome.config}\`** — ${outcome.failures.length} failing${outcome.note ? ` · ${outcome.note}` : ''}`);
+        for (const failure of outcome.failures) {
+            lines.push(`- \`${failure.location}\` — ${failure.title}: ${failure.firstError}`);
+        }
+        lines.push('');
+    }
+
+    lines.push(`Run log: \`${logPath}\``);
+    return lines.join('\n');
+}
+
+/**
+ * @summary Executes the nightly run: hold the lock, run each declared config, and on ANY red push exactly one
+ * normal-priority (mailbox-drain, never a wake storm) A2A digest. Green = silence. Always releases the lock.
+ * @returns {Promise<Object>} run outcome `{red, sent, reason?}`.
+ */
+export async function runNightlyE2e() {
+    const nowIso  = new Date().toISOString(),
+          logPath = `${STATE_DIR}/logs/run-${nowIso.replace(/[:.]/g, '-')}.log`;
+
+    if (!(await acquireLock(nowIso))) {
+        return {red: false, sent: false, reason: 'lock-held'};
+    }
+
+    try {
+        const outcomes = E2E_CONFIGS.map(runConfig),
+              red      = outcomes.some(o => o.failures.length > 0 || !o.ran);
+
+        await fs.writeJson(STATE_PATH, {
+            at     : nowIso,
+            red,
+            configs: outcomes.map(o => ({config: o.config, failing: o.failures.length, ran: o.ran, note: o.note})),
+            logPath
+        }, {spaces: 2});
+
+        if (!red) {
+            console.error('[nightlyE2eRunner] All declared e2e configs green — staying silent.');
+            return {red: false, sent: false};
+        }
+
+        const sender = process.env.NEO_AGENT_IDENTITY || '@system';
+        await LifecycleService.initAsync();
+        await GraphService.initAsync();
+
+        await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
+            await MailboxService.addMessage({
+                to      : 'AGENT:*',
+                subject : `[nightly-e2e][RED] ${outcomes.reduce((n, o) => n + o.failures.length, 0)} failing whitebox-e2e spec(s) — ${nowIso.slice(0, 10)}`,
+                body    : formatDigest(outcomes, logPath),
+                priority: 'normal'   // mailbox-drain class (wake-tier compliant) — never a wake storm
+            });
+        });
+
+        console.error('[nightlyE2eRunner] RED digest sent to AGENT:* (normal priority).');
+        return {red: true, sent: true};
+    } finally {
+        await fs.remove(LOCK_PATH).catch(() => {});
+    }
+}
+
+async function main() {
+    const outcome = await runNightlyE2e();
+    // Exit 0 on a clean run OR a clean-but-red run (the digest carries the signal; the process itself succeeded).
+    // A thrown error (below) is the only non-zero exit — an infra failure of the RUNNER, distinct from a suite red.
+    console.error(`[nightlyE2eRunner] Done: ${JSON.stringify(outcome)}`);
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+    main().catch(error => {
+        console.error('[nightlyE2eRunner] Fatal:', error.stack);
+        process.exit(1);
+    });
+}

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -72,11 +72,16 @@ async function acquireLock(nowIso) {
  * @param {Object} entry declared config `{config, results}` — the config path + its reporter output path.
  * @returns {Object} per-config outcome `{config, failures, ran, note}`.
  */
-function runConfig(entry) {
+export function runConfig(entry, {spawn = spawnSync} = {}) {
     console.error(`[nightlyE2eRunner] Running ${entry.config} …`);
+    // Remove any stale reporter output FIRST: a prior run's results.json (or a leftover green one) must never
+    // be read as THIS run's result — that would let an infra failure which writes no fresh report be scored
+    // green, silently suppressing the red digest. The heartbeat's one job is to not go silent.
+    fs.removeSync(entry.results);
+
     // Custom config ONLY — never the default `npx playwright test`. Capture (pipe) rather than inherit so the
     // output backs the per-run log the digest points at; echo it through so an attended run still sees it live.
-    const run = spawnSync('npx', ['playwright', 'test', '-c', entry.config], {encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']});
+    const run = spawn('npx', ['playwright', 'test', '-c', entry.config], {encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']});
 
     if (run.stdout) process.stdout.write(run.stdout);
     if (run.stderr) process.stderr.write(run.stderr);
@@ -112,7 +117,7 @@ export async function runNightlyE2e() {
     }
 
     try {
-        const outcomes = E2E_CONFIGS.map(runConfig),
+        const outcomes = E2E_CONFIGS.map(entry => runConfig(entry)),
               red      = isRed(outcomes);
 
         // Back the digest's `Run log:` pointer with a real file: ensure the logs dir, write the captured

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -16,14 +16,15 @@
  * Out of scope (per the ticket): CI integration (the outside-CI discipline stands), fixing the reds (the digest
  * points; owners fix), and unit/integration suites (CI owns those).
  */
-import {spawnSync}           from 'node:child_process';
-import path                  from 'node:path';
-import {fileURLToPath}       from 'node:url';
-import fs                    from 'fs-extra';
-import GraphService          from '../../services/memory-core/GraphService.mjs';
-import LifecycleService      from '../../services/memory-core/lifecycle/SystemLifecycleService.mjs';
-import MailboxService        from '../../services/memory-core/MailboxService.mjs';
-import RequestContextService from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {spawnSync}                            from 'node:child_process';
+import path                                   from 'node:path';
+import {fileURLToPath}                        from 'node:url';
+import fs                                     from 'fs-extra';
+import GraphService                           from '../../services/memory-core/GraphService.mjs';
+import LifecycleService                       from '../../services/memory-core/lifecycle/SystemLifecycleService.mjs';
+import MailboxService                         from '../../services/memory-core/MailboxService.mjs';
+import RequestContextService                  from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {collectFailures, formatDigest, isRed} from './nightlyE2eDigest.mjs';
 
 /**
  * The whitebox-e2e configs the nightly run executes. ADDITIVE: append a config here as a suite lands
@@ -66,37 +67,6 @@ async function acquireLock(nowIso) {
 }
 
 /**
- * @summary Walks a Playwright JSON report and collects every failed spec as an actionable pointer.
- * A spec is failing when it is not `ok` (Playwright sets `ok:false` for unexpected outcomes). Returns the
- * spec title, its `file:line`, and the FIRST error line (no full stack — the digest points, the owner opens).
- * @param {Object} report Parsed Playwright `json` reporter output.
- * @returns {Object[]} failing specs — each `{title, location, firstError}`.
- */
-function collectFailures(report) {
-    const failures = [];
-
-    const walk = suite => {
-        for (const spec of suite.specs || []) {
-            if (spec.ok === false) {
-                const result    = spec.tests?.[0]?.results?.find(r => r.status !== 'passed' && r.status !== 'skipped') || spec.tests?.[0]?.results?.[0],
-                      rawError  = result?.errors?.[0]?.message || result?.error?.message || 'no error message captured',
-                      firstLine = String(rawError).split('\n').find(line => line.trim().length > 0)?.trim() || 'no error message captured';
-
-                failures.push({
-                    title     : spec.title,
-                    location  : `${spec.file || suite.file || '?'}:${spec.line ?? '?'}`,
-                    firstError: firstLine.length > 240 ? `${firstLine.slice(0, 240)}…` : firstLine
-                });
-            }
-        }
-        for (const child of suite.suites || []) walk(child);
-    };
-
-    for (const suite of report.suites || []) walk(suite);
-    return failures;
-}
-
-/**
  * @summary Runs one e2e config to completion and reads back its JSON reporter output. A non-zero exit with no
  * parseable results is itself a red (an infra/boot failure the digest must surface, not swallow).
  * @param {Object} entry declared config `{config, results}` — the config path + its reporter output path.
@@ -124,30 +94,6 @@ function runConfig(entry) {
 }
 
 /**
- * @summary Formats the red digest markdown: per-config failing specs + first errors + the run-log path, so it
- * is actionable without thread archaeology.
- * @param {Array} outcomes per-config outcomes.
- * @param {String} logPath the run-log path.
- * @returns {String} digest body.
- */
-function formatDigest(outcomes, logPath) {
-    const lines = ['Nightly whitebox-e2e run surfaced RED. Red-as-pointer — owners fix, this digest only points.', ''];
-
-    for (const outcome of outcomes) {
-        if (outcome.failures.length === 0 && outcome.ran && !outcome.note) continue;
-
-        lines.push(`**\`${outcome.config}\`** — ${outcome.failures.length} failing${outcome.note ? ` · ${outcome.note}` : ''}`);
-        for (const failure of outcome.failures) {
-            lines.push(`- \`${failure.location}\` — ${failure.title}: ${failure.firstError}`);
-        }
-        lines.push('');
-    }
-
-    lines.push(`Run log: \`${logPath}\``);
-    return lines.join('\n');
-}
-
-/**
  * @summary Executes the nightly run: hold the lock, run each declared config, and on ANY red push exactly one
  * normal-priority (mailbox-drain, never a wake storm) A2A digest. Green = silence. Always releases the lock.
  * @returns {Promise<Object>} run outcome `{red, sent, reason?}`.
@@ -162,7 +108,7 @@ export async function runNightlyE2e() {
 
     try {
         const outcomes = E2E_CONFIGS.map(runConfig),
-              red      = outcomes.some(o => o.failures.length > 0 || !o.ran);
+              red      = isRed(outcomes);
 
         await fs.writeJson(STATE_PATH, {
             at     : nowIso,

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eDigest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eDigest.spec.mjs
@@ -1,0 +1,86 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    collectFailures,
+    formatDigest,
+    isRed
+} from '../../../../../../ai/scripts/lifecycle/nightlyE2eDigest.mjs';
+
+// A Playwright json report with one failing spec nested under a suite + one passing sibling.
+const redReport = {
+    suites: [{
+        title : 'root',
+        file  : 'test/playwright/e2e/foo.spec.mjs',
+        specs : [{title: 'top-level passes', line: 10, ok: true, tests: [{results: [{status: 'passed'}]}]}],
+        suites: [{
+            title: 'nested',
+            file : 'test/playwright/e2e/foo.spec.mjs',
+            specs: [{
+                title: 'drives the thing',
+                file : 'test/playwright/e2e/foo.spec.mjs',
+                line : 42,
+                ok   : false,
+                tests: [{results: [{status: 'failed', errors: [{message: 'Error: expected running, got gated\n  at foo.spec.mjs:42:7'}]}]}]
+            }]
+        }]
+    }]
+};
+
+test.describe('nightlyE2eDigest (#14685 — pure parse/format core)', () => {
+    test('collectFailures walks nested suites and returns actionable pointers (title, file:line, FIRST error line)', () => {
+        const failures = collectFailures(redReport);
+
+        expect(failures).toHaveLength(1);
+        expect(failures[0]).toEqual({
+            title     : 'drives the thing',
+            location  : 'test/playwright/e2e/foo.spec.mjs:42',
+            firstError: 'Error: expected running, got gated'   // first non-empty line only, no stack
+        });
+    });
+
+    test('collectFailures returns [] for an all-green report — nothing to point at', () => {
+        const green = {suites: [{specs: [{title: 'ok', line: 1, ok: true, tests: [{results: [{status: 'passed'}]}]}]}]};
+        expect(collectFailures(green)).toEqual([]);
+    });
+
+    test('collectFailures is fail-open on a malformed/empty report (no suites, null)', () => {
+        expect(collectFailures(null)).toEqual([]);
+        expect(collectFailures({})).toEqual([]);
+        expect(collectFailures({suites: []})).toEqual([]);
+    });
+
+    test('collectFailures truncates a very long first-error line so the digest stays scannable', () => {
+        const long   = `Error: ${'x'.repeat(400)}`,
+              report = {suites: [{specs: [{title: 't', file: 'a.mjs', line: 1, ok: false, tests: [{results: [{status: 'failed', error: {message: long}}]}]}]}]},
+              row    = collectFailures(report)[0];
+
+        expect(row.firstError.endsWith('…')).toBe(true);
+        expect(row.firstError.length).toBeLessThanOrEqual(241);
+    });
+
+    test('isRed is true on a failing spec, true on an infra red (ran:false), false only when all clean-green', () => {
+        expect(isRed([{config: 'c', failures: [{}], ran: true}])).toBe(true);
+        expect(isRed([{config: 'c', failures: [], ran: false}])).toBe(true);   // infra/boot red, never swallowed
+        expect(isRed([{config: 'c', failures: [], ran: true}])).toBe(false);
+        expect(isRed([])).toBe(false);
+    });
+
+    test('formatDigest names the config, spec pointer, error, and run-log path; skips clean-green configs', () => {
+        const outcomes = [
+            {config: 'test/playwright/playwright.config.e2e.mjs', failures: collectFailures(redReport), ran: true, note: ''},
+            {config: 'test/playwright/playwright.config.other.mjs', failures: [], ran: true, note: ''}   // clean-green → omitted
+        ];
+        const digest = formatDigest(outcomes, '.neo-ai-data/nightly-e2e/logs/run-x.log');
+
+        expect(digest).toContain('surfaced RED');
+        expect(digest).toContain('**`test/playwright/playwright.config.e2e.mjs`** — 1 failing');
+        expect(digest).toContain('`test/playwright/e2e/foo.spec.mjs:42` — drives the thing: Error: expected running, got gated');
+        expect(digest).toContain('Run log: `.neo-ai-data/nightly-e2e/logs/run-x.log`');
+        expect(digest).not.toContain('config.other.mjs');   // clean-green config produces no line
+    });
+
+    test('formatDigest surfaces an infra red (no failing specs, but ran:false + note)', () => {
+        const digest = formatDigest([{config: 'c.mjs', failures: [], ran: false, note: 'runner exited 1 with no report (infra/boot failure)'}], 'log');
+        expect(digest).toContain('**`c.mjs`** — 0 failing · runner exited 1 with no report (infra/boot failure)');
+    });
+});

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eDigest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eDigest.spec.mjs
@@ -1,6 +1,10 @@
 import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import os             from 'node:os';
+import path           from 'node:path';
 
 import {
+    buildRunLog,
     collectFailures,
     formatDigest,
     isRed
@@ -82,5 +86,40 @@ test.describe('nightlyE2eDigest (#14685 — pure parse/format core)', () => {
     test('formatDigest surfaces an infra red (no failing specs, but ran:false + note)', () => {
         const digest = formatDigest([{config: 'c.mjs', failures: [], ran: false, note: 'runner exited 1 with no report (infra/boot failure)'}], 'log');
         expect(digest).toContain('**`c.mjs`** — 0 failing · runner exited 1 with no report (infra/boot failure)');
+    });
+
+    test('buildRunLog carries each config captured output into the log body (never a phantom)', () => {
+        const body = buildRunLog([
+            {config: 'a.mjs', output: '$ npx playwright test -c a.mjs\n42 passed'},
+            {config: 'b.mjs', note: 'runner exited 1 with no report (infra/boot failure)', output: '$ npx playwright test -c b.mjs\nboot timeout'}
+        ], '2026-07-04T00:00:00.000Z');
+
+        expect(body).toContain('# Nightly whitebox-e2e run 2026-07-04T00:00:00.000Z');
+        expect(body).toContain('## a.mjs');
+        expect(body).toContain('42 passed');
+        expect(body).toContain('## b.mjs — runner exited 1 with no report (infra/boot failure)');
+        expect(body).toContain('boot timeout');
+    });
+
+    test('buildRunLog marks a config that produced no captured output rather than emitting an empty section', () => {
+        expect(buildRunLog([{config: 'a.mjs'}])).toContain('(no captured output)');
+    });
+
+    test('the run-log path resolves to a real, non-empty file once written — the phantom-log regression', () => {
+        const outcomes = [{config: 'a.mjs', output: '$ npx playwright test -c a.mjs\n1 failed'}],
+              logPath  = path.join(os.tmpdir(), `neo-nightly-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`, 'run.log');
+
+        // Mirror the runner's write path exactly: ensure the logs dir, then write the built body.
+        fs.ensureDirSync(path.dirname(logPath));
+        fs.writeFileSync(logPath, buildRunLog(outcomes, '2026-07-04T00:00:00.000Z'), 'utf8');
+
+        try {
+            expect(fs.pathExistsSync(logPath)).toBe(true);
+            const onDisk = fs.readFileSync(logPath, 'utf8');
+            expect(onDisk.length).toBeGreaterThan(0);
+            expect(onDisk).toContain('1 failed');   // the digest's `Run log:` pointer now resolves to real content
+        } finally {
+            fs.removeSync(path.dirname(logPath));
+        }
     });
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/nightlyE2eRunner.spec.mjs
@@ -1,0 +1,73 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'NightlyE2eRunnerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import os             from 'node:os';
+import path           from 'node:path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+// runConfig imports the memory-core services at module load, so pull it in AFTER Neo is initialized.
+test.describe('nightlyE2eRunner.runConfig — stale-report suppression guard (#14685)', () => {
+    let runConfig, tmpDir;
+
+    test.beforeAll(async () => {
+        runConfig = (await import('../../../../../../ai/scripts/lifecycle/nightlyE2eRunner.mjs')).runConfig;
+    });
+
+    test.beforeEach(() => {
+        tmpDir = path.join(os.tmpdir(), `neo-nightly-runner-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        fs.ensureDirSync(tmpDir);
+    });
+
+    test.afterEach(() => {
+        fs.removeSync(tmpDir);
+    });
+
+    test('a stale green results.json cannot suppress a red — it is cleared before the run, so a no-report run scores infra-red', () => {
+        const results = path.join(tmpDir, 'results.json');
+
+        // A leftover GREEN report from a PRIOR run sits on disk.
+        fs.writeJsonSync(results, {suites: [{title: 'root', file: 'x.spec.mjs', specs: [{title: 'ok', line: 1, ok: true, tests: [{results: [{status: 'passed'}]}]}]}]});
+
+        // THIS run fails to boot and writes NO fresh report (non-zero exit, no results.json write).
+        const fakeSpawn = () => ({status: 1, stdout: '', stderr: 'boot failed'});
+
+        const outcome = runConfig({config: 'e2e.config.mjs', results}, {spawn: fakeSpawn});
+
+        // The stale green must NOT be read as this run's result — it surfaces as an infra red, never green.
+        expect(outcome.ran).toBe(false);
+        expect(outcome.note).toContain('infra/boot failure');
+        expect(outcome.failures).toEqual([]);
+        expect(fs.pathExistsSync(results)).toBe(false);   // stale cleared; this run wrote none
+    });
+
+    test('a FRESH report written by the run is still read (the clear only removes STALE output)', () => {
+        const results = path.join(tmpDir, 'results.json');
+
+        // The run writes a fresh FAILING report as it executes (runConfig clears stale first, then spawns).
+        const fakeSpawn = () => {
+            fs.writeJsonSync(results, {suites: [{title: 'root', file: 'x.spec.mjs', specs: [{title: 'boom', file: 'x.spec.mjs', line: 3, ok: false, tests: [{results: [{status: 'failed', errors: [{message: 'Error: boom\n  at x.spec.mjs:3:1'}]}]}]}]}]});
+            return {status: 1, stdout: '', stderr: ''};
+        };
+
+        const outcome = runConfig({config: 'e2e.config.mjs', results}, {spawn: fakeSpawn});
+
+        expect(outcome.ran).toBe(true);
+        expect(outcome.failures.length).toBe(1);
+        expect(outcome.failures[0].title).toBe('boom');
+    });
+});


### PR DESCRIPTION
Resolves #14685

**Ready — runner core + pure-logic unit coverage + staged plist + activation docs all landed (commits 1–3). The live red/green dry-run + cross-family review are the remaining Post-Merge / gate items.**

The unattended quality heartbeat. e2e lives OUTSIDE CI by design (failing-honest discipline — a whitebox proof may be legitimately red without blocking a merge), but nothing ran it on a schedule, so red states sat undiscovered (the 3-week middleware staleness failure mode). This runs the declared whitebox-e2e configs nightly and, on ANY red, pushes ONE mailbox-drain-class A2A digest — red-as-pointer made push, not pull.

## What landed (commit 1)
`ai/scripts/lifecycle/nightlyE2eRunner.mjs` — `runNightlyE2e()`:
- **Lockfile hygiene:** an exclusive PID lockfile with 6h stale-steal; a fresh lock aborts rather than double-running the suite; `finally` always releases it.
- **Custom-config-only:** runs each header-declared config via `-c <config>` — never the default `npx playwright test` (the inherited critical rule).
- **Red-only digest:** parses each config's `json` reporter output, collects failing specs (title · `file:line` · first-error line, no full stack), and on any red sends ONE `normal`-priority (mailbox-drain, never a wake storm) A2A digest to `AGENT:*` via the `@system` / `MailboxService.addMessage` pattern. Green runs are **silent**.
- **Infra-red honesty:** a non-zero exit with no parseable report is surfaced as an infra/boot red, not swallowed as green.
- **Additive config list** declared in the module header (append as dock e2e, FM NL-proofs, tour-replay suites land).

## Deltas from ticket
- Placement is `ai/scripts/lifecycle/` (sibling to `swarmWakeCooldown.mjs`), not a new dir — that sibling IS the lifecycle-script + `@system`-A2A-send precedent, lifted verbatim (structural-pre-flight fast-path).
- The `#12964` middleware LaunchAgent precedent is cross-repo; its hardening *pattern* (lockfile, stale-steal, structured stderr, finally-hygiene) is followed here; the plist itself is authored fresh in the next commit.

## Test Evidence
Evidence: L2 (unit — 7 `nightlyE2eDigest` specs green: nested-suite parse, all-green→[], fail-open, first-error truncation, `isRed`, digest formatting, infra-red) → L2 achieved for the pure parse/format core. The runner's live I/O (spawn playwright → parse → A2A digest) is exercised by the Post-Merge dry-run — it needs a scheduled host, the sandbox ceiling here.
- `npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/nightlyE2eDigest.spec.mjs` → **7 passed** (commit 2).
- `node --check` valid; `check-jsdoc-types` 0 unparseable; `check-ticket-archaeology` clean; block-alignment clean.

## Post-Merge Validation
- [x] Unit coverage for the pure parse/format core (7 specs; commit 2, service-free module so the spec needn't load memory-core services).
- [x] Staged-not-auto-installed `.plist` + activation README under `ai/scripts/lifecycle/nightly-e2e/` (commit 3).
- [ ] One live nightly dry-run: install the plist, `launchctl kickstart`, confirm a deliberately-red suite → digest arrives and green → silence (needs a scheduled runner host — sandbox ceiling).
- [ ] Cross-family review.

Related: #14705 (the review where I surfaced this e2e-not-guarded [TOOLING_GAP]) · #14591 / #14563-class (the e2e suites this guards) · the middleware-scheduler LaunchAgent precedent.

Authored by Ada (Claude Opus 4.8, Claude Code). Session 9a6b25ba-1dd8-4269-8fbf-57a461fd0978.
