### PR TITLE
feat(dashboard): dockPreview.v1 producer + hit-test unit test (#14866)

### DIFF
--- a/src/dashboard/DockPreviewProducer.mjs
+++ b/src/dashboard/DockPreviewProducer.mjs
@@ -1,0 +1,186 @@
+import Base from '../core/Base.mjs';
+
+/**
+ * @class Neo.dashboard.DockPreviewProducer
+ * @extends Neo.core.Base
+ *
+ * @summary Hit-test producer for the harness dock drag: maps a pointer plus the rendered dock-zone
+ * rects to a runtime-only `neo.harness.dockPreview.v1` payload — the COMPUTE half of the preview →
+ * operation pipeline (`learn/agentos/decisions/0029-harness-docking-design.md` §2.3, schema in
+ * `learn/agentos/HarnessDockZoneModel.md`). It is the object an owning dock workspace wires into
+ * {@link Neo.dashboard.CrossWindowDragTarget#previewFor} (and, for the boolean claim, `hitTest`);
+ * the same compute path serves in-window drags.
+ *
+ * **Instance + config, not statics (by design).** The geometry thresholds are **non-reactive
+ * configs** on the prototype rather than static class fields, so they are tunable per app via
+ * `Neo.overwrites`, per instance at `Neo.create` time, and overridable by subclasses — the
+ * customization surface `core.Base` exists to provide. The hit-test methods are instance methods
+ * for the same reason: a workspace with a different drop grammar subclasses and overrides
+ * `resolvePlacementKind` rather than forking the payload assembly. Owners hold one producer instance
+ * (`Neo.create(DockPreviewProducer)`) and call `produce()` per hover frame.
+ *
+ * Boundaries (binding, per the §2.3 / dock-zone-model contracts):
+ *
+ * - **Pure + runtime-only.** Input is transient geometry (rects, pointer); output is a transient
+ *   `dockPreview`. Nothing here is written into the persisted dock-zone model, and the methods have
+ *   no side effects — safe to call on every hover frame and inside a `hitTest`.
+ * - **Layer-blind.** `src/dashboard/` must not import the app-layer `AgentOS.view.DockPreview`
+ *   renderer/validator. So this producer re-derives the schema's placement vocabulary locally; the
+ *   producer → consumer contract is PINNED in the unit test (which may import both layers) by
+ *   asserting every produced payload satisfies `DockPreview.isValidPreview`.
+ * - **Fail closed.** A malformed rect, a pointer outside every zone, or a missing item id yields
+ *   `null` (no affordance) rather than a guess — mirroring the renderer's fail-closed clear.
+ *
+ * Placement grammar: `tab-into` (interior), `edge-*` (outer bands → split the node), and
+ * `split-before`/`split-after` (an edge that runs ALONG the target's own parent-split axis → join
+ * that existing split as a sibling, carrying its orientation). An optional split `ratio` is not
+ * emitted yet — the consumer defaults an absent ratio to an even split.
+ */
+class DockPreviewProducer extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockPreviewProducer'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockPreviewProducer',
+        /**
+         * @member {String} ntype='dock-preview-producer'
+         * @protected
+         */
+        ntype: 'dock-preview-producer',
+        /**
+         * The dockPreview contract schema this producer emits. A non-reactive config (kept in sync
+         * with the consumer via the unit-test pin, since the app-layer validator cannot be imported
+         * here) so a future schema revision is a config bump, not a class edit.
+         * @member {String} schema='neo.harness.dockPreview.v1'
+         */
+        schema: 'neo.harness.dockPreview.v1',
+        /**
+         * Fraction of a zone rect's SMALLER dimension treated as an edge band. Inside a band the
+         * nearest edge wins (`edge-*` / `split-*`); the interior maps to `tab-into`. A non-reactive
+         * config — not a static field — so the edge-affordance thickness is tunable per app
+         * (`Neo.overwrites`), per instance, or per subclass without forking the class. Echoes the
+         * renderer's fixed `edgeBandSize` at typical pane sizes while staying resolution-independent.
+         * @member {Number} edgeBandRatio=0.24
+         */
+        edgeBandRatio: 0.24
+    }
+
+    /**
+     * @summary Pure geometry: which `placement.kind` does `pointer` fall into within one node rect?
+     *
+     * Five-zone hit-test — the interior maps to `tab-into`, the four outer edge bands to an edge
+     * placement. When `orientation` is supplied (the node's PARENT-split axis), an edge that runs
+     * along that axis resolves to a sibling insertion in the existing split — `split-before` (the
+     * leading edge: left for horizontal, top for vertical) / `split-after` (trailing) — instead of a
+     * node-splitting `edge-*`; perpendicular edges stay `edge-*`. Corner ties resolve
+     * deterministically in top → bottom → left → right order (stable renderer diffing). Returns
+     * `'rejected'` when the pointer is outside the rect or the rect is non-numeric — the fail-closed
+     * "no candidate" verdict. Override in a subclass for a different drop grammar.
+     * @param {Object|null} rect {x, y, width, height}
+     * @param {Object|null} pointer {x, y}
+     * @param {String} [orientation] the node's parent-split orientation: `'horizontal'` | `'vertical'`
+     * @returns {String} a `split-*` / `edge-*` kind, `'tab-into'`, or `'rejected'`
+     */
+    resolvePlacementKind(rect, pointer, orientation) {
+        if (!rect || !pointer) return 'rejected';
+
+        let {height, width, x, y} = rect,
+            {x: px, y: py}        = pointer;
+
+        if ([height, width, x, y, px, py].some(v => typeof v !== 'number' || Number.isNaN(v))) return 'rejected';
+        if (width <= 0 || height <= 0)                                                          return 'rejected';
+        if (px < x || px > x + width || py < y || py > y + height)                              return 'rejected';
+
+        let band    = this.edgeBandRatio * Math.min(width, height),
+            dTop    = py - y,
+            dBottom = (y + height) - py,
+            dLeft   = px - x,
+            dRight  = (x + width) - px,
+            nearest = Math.min(dTop, dBottom, dLeft, dRight);
+
+        if (nearest > band) return 'tab-into';
+
+        let edge = nearest === dTop ? 'top' : nearest === dBottom ? 'bottom' : nearest === dLeft ? 'left' : 'right';
+
+        // A node already inside a split becomes a before/after sibling along that split's OWN axis
+        // (join the existing split); the perpendicular edges split the node itself (`edge-*`).
+        if (orientation === 'horizontal' && (edge === 'left' || edge === 'right')) return edge === 'left' ? 'split-before' : 'split-after';
+        if (orientation === 'vertical'   && (edge === 'top'  || edge === 'bottom')) return edge === 'top'  ? 'split-before' : 'split-after';
+
+        return `edge-${edge}`
+    }
+
+    /**
+     * @summary Finds the innermost dock zone whose rect contains `pointer`, or null.
+     *
+     * Zones are expected already ordered outermost → innermost (the adapter projects them in tree
+     * order); the LAST containing rect wins so a nested tabs/split node beats its ancestor. Skips
+     * malformed entries rather than throwing. Containment is orientation-independent, so the parent
+     * axis is not needed here — only `produce()` needs it to label the placement.
+     * @param {Object[]|null} zones [{nodeId, rect, orientation?, type?}]
+     * @param {Object|null} pointer {x, y}
+     * @returns {Object|null} the winning zone, or null when the pointer is over none
+     */
+    hitTestZone(zones, pointer) {
+        if (!Array.isArray(zones) || !pointer) return null;
+
+        let hit = null;
+
+        for (let zone of zones) {
+            if (zone && typeof zone.nodeId === 'string' && this.resolvePlacementKind(zone.rect, pointer) !== 'rejected') {
+                hit = zone
+            }
+        }
+
+        return hit
+    }
+
+    /**
+     * @summary Produces a schema-valid `dockPreview.v1` for a hover, or null outside all affordances.
+     *
+     * Hit-tests the pointer against `zones`, resolves the `placement.kind` (using the winning zone's
+     * `orientation` for split-vs-edge), and assembles the runtime-only payload. Split placements
+     * carry `placement.orientation` (contract-required). `previewId` is deterministic
+     * (`preview:<item>:<node>:<kind>`) so repeat frames over the same candidate are stable for
+     * renderer diffing — no time/random source. Returns null (not a `rejected` payload) when there
+     * is no zone under the pointer or the item id is missing: no candidate, no affordance.
+     * @param {Object} params
+     * @param {Object} params.pointer {x, y} window-local pointer
+     * @param {Object[]} params.zones [{nodeId, rect, orientation?}] rendered dock-zone rects, outer → inner
+     * @param {String} params.itemId the dragged dock item id
+     * @param {String} [params.containerId] the hovered workspace/container id
+     * @param {Object} [params.source] producer surface, e.g. {surface, sortZoneId}
+     * @param {String} [params.sourceNodeId] the drag's origin dock node (used as sortZoneId fallback)
+     * @returns {Object|null} a `neo.harness.dockPreview.v1` payload, or null
+     */
+    produce({pointer, zones, itemId, containerId=null, source=null, sourceNodeId=null}={}) {
+        if (typeof itemId !== 'string' || !itemId) return null;
+
+        let zone = this.hitTestZone(zones, pointer);
+
+        if (!zone) return null;
+
+        let kind = this.resolvePlacementKind(zone.rect, pointer, zone.orientation);
+
+        if (kind === 'rejected') return null;
+
+        let placement = {kind};
+
+        if (kind === 'split-before' || kind === 'split-after') {
+            placement.orientation = zone.orientation
+        }
+
+        return {
+            schema   : this.schema,
+            previewId: `preview:${itemId}:${zone.nodeId}:${kind}`,
+            itemId,
+            source   : source ?? {surface: 'dashboard-sort-zone', sortZoneId: sourceNodeId},
+            target   : {containerId, nodeId: zone.nodeId},
+            placement,
+            feedback : {state: 'accepted'}
+        }
+    }
+}
+
+export default Neo.setupClass(DockPreviewProducer);

