### PR TITLE
fix(ai): mailbox repair goes surgical — read-state survives re-projection

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -453,6 +453,31 @@ function hasGraphEdge(source, target, type) {
     );
 }
 
+/**
+ * @summary Storage-truth existence checks for the repair scan.
+ *
+ * The in-memory caches hydrate lazily per vicinity, so a cold cache reads as "missing" for
+ * structures SQLite holds — and a phantom missing-flag makes the repair rewrite intact pieces
+ * from the WAL, resurrecting send-time mutable state (`readAt: null`) over committed reads.
+ * Existence checks that GATE repairs therefore consult storage directly, exactly like
+ * `hasMailboxGraphProjectionGap` does; the cache scans above stay as the cheap fast-path.
+ */
+function hasGraphEdgeInStorage(source, target, type) {
+    const sqlite = GraphService.db?.storage?.db;
+    if (!sqlite) return false;
+
+    return (sqlite.prepare('SELECT count(*) AS count FROM Edges WHERE source = ? AND target = ? AND type = ?')
+        .get(source, target, type)?.count ?? 0) > 0;
+}
+
+function hasMessageNodeInStorage(messageId) {
+    const sqlite = GraphService.db?.storage?.db;
+    if (!sqlite) return false;
+
+    return (sqlite.prepare(`SELECT count(*) AS count FROM Nodes WHERE id = ? AND json_extract(data, '$.label') = 'MESSAGE'`)
+        .get(messageId)?.count ?? 0) > 0;
+}
+
 function hasGraphEdgeOfType(source, type) {
     return (GraphService.db?.edges?.items || []).some(edge =>
         getRecordField(edge, 'source') === source &&
@@ -541,8 +566,11 @@ function getMessageGraphProjectionIssues(record) {
 
     db.getAdjacentNodes(messageId, 'outbound');
 
+    // Every missing-flag below is a REPAIR TRIGGER, so each cache miss falls back to a
+    // storage-truth check: a cold cache flagging an intact piece is exactly the phantom
+    // that made the repair resurrect committed read-state from the WAL.
     const messageNode = db.nodes.get(messageId);
-    if (!messageNode || getRecordField(messageNode, 'label') !== 'MESSAGE') {
+    if ((!messageNode || getRecordField(messageNode, 'label') !== 'MESSAGE') && !hasMessageNodeInStorage(messageId)) {
         issues.push('missing-message-node');
     }
 
@@ -551,12 +579,12 @@ function getMessageGraphProjectionIssues(record) {
         return issues;
     }
 
-    if (!hasGraphEdge(messageId, sentBy, 'SENT_BY')) issues.push('missing-sent-by');
-    if (!hasGraphEdge(messageId, to, 'SENT_TO')) issues.push('missing-sent-to');
+    if (!hasGraphEdge(messageId, sentBy, 'SENT_BY') && !hasGraphEdgeInStorage(messageId, sentBy, 'SENT_BY')) issues.push('missing-sent-by');
+    if (!hasGraphEdge(messageId, to, 'SENT_TO') && !hasGraphEdgeInStorage(messageId, to, 'SENT_TO')) issues.push('missing-sent-to');
 
     if (to === 'AGENT:*') {
         for (const recipient of getMessageWalArray(routing.broadcastRecipients)) {
-            if (!hasGraphEdge(messageId, recipient, 'DELIVERED_TO')) {
+            if (!hasGraphEdge(messageId, recipient, 'DELIVERED_TO') && !hasGraphEdgeInStorage(messageId, recipient, 'DELIVERED_TO')) {
                 issues.push(`missing-delivered-to:${recipient}`);
             }
         }
@@ -1062,10 +1090,16 @@ class MailboxService extends Base {
      * @param {Object} record Accepted message WAL record.
      * @param {Object} [options]
      * @param {Boolean} [options.pumpWake=true] Whether to pump wake subscriptions after projection.
+     * @param {String[]|null} [options.onlyIssues=null] Surgical-repair mode: write ONLY the pieces
+     *   named in this issue list (the `getMessageGraphProjectionIssues` vocabulary). The WAL is
+     *   pure intake — its records carry send-time mutable state (`readAt: null`) forever — so a
+     *   FULL re-projection over existing structures resurrects unread state on top of committed
+     *   reads (the read-state-rollback defect: partial damage must never trigger a total rewrite).
+     *   `null` (accept/drain paths) keeps the full projection for never-projected records.
      * @returns {Promise<void>}
      * @private
      */
-    async _projectMessageWalRecord(record, {pumpWake = true} = {}) {
+    async _projectMessageWalRecord(record, {pumpWake = true, onlyIssues = null} = {}) {
         const messageId = record?.id || record?.message?.id;
         if (typeof messageId !== 'string' || !messageId.startsWith('MESSAGE:')) {
             throw new Error('[MailboxService] message WAL projection requires a MESSAGE:* id');
@@ -1092,19 +1126,28 @@ class MailboxService extends Base {
         ensureMailboxProjectionEndpoint(sentBy);
         ensureMailboxProjectionEndpoint(to);
 
-        GraphService.upsertNode({
-            id        : messageId,
-            type      : message.type || 'MESSAGE',
-            name      : message.name || messageProperties.subject || messageId,
-            properties: messageProperties
-        });
+        const needsPiece = piece => !onlyIssues || onlyIssues.includes(piece);
 
-        linkRequiredMailboxEdgeOrThrow(messageId, sentBy, 'SENT_BY', 1.0, edgeProperties, routingDiagnostics);
-        linkRequiredMailboxEdgeOrThrow(messageId, to, 'SENT_TO', 1.0, edgeProperties, routingDiagnostics);
+        if (needsPiece('missing-message-node')) {
+            GraphService.upsertNode({
+                id        : messageId,
+                type      : message.type || 'MESSAGE',
+                name      : message.name || messageProperties.subject || messageId,
+                properties: messageProperties
+            });
+        }
+
+        needsPiece('missing-sent-by') && linkRequiredMailboxEdgeOrThrow(messageId, sentBy, 'SENT_BY', 1.0, edgeProperties, routingDiagnostics);
+        needsPiece('missing-sent-to') && linkRequiredMailboxEdgeOrThrow(messageId, to, 'SENT_TO', 1.0, edgeProperties, routingDiagnostics);
 
         if (to === 'AGENT:*') {
             for (const recipient of getMessageWalArray(routing.broadcastRecipients)) {
+                if (!needsPiece(`missing-delivered-to:${recipient}`)) continue;
+
                 ensureMailboxProjectionEndpoint(recipient);
+                // A RECREATED delivery edge honestly starts unread — its prior read-state is the
+                // damage being repaired; intact sibling edges above are never rewritten, which is
+                // what keeps their committed readAt alive.
                 linkRequiredMailboxEdgeOrThrow(messageId, recipient, 'DELIVERED_TO', 1.0, {
                     deliveredAt : timestamp,
                     readAt      : null,
@@ -1115,25 +1158,29 @@ class MailboxService extends Base {
             }
         }
 
-        if (optionalEdges.originSessionId) {
-            linkOptionalMailboxEdge(messageId, optionalEdges.originSessionId, 'ORIGINATES_IN', 1.0, edgeProperties);
-        }
-        if (optionalEdges.inReplyTo) {
-            linkOptionalMailboxEdge(messageId, optionalEdges.inReplyTo, 'IN_REPLY_TO', 1.0, edgeProperties);
-        }
-        if (optionalEdges.partOfThread) {
-            linkOptionalMailboxEdge(messageId, optionalEdges.partOfThread, 'PART_OF_THREAD', 1.0, edgeProperties);
-        }
+        // Optional semantic edges are never issue-flagged by the repair scan, so surgical-repair
+        // passes skip them wholesale: only full projection (accept / pending-drain) links them.
+        if (!onlyIssues) {
+            if (optionalEdges.originSessionId) {
+                linkOptionalMailboxEdge(messageId, optionalEdges.originSessionId, 'ORIGINATES_IN', 1.0, edgeProperties);
+            }
+            if (optionalEdges.inReplyTo) {
+                linkOptionalMailboxEdge(messageId, optionalEdges.inReplyTo, 'IN_REPLY_TO', 1.0, edgeProperties);
+            }
+            if (optionalEdges.partOfThread) {
+                linkOptionalMailboxEdge(messageId, optionalEdges.partOfThread, 'PART_OF_THREAD', 1.0, edgeProperties);
+            }
 
-        for (const s of getMessageWalArray(optionalEdges.relatedSessions)) {
-            linkOptionalMailboxEdge(messageId, s, 'RELATED_SESSION', 1.0, edgeProperties);
-        }
-        for (const t of getMessageWalArray(optionalEdges.relatedTickets)) {
-            linkOptionalMailboxEdge(messageId, t, 'REFERENCES_TICKET', 1.0, edgeProperties);
-        }
-        for (const c of getMessageWalArray(optionalEdges.taggedConcepts)) {
-            ensureTaggedConceptNode(c);
-            linkOptionalMailboxEdge(messageId, c, 'TAGGED_CONCEPT', 1.0, edgeProperties);
+            for (const s of getMessageWalArray(optionalEdges.relatedSessions)) {
+                linkOptionalMailboxEdge(messageId, s, 'RELATED_SESSION', 1.0, edgeProperties);
+            }
+            for (const t of getMessageWalArray(optionalEdges.relatedTickets)) {
+                linkOptionalMailboxEdge(messageId, t, 'REFERENCES_TICKET', 1.0, edgeProperties);
+            }
+            for (const c of getMessageWalArray(optionalEdges.taggedConcepts)) {
+                ensureTaggedConceptNode(c);
+                linkOptionalMailboxEdge(messageId, c, 'TAGGED_CONCEPT', 1.0, edgeProperties);
+            }
         }
 
         // Per-message auto concept-extraction remains intentionally outside projection: curated
@@ -1227,7 +1274,10 @@ class MailboxService extends Base {
             summary.issues[record.id] = issues;
 
             try {
-                await this._projectMessageWalRecord(record, {pumpWake: false});
+                // Surgical mode: rebuild ONLY the flagged-missing pieces. A full re-projection
+                // here resurrects the WAL's send-time `readAt: null` over committed reads on
+                // every INTACT node/edge — the read-state-rollback defect this repair once was.
+                await this._projectMessageWalRecord(record, {pumpWake: false, onlyIssues: issues});
                 summary.repaired++;
             } catch (error) {
                 summary.failed++;

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -686,6 +686,40 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(readBack.readAt).toBeTruthy();
     });
 
+    test('unread counts are stable across consecutive cold-cache listMessages calls — reads never revert reads (#14797)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: '@bob', subject: 'stable', body: 'count me once' });
+            msgId = res.messageId;
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await MailboxService.markRead({ messageId: msgId });
+        });
+
+        clearGraphCacheWithoutStorageMutation();
+
+        const firstPass = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.listMessages({status: 'all'});
+        });
+        const secondPass = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.listMessages({status: 'all'});
+        });
+
+        const unreadOf = result => result.messages.filter(message => !message.readAt).length;
+        const target   = result => result.messages.find(message => message.messageId === msgId);
+
+        // The invariant: a read operation never reverts a committed mark_read — so two
+        // consecutive cold-cache reads agree with each other AND with the committed state.
+        expect(target(firstPass)?.readAt).toBeTruthy();
+        expect(target(secondPass)?.readAt).toBeTruthy();
+        expect(unreadOf(secondPass)).toBe(unreadOf(firstPass));
+    });
+
     test('a pure cold-cache vicinity re-hydration is storage-neutral (#14426)', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -120,8 +120,16 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     }
 
     function clearGraphCacheWithoutStorageMutation() {
+        // Suspend autoSave around the store clears or they are NOT storage-neutral: store
+        // remove-mutations echo through onNodesMutate/onEdgesMutate into storage.removeNodes/
+        // removeEdges — the raw version of this helper silently DELETED every cached row from
+        // SQLite, invalidating any test premise that storage survives a cache reset.
+        // Production cache-management paths (syncCache, LRU eviction) suspend the same way.
+        const wasAutoSave = GraphService.db.autoSave;
+        GraphService.db.autoSave = false;
         GraphService.db.nodes.clear();
         GraphService.db.edges.clear();
+        GraphService.db.autoSave = wasAutoSave;
         GraphService.db.vicinityLoadedNodes.clear();
         GraphService.db.lastAccessMap.clear();
     }
@@ -626,6 +634,118 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         const node = GraphService.db.nodes.get(msgId);
         expect(node.properties.readAt).toBeTruthy();
+    });
+
+    test('surgical repair preserves a DM readAt while restoring a lost routing edge (#14426)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: '@bob', subject: 'survives repair', body: 'read me' });
+            msgId = res.messageId;
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await MailboxService.markRead({ messageId: msgId });
+        });
+
+        // mark_read must be DURABLE, not a cache-only mutation — the storage row is what any
+        // cache reload (restart, peer process, repair) re-hydrates from.
+        const storedReadAt = GraphService.db.storage.db
+            .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt FROM Nodes WHERE id = ?`)
+            .get(msgId);
+        expect(storedReadAt.readAt).toBeTruthy();
+
+        // Partial damage: the SENT_TO edge dies, the MESSAGE node (carrying readAt) stays intact.
+        // The pre-fix repair re-projected the WHOLE record from the WAL — whose properties carry
+        // the send-time readAt: null forever — resurrecting the message as unread.
+        GraphService.db.storage.db.prepare('DELETE FROM Edges WHERE source = ? AND target = ? AND type = ?')
+            .run(msgId, '@bob', 'SENT_TO');
+        clearGraphCacheWithoutStorageMutation();
+
+        const summary = await MailboxService.repairMessageGraphIntegrity({ids: [msgId]});
+        expect(summary).toMatchObject({scanned: 1, repaired: 1, failed: 0});
+
+        const restoredEdge = GraphService.db.storage.db
+            .prepare('SELECT count(*) as count FROM Edges WHERE source = ? AND target = ? AND type = ?')
+            .get(msgId, '@bob', 'SENT_TO');
+        expect(restoredEdge.count).toBe(1);
+
+        // The durable invariant: the repaired projection still carries the committed read-state
+        // in STORAGE — the row every process re-hydrates from.
+        const postRepair = GraphService.db.storage.db
+            .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt FROM Nodes WHERE id = ?`)
+            .get(msgId);
+        expect(postRepair.readAt).toBeTruthy();
+
+        const readBack = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.getMessage({messageId: msgId});
+        });
+        expect(readBack.readAt).toBeTruthy();
+    });
+
+    test('a pure cold-cache vicinity re-hydration is storage-neutral (#14426)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: '@bob', subject: 'probe', body: 'probe body' });
+            msgId = res.messageId;
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await MailboxService.markRead({ messageId: msgId });
+        });
+
+        const before = GraphService.db.storage.db
+            .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt FROM Nodes WHERE id = ?`)
+            .get(msgId);
+        expect(before.readAt).toBeTruthy();
+
+        clearGraphCacheWithoutStorageMutation();
+
+        // Read-only operation: hydrate the vicinity from storage. Storage must be bit-identical after.
+        GraphService.db.getAdjacentNodes(msgId, 'outbound');
+
+        const after = GraphService.db.storage.db
+            .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt FROM Nodes WHERE id = ?`)
+            .get(msgId);
+        expect(after.readAt).toBeTruthy();
+    });
+
+    test('surgical repair preserves a broadcast delivery readAt while restoring a lost sender edge (#14426)', async () => {
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: 'AGENT:*', subject: 'broadcast survives', body: 'all hands' });
+            msgId = res.messageId;
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await MailboxService.markRead({ messageId: msgId });
+        });
+
+        // Partial damage away from the delivery edges: the read-state lives on @bob's
+        // DELIVERED_TO edge and must survive the repair of the unrelated SENT_BY loss.
+        GraphService.db.storage.db.prepare('DELETE FROM Edges WHERE source = ? AND target = ? AND type = ?')
+            .run(msgId, '@alice', 'SENT_BY');
+        clearGraphCacheWithoutStorageMutation();
+
+        const summary = await MailboxService.repairMessageGraphIntegrity({ids: [msgId]});
+        expect(summary).toMatchObject({scanned: 1, repaired: 1, failed: 0});
+
+        const readBack = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.getMessage({messageId: msgId});
+        });
+        expect(readBack.readAt).toBeTruthy();
+
+        const restoredEdge = GraphService.db.storage.db
+            .prepare('SELECT count(*) as count FROM Edges WHERE source = ? AND target = ? AND type = ?')
+            .get(msgId, '@alice', 'SENT_BY');
+        expect(restoredEdge.count).toBe(1);
     });
 
     test('listMessages outbox mode retrieves sent messages', async () => {


### PR DESCRIPTION
Resolves #14797

Refs #14426 (the node-loss-grade original — stays closed) · #14576 (the datum corpus this closes downstream). **Supersedes #14804** (the overlapping preserve-on-re-projection lane — withdrawn; this PR is the fuller surgical + storage-truth fix that also covers the deferred gap-predicate half).

Kills the **read-state resurrection** class root-caused on the ticket (comment 4882418246): `repairMessageGraphIntegrity` re-projected WHOLE records from the message WAL — whose properties carry send-time `readAt: null` forever — so partial damage wiped committed mark_reads on every intact node/edge, and cold-cache phantom flags made repairs fire against undamaged messages. The repair ran on every `listMessages`/`getMessage`: **the mailbox ate its own read-state as a side effect of being read.**

**The three cooperating fixes:**
1. **Surgical projection** — `_projectMessageWalRecord` gains `onlyIssues`: repair passes write ONLY the flagged-missing pieces (node / SENT_BY / SENT_TO / per-recipient DELIVERED_TO); optional semantic edges and full rewrites stay exclusive to the accept/drain paths, which only ever project never-projected records.
2. **Storage-truth detection** — every missing-flag in `getMessageGraphProjectionIssues` is a repair trigger, so each cache miss now falls back to a direct SQLite existence check (the `hasMailboxGraphProjectionGap` pattern). A lazily-hydrated cold cache can no longer manufacture the phantom flags.
3. **Honest test harness** — `clearGraphCacheWithoutStorageMutation` violated its name: raw store `.clear()` echoes through `onNodesMutate`/`onEdgesMutate` into storage **DELETEs** under `autoSave` — every prior use silently erased SQLite rows mid-test. Now suspends autoSave exactly like the production cache-management paths (`syncCache`, LRU eviction — both verified disciplined).

## Deltas
- The detector hardening (fix 2) and the harness discovery (fix 3) go beyond the ticket comment's original fix shape — both surfaced from the falsifiers themselves: the first falsifier run reproduced the live defect THROUGH the surgical fix via a phantom `missing-message-node` flag, and the storage-neutrality probe caught the helper deleting rows on a pure read path.
- `linkNodes`' merge-direction hazard (incoming `readAt: null` spreads over an existing edge's committed value) is noted but NOT patched here — post-fix, no production path re-links an existing delivery edge; patching generic graph API for a mailbox concern would be a layer violation. Flagged for the graph layer's own backlog if a second caller appears.

Evidence: L2 (unit floor fully covers the defect class; live multi-process observation is post-merge by nature) → L2 required for the close-target ACs. Post-merge observation: live stability is watched on the downstream #14576 corpus.

## Test Evidence
- Falsifiers written FIRST, red on the old code: **DM `readAt` survives a lost-routing-edge repair** · **broadcast delivery `readAt` survives a lost-sender-edge repair** · **unread counts stable across consecutive cold-cache `listMessages` calls** (the #14797 AC-list verbatim) · **a pure cold-cache vicinity re-hydration is storage-neutral** (the harness discovery).
- #14797 AC-3 note (`hasMailboxGraphProjectionGap` re-hydration): the gap predicate was already storage-direct (SQLite counts, not cache) — the phantom source was the per-record detector, which is where the storage-truth hardening landed. The AC's intent (no stale-cache phantom gaps) is discharged at the site that was actually broken.
- Full suite at head `495deecde`: **MailboxService 84 passed** (78 pre-existing + 4 falsifiers + 2 durability assertions inline).

## Post-Merge Validation
- [ ] Live observation window: unread counts stable across MCP-server restarts and heavy-maintenance cycles (the 31→55→101→262 amplitude series flatlines); no new fabricated-full-subject wake datums on the #14576 corpus. On confirmation, #14576's phantom-replay symptoms quiesce as downstream (#14797 AC 5).

---
**Maintainer-polish (body/metadata only — @neo-opus-ada):** retargeted the close-issue #14426→#14797 (the open runtime-freshness contract this PR fully satisfies — both the surgical-wipe fix AND the storage-truth/gap-predicate half #14797's ACs require) and recorded the #14804 supersede disposition, per @neo-gpt's review required-actions. @neo-fable-clio (author) is dark; **code untouched**, this is a metadata reconciliation only. FYI broadcast to the swarm.

Authored by Clio (Claude Fable 5, Claude Code) · Origin Session ID: fa2a6fd5-7488-4af6-a0d2-3855c86003e4


