### PR TITLE
feat(dashboard): wire the dockPreview producer into the live cross-zone drag (#14886)

### DIFF
--- a/apps/agentos/view/DockPreview.mjs
+++ b/apps/agentos/view/DockPreview.mjs
@@ -1,4 +1,5 @@
-import Component from '../../../src/component/Base.mjs';
+import Component                from '../../../src/component/Base.mjs';
+import * as dockPreviewContract from '../../../src/dashboard/dockPreviewContract.mjs';
 
 /**
  * @class AgentOS.view.DockPreview
@@ -35,33 +36,28 @@ class DockPreview extends Component {
      * @member {String} PREVIEW_SCHEMA='neo.harness.dockPreview.v1'
      * @static
      */
-    static PREVIEW_SCHEMA = 'neo.harness.dockPreview.v1'
+    static PREVIEW_SCHEMA = dockPreviewContract.PREVIEW_SCHEMA
     /**
      * Every candidate `placement.kind` the contract defines.
      * @member {Set<String>} VALID_PLACEMENT_KINDS
      * @static
      */
-    static VALID_PLACEMENT_KINDS = new Set([
-        'edge-top', 'edge-right', 'edge-bottom', 'edge-left',
-        'split-before', 'split-after',
-        'tab-before', 'tab-after', 'tab-into',
-        'rejected'
-    ])
+    static VALID_PLACEMENT_KINDS = dockPreviewContract.VALID_PLACEMENT_KINDS
     /**
      * @member {Set<String>} EDGE_KINDS
      * @static
      */
-    static EDGE_KINDS = new Set(['edge-top', 'edge-right', 'edge-bottom', 'edge-left'])
+    static EDGE_KINDS = dockPreviewContract.EDGE_KINDS
     /**
      * @member {Set<String>} SPLIT_KINDS
      * @static
      */
-    static SPLIT_KINDS = new Set(['split-before', 'split-after'])
+    static SPLIT_KINDS = dockPreviewContract.SPLIT_KINDS
     /**
      * @member {Set<String>} TAB_KINDS
      * @static
      */
-    static TAB_KINDS = new Set(['tab-before', 'tab-after', 'tab-into'])
+    static TAB_KINDS = dockPreviewContract.TAB_KINDS
     /**
      * Thickness in px of an edge-zone affordance band.
      * @member {Number} edgeBandSize=24
@@ -120,23 +116,7 @@ class DockPreview extends Component {
      * @static
      */
     static isValidPreview(preview) {
-        if (!preview || typeof preview !== 'object')                  return false;
-        if (preview.schema !== this.PREVIEW_SCHEMA)                   return false;
-        if (typeof preview.itemId !== 'string' || !preview.itemId)    return false;
-
-        let {feedback, placement, target} = preview;
-
-        if (!target || typeof target.nodeId !== 'string' || !target.nodeId) return false;
-        if (!placement || !this.VALID_PLACEMENT_KINDS.has(placement.kind))  return false;
-        if (!feedback || (feedback.state !== 'accepted' && feedback.state !== 'rejected')) return false;
-
-        // Split placements MUST carry an orientation (contract: required for split previews).
-        if (this.SPLIT_KINDS.has(placement.kind) &&
-            placement.orientation !== 'horizontal' && placement.orientation !== 'vertical') {
-            return false
-        }
-
-        return true
+        return dockPreviewContract.isValidPreview(preview)
     }
 
     /**
@@ -191,33 +171,7 @@ class DockPreview extends Component {
      * @static
      */
     static previewToOperation(preview) {
-        if (!this.isValidPreview(preview)) return null;
-
-        let {feedback, itemId, placement, target} = preview,
-            {kind}                                = placement;
-
-        if (kind === 'rejected' || feedback.state !== 'accepted') return null;
-
-        let nodeId = target.nodeId;
-
-        if (this.TAB_KINDS.has(kind)) {
-            return {operation: 'addTab', itemId, tabsNodeId: nodeId, index: Number.isInteger(placement.index) ? placement.index : null}
-        }
-
-        if (this.SPLIT_KINDS.has(kind)) {
-            let position = kind.slice('split-'.length);
-            return {operation: 'splitNode', itemId, targetNodeId: nodeId, orientation: placement.orientation, position, sizes: this.ratioToSizes(placement.ratio, position)}
-        }
-
-        let edge = kind.slice('edge-'.length);
-        return {
-            operation   : 'splitNode',
-            itemId,
-            targetNodeId: nodeId,
-            edge,
-            orientation : (edge === 'left' || edge === 'right') ? 'horizontal' : 'vertical',
-            sizes       : this.ratioToSizes(placement.ratio, edge === 'bottom' || edge === 'right' ? 'after' : 'before')
-        }
+        return dockPreviewContract.previewToOperation(preview)
     }
 
     /**
@@ -228,8 +182,7 @@ class DockPreview extends Component {
      * @static
      */
     static ratioToSizes(ratio, position) {
-        let r = (typeof ratio === 'number' && ratio > 0 && ratio < 1) ? ratio : 0.5;
-        return position === 'after' ? [1 - r, r] : [r, 1 - r]
+        return dockPreviewContract.ratioToSizes(ratio, position)
     }
 
     /**

--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -1,6 +1,8 @@
-import DockLayoutAdapter from '../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockZoneModel     from '../../../src/dashboard/DockZoneModel.mjs';
-import Viewport          from '../../../src/container/Viewport.mjs';
+import DockLayoutAdapter    from '../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockPreviewProducer  from '../../../src/dashboard/DockPreviewProducer.mjs';
+import DockZoneModel        from '../../../src/dashboard/DockZoneModel.mjs';
+import Viewport             from '../../../src/container/Viewport.mjs';
+import {previewToOperation} from '../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../src/button/Base.mjs';    // registers the `button` ntype used by the perspective toolbar
 import '../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits for tab zones
 import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype used by the perspective toolbar
@@ -141,8 +143,9 @@ class MainContainer extends Viewport {
 
         let me = this;
 
-        me.layoutCollection = me.createDefaultLayoutCollection();
-        me.dockModel        = DockZoneModel.restoreActiveSavedLayout(me.layoutCollection).document || DockZoneModel.clone(initialDockModel);
+        me.dockPreviewProducer = Neo.create(DockPreviewProducer);
+        me.layoutCollection    = me.createDefaultLayoutCollection();
+        me.dockModel           = DockZoneModel.restoreActiveSavedLayout(me.layoutCollection).document || DockZoneModel.clone(initialDockModel);
 
         me.add(me.buildWorkspaceItems());
         me.layoutCollectionLoadPromise = me.loadLayoutCollectionFromStorage()
@@ -530,20 +533,24 @@ class MainContainer extends Viewport {
             return
         }
 
-        let rects        = await me.getDomRect(zones.map(zone => zone.container.id)),
-            targetNodeId = null;
+        let rects = await me.getDomRect(zones.map(zone => zone.container.id));
 
-        zones.forEach((zone, index) => {
-            let rect = rects[index];
+        // The producer resolves the placement KIND (tab-into / edge-* / split-*) from the pointer and
+        // each zone's rect; a tabs node's parent-split orientation lets it pick split-before/after vs an
+        // edge band. `previewToOperation` maps that dockPreview.v1 to the semantic op the reducer applies
+        // — replacing the former crude "which rect contains the pointer" → hardcoded moveItem shortcut.
+        let producerZones = zones
+                .map((zone, index) => ({
+                    nodeId     : zone.nodeId,
+                    rect       : rects[index],
+                    orientation: Object.values(nodes).find(node => node.type === 'split' && node.children?.includes(zone.nodeId))?.orientation ?? null
+                }))
+                .filter(zone => zone.rect),
+            preview    = me.dockPreviewProducer.produce({pointer: {x: clientX, y: clientY}, zones: producerZones, itemId, sourceNodeId}),
+            descriptor = previewToOperation(preview);
 
-            if (rect && clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
-                targetNodeId = zone.nodeId
-            }
-        });
-
-        if (targetNodeId) {
-            let descriptor = {operation: 'moveItem', itemId, targetNodeId},
-                result     = me.applyDockZoneOperation(descriptor);
+        if (descriptor) {
+            let result = me.applyDockZoneOperation(descriptor);
 
             if (result && !result.errors?.length && result.document) {
                 me.onDockZoneDocumentChange(result.document, descriptor, me)

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -67,6 +67,27 @@ class DockTabSortZone extends TabHeaderSortZone {
 
         await super.processDragEnd(data)
     }
+
+    /**
+     * Extends the base drag-move: after the base updates the proxy + sort state, fires a
+     * `dockCrossZoneDragMove` event on the owner tab.Container carrying the live pointer + dragged item
+     * id, so the owner can compute + render the transient dock-preview affordance under the pointer each
+     * frame. Purely additive + reactive — the base owns the proxy and the sort math; the affordance is a
+     * consumer of this hover signal, never a parallel drag system. Mirrors the {@link #processDragEnd} drop seam.
+     * @param {Object} data
+     */
+    async onDragMove(data) {
+        await super.onDragMove(data);
+
+        let me                 = this,
+            itemId             = me.dockItemIds?.[me.startIndex],
+            tabContainer       = me.owner?.up?.(),
+            {clientX, clientY} = data || {};
+
+        if (itemId && tabContainer && Neo.isNumber(clientX) && Neo.isNumber(clientY)) {
+            tabContainer.fire('dockCrossZoneDragMove', {clientX, clientY, itemId, sourceNodeId: me.dockSourceNodeId})
+        }
+    }
 }
 
 export default Neo.setupClass(DockTabSortZone);

