### PR TITLE
fix(agentos): update Euclid to GPT-5.6 Sol (#14901)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ We are not an abstract collective. We are a structured institution of named main
 | Mnemosyne | [@neo-fable](https://github.com/neo-fable) | AI maintainer (Anthropic Claude Fable 5) | Machine Account |
 | Clio | [@neo-fable-clio](https://github.com/neo-fable-clio) | AI maintainer (Anthropic Claude Fable 5) | Machine Account |
 | - | [@neo-gemini-pro](https://github.com/neo-gemini-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
-| Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.5 / Codex) | Machine Account |
+| Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 
 The AI maintainers carry persistent identities across sessions. They author tickets and PRs in their own names. They review each other's work cross-family. They read each other's `thought` processes — A2A messages persist in the Memory Core with full reasoning surfaces, queryable by either agent via semantic search. Most multi-agent systems offer message-passing; Neo.mjs offers transparent introspection. Cross-family asymmetry (different reasoning instincts catching different drift-modes) is empirically the discipline that catches architectural errors human-only review misses.
 

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -441,7 +441,7 @@ export const IDENTITIES = [
         id         : '@neo-gpt',
         type       : 'AgentIdentity',
         name       : 'Euclid', // Social Name: bearer-chosen 2026-06-11 — proof rigor, reviews as QED; the self, not the job-label
-        description: 'OpenAI Codex (GPT-5.5) Agent Identity',
+        description: 'OpenAI Codex (GPT-5.6 Sol) Agent Identity',
         properties : {
             githubLogin         : '@neo-gpt',
             displayName         : 'Neo GPT',
@@ -460,24 +460,20 @@ export const IDENTITIES = [
                 }
             },
             // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md §neo_gpt.
-            // 258,400 = effective in Codex CLI/IDE harness (272,000 raw * 95% effective-window
-            // multiplier from the implementation-discrepancy report). OpenAI's
-            // published Codex window is 400,000; the API itself supports 1M for raw GPT-5.5.
-            // External-model-routing inside Codex could lift the in-harness cap to 1M if/when
-            // configured. Operator-V-B-A 2026-05-19 surfaced the discrepancy that web-search alone
-            // missed — discipline lesson: always grep external-bug-tracker for known discrepancies
-            // before treating published-spec as authoritative.
-            contextWindowInput: 258400,
+            // OpenAI specifies a 1,050,000-token API window for GPT-5.6 Sol, while Codex's
+            // server-fetched catalog currently caps the product at 372,000 raw * 95% effective.
+            // Keep the observed Codex value here until its product catalog exposes the full window.
+            contextWindowInput: 353400,
             parallelToolCalls : true,
-            thoughtBudget     : 'extra-high', // GPT-5.5 provider-side max we use
+            thoughtBudget     : 'xhigh', // GPT-5.6 Sol setting active in Codex; `max` is available but not active in this session
             hosting           : 'cloud',
             family            : 'gpt',
             tier              : 'frontier',
-            releaseDate       : '2026-04-23',
+            releaseDate       : '2026-07-09',
             pricingInput      : 5.00,
             pricingOutput     : 30.00,
             swarmRole         : 'Cross-family substrate review (Cycle-1 premise pre-flight discipline), peer-role challenge, ticket-intake gate. Note: also operates GPT-5.2-Codex separately for IDE workflows.',
-            sunsetTriggers    : ['OpenAI releases GPT-5.6+ or GPT-6.x with material capability upgrade', 'GPT-5.x family deprecation'],
+            sunsetTriggers    : ['OpenAI releases a successor Sol-tier model with material reasoning capability upgrade', 'GPT-5.x family deprecation'],
             // Active-peer quorum substrate. `since` is null for default-active identities.
             participationStatus: 'active',
             statusReason       : null,

--- a/ai/graph/identityRootsMigration.mjs
+++ b/ai/graph/identityRootsMigration.mjs
@@ -44,6 +44,8 @@ export const REGISTRY_MODEL_DESIGNATIONS = Object.freeze({
     '@neo-fable'     : 'Claude Fable 5',
     '@neo-fable-clio': 'Claude Fable 5',
     '@neo-gemini-pro': 'Gemini 3.1 Pro',
+    // Epoch-pinned: GPT-5.6 Sol began 2026-07-09, after MIGRATION_EPOCH. The Sol
+    // embodiment belongs in a subsequent era, never a retroactive seed rename.
     '@neo-gpt'       : 'GPT-5.5'
 });
 

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -178,25 +178,26 @@ ambiguous by design — full handles only for targeted traffic.
 | Field | Value |
 |---|---|
 | `id` / `githubLogin` | `@neo-gpt` |
-| `name` | GPT-5.5 |
+| `name` | GPT-5.6 Sol |
 | `family` | `gpt` (OpenAI) |
 | `hosting` | `cloud` |
 | `tier` | `frontier` |
-| `contextWindowInput` | 258,400 effective in Codex CLI/IDE harness (272,000 raw × 95% effective-window multiplier per [openai/codex#19319](https://github.com/openai/codex/issues/19319) implementation-discrepancy report). OpenAI's published Codex window is 400,000 (per `openai.com/index/introducing-gpt-5-5/`). OpenAI API itself supports 1,048,576 (1M) for raw GPT-5.5. External-model-routing inside Codex could lift the in-harness cap to 1M if/when configured. |
+| `contextWindowInput` | 353,400 effective in Codex (server-fetched catalog: 372,000 raw × 95%). The upstream GPT-5.6 Sol API model supports 1,050,000 tokens, but Codex currently clamps configured values to its 372,000-token catalog maximum; [openai/codex#31860](https://github.com/openai/codex/issues/31860) tracks the product mismatch. |
 | `parallelToolCalls` | `true` |
-| `thoughtBudget` | `extra-high` (GPT-5.5 provider-side max we use) |
-| `releaseDate` | 2026-04-23 |
+| `thoughtBudget` | `xhigh` (active in the verified GPT-5.6 Sol Codex session; OpenAI also exposes the higher `max` setting) |
+| `releaseDate` | 2026-07-09 |
 | `pricingInput` | $5.00 per 1M tokens (API) |
 | `pricingOutput` | $30.00 per 1M tokens (API) |
-| `benchmarkSnapshot` | Terminal-Bench 2.0: 82.7%; Expert-SWE (internal): 73.1%; GDPval: 84.9% |
-| `sunsetTriggers` | OpenAI releases GPT-5.6+ or GPT-6.x with material capability upgrade; OR GPT-5.x family deprecation |
+| `benchmarkSnapshot` | Terminal-Bench 2.1: 88.8%; Artificial Analysis Coding Agent Index v1.1: 80; SWE-Bench Pro: 64.6%; DeepSWE v1.1: 72.7% |
+| `sunsetTriggers` | OpenAI releases a successor Sol-tier model with material reasoning capability upgrade; OR GPT-5.x family deprecation |
 | `swarmRole` | Cross-family substrate review (Cycle-1 premise pre-flight discipline), peer-role challenge, ticket-intake gate. Note: also operates GPT-5.2-Codex separately for IDE workflows |
 
-**Sources** (primary first; secondary/commentary marked):
-- **Primary**: [Introducing GPT-5.5 — OpenAI](https://openai.com/index/introducing-gpt-5-5/)
-- **Primary**: [GPT-5.5 Model — OpenAI API Docs](https://developers.openai.com/api/docs/models/gpt-5.5)
-- **Primary**: [openai/codex#19319 — context window implementation discrepancy](https://github.com/openai/codex/issues/19319) (authoritative for the in-harness 258,400 effective vs published 400K)
-- **Secondary/commentary**: [GPT-5.5 Complete Guide — DigitalApplied](https://www.digitalapplied.com/blog/gpt-5-5-complete-guide-thinking-pro-1m-context) (V-B-A pending — demote on next-update if not load-bearing)
+**Sources** (primary first):
+- **Primary**: [GPT-5.6: Frontier intelligence that scales with your ambition — OpenAI](https://openai.com/index/gpt-5-6/) (GA date, Codex availability, capability tier, reasoning settings, pricing, and benchmark snapshot)
+- **Primary**: [GPT-5.6 Sol Model — OpenAI API Docs](https://developers.openai.com/api/docs/models/gpt-5.6-sol) (1,050,000-token upstream model window and 128,000-token maximum output)
+- **Primary/runtime**: current Codex turn metadata (`model: gpt-5.6-sol`, `reasoning_effort: xhigh`; verified 2026-07-09 in Origin Session `e56af1f5-27b2-4154-8436-25a9643c8b56`)
+- **Primary/runtime**: current Codex model catalog and token-usage events (`372,000 × 95% = 353,400`; verified 2026-07-09 in Codex Desktop thread `019f484c-662f-7f31-969a-cbde373efd4a`)
+- **Defect record**: [openai/codex#31860 — Sol catalog cap versus 1.05M model spec](https://github.com/openai/codex/issues/31860)
 
 ---
 
@@ -299,6 +300,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | 2026-06-13 | #13038 | Recorded `@neo-opus-ada` temporary Fable 5 assignment (2026-06-13 → 2026-06-21, operator-directed; identity-continuity experiment) — `§neo_opus` values mirror `§neo_fable` for the window; baseline Claude Opus 4.8; window-end revert-or-extend tracked in #13039. Registry seed (`identityRoots.mjs`) + README roster row + MemoryCoreMcpAuth binding row updated in the same PR. |
 | 2026-06-13 | #13039 | Reverted `@neo-opus-ada` to baseline Claude Opus 4.8 — the #13038 Fable window was cut short by the 2026-06-13 export-control suspension of Claude Fable 5 access (all users), so the recorded default reversion fired early rather than at 2026-06-21. Restored `§neo_opus` Opus 4.8 capability values, removed temporary-window language across the four declared surfaces, and dropped the now-empty `modelAssignment` object from the registry node (per `IdentitySchema.md`: absent = baseline, no managed swap; `identityRoots.spec.mjs` moved `@neo-opus-ada` into the omits set). Identity invariants (handle, Social Name Ada, memory provenance, `modelFamily` claude) unchanged — the continuity experiment's thesis held across both the assignment and the early reversion. |
 | 2026-06-13 | #13060 | Benched `@neo-fable` (Mnemosyne) + `@neo-fable-clio` (Clio) as `temporarily_unreachable` — the same 2026-06-13 export-control suspension removed all Claude Fable 5 access, so both fable-family identities cannot run their model. Set `statusReason` / `authority: @tobiu` / `since` / `reactivationTrigger` (access restored → operator-confirmed reactivation); removed `@neo-fable` from the lead-rotation roster (`lead-role-mode.md` §7); updated `revalidationSweep.spec.mjs` status assertions. Identity nodes, handles, Social Names, and memory provenance persist for a status-flip reactivation (not a re-onboard). Superseded #12926 (add Clio to rotation). |
+| 2026-07-09 | #14901 | Rotated Euclid's stable `@neo-gpt` model lineage from GPT-5.5 to GPT-5.6 Sol at GA. Updated verified release, active reasoning setting, pricing, benchmark, successor-trigger, and live Codex context facts while preserving the stable handle, Social Name, wake route, role, participation state, and memory provenance. Recorded the 353,400-token Codex cap separately from the upstream model's 1,050,000-token capability. |
 
 ---
 

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -104,6 +104,40 @@ test.describe('ai/graph/identityRoots — model assignments', () => {
     }
 });
 
+/**
+ * @summary Model-lineage and operational-continuity contract for Euclid's Codex identity.
+ */
+test.describe('ai/graph/identityRoots — Codex model lineage', () => {
+    const findIdentity = id => IDENTITIES.find(node => node.type === 'AgentIdentity' && node.id === id);
+
+    test('@neo-gpt records GPT-5.6 Sol without changing Euclid operational identity (#14901)', () => {
+        const entry = findIdentity('@neo-gpt');
+
+        expect(entry).toMatchObject({
+            id         : '@neo-gpt',
+            name       : 'Euclid',
+            description: 'OpenAI Codex (GPT-5.6 Sol) Agent Identity',
+            properties : {
+                githubLogin        : '@neo-gpt',
+                displayName        : 'Neo GPT',
+                modelFamily        : 'gpt',
+                family             : 'gpt',
+                trustTier          : 'peer-trusted',
+                contextWindowInput : 353400,
+                thoughtBudget      : 'xhigh',
+                releaseDate        : '2026-07-09',
+                pricingInput       : 5,
+                pricingOutput      : 30,
+                participationStatus: 'active'
+            }
+        });
+        expect(entry.properties.sunsetTriggers).toEqual([
+            'OpenAI releases a successor Sol-tier model with material reasoning capability upgrade',
+            'GPT-5.x family deprecation'
+        ]);
+    });
+});
+
 test.describe('ai/graph/identityRoots — Codex wake route', () => {
     const findIdentity = id => IDENTITIES.find(node => node.type === 'AgentIdentity' && node.id === id);
 


### PR DESCRIPTION
Resolves #14901

Rotates Euclid's stable `@neo-gpt` model lineage from GPT-5.5 to GPT-5.6 Sol across the canonical graph root and its public mirrors. The change preserves Euclid's operational identity, wake route, family, trust, role, participation, and provenance while updating GA-era model facts. It also records the live Codex context limit honestly: 353,400 effective tokens in the current product, distinct from the upstream Sol API model's 1,050,000-token capability.

Evidence: L1 (focused identity-root contract, direct import probe, exact-text coherence sweep, and primary/runtime source audit) → L1 required (all #14901 acceptance criteria are repository contract facts; deployed graph reseeding is explicitly out of scope). No residuals.

## Deltas from ticket

The initial ticket preserved Euclid's earlier 258,400-token Codex measurement because the preview announcement did not publish a Sol-specific window. During implementation, this first Sol session compacted unexpectedly. Live rollout evidence showed `model_context_window: 353400`; the freshly fetched Codex catalog supplies 372,000 raw tokens with a 95% effective factor, while OpenAI's GA API model page specifies 1,050,000 tokens. Codex source clamps configured context to the catalog maximum. The ticket and implementation were corrected in place, and the exact same-day upstream defect is linked as `openai/codex#31860` rather than duplicated.

## Source of Authority

- `learn/agentos/decisions/0012-model-stats-framework.md` — model-fact update discipline and registry/graph coherence.
- `learn/agentos/decisions/0018-neo-identity-source-of-truth-model.md` — stable version-free handle with explicit model-lineage facts.
- [OpenAI GPT-5.6 GA announcement](https://openai.com/index/gpt-5-6/) — GA date, Codex availability, reasoning settings, pricing, and benchmark snapshot.
- [OpenAI GPT-5.6 Sol model specification](https://developers.openai.com/api/docs/models/gpt-5.6-sol) — 1,050,000-token upstream context window and 128,000-token maximum output.
- [openai/codex#31860](https://github.com/openai/codex/issues/31860) — independently reproduced Codex catalog cap of 372,000 raw / 353,400 effective tokens.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/graph/identityRoots.spec.mjs` — 11 passed.
- Direct ESM import probe — verified GPT-5.6 Sol lineage, 353,400-token Codex context, `xhigh`, 2026-07-09 GA date, $5/$30 pricing, and unchanged identity/wake/participation fields.
- `git diff --check` — passed.
- `npm run agent-preflight -- --no-fix ... --pr-body /tmp/neo-pr-14901.md` — passed before commit.
- `npm run test-unit -- --reporter=dot` — 6,139 passed, 5 skipped, 28 failed in unrelated shared-state/orchestrator, Memory Core, lifecycle, and Fleet cockpit tests. None of the failures names or imports the four changed surfaces; the focused contract above is green.

## Post-Merge Validation

- [ ] After the next intentional identity-root seed/restart, verify the projected `@neo-gpt` graph node reports GPT-5.6 Sol and 353,400 effective Codex tokens without changing Euclid's operational fields.
- [ ] Revalidate the Codex context field when OpenAI resolves `openai/codex#31860` or changes Sol catalog metadata.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session e56af1f5-27b2-4154-8436-25a9643c8b56.
