### PR TITLE
feat(dashboard): transferItem executor — atomic two-document item transfer (#14768)

### DIFF
--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -91,7 +91,11 @@ class DockZoneModel extends Base {
         detachItem       : (document, descriptor) => DockZoneModel.detachItem(document, descriptor),
         closeItem        : (document, descriptor) => DockZoneModel.closeItem(document, descriptor),
         setItemPinned    : (document, descriptor) => DockZoneModel.setItemPinned(document, descriptor),
-        setItemAutoHidden: (document, descriptor) => DockZoneModel.setItemAutoHidden(document, descriptor)
+        setItemAutoHidden: (document, descriptor) => DockZoneModel.setItemAutoHidden(document, descriptor),
+        // transferItem is a TWO-document operation; its single-document dispatch is a fail-closed
+        // redirect so the op still joins the derived `operations` vocabulary without a hand-listed
+        // entry. Execute it through DockZoneModel.transferItem(sourceDocument, targetDocument, …).
+        transferItem     : document => ({document, errors: ['transferItem is a two-document operation; call DockZoneModel.transferItem(sourceDocument, targetDocument, descriptor)']})
     })
 
     /**
@@ -1702,6 +1706,69 @@ class DockZoneModel extends Base {
         return handler
             ? handler(document, descriptor)
             : {document, errors: [`unknown operation "${descriptor.operation}"`]}
+    }
+
+    /**
+     * @summary Atomically transfers `itemId` out of `sourceDocument` and into `targetDocument` in one
+     * commit-or-neither step: the item is removed from the source tree + catalog and placed into the
+     * target through the nested `target` placement descriptor. The item record travels verbatim — no
+     * re-instantiation semantics enter the executor, which operates on documents only.
+     *
+     * Fail-closed and atomic: a validation error on EITHER document returns BOTH inputs untouched plus
+     * a non-empty `errors` array, so a half-transferred item — removed here but not placed there, the
+     * contract's named violation — can never commit. The nested `target` is dispatched through the
+     * landed single-document placement path (`addTab` / `splitNode` via {@link #applyOperation}), so
+     * no second placement grammar is introduced.
+     *
+     * The executor is document-centric: `sourceWorkspaceId` / `targetWorkspaceId` are the caller's
+     * (adapter-tier) resolution keys, used here only to reject a same-workspace transfer — that is a
+     * `moveItem`, not a transfer.
+     * @param {Object} sourceDocument the committed dock-zone document the item leaves
+     * @param {Object} targetDocument the committed dock-zone document the item joins
+     * @param {Object} descriptor {itemId, sourceWorkspaceId, targetWorkspaceId, target}
+     * @returns {{sourceDocument:Object, targetDocument:Object, errors:String[]}}
+     * @static
+     */
+    static transferItem(sourceDocument, targetDocument, {itemId, sourceWorkspaceId, targetWorkspaceId, target} = {}) {
+        let fail   = errors => ({sourceDocument, targetDocument, errors}),
+            record = sourceDocument?.items?.[itemId];
+
+        // Preconditions checked against BOTH documents before any mutation (fail-closed).
+        if (!record)                         return fail([`unknown item "${itemId}"`]);
+        if (record.movable === false)        return fail([`item "${itemId}" is not movable`]);
+        if (targetDocument?.items?.[itemId]) return fail([`item "${itemId}" already exists in the target document`]);
+        if (sourceWorkspaceId !== undefined && sourceWorkspaceId === targetWorkspaceId) {
+            return fail(['transferItem requires distinct source and target workspaces'])
+        }
+        if (!target || (target.operation !== 'addTab' && target.operation !== 'splitNode')) {
+            return fail(['transferItem target must be an addTab or splitNode descriptor'])
+        }
+
+        // Source side: drop from the tree (a no-op for an already-detached item) + catalog, then
+        // normalize + validate through the shared fail-closed commit.
+        let sourceWorking = DockZoneModel.clone(sourceDocument);
+
+        DockZoneModel.detachFromTabs(sourceWorking, itemId);
+        delete sourceWorking.items[itemId];
+
+        let sourceResult = DockZoneModel.commit(sourceDocument, sourceWorking);
+
+        // Target side: insert the verbatim record into the catalog, then place it through the landed
+        // single-document dispatch (which normalizes + validates the target tree). The transfer's
+        // `itemId` overrides any id the caller left in the nested descriptor.
+        let targetWorking = DockZoneModel.clone(targetDocument);
+
+        targetWorking.items[itemId] = DockZoneModel.clone(record);
+
+        let targetResult = DockZoneModel.applyOperation(targetWorking, {...target, itemId}),
+            errors       = [...sourceResult.errors, ...targetResult.errors];
+
+        // Commit-or-neither: any error on either side rolls the whole transfer back to both inputs.
+        if (errors.length) {
+            return fail(errors)
+        }
+
+        return {sourceDocument: sourceResult.document, targetDocument: targetResult.document, errors: []}
     }
 }
 

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1396,5 +1396,142 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
                 expect(DockZoneModel.validate(document)).toEqual([])
             })
         }
