### PR TITLE
fix(grid): refresh tree rows after bulk projection (#14854)

### DIFF
--- a/src/data/TreeStore.mjs
+++ b/src/data/TreeStore.mjs
@@ -186,7 +186,7 @@ class TreeStore extends Store {
      *
      * Iterates through the entire structural layer, silently setting `collapsed = true`
      * on all non-leaf nodes. The visible projection (`_items`) is then completely
-     * re-calculated from the roots, and a single `load` event is fired to trigger a UI refresh.
+     * re-calculated from the roots, and a single `load` event is fired to trigger a forced UI refresh.
      * This avoids the O(N^2) cost of triggering individual `splice` operations.
      *
      * @param {Boolean} [silent=false] True to prevent firing the 'load' event
@@ -216,7 +216,10 @@ class TreeStore extends Store {
         me.calcValueBands();
 
         if (!silent && me[updatingIndex] === 0) {
-            me.fire('load', {items: me._items})
+            me.fire('load', {
+                forceViewData: true,
+                items        : me._items
+            })
         }
     }
 
@@ -441,7 +444,7 @@ class TreeStore extends Store {
      *
      * Iterates through the entire structural layer, silently setting `collapsed = false`
      * on all non-leaf nodes. The visible projection (`_items`) is then completely
-     * re-calculated from the roots, and a single `load` event is fired to trigger a UI refresh.
+     * re-calculated from the roots, and a single `load` event is fired to trigger a forced UI refresh.
      * This avoids the O(N^2) cost of triggering individual `splice` operations.
      *
      * @param {Boolean} [silent=false] True to prevent firing the 'load' event
@@ -471,7 +474,10 @@ class TreeStore extends Store {
         me.calcValueBands();
 
         if (!silent && me[updatingIndex] === 0) {
-            me.fire('load', {items: me._items})
+            me.fire('load', {
+                forceViewData: true,
+                items        : me._items
+            })
         }
     }
 

--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -1254,11 +1254,12 @@ class GridBody extends Component {
     /**
      * @param {Object}   data
      * @param {Object[]} data.items
+     * @param {Boolean}  [data.forceViewData] True when rows must refresh even if record identity is stable.
      * @param {Boolean}  [data.postChunkLoad]
      * @param {Number}   [data.total]
      * @protected
      */
-    onStoreLoad({ items, postChunkLoad, total }) {
+    onStoreLoad({ forceViewData, items, postChunkLoad, total }) {
         let me = this,
             { windowId } = me;
 
@@ -1266,10 +1267,10 @@ class GridBody extends Component {
         // Render the entire chunk for immediate scrollability
         if (total && items.length < total) {
             me.#initialTotalSize = total;
-            me.createViewData();
+            me.createViewData(false, forceViewData === true);
             me.#initialTotalSize = 0
         } else {
-            me.createViewData()
+            me.createViewData(false, forceViewData === true)
         }
 
         if (me.mounted && !postChunkLoad) {

--- a/test/playwright/e2e/grid/TreeBigData.spec.mjs
+++ b/test/playwright/e2e/grid/TreeBigData.spec.mjs
@@ -102,15 +102,17 @@ test.describe('TreeGrid Big Data E2E', () => {
         // 1. Expand All
         await expandAllBtn.click({ force: true });
 
-        // Wait for the first toggle to become expanded
-        await expect(page.locator('.neo-tree-toggle').first()).toHaveClass(/is-expanded/, { timeout: 15000 });
+        const visibleTreeToggle = page.locator('.neo-grid-row:visible .neo-tree-toggle');
+
+        // Wait for the first visible toggle to become expanded
+        await expect(visibleTreeToggle.first()).toHaveClass(/is-expanded/, { timeout: 15000 });
 
         // Close the settings panel to make sure grid rows are clickable without obstruction
         await page.locator('.controls-container-button').click();
         await page.waitForTimeout(500);
 
         // 3. The Bug Reproduction: Collapse a single folder *after* Expand All
-        const firstExpandedFolderDynamic = page.locator('.neo-grid-row:has(.neo-tree-toggle.is-expanded)').first();
+        const firstExpandedFolderDynamic = page.locator('.neo-grid-row:visible:has(.neo-tree-toggle.is-expanded)').first();
         await expect(firstExpandedFolderDynamic).toBeVisible();
 
         const recordId  = await firstExpandedFolderDynamic.getAttribute('data-record-id');
@@ -139,8 +141,8 @@ test.describe('TreeGrid Big Data E2E', () => {
         // 4. Collapse All
         await collapseAllBtn.click({ force: true });
 
-        // Wait for the first toggle to become collapsed
-        await expect(page.locator('.neo-tree-toggle').first()).toHaveClass(/is-collapsed/, { timeout: 15000 });
+        // Wait for the first visible toggle to become collapsed
+        await expect(visibleTreeToggle.first()).toHaveClass(/is-collapsed/, { timeout: 15000 });
 
         // Close the settings panel
         await page.locator('.controls-container-button').click();
@@ -201,8 +203,8 @@ test.describe('TreeGrid Big Data E2E', () => {
         const expandAllBtn = page.locator('.neo-button:has-text("Expand All")');
         await expandAllBtn.click({ force: true });
 
-        // Wait for the first toggle to become expanded
-        await expect(page.locator('.neo-tree-toggle').first()).toHaveClass(/is-expanded/, { timeout: 15000 });
+        // Wait for the first visible toggle to become expanded
+        await expect(page.locator('.neo-grid-row:visible .neo-tree-toggle').first()).toHaveClass(/is-expanded/, { timeout: 15000 });
 
         // Close the settings panel
         await page.locator('.controls-container-button').click();

--- a/test/playwright/unit/grid/StoreInteractions.spec.mjs
+++ b/test/playwright/unit/grid/StoreInteractions.spec.mjs
@@ -33,6 +33,8 @@ import * as core          from '../../../../src/core/_export.mjs';
 import GridContainer      from '../../../../src/grid/Container.mjs';
 import InstanceManager    from '../../../../src/manager/Instance.mjs';
 import Store              from '../../../../src/data/Store.mjs';
+import TreeModel          from '../../../../src/data/TreeModel.mjs';
+import TreeStore          from '../../../../src/data/TreeStore.mjs';
 import VdomHelper         from '../../../../src/vdom/Helper.mjs';
 
 test.describe('Grid & Store Interactions', () => {
@@ -306,5 +308,98 @@ test.describe('Grid & Store Interactions', () => {
         // Content updates for the 2 remaining rows (2 * 3 = 6).
         // Total deltas roughly 18-20.
         expect(deltas.length).toBeLessThanOrEqual(30);
+    });
+});
+
+test.describe('Grid & TreeStore Bulk Projection Interactions', () => {
+    let grid, store;
+
+    class TreeStoreBulkProjectionModel extends TreeModel {
+        static config = {
+            className: 'Test.Unit.Grid.StoreInteractions.TreeStoreBulkProjectionModel',
+            fields: [
+                {name: 'id',   type: 'String'},
+                {name: 'name', type: 'String'}
+            ]
+        }
+    }
+
+    const BulkProjectionModel = Neo.setupClass(TreeStoreBulkProjectionModel);
+
+    test.beforeEach(async () => {
+        store = Neo.create(TreeStore, {
+            autoInitRecords: false,
+            data           : [{
+                id: '1', name: 'Root A', isLeaf: false, collapsed: true
+            }, {
+                id: '1-1', parentId: '1', name: 'Child A1', isLeaf: true
+            }, {
+                id: '2', name: 'Root B', isLeaf: false, collapsed: true
+            }, {
+                id: '2-1', parentId: '2', name: 'Child B1', isLeaf: true
+            }],
+            model: BulkProjectionModel
+        });
+
+        grid = Neo.create(GridContainer, {
+            appName          : 'GridStoreInteractionsTest',
+            bufferColumnRange: 0,
+            bufferRowRange   : 1,
+            columns          : [{
+                dataField: 'name',
+                text     : 'Tree',
+                type     : 'tree',
+                width    : 250
+            }],
+            height            : 240,
+            rowHeight         : 40,
+            store,
+            width             : 300
+        });
+
+        await grid.initVnode();
+        grid.mounted = true;
+
+        grid.body.columnPositions.clear();
+        grid.body.columnPositions.add([{
+            dataField: 'name',
+            width    : 250,
+            x        : 0
+        }]);
+
+        grid.body.set({
+            availableHeight: 200,
+            containerWidth : 300
+        });
+
+        await grid.timeout(50);
+    });
+
+    test.afterEach(async () => {
+        await grid.timeout(20);
+        grid?.destroy();
+        store?.destroy();
+    });
+
+    test('TreeStore bulk projections refresh same-record tree cell state', async () => {
+        const firstRow      = grid.body.items.find(row => row.rowIndex === 0),
+              treeComponent = firstRow.components.name;
+
+        expect(treeComponent.collapsed).toBe(true);
+        expect(treeComponent.vdom.cn[1].cls).toContain('is-collapsed');
+
+        store.expandAll();
+        await grid.timeout(50);
+
+        expect(firstRow.record).toBe(store.getAt(0));
+        expect(treeComponent.collapsed).toBe(false);
+        expect(treeComponent.vdom.cn[1].cls).toContain('is-expanded');
+
+        store.collapseAll();
+        await grid.timeout(50);
+
+        expect(firstRow.record).toBe(store.getAt(0));
+        expect(treeComponent.collapsed).toBe(true);
+        expect(treeComponent.vdom.cn[1].cls).toContain('is-collapsed');
     });
 });


### PR DESCRIPTION
Resolves #14854

TreeStore bulk projections now mark their `load` event with `forceViewData`, and Grid Body consumes that signal to refresh same-record pooled rows. This updates tree column components after `expandAll()` / `collapseAll()` instead of leaving the visible root toggle stuck on the pre-bulk class. The TreeBigData E2E assertions now scope bulk checks to visible tree rows so hidden pooled rows cannot mask the user-visible state.

Evidence: L3 (local Chromium E2E plus focused grid/data unit checks) -> L3 required (TreeGrid BigData user-visible structural interaction ACs). Residual: none.

## Deltas from ticket
- Added a runtime `forceViewData` load payload for TreeStore bulk projections.
- Added a grid unit guard for same-record TreeStore bulk projection refresh.
- Tightened TreeBigData E2E selectors to user-visible row toggles.

## Test Evidence
- `git diff --check` passed.
- `./node_modules/.bin/playwright test -c <local no-webServer unit config> test/playwright/unit/grid/StoreInteractions.spec.mjs -g "TreeStore bulk projections"` -> 1 passed.
- `./node_modules/.bin/playwright test -c <local no-webServer unit config> test/playwright/unit/data/TreeStore.spec.mjs -g "Bulk Operations"` -> 4 passed.
- `./node_modules/.bin/playwright test -c tmp/e2e-14855.config.mjs test/playwright/e2e/grid/TreeBigData.spec.mjs` -> 5 passed.
- Local note: the stock unit config starts a Chroma webServer; this shell lacks the `chroma` binary, so focused non-AI unit checks used the same unit config minus that webServer.

## Post-Merge Validation
- [ ] CI unit and test-scope gates remain green on GitHub.
- [ ] If port 8080 is free in the shared E2E runner, rerun the canonical TreeBigData command from #14854.

## Commits
- `b2dd5a45c4` — `fix(grid): refresh tree rows after bulk projection (#14854)`

Authored by Euclid (GPT-5 Codex, Codex Desktop). Session 6ab85930-3c14-4b18-b3b3-97989d1e75c6.
