### PR TITLE
docs(post-review-pickup): RC-response = one atomic lifecycle step — declare + waking re-review (#14735)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -212,13 +212,19 @@ Before an implementation `[lane-claim]`: `preBriefSession({ticket})` (+ `query_r
 
 ## 3. Author Pickup Matrix
 
-After posting review-response fixups and the author-side commentId handoff, the
-author MUST choose one of these next states before ending the turn:
+The author-side RC-response is **one atomic step, not three optional** (#14735);
+fixup commits alone do NOT discharge it:
+
+1. author-response comment ON the PR — each RA addressed/contested, exact head hash;
+2. A2A re-review request to the reviewer, **waking-required** (RC-class MUST wake, wake-policy #14576);
+3. only then lane-state moves off `own-pr-changes`.
+
+Then choose one of these next states before ending the turn:
 
 | Author state after response | Next pickup target |
 |---|---|
-| Fixup commits pushed and re-review requested | Start the next assigned ticket, draft the next ready PR, file the follow-up ticket discovered during the response, or review a separate PR if that is the current lane. |
-| Current PR still blocks all local work | That blocks only that lane; survey lifecycle, backlog, tech-debt, and ideation surfaces until a next lane is selected. "No independent lane assigned" with an unqueried broader backlog is NOT a terminal. |
+| RC-response discharged (all three above) | Start the next assigned ticket, draft the next ready PR, file the follow-up ticket discovered during the response, or review a separate PR if that is the current lane. |
+| Current PR still blocks all local work | Blocks only that lane; survey lifecycle/backlog/tech-debt/ideation until a next lane is selected (§5). "No independent lane assigned" + unqueried backlog is NOT a terminal. |
 | Reviewer feedback produced a superseding direction | Enter the superseding ticket / PR creation lane if the author owns it; otherwise hand off the supersede target and pick up the next unrelated lane. |
 
 ## 4. Author-Concentration Detector (Telemetry)


### PR DESCRIPTION
Resolves #14735

Codifies the author-side RC-response as **one atomic lifecycle step** in `post-review-pickup-workflow.md §3`, closing the operator-escalated gap (2026-07-04 RC-drain) where done-but-undeclared RC-responses were indistinguishable from ignored — the stalest RC in the queue was actually DONE (PR #14692 pushed fixes, no re-review signal; PR #14627 discharged, silent ~4.75h; a peer eventually verified and sent the reviewer signal manually).

The mechanical enforcement of "pushing fixes ≠ discharging the queue item": after RC fixes, the same lifecycle event MUST produce (1) the author-response comment ON the PR + exact head hash, (2) the **waking-required** A2A re-review request (RC-class must wake, wake-policy #14576), and only (3) then does lane-state move off `own-pr-changes`.

Evidence: L1 (substrate-doc — no unit surface; the codification IS the artifact). `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → **OK** at +250B (at cap, compressed in-place). All three ACs are static/text-checkable against §3. Residual: none.

## Delivered
- `post-review-pickup-workflow.md §3` intro — the three-part atomic action as a numbered list (AC1), with the A2A re-review documented as **waking-required** + wake-policy cross-ref #14576 (AC2).
- §3 matrix first-row entry condition tightened: `Fixup commits pushed and re-review requested` → `RC-response discharged (all three above)`, so the row references the now-explicit atomic step.
- §3 row 2 consolidated (its "unqueried backlog is not a terminal" point already lives at length in §5) to hold the net-bytes line.

## AC coverage
- [x] **AC1** — the author-side RC-response step names the three-part atomic action verbatim (§3 numbered list).
- [x] **AC2** — the A2A re-review request documented as waking-required (RC-class MUST wake, wake-policy #14576).
- [x] **AC3** — net-loaded-bytes discipline: compressed in-place (+250B, at the skill-manifest cap; no new always-loaded file).

## Deltas from ticket
None substantive. Scope held to §3 of the one file — the ticket's named "smallest enforcement" candidate. Out of scope per the ticket: wake-delivery tiering (#14576), reviewer-side template lint (#14688), the optional mechanical detector (each its own leaf).

## Test Evidence
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → **[lint-skill-manifest] OK** (net +250B, at cap).
- Pre-commit hooks green (check-whitespace).
- Substrate-doc change — no unit-test surface; the codification is the artifact.

## Post-Merge Validation
- [ ] None mechanical — the codified atomicity is consumed by agents at the next author-side RC-response boundary.

## Commits
- `3256beebfb` — §3 RC-response atomic-step codification

Authored by Grace (Claude Opus 4.8, Claude Code). Session 8b03a4ba-9ac2-4adf-b610-e53e014ecd8b.
