### PR TITLE
feat(memory-core): temporal-pyramid L1/L2 durable aggregation writer (#14434)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -425,6 +425,24 @@ class Config extends ConfigProvider {
                 graphProjectionDrainIntervalMs : leaf(60000, 'NEO_MC_GRAPH_PROJECTION_DRAIN_INTERVAL_MS', 'number')
             },
             /**
+             * Temporal-pyramid durable aggregation lane (L1 session / L2 daily tiers).
+             * @type {Object}
+             */
+            temporalSummary: {
+                /**
+                 * Master opt-in for the temporal-pyramid aggregation daemon.
+                 * Disabled by default; the daemon exits early when false.
+                 * @type {Boolean}
+                 */
+                aggregationEnabled: leaf(false, 'NEO_MC_TEMPORAL_SUMMARY_ENABLED', 'boolean'),
+                /**
+                 * Aggregation daemon poll interval in ms (default 1 h). The lane runs under the
+                 * shared heavy-maintenance lease, so it yields to REM / defrag siblings.
+                 * @type {Number}
+                 */
+                aggregationIntervalMs: leaf(60 * 60 * 1000, 'NEO_MC_TEMPORAL_SUMMARY_INTERVAL_MS', 'number')
+            },
+            /**
              * Agent OS maintenance orchestrator configuration.
              * @type {Object}
              */

--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -264,7 +264,8 @@ class TemporalSummaryAggregationService extends Base {
      */
     async fetchWindowSources(window) {
         return {
-            devCommits: await this.fetchDevCommits(window)
+            devCommits        : await this.fetchDevCommits(window),
+            sandboxesGraduated: await this.fetchSandboxesGraduated(window)
         }
     }
 
@@ -278,6 +279,29 @@ class TemporalSummaryAggregationService extends Base {
         const raw = this.execCommand(`git log --first-parent origin/dev --since="${windowStart}" --until="${windowEnd}" --format=%H`);
 
         return (raw || '').split('\n').filter(Boolean).map(sha => ({sha}))
+    }
+
+    /**
+     * @summary Binds `sandboxesGraduated` to its named source — closed Discussions carrying a graduation
+     * marker, window-filtered by `closedAt`. Best-effort, bounded recency query (the same reader family the
+     * handoff retrospective uses).
+     * @param {{windowStart:String, windowEnd:String}} window
+     * @returns {Promise<Array<{ref:String, headline:String, at:String}>>}
+     * @protected
+     */
+    async fetchSandboxesGraduated({windowStart, windowEnd}) {
+        const
+            query   = 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name){discussions(first:50,states:CLOSED,orderBy:{field:UPDATED_AT,direction:DESC}){nodes{number title closedAt comments(last:25){nodes{body}}}}}}',
+            raw     = this.execCommand(`gh api graphql -f owner=neomjs -f name=neo -f query='${query}'`),
+            nodes   = JSON.parse(raw || '{}')?.data?.repository?.discussions?.nodes || [],
+            startMs = Date.parse(windowStart),
+            endMs   = Date.parse(windowEnd),
+            markers = ['[GRADUATED_TO_TICKET]', '[RESOLVED_TO_AC]'];
+
+        return nodes
+            .filter(node => node?.closedAt && Date.parse(node.closedAt) >= startMs && Date.parse(node.closedAt) < endMs)
+            .filter(node => (node.comments?.nodes || []).some(comment => markers.some(marker => (comment?.body || '').includes(marker))))
+            .map(node => ({ref: `discussion #${node.number}`, headline: node.title, at: node.closedAt}))
     }
 
     /**

--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -10,6 +10,7 @@ import {
     acquireHeavyMaintenanceLeaseSync,
     releaseHeavyMaintenanceLeaseSync
 } from '../orchestrator/services/heavyMaintenanceLeasePrimitives.mjs';
+import {execSync} from 'node:child_process';
 
 /**
  * @summary The heavy-maintenance lease owner label for this lane — the backpressure invariant keys on it
@@ -262,7 +263,32 @@ class TemporalSummaryAggregationService extends Base {
      * @protected
      */
     async fetchWindowSources(window) {
-        return {}
+        return {
+            devCommits: await this.fetchDevCommits(window)
+        }
+    }
+
+    /**
+     * @summary Binds `devCommits` to its named source — the `dev` first-parent commit log over the window.
+     * @param {{windowStart:String, windowEnd:String}} window
+     * @returns {Promise<Array<{sha:String}>>}
+     * @protected
+     */
+    async fetchDevCommits({windowStart, windowEnd}) {
+        const raw = this.execCommand(`git log --first-parent origin/dev --since="${windowStart}" --until="${windowEnd}" --format=%H`);
+
+        return (raw || '').split('\n').filter(Boolean).map(sha => ({sha}))
+    }
+
+    /**
+     * @summary Runs a read-only shell command + returns stdout. The injectable seam behind every source
+     * fetch, so tests drive the fetches with no `gh` / `git` process.
+     * @param {String} command
+     * @returns {String}
+     * @protected
+     */
+    execCommand(command) {
+        return execSync(command, {encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore']})
     }
 
     /**

--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -2,10 +2,10 @@
 // InstanceManager) lives in `ai/daemons/temporal-summary/daemon.mjs`, following the
 // canonical Orchestrator class+wrapper pattern. `Neo.setupClass(...)` at file bottom
 // uses `globalThis.Neo`, populated by the entry-point bootstrap chain.
-import Base                                    from '../../../src/core/Base.mjs';
-import logger                                  from '../../mcp/server/memory-core/logger.mjs';
-import {composeUnifiedRecord}                  from '../../services/memory-core/helpers/temporalSummaryAggregationEngine.mjs';
-import {Memory_StorageRouter as StorageRouter} from '../../services.mjs';
+import Base                                     from '../../../src/core/Base.mjs';
+import logger                                   from '../../mcp/server/memory-core/logger.mjs';
+import {composeUnifiedRecord, planDailyWindows} from '../../services/memory-core/helpers/temporalSummaryAggregationEngine.mjs';
+import {Memory_StorageRouter as StorageRouter}  from '../../services.mjs';
 import {
     acquireHeavyMaintenanceLeaseSync,
     releaseHeavyMaintenanceLeaseSync
@@ -17,6 +17,13 @@ import {
  * @type {String}
  */
 const LEASE_OWNER = 'temporal-summary-aggregation';
+
+/**
+ * @summary Default trailing daily-window batch per pulse — the bounded, most-recent-first cap the lane
+ * re-aggregates each cycle (recent days are re-folded as their sources settle; older days are frozen).
+ * @type {Number}
+ */
+const DEFAULT_DAILY_WINDOW_COUNT = 7;
 
 /**
  * @summary The temporal-pyramid L1/L2 durable aggregation daemon — the deterministic lane that writes the
@@ -213,7 +220,49 @@ class TemporalSummaryAggregationService extends Base {
      * @protected
      */
     async collectPendingWindows() {
-        return []
+        const
+            anchor   = this.resolveAggregationAnchor(),
+            dayCount = this.dailyWindowCount(),
+            plan     = planDailyWindows({anchor, dayCount});
+
+        return Promise.all(plan.map(async window => ({
+            level      : 'daily',
+            windowStart: window.windowStart,
+            windowEnd  : window.windowEnd,
+            sources    : await this.fetchWindowSources(window)
+        })))
+    }
+
+    /**
+     * @summary The instant the daily-window plan anchors on (the most-recent target day). Overridable seam
+     * so the window plan is deterministic under test.
+     * @returns {String} ISO 8601 UTC.
+     * @protected
+     */
+    resolveAggregationAnchor() {
+        return new Date().toISOString()
+    }
+
+    /**
+     * @summary The trailing daily-window batch size per pulse. Overridable seam.
+     * @returns {Number}
+     * @protected
+     */
+    dailyWindowCount() {
+        return DEFAULT_DAILY_WINDOW_COUNT
+    }
+
+    /**
+     * @summary Fetches one window's source rows (the `deriveVelocityFields` shape) from the six named
+     * substrates — merged PRs, dev commits, sessions, high-impact sessions, decision records, graduations.
+     * The per-substrate reads (`gh` / `git` / Memory Core) land next; the default empty map keeps the lane
+     * honest (it persists true zero-count records) until they do.
+     * @param {{windowStart:String, windowEnd:String}} window
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async fetchWindowSources(window) {
+        return {}
     }
 
     /**

--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -1,0 +1,231 @@
+// Class-only daemon implementation. Entry-point bootstrap (Neo + core/_export +
+// InstanceManager) lives in `ai/daemons/temporal-summary/daemon.mjs`, following the
+// canonical Orchestrator class+wrapper pattern. `Neo.setupClass(...)` at file bottom
+// uses `globalThis.Neo`, populated by the entry-point bootstrap chain.
+import Base                   from '../../../src/core/Base.mjs';
+import logger                 from '../../mcp/server/memory-core/logger.mjs';
+import {composeUnifiedRecord} from '../../services/memory-core/helpers/temporalSummaryAggregationEngine.mjs';
+import {
+    acquireHeavyMaintenanceLeaseSync,
+    releaseHeavyMaintenanceLeaseSync
+} from '../orchestrator/services/heavyMaintenanceLeasePrimitives.mjs';
+
+/**
+ * @summary The heavy-maintenance lease owner label for this lane — the backpressure invariant keys on it
+ * so REM / defrag / this lane never run heavy maintenance concurrently.
+ * @type {String}
+ */
+const LEASE_OWNER = 'temporal-summary-aggregation';
+
+/**
+ * @summary The temporal-pyramid L1/L2 durable aggregation daemon — the deterministic lane that writes the
+ * durable session/daily temporal-summary records + their velocity fields.
+ *
+ * **Shape** — the canonical poll-loop daemon (the `KbGarbageCollectionService` precedent): a
+ * `Neo.core.Base` singleton with `start()` / `stop()` / `scheduleNext()` / `pulse()`. The entry-point
+ * wrapper `ai/daemons/temporal-summary/daemon.mjs` owns the Neo bootstrap + SIGTERM.
+ *
+ * **Backpressure** — every `pulse()` runs under the shared heavy-maintenance lease (the landed
+ * cross-daemon fairness primitive): it acquires the lease, defers the whole pulse without work when
+ * another heavy-maintenance task holds it, and always releases in `finally`. This is the non-negotiable
+ * fairness contract — the lane must never starve the REM / defrag siblings.
+ *
+ * **Split** — the *pure* aggregation (velocity fold + record composition) lives in
+ * `temporalSummaryAggregationEngine.mjs` and is unit-tested in isolation; this class owns only the I/O:
+ * the poll loop, the lease, the window/source reads, and the Chroma + graph upsert. The read + upsert
+ * seams (`collectPendingWindows` / `persistTemporalRecord`) are overridable so the lifecycle + lease
+ * behavior test hermetically; their durable-store implementations land with the source-fetch increment.
+ *
+ * **Opt-in** — `start()` is a no-op unless called with `enabled: true`, and requires a positive
+ * `pollIntervalMs` (the entry wrapper injects both from config; no hidden default).
+ *
+ * @class Neo.ai.daemons.TemporalSummaryAggregationService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see ai/daemons/temporal-summary/daemon.mjs — the entry-point wrapper.
+ * @see ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs — the pure aggregation engine.
+ * @see ai/daemons/kb-gc/KbGarbageCollectionService.mjs — the sibling poll-loop daemon precedent.
+ */
+class TemporalSummaryAggregationService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.TemporalSummaryAggregationService'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.TemporalSummaryAggregationService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * Whether the poll loop is running. Plain singleton state; no reactive hooks.
+         * @member {Boolean} isPolling=false
+         * @protected
+         */
+        isPolling: false,
+        /**
+         * Active `setTimeout` handle for the next pulse; `null` when not scheduled.
+         * @member {Object|null} pollHandle=null
+         * @protected
+         */
+        pollHandle: null,
+        /**
+         * Interval between aggregation pulses in ms; injected by `start()` from config.
+         * @member {Number|null} pollIntervalMs=null
+         * @protected
+         */
+        pollIntervalMs: null
+    }
+
+    /**
+     * @summary Starts the aggregation poll loop. Idempotent; a no-op while already polling and a no-op
+     * when `enabled` is false (the daemon process then has nothing keeping the event loop alive).
+     * @param {Object}   [options]
+     * @param {Boolean}  [options.enabled=false]  Opt-in gate; injected from config by the entry wrapper.
+     * @param {Number}   [options.pollIntervalMs]  Interval between pulses; required + positive when enabled.
+     * @returns {void}
+     */
+    start({enabled = false, pollIntervalMs} = {}) {
+        if (this.isPolling) {
+            logger.debug('[TemporalSummaryAggregationService] Already polling; start() is a no-op.');
+            return
+        }
+
+        if (!enabled) {
+            logger.info('[TemporalSummaryAggregationService] Disabled (enabled=false); not starting.');
+            return
+        }
+
+        if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+            throw new Error('[TemporalSummaryAggregationService] start() requires a positive pollIntervalMs when enabled.')
+        }
+
+        this.pollIntervalMs = pollIntervalMs;
+        this.isPolling      = true;
+
+        logger.info(`[TemporalSummaryAggregationService] Starting temporal-pyramid aggregation (interval: ${pollIntervalMs}ms).`);
+
+        this.scheduleNext()
+    }
+
+    /**
+     * @summary Stops the poll loop. Idempotent. Cancels any pending pulse so a clean SIGTERM does not
+     * leave a timer wedging the event loop.
+     * @returns {void}
+     */
+    stop() {
+        if (this.pollHandle) {
+            clearTimeout(this.pollHandle);
+            this.pollHandle = null
+        }
+
+        this.isPolling = false;
+        logger.info('[TemporalSummaryAggregationService] Aggregation stopped.')
+    }
+
+    /**
+     * @summary Schedules the next pulse. Called after each pulse settles so a single thrown error never
+     * breaks the loop.
+     * @returns {void}
+     * @protected
+     */
+    scheduleNext() {
+        if (!this.isPolling) return;
+
+        this.pollHandle = setTimeout(() => this.pulse().catch(err => {
+            logger.error('[TemporalSummaryAggregationService] Pulse threw uncaught error:', err);
+            this.scheduleNext()
+        }), this.pollIntervalMs)
+    }
+
+    /**
+     * @summary Executes one aggregation pulse under the shared heavy-maintenance lease. Acquires the
+     * lease; if another heavy-maintenance task holds it, defers the whole pulse (no work) and reschedules;
+     * otherwise runs the bounded cycle and always releases the lease in `finally`.
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async pulse() {
+        const lease = this.acquireLease();
+
+        if (!lease.acquired) {
+            logger.info(`[TemporalSummaryAggregationService] Heavy-maintenance lease held by ${lease.lease?.owner ?? 'another task'}; deferring this pulse.`);
+            this.scheduleNext();
+            return
+        }
+
+        try {
+            await this.runCycle()
+        } catch (err) {
+            logger.error('[TemporalSummaryAggregationService] Aggregation cycle failed:', err)
+        } finally {
+            this.releaseLease(lease.lease?.token);
+            this.scheduleNext()
+        }
+    }
+
+    /**
+     * @summary One bounded aggregation cycle: read the pending windows (most-recent-first, bounded), fold
+     * + compose the unified-track record for each, and persist it. Per-agent partition records are added
+     * once their non-attributable-field semantics are pinned.
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async runCycle() {
+        const windows = await this.collectPendingWindows();
+
+        for (const window of windows) {
+            await this.persistTemporalRecord(composeUnifiedRecord(window))
+        }
+    }
+
+    /**
+     * @summary Acquires the shared heavy-maintenance lease for this lane. Overridable seam (tests inject a
+     * deterministic acquire result without touching the on-disk lease file).
+     * @returns {{acquired:Boolean, lease:Object}}
+     * @protected
+     */
+    acquireLease() {
+        return acquireHeavyMaintenanceLeaseSync({owner: LEASE_OWNER, reason: 'temporal-pyramid-l1-l2'})
+    }
+
+    /**
+     * @summary Releases the heavy-maintenance lease held by this lane. Overridable seam. A missing token
+     * (a deferred pulse never acquired) is a no-op.
+     * @param {String} [token] The acquired lease token.
+     * @returns {void}
+     * @protected
+     */
+    releaseLease(token) {
+        if (token) {
+            releaseHeavyMaintenanceLeaseSync({token})
+        }
+    }
+
+    /**
+     * @summary Reads the most-recent-first, bounded batch of windows still needing aggregation, each with
+     * its fetched source rows (the {@link composeUnifiedRecord} input shape). The durable-store
+     * implementation (the six source fetches + the persisted-version diff) lands with the source-fetch
+     * increment; the default no-op keeps the loop inert until it does.
+     * @returns {Promise<Array<Object>>}
+     * @protected
+     */
+    async collectPendingWindows() {
+        return []
+    }
+
+    /**
+     * @summary Persists one composed temporal-summary record to the durable store — the Chroma upsert into
+     * the `temporal-summary` collection plus the `SUMMARY_*` graph label written by this lane only. The
+     * durable-store implementation lands with the source-fetch increment.
+     * @param {{id:String, metadata:Object, velocityFields:Object}} record
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async persistTemporalRecord(record) {
+        logger.debug(`[TemporalSummaryAggregationService] (stub) would persist ${record?.id}`)
+    }
+}
+
+export default Neo.setupClass(TemporalSummaryAggregationService);

--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -265,8 +265,22 @@ class TemporalSummaryAggregationService extends Base {
     async fetchWindowSources(window) {
         return {
             devCommits        : await this.fetchDevCommits(window),
+            adrsLanded        : await this.fetchAdrsLanded(window),
             sandboxesGraduated: await this.fetchSandboxesGraduated(window)
         }
+    }
+
+    /**
+     * @summary Binds `adrsLanded` to its named source — the ADR decision records added to
+     * `learn/agentos/decisions/` within the window (the AdrIngestor's file source), via the git add-log.
+     * @param {{windowStart:String, windowEnd:String}} window
+     * @returns {Promise<Array<{path:String}>>}
+     * @protected
+     */
+    async fetchAdrsLanded({windowStart, windowEnd}) {
+        const raw = this.execCommand(`git log --first-parent origin/dev --since="${windowStart}" --until="${windowEnd}" --diff-filter=A --name-only --format= -- learn/agentos/decisions/`);
+
+        return [...new Set((raw || '').split('\n').filter(line => /^learn\/agentos\/decisions\/\d{4}-.+\.md$/.test(line)))].map(path => ({path}))
     }
 
     /**

--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -305,9 +305,16 @@ class TemporalSummaryAggregationService extends Base {
      * @summary Binds `sessionsPerAgent` + `highImpactSessions` to their named source — the Memory Core session
      * summaries, window-filtered on the numeric `timestamp` metadata (session last-activity in ms). The
      * half-open `[start, end)` bound is pushed into the store query, so this is a bounded window read, never a
-     * full-history scan. A session is multi-agent: `participatingAgents` is the per-agent partition key list,
-     * and the row keeps ALL of them so the engine can credit each participant while still counting the session
-     * once toward `highImpactSessions`.
+     * full-history scan. A session is multi-agent, so the row keeps ALL of its identities: the engine credits
+     * each participant while still counting the session once toward `highImpactSessions`.
+     *
+     * Attribution reads `sourceAgentIdentities` — the canonical, auth-bound `agentIdentity` set of the
+     * session's source memories. It deliberately does NOT read `participatingAgents`, which is a caller-
+     * declared display field carrying free-text like `'Gemini 3.1 Pro (Antigravity)'` or an unprefixed
+     * `'neo-gemini-pro'` alongside a canonical `'@neo-gemini-pro'`. Partitioning on that would credit one
+     * agent under several spellings and silently drop the rest — a durable record must never derive a metric
+     * from self-declared prose. A session whose sources carry no identity yields no per-agent track and still
+     * counts, once, on the unified one.
      * @param {{windowStart:String, windowEnd:String}} window
      * @returns {Promise<Array<{sessionId:String, impact:Number, agentIdentities:String[]}>>}
      * @protected
@@ -325,7 +332,7 @@ class TemporalSummaryAggregationService extends Base {
         return (result?.metadatas || []).map(metadata => ({
             sessionId      : metadata.sessionId,
             impact         : Number(metadata.impact) || 0,
-            agentIdentities: String(metadata.participatingAgents || '').split(',').map(entry => entry.trim()).filter(Boolean)
+            agentIdentities: String(metadata.sourceAgentIdentities || '').split(',').map(entry => entry.trim()).filter(Boolean)
         }))
     }
 

--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -2,10 +2,16 @@
 // InstanceManager) lives in `ai/daemons/temporal-summary/daemon.mjs`, following the
 // canonical Orchestrator class+wrapper pattern. `Neo.setupClass(...)` at file bottom
 // uses `globalThis.Neo`, populated by the entry-point bootstrap chain.
-import Base                                     from '../../../src/core/Base.mjs';
-import logger                                   from '../../mcp/server/memory-core/logger.mjs';
-import {composeUnifiedRecord, planDailyWindows} from '../../services/memory-core/helpers/temporalSummaryAggregationEngine.mjs';
-import {Memory_StorageRouter as StorageRouter}  from '../../services.mjs';
+import Base                                    from '../../../src/core/Base.mjs';
+import logger                                  from '../../mcp/server/memory-core/logger.mjs';
+import {UNIFIED_PARTITION}                     from '../../graph/temporalSummarySchema.mjs';
+import {Memory_StorageRouter as StorageRouter} from '../../services.mjs';
+import {
+    composeAgentRecord,
+    composeUnifiedRecord,
+    planDailyWindows,
+    resolvePartitionKeys
+} from '../../services/memory-core/helpers/temporalSummaryAggregationEngine.mjs';
 import {
     acquireHeavyMaintenanceLeaseSync,
     releaseHeavyMaintenanceLeaseSync
@@ -175,9 +181,9 @@ class TemporalSummaryAggregationService extends Base {
     }
 
     /**
-     * @summary One bounded aggregation cycle: read the pending windows (most-recent-first, bounded), fold
-     * + compose the unified-track record for each, and persist it. Per-agent partition records are added
-     * once their non-attributable-field semantics are pinned.
+     * @summary One bounded aggregation cycle: read the pending windows (most-recent-first, bounded), then for
+     * each window persist the unified-track record plus one record per agent seen in it. The unified track
+     * carries the window facts; each per-agent track carries only what is attributable to that agent.
      * @returns {Promise<void>}
      * @protected
      */
