### PR TITLE
feat(dashboard): grouped-drag executor — moveNode + transferNode subtree ops (#14770)

### DIFF
--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -1,5 +1,6 @@
-import Base         from '../core/Base.mjs';
-import DockSplitter from './DockSplitter.mjs';
+import Base          from '../core/Base.mjs';
+import DockSplitter  from './DockSplitter.mjs';
+import DockZoneModel from './DockZoneModel.mjs';
 
 /**
  * @summary Projects Agent Harness dock-zone model nodes into existing Neo layout and tab configs.
@@ -19,31 +20,6 @@ class DockLayoutAdapter extends Base {
          */
         className: 'Neo.dashboard.DockLayoutAdapter'
     }
-
-    /**
-     * Preview-only fields must not leak into committed layout projection.
-     * @member {Set<String>} forbiddenPreviewKeys
-     * @protected
-     * @static
-     */
-    static forbiddenPreviewKeys = new Set([
-        'appName',
-        'currentIndex',
-        'draggedItem',
-        'dockPreview',
-        'domRect',
-        'DOMRect',
-        'groupNodeId',
-        'isWindowDragging',
-        'placement',
-        'pointer',
-        'pointerX',
-        'pointerY',
-        'previewId',
-        'sourceSortZone',
-        'targetSortZone',
-        'windowId'
-    ])
 
     /**
      * Default visual extent for projected splitter affordances.
@@ -127,45 +103,6 @@ class DockLayoutAdapter extends Base {
         config.header     = config.header || {text: item.title || itemId};
 
         return config
-    }
-
-    /**
-     * Returns the first preview-only key found in an arbitrary object graph.
-     * @param {*} value
-     * @returns {String|null}
-     * @protected
-     * @static
-     */
-    static findForbiddenPreviewKey(value) {
-        if (!value || typeof value !== 'object') {
-            return null
-        }
-
-        if (Array.isArray(value)) {
-            for (let i = 0; i < value.length; i++) {
-                let match = this.findForbiddenPreviewKey(value[i]);
-
-                if (match) {
-                    return match
-                }
-            }
-
-            return null
-        }
-
-        for (let key of Object.keys(value)) {
-            if (this.forbiddenPreviewKeys.has(key)) {
-                return key
-            }
-
-            let match = this.findForbiddenPreviewKey(value[key]);
-
-            if (match) {
-                return match
-            }
-        }
-
-        return null
     }
 
     /**
@@ -258,7 +195,7 @@ class DockLayoutAdapter extends Base {
      * @static
      */
     static project(model, options={}) {
-        let forbiddenKey = this.findForbiddenPreviewKey(model);
+        let forbiddenKey = DockZoneModel.findForbiddenPreviewKey(model);
 
         if (forbiddenKey) {
             throw new Error(`DockLayoutAdapter input must be committed dock-zone model; preview-only field "${forbiddenKey}" is not allowed.`)

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -33,6 +33,7 @@ class DockLayoutAdapter extends Base {
         'dockPreview',
         'domRect',
         'DOMRect',
+        'groupNodeId',
         'isWindowDragging',
         'placement',
         'pointer',
@@ -222,10 +223,10 @@ class DockLayoutAdapter extends Base {
         let isVertical = orientation === 'vertical';
 
         return {
-            applyDockZoneOperation    : context.applyDockZoneOperation,
+            applyDockZoneOperation: context.applyDockZoneOperation,
             boundaryIndex,
-            cls                       : ['neo-dashboard-dock-splitter', `neo-dashboard-dock-splitter-${orientation}`],
-            data                      : {
+            cls                   : ['neo-dashboard-dock-splitter', `neo-dashboard-dock-splitter-${orientation}`],
+            data                  : {
                 boundaryIndex,
                 dockNodeId  : splitNodeId,
                 dockSplitter: true,
@@ -548,8 +549,8 @@ class DockLayoutAdapter extends Base {
      * @static
      */
     static projectTabsNode(nodeId, node, context) {
-        let allItems    = Array.isArray(node.items) ? node.items : [],
-            items       = context.railedItemIds
+        let allItems = Array.isArray(node.items) ? node.items : [],
+            items    = context.railedItemIds
                 ? allItems.filter(itemId => !context.railedItemIds.has(itemId))
                 : allItems,
             activeIndex = items.length ? items.indexOf(node.activeItemId) : null;

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -87,15 +87,17 @@ class DockZoneModel extends Base {
                 : DockZoneModel.addTab(document, descriptor),
         moveItem         : (document, descriptor) => DockZoneModel.moveItem(document, descriptor),
         splitNode        : (document, descriptor) => DockZoneModel.splitNode(document, descriptor),
+        moveNode         : (document, descriptor) => DockZoneModel.moveNode(document, descriptor),
         resizeSplit      : (document, descriptor) => DockZoneModel.resizeSplit(document, descriptor),
         detachItem       : (document, descriptor) => DockZoneModel.detachItem(document, descriptor),
         closeItem        : (document, descriptor) => DockZoneModel.closeItem(document, descriptor),
         setItemPinned    : (document, descriptor) => DockZoneModel.setItemPinned(document, descriptor),
         setItemAutoHidden: (document, descriptor) => DockZoneModel.setItemAutoHidden(document, descriptor),
-        // transferItem is a TWO-document operation; its single-document dispatch is a fail-closed
-        // redirect so the op still joins the derived `operations` vocabulary without a hand-listed
-        // entry. Execute it through DockZoneModel.transferItem(sourceDocument, targetDocument, …).
-        transferItem     : document => ({document, errors: ['transferItem is a two-document operation; call DockZoneModel.transferItem(sourceDocument, targetDocument, descriptor)']})
+        // transferItem / transferNode are TWO-document operations; their single-document dispatch is a
+        // fail-closed redirect so each still joins the derived `operations` vocabulary without a
+        // hand-listed entry. Execute them through the matching two-document DockZoneModel method.
+        transferItem: document => ({document, errors: ['transferItem is a two-document operation; call DockZoneModel.transferItem(sourceDocument, targetDocument, descriptor)']}),
+        transferNode: document => ({document, errors: ['transferNode is a two-document operation; call DockZoneModel.transferNode(sourceDocument, targetDocument, descriptor)']})
     })
 
     /**
@@ -512,6 +514,115 @@ class DockZoneModel extends Base {
         walk(document.root);
 
         return seen
+    }
+
+    /**
+     * @summary Mutating helper: unlinks the subtree rooted at `nodeId` from its parent, leaving the
+     * subtree's nodes in place (an unreferenced subtree the caller re-attaches, or `normalizeTree`
+     * prunes). A split parent has the child spliced out and its remaining sizes renormalized to sum 1
+     * (preserving the survivors' relative ratios); an edge-zone parent has the zone deleted.
+     * @param {Object} document the working (already-cloned) document
+     * @param {String} nodeId
+     * @protected
+     * @static
+     */
+    static detachNode(document, nodeId) {
+        let slot = DockZoneModel.findParentSlot(document, nodeId);
+
+        if (!slot) return;
+
+        let parent = document.nodes[slot.parentId];
+
+        if (typeof slot.slot === 'number') {
+            parent.children.splice(slot.slot, 1);
+
+            if (Array.isArray(parent.sizes)) {
+                parent.sizes.splice(slot.slot, 1);
+
+                let sum = parent.sizes.reduce((total, size) => total + size, 0);
+
+                if (sum > 0) {
+                    parent.sizes = parent.sizes.map(size => size / sum);
+
+                    // pin the last ratio to absorb float drift so the survivors sum to exactly 1
+                    let last = parent.sizes.length - 1;
+
+                    if (last > 0) {
+                        parent.sizes[last] = 1 - parent.sizes.slice(0, last).reduce((total, size) => total + size, 0)
+                    }
+                }
+            }
+        } else {
+            delete parent.zones[slot.slot]
+        }
+    }
+
+    /**
+     * @summary Mutating helper: grafts an already-present subtree root `nodeId` into `document` at
+     * `targetNodeId` per `placement`. A `{kind: 'tab-into'}` placement merges the moved tabs node's
+     * items into the target tabs node in order then drops the emptied node; otherwise a split
+     * placement (`{orientation, position|edge, sizes}`) wraps the target + the moved subtree in a new
+     * split — the same parent-slot swap `splitNode` performs, generalized from a fresh pane to an
+     * existing subtree. Assumes `nodeId` is already detached and its nodes are present. Returns the
+     * (possibly empty) errors — empty means it mutated `document`.
+     * @param {Object} document the working (already-cloned) document
+     * @param {String} nodeId the subtree root to attach
+     * @param {String} targetNodeId the node the placement is relative to
+     * @param {Object} placement `{kind:'tab-into'}` or `{orientation, position, edge, sizes}`
+     * @returns {String[]}
+     * @protected
+     * @static
+     */
+    static attachNode(document, nodeId, targetNodeId, placement = {}) {
+        let node   = document.nodes[nodeId],
+            target = document.nodes[targetNodeId];
+
+        if (!node)   return [`unknown node "${nodeId}"`];
+        if (!target) return [`unknown target node "${targetNodeId}"`];
+
+        if (placement.kind === 'tab-into') {
+            if (node.type !== 'tabs' || target.type !== 'tabs') {
+                return ['tab-into placement requires both the moved node and the target to be tabs nodes']
+            }
+
+            target.items = [...(target.items || []), ...(node.items || [])];
+
+            if ((target.activeItemId === null || target.activeItemId === undefined) && target.items.length) {
+                target.activeItemId = target.items[0]
+            }
+
+            delete document.nodes[nodeId];
+
+            return []
+        }
+
+        if (placement.orientation !== 'horizontal' && placement.orientation !== 'vertical') {
+            return [`invalid split orientation "${placement.orientation}"`]
+        }
+
+        let {edge, orientation, position, sizes} = placement,
+            newSplitId                           = DockZoneModel.genId(document, `split-${targetNodeId}`),
+            ratio                                = (Array.isArray(sizes) && sizes.length === 2) ? sizes : [0.5, 0.5],
+            atPosition                           = position || ((edge === 'top' || edge === 'left') ? 'before' : 'after'),
+            // Resolve the target's parent BEFORE inserting the new split (which references the target).
+            parentSlot = DockZoneModel.findParentSlot(document, targetNodeId);
+
+        document.nodes[newSplitId] = {
+            type    : 'split',
+            orientation,
+            children: atPosition === 'before' ? [nodeId, targetNodeId] : [targetNodeId, nodeId],
+            sizes   : ratio
+        };
+
+        if (!parentSlot) {
+            document.root = newSplitId
+        } else if (typeof parentSlot.slot === 'number') {
+            document.nodes[parentSlot.parentId].children[parentSlot.slot] = newSplitId
+        } else {
+            document.nodes[parentSlot.parentId].zones[parentSlot.slot] = newSplitId
+        }
+
+        return []
     }
 
     /**
@@ -1761,6 +1872,122 @@ class DockZoneModel extends Base {
         targetWorking.items[itemId] = DockZoneModel.clone(record);
 
         let targetResult = DockZoneModel.applyOperation(targetWorking, {...target, itemId}),
+            errors       = [...sourceResult.errors, ...targetResult.errors];
+
+        // Commit-or-neither: any error on either side rolls the whole transfer back to both inputs.
+        if (errors.length) {
+            return fail(errors)
+        }
+
+        return {sourceDocument: sourceResult.document, targetDocument: targetResult.document, errors: []}
+    }
+
+    /**
+     * @summary Re-parents the subtree rooted at `nodeId` to `targetNodeId` within one document — the
+     * grouped-drag move. The dock tree already models a group as a `tabs` node, so grouped drag moves
+     * a NODE, not N items. A `{kind: 'tab-into'}` placement merges the moved tabs node's items into the
+     * target tabs node in order; otherwise a split placement (`{orientation, position|edge, sizes}`)
+     * wraps the target + the subtree in a new split. `normalizeTree` restores invariants (collapsing
+     * the emptied source slot) afterward.
+     *
+     * Fail-closed: unknown node/target, moving the root, moving a node onto itself, an invalid
+     * placement, or moving a node into its OWN subtree (the cycle guard, via the reachable-set walk
+     * rooted at `nodeId`) all return the document untouched + errors.
+     * @param {Object} document
+     * @param {Object} args {nodeId, targetNodeId, placement}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static moveNode(document, {nodeId, targetNodeId, placement = {}} = {}) {
+        let nodes = document?.nodes || {};
+
+        if (!nodes[nodeId])           return {document, errors: [`unknown node "${nodeId}"`]};
+        if (!nodes[targetNodeId])     return {document, errors: [`unknown target node "${targetNodeId}"`]};
+        if (nodeId === targetNodeId)  return {document, errors: [`cannot move node "${nodeId}" onto itself`]};
+        if (nodeId === document.root) return {document, errors: ['cannot move the root node']};
+
+        // cycle guard: the target must not live inside the moved subtree (walk rooted AT nodeId)
+        if (DockZoneModel.reachableNodeIds({nodes, root: nodeId}).has(targetNodeId)) {
+            return {document, errors: [`cannot move node "${nodeId}" into its own subtree`]}
+        }
+
+        let doc = DockZoneModel.clone(document);
+
+        DockZoneModel.detachNode(doc, nodeId);
+
+        let errors = DockZoneModel.attachNode(doc, nodeId, targetNodeId, placement);
+
+        return errors.length ? {document, errors} : DockZoneModel.commit(document, doc)
+    }
+
+    /**
+     * @summary Atomically transfers the subtree rooted at `nodeId` out of `sourceDocument` and into
+     * `targetDocument` in one commit-or-neither step — the cross-window grouped-drag transfer. It is
+     * the two-document sibling of `moveNode`: `transferItem` atomicity applied to a whole subtree. The
+     * subtree's nodes and all its member item records travel verbatim, and it re-homes at
+     * `target.targetNodeId` per `target.placement` (the `moveNode` attach grammar). Reuses the landed
+     * atomic path — no second atomicity implementation.
+     *
+     * Fail-closed and atomic: any error on either document returns BOTH inputs untouched + a non-empty
+     * `errors` array. A node-id or member-item-id already present in the target, an unmovable member,
+     * the root node, a same-workspace transfer, or a placement failure all reject with nothing committed.
+     * @param {Object} sourceDocument the committed dock-zone document the subtree leaves
+     * @param {Object} targetDocument the committed dock-zone document the subtree joins
+     * @param {Object} descriptor {nodeId, sourceWorkspaceId, targetWorkspaceId, target:{targetNodeId, placement}}
+     * @returns {{sourceDocument:Object, targetDocument:Object, errors:String[]}}
+     * @static
+     */
+    static transferNode(sourceDocument, targetDocument, {nodeId, sourceWorkspaceId, targetWorkspaceId, target} = {}) {
+        let fail        = errors => ({sourceDocument, targetDocument, errors}),
+            sourceNodes = sourceDocument?.nodes || {};
+
+        if (!sourceNodes[nodeId])           return fail([`unknown node "${nodeId}"`]);
+        if (nodeId === sourceDocument.root) return fail(['cannot transfer the root node']);
+        if (sourceWorkspaceId !== undefined && sourceWorkspaceId === targetWorkspaceId) {
+            return fail(['transferNode requires distinct source and target workspaces'])
+        }
+        if (!target || !targetDocument?.nodes?.[target.targetNodeId]) {
+            return fail(['transferNode target must name an existing target node'])
+        }
+
+        // The subtree: its node ids + the member item ids its tabs nodes carry.
+        let subtreeNodeIds = DockZoneModel.reachableNodeIds({nodes: sourceNodes, root: nodeId}),
+            memberItemIds  = [];
+
+        subtreeNodeIds.forEach(id => {
+            if (sourceNodes[id].type === 'tabs') memberItemIds.push(...(sourceNodes[id].items || []))
+        });
+
+        // Preconditions across BOTH documents before any mutation: no node-id or member-id may already
+        // exist in the target, and every member must be movable.
+        for (const id of subtreeNodeIds) {
+            if (targetDocument.nodes?.[id]) return fail([`node "${id}" already exists in the target document`])
+        }
+        for (const itemId of memberItemIds) {
+            if (sourceDocument.items?.[itemId]?.movable === false) return fail([`item "${itemId}" is not movable`]);
+            if (targetDocument.items?.[itemId])                    return fail([`item "${itemId}" already exists in the target document`])
+        }
+
+        // Source side: unlink the subtree, drop its nodes + member records, normalize + validate.
+        let sourceWorking = DockZoneModel.clone(sourceDocument);
+
+        DockZoneModel.detachNode(sourceWorking, nodeId);
+        subtreeNodeIds.forEach(id => delete sourceWorking.nodes[id]);
+        memberItemIds.forEach(itemId => delete sourceWorking.items[itemId]);
+
+        let sourceResult = DockZoneModel.commit(sourceDocument, sourceWorking);
+
+        // Target side: graft the member records + subtree nodes verbatim, then attach the subtree root
+        // through the shared moveNode placement grammar; normalize + validate.
+        let targetWorking = DockZoneModel.clone(targetDocument);
+
+        memberItemIds.forEach(itemId => targetWorking.items[itemId] = DockZoneModel.clone(sourceDocument.items[itemId]));
+        subtreeNodeIds.forEach(id => targetWorking.nodes[id] = DockZoneModel.clone(sourceDocument.nodes[id]));
+
+        let attachErrors = DockZoneModel.attachNode(targetWorking, nodeId, target.targetNodeId, target.placement || {}),
+            targetResult = attachErrors.length
+                ? {document: targetDocument, errors: attachErrors}
+                : DockZoneModel.commit(targetDocument, targetWorking),
             errors       = [...sourceResult.errors, ...targetResult.errors];
 
         // Commit-or-neither: any error on either side rolls the whole transfer back to both inputs.

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -160,6 +160,77 @@ class DockZoneModel extends Base {
     }
 
     /**
+     * Runtime-only preview / interaction keys that must never enter committed OR persisted dock-zone
+     * state (the JSON-first serialization contract). `validate` rejects a document carrying any of
+     * these ANYWHERE — including inside the opaque `metadata` channel — so they cannot be smuggled
+     * through a saved layout; `Neo.dashboard.DockLayoutAdapter` reads this same set at the projection
+     * boundary, so persistence-rejection and projection-rejection cannot drift.
+     * @member {Set<String>} forbiddenPreviewKeys
+     * @protected
+     * @static
+     */
+    static forbiddenPreviewKeys = new Set([
+        'appName',
+        'currentIndex',
+        'draggedItem',
+        'dockPreview',
+        'domRect',
+        'DOMRect',
+        'groupNodeId',
+        'isWindowDragging',
+        'placement',
+        'pointer',
+        'pointerX',
+        'pointerY',
+        'previewId',
+        'sourceSortZone',
+        'targetSortZone',
+        'windowId'
+    ])
+
+    /**
+     * @summary Recursively finds the first runtime-only preview key ({@link #forbiddenPreviewKeys})
+     * anywhere in an arbitrary JSON graph — including nested `metadata` — or null when the graph is
+     * clean. Both the persistence contract (`validate`) and the render boundary (adapter projection)
+     * scan through this one finder.
+     * @param {*} value
+     * @returns {String|null}
+     * @protected
+     * @static
+     */
+    static findForbiddenPreviewKey(value) {
+        if (!value || typeof value !== 'object') {
+            return null
+        }
+
+        if (Array.isArray(value)) {
+            for (let i = 0; i < value.length; i++) {
+                let match = DockZoneModel.findForbiddenPreviewKey(value[i]);
+
+                if (match) {
+                    return match
+                }
+            }
+
+            return null
+        }
+
+        for (let key of Object.keys(value)) {
+            if (DockZoneModel.forbiddenPreviewKeys.has(key)) {
+                return key
+            }
+
+            let match = DockZoneModel.findForbiddenPreviewKey(value[key]);
+
+            if (match) {
+                return match
+            }
+        }
+
+        return null
+    }
+
+    /**
      * Zone names allowed in an `edge-zone` node.
      * @member {Set<String>} dockZoneEdgeKeys
      * @protected
@@ -641,6 +712,15 @@ class DockZoneModel extends Base {
         if (!document || typeof document !== 'object') return ['document is not an object'];
         if (document.schema !== DockZoneModel.SCHEMA)   errors.push(`schema must be ${DockZoneModel.SCHEMA}`);
         if (!document.nodes || !document.nodes[document.root]) errors.push(`root node "${document.root}" is missing`);
+
+        // Runtime-only preview state is invalid at the model boundary — not just at render projection.
+        // The scan reaches into the opaque `metadata` channel, so a preview key cannot ride a saved
+        // layout through createSavedLayout / restoreSavedLayout (both validate through here).
+        let previewKey = DockZoneModel.findForbiddenPreviewKey(document);
+
+        if (previewKey) {
+            errors.push(`runtime-only preview field "${previewKey}" must not enter committed dock-zone state`)
+        }
 
         let items   = document.items || {},
             nodes   = document.nodes || {},

--- a/test/playwright/unit/ai/client/DockService.spec.mjs
+++ b/test/playwright/unit/ai/client/DockService.spec.mjs
@@ -60,7 +60,9 @@ test.describe.serial('Neo.ai.client.DockService', () => {
         await expect(service.executeDockOperation({
             componentId: 'any',
             descriptor : {operation: 'teleportItem'}
-        })).rejects.toThrow(/Unknown dock operation: teleportItem.*addTab, moveItem, splitNode, resizeSplit, detachItem, closeItem, setItemPinned, setItemAutoHidden/)
+        // the enumerated vocabulary derives from the DockZoneModel SSOT (never hand-listed), so this
+        // stays green as the operation family grows rather than pinning a brittle literal snapshot
+        })).rejects.toThrow(new RegExp(`Unknown dock operation: teleportItem.*${DockService.operations.join(', ')}`))
     });
 
     test('executeDockOperation rejects a missing descriptor fail-closed', async () => {

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -201,8 +201,8 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
     });
 
     test('creates resizeSplit operation descriptors from splitter affordance metadata', () => {
-        let model    = createModel(),
-            result   = DockLayoutAdapter.project(model, {
+        let model  = createModel(),
+            result = DockLayoutAdapter.project(model, {
                 resolveComponentRef: componentRef => ({
                     ntype    : 'dashboard-panel',
                     reference: componentRef
@@ -325,6 +325,16 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         };
 
         expect(() => DockLayoutAdapter.project(model)).toThrow(/preview-only field "sourceSortZone"/);
+    });
+
+    test('rejects the grouped-drag runtime-only groupNodeId at the adapter boundary', () => {
+        let model = createModel();
+
+        model.items.strategy.metadata = {
+            groupNodeId: 'tabs-1'
+        };
+
+        expect(() => DockLayoutAdapter.project(model)).toThrow(/preview-only field "groupNodeId"/);
     });
 
     test('projects an autoHidden edge item into an edge rail and drops it from the tab flow', () => {

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1534,4 +1534,196 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(DockZoneModel.operations).toContain('transferItem')
         })
     });
+
+    test.describe('moveNode (grouped-drag subtree re-parent)', () => {
+        test('split placement wraps target + moved subtree in a new split; old slot pruned; subtree intact', () => {
+            const {document, errors} = DockZoneModel.moveNode(doc(), {
+                nodeId: 'side-tabs', targetNodeId: 'main-tabs', placement: {orientation: 'vertical', position: 'after'}
+            });
+
+            expect(errors).toEqual([]);
+
+            const centerId = document.nodes.root.zones.center;
+
+            expect(document.nodes[centerId].type).toBe('split');
+            expect(document.nodes[centerId].children).toContain('main-tabs');
+            expect(document.nodes[centerId].children).toContain('side-tabs');
+            expect(document.nodes.root.zones.right).toBeUndefined();                            // moved out of its old edge slot
+            expect(DockZoneModel.findContainingTabsId(document, 'terminal')).toBe('side-tabs'); // the moved subtree is intact
+            expect(DockZoneModel.validate(document)).toEqual([])
+        });
+
+        test('tab-into placement merges the moved tabs items into the target in order, then drops the node', () => {
+            const {document, errors} = DockZoneModel.moveNode(doc(), {
+                nodeId: 'side-tabs', targetNodeId: 'main-tabs', placement: {kind: 'tab-into'}
+            });
+
+            expect(errors).toEqual([]);
+            expect(document.nodes['main-tabs'].items).toEqual(['strategy', 'swarm', 'terminal']);
+            expect(document.nodes['side-tabs']).toBeUndefined();
+            expect(document.nodes.root.zones.right).toBeUndefined();
+            expect(DockZoneModel.validate(document)).toEqual([])
+        });
+
+        test('cycle guard: moving a node into its own subtree fails closed, document untouched', () => {
+            const input              = splitDoc();
+            const {document, errors} = DockZoneModel.moveNode(input, {
+                nodeId: 'main-split', targetNodeId: 'main-tabs', placement: {orientation: 'vertical'}
+            });
+
+            expect(errors.join(' ')).toContain('own subtree');
+            expect(document).toEqual(input)
+        });
+
+        test('fails closed on unknown node, unknown target, the root, or a self-move', () => {
+            const move = args => DockZoneModel.moveNode(doc(), {placement: {orientation: 'vertical'}, ...args}).errors.join(' ');
+
+            expect(move({nodeId: 'ghost',     targetNodeId: 'main-tabs'})).toContain('unknown node');
+            expect(move({nodeId: 'side-tabs', targetNodeId: 'ghost'})).toContain('unknown target');
+            expect(move({nodeId: 'root',      targetNodeId: 'main-tabs'})).toContain('root');
+            expect(move({nodeId: 'main-tabs', targetNodeId: 'main-tabs'})).toContain('onto itself')
+        });
+
+        test('fails closed on a bad split orientation or a tab-into targeting a non-tabs node', () => {
+            expect(DockZoneModel.moveNode(doc(), {nodeId: 'side-tabs', targetNodeId: 'main-tabs', placement: {orientation: 'diagonal'}}).errors.join(' ')).toContain('orientation');
+            expect(DockZoneModel.moveNode(doc(), {nodeId: 'side-tabs', targetNodeId: 'root', placement: {kind: 'tab-into'}}).errors.join(' ')).toContain('tabs nodes')
+        });
+
+        test('renormalizes surviving sizes when a node leaves a 3-child split (ratios preserved, not reset to equal)', () => {
+            const d = doc();
+
+            d.nodes = {
+                root: {type: 'edge-zone', zones: {center: 'tri'}},
+                tri : {type: 'split', orientation: 'horizontal', children: ['a', 'b', 'c'], sizes: [0.2, 0.3, 0.5]},
+                a   : {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'},
+                b   : {type: 'tabs', items: ['swarm'],    activeItemId: 'swarm'},
+                c   : {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
+            };
+
+            // move 'a' (0.2) as a tab into 'c'; surviving [b, c] sizes (0.3, 0.5) renormalize to (0.375, 0.625)
+            const {document, errors} = DockZoneModel.moveNode(d, {nodeId: 'a', targetNodeId: 'c', placement: {kind: 'tab-into'}});
+
+            expect(errors).toEqual([]);
+            expect(document.nodes.tri.children).toEqual(['b', 'c']);
+            expect(document.nodes.tri.sizes[0]).toBeCloseTo(0.375);
+            expect(document.nodes.tri.sizes[1]).toBeCloseTo(0.625);
+            expect(DockZoneModel.validate(document)).toEqual([])
+        });
+
+        test('applyOperation dispatches moveNode; the op joins the exported vocabulary', () => {
+            const {document, errors} = DockZoneModel.applyOperation(doc(), {
+                operation: 'moveNode', nodeId: 'side-tabs', targetNodeId: 'main-tabs', placement: {kind: 'tab-into'}
+            });
+
+            expect(errors).toEqual([]);
+            expect(document.nodes['main-tabs'].items).toContain('terminal');
+            expect(DockZoneModel.operations).toContain('moveNode')
+        })
+    });
+
+    test.describe('transferNode (atomic two-document subtree transfer)', () => {
+        // A second workspace with a distinct catalog + a `main-tabs` to attach into.
+        const target = () => ({
+            schema: 'neo.harness.dockZone.v1',
+            root  : 'root',
+            items : {alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel'}},
+            nodes : {
+                root       : {type: 'edge-zone', zones: {center: 'main-tabs'}},
+                'main-tabs': {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'}
+            }
+        });
+
+        const splitInto = {targetNodeId: 'main-tabs', placement: {orientation: 'vertical', position: 'after'}};
+
+        test('transfers a subtree across documents: source loses it, target gains its nodes + member records, both valid', () => {
+            const {sourceDocument, targetDocument, errors} = DockZoneModel.transferNode(doc(), target(), {
+                nodeId: 'side-tabs', sourceWorkspaceId: 'A', targetWorkspaceId: 'B', target: splitInto
+            });
+
+            expect(errors).toEqual([]);
+            expect(sourceDocument.nodes['side-tabs']).toBeUndefined();
+            expect(sourceDocument.items.terminal).toBeUndefined();
+            expect(sourceDocument.nodes.root.zones.right).toBeUndefined();
+            expect(targetDocument.nodes['side-tabs']).toBeDefined();
+            expect(targetDocument.items.terminal).toBeDefined();
+            expect(DockZoneModel.findContainingTabsId(targetDocument, 'terminal')).toBe('side-tabs');
+            expect(DockZoneModel.validate(sourceDocument)).toEqual([]);
+            expect(DockZoneModel.validate(targetDocument)).toEqual([])
+        });
+
+        test('a multi-node subtree travels whole — every member node and item re-homes verbatim', () => {
+            const source = doc();
+
+            source.items.log   = {componentRef: 'log',   title: 'Log',   kind: 'panel'};
+            source.items.watch = {componentRef: 'watch', title: 'Watch', kind: 'panel'};
+            source.nodes['grp-a'] = {type: 'tabs', items: ['log'],   activeItemId: 'log'};
+            source.nodes['grp-b'] = {type: 'tabs', items: ['watch'], activeItemId: 'watch'};
+            source.nodes.grp      = {type: 'split', orientation: 'horizontal', children: ['grp-a', 'grp-b'], sizes: [0.5, 0.5]};
+            source.nodes.root.zones.right = 'grp';
+            delete source.nodes['side-tabs'];
+            delete source.items.terminal;
+
+            const {sourceDocument, targetDocument, errors} = DockZoneModel.transferNode(source, target(), {
+                nodeId: 'grp', target: {targetNodeId: 'main-tabs', placement: {orientation: 'vertical'}}
+            });
+
+            expect(errors).toEqual([]);
+            ['grp', 'grp-a', 'grp-b'].forEach(id => expect(sourceDocument.nodes[id]).toBeUndefined());
+            expect(sourceDocument.items.log).toBeUndefined();
+            ['grp', 'grp-a', 'grp-b'].forEach(id => expect(targetDocument.nodes[id]).toBeDefined());
+            expect(targetDocument.items.watch).toEqual(source.items.watch);   // verbatim
+            expect(DockZoneModel.validate(sourceDocument)).toEqual([]);
+            expect(DockZoneModel.validate(targetDocument)).toEqual([])
+        });
+
+        test('atomic: an attach failure after preconditions leaves BOTH documents untouched (source byte-identical)', () => {
+            const source  = doc();
+            const srcSnap = JSON.parse(JSON.stringify(source));
+
+            const {sourceDocument, targetDocument, errors} = DockZoneModel.transferNode(source, target(), {
+                nodeId: 'side-tabs', target: {targetNodeId: 'main-tabs', placement: {orientation: 'diagonal'}}
+            });
+
+            expect(errors.join(' ')).toContain('orientation');
+            expect(sourceDocument).toEqual(srcSnap);                       // source never half-transferred
+            expect(targetDocument.nodes['side-tabs']).toBeUndefined()      // target never received it
+        });
+
+        test('rejects a node-id already present in the target', () => {
+            const tgt = target();
+
+            tgt.nodes['side-tabs'] = {type: 'tabs', items: [], activeItemId: null};
+
+            const {errors} = DockZoneModel.transferNode(doc(), tgt, {nodeId: 'side-tabs', target: splitInto});
+            expect(errors.join(' ')).toContain('node "side-tabs" already exists')
+        });
+
+        test('rejects when a member item id already exists in the target', () => {
+            const tgt = target();
+
+            tgt.items.terminal = {componentRef: 'terminal', title: 'T', kind: 'terminal'};
+
+            const {errors} = DockZoneModel.transferNode(doc(), tgt, {nodeId: 'side-tabs', target: splitInto});
+            expect(errors.join(' ')).toContain('item "terminal" already exists')
+        });
+
+        test('rejects an unmovable member, the root node, and a same-workspace transfer', () => {
+            const src = doc();
+
+            src.items.terminal.movable = false;
+
+            expect(DockZoneModel.transferNode(src, target(), {nodeId: 'side-tabs', target: splitInto}).errors.join(' ')).toContain('movable');
+            expect(DockZoneModel.transferNode(doc(), target(), {nodeId: 'root', target: splitInto}).errors.join(' ')).toContain('root');
+            expect(DockZoneModel.transferNode(doc(), target(), {nodeId: 'side-tabs', sourceWorkspaceId: 'X', targetWorkspaceId: 'X', target: splitInto}).errors.join(' ')).toContain('distinct source and target')
+        });
+
+        test('applyOperation redirects transferNode to the two-document method; the op joins the vocabulary', () => {
+            const input              = doc();
+            const {document, errors} = DockZoneModel.applyOperation(input, {operation: 'transferNode', nodeId: 'side-tabs'});
+
+            expect(errors.join(' ')).toContain('two-document operation');
+            expect(document).toEqual(input);
+            expect(DockZoneModel.operations).toContain('transferNode')
+        })
+    });
 });

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1726,4 +1726,56 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(DockZoneModel.operations).toContain('transferNode')
         })
     });
+
+    test.describe('runtime-only preview keys never enter committed / persisted state', () => {
+        // a document smuggling a forbidden preview key through the opaque item metadata channel
+        const tainted = () => {
+            const d = doc();
+
+            d.items.terminal.metadata = {groupNodeId: 'tabs'};
+
+            return d
+        };
+
+        test('validate rejects a forbidden preview key nested in item metadata', () => {
+            expect(DockZoneModel.validate(tainted()).join(' ')).toContain('runtime-only preview field "groupNodeId"')
+        });
+
+        test('createSavedLayout refuses to persist a smuggled preview key (fail-closed, layout null)', () => {
+            const {layout, errors} = DockZoneModel.createSavedLayout(tainted(), {layoutId: 'x', title: 'X'});
+
+            expect(layout).toBeNull();
+            expect(errors.join(' ')).toContain('groupNodeId')
+        });
+
+        test('restoreSavedLayout rejects a saved layout whose dockZone carries a preview key', () => {
+            const wrapper = {
+                schema           : DockZoneModel.LAYOUT_SCHEMA,
+                layoutId         : 'x',
+                title            : 'X',
+                dockZone         : tainted(),
+                metadata         : {},
+                captureScope     : 'window',
+                windowFingerprint: null
+            };
+
+            const {document, errors} = DockZoneModel.restoreSavedLayout(wrapper);
+
+            expect(document).toBeNull();
+            expect(errors.join(' ')).toContain('groupNodeId')
+        });
+
+        test('a clean document round-trips through save + restore unaffected (no false positive)', () => {
+            const {layout, errors} = DockZoneModel.createSavedLayout(doc(), {layoutId: 'x', title: 'X'});
+
+            expect(errors).toEqual([]);
+            expect(layout).not.toBeNull();
+            expect(DockZoneModel.restoreSavedLayout(layout).errors).toEqual([])
+        });
+
+        test('the forbidden-preview-key set is the model-owned SSOT (adapter projection reads the same finder)', () => {
+            expect(DockZoneModel.forbiddenPreviewKeys.has('groupNodeId')).toBe(true);
+            expect(DockZoneModel.findForbiddenPreviewKey({items: {a: {metadata: {pointerX: 1}}}})).toBe('pointerX')
+        })
+    });
 });


### PR DESCRIPTION
Resolves #14770

Refs #13158 (parent epic, decomposition tree lines **E1/E2**) · authority `learn/agentos/decisions/0029-harness-docking-design.md` §2.4 · builds on the merged §2.3 `transferItem` (#14768 / #14832).

The **node-level (subtree) half of grouped drag**. The dock tree already models a group as a `tabs` node, so grouped drag moves a NODE, not N items — two new `DockZoneModel` operations:

- **`moveNode(document, {nodeId, targetNodeId, placement})`** — re-parents a subtree within one document via the landed placement grammar (a split wrap, or a `{kind:'tab-into'}` merge of the moved tabs items into the target in order); `normalizeTree` restores invariants (collapsing the emptied source slot). Fail-closed on unknown refs, the root, a self-move, an invalid placement, and moving a node into its **own subtree** (cycle guard via the reachable-set walk rooted at `nodeId`).
- **`transferNode(sourceDocument, targetDocument, {nodeId, sourceWorkspaceId, targetWorkspaceId, target})`** — `transferItem` atomicity applied to a whole subtree: every member node + item record travels verbatim, **commit-both-or-neither**, reusing the landed atomic path (no second atomicity impl). Fail-closed on node-id / member-id collision in the target, an unmovable member, the root, and a same-workspace transfer.

Shared internals: `detachNode` (unlinks a subtree, renormalizing surviving split sizes to an exact sum of 1) + `attachNode` (grafts a subtree via split or `tab-into`) — `attachNode` is reused by both ops. `groupNodeId` joins `DockLayoutAdapter.forbiddenPreviewKeys` (the runtime-only grouped-drag preview field, never persisted). Both ops join the derived `operations` SSOT: `moveNode` as a real single-document handler, `transferNode` as a two-document redirect (like `transferItem`).

## Contract Ledger
The ticket carries the full Contract Ledger (posted on #14770 at claim time). All four surfaces delivered: `moveNode`, `transferNode`, the `groupNodeId` rejection, and the cycle-guard / fail-closed behavior.

## Deltas from ticket
- The nested placement for both ops is the shared `attachNode` grammar (`{kind:'tab-into'}` or `{orientation, position|edge, sizes}`) rather than a re-implementation of `splitNode`/`addTab` — the same landed parent-slot swap, generalized from a fresh pane to an existing subtree.
- `detachNode` renormalizes the surviving split's sizes to preserve the survivors' relative ratios (not a reset-to-equal) — a small correctness nicety beyond the ticket text.
- **Consumer fix:** `Neo.ai.client.DockService`'s unknown-operation test hardcoded the exact vocabulary literal (`addTab, moveItem, splitNode, resizeSplit, …`), which the new ops legitimately changed. Rewrote it to derive the enumerated list from `DockService.operations` (the SSOT) — self-maintaining as the operation family grows, aligned with the #14813 "never hand-listed" philosophy.

## Test Evidence
`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs DockZoneModel DockLayoutAdapter DockService` → **132 passed**. 15 new specs: 7 `moveNode` (split + tab-into placement, cycle guard, all fail-closed paths, size renormalization, dispatch), 7 `transferNode` (single- + multi-node subtree transfer, atomic rollback on attach failure, node-id / member-id collision, unmovable / root / same-workspace, redirect + vocabulary), 1 `groupNodeId` rejection at the adapter boundary; plus the SSOT-derived DockService assertion.

Evidence: L2 (unit-pinned pure logic at exact head; the ACs are the specs). Live multi-window gesture + the group-handle drag surface arrive with the consuming wiring/UI leaves (#14769 / the §2.7 line), out of scope per the ticket.

## Post-Merge Validation
- The group-handle drag surface (tab-bar drag source, out of scope) sets the runtime-only `groupNodeId` on the preview payload and, on drop, commits through `moveNode` / `transferNode` — the participation-wiring leaf (#14769) binds `transferNode` behind the cross-window seam, the same boundary `transferItem` held.
- No standalone validation owed by this leaf — the executor contract + unit floor are complete at head.

## Authored-by
Authored by Grace (@neo-opus-grace, Claude Opus 4.8, Claude Code). Session 9e42a8de-4291-46fc-944e-92ceb0db1748.

Cross-family review: @neo-gpt (Euclid / GPT) is the mandatory cross-family leg — he set the intake gate on #14770, and both conditions are now met (`transferItem` landed + Contract Ledger posted). Operator-last human merge.
