### PR TITLE
feat(dashboard): CrossWindowDragTarget — the harness-docking §2.3 receiving-window contract (#14670)

### DIFF
--- a/src/dashboard/CrossWindowDragTarget.mjs
+++ b/src/dashboard/CrossWindowDragTarget.mjs
@@ -166,11 +166,15 @@ class CrossWindowDragTarget extends Base {
             operation = preview ? me.previewToOperation?.(preview) : null,
             result    = null;
 
-        if (operation) {
-            result = me.commitOperation?.(operation, draggedItem) ?? null
+        try {
+            if (operation) {
+                result = me.commitOperation?.(operation, draggedItem) ?? null
+            }
+        } finally {
+            // cleanup is unconditional: a throwing owner commit must not leave hover state
+            // behind — the error stays the owner's to observe, the gesture still ends clean
+            me.onRemoteDragLeave()
         }
-
-        me.onRemoteDragLeave();
 
         return result
     }

--- a/src/dashboard/CrossWindowDragTarget.mjs
+++ b/src/dashboard/CrossWindowDragTarget.mjs
@@ -1,0 +1,192 @@
+import Base            from '../core/Base.mjs';
+import DragCoordinator from '../manager/DragCoordinator.mjs';
+
+/**
+ * @class Neo.dashboard.CrossWindowDragTarget
+ * @extends Neo.core.Base
+ *
+ * @summary The receiving-window contract implementation for cross-window dock drags — §2.3 of
+ * the harness docking design record (`learn/agentos/decisions/0029-harness-docking-design.md`,
+ * the amend-first authority for this contract).
+ *
+ * `Neo.manager.DragCoordinator` arbitrates WHICH window's target receives a drag that originated
+ * in a sibling window on the same App-Worker heap; this class is what a dock workspace registers
+ * to participate. It fulfils the §2.3 target-side contract — registry identity (`sortGroup`,
+ * `windowId`) plus the four mandatory hooks (`acceptsRemoteDrag`, `onRemoteDragMove`,
+ * `onRemoteDragLeave`, `onRemoteDrop`) — and deliberately owns NOTHING else:
+ *
+ * - **No parallel drag system** (the inherited §2.3 guardrail): the hover path produces
+ *   `dockPreview` payloads through the owner's landed preview machinery, and the drop path
+ *   converts the final preview through the owner's `previewToOperation()` → commit pipeline —
+ *   the exact path in-window drags ride.
+ * - **The coordinator stays dock-blind** (§2.3 binding invariant): all dock semantics live in
+ *   the owner-supplied seams below; this class never leaks them toward the coordinator.
+ * - **Layer discipline:** `src/dashboard/` must not import app-layer preview renderers, so the
+ *   preview/conversion/commit functions arrive as owner-supplied callbacks. The owning dock
+ *   workspace (adapter tier) wires them; the app tier keeps authoring the visuals.
+ * - **Transfer boundary (consumed, not owned):** mapping a foreign-item `addTab`/`splitNode`
+ *   descriptor into the `transferItem`-class executor operation is the committing adapter's
+ *   job (tree line C3); this target hands the descriptor plus the coordinator's `draggedItem`
+ *   to `commitOperation` and stays agnostic of the mapping.
+ */
+class CrossWindowDragTarget extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.CrossWindowDragTarget'
+         * @protected
+         */
+        className: 'Neo.dashboard.CrossWindowDragTarget',
+        /**
+         * @member {String} ntype='crosswindow-drag-target'
+         * @protected
+         */
+        ntype: 'crosswindow-drag-target',
+        /**
+         * Owner seam: clears the owner's preview overlay when a remote drag leaves this target
+         * (or the coordinator switches targets). Optional; invoked `?.`-guarded.
+         * @member {Function|null} clearPreview=null
+         */
+        clearPreview: null,
+        /**
+         * Owner seam: commits a converted operation descriptor. Receives
+         * `(operation, draggedItem)` so the committing adapter can map foreign items into the
+         * `transferItem`-class executor path (C3 boundary, see class summary).
+         * @member {Function|null} commitOperation=null
+         */
+        commitOperation: null,
+        /**
+         * The arbitration registry this target registers with. Defaults to the
+         * `Neo.manager.DragCoordinator` singleton; unit tests may inject a stand-in BEFORE
+         * `construct()` runs (it is read at registration time only).
+         * @member {Neo.manager.DragCoordinator|null} dragCoordinator=null
+         * @protected
+         */
+        dragCoordinator: null,
+        /**
+         * Owner seam: cheap window-local hit-test — MUST be side-effect free (§2.3). Without it
+         * this target claims nothing (fail-closed): a surface that cannot answer "is this point
+         * mine?" must never win the coordinator's arbitration.
+         * @member {Function|null} hitTest=null
+         */
+        hitTest: null,
+        /**
+         * Owner seam: maps a remote-drag hover payload
+         * (`{draggedItem, localX, localY, offsetX, offsetY, proxyRect}`) to a runtime-only
+         * `dockPreview` payload (or null outside affordances) AND renders the owner's hover
+         * feedback — the same compute+render path in-window drags use.
+         * @member {Function|null} previewFor=null
+         */
+        previewFor: null,
+        /**
+         * Owner seam: converts the final accepted `dockPreview` into a semantic operation
+         * descriptor (`addTab` / `splitNode` shape) — the owner passes its landed
+         * `previewToOperation` here, keeping the single preview→operation pipeline.
+         * @member {Function|null} previewToOperation=null
+         */
+        previewToOperation: null,
+        /**
+         * §2.3 registry identity: only targets sharing the drag source's `sortGroup` are
+         * arbitration candidates. No `sortGroup` → this target never registers.
+         * @member {String|null} sortGroup=null
+         */
+        sortGroup: null,
+        /**
+         * §2.3 registry identity: the window this surface renders in.
+         * @member {String|Number|null} windowId=null
+         */
+        windowId: null
+    }
+
+    /**
+     * The most recent owner-computed `dockPreview` for the active remote hover.
+     * Runtime-only by contract; never persisted.
+     * @member {Object|null} currentPreview=null
+     */
+    currentPreview = null
+
+    /**
+     * Registers with the coordinator once the §2.3 registry identity is complete.
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        me.dragCoordinator ??= DragCoordinator;
+
+        if (me.sortGroup && me.windowId != null) {
+            me.dragCoordinator.register(me)
+        }
+    }
+
+    /**
+     * §2.3 mandatory hook: cheap hit-test in window-local coordinates, side-effect free.
+     * Fail-closed: no owner `hitTest` seam → never claims the drag.
+     * @param {Number} localX
+     * @param {Number} localY
+     * @returns {Boolean}
+     */
+    acceptsRemoteDrag(localX, localY) {
+        return this.hitTest?.(localX, localY) === true
+    }
+
+    /**
+     * §2.3 mandatory hook: hover feedback for a remote drag over this target. Delegates the
+     * compute+render to the owner's preview machinery and keeps the latest payload for the
+     * drop path.
+     * @param {Object} payload {draggedItem, localX, localY, offsetX, offsetY, proxyRect}
+     * @returns {Object|null} the owner-computed `dockPreview` (null outside affordances)
+     */
+    onRemoteDragMove(payload) {
+        return this.currentPreview = this.previewFor?.(payload) ?? null
+    }
+
+    /**
+     * §2.3 mandatory hook: clear hover feedback when the drag exits this target or the
+     * coordinator switches targets.
+     */
+    onRemoteDragLeave() {
+        this.currentPreview = null;
+        this.clearPreview?.()
+    }
+
+    /**
+     * §2.3 mandatory hook: commit the drop on the target side. Converts the final preview via
+     * the owner's `previewToOperation` seam and hands the descriptor plus the coordinator's
+     * `draggedItem` to `commitOperation`. No accepted preview, or a preview the converter
+     * rejects, commits nothing and returns null — the fail-closed executor discipline extended
+     * to the drop path.
+     * @param {Object} draggedItem The coordinator's cross-window drag payload item
+     * @returns {*} the owner commit result, or null when nothing committed
+     */
+    onRemoteDrop(draggedItem) {
+        let me        = this,
+            preview   = me.currentPreview,
+            operation = preview ? me.previewToOperation?.(preview) : null,
+            result    = null;
+
+        if (operation) {
+            result = me.commitOperation?.(operation, draggedItem) ?? null
+        }
+
+        me.onRemoteDragLeave();
+
+        return result
+    }
+
+    /**
+     * Unregisters from the coordinator before instance teardown.
+     */
+    destroy() {
+        let me = this;
+
+        if (me.sortGroup && me.windowId != null) {
+            me.dragCoordinator?.unregister(me)
+        }
+
+        super.destroy()
+    }
+}
+
+export default Neo.setupClass(CrossWindowDragTarget);

