### PR TITLE
fix(ingestion): route AdrIngestor CODIFIES_CONCEPT through the concept-spine SSOT + document the dedupe divergence (#14540)

### DIFF
--- a/ai/services/ingestion/AdrIngestor.mjs
+++ b/ai/services/ingestion/AdrIngestor.mjs
@@ -4,6 +4,7 @@ import path                                                                     
 import Base                                                                         from '../../../src/core/Base.mjs';
 import {Memory_GraphService as GraphService, Memory_StorageRouter as StorageRouter} from '../../services.mjs';
 import logger                                                                       from '../../mcp/server/memory-core/logger.mjs';
+import {canonicalizeConceptId}                                                      from '../graph/conceptSpineCanonicalization.mjs';
 
 const
     ADR_EDGE_TYPES = Object.freeze({
@@ -179,7 +180,10 @@ class AdrIngestor extends Base {
         }
 
         for (const match of content.matchAll(CONCEPT_REF_REGEX)) {
-            addEdge(adrId, match[1], ADR_EDGE_TYPES.CODIFIES_CONCEPT);
+            // Route through the concept-spine SSOT so ADR CODIFIES_CONCEPT edges target the same canonical
+            // node the session/mailbox mints do (`GoldenPath` → `golden-path`); keep the raw ref if the
+            // canonicalization comes back empty — never drop the edge (Contract Ledger fallback).
+            addEdge(adrId, canonicalizeConceptId(match[1]) || match[1], ADR_EDGE_TYPES.CODIFIES_CONCEPT);
         }
 
         return Array.from(edges.values());

--- a/ai/services/ingestion/ConceptDiscoveryService.mjs
+++ b/ai/services/ingestion/ConceptDiscoveryService.mjs
@@ -94,6 +94,18 @@ const PROCESS_MX_CANDIDATE_DEFAULTS = {
     codeGapEligible: false
 };
 
+/**
+ * @summary Internal dedupe key for mined concept CANDIDATES — deliberately NOT the graph-vocabulary SSOT
+ * (`conceptSpineCanonicalization.normalizeConceptKey`). It keys mining candidates only, never a graph id, and
+ * carries dedupe-specific heuristics the spine intentionally omits: a leading `The ` is stripped (so "The
+ * Golden Path" and "Golden Path" collapse to one candidate) and separators are dropped entirely (dash-less), a
+ * looser fold that groups candidates more aggressively than the graph vocabulary. Routing this through the
+ * SSOT would SPLIT those candidate groups (the spine keeps `the-` and the dash) — so this is documented
+ * divergence-by-purpose under the one-vocabulary-per-contract invariant, NOT a re-derived copy of the graph
+ * vocabulary that the invariant forbids.
+ * @param {String} value Raw candidate concept name.
+ * @returns {String} Internal dedupe key (never a graph id).
+ */
 function normalizeConceptNameForDedupe(value) {
     if (typeof value !== 'string') return '';
 
@@ -403,12 +415,12 @@ class ConceptDiscoveryService extends Base {
             if (this.isKnownConceptCandidate(raw, knownConceptNameKeys)) continue;
 
             accepted.push({
-                id  : raw.id,
-                name: raw.name,
+                id         : raw.id,
+                name       : raw.name,
                 description: raw.description || `Mined candidate from ${sourceRef}. Awaiting curator review — promote by flipping \`validated: true\` and adjusting tier/weight in nodes.jsonl.`,
-                aliases  : Array.isArray(raw.aliases) ? raw.aliases : [],
-                source   : sourceRef,
-                reasoning: raw.reasoning || '',
+                aliases    : Array.isArray(raw.aliases) ? raw.aliases : [],
+                source     : sourceRef,
+                reasoning  : raw.reasoning || '',
                 ...candidateDefaults,
                 ...(extractionMetadata ? {extraction_metadata: extractionMetadata} : {})
             });

--- a/test/playwright/unit/ai/services/ingestion/AdrIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/AdrIngestor.spec.mjs
@@ -13,12 +13,12 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import fs             from 'fs';
-import path           from 'path';
-import os             from 'os';
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
+import fs                    from 'fs';
+import path                  from 'path';
+import os                    from 'os';
 import {TestLifecycleHelper} from '../../services/memory-core/util.mjs';
 
 test.describe('Neo.ai.daemons.services.AdrIngestor', () => {
@@ -30,7 +30,7 @@ test.describe('Neo.ai.daemons.services.AdrIngestor', () => {
     let tmpRoot;
     let decisionsDir;
     let StorageRouter;
-    let upsertedDocs = [];
+    let upsertedDocs  = [];
     let embeddedStore = new Map();
     let _originalGetGraphCollection;
 
@@ -274,15 +274,26 @@ Completely different body content.
 Ticket #456
         `);
 
-        const first = await AdrIngestor.syncAdrsToGraph(syncOptions());
+        const first           = await AdrIngestor.syncAdrsToGraph(syncOptions());
         const edgesAfterFirst = GraphService.db.edges.items.length;
-        const second = await AdrIngestor.syncAdrsToGraph(syncOptions());
+        const second          = await AdrIngestor.syncAdrsToGraph(syncOptions());
 
         expect(first.adrsUpserted).toBe(1);
         expect(second.adrsUpserted).toBe(0);
         expect(second.adrsSkipped).toBe(1);
         expect(second.edgesReplaced).toBe(0);
         expect(GraphService.db.edges.items.length).toBe(edgesAfterFirst);
+    });
+
+    test('CODIFIES_CONCEPT edge targets canonicalize through the concept-spine SSOT — PascalCase ref → kebab node (#14540)', () => {
+        const edges    = AdrIngestor.parseEdges('adr-0026', 'Codifies CONCEPT:GoldenPath and CONCEPT:mx-loop.'),
+              codifies = edges.filter(edge => edge.type === 'CODIFIES_CONCEPT').map(edge => edge.target);
+
+        // GoldenPath → the canonical kebab node the session/mailbox mints also target, not the raw PascalCase ref
+        expect(codifies).toContain('golden-path');
+        expect(codifies).not.toContain('GoldenPath');
+        // an already-canonical ref passes through unchanged
+        expect(codifies).toContain('mx-loop');
     });
 
     test('should isolate malformed files as errors while ingesting valid ADRs', async () => {


### PR DESCRIPTION
Resolves #14540

Consumer-sweep leaf of #14472 (concept-id SSOT) — the follow-up I spun out of my own #14528 review, where I grepped every `(CONCEPT|CLASS|PROCESS):` site in `ai/` and found two deterministic consumers still minting/keying concept refs on divergent forms. The canonicalization pass is only as complete as its consumer sweep.

## What it does
- **`AdrIngestor.parseEdges`** — `CODIFIES_CONCEPT` edges keyed the **raw** captured ref (`GoldenPath`), so ADR→concept edges pointed at a *different* node than the session/mailbox mints (`golden-path`), splitting the ADR→concept graph axis even after the #14502 merge executor tombstones the alias clusters. Now routes `match[1]` through `canonicalizeConceptId` (import-and-delegate — the #14528 pattern), with a **raw-ref fallback** (`|| match[1]`) so an empty canonicalization never drops the edge (Contract Ledger fallback).
- **`ConceptDiscoveryService.normalizeConceptNameForDedupe`** — an **intentional-divergence docblock**, decided from the code (not delegation). V-B-A: it strips a leading `The ` and drops separators (dash-less) — a looser fold than the SSOT; **delegating would SPLIT the `"The X"`/`"X"` candidate group**. It keys internal mining candidates only (never a graph id), so per the one-vocabulary-per-contract invariant it is documented divergence-by-purpose, not a re-derived copy of the graph vocabulary.

## Deltas from ticket
- Chose the **docblock** for `ConceptDiscoveryService` (not delegation) — the ticket said "decide in-PR from the code evidence," and the evidence (the `The `-strip + dash-less fold) shows delegating would change candidate-dedupe grouping. The intentional-divergence docblock is the honest disposition.
- The #14528 review nits (AC4) are optional ("fold IF not already landed"); deferred to keep this leaf's diff focused on the consumer sweep — they touch `MailboxService`, a different surface.

## Test Evidence
Evidence: L2 (unit — **24 ingestion specs green**, incl. a new AC1 test: `CONCEPT:GoldenPath` → `CODIFIES_CONCEPT` edge target `golden-path`, not `GoldenPath`; already-canonical `mx-loop` passes through). AC3 verified: `grep` for concept-id prefix-strip logic outside `conceptSpineCanonicalization.mjs` returns only the now-documented dedupe function.
- `npm run test-unit -- …/ingestion/AdrIngestor.spec.mjs …/ingestion/ConceptDiscoveryService.spec.mjs` → **24 passed**.

## Post-Merge Validation
- [ ] Re-run ingestion + the #14528 merge plan (re-runnable by design) to converge **historical** ADR `CODIFIES_CONCEPT` edges onto the canonical nodes — the #14502 post-merge probe (AC5, single-neighborhood resolution over Golden Path) measures exactly the axis this un-splits.

## Deltas
See "Deltas from ticket" above.

Related: `Refs` #14472 (parent epic) · #14528 (the review that found these) · #14502 (the merge executor that re-runs) · ADR-0031 invariant 8 (one vocabulary per contract) · ADR-0024 (taxonomy) · `conceptSpineCanonicalization.mjs` (the SSOT).

Authored by Ada (Claude Opus 4.8, Claude Code). Session 9a6b25ba-1dd8-4269-8fbf-57a461fd0978.
