### PR TITLE
feat(agentos): add keeper blueprint preview (#14764)

### DIFF
--- a/apps/agentos/view/create/BlueprintPreview.mjs
+++ b/apps/agentos/view/create/BlueprintPreview.mjs
@@ -1,0 +1,133 @@
+import Button              from '../../../../src/button/Base.mjs';
+import Container           from '../../../../src/container/Base.mjs';
+import Label               from '../../../../src/component/Label.mjs';
+import {CREATION_STATES}   from './util/creationFlowState.mjs';
+import {BLUEPRINT_SCHEMAS} from './util/blueprintSchema.mjs';
+
+/**
+ * @summary Formats a blueprint's allowlisted config surface for the preview card. The function
+ * iterates the schema registry allowlist, never the candidate's own keys, so render truth mirrors
+ * the validator's structural firewall.
+ * @param {Object|null} blueprint
+ * @returns {String}
+ */
+export function formatPreviewConfig(blueprint) {
+    const schema = BLUEPRINT_SCHEMAS[blueprint?.schema];
+
+    if (!schema || !blueprint?.config) {
+        return 'No config preview';
+    }
+
+    const rows = [];
+
+    schema.configAllowlist.forEach(key => {
+        const value = blueprint.config[key];
+
+        if (value === undefined) return;
+
+        if (key === 'columns' && Array.isArray(value)) {
+            rows.push(`columns: ${value.map(column => `${column.field} -> ${column.text}`).join(' | ')}`);
+        } else if (value == null || ['string', 'number', 'boolean'].includes(typeof value)) {
+            rows.push(`${key}: ${String(value)}`);
+        }
+    });
+
+    return rows.length > 0 ? rows.join(' | ') : 'No allowlisted config values'
+}
+
+/**
+ * @summary Formats the candidate's data size without exposing row internals in the preview chrome.
+ * @param {Object|null} blueprint
+ * @returns {String}
+ */
+export function formatRowCount(blueprint) {
+    const rows = Array.isArray(blueprint?.data) ? blueprint.data.length : 0;
+
+    return `${rows} row${rows === 1 ? '' : 's'}`
+}
+
+/**
+ * @class AgentOS.view.create.BlueprintPreview
+ * @extends Neo.container.Base
+ *
+ * @summary Composing-state confirmation card for the keeper create flow. It renders only the
+ * route-validated candidate parked on the create provider: schema id, title, allowlisted config
+ * summary, row count, and the confirm/edit affordances that dispatch back through the provider
+ * event path.
+ */
+class BlueprintPreview extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.create.BlueprintPreview'
+         * @protected
+         */
+        className: 'AgentOS.view.create.BlueprintPreview',
+        /**
+         * @member {String} ntype='agentos-blueprint-preview'
+         * @protected
+         */
+        ntype: 'agentos-blueprint-preview',
+        /**
+         * @member {String[]} cls=['agentos-blueprint-preview']
+         * @reactive
+         */
+        cls: ['agentos-blueprint-preview'],
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * The preview exists only for a route-accepted candidate in COMPOSING. Refusals render the
+         * existing error strip; an absent candidate means the user is still composing raw intent.
+         * @member {Object}
+         */
+        bind: {
+            hidden: data => data.flowState !== CREATION_STATES.COMPOSING || !data.candidateBlueprint
+        },
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            module: Container,
+            cls   : ['agentos-blueprint-preview-header'],
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                module: Label,
+                cls   : ['agentos-blueprint-preview-schema'],
+                bind  : {text: data => data.candidateBlueprint?.schema || ''}
+            }, {
+                module: Label,
+                cls   : ['agentos-blueprint-preview-title'],
+                flex  : 1,
+                bind  : {text: data => data.candidateBlueprint?.title || ''}
+            }]
+        }, {
+            module: Label,
+            cls   : ['agentos-blueprint-preview-config'],
+            bind  : {text: data => formatPreviewConfig(data.candidateBlueprint)}
+        }, {
+            module: Label,
+            cls   : ['agentos-blueprint-preview-rows'],
+            bind  : {text: data => formatRowCount(data.candidateBlueprint)}
+        }, {
+            module: Container,
+            cls   : ['agentos-blueprint-preview-actions'],
+            layout: {ntype: 'hbox'},
+            items : [{
+                module : Button,
+                text   : 'Confirm',
+                iconCls: 'fas fa-check',
+                handler: 'onConfirmPreview'
+            }, {
+                module : Button,
+                text   : 'Edit',
+                ui     : 'secondary',
+                iconCls: 'fas fa-pen',
+                handler: 'onEditPreview'
+            }]
+        }]
+    }
+}
+
+export default Neo.setupClass(BlueprintPreview);

