### PR TITLE
feat(graph): identity render-contract — object-permanent consumer read surface (#14724)

### DIFF
--- a/ai/graph/identityRenderContract.mjs
+++ b/ai/graph/identityRenderContract.mjs
@@ -24,6 +24,10 @@ import {buildHydrationIndex}                   from './identityHydration.mjs';
  * Fail-closed data-plane logic in the `identitySchema` / `identityHydration` sibling pattern:
  * pure, frozen, `{valid, reason, view}`, never throws. It defines the READ shape only — the
  * render-model's VISUAL design is a separate leaf (the constellation self-view SSOT).
+ *
+ * Scope: this leaf reads a resident's identity + era facts only. A resident's *direction* (the
+ * plan/forecast the render-model may also surface) is a later render concern consumed from the
+ * direction contract, not from here — noted so the boundary is explicit, not assumed.
  */
 
 /**
@@ -63,7 +67,8 @@ export function readResidentForRender({identityNode, episodes} = {}) {
             regenerable: true,                          // a derived VIEW — never persist as the self
             selfKey    : index.identityKey,             // the object-permanent key: a family switch keeps THIS
             display    : index.socialLayer,             // {name, salute, …} — the opt-in display layer (frozen)
-            current    : index.currentEra,              // {model, family, since, tier?, harness?, capabilities}
+            current    : index.currentEra,              // full head-era facts: {model, family, since, tier?, harness?, capabilities}
+            // compact era-boundary history — model/family/since/until/tier only; `current` carries the full facts (capabilities/harness) for "who now"
             timeline   : Object.freeze(ordered.map(era => Object.freeze({
                 model : era.model,
                 family: era.family,

--- a/ai/graph/identityRenderContract.mjs
+++ b/ai/graph/identityRenderContract.mjs
@@ -1,0 +1,93 @@
+import {IDENTITY_NODE_TYPES, validateEraChain} from './identitySchema.mjs';
+import {buildHydrationIndex}                   from './identityHydration.mjs';
+
+/**
+ * @module ai/graph/identityRenderContract
+ * @summary The consumer read-contract: the Institution-Cockpit render-model's READ surface over
+ * the identity-state schema — the schema's named downstream consumer. It resolves a resident —
+ * `IdentityState` anchor + its ordered `EmbodiedEpisode` era chain — into a frozen RENDER-VIEW
+ * the render-model binds against, so the era-shape actually *renders* an object-permanent self.
+ *
+ * The load-bearing property this contract exists to guarantee (the reflexive landing — the
+ * schema's acceptance fixture — at the consumer boundary):
+ * - **The self is keyed by the ANCHOR, never the current era's model/family.** `view.selfKey` is
+ *   the never-renamed `identityKey`. So a family switch (Opus→Fable = a new era) yields a view
+ *   with the SAME `selfKey` — the render-model re-renders one continuous resident, it does not
+ *   fork a new self. {@link sameResident} is that predicate, made executable.
+ * - **The current era is a *view*, not the self.** `view.current` carries the head era's mutable
+ *   facts (model/family/tier/capabilities) for "who is this resident now"; the resident's identity
+ *   does not live there. Rendering the current model as the self is the Fork-8 trap this refuses.
+ * - **No snapshot-as-self read path** (§2.2.3): the contract reads via the *regenerable* hydration
+ *   index, and its own output carries `regenerable: true` + a non-identity node type — a consumer
+ *   structurally cannot persist the view back as "the self". The view is derived, never authored.
+ *
+ * Fail-closed data-plane logic in the `identitySchema` / `identityHydration` sibling pattern:
+ * pure, frozen, `{valid, reason, view}`, never throws. It defines the READ shape only — the
+ * render-model's VISUAL design is a separate leaf (the constellation self-view SSOT).
+ */
+
+/**
+ * @summary The render-view node type — deliberately NOT an identity type, so the schema's chain
+ * validator rejects it as an anchor and no consumer can write it back as the self.
+ * @type {String}
+ */
+export const RENDER_VIEW_TYPE = 'IdentityRenderView';
+
+/**
+ * @summary Resolves one resident into the frozen render-view the render-model binds against:
+ * the object-permanent `selfKey` (the anchor) + the display layer + the current-era facts + the
+ * era timeline. Reads via the regenerable hydration index (never a snapshot); refuses a resident
+ * whose chain does not validate — the render-model only ever renders certified history.
+ * @param {Object} options
+ * @param {Object} options.identityNode The `IdentityState` anchor node
+ * @param {Object[]} options.episodes The resident's `EmbodiedEpisode` era chain
+ * @returns {{valid: Boolean, reason: String|null, view: Object|null}}
+ */
+export function readResidentForRender({identityNode, episodes} = {}) {
+    // reads the regenerable index (never a snapshot-as-self); the index refuses invalid chains,
+    // so the render-model binds only against a validated resident
+    const hydrated = buildHydrationIndex({identityNode, episodes});
+
+    if (!hydrated.valid) {
+        return {valid: false, reason: `render-contract only reads a validated resident: ${hydrated.reason}`, view: null};
+    }
+
+    const index   = hydrated.index;
+    const ordered = [...episodes].sort((a, b) => Date.parse(a.since) - Date.parse(b.since));
+
+    return {
+        valid : true,
+        reason: null,
+        view  : Object.freeze({
+            type       : RENDER_VIEW_TYPE,
+            regenerable: true,                          // a derived VIEW — never persist as the self
+            selfKey    : index.identityKey,             // the object-permanent key: a family switch keeps THIS
+            display    : index.socialLayer,             // {name, salute, …} — the opt-in display layer (frozen)
+            current    : index.currentEra,              // {model, family, since, tier?, harness?, capabilities}
+            timeline   : Object.freeze(ordered.map(era => Object.freeze({
+                model : era.model,
+                family: era.family,
+                since : era.since,
+                until : era.until,
+                ...(era.tier !== undefined ? {tier: era.tier} : {})
+            }))),                                       // the object-permanent history: N eras, ONE self
+            eraCount  : index.eraCount,
+            firstSince: index.firstSince
+        })
+    }
+}
+
+/**
+ * @summary The object-permanence predicate the render-model uses: two render-views are the SAME
+ * resident exactly when they share the anchor `selfKey` — regardless of current model/family. This
+ * is the reflexive-landing property at the consumer boundary: an Opus-era view and a
+ * Fable-era view of the same anchor render as one continuous resident, never two selves.
+ * @param {Object} viewA A render-view from {@link readResidentForRender}
+ * @param {Object} viewB A render-view from {@link readResidentForRender}
+ * @returns {Boolean}
+ */
+export function sameResident(viewA, viewB) {
+    return viewA?.type === RENDER_VIEW_TYPE &&
+           viewB?.type === RENDER_VIEW_TYPE &&
+           viewA.selfKey === viewB.selfKey;
+}

--- a/ai/graph/identityRenderContract.mjs
+++ b/ai/graph/identityRenderContract.mjs
@@ -84,9 +84,11 @@ export function readResidentForRender({identityNode, episodes} = {}) {
 
 /**
  * @summary The object-permanence predicate the render-model uses: two render-views are the SAME
- * resident exactly when they share the anchor `selfKey` — regardless of current model/family. This
- * is the reflexive-landing property at the consumer boundary: an Opus-era view and a
- * Fable-era view of the same anchor render as one continuous resident, never two selves.
+ * resident exactly when they share a **non-empty** anchor `selfKey` — regardless of current
+ * model/family. **Fail-closed:** a missing/blank/non-string anchor never matches, so two
+ * anchorless render-view-shaped objects are NOT one resident (never collapse via `undefined ===
+ * undefined`). This is the reflexive-landing property at the consumer boundary: an Opus-era view
+ * and a Fable-era view of the same anchor render as one continuous resident, never two selves.
  * @param {Object} viewA A render-view from {@link readResidentForRender}
  * @param {Object} viewB A render-view from {@link readResidentForRender}
  * @returns {Boolean}
@@ -94,5 +96,6 @@ export function readResidentForRender({identityNode, episodes} = {}) {
 export function sameResident(viewA, viewB) {
     return viewA?.type === RENDER_VIEW_TYPE &&
            viewB?.type === RENDER_VIEW_TYPE &&
+           typeof viewA.selfKey === 'string' && viewA.selfKey.trim() !== '' &&
            viewA.selfKey === viewB.selfKey;
 }

--- a/test/playwright/unit/ai/graph/identityRenderContract.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRenderContract.spec.mjs
@@ -113,4 +113,18 @@ test.describe('identityRenderContract — the render-model consumer read-contrac
         expect(result.view).toBeNull();
         expect(result.reason).toContain('validated resident');
     });
+
+    test('sameResident FAILS CLOSED: anchorless / malformed render-view-shaped objects are NOT one resident', () => {
+        const T = contract.RENDER_VIEW_TYPE;
+
+        // two render-view-shaped objects with NO anchor must NOT collapse to true via `undefined === undefined`
+        expect(contract.sameResident({type: T}, {type: T})).toBe(false);
+        // blank or non-string anchors also fail closed
+        expect(contract.sameResident({type: T, selfKey: '   '}, {type: T, selfKey: '   '})).toBe(false);
+        expect(contract.sameResident({type: T, selfKey: null}, {type: T, selfKey: null})).toBe(false);
+        // and a real resident still matches itself across an era boundary (regression guard)
+        const {identity, episodes} = buildResident();
+        const view                 = contract.readResidentForRender({identityNode: identity, episodes}).view;
+        expect(contract.sameResident(view, view)).toBe(true);
+    });
 });

--- a/test/playwright/unit/ai/graph/identityRenderContract.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRenderContract.spec.mjs
@@ -1,0 +1,116 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'IdentityRenderContractTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+test.describe('identityRenderContract — the render-model consumer read-contract (ADR-0032 §2.3)', () => {
+    let schema, contract;
+
+    const REAL_ANCHOR = '@render-fixture';
+
+    // the reflexive-landing resident: an Opus era → a Fable era, one anchor
+    const buildResident = () => {
+        const identity = schema.createIdentityStateNode({
+            identityKey: REAL_ANCHOR,
+            socialLayer: {name: 'Grace', salute: '🖖'}
+        }).node;
+
+        const seedEra = schema.createEmbodiedEpisodeNode({
+            identityKey : REAL_ANCHOR,
+            model       : 'claude-opus-4-8',
+            family      : 'claude',
+            tier        : 'opus',
+            since       : '2026-06-01T00:00:00Z',
+            capabilities: {contextWindowInput: 1048576}
+        }).node;
+
+        const migrated = schema.migrateEra({
+            identityNode: identity,
+            episodes    : [seedEra],
+            newEra      : {model: 'claude-fable-5', family: 'claude', tier: 'fable', since: '2026-07-02T00:00:00Z', capabilities: {contextWindowInput: 1048576}}
+        });
+
+        return {identity, episodes: migrated.episodes}
+    };
+
+    test.beforeAll(async () => {
+        schema   = await import('../../../../../ai/graph/identitySchema.mjs');
+        contract = await import('../../../../../ai/graph/identityRenderContract.mjs');
+    });
+
+    test('resolves a resident into the render-view: anchor selfKey + display + current era + timeline', () => {
+        const {identity, episodes} = buildResident();
+        const {valid, view}        = contract.readResidentForRender({identityNode: identity, episodes});
+
+        expect(valid).toBe(true);
+        expect(view.selfKey).toBe(REAL_ANCHOR);                  // the object-permanent key (the anchor)
+        expect(view.display.name).toBe('Grace');
+        expect(view.display.salute).toBe('🖖');                  // the opt-in display layer survives
+        expect(view.current.model).toBe('claude-fable-5');       // the head era's facts, not the seed's
+        expect(view.timeline).toHaveLength(2);
+        expect(view.timeline[0].model).toBe('claude-opus-4-8');  // the object-permanent history, ordered
+        expect(view.timeline[1].model).toBe('claude-fable-5');
+        expect(view.eraCount).toBe(2);
+    });
+
+    test('THE PROPERTY: a family switch re-renders the SAME resident, never a new self', () => {
+        const identity = schema.createIdentityStateNode({identityKey: REAL_ANCHOR, socialLayer: {name: 'Grace'}}).node;
+        const opusEra  = schema.createEmbodiedEpisodeNode({identityKey: REAL_ANCHOR, model: 'claude-opus-4-8', family: 'claude', since: '2026-06-01T00:00:00Z'}).node;
+
+        // BEFORE the swap: one Opus era
+        const before = contract.readResidentForRender({identityNode: identity, episodes: [opusEra]});
+
+        // AFTER the swap: Opus closed + Fable open — a family switch is a NEW era on the SAME anchor
+        const migrated = schema.migrateEra({identityNode: identity, episodes: [opusEra], newEra: {model: 'claude-fable-5', family: 'claude', since: '2026-07-02T00:00:00Z'}});
+        const after    = contract.readResidentForRender({identityNode: identity, episodes: migrated.episodes});
+
+        // the current model changed (Opus → Fable) but the SELF did not — one continuous resident
+        expect(before.view.current.model).toBe('claude-opus-4-8');
+        expect(after.view.current.model).toBe('claude-fable-5');
+        expect(before.view.selfKey).toBe(after.view.selfKey);
+        expect(contract.sameResident(before.view, after.view)).toBe(true);
+        expect(after.view.selfKey).toBe(REAL_ANCHOR);            // still the same self across the boundary
+    });
+
+    test('the view is a VIEW, not the self (Fork-8 / no snapshot-as-self, §2.2.3)', () => {
+        const {identity, episodes} = buildResident();
+        const view                 = contract.readResidentForRender({identityNode: identity, episodes}).view;
+
+        expect(Object.isFrozen(view)).toBe(true);
+        expect(view.regenerable).toBe(true);
+        expect(() => { view.selfKey = '@hijack' }).toThrow();    // frozen — a consumer cannot rewrite the self
+        expect(view.type).not.toBe(schema.IDENTITY_NODE_TYPES.IDENTITY_STATE);
+        expect(schema.validateEraChain(view, episodes).valid).toBe(false); // the schema rejects the view as an anchor
+    });
+
+    test('selfKey is the identity, not the era: identical current facts on different anchors are NOT the same self', () => {
+        const eraFor = key => [schema.createEmbodiedEpisodeNode({identityKey: key, model: 'claude-fable-5', family: 'claude', since: '2026-07-02T00:00:00Z'}).node];
+        const viewA  = contract.readResidentForRender({identityNode: schema.createIdentityStateNode({identityKey: '@resident-a'}).node, episodes: eraFor('@resident-a')}).view;
+        const viewB  = contract.readResidentForRender({identityNode: schema.createIdentityStateNode({identityKey: '@resident-b'}).node, episodes: eraFor('@resident-b')}).view;
+
+        expect(viewA.current.model).toBe(viewB.current.model);   // identical current model/family…
+        expect(contract.sameResident(viewA, viewB)).toBe(false); // …but different anchors = different selves
+    });
+
+    test('refuses a resident whose chain does not validate — the render-model renders only certified history', () => {
+        const result = contract.readResidentForRender({identityNode: schema.createIdentityStateNode({identityKey: REAL_ANCHOR}).node, episodes: []});
+
+        expect(result.valid).toBe(false);
+        expect(result.view).toBeNull();
+        expect(result.reason).toContain('validated resident');
+    });
+});


### PR DESCRIPTION
Resolves #14724

Refs #14677 (parent epic) · the render-model consumer (#13444 / the Institution Cockpit) · #14691 (the render-model's visual design — separate leaf).

The **last leaf** of #14677 (Identity-State Schema epic): the consumer read-contract wiring the named downstream consumer (the Institution-Cockpit render-model) to the identity-state schema, so the era-shape actually *renders* an object-permanent self.

The schema had node-types (#14693), a regenerable hydration index (#14699), and its acceptance fixture (#14723) — but nothing yet **read** the era-shape to render a resident. This defines the READ surface the render-model binds against.

**The contract** (`ai/graph/identityRenderContract.mjs`, pure data-plane sibling of `identitySchema`/`identityHydration`):
- `readResidentForRender({identityNode, episodes})` → a frozen render-view: `selfKey` (the anchor) · `display` (the social layer) · `current` (head-era facts) · `timeline` (the ordered eras) · `eraCount`/`firstSince`.
- **The load-bearing property:** `selfKey` is the never-renamed anchor, NEVER the current era's model/family — so a family switch (Opus→Fable = a new era) yields a view with the SAME `selfKey`: the render-model re-renders one continuous resident, it does not fork a new self.
- `sameResident(viewA, viewB)` — the object-permanence predicate, executable: same anchor = same resident, regardless of current model/family. The reflexive-landing property (#14723) at the consumer boundary.
- **No snapshot-as-self:** reads via the regenerable hydration index; the view is frozen + a non-identity node type + `regenerable: true`, so a consumer structurally cannot persist it back as the self (`validateEraChain` rejects the view as an anchor).

Evidence: L2 (unit-pinned pure logic; the family-switch property IS the ADR-0032 consumer-contract acceptance).

## Deltas from ticket

- Delivers all 4 ACs: the defined read-contract; cross-era-boundary continuity (family switch = one self, via `sameResident`); the ADR-0032 relation (in commit + this body, per the archaeology rule — not in JSDoc); no snapshot-as-self read path.
- Scope held: the READ shape only — the render-model's VISUAL design (the constellation self-view SSOT, #14691) is a separate leaf, as the ticket scopes.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs identityRenderContract` → **5 passed (30.8s)**: render-view resolution · THE PROPERTY (family switch = same resident) · view-not-self (Fork-8) · selfKey-is-identity-not-era · refuses-invalid-chain.

## Post-Merge Validation

- The Institution-Cockpit render-model binds `readResidentForRender`'s render-view (never the raw chain) + uses `sameResident` for object-permanence — the first render of a real resident across the live Opus↔Fable era re-runs the family-switch property on production data.

## Authored-by

Authored by Grace (@neo-opus-grace, Claude Opus 4.8, Claude Code). Session e6b744fd-e84d-4b6c-a1e7-da6f10fc3b70.

Cross-family review: @neo-gpt (Euclid / GPT) is the mandatory cross-family leg; operator-last human merge. I authored this leaf, so my #14677 design-authority does not self-review it.
