### PR TITLE
feat(agentos): cockpit dockZone.v1 default-layout document + unit test (#14657)

### DIFF
--- a/apps/agentos/view/fleet/cockpitDockDocument.mjs
+++ b/apps/agentos/view/fleet/cockpitDockDocument.mjs
@@ -1,0 +1,45 @@
+/**
+ * The Fleet Cockpit's default dock layout, expressed as pure `neo.harness.dockZone.v1` data.
+ *
+ * @summary The SSOT §01 mission-control split — the **fleet zone** (~1.55fr: the density-ranked
+ * agent-card roster + the scale-to-a-glance health bar) above the live **activity stream** (1fr),
+ * which docks to the bottom, with secondary chrome panes declared `autoHidden` (the input the
+ * edge-rail auto-hide contract consumes). Roster-agnostic — the fleet zone is a `componentRef`,
+ * never a per-agent item list, so the document holds for any fleet size.
+ *
+ * This is a **data leaf only**. The projection / render + resize-commit wiring is the sibling leaf;
+ * nothing here reads a `DOMRect`, mounts a component, or touches the drag lifecycle. The document
+ * round-trips `Neo.dashboard.DockZoneModel.validate` (empty error list) and feeds
+ * `Neo.dashboard.DockLayoutAdapter` unchanged. It is intentionally a factory returning a fresh
+ * object per call — never a shared mutable singleton — so consumers and the semantic operations
+ * (which deep-clone) never alias one authored default.
+ *
+ * `componentRef` values name the `AgentOS.view.fleet.*` keeper-view surfaces; the exact
+ * secondary-pane inventory tracks the FM cockpit SSOT map and may be pinned as that map lands.
+ *
+ * @returns {Object} a fresh `neo.harness.dockZone.v1` document
+ */
+export function cockpitDockDocument() {
+    return {
+        schema: 'neo.harness.dockZone.v1',
+        root  : 'cockpit-root',
+        items : {
+            fleet       : {componentRef: 'fleet-grid',      title: 'Fleet',        kind: 'panel'},
+            stream      : {componentRef: 'activity-stream',  title: 'Activity',     kind: 'panel'},
+            detail      : {componentRef: 'agent-detail',     title: 'Agent detail', kind: 'inspector', autoHidden: true},
+            perspectives: {componentRef: 'perspectives',     title: 'Perspectives', kind: 'tool',      autoHidden: true}
+        },
+        nodes: {
+            // Root edge-zone: the primary split in the center, the auto-hidden chrome on the right rail.
+            'cockpit-root'  : {type: 'edge-zone', zones: {center: 'primary-split', right: 'secondary-rail'}},
+            // SSOT §01: fleet zone (~1.55fr) on top, activity stream (1fr) docked at the bottom — vertical split, normalized to sum 1.
+            'primary-split': {type: 'split', orientation: 'vertical', children: ['fleet-tabs', 'stream-tabs'], sizes: [0.6078, 0.3922]},
+            'fleet-tabs'   : {type: 'tabs', items: ['fleet'],  activeItemId: 'fleet'},
+            'stream-tabs'  : {type: 'tabs', items: ['stream'], activeItemId: 'stream'},
+            // Secondary panes collapse to this edge's rail (§2.7): their item records carry `autoHidden`.
+            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives'], activeItemId: 'detail'}
+        }
+    }
+}
+
+export default cockpitDockDocument;

--- a/test/playwright/unit/apps/agentos/cockpitDockDocument.spec.mjs
+++ b/test/playwright/unit/apps/agentos/cockpitDockDocument.spec.mjs
@@ -1,0 +1,67 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AgentOSFleetCockpitDockDocumentTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+test.describe('AgentOS.view.fleet cockpit dock document — dockZone.v1 default layout', () => {
+    let DockZoneModel, cockpitDockDocument;
+
+    test.beforeAll(async () => {
+        DockZoneModel       = (await import('../../../../../src/dashboard/DockZoneModel.mjs')).default;
+        cockpitDockDocument = (await import('../../../../../apps/agentos/view/fleet/cockpitDockDocument.mjs')).default
+    });
+
+    test('validates against DockZoneModel with the v1 schema (zero invariant violations)', () => {
+        const doc = cockpitDockDocument();
+
+        expect(doc.schema).toBe('neo.harness.dockZone.v1');
+        expect(DockZoneModel.validate(doc)).toEqual([])
+    });
+
+    test('expresses the SSOT ~1.55fr / 1fr fleet-over-activity vertical split (activity docks to the bottom)', () => {
+        const split = cockpitDockDocument().nodes['primary-split'];
+
+        expect(split.type).toBe('split');
+        expect(split.orientation).toBe('vertical');
+
+        const [fleetSize, streamSize] = split.sizes;
+        expect(fleetSize + streamSize).toBeCloseTo(1, 6);   // normalized
+        expect(fleetSize / streamSize).toBeCloseTo(1.55, 1) // ~1.55 : 1
+    });
+
+    test('declares the secondary chrome panes autoHidden (the #14617 rail input); primaries are not', () => {
+        const {items} = cockpitDockDocument();
+
+        const autoHidden = Object.entries(items).filter(([, i]) => i.autoHidden === true).map(([id]) => id);
+        expect(autoHidden.length).toBeGreaterThan(0);
+        expect(autoHidden).toEqual(expect.arrayContaining(['detail', 'perspectives']));
+
+        expect(items.fleet.autoHidden).toBeUndefined();
+        expect(items.stream.autoHidden).toBeUndefined()
+    });
+
+    test('is pure data — a fresh, equal document each call (no shared mutable singleton)', () => {
+        const a = cockpitDockDocument(),
+              b = cockpitDockDocument();
+
+        expect(a).not.toBe(b);   // fresh instance
+        expect(a).toEqual(b)     // deterministic content
+    });
+
+    test('the pane inventory covers the two primary zones and every tabs item resolves to a record', () => {
+        const doc = cockpitDockDocument();
+
+        expect(doc.items.fleet.componentRef).toBe('fleet-grid');
+        expect(doc.items.stream.componentRef).toBe('activity-stream');
+
+        const tabItems = Object.values(doc.nodes).filter(n => n.type === 'tabs').flatMap(n => n.items);
+        tabItems.forEach(id => expect(doc.items[id]).toBeDefined())
+    })
+});


### PR DESCRIPTION
Resolves #14657

The FM cockpit's default dock layout as **pure `neo.harness.dockZone.v1` data** — the SSOT §01 mission-control split: the fleet zone (~1.55fr) beside the live activity stream (1fr), with secondary chrome panes declared `autoHidden`. A **data leaf only** — zero projection/render/wiring (that's the sibling leaf); nothing reads a `DOMRect`, mounts a component, or touches the drag lifecycle. A factory returning a fresh document per call (never a shared mutable singleton).

