### PR TITLE
feat(github-workflow): gate approvals over live request-changes (#14534)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -861,7 +861,8 @@ paths:
                   type: object
                   additionalProperties:
                     type: string
-                  description: Optional reviewer-login to disposition map for consciously approving over live `CHANGES_REQUESTED` reviews after applying pr-review §9.1. Only used for `action: create` + `state: APPROVED`; dispositions must be `addressed-by-<current-head-sha>` or `superior-evidence: <specific evidence>`.
+                  description: |
+                    Optional reviewer-login to disposition map for consciously approving over live `CHANGES_REQUESTED` reviews after applying pr-review §9.1. Only used for `action: create` + `state: APPROVED`; dispositions must be `addressed-by-<current-head-sha>` or `superior-evidence: <specific evidence>`.
                   example:
                     neo-gpt: "addressed-by-abc1234"
       responses:

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -813,6 +813,8 @@ paths:
       description: |
         Atomic create/update of a formal PR review. `create` posts body + flips reviewDecision and requires `pr_number`, `state` (APPROVED/REQUEST_CHANGES/COMMENT), and `body`; `update` requires `review_id` (PRR_*) + `body` and cannot change state. Returns reviewId, state, url, and submittedAt.
 
+        State safety: `create` + `state: APPROVED` rejects when the live PR head still has outstanding `CHANGES_REQUESTED` reviews. To proceed after consciously applying the pr-review §9.1 Reviewer-Yield path, pass `acknowledgedRequestChanges` as an object mapping each outstanding RC reviewer login to either `addressed-by-<current-head-sha>` or `superior-evidence: <specific evidence>`.
+
         Mandatory pre-step: read `.agents/skills/pr-review/SKILL.md` and use the cycle-appropriate template.
 
         Validation: `body` must include the 7 visible metric anchors plus silent structural template anchors and preserve the selected template's canonical skeleton; failures return `PR_REVIEW_TEMPLATE_VALIDATION_FAILED` pointing at the skill/template. Do not synthesize substitute headings. The four premise-snapshot fields (`Inputs Read Before Patch`, `Expected Solution Shape`, `Patch Verdict`, `Premise Coherence`) are ALL REQUIRED; `Premise Coherence` is the value-coherence verdict (does the PR's premise cohere with the core values?) — a specific verdict OR a scoped `N/A — no value-surface` for a trivial PR.
@@ -855,6 +857,13 @@ paths:
                   type: string
                   description: The GraphQL node ID of the existing review (required for `update`, e.g. `PRR_*`).
                   example: "PRR_kwDOABcDef1234567890"
+                acknowledgedRequestChanges:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: Optional reviewer-login to disposition map for consciously approving over live `CHANGES_REQUESTED` reviews after applying pr-review §9.1. Only used for `action: create` + `state: APPROVED`; dispositions must be `addressed-by-<current-head-sha>` or `superior-evidence: <specific evidence>`.
+                  example:
+                    neo-gpt: "addressed-by-abc1234"
       responses:
         '200':
           description: |

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -18,6 +18,8 @@ const execAsync                        = promisify(exec);
 const execFileAsync                    = promisify(execFile);
 const PR_REVIEW_TEMPLATE_PATH          = '.agents/skills/pr-review/assets/pr-review-template.md';
 const PR_REVIEW_FOLLOWUP_TEMPLATE_PATH = '.agents/skills/pr-review/assets/pr-review-followup-template.md';
