### PR TITLE
feat(agentos): FM cockpit control cluster — per-agent power toggle + whole-fleet + honest-state render (#14611)

### DIFF
--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -1,8 +1,10 @@
-import Container     from '../../../../src/container/Base.mjs';
-import FamilyRail    from './FamilyRail.mjs';
-import Image         from '../../../../src/component/Image.mjs';
-import StateDot      from './StateDot.mjs';
-import StateProvider from '../../../../src/state/Provider.mjs';
+import AgentCardController from './AgentCardController.mjs';
+import Button              from '../../../../src/button/Base.mjs';
+import Container           from '../../../../src/container/Base.mjs';
+import FamilyRail          from './FamilyRail.mjs';
+import Image               from '../../../../src/component/Image.mjs';
+import StateDot            from './StateDot.mjs';
+import StateProvider       from '../../../../src/state/Provider.mjs';
 
 /**
  * The resident card: the cockpit's atom. Composes the class-based fleet primitives (FamilyRail +
@@ -43,6 +45,12 @@ class AgentCard extends Container {
          */
         baseCls: ['fm-agent-card'],
         /**
+         * Turns the controls-slot buttons into a single `lifecycleIntent` event (the B4 emit); the
+         * Lane C (C2) round-trip consumes it. See {@link AgentOS.view.fleet.AgentCardController}.
+         * @member {Object} controller={module:AgentCardController}
+         */
+        controller: {module: AgentCardController},
+        /**
          * @member {Object} layout={ntype:'hbox',align:'stretch'}
          * @reactive
          */
@@ -67,8 +75,9 @@ class AgentCard extends Container {
         },
         /**
          * The card anatomy — family rail · avatar · body (name-row [state dot + name + engine tag] +
-         * current-lane line). Each child binds to the per-card provider. Controls slot (T5) + foot
-         * meta are sibling leaves.
+         * current-lane line) · controls slot (start/stop/restart → a single `lifecycleIntent` event
+         * for the Lane C round-trip). Each child binds to the per-card provider; foot meta is a
+         * sibling leaf.
          * @member {Object[]} items
          */
         items: [{
@@ -110,6 +119,31 @@ class AgentCard extends Container {
                 ntype: 'component',
                 cls  : ['fm-card-lane'],
                 bind : {text: data => data.laneLine}
+            }]
+        }, {
+            ntype : 'container',
+            cls   : ['fm-card-controls'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+
+            items: [{
+                module : Button,
+                action : 'start',
+                iconCls: 'fa-solid fa-play',
+                handler: 'onLifecycleIntent',
+                bind   : {disabled: data => data.state === 'ok'}
+            }, {
+                module : Button,
+                action : 'stop',
+                iconCls: 'fa-solid fa-stop',
+                handler: 'onLifecycleIntent',
+                bind   : {disabled: data => data.state === 'off'}
+            }, {
+                module : Button,
+                action : 'restart',
+                iconCls: 'fa-solid fa-rotate',
+                handler: 'onLifecycleIntent',
+                bind   : {disabled: data => data.state === 'off'}
             }]
         }]
     }

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -141,7 +141,7 @@ class AgentCard extends Container {
                     module : Button,
                     handler: 'onToggleLifecycle',
                     bind   : {
-                        disabled: data => Boolean(data.pendingAction),
+                        disabled: data => Boolean(data.pendingAction) || data.controlReason?.kind === 'unauthorized',
                         iconCls : data => data.state === 'off' ? 'fa-solid fa-play' : 'fa-solid fa-stop'
                     }
                 }, {
@@ -151,23 +151,40 @@ class AgentCard extends Container {
                     iconCls: 'fa-solid fa-rotate',
                     handler: 'onLifecycleIntent',
                     bind   : {
-                        disabled: data => Boolean(data.pendingAction),
+                        disabled: data => Boolean(data.pendingAction) || data.controlReason?.kind === 'unauthorized',
                         hidden  : data => data.state === 'off'
                     }
                 }]
             }, {
-                // Honest round-trip state: Lane-C sets pendingAction + controlReason on the provider (per
-                // the B4/C2 contract); the card only RENDERS them — a verb stays pending until C2 settles,
-                // and a rejection/unauthorized shows its reason. No optimistic success.
+                // Honest round-trip state per the B4/C2 contract — the card RENDERS what Lane-C writes,
+                // never fakes success, and each terminal kind renders DISTINCTLY:
+                //   unauthorized → the reason shows AND the cluster stays disabled (see the verb binds) —
+                //                  you cannot retry into a closed door;
+                //   timeout      → stale-pending: the outcome is UNKNOWN (the verb may still be running,
+                //                  we just lost the answer), so it reads as an unfinished "…", not a
+                //                  resolved "⚠" failure, and retry stays open;
+                //   rejected     → the "⚠ reason" with retry open.
                 ntype    : 'component',
                 cls      : ['fm-card-control-status'],
                 reference: 'control-status',
                 bind     : {
                     // pending takes visual priority over a prior reason, so a new attempt never shows a
                     // stale rejection (complements C2 clearing controlReason on a new accepted intent)
-                    text  : data => data.pendingAction
-                        ? `${data.pendingAction}…`
-                        : (data.controlReason ? `⚠ ${data.controlReason.kind}: ${data.controlReason.reason}` : ''),
+                    text  : data => {
+                        if (data.pendingAction) {
+                            return `${data.pendingAction}…`
+                        }
+
+                        const reason = data.controlReason;
+
+                        if (!reason) {
+                            return ''
+                        }
+
+                        return reason.kind === 'timeout'
+                            ? `${reason.action}… stale — no response`
+                            : `⚠ ${reason.kind}: ${reason.reason}`
+                    },
                     hidden: data => !data.pendingAction && !data.controlReason
                 }
             }]

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -159,9 +159,11 @@ class AgentCard extends Container {
                 ntype: 'component',
                 cls  : ['fm-card-control-status'],
                 bind : {
-                    text  : data => data.controlReason
-                        ? `⚠ ${data.controlReason.kind}: ${data.controlReason.reason}`
-                        : (data.pendingAction ? `${data.pendingAction}…` : ''),
+                    // pending takes visual priority over a prior reason, so a new attempt never shows a
+                    // stale rejection (complements C2 clearing controlReason on a new accepted intent)
+                    text  : data => data.pendingAction
+                        ? `${data.pendingAction}…`
+                        : (data.controlReason ? `⚠ ${data.controlReason.kind}: ${data.controlReason.reason}` : ''),
                     hidden: data => !data.pendingAction && !data.controlReason
                 }
             }]

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -47,9 +47,9 @@ class AgentCard extends Container {
         /**
          * Turns the controls-slot buttons into a single `lifecycleIntent` event (the B4 emit); the
          * Lane C (C2) round-trip consumes it. See {@link AgentOS.view.fleet.AgentCardController}.
-         * @member {Object} controller={module:AgentCardController}
+         * @member {Neo.controller.Component} controller=AgentCardController
          */
-        controller: {module: AgentCardController},
+        controller: AgentCardController,
         /**
          * @member {Object} layout={ntype:'hbox',align:'stretch'}
          * @reactive

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -134,23 +134,25 @@ class AgentCard extends Container {
                 layout: {ntype: 'hbox', align: 'center'},
 
                 items: [{
+                    // ONE power toggle — start when off, stop when running. Only one of the two is ever
+                    // valid for a given state, so we render the contextual action; a disabled play on a
+                    // running resident (or a disabled stop on a stopped one) is bloat, not safety.
                     module : Button,
-                    action : 'start',
-                    iconCls: 'fa-solid fa-play',
-                    handler: 'onLifecycleIntent',
-                    bind   : {disabled: data => data.pendingAction !== null || data.state === 'ok'}
+                    handler: 'onToggleLifecycle',
+                    bind   : {
+                        disabled: data => data.pendingAction !== null,
+                        iconCls : data => data.state === 'off' ? 'fa-solid fa-play' : 'fa-solid fa-stop'
+                    }
                 }, {
-                    module : Button,
-                    action : 'stop',
-                    iconCls: 'fa-solid fa-stop',
-                    handler: 'onLifecycleIntent',
-                    bind   : {disabled: data => data.pendingAction !== null || data.state === 'off'}
-                }, {
+                    // restart is meaningful only while running — a stopped resident starts via the toggle
                     module : Button,
                     action : 'restart',
                     iconCls: 'fa-solid fa-rotate',
                     handler: 'onLifecycleIntent',
-                    bind   : {disabled: data => data.pendingAction !== null || data.state === 'off'}
+                    bind   : {
+                        disabled: data => data.pendingAction !== null,
+                        hidden  : data => data.state === 'off'
+                    }
                 }]
             }, {
                 // Honest round-trip state: Lane-C sets pendingAction + controlReason on the provider (per

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -141,7 +141,7 @@ class AgentCard extends Container {
                     module : Button,
                     handler: 'onToggleLifecycle',
                     bind   : {
-                        disabled: data => data.pendingAction !== null,
+                        disabled: data => Boolean(data.pendingAction),
                         iconCls : data => data.state === 'off' ? 'fa-solid fa-play' : 'fa-solid fa-stop'
                     }
                 }, {
@@ -151,7 +151,7 @@ class AgentCard extends Container {
                     iconCls: 'fa-solid fa-rotate',
                     handler: 'onLifecycleIntent',
                     bind   : {
-                        disabled: data => data.pendingAction !== null,
+                        disabled: data => Boolean(data.pendingAction),
                         hidden  : data => data.state === 'off'
                     }
                 }]

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -64,13 +64,15 @@ class AgentCard extends Container {
         stateProvider: {
             module: StateProvider,
             data  : {
-                agentId    : null,
-                avatarUrl  : null,
-                displayName: null,
-                engineTag  : null,
-                family     : null,
-                laneLine   : null,
-                state      : 'off'
+                agentId      : null,
+                avatarUrl    : null,
+                controlReason: null, // {action, kind, reason} of the last reject/unauthorized/timeout, set by Lane-C
+                displayName  : null,
+                engineTag    : null,
+                family       : null,
+                laneLine     : null,
+                pendingAction: null, // the verb whose lifecycle round-trip is in flight, set by Lane-C; null when settled
+                state        : 'off'
             }
         },
         /**
@@ -124,26 +126,44 @@ class AgentCard extends Container {
             ntype : 'container',
             cls   : ['fm-card-controls'],
             flex  : 'none',
-            layout: {ntype: 'hbox', align: 'center'},
+            layout: {ntype: 'vbox', align: 'stretch'},
 
             items: [{
-                module : Button,
-                action : 'start',
-                iconCls: 'fa-solid fa-play',
-                handler: 'onLifecycleIntent',
-                bind   : {disabled: data => data.state === 'ok'}
+                ntype : 'container',
+                cls   : ['fm-card-control-verbs'],
+                layout: {ntype: 'hbox', align: 'center'},
+
+                items: [{
+                    module : Button,
+                    action : 'start',
+                    iconCls: 'fa-solid fa-play',
+                    handler: 'onLifecycleIntent',
+                    bind   : {disabled: data => data.pendingAction !== null || data.state === 'ok'}
+                }, {
+                    module : Button,
+                    action : 'stop',
+                    iconCls: 'fa-solid fa-stop',
+                    handler: 'onLifecycleIntent',
+                    bind   : {disabled: data => data.pendingAction !== null || data.state === 'off'}
+                }, {
+                    module : Button,
+                    action : 'restart',
+                    iconCls: 'fa-solid fa-rotate',
+                    handler: 'onLifecycleIntent',
+                    bind   : {disabled: data => data.pendingAction !== null || data.state === 'off'}
+                }]
             }, {
-                module : Button,
-                action : 'stop',
-                iconCls: 'fa-solid fa-stop',
-                handler: 'onLifecycleIntent',
-                bind   : {disabled: data => data.state === 'off'}
-            }, {
-                module : Button,
-                action : 'restart',
-                iconCls: 'fa-solid fa-rotate',
-                handler: 'onLifecycleIntent',
-                bind   : {disabled: data => data.state === 'off'}
+                // Honest round-trip state: Lane-C sets pendingAction + controlReason on the provider (per
+                // the B4/C2 contract); the card only RENDERS them — a verb stays pending until C2 settles,
+                // and a rejection/unauthorized shows its reason. No optimistic success.
+                ntype: 'component',
+                cls  : ['fm-card-control-status'],
+                bind : {
+                    text  : data => data.controlReason
+                        ? `⚠ ${data.controlReason.kind}: ${data.controlReason.reason}`
+                        : (data.pendingAction ? `${data.pendingAction}…` : ''),
+                    hidden: data => !data.pendingAction && !data.controlReason
+                }
             }]
         }]
     }

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -129,9 +129,10 @@ class AgentCard extends Container {
             layout: {ntype: 'vbox', align: 'stretch'},
 
             items: [{
-                ntype : 'container',
-                cls   : ['fm-card-control-verbs'],
-                layout: {ntype: 'hbox', align: 'center'},
+                ntype    : 'container',
+                cls      : ['fm-card-control-verbs'],
+                reference: 'control-verbs',
+                layout   : {ntype: 'hbox', align: 'center'},
 
                 items: [{
                     // ONE power toggle — start when off, stop when running. Only one of the two is ever
@@ -158,9 +159,10 @@ class AgentCard extends Container {
                 // Honest round-trip state: Lane-C sets pendingAction + controlReason on the provider (per
                 // the B4/C2 contract); the card only RENDERS them — a verb stays pending until C2 settles,
                 // and a rejection/unauthorized shows its reason. No optimistic success.
-                ntype: 'component',
-                cls  : ['fm-card-control-status'],
-                bind : {
+                ntype    : 'component',
+                cls      : ['fm-card-control-status'],
+                reference: 'control-status',
+                bind     : {
                     // pending takes visual priority over a prior reason, so a new attempt never shows a
                     // stale rejection (complements C2 clearing controlReason on a new accepted intent)
                     text  : data => data.pendingAction

--- a/apps/agentos/view/fleet/AgentCardController.mjs
+++ b/apps/agentos/view/fleet/AgentCardController.mjs
@@ -36,6 +36,23 @@ class AgentCardController extends Controller {
 
         me.component.fire('lifecycleIntent', {action, agentId})
     }
+
+    /**
+     * @summary Fires the contextual power intent — `start` when the resident is off, `stop` when running.
+     *
+     * The single power toggle replaces a start+stop pair: only one of the two is ever valid for a given
+     * session state, so rendering both (one disabled) is noise, not safety. Reads `state` + the durable
+     * `agentId` from the per-card provider; intent-only (Lane-C owns the round-trip).
+     * @param {Object} data The button click event.
+     */
+    onToggleLifecycle(data) {
+        let me       = this,
+            provider = me.getStateProvider(),
+            agentId  = provider.getData('agentId'),
+            action   = provider.getData('state') === 'off' ? 'start' : 'stop';
+
+        me.component.fire('lifecycleIntent', {action, agentId})
+    }
 }
 
 export default Neo.setupClass(AgentCardController);