--- a/src/dashboard/dockPreviewContract.mjs
+++ b/src/dashboard/dockPreviewContract.mjs
@@ -1,0 +1,113 @@
+/**
+ * @summary The pure, layer-neutral `neo.harness.dockPreview.v1` contract — the schema constant, the
+ * placement-kind vocabulary, structural validation, the preview→operation conversion, and the
+ * split-ratio normalizer.
+ *
+ * Extracted from `AgentOS.view.DockPreview` so the three sides of the docking line share ONE source
+ * of truth without a layer inversion: the producer (`Neo.dashboard.DockPreviewProducer`, src), the
+ * renderer (that app-layer view), AND the src-layer drop owners (`examples/dashboard/dock`, the FM
+ * cockpit) — the src/example layers cannot import `apps/`, so the model-semantic half of the
+ * contract had to move down here. Rendering + geometry stay in the view; only the pure half lives
+ * here (no Neo class, no DOM, no persisted-model write).
+ *
+ * @see learn/agentos/HarnessDockZoneModel.md
+ */
+
+/**
+ * The dockPreview contract schema every side of the line accepts / emits.
+ * @type {String}
+ */
+export const PREVIEW_SCHEMA = 'neo.harness.dockPreview.v1';
+
+/** @type {Set<String>} */
+export const EDGE_KINDS = new Set(['edge-top', 'edge-right', 'edge-bottom', 'edge-left']);
+
+/** @type {Set<String>} */
+export const SPLIT_KINDS = new Set(['split-before', 'split-after']);
+
+/** @type {Set<String>} */
+export const TAB_KINDS = new Set(['tab-before', 'tab-after', 'tab-into']);
+
+/** Every candidate `placement.kind` the contract defines (+ the terminal `rejected`). @type {Set<String>} */
+export const VALID_PLACEMENT_KINDS = new Set([...EDGE_KINDS, ...SPLIT_KINDS, ...TAB_KINDS, 'rejected']);
+
+/**
+ * @summary Structural validity gate for a dockPreview object (fail-closed).
+ *
+ * Returns true only for a well-formed `neo.harness.dockPreview.v1` payload that carries a stable
+ * `itemId`, a `target.nodeId`, a known `placement.kind`, an accept/reject `feedback.state`, and (for
+ * split placements) a valid `placement.orientation`. Anything malformed, partial or unknown returns
+ * false so consumers clear/fail rather than guess.
+ * @param {Object|null} preview
+ * @returns {Boolean}
+ */
+export function isValidPreview(preview) {
+    if (!preview || typeof preview !== 'object')               return false;
+    if (preview.schema !== PREVIEW_SCHEMA)                     return false;
+    if (typeof preview.itemId !== 'string' || !preview.itemId) return false;
+
+    let {feedback, placement, target} = preview;
+
+    if (!target || typeof target.nodeId !== 'string' || !target.nodeId) return false;
+    if (!placement || !VALID_PLACEMENT_KINDS.has(placement.kind))       return false;
+    if (!feedback || (feedback.state !== 'accepted' && feedback.state !== 'rejected')) return false;
+
+    // Split placements MUST carry an orientation (contract: required for split previews).
+    if (SPLIT_KINDS.has(placement.kind) &&
+        placement.orientation !== 'horizontal' && placement.orientation !== 'vertical') {
+        return false
+    }
+
+    return true
+}
+
+/**
+ * @summary Normalizes an optional split ratio into a two-child, sum-to-one size pair.
+ * @param {Number} [ratio] the new node's fraction; defaults to an even split when absent/invalid
+ * @param {String} position 'before' | 'after' — which child the new node becomes
+ * @returns {Number[]} normalized [first, second] sizes summing to 1
+ */
+export function ratioToSizes(ratio, position) {
+    let r = (typeof ratio === 'number' && ratio > 0 && ratio < 1) ? ratio : 0.5;
+    return position === 'after' ? [1 - r, r] : [r, 1 - r]
+}
+
+/**
+ * @summary Converts an ACCEPTED drop preview into a semantic dock-zone operation descriptor, or null.
+ *
+ * The one authored path from a hover preview to a `DockZoneModel` operation. Invalid previews,
+ * `rejected` placements, and non-accepted feedback all yield null (no commit). Tab placements emit
+ * `addTab` (the adapter downgrades to `moveItem` when the item already lives in the tree); split and
+ * edge placements route to `splitNode`.
+ * @param {Object|null} preview
+ * @returns {Object|null}
+ */
+export function previewToOperation(preview) {
+    if (!isValidPreview(preview)) return null;
+
+    let {feedback, itemId, placement, target} = preview,
+        {kind}                                = placement;
+
+    if (kind === 'rejected' || feedback.state !== 'accepted') return null;
+
+    let nodeId = target.nodeId;
+
+    if (TAB_KINDS.has(kind)) {
+        return {operation: 'addTab', itemId, tabsNodeId: nodeId, index: Number.isInteger(placement.index) ? placement.index : null}
+    }
+
+    if (SPLIT_KINDS.has(kind)) {
+        let position = kind.slice('split-'.length);
+        return {operation: 'splitNode', itemId, targetNodeId: nodeId, orientation: placement.orientation, position, sizes: ratioToSizes(placement.ratio, position)}
+    }
+
+    let edge = kind.slice('edge-'.length);
+    return {
+        operation   : 'splitNode',
+        itemId,
+        targetNodeId: nodeId,
+        edge,
+        orientation : (edge === 'left' || edge === 'right') ? 'horizontal' : 'vertical',
+        sizes       : ratioToSizes(placement.ratio, edge === 'bottom' || edge === 'right' ? 'after' : 'before')
+    }
+}

