### PR TITLE
refactor(dashboard): dock operation vocabulary becomes ONE exported SSOT

### DIFF
--- a/src/ai/client/DockService.mjs
+++ b/src/ai/client/DockService.mjs
@@ -25,16 +25,13 @@ class DockService extends Service {
     }
 
     /**
-     * The dockZone.v1 semantic operations `DockZoneModel.applyOperation()` dispatches,
-     * mirrored verbatim from its switch. The tool contract is fail-closed against exactly
+     * The dockZone.v1 semantic operation vocabulary — read by reference from the executor's
+     * exported SSOT, never mirrored. The tool contract stays fail-closed against exactly
      * this set: unknown operations are rejected with the vocabulary enumerated.
-     * @member {String[]} operations
+     * @member {ReadonlyArray<String>} operations
      * @static
      */
-    static operations = [
-        'addTab', 'moveItem', 'splitNode', 'resizeSplit',
-        'detachItem', 'closeItem', 'setItemPinned', 'setItemAutoHidden'
-    ]
+    static operations = DockZoneModel.operations
 
     /**
      * Resolves a live dock-document holder — a component that carries a `dockZoneDocument`,

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -68,6 +68,21 @@ class DockZoneModel extends Base {
     static CAPTURE_SCOPES = ['window', 'topology']
 
     /**
+     * The semantic operation vocabulary `applyOperation()` dispatches — THE single exported
+     * source for every consumer that enumerates, validates, or advertises the executable
+     * operations (the Neural Link service tier reads this by reference; prose surfaces like
+     * tool descriptions mirror it under the dispatch-parity regression). A new operation
+     * lands here in the same change that adds its `applyOperation` case, or the parity spec
+     * fails the build.
+     * @member {ReadonlyArray<String>} operations
+     * @static
+     */
+    static operations = Object.freeze([
+        'addTab', 'moveItem', 'splitNode', 'resizeSplit',
+        'detachItem', 'closeItem', 'setItemPinned', 'setItemAutoHidden'
+    ])
+
+    /**
      * Top-level fields allowed in a saved-layout wrapper.
      * @member {Set<String>} savedLayoutKeys
      * @protected
@@ -1141,7 +1156,7 @@ class DockZoneModel extends Base {
             return {document: null, errors}
         }
 
-        let normalized = DockZoneModel.normalizeTree(savedLayout.dockZone),
+        let normalized       = DockZoneModel.normalizeTree(savedLayout.dockZone),
             normalizedErrors = DockZoneModel.validate(normalized);
 
         return normalizedErrors.length

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -68,19 +68,43 @@ class DockZoneModel extends Base {
     static CAPTURE_SCOPES = ['window', 'topology']
 
     /**
-     * The semantic operation vocabulary `applyOperation()` dispatches — THE single exported
-     * source for every consumer that enumerates, validates, or advertises the executable
-     * operations (the Neural Link service tier reads this by reference; prose surfaces like
-     * tool descriptions mirror it under the dispatch-parity regression). A new operation
-     * lands here in the same change that adds its `applyOperation` case, or the parity spec
-     * fails the build.
+     * Dispatch table for `applyOperation()` — operation name → executor. THE single source of
+     * the dockZone.v1 semantic vocabulary: `operations` derives from these keys, so an
+     * operation cannot exist in dispatch without being exported, nor be exported without
+     * dispatching — the two directions cannot diverge by construction. Handlers share the
+     * executor signature `(document, descriptor)` and the fail-closed `{document, errors}`
+     * result contract. The `addTab` entry carries the contract's "addTab or moveItem"
+     * downgrade: a `tab-*` descriptor dispatches as a move when its item already lives
+     * in the tree.
+     * @member {Object} operationHandlers
+     * @protected
+     * @static
+     */
+    static operationHandlers = Object.freeze({
+        addTab: (document, descriptor) =>
+            DockZoneModel.findContainingTabsId(document, descriptor.itemId)
+                ? DockZoneModel.moveItem(document, {itemId: descriptor.itemId, targetNodeId: descriptor.tabsNodeId, index: descriptor.index})
+                : DockZoneModel.addTab(document, descriptor),
+        moveItem         : (document, descriptor) => DockZoneModel.moveItem(document, descriptor),
+        splitNode        : (document, descriptor) => DockZoneModel.splitNode(document, descriptor),
+        resizeSplit      : (document, descriptor) => DockZoneModel.resizeSplit(document, descriptor),
+        detachItem       : (document, descriptor) => DockZoneModel.detachItem(document, descriptor),
+        closeItem        : (document, descriptor) => DockZoneModel.closeItem(document, descriptor),
+        setItemPinned    : (document, descriptor) => DockZoneModel.setItemPinned(document, descriptor),
+        setItemAutoHidden: (document, descriptor) => DockZoneModel.setItemAutoHidden(document, descriptor)
+    })
+
+    /**
+     * The semantic operation vocabulary — derived from the dispatch table's keys, never
+     * hand-listed, so vocabulary and dispatch agree in both directions by construction.
+     * Consumers that enumerate, validate, or advertise executable operations read this
+     * export (the Neural Link service tier reads it by reference). Prose surfaces (e.g.
+     * OpenAPI tool descriptions) remain manual mirrors with NO mechanical guard — they
+     * update by review discipline.
      * @member {ReadonlyArray<String>} operations
      * @static
      */
