### PR TITLE
feat(agentos): AgentCard resident card — composes class primitives + avatar (#14755)

### DIFF
--- a/apps/agentos/resources/fleet-components.css
+++ b/apps/agentos/resources/fleet-components.css
@@ -85,3 +85,53 @@
         50%      { opacity: .5 }
     }
 }
+
+/* Agent card: the resident's anatomy — family rail · avatar · body (name-row + lane line). COLOR
+   stays in the token layer (tokens.css); this carries geometry + the avatar frame only. */
+.fm-agent-card {
+    align-items: stretch;
+    gap        : 8px;
+    padding    : 8px 10px;
+}
+
+.fm-agent-card .fm-card-avatar {
+    width        : 40px;
+    height       : 40px;
+    flex         : none;
+    border-radius: 50%;
+    object-fit   : cover;
+    background   : color-mix(in srgb, var(--fm-ink-dim) 20%, transparent);
+}
+
+.fm-agent-card .fm-card-body {
+    gap     : 2px;
+    overflow: hidden;
+}
+
+.fm-agent-card .fm-card-name-row {
+    gap: 6px;
+}
+
+.fm-agent-card .fm-card-name {
+    flex         : 1;
+    font-weight  : 600;
+    color        : var(--fm-ink);
+    overflow     : hidden;
+    white-space  : nowrap;
+    text-overflow: ellipsis;
+}
+
+.fm-agent-card .fm-card-engine {
+    flex       : none;
+    font-family: var(--fm-font-mono);
+    font-size  : 10px;
+    color      : var(--fm-ink-dim);
+}
+
+.fm-agent-card .fm-card-lane {
+    font-size    : 11px;
+    color        : var(--fm-ink-dim);
+    overflow     : hidden;
+    white-space  : nowrap;
+    text-overflow: ellipsis;
+}

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -1,0 +1,118 @@
+import Container     from '../../../../src/container/Base.mjs';
+import FamilyRail    from './FamilyRail.mjs';
+import Image         from '../../../../src/component/Image.mjs';
+import StateDot      from './StateDot.mjs';
+import StateProvider from '../../../../src/state/Provider.mjs';
+
+/**
+ * The resident card: the cockpit's atom. Composes the class-based fleet primitives (FamilyRail +
+ * StateDot) with a profile avatar, name, engine tag, and current-lane line into the SSOT card
+ * anatomy.
+ *
+ * **Data-driven from a per-card `state.Provider`** — the resident's display fields live in one place
+ * (`stateProvider.data`) and every child `bind`s to it, so the whole card is ONE binding surface. A
+ * consumer sets the fields at creation (`stateProvider: {data: {...}}`) or reactively via
+ * `card.setState('displayName', …)`; there is no per-field config to thread.
+ *
+ * Render rules at card grain (the institution-cockpit render-model): **avatar**, **displayName**, and
+ * **engineTag** are mutable versioned DISPLAY STATE over the durable `agentId` — setState on any of
+ * them re-renders in place on the SAME card instance and NEVER re-keys (identity is the id, not the
+ * presentation). The **family** rail rebinds in place on a family swap. Session **state** is what the
+ * resident is doing now, never identity.
+ *
+ * The live roster / runtime-status wire binding and the NL-verified card wall are sibling leaves; this
+ * leaf is the card component itself.
+ *
+ * @class AgentOS.view.fleet.AgentCard
+ * @extends Neo.container.Base
+ */
+class AgentCard extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.AgentCard'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.AgentCard',
+        /**
+         * @member {String} ntype='fm-agent-card'
+         * @protected
+         */
+        ntype: 'fm-agent-card',
+        /**
+         * @member {String[]} baseCls=['fm-agent-card']
+         */
+        baseCls: ['fm-agent-card'],
+        /**
+         * @member {Object} layout={ntype:'hbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'hbox', align: 'stretch'},
+        /**
+         * The per-card binding surface. `agentId` is the DURABLE identity — the one field that is
+         * never presentation, never re-keyed; every other field is display state over it.
+         * Session `state` is what the resident is doing now. Every child binds to these.
+         * @member {Object} stateProvider
+         */
+        stateProvider: {
+            module: StateProvider,
+            data  : {
+                agentId    : null,
+                avatarUrl  : null,
+                displayName: null,
+                engineTag  : null,
+                family     : null,
+                laneLine   : null,
+                state      : 'off'
+            }
+        },
+        /**
+         * The card anatomy — family rail · avatar · body (name-row [state dot + name + engine tag] +
+         * current-lane line). Each child binds to the per-card provider. Controls slot (T5) + foot
+         * meta are sibling leaves.
+         * @member {Object[]} items
+         */
+        items: [{
+            module: FamilyRail,
+            flex  : 'none',
+            bind  : {family: data => data.family}
+        }, {
+            module: Image,
+            cls   : ['fm-card-avatar'],
+            flex  : 'none',
+            bind  : {src: data => data.avatarUrl, alt: data => data.displayName}
+        }, {
+            ntype : 'container',
+            cls   : ['fm-card-body'],
+            flex  : 1,
+            layout: {ntype: 'vbox', align: 'stretch'},
+
+            items: [{
+                ntype : 'container',
+                cls   : ['fm-card-name-row'],
+                layout: {ntype: 'hbox', align: 'center'},
+
+                items: [{
+                    module: StateDot,
+                    flex  : 'none',
+                    bind  : {state: data => data.state}
+                }, {
+                    ntype: 'component',
+                    cls  : ['fm-card-name'],
+                    flex : 1,
+                    bind : {text: data => data.displayName}
+                }, {
+                    ntype: 'component',
+                    cls  : ['fm-card-engine'],
+                    flex : 'none',
+                    bind : {text: data => data.engineTag}
+                }]
+            }, {
+                ntype: 'component',
+                cls  : ['fm-card-lane'],
+                bind : {text: data => data.laneLine}
+            }]
+        }]
+    }
+}
+
+export default Neo.setupClass(AgentCard);

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -1,0 +1,80 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FleetAgentCardTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import Instance       from '../../../../../../../src/manager/Instance.mjs';
+
+test.describe('Fleet cockpit AgentCard — resident card composing the class primitives + avatar (#14755)', () => {
+    let AgentCard;
+
+    const readData = (card, key) => card.getStateProvider().getDataConfig(key).get();
+
+    const createCard = data => Neo.create(AgentCard, {appName, stateProvider: {data}});
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../apps/agentos/view/fleet/AgentCard.mjs');
+        AgentCard = mod.default
+    });
+
+    test('is a data-driven card composing the class primitives + the avatar — one provider surface', () => {
+        const card = createCard({
+            agentId: 'vega', avatarUrl: 'vega.png', displayName: 'Vega', family: 'claude', engineTag: 'opus-4.8', state: 'wedged'
+        });
+
+        // the per-card provider is the single binding surface (data-driven, no per-field config threading)
+        expect(card.getStateProvider()).not.toBeNull();
+        expect(readData(card, 'state')).toBe('wedged');
+        expect(readData(card, 'family')).toBe('claude');
+        expect(readData(card, 'avatarUrl')).toBe('vega.png');
+
+        // composes the class primitives (FamilyRail + StateDot) and the avatar Image
+        expect(card.down({ntype: 'fm-family-rail'})).toBeTruthy();
+        expect(card.down({ntype: 'fm-state-dot'})).toBeTruthy();
+        expect(card.down({ntype: 'image'})).toBeTruthy();
+
+        card.destroy()
+    });
+
+    test('ADR-0032: avatar/name/engine are display state over the durable id — setState re-renders in place, never a re-key', () => {
+        const card     = createCard({agentId: 'vega', displayName: 'Vega', avatarUrl: 'a.png', engineTag: 'opus-4.8', state: 'ok'});
+        const beforeId = card.id;
+
+        card.setState({displayName: 'Vega (renamed)', avatarUrl: 'b.png', engineTag: 'fable-5'});
+
+        // the SAME instance — identity is the durable agentId, not the presentation
+        expect(card.id).toBe(beforeId);
+        expect(readData(card, 'agentId')).toBe('vega');
+        expect(readData(card, 'displayName')).toBe('Vega (renamed)');
+        expect(readData(card, 'avatarUrl')).toBe('b.png');
+        expect(readData(card, 'engineTag')).toBe('fable-5');
+        // a display-state change never disturbs the session-state axis
+        expect(readData(card, 'state')).toBe('ok');
+
+        card.destroy()
+    });
+
+    test('family rebind in place (§2.3.3) — a cross-family swap is the SAME resident, not a new self', () => {
+        const card     = createCard({agentId: 'vega', family: 'claude', state: 'ok'});
+        const beforeId = card.id;
+
+        card.setState('family', 'gpt');
+
+        expect(card.id).toBe(beforeId);
+        expect(readData(card, 'family')).toBe('gpt')
+
+        card.destroy()
+    });
+});


