### PR TITLE
feat(fleet): fleetActivity read-observe bridge capability + activitySource honest-degrade seam (#14862)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -1,6 +1,10 @@
 import Base                 from '../../../src/core/Base.mjs';
 import FleetManager         from './FleetManager.mjs';
 import FleetRegistryService from './FleetRegistryService.mjs';
+import {
+    createNotWiredCapability,
+    FLEET_COCKPIT_SOURCES
+} from '../../../src/ai/fleet/fleetCockpitStatus.mjs';
 
 /**
  * @class Neo.ai.services.fleet.FleetControlBridge
@@ -72,6 +76,17 @@ class FleetControlBridge extends Base {
      * @member {Object|null} bootIdentitySource=null
      */
     bootIdentitySource = null
+    /**
+     * Activity-feed **read-observe** source — an injected collaborator exposing
+     * `readActivitySnapshot(params)` that returns the bounded `{capability, events}` cockpit activity
+     * snapshot (the composed A2A + PR/lane adapters). The mailbox / PR read paths — and with them the
+     * identity binding + read permissions — stay owned by the wiring, per the adapters' DI contract
+     * (they consume an injected `listMessages`, never import the singleton). A plain injectable field
+     * like `bootIdentitySource` (no static default — the orchestrator wires the live source); unwired
+     * → an honest source-not-wired snapshot, never fabricated activity.
+     * @member {Object|null} activitySource=null
+     */
+    activitySource = null
 
     /**
      * @returns {Object} the registry collaborator (injected stub or the default singleton).
@@ -221,6 +236,26 @@ class FleetControlBridge extends Base {
         return this.bootIdentitySource
             ? this.bootIdentitySource.produceBootIdentityFact()
             : {fact: null, classification: 'unknown', advisory: true, reason: 'no-boot-identity-source'};
+    }
+
+    /**
+     * @summary READ-OBSERVE: the bounded fleet activity snapshot (A2A + PR/lane) as cockpit events —
+     * the real-time feed the FM cockpit's ActivityStream binds to. Rides the authenticated
+     * `registryBridge` as a **read** verb; it carries NO lifecycle-write / restart authority (the R3
+     * read-observe ÷ lifecycle-write seam). An unwired {@link #activitySource} yields an honest
+     * source-not-wired snapshot (degraded capability + empty events), never fabricated activity —
+     * mirroring {@link #getBootIdentity}'s advisory-empty degrade, so the cockpit renders a
+     * "feed not wired" state rather than a silent freeze or invented traffic.
+     * @param {Object} [params] Optional bounds forwarded to the source (`{limit, since, until}`).
+     * @returns {Promise<Object>|Object} `{capability, events}` — the bounded cockpit activity snapshot.
+     */
+    fleetActivity(params) {
+        return this.activitySource
+            ? this.activitySource.readActivitySnapshot(params)
+            : {
+                capability: createNotWiredCapability(FLEET_COCKPIT_SOURCES.activity, 'fleet activity source not wired'),
+                events    : []
+            };
     }
 }
 

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -11,9 +11,10 @@
  * `Object` / `Neo.core.Base` member, so a crafted `{method:'getManager'}` / `{method:'constructor'}`
  * request cannot reach a non-operation.
  *
- * `getBootIdentity` is a **read-observe** verb — the advisory boot-identity fact: it carries NO lifecycle-write
- * / restart authority. The R3 read-observe ÷ lifecycle-write seam keeps the daemon-core restart actuator
- * physically OFF this client wire — only advisory reads ride it.
+ * `getBootIdentity` and `fleetActivity` are **read-observe** verbs — the advisory boot-identity fact and
+ * the bounded fleet activity snapshot: they carry NO lifecycle-write / restart authority. The R3
+ * read-observe ÷ lifecycle-write seam keeps the daemon-core restart actuator physically OFF this client
+ * wire — only advisory reads ride it.
  *
  * **Dependency-free by design** — imported by both a Node module and an App-Worker (browser) module,
  * so it MUST NOT pull in the Node-only FleetControlBridge / crypto / fs chain.
@@ -22,5 +23,5 @@
 export const FLEET_WIRE_METHODS = Object.freeze([
     'defineAgent', 'setRepo', 'setAvatar', 'listAgents', 'getAgent',
     'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus', 'fleetRuntimeStatus',
-    'getBootIdentity'
+    'getBootIdentity', 'fleetActivity'
 ]);

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -55,6 +55,7 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         FleetControlBridge.registry           = null;
         FleetControlBridge.manager            = null;
         FleetControlBridge.bootIdentitySource = null;
+        FleetControlBridge.activitySource     = null;
     });
 
     // ---- delegation: the registry (define / list / get) half ----
@@ -96,6 +97,30 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         FleetControlBridge.bootIdentitySource = null;
 
         expect(FleetControlBridge.getBootIdentity()).toEqual({fact: null, classification: 'unknown', advisory: true, reason: 'no-boot-identity-source'});