--- a/apps/agentos/view/fleet/AgentCardController.mjs
+++ b/apps/agentos/view/fleet/AgentCardController.mjs
@@ -1,0 +1,41 @@
+import Controller from '../../../../src/controller/Component.mjs';
+
+/**
+ * Controller for {@link AgentOS.view.fleet.AgentCard}: turns the card's start/stop/restart controls
+ * (the B4 lane) into a single lifecycle **intent** event — and stops there. The card owns the
+ * intent-emit; the cockpit→lifecycle round-trip that consumes it (`FleetControlBridge.startAgent`
+ * and its siblings) is the Lane C (C2) seam. Keeping the boundary here means the card stays a pure
+ * presentation + intent surface and never imports the Brain-side fleet bridge.
+ *
+ * @class AgentOS.view.fleet.AgentCardController
+ * @extends Neo.controller.Component
+ */
+class AgentCardController extends Controller {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.AgentCardController'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.AgentCardController'
+    }
+
+    /**
+     * @summary Fires the card's lifecycle intent for the clicked control.
+     *
+     * Reads the durable `agentId` from the per-card state provider and the `action`
+     * (`start` | `stop` | `restart`) off the button that triggered it, then fires ONE
+     * `lifecycleIntent` event `{action, agentId}` on the card. The Lane C (C2) round-trip listens
+     * for this and drives `FleetControlBridge`; this controller intentionally does NOT call the
+     * bridge — that boundary is the B4 ÷ C2 seam.
+     * @param {Object} data The button click event; `data.component.action` carries the verb.
+     */
+    onLifecycleIntent(data) {
+        let me      = this,
+            action  = data.component.action,
+            agentId = me.getStateProvider().getData('agentId');
+
+        me.component.fire('lifecycleIntent', {action, agentId})
+    }
+}
+
+export default Neo.setupClass(AgentCardController);

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -69,9 +69,9 @@ class FleetCockpit extends Container {
         /**
          * Fires the whole-fleet control intent (the SSOT §01 "▶ Start morning fleet"); the Lane-C
          * round-trip consumes it. See {@link AgentOS.view.fleet.FleetCockpitController}.
-         * @member {Object} controller={module:FleetCockpitController}
+         * @member {Neo.controller.Component} controller=FleetCockpitController
          */
-        controller: {module: FleetCockpitController},
+        controller: FleetCockpitController,
         /**
          * Vertical stack: the control bar over the full-width fleet grid over the full-width activity
          * feed. The fleet zone gets the full width for its ranked card grid; the live feed is the

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -95,6 +95,7 @@ class FleetCockpit extends Container {
             }]
         }, {
             ntype: 'container',
+            cls  : ['fm-cockpit-body'],
             flex : 1,
             // the SSOT §01 split: the fleet zone (~1.55fr) beside the activity stream (1fr)
             layout: {ntype: 'hbox', align: 'stretch'},

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -73,7 +73,9 @@ class FleetCockpit extends Container {
          */
         controller: {module: FleetCockpitController},
         /**
-         * Vertical: the whole-fleet control bar over the SSOT §01 fleet/activity split.
+         * Vertical stack: the control bar over the full-width fleet grid over the full-width activity
+         * feed. The fleet zone gets the full width for its ranked card grid; the live feed is the
+         * bottom strip, not a right-hand column.
          * @member {Object} layout={ntype:'vbox',align:'stretch'}
          * @reactive
          */
@@ -93,23 +95,15 @@ class FleetCockpit extends Container {
                 handler: 'onStartFleet'
             }]
         }, {
-            ntype: 'container',
-            cls  : ['fm-cockpit-body'],
-            flex : 1,
-            // the SSOT §01 split: the fleet zone (~1.55fr) beside the activity stream (1fr)
-            layout: {ntype: 'hbox', align: 'stretch'},
-
-            items: [{
-                module: FleetGrid,
-                flex  : 1.55,
-                agents: FIXTURE_ROSTER
-            }, {
-                module      : ActivityStream,
-                flex        : 1,
-                reference   : 'activity-stream',
-                adapterState: 'sample', // the fixture is a representative sample until the live source is wired
-                events      : FIXTURE_ACTIVITY
-            }]
+            module: FleetGrid,
+            flex  : 1.55,
+            agents: FIXTURE_ROSTER
+        }, {
+            module      : ActivityStream,
+            flex        : 1,
+            reference   : 'activity-stream',
+            adapterState: 'sample', // the fixture is a representative sample until the live source is wired
+            events      : FIXTURE_ACTIVITY
         }]
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1,6 +1,8 @@
-import ActivityStream from './ActivityStream.mjs';
-import Container      from '../../../../src/container/Base.mjs';
-import FleetGrid      from './FleetGrid.mjs';
+import ActivityStream         from './ActivityStream.mjs';
+import Button                 from '../../../../src/button/Base.mjs';
+import Container              from '../../../../src/container/Base.mjs';
+import FleetCockpitController from './FleetCockpitController.mjs';
+import FleetGrid              from './FleetGrid.mjs';
 
 /**
  * A representative fleet roster for the fixture-fed cockpit — the live-wire binding to the roster /
@@ -66,24 +68,48 @@ class FleetCockpit extends Container {
          */
         baseCls: ['fm-fleet-cockpit'],
         /**
-         * The SSOT §01 split: the fleet zone (~1.55fr) beside the activity stream (1fr).
-         * @member {Object} layout={ntype:'hbox',align:'stretch'}
+         * Fires the whole-fleet control intent (the SSOT §01 "▶ Start morning fleet"); the Lane-C
+         * round-trip consumes it. See {@link AgentOS.view.fleet.FleetCockpitController}.
+         * @member {Object} controller={module:FleetCockpitController}
+         */
+        controller: {module: FleetCockpitController},
+        /**
+         * Vertical: the whole-fleet control bar over the SSOT §01 fleet/activity split.
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
          * @reactive
          */
