### PR TITLE
fix(graph): Computed GP fallback attributes the measured cause, not hardcoded "REM-starved" (#14879)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -56,6 +56,7 @@ import {
 } from './conceptSliceBuilder.mjs';
 import {
     STRUCTURAL_COLD_START_EPSILON,
+    classifyFrontierEmptyCause,
     inheritParentStructuralWeight,
     rankByDeclaredIntent,
     renderDeclaredIntentFallback
@@ -453,7 +454,17 @@ class GoldenPathSynthesizer extends Base {
             });
         }
 
-        return renderDeclaredIntentFallback(rankByDeclaredIntent(items), aiConfig.goldenPathTopNodeRenderLimit);
+        // Attribute the MEASURED frontier-empty cause (honest-states) instead of the former hardcoded
+        // "REM-starved" guess: this method runs BECAUSE the anchor is empty, and a nonzero
+        // digested-summary count distinguishes an unanchored frontier from a genuine cold-start. The
+        // precise REM backlog/cycle metrics are not available in this SQLite-sourced path, so an
+        // unreadable count degrades to the honest UNATTRIBUTED phrase — never a re-asserted mechanism.
+        let digestedHistory;
+        try { digestedHistory = sqliteDb.prepare("SELECT COUNT(*) AS c FROM Nodes WHERE id LIKE 'summary%'").get()?.c; }
+        catch (error) { digestedHistory = undefined; }
+        const cause = classifyFrontierEmptyCause({digested: digestedHistory, frontierAnchorEmpty: true});
+
+        return renderDeclaredIntentFallback(rankByDeclaredIntent(items), aiConfig.goldenPathTopNodeRenderLimit, cause);
     }
 
     /**

--- a/ai/services/graph/goldenPathPickupBridge.mjs
+++ b/ai/services/graph/goldenPathPickupBridge.mjs
@@ -32,6 +32,20 @@ export const STRUCTURAL_COLD_START_EPSILON = 1e-9;
 export const DECLARED_INTENT_PROVENANCE = 'fallback: declared-intent (frontier empty)';
 
 /**
+ * Stable, honest cause codes for WHY the semantic frontier is empty — the vocabulary the render
+ * attributes from MEASURED pipeline state instead of asserting a fixed mechanism. `UNATTRIBUTED` is
+ * the least-asserting default: when the signals cannot distinguish a cause, we say so rather than
+ * inventing one. (Distinct from `INTENT_STARVED` in `ai/graph/directionAttribution.mjs`, which is a
+ * declared-GOAL-attribution state, not a frontier-pipeline cause.)
+ */
+export const FRONTIER_EMPTY_CAUSE = Object.freeze({
+    COLD_START         : 'COLD_START',
+    REM_STALLED        : 'REM_STALLED',
+    FRONTIER_UNANCHORED: 'FRONTIER_UNANCHORED',
+    UNATTRIBUTED       : 'UNATTRIBUTED'
+});
+
+/**
  * @summary Fail-open activation predicate: the declared-intent fallback fires ONLY when the semantic
  * frontier anchor is empty OR the base route produced zero nodes. It can never fire alongside a healthy
  * route, so it cannot displace the semantic ranking.
@@ -42,6 +56,51 @@ export const DECLARED_INTENT_PROVENANCE = 'fallback: declared-intent (frontier e
  */
 export function shouldActivateFallback({frontierEmpty, routedCount} = {}) {
     return frontierEmpty === true || routedCount === 0;
+}
+
+/**
+ * @summary Honest cause classification for the frontier-empty fallback: maps MEASURED pipeline state
+ * to a stable {@link FRONTIER_EMPTY_CAUSE} code + human phrase, so the render attributes the real
+ * reason the semantic frontier is empty instead of asserting a fixed mechanism. The prior hardcoded
+ * "REM-starved / cold-start" was false whenever the frontier was empty for a different reason — e.g.
+ * the consolidation cycle not firing (the wake daemon off) while digestion itself was healthy
+ * (V-B-A 2026-07-06: `undigested` 7, cycles completing, yet the anchor was empty).
+ *
+ * Least-asserting by design: `recentCycleCount > 0` rules out a stall regardless of `undigested`, and
+ * when the inputs cannot distinguish a cause it returns `UNATTRIBUTED` — it never re-asserts a
+ * mechanism it did not measure.
+ *
+ * @param {Object}  [state]
+ * @param {Number}  [state.digested]           Digested-node count (`0` ⇒ genuine cold-start).
+ * @param {Number}  [state.undigested]         Undigested-node count (backlog signal).
+ * @param {Number}  [state.recentCycleCount]   Completed REM cycles in the recent window (`0` ⇒ not cycling).
+ * @param {Boolean} [state.frontierAnchorEmpty] The semantic frontier anchor set is empty.
+ * @returns {{code: String, phrase: String}}
+ */
+export function classifyFrontierEmptyCause({digested, undigested, recentCycleCount, frontierAnchorEmpty} = {}) {
+    const dig = Number(digested),
+          und = Number(undigested),
+          cyc = Number(recentCycleCount);
+
+    // Genuine cold-start: nothing has ever been digested, so there is no history to anchor.
+    if (Number.isFinite(dig) && dig === 0) {
+        return {code: FRONTIER_EMPTY_CAUSE.COLD_START, phrase: 'cold-start — no digested history to anchor yet'};
+    }
+
+    // REM stalled: undigested work exists but no recent cycle drained it (the consolidation pipeline
+    // is not running). `recentCycleCount > 0` below rules this out even under a transient backlog.
+    if (Number.isFinite(cyc) && cyc === 0 && Number.isFinite(und) && und > 0) {
+        return {code: FRONTIER_EMPTY_CAUSE.REM_STALLED, phrase: 'REM consolidation stalled — undigested work, no recent cycles'};
+    }
+
+    // Digestion is healthy (history exists) yet the anchor is empty: the cycle that repopulates the
+    // frontier is not running even though throughput is fine — the daemon-off case.
+    if (frontierAnchorEmpty === true && Number.isFinite(dig) && dig > 0) {
+        return {code: FRONTIER_EMPTY_CAUSE.FRONTIER_UNANCHORED, phrase: 'frontier unanchored — digested history exists but the anchor is empty'};
+    }
+
+    // Signals cannot distinguish a cause — assert nothing.
+    return {code: FRONTIER_EMPTY_CAUSE.UNATTRIBUTED, phrase: 'cause unattributed — frontier anchor empty for an unmeasured reason'};
 }
 
 /**
@@ -99,12 +158,19 @@ export function rankByDeclaredIntent(items = []) {
  * returns an empty string when there is nothing to surface (the caller then renders the empty section).
  * @param {Object[]} rankedItems Output of `rankByDeclaredIntent` (already sorted + provenance-tagged).
  * @param {Number}   [limit=5]
+ * @param {{code: String, phrase: String}} [cause] The MEASURED frontier-empty cause from
+ *   {@link classifyFrontierEmptyCause}. When omitted, the render attributes no mechanism (the honest
+ *   `UNATTRIBUTED` phrase) rather than the former hardcoded "REM-starved / cold-start".
  * @returns {String} the markdown section, or `''` when there are no items.
  */
