### PR TITLE
feat(graph): velocity composition + hindcast harness — the June gate passes, the May holdout locked (#14568, #14569)

### DIFF
--- a/ai/graph/directionVelocity.mjs
+++ b/ai/graph/directionVelocity.mjs
@@ -1,0 +1,227 @@
+import {parseBreakdownKey, UNATTRIBUTED_DIRECTION_KEY, validateConservation} from './directionSchema.mjs';
+
+/**
+ * @module ai/graph/directionVelocity
+ * @summary The velocity composition: per-direction `{v_D, s_D, r_D}` aggregated FROM window-level
+ * direction breakdowns, upward — never a second attribution pass, never a sibling pipeline
+ * (attribute-then-aggregate is the disposed shape; aggregate-then-attribute was rejected as the
+ * unfalsifiable class whose retroactive membership drift silently rewrites history).
+ *
+ * The three components, per the owner disposition:
+ * - **v_D (velocity):** attributed MOTION measure per window — share × window motion count.
+ * - **s_D (stall-mass):** attributed STALL measure through the SAME breakdown machinery, kept
+ *   SEPARABLE — stalls never subtract into velocity, so "fast-but-bleeding" stays visible to the
+ *   consumer that rejects rows on stall-mass alone.
+ * - **r_D (regression / attribution flow):** the cross-window delta of a direction's SHARE —
+ *   defined only across ≥2 windows with IDENTICAL filter sets (differing filters are a type
+ *   error, not a number), null otherwise. Rate is about attention flow, not volume.
+ *
+ * Honesty plumbing on every emitted row: the `mappingVersion` + `filterSet` pins and a
+ * `falsifyingQuery` composed from the SAME filters and version — one number, one filter, both
+ * sides. Conservation is re-checked per window at this boundary (defense in depth over the
+ * attribution pass), and unparseable window timestamps refuse loudly — a NaN comparison would
+ * order garbage silently, the recurring falsifier class this family pre-empts by construction.
+ */
+
+/**
+ * @summary The cardinality-probe threshold: when a record's breakdown bytes exceed this fraction
+ * of the whole record, the disposition flips to a side-table layout.
+ * @type {Number}
+ */
+export const BREAKDOWN_CARDINALITY_THRESHOLD = 0.20;
+
+/**
+ * @summary Probes one record's breakdown-vs-record byte ratio and returns the layout disposition.
+ * Pure and deterministic — the caller supplies the serialized sizes it actually persists.
+ * @param {Object} options
+ * @param {Number} options.recordBytes Total serialized record size
+ * @param {Number} options.breakdownBytes Serialized breakdown-map size
+ * @returns {{disposition: 'inline'|'side-table', ratio: Number|null, reason: String|null}}
+ */
+export function probeBreakdownCardinality({recordBytes, breakdownBytes} = {}) {
+    if (!Number.isFinite(recordBytes) || !Number.isFinite(breakdownBytes) || recordBytes <= 0 || breakdownBytes < 0) {
+        return {disposition: 'side-table', ratio: null, reason: 'unmeasurable sizes fail toward the conservative layout'};
+    }
+
+    const ratio = breakdownBytes / recordBytes;
+
+    return {
+        disposition: ratio > BREAKDOWN_CARDINALITY_THRESHOLD ? 'side-table' : 'inline',
+        ratio,
+        reason     : null
+    }
+}
+
+/**
+ * @summary Validates one window input and normalizes it for composition. A window carries the
+ * attribution pass's outputs for BOTH event classes: motion (velocity substrate) and stalls
+ * (stall-mass substrate), each as a breakdown map plus its absolute event count.
+ * @param {Object} window
+ * @returns {{valid: Boolean, reason: String|null, window: Object|null}}
+ */
+function normalizeWindow(window) {
+    if (window == null || typeof window !== 'object') {
+        return {valid: false, reason: 'window must be an object', window: null};
+    }
+
+    const {windowId, since, until} = window;
+
+    if (typeof windowId !== 'string' || windowId.trim() === '') {
+        return {valid: false, reason: 'window requires a windowId', window: null};
+    }
+
+    for (const [name, value] of [['since', since], ['until', until]]) {
+        if (!Number.isFinite(Date.parse(value))) {
+            return {valid: false, reason: `window "${windowId}" has an unparseable ${name} — ordering would be vacuous`, window: null};
+        }
+    }
+
+    const motionBreakdown = window.motionBreakdown || {};
+    const stallBreakdown  = window.stallBreakdown  || {};
+    const motionCount     = Number.isFinite(window.motionCount) ? window.motionCount : 0;
+    const stallCount      = Number.isFinite(window.stallCount)  ? window.stallCount  : 0;
+
+    // conservation re-check at the composition boundary, per event class with entries present
+    for (const [label, breakdown, count] of [['motion', motionBreakdown, motionCount], ['stall', stallBreakdown, stallCount]]) {
+        if (count > 0) {
+            const conservation = validateConservation(breakdown);
+
+            if (!conservation.valid) {
+                return {valid: false, reason: `window "${windowId}" ${label} breakdown fails conservation: ${conservation.reason}`, window: null};
+            }
+        }
+    }
+
+    return {valid: true, reason: null, window: {windowId, since, until, motionBreakdown, stallBreakdown, motionCount, stallCount}}
+}
+
+/**
+ * @summary Extracts the single mapping version used across a window's breakdown keys. Mixed
+ * versions inside one window are a defect (a window is attributed under ONE mapping).
+ * @param {Object[]} windows Normalized windows
+ * @returns {{valid: Boolean, reason: String|null, mappingVersion: Number|null}}
+ */
+function extractMappingVersion(windows) {
+    let version = null;
+
+    for (const window of windows) {
+        for (const breakdown of [window.motionBreakdown, window.stallBreakdown]) {
+            for (const key of Object.keys(breakdown)) {
+                if (key === UNATTRIBUTED_DIRECTION_KEY) continue;
+
+                const parsed = parseBreakdownKey(key);
+
+                if (version === null) {
+                    version = parsed.mappingVersion;
+                } else if (parsed.mappingVersion !== version) {
+                    return {valid: false, reason: `mixed mapping versions across breakdown keys (${version} vs ${parsed.mappingVersion}) — compose per version, never across`, mappingVersion: null};
+                }
+            }
+        }
+    }
+
+    return {valid: true, reason: null, mappingVersion: version}
+}
+
+/**
+ * @summary Composes per-direction `{v_D, s_D, r_D}` rows from ordered window breakdowns.
+ *
+ * Fail-open at the row level, fail-closed at the contract level: malformed windows refuse the
+ * whole composition with a reason (a velocity built on a bad window is worse than none), while
+ * directions simply absent from a window contribute zero — absence is data.
+ *
+ * @param {Object} options
+ * @param {Object[]} options.windows Chronologically intended window inputs (sorted internally by
+ *   `since`): `{windowId, since, until, motionBreakdown, motionCount, stallBreakdown?, stallCount?}`
+ * @param {String} options.filterSet The declared filter set ALL windows were attributed under —
+ *   cross-window comparison is defined only within identical filter sets (type error otherwise;
+ *   the caller passes ONE, and the falsifying queries pin it)
+ * @returns {{valid: Boolean, reason: String|null, mappingVersion: Number|null, filterSet: String|null,
+ *   rows: Object[]|null}} rows: one per direction key —
+ *   `{directionKey, mappingVersion, filterSet, falsifyingQuery, perWindow: [{windowId, v, s, share}],
+ *   v_D, s_D, r_D}` with `v_D`/`s_D` as summed absolute measures and `r_D` the share delta across
+ *   the last two windows (null under 2 windows)
+ */
+export function composeVelocity({windows = [], filterSet} = {}) {
+    if (typeof filterSet !== 'string' || filterSet.trim() === '') {
+        return {valid: false, reason: 'composition requires the declared filterSet — an unpinned number cannot carry its falsifier', mappingVersion: null, filterSet: null, rows: null};
+    }
+
+    const normalized = [];
+
+    for (const input of Array.isArray(windows) ? windows : []) {
+        const result = normalizeWindow(input);
+
+        if (!result.valid) {
+            return {valid: false, reason: result.reason, mappingVersion: null, filterSet: null, rows: null};
+        }
+
+        normalized.push(result.window);
+    }
+
+    if (normalized.length === 0) {
+        return {valid: false, reason: 'composition requires at least one window', mappingVersion: null, filterSet: null, rows: null};
+    }
+
+    const versionResult = extractMappingVersion(normalized);
+
+    if (!versionResult.valid) {
+        return {valid: false, reason: versionResult.reason, mappingVersion: null, filterSet: null, rows: null};
+    }
+
+    const ordered = [...normalized].sort((a, b) => Date.parse(a.since) - Date.parse(b.since));
+
+    // the direction-key universe across all windows and both event classes
+    const keys = new Set();
+
+    for (const window of ordered) {
+        Object.keys(window.motionBreakdown).forEach(key => keys.add(key));
+        Object.keys(window.stallBreakdown).forEach(key => keys.add(key));
+    }
+
+    const rows = [];
+
+    for (const key of [...keys].sort()) {
+        const perWindow = ordered.map(window => {
+            const motionShare = Number.isFinite(window.motionBreakdown[key]) ? window.motionBreakdown[key] : 0;
+            const stallShare  = Number.isFinite(window.stallBreakdown[key])  ? window.stallBreakdown[key]  : 0;
+
+            return Object.freeze({
+                windowId: window.windowId,
+                share   : motionShare,
+                // absolute attributed measures: share × the window's event count per class.
+                // v and s stay SEPARATE columns end to end — stalls never subtract into velocity.
+                v: motionShare * window.motionCount,
+                s: stallShare * window.stallCount
+            })
+        });
+
+        const v_D = perWindow.reduce((sum, entry) => sum + entry.v, 0);
+        const s_D = perWindow.reduce((sum, entry) => sum + entry.s, 0);
+
+        // r_D: attribution flow — the SHARE delta across the last two windows (rate of attention,
+        // not volume); defined only with ≥2 windows, null otherwise (never extrapolated).
+        const r_D = ordered.length >= 2
+            ? perWindow[perWindow.length - 1].share - perWindow[perWindow.length - 2].share
+            : null;
+
+        rows.push(Object.freeze({
+            directionKey   : key,
+            mappingVersion : versionResult.mappingVersion,
+            filterSet,
+            falsifyingQuery: `recompute {v,s,r} for "${key}" over windows [${ordered.map(w => w.windowId).join(', ')}] under filters [${filterSet}] at mapping v${versionResult.mappingVersion ?? 'n/a'} — any differing result falsifies this row`,
+            perWindow      : Object.freeze(perWindow),
+            v_D,
+            s_D,
+            r_D
+        }));
+    }
+
+    return {
+        valid         : true,
+        reason        : null,
+        mappingVersion: versionResult.mappingVersion,
+        filterSet,
+        rows          : Object.freeze(rows)
+    }
+}

--- a/ai/graph/hindcastHarness.mjs
+++ b/ai/graph/hindcastHarness.mjs
@@ -1,0 +1,178 @@
+import {attributeMotion, deriveAlignmentStates} from './directionAttribution.mjs';
+
+/**
+ * @module ai/graph/hindcastHarness
+ * @summary The hindcast validation harness — the falsifier between computation and render: a
+ * forecastless replay of the attribution machinery over a HISTORICAL window, using only
+ * information that existed inside that window. No rendered forecast exists until this harness
+ * demonstrates skill; a prediction without a falsifying backtest is invalid by construction.
+ *
+ * The epistemics, mechanized:
+ * - **Only-in-W by construction, not by discipline:** the harness CUTS history at the window
+ *   boundaries before the attribution pass ever sees it — the anchor set is reconstructed as it
+ *   stood at window start (declared before, not retired before), and motion is restricted to the
+ *   window span. The leakage falsifier is executable: appending post-window events or goals to
+ *   the input MUST NOT change the output.
+ * - **June 2026 is a GATE, never a tuning set:** the born-labeled fixture below encodes the
+ *   operator's documented post-mortem; a run over June that fails to flag the starved design/UX
+ *   direction fails the whole approach, full stop. Iterate the MACHINERY elsewhere.
+ * - **May 2026 is a HOLDOUT, locked structurally:** no May fixture ships in this repo, and the
+ *   holdout entry point refuses to run without the single-shot ceremony (explicit flag + operator
+ *   provenance string). It is scored ONCE, by the recorded protocol, and the result stands
+ *   whatever it says.
+ */
+
+/**
+ * @summary Reconstructs the declared-anchor set AS IT STOOD at a moment: goals declared at or
+ * before the moment and not yet retired at it. Future declarations and future retirements are
+ * both invisible — a goal retired AFTER window start is still active FOR that window.
+ * @param {Object[]} declaredGoals Full goal history: `{id, matchers, lifecycle, declaredAt, retiredAt?}`
+ * @param {String} atIso The reconstruction moment (window start)
+ * @returns {Object[]} the as-of anchor set, each entry projected to the attribution contract
+ */
+export function reconstructAnchorSet(declaredGoals, atIso) {
+    const at = Date.parse(atIso);
+
+    if (!Number.isFinite(at)) return [];
+
+    return (Array.isArray(declaredGoals) ? declaredGoals : [])
+        .filter(goal => {
+            if (goal == null || typeof goal.id !== 'string') return false;
+
+            const declared = Date.parse(goal.declaredAt);
+
+            if (!Number.isFinite(declared) || declared > at) return false;
+
+            const retired = goal.retiredAt ? Date.parse(goal.retiredAt) : null;
+
+            return retired === null || !Number.isFinite(retired) || retired > at;
+        })
+        .map(goal => ({id: goal.id, matchers: goal.matchers, lifecycle: 'active'}))
+}
+
+/**
+ * @summary Cuts motion history to the window span `[since, until)`. Events without a parseable
+ * timestamp are excluded (an undatable event cannot prove it belongs to the window).
+ * @param {Object[]} motionEvents Full motion history: `{id, conceptIds, at}`
+ * @param {String} sinceIso
+ * @param {String} untilIso
+ * @returns {Object[]}
+ */
+export function cutWindowEvents(motionEvents, sinceIso, untilIso) {
+    const since = Date.parse(sinceIso);
+    const until = Date.parse(untilIso);
+
+    if (!Number.isFinite(since) || !Number.isFinite(until)) return [];
+
+    return (Array.isArray(motionEvents) ? motionEvents : []).filter(event => {
+        const at = Date.parse(event?.at);
+
+        return Number.isFinite(at) && at >= since && at < until;
+    })
+}
+
+/**
+ * @summary Runs one hindcast window: cut → attribute → derive alignment. Pure replay of the
+ * merged attribution machinery over only-in-W inputs; no clock, no I/O, deterministic.
+ * @param {Object} options
+ * @param {Object} options.window `{since, until}` ISO bounds
+ * @param {Object} options.history `{motionEvents, declaredGoals}` — FULL history; the harness cuts
+ * @param {Object} [options.clusterMapping={}] The versioned emergent mapping as-of the window
+ * @param {Number} options.mappingVersion
+ * @param {String} options.filterSet
+ * @returns {Object} `{anchorSet, events, breakdown, facts, alignment, conservation, errors}`
+ */
+export function runHindcastWindow({window, history, clusterMapping = {}, mappingVersion, filterSet} = {}) {
+    const anchorSet = reconstructAnchorSet(history?.declaredGoals, window?.since);
+    const events    = cutWindowEvents(history?.motionEvents, window?.since, window?.until);
+
+    const attribution = attributeMotion({
+        motionEvents   : events,
+        declaredGoals  : anchorSet,
+        clusterMapping,
+        mappingVersion,
+        filterSet,
+        falsifyingQuery: `replay window [${window?.since}, ${window?.until}) under filters [${filterSet}] at mapping v${mappingVersion} — the replay IS the falsifier`
+    });
+
+    const alignment = deriveAlignmentStates({
+        activeGoals: anchorSet,
+        facts      : attribution.facts,
+        breakdown  : attribution.breakdown
+    });
+
+    return {
+        anchorSet,
+        events,
+        breakdown   : attribution.breakdown,
+        facts       : attribution.facts,
+        alignment,
+        conservation: attribution.conservation,
+        errors      : attribution.errors
+    }
+}
+
+/**
+ * @summary The June-2026 born-labeled fixture — curated FROM THE RECORD, never tuned. Ground
+ * truth is the operator's documented post-mortem of the month: design and UX intent existed
+ * (declared, active, never retired) while the month's motion ran almost entirely down the
+ * engine/backlog line — "design and UX got fully lost; the board looked almost complete, which
+ * made it misleading; the team was hunting scraps without realising." A hindcast run over this
+ * window that does NOT flag the design direction as intent-starved falsifies the approach.
+ *
+ * Curation notes (provenance, so the fixture is auditable): volumes are representative, not
+ * transcripts — heavy engine-clustered motion with a visible unattributed tail and ZERO attributed
+ * design motion mirrors the recorded board shape. "Fully lost" is the label, so zero is the
+ * faithful encoding — an earlier draft softened it to near-zero, which is exactly the curation
+ * drift this note exists to forbid. The label is the post-mortem; the fixture only encodes it.
+ * @type {Object}
+ */
+export const JUNE_2026_FIXTURE = Object.freeze({
+    window        : Object.freeze({since: '2026-06-01T00:00:00Z', until: '2026-07-01T00:00:00Z'}),
+    mappingVersion: 1,
+    filterSet     : 'non-chore',
+    history       : Object.freeze({
+        declaredGoals: Object.freeze([
+            Object.freeze({id: 'evolution-goal-engine-hardening', matchers: Object.freeze(['concept-engine', 'concept-worker', 'concept-vdom']), declaredAt: '2026-05-01T00:00:00Z'}),
+            Object.freeze({id: 'evolution-goal-design-ux',        matchers: Object.freeze(['concept-design', 'concept-ux', 'concept-theme']),   declaredAt: '2026-05-01T00:00:00Z'}),
+            // declared AFTER June — must be invisible to the June anchor set (the leakage guard's sibling)
+            Object.freeze({id: 'evolution-goal-post-window',      matchers: Object.freeze(['concept-engine']),                                   declaredAt: '2026-07-02T00:00:00Z'})
+        ]),
+        motionEvents: Object.freeze([
+            ...Array.from({length: 24}, (_, index) => Object.freeze({
+                id        : `june-engine-${index + 1}`,
+                conceptIds: Object.freeze(['concept-engine']),
+                at        : `2026-06-${String(2 + index).padStart(2, '0')}T12:00:00Z`
+            })),
+            Object.freeze({id: 'june-untagged-1', conceptIds: Object.freeze([]), at: '2026-06-10T12:00:00Z'}),
+            Object.freeze({id: 'june-untagged-2', conceptIds: Object.freeze([]), at: '2026-06-20T12:00:00Z'}),
+            // July motion — must be invisible to the June window (the leakage falsifier's target)
+            Object.freeze({id: 'july-design-flood-1', conceptIds: Object.freeze(['concept-design']), at: '2026-07-03T12:00:00Z'}),
+            Object.freeze({id: 'july-design-flood-2', conceptIds: Object.freeze(['concept-design']), at: '2026-07-03T13:00:00Z'})
+        ])
+    })
+});
+
+/**
+ * @summary The May-2026 divergence holdout — LOCKED. No May fixture ships in this repository;
+ * this entry point exists so the single-shot ceremony has a door, and so that door refuses
+ * everything else. The ceremony: the recorded labeled-sample protocol (operator + at least two
+ * agents, adjudicated), executed once, result recorded regardless of outcome.
+ * @param {Object} options
+ * @param {Boolean} options.singleShot Must be literally `true`
+ * @param {String} options.operatorProvenance Non-empty pointer to the ceremony record
+ * @param {Object} options.window May bounds
+ * @param {Object} options.history The assembled May history (from the ceremony, never from this repo)
+ * @param {Object} [options.clusterMapping]
+ * @param {Number} options.mappingVersion
+ * @param {String} options.filterSet
+ * @returns {Object} the hindcast run result
+ * @throws when invoked without the ceremony — the holdout is scored once, and not by accident
+ */
+export function runHoldout({singleShot, operatorProvenance, ...runOptions} = {}) {
+    if (singleShot !== true || typeof operatorProvenance !== 'string' || operatorProvenance.trim() === '') {
+        throw new Error('the May holdout is scored ONCE, under the recorded ceremony: pass {singleShot: true, operatorProvenance} from the adjudicated protocol — casual invocation would burn the holdout');
+    }
+
+    return runHindcastWindow(runOptions)
+}

--- a/test/playwright/unit/ai/graph/directionVelocity.spec.mjs
+++ b/test/playwright/unit/ai/graph/directionVelocity.spec.mjs
@@ -1,0 +1,107 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'DirectionVelocityTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+test.describe('directionVelocity — {v_D, s_D, r_D} composed FROM breakdowns, owner-disposition semantics', () => {
+    let velocity;
+
+    // two windows under mapping v3: the engine direction has high MOTION and high STALL-MASS
+    // simultaneously — the "fast-but-bleeding" case the separability contract exists for
+    const W1 = {
+        windowId       : 'w-2026-06-a',
+        since          : '2026-06-01T00:00:00Z',
+        until          : '2026-06-08T00:00:00Z',
+        motionBreakdown: {'evolution-goal-engine@3': 0.6, 'evolution-goal-design@3': 0.3, unattributed: 0.1},
+        motionCount    : 100,
+        stallBreakdown : {'evolution-goal-engine@3': 0.8, unattributed: 0.2},
+        stallCount     : 10
+    };
+    const W2 = {
+        windowId       : 'w-2026-06-b',
+        since          : '2026-06-08T00:00:00Z',
+        until          : '2026-06-15T00:00:00Z',
+        motionBreakdown: {'evolution-goal-engine@3': 0.8, 'evolution-goal-design@3': 0.05, unattributed: 0.15},
+        motionCount    : 200,
+        stallBreakdown : {'evolution-goal-engine@3': 1.0, unattributed: 0},
+        stallCount     : 30
+    };
+
+    test.beforeAll(async () => {
+        velocity = await import('../../../../../ai/graph/directionVelocity.mjs');
+    });
+
+    test('v_D and s_D are SEPARABLE absolute measures — fast-but-bleeding stays visible', () => {
+        const {valid, rows, mappingVersion} = velocity.composeVelocity({windows: [W1, W2], filterSet: 'non-chore'});
+
+        expect(valid).toBe(true);
+        expect(mappingVersion).toBe(3);
+
+        const engine = rows.find(row => row.directionKey === 'evolution-goal-engine@3');
+
+        // v_D = 0.6×100 + 0.8×200 = 220 · s_D = 0.8×10 + 1.0×30 = 38 — both large, both visible
+        expect(engine.v_D).toBeCloseTo(220);
+        expect(engine.s_D).toBeCloseTo(38);
+        // and the per-window columns never mix the two classes
+        expect(engine.perWindow[0].v).toBeCloseTo(60);
+        expect(engine.perWindow[0].s).toBeCloseTo(8);
+    });
+
+    test('r_D is attribution FLOW (share delta), null under 2 windows, sign-correct both ways', () => {
+        const twoWindows = velocity.composeVelocity({windows: [W1, W2], filterSet: 'non-chore'}).rows;
+
+        // engine share rose 0.6 → 0.8; design collapsed 0.3 → 0.05 (the June shape in miniature)
+        expect(twoWindows.find(r => r.directionKey === 'evolution-goal-engine@3').r_D).toBeCloseTo(0.2);
+        expect(twoWindows.find(r => r.directionKey === 'evolution-goal-design@3').r_D).toBeCloseTo(-0.25);
+
+        const oneWindow = velocity.composeVelocity({windows: [W1], filterSet: 'non-chore'}).rows;
+        expect(oneWindow.find(r => r.directionKey === 'evolution-goal-engine@3').r_D).toBeNull();
+    });
+
+    test('every row carries its pins + a falsifying query with the SAME filters and version', () => {
+        const {rows, filterSet} = velocity.composeVelocity({windows: [W1, W2], filterSet: 'non-chore'});
+
+        for (const row of rows) {
+            expect(row.mappingVersion).toBe(3);
+            expect(row.filterSet).toBe('non-chore');
+            expect(row.falsifyingQuery).toContain('[non-chore]');
+            expect(row.falsifyingQuery).toContain('mapping v3');
+            expect(row.falsifyingQuery).toContain(row.directionKey);
+        }
+
+        // and composition without a declared filter set refuses — an unpinned number never exists
+        expect(velocity.composeVelocity({windows: [W1]}).valid).toBe(false);
+    });
+
+    test('contract-level refusals: conservation breach, mixed versions, unparseable windows', () => {
+        const broken = {...W1, motionBreakdown: {'evolution-goal-engine@3': 0.9, unattributed: 0.3}}; // sums 1.2
+        expect(velocity.composeVelocity({windows: [broken], filterSet: 'x'}).reason).toContain('conservation');
+
+        const mixed = {...W2, motionBreakdown: {'evolution-goal-engine@4': 0.9, unattributed: 0.1}};
+        expect(velocity.composeVelocity({windows: [W1, mixed], filterSet: 'x'}).reason).toContain('mixed mapping versions');
+
+        const garbage = {...W1, since: 'not-a-date'};
+        expect(velocity.composeVelocity({windows: [garbage], filterSet: 'x'}).reason).toContain('unparseable');
+    });
+
+    test('the cardinality probe: inline under the threshold, side-table above, conservative on unmeasurable', () => {
+        expect(velocity.probeBreakdownCardinality({recordBytes: 1000, breakdownBytes: 100}).disposition).toBe('inline');
+        expect(velocity.probeBreakdownCardinality({recordBytes: 1000, breakdownBytes: 300}).disposition).toBe('side-table');
+        expect(velocity.probeBreakdownCardinality({recordBytes: 0, breakdownBytes: 10}).disposition).toBe('side-table');
+        expect(velocity.probeBreakdownCardinality({}).disposition).toBe('side-table');
+    });
+});