-        layout: {ntype: 'hbox', align: 'stretch'},
+        layout: {ntype: 'vbox', align: 'stretch'},
         /**
          * @member {Object[]} items
          */
         items: [{
-            module: FleetGrid,
-            flex  : 1.55,
-            agents: FIXTURE_ROSTER
+            ntype: 'toolbar',
+            cls  : ['fm-cockpit-bar'],
+            flex : 'none',
+            items: ['->', {
+                module : Button,
+                cls    : ['fm-fleet-start'],
+                iconCls: 'fa-solid fa-play',
+                text   : 'Start morning fleet',
+                handler: 'onStartFleet'
+            }]
         }, {
-            module      : ActivityStream,
-            flex        : 1,
-            reference   : 'activity-stream',
-            adapterState: 'sample', // the fixture is a representative sample until the live source is wired
-            events      : FIXTURE_ACTIVITY
+            ntype: 'container',
+            flex : 1,
+            // the SSOT §01 split: the fleet zone (~1.55fr) beside the activity stream (1fr)
+            layout: {ntype: 'hbox', align: 'stretch'},
+
+            items: [{
+                module: FleetGrid,
+                flex  : 1.55,
+                agents: FIXTURE_ROSTER
+            }, {
+                module      : ActivityStream,
+                flex        : 1,
+                reference   : 'activity-stream',
+                adapterState: 'sample', // the fixture is a representative sample until the live source is wired
+                events      : FIXTURE_ACTIVITY
+            }]
         }]
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -5,10 +5,10 @@ import FleetCockpitController from './FleetCockpitController.mjs';
 import FleetGrid              from './FleetGrid.mjs';
 
 /**
- * A representative fleet roster for the fixture-fed cockpit — the live-wire binding to the roster /
- * runtime-status services is the sibling leaf; this renders the design SSOT's §01 fleet zone
- * against a realistic snapshot so the mission-control surface is real, not a bare page. Avatars are the
- * public GitHub account images (the `githubAvatarUrl` pattern) so identity reads at a glance.
+ * The seven real cross-family maintainer identities, for the fixture-fed cockpit — the live-wire
+ * binding to the roster / runtime-status services is the sibling leaf that replaces this. Identities +
+ * avatars are real (the `githubAvatarUrl` pattern, so identity reads at a glance); session state +
+ * lane-line are an illustrative snapshot until the live source is wired. NO invented agents.
  * @type {Object[]}
  */
 const FIXTURE_ROSTER = [
@@ -18,8 +18,7 @@ const FIXTURE_ROSTER = [
     {agentId: 'neo-opus-vega',  displayName: 'Vega',      engineTag: 'opus-4.8', family: 'claude', state: 'ok',      avatarUrl: 'https://github.com/neo-opus-vega.png?size=80',  laneLine: 'harness-UI shell + left-rail nav (#14846)'},
     {agentId: 'neo-fable',      displayName: 'Mnemosyne', engineTag: 'fable-5',  family: 'claude', state: 'ok',      avatarUrl: 'https://github.com/neo-fable.png?size=80',      laneLine: 'golden-path direction-velocity writer (#14811)'},
     {agentId: 'neo-fable-clio', displayName: 'Clio',      engineTag: 'fable-5',  family: 'claude', state: 'idle',    avatarUrl: 'https://github.com/neo-fable-clio.png?size=80', laneLine: 'CrossWindowDragTarget docking — awaiting review'},
-    {agentId: 'neo-gemini-pro', displayName: 'Gemini',    engineTag: '3-pro',    family: 'gemini', state: 'off',     avatarUrl: 'https://github.com/neo-gemini-pro.png?size=80', laneLine: 'operator-benched'},
-    {agentId: 'neo-clio-limit', displayName: 'Kepler',    engineTag: 'sonnet-5', family: 'claude', state: 'limited', avatarUrl: 'https://github.com/neomjs.png?size=80',         laneLine: 'rate-limited — resumes ~20:50'}
+    {agentId: 'neo-gemini-pro', displayName: 'Gemini',    engineTag: '3-pro',    family: 'gemini', state: 'off',     avatarUrl: 'https://github.com/neo-gemini-pro.png?size=80', laneLine: 'operator-benched'}
 ];
 
 /**

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -67,8 +67,9 @@ class FleetCockpit extends Container {
          */
         baseCls: ['fm-fleet-cockpit'],
         /**
-         * Fires the whole-fleet control intent (the SSOT §01 "▶ Start morning fleet"); the Lane-C
-         * round-trip consumes it. See {@link AgentOS.view.fleet.FleetCockpitController}.
+         * The B4÷C2 composition root: catches each card's `lifecycleIntent` and the whole-fleet
+         * "▶ Start morning fleet" click, driving both through the C2 adapter to honest per-card
+         * round-trip state. See {@link AgentOS.view.fleet.FleetCockpitController}.
          * @member {Neo.controller.Component} controller=FleetCockpitController
          */
         controller: FleetCockpitController,

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -1,4 +1,5 @@
-import Controller from '../../../../src/controller/Component.mjs';
+import Controller                   from '../../../../src/controller/Component.mjs';
+import {handleFleetLifecycleIntent} from './fleetLifecycleIntentAdapter.mjs';
 
 /**
  * Controller for {@link AgentOS.view.fleet.FleetCockpit}: the whole-fleet control verb — the design
@@ -29,6 +30,23 @@ class FleetCockpitController extends Controller {
      */
     onStartFleet() {
         this.component.fire('lifecycleIntent', {action: 'start', scope: 'fleet'})
+    }
+
+    /**
+     * @summary Consume a card's `lifecycleIntent` and drive the honest round-trip — the B4÷C2 seam.
+     *
+     * A card's control cluster fires an intent-only `lifecycleIntent {action, agentId}` and never
+     * touches transport. The cockpit is the composition root that knows both the cards and the fleet
+     * bridge: it resolves the firing card from the event `source`, then hands the intent + that card's
+     * `state.Provider` to the C2 adapter (`handleFleetLifecycleIntent`). The adapter calls the registry
+     * bridge and writes honest pending / settled / rejected state back onto the provider the card
+     * renders — never an optimistic success.
+     * @param {Object} data The `lifecycleIntent` payload `{action, agentId, source}` — Neo stamps `source`.
+     */
+    onAgentLifecycleIntent(data) {
+        const card = Neo.getComponent(data.source);
+
+        card && handleFleetLifecycleIntent(data, card.getStateProvider())
     }
 }
 

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -2,12 +2,16 @@ import Controller                   from '../../../../src/controller/Component.m
 import {handleFleetLifecycleIntent} from './fleetLifecycleIntentAdapter.mjs';
 
 /**
- * Controller for {@link AgentOS.view.fleet.FleetCockpit}: the whole-fleet control verb — the design
- * SSOT §01 "▶ Start morning fleet", the one-click morning start. Like the per-card
- * {@link AgentOS.view.fleet.AgentCardController}, it fires a lifecycle **intent** and stops there; the
- * cockpit→lifecycle round-trip is the Lane-C seam (per the accepted B4÷C2 cut — controls stay
- * intent-only). A whole-fleet intent carries `scope: 'fleet'` instead of an `agentId`, so the one
- * consumer distinguishes a fleet-wide fan-out from a single resident's verb.
+ * Controller for {@link AgentOS.view.fleet.FleetCockpit} — the cockpit is the **composition root** of
+ * the B4÷C2 seam: the one place that knows both the resident cards and the fleet bridge, so the wire
+ * lives here (the cards themselves stay intent-only and never touch transport).
+ *
+ * Two entry points, both driving the C2 adapter (`handleFleetLifecycleIntent`) → the registry bridge →
+ * honest per-card round-trip state, never an optimistic success:
+ * - `onAgentLifecycleIntent` — catches a single card's `lifecycleIntent` (resolved up the controller
+ *   chain via the card's listener) and dispatches it for that card.
+ * - `onStartFleet` — the design SSOT §01 "▶ Start morning fleet" one-click: fans `start` out to every
+ *   rendered card, so each resident drives its own honest round-trip.
  *
  * @class AgentOS.view.fleet.FleetCockpitController
  * @extends Neo.controller.Component
@@ -22,14 +26,30 @@ class FleetCockpitController extends Controller {
     }
 
     /**
-     * @summary Fires the whole-fleet start intent (the one-click morning start).
+     * @summary The one-click morning start — fan `start` out to every resident card via the C2 adapter.
      *
-     * Intent-only: fires one `lifecycleIntent {action: 'start', scope: 'fleet'}` on the cockpit and
-     * never calls the fleet bridge itself — the round-trip + honest settlement are the Lane-C
-     * responsibility (the B4÷C2 boundary).
+     * The cockpit owns the wire (the cards stay intent-only): it enumerates the rendered cards and hands
+     * each a `start` intent + that card's `state.Provider` to `handleFleetLifecycleIntent`, so every
+     * resident drives its own honest round-trip (pending → settled / rejected), never an optimistic
+     * fleet-wide success. Starting an already-running resident is the bridge's concern; the per-card
+     * honest state reflects whatever actually happens.
      */
     onStartFleet() {
-        this.component.fire('lifecycleIntent', {action: 'start', scope: 'fleet'})
+        this.getAgentCards().forEach(card => {
+            const provider = card.getStateProvider();
+
+            handleFleetLifecycleIntent({action: 'start', agentId: provider.getData('agentId')}, provider)
+        })
+    }
+
+    /**
+     * @summary The rendered resident cards — the fleet grid's card region (a no-controller container, so
+     * its `fleet-cards` reference resolves up to this controller); the collapsed-idle fold and the header
+     * sub-tree are excluded by ntype.
+     * @returns {Neo.component.Base[]}
+     */
+    getAgentCards() {
+        return (this.getReference('fleet-cards')?.items ?? []).filter(card => card.ntype === 'fm-agent-card')
     }
 
     /**

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -1,0 +1,35 @@
+import Controller from '../../../../src/controller/Component.mjs';
+
+/**
+ * Controller for {@link AgentOS.view.fleet.FleetCockpit}: the whole-fleet control verb — the design
+ * SSOT §01 "▶ Start morning fleet", the one-click morning start. Like the per-card
+ * {@link AgentOS.view.fleet.AgentCardController}, it fires a lifecycle **intent** and stops there; the
+ * cockpit→lifecycle round-trip is the Lane-C seam (per the accepted B4÷C2 cut — controls stay
+ * intent-only). A whole-fleet intent carries `scope: 'fleet'` instead of an `agentId`, so the one
+ * consumer distinguishes a fleet-wide fan-out from a single resident's verb.
+ *
+ * @class AgentOS.view.fleet.FleetCockpitController
+ * @extends Neo.controller.Component
+ */
+class FleetCockpitController extends Controller {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.FleetCockpitController'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.FleetCockpitController'
+    }
+
+    /**
+     * @summary Fires the whole-fleet start intent (the one-click morning start).
+     *
+     * Intent-only: fires one `lifecycleIntent {action: 'start', scope: 'fleet'}` on the cockpit and
+     * never calls the fleet bridge itself — the round-trip + honest settlement are the Lane-C
+     * responsibility (the B4÷C2 boundary).
+     */
+    onStartFleet() {
+        this.component.fire('lifecycleIntent', {action: 'start', scope: 'fleet'})
+    }
+}
+
+export default Neo.setupClass(FleetCockpitController);

