### PR TITLE
fix(graph): relocate Concept Slice analytics out of the golden-path handoff to a sibling file (#14885)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ test-results/
 
 # Autonomous AI Output files
 resources/content/sandman_handoff.md
+resources/content/sandman_concept_slice.md
 
 # Agent Harness Scratch Artifacts (Issue #11563)
 .gemini/*

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -1432,10 +1432,13 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
 
         // Graph-analytics companion — kept OUT of the strategic handoff, in a sibling file derived from
         // the resolved handoff path so the debug tables never bloat sandman_handoff.md.
+        // Idempotent like the handoff itself: ALWAYS overwrite, so a prior run's analytics can never
+        // survive as fresh output. On the renderer's empty-string degradation path, write an explicit
+        // current-run degraded marker rather than leaving the stale companion behind.
         const conceptSliceFile = path.join(path.dirname(handoffFile), 'sandman_concept_slice.md');
-        if (conceptSliceSection.trim()) {
-            fs.writeFileSync(conceptSliceFile, `# Concept Slice — Native Edge Graph analytics (companion to sandman_handoff.md)\n${conceptSliceSection.trim()}\n`, 'utf-8');
-        }
+        const conceptSliceBody = conceptSliceSection.trim() ||
+            '_No Concept Slice generated this run (renderer degraded or no graph data)._';
+        fs.writeFileSync(conceptSliceFile, `# Concept Slice — Native Edge Graph analytics (companion to sandman_handoff.md)\n${conceptSliceBody}\n`, 'utf-8');
 
         logger.info(`[GoldenPathSynthesizer] Mathematical Golden Path established. Anchored ${topNodes.length} strategic nodes to frontier.`);
 

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -1099,7 +1099,9 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         // TTL pruning and centralized overwrite happen in the same render pass.
         let handoffContent = `# Autonomous Handoff (Dream Pipeline & Golden Path)\n\n`;
         handoffContent += `The Native Edge Graph has audited the codebase structurally. The following architectural coverage gaps currently exist natively within the SQLite matrix.\n\n`;
-        handoffContent += this.constructor.renderConceptSliceHandoffSection({
+        // The Concept Slice is Native-Edge-Graph analytics, not strategic handoff — capture it here and
+        // write it to a sibling companion file below; it is never appended to the handoff itself.
+        const conceptSliceSection = this.constructor.renderConceptSliceHandoffSection({
             capturedAt  : handoffTimestamp,
             graphService: GraphService,
             logger
@@ -1427,6 +1429,13 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         fs.mkdirSync(path.dirname(handoffFile), {recursive: true});
         fs.writeFileSync(handoffFile, handoffContent.trim() + '\n', 'utf-8');
         logger.info(`[GoldenPathSynthesizer] sandman_handoff.md freshly generated via Centralized Pipeline. Golden Path integrated.`);
+
+        // Graph-analytics companion — kept OUT of the strategic handoff, in a sibling file derived from
+        // the resolved handoff path so the debug tables never bloat sandman_handoff.md.
+        const conceptSliceFile = path.join(path.dirname(handoffFile), 'sandman_concept_slice.md');
+        if (conceptSliceSection.trim()) {
+            fs.writeFileSync(conceptSliceFile, `# Concept Slice — Native Edge Graph analytics (companion to sandman_handoff.md)\n${conceptSliceSection.trim()}\n`, 'utf-8');
+        }
 
         logger.info(`[GoldenPathSynthesizer] Mathematical Golden Path established. Anchored ${topNodes.length} strategic nodes to frontier.`);
 

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -137,6 +137,10 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         if (fs.existsSync(tmpHandoffFile)) {
             try { fs.unlinkSync(tmpHandoffFile); } catch(e) {}
         }
+        const tmpConceptSliceFile = path.join(path.dirname(tmpHandoffFile), 'sandman_concept_slice.md');
+        if (fs.existsSync(tmpConceptSliceFile)) {
+            try { fs.unlinkSync(tmpConceptSliceFile); } catch(e) {}
+        }
     });
 
     test.afterAll(async () => {
@@ -561,6 +565,54 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).not.toContain('### @neo-gpt');
         expect(handoffContent).not.toContain('### @neo-opus-grace');
         expect(handoffContent).not.toContain('stale author-grouped PR entry');
+    });
+
+    test('synthesizeGoldenPath splits the Concept Slice to a fresh idempotent companion, incl. the degraded path (#14885)', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs         = GoldenPathSynthesizer.fetchOpenPRs;
+        const originalRenderSlice          = GoldenPathSynthesizer.constructor.renderConceptSliceHandoffSection;
+        const issuesDir                    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-concept-slice-split-'));
+        const companionFile                = path.join(path.dirname(tmpHandoffFile), 'sandman_concept_slice.md');
+        aiConfig.vectorDimension = 2;
+
+        StorageRouter.getGraphCollection   = async () => ({ query: async () => ({ ids: [[]], distances: [[]] }) });
+        StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
+        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [];
+
+        try {
+            // (1) Normal render: a stale companion must be overwritten with the fresh slice; the handoff excludes it.
+            fs.mkdirSync(path.dirname(tmpHandoffFile), {recursive: true});
+            fs.writeFileSync(companionFile, '# STALE — must NOT survive\n');
+            await GoldenPathSynthesizer.synthesizeGoldenPath({issuesDir});
+
+            const handoff = fs.readFileSync(tmpHandoffFile, 'utf-8');
+            expect(handoff).not.toContain('## Concept Slice');
+            expect(handoff).not.toContain('### Edge Deltas');
+            expect(handoff).not.toContain('### Open Gaps per Concept');
+
+            const companion = fs.readFileSync(companionFile, 'utf-8');
+            expect(companion).toContain('Concept Slice — Native Edge Graph analytics'); // header present in the sibling
+            expect(companion).not.toContain('STALE');                                    // idempotent overwrite
+
+            // (2) Degraded render ('' path): the stale companion is still overwritten with a marker, never left fresh.
+            fs.writeFileSync(companionFile, '# STALE AGAIN — degraded path must overwrite\n');
+            GoldenPathSynthesizer.constructor.renderConceptSliceHandoffSection = () => '';
+            await GoldenPathSynthesizer.synthesizeGoldenPath({issuesDir});
+
+            const degraded = fs.readFileSync(companionFile, 'utf-8');
+            expect(degraded).not.toContain('STALE');
+            expect(degraded).toContain('No Concept Slice generated this run');
+        } finally {
+            GoldenPathSynthesizer.constructor.renderConceptSliceHandoffSection = originalRenderSlice;
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
     });
 
     test('synthesizeGoldenPath renders degraded Active PR Cycle State when GitHub PR fetch fails (#13985)', async () => {


### PR DESCRIPTION
Resolves #14885

The Concept Slice (Native Edge Graph analytics — the `Edge Deltas` and `Open Gaps per Concept` tables added by #14505) was appended to the top of `sandman_handoff.md`, the turn-based strategic Golden Path handoff. @tobiu flagged it as debug bloat in our most valuable markdown. This captures the Concept Slice in `GoldenPathSynthesizer` instead of appending it, and writes the cohesive block to a sibling `sandman_concept_slice.md` (path derived from the resolved `aiConfig.handoffFilePath` directory), gitignored like the handoff. The handoff keeps only strategic content; the analytics stay available in the companion file.

Evidence: L2 (unit — GoldenPathSynthesizer + conceptSliceBuilder specs, 50 passed) → L2 sufficient: the change is a generated-file split; the new `synthesizeGoldenPath` split test asserts the two-file contract directly (handoff exclusion + companion write + idempotent overwrite on both render paths). Residual: full-pipeline regeneration is the post-merge visual check below.

## Deltas from ticket
- Relocated the **whole cohesive Concept Slice block** (its `## Concept Slice` header + all three subsections, incl. `Concepts Touched`), not only the 2 flagged tables — it is one self-described "render-only shared slice contract" unit, so moving it whole is cleaner. If `Concepts Touched` should stay in the handoff, that is a trivial follow-up split.
- Path is **derived** from `aiConfig.handoffFilePath` (`path.join(path.dirname(handoffFile), 'sandman_concept_slice.md')`) rather than a new config leaf — ADR-0019-clean (a path-under-root derivation).
- **Idempotent generated output** (cross-family review fix, fixup `e3ef691092`): the companion is now ALWAYS overwritten, matching the handoff's own overwrite semantics. On the renderer's `''` degradation path it writes an explicit current-run marker so a prior run's stale analytics can never survive as fresh output.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs test/playwright/unit/ai/services/graph/conceptSliceBuilder.spec.mjs` → **50 passed** at head `e3ef691092` (45 GoldenPathSynthesizer + 5 conceptSliceBuilder; worktree, exit 0; count verified against static `test()` collection). The new `synthesizeGoldenPath` split test seeds a **stale** companion, runs the pipeline, and asserts: the handoff excludes `## Concept Slice` / `### Edge Deltas` / `### Open Gaps per Concept`; the sibling companion is written with its header; and BOTH the normal render and the degraded (`renderConceptSliceHandoffSection → ''`, stubbed) path overwrite the stale companion. `afterEach` clears the companion.

## Post-Merge Validation
- [ ] After the next sandman run, confirm `sandman_handoff.md` has no `## Concept Slice` / `### Edge Deltas` / `### Open Gaps per Concept`, and the gitignored `sandman_concept_slice.md` contains them.

## Decision Record
`aligned-with` ADR-0019 — reads `aiConfig.handoffFilePath` at the use site (existing), derives the sibling path (no new leaf, no threading/mutation). No ADR amended.

Related: #14505 / #14522 (the Concept Slice addition being relocated).

Authored by Ada (Claude Opus 4.8, Claude Code). Session 9360840f-5d7a-4680-8110-86877722735b.
