### PR TITLE
feat(dashboard): dock perspective restore planner — same-topology, semantic-op, never-remount (#14653)

### DIFF
--- a/src/dashboard/DockRestorePlanner.mjs
+++ b/src/dashboard/DockRestorePlanner.mjs
@@ -1,0 +1,179 @@
+import Base             from '../core/Base.mjs';
+import DockTopologyDiff from './DockTopologyDiff.mjs';
+import DockZoneModel    from './DockZoneModel.mjs';
+
+/**
+ * @class Neo.dashboard.DockRestorePlanner
+ * @extends Neo.core.Base
+ *
+ * @summary Plans + applies a same-topology perspective RESTORE through semantic operations.
+ *
+ * Restore is where object permanence must hold: reaching a captured layout must happen via the
+ * {@link Neo.dashboard.DockZoneModel} executor (`moveItem` / `resizeSplit` / `setItemAutoHidden`), NEVER by
+ * document replacement — a swap would remount every pane, violating the §2.6 reparent-never-recreate promise
+ * (a restore that flickers every pane is a contract violation wearing a feature's name).
+ *
+ * This is the UNCHANGED-topology leaf: the shape fingerprint must match (same split tree + per-node tab
+ * counts). The cross-topology / structure-recreation case (fingerprint mismatch) is a separate leaf; this
+ * planner defers it structurally rather than guessing. A matching fingerprint means per-node item COUNTS are
+ * equal, so `adds`/`removes` cannot occur — but items can still be EXCHANGED across nodes (`moves`) while
+ * preserving every count (two `t2` zones, or a `t2` and a `t1`, swapping items). Those moves are sequenced
+ * collapse-safely; the one residual a matching fingerprint cannot rule out — a cycle of single-item nodes
+ * swapping, unsolvable by ordering under per-step normalization — defers structurally.
+ *
+ * The planner is a PURE fold over `DockTopologyDiff.diffDockDocuments(current, captured)` (direction:
+ * current → captured, planning TOWARD the capture). Application is a sequential, fail-closed executor pass.
+ */
+class DockRestorePlanner extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockRestorePlanner'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockRestorePlanner'
+    }
+
+    /**
+     * @summary Pure planner: two documents → an ordered semantic-operation plan toward the captured layout.
+     *
+     * Fingerprint gate first: a shape mismatch returns a structured deferral (the cross-topology leaf owns
+     * that path) with an empty plan — never a silent partial. Otherwise it maps each diff category to its
+     * operation in a deterministic order (moves → tab reorders ascending target index → resizes → auto-hide
+     * flips; `adds` lead when present). `removes` are NOT destroyed — restore never deletes — they surface as
+     * a `surplus` list the cross-topology dual consumes.
+     * @param {Object} current  The live committed document.
+     * @param {Object} captured The captured layout document to restore toward.
+     * @returns {{deferred: Boolean, reason: (String|null), plan: Object[], surplus: Object[], errors: String[]}}
+     * @static
+     */
+    static planRestore(current, captured) {
+        let fpCurrent  = DockZoneModel.computeShapeFingerprint(current),
+            fpCaptured = DockZoneModel.computeShapeFingerprint(captured),
+            errors     = [...fpCurrent.errors, ...fpCaptured.errors];
+
+        if (errors.length) {
+            return {deferred: false, reason: null, plan: [], surplus: [], errors}
+        }
+
+        // computeShapeFingerprint returns {fingerprint: {shape, nodeCounts, itemCount}, ...}; `shape` is the
+        // canonical structural signature (split tree + per-node tab counts). Same shape ⇒ same topology.
+        if (fpCurrent.fingerprint?.shape !== fpCaptured.fingerprint?.shape) {
+            return {
+                deferred: true,
+                reason  : 'topology-fingerprint-mismatch',
+                plan    : [],
+                surplus : [],
+                errors  : []
+            }
+        }
+
+        let diff = DockTopologyDiff.diffDockDocuments(current, captured);
+
+        if (diff.errors.length) {
+            return {deferred: false, reason: null, plan: [], surplus: [], errors: diff.errors}
+        }
+
+        // Cross-node moves must be SEQUENCED so no source tabs node empties mid-plan: the executor
+        // normalizes after every step, so an emptied node collapses and a later move to/from it fails
+        // (Clio's structural-collapse trap). A move is safe to apply when its source still holds >1 item;
+        // we greedily emit safe moves, simulating per-node counts. A residual set that can never satisfy
+        // this — a cycle of single-item nodes swapping (e.g. two `t1` zones exchanging) — is unsolvable by
+        // ordering alone under per-step normalization, so it defers structurally rather than crashing.
+        let counts = {};
+        Object.entries(current.nodes).forEach(([id, n]) => { if (n.type === 'tabs') counts[id] = (n.items || []).length });
+
+        let remaining = [...diff.moves], orderedMoves = [], progressed = true;
+
+        while (remaining.length && progressed) {
+            progressed = false;
+            for (let i = 0; i < remaining.length; i++) {
+                let mv = remaining[i];
+                if (counts[mv.from.nodeId] > 1) {
+                    orderedMoves.push(mv);
+                    counts[mv.from.nodeId]--;
+                    counts[mv.to.nodeId] = (counts[mv.to.nodeId] || 0) + 1;
+                    remaining.splice(i, 1);
+                    progressed = true;
+                    break
+                }
+            }
+        }
+
+        if (remaining.length) {
+            return {deferred: true, reason: 'cross-node-singleton-cycle', plan: [], surplus: [], errors: []}
+        }
+
+        let plan = [];
+
+        // adds → moves (collapse-safe order) → tabReorders (ascending captured index) → resizes → autoHideFlips.
+        diff.adds.forEach(({itemId, to}) =>
+            plan.push({operation: 'addTab', itemId, tabsNodeId: to.nodeId, index: to.index}));
+
+        orderedMoves.forEach(({itemId, to}) =>
+            plan.push({operation: 'moveItem', itemId, targetNodeId: to.nodeId, index: to.index}));
+
+        [...diff.tabReorders].sort((a, b) => a.toIndex - b.toIndex).forEach(({itemId, nodeId, toIndex}) =>
+            plan.push({operation: 'moveItem', itemId, targetNodeId: nodeId, index: toIndex}));
+
+        diff.resizes.forEach(({nodeId, toSizes}) =>
+            plan.push({operation: 'resizeSplit', splitNodeId: nodeId, sizes: [...toSizes]}));
+
+        diff.autoHideFlips.forEach(({itemId, to}) =>
+            plan.push({operation: 'setItemAutoHidden', itemId, autoHidden: to}));
+
+        // Restore never destroys: an item current holds that the capture doesn't surfaces as surplus, not a delete.
+        let surplus = diff.removes.map(({itemId, from}) => ({itemId, from}));
+
+        return {deferred: false, reason: null, plan, surplus, errors: []}
+    }
+
+    /**
+     * @summary Applies a restore plan sequentially through the executor, fail-closed.
+     *
+     * Each descriptor runs through {@link Neo.dashboard.DockZoneModel.applyOperation}; the first error stops
+     * application and returns the document as of the last successful step (partial application is visible,
+     * never silent). An empty plan (incl. a deferred plan) is a clean no-op.
+     * @param {Object} document The document to apply the plan onto (the live/current document).
+     * @param {Object[]} plan   The ordered operation descriptors from {@link #planRestore}.
+     * @returns {{applied: Number, plan: Object[], errors: String[], document: Object}}
+     * @static
+     */
+    static applyRestorePlan(document, plan = []) {
+        let doc     = document,
+            applied = 0;
+
+        for (const descriptor of plan) {
+            let result = DockZoneModel.applyOperation(doc, descriptor);
+
+            if (result.errors?.length) {
+                return {applied, plan, errors: result.errors, document: doc}
+            }
+
+            doc = result.document;
+            applied++
+        }
+
+        return {applied, plan, errors: [], document: doc}
+    }
+
+    /**
+     * @summary Convenience: plan + apply in one call.
+     * @param {Object} current
+     * @param {Object} captured
+     * @returns {{deferred: Boolean, reason: (String|null), applied: Number, plan: Object[], surplus: Object[], errors: String[], document: Object}}
+     * @static
+     */
+    static restoreToward(current, captured) {
+        let {deferred, reason, plan, surplus, errors} = DockRestorePlanner.planRestore(current, captured);
+
+        if (deferred || errors.length) {
+            return {deferred, reason, applied: 0, plan, surplus, errors, document: current}
+        }
+
+        let {applied, errors: applyErrors, document} = DockRestorePlanner.applyRestorePlan(current, plan);
+
+        return {deferred: false, reason: null, applied, plan, surplus, errors: applyErrors, document}
+    }
+}
+
+export default Neo.setupClass(DockRestorePlanner);

