### PR TITLE
feat(agentos): FM cockpit fleet grid + health bar component slice (#14833)

### DIFF
--- a/apps/agentos/resources/fleet-components.css
+++ b/apps/agentos/resources/fleet-components.css
@@ -197,3 +197,71 @@
     color      : var(--fm-ink-faint);
     text-align : center;
 }
+
+/* Fleet grid: the cockpit's default view (SSOT §01 fleet zone) — a health-summary header over a
+   density-ranked card grid. 3-col desktop, collapsing responsively; every color from the token layer. */
+.fm-fleet-grid {
+    padding: 16px;
+    gap    : 12px;
+}
+
+.fm-fleet-grid .fm-fleet-head {
+    gap        : 10px;
+    font-family: var(--fm-font-mono);
+    font-size  : 11px;
+}
+
+.fm-fleet-grid .fm-fleet-title {
+    letter-spacing: .14em;
+    text-transform: uppercase;
+    color         : var(--fm-ink-faint);
+}
+
+.fm-fleet-grid .fm-fleet-stale {
+    color: var(--fm-ink-faint);
+}
+
+.fm-fleet-grid .fm-fleet-head.is-stale .fm-fleet-stale {
+    color: var(--fm-state-wedged);
+}
+
+.fm-fleet-grid .fm-fleet-cards {
+    display              : grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap                  : 9px;
+    align-content        : start;
+}
+
+@media (max-width: 1024px) {
+    .fm-fleet-grid .fm-fleet-cards { grid-template-columns: repeat(2, minmax(0, 1fr)) }
+}
+
+@media (max-width: 640px) {
+    .fm-fleet-grid .fm-fleet-cards { grid-template-columns: 1fr }
+}
+
+/* Collapsed-idle fold: the calm tier summarised as a count spanning the row (never a silent drop),
+   so the online tier stays in view at 12-20+ agent scale. */
+.fm-fleet-grid .fm-fleet-fold {
+    grid-column  : 1 / -1;
+    padding      : 8px 0;
+    font-family  : var(--fm-font-mono);
+    font-size    : 10.5px;
+    color        : var(--fm-ink-faint);
+    text-align   : center;
+    border       : 1px dashed var(--fm-line-soft);
+    border-radius: 8px;
+}
+
+/* Health bar: the scale-to-a-glance strip of swatch units with live counts. The count VALUE carries
+   the signal; the transition is decoration, gated behind BOTH the animateCounts switch and
+   prefers-reduced-motion (reduced-motion users lose nothing informational). */
+.fm-health-bar {
+    gap: 12px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .fm-health-bar.fm-animate-counts .fm-sw-count {
+        transition: color .3s ease, opacity .3s ease;
+    }
+}