--- a/apps/agentos/view/create/CreateSurface.mjs
+++ b/apps/agentos/view/create/CreateSurface.mjs
@@ -1,3 +1,4 @@
+import BlueprintPreview        from './BlueprintPreview.mjs';
 import Button                  from '../../../../src/button/Base.mjs';
 import Container               from '../../../../src/container/Base.mjs';
 import CreateSurfaceController from './CreateSurfaceController.mjs';
@@ -93,6 +94,8 @@ class CreateSurface extends Container {
                     [CREATION_STATES.ERROR]       : `Blocked: ${data.flowReason || 'generation refused'} — edit and retry; never a dead-end.`
                 })[data.flowState] || ''
             }
+        }, {
+            module: BlueprintPreview
         }, {
             // The action strip — state-dependent affordances, all provider-event dispatchers.
             module: Container,

--- a/apps/agentos/view/create/CreateSurfaceController.mjs
+++ b/apps/agentos/view/create/CreateSurfaceController.mjs
@@ -84,13 +84,18 @@ class CreateSurfaceController extends Controller {
         const provider = this.getProvider(),
               state    = provider.getData('flowState');
 
+        if (provider.getData('candidateBlueprint')) {
+            provider.applyPreviewEdit();
+            return
+        }
+
         provider.applyFlowEvent(state === 'empty' ? CREATION_EVENTS.COMPOSE : CREATION_EVENTS.EDIT)
     }
 
     /**
      * The submit path — the whole spine in one handler, every step branching on bounded
      * `{accepted, reason}` shapes, nothing thrown into the render:
-     * composing → generating → (route) → materialized | error.
+     * composing → generating → (route) → composing+candidate | error.
      * @protected
      */
     async onSubmitIntent() {
@@ -106,30 +111,51 @@ class CreateSurfaceController extends Controller {
         const generate = me.generateBlueprint || (async text => deterministicBlueprintFallback(text));
         const routed   = await routeCreationRequest({request, generate});
 
-        if (!routed.accepted) {
-            provider.applyCreationRouteOutcome(routed); // generating → error, the route's reason verbatim
-            return
-        }
+        provider.applyPreviewRouteOutcome(routed); // accepted → composing+candidate, refused → error
+    }
+
+    /**
+     * Confirms the previewed candidate and runs the existing accept path. MATERIALIZED remains
+     * accept-path truth: route acceptance only created the candidate, never the live instance.
+     * @protected
+     */
+    onConfirmPreview() {
+        const me        = this,
+              provider  = me.getProvider(),
+              blueprint = provider.getData('candidateBlueprint');
+
+        if (!blueprint) return;
+
+        const submitted = provider.applyFlowEvent(CREATION_EVENTS.SUBMIT);
+
+        if (submitted.state !== 'generating') return;
 
         // MATERIALIZED is accept-path truth, never route truth: the provider only leaves
         // `generating` after the accept path has actually put an instance into the stage. Both
         // refusal sources (route above, accept-stage here) land ERROR from `generating`.
         const instanceId = `keeper-grid-${++instanceSeq}`,
               accepted   = acceptBlueprint({
-                  blueprint: routed.blueprint,
+                  blueprint,
                   instanceId,
                   stage    : me.getReference('create-stage'),
                   registry : CreatedInstances
               });
 
         if (accepted.accepted) {
-            provider.applyCreationRouteOutcome(routed); // generating → materialized — now TRUE
-            provider.setData({activeInstanceId: instanceId})
+            provider.applyCreationRouteOutcome(accepted, instanceId); // generating → materialized — now TRUE
         } else {
             // accept-stage refusal AFTER route acceptance (dead stage, duplicate id, coverage
             // defect): honest ERROR carrying the ACCEPT PATH's reason; no active instance
-            provider.applyCreationRouteOutcome({accepted: false, reason: accepted.reason})
+            provider.applyCreationRouteOutcome(accepted)
         }
+    }
+
+    /**
+     * Returns from candidate preview to raw composing via the provider's recorded EDIT event.
+     * @protected
+     */
+    onEditPreview() {
+        this.getProvider().applyPreviewEdit()
     }
 
     /**
@@ -151,7 +177,7 @@ class CreateSurfaceController extends Controller {
 
         if (instanceId) {
             disposeInstance({instanceId, registry: CreatedInstances});
-            provider.setData({activeInstanceId: null})
+            provider.clearActiveInstance()
         }
 
         provider.applyFlowEvent(CREATION_EVENTS.DISPOSE)

--- a/apps/agentos/view/create/CreationStateProvider.mjs
+++ b/apps/agentos/view/create/CreationStateProvider.mjs
@@ -1,6 +1,13 @@
-import Provider                                                from '../../../../src/state/Provider.mjs';
-import CreatedInstances                                        from './store/CreatedInstances.mjs';
-import {CREATION_STATES, nextCreationState, applyRouteOutcome} from './util/creationFlowState.mjs';
+import Provider         from '../../../../src/state/Provider.mjs';
+import EffectManager    from '../../../../src/core/EffectManager.mjs';
+import CreatedInstances from './store/CreatedInstances.mjs';
+import {
+    CREATION_EVENTS,
+    CREATION_STATES,
+    nextCreationState,
+    applyPreviewOutcome,
+    applyRouteOutcome
+} from './util/creationFlowState.mjs';
 
 /**
  * @class AgentOS.view.create.CreationStateProvider
@@ -18,11 +25,12 @@ import {CREATION_STATES, nextCreationState, applyRouteOutcome} from './util/crea
  * targets, instances never move); the provider's contribution is the declarative shared-binding
  * surface, and the promote step working across windows comes with it for free.
  *
- * Views bind `data.flowState` / `data.flowReason` and the exposed `stores.createdInstances`;
- * they never re-derive "which state" from booleans and never write flow state directly —
- * {@link CreationStateProvider#applyFlowEvent} is the ONE writer, guarded by the pure transition
- * oracle. Illegal transitions mutate nothing and return the oracle's bounded refusal, mirroring
- * the pipeline's `{accepted, reason}` vocabulary end to end.
+ * Views bind `data.flowState` / `data.flowReason` / `data.candidateBlueprint` and the exposed
+ * `stores.createdInstances`; they never re-derive "which state" from booleans and never write
+ * flow state directly — {@link CreationStateProvider#applyFlowEvent} and its preview/accept
+ * wrappers are the ONE writer family, guarded by the pure transition oracle. Illegal transitions
+ * mutate nothing and return the oracle's bounded refusal, mirroring the pipeline's
+ * `{accepted, reason}` vocabulary end to end.
  */
 class CreationStateProvider extends Provider {
     static config = {
@@ -37,9 +45,10 @@ class CreationStateProvider extends Provider {
          * @member {Object} data
          */
         data: {
-            activeInstanceId: null,
-            flowReason      : null,
-            flowState       : CREATION_STATES.EMPTY
+            activeInstanceId  : null,
+            candidateBlueprint: null,
+            flowReason        : null,
+            flowState         : CREATION_STATES.EMPTY
         },
         /**
          * The created-instances registry, exposed to bindings — grids/panes in ANY window read
@@ -53,7 +62,7 @@ class CreationStateProvider extends Provider {
 
     /**
      * The ONE flow-state writer: consults the transition oracle and applies ONLY legal
-     * transitions to the provider data (one batched `setData`). Illegal or unknown events leave
+     * transitions to the provider data (one batched provider write). Illegal or unknown events leave
      * the data untouched and return the oracle's bounded result, so callers branch exactly as
      * they do on the pipeline's `{accepted, reason}` shapes — nothing throws.
      * @param {String} event One of the oracle's CREATION_EVENTS
@@ -66,34 +75,133 @@ class CreationStateProvider extends Provider {
 
         // the oracle's illegal shape: unchanged state + a reason. Everything else (including
         // legal same-state transitions and the reason-carrying `refused` arc) applies.
-        if (result.changed || result.reason === null) {
-            this.setData({
-                flowReason: result.reason,
-                flowState : result.state
-            })
-        }
+        this.applyOracleResult(result, this.flowDataForEvent(event));
 
         return result
     }
 
     /**
-     * Maps an accept-path / route outcome to the generating→terminal fork through the same
-     * guarded writer — the ERROR state receives the pipeline's refusal reason for the SSOT's
-     * "always a reason" render.
-     * @param {{accepted: Boolean, reason: String|null}} outcome The route/accept-path result
+     * Maps an emit-side route outcome to the generating→preview fork through the same guarded
+     * writer. Accepted candidates are parked on provider data for the preview card; refusals keep
+     * the existing ERROR branch and never expose a candidate.
+     * @param {{accepted: Boolean, reason: String|null, blueprint: Object|null}} outcome The route result
      * @returns {{state: String, reason: String|null, changed: Boolean}}
      */
-    applyCreationRouteOutcome(outcome) {
-        const result = applyRouteOutcome(this.getData('flowState'), outcome);
+    applyPreviewRouteOutcome(outcome) {
+        const result = applyPreviewOutcome(this.getData('flowState'), outcome);
 
-        if (result.changed || result.reason === null) {
-            this.setData({
-                flowReason: result.reason,
-                flowState : result.state
-            })
-        }
+        this.applyOracleResult(result, {
+            candidateBlueprint: outcome?.accepted ? outcome.blueprint || null : null
+        });
 
         return result
+    }
+
+    /**
+     * EDIT from a previewed candidate is a real flow event: the candidate is cleared by the provider
+     * wrapper that records the event, not by component-local state.
+     * @returns {{state: String, reason: String|null, changed: Boolean}}
+     */
+    applyPreviewEdit() {
+        const result = nextCreationState(this.getData('flowState'), CREATION_EVENTS.EDIT);
+
+        this.applyOracleResult(result, {candidateBlueprint: null});
+
+        return result
+    }
+
+    /**
+     * Maps the accept path to the terminal fork. MATERIALIZED is truth only after the stage insert
+     * succeeded; refused accept paths land ERROR and clear the preview candidate.
+     * @param {{accepted: Boolean, reason: String|null}} outcome The accept-path result
+     * @param {String|null} [instanceId=null] Active instance id when accepted
+     * @returns {{state: String, reason: String|null, changed: Boolean}}
+     */
+    applyCreationRouteOutcome(outcome, instanceId=null) {
+        const result = applyRouteOutcome(this.getData('flowState'), outcome);
+
+        this.applyOracleResult(result, {
+            activeInstanceId  : outcome?.accepted ? instanceId : null,
+            candidateBlueprint: null
+        });
+
+        return result
+    }
+
+    /**
+     * Active instance cleanup belongs with the provider data that records it.
+     */
+    clearActiveInstance() {
+        this.setData({activeInstanceId: null})
+    }
+
+    /**
+     * Extra data mutations coupled to legal flow events.
+     * @param {String} event
+     * @returns {Object}
+     * @protected
+     */
+    flowDataForEvent(event) {
+        return event === CREATION_EVENTS.RESET || event === CREATION_EVENTS.DISPOSE
+            ? {candidateBlueprint: null}
+            : {}
+    }
+
+    /**
+     * Applies an oracle result plus same-event provider data in one batch.
+     * @param {{state: String, reason: String|null, changed: Boolean}} result
+     * @param {Object} [extraData={}]
+     * @protected
+     */
+    applyOracleResult(result, extraData={}) {
+        if (result.changed || result.reason === null) {
+            const
+                data                     = {...extraData},
+                hasCandidateBlueprintKey = Object.prototype.hasOwnProperty.call(data, 'candidateBlueprint'),
+                candidateBlueprint       = data.candidateBlueprint;
+
+            delete data.candidateBlueprint;
+
+            EffectManager.pause();
+            try {
+                this.internalSetData({
+                    ...data,
+                    flowReason: result.reason,
+                    flowState : result.state
+                }, undefined, this);
+
+                if (hasCandidateBlueprintKey) {
+                    this.setAtomicData('candidateBlueprint', candidateBlueprint)
+                }
+            } finally {
+                EffectManager.resume()
+            }
+        }
+    }
+
+    /**
+     * Provider `setData()` expands plain objects into nested configs; route candidates need to stay
+     * atomic so bindings can read `data.candidateBlueprint` as the display source object.
+     * @param {String} key
+     * @param {*} value
+     * @protected
+     */
+    setAtomicData(key, value) {
+        const config = this.getDataConfig(key);
+
+        if (!config) {
+            this.internalSetData(key, value, this);
+            return
+        }
+
+        const
+            adjusted = this.adjustValue(value),
+            oldValue = config.get(),
+            changed  = config.set(adjusted);
+
+        if (changed) {
+            this.onDataPropertyChange(key, adjusted, oldValue)
+        }
     }
 }
 

--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -21,9 +21,10 @@
  * illegal transition returns the CURRENT state plus a reason, so the hook cancels the update
  * (neo core's return-`undefined`-from-beforeSet idiom) rather than corrupting state.
  *
- * The accept-path outcome drives the generating→terminal fork: an accepted route result advances
- * to MATERIALIZED; a refused one advances to ERROR carrying the refusal reason to the SSOT's
- * "always a reason" error render.
+ * The route outcome first drives the generating→preview fork: an accepted route result parks the
+ * candidate and returns to COMPOSING; a refused one advances to ERROR carrying the refusal reason.
+ * The accept-path outcome later drives the generating→terminal fork: only a successfully inserted
+ * instance advances to MATERIALIZED.
  */
 
 /**
@@ -44,14 +45,15 @@ export const CREATION_STATES = Object.freeze({
  * @type {Object}
  */
 export const CREATION_EVENTS = Object.freeze({
-    COMPOSE : 'compose',  // the user starts typing an intent
-    SUBMIT  : 'submit',   // the previewed blueprint is sent to the route
-    ACCEPTED: 'accepted', // the route returned a validated blueprint
-    REFUSED : 'refused',  // the route/validator refused (carries a reason)
-    EDIT    : 'edit',     // back to composing to refine words/blueprint
-    RETRY   : 'retry',    // from ERROR, edit-and-retry
-    RESET   : 'reset',    // clear back to the empty invitation
-    DISPOSE : 'dispose'   // the materialized panel is disposed
+    COMPOSE  : 'compose',   // the user starts typing an intent
+    SUBMIT   : 'submit',    // the intent/candidate enters a guarded route or accept step
+    PREVIEWED: 'previewed', // the route returned a validated candidate for human confirmation
+    ACCEPTED : 'accepted',  // the accept path inserted the blueprint into the stage
+    REFUSED  : 'refused',   // the route/validator/accept path refused (carries a reason)
+    EDIT     : 'edit',      // back to composing to refine words/blueprint
+    RETRY    : 'retry',     // from ERROR, edit-and-retry
+    RESET    : 'reset',     // clear back to the empty invitation
+    DISPOSE  : 'dispose'    // the materialized panel is disposed
 });
 
 /**
@@ -69,9 +71,10 @@ const TRANSITIONS = Object.freeze({
         [CREATION_EVENTS.RESET] : CREATION_STATES.EMPTY
     }),
     [CREATION_STATES.GENERATING]: Object.freeze({
-        [CREATION_EVENTS.ACCEPTED]: CREATION_STATES.MATERIALIZED,
-        [CREATION_EVENTS.REFUSED] : CREATION_STATES.ERROR,
-        [CREATION_EVENTS.RESET]   : CREATION_STATES.EMPTY   // the cancellable path
+        [CREATION_EVENTS.PREVIEWED]: CREATION_STATES.COMPOSING,
+        [CREATION_EVENTS.ACCEPTED] : CREATION_STATES.MATERIALIZED,
+        [CREATION_EVENTS.REFUSED]  : CREATION_STATES.ERROR,
+        [CREATION_EVENTS.RESET]    : CREATION_STATES.EMPTY   // the cancellable path
     }),
     [CREATION_STATES.MATERIALIZED]: Object.freeze({
         [CREATION_EVENTS.EDIT]   : CREATION_STATES.COMPOSING, // mutate the live app via a follow-up
@@ -121,6 +124,24 @@ export function nextCreationState(current, event, {reason} = {}) {
     }
 
     return {state: target, reason: null, changed: target !== current};
+}
+
+/**
+ * @summary Maps an emit-side route outcome (`{accepted, reason, blueprint}`) to the preview fork
+ * from GENERATING. Accepted means a validated candidate can render for human confirmation; refused
+ * means the route/validator blocked it and the flow lands in ERROR with the refusal reason.
+ * @param {String} current Should be GENERATING; any other state returns unchanged with a reason
+ * @param {{accepted: Boolean, reason: String|null}} outcome The route result
+ * @returns {{state: String, reason: String|null, changed: Boolean}}
+ */
+export function applyPreviewOutcome(current, outcome) {
+    if (current !== CREATION_STATES.GENERATING) {
+        return {state: current, reason: `preview outcome only resolves from generating, not "${current}"`, changed: false};
+    }
+
+    return outcome?.accepted
+        ? nextCreationState(current, CREATION_EVENTS.PREVIEWED)
+        : nextCreationState(current, CREATION_EVENTS.REFUSED, {reason: outcome?.reason});
 }
 
 /**

--- a/test/playwright/unit/apps/agentos/create/createSurface.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/createSurface.spec.mjs
@@ -17,7 +17,7 @@ import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 
 test.describe('CreateSurface — the wedge screen: five states, one provider, the whole spine (#14720)', () => {
-    let Controller, Provider, oracle, deterministicBlueprintFallback;
+    let Controller, Provider, oracle, deterministicBlueprintFallback, formatPreviewConfig;
 
     // a stage double honoring the container seam the controller drives
     const createStageDouble = () => {
@@ -70,9 +70,10 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
         Provider   = (await import('../../../../../../apps/agentos/view/create/CreationStateProvider.mjs')).default;
         oracle     = await import('../../../../../../apps/agentos/view/create/util/creationFlowState.mjs');
         deterministicBlueprintFallback = (await import('../../../../../../apps/agentos/view/create/CreateSurfaceController.mjs')).deterministicBlueprintFallback;
+        formatPreviewConfig = (await import('../../../../../../apps/agentos/view/create/BlueprintPreview.mjs')).formatPreviewConfig;
     });
 
-    test('the happy wedge: compose → submit → materialized, instance in the stage AND the registry', async () => {
+    test('the happy wedge: compose → submit → preview → confirm → materialized, instance in the stage AND the registry', async () => {
         const {provider, stage, controller, CreatedInstances} = await createRig();
         const S                                               = oracle.CREATION_STATES;
 
@@ -83,7 +84,14 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
 
         await controller.onSubmitIntent();
 
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);
+        expect(provider.getData('candidateBlueprint').schema).toBe('grid@1');
+        expect(stage.added).toHaveLength(0);                          // route acceptance is preview only
+
+        controller.onConfirmPreview();
+
         expect(provider.getData('flowState')).toBe(S.MATERIALIZED);
+        expect(provider.getData('candidateBlueprint')).toBeNull();
         expect(stage.added).toHaveLength(1);                          // the ONE create path was used
         expect(stage.added[0].ntype).toBe('grid-container');
 
@@ -113,6 +121,7 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
 
         expect(provider.getData('flowState')).toBe(S.ERROR);
         expect(provider.getData('flowReason')).toContain('forbidden key'); // the pipeline reason, verbatim
+        expect(provider.getData('candidateBlueprint')).toBeNull();          // refused candidates never preview
         expect(stage.added).toHaveLength(0);                              // nothing reached the stage
 
         controller.onRetry();
@@ -133,10 +142,15 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
 
         controller.onIntentChange();
         await controller.onSubmitIntent();
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);
+        expect(provider.getData('candidateBlueprint')).not.toBeNull();
+
+        controller.onConfirmPreview();
 
         expect(provider.getData('flowState')).toBe(S.ERROR);              // never materialized
         expect(provider.getData('flowReason')).toContain('stage');        // the ACCEPT path's reason, not the route's
         expect(provider.getData('activeInstanceId')).toBeNull();          // no phantom instance
+        expect(provider.getData('candidateBlueprint')).toBeNull();        // no stale candidate behind ERROR
 
         controller.onRetry();
         expect(provider.getData('flowState')).toBe(S.COMPOSING);          // recoverable like every refusal
@@ -150,6 +164,7 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
 
         controller.onIntentChange();
         await controller.onSubmitIntent();
+        controller.onConfirmPreview();
         const instanceId = provider.getData('activeInstanceId');
 
         controller.onDispose();
@@ -159,6 +174,46 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
         expect(CreatedInstances.resolveTarget({instanceId}).state).toBe('disposed');
 
         provider.destroy(); controller.destroy()
+    });
+
+    test('edit preview clears only the candidate and restores the composing affordance', async () => {
+        const {provider, stage, field, controller} = await createRig({request: 'make a fleet grid'});
+        const S                                    = oracle.CREATION_STATES;
+
+        controller.onIntentChange();
+        await controller.onSubmitIntent();
+
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);
+        expect(provider.getData('candidateBlueprint')).not.toBeNull();
+
+        controller.onEditPreview();
+
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);
+        expect(provider.getData('candidateBlueprint')).toBeNull();
+        expect(field.value).toBe('make a fleet grid');
+        expect(stage.added).toHaveLength(0);
+
+        provider.destroy(); controller.destroy()
+    });
+
+    test('preview config rendering follows the schema allowlist, never candidate keys', () => {
+        const hostile = {
+            schema: 'grid@1',
+            title : 'Hostile extra',
+            config: {
+                columns: [{field: 'safe', text: 'Safe'}],
+                height : 320,
+                evil   : 'must not render'
+            },
+            data: [{safe: 'yes'}]
+        };
+
+        const text = formatPreviewConfig(hostile);
+
+        expect(text).toContain('columns: safe -> Safe');
+        expect(text).toContain('height: 320');
+        expect(text).not.toContain('evil');
+        expect(text).not.toContain('must not render');
     });
 
     test('no flow booleans anywhere: state truth lives ONLY on the provider (the §7.5.1 audit line)', async () => {

--- a/test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs
@@ -16,19 +16,22 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 test.describe('creationFlowState — the five keeper-flow states as a pure machine (#14711)', () => {
-    let S, E, next, applyRouteOutcome;
+    let S, E, next, applyPreviewOutcome, applyRouteOutcome;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../apps/agentos/view/create/util/creationFlowState.mjs');
         S = mod.CREATION_STATES;
         E = mod.CREATION_EVENTS;
         next = mod.nextCreationState;
+        applyPreviewOutcome = mod.applyPreviewOutcome;
         applyRouteOutcome = mod.applyRouteOutcome;
     });
 
     test('the SSOT wedge flow runs end to end through legal transitions', () => {
-        // empty → composing → generating → materialized, then dispose back to empty
+        // empty → composing → generating → previewed/composing → generating → materialized
         expect(next(S.EMPTY, E.COMPOSE)).toEqual({state: S.COMPOSING, reason: null, changed: true});
+        expect(next(S.COMPOSING, E.SUBMIT).state).toBe(S.GENERATING);
+        expect(next(S.GENERATING, E.PREVIEWED).state).toBe(S.COMPOSING);
         expect(next(S.COMPOSING, E.SUBMIT).state).toBe(S.GENERATING);
         expect(next(S.GENERATING, E.ACCEPTED).state).toBe(S.MATERIALIZED);
         expect(next(S.MATERIALIZED, E.DISPOSE).state).toBe(S.EMPTY);
@@ -59,6 +62,7 @@ test.describe('creationFlowState — the five keeper-flow states as a pure machi
         const illegal = [
             [S.EMPTY, E.SUBMIT],
             [S.COMPOSING, E.ACCEPTED],
+            [S.COMPOSING, E.PREVIEWED],
             [S.EMPTY, E.DISPOSE],
             [S.MATERIALIZED, E.SUBMIT],
             [S.ERROR, E.ACCEPTED]
@@ -77,7 +81,7 @@ test.describe('creationFlowState — the five keeper-flow states as a pure machi
     });
 
     test('applyRouteOutcome maps a real-shaped route result to the terminal fork', () => {
-        // accepted → materialized
+        // accepted → materialized (accept path truth)
         expect(applyRouteOutcome(S.GENERATING, {accepted: true, reason: null}).state).toBe(S.MATERIALIZED);
 
         // refused → error, reason carried from the pipeline
@@ -88,5 +92,15 @@ test.describe('creationFlowState — the five keeper-flow states as a pure machi
         // only resolves from generating — a stray outcome elsewhere is a no-op with a reason
         expect(applyRouteOutcome(S.COMPOSING, {accepted: true}).changed).toBe(false);
         expect(applyRouteOutcome(S.MATERIALIZED, {accepted: false, reason: 'x'}).state).toBe(S.MATERIALIZED);
+    });
+
+    test('applyPreviewOutcome maps route acceptance to the human-confirmation card', () => {
+        expect(applyPreviewOutcome(S.GENERATING, {accepted: true, reason: null}).state).toBe(S.COMPOSING);
+
+        const refused = applyPreviewOutcome(S.GENERATING, {accepted: false, reason: 'blocked'});
+        expect(refused.state).toBe(S.ERROR);
+        expect(refused.reason).toBe('blocked');
+
+        expect(applyPreviewOutcome(S.EMPTY, {accepted: true}).changed).toBe(false);
     });
 });

--- a/test/playwright/unit/apps/agentos/create/creationStateProvider.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/creationStateProvider.spec.mjs
@@ -87,6 +87,32 @@ test.describe('CreationStateProvider — the shared flow-state surface, oracle-g
         provider.destroy()
     });
 
+    test('an accepted route outcome parks an atomic candidate for preview, then edit clears it', () => {
+        const provider  = Neo.create(ProviderClass, {}),
+              blueprint = {
+                  schema: 'grid@1',
+                  title : 'Preview me',
+                  config: {columns: [{field: 'item', text: 'Item'}]},
+                  data  : [{item: 'one'}]
+              };
+
+        provider.applyFlowEvent(E.COMPOSE);
+        provider.applyFlowEvent(E.SUBMIT);
+
+        const previewed = provider.applyPreviewRouteOutcome({accepted: true, blueprint, reason: null});
+
+        expect(previewed.state).toBe(S.COMPOSING);
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);
+        expect(provider.getData('candidateBlueprint')).toEqual(blueprint);
+
+        provider.applyPreviewEdit();
+
+        expect(provider.getData('flowState')).toBe(S.COMPOSING);
+        expect(provider.getData('candidateBlueprint')).toBeNull();
+
+        provider.destroy()
+    });
+
     test('the registry is exposed to bindings via stores', () => {
         const provider = Neo.create(ProviderClass, {});
 


### PR DESCRIPTION
Resolves #14764

Adds the create-module blueprint preview card between route acceptance and accept-path materialization. The controller now parks a validated candidate on the CreationStateProvider, renders it through a class-based BlueprintPreview, and only materializes after the human confirm affordance runs the existing accept path.

Evidence: L2 (static checks + provider/controller direct probe; local Playwright harness stalled before test execution) -> L2 required (ticket ACs are state-machine, provider, controller, and render-helper behavior unit-pinned without a browser render). Residual: none for the close-target ACs.

## Deltas from ticket
- Added an explicit PREVIEWED transition so route acceptance returns to composing with a provider-owned candidate instead of claiming materialized.
- Parked candidateBlueprint atomically inside CreationStateProvider because Provider.setData expands plain objects into nested configs by design.
- Kept the preview renderer allowlist-driven via BLUEPRINT_SCHEMAS and avoided candidate Object.keys traversal.

## Test Evidence
- `node --check apps/agentos/view/create/BlueprintPreview.mjs apps/agentos/view/create/CreationStateProvider.mjs apps/agentos/view/create/CreateSurfaceController.mjs apps/agentos/view/create/util/creationFlowState.mjs`
- `node --check test/playwright/unit/apps/agentos/create/createSurface.spec.mjs test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs test/playwright/unit/apps/agentos/create/creationStateProvider.spec.mjs`
- `npm run agent-preflight -- --no-fix apps/agentos/view/create/BlueprintPreview.mjs apps/agentos/view/create/CreateSurface.mjs apps/agentos/view/create/CreateSurfaceController.mjs apps/agentos/view/create/CreationStateProvider.mjs apps/agentos/view/create/util/creationFlowState.mjs test/playwright/unit/apps/agentos/create/createSurface.spec.mjs test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs test/playwright/unit/apps/agentos/create/creationStateProvider.spec.mjs` passed.
- Direct Node provider/controller probe passed: submit parks `grid@1` candidate, confirm materializes, refused route keeps candidate null, hostile config key is not rendered.
- `npm run test-unit -- test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs test/playwright/unit/apps/agentos/create/createSurface.spec.mjs` was interrupted after the local Playwright runner produced no result output for about 2 minutes; a single-spec retry with line reporter also stalled before test output. No Playwright pass is claimed from local.

## Post-Merge Validation
- [ ] GitHub Actions `unit` confirms the updated create-flow specs under CI.
- [ ] Create surface smoke confirms the preview card appears after route acceptance and before confirm materialization.

## Commits
- `4380dd4289` - `feat(agentos): add keeper blueprint preview (#14764)`

Authored by Euclid (GPT-5, Codex Desktop). Session 6439a7c5-5f2f-4658-9226-835c317c7a0b.