### PR TITLE
feat(graph): attribute the measured REM_STALLED cause in the GP fallback via real pipeline state (#14883)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -393,9 +393,12 @@ class GoldenPathSynthesizer extends Base {
      * (open-epic membership x parent activity, recency), and render the provenance-led section. Returns `''`
      * when nothing qualifies, so the caller renders the normal empty section. Read-only + additive — it
      * cannot zero or gate the base route; it only fires when the route already produced nothing.
+     * @param {Object} [remState={}] Measured REM pipeline state (`{undigested, digested, recentCycles}`)
+     *   from `HealthService.getRemPipelineState()`, fetched by the async caller; feeds the honest cause
+     *   classification. A missing/partial object degrades to the `UNATTRIBUTED` phrase (never a guessed cause).
      * @returns {String}
      */
-    static buildDeclaredIntentFallback() {
+    static buildDeclaredIntentFallback(remState = {}) {
         const sqliteDb = GraphService.db?.storage?.db;
         if (!sqliteDb) return '';
 
@@ -454,15 +457,16 @@ class GoldenPathSynthesizer extends Base {
             });
         }
 
-        // Attribute the MEASURED frontier-empty cause (honest-states) instead of the former hardcoded
-        // "REM-starved" guess: this method runs BECAUSE the anchor is empty, and a nonzero
-        // digested-summary count distinguishes an unanchored frontier from a genuine cold-start. The
-        // precise REM backlog/cycle metrics are not available in this SQLite-sourced path, so an
-        // unreadable count degrades to the honest UNATTRIBUTED phrase — never a re-asserted mechanism.
-        let digestedHistory;
-        try { digestedHistory = sqliteDb.prepare("SELECT COUNT(*) AS c FROM Nodes WHERE id LIKE 'summary%'").get()?.c; }
-        catch (error) { digestedHistory = undefined; }
-        const cause = classifyFrontierEmptyCause({digested: digestedHistory, frontierAnchorEmpty: true});
+        // Attribute the MEASURED frontier-empty cause (honest-states) from the caller-supplied REM
+        // pipeline state: this method runs BECAUSE the anchor is empty, and undigested + recent-cycle
+        // counts let the classifier distinguish REM_STALLED (backlog, no recent cycle) from a merely
+        // FRONTIER_UNANCHORED anchor. A missing/partial remState degrades to the honest UNATTRIBUTED phrase.
+        const cause = classifyFrontierEmptyCause({
+            digested           : remState.digested,
+            undigested         : remState.undigested,
+            recentCycleCount   : Array.isArray(remState.recentCycles) ? remState.recentCycles.length : undefined,
+            frontierAnchorEmpty: true
+        });
 
         return renderDeclaredIntentFallback(rankByDeclaredIntent(items), aiConfig.goldenPathTopNodeRenderLimit, cause);
     }