--- a/apps/agentos/view/fleet/FleetGrid.mjs
+++ b/apps/agentos/view/fleet/FleetGrid.mjs
@@ -1,0 +1,233 @@
+import AgentCard from './AgentCard.mjs';
+import Component from '../../../../src/component/Base.mjs';
+import Container from '../../../../src/container/Base.mjs';
+import HealthBar from './HealthBar.mjs';
+
+/**
+ * Whether a session state is "online" — present and engaged (working, or present-but-blocked /
+ * rate-limited). These lead the grid and are never folded: a wedged or rate-limited agent is a
+ * thing the operator must see, not calm background. `idle` is its own middle tier; everything
+ * else (benched / offline / unknown-guest) is the tail.
+ * @param {String} state
+ * @returns {Boolean}
+ */
+const isOnline = state => state === 'ok' || state === 'limited' || state === 'wedged';
+
+/**
+ * @summary Pure fleet ranking — the deterministic fold ordering the measured fleet-density evidence
+ * requires. Partitions the roster into three tiers — **online** (working/wedged/rate-limited, lead,
+ * never folded), **idle** (the calm middle, collapsible), and **benched** (offline + unknown-guest
+ * tail) — each sorted by `agentId` so identical inputs produce byte-identical order (snapshot-stable,
+ * no dependence on roster arrival order). `folded` trips at `foldThreshold` registered agents: below
+ * it the grid shows every card (the 3-col view); at/above it the idle tier collapses to a count so a
+ * 12–20-agent fleet never buries the online agents under a wall of idle cards. Pure + serializable;
+ * the grid renders its result, so the ordering is unit-provable in isolation.
+ * @param {Object[]} agents Roster entries carrying a `state` field.
+ * @param {Object} [options]
+ * @param {Number} [options.foldThreshold=12] Registered-agent count at/above which the idle tier collapses.
+ * @returns {{online: Object[], idle: Object[], benched: Object[], folded: Boolean, idleCount: Number, total: Number}}
+ */
+export function rankFleet(agents, {foldThreshold = 12} = {}) {
+    const list = Array.isArray(agents) ? agents : [],
+          byId = (a, b) => String(a?.agentId ?? '').localeCompare(String(b?.agentId ?? '')),
+
+          online  = list.filter(agent => isOnline(agent?.state)).sort(byId),
+          idle    = list.filter(agent => agent?.state === 'idle').sort(byId),
+          benched = list.filter(agent => !isOnline(agent?.state) && agent?.state !== 'idle').sort(byId),
+
+          folded  = list.length >= foldThreshold;
+
+    return {online, idle, benched, folded, idleCount: idle.length, total: list.length}
+}
+
+/**
+ * @summary The fleet grid — the cockpit's default view (SSOT §01 fleet zone): a health-summary bar
+ * over a ranked, density-aware grid of {@link AgentCard}s. Composes the built primitives (AgentCard ·
+ * {@link HealthBar} → HealthSwatch/StateDot) and lays them out against the MEASURED fleet density
+ * rather than the mock's six-agent assumption: below `foldThreshold` every card renders (the 3-col
+ * view); at/above it the idle tier collapses to a count so the online agents stay in view at 12–20+
+ * scale. The header (title + health bar) is a STABLE sub-tree updated in place — only the card set
+ * rebuilds on a roster change, so the glance-instrument counts animate rather than flashing. On
+ * adapter loss it degrades honestly — a stale banner over the last-known roster, never a blanked grid.
+ *
+ * The live-roster / runtime-status wire binding and the NL-verified mount at live scale are
+ * sibling leaves; this leaf is the grid component + its ranking contract, unit-provable against
+ * fixture rosters.
+ *
+ * @class AgentOS.view.fleet.FleetGrid
+ * @extends Neo.container.Base
+ */
+class FleetGrid extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.FleetGrid'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.FleetGrid',
+        /**
+         * @member {String} ntype='fm-fleet-grid'
+         * @protected
+         */
+        ntype: 'fm-fleet-grid',
+        /**
+         * @member {String[]} baseCls=['fm-fleet-grid']
+         */
+        baseCls: ['fm-fleet-grid'],
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * The roster to render — every card and the health counts derive from it.
+         * @member {Object[]} agents_=[]
+         * @reactive
+         */
+        agents_: [],
+        /**
+         * Registered-agent count at/above which the idle tier collapses to a count (density-derived).
+         * Config-driven so the threshold is tunable, not hard-coded at the call site.
+         * @member {Number} foldThreshold_=12
+         * @reactive
+         */
+        foldThreshold_: 12,
+        /**
+         * Feed liveness — `live` renders normally; `stale` renders the degrade banner over the
+         * last-known roster (never a blanked grid).
+         * @member {String} adapterState_='live'
+         * @reactive
+         */
+        adapterState_: 'live',
+        /**
+         * A STABLE surface: the header (title · stale marker · flex spacer · live {@link HealthBar})
+         * and the card region. Only the card region's items rebuild on a roster change — the header
+         * and its health bar are updated in place so the counts animate rather than flash.
+         * @member {Object[]} items
+         */
+        items: [{
+            ntype    : 'container',
+            cls      : ['fm-fleet-head', 'is-live'],
+            flex     : 'none',
+            layout   : {ntype: 'hbox', align: 'center'},
+            reference: 'fleet-head',
+
+            items: [
+                {module: Component, cls: ['fm-fleet-title'], reference: 'fleet-title', flex: 'none', text: 'Fleet · 0 agents'},
+                {module: Component, cls: ['fm-fleet-stale'], reference: 'fleet-stale', flex: 'none', text: ''},
+                {ntype: 'component', flex: 1},
+                {module: HealthBar, reference: 'fleet-health', flex: 'none'}
+            ]
+        }, {
+            ntype    : 'container',
+            cls      : ['fm-fleet-cards'],
+            flex     : 1,
+            layout   : {ntype: 'base'},
+            reference: 'fleet-cards',
+            items    : []
+        }]
+    }
+
+    /**
+     * @summary Populate the roster-derived surface once constructed (the header sub-tree exists from
+     * static config; its content + the card set are data-derived).
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+        this.refreshGrid()
+    }
+
+    /**
+     * @param {Object[]} value
+     * @param {Object[]} oldValue
+     * @protected
+     */
+    afterSetAgents(value, oldValue) {
+        this.isConstructed && this.refreshGrid()
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetFoldThreshold(value, oldValue) {
+        this.isConstructed && this.refreshGrid()
+    }
+
+    /**
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetAdapterState(value, oldValue) {
+        this.isConstructed && this.refreshGrid()
+    }
+
+    /**
+     * @summary Refresh the surface: update the stable header in place (title · stale marker · health
+     * bar counts) and rebuild only the ranked card set (online cards → collapsed-idle fold when over
+     * threshold, else idle cards → benched tail).
+     */
+    refreshGrid() {
+        const rank  = rankFleet(this.agents, {foldThreshold: this.foldThreshold}),
+              stale = this.adapterState === 'stale';
+
+        // header — updated in place; the health bar instance persists so counts animate, not flash
+        this.getReference('fleet-title').text    = `Fleet · ${rank.total} agents`;
+        this.getReference('fleet-stale').text    = stale ? 'stale — reconnecting' : '';
+        this.getReference('fleet-health').agents = this.agents;
+        this.getReference('fleet-head').cls      = ['fm-fleet-head', stale ? 'is-stale' : 'is-live'];
+
+        // card set — rebuilt (the visible cards change with the roster)
+        const cards = [...rank.online.map(agent => this.agentCardConfig(agent))];
+
+        if (rank.folded) {
+            rank.idleCount > 0 && cards.push(this.foldConfig(rank.idleCount))
+        } else {
+            cards.push(...rank.idle.map(agent => this.agentCardConfig(agent)))
+        }
+
+        cards.push(...rank.benched.map(agent => this.agentCardConfig(agent)));
+
+        const cardsContainer = this.getReference('fleet-cards');
+
+        cardsContainer.removeAll(true);
+        cardsContainer.add(cards)
+    }
+
+    /**
+     * @summary One AgentCard config from a roster entry — maps the entry onto the card's per-card
+     * `stateProvider.data` binding surface (the card owns its own render; this just seeds it).
+     * @param {Object} agent
+     * @returns {Object}
+     */
+    agentCardConfig(agent) {
+        return {
+            module       : AgentCard,
+            stateProvider: {
+                data: {
+                    agentId    : agent?.agentId     ?? null,
+                    avatarUrl  : agent?.avatarUrl   ?? null,
+                    displayName: agent?.displayName ?? null,
+                    engineTag  : agent?.engineTag   ?? null,
+                    family     : agent?.family      ?? null,
+                    laneLine   : agent?.laneLine    ?? null,
+                    state      : agent?.state       ?? 'off'
+                }
+            }
+        }
+    }
+
+    /**
+     * @summary The collapsed-idle fold — the honest count of idle agents held out of the grid at
+     * scale (never a silent drop; the calm tier is summarised, the online tier stays in view).
+     * @param {Number} idleCount
+     * @returns {Object}
+     */
+    foldConfig(idleCount) {
+        return {module: Component, cls: ['fm-fleet-fold'], text: `${idleCount} idle`}
+    }
+}
+
+export default Neo.setupClass(FleetGrid);