@@ -185,8 +191,25 @@ class TemporalSummaryAggregationService extends Base {
         const windows = await this.collectPendingWindows();
 
         for (const window of windows) {
-            await this.persistTemporalRecord(composeUnifiedRecord(window))
+            for (const partition of this.resolveWindowPartitions(window)) {
+                await this.persistTemporalRecord(partition === UNIFIED_PARTITION
+                    ? composeUnifiedRecord(window)
+                    : composeAgentRecord({...window, partition}))
+            }
         }
+    }
+
+    /**
+     * @summary The partition tracks one window aggregates into: the unified track, plus one per distinct agent
+     * observed in the window's session rows. A window whose session source is absent yields the unified track
+     * alone — the lane writes no per-agent record it cannot attribute.
+     * @param {Object} window
+     * @param {Object} [window.sources={}] The window's fetched source rows.
+     * @returns {String[]}
+     * @protected
+     */
+    resolveWindowPartitions({sources = {}}) {
+        return resolvePartitionKeys((sources.sessions || []).map(session => session?.agentIdentity))
     }
 
     /**

--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -2,6 +2,7 @@
 // InstanceManager) lives in `ai/daemons/temporal-summary/daemon.mjs`, following the
 // canonical Orchestrator class+wrapper pattern. `Neo.setupClass(...)` at file bottom
 // uses `globalThis.Neo`, populated by the entry-point bootstrap chain.
+import AiConfig                                from '../../config.mjs';
 import Base                                    from '../../../src/core/Base.mjs';
 import logger                                  from '../../mcp/server/memory-core/logger.mjs';
 import {UNIFIED_PARTITION}                     from '../../graph/temporalSummarySchema.mjs';
@@ -213,13 +214,19 @@ class TemporalSummaryAggregationService extends Base {
     }
 
     /**
-     * @summary Acquires the shared heavy-maintenance lease for this lane. Overridable seam (tests inject a
+     * @summary Acquires the shared heavy-maintenance lease for this lane. The stale TTL is read from the
+     * config SSOT at the use site — the lease primitive is Neo-free and carries no TTL default by design, so
+     * omitting it makes the primitive throw at the production boundary. Overridable seam (tests inject a
      * deterministic acquire result without touching the on-disk lease file).
      * @returns {{acquired:Boolean, lease:Object}}
      * @protected
      */
     acquireLease() {
-        return acquireHeavyMaintenanceLeaseSync({owner: LEASE_OWNER, reason: 'temporal-pyramid-l1-l2'})
+        return acquireHeavyMaintenanceLeaseSync({
+            owner       : LEASE_OWNER,
+            reason      : 'temporal-pyramid-l1-l2',
+            staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs
+        })
     }
 
     /**

--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -2,9 +2,10 @@
 // InstanceManager) lives in `ai/daemons/temporal-summary/daemon.mjs`, following the
 // canonical Orchestrator class+wrapper pattern. `Neo.setupClass(...)` at file bottom
 // uses `globalThis.Neo`, populated by the entry-point bootstrap chain.
-import Base                   from '../../../src/core/Base.mjs';
-import logger                 from '../../mcp/server/memory-core/logger.mjs';
-import {composeUnifiedRecord} from '../../services/memory-core/helpers/temporalSummaryAggregationEngine.mjs';
+import Base                                    from '../../../src/core/Base.mjs';
+import logger                                  from '../../mcp/server/memory-core/logger.mjs';
+import {composeUnifiedRecord}                  from '../../services/memory-core/helpers/temporalSummaryAggregationEngine.mjs';
+import {Memory_StorageRouter as StorageRouter} from '../../services.mjs';
 import {
     acquireHeavyMaintenanceLeaseSync,
     releaseHeavyMaintenanceLeaseSync
@@ -216,15 +217,23 @@ class TemporalSummaryAggregationService extends Base {
     }
 
     /**
-     * @summary Persists one composed temporal-summary record to the durable store — the Chroma upsert into
-     * the `temporal-summary` collection plus the `SUMMARY_*` graph label written by this lane only. The
-     * durable-store implementation lands with the source-fetch increment.
+     * @summary Persists one composed temporal-summary record via the Chroma upsert into the
+     * `temporal-summary` collection: the five-field metadata is the query contract, the velocity payload
+     * is the document body, keyed by the deterministic doc id (so a re-aggregation of the same
+     * window+track+version overwrites in place). The per-level `SUMMARY_*` graph label written by this lane
+     * lands with the node-type-table update.
      * @param {{id:String, metadata:Object, velocityFields:Object}} record
      * @returns {Promise<void>}
      * @protected
      */
     async persistTemporalRecord(record) {
-        logger.debug(`[TemporalSummaryAggregationService] (stub) would persist ${record?.id}`)
+        const collection = await StorageRouter.getTemporalSummaryCollection();
+
+        await collection.upsert({
+            ids      : [record.id],
+            documents: [JSON.stringify(record.velocityFields)],
+            metadatas: [record.metadata]
+        })
     }
 }
 

--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -17,7 +17,10 @@ import {
     acquireHeavyMaintenanceLeaseSync,
     releaseHeavyMaintenanceLeaseSync
 } from '../orchestrator/services/heavyMaintenanceLeasePrimitives.mjs';
-import {execSync} from 'node:child_process';
+import {execSync}           from 'node:child_process';
+import {parse as parseYaml} from 'yaml';
+import fs                   from 'node:fs';
+import path                 from 'node:path';
 
 /**
  * @summary The heavy-maintenance lease owner label for this lane — the backpressure invariant keys on it
@@ -294,11 +297,66 @@ class TemporalSummaryAggregationService extends Base {
      */
     async fetchWindowSources(window) {
         return {
+            mergedPrs         : await this.fetchMergedPrs(window),
             devCommits        : await this.fetchDevCommits(window),
             adrsLanded        : await this.fetchAdrsLanded(window),
             sandboxesGraduated: await this.fetchSandboxesGraduated(window),
             sessions          : await this.fetchSessions(window)
         }
+    }
+
+    /**
+     * @summary Reads every synced content record of one type (`'pulls'`, `'discussions'`) from the repo-tracked
+     * GitHub sync under `resources/content/<type>/chunk-*`. The corpus is **complete**: a durable metric is
+     * never derived from a truncated live API page, because a confidently-wrong count is worse than none. The
+     * repo-relative root derives from the Tier-1 `projectRoot` leaf at the use site — the sync is fixed repo
+     * substrate, so it needs no config leaf of its own. A missing root is a broken checkout, not an empty
+     * window, and fails loud rather than silently reporting zero.
+     * @param {String} type The content type directory name.
+     * @returns {Array<{frontmatter:Object, body:String}>}
+     * @protected
+     */
+    readContentRecords(type) {
+        const root = path.resolve(AiConfig.projectRoot, 'resources', 'content', type);
+
+        if (!fs.existsSync(root)) {
+            throw new Error(`readContentRecords: missing synced content root ${root} — a broken checkout would otherwise report an honest-looking zero.`)
+        }
+
+        return fs.readdirSync(root, {withFileTypes: true})
+            .filter(entry => entry.isDirectory() && entry.name.startsWith('chunk-'))
+            .flatMap(chunk => fs.readdirSync(path.join(root, chunk.name))
+                .filter(name => name.endsWith('.md'))
+                .map(name => fs.readFileSync(path.join(root, chunk.name, name), 'utf8')))
+            .map(raw => {
+                const match = raw.match(/^---\n([\s\S]*?)\n---/);
+
+                return {frontmatter: match ? parseYaml(match[1]) : {}, body: raw}
+            })
+    }
+
+    /**
+     * @summary Binds `mergedPrs` to its named source — the merged pull requests in the repo-tracked GitHub PR
+     * sync, filtered by `mergedAt` into the half-open window. `state` and `mergedAt` are structured frontmatter
+     * facts, so this count is exact rather than inferred from prose.
+     * @param {{windowStart:String, windowEnd:String}} window
+     * @returns {Promise<Array<{number:Number, mergedAt:String}>>}
+     * @protected
+     */
+    async fetchMergedPrs({windowStart, windowEnd}) {
+        const
+            startMs = Date.parse(windowStart),
+            endMs   = Date.parse(windowEnd);
+
+        return this.readContentRecords('pulls')
+            .map(record => record.frontmatter)
+            .filter(frontmatter => frontmatter.state === 'MERGED' && frontmatter.mergedAt)
+            .filter(frontmatter => {
+                const mergedMs = Date.parse(String(frontmatter.mergedAt));
+
+                return mergedMs >= startMs && mergedMs < endMs
+            })
+            .map(frontmatter => ({number: frontmatter.number, mergedAt: String(frontmatter.mergedAt)}))
     }
 
     /**
@@ -363,25 +421,34 @@ class TemporalSummaryAggregationService extends Base {
 
     /**
      * @summary Binds `sandboxesGraduated` to its named source — closed Discussions carrying a graduation
-     * marker, window-filtered by `closedAt`. Best-effort, bounded recency query (the same reader family the
-     * handoff retrospective uses).
+     * marker, window-filtered by `closedAt`, read from the **complete** repo-tracked Discussions sync.
+     *
+     * This deliberately does not query the live API. A `discussions(first: 50, orderBy: UPDATED_AT)` page plus
+     * `comments(last: 25)` silently undercounts: a discussion closed inside the window but not recently
+     * *updated* falls off the page, and a marker in an earlier comment falls off the comment tail. The synced
+     * corpus carries every discussion with its full body, so the count is exact rather than plausible.
      * @param {{windowStart:String, windowEnd:String}} window
      * @returns {Promise<Array<{ref:String, headline:String, at:String}>>}
      * @protected
      */
     async fetchSandboxesGraduated({windowStart, windowEnd}) {
         const
-            query   = 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name){discussions(first:50,states:CLOSED,orderBy:{field:UPDATED_AT,direction:DESC}){nodes{number title closedAt comments(last:25){nodes{body}}}}}}',
-            raw     = this.execCommand(`gh api graphql -f owner=neomjs -f name=neo -f query='${query}'`),
-            nodes   = JSON.parse(raw || '{}')?.data?.repository?.discussions?.nodes || [],
             startMs = Date.parse(windowStart),
             endMs   = Date.parse(windowEnd),
             markers = ['[GRADUATED_TO_TICKET]', '[RESOLVED_TO_AC]'];
 
