### PR TITLE
feat(ai): warn on stale config overlays in preflight (#14675)

### DIFF
--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -310,8 +310,24 @@ function projectRequiredLeaves(src) {
  * @param {{key: String, env: String, type: String, configDefault: String, templateDefault: String}} leaf Drift item.
  * @returns {String}
  */
-function formatChangedLeafDefault(leaf) {
+export function formatChangedLeafDefault(leaf) {
     return `${leaf.key} (${leaf.env}, ${leaf.type}): ${leaf.configDefault} -> ${leaf.templateDefault}`
+}
+
+/**
+ * Formats template-vs-overlay drift into stable operator-facing rows.
+ *
+ * @param {{missingImports: String[], missingExports: String[], missingEnvVars: String[], missingRequiredLeaves: String[], changedLeafDefaults: Object[]}} drift Drift shape.
+ * @returns {String[]}
+ */
+export function formatStaleOverlayDriftItems(drift) {
+    return [
+        ...drift.missingImports.map(item => `import: ${item}`),
+        ...drift.missingExports.map(item => `export: ${item}`),
+        ...drift.missingEnvVars.map(item => `env: ${item}`),
+        ...drift.missingRequiredLeaves.map(item => `required-leaf: ${item}`),
+        ...drift.changedLeafDefaults.map(item => `leaf-default: ${formatChangedLeafDefault(item)}`)
+    ]
 }
 
 /**
@@ -511,6 +527,127 @@ export function detectDrift(templateShape, configShape) {
         changedLeafDefaults,
         hasDrift: missingImports.length + missingExports.length + missingEnvVars.length + missingRequiredLeaves.length + changedLeafDefaults.length > 0
     }
+}
+
+/**
+ * @summary True for the class-subclass overlay shape introduced by the inheritance root fix.
+ *
+ * Snapshot overlays must receive full missing-leaf diffing. Subclass overlays inherit absent leaves
+ * by construction, so local preflight should only flag same-leaf conflicts that the subclass explicitly
+ * overrides.
+ *
+ * @param {String} src Active overlay source.
+ * @returns {Boolean}
+ */
+function isSubclassOverlaySource(src) {
+    return /\bextends\s+[A-Za-z_$][\w$]*\b/.test(src)
+}
+
+/**
+ * @summary Detects only residual conflicts in subclass-style overlays.
+ *
+ * A subclass overlay may omit most template leaves because inheritance supplies them. The residual stale
+ * class is an explicit leaf in the subclass that still targets a template-owned env/type identity but no
+ * longer matches the template default. New operator-only leaves stay local and are not template drift.
+ *
+ * @param {{leafDefaults: Object[]}} templateShape Projected template shape.
+ * @param {{leafDefaults: Object[]}} configShape Projected active overlay shape.
+ * @returns {{missingImports: String[], missingExports: String[], missingEnvVars: String[], missingRequiredLeaves: String[], changedLeafDefaults: Object[], hasDrift: Boolean}}
+ */
+function detectSubclassOverlayResidualDrift(templateShape, configShape) {
+    const templateLeafDefaults = new Map((templateShape.leafDefaults || []).map(leaf => [leafDefaultIdentity(leaf), leaf]));
+    const changedLeafDefaults  = (configShape.leafDefaults || [])
+        .map(configLeaf => {
+            const templateLeaf = templateLeafDefaults.get(leafDefaultIdentity(configLeaf));
+
+            if (!templateLeaf || configLeaf.default === templateLeaf.default) {
+                return null
+            }
+
+            return {
+                key            : configLeaf.key,
+                env            : configLeaf.env,
+                type           : configLeaf.type,
+                templateDefault: templateLeaf.default,
+                configDefault  : configLeaf.default
+            }
+        })
+        .filter(Boolean);
+
+    return {
+        missingImports       : [],
+        missingExports       : [],
+        missingEnvVars       : [],
+        missingRequiredLeaves: [],
+        changedLeafDefaults,
+        hasDrift             : changedLeafDefaults.length > 0
+    }
+}
+
+/**
+ * @summary Collects stale local config overlays for advisory local-dev preflight reporting.
+ *
+ * This is the read-only sibling of {@link initTier1Config} / {@link initConfigs}: it never clones,
+ * migrates, or throws. It exists for `agent-preflight`, where stale gitignored overlays should be
+ * visible before PR/review churn but must not turn an unrelated source preflight into a hard fail.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.aiRoot=aiDir] Tier-1 root containing `config.template.mjs` / `config.mjs`.
+ * @param {String} [options.serversRoot=serversDir] Server root containing per-server config templates.
+ * @returns {Array<{label: String, drift: Object, items: String[]}>}
+ */
+export function collectStaleOverlayFindings({aiRoot = aiDir, serversRoot = serversDir} = {}) {
+    const findings = [];
+
+    const collectPair = ({activePath, label, materializeTemplate = source => source, templatePath}) => {
+        if (!fs.existsSync(templatePath) || !fs.existsSync(activePath)) {
+            return
+        }
+
+        const
+            templateSrc   = materializeTemplate(fs.readFileSync(templatePath, 'utf-8')),
+            activeSrc     = fs.readFileSync(activePath, 'utf-8'),
+            templateShape = projectSourceShape(templateSrc),
+            activeShape   = projectSourceShape(activeSrc),
+            drift         = isSubclassOverlaySource(activeSrc)
+                ? detectSubclassOverlayResidualDrift(templateShape, activeShape)
+                : detectDrift(templateShape, activeShape);
+
+        if (drift.hasDrift) {
+            findings.push({
+                label,
+                drift,
+                items: formatStaleOverlayDriftItems(drift)
+            })
+        }
+    };
+
+    collectPair({
+        activePath  : path.join(aiRoot, 'config.mjs'),
+        label       : 'Tier-1 ai/config.mjs',
+        templatePath: path.join(aiRoot, 'config.template.mjs')
+    });
+
+    if (!fs.existsSync(serversRoot)) {
+        return findings
+    }
+
+    for (const serverName of fs.readdirSync(serversRoot).sort()) {
+        const serverPath = path.join(serversRoot, serverName);
+
+        if (!fs.statSync(serverPath).isDirectory()) {
+            continue
+        }
+
+        collectPair({
+            activePath         : path.join(serverPath, 'config.mjs'),
+            label              : `${serverName}/config.mjs`,
+            materializeTemplate: materializeServerConfigTemplate,
+            templatePath       : path.join(serverPath, 'config.template.mjs')
+        })
+    }
+
+    return findings
 }
 
 /**

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -4,6 +4,8 @@ import {Command}                  from 'commander';
 import path                       from 'node:path';
 import process                    from 'node:process';
 import {fileURLToPath}            from 'node:url';
+import {collectStaleOverlayFindings}
+                                   from '../../ai/scripts/setup/initServerConfigs.mjs';
 
 const
     __filename = fileURLToPath(import.meta.url),
@@ -312,6 +314,7 @@ function runPrBodyGate({cwd, existsSyncImpl, prBody, prDraft, readFileSyncImpl})
  */
 export function runAgentPreflight({
     argv             = process.argv.slice(2),
+    collectStaleOverlayFindingsImpl = collectStaleOverlayFindings,
     cwd              = process.cwd(),
     execFileSyncImpl = execFileSync,
     existsSyncImpl   = existsSync,
@@ -389,6 +392,23 @@ export function runAgentPreflight({
                 failures.push(result.name)
             }
         }
+    }
+
+    // Advisory-only local overlay drift check. Gitignored config.mjs overlays can go stale even when the
+    // staged source gates are green; surfacing the exact STALE_OVERLAY rows here prevents false-green PR
+    // churn without mutating operator-local files or failing unrelated preflight runs.
+    try {
+        const staleOverlayFindings = collectStaleOverlayFindingsImpl();
+
+        if (staleOverlayFindings.length > 0) {
+            writeLine(stdout, 'agent-preflight: STALE_OVERLAY warning(s) (non-blocking):');
+            staleOverlayFindings.forEach(finding => {
+                writeLine(stdout, `  - ${finding.label}`);
+                finding.items.forEach(item => writeLine(stdout, `    + ${item}`))
+            })
+        }
+    } catch (error) {
+        writeLine(stdout, `agent-preflight: STALE_OVERLAY check skipped (${error.message}).`)
     }
 
     if (options.prBody) {

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -219,6 +219,36 @@ test.describe('agent-preflight utility', () => {
         expect(stdout).toContain('agent-preflight: PR body contains the required template anchors.')
     });
 
+    test('emits STALE_OVERLAY findings as a non-blocking local-dev warning (#14675)', () => {
+        let stdout = '';
+        let stderr = '';
+
+        const status = runAgentPreflight({
+            argv                           : ['--no-fix'],
+            collectStaleOverlayFindingsImpl: () => [{
+                label: 'Tier-1 ai/config.mjs',
+                items: [
+                    'env: NEO_AUTH_MODE',
+                    "leaf-default: modelProvider (NEO_MODEL_PROVIDER, string): 'gemini' -> 'openAiCompatible'"
+                ]
+            }],
+            cwd             : '/repo',
+            execFileSyncImpl: cmd => cmd === 'git' ? '' : '',
+            existsSyncImpl  : () => true,
+            readFileSyncImpl: () => validBody,
+            stderr          : {write: value => { stderr += value }},
+            stdout          : {write: value => { stdout += value }}
+        });
+
+        expect(status).toBe(0);
+        expect(stderr).toBe('');
+        expect(stdout).toContain('agent-preflight: 0 .mjs files in scope; skipped source gates.');
+        expect(stdout).toContain('agent-preflight: STALE_OVERLAY warning(s) (non-blocking):');
+        expect(stdout).toContain('Tier-1 ai/config.mjs');
+        expect(stdout).toContain('env: NEO_AUTH_MODE');
+        expect(stdout).toContain('leaf-default: modelProvider')
+    });
+
     test('runs the draft PR body gate when requested', () => {
         let stdout = '';
         let stderr = '';
@@ -375,8 +405,8 @@ test.describe('agent-preflight — Contract Ledger drift (#14119)', () => {
             },
             existsSyncImpl  : () => true,
             readFileSyncImpl: () => `${validBody}\n${ledgerBody}`,
-            stderr: {write: value => { stderr += value }},
-            stdout: {write: value => { stdout += value }}
+            stderr          : {write: value => { stderr += value }},
+            stdout          : {write: value => { stdout += value }}
         });
 
         expect(status).toBe(0); // drift is WARN-only — never fails the preflight

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -26,7 +26,8 @@ import path            from 'path';
 test.describe.configure({mode: 'serial'});
 
 test.describe('initServerConfigs — template drift detection (#10815)', () => {
-    let initConfigs, projectSourceShape, projectShape, detectDrift, materializeServerConfigTemplate, listServersWithTemplates, hasConfigTemplate;
+    let initConfigs, projectSourceShape, projectShape, detectDrift, materializeServerConfigTemplate, listServersWithTemplates, hasConfigTemplate,
+        collectStaleOverlayFindings, formatStaleOverlayDriftItems;
     let workRoot;
 
     function recordingLogger() {
@@ -66,7 +67,9 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
             detectDrift,
             materializeServerConfigTemplate,
             listServersWithTemplates,
-            hasConfigTemplate
+            hasConfigTemplate,
+            collectStaleOverlayFindings,
+            formatStaleOverlayDriftItems
         } = await import('../../../../../../ai/scripts/setup/initServerConfigs.mjs'));
 
         workRoot = path.resolve(process.cwd(), 'tmp', `init-server-configs-${process.pid}-${Date.now()}`);
@@ -621,6 +624,126 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
             templateDefault: `'openAiCompatible'`,
             configDefault  : `'gemini'`
         }]);
+    });
+
+    test('formatStaleOverlayDriftItems names exact missing and conflicting leaves (#14675)', () => {
+        expect(formatStaleOverlayDriftItems({
+            missingImports       : ['../shared/newImport.mjs:newHelper'],
+            missingExports       : ['exportedHelper'],
+            missingEnvVars       : ['NEO_AUTH_MODE'],
+            missingRequiredLeaves: ['gitlabApiBaseUrl (NEO_AUTH_GITLAB_API_BASE_URL, string): {requiredFor: []}'],
+            changedLeafDefaults  : [{
+                key            : 'modelProvider',
+                env            : 'NEO_MODEL_PROVIDER',
+                type           : 'string',
+                configDefault  : `'gemini'`,
+                templateDefault: `'openAiCompatible'`
+            }]
+        })).toEqual([
+            'import: ../shared/newImport.mjs:newHelper',
+            'export: exportedHelper',
+            'env: NEO_AUTH_MODE',
+            'required-leaf: gitlabApiBaseUrl (NEO_AUTH_GITLAB_API_BASE_URL, string): {requiredFor: []}',
+            "leaf-default: modelProvider (NEO_MODEL_PROVIDER, string): 'gemini' -> 'openAiCompatible'"
+        ])
+    });
+
+    test('collectStaleOverlayFindings returns read-only advisory findings for Tier-1 and server overlays (#14675)', () => {
+        const root        = path.join(workRoot, 'collect-stale-overlay');
+        const aiRoot      = path.join(root, 'ai');
+        const serversRoot = path.join(root, 'server');
+        const serverRoot  = path.join(serversRoot, 'memory-core');
+
+        fs.mkdirSync(aiRoot, {recursive: true});
+        fs.mkdirSync(serverRoot, {recursive: true});
+
+        const tier1Template = [
+            `export default {auth: {`,
+            `    mode: leaf('oidc', 'NEO_AUTH_MODE', 'string'),`,
+            `    gitlabApiBaseUrl: leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string', {requiredFor: [{modes: ['gitlab-pat']}]})`,
+            `}};`,
+            ``
+        ].join('\n');
+        const tier1Config = [
+            `export default {auth: {`,
+            `    gitlabApiBaseUrl: leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string')`,
+            `}};`,
+            ``
+        ].join('\n');
+        const serverTemplate = [
+            `import AiConfig from '../../../config.template.mjs';`,
+            `export default {model: leaf('openAiCompatible', 'NEO_MODEL_PROVIDER', 'string')};`,
+            ``
+        ].join('\n');
+        const serverConfig = [
+            `import AiConfig from '../../../config.mjs';`,
+            `export default {model: leaf('gemini', 'NEO_MODEL_PROVIDER', 'string')};`,
+            ``
+        ].join('\n');
+
+        fs.writeFileSync(path.join(aiRoot, 'config.template.mjs'), tier1Template);
+        fs.writeFileSync(path.join(aiRoot, 'config.mjs'), tier1Config);
+        fs.writeFileSync(path.join(serverRoot, 'config.template.mjs'), serverTemplate);
+        fs.writeFileSync(path.join(serverRoot, 'config.mjs'), serverConfig);
+
+        const findings = collectStaleOverlayFindings({aiRoot, serversRoot});
+
+        expect(findings.map(finding => finding.label)).toEqual([
+            'Tier-1 ai/config.mjs',
+            'memory-core/config.mjs'
+        ]);
+        expect(findings[0].items).toEqual(expect.arrayContaining([
+            'env: NEO_AUTH_MODE',
+            expect.stringContaining('required-leaf: gitlabApiBaseUrl')
+        ]));
+        expect(findings[1].items).toEqual([
+            "leaf-default: model (NEO_MODEL_PROVIDER, string): 'gemini' -> 'openAiCompatible'"
+        ]);
+        expect(fs.readFileSync(path.join(aiRoot, 'config.mjs'), 'utf-8')).toBe(tier1Config);
+        expect(fs.readFileSync(path.join(serverRoot, 'config.mjs'), 'utf-8')).toBe(serverConfig);
+    });
+
+    test('collectStaleOverlayFindings limits subclass overlays to residual conflicts (#14675)', () => {
+        const root   = path.join(workRoot, 'collect-subclass-overlay');
+        const aiRoot = path.join(root, 'ai');
+
+        fs.mkdirSync(aiRoot, {recursive: true});
+
+        const templateSrc = [
+            `export class AiConfigBase {`,
+            `    static config = {data: {`,
+            `        modelProvider: leaf('openAiCompatible', 'NEO_MODEL_PROVIDER', 'string'),`,
+            `        timeout      : leaf(1000, 'NEO_TIMEOUT', 'number')`,
+            `    }}`,
+            `}`,
+            `export default AiConfigBase;`,
+            ``
+        ].join('\n');
+        const subclassOverlaySrc = [
+            `import {AiConfigBase} from './config.template.mjs';`,
+            `class AiConfig extends AiConfigBase {`,
+            `    static config = {data: {`,
+            `        modelProvider: leaf('gemini', 'NEO_MODEL_PROVIDER', 'string')`,
+            `    }}`,
+            `}`,
+            `export default AiConfig;`,
+            ``
+        ].join('\n');
+
+        fs.writeFileSync(path.join(aiRoot, 'config.template.mjs'), templateSrc);
+        fs.writeFileSync(path.join(aiRoot, 'config.mjs'), subclassOverlaySrc);
+
+        const findings = collectStaleOverlayFindings({
+            aiRoot,
+            serversRoot: path.join(root, 'missing-servers')
+        });
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0].label).toBe('Tier-1 ai/config.mjs');
+        expect(findings[0].items).toEqual([
+            "leaf-default: modelProvider (NEO_MODEL_PROVIDER, string): 'gemini' -> 'openAiCompatible'"
+        ]);
+        expect(findings[0].items.some(item => item.includes('NEO_TIMEOUT'))).toBe(false);
     });
 
     test('same-env leaf default drift warns without overwriting (#12767)', async () => {


### PR DESCRIPTION
Resolves #14675
Related: #14564
Related: #14674

Wires local `agent-preflight` to emit advisory `STALE_OVERLAY` warnings for stale gitignored config overlays. The report reuses the existing template-vs-overlay projection and names actionable rows for missing imports, exports, env leaves, required leaves, and same-leaf default conflicts without mutating operator-local files or failing unrelated preflight runs.

Evidence: L2 local unit/static validation -> L2 required for local-dev preflight warning semantics. Residual: post-merge validation should confirm the generic subclass residual-conflict detector against #14674 final class/export names after that root-fix PR lands.

## Deltas from ticket
- Added `collectStaleOverlayFindings()` and stable `STALE_OVERLAY` row formatting in `ai/scripts/setup/initServerConfigs.mjs`.
- Wired `buildScripts/util/agent-preflight.mjs` to print those findings as non-blocking local-dev warnings.
- Covered both shapes: snapshot overlays receive the full missing-leaf diff; subclass-shaped overlays are limited to explicit same-leaf residual conflicts so inherited leaves are not false-reported as missing.
- Used a generic class-shaped subclass fixture because #14674 is still open and has not provided final template class names on `dev`.

## Test Evidence
- `npm run agent-preflight -- --no-fix buildScripts/util/agent-preflight.mjs ai/scripts/setup/initServerConfigs.mjs test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs` passed.
- `NEO_CHROMA_PORT_TEST=18185 npm run test-unit -- test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs --workers=1 --reporter=line --timeout=30000` passed: 73 passed.
- Pre-push freshness passed: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `06df0fb9f2 feat(ai): warn on stale config overlays in preflight (#14675)`.

## Post-Merge Validation
- [ ] Run `npm run agent-preflight -- --no-fix` in a clone with an intentionally stale snapshot overlay and verify `STALE_OVERLAY` names exact missing leaves.
- [ ] After #14674 lands, verify its final subclass overlay syntax still satisfies the generic `extends` residual-conflict path, or file the narrow follow-up if its class shape needs a tighter detector.

## Commits
- `06df0fb9f2` - `feat(ai): warn on stale config overlays in preflight (#14675)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019f2c26-7b3d-7683-b23c-ec6b33131844.