--- a/apps/agentos/view/fleet/HealthBar.mjs
+++ b/apps/agentos/view/fleet/HealthBar.mjs
@@ -1,0 +1,147 @@
+import Container    from '../../../../src/container/Base.mjs';
+import HealthSwatch from './HealthSwatch.mjs';
+
+/**
+ * Canonical category order for the health summary — the five session-state buckets in the SSOT
+ * legend order (working · idle · wedged · rate-limited · benched/offline). One vocabulary shared
+ * with {@link HealthSwatch} / {@link StateDot} on the agent-health axis.
+ * @type {String[]}
+ */
+const HEALTH_ORDER = ['ok', 'idle', 'wedged', 'limited', 'off'];
+
+/**
+ * @summary Pure fleet → per-category counts — the scale-to-a-glance tally.
+ * Buckets each agent's session `state` into the five canonical categories — the SSOT legend has no
+ * sixth category, so an unknown / guest / unsupported runtime state folds into `off` (benched-offline),
+ * matching the grid's benched tier, rather than a literal key the five-swatch bar would never render.
+ * Every agent therefore lands in a RENDERED bucket and the visible bar total can never undercount the
+ * roster. Pure + serializable; the bar renders its result, so the tally is unit-provable in isolation.
+ * @param {Object[]} agents Roster entries carrying a `state` field.
+ * @returns {Object} `{ok, idle, wedged, limited, off}` — exactly the five canonical keys (zero-filled); the counts sum to the roster length.
+ */
+export function healthCounts(agents) {
+    const list   = Array.isArray(agents) ? agents : [],
+          counts = {ok: 0, idle: 0, wedged: 0, limited: 0, off: 0};
+
+    list.forEach(agent => {
+        // canonical state → its own bucket; anything else (guest/unknown/absent) → off, never a 6th key
+        const bucket = Object.hasOwn(counts, agent?.state) ? agent.state : 'off';
+
+        counts[bucket] += 1
+    });
+
+    return counts
+}
+
+/**
+ * @summary The fleet health-summary bar — the scale-to-a-glance instrument:
+ * the counts must read before any single card does. Composes one {@link HealthSwatch} per canonical
+ * category (working · idle · wedged · rate-limited · benched) in legend order, each carrying its live
+ * count. The swatch instances are STABLE across roster changes — `afterSetAgents` updates their
+ * counts in place rather than rebuilding — so a count transition animates smoothly instead of
+ * flashing, and the CSS pulse stays gated behind `prefers-reduced-motion` (the count value, not the
+ * motion, carries the signal).
+ *
+ * The live-roster wire binding is the sibling leaf; this leaf renders whatever roster it is
+ * handed, unit-provable against a fixture.
+ *
+ * @class AgentOS.view.fleet.HealthBar
+ * @extends Neo.container.Base
+ */
+class HealthBar extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.HealthBar'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.HealthBar',
+        /**
+         * @member {String} ntype='fm-health-bar'
+         * @protected
+         */
+        ntype: 'fm-health-bar',
+        /**
+         * @member {String[]} baseCls=['fm-health-bar']
+         */
+        baseCls: ['fm-health-bar'],
+        /**
+         * @member {Object} layout={ntype:'hbox',align:'center'}
+         * @reactive
+         */
+        layout: {ntype: 'hbox', align: 'center'},
+        /**
+         * The roster the counts derive from; the counts refresh whenever it changes.
+         * @member {Object[]} agents_=[]
+         * @reactive
+         */
+        agents_: [],
+        /**
+         * Whether count transitions animate — carried onto the bar as a class the CSS reads (the
+         * animation itself is additionally gated behind `prefers-reduced-motion`, so this is the
+         * explicit off-switch and reduced-motion is the implicit one).
+         * @member {Boolean} animateCounts_=true
+         * @reactive
+         */
+        animateCounts_: true,
+        /**
+         * One stable swatch per canonical category, in legend order — counts update in place.
+         * @member {Object[]} items
+         */
+        items: HEALTH_ORDER.map(state => ({module: HealthSwatch, flex: 'none', state, count: 0}))
+    }
+
+    /**
+     * @summary Seed the counts once constructed (the swatches exist from static config; only their
+     * counts are data-derived).
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+        this.updateAnimateCls();
+        this.applyCounts()
+    }
+
+    /**
+     * @param {Object[]} value
+     * @param {Object[]} oldValue
+     * @protected
+     */
+    afterSetAgents(value, oldValue) {
+        this.isConstructed && this.applyCounts()
+    }
+
+    /**
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetAnimateCounts(value, oldValue) {
+        this.isConstructed && this.updateAnimateCls()
+    }
+
+    /**
+     * @summary Reflect the `animateCounts` switch as a class the CSS reads (the pulse stays
+     * additionally gated behind `prefers-reduced-motion`).
+     * @protected
+     */
+    updateAnimateCls() {
+        const cls = (this.cls || []).filter(c => c !== 'fm-animate-counts');
+
+        this.animateCounts && cls.push('fm-animate-counts');
+        this.cls = cls
+    }
+
+    /**
+     * @summary Push the current per-category counts onto the stable swatch instances — in place, so
+     * the transition animates rather than the bar rebuilding.
+     */
+    applyCounts() {
+        const counts = healthCounts(this.agents);
+
+        this.items.forEach(swatch => {
+            swatch.count = counts[swatch.state] ?? 0
+        })
+    }
+}
+
+export default Neo.setupClass(HealthBar);

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
@@ -1,0 +1,147 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FleetGridTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import Instance       from '../../../../../../../src/manager/Instance.mjs';
+
+test.describe('Fleet cockpit FleetGrid + HealthBar — density-ranked grid (#14599)', () => {
+    let FleetGrid, HealthBar, rankFleet, healthCounts;
+
+    // a roster from a list of states; agentIds are shuffled-stable so the sort is provable
+    const roster = states => states.map((state, i) => ({
+        agentId    : `agent-${String((states.length - i)).padStart(2, '0')}`,
+        displayName: `Agent ${i}`,
+        state
+    }));
+
+    const cardsBox   = grid => grid.items.find(item => item.cls.includes('fm-fleet-cards'));
+    const agentCards = grid => cardsBox(grid).items.filter(item => item.ntype === 'fm-agent-card');
+    const foldRow    = grid => cardsBox(grid).items.find(item => item.cls.includes('fm-fleet-fold'));
+    const head       = grid => grid.items.find(item => item.cls.includes('fm-fleet-head'));
+    const swatchOf   = (bar, state) => bar.items.find(sw => sw.state === state);
+
+    test.beforeAll(async () => {
+        const gridMod = await import('../../../../../../../apps/agentos/view/fleet/FleetGrid.mjs'),
+              barMod  = await import('../../../../../../../apps/agentos/view/fleet/HealthBar.mjs');
+
+        FleetGrid    = gridMod.default;
+        rankFleet    = gridMod.rankFleet;
+        HealthBar    = barMod.default;
+        healthCounts = barMod.healthCounts
+    });
+
+    test('healthCounts is the pure tally — five canonical categories; unknown/guest folds into off (no 6th key, no undercount)', () => {
+        const counts = healthCounts(roster(['ok', 'ok', 'idle', 'off', 'limited', 'wedged']));
+        expect(counts).toEqual({ok: 2, idle: 1, wedged: 1, limited: 1, off: 1});
+
+        // zero-fill: exactly the five canonical keys, present even when absent
+        expect(healthCounts([])).toEqual({ok: 0, idle: 0, wedged: 0, limited: 0, off: 0});
+
+        // unknown / guest / unsupported → off (benched), matching the grid's benched tier — NEVER a literal 6th key
+        const withGuest = healthCounts(roster(['ok', 'mysterious', 'guest']));
+        expect(withGuest).toEqual({ok: 1, idle: 0, wedged: 0, limited: 0, off: 2});
+        expect(Object.keys(withGuest).sort()).toEqual(['idle', 'limited', 'off', 'ok', 'wedged']);
+        // the five visible counts sum to the roster size — the bar can never undercount
+        expect(Object.values(withGuest).reduce((a, b) => a + b, 0)).toBe(3);
+
+        // non-array guard
+        expect(healthCounts(null)).toEqual({ok: 0, idle: 0, wedged: 0, limited: 0, off: 0})
+    });
+
+    test('rankFleet tiers deterministically (online → idle → benched, sorted by agentId) with the fold threshold', () => {
+        // 4 online (ok/limited/wedged) · 3 idle · 2 benched(off) + 1 unknown-guest → benched tail
+        const rank = rankFleet(roster(['ok', 'idle', 'off', 'limited', 'idle', 'wedged', 'off', 'idle', 'guest', 'ok']), {foldThreshold: 12});
+
+        expect(rank.online.length).toBe(4);   // 2 ok + 1 limited + 1 wedged
+        expect(rank.idle.length).toBe(3);
+        expect(rank.benched.length).toBe(3);   // 2 off + 1 unknown-guest (tail, not dropped)
+        expect(rank.total).toBe(10);
+        expect(rank.folded).toBe(false);       // 10 < 12
+
+        // deterministic order: each tier sorted by agentId regardless of arrival order
+        const ids = rank.online.map(a => a.agentId);
+        expect(ids).toEqual([...ids].sort());
+
+        // threshold is inclusive at the boundary
+        expect(rankFleet(roster(Array(11).fill('ok')), {foldThreshold: 12}).folded).toBe(false);
+        expect(rankFleet(roster(Array(12).fill('ok')), {foldThreshold: 12}).folded).toBe(true);
+        expect(rankFleet(roster(Array(20).fill('idle')), {foldThreshold: 12}).folded).toBe(true)
+    });
+
+    test('below threshold the grid renders every card in ranked order — no fold', () => {
+        const grid = Neo.create(FleetGrid, {appName, foldThreshold: 12, agents: roster(['ok', 'idle', 'off', 'ok', 'idle', 'wedged'])});
+
+        expect(agentCards(grid).length).toBe(6);   // all six render
+        expect(foldRow(grid)).toBeFalsy();          // nothing collapsed
+        expect(head(grid).items.find(i => i.cls.includes('fm-fleet-title')).text).toBe('Fleet · 6 agents');
+
+        grid.destroy()
+    });
+
+    test('at/over threshold the idle tier collapses to an honest count — online + benched stay as cards', () => {
+        // 4 online · 6 idle · 2 benched = 12 → folded
+        const grid = Neo.create(FleetGrid, {appName, foldThreshold: 12, agents: roster([
+            'ok', 'ok', 'limited', 'wedged',
+            'idle', 'idle', 'idle', 'idle', 'idle', 'idle',
+            'off', 'off'
+        ])});
+
+        // online (4) + benched (2) render as cards; the six idle do NOT
+        expect(agentCards(grid).length).toBe(6);
+        // the fold surfaces the folded idle count — never a silent drop
+        expect(foldRow(grid)).toBeTruthy();
+        expect(foldRow(grid).text).toBe('6 idle');
+
+        grid.destroy()
+    });
+
+    test('HealthBar renders the five swatches and updates counts IN PLACE across roster changes (no rebuild)', () => {
+        const bar = Neo.create(HealthBar, {appName, agents: roster(['ok', 'ok', 'idle', 'off'])});
+
+        expect(bar.items.length).toBe(5);
+        expect(swatchOf(bar, 'ok').count).toBe(2);
+        expect(swatchOf(bar, 'idle').count).toBe(1);
+        expect(swatchOf(bar, 'off').count).toBe(1);
+        expect(swatchOf(bar, 'wedged').count).toBe(0);   // zero still renders (confirms "none")
+
+        // stable instances: capture ids, change the roster, assert SAME swatch instances updated
+        const idsBefore = bar.items.map(sw => sw.id);
+        bar.agents = roster(['ok', 'ok', 'ok', 'wedged', 'wedged']);
+        expect(bar.items.map(sw => sw.id)).toEqual(idsBefore);   // not recreated → the count transition can animate
+        expect(swatchOf(bar, 'ok').count).toBe(3);
+        expect(swatchOf(bar, 'wedged').count).toBe(2);
+        expect(swatchOf(bar, 'idle').count).toBe(0);
+
+        // guest/unknown folds into the VISIBLE off swatch — the five-swatch bar never undercounts a roster
+        bar.agents = roster(['ok', 'guest', 'mysterious']);
+        expect(bar.items.length).toBe(5);              // still no 6th swatch
+        expect(swatchOf(bar, 'off').count).toBe(2);    // guest + mysterious rendered as benched
+        expect(swatchOf(bar, 'ok').count).toBe(1);
+
+        bar.destroy()
+    });
+
+    test('degrades honestly on adapter loss — a stale header, never a blanked grid', () => {
+        const grid = Neo.create(FleetGrid, {appName, adapterState: 'stale', agents: roster(['ok', 'idle', 'off'])});
+
+        expect(head(grid).cls).toContain('is-stale');
+        expect(head(grid).items.find(i => i.cls.includes('fm-fleet-stale')).text).toBe('stale — reconnecting');
+        // the cards still render — degrade surfaces the state, it does not blank the grid
+        expect(agentCards(grid).length).toBe(3);
+
+        grid.destroy()
+    });
+});