-export function renderDeclaredIntentFallback(rankedItems = [], limit = 5) {
+export function renderDeclaredIntentFallback(rankedItems = [], limit = 5, cause) {
     const items = (Array.isArray(rankedItems) ? rankedItems : []).slice(0, Math.max(0, limit));
 
     if (items.length === 0) return '';
+
+    // Attribute the MEASURED cause; never re-assert an unmeasured mechanism (the honest-states fix).
+    // A malformed/absent `cause` degrades to the least-asserting UNATTRIBUTED phrase (single source).
+    const causePhrase = (cause && typeof cause.phrase === 'string' && cause.phrase) || classifyFrontierEmptyCause().phrase;
 
     const lines = items.map((item, index) =>
         `${index + 1}. #${item.id}${item.inOpenEpic ? ` — open-epic leaf (activity ${Number(item.epicActivity) || 0})` : ''}`
@@ -113,7 +179,7 @@ export function renderDeclaredIntentFallback(rankedItems = [], limit = 5) {
     return [
         `### Computed Golden Path — ${DECLARED_INTENT_PROVENANCE}`,
         '',
-        `> The semantic frontier is empty (REM-starved / cold-start). Ranking ${items.length} unblocked open-epic-tree leaf/leaves by declared intent instead — **provisional, not the semantic ranking.**`,
+        `> The semantic frontier is empty (${causePhrase}). Ranking ${items.length} unblocked open-epic-tree leaf/leaves by declared intent instead — **provisional, not the semantic ranking.**`,
         '',
         ...lines,
         ''

--- a/test/playwright/unit/ai/services/graph/goldenPathPickupBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/goldenPathPickupBridge.spec.mjs
@@ -2,7 +2,9 @@ import {test, expect} from '@playwright/test';
 
 import {
     DECLARED_INTENT_PROVENANCE,
+    FRONTIER_EMPTY_CAUSE,
     PICKUP_BRIDGE_PARENT_ALPHA,
+    classifyFrontierEmptyCause,
     inheritParentStructuralWeight,
     rankByDeclaredIntent,
     renderDeclaredIntentFallback,
@@ -70,5 +72,34 @@ test.describe('goldenPathPickupBridge', () => {
     test('fallback render is empty when there is nothing to surface (caller renders the empty section)', () => {
         expect(renderDeclaredIntentFallback([])).toBe('');
         expect(renderDeclaredIntentFallback(undefined)).toBe('');
+    });
+
+    test('classifyFrontierEmptyCause attributes the MEASURED cause, never a fixed mechanism', () => {
+        // Genuine cold-start: no digested history to anchor.
+        expect(classifyFrontierEmptyCause({digested: 0, undigested: 0, recentCycleCount: 0, frontierAnchorEmpty: true}).code)
+            .toBe(FRONTIER_EMPTY_CAUSE.COLD_START);
+        // REM stalled: an undigested backlog with no recent cycle to drain it.
+        expect(classifyFrontierEmptyCause({digested: 1460, undigested: 40, recentCycleCount: 0, frontierAnchorEmpty: true}).code)
+            .toBe(FRONTIER_EMPTY_CAUSE.REM_STALLED);
+        // The daemon-off regression (2026-07-06): digestion healthy, cycles running, anchor STILL empty.
+        // This is exactly where the old code lied "REM-starved"; it must now read FRONTIER_UNANCHORED.
+        expect(classifyFrontierEmptyCause({digested: 1460, undigested: 7, recentCycleCount: 5, frontierAnchorEmpty: true}).code)
+            .toBe(FRONTIER_EMPTY_CAUSE.FRONTIER_UNANCHORED);
+        // Signals cannot distinguish a cause → assert nothing.
+        expect(classifyFrontierEmptyCause().code).toBe(FRONTIER_EMPTY_CAUSE.UNATTRIBUTED);
+    });
+
+    test('fallback render attributes the MEASURED cause and NEVER hardcodes "REM-starved"', () => {
+        const ranked = rankByDeclaredIntent([{id: '101', inOpenEpic: true, epicActivity: 2, filedAt: '2026-07-04T02:00:00Z'}]);
+
+        const unanchored = classifyFrontierEmptyCause({digested: 1460, undigested: 7, recentCycleCount: 5, frontierAnchorEmpty: true});
+        const md         = renderDeclaredIntentFallback(ranked, 5, unanchored);
+        expect(md).toContain(unanchored.phrase);   // the measured cause is rendered verbatim
+        expect(md).not.toContain('REM-starved');    // the old hardcoded lie is gone
+
+        // No cause supplied → honest UNATTRIBUTED default, still never the fixed mechanism.
+        const noCause = renderDeclaredIntentFallback(ranked, 5);
+        expect(noCause).toContain('unattributed');
+        expect(noCause).not.toContain('REM-starved');
     });
 });


### PR DESCRIPTION
Resolves #14879

The Computed Golden Path frontier-empty fallback rendered a hardcoded, unmeasured cause — `"The semantic frontier is empty (REM-starved / cold-start)"` — regardless of the actual pipeline state. @tobiu hit it and called it *"not even slightly accurate"*; V-B-A falsified the "REM-starved" claim (REM was healthy — `undigested: 7`, cycles completing; the real cause was the wake daemon being off → the frontier anchor left unpopulated). This makes the render attribute the **measured** cause via a new pure `classifyFrontierEmptyCause` (honest `FRONTIER_EMPTY_CAUSE` codes), degrading to an honest `UNATTRIBUTED` phrase — never a re-asserted mechanism. The SQLite-sourced caller is wired with a verified digested-history signal that distinguishes the operator's `FRONTIER_UNANCHORED` case from a genuine `COLD_START`.

Evidence: L2 (unit — pure classifier + render + guarded synthesizer wiring; `test-unit` **55 passed**) → L2 sufficient: the close-target ACs are pure-logic + a render-string assertion, fully unit-covered (incl. the daemon-off `FRONTIER_UNANCHORED` case). Residual: none blocking — the precise REM-backlog/cycle metric attribution (`REM_STALLED` refinement) is a documented deferral, not an AC of this leaf.

## Deltas from ticket
- **Not `INTENT_STARVED`.** The ticket framed reusing `INTENT_STARVED`; the diff deliberately does NOT — V-B-A showed `INTENT_STARVED` (`ai/graph/directionAttribution.mjs`) is a declared-**goal**-attribution state, not a frontier-pipeline cause. Forcing it would repeat the exact dishonesty being fixed. The classifier uses distinct pipeline codes and documents the distinction. This supersedes the ticket body's INTENT_STARVED-reuse prose.
- **Verified signal, not exact REM metrics.** The caller passes a VERIFIED "digested-history-exists" signal (nonzero `summary%` node count), not the pipeline's exact `digested`/`undigested`/`recentCycles`: V-B-A against the live graph DB showed those are not cleanly queryable from this SQLite path (`$.type` null for ~143k nodes; no count matches the pipeline figure) — a naive count would ship a NEW wrong number. The precise `REM_STALLED` attribution is deferred to a follow-up that plumbs real pipeline state.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/services/graph/goldenPathPickupBridge.spec.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` → **55 passed (52.2s)**, exit 0 (clean serial run).
- New: `classifyFrontierEmptyCause` covers `COLD_START` / `REM_STALLED` / `FRONTIER_UNANCHORED` / `UNATTRIBUTED`, incl. the daemon-off case (`digested>0` + cycles + anchor-empty → `FRONTIER_UNANCHORED`, never "REM-starved"); render asserts the measured cause and never contains "REM-starved".
- Non-breaking: `cause` is an optional 3rd param; existing provenance/item/limit assertions unchanged.

## Post-Merge Validation
- [ ] Confirm a live frontier-empty fallback renders the measured cause (e.g. `frontier unanchored — digested history exists but the anchor is empty`) instead of "REM-starved / cold-start".

## Decision Record
`aligned-with` #14565 direction-attribution (sibling honest-states vocabulary); no ADR amended. ADR-0019 read pre-flight — the touched synthesizer method reads `aiConfig` at the use site; no new config threading / aliasing / mutation introduced.

Related: #14472 (parent epic), #14565 (direction-attribution vocabulary).

Authored by Ada (Claude Opus 4.8, Claude Code). Session 9360840f-5d7a-4680-8110-86877722735b.
