### PR TITLE
fix(agentos): use product language for account setup (#14884)

### DIFF
--- a/apps/agentos/view/Accounts.mjs
+++ b/apps/agentos/view/Accounts.mjs
@@ -130,25 +130,25 @@ class Accounts extends DashboardPanel {
                     cls    : ['agent-button', 'agent-submit-button'],
                     handler: 'up.onSubmitAgentClick',
                     iconCls: 'fa fa-lock',
-                    text   : 'Submit to Bridge'
+                    text   : 'Add agent'
                 }, {
                     module : Button,
                     cls    : ['agent-button'],
                     handler: 'up.onLoadSampleClick',
                     iconCls: 'fa fa-pen-to-square',
-                    text   : 'Edit Sample'
+                    text   : 'Use sample'
                 }, {
                     module : Button,
                     cls    : ['agent-button', 'agent-connect-button'],
                     handler: 'up.onConnectExternalHarnessClick',
                     iconCls: 'fa fa-plug',
-                    text   : 'Connect Harness (NL-MCP)'
+                    text   : 'Connect harness'
                 }]
             }, {
                 ntype    : 'component',
                 cls      : ['agent-bridge-status', 'is-waiting'],
                 reference: 'bridge-status',
-                vdom     : {cn: [{text: 'Fleet Registry bridge unavailable in dev-server mode. Submit fails closed; no PAT is stored in browser state.'}]}
+                vdom     : {cn: [{text: 'Agent setup is unavailable in dev-server mode. Add agent fails closed; no PAT is stored in browser state.'}]}
             }]
         }]
     }
@@ -165,7 +165,7 @@ class Accounts extends DashboardPanel {
             harnessType    : values.harnessType,
             credentialState: 'stored-node-side',
             lifecycleState : 'gated',
-            statusText     : 'Definition accepted by Fleet Registry bridge; lifecycle controls remain gated.',
+            statusText     : 'Agent added; lifecycle controls remain gated.',
             updatedAt      : new Date().toISOString()
         }
     }
@@ -185,7 +185,7 @@ class Accounts extends DashboardPanel {
 
         this.updateBridgeStatus(
             'is-waiting',
-            'Sample loaded for editing. Enter a PAT to submit; the value will be cleared after the bridge attempt.'
+            'Sample loaded. Enter a PAT to add the agent; the value clears after the attempt.'
         )
     }
 
@@ -202,7 +202,7 @@ class Accounts extends DashboardPanel {
         const githubUsername = values.githubUsername?.trim();
 
         if (!valid || !githubUsername || !values.harnessType || !values.credential) {
-            this.updateBridgeStatus('is-error', 'Definition incomplete. GitHub username, harness type, and PAT are required.');
+            this.updateBridgeStatus('is-error', 'Agent setup incomplete. GitHub username, harness type, and PAT are required.');
             return
         }
 
@@ -215,9 +215,9 @@ class Accounts extends DashboardPanel {
         try {
             await this.submitToFleetRegistryBridge(payload);
             this.upsertPublicAgentDefinition(this.createPublicAgentDefinition(payload));
-            this.updateBridgeStatus('is-live', 'Definition submitted through the Fleet Registry bridge. PAT was not retained in the app worker.')
+            this.updateBridgeStatus('is-live', 'Agent added. PAT was not retained in the app worker.')
         } catch (error) {
-            this.updateBridgeStatus('is-error', 'Fleet Registry bridge unavailable. Nothing was stored in browser state; PAT field was cleared.')
+            this.updateBridgeStatus('is-error', 'Could not add agent. Nothing was stored in browser state; PAT field was cleared.')
         } finally {
             await this.clearCredentialField()
         }
@@ -233,9 +233,9 @@ class Accounts extends DashboardPanel {
     async onConnectExternalHarnessClick() {
         try {
             const result = await this.connectExternalHarnessBridge({action: 'start'});
-            this.updateBridgeStatus('is-live', result?.message || 'External harness connected through the Neural Link bridge.')
+            this.updateBridgeStatus('is-live', result?.message || 'External harness connected.')
         } catch (error) {
-            this.updateBridgeStatus('is-error', 'Neural Link connection bridge unavailable in dev-server mode. Connect fails closed; no connection state was stored in the app worker.')
+            this.updateBridgeStatus('is-error', 'Harness connection unavailable in dev-server mode. Connect fails closed; no connection state was stored in the app worker.')
         }
     }
 

--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -55,6 +55,22 @@ test.describe('AgentOS.view.Accounts credential boundary', () => {
         expect(source).toContain('AgentDefinitions.add');
         expect(source).toContain('createPublicAgentDefinition');
         expect(source).not.toMatch(/AgentDefinitions\.add\(\s*values/)
+    });
+
+    test('visible setup actions use product language instead of bridge/protocol labels', () => {
+        const source = fs.readFileSync(viewPath, 'utf8');
+
+        expect(source).toContain("text   : 'Add agent'");
+        expect(source).toContain("text   : 'Use sample'");
+        expect(source).toContain("text   : 'Connect harness'");
+        expect(source).toContain('Agent setup is unavailable in dev-server mode. Add agent fails closed');
+        expect(source).toContain('Harness connection unavailable in dev-server mode. Connect fails closed');
+
+        expect(source).not.toContain("text   : 'Submit to Bridge'");
+        expect(source).not.toContain("text   : 'Connect Harness (NL-MCP)'");
+        expect(source).not.toContain('Fleet Registry bridge unavailable in dev-server mode. Submit fails closed');
+        expect(source).not.toContain('Definition submitted through the Fleet Registry bridge');
+        expect(source).not.toContain('External harness connected through the Neural Link bridge')
     })
 });
 


### PR DESCRIPTION
Resolves #14884

Updates the Agent OS Accounts setup surface to use product-language labels and status copy for the add-agent and harness-connect actions, while keeping the existing fail-closed credential handling intact. This leaves the broader onboarding flow and larger design/model work open on their own tickets.

Related: #14614
Related: #14807
Related: #14805
Related: #14809

Evidence: L2 (focused Playwright unit/source-guard coverage plus static diff/preflight hygiene in the local Codex sandbox) -> L2 required (visible-copy and fail-closed status ACs). Residual: none for #14884.

## Deltas from ticket

Created #14884 after implementation was isolated from the broader onboarding lane, so this PR can close the product-language slice without claiming all of #14614. No substantive implementation delta from #14884.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/Accounts.spec.mjs` - 9 passed (30.5s).
- `git diff --check origin/dev...HEAD` - passed.
- `git log origin/dev..HEAD --format='%h%x09%s%n%b'` - only `34d952fd68 fix(agentos): use product language for account setup (#14884)`.
- `npm run --silent ai:structure-map -- --files --loc` - passed during issue creation placement check.
- `npm run agent-preflight -- --no-fix --pr-body tmp/pr-body-14884.md apps/agentos/view/Accounts.mjs test/playwright/unit/apps/agentos/Accounts.spec.mjs` - passed.

## Post-Merge Validation

- [ ] Open Accounts in the Agent OS dev-server and verify the buttons read Add agent / Use sample / Connect harness with no Bridge/NL-MCP primary labels.

## Commits

- `34d952fd68` - product-language setup copy and source guard.

Authored by Euclid (GPT-5, Codex Desktop). Session e0af78f0-80e9-485d-ae00-654ce902178d.