-        return nodes
-            .filter(node => node?.closedAt && Date.parse(node.closedAt) >= startMs && Date.parse(node.closedAt) < endMs)
-            .filter(node => (node.comments?.nodes || []).some(comment => markers.some(marker => (comment?.body || '').includes(marker))))
-            .map(node => ({ref: `discussion #${node.number}`, headline: node.title, at: node.closedAt}))
+        return this.readContentRecords('discussions')
+            .filter(({frontmatter}) => {
+                const closedMs = frontmatter.closedAt ? Date.parse(String(frontmatter.closedAt)) : NaN;
+
+                return Number.isFinite(closedMs) && closedMs >= startMs && closedMs < endMs
+            })
+            .filter(({body}) => markers.some(marker => body.includes(marker)))
+            .map(({frontmatter}) => ({
+                ref     : `discussion #${frontmatter.number}`,
+                headline: frontmatter.title,
+                at      : String(frontmatter.closedAt)
+            }))
     }
 
     /**

--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -210,7 +210,7 @@ class TemporalSummaryAggregationService extends Base {
      * @protected
      */
     resolveWindowPartitions({sources = {}}) {
-        return resolvePartitionKeys((sources.sessions || []).map(session => session?.agentIdentity))
+        return resolvePartitionKeys((sources.sessions || []).flatMap(session => session?.agentIdentities || []))
     }
 
     /**
@@ -296,8 +296,37 @@ class TemporalSummaryAggregationService extends Base {
         return {
             devCommits        : await this.fetchDevCommits(window),
             adrsLanded        : await this.fetchAdrsLanded(window),
-            sandboxesGraduated: await this.fetchSandboxesGraduated(window)
+            sandboxesGraduated: await this.fetchSandboxesGraduated(window),
+            sessions          : await this.fetchSessions(window)
         }
+    }
+
+    /**
+     * @summary Binds `sessionsPerAgent` + `highImpactSessions` to their named source — the Memory Core session
+     * summaries, window-filtered on the numeric `timestamp` metadata (session last-activity in ms). The
+     * half-open `[start, end)` bound is pushed into the store query, so this is a bounded window read, never a
+     * full-history scan. A session is multi-agent: `participatingAgents` is the per-agent partition key list,
+     * and the row keeps ALL of them so the engine can credit each participant while still counting the session
+     * once toward `highImpactSessions`.
+     * @param {{windowStart:String, windowEnd:String}} window
+     * @returns {Promise<Array<{sessionId:String, impact:Number, agentIdentities:String[]}>>}
+     * @protected
+     */
+    async fetchSessions({windowStart, windowEnd}) {
+        const
+            collection = await StorageRouter.getSummaryCollection(),
+            result     = await collection.get({
+                where: {$and: [
+                    {timestamp: {$gte: Date.parse(windowStart)}},
+                    {timestamp: {$lt : Date.parse(windowEnd)}}
+                ]}
+            });
+
+        return (result?.metadatas || []).map(metadata => ({
+            sessionId      : metadata.sessionId,
+            impact         : Number(metadata.impact) || 0,
+            agentIdentities: String(metadata.participatingAgents || '').split(',').map(entry => entry.trim()).filter(Boolean)
+        }))
     }
 
     /**

--- a/ai/daemons/temporal-summary/daemon.mjs
+++ b/ai/daemons/temporal-summary/daemon.mjs
@@ -1,0 +1,66 @@
+/**
+ * @module ai/daemons/temporal-summary/daemon
+ * @summary Thin Node-process boot wrapper for the temporal-pyramid aggregation daemon.
+ *
+ * Owns Neo namespace bootstrap + SIGTERM / SIGINT clean-stop signal handling +
+ * `TemporalSummaryAggregationService.start()` invocation. The class definition (the lease-aware
+ * poll loop, bounded daily-window planning, the six velocity source fetches, and the unified +
+ * per-agent partition writes) lives in
+ * `ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs`.
+ *
+ * This split matches the canonical Orchestrator class+wrapper pattern: class files in
+ * `ai/daemons/` never import Neo; entry-point scripts own the Neo + core/_export +
+ * InstanceManager bootstrap chain.
+ *
+ * The service takes `enabled` / `pollIntervalMs` as required injected arguments and fails loud
+ * without them — it carries no config defaults of its own. This entry point is the config-aware
+ * boundary that resolves them from the SSOT at the use site.
+ *
+ * Persistent-process invocation: launchd / systemd should target this script
+ * (`node ai/daemons/temporal-summary/daemon.mjs`), or `npm run ai:temporal-summary`. The daemon is
+ * opt-in — it exits early unless `AiConfig.temporalSummary.aggregationEnabled` is true.
+ *
+ * @see ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+ * @see ai/daemons/kb-gc/daemon.mjs (sibling wrapper precedent)
+ */
+
+// Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate
+// `globalThis.Neo` so any module using `Neo.setupClass()` at module-load succeeds.
+// `InstanceManager` binds `Neo.find` / `Neo.get` aliases.
+import Neo             from '../../../src/Neo.mjs';
+import * as core       from '../../../src/core/_export.mjs';
+import InstanceManager from '../../../src/manager/Instance.mjs';
+
+import AiConfig                          from '../../config.mjs';
+import logger                            from '../../mcp/server/memory-core/logger.mjs';
+import TemporalSummaryAggregationService from './TemporalSummaryAggregationService.mjs';
+import {assertConfigFresh}               from '../../scripts/setup/initServerConfigs.mjs';
+import {fileURLToPath, pathToFileURL}    from 'node:url';
+
+const cleanShutdown = signal => {
+    logger.info(`[TemporalSummaryAggregationService] Received ${signal}; stopping.`);
+    TemporalSummaryAggregationService.stop();
+    process.exit(0);
+};
+
+// Process-entry only: register signal handlers + run the stale-overlay boot guard + start the
+// service ONLY when this daemon is the main module, never on import — preserves the process-entry
+// isolation invariant (mirrors the kb-gc + orchestrator daemons).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    process.on('SIGTERM', () => cleanShutdown('SIGTERM'));
+    process.on('SIGINT',  () => cleanShutdown('SIGINT'));
+
+    const {findings} = AiConfig.validateRequiredEnv({entrypoint: 'temporal-summary-daemon'});
+    assertConfigFresh({
+        requiredFindings: findings,
+        serverPath      : fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))
+    })
+        .then(() => TemporalSummaryAggregationService.start({
+            enabled       : AiConfig.temporalSummary.aggregationEnabled,
+            pollIntervalMs: AiConfig.temporalSummary.aggregationIntervalMs
+        }))
+        .catch(err => {
+            logger.error('[TemporalSummaryAggregationService] Daemon start failed:', err);
+            process.exit(1);
+        });
+}

--- a/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
+++ b/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
@@ -1,5 +1,6 @@
 import {
     createTemporalSummaryDocId,
+    UNIFIED_PARTITION,
     validateTemporalSummaryMetadata
 } from '../../../graph/temporalSummarySchema.mjs';
 
@@ -134,4 +135,20 @@ export function resolveDailyWindow(anchor) {
     end.setUTCDate(end.getUTCDate() + 1);
 
     return {windowStart: start.toISOString(), windowEnd: end.toISOString()}
+}
+
+/**
+ * @summary Resolves the partition tracks a window aggregates into: the single `'unified'` track plus one
+ * `'@<identity>'` track per distinct agent seen in the window. Deterministic + de-duped, `'unified'` always
+ * first; blank or non-`'@'` identities are dropped (they are not valid partition keys). The service folds
+ * each returned partition separately so per-agent future-self continuity and the unified view stay in step.
+ * @param {String[]} [agentIdentities=[]] Canonical `'@<identity>'` ids observed in the window.
+ * @returns {String[]} `['unified', ...sorted per-agent tracks]`.
+ */
+export function resolvePartitionKeys(agentIdentities = []) {
+    const perAgentTracks = [...new Set(agentIdentities)]
+        .filter(identity => typeof identity === 'string' && identity.startsWith('@') && identity.length > 1)
+        .sort();
+
+    return [UNIFIED_PARTITION, ...perAgentTracks]
 }

--- a/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
+++ b/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
@@ -1,5 +1,6 @@
 import {
     createTemporalSummaryDocId,
+    isValidPartition,
     UNIFIED_PARTITION,
     validateTemporalSummaryMetadata
 } from '../../../graph/temporalSummarySchema.mjs';
@@ -32,6 +33,24 @@ export const VELOCITY_FIELD_SOURCES = Object.freeze({
     adrsLanded        : 'landed architectural decision records (decisions dir / graph nodes)',
     sandboxesGraduated: 'Discussion graduation markers (GitHub Discussions sync)'
 });
+
+/**
+ * @summary The velocity fields that are window-scoped facts rather than agent-attributable measurements: each
+ * counts whole-repository activity across the window, so no share of it belongs to any single agent. They are
+ * attributed ONLY on the unified track, and are `null` on every per-agent `'@<identity>'` partition by design.
+ *
+ * `null` — not `0`, and not the repeated window count — is the only honest value there:
+ * - `0` would assert a measurement ("this agent contributed none") that was never taken.
+ * - Repeating the window count on each track invites silent double-counting the moment a consumer aggregates
+ *   across partitions — precisely the class of error a durable record must not seed.
+ * - `null` carries the only safe upgrade path: should a field ever become agent-attributable, `null → measured`
+ *   is additive for consumers that already skip null, whereas `repeated → measured` would silently change
+ *   meaning underneath them.
+ * @type {ReadonlyArray<String>}
+ */
+export const WINDOW_SCOPED_VELOCITY_FIELDS = Object.freeze([
+    'mergedPrs', 'devCommits', 'adrsLanded', 'sandboxesGraduated'
+]);
 
 /**
  * @summary The session-impact floor for the `highImpactSessions` velocity field.
@@ -156,8 +175,8 @@ export function resolvePartitionKeys(agentIdentities = []) {
 /**
  * @summary Composes the unified-track record for one window — the whole-window fold (all sources) under
  * the `'unified'` partition. The unified track is always present (per-agent tracks are additive); the
- * service fetches the window's sources, calls this, and persists the returned record. Per-agent track
- * composition is a separate step (its non-attributable-field semantics are still being pinned).
+ * service fetches the window's sources, calls this, and persists the returned record. Per-agent tracks are
+ * composed by {@link composeAgentRecord}, which carries only the agent-attributable fields.
  * @param {Object} params
  * @param {String} params.level        `'session'` (L1) or `'daily'` (L2).
  * @param {String} params.windowStart  ISO 8601 UTC.
@@ -174,6 +193,54 @@ export function composeUnifiedRecord({level, windowStart, windowEnd, version = 1
         windowEnd,
         version,
         velocityFields: deriveVelocityFields(sources)
+    })
+}
+
+/**
+ * @summary Folds a window's fetched source rows into the six velocity fields for ONE per-agent track. Session
+ * rows are filtered to this partition's agent before the fold, so `sessionsPerAgent` / `highImpactSessions`
+ * carry that agent's measurements alone; every {@link WINDOW_SCOPED_VELOCITY_FIELDS} entry is `null` (that
+ * constant carries the reasoning). Fails closed on the unified track or a malformed identity — folding a
+ * per-agent record under the wrong partition would silently mis-attribute the whole window.
+ * @param {Object} params
+ * @param {String} params.partition    A per-agent `'@<identity>'` track.
+ * @param {Object} [params.sources={}] The window's fetched source arrays ({@link deriveVelocityFields} shape).
+ * @returns {{mergedPrs:null, devCommits:null, adrsLanded:null, sandboxesGraduated:null, highImpactSessions:Number, sessionsPerAgent:Object}}
+ */
+export function deriveAgentVelocityFields({partition, sources = {}}) {
+    if (partition === UNIFIED_PARTITION || !isValidPartition(partition)) {
+        throw new Error(`deriveAgentVelocityFields: expected a per-agent '@<identity>' track — got ${JSON.stringify(partition)}`)
+    }
+
+    const
+        agentSessions                          = (sources.sessions || []).filter(session => session?.agentIdentity === partition),
+        {highImpactSessions, sessionsPerAgent} = deriveVelocityFields({sessions: agentSessions}),
+        windowScopedFields                     = Object.fromEntries(WINDOW_SCOPED_VELOCITY_FIELDS.map(field => [field, null]));
+
+    return {...windowScopedFields, highImpactSessions, sessionsPerAgent}
+}
+
+/**
+ * @summary Composes one per-agent track record for a window — the agent-attributable fold under the
+ * `'@<identity>'` partition. The unified track ({@link composeUnifiedRecord}) owns the window facts; this
+ * record carries only what is attributable to the agent, leaving the window-scoped fields `null`.
+ * @param {Object} params
+ * @param {String} params.level        `'session'` (L1) or `'daily'` (L2).
+ * @param {String} params.partition    A per-agent `'@<identity>'` track.
+ * @param {String} params.windowStart  ISO 8601 UTC.
+ * @param {String} params.windowEnd    ISO 8601 UTC.
+ * @param {Number} [params.version=1]  Positive-integer append-only re-aggregation counter.
+ * @param {Object} [params.sources={}] The window's fetched source arrays ({@link deriveVelocityFields} shape).
+ * @returns {{id:String, metadata:Object, velocityFields:Object}}
+ */
+export function composeAgentRecord({level, partition, windowStart, windowEnd, version = 1, sources = {}}) {
+    return buildTemporalSummaryDocument({
+        level,
+        partition,
+        windowStart,
+        windowEnd,
+        version,
+        velocityFields: deriveAgentVelocityFields({partition, sources})
     })
 }
 

--- a/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
+++ b/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
@@ -109,3 +109,29 @@ export function buildTemporalSummaryDocument({level, partition, windowStart, win
         velocityFields
     }
 }
+
+/**
+ * @summary Resolves the half-open UTC-day window for an L2 (daily) aggregation anchored at any instant in
+ * the day: `windowStart` is the day's `00:00:00.000Z`, `windowEnd` is the next day's `00:00:00.000Z`. The
+ * half-open `[start, end)` shape guarantees one instant never falls in two daily windows — the aggregation
+ * lane fetches source rows in `[windowStart, windowEnd)` and folds them through {@link deriveVelocityFields}.
+ * @param {String|Date} anchor An ISO 8601 timestamp string or Date within the target UTC day.
+ * @returns {{windowStart:String, windowEnd:String}}
+ */
+export function resolveDailyWindow(anchor) {
+    const anchorMs = anchor instanceof Date ? anchor.getTime() : Date.parse(anchor);
+
+    if (Number.isNaN(anchorMs)) {
+        throw new Error(`resolveDailyWindow: invalid anchor — ${JSON.stringify(anchor)}`)
+    }
+
+    const start = new Date(anchorMs);
+
+    start.setUTCHours(0, 0, 0, 0);
+
+    const end = new Date(start.getTime());
+
+    end.setUTCDate(end.getUTCDate() + 1);
+
+    return {windowStart: start.toISOString(), windowEnd: end.toISOString()}
+}

--- a/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
+++ b/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
@@ -176,3 +176,28 @@ export function composeUnifiedRecord({level, windowStart, windowEnd, version = 1
         velocityFields: deriveVelocityFields(sources)
     })
 }
+
+/**
+ * @summary Plans the most-recent-first daily (L2) windows to aggregate: the UTC day containing `anchor`
+ * plus the preceding `dayCount - 1` days. Bounded + deterministic — the lane plans a fixed trailing batch,
+ * never an unbounded history scan; the service fetches each window's sources + folds them. The returned
+ * windows are contiguous, non-overlapping, and ordered most-recent-first.
+ * @param {Object}      params
+ * @param {String|Date} params.anchor         Instant within the most-recent target day.
+ * @param {Number}      [params.dayCount=7]   Trailing day count to plan (coerced to >= 1).
+ * @returns {Array<{windowStart:String, windowEnd:String}>}
+ */
+export function planDailyWindows({anchor, dayCount = 7} = {}) {
+    const
+        count   = Number.isInteger(dayCount) && dayCount > 0 ? dayCount : 1,
+        windows = [resolveDailyWindow(anchor)];
+
+    for (let i = 1; i < count; i++) {
+        // 1ms before the prior window's start lands in the previous UTC day
+        const previousDayAnchor = new Date(Date.parse(windows[i - 1].windowStart) - 1);
+
+        windows.push(resolveDailyWindow(previousDayAnchor))
+    }
+
+    return windows
+}

