### PR TITLE
feat(agentos): add fleet route wiring (#14632)

### DIFF
--- a/apps/agentos/view/Viewport.mjs
+++ b/apps/agentos/view/Viewport.mjs
@@ -77,7 +77,7 @@ class Viewport extends BaseViewport {
             items: [{
                 ntype : 'component',
                 cls   : ['agent-welcome'],
-                header: {iconCls: 'fa-solid fa-house', text: 'Home'},
+                header: {iconCls: 'fa-solid fa-house', route: '/home', text: 'Home'},
                 html  : '<div class="agent-welcome-inner">' +
                             '<p class="agent-welcome-eyebrow">Neo Agent OS</p>' +
                             '<h1 class="agent-welcome-h1">Mission control for a cross-model AI engineering team.</h1>' +
@@ -85,14 +85,14 @@ class Viewport extends BaseViewport {
                         '</div>'
             }, {
                 module: FleetCockpit,
-                header: {iconCls: 'fa-solid fa-satellite-dish', text: 'Fleet'}
+                header: {iconCls: 'fa-solid fa-satellite-dish', route: '/fleet', text: 'Fleet'}
             }, {
                 // FleetSettingsPanel is a dashboard.Panel, so its keeper-view rides a dashboard.Container
                 // to keep the detach-to-window (pop-out) host — the WindowOps E2E contract + the working
                 // lifecycle pop-out. The rail tab reads this wrapper's `header`.
                 module   : Dashboard,
                 cls      : ['agent-control-dashboard'],
-                header   : {iconCls: 'fa-solid fa-sliders', text: 'Control'},
+                header   : {iconCls: 'fa-solid fa-sliders', route: '/control', text: 'Control'},
                 popupUrl : 'apps/agentos/childapps/widget/index.html',
                 sortGroup: 'neo-connected-dashboard',
 
@@ -106,7 +106,7 @@ class Viewport extends BaseViewport {
                 // identity panel keeps the pop-out affordance and stays structurally idiomatic.
                 module   : Dashboard,
                 cls      : ['agent-accounts-dashboard'],
-                header   : {iconCls: 'fa-solid fa-id-badge', text: 'Accounts'},
+                header   : {iconCls: 'fa-solid fa-id-badge', route: '/accounts', text: 'Accounts'},
                 popupUrl : 'apps/agentos/childapps/widget/index.html',
                 sortGroup: 'neo-connected-dashboard',
 
@@ -118,7 +118,7 @@ class Viewport extends BaseViewport {
             }, {
                 ntype : 'component',
                 cls   : ['agent-placeholder'],
-                header: {iconCls: 'fa-solid fa-comments', text: 'Chat'},
+                header: {iconCls: 'fa-solid fa-comments', route: '/chat', text: 'Chat'},
                 html  : '<div class="agent-placeholder-inner">Chat — prompt an agent → a live widget pane you can dock and pop out. The dockable QT work-area lands here next.</div>'
             }]
         }]

--- a/apps/agentos/view/ViewportController.mjs
+++ b/apps/agentos/view/ViewportController.mjs
@@ -6,7 +6,14 @@ import Controller from '../../../src/controller/Component.mjs';
  */
 class ViewportController extends Controller {
     static config = {
-        className: 'AgentOS.view.ViewportController'
+        className: 'AgentOS.view.ViewportController',
+        routes   : {
+            '/accounts': 'onAccountsRoute',
+            '/chat'    : 'onChatRoute',
+            '/control' : 'onControlRoute',
+            '/fleet'   : 'onFleetRoute',
+            '/home'    : 'onHomeRoute'
+        }
     }
 
     /**
@@ -25,6 +32,54 @@ class ViewportController extends Controller {
                 me.setTheme('neo-theme-neo-dark', false)
             }
         })
+    }
+
+    /**
+     * @summary Activates the shell keeper-view whose header button owns the route.
+     * @param {String} route
+     */
+    activateRoute(route) {
+        let shell = this.getReference('shell'),
+            tab   = shell?.getTabBar()?.items?.find(button => button.route === route);
+
+        if (tab) {
+            shell.activeIndex = tab.index
+        }
+    }
+
+    /**
+     * @summary Activates the Accounts keeper-view from the route.
+     */
+    onAccountsRoute() {
+        this.activateRoute('/accounts')
+    }
+
+    /**
+     * @summary Activates the Chat keeper-view from the route.
+     */
+    onChatRoute() {
+        this.activateRoute('/chat')
+    }
+
+    /**
+     * @summary Activates the Control keeper-view from the route.
+     */
+    onControlRoute() {
+        this.activateRoute('/control')
+    }
+
+    /**
+     * @summary Activates the Fleet keeper-view from the route.
+     */
+    onFleetRoute() {
+        this.activateRoute('/fleet')
+    }
+
+    /**
+     * @summary Activates the Home keeper-view from the route.
+     */
+    onHomeRoute() {
+        this.activateRoute('/home')
     }
 
     /**

--- a/test/playwright/unit/apps/agentos/ViewportController.spec.mjs
+++ b/test/playwright/unit/apps/agentos/ViewportController.spec.mjs
@@ -1,0 +1,88 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AgentOSViewportControllerRouteTest'
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../../src/Neo.mjs';
+import * as core          from '../../../../../src/core/_export.mjs';
+import Viewport           from '../../../../../apps/agentos/view/Viewport.mjs';
+import ViewportController from '../../../../../apps/agentos/view/ViewportController.mjs';
+
+test.describe('AgentOS.view.ViewportController — route → keeper-view tab', () => {
+    function createController() {
+        const tabButtons = [
+            {route: '/home',     index: 0},
+            {route: '/fleet',    index: 1},
+            {route: '/control',  index: 2},
+            {route: '/accounts', index: 3},
+            {route: '/chat',     index: 4}
+        ];
+
+        const shell = {
+            activeIndex: null,
+            getTabBar  : () => ({items: tabButtons})
+        };
+
+        const controller = Object.create(ViewportController.prototype);
+
+        controller.getReference = reference => reference === 'shell' ? shell : null;
+
+        return {controller, shell}
+    }
+
+    test('declares routes for each left-rail keeper-view', () => {
+        expect(ViewportController.config.routes).toEqual({
+            '/accounts': 'onAccountsRoute',
+            '/chat'    : 'onChatRoute',
+            '/control' : 'onControlRoute',
+            '/fleet'   : 'onFleetRoute',
+            '/home'    : 'onHomeRoute'
+        })
+    });
+
+    test('activates the Fleet keeper-view from the fleet route without a hardcoded array lookup', () => {
+        const {controller, shell} = createController();
+
+        controller.onFleetRoute();
+
+        expect(shell.activeIndex).toBe(1)
+    });
+
+    test('activates every shell route by matching the tab header route', () => {
+        const {controller, shell} = createController();
+
+        controller.onHomeRoute();
+        expect(shell.activeIndex).toBe(0);
+
+        controller.onControlRoute();
+        expect(shell.activeIndex).toBe(2);
+
+        controller.onAccountsRoute();
+        expect(shell.activeIndex).toBe(3);
+
+        controller.onChatRoute();
+        expect(shell.activeIndex).toBe(4)
+    });
+
+    test('leaves the active shell view unchanged when the route has no tab match', () => {
+        const {controller, shell} = createController();
+
+        shell.activeIndex = 1;
+
+        controller.activateRoute('/unknown');
+
+        expect(shell.activeIndex).toBe(1)
+    });
+
+    test('keeps the authored shell header routes aligned with the controller routes', () => {
+        const shellConfig = Viewport.config.items.find(item => item.reference === 'shell'),
+              routes      = shellConfig.items.map(item => item.header.route);
+
+        expect(routes).toEqual(['/home', '/fleet', '/control', '/accounts', '/chat']);
+        expect(routes.sort()).toEqual(Object.keys(ViewportController.config.routes).sort())
+    })
+});


### PR DESCRIPTION
Resolves #14632

Adds route ownership to the current Agent OS left-rail shell by giving each header button a route and mapping `ViewportController` routes back to shell tab activation. Fleet keeps the existing mount/default behavior; route handling now makes `/fleet` activate the Fleet keeper-view without duplicating the already-shipped shell.

Evidence: L2 unit/static validation achieved for route-to-tab activation and authored config alignment; L3 running-app validation remains post-merge because this PR only adds route wiring and the cockpit shell was already rendered by prior Fleet Manager work. Residual: none for #14632's remaining route-wiring slice.

Related: #14560
Refs #14631

## Deltas from ticket
The broad nav target and module mount were already present on current `dev`; this PR does not add another module root. It implements the remaining route wiring against `apps/agentos/view/Viewport.mjs` and `apps/agentos/view/ViewportController.mjs`, and deliberately does not implement `#fleet/agent/<id>`-class deep linking because the ticket body calls that a later leaf.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/apps/agentos/ViewportController.spec.mjs` — 5 passed.
- `git diff --cached --check` — passed before commit.
- Commit hook checks passed: `check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, `check-jsdoc-types`, `check-ticket-archaeology`, `check-block-alignment --staged`.

## Post-Merge Validation
- [ ] Navigate to the Agent OS Fleet route in a dev-server build and verify the left rail selects the Fleet keeper-view.
- [ ] Confirm the existing default Fleet cockpit remains the initial shell view after merge.

Authored by Euclid (GPT-5, Codex Desktop). Session e0af78f0-80e9-485d-ae00-654ce902178d.