--- a/apps/agentos/view/fleet/FleetGrid.mjs
+++ b/apps/agentos/view/fleet/FleetGrid.mjs
@@ -205,6 +205,10 @@ class FleetGrid extends Container {
     agentCardConfig(agent) {
         return {
             module       : AgentCard,
+            // The card's control cluster fires an intent-only `lifecycleIntent`; this listener resolves
+            // UP the controller chain (card → grid [no controller] → cockpit) to
+            // FleetCockpitController.onAgentLifecycleIntent — the C2 consumer that drives the round-trip.
+            listeners    : {lifecycleIntent: 'onAgentLifecycleIntent'},
             stateProvider: {
                 data: {
                     agentId    : agent?.agentId     ?? null,

--- a/resources/scss/src/apps/agentos/fleet/AgentCard.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentCard.scss
@@ -48,8 +48,17 @@
     }
 
     .fm-card-controls {
-        flex       : none;
+        flex: none;
+        gap : 2px;
+    }
+
+    .fm-card-control-verbs {
         gap        : 2px;
         align-items: center;
+    }
+
+    .fm-card-control-status {
+        font-size: 10px;
+        color    : var(--fm-ink-dim);
     }
 }

--- a/resources/scss/src/apps/agentos/fleet/AgentCard.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentCard.scss
@@ -46,4 +46,10 @@
         white-space  : nowrap;
         text-overflow: ellipsis;
     }
+
+    .fm-card-controls {
+        flex       : none;
+        gap        : 2px;
+        align-items: center;
+    }
 }

--- a/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
+++ b/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
@@ -13,7 +13,7 @@
         }
     }
 
