### PR TITLE
feat(agentos): add keeper created pane chrome (#14765)

### DIFF
--- a/apps/agentos/view/create/CreatedPane.mjs
+++ b/apps/agentos/view/create/CreatedPane.mjs
@@ -1,0 +1,210 @@
+import Button            from '../../../../src/button/Base.mjs';
+import Container         from '../../../../src/container/Base.mjs';
+import Label             from '../../../../src/component/Label.mjs';
+import StateProvider     from '../../../../src/state/Provider.mjs';
+import CreatedInstances  from './store/CreatedInstances.mjs';
+import {CREATION_EVENTS} from './util/creationFlowState.mjs';
+
+/**
+ * @class AgentOS.view.create.CreatedPane
+ * @extends Neo.container.Base
+ *
+ * @summary Registry-owned chrome for a keeper-created live widget. The pane is the render target:
+ * the child component remains the mutation target (`instanceId`), while `paneRef` records the
+ * wrapper id so lifecycle controls destroy chrome + content together.
+ *
+ * The title reads the CreatedInstances registry record through a per-pane state.Provider. Storing
+ * the record in provider data lets the provider's record-field bridge re-run bindings when
+ * `CreatedInstances.markMutated()` retitles the registry entry, without reaching into the child
+ * component tree or duplicating title state on the pane.
+ */
+class CreatedPane extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.create.CreatedPane'
+         * @protected
+         */
+        className: 'AgentOS.view.create.CreatedPane',
+        /**
+         * @member {String} ntype='agentos-created-pane'
+         * @protected
+         */
+        ntype: 'agentos-created-pane',
+        /**
+         * The live widget component config inserted into the pane body.
+         * @member {Object|Neo.component.Base|null} content=null
+         * @reactive
+         */
+        content_: null,
+        /**
+         * @member {String[]} cls=['agentos-created-pane']
+         * @reactive
+         */
+        cls: ['agentos-created-pane'],
+        /**
+         * @member {String|null} instanceId=null
+         * @reactive
+         */
+        instanceId_: null,
+        /**
+         * Optional unit/live seam for moving this pane into another render target. A real popup
+         * surface can inject a container; tests inject the same `add()` seam used by the multi-window
+         * demos.
+         * @member {Function|Neo.container.Base|null} promoteTarget=null
+         * @reactive
+         */
+        promoteTarget_: null,
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * Per-pane binding surface. The parent create-module provider remains the flow-state owner.
+         * @member {Object} stateProvider
+         */
+        stateProvider: {
+            module: StateProvider,
+            data  : {
+                lastPromoteReason: null,
+                promoted         : false,
+                record           : null
+            }
+        },
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            module: Container,
+            cls   : ['agentos-created-pane-header'],
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                module   : Label,
+                reference: 'created-pane-title',
+                cls      : ['agentos-created-pane-title'],
+                flex     : 1,
+                bind     : {text: 'record.title'}
+            }, {
+                module : Button,
+                cls    : ['agentos-created-pane-promote'],
+                iconCls: 'far fa-window-maximize',
+                text   : 'Promote',
+                handler: 'up.onPromote',
+                bind   : {disabled: data => data.promoted}
+            }, {
+                module : Button,
+                cls    : ['agentos-created-pane-dispose'],
+                iconCls: 'fa fa-trash',
+                text   : 'Dispose',
+                handler: 'up.onDispose'
+            }]
+        }, {
+            module   : Container,
+            reference: 'created-pane-body',
+            cls      : ['agentos-created-pane-body'],
+            flex     : 1,
+            layout   : {ntype: 'fit'}
+        }]
+    }
+
+    /**
+     * @protected
+     */
+    afterSetContent(value, oldValue) {
+        if (this.isConstructed) {
+            this.mountContent()
+        }
+    }
+
+    /**
+     * @protected
+     */
+    afterSetInstanceId(value, oldValue) {
+        if (this.isConstructed) {
+            this.syncRecord()
+        }
+    }
+
+    /**
+     * @protected
+     */
+    onConstructed() {
+        super.onConstructed();
+
+        this.mountContent();
+        this.syncRecord()
+    }
+
+    /**
+     * Inserts the accepted widget config into the body slot exactly once.
+     * @returns {Neo.component.Base|null}
+     */
+    mountContent() {
+        const
+            body    = this.down({reference: 'created-pane-body'}),
+            content = this.content;
+
+        if (!body || !content || body.items?.length) {
+            return body?.items?.[0] || null
+        }
+
+        return body.add(content, true)
+    }
+
+    /**
+     * Registry-driven title binding anchor.
+     * @returns {Object|null}
+     */
+    syncRecord() {
+        const record = this.instanceId ? CreatedInstances.resolveTarget({instanceId: this.instanceId}) : null;
+
+        this.setState('record', record);
+
+        return record
+    }
+
+    /**
+     * Disposes the keeper-owned pane and its content, then moves the parent flow back to empty.
+     * @returns {{accepted: Boolean, reason: String|null, record: Object|null}}
+     */
+    onDispose() {
+        const
+            me           = this,
+            flowProvider = me.stateProvider?.getParent?.(),
+            result       = CreatedInstances.markDisposed(me.instanceId);
+
+        if (result.accepted) {
+            flowProvider?.setData({activeInstanceId: null});
+            flowProvider?.applyFlowEvent?.(CREATION_EVENTS.DISPOSE);
+            me.destroy()
+        }
+
+        return result
+    }
+
+    /**
+     * Moves the pane into an injected render target; the registry record and child instance id stay
+     * untouched, matching the shared-worker "windows are render targets" topology.
+     * @returns {{accepted: Boolean, reason: String|null, pane: AgentOS.view.create.CreatedPane|null}}
+     */
+    onPromote() {
+        const
+            me              = this,
+            {promoteTarget} = me,
+            target          = Neo.isFunction(promoteTarget) ? promoteTarget({pane: me, instanceId: me.instanceId, record: me.syncRecord()}) : promoteTarget;
+
+        if (!target || typeof target.add !== 'function') {
+            const reason = 'no promote target available for created pane';
+
+            me.setState({lastPromoteReason: reason, promoted: false});
+            return {accepted: false, reason, pane: null}
+        }
+
+        target.add(me);
+        me.setState({lastPromoteReason: null, promoted: true});
+
+        return {accepted: true, reason: null, pane: me}
+    }
+}
+
+export default Neo.setupClass(CreatedPane);

