### PR TITLE
test(e2e): update FormsEngine live preview route (#14856)

### DIFF
--- a/test/playwright/e2e/rendering/LivePreviewMultiWindow.spec.mjs
+++ b/test/playwright/e2e/rendering/LivePreviewMultiWindow.spec.mjs
@@ -7,6 +7,8 @@ const environments = [
     { name: 'Dist Prod', path: '/dist/production/apps/portal/' }
 ];
 
+const formsEngineRoute = '#/learn/benefits/body/FormsEngine';
+
 async function verifyLivePreviewPopout(page, livePreviewLocatorOptions = undefined) {
     const livePreview = page.locator('.neo-code-live-preview', livePreviewLocatorOptions).first();
     await expect(livePreview).toBeVisible({ timeout: 30000 });
@@ -82,7 +84,7 @@ test.describe('LivePreview Multi-Window Functionality (Issue #9586)', () => {
             });
 
             test('Popout LivePreview from Learn Route (FormsEngine)', async ({ page }) => {
-                await page.goto(`${env.path}#/learn/benefits/FormsEngine`);
+                await page.goto(`${env.path}${formsEngineRoute}`);
                 await verifyLivePreviewPopout(page);
             });
 
@@ -93,7 +95,7 @@ test.describe('LivePreview Multi-Window Functionality (Issue #9586)', () => {
                 await verifyLivePreviewPopout(page);
 
                 // 2. Navigate to Learn Route via hash
-                await page.evaluate(() => window.location.hash = '#/learn/benefits/FormsEngine');
+                await page.evaluate(route => window.location.hash = route, formsEngineRoute);
 
                 // Wait for the new route to render and DOM to update
                 await page.waitForTimeout(3000);
@@ -103,7 +105,7 @@ test.describe('LivePreview Multi-Window Functionality (Issue #9586)', () => {
             });
 
             test('Sequential Route: Learn -> Home -> Popout', async ({ page }) => {
-                await page.goto(`${env.path}#/learn/benefits/FormsEngine`);
+                await page.goto(`${env.path}${formsEngineRoute}`);
 
                 // 1. Verify on Learn Route
                 await verifyLivePreviewPopout(page);


### PR DESCRIPTION
Resolves #14856

Updates the LivePreview multi-window E2E FormsEngine route to the current Learn tree path, `#/learn/benefits/body/FormsEngine`, and reuses that route in all Learn-route navigation points. The tested page still contains the live-preview blocks; the previous route was stale after the Learn content moved under `benefits/body`.

Evidence: L3 (isolated local browser E2E across Dev, Dist Dev, and Dist Prod) -> L3 required (#14856 route/popout regression ACs). Residual: none.

## Deltas from ticket

None substantive. The fix is the intended route-fixture update; the product content already exists at `learn/benefits/body/FormsEngine.md` and `learn/tree.json` registers it as `benefits/body/FormsEngine`.

## Test Evidence

- `npm run agent-preflight -- --no-fix test/playwright/e2e/rendering/LivePreviewMultiWindow.spec.mjs` -> passed.
- `./node_modules/.bin/playwright test -c tmp/e2e-full-8097.config.mjs test/playwright/e2e/rendering/LivePreviewMultiWindow.spec.mjs` -> 12 passed (2.6m).

## Post-Merge Validation

- [ ] PR-head CI remains green.

## Commits

- `05084903e7` — `test(e2e): update FormsEngine live preview route (#14856)`

Authored by Euclid (GPT-5, Codex Desktop). Session 6ab85930-3c14-4b18-b3b3-97989d1e75c6.
