### PR TITLE
fix(e2e): bind AgentOS Neural Link tests to page session (#14858)

### DIFF
--- a/test/playwright/e2e/agentos/FleetCockpitLifecycleNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitLifecycleNL.spec.mjs
@@ -1,7 +1,5 @@
 import {test, expect} from '../../fixtures.mjs';
 import {
-    NeuralLink_ComponentService,
-    NeuralLink_ConnectionService,
     NeuralLink_DataService,
     NeuralLink_InstanceService
 } from '../../../../ai/services.mjs';
@@ -129,25 +127,24 @@ test.describe('AgentOS Fleet cockpit lifecycle controls (Neural Link)', () => {
             await page.locator('.agent-shell').getByText('Control', {exact: true}).click();
             await expect(page.locator('.agent-panel-settings')).toBeVisible({timeout: 30000});
 
-            // Use the fixture to own bridge startup, then bind by app name: AgentOS SharedWorker
-            // exposes a page-local app id via getWorkerId(), while the bridge registers `agentos`.
+            // Use the fixture to own bridge startup and bind to this page's App Worker id.
+            // Raw app-name session lookup can pick an older same-name session.
             expect(neuralLink.bridgePort).toBeGreaterThan(0);
 
-            const sessionId = await NeuralLink_ConnectionService.waitForSession('agentos', 30000),
-                  panels    = await NeuralLink_ComponentService.queryComponent({
-                      sessionId,
-                      selector        : {className: 'AgentOS.view.FleetSettingsPanel'},
-                      returnProperties: ['id', 'className', 'reference', 'windowId']
-                  }),
-                  buttons   = await NeuralLink_ComponentService.queryComponent({
-                      sessionId,
-                      selector        : {ntype: 'button'},
-                      returnProperties: ['id', 'text', 'handler']
-                  }),
+            const app       = await neuralLink.connectToApp('AgentOS'),
+                  sessionId = app.sessionId,
+                  panels    = await app.queryComponent(
+                      {className: 'AgentOS.view.FleetSettingsPanel'},
+                      ['id', 'className', 'reference', 'windowId']
+                  ),
+                  buttons   = await app.queryComponent(
+                      {ntype: 'button'},
+                      ['id', 'text', 'handler']
+                  ),
                   storeId   = await getAgentDefinitionsStoreId(sessionId);
 
-            expect(panels.components).toHaveLength(1);
-            expect(buttons.components.map(button => button.properties.text)).toEqual(expect.arrayContaining([
+            expect(panels).toHaveLength(1);
+            expect(buttons.map(button => button.properties.text)).toEqual(expect.arrayContaining([
                 'Start',
                 'Stop',
                 'Restart'
@@ -186,7 +183,8 @@ test.describe('AgentOS Fleet cockpit lifecycle controls (Neural Link)', () => {
             await expect(page.locator('.agent-panel-settings')).toBeVisible({timeout: 30000});
             expect(neuralLink.bridgePort).toBeGreaterThan(0);
 
-            const sessionId = await NeuralLink_ConnectionService.waitForSession('agentos', 30000),
+            const app       = await neuralLink.connectToApp('AgentOS'),
+                  sessionId = app.sessionId,
                   storeId   = await getAgentDefinitionsStoreId(sessionId);
 
             await seedPublicAgentRow(sessionId, storeId);

--- a/test/playwright/e2e/neural-link/WindowOps.spec.mjs
+++ b/test/playwright/e2e/neural-link/WindowOps.spec.mjs
@@ -42,7 +42,13 @@ test.describe('Neural Link window operations (e2e)', () => {
             parentId : dashboard.id
         });
 
-        const sourceWindows = (await app.getWindowTopology()).filter(win => win.sessionId === app.sessionId);
+        const getBoundWindows = async () => {
+            const windows = await app.getWindowTopology();
+
+            return windows.filter(win => win.appWorkerId === app.sessionId)
+        };
+
+        const sourceWindows = await getBoundWindows();
         expect(sourceWindows.some(win => win.appName === 'AgentOS')).toBe(true);
 
         try {
@@ -70,12 +76,12 @@ test.describe('Neural Link window operations (e2e)', () => {
             await expect(popup.locator('.agent-panel-settings')).toBeVisible({timeout: 30000});
 
             await expect.poll(async () => {
-                const windows = (await app.getWindowTopology()).filter(win => win.sessionId === app.sessionId);
+                const windows = await getBoundWindows();
                 return windows.length
             }, {timeout: 15000}).toBeGreaterThan(sourceWindows.length);
 
             const
-                windows     = (await app.getWindowTopology()).filter(win => win.sessionId === app.sessionId),
+                windows     = await getBoundWindows(),
                 popupWindow = windows.find(win => win.appName === 'AgentOSWidget');
 
             expect(popupWindow?.windowId, 'popup should register a logical window id').toBeTruthy();

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -135,10 +135,12 @@ export const test = base.extend({
                 }
 
                 // Prefer the page's own worker id (exact-id match); fall back to explicit / inferred appName.
-                // A top-level app's getWorkerId() resolves to a string, but a childapp that joined an existing
-                // SharedWorker gets the raw remote-reply envelope ({action:'reply', data, ...}) instead — not a
-                // usable session-id match — so treat a non-string workerId as absent and use the appName fallback.
-                const targetId = (typeof workerId === 'string' && workerId ? workerId : null) || appName || inferredAppName;
+                // Some SharedWorker remotes return the raw reply envelope instead of unwrapping the data field.
+                // The `data` payload is still the App Worker id and remains the only same-name-safe target.
+                const normalizedWorkerId = typeof workerId === 'string' ? workerId : workerId?.data,
+                      targetId           = typeof normalizedWorkerId === 'string' && normalizedWorkerId ?
+                          normalizedWorkerId :
+                          appName || inferredAppName;
                 if (!targetId) {
                     throw new Error('neuralLink.connectToApp requires either an initialized Neo environment or an explicit appName to wait for.');
                 }


### PR DESCRIPTION
Resolves #14858

AgentOS Neural Link E2Es now identity-bind to the Playwright page's own App Worker session even when the shared bridge already contains an older same-name `agentos` session. The shared fixture unwraps remote reply envelopes from `Neo.worker.App.getWorkerId()`, the lifecycle spec uses the fixture SDK instead of raw app-name lookup, and WindowOps filters topology by `appWorkerId`.

Evidence: L3 (live Chrome + Neural Link E2E probe on an isolated dev server with a stale same-name bridge session present) -> L3 required (#14858 current-page binding and focused ordering ACs). No residuals.

## Deltas from ticket

- Shared fixture hardening was required: a direct browser probe showed AgentOS SharedWorker `getWorkerId()` returning `{action:"reply", data:"<sessionId>"}`. The old fixture discarded that non-string envelope and fell back to app-name lookup.
- Validation used an isolated webpack dev server on `:8095` because the existing local `:8080` server was stale and served the pre-#14847 AgentOS shell. No tracked validation config was added.

## Test Evidence

- `node --check test/playwright/fixtures.mjs`
- `node --check test/playwright/e2e/agentos/FleetCockpitLifecycleNL.spec.mjs`
- `node --check test/playwright/e2e/neural-link/WindowOps.spec.mjs`
- `git diff --check`
- `npm run agent-preflight -- --no-fix test/playwright/fixtures.mjs test/playwright/e2e/agentos/FleetCockpitLifecycleNL.spec.mjs test/playwright/e2e/neural-link/WindowOps.spec.mjs`
- Direct probe against `http://localhost:8095/apps/agentos/index.html`: `getWorkerId().data` matched the current page session while the bridge still contained an older `agentos` session.
- `./node_modules/.bin/playwright test -c test/playwright/playwright.config.e2e.14858.mjs test/playwright/e2e/agentos/Cockpit.spec.mjs test/playwright/e2e/agentos/FleetCockpitLifecycleNL.spec.mjs test/playwright/e2e/neural-link/WindowOps.spec.mjs --workers=1` passed 4/4. The temporary config changed only `baseURL` to the fresh `:8095` server and disabled `webServer`; it was removed before commit.

## Post-Merge Validation

- [ ] Re-run the focused ordering with canonical `test/playwright/playwright.config.e2e.mjs` after ensuring `:8080` is a fresh dev server, not a stale reused process.

## Commits

- `69a2011252` - `fix(e2e): bind AgentOS Neural Link tests to page session (#14858)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019f306e-3ffb-7980-984b-175a3c0072ac.
