### PR TITLE
refactor(graph): rename direction hindcast replay helper (#14845)

### DIFF
--- a/ai/graph/directionHindcastReplay.mjs
+++ b/ai/graph/directionHindcastReplay.mjs
@@ -1,14 +1,14 @@
 import {attributeMotion, deriveAlignmentStates} from './directionAttribution.mjs';
 
 /**
- * @module ai/graph/hindcastHarness
- * @summary The hindcast validation harness — the falsifier between computation and render: a
+ * @module ai/graph/directionHindcastReplay
+ * @summary The direction hindcast replay — the falsifier between computation and render: a
  * forecastless replay of the attribution machinery over a HISTORICAL window, using only
- * information that existed inside that window. No rendered forecast exists until this harness
+ * information that existed inside that window. No rendered forecast exists until this replay
  * demonstrates skill; a prediction without a falsifying backtest is invalid by construction.
  *
  * The epistemics, mechanized:
- * - **Only-in-W by construction, not by discipline:** the harness CUTS history at the window
+ * - **Only-in-W by construction, not by discipline:** the replay CUTS history at the window
  *   boundaries before the attribution pass ever sees it — the anchor set is reconstructed as it
  *   stood at window start (declared before, not retired before), and motion is restricted to the
  *   window span. The leakage falsifier is executable: appending post-window events or goals to
@@ -76,7 +76,7 @@ export function cutWindowEvents(motionEvents, sinceIso, untilIso) {
  * merged attribution machinery over only-in-W inputs; no clock, no I/O, deterministic.
  * @param {Object} options
  * @param {Object} options.window `{since, until}` ISO bounds
- * @param {Object} options.history `{motionEvents, declaredGoals}` — FULL history; the harness cuts
+ * @param {Object} options.history `{motionEvents, declaredGoals}` — FULL history; the replay cuts
  * @param {Object} [options.clusterMapping={}] The versioned emergent mapping as-of the window
  * @param {Number} options.mappingVersion
  * @param {String} options.filterSet

--- a/test/playwright/unit/ai/graph/directionHindcastReplay.spec.mjs
+++ b/test/playwright/unit/ai/graph/directionHindcastReplay.spec.mjs
@@ -1,6 +1,6 @@
 import {setup} from '../../../setup.mjs';
 
-const appName = 'HindcastHarnessTest';
+const appName = 'DirectionHindcastReplayTest';
 
 setup({
     neoConfig: {
@@ -17,16 +17,16 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../src/Neo.mjs';
 import * as core      from '../../../../../src/core/_export.mjs';
 
-test.describe('hindcastHarness — only-in-W by construction, the June gate, the May lock', () => {
-    let harness;
+test.describe('directionHindcastReplay — only-in-W by construction, the June gate, the May lock', () => {
+    let replay;
 
     test.beforeAll(async () => {
-        harness = await import('../../../../../ai/graph/hindcastHarness.mjs');
+        replay = await import('../../../../../ai/graph/directionHindcastReplay.mjs');
     });
 
     test('THE JUNE GATE: the born-labeled fixture detects the starved design/UX direction — or the approach fails', () => {
-        const {window, history, mappingVersion, filterSet} = harness.JUNE_2026_FIXTURE;
-        const run                                          = harness.runHindcastWindow({window, history, mappingVersion, filterSet});
+        const {window, history, mappingVersion, filterSet} = replay.JUNE_2026_FIXTURE;
+        const run                                          = replay.runHindcastWindow({window, history, mappingVersion, filterSet});
 
         // the anchor set at June start: both declared intents active; the post-window goal invisible
         expect(run.anchorSet.map(goal => goal.id).sort()).toEqual(['evolution-goal-design-ux', 'evolution-goal-engine-hardening']);
@@ -47,7 +47,7 @@ test.describe('hindcastHarness — only-in-W by construction, the June gate, the
     });
 
     test('NO FUTURE LEAKAGE, by construction: post-window events and goals cannot alter the run', () => {
-        const {window, history, mappingVersion, filterSet} = harness.JUNE_2026_FIXTURE;
+        const {window, history, mappingVersion, filterSet} = replay.JUNE_2026_FIXTURE;
 
         // baseline: the fixture ALREADY contains July motion + a July goal — strip them for the control
         const strippedHistory = {
@@ -55,8 +55,8 @@ test.describe('hindcastHarness — only-in-W by construction, the June gate, the
             motionEvents : history.motionEvents.filter(event => Date.parse(event.at) < Date.parse(window.until))
         };
 
-        const withFuture    = harness.runHindcastWindow({window, history, mappingVersion, filterSet});
-        const withoutFuture = harness.runHindcastWindow({window, history: strippedHistory, mappingVersion, filterSet});
+        const withFuture    = replay.runHindcastWindow({window, history, mappingVersion, filterSet});
+        const withoutFuture = replay.runHindcastWindow({window, history: strippedHistory, mappingVersion, filterSet});
 
         // deep-equal outputs: the future was structurally invisible (the July design flood changed NOTHING)
         expect(JSON.stringify(withFuture.breakdown)).toBe(JSON.stringify(withoutFuture.breakdown));
@@ -72,7 +72,7 @@ test.describe('hindcastHarness — only-in-W by construction, the June gate, the
             {id: 'g-future',  matchers: ['c4'], declaredAt: '2026-07-05T00:00:00Z'}
         ];
 
-        const atJuneStart = harness.reconstructAnchorSet(goals, '2026-06-01T00:00:00Z');
+        const atJuneStart = replay.reconstructAnchorSet(goals, '2026-06-01T00:00:00Z');
         const ids         = atJuneStart.map(goal => goal.id).sort();
 
         // g-retired retires MID-window → still active AT window start; g-prior retired before → gone; g-future → invisible
@@ -81,15 +81,15 @@ test.describe('hindcastHarness — only-in-W by construction, the June gate, the
     });
 
     test('THE MAY LOCK: the holdout door refuses everything but the recorded ceremony', () => {
-        const {window, history, mappingVersion, filterSet} = harness.JUNE_2026_FIXTURE;
+        const {window, history, mappingVersion, filterSet} = replay.JUNE_2026_FIXTURE;
 
-        expect(() => harness.runHoldout({window, history, mappingVersion, filterSet})).toThrow(/scored ONCE/);
-        expect(() => harness.runHoldout({singleShot: false, operatorProvenance: 'x', window, history, mappingVersion, filterSet})).toThrow(/ceremony/);
-        expect(() => harness.runHoldout({singleShot: true, operatorProvenance: '', window, history, mappingVersion, filterSet})).toThrow(/ceremony/);
+        expect(() => replay.runHoldout({window, history, mappingVersion, filterSet})).toThrow(/scored ONCE/);
+        expect(() => replay.runHoldout({singleShot: false, operatorProvenance: 'x', window, history, mappingVersion, filterSet})).toThrow(/ceremony/);
+        expect(() => replay.runHoldout({singleShot: true, operatorProvenance: '', window, history, mappingVersion, filterSet})).toThrow(/ceremony/);
 
         // and WITH the ceremony, the door opens onto the same pure replay (proven on June data —
         // the May data itself never enters this repository)
-        const ceremonial = harness.runHoldout({singleShot: true, operatorProvenance: 'unit-proof: the adjudicated-protocol pointer goes here', window, history, mappingVersion, filterSet});
+        const ceremonial = replay.runHoldout({singleShot: true, operatorProvenance: 'unit-proof: the adjudicated-protocol pointer goes here', window, history, mappingVersion, filterSet});
         expect(ceremonial.conservation.valid).toBe(true);
     });
 });


### PR DESCRIPTION
Resolves #14845

Renames the direction-validation helper away from overloaded Agent Harness vocabulary: `ai/graph/hindcastHarness.mjs` becomes `ai/graph/directionHindcastReplay.mjs`, with the matching unit spec renamed and local prose/import identifiers updated. Behavior is intentionally unchanged; the June gate, no-future-leakage proof, anchor reconstruction, and May holdout guard remain the same pure replay contract.

Evidence: L2 (focused unit/static verification for a same-directory module/spec rename). Residual: none for #14845 after the post-open #14812 backlink comment.

## Deltas from ticket

No substantive scope change. Structural pre-flight classified this as a same-directory `.mjs` rename, so there is no novel directory choice or map-maintenance requirement.

## Test Evidence

- `git diff --cached --check` -> pass before commit.
- `node --check ai/graph/directionHindcastReplay.mjs` -> pass.
- `node --check test/playwright/unit/ai/graph/directionHindcastReplay.spec.mjs` -> pass.
- `rg -n "hindcastHarness|HindcastHarness|ai/graph/hindcastHarness|Hindcast Harness" ai src test learn .agents README.md --glob '!resources/**'` -> no code/source references.
- `rg -n "harness" ai/graph/directionHindcastReplay.mjs test/playwright/unit/ai/graph/directionHindcastReplay.spec.mjs` -> no helper-local harness wording.
- `UNIT_TEST_MODE=true npx playwright test -c /private/tmp/neo-pr-14845-unit-no-webserver.config.mjs test/playwright/unit/ai/graph/directionHindcastReplay.spec.mjs` -> 4 passed.

## Post-Merge Validation

- [ ] The generated `resources/content/**` mirrors naturally refresh away from the old path after the GitHub sync/indexing pipeline consumes the merged PR.

## Intake / Source of Authority

- Live #14845 thread: correct labels, no prior assignee, no comments, complete contract ledger.
- Current-source sweep: the stale helper name was code-local to `ai/graph/hindcastHarness.mjs` and its unit spec.
- ADR successor-risk: aligned with ADR 0020 and ADR 0033; this PR does not amend either record.
- Memory/KB sweep: confirmed #14845 is the existing cleanup path created from the #14812 naming correction; no newer duplicate/superseding lane found.

## Commit

- `13596043cc` — `refactor(graph): rename direction hindcast replay helper (#14845)`

Authored by Euclid (GPT-5.5, Codex Desktop). Session 019f306e-3ffb-7980-984b-175a3c0072ac.
