### PR TITLE
fix(e2e): repair childapp connect readiness proof (#14830)

### DIFF
--- a/test/playwright/e2e/NeuralLinkChildappConnect.spec.mjs
+++ b/test/playwright/e2e/NeuralLinkChildappConnect.spec.mjs
@@ -19,8 +19,9 @@ test.describe('Neural Link — childapp connect (SharedWorker topology)', () => 
 
     test('connectToApp resolves a childapp + reads a live component', async ({page, neuralLink}) => {
         await page.goto('/apps/colors/childapps/widget/index.html');
-        // the childapp viewport mounts — the app is live before we connect
-        await page.waitForSelector('.neo-viewport', {state: 'visible', timeout: 30000});
+        // The childapp-connect proof is topology, not visual layout: an empty viewport may be
+        // attached but hidden, while still being a valid Neural Link readback target.
+        await page.waitForSelector('#colors-widget-viewport', {state: 'attached', timeout: 30000});
 
         // a childapp joins the parent SharedWorker session; `ColorsWidget` is a WINDOW within it,
         // so the session is reached via the worker appName.


### PR DESCRIPTION
Resolves #14830

Repairs the Neural Link childapp-connect e2e proof by waiting for the stable `colors-widget-viewport` root to be attached before connecting, instead of treating viewport visibility as the readiness contract. The test still connects through `neuralLink.connectToApp('colors')` and reads `ColorsWidget.view.Viewport` from the App Worker.

Evidence: L2 focused whitebox e2e covers the close target. Residual: none for #14830.

## Deltas from ticket

The original visible-viewport wait currently passed on fresh `dev`, so the local failure was not reproducible today. The source still carried the wrong readiness predicate for the ticket's topology contract, so this PR keeps the scope narrow and changes only the pre-connect wait to the stable attached root id.

## Test Evidence

- `node --check test/playwright/e2e/NeuralLinkChildappConnect.spec.mjs`
- `git diff --check`
- `npx playwright test test/playwright/e2e/NeuralLinkChildappConnect.spec.mjs -c test/playwright/playwright.config.e2e.mjs` -> 1 passed
- `npx playwright test test/playwright/e2e/NeuralLinkWindowOps.spec.mjs -c test/playwright/playwright.config.e2e.mjs` -> 1 passed
- `find apps/agentos/view -maxdepth 2 -path '*create*' -print` -> no output

## Post-Merge Validation

- [ ] Focused `NeuralLinkChildappConnect.spec.mjs` remains green against `dev` after merge.
- [ ] Focused `NeuralLinkWindowOps.spec.mjs` remains green against `dev` after merge.

Authored by Euclid (GPT-5 Codex, Codex Desktop). Session 6ab85930-3c14-4b18-b3b3-97989d1e75c6.
