### PR TITLE
feat(graph): retrospective graduations reader completes the enrichment coverage (#14738)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -695,6 +695,28 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Fetches Discussions graduated within a window — the last retrospective fact class.
+     * Graduations are Discussion closures carrying a graduation marker in their comments, and
+     * `gh search` does not cover Discussions, so this uses a bounded recency-ordered closed-Discussion
+     * GraphQL query and detects the marker vocabulary. Best-effort, like every sibling reader.
+     * @param {Date} since Lower window bound.
+     * @returns {Promise<Array<{ref: String, headline: String, at: String}>>}
+     */
+    async fetchRecentGraduations(since) {
+        const { execSync }       = await import('child_process');
+        const query              = 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name){discussions(first:30,states:CLOSED,orderBy:{field:UPDATED_AT,direction:DESC}){nodes{number title closedAt comments(last:25){nodes{body}}}}}}';
+        const raw                = execSync(`gh api graphql -f owner=neomjs -f name=neo -f query='${query}'`, {encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore']});
+        const nodes              = JSON.parse(raw)?.data?.repository?.discussions?.nodes || [];
+        const sinceMs            = since.getTime();
+        const GRADUATION_MARKERS = ['[GRADUATED_TO_TICKET]', '[RESOLVED_TO_AC]'];
+
+        return nodes
+            .filter(node => node?.closedAt && Date.parse(node.closedAt) >= sinceMs)
+            .filter(node => (node.comments?.nodes || []).some(c => GRADUATION_MARKERS.some(m => (c?.body || '').includes(m))))
+            .map(node => ({ref: `discussion #${node.number}`, headline: node.title, at: node.closedAt}));
+    }
+
+    /**
      * @summary Assembles + renders the handoff retrospective section (the history leg) from window
      * facts. Static + pure over its inputs: the assembler folds, the render emits — this shim is
      * the synthesizer's stable seam to both, mirroring the computed-GP render shims.
@@ -1324,7 +1346,8 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 // per-class best-effort: a failing reader drops ITS classes and narrows the
                 // declared label, so coverage is never overstated
                 let closedIssues = [], openedIssues = [], issueClassesLive = false,
-                    sessions     = [], sessionClassLive = false;
+                    sessions     = [], sessionClassLive = false,
+                    graduations  = [], graduationsClassLive = false;
 
                 try {
                     closedIssues = (await this.fetchRecentClosedIssues(windowStart))
@@ -1345,14 +1368,22 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                     logger.warn('[GoldenPathSynthesizer] Retrospective session reader failed — dropping the session class', sessionError);
                 }
 
+                try {
+                    graduations          = await this.fetchRecentGraduations(windowStart);
+                    graduationsClassLive = true;
+                } catch (graduationError) {
+                    logger.warn('[GoldenPathSynthesizer] Retrospective graduations reader failed — dropping the graduations class', graduationError);
+                }
+
                 const coveredClasses = [
                     'merged+opened PRs',
-                    ...(issueClassesLive  ? ['closed+opened issues'] : []),
-                    ...(sessionClassLive  ? ['sessions']             : [])
+                    ...(issueClassesLive     ? ['closed+opened issues'] : []),
+                    ...(sessionClassLive     ? ['sessions']             : []),
+                    ...(graduationsClassLive ? ['graduations']          : [])
                 ];
 
                 retrospectiveAppend = this.constructor.renderHandoffRetrospectiveSection({
-                    facts: {mergedPrs, openedPrs, closedIssues, openedIssues, sessions},
+                    facts: {mergedPrs, openedPrs, closedIssues, openedIssues, graduations, sessions},
                     grain: RETROSPECTIVE_GRAINS.THREE_DAY,
                     now  : capturedAt,
                     // the label names exactly what these counts cover, per class, so the render

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -704,7 +704,7 @@ class GoldenPathSynthesizer extends Base {
      */
     async fetchRecentGraduations(since) {
         const { execSync }       = await import('child_process');
-        const query              = 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name){discussions(first:30,states:CLOSED,orderBy:{field:UPDATED_AT,direction:DESC}){nodes{number title closedAt comments(last:25){nodes{body}}}}}}';
+        const query              = 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name){discussions(first:50,states:CLOSED,orderBy:{field:UPDATED_AT,direction:DESC}){nodes{number title closedAt comments(last:25){nodes{body}}}}}}';
         const raw                = execSync(`gh api graphql -f owner=neomjs -f name=neo -f query='${query}'`, {encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore']});
         const nodes              = JSON.parse(raw)?.data?.repository?.discussions?.nodes || [];
         const sinceMs            = since.getTime();

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -474,6 +474,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalFetchRecentClosedIssues = GoldenPathSynthesizer.fetchRecentClosedIssues;
         const originalFetchRecentOpenedIssues = GoldenPathSynthesizer.fetchRecentOpenedIssues;
         const originalFetchRecentSessions     = GoldenPathSynthesizer.fetchRecentSessions;
+        const originalFetchRecentGraduations  = GoldenPathSynthesizer.fetchRecentGraduations;
 
         GoldenPathSynthesizer.fetchOpenPRs            = async () => [];
         GoldenPathSynthesizer.fetchRecentMergedPRs    = async () => [
@@ -481,6 +482,9 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         ];
         GoldenPathSynthesizer.fetchRecentClosedIssues = async () => [];
         GoldenPathSynthesizer.fetchRecentOpenedIssues = async () => [];
+        // graduations reads successfully (empty) — a SURVIVING class, so it stays in the coverage
+        // label; stubbed to keep this unit hermetic (no live Discussions read leaking through)
+        GoldenPathSynthesizer.fetchRecentGraduations  = async () => [];
         // the session READER fails (the enrichment try/catch seam — same class as a Chroma outage)
         GoldenPathSynthesizer.fetchRecentSessions = async () => {
             throw new Error('summary metadata read unavailable');
@@ -494,6 +498,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             GoldenPathSynthesizer.fetchRecentClosedIssues = originalFetchRecentClosedIssues;
             GoldenPathSynthesizer.fetchRecentOpenedIssues = originalFetchRecentOpenedIssues;
             GoldenPathSynthesizer.fetchRecentSessions     = originalFetchRecentSessions;
+            GoldenPathSynthesizer.fetchRecentGraduations  = originalFetchRecentGraduations;
             StorageRouter.getGraphCollection              = originalGetGraphCollection;
             StorageRouter.getSummaryCollection            = originalGetSummaryCollection;
             TextEmbeddingService.embedText                = originalEmbedText;
@@ -503,11 +508,13 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
 
         // the handoff still renders with the surviving classes; the coverage label OMITS sessions
         expect(handoffContent).toContain('## Handoff Retrospective (3-Day');
-        expect(handoffContent).toContain('- Merged PRs: 1 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
+        expect(handoffContent).toContain('- Merged PRs: 1 `[filters: merged+opened PRs · closed+opened issues · graduations, all authors]`');
         expect(handoffContent).not.toContain('· sessions,');
         // the sessions COUNT line still renders (honest 0 under the declared label) — the class
         // is absent from coverage, not silently faked
-        expect(handoffContent).toContain('- Sessions: 0 `[filters: merged+opened PRs · closed+opened issues, all authors]`');
+        expect(handoffContent).toContain('- Sessions: 0 `[filters: merged+opened PRs · closed+opened issues · graduations, all authors]`');
+        // graduations SURVIVES (read succeeded, empty) — present in the coverage label + honest 0 count
+        expect(handoffContent).toContain('- Graduations: 0 `[filters: merged+opened PRs · closed+opened issues · graduations, all authors]`');
     });
 
     test('synthesizeGoldenPath overwrites stale author sections when semantic candidates are empty', async () => {

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -387,6 +387,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalFetchRecentMergedPRs    = GoldenPathSynthesizer.fetchRecentMergedPRs;
         const originalFetchRecentClosedIssues = GoldenPathSynthesizer.fetchRecentClosedIssues;
         const originalFetchRecentOpenedIssues = GoldenPathSynthesizer.fetchRecentOpenedIssues;
+        const originalFetchRecentGraduations  = GoldenPathSynthesizer.fetchRecentGraduations;
 
         // opened-PRs come from the open-PR list (in-window); merged-PRs from the bounded merged query
         GoldenPathSynthesizer.fetchOpenPRs = async () => [
@@ -404,6 +405,11 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         GoldenPathSynthesizer.fetchRecentOpenedIssues = async () => [
             {number: 14731, title: 'identityRoots migration', createdAt: hoursAgo(1)}
         ];
+        // graduations: one in-window graduated Discussion + one out-of-window the fold excludes
+        GoldenPathSynthesizer.fetchRecentGraduations = async () => [
+            {ref: 'discussion #14561', headline: 'Ideation graduated to ticket', at: hoursAgo(2)},
+            {ref: 'discussion #90000', headline: 'ancient graduation outside the window', at: hoursAgo(500)}
+        ];
 
         try {
             await GoldenPathSynthesizer.synthesizeGoldenPath({now});
@@ -412,6 +418,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             GoldenPathSynthesizer.fetchRecentMergedPRs    = originalFetchRecentMergedPRs;
             GoldenPathSynthesizer.fetchRecentClosedIssues = originalFetchRecentClosedIssues;
             GoldenPathSynthesizer.fetchRecentOpenedIssues = originalFetchRecentOpenedIssues;
+            GoldenPathSynthesizer.fetchRecentGraduations  = originalFetchRecentGraduations;
             StorageRouter.getGraphCollection              = originalGetGraphCollection;
             StorageRouter.getSummaryCollection            = originalGetSummaryCollection;
             TextEmbeddingService.embedText                = originalEmbedText;
@@ -420,16 +427,16 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
 
         expect(handoffContent).toContain('## Handoff Retrospective (3-Day');
-        expect(handoffContent).toContain('- Merged PRs: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
-        expect(handoffContent).toContain('- Opened PRs: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
-        expect(handoffContent).toContain('- Closed issues: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
-        expect(handoffContent).toContain('- Opened issues: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
+        expect(handoffContent).toContain('- Merged PRs: 1 `[filters: merged+opened PRs · closed+opened issues · sessions · graduations, all authors]`');
+        expect(handoffContent).toContain('- Opened PRs: 1 `[filters: merged+opened PRs · closed+opened issues · sessions · graduations, all authors]`');
+        expect(handoffContent).toContain('- Closed issues: 1 `[filters: merged+opened PRs · closed+opened issues · sessions · graduations, all authors]`');
+        expect(handoffContent).toContain('- Opened issues: 1 `[filters: merged+opened PRs · closed+opened issues · sessions · graduations, all authors]`');
         // the real metadata path: exactly the in-window session counts; the rendered ref carries
         // the 8-char id + agent headline; stale + undateable rows are excluded FROM THE SECTION
         // (other handoff sections legitimately consume the same summary metadata — scope the
         // exclusion to the retrospective slice)
         const retroSection = handoffContent.split('## Handoff Retrospective')[1].split('\n## ')[0];
-        expect(handoffContent).toContain('- Sessions: 1 `[filters: merged+opened PRs · closed+opened issues · sessions, all authors]`');
+        expect(handoffContent).toContain('- Sessions: 1 `[filters: merged+opened PRs · closed+opened issues · sessions · graduations, all authors]`');
         expect(retroSection).toContain('session abcdef12 — session (@neo-fable)');
         expect(retroSection).not.toContain('stale-se');
         expect(retroSection).not.toContain('undateab');
@@ -437,6 +444,11 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).toContain('PR #14682 — registry snapshot clone');
         expect(handoffContent).toContain('#14588 — GP zero-routes collapse');
         expect(handoffContent).toContain('#14731 — identityRoots migration');
+        // graduations: the in-window graduated Discussion is counted + rendered; the
+        // out-of-window one is excluded by the same window fold as every sibling class
+        expect(handoffContent).toContain('- Graduations: 1 `[filters: merged+opened PRs · closed+opened issues · sessions · graduations, all authors]`');
+        expect(handoffContent).toContain('discussion #14561 — Ideation graduated to ticket');
+        expect(retroSection).not.toContain('discussion #90000');
         // out-of-window facts never render — counts stay honest per class
         expect(handoffContent).not.toContain('ancient merge outside the window');
         expect(handoffContent).not.toContain('ancient close outside the window');


### PR DESCRIPTION
Resolves #14738

The last fact class of the handoff-retrospective enrichment family (#14721 — five classes live at its close). `fetchRecentGraduations` reads recently-closed Discussions via a bounded GraphQL query — `gh search` has no Discussion coverage — and detects the graduation-marker vocabulary (`[GRADUATED_TO_TICKET]` / `[RESOLVED_TO_AC]`), returning `{ref, headline, at}` facts like every sibling reader. It slots into the compositional coverage label as one array entry (per-class best-effort: a failing reader drops exactly its class, never overstating coverage). The assembler + render already declared the `graduations` class (`handoffRetrospectiveAssembler.mjs:39`, `handoffRetrospective.mjs:174`) — this wires the one missing reader.

Evidence: L2 (unit — GoldenPathSynthesizer spec, 45 passed) → L2 sufficient: the AC is a bounded reader + its slot-in + a written-handoff integration assertion, all unit-covered. Residual: a live sandman run counting real graduations (post-merge — the reader hits live Discussions, mocked in unit).

## Deltas from ticket
- Marker set is `[GRADUATED_TO_TICKET]` + `[RESOLVED_TO_AC]` (the graduation-**outcome** markers). `[GRADUATION_APPROVED]` is a consensus/quorum signal, not a graduation outcome, so it is deliberately excluded.
- The GraphQL query hardcodes `owner=neomjs name=neo` (the canonical repo this synthesizer serves), consistent with the sibling readers' repo-implicit `gh` calls. A config-derived repo is a trivial follow-up if preferred.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` → **45 passed** (worktree, exit 0). The #14706 retrospective integration test now mocks `fetchRecentGraduations` (one in-window graduated Discussion + one out-of-window) and asserts: `- Graduations: 1`, the `· graduations` coverage-label entry across every class count, the rendered `discussion #14561 — Ideation graduated to ticket` top-event, and the out-of-window `discussion #90000` folded out (the window firewall, re-asserted per the AC).

## Post-Merge Validation
- [ ] A live sandman run counts + renders real recently-graduated Discussions in the handoff retrospective (the reader hits live Discussions; mocked in unit).

## Merge coordination
Touches `GoldenPathSynthesizer.mjs` in the **retrospective region** (`fetchRecentGraduations` + the assembly block) — a different region from my other open PRs on this file (#14888 concept-slice; #14890 `buildDeclaredIntentFallback`). No hunk overlap; whichever merges first, the others rebase trivially.

## Decision Record
None — additive reader following the established sibling pattern; no ADR, config, or consumed-contract change (the `graduations` fact class was already declared).

Related: #14721 (the enrichment family), #14603 / #14706 (render + assembler contracts).

Authored by Ada (Claude Opus 4.8, Claude Code). Session 9360840f-5d7a-4680-8110-86877722735b.
