### PR TITLE
feat(agentos): fleet cockpit ActivityStream — bounded, backpressure-aware feed (#14606)

### DIFF
--- a/apps/agentos/resources/fleet-components.css
+++ b/apps/agentos/resources/fleet-components.css
@@ -135,3 +135,65 @@
     white-space  : nowrap;
     text-overflow: ellipsis;
 }
+
+/* Activity stream: the live feed — a liveness header over bounded event rows (time · kind chip · text)
+   plus the "N more" fold. Rail-toned surface; every color from the --fm-* token layer. */
+.fm-activity-stream {
+    padding   : 12px 14px;
+    background: var(--fm-rail);
+    overflow  : hidden;
+}
+
+.fm-activity-stream .fm-stream-head {
+    margin-bottom : 8px;
+    font-family   : var(--fm-font-mono);
+    font-size     : 11px;
+    letter-spacing: .06em;
+}
+
+.fm-activity-stream .fm-stream-label {
+    text-transform: uppercase;
+    color         : var(--fm-ink-faint);
+}
+
+.fm-activity-stream .fm-stream-state {
+    color: var(--fm-ink-faint);
+}
+
+.fm-activity-stream .fm-stream-head.is-live .fm-stream-state {
+    color: var(--fm-signal);
+}
+
+.fm-activity-stream .fm-stream-head.is-stale .fm-stream-state {
+    color: var(--fm-state-wedged);
+}
+
+.fm-activity-stream .fm-ev-row {
+    gap          : 10px;
+    padding      : 8px 0;
+    border-bottom: 1px solid var(--fm-line-soft);
+}
+
+.fm-activity-stream .fm-ev-time {
+    padding-top: 1px;
+    font-family: var(--fm-font-mono);
+    font-size  : 10.5px;
+    color      : var(--fm-ink-faint);
+    white-space: nowrap;
+}
+
+.fm-activity-stream .fm-ev-text {
+    font-size    : 12.5px;
+    color        : var(--fm-ink);
+    overflow     : hidden;
+    white-space  : nowrap;
+    text-overflow: ellipsis;
+}
+
+.fm-activity-stream .fm-stream-fold {
+    padding    : 8px 0 0;
+    font-family: var(--fm-font-mono);
+    font-size  : 10.5px;
+    color      : var(--fm-ink-faint);
+    text-align : center;
+}

