### PR TITLE
fix(memory-core): preserve committed read-state across mailbox WAL re-projection (#14797)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1092,11 +1092,26 @@ class MailboxService extends Base {
         ensureMailboxProjectionEndpoint(sentBy);
         ensureMailboxProjectionEndpoint(to);
 
+        // The message WAL is pure intake: its record always carries creation-time read/archive state
+        // (readAt: null). A repair re-projection must therefore NOT re-materialize from the WAL
+        // blindly — that reverts a committed mark_read (or archive) which lives only on the live graph
+        // projection, resurrecting a read message as unread. Capture the current committed
+        // post-delivery state from the LIVE projection (which the re-projection is about to overwrite
+        // in place) and carry it forward, so repair is structure-only. On a genuine first projection
+        // the node does not exist yet, so this resolves to null and intake semantics are unchanged.
+        const existingMessageNode = GraphService.db?.nodes?.get?.(messageId) || null,
+            preservedNodeReadAt   = existingMessageNode?.properties?.readAt     ?? null,
+            preservedNodeArchived = existingMessageNode?.properties?.archivedAt ?? null;
+
         GraphService.upsertNode({
             id        : messageId,
             type      : message.type || 'MESSAGE',
             name      : message.name || messageProperties.subject || messageId,
-            properties: messageProperties
+            properties: {
+                ...messageProperties,
+                readAt    : preservedNodeReadAt   ?? messageProperties.readAt     ?? null,
+                archivedAt: preservedNodeArchived ?? messageProperties.archivedAt ?? null
+            }
         });
 
         linkRequiredMailboxEdgeOrThrow(messageId, sentBy, 'SENT_BY', 1.0, edgeProperties, routingDiagnostics);
@@ -1105,9 +1120,15 @@ class MailboxService extends Base {
         if (to === 'AGENT:*') {
             for (const recipient of getMessageWalArray(routing.broadcastRecipients)) {
                 ensureMailboxProjectionEndpoint(recipient);
+                // The per-recipient DELIVERED_TO edge is the SOLE carrier of a broadcast recipient's
+                // mark_read/archive — the WAL never holds it. Preserve any committed state across
+                // re-projection instead of hardcoding readAt: null (the resurrection wipe).
+                const existingDeliveryEdge = getBroadcastDeliveryEdge(messageId, recipient),
+                    existingDeliveryProps  = existingDeliveryEdge ? getRecordProperties(existingDeliveryEdge) : null;
                 linkRequiredMailboxEdgeOrThrow(messageId, recipient, 'DELIVERED_TO', 1.0, {
                     deliveredAt : timestamp,
-                    readAt      : null,
+                    readAt      : existingDeliveryProps?.readAt     ?? null,
+                    archivedAt  : existingDeliveryProps?.archivedAt ?? null,
                     deliveryKind: 'broadcast',
                     userId      : senderUserId,
                     sharedEntity: true

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -347,6 +347,84 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         }
     });
 
+    // Read-state resurrection: repairMessageGraphIntegrity re-projects the pure-intake WAL
+    // record (readAt: null) over the LIVE graph projection on every listMessages/getMessage. A
+    // committed mark_read lives only on the projection, never in the WAL. The DM carrier is the wipe
+    // vector — re-projection `upsertNode`s the MESSAGE node, overwriting its readAt (the node tests
+    // below fail without the preservation fix). The broadcast DELIVERED_TO edge is protected by
+    // `linkNodes` skipping an already-present edge, so an intact read survives re-projection; the
+    // edge-side preservation is the symmetric hardening for the re-create path. These exercise the
+    // re-projection directly over a live, read projection.
+    async function walRecordFor(messageId) {
+        return (await readWalMessages({ dir: messageWalDir })).find(record => (record.id || record.message?.id) === messageId);
+    }
+
+    test('re-projection preserves a committed mark_read on the broadcast DELIVERED_TO edge — read-state resurrection (#14797)', async () => {
+        const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            return await MailboxService.addMessage({ to: 'AGENT:*', subject: 'broadcast read then repaired', body: 'durable body' });
+        });
+
+        // @bob reads it — readAt committed on his per-recipient DELIVERED_TO edge.
+        const readResult = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.markRead({ messageId: res.messageId });
+        });
+        expect(readResult.readAt).toBeTruthy();
+
+        // Re-project the WAL record over the live projection (the repair path). It must NOT re-link
+        // DELIVERED_TO with a hardcoded readAt: null over @bob's committed read.
+        await MailboxService._projectMessageWalRecord(await walRecordFor(res.messageId), { pumpWake: false });
+
+        const afterRepair = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.getMessage({ messageId: res.messageId });
+        });
+        expect(afterRepair.readAt).toBe(readResult.readAt);
+    });
+
+    test('re-projection preserves a committed mark_read on the DM node — read-state resurrection (#14797)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            return await MailboxService.addMessage({ to: '@bob', subject: 'read then repaired', body: 'durable body' });
+        });
+
+        const readResult = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.markRead({ messageId: res.messageId });
+        });
+        expect(readResult.readAt).toBeTruthy();
+
+        // Re-project over the live projection — the DM node's committed readAt must survive.
+        await MailboxService._projectMessageWalRecord(await walRecordFor(res.messageId), { pumpWake: false });
+
+        const afterRepair = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.getMessage({ messageId: res.messageId });
+        });
+        expect(afterRepair.readAt).toBe(readResult.readAt);
+    });
+
+    test('re-projection keeps a read DM out of the unread count — read-state resurrection (#14797)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            return await MailboxService.addMessage({ to: '@bob', subject: 'read count', body: 'durable body' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await MailboxService.markRead({ messageId: res.messageId });
+        });
+
+        // A read message must not re-enter the unread count when the projection is repaired.
+        await MailboxService._projectMessageWalRecord(await walRecordFor(res.messageId), { pumpWake: false });
+
+        const count = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.countMessages({ status: 'unread' });
+        });
+        expect(count.count).toBe(0);
+    });
+
     test('post-sync canary: accepted unread self-message survives destructive graph clear (#14426)', async () => {
         const res = await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
             return await MailboxService.addMessage({


### PR DESCRIPTION
Resolves #14797

The **re-projection preservation** half of the mailbox read-state resurrection — the mechanism @neo-fable-clio root-caused (her forensics + @neo-fable's amplitude series), which I V-B-A'd against the code and then narrowed with a falsifier.

## The bug, verified in code
`repairMessageGraphIntegrity` re-projects the pure-intake message WAL record (`readAt: null`) over the **live** graph projection, and it runs on **every** `listMessages` (:1287) and `getMessage` (:1461). A committed `mark_read` lives only on the projection, never in the WAL — so a blind re-projection reverts it, resurrecting a read message as unread.

## The narrowing (a falsifier finding worth recording)
Writing the falsifier surfaced that the two carriers behave **differently** under re-projection:
- **DM node — the wipe vector.** `_projectMessageWalRecord` `upsertNode`s the MESSAGE node, overwriting its `readAt` back to `null`. Reproduced deterministically (RED without the fix).
- **Broadcast `DELIVERED_TO` edge — already protected for the intact case.** `GraphService.linkNodes` **skips an already-present edge**, so re-projecting over an intact read edge does **not** wipe it (the broadcast spec is green with or without the fix — kept as an invariant guard). The edge-side preservation here is the **symmetric hardening** for the re-*create* (eviction) path.

## The fix
`_projectMessageWalRecord` captures the current committed `readAt`/`archivedAt` from the live projection **before** re-materializing and carries it forward — repair becomes structure-only, never state-reverting. On a genuine first projection there is no prior state, so it resolves to `null` and intake semantics are unchanged. Applied to both carriers (node overwrite-fix + edge defensive preservation).

## Test Evidence
Evidence: L2 (unit — **83/83 MailboxService specs green**, incl. 3 new). Falsifier-first, verified RED→GREEN by stashing only the service change:
- `re-projection preserves a committed mark_read on the DM node` — **RED** on today's code (`readAt` → `null`), GREEN with the fix.
- `re-projection keeps a read DM out of the unread count` — **RED** without the fix, GREEN with it.
- `re-projection preserves a committed mark_read on the broadcast DELIVERED_TO edge` — invariant guard (green both ways; documents the `linkNodes`-skip protection).
- `npm run test-unit -- .../memory-core/MailboxService.spec.mjs` → **83 passed**.

## Post-Merge Validation
- [ ] **reopen-trigger / follow-up (Clio's fix #2):** the gap predicate `hasMailboxGraphProjectionGap()` trusts a stale in-memory cache and can perceive an intact projection as a gap → spurious repair. Fix #1 (this PR) makes re-projection non-destructive for the DM-node + intact-edge carriers, but the broadcast **edge-eviction** path (edge seen as missing → re-created fresh with `readAt: null`) still resurrects until the gap predicate re-hydrates vicinity before deciding. Track as a sibling of #14797.
- [ ] Verify #14576 phantom-wake-replay amplitude drops once this lands (the digest input stops lying for the DM/intact-edge classes).

## Deltas
- Scoped to the re-projection preservation (fix #1). The gap-predicate cache-hydration (fix #2) is a separate follow-up per the finding above — kept out to ship the proven, deterministic fix rather than bundle an unproven cache-coherence change into the coordination backbone.

Related: `Refs` #14426 (closed — node-loss grade) · #14576 (downstream wake corpus). Forensics: @neo-fable-clio + @neo-fable. Code-verification + falsifier + fix: @neo-opus-ada.

Authored by Ada (Claude Opus 4.8, Claude Code). Session 9a6b25ba-1dd8-4269-8fbf-57a461fd0978.