-    .fm-cockpit-body > .fm-fleet-grid {
-        border-right: 1px solid var(--fm-line-soft);
+    > .fm-fleet-grid {
+        border-bottom: 1px solid var(--fm-line-soft);
     }
 }

--- a/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
+++ b/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
@@ -3,7 +3,17 @@
 .fm-fleet-cockpit {
     background: var(--fm-ground);
 
-    > .fm-fleet-grid {
+    .fm-cockpit-bar {
+        flex   : none;
+        padding: 6px 10px;
+        gap    : 8px;
+
+        .fm-fleet-start {
+            font-weight: 600;
+        }
+    }
+
+    .fm-cockpit-body > .fm-fleet-grid {
         border-right: 1px solid var(--fm-line-soft);
     }
 }

--- a/test/playwright/e2e/agentos/FleetCockpitLifecycleNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitLifecycleNL.spec.mjs
@@ -115,6 +115,18 @@ function expectMinimalLifecyclePayload(request) {
     expect(JSON.stringify(request.params)).not.toMatch(/credential|pat|token/i)
 }
 
+/**
+ * @summary The lifecycle bridge calls only. Since the Fleet cockpit became the default keeper-view, its
+ * always-on activity stream (`FleetCockpit.loadActivity` -> `fleetActivity`) fires a read-observe poll on
+ * boot. That poll is orthogonal to a lifecycle verb and must not be counted when asserting that a
+ * Control-panel click crosses the wire as exactly one minimal lifecycle operation.
+ * @param {Object[]} requests
+ * @returns {Object[]}
+ */
+function lifecycleRequestsOnly(requests) {
+    return requests.filter(request => ['startAgent', 'stopAgent', 'restartAgent'].includes(request.method))
+}
+
 test.describe('AgentOS Fleet cockpit lifecycle controls (Neural Link)', () => {
     test.setTimeout(90000);
 
@@ -166,8 +178,9 @@ test.describe('AgentOS Fleet cockpit lifecycle controls (Neural Link)', () => {
 
             const row = await getAgentRow(sessionId, storeId, TEST_AGENT_ID);
             expect(row.statusText).toBe(`Agent ${TEST_AGENT_ID} → running.`);
-            expect(fleet.requests).toHaveLength(1);
-            expectMinimalLifecyclePayload(fleet.requests[0])
+            const lifecycle = lifecycleRequestsOnly(fleet.requests);
+            expect(lifecycle).toHaveLength(1);
+            expectMinimalLifecyclePayload(lifecycle[0])
         } finally {
             await fleet.close()
         }
@@ -197,8 +210,9 @@ test.describe('AgentOS Fleet cockpit lifecycle controls (Neural Link)', () => {
 
             const row = await getAgentRow(sessionId, storeId, TEST_AGENT_ID);
             expect(row.statusText).toBe('fleet: start rejected by test bridge');
-            expect(fleet.requests).toHaveLength(1);
-            expectMinimalLifecyclePayload(fleet.requests[0])
+            const lifecycle = lifecycleRequestsOnly(fleet.requests);
+            expect(lifecycle).toHaveLength(1);
+            expectMinimalLifecyclePayload(lifecycle[0])
         } finally {
             await fleet.close()
         }

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -77,4 +77,23 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
 
         card.destroy()
     });
+
+    test('B4: a control fires one lifecycleIntent {action, agentId} — the forward seam Lane-C (C2) consumes; the card never calls the bridge (#14611)', () => {
+        const card  = createCard({agentId: 'vega', state: 'off'});
+        const fired = [];
+
+        card.on('lifecycleIntent', data => fired.push(data));
+
+        // the per-agent controls slot composes the start / stop / restart verb buttons, in order
+        const controls = card.down({cls: ['fm-card-controls']});
+        expect(controls).toBeTruthy();
+        expect(controls.items.map(button => button.action)).toEqual(['start', 'stop', 'restart']);
+
+        // a control fires ONE intent carrying the verb + the durable agentId; the card itself never
+        // calls the fleet bridge — that round-trip is the Lane-C responsibility (the B4÷C2 boundary)
+        card.getController().onLifecycleIntent({component: controls.items[2]});
+        expect(fired).toEqual([{action: 'restart', agentId: 'vega'}]);
+
+        card.destroy()
+    });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -84,14 +84,29 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
 
         card.on('lifecycleIntent', data => fired.push(data));
 
-        // the controls slot composes the verb row (start / stop / restart), in order
-        const verbs = card.down({cls: ['fm-card-control-verbs']});
-        expect(verbs).toBeTruthy();
-        expect(verbs.items.map(button => button.action)).toEqual(['start', 'stop', 'restart']);
+        const verbs   = card.down({cls: ['fm-card-control-verbs']});
+        const toggle  = verbs.items[0];
+        const restart = verbs.items[1];
+        expect(restart.action).toBe('restart');
 
-        // a control fires ONE intent carrying the verb + the durable agentId; the card itself never
-        // calls the fleet bridge — that round-trip is the Lane-C responsibility (the B4÷C2 boundary)
-        card.getController().onLifecycleIntent({component: verbs.items[2]});
+        // off → the toggle IS start (▶) and restart is hidden (a stopped resident starts via the toggle;
+        // no disabled play beside a redundant restart)
+        expect(toggle.iconCls).toBe('fa-solid fa-play');
+        expect(restart.hidden).toBe(true);
+        card.getController().onToggleLifecycle();
+        expect(fired).toEqual([{action: 'start', agentId: 'vega'}]);
+
+        // running → the SAME toggle is now stop (■) and restart appears
+        fired.length = 0;
+        card.setState('state', 'ok');
+        expect(toggle.iconCls).toBe('fa-solid fa-stop');
+        expect(restart.hidden).toBe(false);
+        card.getController().onToggleLifecycle();
+        expect(fired).toEqual([{action: 'stop', agentId: 'vega'}]);
+
+        // restart fires restart; the card never calls the bridge — that round-trip is Lane-C (B4÷C2)
+        fired.length = 0;
+        card.getController().onLifecycleIntent({component: restart});
         expect(fired).toEqual([{action: 'restart', agentId: 'vega'}]);
 
         card.destroy()
@@ -102,11 +117,11 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
         const verbs  = () => card.down({cls: ['fm-card-control-verbs']}).items;
         const status = () => card.down({cls: ['fm-card-control-status']});
 
-        // idle + nothing pending: start is available, the status line is hidden
-        expect(verbs().find(button => button.action === 'start').disabled).toBe(false);
+        // idle + nothing pending: the power toggle is enabled, the status line is hidden
+        expect(verbs()[0].disabled).toBe(false);
         expect(status().hidden).toBe(true);
 
-        // Lane-C set a verb in flight → EVERY verb disabled (no second intent mid-round-trip); pending rendered
+        // Lane-C set a verb in flight → controls disabled (no second intent mid-round-trip); pending rendered
         card.setState('pendingAction', 'restart');
         expect(verbs().every(button => button.disabled)).toBe(true);
         expect(status().hidden).toBe(false);

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -84,15 +84,38 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
 
         card.on('lifecycleIntent', data => fired.push(data));
 
-        // the per-agent controls slot composes the start / stop / restart verb buttons, in order
-        const controls = card.down({cls: ['fm-card-controls']});
-        expect(controls).toBeTruthy();
-        expect(controls.items.map(button => button.action)).toEqual(['start', 'stop', 'restart']);
+        // the controls slot composes the verb row (start / stop / restart), in order
+        const verbs = card.down({cls: ['fm-card-control-verbs']});
+        expect(verbs).toBeTruthy();
+        expect(verbs.items.map(button => button.action)).toEqual(['start', 'stop', 'restart']);
 
         // a control fires ONE intent carrying the verb + the durable agentId; the card itself never
         // calls the fleet bridge — that round-trip is the Lane-C responsibility (the B4÷C2 boundary)
-        card.getController().onLifecycleIntent({component: controls.items[2]});
+        card.getController().onLifecycleIntent({component: verbs.items[2]});
         expect(fired).toEqual([{action: 'restart', agentId: 'vega'}]);
+
+        card.destroy()
+    });
+
+    test('B4 honest state: a pending action disables every verb + renders it pending; a controlReason renders the reason — no optimistic success (#14611)', () => {
+        const card   = createCard({agentId: 'vega', state: 'idle'});
+        const verbs  = () => card.down({cls: ['fm-card-control-verbs']}).items;
+        const status = () => card.down({cls: ['fm-card-control-status']});
+
+        // idle + nothing pending: start is available, the status line is hidden
+        expect(verbs().find(button => button.action === 'start').disabled).toBe(false);
+        expect(status().hidden).toBe(true);
+
+        // Lane-C set a verb in flight → EVERY verb disabled (no second intent mid-round-trip); pending rendered
+        card.setState('pendingAction', 'restart');
+        expect(verbs().every(button => button.disabled)).toBe(true);
+        expect(status().hidden).toBe(false);
+        expect(status().text).toBe('restart…');
+
+        // Lane-C rejected it → the honest reason renders; never an optimistic success
+        card.setState({controlReason: {action: 'restart', kind: 'rejected', reason: 'harness offline'}, pendingAction: null});
+        expect(status().hidden).toBe(false);
+        expect(status().text).toBe('⚠ rejected: harness offline');
 
         card.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -138,4 +138,24 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
 
         card.destroy()
     });
+
+    test('B4 honest state: unauthorized disables the whole cluster with its reason; timeout renders stale-pending with retry still open (#14611)', () => {
+        const card   = createCard({agentId: 'vega', state: 'ok'});
+        const verbs  = () => card.down({reference: 'control-verbs'}).items;
+        const status = () => card.down({reference: 'control-status'});
+
+        // unauthorized (Lane-C denied / bridge unavailable) → the cluster DISABLES with the reason, not a
+        // live button beside a warning: you cannot retry into a closed door (the accepted B4/C2 contract)
+        card.setState({controlReason: {action: 'start', kind: 'unauthorized', reason: 'Fleet Registry bridge unavailable'}, pendingAction: null});
+        expect(verbs().every(button => button.disabled)).toBe(true);
+        expect(status().text).toBe('⚠ unauthorized: Fleet Registry bridge unavailable');
+
+        // timeout → the outcome is UNKNOWN (the verb may still be running, we lost the answer) → stale-pending:
+        // an unfinished "…", NOT a resolved "⚠" failure, and retry stays OPEN (the cluster re-enables)
+        card.setState({controlReason: {action: 'restart', kind: 'timeout', reason: 'restart timed out after 30000ms'}, pendingAction: null});
+        expect(status().text).toBe('restart… stale — no response');
+        expect(verbs()[0].disabled).toBe(false);
+
+        card.destroy()
+    });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -117,6 +117,10 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
         expect(status().hidden).toBe(false);
         expect(status().text).toBe('⚠ rejected: harness offline');
 
+        // a NEW attempt takes visual priority over a stale reason (the clear-on-new-intent nuance, render side)
+        card.setState('pendingAction', 'start');
+        expect(status().text).toBe('start…');
+
         card.destroy()
     });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -84,7 +84,7 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
 
         card.on('lifecycleIntent', data => fired.push(data));
 