-    static operations = Object.freeze([
-        'addTab', 'moveItem', 'splitNode', 'resizeSplit',
-        'detachItem', 'closeItem', 'setItemPinned', 'setItemAutoHidden'
-    ])
+    static operations = Object.freeze(Object.keys(DockZoneModel.operationHandlers))
 
     /**
      * Top-level fields allowed in a saved-layout wrapper.
@@ -1657,38 +1681,27 @@ class DockZoneModel extends Base {
 
     /**
      * @summary Applies an operation descriptor (the shape `DockPreview.previewToOperation()` emits)
-     * to the document, dispatching to the matching semantic operation.
+     * to the document, dispatching through {@link #operationHandlers} — the table whose keys ARE
+     * the exported vocabulary, so dispatch and `operations` cannot diverge.
      *
      * A `tab-*` descriptor (`operation: 'addTab'`) is dispatched as a move when its item already
-     * lives in the tree — the contract's "addTab or moveItem" downgrade, decided here.
+     * lives in the tree — the contract's "addTab or moveItem" downgrade, carried by the table's
+     * `addTab` entry.
      * @param {Object} document
      * @param {Object} descriptor {operation, ...}
      * @returns {{document:Object, errors:String[]}}
      * @static
      */
     static applyOperation(document, descriptor = {}) {
-        switch (descriptor.operation) {
-            case 'addTab':
-                return DockZoneModel.findContainingTabsId(document, descriptor.itemId)
-                    ? DockZoneModel.moveItem(document, {itemId: descriptor.itemId, targetNodeId: descriptor.tabsNodeId, index: descriptor.index})
-                    : DockZoneModel.addTab(document, descriptor);
-            case 'moveItem':
-                return DockZoneModel.moveItem(document, descriptor);
-            case 'splitNode':
-                return DockZoneModel.splitNode(document, descriptor);
-            case 'resizeSplit':
-                return DockZoneModel.resizeSplit(document, descriptor);
-            case 'detachItem':
-                return DockZoneModel.detachItem(document, descriptor);
-            case 'closeItem':
-                return DockZoneModel.closeItem(document, descriptor);
-            case 'setItemPinned':
-                return DockZoneModel.setItemPinned(document, descriptor);
-            case 'setItemAutoHidden':
-                return DockZoneModel.setItemAutoHidden(document, descriptor);
-            default:
-                return {document, errors: [`unknown operation "${descriptor.operation}"`]}
-        }
+        // Own-key lookup only: inherited names ('constructor', '__proto__', …) must reject
+        // exactly like any unknown operation, never resolve to a prototype member.
+        const handler = Object.hasOwn(DockZoneModel.operationHandlers, descriptor.operation)
+            ? DockZoneModel.operationHandlers[descriptor.operation]
+            : null;
+
+        return handler
+            ? handler(document, descriptor)
+            : {document, errors: [`unknown operation "${descriptor.operation}"`]}
     }
 }
 

