### PR TITLE
feat(agentos): fleet card-factory — cockpit DTO → dock card blueprints (#14799)

### DIFF
--- a/apps/agentos/view/fleet/fleetCardFactory.mjs
+++ b/apps/agentos/view/fleet/fleetCardFactory.mjs
@@ -1,0 +1,79 @@
+/**
+ * @summary Fleet card-factory — transforms the Body-side fleet-cockpit DTO into per-card descriptors
+ * for the workspace dock. This is the UPSTREAM half of the card-wall seam: it registers a stable
+ * component ref per resident and emits a serializable creation blueprint; the dock owns arrangement,
+ * perspectives, and the placement lifecycle. Two rules from the merged docking contract shape it:
+ *
+ * 1. It emits BLUEPRINTS, not live instances. Perspective-restore re-instantiates a card from its
+ *    blueprint when no live instance exists, so a factory that only handed live instances would make a
+ *    restored layout render placeholders instead of cards. The (componentRef, blueprint) pair IS the
+ *    lifecycle contract — this upstream side needs no teardown protocol with the dock.
+ * 2. The cards are layout-blind. This transform never reads or emits layout state; it maps identity +
+ *    display data only, and the dock does the placing.
+ *
+ * Pure data-plane: no component import (the card is named by its serializable `ntype`; the dock's app
+ * registers the AgentCard class), no live objects, JSON-serializable end-to-end.
+ * @module apps/agentos/view/fleet/fleetCardFactory
+ */
+
+const AGENT_CARD_NTYPE = 'fm-agent-card';
+
+const AGENT_CARD_POLICY = Object.freeze({closable: true, pinnable: true, movable: true});
+
+/**
+ * @summary Stable, durable-identity-keyed dock ref for a resident's card. Keyed on the `agentId` (never
+ * presentation), so the dock resolves the SAME card across a rename / re-avatar / family swap.
+ * @param {String} agentId
+ * @returns {String}
+ */
+export function agentCardComponentRef(agentId) {
+    return `fm-agent-card-${agentId}`
+}
+
+/**
+ * @summary Map one fleet-cockpit DTO row to its dock card descriptor: a stable componentRef, a
+ * serializable creation blueprint (the card's `ntype` + the per-card provider data), agent-card policy
+ * hints, and JSON identity metadata. Field mapping is null-safe and forward-compatible — `engineTag`,
+ * `family`, and `laneLine` map through as `null` until the DTO enrichment + activity/runtime wires
+ * land, with no change needed here.
+ * @param {Object} row=({}) A fleet-cockpit DTO row.
+ * @returns {Object} `{componentRef, blueprint, policy, metadata}`
+ */
+export function toAgentCardDescriptor(row = {}) {
+    const agentId = row.id ?? null;
+
+    return {
+        componentRef: agentCardComponentRef(agentId),
+        blueprint   : {
+            ntype        : AGENT_CARD_NTYPE,
+            stateProvider: {
+                data: {
+                    agentId,
+                    avatarUrl  : row.avatarUrl ?? null,
+                    displayName: row.displayName ?? null,
+                    engineTag  : row.engineTag ?? null,
+                    family     : row.family ?? null,
+                    laneLine   : row.laneLine ?? null,
+                    state      : row.lifecycle?.state ?? 'off'
+                }
+            }
+        },
+        policy  : {...AGENT_CARD_POLICY},
+        metadata: {
+            agentId,
+            githubUsername: row.githubUsername ?? null
+        }
+    }
+}
+
+/**
+ * @summary Transform the fleet-cockpit DTO into the ordered set of dock card descriptors — one per
+ * resident row — for the dock to place, restore, and reparent layout-blind AgentCards.
+ * @param {Object} cockpitStatus=({}) The DTO from `createFleetCockpitStatus` (`{sources, capabilities, rows, events}`).
+ * @returns {Object[]} One `{componentRef, blueprint, policy, metadata}` per row.
+ */
+export function createFleetCardDescriptors(cockpitStatus = {}) {
+    const rows = Array.isArray(cockpitStatus.rows) ? cockpitStatus.rows : [];
+
+    return rows.map(toAgentCardDescriptor)
+}

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
@@ -1,0 +1,98 @@
+import {setup} from '../../../../../setup.mjs'
+
+const appName = 'FleetCardFactoryTest'
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+})
+
+import {test, expect} from '@playwright/test'
+import Neo            from '../../../../../../../src/Neo.mjs'
+import * as core      from '../../../../../../../src/core/_export.mjs'
+
+import {createFleetCockpitStatus} from '../../../../../../../src/ai/fleet/fleetCockpitStatus.mjs'
+import {
+    agentCardComponentRef,
+    createFleetCardDescriptors,
+    toAgentCardDescriptor
+} from '../../../../../../../apps/agentos/view/fleet/fleetCardFactory.mjs'
+
+test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#14799)', () => {
+    test('maps each cockpit DTO row to a descriptor with a stable, agentId-keyed componentRef', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents: [
+                {id: 'vega',  githubUsername: 'neo-opus-vega', displayName: 'Vega'},
+                {id: 'grace', githubUsername: 'neo-opus-grace'}
+            ],
+            fleetStatus: []
+        })
+
+        const cards = createFleetCardDescriptors(snapshot)
+
+        expect(cards).toHaveLength(2)
+        expect(cards[0].componentRef).toBe('fm-agent-card-vega')
+        expect(cards[1].componentRef).toBe('fm-agent-card-grace')
+        // the ref is keyed on the durable agentId — the same helper the dock resolves against
+        expect(cards[0].componentRef).toBe(agentCardComponentRef('vega'))
+    })
+
+    test('emits a fully JSON-serializable blueprint (ntype + provider data — no live objects)', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents     : [{id: 'vega', githubUsername: 'neo-opus-vega', displayName: 'Vega'}],
+            fleetStatus: []
+        })
+
+        const [card] = createFleetCardDescriptors(snapshot)
+
+        expect(card.blueprint.ntype).toBe('fm-agent-card')
+        expect(card.blueprint.stateProvider.data.agentId).toBe('vega')
+        expect(card.blueprint.stateProvider.data.displayName).toBe('Vega')
+        // the avatar auto-derived through the DTO (from the GitHub account) rides into the blueprint
+        expect(card.blueprint.stateProvider.data.avatarUrl).toBe('https://github.com/neo-opus-vega.png?size=80')
+
+        // serializable end-to-end — a captured perspective can restore a real card from the blueprint
+        expect(() => JSON.stringify(card.blueprint)).not.toThrow()
+        expect(JSON.parse(JSON.stringify(card.blueprint))).toEqual(card.blueprint)
+    })
+
+    test('policy hints default to all-true for agent cards', () => {
+        const card = toAgentCardDescriptor({id: 'vega'})
+
+        expect(card.policy).toEqual({closable: true, pinnable: true, movable: true})
+    })
+
+    test('null-safe + forward-compatible: a sparse row yields null display fields, never undefined', () => {
+        const card   = toAgentCardDescriptor({id: 'ghost'})
+        const {data} = card.blueprint.stateProvider
+
+        expect(card.componentRef).toBe('fm-agent-card-ghost')
+        expect(data.agentId).toBe('ghost')
+        // fields the DTO does not carry yet (pending enrichment / the activity+runtime wires) → null
+        expect(data.engineTag).toBeNull()
+        expect(data.family).toBeNull()
+        expect(data.laneLine).toBeNull()
+        expect(data.avatarUrl).toBeNull()
+        // no session state known yet → the benched/offline default
+        expect(data.state).toBe('off')
+        // no undefined leaking into the serializable metadata
+        expect(card.metadata.githubUsername).toBeNull()
+    })
+
+    test('maps the session state through from the DTO lifecycle axis', () => {
+        const card = toAgentCardDescriptor({id: 'vega', lifecycle: {state: 'ok'}})
+
+        expect(card.blueprint.stateProvider.data.state).toBe('ok')
+    })
+
+    test('createFleetCardDescriptors tolerates a rowless / empty DTO', () => {
+        expect(createFleetCardDescriptors({})).toEqual([])
+        expect(createFleetCardDescriptors()).toEqual([])
+    })
+})


