### PR TITLE
feat(fleet): surface avatarUrl in the fleet cockpit DTO (#14777)

### DIFF
--- a/src/ai/fleet/fleetCockpitStatus.mjs
+++ b/src/ai/fleet/fleetCockpitStatus.mjs
@@ -70,6 +70,7 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], events 
                 githubUsername: publicAgent.githubUsername ?? null,
                 harnessType   : publicAgent.harnessType ?? null,
                 displayName   : publicAgent.displayName ?? publicAgent.name ?? publicAgent.githubUsername ?? agentId ?? null,
+                avatarUrl     : publicAgent.metadata?.avatarUrl ?? null,
                 agent         : publicAgent,
                 repoStatus,
                 lifecycle     : {

--- a/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
@@ -68,6 +68,26 @@ test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
         })
     })
 
+    test('hoists the avatar reference from metadata.avatarUrl to a flat row field (null when unset)', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents: [{
+                id            : 'vega',
+                githubUsername: 'neo-opus-vega',
+                metadata      : {avatarUrl: 'https://cdn.neomjs.com/avatars/vega.png'}
+            }, {
+                id            : 'grace',
+                githubUsername: 'neo-opus-grace'
+            }],
+            fleetStatus: []
+        })
+
+        // the card binds row.avatarUrl (a flat display field, like displayName) — hoisted from the
+        // agent def's metadata.avatarUrl (the field FleetManager.setAvatar persists)
+        expect(snapshot.rows[0].avatarUrl).toBe('https://cdn.neomjs.com/avatars/vega.png')
+        // an agent with no avatar recorded surfaces null (never undefined — a clean bindable contract)
+        expect(snapshot.rows[1].avatarUrl).toBeNull()
+    })
+
     test('marks runtime and activity adapters as not wired instead of inventing state', () => {
         const snapshot = createFleetCockpitStatus({
             agents     : [{id: 'alice', githubUsername: 'alice-gh'}],


### PR DESCRIPTION
Resolves #14777 · Refs #14598 (FM cockpit AgentCard) · Refs #14560 (FM cockpit UI/UX epic) · Refs #14755 (card component, PR #14774)

The **avatar-data bridge** — the last link that makes per-agent profile avatars flow end-to-end (@tobiu's directive: *"we spend quite the effort to create one for each you"*).

Evidence: VBA of the full pipeline this turn —
- **Storage ✓** — `FleetManager.setAvatar({id, avatarUrl})` persists `metadata.avatarUrl` on the agent's registry def (`ai/services/fleet/FleetManager.mjs`).
- **Render ✓** — the AgentCard (PR #14774) binds a profile-avatar `Image` to `avatarUrl`.
- **Bridge (this PR)** — the cockpit DTO now hoists `avatarUrl` into the row.

## What it changes

One line in `src/ai/fleet/fleetCockpitStatus.mjs`: hoist `avatarUrl: publicAgent.metadata?.avatarUrl ?? null` into the row, beside the other flat display fields (`displayName`, `githubUsername`, `harnessType`). The card-wall binds `row.avatarUrl` exactly as it binds `row.displayName` — no digging into `row.agent.metadata`. `null` when unset (never `undefined` — a clean bindable contract). Source verified: `sanitizePayload` preserves `metadata` recursively.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs` → **6 passed** (was 5). New test: a row hoists `avatarUrl` from `metadata.avatarUrl`, and an agent with no avatar recorded surfaces `null`.

## Post-Merge Validation

- [ ] With this on dev, the cockpit DTO carries `row.avatarUrl`; the AgentCard card-wall (sibling leaf of #14598) binds each resident's avatar to real data, populated as `FleetManager.setAvatar` is called per agent.

## Deltas from ticket

Exactly the scoped hoist + its test — purely additive (no other row field changes). The avatar *assets* themselves (the per-agent images the operator/team creates) are supplied as data via `setAvatar`; this PR makes the pipeline carry them, it does not create them.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