@@ -1085,7 +1089,16 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             });
             logger.info('[GoldenPathSynthesizer] Computed route contradicted Current Focus; rendered diagnostic instead of routing content work.');
         } else {
-            const declaredIntentFallback = this.constructor.buildDeclaredIntentFallback();
+            // Fetch measured REM pipeline state so the fallback attributes the real cause (REM_STALLED vs
+            // FRONTIER_UNANCHORED); the async fetch lives here to keep the SQLite fallback builder sync.
+            let remState = {};
+            try {
+                const {default: HealthService} = await import('../../services/memory-core/HealthService.mjs');
+                remState = await HealthService.getRemPipelineState();
+            } catch (error) {
+                logger.warn(`[GoldenPathSynthesizer] REM pipeline state unavailable for fallback cause: ${error.message}`);
+            }
+            const declaredIntentFallback = this.constructor.buildDeclaredIntentFallback(remState);
             if (declaredIntentFallback) {
                 markdownAppend = declaredIntentFallback;
                 logger.info('[GoldenPathSynthesizer] Frontier empty — rendered declared-intent fallback (unblocked open-epic tree leaves).');

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -458,13 +458,16 @@ class GoldenPathSynthesizer extends Base {
         }
 
         // Attribute the MEASURED frontier-empty cause (honest-states) from the caller-supplied REM
-        // pipeline state: this method runs BECAUSE the anchor is empty, and undigested + recent-cycle
-        // counts let the classifier distinguish REM_STALLED (backlog, no recent cycle) from a merely
-        // FRONTIER_UNANCHORED anchor. A missing/partial remState degrades to the honest UNATTRIBUTED phrase.
-        const cause = classifyFrontierEmptyCause({
-            digested           : remState.digested,
-            undigested         : remState.undigested,
-            recentCycleCount   : Array.isArray(remState.recentCycles) ? remState.recentCycles.length : undefined,
+        // pipeline state. get_rem_pipeline_state is an operator-facing DIAGNOSTIC envelope: a failed axis
+        // projects a fallback 0 / [] plus an `axisErrors` marker. Those sentinels must NOT become asserted
+        // GP causes — a failed axis reads as unknown (undefined) so the classifier degrades to UNATTRIBUTED
+        // rather than a confident COLD_START / REM_STALLED from a fallback value.
+        const axisErrors = remState.axisErrors || {};
+        const cause      = classifyFrontierEmptyCause({
+            digested        : axisErrors.digested     ? undefined : remState.digested,
+            undigested      : axisErrors.undigested   ? undefined : remState.undigested,
+            recentCycleCount: axisErrors.recentCycles ? undefined
+                               : (Array.isArray(remState.recentCycles) ? remState.recentCycles.length : undefined),
             frontierAnchorEmpty: true
         });
 

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -722,20 +722,26 @@ export async function buildRemPipelineState({sessionId, axisTimeoutMs = aiConfig
                   .filter(([, error]) => error)
           );
 
-    const recentCycles = await resolveRemBlock('recentCycles', async () => {
+    // Tracked inline (not via resolveRemBlock's silent fallback) so a failed cycle read is marked in
+    // axisErrors below — a fallback [] must never masquerade as a measured empty cycle window downstream.
+    let recentCycles = [], recentCyclesError;
+    try {
         const entries = await readRecentRemRunStates({
             dir  : aiConfig.remRunStateDir,
             limit: aiConfig.remRunRecentLimit
         });
 
-        return entries.map(entry => ({
+        recentCycles = entries.map(entry => ({
             runId              : entry.runId,
             wallClockMs        : entry.wallClockMs,
             cycleOverflowSignal: entry.cycleOverflowSignal,
             cycleOverflowRatio : entry.cycleOverflowRatio,
             outcome            : entry.outcome
         }));
-    }, []);
+    } catch (e) {
+        logger.warn('[HealthService] get_rem_pipeline_state block recentCycles failed:', e?.message ?? e);
+        recentCyclesError = e;
+    }
 
     const state = {
         undigested,
@@ -744,6 +750,10 @@ export async function buildRemPipelineState({sessionId, axisTimeoutMs = aiConfig
         topologyConflicts,
         recentCycles
     };
+
+    if (recentCyclesError) {
+        axisErrors.recentCycles = recentCyclesError;
+    }
 
     if (Object.keys(axisErrors).length) {
         state.axisErrors = axisErrors;

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -2212,6 +2212,21 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const noState = GoldenPathSynthesizer.constructor.buildDeclaredIntentFallback();
         expect(noState).toContain('unattributed');
         expect(noState).not.toContain('REM-starved');
+
+        // Diagnostic-envelope safety: a FAILED axis projects a fallback 0/[] plus an axisErrors marker,
+        // which must NOT become an asserted cause. A failed `digested` axis (fallback 0) reads as unknown
+        // → UNATTRIBUTED, never a confident COLD_START.
+        const degradedDigested = GoldenPathSynthesizer.constructor.buildDeclaredIntentFallback(
+            {digested: 0, undigested: 0, recentCycles: [{outcome: 'completed'}], axisErrors: {digested: 'timeout'}});
+        expect(degradedDigested).toContain('unattributed');
+        expect(degradedDigested).not.toContain('cold-start');
+
+        // A failed recent-cycle read (fallback []) must NOT produce REM_STALLED from the sentinel; the
+        // measured digested backlog still resolves it honestly to FRONTIER_UNANCHORED.
+        const degradedCycles = GoldenPathSynthesizer.constructor.buildDeclaredIntentFallback(
+            {undigested: 40, digested: 100, recentCycles: [], axisErrors: {recentCycles: 'read-failed'}});
+        expect(degradedCycles).not.toContain('REM consolidation stalled');
+        expect(degradedCycles).toContain('frontier unanchored');
     });
 });
 

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -2193,6 +2193,26 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(md).toContain('#911');                                        // surfaced from SQLite despite the cold node cache
         expect(md).toContain('fallback: declared-intent (frontier empty)');
     });
+
+    test('buildDeclaredIntentFallback attributes the MEASURED REM cause from caller-supplied pipeline state (#14883)', () => {
+        GraphService.upsertNode({id: 'issue-920', type: 'ISSUE', properties: {state: 'OPEN', labels: ['epic', 'ai'], title: 'Epic'}});
+        GraphService.upsertNode({id: 'issue-921', type: 'ISSUE', properties: {state: 'OPEN', labels: ['bug', 'ai'], title: 'Leaf', createdAt: '2026-07-04T02:00:00Z'}});
+        GraphService.linkNodes('issue-920', 'issue-921', 'PARENT_OF', 1.0);
+
+        // Genuine REM stall — undigested backlog, no recent cycle → REM_STALLED (not the old "REM-starved" guess).
+        const stalled = GoldenPathSynthesizer.constructor.buildDeclaredIntentFallback({undigested: 40, digested: 100, recentCycles: []});
+        expect(stalled).toContain('REM consolidation stalled');
+        expect(stalled).not.toContain('REM-starved');
+
+        // Healthy digestion + recent cycles but an empty anchor → FRONTIER_UNANCHORED (the daemon-off case).
+        const unanchored = GoldenPathSynthesizer.constructor.buildDeclaredIntentFallback({undigested: 3, digested: 100, recentCycles: [{outcome: 'completed'}]});
+        expect(unanchored).toContain('frontier unanchored');
+
+        // No measured state (fetch failed) → honest UNATTRIBUTED, never a guessed mechanism.
+        const noState = GoldenPathSynthesizer.constructor.buildDeclaredIntentFallback();
+        expect(noState).toContain('unattributed');
+        expect(noState).not.toContain('REM-starved');
+    });
 });
 
 test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from canonical @identity', () => {


### PR DESCRIPTION
Resolves #14883

#14882 shipped the honest-states classifier but wired the caller with a digested-history proxy (a `summary%` node count), so `REM_STALLED` could never fire — the render could only reach `FRONTIER_UNANCHORED` / `UNATTRIBUTED`. This fetches the **real** REM pipeline state — `HealthService.getRemPipelineState()` (`{undigested, digested, recentCycles}`) — at the already-async caller and passes it into `classifyFrontierEmptyCause`. A genuine stall (undigested backlog, no recent cycle) now renders `REM_STALLED`, and the real `digested` figure replaces the proxy. The async fetch lives in the caller (matching the existing `await import('../../services/memory-core/…')` pattern) to keep the SQLite fallback builder sync; a missing/failed `remState` degrades to the honest `UNATTRIBUTED` phrase.

Evidence: L2 (unit — GoldenPathSynthesizer + goldenPathPickupBridge specs, 55 passed; a new whitebox test drives REM_STALLED / FRONTIER_UNANCHORED / UNATTRIBUTED through the wiring) → L2 sufficient: the ACs are the classifier inputs + the render string, both unit-covered. Residual: a live sandman run confirming REM_STALLED under a real stall (post-merge check).

## Deltas from ticket
- The REM accessor is `HealthService.getRemPipelineState()` (default export → `.getRemPipelineState()`, the verified `toolService` pattern), dynamic-imported at the async caller — no cross-service static import at module top.
- Non-breaking: `buildDeclaredIntentFallback(remState = {})` — existing no-arg calls (and the two existing specs) still work, degrading to `UNATTRIBUTED`.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs test/playwright/unit/ai/services/graph/goldenPathPickupBridge.spec.mjs` → **55 passed** (worktree, exit 0). New test `buildDeclaredIntentFallback attributes the MEASURED REM cause…`: a stall `remState` (`undigested:40, recentCycles:[]`) renders `REM consolidation stalled` and never `REM-starved`; a healthy-digestion-empty-anchor `remState` renders `frontier unanchored`; no `remState` renders `unattributed`.

## Post-Merge Validation
- [ ] After a live sandman run with a genuine consolidation backlog + no recent cycle, confirm the Computed GP fallback renders `REM consolidation stalled…`.

## Merge coordination
Both this PR and #14888 touch `GoldenPathSynthesizer.mjs` in **different regions** (this = the `buildDeclaredIntentFallback` method + its caller; #14888 = the Concept Slice append/write). No overlapping hunks, but **merge #14888 first** (it is green + cross-family-routed and ahead); this branch rebases trivially onto the result.

## Decision Record
`aligned-with` ADR-0019 — reads `aiConfig.goldenPathTopNodeRenderLimit` at the use site (existing); the REM accessor is a service method, not config; no threading/mutation. No ADR amended.

Related: #14882 (parent fix this completes), #14472 (epic), #14565 (direction-attribution vocabulary).

Authored by Ada (Claude Opus 4.8, Claude Code). Session 9360840f-5d7a-4680-8110-86877722735b.