Evidence: L2 (unit — the document is pure data, 5/5 green incl. `DockZoneModel.validate(doc) === []`) → L2 fully covers the ACs (validation + inventory + autoHidden are static/unit-checkable). Residual: none.

## Delivered
- `apps/agentos/view/fleet/cockpitDockDocument.mjs` — the `dockZone.v1` document: edge-zone root → a center fleet·stream horizontal split (0.6078 / 0.3922 ≈ 1.55:1) + a right rail of `autoHidden` secondaries.
- Unit test — validates via `DockZoneModel.validate` (empty error list), the ~1.55/1 split proportions, secondary-panes `autoHidden` (primaries not), pure-data (fresh, equal doc per call), and pane-inventory resolution.

## Deltas from ticket
None substantive. `componentRef`s name the `AgentOS.view.fleet.*` surfaces; the exact secondary-pane inventory (`detail`, `perspectives` here) tracks the FM cockpit SSOT map and can be pinned as it lands — flagged on the ticket. The projection / resize-commit wiring is the sibling leaf (out of scope).

## Test Evidence
- `npm run test-unit -- test/playwright/unit/apps/agentos/cockpitDockDocument.spec.mjs` → **5 passed (30.8s)**, including `DockZoneModel.validate(cockpitDockDocument()) === []`.

## Post-Merge Validation
- [ ] None for this PR — the document is fully unit-covered. The projection render consumes it in the sibling leaf.

## Commits
- `255d97abde` — cockpit `dockZone.v1` document + unit test

Authored by Grace (Claude Opus 4.8, Claude Code). Session 8b03a4ba-9ac2-4adf-b610-e53e014ecd8b.