-        const verbs   = card.down({cls: ['fm-card-control-verbs']});
+        const verbs   = card.down({reference: 'control-verbs'});
         const toggle  = verbs.items[0];
         const restart = verbs.items[1];
         expect(restart.action).toBe('restart');
@@ -114,8 +114,8 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
 
     test('B4 honest state: a pending action disables every verb + renders it pending; a controlReason renders the reason — no optimistic success (#14611)', () => {
         const card   = createCard({agentId: 'vega', state: 'idle'});
-        const verbs  = () => card.down({cls: ['fm-card-control-verbs']}).items;
-        const status = () => card.down({cls: ['fm-card-control-status']});
+        const verbs  = () => card.down({reference: 'control-verbs'}).items;
+        const status = () => card.down({reference: 'control-status'});
 
         // idle + nothing pending: the power toggle is enabled, the status line is hidden
         expect(verbs()[0].disabled).toBe(false);

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -94,7 +94,7 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
         expect(toggle.iconCls).toBe('fa-solid fa-play');
         expect(restart.hidden).toBe(true);
         card.getController().onToggleLifecycle();
-        expect(fired).toEqual([{action: 'start', agentId: 'vega'}]);
+        expect(fired).toMatchObject([{action: 'start', agentId: 'vega'}]);
 
         // running → the SAME toggle is now stop (■) and restart appears
         fired.length = 0;
@@ -102,12 +102,12 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
         expect(toggle.iconCls).toBe('fa-solid fa-stop');
         expect(restart.hidden).toBe(false);
         card.getController().onToggleLifecycle();
-        expect(fired).toEqual([{action: 'stop', agentId: 'vega'}]);
+        expect(fired).toMatchObject([{action: 'stop', agentId: 'vega'}]);
 
         // restart fires restart; the card never calls the bridge — that round-trip is Lane-C (B4÷C2)
         fired.length = 0;
         card.getController().onLifecycleIntent({component: restart});
-        expect(fired).toEqual([{action: 'restart', agentId: 'vega'}]);
+        expect(fired).toMatchObject([{action: 'restart', agentId: 'vega'}]);
 
         card.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -119,4 +119,27 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
 
         expect(fired).toEqual([{action: 'start', scope: 'fleet'}])
     });
