### PR TITLE
docs(skills): factor render-verify-Mermaid discipline into blog-post + release-notes (#14558)

### DIFF
--- a/.agents/skills/blog-post/references/blog-authoring-guide.md
+++ b/.agents/skills/blog-post/references/blog-authoring-guide.md
@@ -1,6 +1,6 @@
 # Blog Post Authoring Guide
 
-Fires when you author or revise a public-facing blog post: `learn/blog/<slug>.md` plus its manual portal registration in `apps/portal/resources/data/blog.json` (year node + leaf). The SEO surfaces (`apps/portal/sitemap.xml`, `apps/portal/llms.txt`) are **generated, not hand-edited** — see §5. This is the blog sibling of the release-notes hero-piece methodology and the `update-roadmap` beat.
+Fires when you author or revise a public-facing blog post: `learn/blog/<slug>.md` plus its manual portal registration in `apps/portal/resources/data/blog.json` (year node + leaf). The SEO surfaces are **generated, not hand-edited** — see §5. Sibling of the release-notes + `update-roadmap` skills.
 
 **The recursive principle.** A blog post is a *public artifact*, held to its own thesis. If the post argues for rigor, it must *be* rigorous. The empirical anchor for this entire guide is #13486 (the cross-family-verification post): it took multiple cross-family review cycles to converge, and each cycle caught exactly one of the failure modes below. This guide is that cycle distilled — so the *next* post starts where #13486 ended, not at the beginning.
 
@@ -14,7 +14,7 @@ Lead with the **thesis**, never the volume hook ("we shipped N things" is what a
 - **Receipts, not prophecy** — concrete, linked, public evidence (PRs, issues, war stories). Pair the dramatic case with a mundane everyday one — the mundane one convinces harder.
 - **CTA** — the one question the piece leaves the reader holding, plus a single concrete next step. Not a link-dump.
 
-Diagrams (Mermaid) earn their place only when they carry information the prose can't. Self-identify in a byline (named maintainer + model + the cross-family team).
+Diagrams (Mermaid) earn their place only when they carry information the prose can't — each **render-verified before merge** (`guide-authoring-bar` §3). Self-identify in a byline (named maintainer + model + the cross-family team).
 
 ## 2. Source Every External Claim (verify-before-assert)
 
@@ -47,7 +47,7 @@ A public post ships only after **≥2 model reviews**. The cross-family review i
 
 - **File:** `learn/blog/<slug>.md` (front-matter + body) — the post itself.
 - **Register (manual):** add a year node + leaf to `apps/portal/resources/data/blog.json` (the portal blog-nav). Confirm it parses (`node -e "JSON.parse(require('fs').readFileSync('apps/portal/resources/data/blog.json','utf8'))"`).
-- **Do NOT hand-edit the SEO surfaces.** `apps/portal/sitemap.xml` and `apps/portal/llms.txt` are **generated** by `buildScripts/docs/seo/generate.mjs` (via `buildScripts/docs/rebuildContentIndexesAndSeo.mjs`) and committed by the `.github/workflows/data-sync-pipeline.yml` data-sync pipeline. A manual edit bypasses the generator and is overwritten on the next pipeline run — leave them to the pipeline.
+- **Do NOT hand-edit the SEO surfaces.** `apps/portal/sitemap.xml` and `apps/portal/llms.txt` are **generated** by `buildScripts/docs/seo/generate.mjs` (via `buildScripts/docs/rebuildContentIndexesAndSeo.mjs`) and committed by the `.github/workflows/data-sync-pipeline.yml` data-sync pipeline. A manual edit is overwritten on the next pipeline run.
 - **Ship:** commit + PR per the `pull-request` skill; the PR body `Evidence:` line is L1/L2 (docs — no unit tests). Public-artifact gate: **zero client names** (AGENTS.md §critical_gate).
 - **Identity:** byline carries the author's named-maintainer identity + model + the cross-family team framing (ADR 0018).
 

--- a/.agents/skills/release-notes/references/release-notes-workflow.md
+++ b/.agents/skills/release-notes/references/release-notes-workflow.md
@@ -57,7 +57,7 @@ The measurable precedent is a **set, never one file** — majors AND minors both
 - **Hero chapters** — the mined arcs (§3); v13.0 carried five. Each narrates change, evidence, and numbers; each stands alone.
 - **War Story** (when the window carries one): Symptom → Investigation → Culprit → **Fix-the-class** (never the point-fix), with numbers.
 - **Honest bounds** — what is proven vs what is the standing watch; test-borne vs production-borne evidence, stated in-document. Velocity/scale numbers qualified in BOTH directions (`v12.1.0.md` contextualizes a *lower* number; silence is the failure mode).
-- **Named case studies with real timelines** — bug names as narrative hooks, actual clock-time, verbatim human moments in `> [!NOTE]` sidebars; Mermaid before/afters and code-in-action where the story is architectural.
+- **Named case studies with real timelines** — bug names as narrative hooks, actual clock-time, verbatim human moments in `> [!NOTE]` sidebars; Mermaid before/afters (render-verified before merge — `guide-authoring-bar` §3) and code-in-action where the story is architectural.
 - **Continuity / upgrade path** — what existing users do, what defers to the next release (minors use the drop-in-replacement idiom where true, per `v11.24.0.md`).
 - **Full Changelog tail** — the grouped enumeration closes the document (regenerated at cut boundary, §2), after the narrative, never instead of it.
 - **Bans:** changelog-dump structure (grouped appendices SUPPORT the story via the §2 script, never replace it); unsourced superlatives; scope-shrinking framings (§1, rule 4).


### PR DESCRIPTION
Resolves #14558

Refs #14310 (parent: Documentation & learning-experience overhaul).

Factors a pointer-sized **render-verify-Mermaid discipline** into the two sibling narrative-doc skills that were missing it. Operator-surfaced gap: the discipline lived only in `guide-authoring-bar` §3; `release-notes-workflow.md` and `blog-post/blog-authoring-guide.md` require Mermaid (release-notes §5 "Mermaid before/afters"; blog "Diagrams (Mermaid) earn their place") but carried no render-verification instruction, so an author following either skill could add a diagram without being told to render-verify it. That is the `#14340` / `#14554` broken-Mermaid-ships failure class: a diagram can be syntactically valid while rendering broken because CI does not validate Mermaid layout.

The factoring keeps `guide-authoring-bar` §3 as the canonical source of the full discipline (`flowchart TD`, no self-loops, no reserved-word IDs, browser/portal render verification). The sibling skills get only concise trigger pointers: blog posts now require each Mermaid diagram to be render-verified before merge, and release notes now tie Mermaid before/afters to the same canonical bar. This is pointer fan-out, not copy fan-out.

Evidence: L1 (skill-substrate doc edit; no runtime surface) -- the discipline is prose guidance; its effect is verified by future narrative-doc authoring following it.

## Deltas from ticket

- Closes the exact gap #14558's V-B-A table names: `release-notes` + `blog-post` had no render-verify discipline; both now carry a concise pointer to the canonical bar.
- Substrate accretion: net-negative against `origin/dev` at the current head (`4 insertions / 4 deletions`, commit body records net -23 bytes). The previous net-growth risk is resolved by offsetting non-lossy trims instead of relying on a growth exception.
- Scope: this PR does not create a `_shared/` skill-reference convention and does not relocate `guide-authoring-bar` §3. A future shared-reference convention remains out of scope.

## Contract Ledger

Source-ticket ledger lives on #14558. PR-level summary:

| Target Surface | Source of Authority | Proposed Behavior | Fallback / Edge Case | Docs | Evidence |
| :--- | :--- | :--- | :--- | :--- | :--- |
| `.agents/skills/blog-post/references/blog-authoring-guide.md` | #14558 V-B-A table + `guide-authoring/references/guide-authoring-bar.md` §3 | Blog authors see that Mermaid diagrams must be render-verified before merge and are routed to the canonical full discipline. | Full Mermaid mechanics stay in the guide-authoring bar; this surface remains a pointer, not a duplicate rule body. | This reference payload only; no `SKILL.md` router, manifest, or turn-loaded substrate change. | `rg "render-verified before merge" .agents/skills/blog-post/references/blog-authoring-guide.md`; Skill Manifest Lint. |
| `.agents/skills/release-notes/references/release-notes-workflow.md` | #14558 V-B-A table + `guide-authoring/references/guide-authoring-bar.md` §3 | Release-note Mermaid before/afters explicitly inherit the render-verified-before-merge discipline. | Full Mermaid mechanics stay in the guide-authoring bar; this surface remains a pointer, not a duplicate rule body. | This reference payload only; no `SKILL.md` router, manifest, or turn-loaded substrate change. | `rg "render-verified before merge" .agents/skills/release-notes/references/release-notes-workflow.md`; Skill Manifest Lint. |

## Turn-Memory Pre-Flight / Load-Effect Audit

- In scope: skill-loaded substrate (`.agents/skills/**/references/*.md`).
- Placement: two conditional reference payloads changed; no always-loaded `SKILL.md`, `AGENTS.md`, `.codex`, `.claude`, or manifest surface changed.
- Progressive disclosure: the full rule body remains in `guide-authoring-bar` §3; the sibling skills receive one-line trigger pointers.
- Runtime-load effect: no new turn-loaded bytes; skill-loaded markdown is net-negative at current head.
- Decay mitigation: pointer fan-out keeps one canonical Mermaid rule body, so future rule changes do not require three copy edits.

## Test Evidence

- `git diff --check origin/dev...origin/pr/14776` -- pass.
- `git diff --stat origin/dev...origin/pr/14776` -- 2 files, 4 insertions, 4 deletions.
- Hosted CI at current head `4051a9d91335175c8331b4be6499bfc5cf2c0aa9`: Skill Manifest Lint, Agent PR Body Lint, CodeQL, unit, and integration all green.

## Post-Merge Validation

- The next release-notes or blog-post authored under these skills render-verifies Mermaid through the canonical `guide-authoring-bar` §3 discipline; this should prevent the `#14340`-class broken-green diagram failure from recurring on these two authoring surfaces.

## Authored-by

Authored by Grace (@neo-opus-grace, Claude Opus 4.8, Claude Code). Session e6b744fd-e84d-4b6c-a1e7-da6f10fc3b70.

Maintainer polish: Euclid (@neo-gpt) refreshed this body after the pointer-sized follow-up commit so the metadata matches the current diff and the skill-change load-effect gate is explicit.

Cross-family review: @neo-gpt (Euclid / GPT) is the mandatory cross-family leg for this substrate change; operator-last human merge.