-    })
+    });
+
+    test.describe('transferItem (atomic two-document transfer)', () => {
+        // A second workspace document with a distinct catalog, so a transfer into it never
+        // collides on item id with the source doc()'s 'terminal'.
+        const target = () => ({
+            schema: 'neo.harness.dockZone.v1',
+            root  : 'root',
+            items : {alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel'}},
+            nodes : {
+                root       : {type: 'edge-zone', zones: {center: 'main-tabs'}},
+                'main-tabs': {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'}
+            }
+        });
+
+        const addTabTarget = {operation: 'addTab', tabsNodeId: 'main-tabs'};
+
+        test('moves an item across documents: source loses it (tree + catalog), target gains it, both valid', () => {
+            const {sourceDocument, targetDocument, errors} = DockZoneModel.transferItem(doc(), target(), {
+                itemId: 'terminal', sourceWorkspaceId: 'A', targetWorkspaceId: 'B', target: addTabTarget
+            });
+
+            expect(errors).toEqual([]);
+            // source: terminal gone from catalog + tree; the emptied side-tabs collapsed + its edge zone pruned
+            expect(sourceDocument.items.terminal).toBeUndefined();
+            expect(DockZoneModel.findContainingTabsId(sourceDocument, 'terminal')).toBeNull();
+            expect(sourceDocument.nodes['side-tabs']).toBeUndefined();
+            expect(sourceDocument.nodes.root.zones.right).toBeUndefined();
+            // target: terminal now in catalog + main-tabs tree
+            expect(targetDocument.items.terminal).toBeDefined();
+            expect(targetDocument.nodes['main-tabs'].items).toContain('terminal');
+            // both documents remain contract-valid
+            expect(DockZoneModel.validate(sourceDocument)).toEqual([]);
+            expect(DockZoneModel.validate(targetDocument)).toEqual([])
+        });
+
+        test('the item record travels verbatim — policy hints, metadata, and a railed autoHidden state intact', () => {
+            const record = {componentRef: 'terminal', title: 'Terminal', kind: 'terminal', closable: false, pinnable: true, movable: true, autoHidden: true, metadata: {pid: 42}};
+            const source = doc();
+
+            source.items.terminal = {...record};
+
+            const {targetDocument, errors} = DockZoneModel.transferItem(source, target(), {itemId: 'terminal', target: addTabTarget});
+
+            expect(errors).toEqual([]);
+            expect(targetDocument.items.terminal).toEqual(record);        // verbatim, incl. autoHidden
+            expect(DockZoneModel.validate(targetDocument)).toEqual([])    // a railed item is a valid arrival
+        });
+
+        test('atomic: a target-side placement failure leaves BOTH documents untouched (source byte-identical)', () => {
+            const source         = doc();
+            const tgt            = target();
+            const sourceSnapshot = JSON.parse(JSON.stringify(source));
+            const tgtSnapshot    = JSON.parse(JSON.stringify(tgt));
+
+            // the nested target points at a node that does not exist → placement fails
+            const {sourceDocument, targetDocument, errors} = DockZoneModel.transferItem(source, tgt, {
+                itemId: 'terminal', target: {operation: 'addTab', tabsNodeId: 'ghost-tabs'}
+            });
+
+            expect(errors.length).toBeGreaterThan(0);
+            expect(sourceDocument).toEqual(sourceSnapshot);   // source never half-transferred
+            expect(targetDocument).toEqual(tgtSnapshot);      // target never received it
+            expect(sourceDocument.items.terminal).toBeDefined()
+        });
+
+        test('rejects an unmovable item fail-closed, both documents untouched', () => {
+            const source = doc();
+
+            source.items.terminal.movable = false;
+
+            const {sourceDocument, targetDocument, errors} = DockZoneModel.transferItem(source, target(), {itemId: 'terminal', target: addTabTarget});
+
+            expect(errors.join(' ')).toContain('movable');
+            expect(sourceDocument.items.terminal).toBeDefined();
+            expect(targetDocument.items.terminal).toBeUndefined()
+        });
+
+        test('rejects an unknown item fail-closed', () => {
+            const {errors} = DockZoneModel.transferItem(doc(), target(), {itemId: 'ghost', target: addTabTarget});
+            expect(errors.join(' ')).toContain('unknown item')
+        });
+
+        test('rejects a transfer when the target already holds the item id', () => {
+            const tgt = target();
+
+            tgt.items.terminal = {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'};
+
+            const {errors} = DockZoneModel.transferItem(doc(), tgt, {itemId: 'terminal', target: addTabTarget});
+            expect(errors.join(' ')).toContain('already exists in the target')
+        });
+
+        test('rejects a same-workspace transfer (that is a moveItem, not a transfer)', () => {
+            const {errors} = DockZoneModel.transferItem(doc(), target(), {
+                itemId: 'terminal', sourceWorkspaceId: 'A', targetWorkspaceId: 'A', target: addTabTarget
+            });
+
+            expect(errors.join(' ')).toContain('distinct source and target')
+        });
+
+        test('rejects a nested target that is not a placement descriptor (addTab / splitNode)', () => {
+            const {errors} = DockZoneModel.transferItem(doc(), target(), {itemId: 'terminal', target: {operation: 'closeItem'}});
+            expect(errors.join(' ')).toContain('addTab or splitNode')
+        });
+
+        test('reuses the landed placement validation — a malformed nested target fails closed, source untouched', () => {
+            const {sourceDocument, errors} = DockZoneModel.transferItem(doc(), target(), {
+                itemId: 'terminal', target: {operation: 'splitNode', targetNodeId: 'main-tabs', orientation: 'sideways'}
+            });
+
+            expect(errors.length).toBeGreaterThan(0);
+            expect(sourceDocument.items.terminal).toBeDefined()
+        });
+
+        test('places via a splitNode target descriptor', () => {
+            const {targetDocument, errors} = DockZoneModel.transferItem(doc(), target(), {
+                itemId: 'terminal',
+                target: {operation: 'splitNode', targetNodeId: 'main-tabs', orientation: 'vertical', position: 'after', sizes: [0.5, 0.5]}
+            });
+
+            expect(errors).toEqual([]);
+            expect(targetDocument.items.terminal).toBeDefined();
+            expect(DockZoneModel.findContainingTabsId(targetDocument, 'terminal')).not.toBeNull();
+            expect(DockZoneModel.validate(targetDocument)).toEqual([])
+        });
+
+        test('applyOperation redirects a single-document transferItem descriptor to the two-document method', () => {
+            const input              = doc();
+            const {document, errors} = DockZoneModel.applyOperation(input, {operation: 'transferItem', itemId: 'terminal'});
+
+            expect(errors.join(' ')).toContain('two-document operation');
+            expect(document).toEqual(input)   // untouched
+        });
+
+        test('transferItem joins the exported operation vocabulary (SSOT)', () => {
+            expect(DockZoneModel.operations).toContain('transferItem')
+        })
+    });
 });


### PR DESCRIPTION
Resolves #14768

Refs #13158 (parent epic, decomposition tree line **C3**) · authority `learn/agentos/decisions/0029-harness-docking-design.md` §2.3 · unblocked by the merged C1 receiving-window target (#14757) and the operation-vocabulary SSOT (#14813 / #14715).

The **`transferItem`** executor — the operation a cross-window drop ultimately commits. C1 (#14757) landed the receiving-window *target* contract but explicitly deferred the operation itself: a drop could only commit same-document ops, and any ad-hoc "remove here, add there" can strand a half-transferred item (the ADR names that a contract violation, not an error state). This is the atomic two-document operation that closes the gap.

**The op** (`src/dashboard/DockZoneModel.mjs`):
- `transferItem(sourceDocument, targetDocument, {itemId, sourceWorkspaceId, targetWorkspaceId, target})` → `{sourceDocument, targetDocument, errors}`.
- Removes the item from the source tree + catalog, inserts the **verbatim** record into the target catalog, and places it via the nested `target` descriptor (`{operation: 'addTab'|'splitNode', …}`) — dispatched through the landed single-document `applyOperation`, so no second placement grammar is introduced.
- **Atomic, fail-closed, commit-or-neither:** a validation error on *either* document returns BOTH inputs untouched + a non-empty `errors` array. A half-transferred item cannot commit.
- **Document-centric:** `sourceWorkspaceId` / `targetWorkspaceId` are the caller's (adapter-tier) resolution keys; used here only to reject a same-workspace transfer (that is a `moveItem`).
- **Vocabulary SSOT:** joins the derived `operations` export via a fail-closed two-document *redirect* entry in `operationHandlers` — so the op is advertised and cannot diverge from dispatch, while single-document `applyOperation` guides a caller to the two-document method.

## AC mapping
- **Atomic two-document commit-or-neither** — spec: a forced target-side failure leaves the source byte-identical.
- **Item record travels verbatim** — no re-instantiation; spec covers policy hints, metadata, and a railed `autoHidden: true` (a railed item transfers its committed state).
- **Nested `target` reuses landed placement validation** — dispatched through `applyOperation`; a malformed placement fails closed.
- **Fail-closed `{sourceDocument, targetDocument, errors}` result; policy hints enforced** — `movable: false`, unknown item, target-id collision, and same-workspace all reject.

## Deltas from ticket
- The nested placement is dispatched through `applyOperation` (the landed SSOT dispatch) rather than calling `addTab` / `splitNode` directly — same landed validation, zero new placement grammar, and it auto-tracks the vocabulary.
- `transferItem` joins `operations` via a fail-closed redirect handler (a two-document op cannot execute on the single-document path); the ticket's "joins whatever exported vocabulary shape #14715 landed" resolves to this. Consumer consequence (verified): `Neo.ai.client.DockService` now advertises `transferItem` in `getDockTopology`, and its single-holder `executeDockOperation` returns a structured `applied:false` redirect — the two-holder execution wiring is the participation leaf (#14769), out of scope here.

## Test Evidence
`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs DockZoneModel` → **91 passed** (12 new `transferItem` specs: cross-document move + source-slot collapse, verbatim record incl. railed `autoHidden`, atomicity on target-side failure, `movable` / unknown-item / target-collision / same-workspace / non-placement fail-closed, malformed-placement fail-closed, `splitNode` variant, `applyOperation` redirect, SSOT vocabulary membership).

Consumer regression check: `… DockService` → **12 passed** — the vocabulary-by-reference consumer is unaffected.

Evidence: L2 (unit-pinned pure logic at exact head; the ACs are the specs). Live multi-window gesture evidence arrives with the consuming C-tranche wiring + demo leaves (out of scope per the ticket).

## Post-Merge Validation
- The participation-wiring leaf (#14769) binds `transferItem` behind the C1 receiving-window target's `commitOperation` seam: a real pane dragged across two harness windows commits through this op, and the two-holder `DockService` execution path lands there.
- No standalone validation owed by this leaf — the executor contract + unit floor are complete at head.

## Authored-by
Authored by Grace (@neo-opus-grace, Claude Opus 4.8, Claude Code). Session 9e42a8de-4291-46fc-944e-92ceb0db1748.

Cross-family review: @neo-gpt (Euclid / GPT) is the mandatory cross-family leg; operator-last human merge. I authored this leaf under the epic owner's drive, so my #13158 authorship does not self-review it.
