### PR TITLE
feat(dashboard): dock cross-zone tab drag — tab-into model move + green e2e (#14857)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -224,10 +224,10 @@ class MainContainer extends Viewport {
      * @returns {Object}
      */
     createPerspectiveToolbar() {
-        let me            = this,
-            collection    = me.layoutCollection,
+        let me             = this,
+            collection     = me.layoutCollection,
             activeLayoutId = collection?.activeLayoutId,
-            layoutButtons = Object.values(collection?.layouts || {}).map(layout => ({
+            layoutButtons  = Object.values(collection?.layouts || {}).map(layout => ({
                 cls    : layout.layoutId === activeLayoutId ? ['neo-dashboard-dock-perspective-active'] : [],
                 data   : {layoutId: layout.layoutId},
                 handler: () => me.restorePerspective(layout.layoutId),
@@ -248,9 +248,9 @@ class MainContainer extends Viewport {
                     alignItems : 'center',
                     color      : '#777',
                     display    : 'flex',
-                    fontWeight  : 600,
-                    marginRight : '12px',
-                    whiteSpace  : 'nowrap'
+                    fontWeight : 600,
+                    marginRight: '12px',
+                    whiteSpace : 'nowrap'
                 },
                 html: 'Perspectives'
             }, ...layoutButtons, {
@@ -452,8 +452,8 @@ class MainContainer extends Viewport {
         }
 
         removed = DockZoneModel.removeSavedLayout(collection, {
-            layoutId            : activeLayoutId,
-            replacementLayoutId : replacementId
+            layoutId           : activeLayoutId,
+            replacementLayoutId: replacementId
         });
 
         if (removed.errors.length) {
@@ -500,9 +500,55 @@ class MainContainer extends Viewport {
 
         return DockLayoutAdapter.project(me.dockModel, {
             applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
+            onDockCrossZoneDrop     : me.onDockCrossZoneDrop.bind(me),
             onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
             resolveComponentRef
         })
+    }
+
+    /**
+     * Cross-zone drop reducer: a dock tab-header released outside its own toolbar reports its release point
+     * here (via {@link Neo.dashboard.DockTabSortZone}). Resolves which tabs zone is under the pointer and,
+     * when it differs from the source, commits a semantic `moveItem` — relocating the item across zones in
+     * the committed dockZone.v1 document. A same-zone drop is a no-op (the within-toolbar reorder already
+     * committed via the `moveTo` listener).
+     * @param {Object} data
+     * @param {Number} data.clientX
+     * @param {Number} data.clientY
+     * @param {String} data.itemId       The dock item id being dragged.
+     * @param {String} data.sourceNodeId The tabs node the drag started in.
+     */
+    async onDockCrossZoneDrop({clientX, clientY, itemId, sourceNodeId}) {
+        let me    = this,
+            nodes = me.dockModel?.nodes || {},
+            zones = Object.keys(nodes)
+                .filter(nodeId => nodes[nodeId].type === 'tabs' && nodeId !== sourceNodeId)
+                .map(nodeId => ({nodeId, container: me.down({dockNodeId: nodeId})}))
+                .filter(zone => zone.container);
+
+        if (!zones.length) {
+            return
+        }
+
+        let rects        = await me.getDomRect(zones.map(zone => zone.container.id)),
+            targetNodeId = null;
+
+        zones.forEach((zone, index) => {
+            let rect = rects[index];
+
+            if (rect && clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
+                targetNodeId = zone.nodeId
+            }
+        });
+
+        if (targetNodeId) {
+            let descriptor = {operation: 'moveItem', itemId, targetNodeId},
+                result     = me.applyDockZoneOperation(descriptor);
+
+            if (result && !result.errors?.length && result.document) {
+                me.onDockZoneDocumentChange(result.document, descriptor, me)
+            }
+        }
     }
 }
 

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -1,6 +1,7 @@
-import Base          from '../core/Base.mjs';
-import DockSplitter  from './DockSplitter.mjs';
-import DockZoneModel from './DockZoneModel.mjs';
+import Base            from '../core/Base.mjs';
+import DockSplitter    from './DockSplitter.mjs';
+import DockTabSortZone from './DockTabSortZone.mjs';
+import DockZoneModel   from './DockZoneModel.mjs';
 
 /**
  * @summary Projects Agent Harness dock-zone model nodes into existing Neo layout and tab configs.
@@ -210,6 +211,7 @@ class DockLayoutAdapter extends Base {
             dockZoneDocument        : options.dockZoneDocument || model,
             items                   : model.items || {},
             nodes                   : model.nodes,
+            onDockCrossZoneDrop     : options.onDockCrossZoneDrop,
             onDockZoneDocumentChange: options.onDockZoneDocumentChange,
             resolveComponentRef     : options.resolveComponentRef || (() => null)
         })
@@ -507,8 +509,23 @@ class DockLayoutAdapter extends Base {
             // tab.Container drags; the model owns the result. (Cross-zone drag rides the dashboard SortZone
             // in a follow-up slice.)
             dragResortable: true,
-            items         : items.map(itemId => this.projectItem(itemId, context)),
-            listeners     : {
+            // The header toolbar's SortZone is the dock-aware subclass: within-toolbar drops fire `moveTo`
+            // (below), cross-zone drops report their release point to `onDockCrossZoneDrop` so the owner can
+            // hit-test the target zone and commit a `moveItem`. Still one drag system — no parallel pipeline.
+            headerToolbar : {
+                sortZoneConfig: {
+                    module          : DockTabSortZone,
+                    dockItemIds     : items,
+                    dockSourceNodeId: nodeId
+                }
+            },
+            items    : items.map(itemId => this.projectItem(itemId, context)),
+            listeners: {
+                // Cross-zone: the dock-aware SortZone fires `dockCrossZoneDrop` on this tab.Container; the
+                // closure holds `context` (captured here, not serialized), so the reducer survives config
+                // cloning and needs no component-tree walk. The reducer hit-tests the target zone + commits.
+                dockCrossZoneDrop: data => context.onDockCrossZoneDrop?.(data),
+                // Within-container reorder rides the container's own `moveTo` event.
                 moveTo: data => {
                     let itemId = items[data.fromIndex],
                         result = context.applyDockZoneOperation?.({operation: 'addTab', itemId, tabsNodeId: nodeId, index: data.toIndex});

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -1,0 +1,72 @@
+import TabHeaderSortZone from '../draggable/tab/header/toolbar/SortZone.mjs';
+
+/**
+ * @class Neo.dashboard.DockTabSortZone
+ * @extends Neo.draggable.tab.header.toolbar.SortZone
+ *
+ * @summary Dock-aware tab-header SortZone — routes a cross-zone tab drop to a semantic `moveItem`.
+ *
+ * The base tab-header SortZone reorders tab buttons WITHIN their own toolbar (the within-container
+ * gesture). This subclass adds the *cross-zone* half without a parallel drag system: on every drop it
+ * reports the release point + the dragged item's dock id to the owner-provided {@link #onDockCrossZoneDrop}
+ * handler. The handler hit-tests which dock zone is under the pointer — the SAME zone is a no-op (the
+ * within-toolbar reorder already committed), a DIFFERENT zone commits a `moveItem` through the dock model.
+ *
+ * It reuses the existing drag lifecycle end-to-end: the base SortZone owns the proxy, the sort math, and
+ * the drag data ({@link Neo.draggable.container.SortZone#onDragMove} threads `clientX`/`clientY`); this
+ * class only reads the outcome and forwards it. No popup / window-detach path is involved
+ * (`enableProxyToPopup` stays at its `false` default).
+ */
+class DockTabSortZone extends TabHeaderSortZone {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockTabSortZone'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockTabSortZone',
+        /**
+         * @member {String} ntype='dock-tab-sortzone'
+         * @protected
+         */
+        ntype: 'dock-tab-sortzone',
+        /**
+         * The dock item ids this toolbar projects, in tab-button order. `startIndex` indexes into this.
+         * @member {String[]|null} dockItemIds=null
+         */
+        dockItemIds: null,
+        /**
+         * The dock-zone (tabs node) id this toolbar renders — the source of a cross-zone move.
+         * @member {String|null} dockSourceNodeId=null
+         */
+        dockSourceNodeId: null
+    }
+
+    /**
+     * Extends the base drag-end: fires a `dockCrossZoneDrop` event on the owner tab.Container (`owner.up()`)
+     * carrying the release point + dragged item id. The adapter wires the listener for it — the same
+     * tab.Container node whose `moveTo` listener handles the within-container reorder — and its closure holds
+     * the dock reducer (the reliable seam: a closure captured at projection time, not a cloned config nor a
+     * component-tree walk). Fires BEFORE `super`: the base drag-end resets `startIndex` and its within-reorder
+     * commit can trigger a deferred re-projection that destroys this tab container, so firing after would
+     * land on a dead component.
+     * @param {Object} data
+     */
+    async processDragEnd(data) {
+        let me     = this,
+            itemId = me.dockItemIds?.[me.startIndex],
+            // Resolve the tab.Container + fire BEFORE super: the base drag-end tears down the owner linkage
+            // AND its within-reorder commit can trigger a deferred re-projection that destroys this tab
+            // container — firing after super would land on a dead component. Same node whose `moveTo`
+            // listener the adapter wires.
+            tabContainer = me.owner?.up?.(),
+            {clientX, clientY} = data || {};
+
+        if (itemId && tabContainer && Neo.isNumber(clientX) && Neo.isNumber(clientY)) {
+            tabContainer.fire('dockCrossZoneDrop', {clientX, clientY, itemId, sourceNodeId: me.dockSourceNodeId})
+        }
+
+        await super.processDragEnd(data)
+    }
+}
+
+export default Neo.setupClass(DockTabSortZone);

--- a/test/playwright/e2e/dashboard/DockCrossZoneDragNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockCrossZoneDragNL.spec.mjs
@@ -1,0 +1,65 @@
+import { test, expect } from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e for "release a tab into a NEW target drop zone" — the cross-zone gesture beyond the
+ * within-container reorder. Dragging a tab header OUT of its tabs node and dropping it over a DIFFERENT
+ * zone relocates the item in the committed dockZone.v1 document (a semantic `moveItem` to the target
+ * tabs node).
+ *
+ * The gesture rides the existing tab-header drag lifecycle: `Neo.dashboard.DockTabSortZone` fires a
+ * `dockCrossZoneDrop` on its tab.Container on drop; the owner reducer hit-tests the rendered zone under
+ * the pointer and commits the `moveItem`. This slice commits the model move DIRECTLY from the hit-test —
+ * the `dockPreview.v1` hover-affordance producer + `previewToOperation` rendering path is a follow-up leaf.
+ *
+ * Run: npx playwright test dashboard/DockCrossZoneDragNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Dock cross-zone drag journey (Neural Link)', () => {
+    test.setTimeout(90000);
+    test.use({ viewport: { width: 1600, height: 900 } });
+
+    const tabsNodeHolding = (doc, itemId) =>
+        Object.entries(doc?.nodes || {}).find(([, n]) => n.type === 'tabs' && (n.items || []).includes(itemId))?.[0];
+
+    test('dragging a tab header into another zone relocates the item in the committed dock model', async ({ page, neuralLink }) => {
+        await page.goto('/examples/dashboard/dock/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+        await page.waitForTimeout(2500); // settle worker boot + first render
+
+        const app      = await neuralLink.connectToApp('Neo.examples.dashboard.dock');
+        const holders  = await app.findInstances({ className: 'Neo.examples.dashboard.dock.MainContainer' }, ['id']);
+        const holderId = Array.isArray(holders) ? holders[0]?.id : holders?.id;
+        expect(holderId, 'the dock MainContainer must exist in the App Worker').toBeTruthy();
+
+        const readModel = async () => (await app.getComponent(holderId, ['dockModel'])).dockModel;
+
+        const before     = await readModel();
+        const sourceNode = tabsNodeHolding(before, 'strategy');
+        expect(sourceNode, 'strategy must start in main-tabs').toBe('main-tabs');
+        expect(tabsNodeHolding(before, 'terminal'), 'terminal must start in terminal-tabs').toBe('terminal-tabs');
+
+        // drag the Strategy header (main-tabs) and drop it over the Terminal zone (a DIFFERENT tabs node)
+        const strategyTab = page.locator('.neo-tab-header-button', { hasText: 'Strategy' }).first();
+        const terminalTab = page.locator('.neo-tab-header-button', { hasText: 'Terminal' }).first();
+        await expect(strategyTab, 'the Strategy tab header must render').toBeVisible({ timeout: 10000 });
+        await expect(terminalTab, 'the Terminal tab header must render').toBeVisible({ timeout: 10000 });
+
+        const from = await strategyTab.boundingBox();
+        const to   = await terminalTab.boundingBox();
+
+        // native cross-zone drag: Strategy header → onto the Terminal zone (the {steps} cadence arms the drag sensor)
+        await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(from.x + from.width / 2, from.y + from.height + 20, { steps: 20 }); // break out of the toolbar
+        await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2, { steps: 40 });          // travel to the target zone
+        await page.mouse.up();
+        await page.waitForTimeout(1000);
+
+        const after      = await readModel();
+        const targetNode = tabsNodeHolding(after, 'strategy');
+        console.log('[cross-zone] strategy:', sourceNode, '->', targetNode, '| terminal-tabs items:', JSON.stringify(after?.nodes?.['terminal-tabs']?.items));
+
+        // worker truth: the drop must have relocated strategy OUT of main-tabs INTO terminal-tabs
+        expect(targetNode, 'the cross-zone drop must move strategy to the Terminal zone — the producer contract')
+            .toBe('terminal-tabs');
+    });
+});


### PR DESCRIPTION
Resolves #14857

**What kind of change does this PR introduce?** Feature (`- [x] Feature`) · **Breaking?** No · Submitted to `dev` ✓

Releasing a tab header into a **different** dock zone now relocates the item in the committed `dockZone.v1` document — the marquee "drop a tab into a new target drop zone" gesture, one step beyond #14850's within-container reorder.

## What changed

**Reuse-and-route, no parallel drag system.** A dock-aware tab-header SortZone (`src/dashboard/DockTabSortZone.mjs`) rides the *existing* drag lifecycle — the base SortZone owns the proxy, the sort math, and the `clientX/clientY` in the drag data. On drop it fires a `dockCrossZoneDrop` event on its `tab.Container` (`owner.up()`, fired **before** `super` — the base drag-end resets `startIndex` and its within-reorder commit can trigger a deferred re-projection that destroys the container).

The adapter (`DockLayoutAdapter.projectTabsNode`) wires the `dockCrossZoneDrop` listener beside the within-container `moveTo` one; the listener's **closure holds the reducer** (`context.onDockCrossZoneDrop`, captured at projection time). This is the reliable seam: Neo's config clone strips functions from nested config, and the holder id is unset at projection — a closure sidesteps both. `project()` now threads `onDockCrossZoneDrop` through the context allowlist.

The reducer (`MainContainer.onDockCrossZoneDrop`) hit-tests which tabs zone is under the pointer (`getDomRect` over the projected zone containers) and commits a semantic `moveItem` via the landed `applyDockZoneOperation` → `onDockZoneDocumentChange` loop. A same-zone drop is a no-op (the within-toolbar reorder already committed).

Evidence: the whitebox-e2e drags "Strategy" out of `main-tabs` onto the Terminal zone and reads App-Worker truth — `strategy: main-tabs → terminal-tabs`, `terminal-tabs.items: ["terminal","strategy"]`.

## Test Evidence

- **Whitebox-e2e** `test/playwright/e2e/dashboard/DockCrossZoneDragNL.spec.mjs` (ships green in this PR per the gesture-proof guardrail):
  - `strategy: main-tabs → terminal-tabs` — a native cross-zone drag mutated the committed model (App-Worker truth via the Neural Link fixture).
  - Run: `npx playwright test dashboard/DockCrossZoneDragNL -c test/playwright/playwright.config.e2e.mjs --workers=1`
- **Regression** `dashboard/DockDragDropNL` (within-container reorder) stays green — `2 passed` together.
- **Unit** `DockLayoutAdapter` + `DockZoneModel`: **123 passed** — projection shape unchanged for existing consumers.
- Verified against a `dev`-based branch on an own dev server (not the reused operator clone).

## Post-Merge Validation

- Manual: open `examples/dashboard/dock/`, drag a tab header out of its zone and release it over another zone — the tab relocates and the change survives a perspective round-trip.
- CI note: the whitebox e2e is not gated per-PR (`test.yml` runs `integration-unified` + `unit` only) — the proof is the local green run + the shipped spec (a suite-wide gap, not this PR's).

## Deltas

- vs `#14857` (re-scoped to match this diff, per review): delivers the **functional tab-into cross-zone model move** — hit-test on drop → `moveItem`, e2e-proven, fail-closed. It commits DIRECTLY from the hit-test; it does **not** produce `dockPreview.v1`, render the `DockPreview` hover affordance, add `edge-*`/`split-*` placements, or add a hit-test unit — those are split to **#14866** (the `dockPreview.v1` producer + rendering leaf).
- `#14866` (not this PR) is what **unblocks `#14769`** — its `previewFor` seam binds to the `dockPreview.v1` producer, which #14866 lands.
- Behavior note: on a cross-zone drop the base within-reorder still runs; the async `moveItem` commits last and the re-projection reflects it (verified by the e2e). Suppressing the transient within-reorder is a polish follow-up, not a correctness gap.

## Out of Scope (→ #14866)

`dockPreview.v1` production · the `DockPreview` hover overlay · `edge-*`/`split-*` drop-to-split placements · hit-test unit · cross-window transfer (`#14769`) · grouped-node drag (`#14770`).

Authored by Grace (@neo-claude-opus, Opus 4.8). Cross-family review requested (Euclid / @neo-gpt).

🖖
