### PR TITLE
feat(agentos): add keeper mutation grammar (#14763)

### DIFF
--- a/apps/agentos/view/create/CreateSurfaceController.mjs
+++ b/apps/agentos/view/create/CreateSurfaceController.mjs
@@ -1,8 +1,14 @@
-import Controller                                                from '../../../../src/controller/Component.mjs';
-import CreatedInstances                                          from './store/CreatedInstances.mjs';
-import {CREATION_EVENTS}                                         from './util/creationFlowState.mjs';
-import {routeCreationRequest}                                    from './util/requestRoute.mjs';
-import {acceptBlueprint, createInsertRegistrar, disposeInstance} from './util/acceptPath.mjs';
+import Controller                                   from '../../../../src/controller/Component.mjs';
+import CreatedInstances                             from './store/CreatedInstances.mjs';
+import {CREATION_EVENTS, CREATION_STATES}           from './util/creationFlowState.mjs';
+import {routeCreationRequest}                       from './util/requestRoute.mjs';
+import {parseMutationIntent, resolveMutationTarget} from './util/mutationIntent.mjs';
+import {
+    acceptBlueprint,
+    createInsertRegistrar,
+    disposeInstance,
+    mutateInstance
+} from './util/acceptPath.mjs';
 
 let instanceSeq = 0;
 
@@ -54,7 +60,14 @@ class CreateSurfaceController extends Controller {
          * fallback until the NL leaf lands the live generator.
          * @member {Function|null} generateBlueprint=null
          */
-        generateBlueprint: null
+        generateBlueprint: null,
+        /**
+         * Optional `(instanceId) => live component` mutation seam. Production leaves this null so the
+         * accept path resolves through `Neo.get`; tests can inject a stage double without registering
+         * real components in the instance manager.
+         * @member {Function|null} resolveComponent=null
+         */
+        resolveComponent: null
     }
 
     /**
@@ -84,20 +97,27 @@ class CreateSurfaceController extends Controller {
         const provider = this.getProvider(),
               state    = provider.getData('flowState');
 
-        provider.applyFlowEvent(state === 'empty' ? CREATION_EVENTS.COMPOSE : CREATION_EVENTS.EDIT)
+        provider.applyFlowEvent(state === CREATION_STATES.EMPTY ? CREATION_EVENTS.COMPOSE : CREATION_EVENTS.EDIT)
     }
 
     /**
      * The submit path — the whole spine in one handler, every step branching on bounded
      * `{accepted, reason}` shapes, nothing thrown into the render:
-     * composing → generating → (route) → materialized | error.
+     * composing → generating → create route → materialized | error; materialized → generating →
+     * mutation route → materialized | error.
      * @protected
      */
     async onSubmitIntent() {
         const me       = this,
               provider = me.getProvider(),
               field    = me.getReference('intent-field'),
-              request  = String(field?.value || '');
+              request  = String(field?.value || ''),
+              state    = provider.getData('flowState');
+
+        if (state === CREATION_STATES.MATERIALIZED) {
+            me.submitMutationIntent({provider, request});
+            return
+        }
 
         const submitted = provider.applyFlowEvent(CREATION_EVENTS.SUBMIT);
 
@@ -129,6 +149,47 @@ class CreateSurfaceController extends Controller {
             // accept-stage refusal AFTER route acceptance (dead stage, duplicate id, coverage
             // defect): honest ERROR carrying the ACCEPT PATH's reason; no active instance
             provider.applyCreationRouteOutcome({accepted: false, reason: accepted.reason})
+        }
+    }
+
+    /**
+     * Routes a follow-up intent against the created-instance registry, then lets the existing
+     * accept-path mutation primitive consume the validator-owned merged blueprint.
+     * @param {Object} options
+     * @param {AgentOS.view.create.CreationStateProvider} options.provider
+     * @param {String} options.request
+     * @protected
+     */
+    submitMutationIntent({provider, request}) {
+        const submitted = provider.applyFlowEvent(CREATION_EVENTS.SUBMIT);
+
+        if (submitted.state !== 'generating') return;
+
+        const parsed = parseMutationIntent(request);
+
+        if (!parsed.accepted) {
+            provider.applyCreationRouteOutcome(parsed);
+            return
+        }
+
+        const target = resolveMutationTarget({registry: CreatedInstances, selector: parsed.selector});
+
+        if (!target.accepted) {
+            provider.applyCreationRouteOutcome(target);
+            return
+        }
+
+        const mutation = mutateInstance({
+            instanceId: target.record.instanceId,
+            mutation  : parsed.mutation,
+            registry  : CreatedInstances,
+            ...(this.resolveComponent ? {resolveComponent: this.resolveComponent} : {})
+        });
+
+        provider.applyCreationRouteOutcome(mutation);
+
+        if (mutation.accepted) {
+            provider.setData({activeInstanceId: target.record.instanceId})
         }
     }
 

--- a/apps/agentos/view/create/util/creationFlowState.mjs
+++ b/apps/agentos/view/create/util/creationFlowState.mjs
@@ -45,7 +45,7 @@ export const CREATION_STATES = Object.freeze({
  */
 export const CREATION_EVENTS = Object.freeze({
     COMPOSE : 'compose',  // the user starts typing an intent
-    SUBMIT  : 'submit',   // the previewed blueprint is sent to the route
+    SUBMIT  : 'submit',   // the intent enters the create route or follow-up mutation route
     ACCEPTED: 'accepted', // the route returned a validated blueprint
     REFUSED : 'refused',  // the route/validator refused (carries a reason)
     EDIT    : 'edit',     // back to composing to refine words/blueprint
@@ -74,7 +74,8 @@ const TRANSITIONS = Object.freeze({
         [CREATION_EVENTS.RESET]   : CREATION_STATES.EMPTY   // the cancellable path
     }),
     [CREATION_STATES.MATERIALIZED]: Object.freeze({
-        [CREATION_EVENTS.EDIT]   : CREATION_STATES.COMPOSING, // mutate the live app via a follow-up
+        [CREATION_EVENTS.EDIT]   : CREATION_STATES.MATERIALIZED, // follow-up text edits do not dematerialize the app
+        [CREATION_EVENTS.SUBMIT] : CREATION_STATES.GENERATING,
         [CREATION_EVENTS.DISPOSE]: CREATION_STATES.EMPTY,
         [CREATION_EVENTS.RESET]  : CREATION_STATES.EMPTY
     }),

--- a/apps/agentos/view/create/util/mutationIntent.mjs
+++ b/apps/agentos/view/create/util/mutationIntent.mjs
@@ -1,0 +1,255 @@
+/**
+ * @module AgentOS.view.create.util.mutationIntent
+ * @summary Bounded, fail-closed parser + target resolver for keeper follow-up mutations.
+ *
+ * This module is the create-flow sibling of the first-widget childapp's edit grammar: short natural
+ * language follow-ups become schema-allowlisted mutation partials, never executable code, and target
+ * phrases resolve through the created-instance registry instead of walking the component tree. It is
+ * deliberately deterministic until the NL boundary lands: unknown wording refuses with a reason, and
+ * ambiguous titles refuse rather than guessing which live instance to mutate.
+ */
+
+const
+    DEFAULT_LARGE_HEIGHT = 520,
+    DEFAULT_SMALL_HEIGHT = 320,
+    DEFAULT_LARGE_WIDTH  = 720,
+    DEFAULT_SMALL_WIDTH  = 420,
+    MAX_REQUEST_LENGTH   = 240,
+    MAX_TITLE_LENGTH     = 80;
+
+/**
+ * @summary Mutation intake refusal stages.
+ * @type {Object}
+ */
+export const MUTATION_INTENT_STAGES = Object.freeze({
+    REQUEST: 'request',
+    TARGET : 'target'
+});
+
+/**
+ * @param {String} value
+ * @returns {String}
+ */
+function cleanTitle(value) {
+    return value.trim().replace(/^["']|["']$/g, '').replace(/\s+/g, ' ')
+}
+
+/**
+ * @param {String} value
+ * @returns {String}
+ */
+function normalizeTitle(value) {
+    return cleanTitle(value).toLowerCase()
+}
+
+/**
+ * @param {String} value
+ * @returns {String}
+ */
+function titleCase(value) {
+    return cleanTitle(value).replace(/\w\S*/g, word => word[0].toUpperCase() + word.slice(1).toLowerCase())
+}
+
+/**
+ * @param {String} phrase
+ * @returns {Object}
+ */
+function selectorFromPhrase(phrase='') {
+    const cleaned = cleanTitle(phrase).toLowerCase();
+
+    if (!cleaned || ['it', 'this', 'the grid', 'grid'].includes(cleaned)) {
+        return {}
+    }
+
+    if (phrase.startsWith('"') || phrase.startsWith("'")) {
+        return {title: cleanTitle(phrase)}
+    }
+
+    const titled = cleanTitle(phrase).replace(/^the\s+/i, '');
+
+    return titled ? {title: titleCase(titled)} : {}
+}
+
+/**
+ * @param {String} rawTitle
+ * @returns {{accepted: Boolean, title: String|null, reason: String|null}}
+ */
+function parseNewTitle(rawTitle) {
+    const title = cleanTitle(rawTitle);
+
+    if (!title) {
+        return {accepted: false, title: null, reason: 'New title is empty.'}
+    }
+
+    if (title.length > MAX_TITLE_LENGTH) {
+        return {accepted: false, title: null, reason: `Title is too long (max ${MAX_TITLE_LENGTH} characters).`}
+    }
+
+    return {accepted: true, title, reason: null}
+}
+
+/**
+ * @param {String} rawRows
+ * @returns {{accepted: Boolean, data: Object[]|null, reason: String|null}}
+ */
+function parseRows(rawRows) {
+    let data;
+
+    try {
+        data = JSON.parse(rawRows)
+    } catch (error) {
+        return {accepted: false, data: null, reason: 'Data rows must be a JSON array of row objects.'}
+    }
+
+    if (!Array.isArray(data)) {
+        return {accepted: false, data: null, reason: 'Data rows must be a JSON array.'}
+    }
+
+    if (data.some(row => row == null || typeof row !== 'object' || Array.isArray(row))) {
+        return {accepted: false, data: null, reason: 'Data rows must contain only row objects.'}
+    }
+
+    return {accepted: true, data, reason: null}
+}
+
+/**
+ * Parses one follow-up mutation intent into a registry selector plus a schema-allowlisted mutation.
+ *
+ * @param {String} text
+ * @returns {{accepted: true, selector: Object, mutation: Object, stage: null, reason: null}|{accepted: false, selector: null, mutation: null, stage: String, reason: String}}
+ */
+export function parseMutationIntent(text) {
+    if (typeof text !== 'string') {
+        return {accepted: false, selector: null, mutation: null, reason: 'Mutation intent must be text.', stage: MUTATION_INTENT_STAGES.REQUEST}
+    }
+
+    const trimmed = text.trim();
+
+    if (!trimmed) {
+        return {accepted: false, selector: null, mutation: null, reason: 'Mutation intent is empty — type a follow-up change.', stage: MUTATION_INTENT_STAGES.REQUEST}
+    }
+
+    if (trimmed.length > MAX_REQUEST_LENGTH) {
+        return {accepted: false, selector: null, mutation: null, reason: `Mutation intent is too long (max ${MAX_REQUEST_LENGTH} characters).`, stage: MUTATION_INTENT_STAGES.REQUEST}
+    }
+
+    if (/[<>]/.test(trimmed)) {
+        return {accepted: false, selector: null, mutation: null, reason: 'Mutation intent must be plain text (no markup).', stage: MUTATION_INTENT_STAGES.REQUEST}
+    }
+
+    let match = trimmed.match(/^make\s+(.+?)\s+(taller|shorter|wider|narrower|bigger|larger|smaller)$/i);
+
+    if (match) {
+        const
+            selector = selectorFromPhrase(match[1]),
+            size     = match[2].toLowerCase(),
+            config   = {};
+
+        if (size === 'taller') {
+            config.height = DEFAULT_LARGE_HEIGHT
+        } else if (size === 'shorter') {
+            config.height = DEFAULT_SMALL_HEIGHT
+        } else if (size === 'wider') {
+            config.width = DEFAULT_LARGE_WIDTH
+        } else if (size === 'narrower') {
+            config.width = DEFAULT_SMALL_WIDTH
+        } else if (size === 'smaller') {
+            config.height = DEFAULT_SMALL_HEIGHT;
+            config.width  = DEFAULT_SMALL_WIDTH
+        } else {
+            config.height = DEFAULT_LARGE_HEIGHT;
+            config.width  = DEFAULT_LARGE_WIDTH
+        }
+
+        return {accepted: true, selector, mutation: {config}, reason: null, stage: null}
+    }
+
+    match = trimmed.match(/^(?:rename|retitle)\s+(?:(.+?)\s+)?to\s+(.+)$/i);
+
+    if (match) {
+        const title = parseNewTitle(match[2]);
+
+        if (!title.accepted) {
+            return {accepted: false, selector: null, mutation: null, reason: title.reason, stage: MUTATION_INTENT_STAGES.REQUEST}
+        }
+
+        return {accepted: true, selector: selectorFromPhrase(match[1] || ''), mutation: {title: title.title}, reason: null, stage: null}
+    }
+
+    match = trimmed.match(/^(?:replace|set)\s+(?:(.+?)\s+)?(?:data\s+rows|rows|data)\s+(?:with|to)\s+(.+)$/i);
+
+    if (match) {
+        const rows = parseRows(match[2]);
+
+        if (!rows.accepted) {
+            return {accepted: false, selector: null, mutation: null, reason: rows.reason, stage: MUTATION_INTENT_STAGES.REQUEST}
+        }
+
+        return {accepted: true, selector: selectorFromPhrase(match[1] || ''), mutation: {data: rows.data}, reason: null, stage: null}
+    }
+
+    return {
+        accepted: false,
+        selector: null,
+        mutation: null,
+        reason  : 'Unknown mutation. Try "make it taller", "rename it to Q3 Metrics", or "replace data with [{\\"item\\":\\"A\\"}]".',
+        stage   : MUTATION_INTENT_STAGES.REQUEST
+    }
+}
+
+/**
+ * Resolves a parsed mutation selector against the created-instance registry.
+ *
+ * @param {Object} options
+ * @param {Object} options.registry CreatedInstances singleton or test double
+ * @param {Object} [options.selector={}]
+ * @returns {{accepted: Boolean, record: Object|null, reason: String|null, stage: String|null}}
+ */
+export function resolveMutationTarget({registry, selector={}} = {}) {
+    if (!registry || typeof registry.resolveTarget !== 'function') {
+        return {accepted: false, record: null, reason: 'created-instance registry unavailable', stage: MUTATION_INTENT_STAGES.TARGET}
+    }
+
+    if (selector.instanceId) {
+        const record = registry.resolveTarget({instanceId: selector.instanceId});
+
+        return record
+            ? {accepted: true, record, reason: null, stage: null}
+            : {accepted: false, record: null, reason: `No created instance found for "${selector.instanceId}".`, stage: MUTATION_INTENT_STAGES.TARGET}
+    }
+
+    if (selector.title) {
+        const
+            expected = normalizeTitle(selector.title),
+            matches  = [];
+
+        registry.items?.forEach(record => {
+            if (record.state === 'live' && normalizeTitle(record.title) === expected) {
+                matches.push(record)
+            }
+        });
+
+        if (matches.length > 1) {
+            const names = matches.map(record => `${record.instanceId} (${record.title})`).join(', ');
+
+            return {
+                accepted: false,
+                record  : null,
+                reason  : `Target title "${selector.title}" is ambiguous: ${names}. Name a more specific target.`,
+                stage   : MUTATION_INTENT_STAGES.TARGET
+            }
+        }
+
+        if (matches.length === 1) {
+            return {accepted: true, record: matches[0], reason: null, stage: null}
+        }
+
+        return {accepted: false, record: null, reason: `No live created instance titled "${selector.title}".`, stage: MUTATION_INTENT_STAGES.TARGET}
+    }
+
+    const record = registry.resolveTarget({});
+
+    return record
+        ? {accepted: true, record, reason: null, stage: null}
+        : {accepted: false, record: null, reason: 'No live created instance to mutate yet.', stage: MUTATION_INTENT_STAGES.TARGET}
+}

--- a/test/playwright/unit/apps/agentos/create/createSurface.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/createSurface.spec.mjs
@@ -20,14 +20,19 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
     let Controller, Provider, oracle, deterministicBlueprintFallback;
 
     // a stage double honoring the container seam the controller drives
-    const createStageDouble = () => {
+    const createStageDouble = liveComponents => {
         const observers = [];
         return {
             added: [],
             on(event, handler, scope) { event === 'insert' && observers.push([handler, scope]) },
             add(config) {
                 this.added.push(config);
-                const item = {...config};
+                const item = {
+                    ...config,
+                    set(values) { Object.assign(this, values) }
+                };
+
+                liveComponents[config.id] = item;
                 observers.forEach(([handler, scope]) => handler.call(scope || null, {item}));
                 return item
             }
@@ -37,9 +42,11 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
     // a controller double: real class instance shape minus the component tree — we drive its
     // handlers with injected provider/stage/field seams
     const createRig = async ({generate, request = 'build me a neo grid'} = {}) => {
-        const provider = Neo.create(Provider, {});
-        const stage    = createStageDouble();
-        const field    = {value: request};
+        const
+            provider       = Neo.create(Provider, {}),
+            liveComponents = {},
+            stage          = createStageDouble(liveComponents),
+            field          = {value: request};
 
         // a minimal owning-component double: the controller's construct chain walks
         // component.parent, and getProvider reads component.getStateProvider()
@@ -51,7 +58,11 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
             un              : () => {}
         };
 
-        const controller = Neo.create(Controller, {component: componentDouble, generateBlueprint: generate || null});
+        const controller = Neo.create(Controller, {
+            component        : componentDouble,
+            generateBlueprint: generate || null,
+            resolveComponent : id => liveComponents[id] || null
+        });
 
         // seam the reference lookups (the component tree is the SSOT-gated chrome; this
         // spec proves the CONTROLLER contract against the real provider + real spine)
@@ -62,7 +73,7 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
         const {default: CreatedInstances} = await import('../../../../../../apps/agentos/view/create/store/CreatedInstances.mjs');
         stage.on('insert', createInsertRegistrar({registry: CreatedInstances}), controller);
 
-        return {provider, stage, field, controller, CreatedInstances}
+        return {provider, stage, field, controller, CreatedInstances, liveComponents}
     };
 
     test.beforeAll(async () => {
@@ -157,6 +168,33 @@ test.describe('CreateSurface — the wedge screen: five states, one provider, th
         expect(provider.getData('flowState')).toBe(S.EMPTY);
         expect(provider.getData('activeInstanceId')).toBeNull();
         expect(CreatedInstances.resolveTarget({instanceId}).state).toBe('disposed');
+
+        provider.destroy(); controller.destroy()
+    });
+
+    test('materialized follow-up submit mutates the latest live grid through the merged blueprint', async () => {
+        const {provider, field, controller, CreatedInstances, liveComponents} = await createRig();
+        const S                                                               = oracle.CREATION_STATES;
+
+        controller.onIntentChange();
+        await controller.onSubmitIntent();
+
+        const instanceId = provider.getData('activeInstanceId');
+        expect(provider.getData('flowState')).toBe(S.MATERIALIZED);
+
+        field.value = 'make it taller';
+        controller.onIntentChange();
+        expect(provider.getData('flowState')).toBe(S.MATERIALIZED);
+
+        await controller.onSubmitIntent();
+
+        const record = CreatedInstances.resolveTarget({instanceId});
+
+        expect(provider.getData('flowState')).toBe(S.MATERIALIZED);
+        expect(provider.getData('activeInstanceId')).toBe(instanceId);
+        expect(liveComponents[instanceId].height).toBe(520);
+        expect(record.blueprintSnapshot.config.height).toBe(520);
+        expect(record.blueprintSnapshot.config.columns).toHaveLength(2); // merge preserved creation columns
 
         provider.destroy(); controller.destroy()
     });

--- a/test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs
@@ -31,6 +31,9 @@ test.describe('creationFlowState — the five keeper-flow states as a pure machi
         expect(next(S.EMPTY, E.COMPOSE)).toEqual({state: S.COMPOSING, reason: null, changed: true});
         expect(next(S.COMPOSING, E.SUBMIT).state).toBe(S.GENERATING);
         expect(next(S.GENERATING, E.ACCEPTED).state).toBe(S.MATERIALIZED);
+        expect(next(S.MATERIALIZED, E.EDIT).state).toBe(S.MATERIALIZED);
+        expect(next(S.MATERIALIZED, E.SUBMIT).state).toBe(S.GENERATING);
+        expect(next(S.GENERATING, E.ACCEPTED).state).toBe(S.MATERIALIZED);
         expect(next(S.MATERIALIZED, E.DISPOSE).state).toBe(S.EMPTY);
 
         // the error arm and its recovery: generating → error → (retry) composing
@@ -60,7 +63,6 @@ test.describe('creationFlowState — the five keeper-flow states as a pure machi
             [S.EMPTY, E.SUBMIT],
             [S.COMPOSING, E.ACCEPTED],
             [S.EMPTY, E.DISPOSE],
-            [S.MATERIALIZED, E.SUBMIT],
             [S.ERROR, E.ACCEPTED]
         ];
 

--- a/test/playwright/unit/apps/agentos/create/mutationIntent.spec.mjs
+++ b/test/playwright/unit/apps/agentos/create/mutationIntent.spec.mjs
@@ -1,0 +1,111 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'MutationIntentTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe('mutationIntent — bounded follow-up grammar + registry target resolution (#14763)', () => {
+    let parseMutationIntent, resolveMutationTarget;
+
+    const createRegistryDouble = records => ({
+        items: records,
+        resolveTarget(selector={}) {
+            if (selector.instanceId) {
+                return records.find(record => record.instanceId === selector.instanceId) || null
+            }
+
+            let candidate = null;
+            records.forEach(record => {
+                if (record.state === 'live'
+                    && (selector.title === undefined || record.title === selector.title)
+                    && (!candidate || record.creationIndex > candidate.creationIndex)
+                ) {
+                    candidate = record
+                }
+            });
+
+            return candidate
+        }
+    });
+
+    test.beforeAll(async () => {
+        ({parseMutationIntent, resolveMutationTarget} = await import('../../../../../../apps/agentos/view/create/util/mutationIntent.mjs'))
+    });
+
+    test('parses the three v1 intent classes to mutation allowlist shapes', () => {
+        expect(parseMutationIntent('make it taller')).toEqual({
+            accepted: true,
+            selector: {},
+            mutation: {config: {height: 520}},
+            reason  : null,
+            stage   : null
+        });
+
+        expect(parseMutationIntent('make the sales grid wider')).toEqual({
+            accepted: true,
+            selector: {title: 'Sales Grid'},
+            mutation: {config: {width: 720}},
+            reason  : null,
+            stage   : null
+        });
+
+        expect(parseMutationIntent('rename the sales grid to Q3 Metrics')).toEqual({
+            accepted: true,
+            selector: {title: 'Sales Grid'},
+            mutation: {title: 'Q3 Metrics'},
+            reason  : null,
+            stage   : null
+        });
+
+        expect(parseMutationIntent('replace data with [{"item":"A"},{"item":"B"}]')).toEqual({
+            accepted: true,
+            selector: {},
+            mutation: {data: [{item: 'A'}, {item: 'B'}]},
+            reason  : null,
+            stage   : null
+        })
+    });
+
+    test('refuses unknown, overlong, markup, and non-row data inputs', () => {
+        expect(parseMutationIntent('spin it around').accepted).toBe(false);
+        expect(parseMutationIntent('make it <b>bigger</b>').reason).toContain('plain text');
+        expect(parseMutationIntent('make ' + 'x'.repeat(241)).accepted).toBe(false);
+        expect(parseMutationIntent('replace data with {"item":"A"}').reason).toContain('JSON array');
+        expect(parseMutationIntent('replace data with ["A"]').reason).toContain('row objects')
+    });
+
+    test('resolves explicit titles, latest-live fallback, and ambiguous title refusals', () => {
+        const registry = createRegistryDouble([
+            {instanceId: 'grid-1', title: 'Sales Grid', creationIndex: 1, state: 'live'},
+            {instanceId: 'grid-2', title: 'People Grid', creationIndex: 2, state: 'live'},
+            {instanceId: 'grid-3', title: 'Old Grid', creationIndex: 3, state: 'disposed'}
+        ]);
+
+        expect(resolveMutationTarget({registry, selector: {title: 'sales grid'}}).record.instanceId).toBe('grid-1');
+        expect(resolveMutationTarget({registry, selector: {}}).record.instanceId).toBe('grid-2');
+        expect(resolveMutationTarget({registry, selector: {title: 'Old Grid'}}).accepted).toBe(false);
+
+        const ambiguous = createRegistryDouble([
+            {instanceId: 'sales-1', title: 'Sales Grid', creationIndex: 1, state: 'live'},
+            {instanceId: 'sales-2', title: 'Sales Grid', creationIndex: 2, state: 'live'}
+        ]);
+
+        const result = resolveMutationTarget({registry: ambiguous, selector: {title: 'Sales Grid'}});
+
+        expect(result.accepted).toBe(false);
+        expect(result.reason).toContain('ambiguous');
+        expect(result.reason).toContain('sales-1');
+        expect(result.reason).toContain('sales-2')
+    });
+});


### PR DESCRIPTION
Resolves #14763
Related: #13349
Related: #14767

Adds the create-module follow-up mutation intake: bounded deterministic parsing for resize / retitle / JSON data-row replacement, target resolution that falls back to latest-live for generic `the grid` intents, explicit-title ambiguity refusal, and materialized-state submit wiring through the existing `mutateInstance()` merge-then-validate path.

Evidence: L2 (static checks, direct Node parser/state/controller probes, pre-commit hooks) → L3 required (GitHub unit + integration CI must exercise the Playwright harness cleanly). Residual: local `npm run test-unit` did not reach reporter output in this checkout, including on an unchanged baseline childapp parser spec [#14763].

## Deltas from ticket

The scope matches the ticket. The ambiguity refusal lives in the new create-module mutation resolver rather than changing `CreatedInstances.resolveTarget()`, preserving that lower-level store method's existing latest-live-by-title behavior for existing call sites. The controller also gets a `resolveComponent` test seam; production still resolves live components through the accept path's `Neo.get` default.

## Test Evidence

- `node --check apps/agentos/view/create/util/mutationIntent.mjs`
- `node --check apps/agentos/view/create/CreateSurfaceController.mjs`
- `node --check apps/agentos/view/create/util/creationFlowState.mjs`
- `node --check test/playwright/unit/apps/agentos/create/mutationIntent.spec.mjs`
- `node --check test/playwright/unit/apps/agentos/create/createSurface.spec.mjs`
- `node --check test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs`
- Direct Node parser/resolver probe: `make the sales grid wider`, `make the grid bigger`, JSON row replacement, and ambiguous `Sales Grid` refusal returned expected bounded shapes.
- Direct Node controller probe: create grid → submit `make it taller` from materialized state; result `{state:"materialized", liveHeight:520, snapshotHeight:520, columns:2}`.
- `npm run agent-preflight -- --no-fix apps/agentos/view/create/CreateSurfaceController.mjs apps/agentos/view/create/util/creationFlowState.mjs apps/agentos/view/create/util/mutationIntent.mjs test/playwright/unit/apps/agentos/create/createSurface.spec.mjs test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs test/playwright/unit/apps/agentos/create/mutationIntent.spec.mjs` — passed.
- `git diff --cached --check` — passed before commit.
- Commit hooks passed: whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, block alignment.
- Attempted `npm run test-unit -- test/playwright/unit/apps/agentos/create/mutationIntent.spec.mjs test/playwright/unit/apps/agentos/create/creationFlowState.spec.mjs test/playwright/unit/apps/agentos/create/createSurface.spec.mjs test/playwright/unit/apps/agentos/create/acceptPath.spec.mjs test/playwright/unit/apps/agentos/childapps/widget/util/parseEditRequest.spec.mjs --workers=1`; interrupted after no reporter output. A baseline run of the unchanged childapp parser spec stalled the same way.

## Post-Merge Validation

- [ ] Confirm GitHub `unit` and `integration-unified` are green at the PR head.
- [ ] In the create surface, create a grid and submit `make it taller`; the flow remains materialized and the registry snapshot records height `520`.

Authored by Euclid (GPT-5, Codex Desktop). Session 019f2c26-7b3d-7683-b23c-ec6b33131844.