### PR TITLE
fix(ai): verify lane-state PR gate evidence (#14713)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -52,7 +52,8 @@ import {buildDeferenceStopHookDirective,
         parseOutcomeToVerdict,
         scanHoldLexicon,
         STOP_HOOK_TURN_OPTIONS_HINT} from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
-import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+import {collectLaneStateToolEvidenceFromJsonl,
+        validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
 export {isOperatorInLoop, parseOutcomeToVerdict};
 
@@ -441,6 +442,15 @@ async function main() {
     } catch (e) {
         // best-effort; isOperatorInLoop falls back to stop_hook_active when promptingText is empty
     }
+    let evidenceText = '';
+    try {
+        if (input.transcript_path) {
+            evidenceText = collectLaneStateToolEvidenceFromJsonl(fs.readFileSync(input.transcript_path, 'utf8'));
+        }
+    } catch {
+        // Missing transcript evidence is an agent-proof failure, not a hook failure.
+        evidenceText = '';
+    }
     const promptContext = classifyPromptingContext({
         stopHookActive: !!input.stop_hook_active,
         promptingText
@@ -476,7 +486,10 @@ async function main() {
 
     let verdict;
     try {
-        verdict = parseOutcomeToVerdict({descriptor, parseError}, validateLaneStateTerminal);
+        verdict = parseOutcomeToVerdict(
+            {descriptor, parseError},
+            laneState => validateLaneStateTerminal(laneState, {evidenceText})
+        );
     } catch (e) {
         // A validator/mapping bug is OUR failure → never block; allow + audit.
         auditLog(`VALIDATOR-ERROR: ${e.message}; allowing stop.`);

--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -22,7 +22,9 @@ import {classifyPromptingContext,
         LANE_STATE_SCHEMA_HINT,
         parseOutcomeToVerdict,
         STOP_HOOK_TURN_OPTIONS_HINT} from '../../ai/scripts/lifecycle/stopHookDecision.mjs';
-import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+import {collectLaneStateToolEvidenceFromJsonl,
+        collectLaneStateToolEvidenceFromMessages,
+        validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
 export const CODEX_STOP_BLOCK_INJECTION_SUPPORTED = true;
 export const CODEX_PROMPT_CONTEXT_TTL_MS           = 10 * 60 * 1000;
@@ -375,6 +377,31 @@ export function extractPromptingText(input = {}, {logDir} = {}) {
 }
 
 /**
+ * @summary Collects same-turn tool-call evidence from Codex Stop payload records.
+ * @param {Object} [input={}]
+ * @returns {String}
+ */
+export function collectCodexLaneStateEvidence(input = {}) {
+    const chunks   = [],
+          messages = input.messages ?? input.conversation ?? input.transcript;
+
+    if (Array.isArray(messages)) {
+        chunks.push(collectLaneStateToolEvidenceFromMessages(messages));
+    }
+
+    const transcriptPath = input.transcript_path ?? input.transcriptPath;
+    if (transcriptPath) {
+        try {
+            chunks.push(collectLaneStateToolEvidenceFromJsonl(fs.readFileSync(transcriptPath, 'utf8')));
+        } catch {
+            // Missing evidence is handled by the validator as an unearned PR gate.
+        }
+    }
+
+    return chunks.filter(Boolean).join('\n');
+}
+
+/**
  * @summary Builds the no-hold reminder text without claiming Codex can inject it yet.
  * @param {String} verdictReason
  * @returns {String}
@@ -479,6 +506,7 @@ export function classifyCodexStopPayload(input = {}, {enforcing = false, logDir}
     const stopHookActive                                                      = !!(input.stop_hook_active || input.stopHookActive),
           {text, source}                                                      = extractFinalAssistantText(input),
           {text: promptingText, source: promptSource}                         = extractPromptingText(input, {logDir}),
+          evidenceText                                                        = collectCodexLaneStateEvidence(input),
           promptContext                                                       = classifyPromptingContext({stopHookActive, promptingText}),
           {autonomousHandoff, handoffReason, handoffWindowMs, operatorInLoop} = promptContext;
 
@@ -504,7 +532,10 @@ export function classifyCodexStopPayload(input = {}, {enforcing = false, logDir}
         parseError = e;
     }
 
-    const verdict = parseOutcomeToVerdict({descriptor, parseError}, validateLaneStateTerminal);
+    const verdict = parseOutcomeToVerdict(
+        {descriptor, parseError},
+        laneState => validateLaneStateTerminal(laneState, {evidenceText})
+    );
 
     return {
         ...decideCodexHookAction(verdict, {

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -17,8 +17,8 @@ export const LANE_STATE_SCHEMA_HINT = `Machine lane-state block to emit with you
 \`\`\`lane-state
 {"wakeDisposition":"awareness","laneContinuation":"next-lane","namedGates":[],"awaitingOwnPrOnly":false}
 \`\`\`
-Validator gotchas: if an own PR is only awaiting merge/review/CI, use laneContinuation "next-lane"; "active-lane" + awaitingOwnPrOnly:true is invalid. Every namedGates[] entry needs a same-turn checkedAt; mergeClaim must use field "mergedAt".
-Consumption honesty: namedGates[] is audit/coordination payload (peer-visible gate state; the audit ledger) — it is validated for shape but does NOT influence the block/allow decision in autonomous mode.`;
+Validator gotchas: if an own PR is only awaiting merge/review/CI, use laneContinuation "next-lane"; "active-lane" + awaitingOwnPrOnly:true is invalid. Every namedGates[] entry needs a same-turn checkedAt; PR-shaped gates also need same-turn fetch evidence in the tool history; mergeClaim must use field "mergedAt".
+Consumption honesty: namedGates[] is audit/coordination payload (peer-visible gate state; the audit ledger). In autonomous mode it explains the block reason; it is not a stop-license.`;
 
 /**
  * @summary Compact cross-harness turn-end options hint for Stop-hook injections.

--- a/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
+++ b/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
@@ -12,6 +12,153 @@
  * @module Neo.ai.scripts.lifecycle.validateLaneStateTerminal
  */
 
+const PR_REF_RE = /\b(?:PR|pull request)\s*#?(\d+)\b/i;
+
+/**
+ * @summary Safely serializes hook transcript records for evidence scanning.
+ * @param {*} value
+ * @returns {String}
+ * @protected
+ */
+function safeStringify(value) {
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return '';
+    }
+}
+
+/**
+ * @summary Returns whether a transcript object is a tool-call-shaped record.
+ * @param {*} value
+ * @returns {Boolean}
+ * @protected
+ */
+function isToolEvidenceObject(value) {
+    if (!value || typeof value !== 'object') return false;
+
+    const type = String(value.type ?? value.payload?.type ?? value.message?.type ?? '').toLowerCase(),
+          name = String(value.name ?? value.recipient_name ?? value.tool ?? '').toLowerCase();
+
+    return type.includes('tool_use') ||
+        type.includes('tool_call') ||
+        type.includes('function_call') ||
+        type.includes('local_shell') ||
+        type.includes('command') ||
+        name.includes('bash') ||
+        name.includes('exec') ||
+        name.includes('shell') ||
+        name.includes('github') ||
+        name === 'gh' ||
+        name.includes('mcp__neo_mjs_github_workflow');
+}
+
+/**
+ * @summary Adds tool-call-shaped transcript surfaces to the evidence chunks.
+ * @param {*} record
+ * @param {String[]} chunks
+ * @protected
+ */
+function collectToolEvidenceRecord(record, chunks) {
+    if (!record || typeof record !== 'object') return;
+
+    const candidates = [
+        record,
+        record.payload,
+        record.item,
+        record.message,
+        record.payload?.item,
+        record.payload?.message,
+        record.item?.payload,
+        record.message?.payload
+    ];
+
+    for (const candidate of candidates) {
+        if (isToolEvidenceObject(candidate)) chunks.push(safeStringify(candidate));
+    }
+
+    const contentCandidates = [
+        record.content,
+        record.payload?.content,
+        record.item?.content,
+        record.message?.content,
+        record.payload?.message?.content,
+        record.item?.message?.content
+    ];
+
+    for (const content of contentCandidates) {
+        const blocks = Array.isArray(content) ? content : [content];
+        for (const block of blocks) {
+            if (isToolEvidenceObject(block)) chunks.push(safeStringify(block));
+        }
+    }
+}
+
+/**
+ * @summary Collects same-turn tool-call evidence from message-like hook records.
+ * @param {Object[]} [messages=[]]
+ * @returns {String}
+ */
+export function collectLaneStateToolEvidenceFromMessages(messages = []) {
+    if (!Array.isArray(messages)) return '';
+
+    const chunks = [];
+    for (const record of messages) {
+        collectToolEvidenceRecord(record, chunks);
+    }
+    return chunks.filter(Boolean).join('\n');
+}
+
+/**
+ * @summary Collects same-turn tool-call evidence from JSONL hook transcripts.
+ * @param {String} [jsonl='']
+ * @returns {String}
+ */
+export function collectLaneStateToolEvidenceFromJsonl(jsonl = '') {
+    if (typeof jsonl !== 'string') return '';
+
+    const chunks = [];
+    for (const line of jsonl.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+
+        let record;
+        try { record = JSON.parse(trimmed); } catch { continue; }
+        collectToolEvidenceRecord(record, chunks);
+    }
+    return chunks.filter(Boolean).join('\n');
+}
+
+/**
+ * @summary Extracts the PR number from an explicit PR-shaped gate reference.
+ * @param {String} ref
+ * @returns {Number|null}
+ */
+export function extractPrNumberFromGateRef(ref = '') {
+    const match = String(ref).match(PR_REF_RE);
+    return match ? Number(match[1]) : null;
+}
+
+/**
+ * @summary Returns whether same-turn tool-call evidence fetched the named PR.
+ * @param {Number} prNumber
+ * @param {String} [evidenceText='']
+ * @returns {Boolean}
+ */
+export function hasSameTurnPrFetchEvidence(prNumber, evidenceText = '') {
+    if (!Number.isInteger(prNumber) || !evidenceText) return false;
+
+    const n        = String(prNumber),
+          patterns = [
+              new RegExp(`\\bgh\\s+pr\\s+(?:view|checks)\\s+${n}\\b`, 'i'),
+              new RegExp(`\\bgh\\s+api\\b[\\s\\S]{0,400}\\b(?:pulls|pullRequests|pullRequest)\\b[\\s\\S]{0,200}\\b${n}\\b`, 'i'),
+              new RegExp(`\\b(?:get_pull_request|getPullRequest|get_conversation|getConversation)\\b[\\s\\S]{0,300}\\b(?:pr_number|pullRequestNumber|pull_request_number|number)\\b\\D{0,20}${n}\\b`, 'i'),
+              new RegExp(`\\b(?:pr_number|pullRequestNumber|pull_request_number)\\b\\D{0,20}${n}\\b`, 'i')
+          ];
+
+    return patterns.some(pattern => pattern.test(evidenceText));
+}
+
 /**
  * The lane-continuation states that answer "may the turn end?" — all three are DRIVING continuations.
  * Per §no_hold_state there is no hold state: the only valid turn-state is on / jumped-to a high-value
@@ -35,18 +182,21 @@ export const NON_TERMINAL_DISPOSITIONS = ['awareness', 'stale', 'suppressed'];
  *     `laneContinuation` is required.
  *  2. `laneContinuation='active-lane'` may not be only an own PR awaiting merge/review/CI (a
  *     background watch); that resolves to `next-lane` unless there is concrete author work on it.
- *  3. Every named PR/issue gate must cite a same-turn `checkedAt` (stale gate names are not evidence);
- *     a gate flagged `mergeClaim` must cite `field === 'mergedAt'` (reading a PR's `state`/CLOSED is
- *     not merge proof — a closed PR may be un-merged).
+ *  3. Every named PR/issue gate must cite a same-turn `checkedAt` (stale gate names are not evidence).
+ *     PR-shaped gates must also be backed by same-turn tool-call evidence that fetched the PR; a gate
+ *     flagged `mergeClaim` must cite `field === 'mergedAt'` (reading a PR's `state`/CLOSED is not
+ *     merge proof — a closed PR may be un-merged).
  *
  * @param {Object} [laneState={}]
  * @param {String} [laneState.wakeDisposition] One of `actionable|awareness|stale|suppressed|incident`.
  * @param {String} [laneState.laneContinuation] One of `active-lane|next-lane|blocker-routed`.
  * @param {Object[]} [laneState.namedGates] Named PR/issue gates this terminal cites: `[{ref, checkedAt, mergeClaim?, field?}]`.
  * @param {Boolean} [laneState.awaitingOwnPrOnly] True when the only cited lane is an own PR awaiting merge/review/CI.
+ * @param {Object} [options]
+ * @param {String} [options.evidenceText] Same-turn tool-call evidence collected from hook transcripts.
  * @returns {{valid: Boolean, violations: String[]}} `valid` is true when no rule is violated.
  */
-export function validateLaneStateTerminal(laneState = {}) {
+export function validateLaneStateTerminal(laneState = {}, {evidenceText = ''} = {}) {
     const {
         wakeDisposition,
         laneContinuation,
@@ -73,11 +223,19 @@ export function validateLaneStateTerminal(laneState = {}) {
         violations.push('active-lane cannot be only an own PR awaiting merge/review/CI (a background watch) — it resolves to next-lane unless there is concrete author work on that PR this turn.');
     }
 
-    // Rule 3 — named gates need a same-turn checkedAt; a merge claim must read the authoritative field.
+    // Rule 3 — named gates need a same-turn checkedAt; PR gates need a same-turn fetch; merge claims
+    // must read the authoritative field.
     for (const gate of namedGates) {
         if (!gate?.checkedAt) {
             violations.push(`Named gate ${gate?.ref ?? '(unnamed)'} must cite a same-turn checkedAt — a stale gate name is not evidence.`);
-        } else if (gate.mergeClaim && gate.field !== 'mergedAt') {
+        } else {
+            const prNumber = extractPrNumberFromGateRef(gate.ref);
+            if (prNumber && !hasSameTurnPrFetchEvidence(prNumber, evidenceText)) {
+                violations.push(`Named gate ${gate.ref} cites checkedAt but no same-turn PR fetch evidence was found for PR #${prNumber} — run gh pr view/checks or the GitHub workflow PR fetch in this turn before naming it.`);
+            }
+        }
+
+        if (gate?.mergeClaim && gate.field !== 'mergedAt') {
             violations.push(`Named gate ${gate.ref ?? '(unnamed)'} claims merge state but cites field ${gate.field ? `'${gate.field}'` : '(none)'} — a merge claim must read mergedAt (a PR's state/CLOSED is not merge proof).`);
         }
     }

--- a/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
+++ b/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
@@ -148,12 +148,14 @@ export function extractPrNumberFromGateRef(ref = '') {
 export function hasSameTurnPrFetchEvidence(prNumber, evidenceText = '') {
     if (!Number.isInteger(prNumber) || !evidenceText) return false;
 
-    const n        = String(prNumber),
-          patterns = [
+    const n                    = String(prNumber),
+          prNumberParamPattern = `\\b(?:pr_number|pullRequestNumber|pull_request_number)\\b\\D{0,20}${n}\\b`,
+          stateFieldPattern    = '\\b(?:mergedAt|mergeable|reviewDecision|statusCheckRollup|mergeStateStatus)\\b',
+          patterns             = [
               new RegExp(`\\bgh\\s+pr\\s+(?:view|checks)\\s+${n}\\b`, 'i'),
               new RegExp(`\\bgh\\s+api\\b[\\s\\S]{0,400}\\b(?:pulls|pullRequests|pullRequest)\\b[\\s\\S]{0,200}\\b${n}\\b`, 'i'),
               new RegExp(`\\b(?:get_pull_request|getPullRequest|get_conversation|getConversation)\\b[\\s\\S]{0,300}\\b(?:pr_number|pullRequestNumber|pull_request_number|number)\\b\\D{0,20}${n}\\b`, 'i'),
-              new RegExp(`\\b(?:pr_number|pullRequestNumber|pull_request_number)\\b\\D{0,20}${n}\\b`, 'i')
+              new RegExp(`${prNumberParamPattern}[\\s\\S]{0,300}${stateFieldPattern}|${stateFieldPattern}[\\s\\S]{0,300}${prNumberParamPattern}`, 'i')
           ];
 
     return patterns.some(pattern => pattern.test(evidenceText));

--- a/test/playwright/unit/ai/scripts/lifecycle/parseLaneState.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/parseLaneState.spec.mjs
@@ -51,7 +51,9 @@ test.describe('parseLaneState — fenced lane-state block extraction', () => {
     test('round-trips into validateLaneStateTerminal — the hook seam end-to-end (#12633)', () => {
         // A valid next-lane terminal emitted as a block parses + validates clean (the wired path fires PASS).
         const ok = '```lane-state\n{"wakeDisposition":"actionable","laneContinuation":"next-lane","namedGates":[{"ref":"PR #99","checkedAt":"2026-06-20T03:41:00Z","mergeClaim":false}],"awaitingOwnPrOnly":false}\n```';
-        expect(validateLaneStateTerminal(parseLaneState(ok)).valid).toBe(true);
+        expect(validateLaneStateTerminal(parseLaneState(ok), {
+            evidenceText: 'tool_call: gh pr view 99 --json state,mergedAt,reviewDecision'
+        }).valid).toBe(true);
 
         // A stale-gate terminal (gate named without checkedAt) parses, then the validator REJECTS it —
         // proving the parse-then-validate seam fires the gate on real emitted text.

--- a/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
@@ -5,9 +5,9 @@ setup({
     appConfig: {name: 'ValidateLaneStateTerminalTest', isMounted: () => true, vnodeInitialising: false}
 });
 
-import {test, expect}              from '@playwright/test';
-import Neo                         from '../../../../../../src/Neo.mjs';
-import * as core                   from '../../../../../../src/core/_export.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
 import {collectLaneStateToolEvidenceFromJsonl,
         collectLaneStateToolEvidenceFromMessages,
         extractPrNumberFromGateRef,
@@ -119,7 +119,30 @@ test.describe('validateLaneStateTerminal — turn-terminal evidence shape', () =
     test('same-turn evidence accepts scoped GitHub PR fetches, not unrelated PR text', () => {
         expect(hasSameTurnPrFetchEvidence(14822, 'gh pr view 14822 --json state,mergedAt')).toBe(true);
         expect(hasSameTurnPrFetchEvidence(14822, 'get_conversation {"pr_number":14822}')).toBe(true);
+        expect(hasSameTurnPrFetchEvidence(14822, 'github_tool {"pr_number":14822,"mergeStateStatus":"CLEAN"}')).toBe(true);
         expect(hasSameTurnPrFetchEvidence(14822, 'mentioned PR #14822 in final prose')).toBe(false);
+    });
+
+    test('same-turn PR mutation or diff calls do not satisfy PR state-fetch evidence (#14713)', () => {
+        const mutationEvidence = [
+            'manage_pr_review {"pr_number":14822,"state":"APPROVED"}',
+            'manage_pr_reviewers {"pr_number":14822,"reviewers":["neo-opus-grace"]}',
+            'get_pull_request_diff {"pr_number":14822}'
+        ];
+
+        for (const evidenceText of mutationEvidence) {
+            expect(hasSameTurnPrFetchEvidence(14822, evidenceText)).toBe(false);
+
+            const result = validateLaneStateTerminal({
+                laneContinuation: 'next-lane',
+                namedGates      : [{ref: 'PR #14822', checkedAt: NOW}]
+            }, {
+                evidenceText
+            });
+
+            expect(result.valid).toBe(false);
+            expect(result.violations.join(' ')).toContain('no same-turn PR fetch evidence');
+        }
     });
 
     test('collects PR fetch evidence from Claude-style tool_use JSONL', () => {

--- a/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
@@ -8,7 +8,11 @@ setup({
 import {test, expect}              from '@playwright/test';
 import Neo                         from '../../../../../../src/Neo.mjs';
 import * as core                   from '../../../../../../src/core/_export.mjs';
-import {validateLaneStateTerminal} from '../../../../../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+import {collectLaneStateToolEvidenceFromJsonl,
+        collectLaneStateToolEvidenceFromMessages,
+        extractPrNumberFromGateRef,
+        hasSameTurnPrFetchEvidence,
+        validateLaneStateTerminal} from '../../../../../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
 test.describe('validateLaneStateTerminal — turn-terminal evidence shape', () => {
     const NOW = '2026-06-20T00:00:00.000Z';
@@ -48,10 +52,29 @@ test.describe('validateLaneStateTerminal — turn-terminal evidence shape', () =
         expect(result.violations.join(' ')).toContain('checkedAt');
     });
 
-    test('a named gate WITH a same-turn checkedAt passes', () => {
+    test('an issue gate WITH a same-turn checkedAt passes without PR fetch evidence', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'next-lane',
+            namedGates      : [{ref: 'issue #13572', checkedAt: NOW}]
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('a PR gate with checkedAt but no same-turn PR fetch evidence fails (#14713)', () => {
         const result = validateLaneStateTerminal({
             laneContinuation: 'next-lane',
             namedGates      : [{ref: 'PR #13572', checkedAt: NOW}]
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('no same-turn PR fetch evidence');
+    });
+
+    test('a PR gate WITH checkedAt and same-turn gh fetch evidence passes (#14713)', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'next-lane',
+            namedGates      : [{ref: 'PR #13572', checkedAt: NOW}]
+        }, {
+            evidenceText: 'tool_call: gh pr view 13572 --json state,mergedAt,reviewDecision'
         });
         expect(result.valid).toBe(true);
     });
@@ -81,7 +104,46 @@ test.describe('validateLaneStateTerminal — turn-terminal evidence shape', () =
         const result = validateLaneStateTerminal({
             laneContinuation: 'next-lane',
             namedGates      : [{ref: 'PR #12619', checkedAt: NOW, mergeClaim: true, field: 'mergedAt'}]
+        }, {
+            evidenceText: 'tool_call: gh pr view 12619 --json state,mergedAt,reviewDecision'
         });
         expect(result.valid).toBe(true);
+    });
+
+    test('extractPrNumberFromGateRef only treats explicit PR refs as PR-shaped gates', () => {
+        expect(extractPrNumberFromGateRef('PR #14822')).toBe(14822);
+        expect(extractPrNumberFromGateRef('pull request 14822')).toBe(14822);
+        expect(extractPrNumberFromGateRef('issue #14822')).toBeNull();
+    });
+
+    test('same-turn evidence accepts scoped GitHub PR fetches, not unrelated PR text', () => {
+        expect(hasSameTurnPrFetchEvidence(14822, 'gh pr view 14822 --json state,mergedAt')).toBe(true);
+        expect(hasSameTurnPrFetchEvidence(14822, 'get_conversation {"pr_number":14822}')).toBe(true);
+        expect(hasSameTurnPrFetchEvidence(14822, 'mentioned PR #14822 in final prose')).toBe(false);
+    });
+
+    test('collects PR fetch evidence from Claude-style tool_use JSONL', () => {
+        const jsonl = [
+            JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [
+                {type: 'tool_use', name: 'Bash', input: {command: 'gh pr view 14822 --json state,mergedAt'}}
+            ]}}),
+            JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [
+                {type: 'text', text: 'Final text mentions gh pr view 1 but is not tool evidence'}
+            ]}})
+        ].join('\n');
+
+        const evidence = collectLaneStateToolEvidenceFromJsonl(jsonl);
+        expect(evidence).toContain('gh pr view 14822');
+        expect(evidence).not.toContain('Final text mentions');
+    });
+
+    test('collects PR fetch evidence from Codex-style function-call records', () => {
+        const evidence = collectLaneStateToolEvidenceFromMessages([
+            {type: 'response_item', payload: {type: 'function_call', name: 'functions.exec_command', arguments: '{"cmd":"gh pr view 14822 --json state"}'}},
+            {role: 'assistant', content: 'Final text mentions gh pr view 1 but is not tool evidence'}
+        ]);
+
+        expect(evidence).toContain('gh pr view 14822');
+        expect(evidence).not.toContain('Final text mentions');
     });
 });

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -7,6 +7,7 @@ import path           from 'node:path';
 import {
     CODEX_STOP_BLOCK_INJECTION_SUPPORTED,
     buildNoHoldReminder,
+    collectCodexLaneStateEvidence,
     classifyCodexStopPayload,
     decideCodexHookAction,
     extractFinalAssistantText,
@@ -330,6 +331,42 @@ test.describe('codex-lane-state-stop - lane-state classification', () => {
         expect(result.reason).toContain('valid lane-state terminal');
         expect(result.promptSource).toBe('messages');
         expect(result.operatorInLoop).toBe(false);
+    });
+
+    test('PR-shaped namedGate without same-turn fetch evidence is invalid (#14713)', () => {
+        const prTerminal = block('{"laneContinuation":"next-lane","namedGates":[{"ref":"PR #14822","checkedAt":"2026-07-04T20:52:22Z"}],"awaitingOwnPrOnly":false}'),
+              result     = classifyWithIsolatedPromptContext({
+                  messages: [
+                      {role: 'user',      content: '[WAKE][priority:normal] 1 events'},
+                      {role: 'assistant', content: prTerminal}
+                  ]
+              });
+
+        expect(result.verdict.valid).toBe(false);
+        expect(result.verdict.reason).toContain('no same-turn PR fetch evidence');
+    });
+
+    test('PR-shaped namedGate with same-turn Codex tool evidence validates (#14713)', () => {
+        const prTerminal = block('{"laneContinuation":"next-lane","namedGates":[{"ref":"PR #14822","checkedAt":"2026-07-04T20:52:22Z"}],"awaitingOwnPrOnly":false}'),
+              toolRecord = {
+                  type   : 'response_item',
+                  payload: {
+                      type     : 'function_call',
+                      name     : 'functions.exec_command',
+                      arguments: '{"cmd":"gh pr view 14822 --json state,mergedAt,reviewDecision"}'
+                  }
+              },
+              result     = classifyWithIsolatedPromptContext({
+                  messages: [
+                      {role: 'user', content: '[WAKE][priority:normal] 1 events'},
+                      toolRecord,
+                      {role: 'assistant', content: prTerminal}
+                  ]
+              });
+
+        expect(collectCodexLaneStateEvidence({messages: [toolRecord]})).toContain('gh pr view 14822');
+        expect(result.verdict.valid).toBe(true);
+        expect(result.verdict.reason).toBe('valid lane-state terminal');
     });
 
     test('absent lane-state would-block with no-hold reminder', () => {

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -304,10 +304,10 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
      * operator-vs-wake classification surface. Otherwise the final text rides `last_assistant_message`
      * with no transcript → no confirmable prompt → fail-closed autonomous.
      * @param {String} finalText
-     * @param {{enforce: Boolean, promptingText: (String|null), stopHookActive: Boolean}} [opts]
+     * @param {{enforce: Boolean, promptingText: (String|null), stopHookActive: Boolean, toolCommand: String|null}} [opts]
      * @returns {Promise<{stdout: String, log: String}>}
      */
-    function runHook(finalText, {enforce = false, promptingText = null, stopHookActive = false, lifecycleState = null} = {}) {
+    function runHook(finalText, {enforce = false, promptingText = null, stopHookActive = false, lifecycleState = null, toolCommand = null} = {}) {
         return new Promise((resolve, reject) => {
             const dir            = fs.mkdtempSync(path.join(os.tmpdir(), 'lane-hook-e2e-')),
                   transcriptPath = path.join(dir, 'transcript.jsonl'),
@@ -319,10 +319,19 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
             }
 
             if (promptingText !== null) {
-                fs.writeFileSync(transcriptPath, [
-                    JSON.stringify({type: 'user',      message: {role: 'user',      content: promptingText}}),
-                    JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: finalText}]}})
-                ].join('\n') + '\n');
+                const records = [
+                    JSON.stringify({type: 'user', message: {role: 'user', content: promptingText}})
+                ];
+
+                if (toolCommand) {
+                    records.push(JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [
+                        {type: 'tool_use', name: 'Bash', input: {command: toolCommand}}
+                    ]}}));
+                }
+
+                records.push(JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: finalText}]}}));
+
+                fs.writeFileSync(transcriptPath, records.join('\n') + '\n');
                 payload.transcript_path = transcriptPath;
             } else {
                 payload.last_assistant_message = finalText;
@@ -402,6 +411,26 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         const {stdout, log} = await runHook(validTerminal, {enforce: true, promptingText: '[WAKE][priority:normal] 1 events'});
         expect(log).toContain('BLOCK');
         expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('PR-shaped namedGate without same-turn fetch evidence is an invalid terminal (#14713)', async () => {
+        const prTerminal = `Live gate checked.\n\n${block('{"laneContinuation":"next-lane","namedGates":[{"ref":"PR #14822","checkedAt":"2026-07-04T20:52:22Z"}],"awaitingOwnPrOnly":false}')}`,
+              {log}      = await runHook(prTerminal, {promptingText: '[WAKE][priority:normal] 1 events'});
+
+        expect(log).toContain('WOULD-BLOCK');
+        expect(log).toContain('no same-turn PR fetch evidence');
+    });
+
+    test('PR-shaped namedGate with same-turn tool evidence validates (#14713)', async () => {
+        const prTerminal = `Live gate checked.\n\n${block('{"laneContinuation":"next-lane","namedGates":[{"ref":"PR #14822","checkedAt":"2026-07-04T20:52:22Z"}],"awaitingOwnPrOnly":false}')}`,
+              {log}      = await runHook(prTerminal, {
+                  promptingText: '[WAKE][priority:normal] 1 events',
+                  toolCommand  : 'gh pr view 14822 --json state,mergedAt,reviewDecision'
+              });
+
+        expect(log).toContain('WOULD-BLOCK');
+        expect(log).toContain('valid lane-state terminal');
+        expect(log).not.toContain('no same-turn PR fetch evidence');
     });
 
     test('an ABSENT emission (no operator) → WOULD-BLOCK (dry-run)', async () => {

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -30,12 +30,13 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
         expect(LANE_STATE_SCHEMA_HINT).toContain('"awaitingOwnPrOnly":false');
         expect(LANE_STATE_SCHEMA_HINT).toContain('awaitingOwnPrOnly:true is invalid');
         expect(LANE_STATE_SCHEMA_HINT).toContain('same-turn checkedAt');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('same-turn fetch evidence');
         expect(LANE_STATE_SCHEMA_HINT).toContain('field "mergedAt"');
     });
 
-    test('LANE_STATE_SCHEMA_HINT: states consumption honesty — namedGates is audit/coordination payload, not admission evidence (regression: demanded-but-unread contract)', () => {
+    test('LANE_STATE_SCHEMA_HINT: states consumption honesty — namedGates is audit/coordination payload, not a stop-license', () => {
         expect(LANE_STATE_SCHEMA_HINT).toContain('Consumption honesty');
-        expect(LANE_STATE_SCHEMA_HINT).toContain('does NOT influence the block/allow decision');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('not a stop-license');
     });
 
     test('STOP_HOOK_TURN_OPTIONS_HINT: compactly names operator dialogue, memory, and fail-closed behavior', () => {


### PR DESCRIPTION
Resolves #14713
Related: #13652
Related: #13589
Related: #12633

Adds same-turn PR fetch evidence as the mechanical gate for PR-shaped `namedGates`: the shared lane-state validator now accepts `checkedAt` for issue gates, but requires transcript-visible `gh pr view/checks`, GitHub API, or workflow PR-fetch evidence before a PR gate can be used as terminal audit payload. The Claude and Codex Stop adapters collect evidence from their hook transcripts/messages and pass it into the shared validator without adding hook-time network I/O.

Evidence: L2 local static/direct hook validation -> L2 required for Stop-hook transcript validation. Residual: live post-merge hook transcript validation on both harnesses remains post-merge because the local Playwright unit runner hung before executing tests in this checkout.

## Deltas from ticket
- Chose mechanism A from the ticket: evidence-of-fetch via same-turn transcript records, no Stop-hook network I/O.
- Limited the stricter evidence rule to explicit PR-shaped gates; issue/doc gates still require `checkedAt` but do not require PR fetch evidence.
- Updated the schema hint so blocked hook continuations explain that PR gates need a same-turn fetch record.
- Added unit coverage for validator, Claude hook transcript collection, Codex hook message/transcript collection, and the schema hint.

## Test Evidence
- `git diff --check origin/dev...HEAD` passed after rebasing onto current `origin/dev`.
- `node --check` passed for all edited source/spec files.
- Direct validator probe passed: missing PR fetch fails; `gh pr view 14713` and `gh pr checks 14713` evidence pass.
- Direct Codex hook probe passed: `collectCodexLaneStateEvidence()` extracts PR-fetch evidence from message records.
- Direct Claude transcript probe passed: shared JSONL evidence collector extracts PR-fetch evidence from Stop transcripts.
- `npm run agent-preflight -- --no-fix ai/scripts/lifecycle/validateLaneStateTerminal.mjs ai/scripts/lifecycle/stopHookDecision.mjs .claude/hooks/laneStateStopHook.mjs .codex/hooks/codex-lane-state-stop.mjs test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs test/playwright/unit/ai/scripts/lifecycle/parseLaneState.spec.mjs test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs` passed: 9 files scanned, 0 archaeology violations, all requested gates passed.
- Pre-commit hooks passed before the initial commit; the final head was rebased cleanly onto `origin/dev`.
- Playwright focused runner caveat: attempted `npm run test-unit -- ...` and direct `./node_modules/.bin/playwright test ... -c test/playwright/playwright.config.unit.mjs --reporter=line --workers=1 --timeout=30000`; both hung before test output and were interrupted, so those are not claimed green.

## Post-Merge Validation
- [ ] In a live Codex Stop transcript, emit a PR-shaped namedGate after a real `gh pr view <n>` and verify the hook accepts the gate evidence.
- [ ] Repeat without a same-turn PR fetch and verify the hook reason names the missing fetch evidence.
- [ ] Mirror the same transcript check through the Claude Stop hook path.

## Commits
- `67d34a05c3` - `fix(ai): verify lane-state PR gate evidence (#14713)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019f2c26-7b3d-7683-b23c-ec6b33131844.