--- a/apps/agentos/view/create/store/CreatedInstances.mjs
+++ b/apps/agentos/view/create/store/CreatedInstances.mjs
@@ -80,9 +80,9 @@ class CreatedInstances extends Store {
             title,
             blueprintSnapshot: snapshot.value,
             paneRef,
-            createdAt    : new Date().toISOString(),
-            creationIndex: this.nextCreationIndex(),
-            state        : 'live'
+            createdAt        : new Date().toISOString(),
+            creationIndex    : this.nextCreationIndex(),
+            state            : 'live'
         })[0];
 
         return {accepted: true, reason: null, record}
@@ -129,13 +129,10 @@ class CreatedInstances extends Store {
             }
         }
 
-        if ('title' in changes) {
-            record.title = changes.title
-        }
-
-        if (snapshot) {
-            record.blueprintSnapshot = snapshot.value
-        }
+        record.set({
+            ...('title' in changes ? {title: changes.title} : {}),
+            ...(snapshot ? {blueprintSnapshot: snapshot.value} : {})
+        });
 
         return {accepted: true, reason: null, record}
     }
@@ -157,7 +154,7 @@ class CreatedInstances extends Store {
             return {accepted: false, reason: `instanceId "${instanceId}" is already disposed`, record: null}
         }
 
-        record.state = 'disposed';
+        record.set({state: 'disposed'});
 
         return {accepted: true, reason: null, record}
     }

