### PR TITLE
fix(ai): surface workspace safety boot diagnostics (#14798)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -231,7 +231,7 @@ class Config extends ConfigProvider {
              * trail observable from the host shell. Default: `<neoRootDir>/.neo-ai-data/logs/`.
              * @type {string}
              */
-            logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs')),
+            logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs'), 'NEO_KB_LOG_PATH', 'string'),
             /**
              * @summary Retention policy for Knowledge Base MCP diagnostic log files.
              *

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -649,7 +649,7 @@ class Config extends ConfigProvider {
              * `nl-server-`). Per-server file isolation, single tailable directory.
              * @type {string}
              */
-            logPath: leaf(path.resolve(cwd, '.neo-ai-data/logs')),
+            logPath: leaf(path.resolve(cwd, '.neo-ai-data/logs'), 'NEO_MEMORY_LOG_PATH', 'string'),
             /**
              * @summary Retention policy for Memory Core MCP diagnostic log files.
              *

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -2,9 +2,9 @@
 // the SSOT chain — matches memory-core/knowledge-base. This server reads no Tier-1 leaf
 // directly; they resolve through the parent chain, not a binding.
 import '../../../config.template.mjs';
-import os              from 'os';
-import path            from 'path';
-import {fileURLToPath} from 'url';
+import os                                          from 'os';
+import path                                        from 'path';
+import {fileURLToPath}                             from 'url';
 import ConfigProvider, { createConfigProxy, leaf } from '../../../ConfigProvider.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -79,7 +79,7 @@ class Config extends ConfigProvider {
              * Per-server file isolation, single tailable directory.
              * @type {string}
              */
-            logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs')),
+            logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs'), 'NEO_NL_LOG_PATH', 'string'),
             /**
              * @summary Retention policy for Neural Link MCP diagnostic log files.
              *

--- a/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
+++ b/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
@@ -43,27 +43,153 @@ const PULSE_TIMEOUT_MS = 30000;
 const SIGTERM_GRACE_MS = 5000;
 
 /**
+ * @summary Returns true when the path exists.
+ * @param {String} targetPath
+ * @returns {Promise<Boolean>}
+ */
+async function pathExists(targetPath) {
+    try {
+        await fs.access(targetPath);
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * @summary Formats the first-level entries in a directory for failure diagnostics.
+ * @param {String} directoryPath
+ * @returns {Promise<String>}
+ */
+async function listDirectoryEntries(directoryPath) {
+    try {
+        const entries = await fs.readdir(directoryPath, {withFileTypes: true});
+
+        return entries
+            .map(entry => `${entry.isDirectory() ? 'd' : entry.isFile() ? 'f' : '?'} ${entry.name}`)
+            .sort()
+            .join('\n') || '(empty)'
+    } catch (err) {
+        return `(unavailable: ${err.code || err.message})`
+    }
+}
+
+/**
+ * @summary Builds the daemon-boot diagnostic payload for a failed log wait.
+ * @param {Object} options
+ * @param {String} options.reason
+ * @param {Number} options.timeoutMs
+ * @param {String} options.logPath
+ * @param {String} [options.dataDir]
+ * @param {String} options.lastContent
+ * @param {import('node:child_process').ChildProcess} [options.daemonProcess]
+ * @param {{code:Number|null, signal:String|null}} [options.processExit]
+ * @param {Error} [options.processError]
+ * @param {Function} [options.getStdout]
+ * @param {Function} [options.getStderr]
+ * @returns {Promise<String>}
+ */
+async function formatLogWaitDiagnostics({
+    dataDir,
+    daemonProcess,
+    getStderr = () => '',
+    getStdout = () => '',
+    lastContent,
+    logPath,
+    processError,
+    processExit,
+    reason,
+    timeoutMs
+}) {
+    const dataDirListing = dataDir ? await listDirectoryEntries(dataDir) : '(not provided)',
+          logExists      = await pathExists(logPath),
+          stderr         = getStderr(),
+          stdout         = getStdout();
+
+    return [
+        `Timed out after ${timeoutMs}ms waiting for log predicate.`,
+        `Reason: ${reason}`,
+        `Process: pid=${daemonProcess?.pid ?? 'n/a'} exitCode=${processExit?.code ?? daemonProcess?.exitCode ?? null} signal=${processExit?.signal ?? daemonProcess?.signalCode ?? null} killed=${daemonProcess?.killed ?? false}`,
+        processError ? `Process error: ${processError.stack || processError.message}` : null,
+        `Log: path=${logPath} exists=${logExists}`,
+        `Data dir: ${dataDir || '(not provided)'}\n${dataDirListing}`,
+        `Last log content (${lastContent.length} bytes):\n${lastContent || '(empty)'}`,
+        `stdout (${stdout.length} bytes):\n${stdout || '(empty)'}`,
+        `stderr (${stderr.length} bytes):\n${stderr || '(empty)'}`
+    ].filter(Boolean).join('\n\n')
+}
+
+/**
  * @summary Polls a log file until a predicate matches its content or the timeout elapses.
  * @param {String} logPath
  * @param {(content:String)=>Boolean} predicate
  * @param {Number} timeoutMs
+ * @param {Object} [options]
+ * @param {import('node:child_process').ChildProcess} [options.daemonProcess]
+ * @param {String} [options.dataDir]
+ * @param {Function} [options.getStdout]
+ * @param {Function} [options.getStderr]
  * @returns {Promise<String>} The matching content snapshot.
  */
-async function waitForLogContent(logPath, predicate, timeoutMs) {
+async function waitForLogContent(logPath, predicate, timeoutMs, {
+    daemonProcess,
+    dataDir,
+    getStderr,
+    getStdout
+} = {}) {
     const deadline    = Date.now() + timeoutMs;
-    let   lastContent = '';
+    let   lastContent = '',
+          processError = null,
+          processExit  = null;
 
-    while (Date.now() < deadline) {
-        try {
-            lastContent = await fs.readFile(logPath, 'utf8');
-            if (predicate(lastContent)) return lastContent;
-        } catch (err) {
-            if (err.code !== 'ENOENT') throw err;
+    const onError = err => { processError = err; },
+          onExit  = (code, signal) => { processExit = {code, signal}; };
+
+    daemonProcess?.once('error', onError);
+    daemonProcess?.once('exit', onExit);
+
+    try {
+        while (Date.now() < deadline) {
+            if (processError || processExit || daemonProcess?.exitCode !== null) {
+                throw new Error(await formatLogWaitDiagnostics({
+                    dataDir,
+                    daemonProcess,
+                    getStderr,
+                    getStdout,
+                    lastContent,
+                    logPath,
+                    processError,
+                    processExit,
+                    reason: processError
+                        ? 'daemon process emitted error before the log predicate matched'
+                        : 'daemon process exited before the log predicate matched',
+                    timeoutMs
+                }))
+            }
+
+            try {
+                lastContent = await fs.readFile(logPath, 'utf8');
+                if (predicate(lastContent)) return lastContent;
+            } catch (err) {
+                if (err.code !== 'ENOENT') throw err;
+            }
+            await new Promise(resolve => setTimeout(resolve, 200));
         }
-        await new Promise(resolve => setTimeout(resolve, 200));
-    }
 
-    throw new Error(`Timed out after ${timeoutMs}ms waiting for log predicate. Last content (${lastContent.length} bytes):\n${lastContent}`);
+        throw new Error(await formatLogWaitDiagnostics({
+            dataDir,
+            daemonProcess,
+            getStderr,
+            getStdout,
+            lastContent,
+            logPath,
+            reason: 'timeout elapsed before the log predicate matched',
+            timeoutMs
+        }))
+    } finally {
+        daemonProcess?.off('error', onError);
+        daemonProcess?.off('exit', onExit);
+    }
 }
 
 /**
@@ -104,6 +230,7 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
 
     let workspaceDir;
     let dataDir;
+    let mcpLogPath;
     let logPath;
     let dbPath;
     let daemonProcess;
@@ -113,6 +240,7 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
     test.beforeEach(async () => {
         workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-workspace-safety-'));
         dataDir      = path.join(workspaceDir, 'orchestrator-daemon');
+        mcpLogPath   = path.join(workspaceDir, '.neo-ai-data/logs');
         logPath      = path.join(dataDir, 'orchestrator.log');
         dbPath       = path.join(workspaceDir, 'memory-core-graph.sqlite');
         // The orchestrator now self-bootstraps its sqlite + schema on
@@ -147,6 +275,10 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
                 NEO_AI_DEPLOYMENT_MODE  : 'cloud',
                 NEO_AI_ORCHESTRATOR_DIR : dataDir,
                 NEO_AI_DB_PATH          : dbPath,
+                NEO_KB_LOG_PATH         : mcpLogPath,
+                NEO_MEMORY_LOG_PATH     : mcpLogPath,
+                NEO_MEMORY_DB_PATH      : dbPath,
+                NEO_NL_LOG_PATH         : mcpLogPath,
                 NEO_HEARTBEAT_ALIVE_PATH: path.join(workspaceDir, 'heartbeat.alive'),
                 NEO_BACKUP_PATH         : path.join(workspaceDir, 'backups')
             },
@@ -159,7 +291,13 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
         const logContent = await waitForLogContent(
             logPath,
             content => content.includes('[Orchestrator] Started.'),
-            BOOT_TIMEOUT_MS
+            BOOT_TIMEOUT_MS,
+            {
+                daemonProcess,
+                dataDir,
+                getStderr: () => stderrBuf,
+                getStdout: () => stdoutBuf
+            }
         );
 
         // AC3: Process is still alive after boot completion.
@@ -205,6 +343,48 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
         }
     });
 
+    test('#14798 — cloud boot wait diagnostics include child exit, streams, log state, and data-dir listing', async () => {
+        await fs.mkdir(dataDir, {recursive: true});
+        await fs.writeFile(path.join(dataDir, 'probe.txt'), 'diagnostic marker');
+
+        daemonProcess = spawn(process.execPath, [
+            '-e',
+            'console.log("probe stdout"); console.error("probe stderr"); setTimeout(() => process.exit(42), 10);'
+        ], {
+            cwd  : workspaceDir,
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+
+        daemonProcess.stdout.on('data', chunk => { stdoutBuf += chunk.toString(); });
+        daemonProcess.stderr.on('data', chunk => { stderrBuf += chunk.toString(); });
+
+        let error;
+
+        try {
+            await waitForLogContent(
+                logPath,
+                content => content.includes('[Orchestrator] Started.'),
+                BOOT_TIMEOUT_MS,
+                {
+                    daemonProcess,
+                    dataDir,
+                    getStderr: () => stderrBuf,
+                    getStdout: () => stdoutBuf
+                }
+            )
+        } catch (err) {
+            error = err
+        }
+
+        expect(error?.message).toContain('daemon process exited before the log predicate matched');
+        expect(error.message).toContain('exitCode=42');
+        expect(error.message).toContain('Log: path=');
+        expect(error.message).toContain('exists=false');
+        expect(error.message).toContain('f probe.txt');
+        expect(error.message).toContain('probe stdout');
+        expect(error.message).toContain('probe stderr')
+    });
+
     test('AC4 — swarm-heartbeat target resolver degrades-with-log when selfIdentity is missing', async () => {
         // The swarm-heartbeat lane now defaults OFF, so this test explicitly enables it
         // (NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED) to make the resolver fire, rather than
@@ -218,6 +398,10 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
                 NEO_AI_DEPLOYMENT_MODE                        : 'local',
                 NEO_AI_ORCHESTRATOR_DIR                       : dataDir,
                 NEO_AI_DB_PATH                                : dbPath,
+                NEO_KB_LOG_PATH                               : mcpLogPath,
+                NEO_MEMORY_LOG_PATH                           : mcpLogPath,
+                NEO_MEMORY_DB_PATH                            : dbPath,
+                NEO_NL_LOG_PATH                               : mcpLogPath,
                 NEO_HEARTBEAT_ALIVE_PATH                      : path.join(workspaceDir, 'heartbeat.alive'),
                 NEO_BACKUP_PATH                               : path.join(workspaceDir, 'backups'),
                 NEO_AGENT_IDENTITY                            : '',


### PR DESCRIPTION
Resolves #14798

`workspaceSafety.spec.mjs` now fails fast when the orchestrator child exits before the boot log predicate matches, and the thrown error includes child exit state, log existence, data-dir listing, last log content, stdout, and stderr. The fresh-workspace daemon spawns also isolate the MCP file-sink logs and Memory Core graph DB through canonical env-owned config leaves instead of overlays or runtime singleton mutation.

Evidence: L3 (real orchestrator daemon booted in the focused integration spec and the synthetic crash path emitted full diagnostics) -> L3 required (fresh-workspace runtime boot proof + diagnostic failure contract). Residual: hosted PR CI check pending for #14798.

## Deltas from ticket

The ticket identified an opaque boot timeout. During implementation, the new diagnostic surfaced two additional isolation leaks in this local clone: file-sink MCP logs were resolving through repo-root `.neo-ai-data/logs`, and Memory Core graph storage needed the canonical `NEO_MEMORY_DB_PATH` env alongside the existing orchestrator DB env. This PR fixes those in the test harness by construction.

Changed config keys:

- `ai/mcp/server/knowledge-base/config.template.mjs`: `logPath` now supports `NEO_KB_LOG_PATH`.
- `ai/mcp/server/memory-core/config.template.mjs`: `logPath` now supports `NEO_MEMORY_LOG_PATH`.
- `ai/mcp/server/neural-link/config.template.mjs`: `logPath` now supports `NEO_NL_LOG_PATH`.

Local config follow-up:

- No gitignored `config.mjs` file is committed.
- Active clones should regenerate or migrate local MCP configs after merge so the local `config.mjs` shape carries these env bindings.
- Harness restart is recommended for already-running KB / Memory Core / Neural Link MCP servers; new processes read the env leaves at config construction.

## Test Evidence

- `node --check` on the three changed MCP templates and `test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs`: passed.
- `git diff --check`: passed.
- `node buildScripts/util/check-block-alignment.mjs ai/mcp/server/knowledge-base/config.template.mjs ai/mcp/server/memory-core/config.template.mjs ai/mcp/server/neural-link/config.template.mjs test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs`: passed.
- `npm run test-integration-unified -- test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs`: 3 passed.
- Direct Node env-leaf probe for `NEO_KB_LOG_PATH`, `NEO_MEMORY_LOG_PATH`, and `NEO_NL_LOG_PATH`: passed.
- `npm run --silent ai:structure-map -- --files --loc`: passed.
- `npm run agent-preflight -- --no-fix ai/mcp/server/knowledge-base/config.template.mjs ai/mcp/server/memory-core/config.template.mjs ai/mcp/server/neural-link/config.template.mjs test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs`: passed.
- Commit hook checks: passed.

Not counted as evidence: `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/config.template.spec.mjs` produced no output for several minutes and was interrupted after no matching runner process remained visible.

## Post-Merge Validation

- [ ] Hosted PR CI reports `integration-unified` green at the PR head.
- [ ] Active peer clones regenerate or migrate local MCP configs before relying on the new log-path env overrides.
- [ ] Restart already-running KB / Memory Core / Neural Link MCP servers if their process needs the new env-binding support.

## Commits

- `65f3c8de90` - `fix(ai): surface workspace safety boot diagnostics (#14798)`

Authored by Euclid (GPT-5, Codex Desktop). Session 6439a7c5-5f2f-4658-9226-835c317c7a0b.