### PR DESCRIPTION
Resolves #14799 · Refs #14598 (FM cockpit AgentCard) · Refs #14560 · Refs #14789 (flagship dock render — the downstream consumer) · Refs #14785 (avatar, merged)

My upstream half of the card-wall seam, built to Clio's ADR-0029 §2.6 container contract: a pure, serializable transform from the fleet-cockpit DTO to per-card dock descriptors. The dock owns arrangement / perspectives / lifecycle; this side registers refs + emits blueprints.

Evidence: L2 — `fleetCardFactory.spec.mjs` **6/6 green** (descriptor shape, componentRef stability, blueprint serializability + round-trip, null-safe mapping, empty-DTO tolerance).

## What it builds

`apps/agentos/view/fleet/fleetCardFactory.mjs` — `createFleetCardDescriptors(cockpitStatus)` → one descriptor per DTO row:
- **componentRef** `fm-agent-card-${agentId}` — stable, keyed on the *durable* agentId (never presentation), so the dock resolves the SAME card across a rename / re-avatar / family swap.
- **blueprint** `{ntype: 'fm-agent-card', stateProvider: {data: {…}}}` — fully JSON-serializable; the dock re-instantiates from it on perspective-restore when no live instance exists.
- **policy** `{closable, pinnable, movable}` all true (agent-card defaults).
- **metadata** JSON identity (agentId, githubUsername).

**Blueprints, not instances** — the correction Clio flagged: instance-handing makes a restored perspective render placeholders instead of cards. The `(componentRef, blueprint)` pair is the lifecycle contract, so this upstream side needs no teardown protocol.

**Layout-blind + pure data-plane** — no layout state read or emitted, no component import (the card is named by its serializable `ntype`; the app registers the class), no live objects.

**Null-safe + forward-compatible** — `agentId` / `avatarUrl` (auto-derived from the GitHub account via #14785) / `displayName` / `state` map now; `engineTag` / `family` / `laneLine` map through as `null` until the DTO enrichment + activity/runtime wires land, with no factory change needed then.

## Test Evidence

`npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs` → **6 passed**. The spec uses the real `createFleetCockpitStatus` DTO as input, so it proves the factory consumes the live cockpit shape — including the GitHub-derived avatar riding into the blueprint.

## Post-Merge Validation

- [ ] With this on dev, the #14789 flagship dock can consume `createFleetCardDescriptors` output to place/restore layout-blind AgentCards; NL/preview visual verification of the rendered dock is the flagship's step.

## Deltas from ticket

Exactly the scoped transform + its spec. DTO enrichment for `family`/`engineTag` (surfacing them on the row, like avatarUrl) and the `laneLine`/`state` activity+runtime wires are separate follow-ons — the factory already maps them forward-compatibly. Blueprint names the card by `ntype` (serializable); if the dock prefers `className`, a one-line change.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
