### PR TITLE
feat(agentos): bind the cockpit ActivityStream to the fleetActivity feed + honest sample/live/stale states (#14868)

### DIFF
--- a/apps/agentos/view/fleet/ActivityStream.mjs
+++ b/apps/agentos/view/fleet/ActivityStream.mjs
@@ -71,8 +71,9 @@ class ActivityStream extends Container {
          */
         maxVisible_: 15,
         /**
-         * Feed liveness — `live` streams; `stale` renders the degrade banner (adapter loss), never a
-         * silent freeze.
+         * Feed liveness — `live` streams; `sample` labels a representative (source-not-wired) feed so it
+         * is never mistaken for live; `stale` renders the degrade banner (adapter loss). None of the
+         * three is a silent freeze — the header always states which one is showing.
          * @member {String} adapterState_='live'
          * @reactive
          */
@@ -134,20 +135,24 @@ class ActivityStream extends Container {
     }
 
     /**
-     * @summary The liveness header — a label + a streaming/stale indicator (the honest-degrade surface).
+     * @summary The liveness header — a label + an honest state indicator: `● streaming` (live),
+     * `sample · live feed pending` (representative, source not wired), or `stale — reconnecting`
+     * (adapter loss). The state is always named so the feed can never silently pose as live.
      * @returns {Object}
      */
     headerConfig() {
-        const stale = this.adapterState === 'stale';
+        const state     = this.adapterState,
+              stateText = {sample: 'sample · live feed pending', stale: 'stale — reconnecting'}[state] ?? '● streaming',
+              stateCls  = {sample: 'is-sample', stale: 'is-stale'}[state] ?? 'is-live';
 
         return {
             module: Container,
-            cls   : ['fm-stream-head', stale ? 'is-stale' : 'is-live'],
+            cls   : ['fm-stream-head', stateCls],
             flex  : 'none',
             layout: {ntype: 'hbox', align: 'center'},
             items : [
                 {module: Component, cls: ['fm-stream-label'], flex: 1,      text: 'Live activity'},
-                {module: Component, cls: ['fm-stream-state'], flex: 'none', text: stale ? 'stale — reconnecting' : '● streaming'}
+                {module: Component, cls: ['fm-stream-state'], flex: 'none', text: stateText}
             ]
         }
     }
@@ -204,13 +209,14 @@ class ActivityStream extends Container {
     }
 
     /**
-     * @summary The row's human text — the event payload's summary when present, else an agent + type
-     * fallback so an un-summarized event still reads.
+     * @summary The row's human text — the event payload's summary/subject when present, else an agent +
+     * type fallback so an un-summarized event still reads. `subject` is the live A2A/PR/lane adapter's
+     * text field (fixtures carry `text`); both are honored so real feed events render meaningfully.
      * @param {Object} event
      * @returns {String}
      */
     eventText(event) {
-        return event?.payload?.text ?? event?.payload?.summary ?? `${event?.agentId ?? 'fleet'} · ${event?.type ?? 'event'}`
+        return event?.payload?.text ?? event?.payload?.summary ?? event?.payload?.subject ?? `${event?.agentId ?? 'fleet'} · ${event?.type ?? 'event'}`
     }
 }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -79,10 +79,53 @@ class FleetCockpit extends Container {
             flex  : 1.55,
             agents: FIXTURE_ROSTER
         }, {
-            module: ActivityStream,
-            flex  : 1,
-            events: FIXTURE_ACTIVITY
+            module      : ActivityStream,
+            flex        : 1,
+            reference   : 'activity-stream',
+            adapterState: 'sample', // the fixture is a representative sample until the live source is wired
+            events      : FIXTURE_ACTIVITY
         }]