--- a/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
@@ -1,0 +1,127 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoDashboardDockPreviewProducerTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+test.describe('Neo.dashboard.DockPreviewProducer (ADR 0029 §2.3 — the dock preview producer)', () => {
+    let DockPreviewProducer, DockPreview, producer;
+
+    const RECT = {x: 0, y: 0, width: 100, height: 100}; // default band = 0.24 * 100 = 24
+
+    test.beforeAll(async () => {
+        DockPreviewProducer = (await import('../../../../src/dashboard/DockPreviewProducer.mjs')).default;
+        DockPreview         = (await import('../../../../apps/agentos/view/DockPreview.mjs')).default;
+        producer            = Neo.create(DockPreviewProducer)
+    });
+
+    test.afterAll(() => {
+        producer?.destroy()
+    });
+
+    test('resolvePlacementKind maps the five zones deterministically', () => {
+        const k = (x, y) => producer.resolvePlacementKind(RECT, {x, y});
+
+        expect(k(50, 50)).toBe('tab-into');
+        expect(k(50, 10)).toBe('edge-top');
+        expect(k(50, 90)).toBe('edge-bottom');
+        expect(k(10, 50)).toBe('edge-left');
+        expect(k(90, 50)).toBe('edge-right');
+        expect(k(5,  5 )).toBe('edge-top');    // corner tie resolves top > left (deterministic order)
+        expect(k(50, 23.9)).toBe('edge-top');  // just inside the edge band
+        expect(k(50, 24.1)).toBe('tab-into')   // just past the edge band
+    });
+
+    test('resolvePlacementKind is fail-closed for outside / malformed input', () => {
+        expect(producer.resolvePlacementKind(RECT, {x: 150, y: 50})).toBe('rejected');       // outside x
+        expect(producer.resolvePlacementKind(RECT, {x: 50,  y: -1})).toBe('rejected');       // outside y
+        expect(producer.resolvePlacementKind(null, {x: 5, y: 5})).toBe('rejected');          // no rect
+        expect(producer.resolvePlacementKind({x: 0, y: 0, width: 0, height: 100}, {x: 0, y: 5})).toBe('rejected'); // zero width
+        expect(producer.resolvePlacementKind(RECT, {x: 'a', y: 5})).toBe('rejected')         // non-numeric
+    });
+
+    test('edgeBandRatio is a config, not a static field — a wider band re-zones the same pointer', () => {
+        // the extensibility payoff: an app / subclass tunes the affordance thickness via config
+        const wide = Neo.create(DockPreviewProducer, {edgeBandRatio: 0.4}); // band = 40 on a 100px rect
+
+        expect(producer.resolvePlacementKind(RECT, {x: 50, y: 30})).toBe('tab-into'); // default band 24: 30 > 24
+        expect(wide.resolvePlacementKind(RECT, {x: 50, y: 30})).toBe('edge-top');     // wide band 40: 30 < 40
+
+        wide.destroy()
+    });
+
+    test('resolvePlacementKind resolves split-before/after along the parent-split axis', () => {
+        // horizontal split: children side-by-side → left/right edges are sibling insertions; top/bottom split the node
+        const h = (x, y) => producer.resolvePlacementKind(RECT, {x, y}, 'horizontal');
+        expect(h(8,  50)).toBe('split-before'); // leading (left)
+        expect(h(92, 50)).toBe('split-after');  // trailing (right)
+        expect(h(50, 8 )).toBe('edge-top');     // perpendicular edge stays a node split
+        expect(h(50, 92)).toBe('edge-bottom');
+        expect(h(50, 50)).toBe('tab-into');
+
+        // vertical split: children stacked → top/bottom are sibling insertions; left/right split the node
+        const v = (x, y) => producer.resolvePlacementKind(RECT, {x, y}, 'vertical');
+        expect(v(50, 8 )).toBe('split-before'); // leading (top)
+        expect(v(50, 92)).toBe('split-after');  // trailing (bottom)
+        expect(v(8,  50)).toBe('edge-left');    // perpendicular edge stays a node split
+        expect(v(92, 50)).toBe('edge-right')
+    });
+
+    test('produce carries placement.orientation for split-* and passes the consumer validator', () => {
+        const zones   = [{nodeId: 'side-split-child', rect: RECT, orientation: 'vertical'}];
+        const preview = producer.produce({pointer: {x: 50, y: 8}, zones, itemId: 'terminal'});
+
+        expect(preview.placement.kind).toBe('split-before');
+        expect(preview.placement.orientation).toBe('vertical');  // contract: split placements MUST carry orientation
+        expect(preview.previewId).toBe('preview:terminal:side-split-child:split-before');
+        expect(DockPreview.isValidPreview(preview)).toBe(true)   // THE PIN — incl. the split-orientation requirement
+    });
+
+    test('hitTestZone returns the innermost containing zone, or null', () => {
+        const zones = [
+            {nodeId: 'root',      rect: {x: 0,  y: 0,  width: 200, height: 200}},
+            {nodeId: 'main-tabs', rect: {x: 50, y: 50, width: 100, height: 100}}
+        ];
+
+        expect(producer.hitTestZone(zones, {x: 100, y: 100}).nodeId).toBe('main-tabs'); // inner wins
+        expect(producer.hitTestZone(zones, {x: 10,  y: 10 }).nodeId).toBe('root');       // only outer contains
+        expect(producer.hitTestZone(zones, {x: 500, y: 500})).toBeNull();                // over none
+        expect(producer.hitTestZone([{rect: RECT}], {x: 5, y: 5})).toBeNull();           // no nodeId → skipped
+        expect(producer.hitTestZone(null, {x: 1, y: 1})).toBeNull()
+    });
+
+    test('produce emits a dockPreview.v1 that PASSES the consumer validator (producer→consumer pin)', () => {
+        const zones = [{nodeId: 'main-tabs', rect: RECT}];
+
+        // one produce per resolvable kind — each MUST satisfy the landed DockPreview.isValidPreview (write === read)
+        for (const [x, y, kind] of [[50, 50, 'tab-into'], [50, 8, 'edge-top'], [92, 50, 'edge-right'], [8, 50, 'edge-left'], [50, 92, 'edge-bottom']]) {
+            const preview = producer.produce({pointer: {x, y}, zones, itemId: 'strategy', containerId: 'workspace'});
+
+            expect(preview.schema).toBe('neo.harness.dockPreview.v1');
+            expect(preview.placement.kind).toBe(kind);
+            expect(preview.target.nodeId).toBe('main-tabs');
+            expect(preview.feedback.state).toBe('accepted');
+            expect(DockPreview.isValidPreview(preview)).toBe(true) // THE PIN
+        }
+    });
+
+    test('produce is deterministic and fail-closed', () => {
+        const zones = [{nodeId: 'main-tabs', rect: RECT}];
+
+        const a = producer.produce({pointer: {x: 50, y: 50}, zones, itemId: 'strategy'});
+        const b = producer.produce({pointer: {x: 50, y: 50}, zones, itemId: 'strategy'});
+
+        expect(a.previewId).toBe(b.previewId);                              // stable id — no time / random source
+        expect(a.previewId).toBe('preview:strategy:main-tabs:tab-into');
+
+        expect(producer.produce({pointer: {x: 50,  y: 50 }, zones, itemId: ''})).toBeNull();        // no item id
+        expect(producer.produce({pointer: {x: 500, y: 500}, zones, itemId: 'strategy'})).toBeNull(); // over no zone
+        expect(producer.produce()).toBeNull()                                                        // no args
+    })
+});


