### PR TITLE
feat(agentos): add fleet lifecycle intent adapter (#14889)

### DIFF
--- a/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.mjs
+++ b/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.mjs
@@ -1,0 +1,191 @@
+/**
+ * @summary C2 adapter for Fleet cockpit lifecycle intents: consume a per-card
+ * `lifecycleIntent`, call the existing registry bridge lifecycle verb, and write the honest
+ * round-trip state back to the card's `state.Provider`.
+ *
+ * The B4 control surface owns intent emission + rendering. This helper owns the transport-adapter
+ * half only: no Node-side imports, no bespoke bridge path, and no optimistic success state. The
+ * provider contract is the two-field seam consumed by the B4 control renderer:
+ * `pendingAction:String|null` and `controlReason:{action,kind,reason}|null`.
+ * @module apps/agentos/view/fleet/fleetLifecycleIntentAdapter
+ */
+
+export const DEFAULT_LIFECYCLE_TIMEOUT_MS = 30_000;
+
+export const LIFECYCLE_ACTION_METHODS = Object.freeze({
+    restart: 'restartAgent',
+    start  : 'startAgent',
+    stop   : 'stopAgent'
+});
+
+const SECRET_PATTERNS = [
+    /\b(?:github_pat|ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]+/gi,
+    /\b(PAT|token|credential|secret)\b\s*[:=]?\s*[^\s,;]+/gi
+];
+
+/**
+ * @summary Resolve the injected pane-facing Fleet registry bridge.
+ * @returns {Object|null}
+ */
+export function getFleetRegistryBridge() {
+    return globalThis.AgentOS?.fleet?.registryBridge || null
+}
+
+/**
+ * @summary Redact secret-shaped material before a bridge error becomes UI/provider state.
+ * @param {*} value
+ * @param {String} fallback
+ * @returns {String}
+ */
+export function sanitizeControlReason(value, fallback='Lifecycle request failed') {
+    let reason = String(value || '').trim() || fallback;
+
+    SECRET_PATTERNS.forEach(pattern => {
+        reason = reason.replace(pattern, '[redacted]')
+    });
+
+    return reason
+}
+
+/**
+ * @summary Build the terminal non-success provider payload.
+ * @param {String} action
+ * @param {'rejected'|'unauthorized'|'timeout'} kind
+ * @param {*} reason
+ * @returns {{action:String, kind:String, reason:String}}
+ */
+export function createControlReason(action, kind, reason) {
+    return {
+        action,
+        kind,
+        reason: sanitizeControlReason(reason, `${action || 'lifecycle'} request ${kind}`)
+    }
+}
+
+/**
+ * @summary Write one or more lifecycle-control fields onto a StateProvider-like object.
+ * @param {Object} stateProvider A Neo.state.Provider or a test double exposing `setData()` / `data`.
+ * @param {Object} values
+ */
+export function writeLifecycleControlState(stateProvider, values) {
+    if (typeof stateProvider?.setData === 'function') {
+        stateProvider.setData(values);
+        return
+    }
+
+    if (stateProvider?.data && typeof stateProvider.data === 'object') {
+        Object.assign(stateProvider.data, values);
+        return
+    }
+
+    throw new Error('fleet lifecycle intent adapter requires a card stateProvider')
+}
+
+/**
+ * @summary Create the adapter-local timeout sentinel error.
+ * @param {String} action
+ * @param {Number} timeoutMs
+ * @returns {Error}
+ */
+function createTimeoutError(action, timeoutMs) {
+    const error = new Error(`${action} timed out after ${timeoutMs}ms`);
+    error.isFleetLifecycleTimeout = true;
+    return error
+}
+
+/**
+ * @summary Race a bridge operation against the lifecycle honesty timeout.
+ * @param {Promise} promise
+ * @param {String} action
+ * @param {Object} options
+ * @returns {Promise}
+ */
+function withTimeout(promise, action, {
+    clearTimeoutFn = clearTimeout,
+    setTimeoutFn   = setTimeout,
+    timeoutMs      = DEFAULT_LIFECYCLE_TIMEOUT_MS
+} = {}) {
+    if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+        return promise
+    }
+
+    let timeoutId;
+
+    const timeout = new Promise((resolve, reject) => {
+        timeoutId = setTimeoutFn(() => reject(createTimeoutError(action, timeoutMs)), timeoutMs)
+    });
+
+    return Promise.race([promise, timeout]).finally(() => clearTimeoutFn(timeoutId))
+}
+
+/**
+ * @summary Consume one per-card lifecycle intent and write honest provider state for B4 to render.
+ * @param {Object} intent
+ * @param {'start'|'stop'|'restart'} intent.action
+ * @param {String} intent.agentId Durable fleet agent id.
+ * @param {Object} stateProvider The target card's `state.Provider`.
+ * @param {Object} [options]
+ * @param {Object|null} [options.bridge=getFleetRegistryBridge()] Test seam or injected registry bridge.
+ * @param {Number} [options.timeoutMs=30000] Timeout for settle-or-reject honesty.
+ * @returns {Promise<Object>} Result metadata for controller/tests.
+ */
+export async function handleFleetLifecycleIntent(intent={}, stateProvider, options={}) {
+    options ||= {};
+
+    const
+        {action, agentId} = intent,
+        method            = LIFECYCLE_ACTION_METHODS[action],
+        bridge            = Object.hasOwn(options, 'bridge') ? options.bridge : getFleetRegistryBridge();
+
+    if (!method) {
+        const controlReason = createControlReason(action, 'rejected', `Unsupported lifecycle action '${action}'`);
+
+        writeLifecycleControlState(stateProvider, {pendingAction: null, controlReason});
+
+        return {accepted: false, action, method: null, ok: false, status: 'rejected', controlReason}
+    }
+
+    if (!agentId) {
+        const controlReason = createControlReason(action, 'rejected', 'Lifecycle intent is missing agentId');
+
+        writeLifecycleControlState(stateProvider, {pendingAction: null, controlReason});
+
+        return {accepted: false, action, method, ok: false, status: 'rejected', controlReason}
+    }
+
+    if (typeof bridge?.[method] !== 'function') {
+        const controlReason = createControlReason(action, 'unauthorized', 'Fleet Registry bridge unavailable');
+
+        writeLifecycleControlState(stateProvider, {pendingAction: null, controlReason});
+
+        return {accepted: false, action, method, ok: false, status: 'unauthorized', controlReason}
+    }
+
+    writeLifecycleControlState(stateProvider, {
+        controlReason: null,
+        pendingAction: action
+    });
+
+    try {
+        const result = await withTimeout(
+            Promise.resolve().then(() => bridge[method](agentId)),
+            action,
+            options
+        );
+
+        writeLifecycleControlState(stateProvider, {
+            controlReason: null,
+            pendingAction: null
+        });
+
+        return {accepted: true, action, method, ok: true, status: 'settled', result}
+    } catch (error) {
+        const
+            kind          = error?.isFleetLifecycleTimeout ? 'timeout' : 'rejected',
+            controlReason = createControlReason(action, kind, error?.message);
+
+        writeLifecycleControlState(stateProvider, {pendingAction: null, controlReason});
+
+        return {accepted: true, action, method, ok: false, status: kind, controlReason}
+    }
+}

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.spec.mjs
@@ -1,0 +1,161 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FleetLifecycleIntentAdapterTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+import {
+    createControlReason,
+    handleFleetLifecycleIntent,
+    sanitizeControlReason,
+    writeLifecycleControlState
+} from '../../../../../../../apps/agentos/view/fleet/fleetLifecycleIntentAdapter.mjs';
+
+const createProvider = (data = {}) => ({
+    data  : {pendingAction: null, controlReason: null, ...data},
+    writes: [],
+
+    setData(values) {
+        this.writes.push({...values});
+        Object.assign(this.data, values)
+    }
+});
+
+test.describe('fleetLifecycleIntentAdapter — lifecycleIntent → registry bridge → provider state (#14889)', () => {
+    test('maps start/stop/restart intents to existing bridge verbs with agentId-only payloads', async () => {
+        const
+            provider = createProvider({controlReason: {action: 'stop', kind: 'rejected', reason: 'old failure'}}),
+            calls    = [],
+            bridge   = {
+                startAgent  : async id => { calls.push(['startAgent', id]); return {state: 'running'} },
+                stopAgent   : async id => { calls.push(['stopAgent', id]); return {state: 'stopped'} },
+                restartAgent: async id => { calls.push(['restartAgent', id]); return {state: 'running'} }
+            };
+
+        await handleFleetLifecycleIntent({action: 'start', agentId: 'vega'}, provider, {bridge});
+        await handleFleetLifecycleIntent({action: 'stop', agentId: 'vega'}, provider, {bridge});
+        await handleFleetLifecycleIntent({action: 'restart', agentId: 'vega'}, provider, {bridge});
+
+        expect(calls).toEqual([
+            ['startAgent', 'vega'],
+            ['stopAgent', 'vega'],
+            ['restartAgent', 'vega']
+        ]);
+        // Secret boundary: bridge verbs receive the operation-specific id only, never an object carrying PATs.
+        expect(calls.every(([, payload]) => typeof payload === 'string')).toBe(true);
+        expect(provider.data.pendingAction).toBeNull();
+        expect(provider.data.controlReason).toBeNull()
+    });
+
+    test('sets pendingAction and clears stale controlReason when an accepted intent enters pending', async () => {
+        const
+            provider     = createProvider({controlReason: {action: 'start', kind: 'rejected', reason: 'old'}}),
+            bridge       = {startAgent: () => Promise.resolve({state: 'running'})},
+            settleResult = await handleFleetLifecycleIntent({action: 'start', agentId: 'vega'}, provider, {bridge});
+
+        expect(provider.writes[0]).toEqual({controlReason: null, pendingAction: 'start'});
+        expect(provider.writes.at(-1)).toEqual({controlReason: null, pendingAction: null});
+        expect(settleResult).toMatchObject({accepted: true, action: 'start', method: 'startAgent', ok: true, status: 'settled'})
+    });
+
+    test('bridge rejection clears pendingAction and writes a sanitized rejected reason', async () => {
+        const
+            provider = createProvider(),
+            bridge   = {restartAgent: async () => { throw new Error('PAT: github_pat_secretvalue') }},
+            result   = await handleFleetLifecycleIntent({action: 'restart', agentId: 'vega'}, provider, {bridge});
+
+        expect(provider.data.pendingAction).toBeNull();
+        expect(provider.data.controlReason).toEqual({
+            action: 'restart',
+            kind  : 'rejected',
+            reason: '[redacted]'
+        });
+        expect(result).toMatchObject({accepted: true, ok: false, status: 'rejected'})
+    });
+
+    test('missing bridge fails closed as unauthorized without accepting a pending action', async () => {
+        const
+            provider = createProvider(),
+            result   = await handleFleetLifecycleIntent({action: 'stop', agentId: 'vega'}, provider, {bridge: null});
+
+        expect(provider.writes).toEqual([{
+            pendingAction: null,
+            controlReason: {action: 'stop', kind: 'unauthorized', reason: 'Fleet Registry bridge unavailable'}
+        }]);
+        expect(result).toMatchObject({accepted: false, ok: false, status: 'unauthorized'})
+    });
+
+    test('unsupported action rejects before calling the bridge', async () => {
+        const
+            provider = createProvider(),
+            bridge   = {startAgent: async () => { throw new Error('must not call') }},
+            result   = await handleFleetLifecycleIntent({action: 'remove', agentId: 'vega'}, provider, {bridge});
+
+        expect(provider.data.pendingAction).toBeNull();
+        expect(provider.data.controlReason).toEqual({
+            action: 'remove',
+            kind  : 'rejected',
+            reason: "Unsupported lifecycle action 'remove'"
+        });
+        expect(result).toMatchObject({accepted: false, method: null, ok: false, status: 'rejected'})
+    });
+
+    test('timeout clears pendingAction and writes a timeout reason', async () => {
+        const
+            provider     = createProvider(),
+            bridge       = {startAgent: () => new Promise(() => {})},
+            setTimeoutFn = fn => {
+                fn();
+                return 'timeout-id'
+            },
+            clearCalls   = [],
+            result       = await handleFleetLifecycleIntent({action: 'start', agentId: 'vega'}, provider, {
+                bridge,
+                clearTimeoutFn: id => clearCalls.push(id),
+                setTimeoutFn,
+                timeoutMs     : 1
+            });
+
+        expect(clearCalls).toEqual(['timeout-id']);
+        expect(provider.data.pendingAction).toBeNull();
+        expect(provider.data.controlReason).toEqual({
+            action: 'start',
+            kind  : 'timeout',
+            reason: 'start timed out after 1ms'
+        });
+        expect(result).toMatchObject({accepted: true, ok: false, status: 'timeout'})
+    });
+
+    test('the provider writer supports StateProvider-style setData and plain data fallbacks', () => {
+        const provider = createProvider();
+
+        writeLifecycleControlState(provider, {
+            controlReason: createControlReason('start', 'rejected', 'no slot'),
+            pendingAction: null
+        });
+
+        expect(provider.data.controlReason).toEqual({action: 'start', kind: 'rejected', reason: 'no slot'});
+
+        const fallback = {data: {pendingAction: 'stop'}};
+        writeLifecycleControlState(fallback, {pendingAction: null});
+        expect(fallback.data.pendingAction).toBeNull()
+    });
+
+    test('reason sanitization redacts token-shaped strings', () => {
+        expect(sanitizeControlReason('token: ghp_abc123 should not render')).toBe('[redacted] should not render');
+        expect(sanitizeControlReason('plain lifecycle failure')).toBe('plain lifecycle failure')
+    });
+});