### PR DESCRIPTION
Resolves #14755 · Refs #14598 (AgentCard epic — the resident card wall) · Refs #14560 (FM cockpit UI/UX epic) · Refs #14445 (institution-cockpit render-model / ADR-0032)

The pattern-setting Fleet Manager composer: the resident **AgentCard**. @tobiu directed profile avatars per card (*"agent cards need profile avatars => we spend quite the effort to create one for each you"*) — this builds the card **class-based** (the operator's functional→class veto, VBA-confirmed apps/ is 320:9 class), composing the merged class primitives (StateDot #14746 + FamilyRail #14747).

Evidence: L2 — `agentCard.spec.mjs` **3/3 green** (one provider surface + composition; ADR-0032 display-state-over-durable-id re-render-in-place; family rebind-in-place).

## What it builds

A class `Container` (`extends Neo.container.Base`, the `src/component/Chip.mjs` idiom) composing:
- **FamilyRail** (class primitive) — bound to `family`, the era-tint rail.
- **profile-avatar `Image`** — bound `src: avatarUrl`, `alt: displayName` (the operator's avatar directive; a resident's `metadata.avatarUrl` flows onto the card as display state).
- **StateDot** (class primitive) — bound to `state`, the agent-health dot.
- **name / engine-tag / current-lane** — bound to `displayName` / `engineTag` / `laneLine`.

**One binding surface** — a per-card `state.Provider` holds the resident's display fields; every child `bind`s to it. A consumer creates the card with the resident's row (`stateProvider: {data: {...}}`) or mutates reactively via `card.setState('displayName', …)`. There is no per-field config to thread through the tree.

**Render-model (ADR-0032):** `avatarUrl` / `displayName` / `engineTag` are mutable versioned DISPLAY STATE over the durable `agentId` — a setState re-renders the SAME card in place and NEVER re-keys (identity is the id, not the presentation). The **family** rail rebinds in place on a cross-family swap. Session **state** is what the resident is doing now, never identity.

## Test Evidence

`npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs` → **3 passed**:
1. a data-driven card composes FamilyRail + StateDot + the avatar Image through one provider surface.
2. ADR-0032 — a display-state setState (avatar/name/engine) re-renders in place (same instance id, durable `agentId` unchanged, session-state axis undisturbed).
3. family rebinds in place — a cross-family swap is the SAME resident, not a new self.

Composer unit-test note (friction→gold for the next FM composer): a Container-composer with declarative child `bind`s needs the `manager/Instance` import in the spec — the binds resolve via `Neo.get` during child construct, and without it the whole construct aborts (a silent-looking `getStateProvider() === null`).

## Post-Merge Validation

- [ ] With this on dev, the FM card component exists class-based; the sibling leaves under #14598 (live-wire data binding — roster #14571 / runtime-status #14595, no-mock — and the NL-verified card-wall mount) build on it.
- [ ] The `.fm-agent-card` anatomy renders coherently at the card wall (hbox: rail · avatar · body[name-row + lane]); token-only colors, no hand-rolled palette.

## Deltas from ticket

This leaf is the card **component** + its unit spec + the `.fm-agent-card` CSS anatomy. Live-wire data binding (roster/runtime-status, no-mock) and the NL-verified card-wall mount are **sibling leaves** of #14598, not this one. The avatar is wired to the `avatarUrl` display-state field here; the per-agent avatar *assets* and the `FleetManager.setAvatar` write-surface are the data side (separate lane).

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