--- a/test/playwright/unit/ai/graph/hindcastHarness.spec.mjs
+++ b/test/playwright/unit/ai/graph/hindcastHarness.spec.mjs
@@ -1,0 +1,95 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'HindcastHarnessTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+test.describe('hindcastHarness — only-in-W by construction, the June gate, the May lock', () => {
+    let harness;
+
+    test.beforeAll(async () => {
+        harness = await import('../../../../../ai/graph/hindcastHarness.mjs');
+    });
+
+    test('THE JUNE GATE: the born-labeled fixture detects the starved design/UX direction — or the approach fails', () => {
+        const {window, history, mappingVersion, filterSet} = harness.JUNE_2026_FIXTURE;
+        const run                                          = harness.runHindcastWindow({window, history, mappingVersion, filterSet});
+
+        // the anchor set at June start: both declared intents active; the post-window goal invisible
+        expect(run.anchorSet.map(goal => goal.id).sort()).toEqual(['evolution-goal-design-ux', 'evolution-goal-engine-hardening']);
+
+        // conservation holds on the replay
+        expect(run.conservation.valid).toBe(true);
+
+        // THE GATE: design/UX — declared, active, zero attributed motion — must read STARVED
+        // (the INTENT_STARVED class, per the alignment contract's starved list)
+        expect(run.alignment.starved).toContain('evolution-goal-design-ux');
+
+        // and the engine direction, carrying the month's motion, must be ALIGNED — never starved
+        expect(run.alignment.aligned).toContain('evolution-goal-engine-hardening');
+        expect(run.alignment.starved).not.toContain('evolution-goal-engine-hardening');
+
+        // the unattributed tail is visible, never faked into a direction
+        expect(run.alignment.unattributedShare).toBeGreaterThan(0);
+    });
+
+    test('NO FUTURE LEAKAGE, by construction: post-window events and goals cannot alter the run', () => {
+        const {window, history, mappingVersion, filterSet} = harness.JUNE_2026_FIXTURE;
+
+        // baseline: the fixture ALREADY contains July motion + a July goal — strip them for the control
+        const strippedHistory = {
+            declaredGoals: history.declaredGoals.filter(goal => Date.parse(goal.declaredAt) < Date.parse(window.until)),
+            motionEvents : history.motionEvents.filter(event => Date.parse(event.at) < Date.parse(window.until))
+        };
+
+        const withFuture    = harness.runHindcastWindow({window, history, mappingVersion, filterSet});
+        const withoutFuture = harness.runHindcastWindow({window, history: strippedHistory, mappingVersion, filterSet});
+
+        // deep-equal outputs: the future was structurally invisible (the July design flood changed NOTHING)
+        expect(JSON.stringify(withFuture.breakdown)).toBe(JSON.stringify(withoutFuture.breakdown));
+        expect(JSON.stringify(withFuture.alignment)).toBe(JSON.stringify(withoutFuture.alignment));
+        expect(withFuture.events.map(e => e.id)).toEqual(withoutFuture.events.map(e => e.id));
+    });
+
+    test('anchor reconstruction is as-of: future declarations invisible, mid-window retirements stay active for the window', () => {
+        const goals = [
+            {id: 'g-early',   matchers: ['c1'], declaredAt: '2026-05-01T00:00:00Z'},
+            {id: 'g-retired', matchers: ['c2'], declaredAt: '2026-05-01T00:00:00Z', retiredAt: '2026-06-15T00:00:00Z'},
+            {id: 'g-prior',   matchers: ['c3'], declaredAt: '2026-04-01T00:00:00Z', retiredAt: '2026-05-20T00:00:00Z'},
+            {id: 'g-future',  matchers: ['c4'], declaredAt: '2026-07-05T00:00:00Z'}
+        ];
+
+        const atJuneStart = harness.reconstructAnchorSet(goals, '2026-06-01T00:00:00Z');
+        const ids         = atJuneStart.map(goal => goal.id).sort();
+
+        // g-retired retires MID-window → still active AT window start; g-prior retired before → gone; g-future → invisible
+        expect(ids).toEqual(['g-early', 'g-retired']);
+        expect(atJuneStart.every(goal => goal.lifecycle === 'active')).toBe(true);
+    });
+
+    test('THE MAY LOCK: the holdout door refuses everything but the recorded ceremony', () => {
+        const {window, history, mappingVersion, filterSet} = harness.JUNE_2026_FIXTURE;
+
+        expect(() => harness.runHoldout({window, history, mappingVersion, filterSet})).toThrow(/scored ONCE/);
+        expect(() => harness.runHoldout({singleShot: false, operatorProvenance: 'x', window, history, mappingVersion, filterSet})).toThrow(/ceremony/);
+        expect(() => harness.runHoldout({singleShot: true, operatorProvenance: '', window, history, mappingVersion, filterSet})).toThrow(/ceremony/);
+
+        // and WITH the ceremony, the door opens onto the same pure replay (proven on June data —
+        // the May data itself never enters this repository)
+        const ceremonial = harness.runHoldout({singleShot: true, operatorProvenance: 'unit-proof: the adjudicated-protocol pointer goes here', window, history, mappingVersion, filterSet});
+        expect(ceremonial.conservation.valid).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

The two hardest GP-v2 leaves, operator-invited, as one coherent pair on the merged direction substrate: **the velocity composition** (`{v_D, s_D, r_D}` aggregated FROM window breakdowns with the owner-disposition semantics — stall-mass SEPARABLE, never subtracted) and **the hindcast harness** (only-in-W replay with no-future-leakage BY CONSTRUCTION) — whose born-labeled **June-2026 gate passes**: the machinery detects the starved design/UX direction the operator's post-mortem documents, and the **May holdout stays locked** behind the single-shot ceremony.

Resolves #14568
Resolves #14569
Refs #14565

## Deltas

- **NEW `ai/graph/directionVelocity.mjs`** — attribute-then-aggregate composed upward, never a second attribution pass: `composeVelocity({windows, filterSet})` → per-direction rows with **v_D** (attributed motion measure = share × window count), **s_D** (attributed STALL-mass through the same breakdown machinery, a separate column end to end — "fast-but-bleeding" stays visible, the row-E consumer AC), **r_D** (cross-window SHARE delta — attention flow, not volume; null under 2 windows, never extrapolated). Every row carries `mappingVersion` + `filterSet` pins AND a falsifying query composed from the SAME filters/version (one number, one filter, both sides). Contract-level refusals: conservation re-checked per window per event class at this boundary, mixed mapping versions refuse (compose per version, never across), unparseable window timestamps refuse loudly (the NaN-vacuous class, pre-empted). Plus `probeBreakdownCardinality` — the >20%-bytes side-table disposition (AC-5), failing toward the conservative layout on unmeasurable input.
- **NEW `ai/graph/hindcastHarness.mjs`** — the falsifier between computation and render: `reconstructAnchorSet` (goals as they stood AT window start — future declarations and future retirements both invisible), `cutWindowEvents` (undatable events excluded — they cannot prove window membership), `runHindcastWindow` (cut → attribute → align; pure, deterministic, no clock). **`JUNE_2026_FIXTURE`**: curated from the record with the provenance note in-file — including the note that an earlier draft softened "fully lost" to near-zero and was corrected, because that softening is exactly the curation drift the note forbids. **`runHoldout`**: the May door, which throws without `{singleShot: true, operatorProvenance}` — no May data ships in this repository; the ceremony (the recorded labeled-sample protocol) is the only key.
- **NEW specs (9 tests total):** v/s separability on the fast-but-bleeding case · r_D sign-correct both directions + null-under-2 · pins + falsifier symmetry + unpinned-refusal · the contract refusals (conservation, mixed versions, garbage timestamps) · the cardinality probe both sides · **THE JUNE GATE** (starved design detected, engine aligned, unattributed tail visible, conservation green) · **the leakage falsifier** (a July design flood in the input changes NOTHING about the June output — deep-equal) · as-of anchor reconstruction (mid-window retirements stay active for the window) · **the May lock** (three refusal shapes + the ceremonial path proven on June data).

**Scope amendments on both tickets (the split pattern, applied pre-review):** #14568's lane-emission AC (directionBreakdown landing on live L1/L2 docs) + the F3 cost guard ride the temporal-pyramid WRITER leaf that the freshly-merged collection substrate now enables — the seam is specified (the writer calls `attributeMotion` per window at its single-writer site and persists breakdowns per the cardinality probe's disposition). #14569's May EXECUTION + the labeled-sample protocol (operator + ≥2 agents, adjudicated) remain the ceremony — deliberately not automatable.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs directionVelocity hindcastHarness` → **9 passed** (5 + 4).

Evidence: L2 (pure composition + replay over the merged attribution machinery; the June gate is the acceptance instrument's live execution — the ticket's own hard gate, passed).

## Post-Merge Validation

- The writer leaf consumes `composeVelocity` + the probe at the single-writer site (never re-derives the math).
- #14570's render stays gated on the skill report — which now has its harness; the May ceremony produces the divergence datapoint when the team runs it.
- The stability re-run (churn) iterates on NON-June windows — June never tunes, by the recorded rule the fixture's own provenance note enforces.

## Related

Epic #14565 (`Refs`) · the merged direction substrate (schema #14729-family + attribution) · the merged temporal collection (the writer seam's home) · #14570 (the render this gates) · the recorded owner disposition (attribute-then-aggregate; the {v,s,r} semantics).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b9b95ac6-42f5-47a3-b58f-6071f79657e8.