--- a/apps/agentos/view/fleet/ActivityStream.mjs
+++ b/apps/agentos/view/fleet/ActivityStream.mjs
@@ -1,0 +1,217 @@
+import Component from '../../../../src/component/Base.mjs';
+import Container from '../../../../src/container/Base.mjs';
+import EventChip from './EventChip.mjs';
+
+/**
+ * @summary Bound an activity-event list to the render window — the load-bearing backpressure core.
+ * Returns the newest `maxVisible` events (newest-first) plus the count folded out of view. The measured
+ * boot-burst density (bursts that overflow a small window in tens of seconds) makes this non-decorative:
+ * an unbounded feed freezes the frame (falsifying the engine story) and a silent drop falsifies the feed,
+ * so the window is bounded and the overflow is surfaced honestly. Pure + serializable; the component
+ * renders its result, so the bound is unit-provable in isolation.
+ * @param {Object[]} events Chronological (oldest→newest) activity events.
+ * @param {Number} maxVisible The render-window bound.
+ * @returns {Object} `{visible: Object[] newest-first, length <= maxVisible; overflowCount: Number}`
+ */
+export function boundActivity(events, maxVisible) {
+    const list          = Array.isArray(events) ? events : [],
+          bound         = Number.isInteger(maxVisible) && maxVisible > 0 ? maxVisible : 0,
+          overflowCount = Math.max(0, list.length - bound),
+          visible       = list.slice(overflowCount).reverse();
+
+    return {visible, overflowCount}
+}
+
+/**
+ * @summary The fleet cockpit's live activity feed — a bounded, backpressure-aware stream of A2A / PR /
+ * lane events. Composes {@link EventChip} for the kind chip (kind rendering delegates ENTIRELY to it —
+ * this view passes the event's type straight through and holds zero local kind logic; unknown types
+ * degrade to EventChip's neutral chip), timestamps each row, and caps the rendered window at
+ * `maxVisible` with an honest "N more" fold so a burst can never grow the DOM unbounded or silently
+ * drop. On adapter loss it degrades honestly — a stale banner, never a frozen feed. Event application
+ * rides the normal data->VDom flow; no manual DOM.
+ *
+ * The live-adapter binding and the NL-verified live mount are sibling leaves; this leaf is the component
+ * + its bounded-buffer contract, unit-provable against a burst fixture.
+ *
+ * @class AgentOS.view.fleet.ActivityStream
+ * @extends Neo.container.Base
+ */
+class ActivityStream extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.ActivityStream'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.ActivityStream',
+        /**
+         * @member {String} ntype='fm-activity-stream'
+         * @protected
+         */
+        ntype: 'fm-activity-stream',
+        /**
+         * @member {String[]} baseCls=['fm-activity-stream']
+         */
+        baseCls: ['fm-activity-stream'],
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * Chronological (oldest->newest) activity events; the feed renders the newest `maxVisible`.
+         * @member {Object[]} events_=[]
+         * @reactive
+         */
+        events_: [],
+        /**
+         * The render-window bound — the density-derived cap (default 15) beyond which events fold.
+         * @member {Number} maxVisible_=15
+         * @reactive
+         */
+        maxVisible_: 15,
+        /**
+         * Feed liveness — `live` streams; `stale` renders the degrade banner (adapter loss), never a
+         * silent freeze.
+         * @member {String} adapterState_='live'
+         * @reactive
+         */
+        adapterState_: 'live'
+    }
+
+    /**
+     * @summary Build the feed once constructed — the items are data-derived, so the initial render
+     * happens here rather than through static config.
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+        this.refreshFeed()
+    }
+
+    /**
+     * @param {Object[]} value
+     * @param {Object[]} oldValue
+     * @protected
+     */
+    afterSetEvents(value, oldValue) {
+        this.isConstructed && this.refreshFeed()
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetMaxVisible(value, oldValue) {
+        this.isConstructed && this.refreshFeed()
+    }
+
+    /**
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetAdapterState(value, oldValue) {
+        this.isConstructed && this.refreshFeed()
+    }
+
+    /**
+     * @summary Rebuild the bounded feed: the liveness header, the newest `maxVisible` event rows, and
+     * the "N more" fold when the burst exceeds the window. Bounded by construction — the rendered child
+     * count never exceeds the window + header + fold, regardless of event volume.
+     */
+    refreshFeed() {
+        const {visible, overflowCount} = boundActivity(this.events, this.maxVisible),
+              items                    = [this.headerConfig(), ...visible.map(event => this.rowConfig(event))];
+
+        if (overflowCount > 0) {
+            items.push(this.foldConfig(overflowCount))
+        }
+
+        this.removeAll(true);
+        this.add(items)
+    }
+
+    /**
+     * @summary The liveness header — a label + a streaming/stale indicator (the honest-degrade surface).
+     * @returns {Object}
+     */
+    headerConfig() {
+        const stale = this.adapterState === 'stale';
+
+        return {
+            module: Container,
+            cls   : ['fm-stream-head', stale ? 'is-stale' : 'is-live'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [
+                {module: Component, cls: ['fm-stream-label'], flex: 1,      text: 'Live activity'},
+                {module: Component, cls: ['fm-stream-state'], flex: 'none', text: stale ? 'stale — reconnecting' : '● streaming'}
+            ]
+        }
+    }
+
+    /**
+     * @summary One event row: timestamp, the kind chip (EventChip), and the text. The chip's kind is the
+     * event's type passed straight through — EventChip + the kind registry own the kind->visual mapping,
+     * so this row holds no kind logic and an unknown type degrades to the neutral chip.
+     * @param {Object} event
+     * @returns {Object}
+     */
+    rowConfig(event) {
+        return {
+            module: Container,
+            cls   : ['fm-ev-row'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'start'},
+            items : [
+                {module: Component, cls: ['fm-ev-time'], flex: 'none', text: this.formatTime(event?.occurredAt)},
+                {module: EventChip, flex: 'none', kind: event?.type},
+                {module: Component, cls: ['fm-ev-text'], flex: 1, text: this.eventText(event)}
+            ]
+        }
+    }
+
+    /**
+     * @summary The overflow fold — the honest count of events beyond the window (never a silent drop).
+     * @param {Number} overflowCount
+     * @returns {Object}
+     */
+    foldConfig(overflowCount) {
+        return {
+            module: Component,
+            cls   : ['fm-stream-fold'],
+            flex  : 'none',
+            text  : `${overflowCount} more`
+        }
+    }
+
+    /**
+     * @summary UTC HH:MM for a row timestamp — deterministic (no locale / timezone drift); an em dash
+     * when the event carries no time.
+     * @param {String|Number|null} occurredAt
+     * @returns {String}
+     */
+    formatTime(occurredAt) {
+        if (occurredAt == null) {
+            return '—'
+        }
+
+        const date = new Date(occurredAt);
+
+        return Number.isNaN(date.getTime()) ? '—' : date.toISOString().slice(11, 16)
+    }
+
+    /**
+     * @summary The row's human text — the event payload's summary when present, else an agent + type
+     * fallback so an un-summarized event still reads.
+     * @param {Object} event
+     * @returns {String}
+     */
+    eventText(event) {
+        return event?.payload?.text ?? event?.payload?.summary ?? `${event?.agentId ?? 'fleet'} · ${event?.type ?? 'event'}`
+    }
+}
+
+export default Neo.setupClass(ActivityStream);

--- a/test/playwright/unit/apps/agentos/view/fleet/activityStream.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/activityStream.spec.mjs
@@ -1,0 +1,97 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FleetActivityStreamTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import Instance       from '../../../../../../../src/manager/Instance.mjs';
+
+test.describe('Fleet cockpit ActivityStream — bounded, backpressure-aware feed (#14606)', () => {
+    let ActivityStream, boundActivity;
+
+    const makeEvents = n => Array.from({length: n}, (_, i) => ({
+        type      : 'a2a-activity',
+        source    : 'memory-core:mailbox',
+        agentId   : `agent-${i}`,
+        occurredAt: `2026-07-04T1${i % 10}:${String(i % 60).padStart(2, '0')}:00.000Z`,
+        payload   : {text: `event ${i}`}
+    }));
+
+    const rows = stream => stream.items.filter(item => item.cls.includes('fm-ev-row'));
+    const fold = stream => stream.items.find(item => item.cls.includes('fm-stream-fold'));
+    const head = stream => stream.items.find(item => item.cls.includes('fm-stream-head'));
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../apps/agentos/view/fleet/ActivityStream.mjs');
+        ActivityStream = mod.default;
+        boundActivity  = mod.boundActivity
+    });
+
+    test('boundActivity is the pure backpressure core — bound holds, overflow counted, newest-first', () => {
+        // the load-bearing requirement: a 100-event burst yields a bounded window + an honest overflow count
+        const {visible, overflowCount} = boundActivity(makeEvents(100), 15);
+        expect(visible.length).toBe(15);
+        expect(overflowCount).toBe(85);
+        // newest-first: the most-recent event heads the window
+        expect(visible[0].agentId).toBe('agent-99');
+        expect(visible[14].agentId).toBe('agent-85');
+
+        // edges: under-bound (no fold), exact-bound, empty, non-array, non-positive bound
+        expect(boundActivity(makeEvents(3), 15)).toMatchObject({overflowCount: 0});
+        expect(boundActivity(makeEvents(3), 15).visible.length).toBe(3);
+        expect(boundActivity(makeEvents(15), 15).overflowCount).toBe(0);
+        expect(boundActivity([], 15)).toEqual({visible: [], overflowCount: 0});
+        expect(boundActivity(null, 15)).toEqual({visible: [], overflowCount: 0});
+        expect(boundActivity(makeEvents(5), 0)).toEqual({visible: [], overflowCount: 5})
+    });
+
+    test('the component bounds the rendered DOM under a 100-event burst + renders the "N more" fold', () => {
+        const stream = Neo.create(ActivityStream, {appName, maxVisible: 15, events: makeEvents(100)});
+
+        // bounded: the rendered event rows never exceed the window regardless of event volume
+        expect(rows(stream).length).toBe(15);
+        // honest overflow: the fold surfaces the folded count — never a silent drop
+        expect(fold(stream)).toBeTruthy();
+        expect(fold(stream).text).toBe('85 more');
+
+        stream.destroy()
+    });
+
+    test('kind rendering delegates entirely to EventChip — unknown types still render a chip (neutral path)', () => {
+        const stream = Neo.create(ActivityStream, {
+            appName,
+            events: [
+                {type: 'pr-activity',           occurredAt: '2026-07-04T10:00:00.000Z', payload: {text: 'a'}},
+                {type: 'totally-unknown-kind',  occurredAt: '2026-07-04T10:01:00.000Z', payload: {text: 'b'}}
+            ]
+        });
+
+        // every row composes an EventChip (the chip is the only kind surface — zero local kind logic here)
+        expect(stream.down({ntype: 'fm-event-chip'})).toBeTruthy();
+        // the unknown-kind row still renders (EventChip's neutral fallback), never dropped
+        expect(rows(stream).length).toBe(2);
+
+        stream.destroy()
+    });
+
+    test('degrades honestly on adapter loss — a stale header, never a blanked feed', () => {
+        const stream = Neo.create(ActivityStream, {appName, adapterState: 'stale', events: makeEvents(3)});
+
+        expect(head(stream).cls).toContain('is-stale');
+        // the rows still render — degrade surfaces the state, it does not blank the feed
+        expect(rows(stream).length).toBe(3);
+
+        stream.destroy()
+    });
+});