### PR DESCRIPTION
Resolves #14866

**Delivers the `dockPreview.v1` producer — the full scope of the (narrowed) #14866.** The hover-affordance rendering + drop-routing + e2e are a separate browser-gated leaf, **#14886** (blocked-by this); they are NOT part of this PR.

Adds `Neo.dashboard.DockPreviewProducer` — the COMPUTE half of the dock preview→operation pipeline: pure `(pointer, zone rects) → neo.harness.dockPreview.v1{placement.kind}`, the owner callback for `CrossWindowDragTarget.previewFor` / `hitTest`. Layer-blind (`src/dashboard/` cannot import the app-layer validator); the producer→consumer contract is pinned in the unit test via `DockPreview.isValidPreview`.

Evidence: L2 (unit — pure logic, 8/8 green locally incl. the `isValidPreview` pin across every placement kind) → L2 fully covers the narrowed close-target (the producer + its unit test). Residual: none — the browser-gated integration is #14886, out of scope here.

## Delivered — the producer (narrowed #14866, complete)
- `resolvePlacementKind` — 5-zone hit-test: interior→`tab-into`, outer bands→`edge-*`, and (given the node's parent-split `orientation`) an axis-aligned edge→`split-before`/`split-after` (join the existing split); deterministic corner tie-break; fail-closed.
- `hitTestZone` — innermost-containing-zone wins; skips malformed entries.
- `produce` — `dockPreview.v1` assembly (split placements carry the contract-required `orientation`), deterministic `previewId`, fail-closed.
- **Instance + non-reactive configs** (`schema`, `edgeBandRatio`), not static fields — geometry tunable via `Neo.overwrites` / instance / subclass (per operator review).
- Unit test — 8 cases incl. the producer→consumer pin across every kind + the config-customization proof.

## Deltas from ticket
Scope narrowed during review: #14866 was over-bundled (producer + rendering). This PR delivers the producer; the hover-affordance rendering + drop-routing + `DockCrossZoneDragNL` e2e split to **#14886** (browser-gated, blocked-by #14866). The `zones` input contract `[{nodeId, rect, orientation?}]` is this leaf's design.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs` → **8 passed (30.8s)**, including `DockPreview.isValidPreview(produce(...)) === true` across all kinds + the split-orientation requirement + the config-customization case.

## Post-Merge Validation
- [ ] None for this PR — the producer is fully unit-covered. The live-drag rendering + e2e are tracked in #14886.

## Commits
- `c0f6c24e32` — producer (config-tunable, all placement kinds) + unit test

Authored by Grace (Claude Opus 4.8, Claude Code). Session 8b03a4ba-9ac2-4adf-b610-e53e014ecd8b.