### PR DESCRIPTION
Resolves #14889

Adds the Fleet cockpit C2 lifecycle-intent adapter as a dependency-light Body helper. It consumes per-card `{action, agentId}` intents, maps `start` / `stop` / `restart` to the existing `registryBridge.startAgent|stopAgent|restartAgent` verbs, and writes the honest two-field provider state (`pendingAction`, `controlReason`) for the B4 renderer to consume without importing Brain-side fleet services or inventing optimistic success.

Evidence: L2 unit/static evidence fully covers this adapter helper. L4 click-to-settle proof remains the composed B4+C2 follow-up once the B4 control PR lands.

## Deltas from ticket

Implemented the adapter as an isolated `apps/agentos/view/fleet/` helper rather than wiring directly into `AgentCard` / `FleetCockpit`, because PR #14892 currently owns the B4 view/controller surfaces. The helper is ready for that controller to call and keeps this PR collision-free.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.spec.mjs`
- `npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.spec.mjs test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs --workers=1`
- `node --check apps/agentos/view/fleet/fleetLifecycleIntentAdapter.mjs`
- `node --check test/playwright/unit/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.spec.mjs`
- `npm run --silent ai:structure-map -- --files --loc`
- `git diff --cached --check`
- Pre-commit lint-staged gates passed on commit `a39df533be`.

## Post-Merge Validation

- [ ] After the B4 control surface lands, wire its `lifecycleIntent` handler to `handleFleetLifecycleIntent()` and verify click -> pending -> settle/reject render in the live cockpit.

## Commits

- `a39df533be` — `feat(agentos): add fleet lifecycle intent adapter (#14889)`

Authored by Euclid (GPT-5, Codex Desktop). Session e0af78f0-80e9-485d-ae00-654ce902178d.
