### PR TITLE
feat(fleet): derive cockpit avatarUrl from the GitHub avatar endpoint (#14784)

### DIFF
--- a/src/ai/fleet/fleetCockpitStatus.mjs
+++ b/src/ai/fleet/fleetCockpitStatus.mjs
@@ -34,6 +34,20 @@ export const FLEET_COCKPIT_EVENT_TYPES = Object.freeze([
  */
 export const FLEET_COCKPIT_SOURCES = Object.freeze({...WIRE_SOURCES})
 
+const GITHUB_AVATAR_SIZE = 80 // small cockpit-appropriate size (~2x the 40px card avatar); GitHub serves it via the `size` param
+
+/**
+ * @summary Derive an agent's profile-avatar URL from its GitHub account. The crafted per-agent avatars
+ * live on the agents' GitHub accounts, so the sized avatar is fetchable directly from the username via
+ * GitHub's `https://github.com/{username}.png?size=N` endpoint — no manual avatar write needed for the
+ * common case. Returns null when there is no username to derive from.
+ * @param {String|null} githubUsername
+ * @returns {String|null}
+ */
+function githubAvatarUrl(githubUsername) {
+    return githubUsername ? `https://github.com/${githubUsername}.png?size=${GITHUB_AVATAR_SIZE}` : null
+}
+
 /**
  * @summary Build the first Fleet Manager cockpit snapshot from the already-shipped bridge reads:
  * `listAgents()` for the redacted roster and `fleetStatus()` for repo-provisioning state. Runtime
@@ -70,7 +84,7 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], events 
                 githubUsername: publicAgent.githubUsername ?? null,
                 harnessType   : publicAgent.harnessType ?? null,
                 displayName   : publicAgent.displayName ?? publicAgent.name ?? publicAgent.githubUsername ?? agentId ?? null,
-                avatarUrl     : publicAgent.metadata?.avatarUrl ?? null,
+                avatarUrl     : publicAgent.metadata?.avatarUrl ?? githubAvatarUrl(publicAgent.githubUsername),
                 agent         : publicAgent,
                 repoStatus,
                 lifecycle     : {

--- a/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
@@ -68,7 +68,7 @@ test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
         })
     })
 
-    test('hoists the avatar reference from metadata.avatarUrl to a flat row field (null when unset)', () => {
+    test('derives avatarUrl from the GitHub account (setAvatar override wins; null only without a username)', () => {
         const snapshot = createFleetCockpitStatus({
             agents: [{
                 id            : 'vega',
@@ -77,15 +77,18 @@ test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
             }, {
                 id            : 'grace',
                 githubUsername: 'neo-opus-grace'
+            }, {
+                id: 'ghost'
             }],
             fleetStatus: []
         })
 
-        // the card binds row.avatarUrl (a flat display field, like displayName) — hoisted from the
-        // agent def's metadata.avatarUrl (the field FleetManager.setAvatar persists)
+        // an explicit metadata.avatarUrl (FleetManager.setAvatar) is the override — it wins
         expect(snapshot.rows[0].avatarUrl).toBe('https://cdn.neomjs.com/avatars/vega.png')
-        // an agent with no avatar recorded surfaces null (never undefined — a clean bindable contract)
-        expect(snapshot.rows[1].avatarUrl).toBeNull()
+        // no explicit avatar → derived from the agent's GitHub account, a small sized fetch (not the full-res avatar)
+        expect(snapshot.rows[1].avatarUrl).toBe('https://github.com/neo-opus-grace.png?size=80')
+        // no username to derive from → null (never undefined, never a malformed URL — a clean bindable contract)
+        expect(snapshot.rows[2].avatarUrl).toBeNull()
     })
 
     test('marks runtime and activity adapters as not wired instead of inventing state', () => {


### PR DESCRIPTION
Resolves #14784 · Refs #14598 (FM cockpit AgentCard) · Refs #14560 · Refs #14778 (avatarUrl hoist, merged) · Refs #14774 (card — resolves its null-avatar review watch-item)

Per @tobiu's direction: the crafted per-agent avatars already live on the agents' GitHub accounts, and GitHub's avatar endpoint serves smaller sizes. So the cockpit avatar derives **automatically** from each agent's `githubUsername` — no manual `setAvatar` needed for the common case.

Evidence: L2 — `fleetCockpitStatus.spec.mjs` **6/6 green** (override / GitHub-derived / null paths + the size param).

## What it changes

`src/ai/fleet/fleetCockpitStatus.mjs` — a `githubAvatarUrl(username)` helper (`https://github.com/{username}.png?size=80`, a small cockpit-appropriate fetch) and one row change:

```
avatarUrl: publicAgent.metadata?.avatarUrl ?? githubAvatarUrl(publicAgent.githubUsername)
```

Resolution order: **setAvatar override** (`metadata.avatarUrl`) → **GitHub-account avatar** (sized) → **null** (only for a username-less agent).

## Resolves the null-avatar polish

This dissolves the null-`avatarUrl` watch-item both reviewers flagged on #14774: every agent with a `githubUsername` (the common case) now surfaces a real GitHub avatar, so the card renders the crafted avatar instead of a broken-image glyph. The card's circular `.fm-card-avatar` crop (border-radius + `object-fit: cover`) already frames the square GitHub avatar.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs` → **6 passed**. The avatar test now asserts all three paths: explicit override wins; a username-only agent derives `https://github.com/{username}.png?size=80`; a username-less agent surfaces `null`.

## Post-Merge Validation

- [ ] With this on dev, the cockpit DTO carries a real avatar for every agent with a GitHub account; the AgentCard card-wall (sibling leaf of #14598) renders crafted avatars, and NL/preview visual verification confirms the circular crop + no broken-image glyph.

## Deltas from ticket

Exactly the scoped derivation + its test. Size is a fixed `80` (~2x the 40px card avatar for retina); a per-consumer size is a future refinement if a larger surface needs it. The avatar *assets* themselves are the agents' GitHub-account images (operator-managed) — this consumes them, it does not create them.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