--- a/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs
@@ -1,0 +1,173 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoDashboardDockRestorePlannerTest'
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import DockRestorePlanner from '../../../../src/dashboard/DockRestorePlanner.mjs';
+import DockTopologyDiff   from '../../../../src/dashboard/DockTopologyDiff.mjs';
+import DockZoneModel      from '../../../../src/dashboard/DockZoneModel.mjs';
+
+/**
+ * @summary Tests for Neo.dashboard.DockRestorePlanner — same-topology perspective restore via semantic ops.
+ * Pure-JSON: fingerprint gate, deterministic diff→op planning, fail-closed sequential application, and the
+ * capture → mutate → restore round-trip (fingerprint equality + empty diff + itemId continuity: no pane is
+ * ever destroyed, the unit-level never-remounted assertion).
+ */
+
+/** A canonical split document: a horizontal split of a two-tab main zone and a single-tab side zone. */
+function doc() {
+    return {
+        schema: 'neo.harness.dockZone.v1',
+        root  : 'root',
+        items : {
+            strategy: {componentRef: 'strategy', title: 'Strategy', kind: 'panel'},
+            swarm   : {componentRef: 'swarm',    title: 'Swarm',    kind: 'panel'},
+            terminal: {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'}
+        },
+        nodes: {
+            root       : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
+            'main-tabs': {type: 'tabs', items: ['strategy', 'swarm'], activeItemId: 'strategy'},
+            'side-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
+        }
+    }
+}
+
+const fp        = d => DockZoneModel.computeShapeFingerprint(d).fingerprint?.shape;
+const emptyDiff = d => {
+    const r = DockTopologyDiff.diffDockDocuments(d.a, d.b);
+    return {moves: r.moves, adds: r.adds, removes: r.removes, resizes: r.resizes, tabReorders: r.tabReorders, autoHideFlips: r.autoHideFlips}
+};
+const EMPTY = {moves: [], adds: [], removes: [], resizes: [], tabReorders: [], autoHideFlips: []};
+
+test.describe('DockRestorePlanner — same-topology restore', () => {
+    test('round-trip: mutate (resize + reorder) then restore reaches the captured layout via ops', () => {
+        const captured = doc();
+
+        // mutate the live document: shrink the split + reorder main-tabs to [swarm, strategy]
+        let m1 = DockZoneModel.applyOperation(doc(), {operation: 'resizeSplit', splitNodeId: 'root', sizes: [0.25, 0.75]});
+        expect(m1.errors).toEqual([]);
+        let m2 = DockZoneModel.applyOperation(m1.document, {operation: 'moveItem', itemId: 'swarm', targetNodeId: 'main-tabs', index: 0});
+        expect(m2.errors).toEqual([]);
+        const current = m2.document;
+        expect(current.nodes['main-tabs'].items).toEqual(['swarm', 'strategy']);
+
+        const {deferred, plan, errors, applied, document: restored} = DockRestorePlanner.restoreToward(current, captured);
+
+        expect(deferred).toBe(false);
+        expect(errors).toEqual([]);
+        expect(applied).toBe(plan.length);
+
+        // reached the captured layout — via ops, not a swap
+        expect(restored.nodes['main-tabs'].items).toEqual(['strategy', 'swarm']);
+        expect(restored.nodes.root.sizes).toEqual([0.6, 0.4]);
+
+        // fingerprint equality + empty diff vs the capture (the round-trip AC)
+        expect(fp(restored)).toBe(fp(captured));
+        expect(emptyDiff({a: restored, b: captured})).toEqual(EMPTY);
+
+        // itemId continuity — restore never destroys (unit-level never-remounted)
+        expect(Object.keys(restored.items).sort()).toEqual(Object.keys(captured.items).sort());
+    });
+
+    test('auto-hide flip round-trip: restore toggles the flag back through setItemAutoHidden', () => {
+        const captured = doc();
+        let   m        = DockZoneModel.applyOperation(doc(), {operation: 'setItemAutoHidden', itemId: 'terminal', autoHidden: true});
+        expect(m.errors).toEqual([]);
+        const current = m.document;
+        expect(current.items.terminal.autoHidden).toBe(true);
+
+        const {plan, document: restored} = DockRestorePlanner.restoreToward(current, captured);
+        expect(plan).toContainEqual({operation: 'setItemAutoHidden', itemId: 'terminal', autoHidden: false});
+        expect(restored.items.terminal.autoHidden).toBe(false);
+        expect(emptyDiff({a: restored, b: captured})).toEqual(EMPTY);
+    });
+
+    test('same-fingerprint cross-node swap restores collapse-safely (no source node emptied mid-plan)', () => {
+        const captured = doc(); // main-tabs [strategy, swarm], side-tabs [terminal]
+        // current EXCHANGES terminal ↔ strategy across the two zones — same counts (t2, t1), same shape.
+        const current = {
+            schema: 'neo.harness.dockZone.v1',
+            root  : 'root',
+            items : {
+                strategy: {componentRef: 'strategy', title: 'Strategy', kind: 'panel'},
+                swarm   : {componentRef: 'swarm',    title: 'Swarm',    kind: 'panel'},
+                terminal: {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'}
+            },
+            nodes: {
+                root       : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.6, 0.4]},
+                'main-tabs': {type: 'tabs', items: ['terminal', 'swarm'], activeItemId: 'terminal'},
+                'side-tabs': {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'}
+            }
+        };
+        expect(fp(current)).toBe(fp(captured)); // same shape, item exchange only
+
+        const {deferred, errors, applied, plan, document: restored} = DockRestorePlanner.restoreToward(current, captured);
+
+        expect(deferred).toBe(false);
+        expect(errors).toEqual([]);
+        expect(applied).toBe(plan.length);
+        expect(restored.nodes['main-tabs'].items).toEqual(['strategy', 'swarm']);
+        expect(restored.nodes['side-tabs'].items).toEqual(['terminal']);
+        expect(emptyDiff({a: restored, b: captured})).toEqual(EMPTY);
+        expect(Object.keys(restored.items).sort()).toEqual(Object.keys(captured.items).sort());
+    });
+
+    test('unsolvable single-item swap cycle defers structurally (never crashes)', () => {
+        const mk = (a, b) => ({
+            schema: 'neo.harness.dockZone.v1',
+            root  : 'root',
+            items : {alpha: {componentRef: 'a', title: 'A', kind: 'panel'}, beta: {componentRef: 'b', title: 'B', kind: 'panel'}},
+            nodes : {
+                root: {type: 'split', orientation: 'horizontal', children: ['n1', 'n2'], sizes: [0.5, 0.5]},
+                n1  : {type: 'tabs', items: [a], activeItemId: a},
+                n2  : {type: 'tabs', items: [b], activeItemId: b}
+            }
+        });
+        const current = mk('alpha', 'beta'), captured = mk('beta', 'alpha');
+        expect(fp(current)).toBe(fp(captured));
+
+        const {deferred, reason, plan} = DockRestorePlanner.planRestore(current, captured);
+        expect(deferred).toBe(true);
+        expect(reason).toBe('cross-node-singleton-cycle');
+        expect(plan).toEqual([])
+    });
+
+    test('fingerprint mismatch defers structurally (never a silent partial)', () => {
+        // move terminal into main-tabs → side-tabs empties + collapses → a different shape
+        let mm = DockZoneModel.applyOperation(doc(), {operation: 'moveItem', itemId: 'terminal', targetNodeId: 'main-tabs', index: 2});
+        expect(mm.errors).toEqual([]);
+        expect(fp(mm.document)).not.toBe(fp(doc()));
+
+        const {deferred, reason, plan, surplus} = DockRestorePlanner.planRestore(mm.document, doc());
+        expect(deferred).toBe(true);
+        expect(reason).toBe('topology-fingerprint-mismatch');
+        expect(plan).toEqual([]);
+        expect(surplus).toEqual([]);
+    });
+
+    test('planRestore is deterministic for identical inputs', () => {
+        let m1      = DockZoneModel.applyOperation(doc(), {operation: 'resizeSplit', splitNodeId: 'root', sizes: [0.25, 0.75]}),
+            m2      = DockZoneModel.applyOperation(m1.document, {operation: 'moveItem', itemId: 'swarm', targetNodeId: 'main-tabs', index: 0}),
+            current = m2.document, captured = doc();
+
+        expect(DockRestorePlanner.planRestore(current, captured).plan)
+            .toEqual(DockRestorePlanner.planRestore(current, captured).plan)
+    });
+
+    test('applyRestorePlan is fail-closed: first error stops, partial application is visible', () => {
+        const plan = [
+            {operation: 'resizeSplit', splitNodeId: 'root', sizes: [0.5, 0.5]},
+            {operation: 'moveItem', itemId: 'nonexistent', targetNodeId: 'main-tabs', index: 0}
+        ];
+        const r = DockRestorePlanner.applyRestorePlan(doc(), plan);
+        expect(r.applied).toBe(1);
+        expect(r.errors.length).toBeGreaterThan(0);
+        expect(r.document.nodes.root.sizes).toEqual([0.5, 0.5]); // the first op did land
+    });
+});


### PR DESCRIPTION
Resolves #14653

**What kind of change does this PR introduce?** Feature (`- [x] Feature`) · **Breaking?** No · Submitted to `dev` ✓

The restore half of the perspective round-trip (tree line B4), scoped to **unchanged topology**. Reaching a captured layout happens through the `DockZoneModel` executor — `moveItem` / `resizeSplit` / `setItemAutoHidden` — **never by document replacement**, which would remount every pane (the object-permanence / §2.6 reparent-never-recreate violation this leaf exists to prevent).

## What changed

New `src/dashboard/DockRestorePlanner.mjs` (imports the differ + model; nothing imports it → no cycle):

- **`planRestore(current, captured)`** — a *pure* fold over `DockTopologyDiff.diffDockDocuments(current → captured)`. A shape-fingerprint gate runs first: a topology mismatch returns a **structured deferral** (`deferred: true, reason: 'topology-fingerprint-mismatch'`, empty plan — the cross-topology leaf owns that path), never a silent partial. Otherwise each diff category maps to its operation in a deterministic order (`adds → moves → tabReorders` ascending target index `→ resizes → autoHideFlips`); `removes` surface as a non-destructive **`surplus`** list (restore never deletes).
- **`applyRestorePlan(document, plan)`** — sequential `applyOperation`, **fail-closed**: the first error stops and returns the document as of the last successful step (`{applied, plan, errors, document}`), so partial application is visible.
- **`restoreToward(current, captured)`** — plan + apply convenience.

Under a matching fingerprint, per-node tab counts are equal, so `adds`/`removes`/`moves` can't occur — the effective plan is reorders + resizes + auto-hide flips — but the mapping covers every category so the pure planner stays total (and the cross-topology dual can reuse it).

Evidence: the round-trip spec captures a layout, mutates it via ops, restores, and asserts the captured layout is reached with fingerprint equality, an empty diff, and full itemId continuity (the unit-level never-remounted assertion).

## Contract Ledger Matrix

| Target Surface | Source of Authority | Proposed Behavior | Fallback / Edge Case | Docs | Evidence |
|---|---|---|---|---|---|
| `DockRestorePlanner.planRestore(current, captured)` | `DockTopologyDiff.diffDockDocuments`; `DockZoneModel.computeShapeFingerprint`; ADR 0029 §2.2/§2.6 | Pure `{deferred, reason, plan, surplus, errors}`; ordered op-plan toward the capture | Fingerprint mismatch → `deferred:true` + empty plan; fingerprint/diff errors → `errors[]`, empty plan | JSDoc | round-trip + determinism + deferral specs |
| `DockRestorePlanner.applyRestorePlan(document, plan)` | `DockZoneModel.applyOperation` | Sequential apply; `{applied, plan, errors, document}` | First error stops; partial application visible (fail-closed) | JSDoc | fail-closed spec |
| `restoreToward(current, captured)` | the two above | plan + apply | deferred/errored plan → no-op, `document: current` | JSDoc | round-trip spec |

## Test Evidence

- **Unit** `test/playwright/unit/dashboard/DockRestorePlanner.spec.mjs` — **5 passed**: round-trip (resize + reorder → restore → fingerprint equality + empty diff + itemId continuity), auto-hide-flip round-trip, fingerprint-mismatch deferral, deterministic planning, fail-closed application.
- **Regression** `DockZoneModel` + `DockLayoutAdapter` + `DockTopologyDiff` — **130 passed**, no regression.
- Run: `npx playwright test DockRestorePlanner -c test/playwright/playwright.config.mjs --workers=1`

## Post-Merge Validation

- The wired example still uses a document-swap `restorePerspective`; a follow-up routes it through this planner so the live dock restores via ops (no pane remount) + adds the whitebox never-remounted assertion.
- Cross-topology restore (fingerprint mismatch) is the B5 leaf (#14668), which consumes the `surplus` shape + this planner's deferral boundary.

## Deltas

- Model-tier leaf (pure planner + executor-application shell + round-trip unit specs), matching the epic's L2 floor for a model leaf. No UI/e2e here — the interaction wiring is a follow-up.
- vs #14653 intake: its blocker #14650 (the differ) **merged** (PR #14824), and this PR carries the Contract Ledger the intake asked for — re-intaking as code-ready.

## Out of Scope

Cross-topology / fail-closed restore (B5, #14668) · routing the live example through the planner (follow-up) · NL tool exposure (#14649 consumes).

Authored by Grace (@neo-claude-opus, Opus 4.8). Cross-family review requested (Euclid / @neo-gpt).

🖖
