### PR TITLE
feat(agentos): button-hierarchy consumption layer + toolbar collision fix (#14809)

### DIFF
--- a/apps/agentos/index.html
+++ b/apps/agentos/index.html
@@ -7,6 +7,7 @@
     <title>Neo.mjs Agent OS</title>
     <link rel="stylesheet" href="./resources/tokens.css">
     <link rel="stylesheet" href="./resources/fleet-components.css">
+    <link rel="stylesheet" href="./resources/agentos-components.css">
 </head>
 
 <body>

--- a/apps/agentos/resources/agentos-components.css
+++ b/apps/agentos/resources/agentos-components.css
@@ -1,0 +1,61 @@
+/**
+ * Agent OS view consumption layer — binds the design-SSOT tokens (tokens.css) to the agentos view
+ * classes. tokens.css defines the palette (extracted 1:1 from the Fleet Manager cockpit design SSOT)
+ * and is loaded in index.html; this file is where the views finally CONSUME it. Colors come only from
+ * the --fm-* token layer (no hand-rolled palette); the --fm-signal accent is used sparingly — the one
+ * key action per surface. Companion to fleet-components.css (the cockpit-primitive consumption layer).
+ *
+ * First slice: the button hierarchy + the action-toolbar layout (fixing the default-toolbar collision).
+ */
+
+/* ---------------------------------------------------------------- button hierarchy ----------------- */
+/* Every agentos button carries `agent-button` (+ a variant). Base = a quiet, panel-toned control from
+   the token layer; only the primary action reaches for the signal accent. `.neo-button.agent-button`
+   is specificity-robust against the default neo-button theme regardless of stylesheet load order. */
+.neo-button.agent-button {
+    border       : 1px solid var(--fm-line);
+    border-radius: 6px;
+    background   : var(--fm-panel-2);
+    color        : var(--fm-ink);
+    box-shadow   : none;
+    font-family  : var(--fm-font-sans);
+    font-weight  : 500;
+    transition   : background .15s ease, border-color .15s ease, color .15s ease;
+}
+
+.neo-button.agent-button:hover {
+    border-color: var(--fm-ink-dim);
+    background   : var(--fm-panel);
+    color        : var(--fm-ink);
+}
+
+/* the glyph + label inherit the button's ink, so a variant re-tint carries through both */
+.neo-button.agent-button .neo-button-glyph,
+.neo-button.agent-button .neo-button-text {
+    color: inherit;
+}
+
+/* primary — the single key action (submit) reaches for the signal accent, used sparingly */
+.neo-button.agent-submit-button {
+    border-color: color-mix(in srgb, var(--fm-signal) 55%, var(--fm-line));
+    background   : color-mix(in srgb, var(--fm-signal) 14%, var(--fm-panel-2));
+    color        : var(--fm-signal);
+}
+
+.neo-button.agent-submit-button:hover {
+    border-color: var(--fm-signal);
+    background   : color-mix(in srgb, var(--fm-signal) 24%, var(--fm-panel-2));
+    color        : var(--fm-signal);
+}
+
+/* ---------------------------------------------------------------- action toolbars ------------------ */
+/* The default neo-toolbar is flex-wrap:nowrap; three long-text buttons cram and collide in a narrow
+   panel (the operator-flagged bug). Wrap + gap so they space cleanly. neo's default is
+   `.neo-flex-container.neo-flex-wrap-nowrap` (0,2,0) and the theme loads after this file, so the
+   override needs 0,3,0 to win on specificity. */
+.neo-flex-container.neo-toolbar.agent-form-actions,
+.neo-flex-container.neo-toolbar.agent-fleet-actions {
+    flex-wrap : wrap;
+    gap       : 8px;
+    background: transparent;
+}


### PR DESCRIPTION
Resolves #14809 · Leaf of #14805 (agentos design conformance) · Refs #14578 (tokens SSOT) · Refs #14560

The first slice of the `agentos-components.css` consumption layer (steward-shaped by Mnemosyne — the fleet-components.css pattern extended): the **button hierarchy**. Establishes the file + wires it into `index.html`.

Evidence: visual verification live on the dev server (:8085); before/after computed styles below.

## What it changes

`apps/agentos/resources/agentos-components.css` (new; `<link>` added to index.html after tokens.css):
- `.neo-button.agent-button` — base: quiet panel-toned control from the token layer (`--fm-panel-2` / `--fm-line` / `--fm-ink`), hover to `--fm-panel` / `--fm-ink-dim`.
- `.neo-button.agent-submit-button` — primary: `--fm-signal`, used **sparingly** (the one key action).
- glyph + label inherit the button ink, so a variant re-tint carries through both.
- `.neo-flex-container.neo-toolbar.agent-form-actions` / `.agent-fleet-actions` — `flex-wrap` + `gap` so the buttons space/wrap instead of colliding.

Specificity note (V-B-A'd): the neo theme loads *after* the app's static `<link>`s, so the base overrides use `.neo-button.agent-button` (0,2,0 > `neo-button` 0,1,0) and the toolbar-wrap uses `.neo-flex-container.neo-toolbar.agent-*-actions` (0,3,0 > neo's `.neo-flex-container.neo-flex-wrap-nowrap` 0,2,0) — winning on specificity, not load order.

## Test Evidence (screenshot gate — live :8085)

**Before** (default neo theme, zero SSOT consumption):
- All buttons default **blue**; the Accounts action toolbar `flex-wrap: nowrap` at ~407px → three long-text buttons **collide** (toolbar height 48px, buttons overlapping — the operator's render evidence).

**After** (token-bound):
- Submit button computed `color: rgb(94, 234, 212)` = `--fm-signal`; `background` = signal-tinted panel (was default blue). Edit Sample / Connect Harness / Start / Stop / Restart = quiet panel-toned base buttons.
- Accounts toolbar `flex-wrap: wrap`, height 48 → **104px** — buttons wrap to two rows, **no collision**.
- No console errors.

(Screenshots captured via the preview harness; reviewers can inspect live at :8085 or reproduce with `.claude/launch.json` → `neo-dev-server`.)

## Post-Merge Validation

- [ ] Buttons render on-theme across Accounts + Fleet controls (no default blue) on dev.
- [ ] The remaining per-surface leaves (Accounts fields, Fleet grid density/truncation, viewport chrome, keeper wedge) continue #14805, each with the before/after gate.

## Deltas from ticket

The button-hierarchy slice + the shared toolbar-collision fix. Panels / grid density / form-field + viewport-chrome conformance are the sibling #14805 per-surface leaves. CSS + index.html only — no view logic changed.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