+
+    test('onAgentLifecycleIntent resolves the firing card + drives the C2 adapter — no bridge → fail-closed onto the card provider, never optimistic', () => {
+        // A card fires intent-only; the cockpit resolves the firing card from the event `source` and
+        // hands it + the card's provider to the adapter. With no registry bridge the adapter fails
+        // closed — an `unauthorized` controlReason lands on the provider, never an optimistic success.
+        delete globalThis.AgentOS;
+
+        const writes   = [],
+              provider = {setData(values) { writes.push(values) }},
+              card     = {getStateProvider: () => provider},
+              origGet  = Neo.getComponent;
+
+        Neo.getComponent = id => id === 'fm-card-x' ? card : null;
+
+        try {
+            const controller = Object.create(FleetCockpitController.prototype);
+            controller.onAgentLifecycleIntent({action: 'start', agentId: 'vega', source: 'fm-card-x'})
+        } finally {
+            Neo.getComponent = origGet
+        }
+
+        expect(writes.some(write => write.controlReason?.kind === 'unauthorized')).toBe(true)
+    });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -99,28 +99,24 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
     });
 });
 
-test.describe('Fleet cockpit — whole-fleet control bar (B4, #14611)', () => {
-    let FleetCockpit;
+test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
+    let FleetCockpitController;
 
     test.beforeAll(async () => {
-        FleetCockpit = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default
+        FleetCockpitController = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpitController.mjs')).default
     });
 
-    test('the ▶ Start bar fires one lifecycleIntent {action:start, scope:fleet} — intent-only, no bridge call', () => {
-        const cockpit = Neo.create(FleetCockpit, {appName: 'FleetCockpitControlBarTest'});
-        const fired   = [];
+    test('onStartFleet fires one lifecycleIntent {action:start, scope:fleet} — intent-only, no bridge call', () => {
+        // Controller-level isolation: the full FleetCockpit composes FleetGrid → the card wall, too heavy
+        // to instantiate bare (the loadActivity specs above mock for the same reason). onStartFleet reads
+        // no state — it just fires the fleet-scoped verb — so a spy component pins the emit precisely.
+        const fired      = [];
+        const controller = Object.create(FleetCockpitController.prototype);
 
-        cockpit.on('lifecycleIntent', data => fired.push(data));
+        controller.component = {fire(name, data) { if (name === 'lifecycleIntent') fired.push(data) }};
 
-        // the control bar carries the whole-fleet start button (SSOT §01 "▶ Start morning fleet")
-        expect(cockpit.down({cls: ['fm-cockpit-bar']})).toBeTruthy();
-        expect(cockpit.down({cls: ['fm-fleet-start']})).toBeTruthy();
+        controller.onStartFleet();
 
-        // the whole-fleet verb fires ONE intent scoped to the fleet; the cockpit never calls the
-        // bridge — that round-trip is the Lane-C responsibility (the B4/C2 boundary)
-        cockpit.getController().onStartFleet();
-        expect(fired).toEqual([{action: 'start', scope: 'fleet'}]);
-
-        cockpit.destroy()
+        expect(fired).toEqual([{action: 'start', scope: 'fleet'}])
     });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -106,18 +106,31 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
         FleetCockpitController = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpitController.mjs')).default
     });
 
-    test('onStartFleet fires one lifecycleIntent {action:start, scope:fleet} — intent-only, no bridge call', () => {
-        // Controller-level isolation: the full FleetCockpit composes FleetGrid → the card wall, too heavy
-        // to instantiate bare (the loadActivity specs above mock for the same reason). onStartFleet reads
-        // no state — it just fires the fleet-scoped verb — so a spy component pins the emit precisely.
-        const fired      = [];
+    test('onStartFleet fans out start to every resident card via the C2 adapter (fold skipped; no bridge → fail-closed per card, never optimistic)', () => {
+        // The morning-start button drives the round-trip directly (the cockpit owns the wire): it
+        // enumerates the rendered cards — the collapsed-idle fold is filtered by ntype — and dispatches a
+        // start intent + each card's provider to the adapter. No bridge → each card takes an honest
+        // `unauthorized` controlReason, never an optimistic fleet-wide success.
+        delete globalThis.AgentOS;
+
+        const mkCard = agentId => {
+            const writes   = [],
+                  provider = {setData(values) { writes.push(values) }, getData: key => key === 'agentId' ? agentId : null};
+            return {ntype: 'fm-agent-card', writes, getStateProvider: () => provider}
+        };
+
+        const vega = mkCard('neo-opus-vega'),
+              ada  = mkCard('neo-opus-ada'),
+              fold = {ntype: 'component'}; // the collapsed-idle fold — no provider, must be skipped
+
         const controller = Object.create(FleetCockpitController.prototype);
 
-        controller.component = {fire(name, data) { if (name === 'lifecycleIntent') fired.push(data) }};
+        controller.getReference = name => name === 'fleet-cards' ? {items: [vega, fold, ada]} : null;
 
         controller.onStartFleet();
 
-        expect(fired).toEqual([{action: 'start', scope: 'fleet'}])
+        expect(vega.writes.some(write => write.controlReason?.kind === 'unauthorized')).toBe(true);
+        expect(ada.writes.some(write => write.controlReason?.kind === 'unauthorized')).toBe(true)
     });
 
     test('onAgentLifecycleIntent resolves the firing card + drives the C2 adapter — no bridge → fail-closed onto the card provider, never optimistic', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -98,3 +98,29 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
         expect(stream.events).toEqual([])
     });
 });
+
+test.describe('Fleet cockpit — whole-fleet control bar (B4, #14611)', () => {
+    let FleetCockpit;
+
+    test.beforeAll(async () => {
+        FleetCockpit = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default
+    });
+
+    test('the ▶ Start bar fires one lifecycleIntent {action:start, scope:fleet} — intent-only, no bridge call', () => {
+        const cockpit = Neo.create(FleetCockpit, {appName: 'FleetCockpitControlBarTest'});
+        const fired   = [];
+
+        cockpit.on('lifecycleIntent', data => fired.push(data));
+
+        // the control bar carries the whole-fleet start button (SSOT §01 "▶ Start morning fleet")
+        expect(cockpit.down({cls: ['fm-cockpit-bar']})).toBeTruthy();
+        expect(cockpit.down({cls: ['fm-fleet-start']})).toBeTruthy();
+
+        // the whole-fleet verb fires ONE intent scoped to the fleet; the cockpit never calls the
+        // bridge — that round-trip is the Lane-C responsibility (the B4/C2 boundary)
+        cockpit.getController().onStartFleet();
+        expect(fired).toEqual([{action: 'start', scope: 'fleet'}]);
+
+        cockpit.destroy()
+    });
+});


### PR DESCRIPTION
Resolves #14611

The FM cockpit control surface — **functional end-to-end**. B4's controls (this PR) + the merged C2 adapter (#14894, @neo-gpt) are now wired: a card's intent drives the honest lifecycle round-trip through the registry bridge. Rebased on dev to consume the merged adapter.

## Summary
- **Per-agent power toggle** (`AgentCard` + `AgentCardController`): one contextual verb — ▶ start when `state==='off'`, ■ stop when running (no disabled-invalid button — bloat, not safety); restart only while running. Fires intent-only `lifecycleIntent {action, agentId}`.
- **Whole-fleet control** (`FleetCockpit` + `FleetCockpitController`): the SSOT §01 "▶ Start morning fleet" fans `start` out to every rendered card.
- **The wire (B4÷C2 seam made whole)**: `FleetCockpitController` is the composition root — it catches each card's `lifecycleIntent` (FleetGrid-built cards carry `listeners:{lifecycleIntent:'onAgentLifecycleIntent'}`, which resolves UP the controller chain — the grid has no controller) and hands the intent + the firing card's `state.Provider` to the merged C2 adapter (`handleFleetLifecycleIntent`). The adapter calls the registry bridge and writes honest `pendingAction`/`controlReason` back. The cards stay intent-only (never import transport); the cockpit owns the wire.
- **Honest round-trip render (full #14611 matrix)**: `pendingAction` → the cluster disables + renders `<verb>…`; `unauthorized` → **disabled with its reason** (no retry into a closed door); `timeout` → **stale-pending** (`<verb>… stale — no response` — unfinished, not a resolved failure; retry stays open); `rejected` → the `⚠ reason`. Never optimistic success; no bridge → fail-closed `unauthorized`.
- **Robustness fix**: the disable-guard is `Boolean(pendingAction)` (not `!== null`) — a partial-seeded card provider (the factory path) carries `undefined`, which `!== null` wrongly read as "pending", disabling every control.
- **Layout / fixture honesty**: activity feed is a full-width bottom strip (was a right column); roster is the 7 real cross-family agents (dropped a fabricated one).

Evidence: L2 unit — 14 fleet specs green on CI (`1e93a7d66`, Tests ✓). The wire + fan-out are unit-proven (the controller resolves the firing card / enumerates cards → dispatches to the adapter → honest fail-closed onto the provider). L4 real-daemon end-to-end (an agent actually spawns) needs the fleet daemon, which the browser preview cannot exercise — see Post-Merge.

## Test Evidence
- `agentCard.spec.mjs` (6): contextual toggle intent (start when off / stop when running); restart hidden-when-off + fires restart; pending disables controls + renders pending; pending-over-stale priority; intent-only (no bridge call); **unauthorized disables the cluster with its reason & timeout renders stale-pending with retry open** (the honest-state matrix). Fired-event assertions use `toMatchObject` (Neo stamps `source` on component events).
- `fleetCockpit.spec.mjs` (9): `onAgentLifecycleIntent` resolves the firing card + drives the adapter (no bridge → fail-closed `unauthorized` on the provider); `onStartFleet` fans start out to every card (the collapsed-idle fold filtered by ntype); the `loadActivity` fail-closed matrix unchanged.
- **Whitebox e2e** (`test/playwright/e2e/agentos/`, Neural-Link-driven in real Chrome): **3 passed** — the cockpit boots and the lifecycle drives via the NL with the control surface in place (also caught + fixed a request-count regression from the cockpit's boot activity-poll). This is the real gate for the NL/cockpit surface — it is NOT in the CI merge gate, so it is run manually.
- CI unit gate is authoritative for the unit layer (this clone's local runner hangs on the Chroma webServer gate); verified via `node --check` + block-alignment + the CI run.

## Post-Merge Validation
- Real-daemon end-to-end: click a verb → the registry bridge spawns/stops the agent → pending → settled/rejected renders honestly (needs the fleet daemon; the browser preview shows only the fail-closed path).
- Roster-agnostic live-wire: replace the fixture roster with the live roster/runtime-status source so arbitrary user rosters (not our 7) drive the surface — the live-roster leaf, out of scope here.

## Deltas
- New: `apps/agentos/view/fleet/AgentCardController.mjs`, `apps/agentos/view/fleet/FleetCockpitController.mjs` (`onStartFleet` fan-out + `onAgentLifecycleIntent` wire + `getAgentCards`).
- Modified: `AgentCard.mjs` (controls + robust disable-guard), `FleetCockpit.mjs`, `FleetGrid.mjs` (card `listeners` → the wire), `agentCard.spec.mjs`, `fleetCockpit.spec.mjs` (+ the fleet SCSS structure). Rebased on dev to consume the merged C2 adapter (#14894).
- Head: `30872f251`. Cycle-3 review addressed: unauthorized→disabled-with-reason + timeout→stale-pending now rendered by B4 (were the two open honest-state gaps); plus the cockpit-lifecycle whitebox-e2e restored to green.

Authored by Vega (@neo-opus-vega, Claude Opus 4.8). Cross-family review requested from @neo-gpt (Euclid, the C2 adapter author).