+    }
+
+    /**
+     * @summary On construct, bind the activity stream to the live fleet feed.
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+        this.loadActivity()
+    }
+
+    /**
+     * @summary Bind the activity stream to the live fleet feed: poll the read-observe `fleetActivity`
+     * verb on the injected registry bridge and route its honest capability state to the stream. Wired →
+     * live events (the feed returns newest-first; the stream renders chronological, so reverse); a
+     * not-wired source or absent bridge leaves the representative sample in place (honestly labelled by
+     * the stream header); a degraded source renders the stale banner. Never presents the sample as live,
+     * and fails closed to the sample rather than blanking the surface.
+     * @protected
+     */
+    async loadActivity() {
+        let me     = this,
+            stream = me.getReference('activity-stream'),
+            bridge = globalThis.AgentOS?.fleet?.registryBridge;
+
+        if (!stream || typeof bridge?.fleetActivity !== 'function') {
+            return
+        }
+
+        try {
+            const {capability, events} = await bridge.fleetActivity() ?? {};
+
+            if (capability?.state === 'wired' && Array.isArray(events) && events.length > 0) {
+                stream.set({adapterState: 'live', events: events.slice().reverse()})
+            } else if (capability?.state === 'degraded') {
+                stream.adapterState = 'stale'
+            }
+            // not-wired / empty → keep the honestly-labelled 'sample' seed
+        } catch (error) {
+            // fail-closed: the sample seed stays rather than blanking the feed
+        }
     }
 }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -98,11 +98,14 @@ class FleetCockpit extends Container {
 
     /**
      * @summary Bind the activity stream to the live fleet feed: poll the read-observe `fleetActivity`
-     * verb on the injected registry bridge and route its honest capability state to the stream. Wired →
-     * live events (the feed returns newest-first; the stream renders chronological, so reverse); a
-     * not-wired source or absent bridge leaves the representative sample in place (honestly labelled by
-     * the stream header); a degraded source renders the stale banner. Never presents the sample as live,
-     * and fails closed to the sample rather than blanking the surface.
+     * verb on the injected registry bridge and route its honest capability state to the stream:
+     * - `wired` → **live** (the feed is newest-first; the stream renders chronological, so reverse). A
+     *   wired source is live even when momentarily empty — it is streaming, just quiet — so an empty
+     *   wired feed stays `live` (empty), never the sample: falling back to the sample would falsely
+     *   imply the source is not wired.
+     * - `degraded` → the **stale** banner.
+     * - not-wired / absent bridge / a thrown source → leave the representative **sample** in place
+     *   (honestly labelled by the stream header); fail closed rather than blanking the surface.
      * @protected
      */
     async loadActivity() {
@@ -117,12 +120,12 @@ class FleetCockpit extends Container {
         try {
             const {capability, events} = await bridge.fleetActivity() ?? {};
 
-            if (capability?.state === 'wired' && Array.isArray(events) && events.length > 0) {
-                stream.set({adapterState: 'live', events: events.slice().reverse()})
+            if (capability?.state === 'wired') {
+                stream.set({adapterState: 'live', events: Array.isArray(events) ? events.slice().reverse() : []})
             } else if (capability?.state === 'degraded') {
                 stream.adapterState = 'stale'
             }
-            // not-wired / empty → keep the honestly-labelled 'sample' seed
+            // not-wired / absent bridge → keep the honestly-labelled 'sample' seed
         } catch (error) {
             // fail-closed: the sample seed stays rather than blanking the feed
         }

--- a/test/playwright/unit/apps/agentos/view/fleet/activityStream.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/activityStream.spec.mjs
@@ -94,4 +94,31 @@ test.describe('Fleet cockpit ActivityStream — bounded, backpressure-aware feed
 
         stream.destroy()
     });
+
+    test('event text reads the live-adapter payload subject, not just the fixture text field', () => {
+        // the live A2A/PR/lane adapters carry the row text in payload.subject (fixtures use payload.text);
+        // both must render meaningfully rather than falling to the "agentId · type" fallback
+        const stream = Neo.create(ActivityStream, {
+            appName,
+            events: [{type: 'a2a-activity', agentId: 'neo-opus-vega', occurredAt: '2026-07-04T10:00:00.000Z', payload: {subject: '[lane-claim] #14606 activity live-binding'}}]
+        });
+
+        const textItem = rows(stream)[0].items.find(item => item.cls.includes('fm-ev-text'));
+        expect(textItem.text).toBe('[lane-claim] #14606 activity live-binding');
+
+        stream.destroy()
+    });
+
+    test('sample state labels a representative (source-not-wired) feed honestly — never "streaming"', () => {
+        const stream = Neo.create(ActivityStream, {appName, adapterState: 'sample', events: makeEvents(3)});
+
+        expect(head(stream).cls).toContain('is-sample');
+        const stateItem = head(stream).items.find(item => item.cls.includes('fm-stream-state'));
+        expect(stateItem.text).toBe('sample · live feed pending');
+        expect(stateItem.text).not.toContain('streaming');   // a sample must never pose as live
+        // the sample is shown, not blanked
+        expect(rows(stream).length).toBe(3);
+
+        stream.destroy()
+    });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1,0 +1,100 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FleetCockpitLoadActivityTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import Instance       from '../../../../../../../src/manager/Instance.mjs';
+
+/**
+ * Covers the fail-closed matrix for `FleetCockpit.loadActivity()` — the app-side consumption of the
+ * read-observe `fleetActivity` bridge verb.
+ *
+ * `loadActivity`'s unit is its ROUTING decision: given the bridge's honest capability state, which
+ * `adapterState` (+ event order) does it apply to the stream? The stream is a collaborator, so it is
+ * mocked with a spy that records what `loadActivity` sets — this pins the routing precisely and in
+ * isolation. That the REAL `ActivityStream` renders each `adapterState` (sample / live / stale) is
+ * covered by `activityStream.spec.mjs`; here we prove `loadActivity` chooses the right one.
+ */
+test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', () => {
+    let FleetCockpit;
+
+    const clearBridge = () => { delete globalThis.AgentOS };
+
+    // a spy stream: `loadActivity` either assigns `adapterState` directly (stale) or calls `set({...})`
+    // (live); both land on the same object so the resulting state is assertable.
+    const makeStream = () => ({adapterState: 'sample', events: null, set(config) { Object.assign(this, config) }});
+
+    /**
+     * @param {Object|null} bridge The stubbed `registryBridge` (or null for "no bridge").
+     * @returns {Promise<Object>} the spy stream after loadActivity routed to it.
+     */
+    const routeLoadActivity = async bridge => {
+        bridge ? (globalThis.AgentOS = {fleet: {registryBridge: bridge}}) : clearBridge();
+
+        const stream  = makeStream(),
+              cockpit = {getReference: reference => reference === 'activity-stream' ? stream : null};
+
+        await FleetCockpit.prototype.loadActivity.call(cockpit);
+
+        return stream
+    };
+
+    test.beforeAll(async () => {
+        FleetCockpit = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default
+    });
+
+    test.afterEach(() => clearBridge());
+
+    test('no bridge → keeps the honestly-labelled sample seed (fail-closed, no crash)', async () => {
+        expect((await routeLoadActivity(null)).adapterState).toBe('sample')
+    });
+
+    test('a bridge without fleetActivity → keeps the sample seed', async () => {
+        expect((await routeLoadActivity({})).adapterState).toBe('sample')
+    });
+
+    test('not-wired capability → keeps the sample seed', async () => {
+        const stream = await routeLoadActivity({fleetActivity: async () => ({capability: {state: 'not-wired'}, events: []})});
+        expect(stream.adapterState).toBe('sample')
+    });
+
+    test('degraded capability → the stale banner', async () => {
+        const stream = await routeLoadActivity({fleetActivity: async () => ({capability: {state: 'degraded'}, events: []})});
+        expect(stream.adapterState).toBe('stale')
+    });
+
+    test('a thrown source → fail-closed, keeps the sample seed (never blanks or falsely goes live)', async () => {
+        const stream = await routeLoadActivity({fleetActivity: async () => { throw new Error('bridge boom') }});
+        expect(stream.adapterState).toBe('sample')
+    });
+
+    test('wired + events → live, reversing the newest-first feed to chronological for the stream', async () => {
+        const stream = await routeLoadActivity({fleetActivity: async () => ({
+            capability: {state: 'wired'},
+            events    : [ // newest-first, as the adapter sorts
+                {type: 'a2a-activity', occurredAt: '2026-07-04T12:00:00.000Z', payload: {subject: 'newest'}},
+                {type: 'a2a-activity', occurredAt: '2026-07-04T11:00:00.000Z', payload: {subject: 'older'}}
+            ]
+        })});
+        expect(stream.adapterState).toBe('live');
+        expect(stream.events.map(event => event.payload.subject)).toEqual(['older', 'newest'])
+    });
+
+    test('wired + empty → live (streaming but quiet), never the sample — a wired source is live', async () => {
+        const stream = await routeLoadActivity({fleetActivity: async () => ({capability: {state: 'wired'}, events: []})});
+        expect(stream.adapterState).toBe('live');
+        expect(stream.events).toEqual([])
+    });
+});


### PR DESCRIPTION
Resolves #14868

Refs #14606 (FM cockpit ActivityStream live-binding — this is its app-side consumption slice)

The shipped shell rendered the ActivityStream with a hardcoded `● streaming` header over **fixture** events — a liveness misstatement. This binds the stream to the real feed (the `fleetActivity` capability merged in #14863) and states its source honestly.

Evidence: L2 (unit-tested — the `ActivityStream` subject/label rendering *and* the `FleetCockpit.loadActivity` fail-closed matrix; 13/13 locally). Residual: none for this slice — the NL-verifiable live e2e mount is a #14606 follow-up. Note: this clone's stock unit runner hangs on its Chroma `webServer`, so I ran these non-AI specs via a webServer-stripped unit config (13/13 pass); the CI `unit` gate is authoritative.

## What it builds

- **`FleetCockpit.loadActivity()`** — on construct, polls the read-observe `fleetActivity` verb on `globalThis.AgentOS.fleet.registryBridge` and routes the feed's honest capability state to the stream: `wired` → **live** (even when momentarily empty — a wired source is streaming, just quiet, so it never falls back to the sample; the feed is newest-first, reversed to chronological); `not-wired` / absent bridge → the representative sample stays (honestly labelled); `degraded` → the stale banner. Fail-closed (guards + `try/catch`) — it cannot break construction, and never presents the sample as live.
- **`ActivityStream`** — a new `sample` header state (`sample · live feed pending`), and `eventText` now reads `payload.subject` (the live A2A/PR/lane adapter's text field) alongside the fixture's `payload.text`, so real feed events render meaningfully instead of the `agentId · type` fallback.

## Test Evidence

Two specs, **13/13 locally** (via a webServer-stripped unit config — this clone's Chroma `webServer` hangs):
- `activityStream.spec.mjs` (+2): `eventText` renders `payload.subject`; the `sample` state renders `sample · live feed pending` (asserts it never contains `streaming`) while still showing rows. Existing bounded-buffer / kind-delegation / stale-degrade tests unchanged.
- `fleetCockpit.spec.mjs` (new, 7): the `loadActivity` **fail-closed matrix** — no bridge / no `fleetActivity` / not-wired / thrown → `sample`; `degraded` → `stale`; `wired`+events → `live` with the newest-first feed reversed to chronological; `wired`+empty → `live` (empty), never `sample`. The stream collaborator is spied so the routing is asserted in isolation.

`node --check` + block-alignment green; the CI `unit` gate is authoritative.

## Post-Merge Validation

- [ ] CI `unit` gate green (the authoritative run for this slice).
- [ ] #14606 follow-ups: the orchestrator-side real `activitySource` wiring (`devFleetServer` ↔ memory-core mailbox) — until it lands the feed is honest `sample`; and the NL-verifiable live e2e mount (on #14859's hardened fixture).

## Deltas from ticket (#14868)

Exactly the slice scope: the app-side poll + the honest `sample`/`live`/`stale` routing + the `eventText` subject fix + unit tests. The real-source wiring and the e2e mount are explicit #14606 follow-ups, not smuggled in here.

Authored by Vega (Claude Opus 4.8, Claude Code). Session 3bc21462-8122-4b02-81e4-324ed781e1ac.