--- a/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
+++ b/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
@@ -1,0 +1,111 @@
+import {
+    createTemporalSummaryDocId,
+    validateTemporalSummaryMetadata
+} from '../../../graph/temporalSummarySchema.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/temporalSummaryAggregationEngine
+ * @summary Pure aggregation engine for the temporal-pyramid durable tiers — L1 (session) / L2 (daily).
+ * Folds a window's already-fetched source rows into the deterministic velocity fields and composes the
+ * temporal-summary document (id + five-field metadata + payload) through the temporal-summary schema.
+ *
+ * No I/O lives here: the scheduled `TemporalSummaryAggregationService` owns the fetch (GitHub/git/Memory
+ * Core reads) and the Chroma/graph upsert under the backpressure lease; this engine is the unit-tested
+ * pure fold, mirroring the `kbGarbageCollectionEngine` split (the classification is pure + isolated, the
+ * daemon owns the I/O). Prose is never a metric source — every field binds to a named substrate the
+ * service reads. The per-direction breakdown (`{v, s, r}`) is a separate velocity leaf that extends this
+ * fold on the same single writer — out of scope here.
+ */
+
+/**
+ * @summary The deterministic velocity fields keyed to the named source substrate each binds to. The
+ * service fetches from these substrates; the engine folds — the map is the contract that keeps prose out
+ * of the numbers.
+ * @type {Readonly<Object>}
+ */
+export const VELOCITY_FIELD_SOURCES = Object.freeze({
+    mergedPrs         : 'GitHub PR sync — merged-PR graph nodes within the window',
+    devCommits        : 'git first-parent log over the window on dev',
+    sessionsPerAgent  : 'Memory Core session nodes, per-agent partition keys',
+    highImpactSessions: 'Memory Core session impact metadata (impact >= 90)',
+    adrsLanded        : 'landed architectural decision records (decisions dir / graph nodes)',
+    sandboxesGraduated: 'Discussion graduation markers (GitHub Discussions sync)'
+});
+
+/**
+ * @summary The session-impact floor for the `highImpactSessions` velocity field.
+ * @type {Number}
+ */
+export const HIGH_IMPACT_THRESHOLD = 90;
+
+/**
+ * @summary Folds a window's fetched source rows into the six velocity fields. Pure + deterministic:
+ * identical input → identical output; an absent or empty source folds to an honest `0` / `{}` (a window
+ * with no merged PRs reports `mergedPrs: 0`, never a faked or omitted count).
+ * @param {Object} [sources]
+ * @param {Array}  [sources.mergedPrs=[]]          Merged-PR rows in the window.
+ * @param {Array}  [sources.devCommits=[]]         `dev` first-parent commit rows in the window.
+ * @param {Array}  [sources.sessions=[]]           Memory Core session rows (each carries `{agentIdentity, impact}`).
+ * @param {Array}  [sources.adrsLanded=[]]         Decision-record rows landed in the window.
+ * @param {Array}  [sources.sandboxesGraduated=[]] Discussion-graduation rows in the window.
+ * @returns {{mergedPrs:Number, devCommits:Number, sessionsPerAgent:Object, highImpactSessions:Number, adrsLanded:Number, sandboxesGraduated:Number}}
+ */
+export function deriveVelocityFields({
+    mergedPrs          = [],
+    devCommits         = [],
+    sessions           = [],
+    adrsLanded         = [],
+    sandboxesGraduated = []
+} = {}) {
+    const sessionsPerAgent = {};
+
+    for (const session of sessions) {
+        const agentIdentity = session?.agentIdentity;
+
+        if (agentIdentity) {
+            sessionsPerAgent[agentIdentity] = (sessionsPerAgent[agentIdentity] || 0) + 1
+        }
+    }
+
+    const highImpactSessions = sessions.filter(session => Number(session?.impact) >= HIGH_IMPACT_THRESHOLD).length;
+
+    return {
+        mergedPrs         : mergedPrs.length,
+        devCommits        : devCommits.length,
+        adrsLanded        : adrsLanded.length,
+        sandboxesGraduated: sandboxesGraduated.length,
+        highImpactSessions,
+        sessionsPerAgent
+    }
+}
+
+/**
+ * @summary Composes one temporal-summary document from window metadata + derived velocity fields. The
+ * five-field metadata contract is validated fail-closed through the temporal-summary schema; the velocity
+ * fields ride the document payload (the metadata rejects extras by construction, so they are never
+ * smuggled into it). Idempotent: same window + track + version → the same id (re-aggregation overwrites
+ * in place); a bumped `version` mints a new id (append-only history).
+ * @param {Object} params
+ * @param {String} params.level          `'session'` (L1) or `'daily'` (L2).
+ * @param {String} params.partition      `'unified'` or a per-agent `'@<identity>'` track.
+ * @param {String} params.windowStart    ISO 8601 UTC, strictly before `windowEnd`.
+ * @param {String} params.windowEnd      ISO 8601 UTC.
+ * @param {Number} params.version        Positive-integer append-only re-aggregation counter.
+ * @param {Object} params.velocityFields The {@link deriveVelocityFields} output.
+ * @returns {{id:String, metadata:Object, velocityFields:Object}}
+ */
+export function buildTemporalSummaryDocument({level, partition, windowStart, windowEnd, version, velocityFields}) {
+    const
+        metadata        = {level, partition, windowStart, windowEnd, version},
+        {valid, errors} = validateTemporalSummaryMetadata(metadata);
+
+    if (!valid) {
+        throw new Error(`buildTemporalSummaryDocument: invalid metadata — ${errors.join('; ')}`)
+    }
+
+    return {
+        id      : createTemporalSummaryDocId(metadata),
+        metadata,
+        velocityFields
+    }
+}

--- a/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
+++ b/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
@@ -152,3 +152,27 @@ export function resolvePartitionKeys(agentIdentities = []) {
 
     return [UNIFIED_PARTITION, ...perAgentTracks]
 }
+
+/**
+ * @summary Composes the unified-track record for one window — the whole-window fold (all sources) under
+ * the `'unified'` partition. The unified track is always present (per-agent tracks are additive); the
+ * service fetches the window's sources, calls this, and persists the returned record. Per-agent track
+ * composition is a separate step (its non-attributable-field semantics are still being pinned).
+ * @param {Object} params
+ * @param {String} params.level        `'session'` (L1) or `'daily'` (L2).
+ * @param {String} params.windowStart  ISO 8601 UTC.
+ * @param {String} params.windowEnd    ISO 8601 UTC.
+ * @param {Number} [params.version=1]  Positive-integer append-only re-aggregation counter.
+ * @param {Object} [params.sources={}] The window's fetched source arrays ({@link deriveVelocityFields} shape).
+ * @returns {{id:String, metadata:Object, velocityFields:Object}}
+ */
+export function composeUnifiedRecord({level, windowStart, windowEnd, version = 1, sources = {}}) {
+    return buildTemporalSummaryDocument({
+        level,
+        partition     : UNIFIED_PARTITION,
+        windowStart,
+        windowEnd,
+        version,
+        velocityFields: deriveVelocityFields(sources)
+    })
+}

--- a/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
+++ b/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs
@@ -62,10 +62,14 @@ export const HIGH_IMPACT_THRESHOLD = 90;
  * @summary Folds a window's fetched source rows into the six velocity fields. Pure + deterministic:
  * identical input → identical output; an absent or empty source folds to an honest `0` / `{}` (a window
  * with no merged PRs reports `mergedPrs: 0`, never a faked or omitted count).
+ * A session is multi-agent: each row carries `agentIdentities` (every agent that participated). Both folds
+ * respect that shape — `sessionsPerAgent` credits the session to each participant, while `highImpactSessions`
+ * counts the SESSION once regardless of how many agents took part. Exploding one row per participant would
+ * inflate the high-impact count by the size of the swarm.
  * @param {Object} [sources]
  * @param {Array}  [sources.mergedPrs=[]]          Merged-PR rows in the window.
  * @param {Array}  [sources.devCommits=[]]         `dev` first-parent commit rows in the window.
- * @param {Array}  [sources.sessions=[]]           Memory Core session rows (each carries `{agentIdentity, impact}`).
+ * @param {Array}  [sources.sessions=[]]           Memory Core session rows (each carries `{agentIdentities, impact}`).
  * @param {Array}  [sources.adrsLanded=[]]         Decision-record rows landed in the window.
  * @param {Array}  [sources.sandboxesGraduated=[]] Discussion-graduation rows in the window.
  * @returns {{mergedPrs:Number, devCommits:Number, sessionsPerAgent:Object, highImpactSessions:Number, adrsLanded:Number, sandboxesGraduated:Number}}
