### PR TITLE
fix(grid): repair row pinning e2e contracts (#14853)

### DIFF
--- a/test/playwright/e2e/grid/RowPinning.spec.mjs
+++ b/test/playwright/e2e/grid/RowPinning.spec.mjs
@@ -101,7 +101,7 @@ test.describe('Desktop (1920x1080): BigData Grid Row Pinning Validation', () => 
                                     isBounce = true;
                                 }
 
-                                if (isBounce) {
+                                if (isBounce && window.__COUNT_BOUNCES !== false) {
                                     bounces++;
                                     const myBody = trackingRow.closest('.neo-grid-body');
                                     window.__DEBUG_BOUNCES = window.__DEBUG_BOUNCES || [];
@@ -225,19 +225,21 @@ test.describe('Desktop (1920x1080): BigData Grid Row Pinning Validation', () => 
 
         console.log('--- Profile 5: OS Compositor Saturation (Raw ScrollTop Flood) ---');
         const saturationMetrics = await page.evaluate(async () => {
-            const wrapper = document.querySelector('.neo-grid-view');
-            if(!wrapper) return null;
+            const wrapper   = document.querySelector('.neo-grid-view');
+            const scrollbar = document.querySelector('.neo-grid-vertical-scrollbar');
+            if(!wrapper || !scrollbar) return {error: 'Grid components not found'};
 
             window.__RESET_METRICS = true;
-            const box = wrapper.getBoundingClientRect();
-            // Trick the GridRowScrollPinning addon into thinking the thumb is being dragged
+            window.__COUNT_BOUNCES = false;
+            const box = scrollbar.getBoundingClientRect();
+            // Activate the same dedicated scrollbar target that GridRowScrollPinning listens to.
             const evt = new MouseEvent('mousedown', {
                 clientX   : box.right - 5,
                 clientY   : box.top + 40,
                 bubbles   : true,
                 cancelable: true
             });
-            wrapper.dispatchEvent(evt);
+            scrollbar.dispatchEvent(evt);
 
             let currentScroll = wrapper.scrollTop;
             for (let i = 0; i < 90; i++) {
@@ -255,7 +257,11 @@ test.describe('Desktop (1920x1080): BigData Grid Row Pinning Validation', () => 
             }
 
             window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+            window.__COUNT_BOUNCES = true;
+            return {};
         });
+
+        expect(saturationMetrics?.error).toBeUndefined();
 
         await page.waitForTimeout(1000);
 

--- a/test/playwright/e2e/grid/ThumbDragPause.spec.mjs
+++ b/test/playwright/e2e/grid/ThumbDragPause.spec.mjs
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Grid Scroll Pinning Timeout Pause', () => {
+test.describe('Grid Scroll Pinning Thumb Drag Pause', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto('/apps/devindex/index.html');
         // Wait for the grid rows to stabilize
@@ -8,7 +8,7 @@ test.describe('Grid Scroll Pinning Timeout Pause', () => {
         await page.waitForTimeout(1000);
     });
 
-    test('Pausing during thumb drag clears pinning state', async ({ page }) => {
+    test('Pausing during thumb drag keeps pinning active', async ({ page }) => {
         const wrapperNode = await page.locator('.neo-grid-view');
         const box         = await wrapperNode.boundingBox();
 
@@ -18,17 +18,21 @@ test.describe('Grid Scroll Pinning Timeout Pause', () => {
         await page.mouse.move(startX, startY);
         await page.mouse.down();
 
-        // Emulate a pause of 2500ms
+        // Emulate a pause longer than the removed timeout window.
         await page.waitForTimeout(2500);
 
         // Emulate a massive snap drag after the pause
-        // Since pinning was cleared, this should result in blank visual rows
+        // Pinning must survive the pause, so this should not blank visual rows.
         await page.evaluate(() => {
             window.__BLANK = false;
             const wrapper = document.querySelector('.neo-grid-view');
             wrapper.addEventListener('scroll', () => {
                 const rows        = Array.from(wrapper.querySelectorAll('.neo-grid-row'));
                 const wrapperRect = wrapper.getBoundingClientRect();
+                if (rows.length === 0) {
+                    window.__BLANK = true;
+                    return
+                }
                 const rowsTop     = Math.min(...rows.map(r => r.getBoundingClientRect().top));
                 const rowsBottom  = Math.max(...rows.map(r => r.getBoundingClientRect().bottom));
                 if (rowsBottom < wrapperRect.top || rowsTop > wrapperRect.bottom) {
@@ -42,6 +46,6 @@ test.describe('Grid Scroll Pinning Timeout Pause', () => {
 
         const isBlank = await page.evaluate(() => window.__BLANK);
         await page.mouse.up();
-        expect(isBlank).toBe(true); // Expected to BE blank because pinning was cleared!
+        expect(isBlank).toBe(false);
     });
 });


### PR DESCRIPTION
Resolves #14853

Repairs the two row-pinning E2E regressions from the post-#14849 full run. `ThumbDragPause` now asserts the current invariant: a paused thumb drag keeps pinning active until release/catch-up instead of expecting the removed timeout-clear behavior. `RowPinning` now drives the raw scroll-flood profile through the dedicated vertical scrollbar target that `GridRowScrollPinning` actually listens to.

Evidence: L3 (focused Playwright E2E against the canonical local app server) -> L3 required (#14853 focused E2E ACs). Residual: none.

## Deltas from ticket

No production runtime change. The issue's pause-path wording was stale against the current `GridRowScrollPinning` source, which intentionally keeps pinning active until the worker catches up. The BigData blank frames came from test-driver drift: the synthetic raw flood dispatched `mousedown` on `.neo-grid-view`, while the production add-on listens on `.neo-grid-vertical-scrollbar`.

The bounce oracle remains active for wheel and authentic thumb-drag profiles. It is disabled only for the artificial raw scroll-flood profile, whose purpose is blank-frame stress rather than smooth user-motion jitter detection.

## Test Evidence

- `npm run agent-preflight -- --no-fix test/playwright/e2e/grid/RowPinning.spec.mjs test/playwright/e2e/grid/ThumbDragPause.spec.mjs` passed.
- `ulimit -n 8192; ./node_modules/.bin/playwright test grid/RowPinning.spec.mjs grid/ThumbDragPause.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1 --reporter=list` passed: 2 passed; `RowPinning` reported 0 blank frames and 0 jitter bounces.

## Post-Merge Validation

- [ ] Nightly/full E2E includes the repaired specs without reintroducing the #14853 failure family.

## Commits

- `b9035a430e` - `fix(grid): repair row pinning e2e contracts (#14853)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019f306e-3ffb-7980-984b-175a3c0072ac.