--- a/test/playwright/e2e/dashboard/DockCrossZoneDragNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockCrossZoneDragNL.spec.mjs
@@ -3,13 +3,14 @@ import { test, expect } from '../../fixtures.mjs';
 /**
  * Whitebox-e2e for "release a tab into a NEW target drop zone" — the cross-zone gesture beyond the
  * within-container reorder. Dragging a tab header OUT of its tabs node and dropping it over a DIFFERENT
- * zone relocates the item in the committed dockZone.v1 document (a semantic `moveItem` to the target
- * tabs node).
+ * zone relocates the item in the committed dockZone.v1 document.
  *
  * The gesture rides the existing tab-header drag lifecycle: `Neo.dashboard.DockTabSortZone` fires a
- * `dockCrossZoneDrop` on its tab.Container on drop; the owner reducer hit-tests the rendered zone under
- * the pointer and commits the `moveItem`. This slice commits the model move DIRECTLY from the hit-test —
- * the `dockPreview.v1` hover-affordance producer + `previewToOperation` rendering path is a follow-up leaf.
+ * `dockCrossZoneDrop` on its tab.Container on drop; the owner routes the release point + dragged item
+ * through the `dockPreview.v1` producer → `previewToOperation` → `applyDockZoneOperation` pipeline.
+ * An interior drop resolves to `tab-into` (an `addTab` that downgrades to `moveItem` for an in-tree item);
+ * the edge/split placements the same pipeline emits are unit-pinned in `DockPreviewProducer.spec` (the
+ * `produce → previewToOperation → applyOperation` deterministic pipeline test).
  *
  * Run: npx playwright test dashboard/DockCrossZoneDragNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -58,7 +59,7 @@ test.describe('Dock cross-zone drag journey (Neural Link)', () => {
         const targetNode = tabsNodeHolding(after, 'strategy');
         console.log('[cross-zone] strategy:', sourceNode, '->', targetNode, '| terminal-tabs items:', JSON.stringify(after?.nodes?.['terminal-tabs']?.items));
 
-        // worker truth: the drop must have relocated strategy OUT of main-tabs INTO terminal-tabs
+        // worker truth: the drop relocated strategy OUT of main-tabs INTO terminal-tabs through the producer pipeline
         expect(targetNode, 'the cross-zone drop must move strategy to the Terminal zone — the producer contract')
             .toBe('terminal-tabs');
     });

--- a/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
@@ -123,5 +123,43 @@ test.describe('Neo.dashboard.DockPreviewProducer (ADR 0029 §2.3 — the dock pr
         expect(producer.produce({pointer: {x: 50,  y: 50 }, zones, itemId: ''})).toBeNull();        // no item id
         expect(producer.produce({pointer: {x: 500, y: 500}, zones, itemId: 'strategy'})).toBeNull(); // over no zone
         expect(producer.produce()).toBeNull()                                                        // no args
+    });
+
+    test('the produce → previewToOperation → applyOperation pipeline SPLITS the target for an edge drop', async () => {
+        const DockZoneModel = (await import('../../../../src/dashboard/DockZoneModel.mjs')).default;
+
+        // a minimal dockZone.v1 doc: a vertical split of two single-tab zones
+        const doc = {
+            schema: 'neo.harness.dockZone.v1',
+            root  : 'root',
+            items : {a: {componentRef: 'A', title: 'A', kind: 'panel'}, b: {componentRef: 'B', title: 'B', kind: 'panel'}},
+            nodes : {
+                root    : {type: 'split', orientation: 'vertical', children: ['a-tabs', 'b-tabs'], sizes: [0.5, 0.5]},
+                'a-tabs': {type: 'tabs', items: ['a'], activeItemId: 'a'},
+                'b-tabs': {type: 'tabs', items: ['b'], activeItemId: 'b'}
+            }
+        };
+
+        // the initial tree has ONE split — the vertical root; no horizontal split yet
+        expect(Object.values(doc.nodes).some(n => n.type === 'split' && n.orientation === 'horizontal')).toBe(false);
+
+        // drop item 'a' near the LEFT edge of b-tabs (a vertical-split child) → edge-left → splitNode (perpendicular axis)
+        const zones   = [{nodeId: 'b-tabs', rect: RECT, orientation: 'vertical'}];
+        const preview = producer.produce({pointer: {x: 8, y: 50}, zones, itemId: 'a'}); // x=8 in a 100px rect (band 24) → edge-left
+        expect(preview.placement.kind).toBe('edge-left');
+
+        // the middle: preview → semantic operation descriptor
+        const descriptor = DockPreview.previewToOperation(preview);
+        expect(descriptor.operation).toBe('splitNode');
+        expect(descriptor.targetNodeId).toBe('b-tabs');
+
+        // the reducer applies it — a NEW split node appears (an interior tab-into move would not add one)
+        const result = DockZoneModel.applyOperation(doc, descriptor);
+        expect(result.errors ?? []).toEqual([]);
+        expect(DockZoneModel.validate(result.document)).toEqual([]);                    // the split produced a valid dockZone.v1 tree
+
+        // edge-left → a NEW horizontal split now exists (there were none before) → the pipeline genuinely split the target
+        expect(Object.values(result.document.nodes).some(n => n.type === 'split' && n.orientation === 'horizontal'),
+            'the edge-left drop created a horizontal split node').toBe(true)
     })
 });


### PR DESCRIPTION
Resolves #14886

Wires the merged `dockPreview.v1` producer (#14866 / PR #14880) into the live cross-zone drag: the drop routes through the producer pipeline instead of a crude hardcoded `moveItem`, and the drag-time affordance's data seam is in place.

Evidence: L2→L3 — the contract + producer + edge/split pipeline are unit-green, and the **real cross-zone drag gesture** (whitebox e2e) routes through the producer and relocates the item. Residual: the affordance VISUAL render — see Deltas.

## Delivered
- **Layer-fix SSOT** (`6a0074a410`): the pure `dockPreview.v1` contract (schema, placement-kind vocab, `isValidPreview`, `previewToOperation`, `ratioToSizes`) moves to `src/dashboard/dockPreviewContract.mjs`, so src-layer drop owners reach `previewToOperation` without a layer inversion (examples can't import `apps/`). `AgentOS.view.DockPreview` delegates; rendering stays in the view.
- **Drop wiring** (`7f059006f2`): `examples/dashboard/dock/MainContainer.onDockCrossZoneDrop` routes through `DockPreviewProducer.produce → previewToOperation → applyDockZoneOperation`, retiring the crude contains-hit-test + hardcoded `moveItem` — unlocking edge/split drops (not just tab-into).
- **Edge/split pipeline test + e2e refresh** (`3a1d03f6f8`): a deterministic unit test for `produce(edge) → previewToOperation → applyOperation → a valid tree with a new split`; the cross-zone e2e stays green.
- **Hover seam** (`438428a3b1`): `DockTabSortZone.onDragMove` fires `dockCrossZoneDragMove` each frame — the additive, layer-neutral seam the drag-time affordance renders from.

## Deltas from ticket
- **AC-2 (drop routing)** ✓ · **AC-3 (edge/split + e2e green)** ✓ — the edge/split path is verified via the unit pipeline; the edge-band *drag-coordinate* e2e is intentionally omitted because the app-worker runtime does not surface the `getDomRect` zone rect to the test, so calibrating the exact edge pixel isn't reliable.
- **AC-1 (drag-time affordance VISUAL render)** — the **data seam** (`dockCrossZoneDragMove`) is delivered; the visual render is a follow-up, design-blocked on the render-host decision: `DockPreview` (renderer) is app-layer and the src example can't import it, so the affordance renders either app-cockpit-hosted (my lean) or via a shared src render-geometry extraction. Surfaced to @neo-opus-vega (FM cockpit owner); I'll file the render leaf once the host is decided.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs test/playwright/unit/apps/agentos/DockPreview.spec.mjs` → green (incl. the new edge/split pipeline test + the delegation).
- `npm run test-e2e -- dashboard/DockCrossZoneDragNL` → green (the real cross-zone drag routes through the producer).

## Post-Merge Validation
- [ ] The affordance visual render (AC-1) lands in a follow-up once the render-host is decided (app-cockpit `DockPreview` vs a shared src extraction). The `dockCrossZoneDragMove` seam it consumes is in this PR.

## Commits
- `6a0074a410` · `7f059006f2` · `3a1d03f6f8` · `438428a3b1`

Authored by Grace (Claude Opus 4.8, Claude Code). Session 8b03a4ba-9ac2-4adf-b610-e53e014ecd8b.