@@ -80,13 +84,14 @@ export function deriveVelocityFields({
     const sessionsPerAgent = {};
 
     for (const session of sessions) {
-        const agentIdentity = session?.agentIdentity;
-
-        if (agentIdentity) {
-            sessionsPerAgent[agentIdentity] = (sessionsPerAgent[agentIdentity] || 0) + 1
+        for (const agentIdentity of session?.agentIdentities || []) {
+            if (agentIdentity) {
+                sessionsPerAgent[agentIdentity] = (sessionsPerAgent[agentIdentity] || 0) + 1
+            }
         }
     }
 
+    // counts sessions, not (session, agent) pairs — a 3-agent high-impact session is one high-impact session
     const highImpactSessions = sessions.filter(session => Number(session?.impact) >= HIGH_IMPACT_THRESHOLD).length;
 
     return {
@@ -198,8 +203,9 @@ export function composeUnifiedRecord({level, windowStart, windowEnd, version = 1
 
 /**
  * @summary Folds a window's fetched source rows into the six velocity fields for ONE per-agent track. Session
- * rows are filtered to this partition's agent before the fold, so `sessionsPerAgent` / `highImpactSessions`
- * carry that agent's measurements alone; every {@link WINDOW_SCOPED_VELOCITY_FIELDS} entry is `null` (that
+ * rows are filtered to the sessions this agent participated in, so `sessionsPerAgent` / `highImpactSessions`
+ * carry that agent's measurements alone — a co-participant's identity never leaks onto this track, even though
+ * the same session also lands on theirs. Every {@link WINDOW_SCOPED_VELOCITY_FIELDS} entry is `null` (that
  * constant carries the reasoning). Fails closed on the unified track or a malformed identity — folding a
  * per-agent record under the wrong partition would silently mis-attribute the whole window.
  * @param {Object} params
@@ -213,9 +219,10 @@ export function deriveAgentVelocityFields({partition, sources = {}}) {
     }
 
     const
-        agentSessions                          = (sources.sessions || []).filter(session => session?.agentIdentity === partition),
-        {highImpactSessions, sessionsPerAgent} = deriveVelocityFields({sessions: agentSessions}),
-        windowScopedFields                     = Object.fromEntries(WINDOW_SCOPED_VELOCITY_FIELDS.map(field => [field, null]));
+        agentSessions      = (sources.sessions || []).filter(session => (session?.agentIdentities || []).includes(partition)),
+        highImpactSessions = agentSessions.filter(session => Number(session?.impact) >= HIGH_IMPACT_THRESHOLD).length,
+        sessionsPerAgent   = agentSessions.length > 0 ? {[partition]: agentSessions.length} : {},
+        windowScopedFields = Object.fromEntries(WINDOW_SCOPED_VELOCITY_FIELDS.map(field => [field, null]));
 
     return {...windowScopedFields, highImpactSessions, sessionsPerAgent}
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "ai:kb-alerting"                       : "node ./ai/daemons/kb-alerting/daemon.mjs",
         "ai:kb-reconciliation"                 : "node ./ai/daemons/kb-reconciliation/daemon.mjs",
         "ai:kb-gc"                             : "node ./ai/daemons/kb-gc/daemon.mjs",
+        "ai:temporal-summary"                  : "node ./ai/daemons/temporal-summary/daemon.mjs",
         "ai:orchestrator"                      : "node ./ai/daemons/orchestrator/daemon.mjs",
         "ai:revalidation-sweep"                : "node ./ai/scripts/lifecycle/revalidationSweep.mjs",
         "ai:run-sandman"                       : "node ./ai/scripts/runners/runSandman.mjs",

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -54,7 +54,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         TemporalSummaryAggregationService.pollIntervalMs = null;
 
         // Drop instance-method seam overrides so the real prototype methods resurface for the next test.
-        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle', 'resolveAggregationAnchor', 'dailyWindowCount', 'fetchWindowSources', 'fetchDevCommits', 'fetchSandboxesGraduated', 'fetchAdrsLanded', 'fetchSessions', 'execCommand']) {
+        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle', 'resolveAggregationAnchor', 'dailyWindowCount', 'fetchWindowSources', 'fetchDevCommits', 'fetchSandboxesGraduated', 'fetchAdrsLanded', 'fetchSessions', 'fetchMergedPrs', 'readContentRecords', 'execCommand']) {
             delete TemporalSummaryAggregationService[seam]
         }
     });
@@ -154,6 +154,58 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         expect(upserts[0].ids).toEqual([record.id]);
         expect(upserts[0].metadatas).toEqual([record.metadata]);
         expect(JSON.parse(upserts[0].documents[0])).toEqual({mergedPrs: 3})
+    });
+
+    test('readContentRecords fails loud on a missing sync root — a broken checkout is not an empty window', () => {
+        expect(() => TemporalSummaryAggregationService.readContentRecords('no-such-type'))
+            .toThrow(/missing synced content root/)
+    });
+
+    test('fetchMergedPrs counts only MERGED records whose mergedAt lands in the half-open window', async () => {
+        TemporalSummaryAggregationService.readContentRecords = type => {
+            expect(type).toBe('pulls');
+
+            return [
+                {frontmatter: {number: 1, state: 'MERGED', mergedAt: '2026-07-05T10:00:00Z'}, body: ''},
+                {frontmatter: {number: 2, state: 'MERGED', mergedAt: '2026-07-06T00:00:00Z'}, body: ''},  // windowEnd is exclusive
+                {frontmatter: {number: 3, state: 'CLOSED', mergedAt: null},                   body: ''},  // closed, never merged
+                {frontmatter: {number: 4, state: 'OPEN',   mergedAt: null},                   body: ''},
+                {frontmatter: {number: 5, state: 'MERGED', mergedAt: '2026-07-04T23:59:59Z'}, body: ''}   // before windowStart
+            ]
+        };
+
+        const merged = await TemporalSummaryAggregationService.fetchMergedPrs({
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z'
+        });
+
+        expect(merged.map(pr => pr.number)).toEqual([1])
+    });
+
+    test('fetchSandboxesGraduated reads the complete synced corpus, never a truncated live query', async () => {
+        let execCalls = 0;
+
+        TemporalSummaryAggregationService.execCommand        = () => { execCalls++; return '' };
+        TemporalSummaryAggregationService.readContentRecords = type => {
+            expect(type).toBe('discussions');
+
+            return [
+                {frontmatter: {number: 10, title: 'graduated', closedAt: '2026-07-05T10:00:00Z'}, body: 'text [GRADUATED_TO_TICKET] more'},
+                {frontmatter: {number: 11, title: 'resolved',  closedAt: '2026-07-05T11:00:00Z'}, body: 'text [RESOLVED_TO_AC] more'},
+                {frontmatter: {number: 12, title: 'no marker', closedAt: '2026-07-05T12:00:00Z'}, body: 'ordinary discussion'},
+                {frontmatter: {number: 13, title: 'still open', closedAt: null},                  body: '[GRADUATED_TO_TICKET]'},
+                {frontmatter: {number: 14, title: 'out of window', closedAt: '2026-07-09T00:00:00Z'}, body: '[GRADUATED_TO_TICKET]'}
+            ]
+        };
+
+        const graduated = await TemporalSummaryAggregationService.fetchSandboxesGraduated({
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z'
+        });
+
+        // no `gh api graphql` page — the corpus is complete, so the count cannot be silently truncated
+        expect(execCalls).toBe(0);
+        expect(graduated.map(entry => entry.ref)).toEqual(['discussion #10', 'discussion #11'])
     });
 
     test('fetchSessions binds sessions to the summary collection over a bounded half-open window', async () => {
@@ -328,6 +380,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         TemporalSummaryAggregationService.fetchSandboxesGraduated = async () => [];   // isolate the devCommits binding
         TemporalSummaryAggregationService.fetchAdrsLanded        = async () => [];
         TemporalSummaryAggregationService.fetchSessions          = async () => [];
+        TemporalSummaryAggregationService.fetchMergedPrs         = async () => [];
 
         const sources = await TemporalSummaryAggregationService.fetchWindowSources({
             windowStart: '2026-07-05T00:00:00.000Z',
@@ -340,17 +393,16 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         expect(commands[0]).toContain('--until="2026-07-06T00:00:00.000Z"')
     });
 
-    test('fetchSandboxesGraduated binds to in-window closed Discussions carrying a graduation marker', async () => {
-        const graphqlResponse = JSON.stringify({data: {repository: {discussions: {nodes: [
-            {number: 10, title: 'graduated in window',  closedAt: '2026-07-05T06:00:00.000Z', comments: {nodes: [{body: 'done [GRADUATED_TO_TICKET]'}]}},
-            {number: 11, title: 'closed but no marker', closedAt: '2026-07-05T07:00:00.000Z', comments: {nodes: [{body: 'just closed'}]}},
-            {number: 12, title: 'graduated out of window', closedAt: '2026-07-01T00:00:00.000Z', comments: {nodes: [{body: '[RESOLVED_TO_AC]'}]}}
-        ]}}}});
-
-        TemporalSummaryAggregationService.fetchDevCommits = async () => [];
-        TemporalSummaryAggregationService.fetchAdrsLanded = async () => [];
-        TemporalSummaryAggregationService.fetchSessions   = async () => [];
-        TemporalSummaryAggregationService.execCommand     = () => graphqlResponse;
+    test('fetchWindowSources threads the graduated Discussions through from the synced corpus', async () => {
+        TemporalSummaryAggregationService.fetchDevCommits    = async () => [];
+        TemporalSummaryAggregationService.fetchAdrsLanded    = async () => [];
+        TemporalSummaryAggregationService.fetchSessions      = async () => [];
+        TemporalSummaryAggregationService.fetchMergedPrs     = async () => [];
+        TemporalSummaryAggregationService.readContentRecords = () => [
+            {frontmatter: {number: 10, title: 'graduated in window', closedAt: '2026-07-05T06:00:00.000Z'}, body: 'done [GRADUATED_TO_TICKET]'},
+            {frontmatter: {number: 11, title: 'closed but no marker', closedAt: '2026-07-05T07:00:00.000Z'}, body: 'just closed'},
+            {frontmatter: {number: 12, title: 'graduated out of window', closedAt: '2026-07-01T00:00:00.000Z'}, body: '[RESOLVED_TO_AC]'}
+        ];
 
         const sources = await TemporalSummaryAggregationService.fetchWindowSources({
             windowStart: '2026-07-05T00:00:00.000Z',
@@ -367,6 +419,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         TemporalSummaryAggregationService.fetchDevCommits         = async () => [];
         TemporalSummaryAggregationService.fetchSandboxesGraduated = async () => [];
         TemporalSummaryAggregationService.fetchSessions           = async () => [];
+        TemporalSummaryAggregationService.fetchMergedPrs          = async () => [];
         TemporalSummaryAggregationService.execCommand            = () => 'learn/agentos/decisions/0034-new-adr.md\nsrc/unrelated.mjs\nlearn/agentos/decisions/README.md\n';
 
         const sources = await TemporalSummaryAggregationService.fetchWindowSources({

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -149,6 +149,58 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         expect(JSON.parse(upserts[0].documents[0])).toEqual({mergedPrs: 3})
     });
 
+    test('runCycle persists the unified track plus one record per agent seen in the window', async () => {
+        const persisted = [];
+
+        TemporalSummaryAggregationService.collectPendingWindows = async () => [{
+            level      : 'daily',
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z',
+            sources    : {
+                mergedPrs: [{n: 1}, {n: 2}],
+                sessions : [
+                    {agentIdentity: '@neo-opus-ada', impact: 95},
+                    {agentIdentity: '@neo-gpt',      impact: 10}
+                ]
+            }
+        }];
+        TemporalSummaryAggregationService.persistTemporalRecord = async record => { persisted.push(record) };
+
+        await TemporalSummaryAggregationService.runCycle();
+
+        expect(persisted.map(record => record.metadata.partition)).toEqual(['unified', '@neo-gpt', '@neo-opus-ada']);
+
+        const [unified, gpt, ada] = persisted;
+
+        // the window fact is attributed exactly once — on the unified track
+        expect(unified.velocityFields.mergedPrs).toBe(2);
+        expect(ada.velocityFields.mergedPrs).toBeNull();
+        expect(gpt.velocityFields.mergedPrs).toBeNull();
+
+        // each per-agent track carries only its own attributable measurements
+        expect(ada.velocityFields.highImpactSessions).toBe(1);
+        expect(gpt.velocityFields.highImpactSessions).toBe(0);
+        expect(ada.velocityFields.sessionsPerAgent).toEqual({'@neo-opus-ada': 1})
+    });
+
+    test('runCycle writes the unified track alone when no session source attributes the window', async () => {
+        const persisted = [];
+
+        TemporalSummaryAggregationService.collectPendingWindows = async () => [{
+            level      : 'daily',
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z',
+            sources    : {devCommits: [{sha: 'a'}]}   // sessions source not yet bound
+        }];
+        TemporalSummaryAggregationService.persistTemporalRecord = async record => { persisted.push(record) };
+
+        await TemporalSummaryAggregationService.runCycle();
+
+        // no per-agent record the lane cannot attribute
+        expect(persisted).toHaveLength(1);
+        expect(persisted[0].metadata.partition).toBe('unified')
+    });
+
     test('collectPendingWindows plans the trailing daily windows + attaches each window fetched sources', async () => {
         TemporalSummaryAggregationService.resolveAggregationAnchor = () => '2026-07-06T12:00:00.000Z';
         TemporalSummaryAggregationService.dailyWindowCount         = () => 2;

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -47,7 +47,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         TemporalSummaryAggregationService.pollIntervalMs = null;
 
         // Drop instance-method seam overrides so the real prototype methods resurface for the next test.
-        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle', 'resolveAggregationAnchor', 'dailyWindowCount', 'fetchWindowSources', 'fetchDevCommits', 'fetchSandboxesGraduated', 'execCommand']) {
+        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle', 'resolveAggregationAnchor', 'dailyWindowCount', 'fetchWindowSources', 'fetchDevCommits', 'fetchSandboxesGraduated', 'fetchAdrsLanded', 'execCommand']) {
             delete TemporalSummaryAggregationService[seam]
         }
     });
@@ -167,6 +167,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
 
         TemporalSummaryAggregationService.execCommand            = command => { commands.push(command); return 'abc123\ndef456\n' };
         TemporalSummaryAggregationService.fetchSandboxesGraduated = async () => [];   // isolate the devCommits binding
+        TemporalSummaryAggregationService.fetchAdrsLanded        = async () => [];
 
         const sources = await TemporalSummaryAggregationService.fetchWindowSources({
             windowStart: '2026-07-05T00:00:00.000Z',
@@ -187,6 +188,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         ]}}}});
 
         TemporalSummaryAggregationService.fetchDevCommits = async () => [];
+        TemporalSummaryAggregationService.fetchAdrsLanded = async () => [];
         TemporalSummaryAggregationService.execCommand     = () => graphqlResponse;
 
         const sources = await TemporalSummaryAggregationService.fetchWindowSources({
@@ -198,5 +200,19 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         expect(sources.sandboxesGraduated).toEqual([
             {ref: 'discussion #10', headline: 'graduated in window', at: '2026-07-05T06:00:00.000Z'}
         ])
+    });
+
+    test('fetchAdrsLanded binds to ADR records added under learn/agentos/decisions within the window', async () => {
+        TemporalSummaryAggregationService.fetchDevCommits         = async () => [];
+        TemporalSummaryAggregationService.fetchSandboxesGraduated = async () => [];
+        TemporalSummaryAggregationService.execCommand            = () => 'learn/agentos/decisions/0034-new-adr.md\nsrc/unrelated.mjs\nlearn/agentos/decisions/README.md\n';
+
+        const sources = await TemporalSummaryAggregationService.fetchWindowSources({
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z'
+        });
+
+        // only the NNNN-*.md ADR record matches — the unrelated file + the README are excluded
+        expect(sources.adrsLanded).toEqual([{path: 'learn/agentos/decisions/0034-new-adr.md'}])
     })
 });

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -1,0 +1,130 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'TemporalSummaryAggregationServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+// Test-side entry-point bootstrap: Neo + core/_export populate `globalThis.Neo` before the dynamic
+// service import below (the class file no longer imports Neo — the class+wrapper split).
+import Neo       from '../../../../../../src/Neo.mjs';
+import * as core from '../../../../../../src/core/_export.mjs';
+
+import {test, expect} from '@playwright/test';
+
+test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
+    let TemporalSummaryAggregationService, logger, originals = {};
+
+    test.beforeAll(async () => {
+        TemporalSummaryAggregationService = (await import('../../../../../../ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs')).default;
+        logger                            = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
+
+        originals = {info: logger.info, debug: logger.debug, error: logger.error};
+        logger.info  = () => {};
+        logger.debug = () => {};
+        logger.error = () => {}
+    });
+
+    test.afterAll(() => {
+        logger.info  = originals.info;
+        logger.debug = originals.debug;
+        logger.error = originals.error
+    });
+
+    test.afterEach(() => {
+        TemporalSummaryAggregationService.stop();
+        TemporalSummaryAggregationService.isPolling      = false;
+        TemporalSummaryAggregationService.pollIntervalMs = null;
+
+        // Drop instance-method seam overrides so the real prototype methods resurface for the next test.
+        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle']) {
+            delete TemporalSummaryAggregationService[seam]
+        }
+    });
+
+    test('start() is a no-op when enabled is false', () => {
+        let scheduled = 0;
+
+        TemporalSummaryAggregationService.scheduleNext = () => { scheduled++ };
+        TemporalSummaryAggregationService.start({enabled: false, pollIntervalMs: 1000});
+
+        expect(TemporalSummaryAggregationService.isPolling).toBe(false);
+        expect(scheduled).toBe(0)
+    });
+
+    test('start() schedules when enabled + is idempotent', () => {
+        let scheduled = 0;
+
+        TemporalSummaryAggregationService.scheduleNext = () => { scheduled++ };
+
+        TemporalSummaryAggregationService.start({enabled: true, pollIntervalMs: 1000});
+        expect(TemporalSummaryAggregationService.isPolling).toBe(true);
+        expect(scheduled).toBe(1);
+
+        // second start() while polling is a no-op — no second schedule
+        TemporalSummaryAggregationService.start({enabled: true, pollIntervalMs: 1000});
+        expect(scheduled).toBe(1)
+    });
+
+    test('start() throws when enabled without a positive pollIntervalMs', () => {
+        expect(() => TemporalSummaryAggregationService.start({enabled: true})).toThrow(/positive pollIntervalMs/)
+    });
+
+    test('pulse() defers the whole cycle when the heavy-maintenance lease is held', async () => {
+        let cycles = 0, releases = 0;
+
+        TemporalSummaryAggregationService.scheduleNext = () => {};
+        TemporalSummaryAggregationService.acquireLease = () => ({acquired: false, lease: {owner: 'rem-daemon'}});
+        TemporalSummaryAggregationService.runCycle     = async () => { cycles++ };
+        TemporalSummaryAggregationService.releaseLease = () => { releases++ };
+
+        await TemporalSummaryAggregationService.pulse();
+
+        expect(cycles).toBe(0);   // deferred — no aggregation runs under a held lease
+        expect(releases).toBe(0)  // never acquired → nothing to release
+    });
+
+    test('pulse() runs the cycle + releases the lease when acquired', async () => {
+        const persisted     = [];
+        let   releasedToken = null;
+
+        TemporalSummaryAggregationService.scheduleNext          = () => {};
+        TemporalSummaryAggregationService.acquireLease          = () => ({acquired: true, lease: {token: 'tok-1'}});
+        TemporalSummaryAggregationService.releaseLease          = token => { releasedToken = token };
+        TemporalSummaryAggregationService.collectPendingWindows = async () => [{
+            level      : 'daily',
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z',
+            sources    : {mergedPrs: [{n: 1}]}
+        }];
+        TemporalSummaryAggregationService.persistTemporalRecord = async record => { persisted.push(record) };
+
+        await TemporalSummaryAggregationService.pulse();
+
+        expect(releasedToken).toBe('tok-1');   // lease always released in finally
+        expect(persisted).toHaveLength(1);
+        expect(persisted[0].metadata.partition).toBe('unified');
+        expect(persisted[0].velocityFields.mergedPrs).toBe(1)
+    });
+
+    test('pulse() still releases the lease when the cycle throws', async () => {
+        let releasedToken = null;
+
+        TemporalSummaryAggregationService.scheduleNext = () => {};
+        TemporalSummaryAggregationService.acquireLease = () => ({acquired: true, lease: {token: 'tok-2'}});
+        TemporalSummaryAggregationService.releaseLease = token => { releasedToken = token };
+        TemporalSummaryAggregationService.runCycle     = async () => { throw new Error('boom') };
+
+        await TemporalSummaryAggregationService.pulse();   // pulse swallows the cycle error
+
+        expect(releasedToken).toBe('tok-2')   // finally released despite the throw
+    })
+});

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -164,9 +164,9 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
                 queries.push(args);
 
                 return {metadatas: [
-                    {sessionId: 's1', impact: 95, participatingAgents: '@neo-opus-ada,@neo-gpt'},
-                    {sessionId: 's2', impact: 10, participatingAgents: '@neo-opus-ada'},
-                    {sessionId: 's3', impact: 40, participatingAgents: ''}
+                    {sessionId: 's1', impact: 95, sourceAgentIdentities: '@neo-opus-ada,@neo-gpt'},
+                    {sessionId: 's2', impact: 10, sourceAgentIdentities: '@neo-opus-ada'},
+                    {sessionId: 's3', impact: 40, sourceAgentIdentities: ''}
                 ]}
             }
         });
@@ -189,6 +189,44 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         // an unattributed session survives as a row (it still counts toward the unified window) with no identities
         expect(sessions[2].agentIdentities).toEqual([]);
         expect(sessions[0].impact).toBe(95)
+    });
+
+    test('fetchSessions attributes on canonical sourceAgentIdentities, never the display participatingAgents', async () => {
+        StorageRouter.getSummaryCollection = async () => ({
+            get: async () => ({metadatas: [{
+                sessionId: 's1',
+                impact   : 95,
+                // real shapes observed in the live summary collection — caller-declared free text
+                participatingAgents  : 'Gemini 3.1 Pro (Antigravity),neo-gemini-pro,@neo-gemini-pro',
+                sourceAgentIdentities: '@neo-gemini-pro'
+            }]})
+        });
+
+        const [session] = await TemporalSummaryAggregationService.fetchSessions({
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z'
+        });
+
+        // one agent, one canonical identity — the display field spells it three ways, and partitioning on it
+        // would credit the same agent under several keys while silently dropping the unprefixed spellings
+        expect(session.agentIdentities).toEqual(['@neo-gemini-pro'])
+    });
+
+    test('fetchSessions yields no per-agent identity when the session sources carry none', async () => {
+        StorageRouter.getSummaryCollection = async () => ({
+            get: async () => ({metadatas: [
+                {sessionId: 's1', impact: 95, participatingAgents: 'Claude Opus 4.7 (Claude Code)', sourceAgentIdentities: ''}
+            ]})
+        });
+
+        const [session] = await TemporalSummaryAggregationService.fetchSessions({
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z'
+        });
+
+        // honest absence: a pre-provenance session gets no per-agent track, and still counts once on unified
+        expect(session.agentIdentities).toEqual([]);
+        expect(session.impact).toBe(95)
     });
 
     test('acquireLease forwards the AiConfig stale TTL — the primitive carries no default and throws without it', async () => {

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -149,6 +149,33 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         expect(JSON.parse(upserts[0].documents[0])).toEqual({mergedPrs: 3})
     });
 
+    test('acquireLease forwards the AiConfig stale TTL — the primitive carries no default and throws without it', async () => {
+        const
+            fs     = await import('node:fs'),
+            path   = await import('node:path'),
+            source = fs.readFileSync(
+                path.resolve(process.cwd(), 'ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs'),
+                'utf8'
+            );
+
+        // the lease seam is stubbed in every behavioral test above, so a missing staleAfterMs would only
+        // surface at the production boundary — this pins the use-site read that keeps it from regressing
+        expect(source).toContain('staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs');
+
+        const
+            {buildLeasePayload} = await import('../../../../../../ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs'),
+            {default: AiConfig} = await import('../../../../../../ai/config.mjs'),
+            staleAfterMs        = AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs;
+
+        // the guard above is only meaningful if the leaf actually resolves to a positive TTL
+        expect(Number.isFinite(staleAfterMs)).toBe(true);
+        expect(staleAfterMs).toBeGreaterThan(0);
+
+        // the exact options acquireLease() passes are accepted by the primitive that would otherwise throw
+        expect(() => buildLeasePayload({owner: 'temporal-summary-aggregation', reason: 'temporal-pyramid-l1-l2', staleAfterMs})).not.toThrow();
+        expect(() => buildLeasePayload({owner: 'temporal-summary-aggregation', reason: 'temporal-pyramid-l1-l2'})).toThrow(/staleAfterMs/)
+    });
+
     test('runCycle persists the unified track plus one record per agent seen in the window', async () => {
         const persisted = [];
 

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -47,7 +47,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         TemporalSummaryAggregationService.pollIntervalMs = null;
 
         // Drop instance-method seam overrides so the real prototype methods resurface for the next test.
-        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle']) {
+        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle', 'resolveAggregationAnchor', 'dailyWindowCount', 'fetchWindowSources']) {
             delete TemporalSummaryAggregationService[seam]
         }
     });
@@ -147,5 +147,18 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         expect(upserts[0].ids).toEqual([record.id]);
         expect(upserts[0].metadatas).toEqual([record.metadata]);
         expect(JSON.parse(upserts[0].documents[0])).toEqual({mergedPrs: 3})
+    });
+
+    test('collectPendingWindows plans the trailing daily windows + attaches each window fetched sources', async () => {
+        TemporalSummaryAggregationService.resolveAggregationAnchor = () => '2026-07-06T12:00:00.000Z';
+        TemporalSummaryAggregationService.dailyWindowCount         = () => 2;
+        TemporalSummaryAggregationService.fetchWindowSources       = async window => ({mergedPrs: [{w: window.windowStart}]});
+
+        const windows = await TemporalSummaryAggregationService.collectPendingWindows();
+
+        expect(windows).toHaveLength(2);
+        expect(windows[0]).toMatchObject({level: 'daily', windowStart: '2026-07-06T00:00:00.000Z', windowEnd: '2026-07-07T00:00:00.000Z'});
+        expect(windows[1].windowStart).toBe('2026-07-05T00:00:00.000Z');
+        expect(windows[0].sources.mergedPrs[0].w).toBe('2026-07-06T00:00:00.000Z')
     })
 });

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -28,7 +28,13 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         logger                            = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
         StorageRouter                     = (await import('../../../../../../ai/services.mjs')).Memory_StorageRouter;
 
-        originals = {info: logger.info, debug: logger.debug, error: logger.error, getTemporalSummaryCollection: StorageRouter.getTemporalSummaryCollection};
+        originals = {
+            info                        : logger.info,
+            debug                       : logger.debug,
+            error                       : logger.error,
+            getTemporalSummaryCollection: StorageRouter.getTemporalSummaryCollection,
+            getSummaryCollection        : StorageRouter.getSummaryCollection
+        };
         logger.info  = () => {};
         logger.debug = () => {};
         logger.error = () => {}
@@ -42,12 +48,13 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
 
     test.afterEach(() => {
         StorageRouter.getTemporalSummaryCollection = originals.getTemporalSummaryCollection;
+        StorageRouter.getSummaryCollection         = originals.getSummaryCollection;
         TemporalSummaryAggregationService.stop();
         TemporalSummaryAggregationService.isPolling      = false;
         TemporalSummaryAggregationService.pollIntervalMs = null;
 
         // Drop instance-method seam overrides so the real prototype methods resurface for the next test.
-        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle', 'resolveAggregationAnchor', 'dailyWindowCount', 'fetchWindowSources', 'fetchDevCommits', 'fetchSandboxesGraduated', 'fetchAdrsLanded', 'execCommand']) {
+        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle', 'resolveAggregationAnchor', 'dailyWindowCount', 'fetchWindowSources', 'fetchDevCommits', 'fetchSandboxesGraduated', 'fetchAdrsLanded', 'fetchSessions', 'execCommand']) {
             delete TemporalSummaryAggregationService[seam]
         }
     });
@@ -149,6 +156,41 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         expect(JSON.parse(upserts[0].documents[0])).toEqual({mergedPrs: 3})
     });
 
+    test('fetchSessions binds sessions to the summary collection over a bounded half-open window', async () => {
+        const queries = [];
+
+        StorageRouter.getSummaryCollection = async () => ({
+            get: async args => {
+                queries.push(args);
+
+                return {metadatas: [
+                    {sessionId: 's1', impact: 95, participatingAgents: '@neo-opus-ada,@neo-gpt'},
+                    {sessionId: 's2', impact: 10, participatingAgents: '@neo-opus-ada'},
+                    {sessionId: 's3', impact: 40, participatingAgents: ''}
+                ]}
+            }
+        });
+
+        const sessions = await TemporalSummaryAggregationService.fetchSessions({
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z'
+        });
+
+        // the half-open [start, end) bound is pushed into the store query — a bounded read, not a full scan
+        expect(queries).toHaveLength(1);
+        expect(queries[0].where).toEqual({$and: [
+            {timestamp: {$gte: Date.parse('2026-07-05T00:00:00.000Z')}},
+            {timestamp: {$lt : Date.parse('2026-07-06T00:00:00.000Z')}}
+        ]});
+
+        // participatingAgents is the per-agent partition key list — a session keeps ALL of its participants
+        expect(sessions[0].agentIdentities).toEqual(['@neo-opus-ada', '@neo-gpt']);
+        expect(sessions[1].agentIdentities).toEqual(['@neo-opus-ada']);
+        // an unattributed session survives as a row (it still counts toward the unified window) with no identities
+        expect(sessions[2].agentIdentities).toEqual([]);
+        expect(sessions[0].impact).toBe(95)
+    });
+
     test('acquireLease forwards the AiConfig stale TTL — the primitive carries no default and throws without it', async () => {
         const
             fs     = await import('node:fs'),
@@ -186,8 +228,8 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
             sources    : {
                 mergedPrs: [{n: 1}, {n: 2}],
                 sessions : [
-                    {agentIdentity: '@neo-opus-ada', impact: 95},
-                    {agentIdentity: '@neo-gpt',      impact: 10}
+                    {agentIdentities: ['@neo-opus-ada'], impact: 95},
+                    {agentIdentities: ['@neo-gpt'],      impact: 10}
                 ]
             }
         }];
@@ -247,6 +289,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         TemporalSummaryAggregationService.execCommand            = command => { commands.push(command); return 'abc123\ndef456\n' };
         TemporalSummaryAggregationService.fetchSandboxesGraduated = async () => [];   // isolate the devCommits binding
         TemporalSummaryAggregationService.fetchAdrsLanded        = async () => [];
+        TemporalSummaryAggregationService.fetchSessions          = async () => [];
 
         const sources = await TemporalSummaryAggregationService.fetchWindowSources({
             windowStart: '2026-07-05T00:00:00.000Z',
@@ -268,6 +311,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
 
         TemporalSummaryAggregationService.fetchDevCommits = async () => [];
         TemporalSummaryAggregationService.fetchAdrsLanded = async () => [];
+        TemporalSummaryAggregationService.fetchSessions   = async () => [];
         TemporalSummaryAggregationService.execCommand     = () => graphqlResponse;
 
         const sources = await TemporalSummaryAggregationService.fetchWindowSources({
@@ -284,6 +328,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
     test('fetchAdrsLanded binds to ADR records added under learn/agentos/decisions within the window', async () => {
         TemporalSummaryAggregationService.fetchDevCommits         = async () => [];
         TemporalSummaryAggregationService.fetchSandboxesGraduated = async () => [];
+        TemporalSummaryAggregationService.fetchSessions           = async () => [];
         TemporalSummaryAggregationService.execCommand            = () => 'learn/agentos/decisions/0034-new-adr.md\nsrc/unrelated.mjs\nlearn/agentos/decisions/README.md\n';
 
         const sources = await TemporalSummaryAggregationService.fetchWindowSources({

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -47,7 +47,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         TemporalSummaryAggregationService.pollIntervalMs = null;
 
         // Drop instance-method seam overrides so the real prototype methods resurface for the next test.
-        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle', 'resolveAggregationAnchor', 'dailyWindowCount', 'fetchWindowSources']) {
+        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle', 'resolveAggregationAnchor', 'dailyWindowCount', 'fetchWindowSources', 'fetchDevCommits', 'execCommand']) {
             delete TemporalSummaryAggregationService[seam]
         }
     });
@@ -160,5 +160,21 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         expect(windows[0]).toMatchObject({level: 'daily', windowStart: '2026-07-06T00:00:00.000Z', windowEnd: '2026-07-07T00:00:00.000Z'});
         expect(windows[1].windowStart).toBe('2026-07-05T00:00:00.000Z');
         expect(windows[0].sources.mergedPrs[0].w).toBe('2026-07-06T00:00:00.000Z')
+    });
+
+    test('fetchWindowSources binds devCommits to the dev first-parent window log', async () => {
+        const commands = [];
+
+        TemporalSummaryAggregationService.execCommand = command => { commands.push(command); return 'abc123\ndef456\n' };
+
+        const sources = await TemporalSummaryAggregationService.fetchWindowSources({
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z'
+        });
+
+        expect(sources.devCommits).toEqual([{sha: 'abc123'}, {sha: 'def456'}]);
+        expect(commands[0]).toContain('git log --first-parent origin/dev');
+        expect(commands[0]).toContain('--since="2026-07-05T00:00:00.000Z"');
+        expect(commands[0]).toContain('--until="2026-07-06T00:00:00.000Z"')
     })
 });

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -21,13 +21,14 @@ import * as core from '../../../../../../src/core/_export.mjs';
 import {test, expect} from '@playwright/test';
 
 test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
-    let TemporalSummaryAggregationService, logger, originals = {};
+    let TemporalSummaryAggregationService, logger, StorageRouter, originals = {};
 
     test.beforeAll(async () => {
         TemporalSummaryAggregationService = (await import('../../../../../../ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs')).default;
         logger                            = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
+        StorageRouter                     = (await import('../../../../../../ai/services.mjs')).Memory_StorageRouter;
 
-        originals = {info: logger.info, debug: logger.debug, error: logger.error};
+        originals = {info: logger.info, debug: logger.debug, error: logger.error, getTemporalSummaryCollection: StorageRouter.getTemporalSummaryCollection};
         logger.info  = () => {};
         logger.debug = () => {};
         logger.error = () => {}
@@ -40,6 +41,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
     });
 
     test.afterEach(() => {
+        StorageRouter.getTemporalSummaryCollection = originals.getTemporalSummaryCollection;
         TemporalSummaryAggregationService.stop();
         TemporalSummaryAggregationService.isPolling      = false;
         TemporalSummaryAggregationService.pollIntervalMs = null;
@@ -126,5 +128,24 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         await TemporalSummaryAggregationService.pulse();   // pulse swallows the cycle error
 
         expect(releasedToken).toBe('tok-2')   // finally released despite the throw
+    });
+
+    test('persistTemporalRecord upserts the record into the temporal-summary collection by its doc id', async () => {
+        const upserts = [];
+
+        StorageRouter.getTemporalSummaryCollection = async () => ({upsert: async args => { upserts.push(args) }});
+
+        const record = {
+            id            : 'temporal-summary-daily-unified-2026-07-05-v1',
+            metadata      : {level: 'daily', partition: 'unified', windowStart: '2026-07-05T00:00:00.000Z', windowEnd: '2026-07-06T00:00:00.000Z', version: 1},
+            velocityFields: {mergedPrs: 3}
+        };
+
+        await TemporalSummaryAggregationService.persistTemporalRecord(record);
+
+        expect(upserts).toHaveLength(1);
+        expect(upserts[0].ids).toEqual([record.id]);
+        expect(upserts[0].metadatas).toEqual([record.metadata]);
+        expect(JSON.parse(upserts[0].documents[0])).toEqual({mergedPrs: 3})
     })
 });

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -47,7 +47,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         TemporalSummaryAggregationService.pollIntervalMs = null;
 
         // Drop instance-method seam overrides so the real prototype methods resurface for the next test.
-        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle', 'resolveAggregationAnchor', 'dailyWindowCount', 'fetchWindowSources', 'fetchDevCommits', 'execCommand']) {
+        for (const seam of ['scheduleNext', 'acquireLease', 'releaseLease', 'collectPendingWindows', 'persistTemporalRecord', 'runCycle', 'resolveAggregationAnchor', 'dailyWindowCount', 'fetchWindowSources', 'fetchDevCommits', 'fetchSandboxesGraduated', 'execCommand']) {
             delete TemporalSummaryAggregationService[seam]
         }
     });
@@ -165,7 +165,8 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
     test('fetchWindowSources binds devCommits to the dev first-parent window log', async () => {
         const commands = [];
 
-        TemporalSummaryAggregationService.execCommand = command => { commands.push(command); return 'abc123\ndef456\n' };
+        TemporalSummaryAggregationService.execCommand            = command => { commands.push(command); return 'abc123\ndef456\n' };
+        TemporalSummaryAggregationService.fetchSandboxesGraduated = async () => [];   // isolate the devCommits binding
 
         const sources = await TemporalSummaryAggregationService.fetchWindowSources({
             windowStart: '2026-07-05T00:00:00.000Z',
@@ -176,5 +177,26 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         expect(commands[0]).toContain('git log --first-parent origin/dev');
         expect(commands[0]).toContain('--since="2026-07-05T00:00:00.000Z"');
         expect(commands[0]).toContain('--until="2026-07-06T00:00:00.000Z"')
+    });
+
+    test('fetchSandboxesGraduated binds to in-window closed Discussions carrying a graduation marker', async () => {
+        const graphqlResponse = JSON.stringify({data: {repository: {discussions: {nodes: [
+            {number: 10, title: 'graduated in window',  closedAt: '2026-07-05T06:00:00.000Z', comments: {nodes: [{body: 'done [GRADUATED_TO_TICKET]'}]}},
+            {number: 11, title: 'closed but no marker', closedAt: '2026-07-05T07:00:00.000Z', comments: {nodes: [{body: 'just closed'}]}},
+            {number: 12, title: 'graduated out of window', closedAt: '2026-07-01T00:00:00.000Z', comments: {nodes: [{body: '[RESOLVED_TO_AC]'}]}}
+        ]}}}});
+
+        TemporalSummaryAggregationService.fetchDevCommits = async () => [];
+        TemporalSummaryAggregationService.execCommand     = () => graphqlResponse;
+
+        const sources = await TemporalSummaryAggregationService.fetchWindowSources({
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z'
+        });
+
+        // only the in-window, marker-bearing Discussion survives
+        expect(sources.sandboxesGraduated).toEqual([
+            {ref: 'discussion #10', headline: 'graduated in window', at: '2026-07-05T06:00:00.000Z'}
+        ])
     })
 });

--- a/test/playwright/unit/ai/daemons/temporal-summary/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/daemon.spec.mjs
@@ -1,0 +1,57 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'TemporalSummaryDaemonTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import Neo       from '../../../../../../src/Neo.mjs';
+import * as core from '../../../../../../src/core/_export.mjs';
+
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import path           from 'node:path';
+
+const daemonPath = path.resolve(process.cwd(), 'ai/daemons/temporal-summary/daemon.mjs');
+
+test.describe('ai/daemons/temporal-summary/daemon.mjs', () => {
+    test('importing the wrapper never starts the service — process-entry isolation', async () => {
+        const service = (await import('../../../../../../ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs')).default;
+
+        await import('../../../../../../ai/daemons/temporal-summary/daemon.mjs');
+
+        // the start()/signal-handler block is guarded by the main-module check, so a plain import is inert
+        expect(service.isPolling).toBe(false)
+    });
+
+    test('the entry point injects both required start() arguments from the config SSOT', () => {
+        const source = fs.readFileSync(daemonPath, 'utf8');
+
+        // the service carries no config defaults and fails loud without these — the entry point is the
+        // config-aware boundary that resolves them at the use site
+        expect(source).toContain('enabled       : AiConfig.temporalSummary.aggregationEnabled');
+        expect(source).toContain('pollIntervalMs: AiConfig.temporalSummary.aggregationIntervalMs');
+    });
+
+    test('the config leaves resolve to an opt-in default and a positive interval', async () => {
+        const AiConfig = (await import('../../../../../../ai/config.mjs')).default;
+
+        // opt-in by default: a fresh checkout never silently runs the aggregation lane
+        expect(AiConfig.temporalSummary.aggregationEnabled).toBe(false);
+        expect(AiConfig.temporalSummary.aggregationIntervalMs).toBeGreaterThan(0);
+    });
+
+    test('the wrapper registers clean-stop handlers for both termination signals', () => {
+        const source = fs.readFileSync(daemonPath, 'utf8');
+
+        expect(source).toContain("process.on('SIGTERM'");
+        expect(source).toContain("process.on('SIGINT'");
+        expect(source).toContain('TemporalSummaryAggregationService.stop()')
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
@@ -17,6 +17,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 
 import {
     buildTemporalSummaryDocument,
+    composeUnifiedRecord,
     deriveVelocityFields,
     HIGH_IMPACT_THRESHOLD,
     resolveDailyWindow,
@@ -141,5 +142,21 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
         // blank / non-'@' identities are dropped; an empty window folds to the unified track only
         expect(resolvePartitionKeys(['', 'plain', '@'])).toEqual(['unified']);
         expect(resolvePartitionKeys()).toEqual(['unified'])
+    });
+
+    test('composeUnifiedRecord folds the whole window under the unified partition', () => {
+        const record = composeUnifiedRecord({
+            level      : 'daily',
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z',
+            sources    : {mergedPrs: [{n: 1}, {n: 2}], sessions: [{agentIdentity: '@neo-opus-ada', impact: 95}]}
+        });
+
+        expect(record.metadata.partition).toBe('unified');
+        expect(record.metadata.level).toBe('daily');
+        expect(record.metadata.version).toBe(1);
+        expect(record.velocityFields.mergedPrs).toBe(2);
+        expect(record.velocityFields.highImpactSessions).toBe(1);
+        expect(record.id).toContain('temporal-summary-daily-unified-')
     })
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
@@ -19,6 +19,7 @@ import {
     buildTemporalSummaryDocument,
     deriveVelocityFields,
     HIGH_IMPACT_THRESHOLD,
+    resolveDailyWindow,
     VELOCITY_FIELD_SOURCES
 } from '../../../../../../../ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs';
 
@@ -119,5 +120,16 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
             version       : 1,
             velocityFields: {}
         })).toThrow(/windowStart must be strictly before windowEnd/)
+    });
+
+    test('resolveDailyWindow returns half-open UTC-day bounds for any anchor within the day', () => {
+        const {windowStart, windowEnd} = resolveDailyWindow('2026-07-05T14:37:12.500Z');
+
+        expect(windowStart).toBe('2026-07-05T00:00:00.000Z');
+        expect(windowEnd).toBe('2026-07-06T00:00:00.000Z')
+    });
+
+    test('resolveDailyWindow fails closed on an unparseable anchor', () => {
+        expect(() => resolveDailyWindow('not-a-timestamp')).toThrow(/invalid anchor/)
     })
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
@@ -43,9 +43,9 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
             mergedPrs : [{number: 1}, {number: 2}, {number: 3}],
             devCommits: [{sha: 'a'}, {sha: 'b'}],
             sessions  : [
-                {agentIdentity: '@neo-opus-ada', impact: 95},
-                {agentIdentity: '@neo-opus-ada', impact: 40},
-                {agentIdentity: '@neo-gpt',      impact: HIGH_IMPACT_THRESHOLD}
+                {agentIdentities: ['@neo-opus-ada'], impact: 95},
+                {agentIdentities: ['@neo-opus-ada'], impact: 40},
+                {agentIdentities: ['@neo-gpt'],      impact: HIGH_IMPACT_THRESHOLD}
             ],
             adrsLanded        : [{id: 'ADR-0028'}],
             sandboxesGraduated: [{ref: 'discussion #1'}, {ref: 'discussion #2'}]
@@ -73,9 +73,9 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
         })
     });
 
-    test('deriveVelocityFields ignores session rows with no agentIdentity in the per-agent fold', () => {
+    test('deriveVelocityFields ignores session rows with no agentIdentities in the per-agent fold', () => {
         const fields = deriveVelocityFields({
-            sessions: [{impact: 99}, {agentIdentity: '@neo-opus-ada', impact: 10}]
+            sessions: [{impact: 99}, {agentIdentities: ['@neo-opus-ada'], impact: 10}]
         });
 
         expect(fields.sessionsPerAgent).toEqual({'@neo-opus-ada': 1});
@@ -153,7 +153,7 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
             level      : 'daily',
             windowStart: '2026-07-05T00:00:00.000Z',
             windowEnd  : '2026-07-06T00:00:00.000Z',
-            sources    : {mergedPrs: [{n: 1}, {n: 2}], sessions: [{agentIdentity: '@neo-opus-ada', impact: 95}]}
+            sources    : {mergedPrs: [{n: 1}, {n: 2}], sessions: [{agentIdentities: ['@neo-opus-ada'], impact: 95}]}
         });
 
         expect(record.metadata.partition).toBe('unified');
@@ -162,6 +162,37 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
         expect(record.velocityFields.mergedPrs).toBe(2);
         expect(record.velocityFields.highImpactSessions).toBe(1);
         expect(record.id).toContain('temporal-summary-daily-unified-')
+    });
+
+    test('deriveVelocityFields credits a multi-agent session to each participant but counts it once as high-impact', () => {
+        const fields = deriveVelocityFields({
+            sessions: [
+                {agentIdentities: ['@neo-opus-ada', '@neo-gpt', '@neo-fable'], impact: 95},
+                {agentIdentities: ['@neo-opus-ada'],                           impact: 10}
+            ]
+        });
+
+        // each participant is credited with the shared session
+        expect(fields.sessionsPerAgent).toEqual({'@neo-opus-ada': 2, '@neo-gpt': 1, '@neo-fable': 1});
+        // ...but a 3-agent high-impact session is ONE high-impact session, not three
+        expect(fields.highImpactSessions).toBe(1)
+    });
+
+    test('deriveAgentVelocityFields never leaks a co-participant onto an agent track', () => {
+        const sources = {
+            sessions: [{agentIdentities: ['@neo-opus-ada', '@neo-gpt'], impact: 95}]
+        };
+
+        const ada = deriveAgentVelocityFields({partition: '@neo-opus-ada', sources});
+
+        // the shared session lands on both tracks, but each track names only its own agent
+        expect(ada.sessionsPerAgent).toEqual({'@neo-opus-ada': 1});
+        expect(ada.highImpactSessions).toBe(1);
+
+        const gpt = deriveAgentVelocityFields({partition: '@neo-gpt', sources});
+
+        expect(gpt.sessionsPerAgent).toEqual({'@neo-gpt': 1});
+        expect(gpt.highImpactSessions).toBe(1)
     });
 
     test('WINDOW_SCOPED_VELOCITY_FIELDS pins exactly the four non-agent-attributable window facts', () => {
@@ -181,7 +212,7 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
                 devCommits        : [{sha: 'a'}],
                 adrsLanded        : [{id: 'ADR-0028'}],
                 sandboxesGraduated: [{ref: 'd#1'}],
-                sessions          : [{agentIdentity: '@neo-opus-ada', impact: 95}]
+                sessions          : [{agentIdentities: ['@neo-opus-ada'], impact: 95}]
             }
         });
 
@@ -195,9 +226,9 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
     test('deriveAgentVelocityFields attributes only the partition agent\'s sessions', () => {
         const sources = {
             sessions: [
-                {agentIdentity: '@neo-opus-ada', impact: 95},
-                {agentIdentity: '@neo-opus-ada', impact: 20},
-                {agentIdentity: '@neo-gpt',      impact: 99}
+                {agentIdentities: ['@neo-opus-ada'], impact: 95},
+                {agentIdentities: ['@neo-opus-ada'], impact: 20},
+                {agentIdentities: ['@neo-gpt'],      impact: 99}
             ]
         };
 
@@ -231,7 +262,7 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
     test('composeAgentRecord composes a per-agent track record; the unified track keeps the window facts', () => {
         const
             window  = {level: 'daily', windowStart: '2026-07-05T00:00:00.000Z', windowEnd: '2026-07-06T00:00:00.000Z'},
-            sources = {mergedPrs: [{n: 1}, {n: 2}], sessions: [{agentIdentity: '@neo-opus-ada', impact: 95}]},
+            sources = {mergedPrs: [{n: 1}, {n: 2}], sessions: [{agentIdentities: ['@neo-opus-ada'], impact: 95}]},
             agent   = composeAgentRecord({...window, partition: '@neo-opus-ada', sources}),
             unified = composeUnifiedRecord({...window, sources});
 

--- a/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
@@ -1,0 +1,123 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'TemporalSummaryAggregationEngineTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+import {
+    buildTemporalSummaryDocument,
+    deriveVelocityFields,
+    HIGH_IMPACT_THRESHOLD,
+    VELOCITY_FIELD_SOURCES
+} from '../../../../../../../ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs';
+
+test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', () => {
+    test('VELOCITY_FIELD_SOURCES pins all six velocity fields to a named source', () => {
+        expect(Object.keys(VELOCITY_FIELD_SOURCES).sort()).toEqual([
+            'adrsLanded', 'devCommits', 'highImpactSessions', 'mergedPrs', 'sandboxesGraduated', 'sessionsPerAgent'
+        ]);
+        // every binding names a substrate — prose is never the source of truth
+        Object.values(VELOCITY_FIELD_SOURCES).forEach(source => expect(source.length).toBeGreaterThan(0))
+    });
+
+    test('deriveVelocityFields folds counts, per-agent sessions, and the impact threshold', () => {
+        const fields = deriveVelocityFields({
+            mergedPrs : [{number: 1}, {number: 2}, {number: 3}],
+            devCommits: [{sha: 'a'}, {sha: 'b'}],
+            sessions  : [
+                {agentIdentity: '@neo-opus-ada', impact: 95},
+                {agentIdentity: '@neo-opus-ada', impact: 40},
+                {agentIdentity: '@neo-gpt',      impact: HIGH_IMPACT_THRESHOLD}
+            ],
+            adrsLanded        : [{id: 'ADR-0028'}],
+            sandboxesGraduated: [{ref: 'discussion #1'}, {ref: 'discussion #2'}]
+        });
+
+        expect(fields.mergedPrs).toBe(3);
+        expect(fields.devCommits).toBe(2);
+        expect(fields.adrsLanded).toBe(1);
+        expect(fields.sandboxesGraduated).toBe(2);
+        // impact >= 90 counts (boundary inclusive); the impact-40 row is excluded
+        expect(fields.highImpactSessions).toBe(2);
+        expect(fields.sessionsPerAgent).toEqual({'@neo-opus-ada': 2, '@neo-gpt': 1})
+    });
+
+    test('deriveVelocityFields folds an empty/absent window to honest zeros — never faked or omitted', () => {
+        const fields = deriveVelocityFields();
+
+        expect(fields).toEqual({
+            mergedPrs         : 0,
+            devCommits        : 0,
+            adrsLanded        : 0,
+            sandboxesGraduated: 0,
+            highImpactSessions: 0,
+            sessionsPerAgent  : {}
+        })
+    });
+
+    test('deriveVelocityFields ignores session rows with no agentIdentity in the per-agent fold', () => {
+        const fields = deriveVelocityFields({
+            sessions: [{impact: 99}, {agentIdentity: '@neo-opus-ada', impact: 10}]
+        });
+
+        expect(fields.sessionsPerAgent).toEqual({'@neo-opus-ada': 1});
+        expect(fields.highImpactSessions).toBe(1)
+    });
+
+    test('buildTemporalSummaryDocument mints an id + five-field metadata; velocity fields ride the payload, not metadata', () => {
+        const velocityFields = deriveVelocityFields({mergedPrs: [{number: 1}]});
+        const doc            = buildTemporalSummaryDocument({
+            level      : 'daily',
+            partition  : 'unified',
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z',
+            version    : 1,
+            velocityFields
+        });
+
+        // metadata is exactly the five-field contract — no velocity leakage into the strict metadata
+        expect(Object.keys(doc.metadata).sort()).toEqual(['level', 'partition', 'version', 'windowEnd', 'windowStart']);
+        expect(doc.velocityFields.mergedPrs).toBe(1);
+        expect(doc.id).toContain('temporal-summary-daily-unified-');
+        expect(doc.id).toContain('-v1')
+    });
+
+    test('buildTemporalSummaryDocument is idempotent per window+track+version; a version bump mints a new id', () => {
+        const base = {
+            level         : 'session',
+            partition     : '@neo-opus-ada',
+            windowStart   : '2026-07-05T00:00:00.000Z',
+            windowEnd     : '2026-07-05T01:00:00.000Z',
+            velocityFields: {}
+        };
+
+        const v1      = buildTemporalSummaryDocument({...base, version: 1});
+        const v1again = buildTemporalSummaryDocument({...base, version: 1});
+        const v2      = buildTemporalSummaryDocument({...base, version: 2});
+
+        expect(v1.id).toBe(v1again.id);
+        expect(v2.id).not.toBe(v1.id)
+    });
+
+    test('buildTemporalSummaryDocument fails closed on invalid metadata (inverted window)', () => {
+        expect(() => buildTemporalSummaryDocument({
+            level         : 'daily',
+            partition     : 'unified',
+            windowStart   : '2026-07-06T00:00:00.000Z',
+            windowEnd     : '2026-07-05T00:00:00.000Z',
+            version       : 1,
+            velocityFields: {}
+        })).toThrow(/windowStart must be strictly before windowEnd/)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
@@ -20,6 +20,7 @@ import {
     deriveVelocityFields,
     HIGH_IMPACT_THRESHOLD,
     resolveDailyWindow,
+    resolvePartitionKeys,
     VELOCITY_FIELD_SOURCES
 } from '../../../../../../../ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs';
 
@@ -131,5 +132,14 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
 
     test('resolveDailyWindow fails closed on an unparseable anchor', () => {
         expect(() => resolveDailyWindow('not-a-timestamp')).toThrow(/invalid anchor/)
+    });
+
+    test('resolvePartitionKeys returns unified first + a sorted, de-duped per-agent track set', () => {
+        expect(resolvePartitionKeys(['@neo-gpt', '@neo-opus-ada', '@neo-gpt'])).toEqual([
+            'unified', '@neo-gpt', '@neo-opus-ada'
+        ]);
+        // blank / non-'@' identities are dropped; an empty window folds to the unified track only
+        expect(resolvePartitionKeys(['', 'plain', '@'])).toEqual(['unified']);
+        expect(resolvePartitionKeys()).toEqual(['unified'])
     })
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
@@ -17,13 +17,16 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 
 import {
     buildTemporalSummaryDocument,
+    composeAgentRecord,
     composeUnifiedRecord,
+    deriveAgentVelocityFields,
     deriveVelocityFields,
     HIGH_IMPACT_THRESHOLD,
     planDailyWindows,
     resolveDailyWindow,
     resolvePartitionKeys,
-    VELOCITY_FIELD_SOURCES
+    VELOCITY_FIELD_SOURCES,
+    WINDOW_SCOPED_VELOCITY_FIELDS
 } from '../../../../../../../ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs';
 
 test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', () => {
@@ -159,6 +162,87 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
         expect(record.velocityFields.mergedPrs).toBe(2);
         expect(record.velocityFields.highImpactSessions).toBe(1);
         expect(record.id).toContain('temporal-summary-daily-unified-')
+    });
+
+    test('WINDOW_SCOPED_VELOCITY_FIELDS pins exactly the four non-agent-attributable window facts', () => {
+        expect([...WINDOW_SCOPED_VELOCITY_FIELDS].sort()).toEqual([
+            'adrsLanded', 'devCommits', 'mergedPrs', 'sandboxesGraduated'
+        ]);
+        // the two agent-attributable fields are deliberately absent — they carry measurements per track
+        expect(WINDOW_SCOPED_VELOCITY_FIELDS).not.toContain('sessionsPerAgent');
+        expect(WINDOW_SCOPED_VELOCITY_FIELDS).not.toContain('highImpactSessions')
+    });
+
+    test('deriveAgentVelocityFields nulls every window-scoped field — never 0, never the repeated window count', () => {
+        const fields = deriveAgentVelocityFields({
+            partition: '@neo-opus-ada',
+            sources  : {
+                mergedPrs         : [{n: 1}, {n: 2}, {n: 3}],
+                devCommits        : [{sha: 'a'}],
+                adrsLanded        : [{id: 'ADR-0028'}],
+                sandboxesGraduated: [{ref: 'd#1'}],
+                sessions          : [{agentIdentity: '@neo-opus-ada', impact: 95}]
+            }
+        });
+
+        // null asserts "not attributed at this partition" — 0 would assert an unmeasured contribution,
+        // and repeating the window count (3 mergedPrs) would double-count across tracks
+        WINDOW_SCOPED_VELOCITY_FIELDS.forEach(field => expect(fields[field]).toBeNull());
+        expect(fields.mergedPrs).not.toBe(0);
+        expect(fields.mergedPrs).not.toBe(3)
+    });
+
+    test('deriveAgentVelocityFields attributes only the partition agent\'s sessions', () => {
+        const sources = {
+            sessions: [
+                {agentIdentity: '@neo-opus-ada', impact: 95},
+                {agentIdentity: '@neo-opus-ada', impact: 20},
+                {agentIdentity: '@neo-gpt',      impact: 99}
+            ]
+        };
+
+        const ada = deriveAgentVelocityFields({partition: '@neo-opus-ada', sources});
+
+        expect(ada.sessionsPerAgent).toEqual({'@neo-opus-ada': 2});
+        // @neo-gpt's impact-99 session belongs to its own track, never to Ada's
+        expect(ada.highImpactSessions).toBe(1);
+
+        const gpt = deriveAgentVelocityFields({partition: '@neo-gpt', sources});
+
+        expect(gpt.sessionsPerAgent).toEqual({'@neo-gpt': 1});
+        expect(gpt.highImpactSessions).toBe(1)
+    });
+
+    test('deriveAgentVelocityFields folds an agent with no sessions in the window to honest empties', () => {
+        const fields = deriveAgentVelocityFields({partition: '@neo-opus-vega', sources: {mergedPrs: [{n: 1}]}});
+
+        expect(fields.sessionsPerAgent).toEqual({});
+        expect(fields.highImpactSessions).toBe(0);
+        expect(fields.mergedPrs).toBeNull()
+    });
+
+    test('deriveAgentVelocityFields fails closed on the unified track or a malformed identity', () => {
+        expect(() => deriveAgentVelocityFields({partition: 'unified'})).toThrow(/expected a per-agent/);
+        expect(() => deriveAgentVelocityFields({partition: 'plain'})).toThrow(/expected a per-agent/);
+        expect(() => deriveAgentVelocityFields({partition: '@'})).toThrow(/expected a per-agent/);
+        expect(() => deriveAgentVelocityFields({})).toThrow(/expected a per-agent/)
+    });
+
+    test('composeAgentRecord composes a per-agent track record; the unified track keeps the window facts', () => {
+        const
+            window  = {level: 'daily', windowStart: '2026-07-05T00:00:00.000Z', windowEnd: '2026-07-06T00:00:00.000Z'},
+            sources = {mergedPrs: [{n: 1}, {n: 2}], sessions: [{agentIdentity: '@neo-opus-ada', impact: 95}]},
+            agent   = composeAgentRecord({...window, partition: '@neo-opus-ada', sources}),
+            unified = composeUnifiedRecord({...window, sources});
+
+        expect(agent.metadata.partition).toBe('@neo-opus-ada');
+        expect(agent.velocityFields.mergedPrs).toBeNull();
+        expect(agent.velocityFields.highImpactSessions).toBe(1);
+        expect(agent.id).toContain('temporal-summary-daily-neo-opus-ada-');
+
+        // same window, same source rows: the window fact is attributed once, on the unified track only
+        expect(unified.velocityFields.mergedPrs).toBe(2);
+        expect(agent.id).not.toBe(unified.id)
     });
 
     test('planDailyWindows returns contiguous most-recent-first UTC-day windows, bounded by dayCount', () => {

--- a/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
@@ -20,6 +20,7 @@ import {
     composeUnifiedRecord,
     deriveVelocityFields,
     HIGH_IMPACT_THRESHOLD,
+    planDailyWindows,
     resolveDailyWindow,
     resolvePartitionKeys,
     VELOCITY_FIELD_SOURCES
@@ -158,5 +159,19 @@ test.describe('Neo.ai.services.memory-core.temporalSummaryAggregationEngine', ()
         expect(record.velocityFields.mergedPrs).toBe(2);
         expect(record.velocityFields.highImpactSessions).toBe(1);
         expect(record.id).toContain('temporal-summary-daily-unified-')
+    });
+
+    test('planDailyWindows returns contiguous most-recent-first UTC-day windows, bounded by dayCount', () => {
+        const windows = planDailyWindows({anchor: '2026-07-06T14:00:00.000Z', dayCount: 3});
+
+        expect(windows).toEqual([
+            {windowStart: '2026-07-06T00:00:00.000Z', windowEnd: '2026-07-07T00:00:00.000Z'},
+            {windowStart: '2026-07-05T00:00:00.000Z', windowEnd: '2026-07-06T00:00:00.000Z'},
+            {windowStart: '2026-07-04T00:00:00.000Z', windowEnd: '2026-07-05T00:00:00.000Z'}
+        ]);
+        // contiguous: each window's end is the next-newer window's start
+        expect(windows[1].windowEnd).toBe(windows[0].windowStart);
+        // dayCount coerces to >= 1
+        expect(planDailyWindows({anchor: '2026-07-06T00:00:00.000Z', dayCount: 0})).toHaveLength(1)
     })
 });


### PR DESCRIPTION
> **Merge disposition (2026-07-10):** This PR is the disabled-by-default scaffold and is merge-ready. All residual runtime-enablement work below moved to #14938, assigned to `@neo-gpt`; those items are no longer author actions on this PR. `aggregationEnabled` remains `false` until #14938 is complete. This note supersedes the earlier WIP / “same PR before merge” wording retained below as historical review context.

Resolves #14434
Related: #12679

**Open for design/shape review — WIP lane (not a merge candidate).** Leaf B of the temporal-pyramid substrate: the L1/L2 durable aggregation lane plus the six ADR 0028 §2.4 velocity fields. The load-bearing architecture is complete and unit-tested — the **pure** aggregation engine and the supervised, **lease-aware** aggregation service. All six velocity sources are bound and the daemon entry point has landed. The `SUMMARY_DAILY` graph labels, retention/versioning tests, the ADR 0024 update and an unresolved `sandboxesGraduated` semantics question are tracked in "Remaining in this lane" below and land in this same PR before merge. The lane is not yet end-to-end runnable and **no AC is closed** — please review the shape now; a merge-candidate re-review follows once the remainder lands.

**Review focus:** the pure/IO split (`temporalSummaryAggregationEngine` vs `TemporalSummaryAggregationService`), the engine's window/partition/velocity contract, the backpressure-lease integration in `pulse()`, and the per-field source-binding pattern across all six sources. The remaining items are integration follow-ups plus one open semantics question, not architectural forks.

Evidence: L3 partial (live non-destructive probe — `node ai/daemons/temporal-summary/daemon.mjs` boots the real entry point and exits `0` on the opt-in-disabled path, exercising the Neo bootstrap, the stale-overlay guard and both config-leaf reads) over an L2 base (mock dispatch — pure-engine folds plus poll/lease behavior against a stubbed heavy-maintenance lane and a stubbed `execCommand`) → L3 still required for the durable write path (a real Chroma upsert into the `temporal-summary` collection, and lane registration under a real `MaintenanceBackpressureService`). The lease-acquisition path stays L2 by choice: exercising it live would take the **shared** heavy-maintenance lease and starve the REM/defrag siblings, so it is proxied by a `buildLeasePayload` probe asserting the exact options `acquireLease()` passes. Residual: all seven ACs remain open at this PR head [#14434].

## Why this lane, now (premise-verified)

Traced from #14811 (ADR 0033's direction-velocity leaf), which could not proceed: it wires `directionBreakdown` into "the temporal-pyramid single-writer", but that writer did not exist — `composeVelocity`, `createTemporalSummaryDocId` and the whole temporal-summary schema shipped as **0-consumer modules**. Both prerequisites for building the writer are satisfied: **ADR 0028 is merged** (PR #14428, 2026-07-02) and **Leaf A #14433 is closed** (PR #14733, the `temporal-summary` collection plus the `SUMMARY_*` schema). So #14434 is the genuine actionable leaf, and #14811 unblocks once this lands.

**Merge gate (ticket AC):** ADR 0028 must be `Accepted`. It merged via PR #14428, so the gate is satisfied; this is restated here because the AC requires the gate to be stated in the PR body.

## What has landed on this branch

`ai/services/memory-core/helpers/temporalSummaryAggregationEngine.mjs` — the **pure** aggregation engine (mirrors the `kbGarbageCollectionEngine` pure/IO split):

- `deriveVelocityFields(sources)` folds a window's fetched rows into the six ADR 0028 §2.4 velocity fields (`mergedPrs`, `devCommits`, `sessionsPerAgent`, `highImpactSessions`, `adrsLanded`, `sandboxesGraduated`), each bound to a named source, with honest `0`/`{}` for empty windows.
- `buildTemporalSummaryDocument(...)` composes the document through the Leaf-A schema. It is the **first consumer** of `createTemporalSummaryDocId` / `validateTemporalSummaryMetadata`. Velocity fields ride the document payload; the strict five-field metadata rejects extras. Idempotent per window+track+version, and a version bump mints a new id (append-only).
- `VELOCITY_FIELD_SOURCES` pins the field→named-source contract (prose is never a metric source, ADR 0028 §2.4).
- `resolveDailyWindow` (half-open UTC-day bounds), `resolvePartitionKeys` (unified track first, then a sorted de-duped per-agent set, §2.6), `composeUnifiedRecord`, and `planDailyWindows` (bounded, most-recent-first L2 window batch).
- `WINDOW_SCOPED_VELOCITY_FIELDS` + `deriveAgentVelocityFields` + `composeAgentRecord` — the per-agent track fold. The four window-scoped facts (`mergedPrs`, `devCommits`, `adrsLanded`, `sandboxesGraduated`) are **`null`** on every `@<identity>` track: `0` would assert an unmeasured contribution, and repeating the window count would seed silent double-counting when a consumer aggregates across tracks. `null` is also the only additive upgrade path if a field later becomes agent-attributable. The semantic is encoded at the field definition so no consumer re-derives the question.

`ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs` — the supervised poll loop:

- `start()` is a no-op when disabled, is idempotent when enabled, and fails loud without a positive `pollIntervalMs`.
- `pulse()` defers the whole cycle while the heavy-maintenance lease is held, and releases the lease on both the success and the throw path (ADR 0022 fairness; reuses the landed #12676 `MaintenanceBackpressureService` lane).
- `collectPendingWindows` plans the trailing daily windows and attaches each window's fetched sources; `persistTemporalRecord` upserts a record into the `temporal-summary` collection by its doc id.
- `runCycle` persists the unified track **plus one record per agent observed in the window** (§2.6). A window whose session source is absent yields the unified track alone — the lane writes no per-agent record it cannot attribute.
- **All six** velocity sources are bound to real substrates: `devCommits` (the `dev` first-parent window log), `adrsLanded` (records added under `learn/agentos/decisions/` in-window), `sandboxesGraduated` (marker-bearing Discussions from the complete synced corpus — **see the open semantics defect below; this field is not yet trustworthy**), `mergedPrs` (`state: MERGED` + `mergedAt` from the complete PR sync; 110/110 recovered), and `sessionsPerAgent` + `highImpactSessions` (`fetchSessions` — the Memory Core session summaries, window-filtered by a bounded `$gte`/`$lt` query on the numeric `timestamp` metadata, pushed into the store rather than scanned in JS). Attribution uses the canonical, auth-bound `sourceAgentIdentities`, never the caller-declared `participatingAgents` display field.
- **Per-agent tracks now materialize in production** — `resolveWindowPartitions` reads real participant identities from the bound session source.

## Remaining in this lane (tracked; lands in this PR before merge)

- [ ] **`sandboxesGraduated` is not yet trustworthy — two defects remain open** (the truncation is fixed; these are deeper). Measured on the real corpus: (1) windowing on `closedAt` undercounts by **~95%** — 37 of 39 marker-bearing Discussions are still *open*, and a graduation is the marker, not the close; (2) substring matching counts prose that merely *discusses* a marker (e.g. "before `[GRADUATED_TO_TICKET]`"). The synced body carries no per-comment timestamps, so an honest graduation timestamp is not derivable from this corpus. **Needs a semantics ruling before the field can be read as correct.** Flagged rather than papered over.
- [ ] `SUMMARY_DAILY` graph labels written by this lane only (§2.3); the extractor stays untouched.
- [ ] Retention/versioning policy defined and tested within the `version` field.
- [ ] ADR 0024 §2.2 node-type table updated and cited here (a pre-declared ADR 0028 §2.7 obligation).
- [ ] Cross-family review before merge.

## Contract Ledger — new consumed surface

| Target surface | Source of authority | Behavior | Fallback | Evidence |
|---|---|---|---|---|
| `AiConfig.temporalSummary.aggregationEnabled` | ADR 0019 (config SSOT); kb-gc `gcEnabled` precedent | Master opt-in for the aggregation daemon; `false` by default | none — the daemon exits early | Leaf resolves `false`/boolean; asserted in `daemon.spec.mjs` |
| `AiConfig.temporalSummary.aggregationIntervalMs` | ADR 0019; kb-gc `gcIntervalMs` precedent | Poll interval, default 1 h | none — `start()` fails loud without it | Leaf resolves `3600000`/number; asserted in `daemon.spec.mjs` |
| `npm run ai:temporal-summary` | kb-gc invocation precedent | Launches the daemon entry point | n/a | Real boot, exits `0` on the disabled path |
| `readContentRecords(type)` reads `resources/content/<type>/**` | Tier-2 ruling: fixed repo substrate derives from `AiConfig.projectRoot` | Complete corpus read; missing root throws | none — fail loud, never a silent zero | 117 pull + 91 discussion records; `mergedPrs` recovers 110/110 |

Both leaves are read **at the use site in the entry point only** — the service carries no config defaults and fails loud without injected values (ADR 0019: no primitive-local default, no defensive `?.`, no module-level capture). `ai/config.mjs` is a gitignored standalone snapshot and was re-materialized via `npm run prepare -- --migrate-config`; it is not committed.

**Path question — answered and applied.** @neo-gpt ruled it Tier-2: fixed repo substrate derives from the Tier-1 `projectRoot`; a shared content-root leaf is only warranted if relocatability is genuinely required. That unblocks both remaining source repairs below; no new tier-1 leaf, no C2 duplication.

**One blocker gated the two remaining source repairs.** `mergedPrs` and the `sandboxesGraduated` fix both need `resources/content/**`. ADR 0028 §2.4 offers "graph PR nodes" as an alternative source for `mergedPrs`, but **it does not exist** — there are no PR nodes and no `mergedAt` anywhere in `ai/graph/`. So the only real source is the content sync, and tier-1 `AiConfig` exposes no content root: `contentRoot` / `discussionsDir` are leaves on the **github-workflow child** config, and per ADR 0019 §2.1 reads resolve *up* the provider chain, so a parent cannot read a child's leaf. The options are (a) a tier-1 content-root leaf, which risks the **C2 duplicated-primitive** antipattern against the child's existing leaves, or (b) hardcoding the path, which is the **A1** antipattern. This is a single deliberate config decision, not two independent chores; routed to @neo-gpt (the reviewer who surfaced it) rather than guessed at.

## Deltas from ticket

- **Pure/IO split was not prescribed by the ticket.** The ticket describes one aggregation lane; the implementation separates a pure engine (`ai/services/memory-core/helpers/`) from the IO-bearing service (`ai/daemons/temporal-summary/`), following the existing `kbGarbageCollectionEngine` precedent. This is what makes the per-field source-binding AC testable without a live Chroma or a live `git`.
- **Velocity sources land incrementally, one commit per named source.** The ticket folds velocity fields into this leaf as a single obligation. Three of six are bound so far; the engine's honest-zero fold means a partially bound `fetchWindowSources` writes true zero-count records instead of fabricating or omitting fields. No AC is weakened, and the remaining three are tracked in the checklist above.
- **Attribution binds to canonical identity, not the display field.** `fetchSessions` first partitioned on `participatingAgents`; a live-data probe (surfaced in peer review) showed that field is caller-declared free text. Measured on a real 30-day window of 282 session summaries, it would have written **16 partition tracks for 7 real agents** into an append-only durable record — `@neo-gpt` fragmented across 5 spellings, `@neo-opus-vega` across 4, one key truncated mid-parenthetical (`'@neo-opus-grace / Grace (Claude Opus 4.8'`, because display names contain commas and the field is comma-split), `@neo-gemini-pro` dropped entirely, and 86/282 sessions yielding no per-agent track. 56 distinct raw strings for 7 agents. Now bound to `sourceAgentIdentities` (derived from each source memory's auth-bound `agentIdentity`): same window, **282/282 attributed, 7 canonical partitions**.
- **A session is multi-agent, so the row contract carries `agentIdentities` (plural).** Binding the real source exposed a latent double-count: `participatingAgents` is a list, so a one-identity-per-row contract would have forced a choice between exploding rows (inflating `highImpactSessions` by the size of the swarm) and dropping attribution. `sessionsPerAgent` now credits every participant while `highImpactSessions` counts the session once, and a co-participant never leaks onto another agent's track.
- **`planDailyWindows` bounds the batch by `dayCount`.** The ticket says "bounded batches" without a bound; the service exposes `dailyWindowCount()` as the overridable seam, defaulting to `DEFAULT_DAILY_WINDOW_COUNT`.
- No scope was added beyond the ticket, and nothing in Out of Scope (L3–L5 synthesis, consumer surfaces, Leaf-A schema, deep-history backfill) was touched.

## Test Evidence

Both suites were run on this PR head, in a bootstrapped worktree, exit 0:

```
npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/temporalSummaryAggregationEngine.spec.mjs
  → 20 passed (30.8s)

npm run test-unit -- test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
  → 15 passed (1.0m)

npm run test-unit -- test/playwright/unit/ai/daemons/temporal-summary/
  → 24 passed (32.0s)   # service 20 + daemon 4
```

Engine (20): `VELOCITY_FIELD_SOURCES` pins all six fields to a named source; velocity folds over counts, the per-agent session map, and the impact threshold; honest zeros on an empty/absent window; five-field metadata isolation; doc-id idempotence per window+track+version plus version-bump mint; fail-closed on inverted-window metadata; `resolveDailyWindow` UTC-day bounds plus fail-closed on an unparseable anchor; `resolvePartitionKeys` unified-first sorted de-duped tracks; `composeUnifiedRecord`; `planDailyWindows` contiguous most-recent-first bounded windows. Per-agent (6 new): `WINDOW_SCOPED_VELOCITY_FIELDS` pins exactly the four non-attributable facts; `deriveAgentVelocityFields` nulls every window-scoped field (asserted **not** `0` and **not** the repeated window count), attributes only the partition agent's sessions, folds a session-less agent to honest empties, and fails closed on the unified track or a malformed identity; `composeAgentRecord` mints a distinct per-agent doc id while the unified track keeps the window fact.

Service (15): `start()` disabled no-op, enabled idempotence, fail-loud on a non-positive `pollIntervalMs`; `pulse()` defers under a held lease, runs and releases on success, releases on throw; `persistTemporalRecord` upserts by doc id; `collectPendingWindows` window planning plus source attachment; per-field source binding asserted for `devCommits`, `sandboxesGraduated`, `adrsLanded`. Lease boundary (1 new): `acquireLease` forwards the AiConfig stale TTL — a source-contract guard plus a probe proving `buildLeasePayload` accepts the exact options `acquireLease()` passes and throws without them. Per-agent (2 new): `runCycle` persists `['unified', '@neo-gpt', '@neo-opus-ada']` for a two-agent window with the window fact attributed exactly once (unified) and `null` on both agent tracks; `runCycle` writes the unified track alone when no session source attributes the window.

The durable-write and scheduling ACs are not closed by this evidence — see the `Evidence:` declaration above.

## Post-Merge Validation

- [ ] The scheduled lane registers under the live `MaintenanceBackpressureService` and does not starve the REM/defrag siblings (ADR 0022 fairness) across a full poll interval.
- [ ] L1/L2 records appear in the live Chroma `temporal-summary` collection with the five-field metadata intact, and a re-run of the same window is idempotent (no duplicate ids).
- [ ] `SUMMARY_DAILY` labels appear in the graph written by this lane only; the extractor emits none.
- [ ] The six velocity fields on a real window reconcile against their named sources (spot-check `devCommits` against `git log --first-parent origin/dev`).
- [ ] #14811 (`directionBreakdown`) can consume this writer — the seam it was blocked on now has a producer.

## Commits

- `f3461a02` — aggregation engine: velocity fields plus document composition
- `f379c7c7` — `resolveDailyWindow` (L2 UTC-day bounds)
- `292f2c5e` — `resolvePartitionKeys` (unified plus per-agent tracks)
- `2ec160a5` — `composeUnifiedRecord` (unified-track window fold)
- `99ba8b24` — aggregation daemon service: lease-aware poll loop
- `133191b3` — `persistTemporalRecord`: Chroma upsert to the `temporal-summary` collection
- `4be71282` — `planDailyWindows` (bounded most-recent-first L2 batch)
- `0dc9adbc` — wire `collectPendingWindows` to the bounded daily-window plan
- `afb00f72` — bind `devCommits` to the `dev` first-parent window log
- `e7494d9e` — bind `sandboxesGraduated` to in-window graduated Discussions
- `cb03e27f` — bind `adrsLanded` to in-window ADR records
- `3194bce2` — per-agent partition tracks; `null` window-scoped velocity fields (§2.6)
- `68d48823` — pass the AiConfig stale TTL to the heavy-maintenance lease (production-boundary crash)
- `ee471454` — bind `sessions` to the summary collection (bounded window query); multi-agent session fold
- `f812a782` — aggregation daemon entry point + `temporalSummary` config leaves
- `4da2beec` — attribute sessions on canonical `sourceAgentIdentities` (identity-fragmentation fix)
- `7cd94549` — bind `mergedPrs`; read Discussions from the complete synced corpus

## Decision authority

ADR 0028 (temporal-pyramid substrate) §2.1/§2.3/§2.4/§2.6/§2.7 · ADR 0022 (heavy-maintenance scheduling fairness) · ADR 0024 (node-type obligation, to be updated in-PR) · reuses the landed PR #12676 backpressure pattern · consumes the Leaf-A #14433 schema. Durable JSDoc carries no ADR or ticket refs (archaeology hook); the authority lives here in the PR body.

**Null-on-per-agent-track semantics** are a design ruling from the #12679 epic owner (@neo-fable), answering the open question this engine previously carried in prose ("its non-attributable-field semantics are still being pinned"). ADR 0028 §2.6 mandates per-agent + unified tracks but does not rule on how non-attributable fields render on an agent track — the ruling fills that gap rather than contradicting the ADR, and matches the honest-states discipline (never render an unmeasured attribution).

Authored by Ada (Claude Opus 4.8, Claude Code). Session f1a4f6c4-46eb-4445-b315-2baa849990f3.