+    });
+
+    // ---- read-observe: the fleet activity snapshot (advisory read verb; carries no lifecycle-write) ----
+
+    test('fleetActivity returns the injected source snapshot — read-observe, never a lifecycle-write', async () => {
+        const snapshot = {
+            capability: {source: 'fleet:activity-adapters', state: 'wired', confidence: 'observed'},
+            events    : [{type: 'lane-claim', source: 'memory-core:mailbox', agentId: 'neo-opus-vega', occurredAt: '2026-07-05T00:00:00.000Z', payload: {kind: 'a2a-lane-claim', subject: '[lane-claim] #14606'}}]
+        };
+        FleetControlBridge.activitySource = {readActivitySnapshot: async params => { calls.push(['readActivitySnapshot', params]); return snapshot; }};
+
+        const result = await FleetControlBridge.fleetActivity({limit: 25});
+
+        expect(result).toEqual(snapshot);
+        expect(calls).toEqual([['readActivitySnapshot', {limit: 25}]]);   // bounds forwarded verbatim to the source
+    });
+
+    test('fleetActivity yields an honest source-not-wired snapshot when the source is unwired — never fabricated activity', () => {
+        FleetControlBridge.activitySource = null;
+
+        const result = FleetControlBridge.fleetActivity();
+
+        expect(result.events).toEqual([]);   // no invented traffic
+        expect(result.capability).toMatchObject({state: 'not-wired', confidence: 'none', reason: 'fleet activity source not wired'});
     });
 
     // ---- delegation: the lifecycle (start / stop / restart / remove / status) half ----

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -98,12 +98,13 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
         expect(res.ok).toBe(false);
     });
 
-    test('the wire allowlist is exactly the pane operations (+ the read-observe getBootIdentity) — no resolver seams', () => {
+    test('the wire allowlist is exactly the pane operations (+ the read-observe getBootIdentity / fleetActivity) — no resolver seams', () => {
         expect([...FLEET_WIRE_METHODS].sort()).toEqual(
-            // fleet-agent operations + the read-observe boot-identity fact (advisory read, no lifecycle-write)
-            ['defineAgent', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'removeAgent', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
+            // fleet-agent operations + the read-observe verbs (boot-identity fact + activity snapshot — advisory reads, no lifecycle-write)
+            ['defineAgent', 'fleetActivity', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'removeAgent', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
         );
-        expect(FLEET_WIRE_METHODS).toContain('getBootIdentity');   // the read-observe verb rides the wire; the lifecycle-write restart actuator does NOT (R3)
+        expect(FLEET_WIRE_METHODS).toContain('getBootIdentity');   // the read-observe verbs ride the wire; the lifecycle-write restart actuator does NOT (R3)
+        expect(FLEET_WIRE_METHODS).toContain('fleetActivity');
         expect(FLEET_WIRE_METHODS).not.toContain('getManager');
         expect(FLEET_WIRE_METHODS).not.toContain('getRegistry');
     });


### PR DESCRIPTION
Resolves #14862

Refs #14606 (FM cockpit ActivityStream live-binding — this is its Brain-side exposure prerequisite)

The Brain-side foundation of the ActivityStream live-binding: a read-observe `fleetActivity` verb that exposes the bounded cockpit activity snapshot (A2A + PR/lane) to the app, so the ActivityStream can bind a live feed instead of a fixture. The component + bounded buffer are already done (#14831); the adapters are closed (#14572/#14573); the missing piece was a consumable app-facing surface.

Evidence: L2 (unit-tested Brain capability — this slice's AC is fully unit-covered; no runtime/e2e AC, so no sandbox ceiling in play. The live NL e2e mount is an explicit follow-up slice of #14606). Residual: none for this slice.

## What it builds

- `fleetActivity` on `FLEET_WIRE_METHODS` (a read-observe verb alongside `getBootIdentity`) → auto-exposed by `createFleetRegistryBridge`, routed by `dispatchFleetRequest`.
- `FleetControlBridge.fleetActivity(params)` delegating to an injectable `activitySource` seam. Unwired → an honest `source-not-wired` snapshot (`createNotWiredCapability` + `events: []`), mirroring `bootIdentitySource`'s advisory-empty degrade — never fabricated activity, so the cockpit renders a "feed not wired" state rather than a silent freeze or invented traffic. No lifecycle-write authority (the R3 read-observe seam).

## Test Evidence

`FleetControlBridge.spec.mjs` — 2 new tests: a wired `activitySource` passes the snapshot through with bounds forwarded verbatim; an unwired source yields the honest `not-wired` degrade with empty events. `dispatchFleetRequest.spec.mjs` — the exact wire-allowlist guard updated to include `fleetActivity` (proving the SSOT client/server ends stay in lock-step). Both `fleetActivity` tests pass locally; the CI `unit` gate is the authoritative check.

## Post-Merge Validation

- [ ] Follow-up slices of #14606: the app-side binding (FleetCockpit polls `fleetActivity` → ActivityStream.events), the orchestrator-side real `activitySource` wiring (mailbox + PR adapters), and the NL-verifiable live e2e mount (on the #14859 hardened fixture).

## Deltas from ticket (#14862)

Exactly the slice scope: the `fleetActivity` capability + `activitySource` honest-degrade seam + unit tests. The app-binding, real-source wiring, and e2e mount are explicitly out-of-scope follow-ups.

Authored by Vega (@neo-opus-vega · Claude Opus 4.8 · Claude Code) — origin session 3bc21462.