### PR DESCRIPTION
Resolves #14833 (component slice) · Refs #14599 (parent — live-wire binding #14595 + NL-verifiable mount remain OPEN, host-gated) · Refs #14560 (epic) · Refs #14592 (density evidence) · Refs #14598 / #14593 (composed primitives)

The cockpit's default view (SSOT §01 fleet zone, `apps/agentos/design/fleet-manager-cockpit-plan.html`): a scale-to-a-glance health bar over a density-ranked grid of AgentCards. Composes the already-built primitives and honors the cockpit-plan design + the measured #14592 density evidence — ranked-fold at scale, not the mock's six-agent / two-column assumption.

**Close-target scope:** #14599 bundles this component with the live-wire binding (#14595) + the NL-verifiable live mount — both host-gated (no cockpit shell mounts the fleet components yet; #14615 is `dropped`/`not-code-ready`). This PR Resolves the unit-provable **component slice** (#14833); #14599 stays OPEN for the live wire + mount. Same split as #14831 ⊂ #14606.

Evidence: L2 — `fleetGrid.spec.mjs` **6/6 green** (pure `rankFleet` / `healthCounts` cores + component DOM: fold thresholds at 6/12/20, deterministic tiering, in-place health counts, honest degrade). L2 fully covers #14833's component-only ACs.