--- a/apps/agentos/view/create/util/acceptPath.mjs
+++ b/apps/agentos/view/create/util/acceptPath.mjs
@@ -1,3 +1,4 @@
+import CreatedPane                           from '../CreatedPane.mjs';
 import {validateBlueprint, validateMutation} from './blueprintSchema.mjs';
 
 /**
@@ -62,28 +63,37 @@ export const SCHEMA_MATERIALIZERS = Object.freeze({
          * @returns {Object} stage-insertable component config
          */
         materialize(blueprint, {instanceId}) {
-            const columns = blueprint.config.columns.map(column => ({dataField: column.field, text: column.text}));
+            const
+                columns = blueprint.config.columns.map(column => ({dataField: column.field, text: column.text})),
+                paneRef = `${instanceId}-pane`;
 
             return {
-                // id + reference both set to the instanceId (the shipped first-widget parity):
-                // the id makes the instance resolvable via the core instance manager
-                // (Neo.get); the reference keeps container-scoped getReference() lookups working
-                id       : instanceId,
-                ntype    : 'grid-container',
-                reference: instanceId,
-                title    : blueprint.title,
+                module   : CreatedPane,
+                ntype    : 'agentos-created-pane',
+                id       : paneRef,
+                reference: paneRef,
+                instanceId,
                 flex     : 1,
-                columns,
-                ...(blueprint.config.height !== undefined ? {height: blueprint.config.height} : {}),
-                ...(blueprint.config.width  !== undefined ? {width : blueprint.config.width}  : {}),
-                store: {
-                    model: {fields: columns.map(column => ({name: column.dataField, type: 'String'}))},
-                    data : blueprint.data
-                },
                 // provenance stamp: the insert-side registrar reads this to write the registry
-                // record at the same moment the provenance projection fires; external
-                // create_component inserts carry no stamp and are untouched by the registrar
-                blueprintMeta: {instanceId, schema: blueprint.schema, title: blueprint.title, blueprintSnapshot: blueprint}
+                // record at the same moment the pane lands. The child remains the mutation target.
+                blueprintMeta: {instanceId, schema: blueprint.schema, title: blueprint.title, blueprintSnapshot: blueprint},
+                content      : {
+                    // id + reference both set to the instanceId (the shipped first-widget parity):
+                    // the id makes the instance resolvable via the core instance manager
+                    // (Neo.get); the reference keeps container-scoped getReference() lookups working
+                    id       : instanceId,
+                    ntype    : 'grid-container',
+                    reference: instanceId,
+                    title    : blueprint.title,
+                    flex     : 1,
+                    columns,
+                    ...(blueprint.config.height !== undefined ? {height: blueprint.config.height} : {}),
+                    ...(blueprint.config.width  !== undefined ? {width : blueprint.config.width}  : {}),
+                    store: {
+                        model: {fields: columns.map(column => ({name: column.dataField, type: 'String'}))},
+                        data : blueprint.data
+                    }
+                }
             }
         },
         /**
@@ -249,13 +259,16 @@ export function mutateInstance({instanceId, mutation, registry, resolveComponent
  * @returns {{accepted: Boolean, reason: String|null, stage: String|null}}
  */
 export function disposeInstance({instanceId, registry, resolveComponent = resolveViaInstanceManager} = {}) {
-    const flipped = registry?.markDisposed?.(instanceId);
+    const
+        record  = registry?.resolveTarget?.({instanceId}),
+        paneRef = record?.paneRef,
+        flipped = registry?.markDisposed?.(instanceId);
 
     if (!flipped?.accepted) {
         return {accepted: false, reason: flipped?.reason || 'registry unavailable', stage: ACCEPT_STAGES.DISPOSE};
     }
 
-    const component = typeof resolveComponent === 'function' ? resolveComponent(instanceId) : null;
+    const component = typeof resolveComponent === 'function' ? (resolveComponent(paneRef || instanceId) || (paneRef ? resolveComponent(instanceId) : null)) : null;
 
     component?.destroy?.();
 

--- a/test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs
@@ -62,10 +62,13 @@ test.describe('acceptPath — blueprint → live instance via the ONE create pat
         const result = accept.acceptBlueprint({blueprint: validGrid('Accept Grid'), instanceId: 'ap-1', stage});
 
         expect(result.accepted).toBe(true);
-        expect(result.config.ntype).toBe('grid-container');           // wire-safe, never a module ref
-        expect(result.config.id).toBe('ap-1');                        // instance-manager resolvable (Neo.get)
-        expect(result.config.reference).toBe('ap-1');
-        expect(result.config.columns).toEqual([{dataField: 'name', text: 'Name'}, {dataField: 'city', text: 'City'}]);
+        expect(result.config.ntype).toBe('agentos-created-pane');     // keeper chrome wraps the live widget
+        expect(result.config.id).toBe('ap-1-pane');                   // paneRef, not mutation target
+        expect(result.config.reference).toBe('ap-1-pane');
+        expect(result.config.content.id).toBe('ap-1');                // instance-manager resolvable (Neo.get)
+        expect(result.config.content.ntype).toBe('grid-container');   // wire-safe, never a module ref
+        expect(result.config.content.reference).toBe('ap-1');
+        expect(result.config.content.columns).toEqual([{dataField: 'name', text: 'Name'}, {dataField: 'city', text: 'City'}]);
         expect(stage.added).toHaveLength(1);                          // the ONE create path was used
 
         // the insert event wrote the registry record with the provenance stamp
@@ -73,7 +76,7 @@ test.describe('acceptPath — blueprint → live instance via the ONE create pat
 
         expect(record.state).toBe('live');
         expect(record.blueprintSchema).toBe('grid@1');
-        expect(record.paneRef).toBe('ap-1');
+        expect(record.paneRef).toBe('ap-1-pane');
         expect(record.blueprintSnapshot.title).toBe('Accept Grid');
     });
 
@@ -192,15 +195,15 @@ test.describe('acceptPath — blueprint → live instance via the ONE create pat
         stage.on('insert', registrar);
         accept.acceptBlueprint({blueprint: validGrid('Dispose Grid'), instanceId: 'ap-d1', stage});
 
-        let   destroyed = false;
-        const result    = accept.disposeInstance({
+        let   destroyedId = null;
+        const result      = accept.disposeInstance({
             instanceId      : 'ap-d1',
             registry        : CreatedInstances,
-            resolveComponent: () => ({destroy() { destroyed = true }})
+            resolveComponent: id => ({destroy() { destroyedId = id }})
         });
 
         expect(result.accepted).toBe(true);
-        expect(destroyed).toBe(true);
+        expect(destroyedId).toBe('ap-d1-pane');
         expect(CreatedInstances.resolveTarget({instanceId: 'ap-d1'}).state).toBe('disposed');
 
         // disposed instances refuse mutation through the accept path too

--- a/test/playwright/unit/apps/agentos/create/createSurface.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/createSurface.spec.mjs
@@ -17,7 +17,7 @@ import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 
 test.describe('CreateSurface — the wedge screen: five states, one provider, the whole spine (#14720)', () => {
-    let Controller, Provider, oracle, deterministicBlueprintFallback;
+    let Controller, CreatedPane, Provider, oracle, deterministicBlueprintFallback;
 
     // a stage double honoring the container seam the controller drives
     const createStageDouble = () => {
@@ -67,6 +67,7 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
 
     test.beforeAll(async () => {
         Controller = (await import('../../../../../../apps/agentos/view/create/CreateSurfaceController.mjs')).default;
+        CreatedPane = (await import('../../../../../../apps/agentos/view/create/CreatedPane.mjs')).default;
         Provider   = (await import('../../../../../../apps/agentos/view/create/CreationStateProvider.mjs')).default;
         oracle     = await import('../../../../../../apps/agentos/view/create/util/creationFlowState.mjs');
         deterministicBlueprintFallback = (await import('../../../../../../apps/agentos/view/create/CreateSurfaceController.mjs')).deterministicBlueprintFallback;
@@ -85,7 +86,8 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
 
         expect(provider.getData('flowState')).toBe(S.MATERIALIZED);
         expect(stage.added).toHaveLength(1);                          // the ONE create path was used
-        expect(stage.added[0].ntype).toBe('grid-container');
+        expect(stage.added[0].ntype).toBe('agentos-created-pane');
+        expect(stage.added[0].content.ntype).toBe('grid-container');
 
         const instanceId = provider.getData('activeInstanceId');
         expect(instanceId).toMatch(/^keeper-grid-/);
@@ -93,6 +95,7 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
         const record = CreatedInstances.resolveTarget({instanceId});
         expect(record.state).toBe('live');
         expect(record.blueprintSchema).toBe('grid@1');
+        expect(record.paneRef).toBe(`${instanceId}-pane`);
 
         provider.destroy(); controller.destroy()
     });
@@ -157,6 +160,44 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
         expect(provider.getData('flowState')).toBe(S.EMPTY);
         expect(provider.getData('activeInstanceId')).toBeNull();
         expect(CreatedInstances.resolveTarget({instanceId}).state).toBe('disposed');
+
+        provider.destroy(); controller.destroy()
+    });
+
+    test('created pane chrome binds title, disposes via registry, and promotes by moving render target only', async () => {
+        const
+            {provider, stage, controller, CreatedInstances} = await createRig(),
+            S                                               = oracle.CREATION_STATES;
+
+        controller.onIntentChange();
+        await controller.onSubmitIntent();
+
+        const
+            instanceId = provider.getData('activeInstanceId'),
+            paneConfig = {...stage.added[0], content: {ntype: 'component', id: instanceId, reference: instanceId}},
+            pane       = Neo.create(CreatedPane, paneConfig),
+            titleLabel = pane.down({reference: 'created-pane-title'}),
+            target     = {added: [], add(item) { this.added.push(item); return item }};
+
+        pane.stateProvider.parent = provider;
+
+        expect(titleLabel.text).toBe(CreatedInstances.resolveTarget({instanceId}).title);
+
+        CreatedInstances.markMutated(instanceId, {title: 'Retitled Grid'});
+        expect(titleLabel.text).toBe('Retitled Grid');
+
+        pane.promoteTarget = () => target;
+        expect(pane.onPromote()).toMatchObject({accepted: true, pane});
+        expect(target.added[0]).toBe(pane);
+        expect(CreatedInstances.resolveTarget({instanceId}).state).toBe('live');
+
+        await pane.timeout(1);
+        pane.onDispose();
+
+        expect(provider.getData('flowState')).toBe(S.EMPTY);
+        expect(provider.getData('activeInstanceId')).toBeNull();
+        expect(CreatedInstances.resolveTarget({instanceId}).state).toBe('disposed');
+        expect(pane.isDestroying).toBe(true);
 
         provider.destroy(); controller.destroy()
     });


### PR DESCRIPTION
Resolves #14765

Adds keeper-owned pane chrome around materialized create-module widgets: the pane owns title/dispose/promote controls, while the live child keeps the original `instanceId` as the mutation target. The registry now stores `paneRef` for lifecycle teardown and uses `record.set()` for title/state changes so provider record-field bindings update instead of drifting from direct property writes.

Evidence: L2 local harness coverage and direct Node probes achieved for the keeper-pane ACs; L3 live popup/window promotion remains post-merge/manual because this slice exposes the injected render-target seam rather than a concrete popup surface.

## Deltas from ticket
Promote is implemented as an injected render-target seam (`promoteTarget.add(pane)`) with unit-level proof. That preserves the shared-worker "windows are render targets" topology while leaving a concrete live popup/window surface to the surface-integration follow-up lane.

## Test Evidence
- `npm run agent-preflight -- --no-fix apps/agentos/view/create/CreatedPane.mjs apps/agentos/view/create/store/CreatedInstances.mjs apps/agentos/view/create/util/acceptPath.mjs test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs test/playwright/unit/apps/agentos/create/createSurface.spec.mjs` passed on rebased head.
- `node --check apps/agentos/view/create/CreatedPane.mjs`
- `node --check apps/agentos/view/create/store/CreatedInstances.mjs`
- `node --check apps/agentos/view/create/util/acceptPath.mjs`
- `node --check test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs`
- `node --check test/playwright/unit/apps/agentos/create/createSurface.spec.mjs`
- `git diff --check` and `git diff --cached --check` passed before commit.
- Direct accept-path probe passed: `{"accepted":true,"ntype":"agentos-created-pane","contentNtype":"grid-container","paneRef":"ap-probe-current-pane","destroyedId":"ap-probe-current-pane","disposed":true,"state":"disposed"}`.
- Direct CreatedPane probe passed: `{"active":null,"before":"Before","after":"After","promoted":true,"targetMoved":true,"recordState":"disposed","paneDestroying":true}`.
- Focused Playwright unit command attempted: `npm run test-unit -- test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs test/playwright/unit/apps/agentos/create/createSurface.spec.mjs --reporter=line --workers=1`; local runner emitted only the Playwright invocation and stalled for 60 seconds, then was stopped with Ctrl-C. This is not counted as passing evidence.

## Post-Merge Validation
- [ ] In a live AgentOS window, create a keeper widget and verify the title/dispose pane chrome renders around the widget.
- [ ] Exercise a concrete popup/window promotion target once the live promotion surface lands.

## Commit
- `932195e284` — `feat(agentos): add keeper created pane chrome (#14765)`

Authored by Euclid (GPT-5, Codex Desktop). Session 6439a7c5-5f2f-4658-9226-835c317c7a0b.