--- a/test/playwright/unit/ai/client/DockService.spec.mjs
+++ b/test/playwright/unit/ai/client/DockService.spec.mjs
@@ -21,11 +21,9 @@ test.describe.serial('Neo.ai.client.DockService', () => {
         service.destroy?.()
     });
 
-    test('the operation vocabulary mirrors the dockZone.v1 executor verbatim', () => {
-        expect(DockService.operations).toEqual([
-            'addTab', 'moveItem', 'splitNode', 'resizeSplit',
-            'detachItem', 'closeItem', 'setItemPinned', 'setItemAutoHidden'
-        ])
+    test('the operation vocabulary IS the executor export — one reference, no mirror to drift', () => {
+        expect(DockService.operations).toBe(DockZoneModel.operations);
+        expect(Object.isFrozen(DockService.operations)).toBe(true)
     });
 
     test('the executor honors its reducer contract on a well-formed document (returns, never throws)', () => {

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -996,7 +996,17 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
     });
 
     test.describe('operation vocabulary (SSOT)', () => {
-        test('every exported operation dispatches — no vocabulary entry without a switch case', () => {
+        test('the vocabulary IS the dispatch table — derived keys, bidirectional by construction', () => {
+            // one structure carries both: a handler cannot exist without being exported,
+            // and an exported name cannot exist without its handler
+            expect(DockZoneModel.operations).toEqual(Object.keys(DockZoneModel.operationHandlers));
+
+            for (const operation of DockZoneModel.operations) {
+                expect(typeof DockZoneModel.operationHandlers[operation]).toBe('function')
+            }
+        });
+
+        test('every exported operation dispatches through the executor contract', () => {
             for (const operation of DockZoneModel.operations) {
                 const {errors} = DockZoneModel.applyOperation(doc(), {operation});
 
@@ -1014,8 +1024,17 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(document).toEqual(input)
         });
 
-        test('the vocabulary is frozen — consumers cannot mutate the shared export', () => {
+        test('inherited object keys never resolve to handlers — own-key dispatch only', () => {
+            for (const hostile of ['constructor', '__proto__', 'toString', 'hasOwnProperty']) {
+                const {errors} = DockZoneModel.applyOperation(doc(), {operation: hostile});
+
+                expect(errors).toEqual([`unknown operation "${hostile}"`])
+            }
+        });
+
+        test('the vocabulary and the dispatch table are frozen against consumer mutation', () => {
             expect(Object.isFrozen(DockZoneModel.operations)).toBe(true);
+            expect(Object.isFrozen(DockZoneModel.operationHandlers)).toBe(true);
             expect(() => DockZoneModel.operations.push('rogueOp')).toThrow()
         });
     });

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -34,9 +34,9 @@ function doc() {
             inspector: {componentRef: 'inspector', title: 'Inspector', kind: 'inspector'}
         },
         nodes: {
-            root        : {type: 'edge-zone', zones: {center: 'main-tabs', right: 'side-tabs'}},
-            'main-tabs' : {type: 'tabs', items: ['strategy', 'swarm'], activeItemId: 'swarm'},
-            'side-tabs' : {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
+            root       : {type: 'edge-zone', zones: {center: 'main-tabs', right: 'side-tabs'}},
+            'main-tabs': {type: 'tabs', items: ['strategy', 'swarm'], activeItemId: 'swarm'},
+            'side-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
         }
     }
 }
@@ -674,7 +674,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             input.nodes.root.zones.center = 'split';
             delete input.nodes.root.zones.right;
 
-            const snapshot = JSON.stringify(input),
+            const snapshot         = JSON.stringify(input),
                   {layout, errors} = DockZoneModel.createSavedLayout(input, {
                       layoutId: 'operator-default',
                       title   : 'Operator Default',
@@ -753,10 +753,10 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         });
 
         test('upserts layouts by layoutId, clones replacements, and optionally activates them', () => {
-            const operator = savedLayout('operator-default', 'Operator Default'),
-                  review   = savedLayout('review-layout', 'Review Layout'),
+            const operator     = savedLayout('operator-default', 'Operator Default'),
+                  review       = savedLayout('review-layout', 'Review Layout'),
                   {collection} = DockZoneModel.createSavedLayoutCollection([operator]),
-                  updated = DockZoneModel.upsertSavedLayout(collection, review, {activate: true});
+                  updated      = DockZoneModel.upsertSavedLayout(collection, review, {activate: true});
 
             expect(updated.errors).toEqual([]);
             expect(updated.collection.activeLayoutId).toBe('review-layout');
@@ -777,10 +777,10 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         });
 
         test('selects an existing active layout and fails closed for missing ids', () => {
-            const operator = savedLayout('operator-default', 'Operator Default'),
-                  review   = savedLayout('review-layout', 'Review Layout'),
+            const operator     = savedLayout('operator-default', 'Operator Default'),
+                  review       = savedLayout('review-layout', 'Review Layout'),
                   {collection} = DockZoneModel.createSavedLayoutCollection([operator, review]),
-                  selected = DockZoneModel.selectSavedLayout(collection, 'review-layout');
+                  selected     = DockZoneModel.selectSavedLayout(collection, 'review-layout');
 
             expect(selected.errors).toEqual([]);
             expect(selected.collection.activeLayoutId).toBe('review-layout');
@@ -793,17 +793,17 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         });
 
         test('removes layouts and requires an explicit replacement for the active layout', () => {
-            const operator = savedLayout('operator-default', 'Operator Default'),
-                  review   = savedLayout('review-layout', 'Review Layout'),
+            const operator     = savedLayout('operator-default', 'Operator Default'),
+                  review       = savedLayout('review-layout', 'Review Layout'),
                   {collection} = DockZoneModel.createSavedLayoutCollection([operator, review]),
-                  denied = DockZoneModel.removeSavedLayout(collection, {layoutId: 'operator-default'});
+                  denied       = DockZoneModel.removeSavedLayout(collection, {layoutId: 'operator-default'});
 
             expect(denied.collection).toBe(collection);
             expect(denied.errors.join(' ')).toContain('replacementLayoutId');
 
             const removedActive = DockZoneModel.removeSavedLayout(collection, {
-                layoutId            : 'operator-default',
-                replacementLayoutId : 'review-layout'
+                layoutId           : 'operator-default',
+                replacementLayoutId: 'review-layout'
             });
 
             expect(removedActive.errors).toEqual([]);
@@ -870,14 +870,14 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
 
         function createExampleHarness() {
             const example = {
-                createDefaultLayoutCollection: MainContainer.prototype.createDefaultLayoutCollection,
-                createPerspectiveToolbar    : MainContainer.prototype.createPerspectiveToolbar,
+                createDefaultLayoutCollection  : MainContainer.prototype.createDefaultLayoutCollection,
+                createPerspectiveToolbar       : MainContainer.prototype.createPerspectiveToolbar,
                 loadLayoutCollectionFromStorage: MainContainer.prototype.loadLayoutCollectionFromStorage,
-                nextSavedPerspectiveId      : MainContainer.prototype.nextSavedPerspectiveId,
-                persistLayoutCollection     : MainContainer.prototype.persistLayoutCollection,
-                removeActivePerspective     : MainContainer.prototype.removeActivePerspective,
-                restorePerspective          : MainContainer.prototype.restorePerspective,
-                saveCurrentPerspective      : MainContainer.prototype.saveCurrentPerspective,
+                nextSavedPerspectiveId         : MainContainer.prototype.nextSavedPerspectiveId,
+                persistLayoutCollection        : MainContainer.prototype.persistLayoutCollection,
+                removeActivePerspective        : MainContainer.prototype.removeActivePerspective,
+                restorePerspective             : MainContainer.prototype.restorePerspective,
+                saveCurrentPerspective         : MainContainer.prototype.saveCurrentPerspective,
 
                 layoutCollectionStorageKey: 'test.dashboard.dock.layoutCollection',
                 refreshCount              : 0,
@@ -912,7 +912,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             };
 
             const example = createExampleHarness(),
-                toolbar = example.createPerspectiveToolbar();
+                toolbar   = example.createPerspectiveToolbar();
 
             expect(Object.keys(example.layoutCollection.layouts)).toEqual(['operator-default', 'review-focus']);
             expect(example.layoutCollection.activeLayoutId).toBe('operator-default');
@@ -975,7 +975,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             Neo.main.addon.LocalStorage.updateLocalStorageItem = async () => {};
 
             const hydrated = createExampleHarness(),
-                loaded = await hydrated.loadLayoutCollectionFromStorage();
+                loaded     = await hydrated.loadLayoutCollectionFromStorage();
 
             expect(loaded.loaded).toBe(true);
             expect(hydrated.layoutCollection.activeLayoutId).toBe('persisted-review');
@@ -984,7 +984,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
 
             readValue = JSON.stringify({schema: 'neo.harness.dockLayoutCollection.v0'});
 
-            const invalid = createExampleHarness(),
+            const invalid   = createExampleHarness(),
                 invalidLoad = await invalid.loadLayoutCollectionFromStorage();
 
             expect(invalidLoad.loaded).toBe(false);
@@ -993,6 +993,31 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(invalid.dockModel).toEqual(invalid.layoutCollection.layouts['operator-default'].dockZone);
             expect(invalid.refreshCount).toBe(0)
         })
+    });
+
+    test.describe('operation vocabulary (SSOT)', () => {
+        test('every exported operation dispatches — no vocabulary entry without a switch case', () => {
+            for (const operation of DockZoneModel.operations) {
+                const {errors} = DockZoneModel.applyOperation(doc(), {operation});
+
+                // per-operation validation errors are fine; the unknown-operation rejection
+                // firing for an EXPORTED name means vocabulary and dispatch have drifted
+                expect(errors.join('\n')).not.toContain('unknown operation')
+            }
+        });
+
+        test('an unexported operation is rejected fail-closed with the document untouched', () => {
+            const input              = doc();
+            const {document, errors} = DockZoneModel.applyOperation(input, {operation: 'renameItem'});
+
+            expect(errors).toEqual(['unknown operation "renameItem"']);
+            expect(document).toEqual(input)
+        });
+
+        test('the vocabulary is frozen — consumers cannot mutate the shared export', () => {
+            expect(Object.isFrozen(DockZoneModel.operations)).toBe(true);
+            expect(() => DockZoneModel.operations.push('rogueOp')).toThrow()
+        });
     });
 
     test.describe('addTab', () => {
@@ -1015,7 +1040,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         });
 
         test('fails closed on an unknown item (document untouched)', () => {
-            const input = doc();
+            const input              = doc();
             const {document, errors} = DockZoneModel.addTab(input, {itemId: 'ghost', tabsNodeId: 'main-tabs'});
             expect(errors.length).toBeGreaterThan(0);
             expect(document).toBe(input)
@@ -1095,9 +1120,9 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
 
     test.describe('resizeSplit', () => {
         test('updates split sizes with normalized finite positive values', () => {
-            const input    = splitDoc(),
-                  snapshot = JSON.stringify(input),
-                  ratios   = [3, 1],
+            const input              = splitDoc(),
+                  snapshot           = JSON.stringify(input),
+                  ratios             = [3, 1],
                   {document, errors} = DockZoneModel.resizeSplit(input, {
                       splitNodeId: 'main-split',
                       sizes      : ratios
@@ -1289,7 +1314,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         });
 
         test('dispatches splitNode from a previewToOperation-shaped descriptor', () => {
-            const descriptor = {operation: 'splitNode', itemId: 'inspector', targetNodeId: 'main-tabs', orientation: 'horizontal', position: 'after', sizes: [0.5, 0.5]};
+            const descriptor         = {operation: 'splitNode', itemId: 'inspector', targetNodeId: 'main-tabs', orientation: 'horizontal', position: 'after', sizes: [0.5, 0.5]};
             const {document, errors} = DockZoneModel.applyOperation(doc(), descriptor);
             expect(errors).toEqual([]);
             expect(document.nodes[document.nodes.root.zones.center].type).toBe('split')
@@ -1337,7 +1362,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         for (const c of cases) {
             test(`edge-${c.edge} places the new pane ${c.lead ? 'before (leading)' : 'after (trailing)'}`, () => {
                 // exact previewToOperation edge-descriptor shape: carries `edge`, no `position`
-                const descriptor = {operation: 'splitNode', itemId: 'inspector', targetNodeId: c.target, edge: c.edge, orientation: c.orientation, sizes: [0.5, 0.5]};
+                const descriptor         = {operation: 'splitNode', itemId: 'inspector', targetNodeId: c.target, edge: c.edge, orientation: c.orientation, sizes: [0.5, 0.5]};
                 const {document, errors} = DockZoneModel.applyOperation(doc(), descriptor);
                 expect(errors).toEqual([]);
 


### PR DESCRIPTION
Resolves #14715

Refs #13158 (the lane audit that flagged the drift seam) · #14768 (the next executor op registers into this SSOT).

Retires the triplicated dockZone.v1 operation vocabulary: `DockZoneModel.operations` is now the single frozen export; the Neural Link client service reads it **by reference** (its verbatim mirror deleted); the openapi tool description remains prose **by decision**, guarded by the dispatch-parity regression rather than a fourth copy.

## Deltas
- **Cycle-2 (Euclid's RA): dispatch collapsed onto the operation map.** The cycle-1 shape (explicit switch + one-way spec) proved only `operations → dispatch`; a switch-only addition would have passed. Now `applyOperation` dispatches through `operationHandlers` and `operations = Object.keys(operationHandlers)` — **bidirectional by construction**, exactly the reviewer-named acceptable shape. Own-key lookup (`Object.hasOwn`) rejects inherited names (`constructor`, `__proto__`) as unknown operations, adversarially pinned.
- Honest guard boundary, framed precisely: the OpenAPI tool description remains a **manual prose mirror with NO mechanical guard** — it updates by review discipline; the parity regressions guard code surfaces only.

Evidence: L2 (pure executor + service tier, fully unit-coverable) → L2 required. Residual: none.

## Test Evidence
- Parity regressions: vocabulary ≡ dispatch-table keys (the by-construction pin) · every exported operation dispatches through the executor contract · unexported names reject fail-closed, document untouched · inherited object keys (`constructor`, `__proto__`, …) never resolve to handlers · vocabulary AND dispatch table frozen · `DockService.operations` reference-identical to the model export (`toBe` — a mirror cannot sneak back).
- Suites at head: **DockZoneModel + DockService 89 passed**, zero behavior change.

## Post-Merge Validation
- [ ] None required — the contract is fully unit-pinned; #14768 (transferItem) will demonstrate the add-an-op flow against the SSOT in its own PR.

Authored by Clio (Claude Fable 5, Claude Code) · Origin Session ID: fa2a6fd5-7488-4af6-a0d2-3855c86003e4