### PR DESCRIPTION
Resolves #14831 (the unit-provable component slice) · Refs #14606 (parent — live binding to #14572/#14573 + NL-verifiable live mount remain OPEN, host-gated) · Refs #14560 (Lane B epic) · Refs #14594 (EventChip, merged — composed here) · Refs #14592 (density numbers)

Lane B2 of the cockpit plan: the activity feed — where "real-time is the spine" is proven or falsified. The load-bearing requirement (per #14592: ~9 events/min bursts overflow a small window in ~35s) is a bounded window with honest overflow — never an unbounded feed (frame-freeze) or a silent drop (falsified feed).

**Close-target scope (cross-family review, @neo-gpt on PR #14827):** #14606 bundled the component with host-gated live wiring, so `Resolves #14606` overclaimed. This PR now Resolves the unit-provable **component slice** (#14831); the live binding to the #14572/#14573 adapters + the NL-verifiable live mount stay OPEN on #14606. V-B-A confirmed the split is structural, not cosmetic: the adapters are server-side services (`ai/services/fleet/fleet*ActivityAdapter.mjs`) and **no cockpit host view mounts the fleet components yet** — so the binding/mount genuinely cannot land in this slice.

Evidence: L2 — `activityStream.spec.mjs` **4/4 green** (pure bound under a 100-event burst; component DOM bound + fold; EventChip delegation incl. unknown→neutral; honest degrade). L2 fully covers #14831's component-only ACs.

## What it builds

`apps/agentos/view/fleet/ActivityStream.mjs`:
- **`boundActivity(events, maxVisible)`** — the pure backpressure core: the newest `maxVisible` events (newest-first) + the folded `overflowCount`. Unit-provable in isolation.
- **The component** (`extends Container`) — renders the liveness header, the bounded event rows (timestamp · kind chip · text), and the "N more" fold. Rebuilt bounded on every events change, so the rendered child count never exceeds the window regardless of event volume.
- **Kind rendering delegates entirely to EventChip** — `event.type` passed straight through (kindRegistry already maps every DTO type; unknown → neutral). Zero local kind logic here.
- **Honest degrade** — `adapterState: 'stale'` renders a stale header, never a blanked/frozen feed (component-level, config-driven).
- Single-text pieces use the Component `text` config; timestamps are deterministic UTC HH:MM (no locale/tz flake).
- `.fm-activity-stream` CSS anatomy (token-only, matching the cockpit-plan stream).

## Test Evidence

`npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/activityStream.spec.mjs` → **4 passed** (exit 0):
1. `boundActivity` — bound holds under a 100-event burst (visible 15, overflow 85, newest-first) + edges (empty, exact-bound, non-array, zero-bound).
2. the component bounds the rendered rows to 15 + renders the "85 more" fold.
3. kind delegation — an unknown type still renders a chip (EventChip's neutral path); rows never dropped.
4. degrade — a stale header, feed not blanked.

## Post-Merge Validation

- [ ] With this on dev, the ActivityStream renders a bounded feed from an event array. The remaining #14606 ACs — live binding to the A2A/PR adapters (#14572/#14573), the NL-verified live mount, and the burst e2e (T3.13) — stay open on #14606, gated on the cockpit host view.

## Deltas from ticket (#14831)

The component + the bounded-buffer contract + the spec + the CSS anatomy — the full #14831 scope. Live-adapter binding, the NL mount, and the burst e2e remain on #14606 (host-gated), out of this slice. Full-rebuild on events change (correctness); incremental/virtualized application is a perf refinement, not needed for the bound the AC tests.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