+const ACKNOWLEDGED_RC_ADDRESSED_PREFIX = 'addressed-by-';
+const ACKNOWLEDGED_RC_EVIDENCE_PREFIX  = 'superior-evidence:';
 
 const FULL_PR_REVIEW_TEMPLATE_SKELETON_LABELS = [
     'PR Review Summary',
@@ -571,6 +573,127 @@ function getPrReviewTemplateValidationFailure(body, options) {
         : getCanonicalPrReviewTemplateValidationFailure(body, options);
 }
 
+function isPlainObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function getReviewSubmittedMs(review) {
+    const time = Date.parse(review?.submittedAt || '');
+
+    return Number.isFinite(time) ? time : 0
+}
+
+function isAcknowledgedRequestChangesDisposition(value, headRefOid) {
+    if (typeof value !== 'string') return false;
+
+    const disposition = value.trim();
+
+    if (disposition.startsWith(ACKNOWLEDGED_RC_EVIDENCE_PREFIX)) {
+        return disposition.slice(ACKNOWLEDGED_RC_EVIDENCE_PREFIX.length).trim().length > 0
+    }
+
+    if (!disposition.startsWith(ACKNOWLEDGED_RC_ADDRESSED_PREFIX)) return false;
+
+    const sha = disposition.slice(ACKNOWLEDGED_RC_ADDRESSED_PREFIX.length).trim();
+
+    return /^[0-9a-f]{7,40}$/i.test(sha) && headRefOid.startsWith(sha)
+}
+
+/**
+ * @summary Finds current-head request-changes reviews that have not been superseded by the same reviewer.
+ * GitHub review comments do not clear a formal `CHANGES_REQUESTED`; only a later approving, dismissed,
+ * or request-changes review from the same reviewer changes the disposition this gate consumes.
+ * @param {Object} pullRequest PR GraphQL node including `headRefOid` and `reviews.nodes`.
+ * @returns {Object[]|null} Outstanding reviewer records, or `null` when the live-state shape is incomplete.
+ */
+function getOutstandingRequestChanges(pullRequest) {
+    const
+        headRefOid = pullRequest?.headRefOid,
+        reviews    = pullRequest?.reviews?.nodes;
+
+    if (!Array.isArray(reviews) || !headRefOid) return null;
+
+    const latestByReviewer = new Map();
+
+    [...reviews]
+        .filter(review => review?.author?.login && review?.commit?.oid === headRefOid)
+        .sort((a, b) => getReviewSubmittedMs(a) - getReviewSubmittedMs(b))
+        .forEach(review => {
+            if (['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(review.state)) {
+                latestByReviewer.set(review.author.login, review)
+            }
+        });
+
+    return [...latestByReviewer.values()]
+        .filter(review => review.state === 'CHANGES_REQUESTED')
+        .map(review => ({
+            reviewer   : review.author.login,
+            state      : review.state,
+            commitOid  : review.commit?.oid,
+            submittedAt: review.submittedAt,
+            url        : review.url,
+            databaseId : review.databaseId
+        }))
+}
+
+/**
+ * @summary Builds the fail-closed response for APPROVED reviews over live request-changes state.
+ * The MCP boundary requires explicit reviewer-keyed acknowledgments so approval intent cannot erase an
+ * unaddressed `CHANGES_REQUESTED` review by body-template validity alone.
+ * @param {Object} options Validation options.
+ * @param {Object} [options.acknowledgedRequestChanges] Reviewer-login to disposition map.
+ * @param {Number} options.pr_number Pull request number.
+ * @param {Object} options.pullRequest PR GraphQL node including review state.
+ * @returns {Object|null} Structured validation failure, or `null` when approval can proceed.
+ */
+function getPrReviewStateValidationFailure({acknowledgedRequestChanges, pr_number, pullRequest}) {
+    const headRefOid = pullRequest?.headRefOid,
+          reviews    = pullRequest?.reviews?.nodes;
+
+    if (!headRefOid || !Array.isArray(reviews)) {
+        return {
+            error  : 'PR Review State Validation Failed',
+            message: `Cannot validate live review state for PR #${pr_number}; GitHub did not return headRefOid + review nodes. Refusing to submit APPROVED review.`,
+            code   : 'PR_REVIEW_STATE_VALIDATION_FAILED'
+        }
+    }
+
+    const outstanding = getOutstandingRequestChanges(pullRequest);
+
+    if (!outstanding?.length) return null;
+
+    const ack     = isPlainObject(acknowledgedRequestChanges) ? acknowledgedRequestChanges : null,
+          missing = outstanding
+              .map(({reviewer}) => reviewer)
+              .filter(reviewer => !ack || !Object.hasOwn(ack, reviewer)),
+          invalid = ack
+              ? outstanding
+                  .map(({reviewer}) => reviewer)
+                  .filter(reviewer => Object.hasOwn(ack, reviewer) && !isAcknowledgedRequestChangesDisposition(ack[reviewer], headRefOid))
+              : [];
+
+    if (!missing.length && !invalid.length) return null;
+
+    const reviewerList = outstanding
+        .map(({reviewer, submittedAt, url}) => `@${reviewer}${submittedAt ? ` at ${submittedAt}` : ''}${url ? ` (${url})` : ''}`)
+        .join(', ');
+
+    return {
+        error  : 'PR Review State Validation Failed',
+        message: [
+            `Cannot create APPROVED review on PR #${pr_number} while current head ${headRefOid} has outstanding CHANGES_REQUESTED review(s): ${reviewerList}.`,
+            `Before retrying, follow pr-review §9.1 Reviewer-Yield: either address the request-changes at the current head or provide superior empirical evidence.`,
+            `Pass acknowledgedRequestChanges as an object mapping each RC reviewer login to '${ACKNOWLEDGED_RC_ADDRESSED_PREFIX}${headRefOid.slice(0, 12)}' or '${ACKNOWLEDGED_RC_EVIDENCE_PREFIX} <specific evidence>'.`,
+            missing.length ? `Missing acknowledgment(s): ${missing.map(reviewer => `@${reviewer}`).join(', ')}.` : null,
+            invalid.length ? `Invalid acknowledgment disposition(s): ${invalid.map(reviewer => `@${reviewer}`).join(', ')}.` : null
+        ].filter(Boolean).join(' '),
+        code: 'PR_REVIEW_STATE_VALIDATION_FAILED',
+        headRefOid,
+        reviewDecision: pullRequest.reviewDecision,
+        outstandingRequestChanges: outstanding
+    }
+}
+
 function normalizeCheckoutOptions(options) {
     if (typeof options === 'number') {
         return {pr_number: options};
@@ -1043,11 +1166,12 @@ class PullRequestService extends Base {
      * @param {String} [options.state]          Review state (required for `create`): `APPROVED` | `REQUEST_CHANGES` | `COMMENT`.
      * @param {String} options.body             The review body.
      * @param {String} [options.review_id]      The GraphQL node ID of the existing review (required for `update`; PRR_*).
+     * @param {Object} [options.acknowledgedRequestChanges] Reviewer-login → disposition map required when approving over live `CHANGES_REQUESTED`.
      * @returns {Promise<Object>} Review payload on success (`{message, reviewId, state, url, submittedAt, databaseId?}`) or structured error.
      *
      * @see Neo.ai.services.github-workflow.queries.mutations.ADD_PULL_REQUEST_REVIEW
      */
-    async managePrReview({action, pr_number, state, body, review_id}) {
+    async managePrReview({acknowledgedRequestChanges, action, pr_number, state, body, review_id}) {
         if (!['create', 'update'].includes(action)) {
             return {
                 error  : 'Bad Request',
@@ -1109,6 +1233,18 @@ class PullRequestService extends Base {
                         message: `Pull request #${pr_number} not found or returned no id.`,
                         code   : 'PR_NOT_FOUND'
                     };
+                }
+
+                if (event === 'APPROVE') {
+                    const stateValidationFailure = getPrReviewStateValidationFailure({
+                        acknowledgedRequestChanges,
+                        pr_number,
+                        pullRequest: idData?.repository?.pullRequest
+                    });
+
+                    if (stateValidationFailure) {
+                        return stateValidationFailure
+                    }
                 }
 
                 const reviewData = await GraphqlService.query(ADD_PULL_REQUEST_REVIEW, {

--- a/ai/services/github-workflow/queries/mutations.mjs
+++ b/ai/services/github-workflow/queries/mutations.mjs
@@ -535,6 +535,22 @@ export const GET_PULL_REQUEST_ID = `
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $prNumber) {
         id
+        headRefOid
+        reviewDecision
+        reviews(last: 100) {
+          nodes {
+            state
+            submittedAt
+            url
+            databaseId
+            author {
+              login
+            }
+            commit {
+              oid
+            }
+          }
+        }
       }
     }
   }

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -555,6 +555,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
     let originalQuery;
 
     const PR_NODE_ID  = 'PR_kwDOABcD9999999999';
+    const PR_HEAD_OID = 'abcdef1234567890abcdef1234567890abcdef12';
     const REVIEW_NODE = {
         id         : 'PRR_kwDOABcD1111111111',
         url        : 'https://github.com/neomjs/neo/pull/11273#pullrequestreview-12345',
@@ -562,6 +563,13 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         submittedAt: '2026-05-13T00:00:00Z',
         databaseId : 12345
     };
+    const pullRequestNode = (overrides = {}) => ({
+        id            : PR_NODE_ID,
+        headRefOid    : PR_HEAD_OID,
+        reviewDecision: 'APPROVED',
+        reviews       : {nodes: []},
+        ...overrides
+    });
 
     // Compact review body that passes BOTH layers of the tool-boundary template-anchor validator:
     // - VISIBLE layer: the 7 evaluation-metric tags from pr-review-template.md / pr-review-followup-template.md
@@ -714,7 +722,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         // Tests override per-case via reassigning GraphqlService.query.
         GraphqlService.query = async (queryString) => {
             if (queryString.includes('GetPullRequestId')) {
-                return {repository: {pullRequest: {id: PR_NODE_ID}}};
+                return {repository: {pullRequest: pullRequestNode()}};
             }
 
             if (queryString.includes('AddPullRequestReview')) {
@@ -805,7 +813,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async () => {
             graphqlCallCount++;
-            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            return {repository: {pullRequest: pullRequestNode()}};
         };
 
         const result = await PullRequestService.managePrReview({
@@ -838,12 +846,156 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(result.databaseId).toBe(12345);
     });
 
+    test('#14534: action:create + state:APPROVED rejects over outstanding current-head CHANGES_REQUESTED', async () => {
+        let mutationCallCount = 0;
+
+        GraphqlService.query = async (queryString) => {
+            if (queryString.includes('GetPullRequestId')) {
+                return {
+                    repository: {
+                        pullRequest: {
+                            id            : PR_NODE_ID,
+                            headRefOid    : PR_HEAD_OID,
+                            reviewDecision: 'CHANGES_REQUESTED',
+                            reviews       : {
+                                nodes: [{
+                                    state      : 'CHANGES_REQUESTED',
+                                    submittedAt: '2026-07-03T01:34:00Z',
+                                    url        : 'https://github.com/neomjs/neo/pull/14527#pullrequestreview-1',
+                                    databaseId : 1,
+                                    author     : {login: 'neo-gpt'},
+                                    commit     : {oid: PR_HEAD_OID}
+                                }, {
+                                    state      : 'COMMENTED',
+                                    submittedAt: '2026-07-03T02:00:00Z',
+                                    url        : 'https://github.com/neomjs/neo/pull/14527#pullrequestreview-2',
+                                    databaseId : 2,
+                                    author     : {login: 'neo-gpt'},
+                                    commit     : {oid: PR_HEAD_OID}
+                                }]
+                            }
+                        }
+                    }
+                };
+            }
+
+            if (queryString.includes('AddPullRequestReview')) {
+                mutationCallCount++;
+                return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
+            }
+
+            return null;
+        };
+
+        const result = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 14527,
+            state    : 'APPROVED',
+            body     : VALID_REVIEW_BODY
+        });
+
+        expect(result.error).toBe('PR Review State Validation Failed');
+        expect(result.code).toBe('PR_REVIEW_STATE_VALIDATION_FAILED');
+        expect(result.message).toContain('@neo-gpt');
+        expect(result.message).toContain(PR_HEAD_OID);
+        expect(result.message).toContain('pr-review §9.1 Reviewer-Yield');
+        expect(result.outstandingRequestChanges.map(({reviewer}) => reviewer)).toEqual(['neo-gpt']);
+        expect(mutationCallCount).toBe(0);
+    });
+
+    test('#14534: action:create + state:APPROVED accepts complete current-head acknowledgment', async () => {
+        let capturedVariables;
+
+        GraphqlService.query = async (queryString, variables) => {
+            if (queryString.includes('GetPullRequestId')) {
+                return {
+                    repository: {
+                        pullRequest: {
+                            id            : PR_NODE_ID,
+                            headRefOid    : PR_HEAD_OID,
+                            reviewDecision: 'CHANGES_REQUESTED',
+                            reviews       : {
+                                nodes: [{
+                                    state      : 'CHANGES_REQUESTED',
+                                    submittedAt: '2026-07-03T01:34:00Z',
+                                    url        : 'https://github.com/neomjs/neo/pull/14527#pullrequestreview-1',
+                                    databaseId : 1,
+                                    author     : {login: 'neo-gpt'},
+                                    commit     : {oid: PR_HEAD_OID}
+                                }]
+                            }
+                        }
+                    }
+                };
+            }
+
+            if (queryString.includes('AddPullRequestReview')) {
+                capturedVariables = variables;
+                return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
+            }
+
+            return null;
+        };
+
+        const result = await PullRequestService.managePrReview({
+            acknowledgedRequestChanges: {
+                'neo-gpt': `addressed-by-${PR_HEAD_OID.slice(0, 12)}`
+            },
+            action   : 'create',
+            pr_number: 14527,
+            state    : 'APPROVED',
+            body     : VALID_REVIEW_BODY
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(capturedVariables.event).toBe('APPROVE');
+        expect(result.state).toBe('APPROVED');
+    });
+
+    test('#14534: action:create + state:APPROVED rejects stale acknowledgment', async () => {
+        GraphqlService.query = async (queryString) => {
+            if (queryString.includes('GetPullRequestId')) {
+                return {
+                    repository: {
+                        pullRequest: {
+                            id            : PR_NODE_ID,
+                            headRefOid    : PR_HEAD_OID,
+                            reviewDecision: 'CHANGES_REQUESTED',
+                            reviews       : {
+                                nodes: [{
+                                    state : 'CHANGES_REQUESTED',
+                                    author: {login: 'neo-gpt'},
+                                    commit: {oid: PR_HEAD_OID}
+                                }]
+                            }
+                        }
+                    }
+                };
+            }
+
+            throw new Error('review mutation must not run');
+        };
+
+        const result = await PullRequestService.managePrReview({
+            acknowledgedRequestChanges: {
+                'neo-gpt': 'addressed-by-deadbee'
+            },
+            action   : 'create',
+            pr_number: 14527,
+            state    : 'APPROVED',
+            body     : VALID_REVIEW_BODY
+        });
+
+        expect(result.code).toBe('PR_REVIEW_STATE_VALIDATION_FAILED');
+        expect(result.message).toContain('Invalid acknowledgment disposition(s): @neo-gpt');
+    });
+
     test('action:create + state:REQUEST_CHANGES → state enum maps to REQUEST_CHANGES event', async () => {
         // Mock returns CHANGES_REQUESTED state to mirror real GitHub semantics
         // (event REQUEST_CHANGES → review state CHANGES_REQUESTED).
         let capturedVariables;
         GraphqlService.query = async (queryString, variables) => {
-            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: pullRequestNode()}};
             if (queryString.includes('AddPullRequestReview')) {
                 capturedVariables = variables;
                 return {addPullRequestReview: {pullRequestReview: {...REVIEW_NODE, state: 'CHANGES_REQUESTED'}}};
@@ -867,7 +1019,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
     test('action:create + state:COMMENT → state enum maps to COMMENT event', async () => {
         let capturedVariables;
         GraphqlService.query = async (queryString, variables) => {
-            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: pullRequestNode()}};
             if (queryString.includes('AddPullRequestReview')) {
                 capturedVariables = variables;
                 return {addPullRequestReview: {pullRequestReview: {...REVIEW_NODE, state: 'COMMENTED'}}};
@@ -1023,7 +1175,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async () => {
             graphqlCallCount++;
-            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            return {repository: {pullRequest: pullRequestNode()}};
         };
 
         const result = await PullRequestService.managePrReview({
@@ -1083,7 +1235,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async () => {
             graphqlCallCount++;
-            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            return {repository: {pullRequest: pullRequestNode()}};
         };
 
         const result = await PullRequestService.managePrReview({
@@ -1148,7 +1300,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async () => {
             graphqlCallCount++;
-            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            return {repository: {pullRequest: pullRequestNode()}};
         };
 
         const result = await PullRequestService.managePrReview({
@@ -1169,7 +1321,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async (queryString) => {
             graphqlCallCount++;
-            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: pullRequestNode()}};
             if (queryString.includes('AddPullRequestReview')) return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
             return null;
         };
@@ -1190,7 +1342,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async (queryString) => {
             graphqlCallCount++;
-            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: pullRequestNode()}};
             if (queryString.includes('AddPullRequestReview')) return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
             return null;
         };
@@ -1214,7 +1366,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async () => {
             graphqlCallCount++;
-            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            return {repository: {pullRequest: pullRequestNode()}};
         };
 
         const result = await PullRequestService.managePrReview({
@@ -1239,7 +1391,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async () => {
             graphqlCallCount++;
-            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            return {repository: {pullRequest: pullRequestNode()}};
         };
 
         const result = await PullRequestService.managePrReview({
@@ -1316,7 +1468,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async (queryString) => {
             graphqlCallCount++;
-            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: pullRequestNode()}};
             if (queryString.includes('AddPullRequestReview')) return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
             return null;
         };
@@ -1340,7 +1492,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
             .replace('**Class:** micro — a one-line doc typo fix', '**Class:** a one-line doc typo fix');
 
         let graphqlCallCount = 0;
-        GraphqlService.query = async () => { graphqlCallCount++; return {repository: {pullRequest: {id: PR_NODE_ID}}}; };
+        GraphqlService.query = async () => { graphqlCallCount++; return {repository: {pullRequest: pullRequestNode()}}; };
 
         const result = await PullRequestService.managePrReview({
             action   : 'create',
@@ -1369,7 +1521,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async () => {
             graphqlCallCount++;
-            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            return {repository: {pullRequest: pullRequestNode()}};
         };
 
         const result = await PullRequestService.managePrReview({
@@ -1426,7 +1578,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async (queryString) => {
             graphqlCallCount++;
-            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: pullRequestNode()}};
             if (queryString.includes('AddPullRequestReview')) return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
             return null;
         };
@@ -1450,7 +1602,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async (queryString) => {
             graphqlCallCount++;
-            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: pullRequestNode()}};
             if (queryString.includes('AddPullRequestReview')) return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
             return null;
         };
@@ -1482,7 +1634,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async () => {
             graphqlCallCount++;
-            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            return {repository: {pullRequest: pullRequestNode()}};
         };
 
         const body = [
@@ -1540,7 +1692,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         let graphqlCallCount = 0;
         GraphqlService.query = async (queryString) => {
             graphqlCallCount++;
-            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: pullRequestNode()}};
             if (queryString.includes('AddPullRequestReview')) return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
             return null;
         };


### PR DESCRIPTION
Resolves #14534

`manage_pr_review` now gates `action: create` + `state: APPROVED` on the live review state returned with the PR id lookup. If the current head still has an outstanding `CHANGES_REQUESTED` review, the tool refuses to post an approval unless the caller supplies reviewer-keyed `acknowledgedRequestChanges` showing either an addressed current-head SHA or superior empirical evidence.

Evidence: L2 (mocked GitHub GraphQL unit coverage plus static service/OpenAPI checks) -> L2 required (MCP/service contract behavior; no operator-gated host effect). No residuals.

## Deltas from ticket
Added an explicit `acknowledgedRequestChanges` contract to the MCP schema so conscious Reviewer-Yield exceptions are machine-readable instead of hidden in review prose. `COMMENTED` reviews intentionally do not clear a prior `CHANGES_REQUESTED`; only later `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` formal review states from the same reviewer update the live disposition.

## Test Evidence
- `node --check ai/services/github-workflow/PullRequestService.mjs` passed.
- `node --check ai/services/github-workflow/queries/mutations.mjs` passed.
- `node --check test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` passed.
- `git diff --check` passed.
- `UNIT_TEST_MODE=true npx playwright test -c /private/tmp/neo-14534-unit-no-webserver.config.mjs test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` passed: 63 passed.
- `npm run --silent ai:structure-map -- --files --loc` exited 0.

## Post-Merge Validation
- [ ] Confirm the live GitHub Workflow MCP server exposes the `acknowledgedRequestChanges` schema after deployment/reload.

Authored by Euclid (GPT-5, Codex Desktop). Session 019f306e-3ffb-7980-984b-175a3c0072ac.
