### PR TITLE
fix(ai): retry transient GitHub identity resolution (#14600)

### DIFF
--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -1,20 +1,20 @@
-import {execFile}         from 'child_process';
-import path               from 'path';
-import {fileURLToPath}    from 'url';
-import {promisify}        from 'util';
-import AgentStateService  from '../../../services/github-workflow/AgentStateService.mjs';
-import HealthService      from '../../../services/github-workflow/HealthService.mjs';
-import IssueService       from '../../../services/github-workflow/IssueService.mjs';
-import DiscussionService  from '../../../services/github-workflow/DiscussionService.mjs';
-import LabelService       from '../../../services/github-workflow/LabelService.mjs';
-import LocalFileService   from '../../../services/github-workflow/LocalFileService.mjs';
-import PullRequestService from '../../../services/github-workflow/PullRequestService.mjs';
-import RepositoryService  from '../../../services/github-workflow/RepositoryService.mjs';
-import ToolService        from '../../ToolService.mjs';
-import SyncService        from '../../../services/github-workflow/SyncService.mjs';
+import {execFile}                                                                      from 'child_process';
+import path                                                                            from 'path';
+import {fileURLToPath}                                                                 from 'url';
+import {promisify}                                                                     from 'util';
+import AgentStateService                                                               from '../../../services/github-workflow/AgentStateService.mjs';
+import HealthService                                                                   from '../../../services/github-workflow/HealthService.mjs';
+import IssueService                                                                    from '../../../services/github-workflow/IssueService.mjs';
+import DiscussionService                                                               from '../../../services/github-workflow/DiscussionService.mjs';
+import LabelService                                                                    from '../../../services/github-workflow/LabelService.mjs';
+import LocalFileService                                                                from '../../../services/github-workflow/LocalFileService.mjs';
+import PullRequestService                                                              from '../../../services/github-workflow/PullRequestService.mjs';
+import RepositoryService                                                               from '../../../services/github-workflow/RepositoryService.mjs';
+import ToolService                                                                     from '../../ToolService.mjs';
+import SyncService                                                                     from '../../../services/github-workflow/SyncService.mjs';
 import {assertExpectedIdentity as assertExpectedGitHubIdentity, IdentityAssertionCode} from '../../../graph/assertExpectedIdentity.mjs';
-import RequestContextService from '../shared/services/RequestContextService.mjs';
-import config             from './config.mjs';
+import RequestContextService                                                           from '../shared/services/RequestContextService.mjs';
+import config                                                                          from './config.mjs';
 
 const execFileAsync   = promisify(execFile);
 const __filename      = fileURLToPath(import.meta.url);
@@ -160,6 +160,25 @@ function getGitHubIdentityErrorCode(code) {
 }
 
 /**
+ * @summary Groups write-boundary identity failures into operator-actionable classes.
+ * @param {String} code The shared assertion's `code`.
+ * @returns {String}
+ */
+function getGitHubIdentityErrorClass(code) {
+    switch (code) {
+        case IdentityAssertionCode.NO_AUTHED_LOGIN:
+            return 'identity-resolution-transient';
+        case IdentityAssertionCode.LOGIN_MISMATCH:
+        case IdentityAssertionCode.MEMORY_CORE_MISMATCH:
+            return 'identity-mismatch';
+        case IdentityAssertionCode.EXPECTED_UNMAPPABLE:
+            return 'identity-configuration';
+        default:
+            return 'identity-assertion';
+    }
+}
+
+/**
  * @summary Builds a structured identity guard error for GitHub write-boundary failures.
  * @param {Object} assertion Shared identity assertion failure payload.
  * @returns {Error}
@@ -170,7 +189,8 @@ function createGitHubIdentityError(assertion) {
 
     Object.assign(error, {
         ...assertion,
-        code: getGitHubIdentityErrorCode(assertion.code)
+        code         : getGitHubIdentityErrorCode(assertion.code),
+        identityClass: getGitHubIdentityErrorClass(assertion.code)
     });
 
     return error;
@@ -211,6 +231,15 @@ async function defaultGitHubIdentityAssertion() {
 }
 
 /**
+ * @summary Returns true when an identity assertion is the retryable empty-login resolution class.
+ * @param {Object} assertion Shared identity assertion payload.
+ * @returns {Boolean}
+ */
+function shouldRetryGitHubIdentityAssertion(assertion) {
+    return assertion?.code === IdentityAssertionCode.NO_AUTHED_LOGIN;
+}
+
+/**
  * @summary Wraps a public GitHub write with fail-closed identity-drift validation.
  *
  * The delegate is never invoked unless the expected agent identity and effective
@@ -220,13 +249,19 @@ async function defaultGitHubIdentityAssertion() {
  * @param {Function} delegate The mutating GitHub tool handler.
  * @param {Object} [options]
  * @param {Function} [options.assertExpectedIdentity] Shared identity assertion seam.
+ * @param {Number} [options.identityResolutionRetries=1] Number of retry attempts for transient empty-login resolution.
  * @returns {Function} Guarded async tool handler.
  */
 function buildGitHubWriteIdentityGuard(delegate, {
-    assertExpectedIdentity = defaultGitHubIdentityAssertion
+    assertExpectedIdentity    = defaultGitHubIdentityAssertion,
+    identityResolutionRetries = 1
 } = {}) {
     return async function githubWriteIdentityGuard(...args) {
-        const assertion = await assertExpectedIdentity();
+        let assertion = await assertExpectedIdentity();
+
+        for (let retry = 0; !assertion.ok && retry < identityResolutionRetries && shouldRetryGitHubIdentityAssertion(assertion); retry++) {
+            assertion = await assertExpectedIdentity();
+        }
 
         if (!assertion.ok) {
             throw createGitHubIdentityError(assertion);
@@ -281,7 +316,7 @@ async function defaultBranchDetector() {
     }
 
     const normalizedProjectRoot = path.resolve(config.projectRoot);
-    const normalizedToplevel = path.resolve(toplevel);
+    const normalizedToplevel    = path.resolve(toplevel);
 
     if (normalizedProjectRoot !== normalizedToplevel) {
         throw new Error(
@@ -434,9 +469,9 @@ export {
 };
 
 const toolService = Neo.create(ToolService, {
-    compactToolDescriptions    : true,
+    compactToolDescriptions     : true,
     openApiFilePath,
-    serviceMapping: guardedServiceMapping,
+    serviceMapping              : guardedServiceMapping,
     toolListDescriptionMaxLength: 120
 });
 

--- a/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
@@ -46,8 +46,8 @@ test.describe('Neo.ai.services.github-workflow.toolService — sync_all dev-bran
     });
 
     test('sync_all delegates to SyncService.runFullSync when on dev', async () => {
-        let delegateCalls = 0;
-        const delegate = async (...args) => {
+        let   delegateCalls = 0;
+        const delegate      = async (...args) => {
             delegateCalls++;
             return {message: 'sync ok', args};
         };
@@ -60,18 +60,18 @@ test.describe('Neo.ai.services.github-workflow.toolService — sync_all dev-bran
     });
 
     test('sync_all REJECTS when on a feature branch (no delegate call)', async () => {
-        let delegateCalls = 0;
-        const delegate = async () => { delegateCalls++; return {message: 'should not run'}; };
-        const guarded = buildDevBranchGuard(delegate, async () => 'agent/some-feature-branch');
+        let   delegateCalls = 0;
+        const delegate      = async () => { delegateCalls++; return {message: 'should not run'}; };
+        const guarded       = buildDevBranchGuard(delegate, async () => 'agent/some-feature-branch');
 
         await expect(guarded()).rejects.toThrow(/sync_all REJECTED.*'agent\/some-feature-branch'.*not 'dev'/);
         expect(delegateCalls).toBe(0);
     });
 
     test('sync_all REJECTS when on main (no delegate call)', async () => {
-        let delegateCalls = 0;
-        const delegate = async () => { delegateCalls++; };
-        const guarded = buildDevBranchGuard(delegate, async () => 'main');
+        let   delegateCalls = 0;
+        const delegate      = async () => { delegateCalls++; };
+        const guarded       = buildDevBranchGuard(delegate, async () => 'main');
 
         await expect(guarded()).rejects.toThrow(/sync_all REJECTED.*'main'.*not 'dev'/);
         expect(delegateCalls).toBe(0);
@@ -79,14 +79,14 @@ test.describe('Neo.ai.services.github-workflow.toolService — sync_all dev-bran
 
     test('sync_all REJECTS on detached HEAD (empty branch name)', async () => {
         const delegate = async () => { throw new Error('should not run'); };
-        const guarded = buildDevBranchGuard(delegate, async () => '');
+        const guarded  = buildDevBranchGuard(delegate, async () => '');
 
         await expect(guarded()).rejects.toThrow(/sync_all REJECTED.*'\(detached\)'/);
     });
 
     test('sync_all REJECTS immediately on root mismatch from branch detector', async () => {
         const delegate = async () => { throw new Error('should not run'); };
-        const guarded = buildDevBranchGuard(delegate, async () => {
+        const guarded  = buildDevBranchGuard(delegate, async () => {
             throw new Error('sync_all REJECTED: Root mismatch. MCP server projectRoot...');
         });
 
@@ -95,7 +95,7 @@ test.describe('Neo.ai.services.github-workflow.toolService — sync_all dev-bran
 
     test('sync_all REJECTS with git-error message when branch detector throws', async () => {
         const delegate = async () => { throw new Error('should not run'); };
-        const guarded = buildDevBranchGuard(delegate, async () => {
+        const guarded  = buildDevBranchGuard(delegate, async () => {
             throw new Error('git: not a git repository');
         });
 
@@ -125,7 +125,7 @@ test.describe('Neo.ai.services.github-workflow.toolService — getConversationRo
     let originalPrGetConversation;
 
     test.beforeAll(async () => {
-        const mod             = await import('../../../../../../ai/mcp/server/github-workflow/toolService.mjs');
+        const mod = await import('../../../../../../ai/mcp/server/github-workflow/toolService.mjs');
         getConversationRouter = mod.getConversationRouter;
         IssueService          = (await import('../../../../../../ai/services/github-workflow/IssueService.mjs')).default;
         PullRequestService    = (await import('../../../../../../ai/services/github-workflow/PullRequestService.mjs')).default;
@@ -237,8 +237,8 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
     });
 
     test('delegates a public write when expected agent and viewer login match', async () => {
-        let delegateCalls = 0;
-        const guarded = buildGitHubWriteIdentityGuard(async (...args) => {
+        let   delegateCalls = 0;
+        const guarded       = buildGitHubWriteIdentityGuard(async (...args) => {
             delegateCalls++;
             return {ok: true, args};
         }, {
@@ -256,28 +256,34 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
     });
 
     test('rejects a public write on identity mismatch before delegate invocation', async () => {
-        let delegateCalls = 0;
-        const guarded = buildGitHubWriteIdentityGuard(async () => {
+        let   delegateCalls  = 0;
+        let   assertionCalls = 0;
+        const guarded        = buildGitHubWriteIdentityGuard(async () => {
             delegateCalls++;
             return {ok: true};
         }, {
-            assertExpectedIdentity: async () => ({
-                ok    : false,
-                reason: 'identity drift: authed as neo-opus-ada, expected neo-gpt',
-                code  : 'LOGIN_MISMATCH'
-            })
+            assertExpectedIdentity: async () => {
+                assertionCalls++;
+                return {
+                    ok    : false,
+                    reason: 'identity drift: authed as neo-opus-ada, expected neo-gpt',
+                    code  : 'LOGIN_MISMATCH'
+                }
+            }
         });
 
         await expect(guarded()).rejects.toMatchObject({
-            code  : 'GITHUB_IDENTITY_MISMATCH',
-            reason: 'identity drift: authed as neo-opus-ada, expected neo-gpt'
+            code         : 'GITHUB_IDENTITY_MISMATCH',
+            identityClass: 'identity-mismatch',
+            reason       : 'identity drift: authed as neo-opus-ada, expected neo-gpt'
         });
         expect(delegateCalls).toBe(0);
+        expect(assertionCalls).toBe(1);
     });
 
     test('rejects a public write when expected identity is unresolved', async () => {
-        let delegateCalls = 0;
-        const guarded = buildGitHubWriteIdentityGuard(async () => {
+        let   delegateCalls = 0;
+        const guarded       = buildGitHubWriteIdentityGuard(async () => {
             delegateCalls++;
         }, {
             assertExpectedIdentity: async () => ({
@@ -293,28 +299,62 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
         expect(delegateCalls).toBe(0);
     });
 
-    test('rejects a public write when viewer login probe fails', async () => {
-        let delegateCalls = 0;
-        const guarded = buildGitHubWriteIdentityGuard(async () => {
+    test('retries transient empty-login resolution before delegating', async () => {
+        let   delegateCalls  = 0;
+        let   assertionCalls = 0;
+        const guarded        = buildGitHubWriteIdentityGuard(async () => {
+            delegateCalls++;
+            return {ok: true};
+        }, {
+            assertExpectedIdentity: async () => {
+                assertionCalls++;
+                return assertionCalls === 1
+                    ? {
+                        ok    : false,
+                        reason: 'identity drift: no authed login resolved, expected neo-gpt',
+                        code  : 'NO_AUTHED_LOGIN'
+                    }
+                    : {
+                        ok    : true,
+                        reason: null,
+                        code  : 'OK'
+                    }
+            }
+        });
+
+        await expect(guarded()).resolves.toEqual({ok: true});
+        expect(delegateCalls).toBe(1);
+        expect(assertionCalls).toBe(2);
+    });
+
+    test('rejects a public write when viewer login probe still fails after bounded retry', async () => {
+        let   delegateCalls  = 0;
+        let   assertionCalls = 0;
+        const guarded        = buildGitHubWriteIdentityGuard(async () => {
             delegateCalls++;
         }, {
-            assertExpectedIdentity: async () => ({
-                ok    : false,
-                reason: 'identity drift: no authed login resolved, expected neo-gpt',
-                code  : 'NO_AUTHED_LOGIN'
-            })
+            assertExpectedIdentity: async () => {
+                assertionCalls++;
+                return {
+                    ok    : false,
+                    reason: 'identity drift: no authed login resolved, expected neo-gpt',
+                    code  : 'NO_AUTHED_LOGIN'
+                }
+            }
         });
 
         await expect(guarded()).rejects.toMatchObject({
-            code: 'GITHUB_VIEWER_UNRESOLVED'
+            code         : 'GITHUB_VIEWER_UNRESOLVED',
+            identityClass: 'identity-resolution-transient'
         });
         expect(delegateCalls).toBe(0);
+        expect(assertionCalls).toBe(2);
     });
 
     test('guards public GitHub writes but leaves read and health tools untouched', async () => {
         const readHandler  = async () => ({read: true});
         const writeHandler = async () => ({write: true});
-        const mapping = guardGitHubWriteTools({
+        const mapping      = guardGitHubWriteTools({
             get_conversation    : readHandler,
             healthcheck         : readHandler,
             manage_issue_comment: writeHandler,
@@ -346,8 +386,8 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
 
     test('rejects service mappings with unclassified future tools (#13252)', () => {
         expect(() => guardGitHubWriteTools({
-            get_conversation       : async () => {},
-            future_public_mutation : async () => {}
+            get_conversation      : async () => {},
+            future_public_mutation: async () => {}
         })).toThrow(/Missing classification: future_public_mutation/);
     });
 


### PR DESCRIPTION
Resolves #14600

Adds one bounded retry inside the GitHub Workflow write identity guard for transient empty authed-login resolution while preserving fail-closed behavior for mismatches and unmappable expected identities. It also classifies guard failures with `identityClass` so transient infrastructure flaps do not look identical to spoof-class mismatches.

Evidence: L2 (guard-level retry/mismatch/error-class branch harness plus static/preflight checks) -> L2 required (bounded retry + distinct error classes + unit fixtures). No residuals.

## Deltas from ticket
- Preserves existing machine code `GITHUB_VIEWER_UNRESOLVED` for empty viewer-login failures and adds `identityClass: "identity-resolution-transient"` rather than renaming the code.
- Keeps mismatch and expected-identity configuration failures non-retryable.

## Test Evidence
- `node --check ai/mcp/server/github-workflow/toolService.mjs`
- `node --check test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs`
- `git diff --check`
- `npm run agent-preflight -- --no-fix ai/mcp/server/github-workflow/toolService.mjs test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs`
- Direct Node harness: `guard retry branches passed` for transient empty login -> success, persistent empty login -> `GITHUB_VIEWER_UNRESOLVED` / `identity-resolution-transient`, and `LOGIN_MISMATCH` -> `GITHUB_IDENTITY_MISMATCH` / `identity-mismatch`.
- Attempted focused Playwright unit runs; each stalled before test output and was interrupted:
  - `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs`
  - `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs -g "write identity guard"`
  - `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs -g "write identity guard" --reporter=line --timeout=15000`

## Post-Merge Validation
- [ ] Observe a GitHub Workflow MCP write after any transient empty viewer-login resolution under load; it should retry once before rejecting.
- [ ] Confirm CI unit coverage for `test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs` completes on the hosted runner.

## Commits
- `a9342dcdcc` — `fix(ai): retry transient GitHub identity resolution (#14600)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019f2c26-7b3d-7683-b23c-ec6b33131844.