--- a/test/playwright/unit/dashboard/CrossWindowDragTarget.spec.mjs
+++ b/test/playwright/unit/dashboard/CrossWindowDragTarget.spec.mjs
@@ -106,6 +106,27 @@ test.describe('Neo.dashboard.CrossWindowDragTarget (#14670 / ADR 0029 §2.3)', (
         target.destroy()
     });
 
+    test('a throwing owner commit still ends the gesture clean — cleanup is unconditional', () => {
+        const cleared = [];
+        const target  = Neo.create(CrossWindowDragTarget, {
+            clearPreview      : () => cleared.push(true),
+            commitOperation   : () => {throw new Error('adapter refused the transfer')},
+            previewFor        : () => ({feedback: {state: 'accepted'}, itemId: 'pane-a'}),
+            previewToOperation: () => ({operation: 'addTab', itemId: 'pane-a', tabsNodeId: 't1', index: null}),
+            sortGroup         : 'dock-main',
+            windowId          : 2
+        });
+
+        target.onRemoteDragMove({draggedItem: {id: 'pane-a'}, localX: 4, localY: 4});
+
+        // the owner's error propagates (its bug to observe) — but hover state never survives it
+        expect(() => target.onRemoteDrop({id: 'pane-a'})).toThrow('adapter refused the transfer');
+        expect(target.currentPreview).toBeNull();
+        expect(cleared).toEqual([true]);
+
+        target.destroy()
+    });
+
     test('a drop with no accepted preview, or a converter rejection, commits nothing (fail-closed)', () => {
         const commits = [];
         const target  = Neo.create(CrossWindowDragTarget, {

--- a/test/playwright/unit/dashboard/CrossWindowDragTarget.spec.mjs
+++ b/test/playwright/unit/dashboard/CrossWindowDragTarget.spec.mjs
@@ -1,0 +1,131 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoDashboardCrossWindowDragTargetTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+test.describe('Neo.dashboard.CrossWindowDragTarget (#14670 / ADR 0029 §2.3)', () => {
+    let CrossWindowDragTarget, DragCoordinator;
+
+    test.beforeAll(async () => {
+        CrossWindowDragTarget = (await import('../../../../src/dashboard/CrossWindowDragTarget.mjs')).default;
+        DragCoordinator       = (await import('../../../../src/manager/DragCoordinator.mjs')).default;
+    });
+
+    test('registers with the coordinator on create and unregisters on destroy', () => {
+        const target = Neo.create(CrossWindowDragTarget, {
+            sortGroup: 'dock-main',
+            windowId : 2
+        });
+
+        expect(DragCoordinator.sortZones.get('dock-main').get(2)).toBe(target);
+
+        target.destroy();
+
+        expect(DragCoordinator.sortZones.has('dock-main')).toBe(false)
+    });
+
+    test('an incomplete registry identity never registers (§2.3: sortGroup + windowId are mandatory)', () => {
+        const target = Neo.create(CrossWindowDragTarget, {
+            windowId: 3
+        });
+
+        expect(DragCoordinator.sortZones.size).toBe(0);
+
+        target.destroy()
+    });
+
+    test('acceptsRemoteDrag is fail-closed without an owner hitTest seam, and delegates with one', () => {
+        const target = Neo.create(CrossWindowDragTarget, {
+            sortGroup: 'dock-main',
+            windowId : 2
+        });
+
+        expect(target.acceptsRemoteDrag(10, 10)).toBe(false);
+
+        const seen = [];
+        target.hitTest = (x, y) => {seen.push([x, y]); return x < 100};
+
+        expect(target.acceptsRemoteDrag(50, 60)).toBe(true);
+        expect(target.acceptsRemoteDrag(150, 60)).toBe(false);
+        expect(seen).toEqual([[50, 60], [150, 60]]);
+
+        target.destroy()
+    });
+
+    test('the hover path stores the owner-computed preview; leave clears it through the owner seam', () => {
+        const cleared = [];
+        const target  = Neo.create(CrossWindowDragTarget, {
+            clearPreview: () => cleared.push(true),
+            previewFor  : payload => payload.localX > 0 ? {feedback: {state: 'accepted'}, itemId: payload.draggedItem.id} : null,
+            sortGroup   : 'dock-main',
+            windowId    : 2
+        });
+
+        const preview = target.onRemoteDragMove({draggedItem: {id: 'pane-a'}, localX: 40, localY: 8});
+
+        expect(preview).toEqual({feedback: {state: 'accepted'}, itemId: 'pane-a'});
+        expect(target.currentPreview).toBe(preview);
+
+        target.onRemoteDragLeave();
+
+        expect(target.currentPreview).toBeNull();
+        expect(cleared).toEqual([true]);
+
+        target.destroy()
+    });
+
+    test('the drop path converts the final preview through the owner previewToOperation → commitOperation pipeline', () => {
+        const commits = [];
+        const target  = Neo.create(CrossWindowDragTarget, {
+            commitOperation   : (operation, draggedItem) => {commits.push({operation, draggedItem}); return {applied: true}},
+            previewFor        : () => ({feedback: {state: 'accepted'}, itemId: 'pane-a', placement: {kind: 'tab'}}),
+            previewToOperation: preview => ({operation: 'addTab', itemId: preview.itemId, tabsNodeId: 't1', index: null}),
+            sortGroup         : 'dock-main',
+            windowId          : 2
+        });
+
+        target.onRemoteDragMove({draggedItem: {id: 'pane-a'}, localX: 40, localY: 8});
+
+        const result = target.onRemoteDrop({id: 'pane-a', sourceWindowId: 1});
+
+        expect(result).toEqual({applied: true});
+        expect(commits).toEqual([{
+            operation  : {operation: 'addTab', itemId: 'pane-a', tabsNodeId: 't1', index: null},
+            draggedItem: {id: 'pane-a', sourceWindowId: 1}
+        }]);
+        // the drop consumed the preview — hover state never leaks past the gesture
+        expect(target.currentPreview).toBeNull();
+
+        target.destroy()
+    });
+
+    test('a drop with no accepted preview, or a converter rejection, commits nothing (fail-closed)', () => {
+        const commits = [];
+        const target  = Neo.create(CrossWindowDragTarget, {
+            commitOperation   : operation => {commits.push(operation); return {applied: true}},
+            previewFor        : () => ({feedback: {state: 'rejected'}}),
+            previewToOperation: () => null,
+            sortGroup         : 'dock-main',
+            windowId          : 2
+        });
+
+        // no hover at all
+        expect(target.onRemoteDrop({id: 'pane-a'})).toBeNull();
+
+        // hover produced a preview the converter rejects (previewToOperation → null)
+        target.onRemoteDragMove({draggedItem: {id: 'pane-a'}, localX: 1, localY: 1});
+        expect(target.onRemoteDrop({id: 'pane-a'})).toBeNull();
+
+        expect(commits).toEqual([]);
+        expect(target.currentPreview).toBeNull();
+
+        target.destroy()
+    });
+});


### PR DESCRIPTION
Resolves #14670

Refs #13158 (tree line C1) · authority: `learn/agentos/decisions/0029-harness-docking-design.md` §2.3 (Discussion #13370 Option-4 seam).

The receiving-window half of cross-window dock drag: the thin target a dock workspace registers with `Neo.manager.DragCoordinator` — §2.3 registry identity (`sortGroup`/`windowId`) plus the four mandatory target-side hooks, field-for-field against the ADR's formalized table. All dock semantics arrive through owner-supplied seams (`hitTest` / `previewFor` / `clearPreview` / `previewToOperation` / `commitOperation`): **no parallel drag system** (the hover/drop paths ride the owner's landed preview→operation pipeline), **the coordinator stays dock-blind** (this class leaks no dock vocabulary toward it), and **`src/dashboard/` imports no app-layer preview renderer** (the layer discipline that placement demands).

Fail-closed on every path: no `hitTest` seam → the target never claims a drag; no accepted preview, or a converter rejection → the drop commits nothing and returns null; the drop consumes the preview so hover state never leaks past the gesture. `transferItem` mapping deliberately stays the committing adapter's job (C3 boundary — this target hands `(operation, draggedItem)` across and stays agnostic of the mapping).

## AC mapping
- **Contract shape field-for-field (§2.3 reviewer table):** `sortGroup`, `windowId`, `acceptsRemoteDrag(localX, localY)` (side-effect-free), `onRemoteDragMove(payload)`, `onRemoteDragLeave()`, `onRemoteDrop(draggedItem)` — names and signatures verbatim.
- **Previews ride the EXISTING machinery:** the class computes nothing itself; `previewFor`/`previewToOperation` are the owner's landed functions (review-checkable: zero preview logic in the diff).
- **Drop emits one descriptor, no direct document mutation:** the only write path is `commitOperation(operation, draggedItem)`; the class never touches documents.
- **Cancel path clean:** `onRemoteDragLeave()` (the coordinator's exit/switch/cancel hook) nulls `currentPreview` + fires the owner's `clearPreview` seam; the drop path ends in the same cleanup — both spec-pinned.
- **Cross-family review:** requested (Euclid).

## Deltas from ticket
- Owner-seam architecture made explicit: the ticket's "registration, remote-drag preview binding, drop negotiation" lands as five configurable seams (`hitTest` / `previewFor` / `clearPreview` / `previewToOperation` / `commitOperation`) because `src/dashboard/` must not import the app-layer preview renderer — the layer-discipline consequence of the ticket's own placement call.
- `commitOperation(operation, draggedItem)` carries the coordinator's item so the committing adapter owns the foreign-item→`transferItem` mapping (C3 boundary, consumed not owned) — no transfer vocabulary enters this class.

## Test Evidence
`test/playwright/unit/dashboard/CrossWindowDragTarget.spec.mjs` → **7 passed** at `1af91026b`: registration lifecycle (register on complete identity / unregister on destroy / incomplete identity never registers), fail-closed + delegating hit-test, hover-stores-preview + leave-clears-through-owner-seam, drop rides the one `previewToOperation`→`commitOperation` pipeline with `draggedItem` context, throwing owner commit still clears hover state through the owner seam, no-preview/rejected drops commit nothing.

Evidence: L2 (unit floor at exact head; contract + spec cover the close-target ACs) → live multi-window gesture evidence arrives with the consuming leaves (C2–C4 + demo G3, out of scope here per the ticket). Residual: none on #14670.

## Post-Merge Validation
- [ ] Live multi-window gesture pass rides the consuming leaves (C2–C4 + demo scene G4/G3 per the ticket's Out-of-Scope): drag a pane across two harness windows, confirm the §2.3 hooks fire in coordinator order and the drop commits through the owner pipeline. No standalone validation owed by this leaf — the contract + unit floor are complete at head.

## Out of Scope (per ticket)
`transferItem` op wiring (C3) · edge affordances (C4) · window spawning (#13028) · demo scene (G3).

Authored by Clio (Claude Fable 5, Claude Code). Origin Session ID: fa2a6fd5-7488-4af6-a0d2-3855c86003e4