## What it builds

- **`apps/agentos/view/fleet/FleetGrid.mjs`** — pure `rankFleet` (deterministic online → idle → benched tiering, sorted by `agentId`; fold threshold) + the grid: composes AgentCards, 3-col below threshold, the idle tier collapses to an honest "N idle" count at 12+ so the online agents stay in view at scale. A **stable header** (title + HealthBar updated in place) means only the card set rebuilds on a roster change — the glance counts animate rather than flash. Honest stale-degrade (banner over the last-known roster, never blanked).
- **`apps/agentos/view/fleet/HealthBar.mjs`** — pure `healthCounts` + the 5-category scale-to-a-glance bar: composes HealthSwatch with **stable swatch instances** (in-place count updates), an `animateCounts` config, and a `prefers-reduced-motion` CSS gate (the count value carries the signal; motion is decoration).
- **`.fm-fleet-grid` / `.fm-health-bar` CSS** — token-only anatomy, responsive 3 → 2 → 1 column, reduced-motion honored.

## Test Evidence

`npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs` → **6 passed** (31.5s, exit 0):
1. `healthCounts` pure tally — 5 categories zero-filled, unknown kept under its literal key, non-array guard.
2. `rankFleet` deterministic tiering (online → idle → benched, sorted) + inclusive fold threshold (11 = open, 12/20 = folded).
3. below threshold → every card renders, no fold.
4. at/over threshold → idle collapses to "N idle"; online + benched stay as cards.
5. HealthBar renders 5 swatches + updates counts **in place** (same instance ids across a roster change — the animation foundation).
6. degrade → stale header, grid not blanked.

## Post-Merge Validation

- [ ] With this on dev, FleetGrid + HealthBar render a density-ranked cockpit fleet zone from a roster fixture. The remaining #14599 ACs — the live wire binding for counts (#14595) and the NL-verifiable render at live roster scale — stay OPEN on #14599, gated on the cockpit shell / Lane-C wiring.

## Deltas from ticket (#14833)

The FleetGrid + HealthBar components + the pure cores + the CSS anatomy + the unit spec — the full #14833 slice. Live-wire binding and the NL mount remain on #14599 (host-gated). The literal per-digit count pulse is a HealthSwatch-level refinement (its own concern); this delivers the stable-instance smooth-update foundation + the `animateCounts` config + the reduced-motion gate. Full-rebuild of the card set on roster change (correctness); incremental card diffing is a perf refinement, not needed for the bound the ACs test.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
