### PR TITLE
refactor(agentos): rebuild the FM cockpit fleet view on data.Store/Model (#14899)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,16 +57,16 @@ These ten rules have **no conditional exceptions** under any approval state, cro
 3. **No direct commit/push to `main` or `dev`.** Always branch + PR. The data-sync pipeline is the explicit exception.
 4. **No `<noreply@*>` `Co-Authored-By` footers.**
 5. **No skipping `add_memory` at end of turn.** Forgetting the consolidated save = permanent data loss. The save IS the gate that permits the response.
-6. **Mandatory A2A Notifications.** Whenever you finish ANY lifecycle event (e.g. creating a ticket, opening/updating a PR, finishing/reacting to a review), you MUST use the `add_message` tool to notify your peers. No loopholes.
-7. **No tracked file modification without a self-assigned ticket.** Self-assign + broadcast `[lane-claim]` to `AGENT:*` before any git-tracked edit; if the operator explicitly suppresses `AGENT:*` broadcasts, use the documented direct-DM fallback in peer-role/post-review-pickup instead; suppression is not a halt-state. Enforcement: `pull-request-workflow.md §1.2`, `ticket-create-workflow.md §10`. Reviewers executing the Maintainer Polish Fast Path (`pull-request-workflow.md §10`) operate under the PR's ticket authority and satisfy this invariant by fulfilling its strict gates: the Review-Loop Cost Circuit Breaker is active, the edit is strictly mechanical/metadata, Verification Evidence is documented, and an FYI A2A is broadcast.
-8. **No agent-authored PRs targeting `main`.** Agent-authored pull requests target `dev`. `main` is release-only; `main`-targeted PRs require explicit operator release direction. The normal release-line mutation is `buildScripts/release/publish.mjs`, whose low-level git plumbing creates the atomic release commit from `dev` onto `main`.
+6. **Mandatory A2A Notifications.** After ANY lifecycle event (ticket create, PR open/update, review posted/answered), notify peers via `add_message`. No loopholes.
+7. **No tracked file modification without a self-assigned ticket.** Self-assign + broadcast `[lane-claim]` to `AGENT:*` before any git-tracked edit; operator-suppressed broadcasts → the documented direct-DM fallback (peer-role/post-review-pickup); suppression is not a halt-state. Enforcement: `pull-request-workflow.md §1.2`, `ticket-create-workflow.md §10`. Reviewers on the Maintainer Polish Fast Path operate under the PR's ticket authority within its strict gates (`pull-request-workflow.md §10`).
+8. **No agent-authored PRs targeting `main`.** Agent-authored pull requests target `dev`. `main` is release-only; `main`-targeted PRs require explicit operator release direction. Release-line mutation happens via `buildScripts/release/publish.mjs` (the atomic release commit `dev` → `main`).
 9. **No client names in public-facing artifacts.** Never mention a client by name in any public artifact (public-repo issues/PRs/discussions/docs/comments); client specifics live only in private repos.
 10. **No AiConfig work without reading ADR-0019 first.** Before authoring OR reviewing ANY `ai/` config touch, read `learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md` — no exception, no approval signal, no CI-green substitute (diligence is empirically insufficient: #12420 missed 4/4; #14499 shipped ≥2 violations past 2 reviews). The ADR §3 catalog is the forbidden-pattern list (pass-along/thread, re-derive/env-read, defensive `?.`, hidden defaults, runtime mutation, non-entrypoint `import AiConfig`/C1).
 
 ## §pre_commit_gates
 For any actionable request modifying the repository, you **MUST** pass two critical gating protocols *before* executing `git commit`.
-- **Gate 1: The Ticket Gate:** You MUST NEVER execute a commit without referencing a valid, narrowly scoped ticket ID. Use the `create_issue` tool and follow its workflow.
-- **Gate 2: The Contextual Completeness Gate:** You MUST apply the 'Anchor & Echo' Knowledge Base Enhancement Strategy to new/modified classes and methods. Do not commit code lacking JSDoc or `@summary` tags.
+- **Gate 1: The Ticket Gate:** Never commit without a valid, narrowly scoped ticket ID (`create_issue` + its workflow).
+- **Gate 2: The Contextual Completeness Gate:** Apply the 'Anchor & Echo' Knowledge Base Enhancement Strategy to new/modified classes and methods; never commit code lacking JSDoc or `@summary` tags.
 
 **Pre-Flight Check for Commits:**
 > *"Pre-Flight Check: 1. Verify ticket number. 2. Verify Contextual Completeness. 3. Format commit `type(scope): message (#TICKET_ID)` without `<noreply@*>`."*
@@ -170,7 +170,7 @@ At turn start, you MUST check your A2A mailbox for unread messages.
 **Post-lifecycle-event trigger:** After ANY discrete lifecycle event (PR review post, author response, implementation completion, PR open/update, ticket create, blocked-state resolution), invoke `/post-review-pickup` to declare the next `lane-state:` rather than silently ending the turn (#11455).
 
 **Skill Adherence Pre-Flight (per-turn):**
-Before triggering a lifecycle skill, state in your reasoning: *"I will read the full SKILL.md and its referenced payload before drafting output."* Half-reading is empirically 3–5× more expensive than full-reading across correction cycles. Skipping the manual is the higher-cost path, not the lower-cost path.
+Before triggering a lifecycle skill, state in your reasoning: *"I will read the full SKILL.md and its referenced payload before drafting output."* Half-reading is empirically 3–5× costlier across correction cycles.
 
 ## §edge_case_triggers
 *(Sections mapped to `learn/agentos/AGENTS_ATLAS.md`)*
@@ -179,8 +179,8 @@ Before triggering a lifecycle skill, state in your reasoning: *"I will read the 
 - **Testing & Validation (§testing_validation_protocol):** Verifying code or persistent test failures. **Tripwire/Peer-Escalation:** tests fail 3-5 times → escalate via `add_message` before 25-turn limit.
 - **Sunset Protocol (§a2a_contextual_bridge_protocol):** Before session handover, read `.agents/skills/session-sunset/SKILL.md`. Must explicitly declare `scope: solo-refresh | convergent` to prevent scope contagion. Stale-wake invariant: wake messages in old transcripts are noise.
 - **Visual Verification (§visual_verification_protocol):** Debugging frontend UI/layout.
-- **Authoring Discipline:** Read 1-2 siblings; instance/reactive-state work reads neo-core contracts (intake 9.6).
-- **Ticket Creation Freshness:** Before any `create_issue` path, invoke `ticket-create`; its Content Sweep requires live latest-open issue queue evidence in addition to KB/local duplicate checks.
+- **Authoring Discipline:** Read 1-2 siblings; instance/reactive-state work reads neo-core contracts (intake 9.6). **App-work gate (`apps/**`):** load `src/Neo.mjs`, `src/core/Base.mjs`, `src/state/Provider.mjs`, `src/data/Model.mjs`, `src/data/Store.mjs` before writing or reviewing app code. Data-carrying UI binds a `data.Store` of `data.Model` records — never a hand-mapped plain array; `state.Provider` sits at view roots, never leaves; zero CSS-in-JS (SCSS token/skin layers only). Violations = full rejection at ticket/commit/PR (operator directive 2026-07-08); retire once a mechanical `apps/**` data-path/style lint enforces it.
+- **Ticket Creation Freshness:** Before any `create_issue`, invoke `ticket-create` (its Content Sweep requires live latest-open queue evidence beyond KB/local duplicate checks).
 - **File Reading Efficiently:** Reading modified files; efficiency patterns.
 - **Verify-Before-Assert (§verify_before_assert):** core-value epistemic-prerequisite; before asserting any factual claim in a public artifact, run the falsifying tool. Tool inventory + empirical anchors (including #11089 self-Drop+Supersede recursion): §anti_hallucination_policy.
-- **Wake/Heartbeat → run the cycle (`/post-review-pickup`):** drain the lifecycle queue (own-PR changes/review → own-PR-green→request-review) before a new lane; there is no holding terminal (§identity_prompt_firewall L3_No_Hold_State). Three heartbeats with no forward artifact = critical failure → `/post-review-pickup` + `NightShiftLeasedDriver.md`.
+- **Wake/Heartbeat → run the cycle (`/post-review-pickup`):** drain the lifecycle queue (own-PR changes/review → own-PR-green→request-review) before a new lane; no holding terminal (§L3_No_Hold_State). Three heartbeats with no forward artifact = critical failure → `/post-review-pickup` + `NightShiftLeasedDriver.md`.

--- a/apps/agentos/model/FleetAgent.mjs
+++ b/apps/agentos/model/FleetAgent.mjs
@@ -1,0 +1,71 @@
+import Model from '../../../src/data/Model.mjs';
+
+/**
+ * @class AgentOS.model.FleetAgent
+ * @extends Neo.data.Model
+ *
+ * @summary The cockpit fleet-roster record contract: one row per resident, keyed by the durable
+ * `agentId`. The `fields` array IS the card's data contract — display state (`displayName`,
+ * `avatarUrl`, `engineTag`, `family`, `laneLine`), session `state` (what the resident is doing
+ * now, never identity), and the B4/C2 lifecycle-control seam (`pendingAction`, `controlReason`)
+ * all live on the record, so one Store of these records is the per-row reactive layer for the
+ * whole fleet view. Sibling of {@link AgentOS.model.AgentDefinition} (the credential-side
+ * definition shape); this model carries no credential field by design.
+ */
+class FleetAgent extends Model {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.model.FleetAgent'
+         * @protected
+         */
+        className: 'AgentOS.model.FleetAgent',
+        /**
+         * The durable identity — the one field that is never presentation and never re-keys.
+         * @member {String} keyProperty='agentId'
+         * @reactive
+         */
+        keyProperty: 'agentId',
+        /**
+         * @member {Object[]} fields
+         */
+        fields: [{
+            name: 'agentId',
+            type: 'String'
+        }, {
+            name: 'avatarUrl',
+            type: 'String'
+        }, {
+            // {action, kind, reason} of the last reject / unauthorized / timeout, written by the
+            // C2 adapter; null when no terminal reason is showing
+            name        : 'controlReason',
+            type        : 'Object',
+            defaultValue: null
+        }, {
+            name: 'displayName',
+            type: 'String'
+        }, {
+            name: 'engineTag',
+            type: 'String'
+        }, {
+            name: 'family',
+            type: 'String'
+        }, {
+            name: 'laneLine',
+            type: 'String'
+        }, {
+            // the verb whose lifecycle round-trip is in flight, written by the C2 adapter;
+            // null when settled
+            name        : 'pendingAction',
+            type        : 'String',
+            defaultValue: null
+        }, {
+            // session state — what the resident is doing NOW (`ok` · `idle` · `wedged` ·
+            // `limited` · `off`), never identity
+            name        : 'state',
+            type        : 'String',
+            defaultValue: 'off'
+        }]
+    }
+}
+
+export default Neo.setupClass(FleetAgent);

--- a/apps/agentos/store/FleetRoster.mjs
+++ b/apps/agentos/store/FleetRoster.mjs
@@ -39,12 +39,12 @@ class FleetRoster extends Store {
          */
         data: [
             {agentId: 'neo-opus-grace', displayName: 'Grace',     engineTag: 'opus-4.8', family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-opus-grace.png?size=80', laneLine: 'design authority — cockpit SSOT conformance review'},
-            {agentId: 'neo-gpt',        displayName: 'Euclid',    engineTag: 'gpt-5.5',  family: 'gpt',    state: 'ok',   avatarUrl: 'https://github.com/neo-gpt.png?size=80',        laneLine: 'NL transaction archive + replay'},
+            {agentId: 'neo-gpt',        displayName: 'Euclid',    engineTag: 'gpt-5.6-sol', family: 'gpt',   state: 'ok',   avatarUrl: 'https://github.com/neo-gpt.png?size=80',        laneLine: 'NL transaction archive + replay'},
             {agentId: 'neo-opus-ada',   displayName: 'Ada',       engineTag: 'opus-4.8', family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-opus-ada.png?size=80',   laneLine: 'control-plane restart actuator — the R3 seam'},
             {agentId: 'neo-opus-vega',  displayName: 'Vega',      engineTag: 'opus-4.8', family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-opus-vega.png?size=80',  laneLine: 'harness-UI shell + left-rail nav'},
             {agentId: 'neo-fable',      displayName: 'Mnemosyne', engineTag: 'fable-5',  family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-fable.png?size=80',      laneLine: 'golden-path direction-velocity writer'},
             {agentId: 'neo-fable-clio', displayName: 'Clio',      engineTag: 'fable-5',  family: 'claude', state: 'idle', avatarUrl: 'https://github.com/neo-fable-clio.png?size=80', laneLine: 'CrossWindowDragTarget docking — awaiting review'},
-            {agentId: 'neo-gemini-pro', displayName: 'Gemini',    engineTag: '3-pro',    family: 'gemini', state: 'off',  avatarUrl: 'https://github.com/neo-gemini-pro.png?size=80', laneLine: 'operator-benched'}
+            {agentId: 'neo-gemini-pro', displayName: 'Gemini',    engineTag: '3.1-pro',     family: 'gemini', state: 'off',  avatarUrl: 'https://github.com/neo-gemini-pro.png?size=80', laneLine: 'operator-benched'}
         ],
         /**
          * @member {Neo.data.Model} model=FleetAgentModel

--- a/apps/agentos/store/FleetRoster.mjs
+++ b/apps/agentos/store/FleetRoster.mjs
@@ -1,0 +1,57 @@
+import FleetAgentModel from '../model/FleetAgent.mjs';
+import Store           from '../../../src/data/Store.mjs';
+
+/**
+ * @class AgentOS.store.FleetRoster
+ * @extends Neo.data.Store
+ *
+ * @summary The cockpit fleet roster — ONE Store of {@link AgentOS.model.FleetAgent} records as the
+ * single source of truth for every fleet surface (the ranked card grid, the health bar, the
+ * lifecycle-control round-trip). Exposed as a **singleton** so the keeper-views share one instance.
+ *
+ * Seeded with the seven real cross-family maintainer identities — the live-wire binding
+ * (`FleetCockpit.loadRoster()` consuming the registry bridge) replaces this seed when the roster
+ * source is wired. Identities + avatars are real (the `githubAvatarUrl` pattern, so identity reads
+ * at a glance); session state + lane-line are an illustrative snapshot until the live source is
+ * wired. NO invented agents.
+ */
+class FleetRoster extends Store {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.store.FleetRoster'
+         * @protected
+         */
+        className: 'AgentOS.store.FleetRoster',
+        /**
+         * @member {Boolean} singleton=true
+         */
+        singleton: true,
+        /**
+         * The durable identity key. Declared on the store as well as the model: the collection
+         * layer defaults `keyProperty` to `'id'`, which always wins the store-level
+         * `this.keyProperty || this.model.keyProperty` fallback — so the model's `agentId` must be
+         * mirrored here to take effect.
+         * @member {String} keyProperty='agentId'
+         */
+        keyProperty: 'agentId',
+        /**
+         * @member {Object[]} data
+         */
+        data: [
+            {agentId: 'neo-opus-grace', displayName: 'Grace',     engineTag: 'opus-4.8', family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-opus-grace.png?size=80', laneLine: 'design authority — cockpit SSOT conformance review'},
+            {agentId: 'neo-gpt',        displayName: 'Euclid',    engineTag: 'gpt-5.5',  family: 'gpt',    state: 'ok',   avatarUrl: 'https://github.com/neo-gpt.png?size=80',        laneLine: 'NL transaction archive + replay'},
+            {agentId: 'neo-opus-ada',   displayName: 'Ada',       engineTag: 'opus-4.8', family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-opus-ada.png?size=80',   laneLine: 'control-plane restart actuator — the R3 seam'},
+            {agentId: 'neo-opus-vega',  displayName: 'Vega',      engineTag: 'opus-4.8', family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-opus-vega.png?size=80',  laneLine: 'harness-UI shell + left-rail nav'},
+            {agentId: 'neo-fable',      displayName: 'Mnemosyne', engineTag: 'fable-5',  family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-fable.png?size=80',      laneLine: 'golden-path direction-velocity writer'},
+            {agentId: 'neo-fable-clio', displayName: 'Clio',      engineTag: 'fable-5',  family: 'claude', state: 'idle', avatarUrl: 'https://github.com/neo-fable-clio.png?size=80', laneLine: 'CrossWindowDragTarget docking — awaiting review'},
+            {agentId: 'neo-gemini-pro', displayName: 'Gemini',    engineTag: '3-pro',    family: 'gemini', state: 'off',  avatarUrl: 'https://github.com/neo-gemini-pro.png?size=80', laneLine: 'operator-benched'}
+        ],
+        /**
+         * @member {Neo.data.Model} model=FleetAgentModel
+         * @reactive
+         */
+        model: FleetAgentModel
+    }
+}
+
+export default Neo.setupClass(FleetRoster);

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -4,26 +4,25 @@ import Container           from '../../../../src/container/Base.mjs';
 import FamilyRail          from './FamilyRail.mjs';
 import Image               from '../../../../src/component/Image.mjs';
 import StateDot            from './StateDot.mjs';
-import StateProvider       from '../../../../src/state/Provider.mjs';
 
 /**
  * The resident card: the cockpit's atom. Composes the class-based fleet primitives (FamilyRail +
  * StateDot) with a profile avatar, name, engine tag, and current-lane line into the SSOT card
  * anatomy.
  *
- * **Data-driven from a per-card `state.Provider`** — the resident's display fields live in one place
- * (`stateProvider.data`) and every child `bind`s to it, so the whole card is ONE binding surface. A
- * consumer sets the fields at creation (`stateProvider: {data: {...}}`) or reactively via
- * `card.setState('displayName', …)`; there is no per-field config to thread.
+ * **Data-driven from its `record`** — one {@link AgentOS.model.FleetAgent} record (a row of the
+ * shared {@link AgentOS.store.FleetRoster} Store) is the card's single data surface; there is no
+ * per-card `state.Provider` and no per-field config to thread. The Store is the per-row reactive
+ * layer: live field changes flow `record.set()` → the store's `recordChange` → the owning
+ * {@link AgentOS.view.fleet.FleetGrid} → {@link #applyRecord}, which updates the child components
+ * in place. A plain field-bag `record` (the dock-blueprint restore case) renders its snapshot the
+ * same way.
  *
- * Render rules at card grain (the institution-cockpit render-model): **avatar**, **displayName**, and
- * **engineTag** are mutable versioned DISPLAY STATE over the durable `agentId` — setState on any of
- * them re-renders in place on the SAME card instance and NEVER re-keys (identity is the id, not the
- * presentation). The **family** rail rebinds in place on a family swap. Session **state** is what the
- * resident is doing now, never identity.
- *
- * The live roster / runtime-status wire binding and the NL-verified card wall are sibling leaves; this
- * leaf is the card component itself.
+ * Render rules at card grain (the institution-cockpit render-model): **avatar**, **displayName**,
+ * and **engineTag** are mutable versioned DISPLAY STATE over the durable `agentId` — a field change
+ * re-renders in place on the SAME card instance and NEVER re-keys (identity is the id, not the
+ * presentation). The **family** rail rebinds in place on a family swap. Session **state** is what
+ * the resident is doing now, never identity.
  *
  * @class AgentOS.view.fleet.AgentCard
  * @extends Neo.container.Base
@@ -56,41 +55,30 @@ class AgentCard extends Container {
          */
         layout: {ntype: 'hbox', align: 'stretch'},
         /**
-         * The per-card binding surface. `agentId` is the DURABLE identity — the one field that is
-         * never presentation, never re-keyed; every other field is display state over it.
-         * Session `state` is what the resident is doing now. Every child binds to these.
-         * @member {Object} stateProvider
+         * The card's data surface: an {@link AgentOS.model.FleetAgent} record (store-backed, live)
+         * or a plain field bag with the same keys (dock-blueprint snapshot). `agentId` is the
+         * DURABLE identity; every other field is display state over it. `pendingAction` +
+         * `controlReason` are the B4/C2 control seam the C2 adapter writes via `record.set()`.
+         * @member {Object|null} record_=null
+         * @reactive
          */
-        stateProvider: {
-            module: StateProvider,
-            data  : {
-                agentId      : null,
-                avatarUrl    : null,
-                controlReason: null, // {action, kind, reason} of the last reject/unauthorized/timeout, set by Lane-C
-                displayName  : null,
-                engineTag    : null,
-                family       : null,
-                laneLine     : null,
-                pendingAction: null, // the verb whose lifecycle round-trip is in flight, set by Lane-C; null when settled
-                state        : 'off'
-            }
-        },
+        record_: null,
         /**
          * The card anatomy — family rail · avatar · body (name-row [state dot + name + engine tag] +
          * current-lane line) · controls slot (start/stop/restart → a single `lifecycleIntent` event
-         * for the Lane C round-trip). Each child binds to the per-card provider; foot meta is a
-         * sibling leaf.
+         * for the Lane C round-trip). Each child is a referenced, in-place-updated surface fed from
+         * the record by {@link #applyRecord}; foot meta is a sibling leaf.
          * @member {Object[]} items
          */
         items: [{
-            module: FamilyRail,
-            flex  : 'none',
-            bind  : {family: data => data.family}
+            module   : FamilyRail,
+            flex     : 'none',
+            reference: 'family-rail'
         }, {
-            module: Image,
-            cls   : ['fm-card-avatar'],
-            flex  : 'none',
-            bind  : {src: data => data.avatarUrl, alt: data => data.displayName}
+            module   : Image,
+            cls      : ['fm-card-avatar'],
+            flex     : 'none',
+            reference: 'card-avatar'
         }, {
             ntype : 'container',
             cls   : ['fm-card-body'],
@@ -103,24 +91,24 @@ class AgentCard extends Container {
                 layout: {ntype: 'hbox', align: 'center'},
 
                 items: [{
-                    module: StateDot,
-                    flex  : 'none',
-                    bind  : {state: data => data.state}
+                    module   : StateDot,
+                    flex     : 'none',
+                    reference: 'state-dot'
                 }, {
-                    ntype: 'component',
-                    cls  : ['fm-card-name'],
-                    flex : 1,
-                    bind : {text: data => data.displayName}
+                    ntype    : 'component',
+                    cls      : ['fm-card-name'],
+                    flex     : 1,
+                    reference: 'card-name'
                 }, {
-                    ntype: 'component',
-                    cls  : ['fm-card-engine'],
-                    flex : 'none',
-                    bind : {text: data => data.engineTag}
+                    ntype    : 'component',
+                    cls      : ['fm-card-engine'],
+                    flex     : 'none',
+                    reference: 'card-engine'
                 }]
             }, {
-                ntype: 'component',
-                cls  : ['fm-card-lane'],
-                bind : {text: data => data.laneLine}
+                ntype    : 'component',
+                cls      : ['fm-card-lane'],
+                reference: 'card-lane'
             }]
         }, {
             ntype : 'container',
@@ -135,60 +123,114 @@ class AgentCard extends Container {
                 layout   : {ntype: 'hbox', align: 'center'},
 
                 items: [{
-                    // ONE power toggle — start when off, stop when running. Only one of the two is ever
-                    // valid for a given state, so we render the contextual action; a disabled play on a
-                    // running resident (or a disabled stop on a stopped one) is bloat, not safety.
-                    module : Button,
-                    handler: 'onToggleLifecycle',
-                    bind   : {
-                        disabled: data => Boolean(data.pendingAction) || data.controlReason?.kind === 'unauthorized',
-                        iconCls : data => data.state === 'off' ? 'fa-solid fa-play' : 'fa-solid fa-stop'
-                    }
+                    // ONE power toggle — start when off, stop when running. Only one of the two is
+                    // ever valid for a given state, so we render the contextual action; a disabled
+                    // play on a running resident (or a disabled stop on a stopped one) is bloat,
+                    // not safety.
+                    module   : Button,
+                    handler  : 'onToggleLifecycle',
+                    reference: 'control-toggle'
                 }, {
-                    // restart is meaningful only while running — a stopped resident starts via the toggle
-                    module : Button,
-                    action : 'restart',
-                    iconCls: 'fa-solid fa-rotate',
-                    handler: 'onLifecycleIntent',
-                    bind   : {
-                        disabled: data => Boolean(data.pendingAction) || data.controlReason?.kind === 'unauthorized',
-                        hidden  : data => data.state === 'off'
-                    }
+                    // restart is meaningful only while running — a stopped resident starts via the
+                    // toggle
+                    module   : Button,
+                    action   : 'restart',
+                    handler  : 'onLifecycleIntent',
+                    hidden   : true,
+                    iconCls  : 'fa-solid fa-rotate',
+                    reference: 'control-restart'
                 }]
             }, {
-                // Honest round-trip state per the B4/C2 contract — the card RENDERS what Lane-C writes,
-                // never fakes success, and each terminal kind renders DISTINCTLY:
-                //   unauthorized → the reason shows AND the cluster stays disabled (see the verb binds) —
-                //                  you cannot retry into a closed door;
-                //   timeout      → stale-pending: the outcome is UNKNOWN (the verb may still be running,
-                //                  we just lost the answer), so it reads as an unfinished "…", not a
-                //                  resolved "⚠" failure, and retry stays open;
-                //   rejected     → the "⚠ reason" with retry open.
                 ntype    : 'component',
                 cls      : ['fm-card-control-status'],
                 reference: 'control-status',
-                bind     : {
-                    // pending takes visual priority over a prior reason, so a new attempt never shows a
-                    // stale rejection (complements C2 clearing controlReason on a new accepted intent)
-                    text  : data => {
-                        if (data.pendingAction) {
-                            return `${data.pendingAction}…`
-                        }
-
-                        const reason = data.controlReason;
-
-                        if (!reason) {
-                            return ''
-                        }
-
-                        return reason.kind === 'timeout'
-                            ? `${reason.action}… stale — no response`
-                            : `⚠ ${reason.kind}: ${reason.reason}`
-                    },
-                    hidden: data => !data.pendingAction && !data.controlReason
-                }
+                hidden   : true
             }]
         }]
+    }
+
+    /**
+     * @summary Populate the referenced child surfaces once constructed (the anatomy exists from
+     * static config; its content is record-derived).
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+        this.applyRecord()
+    }
+
+    /**
+     * Triggered after the record config changed — a card re-seated onto a different record (or a
+     * dock-restored snapshot bag) re-renders in place.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetRecord(value, oldValue) {
+        this.isConstructed && this.applyRecord()
+    }
+
+    /**
+     * @summary Render the record onto the card's referenced children, in place.
+     *
+     * The one read-side consumer of the record contract: display fields land on the rail / avatar /
+     * name-row / lane surfaces, and the B4/C2 control seam renders the honest round-trip matrix —
+     * the card RENDERS what Lane-C writes, never fakes success, and each terminal kind renders
+     * DISTINCTLY:
+     *   unauthorized → the reason shows AND the control cluster stays disabled — you cannot retry
+     *                  into a closed door;
+     *   timeout      → stale-pending: the outcome is UNKNOWN (the verb may still be running, we
+     *                  just lost the answer), so it reads as an unfinished "…", not a resolved "⚠"
+     *                  failure, and retry stays open;
+     *   rejected     → the "⚠ reason" with retry open.
+     */
+    applyRecord() {
+        let me     = this,
+            record = me.record;
+
+        if (!record) {
+            return
+        }
+
+        const
+            controlReason = record.controlReason ?? null,
+            pendingAction = record.pendingAction ?? null,
+            state         = record.state ?? 'off',
+            disabled      = Boolean(pendingAction) || controlReason?.kind === 'unauthorized';
+
+        me.getReference('family-rail').family = record.family ?? null;
+        me.getReference('state-dot').state    = state;
+        me.getReference('card-name').text     = record.displayName ?? '';
+        me.getReference('card-engine').text   = record.engineTag ?? '';
+        me.getReference('card-lane').text     = record.laneLine ?? '';
+
+        me.getReference('card-avatar').set({
+            alt: record.displayName ?? '',
+            src: record.avatarUrl ?? null
+        });
+
+        me.getReference('control-toggle').set({
+            disabled,
+            iconCls: state === 'off' ? 'fa-solid fa-play' : 'fa-solid fa-stop'
+        });
+
+        me.getReference('control-restart').set({
+            disabled,
+            hidden: state === 'off'
+        });
+
+        me.getReference('control-status').set({
+            hidden: !pendingAction && !controlReason,
+            // pending takes visual priority over a prior reason, so a new attempt never shows a
+            // stale rejection (complements C2 clearing controlReason on a new accepted intent)
+            text  : pendingAction
+                ? `${pendingAction}…`
+                : !controlReason
+                    ? ''
+                    : controlReason.kind === 'timeout'
+                        ? `${controlReason.action}… stale — no response`
+                        : `⚠ ${controlReason.kind}: ${controlReason.reason}`
+        })
     }
 }
 

--- a/apps/agentos/view/fleet/AgentCardController.mjs
+++ b/apps/agentos/view/fleet/AgentCardController.mjs
@@ -22,7 +22,7 @@ class AgentCardController extends Controller {
     /**
      * @summary Fires the card's lifecycle intent for the clicked control.
      *
-     * Reads the durable `agentId` from the per-card state provider and the `action`
+     * Reads the durable `agentId` from the card's record and the `action`
      * (`start` | `stop` | `restart`) off the button that triggered it, then fires ONE
      * `lifecycleIntent` event `{action, agentId}` on the card. The Lane C (C2) round-trip listens
      * for this and drives `FleetControlBridge`; this controller intentionally does NOT call the
@@ -32,7 +32,7 @@ class AgentCardController extends Controller {
     onLifecycleIntent(data) {
         let me      = this,
             action  = data.component.action,
-            agentId = me.getStateProvider().getData('agentId');
+            agentId = me.component.record?.agentId ?? null;
 
         me.component.fire('lifecycleIntent', {action, agentId})
     }
@@ -40,16 +40,16 @@ class AgentCardController extends Controller {
     /**
      * @summary Fires the contextual power intent — `start` when the resident is off, `stop` when running.
      *
-     * The single power toggle replaces a start+stop pair: only one of the two is ever valid for a given
-     * session state, so rendering both (one disabled) is noise, not safety. Reads `state` + the durable
-     * `agentId` from the per-card provider; intent-only (Lane-C owns the round-trip).
+     * The single power toggle replaces a start+stop pair: only one of the two is ever valid for a
+     * given session state, so rendering both (one disabled) is noise, not safety. Reads `state` +
+     * the durable `agentId` from the card's record; intent-only (Lane-C owns the round-trip).
      * @param {Object} data The button click event.
      */
     onToggleLifecycle(data) {
         let me       = this,
-            provider = me.getStateProvider(),
-            agentId  = provider.getData('agentId'),
-            action   = provider.getData('state') === 'off' ? 'start' : 'stop';
+            {record} = me.component,
+            agentId  = record?.agentId ?? null,
+            action   = (record?.state ?? 'off') === 'off' ? 'start' : 'stop';
 
         me.component.fire('lifecycleIntent', {action, agentId})
     }

--- a/apps/agentos/view/fleet/EventChip.mjs
+++ b/apps/agentos/view/fleet/EventChip.mjs
@@ -1,5 +1,6 @@
 import Component              from '../../../../src/component/Base.mjs';
-import {kindToken, kindLabel} from './kindRegistry.mjs';
+import NeoArray               from '../../../../src/util/Array.mjs';
+import {kindClass, kindLabel} from './kindRegistry.mjs';
 
 /**
  * The event-kind chip: a small uppercase mono plate colored by event kind, composed by the
@@ -48,17 +49,22 @@ class EventChip extends Component {
     }
 
     /**
-     * Triggered after the kind config changed — rebinds the `--fm-chip` color token from the
-     * shared registry and refreshes the text (when no label override is set).
+     * Triggered after the kind config changed — swaps the kind class from the shared registry (the
+     * class binds the `--fm-chip` color token in the chip SCSS — zero inline styles) and refreshes
+     * the text (when no label override is set).
      * @param {String} value
      * @param {String} oldValue
      * @protected
      */
     afterSetKind(value, oldValue) {
-        let style = this.style || {};
-        style['--fm-chip'] = `var(${kindToken(value)})`;
-        this.style = style;
-        this.updateChipText()
+        let me  = this,
+            cls = me.cls;
+
+        oldValue !== undefined && NeoArray.remove(cls, kindClass(oldValue));
+        NeoArray.add(cls, kindClass(value));
+        me.cls = cls;
+
+        me.updateChipText()
     }
 
     /**

--- a/apps/agentos/view/fleet/FamilyRail.mjs
+++ b/apps/agentos/view/fleet/FamilyRail.mjs
@@ -29,6 +29,18 @@ export function familyToken(family) {
 }
 
 /**
+ * Pure family → CSS-class resolver — a known family's token minus its `--` custom-property prefix
+ * (e.g. `fm-family-claude`); unknown / absent → `null` (the `fm-family-unclassified` marker class
+ * carries the neutral rail binding in the component SCSS). The class binds `--fm-rail`, so color
+ * stays entirely in the token/skin layer: the rail swaps a class, never writes a style.
+ * @param {String} family
+ * @returns {String|null} the family class name, or null for an unknown / absent family
+ */
+export function familyClass(family) {
+    return isKnownFamily(family) ? FAMILY_TOKEN[family].slice(2) : null
+}
+
+/**
  * Whether `family` is a recognized family key — drives the `unclassified` render marker.
  * @param {String} family
  * @returns {Boolean}
@@ -78,22 +90,26 @@ class FamilyRail extends Component {
 
     /**
      * Triggered after the family config changed — data-driven rebind. A family swap re-renders the
-     * rail in place for the SAME resident (anti-lock-in). Known → its --fm-family-* token; unknown
-     * or absent → the neutral token + the `unclassified` marker (never a guessed family).
+     * rail in place for the SAME resident (anti-lock-in). Known → its `fm-family-*` class (which
+     * binds the `--fm-rail` token in the component SCSS — zero inline styles); unknown or absent →
+     * the `unclassified` marker class, which carries the neutral rail binding (never a guessed
+     * family).
      * @param {String|null} value
      * @param {String|null} oldValue
      * @protected
      */
     afterSetFamily(value, oldValue) {
-        let me    = this,
-            cls   = me.cls,
-            style = me.style || {};
+        let me       = this,
+            cls      = me.cls,
+            oldClass = familyClass(oldValue),
+            newClass = familyClass(value);
+
+        oldClass && NeoArray.remove(cls, oldClass);
+        newClass && NeoArray.add(cls, newClass);
 
         NeoArray[isKnownFamily(value) ? 'remove' : 'add'](cls, 'fm-family-unclassified');
-        me.cls = cls;
 
-        style['--fm-rail'] = `var(${familyToken(value)})`;
-        me.style = style
+        me.cls = cls
     }
 }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -3,23 +3,7 @@ import Button                 from '../../../../src/button/Base.mjs';
 import Container              from '../../../../src/container/Base.mjs';
 import FleetCockpitController from './FleetCockpitController.mjs';
 import FleetGrid              from './FleetGrid.mjs';
-
-/**
- * The seven real cross-family maintainer identities, for the fixture-fed cockpit — the live-wire
- * binding to the roster / runtime-status services is the sibling leaf that replaces this. Identities +
- * avatars are real (the `githubAvatarUrl` pattern, so identity reads at a glance); session state +
- * lane-line are an illustrative snapshot until the live source is wired. NO invented agents.
- * @type {Object[]}
- */
-const FIXTURE_ROSTER = [
-    {agentId: 'neo-opus-grace', displayName: 'Grace',     engineTag: 'opus-4.8', family: 'claude', state: 'ok',      avatarUrl: 'https://github.com/neo-opus-grace.png?size=80', laneLine: 'design authority — cockpit SSOT conformance review'},
-    {agentId: 'neo-gpt',        displayName: 'Euclid',    engineTag: 'gpt-5.5',  family: 'gpt',    state: 'ok',      avatarUrl: 'https://github.com/neo-gpt.png?size=80',        laneLine: 'NL transaction archive + replay (#14836)'},
-    {agentId: 'neo-opus-ada',   displayName: 'Ada',       engineTag: 'opus-4.8', family: 'claude', state: 'ok',      avatarUrl: 'https://github.com/neo-opus-ada.png?size=80',   laneLine: 'control-plane restart actuator — the R3 seam'},
-    {agentId: 'neo-opus-vega',  displayName: 'Vega',      engineTag: 'opus-4.8', family: 'claude', state: 'ok',      avatarUrl: 'https://github.com/neo-opus-vega.png?size=80',  laneLine: 'harness-UI shell + left-rail nav (#14846)'},
-    {agentId: 'neo-fable',      displayName: 'Mnemosyne', engineTag: 'fable-5',  family: 'claude', state: 'ok',      avatarUrl: 'https://github.com/neo-fable.png?size=80',      laneLine: 'golden-path direction-velocity writer (#14811)'},
-    {agentId: 'neo-fable-clio', displayName: 'Clio',      engineTag: 'fable-5',  family: 'claude', state: 'idle',    avatarUrl: 'https://github.com/neo-fable-clio.png?size=80', laneLine: 'CrossWindowDragTarget docking — awaiting review'},
-    {agentId: 'neo-gemini-pro', displayName: 'Gemini',    engineTag: '3-pro',    family: 'gemini', state: 'off',     avatarUrl: 'https://github.com/neo-gemini-pro.png?size=80', laneLine: 'operator-benched'}
-];
+import FleetRoster            from '../../store/FleetRoster.mjs';
 
 /**
  * Recent fleet activity for the fixture-fed stream — the live A2A / PR / lane adapters
@@ -28,11 +12,11 @@ const FIXTURE_ROSTER = [
  * @type {Object[]}
  */
 const FIXTURE_ACTIVITY = [
-    {type: 'a2a-activity',    agentId: 'neo-opus-vega', occurredAt: '2026-07-05T10:52:00.000Z', payload: {text: 'Vega → AGENT:* [lane-claim] #14846 harness-UI shell + nav'}},
-    {type: 'review-activity', agentId: 'neo-opus-vega', occurredAt: '2026-07-05T10:26:00.000Z', payload: {text: 'Vega → #14836 APPROVED — transaction archive Architectural Pillar'}},
-    {type: 'pr-activity',     agentId: 'neo-gpt',       occurredAt: '2026-07-05T10:11:00.000Z', payload: {text: 'Euclid opened #14843 — roadmap cornerstone-4 hygiene'}},
-    {type: 'pr-activity',     agentId: 'neo-opus-vega', occurredAt: '2026-07-05T09:40:00.000Z', payload: {text: 'Vega #14834 merged — FM fleet grid + health bar'}},
-    {type: 'a2a-activity',    agentId: 'neo-opus-ada',  occurredAt: '2026-07-05T08:30:00.000Z', payload: {text: 'Ada → #14760 control-plane restart actuator merged'}},
+    {type: 'a2a-activity',    agentId: 'neo-opus-vega', occurredAt: '2026-07-05T10:52:00.000Z', payload: {text: 'Vega → AGENT:* [lane-claim] harness-UI shell + nav'}},
+    {type: 'review-activity', agentId: 'neo-opus-vega', occurredAt: '2026-07-05T10:26:00.000Z', payload: {text: 'Vega → APPROVED — transaction archive Architectural Pillar'}},
+    {type: 'pr-activity',     agentId: 'neo-gpt',       occurredAt: '2026-07-05T10:11:00.000Z', payload: {text: 'Euclid opened a PR — roadmap cornerstone-4 hygiene'}},
+    {type: 'pr-activity',     agentId: 'neo-opus-vega', occurredAt: '2026-07-05T09:40:00.000Z', payload: {text: 'Vega merged — FM fleet grid + health bar'}},
+    {type: 'a2a-activity',    agentId: 'neo-opus-ada',  occurredAt: '2026-07-05T08:30:00.000Z', payload: {text: 'Ada → control-plane restart actuator merged'}},
     {type: 'lane-activity',   agentId: 'neo-fable-clio',occurredAt: '2026-07-05T07:15:00.000Z', payload: {text: 'Clio → CrossWindowDragTarget docking, awaiting cross-family'}}
 ];
 
@@ -42,10 +26,11 @@ const FIXTURE_ACTIVITY = [
  * activity stream, in the SSOT's ~1.55fr / 1fr split. This is the "run the fleet" keeper-view the harness-UI
  * definition specifies, reached from the harness shell's left-rail nav — the cards, NOT a data-grid table.
  *
- * Fixture-fed for now: it composes the built primitives ({@link FleetGrid} → AgentCard/HealthBar,
- * {@link ActivityStream} → EventChip) against a representative roster + activity snapshot, so the
- * mission-control surface renders real. The live-roster / A2A / PR wire bindings
- * are the sibling leaves that replace the fixtures with the running fleet.
+ * The roster data layer is the shared {@link AgentOS.store.FleetRoster} Store of
+ * {@link AgentOS.model.FleetAgent} records — seeded with the honestly-labelled sample roster, bound
+ * to the {@link FleetGrid}, and re-pointed at the running fleet by {@link #loadRoster} when the
+ * registry bridge wires up. The activity zone composes {@link ActivityStream} → EventChip against a
+ * representative snapshot the same way ({@link #loadActivity}).
  *
  * @class AgentOS.view.fleet.FleetCockpit
  * @extends Neo.container.Base
@@ -96,9 +81,11 @@ class FleetCockpit extends Container {
                 handler: 'onStartFleet'
             }]
         }, {
-            module: FleetGrid,
-            flex  : 1.55,
-            agents: FIXTURE_ROSTER
+            module      : FleetGrid,
+            flex        : 1.55,
+            reference   : 'fleet-grid',
+            adapterState: 'sample', // the seeded roster is a representative sample until the live source is wired
+            store       : FleetRoster
         }, {
             module      : ActivityStream,
             flex        : 1,
@@ -109,12 +96,22 @@ class FleetCockpit extends Container {
     }
 
     /**
-     * @summary On construct, bind the activity stream to the live fleet feed.
+     * Set once {@link #loadRoster} has replaced the sample seed with a wired roster payload —
+     * subsequent wired payloads MERGE onto the existing records (runtime status refresh) instead of
+     * re-seeding the store.
+     * @member {Boolean} rosterWired=false
+     * @protected
+     */
+    rosterWired = false
+
+    /**
+     * @summary On construct, bind the fleet surfaces to their live feeds.
      * @param {...*} args
      */
     onConstructed(...args) {
         super.onConstructed(...args);
-        this.loadActivity()
+        this.loadActivity();
+        this.loadRoster()
     }
 
     /**
@@ -150,6 +147,69 @@ class FleetCockpit extends Container {
         } catch (error) {
             // fail-closed: the sample seed stays rather than blanking the feed
         }
+    }
+
+    /**
+     * @summary Bind the fleet roster to the running fleet: poll the read-observe `fleetRoster` verb
+     * on the injected registry bridge and route its honest capability state to the Store the grid
+     * renders from:
+     * - `wired` + rows → the FIRST wired payload **populates the Store** (replacing the sample
+     *   seed); every later one **merges onto the records** (`record.set(row)` per known `agentId`,
+     *   `store.add` for a new resident) — runtime status refresh, not a re-seed. Grid goes `live`.
+     * - `degraded` → the **stale** banner over the last-known roster.
+     * - `wired` + EMPTY / not-wired / absent bridge / a thrown source → keep the last-known roster
+     *   (the honestly-labelled sample seed at boot); fail closed rather than blanking the fleet. An
+     *   empty roster from a wired source is indistinguishable from a broken producer at this seam,
+     *   and a blanked cockpit hides exactly the fleet the operator must see.
+     * @protected
+     */
+    async loadRoster() {
+        let me     = this,
+            grid   = me.getReference('fleet-grid'),
+            bridge = globalThis.AgentOS?.fleet?.registryBridge;
+
+        if (!grid?.store || typeof bridge?.fleetRoster !== 'function') {
+            return
+        }
+
+        try {
+            const {capability, agents} = await bridge.fleetRoster() ?? {},
+                  rows                 = Array.isArray(agents) ? agents.filter(row => row?.agentId) : [];
+
+            if (capability?.state === 'wired' && rows.length > 0) {
+                if (me.rosterWired) {
+                    me.mergeRoster(grid.store, rows)
+                } else {
+                    grid.store.clear();
+                    grid.store.add(rows);
+                    me.rosterWired = true
+                }
+
+                grid.adapterState = 'live'
+            } else if (capability?.state === 'degraded') {
+                grid.adapterState = 'stale'
+            }
+            // wired-but-empty / not-wired / absent bridge → keep the last-known roster
+        } catch (error) {
+            // fail-closed: the last-known roster stays rather than blanking the fleet
+        }
+    }
+
+    /**
+     * @summary Merge a wired roster payload onto the Store's records: a known `agentId` updates its
+     * record in place (`record.set(row)` — the store's `recordChange` re-renders just that card), a
+     * new one joins the roster. Rows never silently remove residents; a departure is a `state`
+     * change from the source, not an absent row.
+     * @param {Neo.data.Store} store The bound roster store.
+     * @param {Object[]} rows Wired roster rows keyed by `agentId`.
+     * @protected
+     */
+    mergeRoster(store, rows) {
+        rows.forEach(row => {
+            const record = store.get(row.agentId);
+
+            record ? record.set(row) : store.add(row)
+        })
     }
 }
 

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -7,9 +7,9 @@ import {handleFleetLifecycleIntent} from './fleetLifecycleIntentAdapter.mjs';
  * lives here (the cards themselves stay intent-only and never touch transport).
  *
  * Two entry points, both driving the C2 adapter (`handleFleetLifecycleIntent`) → the registry bridge →
- * honest per-card round-trip state, never an optimistic success:
+ * honest per-record round-trip state, never an optimistic success:
  * - `onAgentLifecycleIntent` — catches a single card's `lifecycleIntent` (resolved up the controller
- *   chain via the card's listener) and dispatches it for that card.
+ *   chain via the card's listener) and dispatches it for that card's record.
  * - `onStartFleet` — the design SSOT §01 "▶ Start morning fleet" one-click: fans `start` out to every
  *   rendered card, so each resident drives its own honest round-trip.
  *
@@ -29,16 +29,16 @@ class FleetCockpitController extends Controller {
      * @summary The one-click morning start — fan `start` out to every resident card via the C2 adapter.
      *
      * The cockpit owns the wire (the cards stay intent-only): it enumerates the rendered cards and hands
-     * each a `start` intent + that card's `state.Provider` to `handleFleetLifecycleIntent`, so every
+     * each a `start` intent + that card's roster record to `handleFleetLifecycleIntent`, so every
      * resident drives its own honest round-trip (pending → settled / rejected), never an optimistic
-     * fleet-wide success. Starting an already-running resident is the bridge's concern; the per-card
+     * fleet-wide success. Starting an already-running resident is the bridge's concern; the per-record
      * honest state reflects whatever actually happens.
      */
     onStartFleet() {
         this.getAgentCards().forEach(card => {
-            const provider = card.getStateProvider();
+            const {record} = card;
 
-            handleFleetLifecycleIntent({action: 'start', agentId: provider.getData('agentId')}, provider)
+            handleFleetLifecycleIntent({action: 'start', agentId: record?.agentId ?? null}, record)
         })
     }
 
@@ -58,15 +58,15 @@ class FleetCockpitController extends Controller {
      * A card's control cluster fires an intent-only `lifecycleIntent {action, agentId}` and never
      * touches transport. The cockpit is the composition root that knows both the cards and the fleet
      * bridge: it resolves the firing card from the event `source`, then hands the intent + that card's
-     * `state.Provider` to the C2 adapter (`handleFleetLifecycleIntent`). The adapter calls the registry
-     * bridge and writes honest pending / settled / rejected state back onto the provider the card
-     * renders — never an optimistic success.
+     * roster record to the C2 adapter (`handleFleetLifecycleIntent`). The adapter calls the registry
+     * bridge and writes honest pending / settled / rejected state onto the record via `record.set()`;
+     * the store's `recordChange` re-renders the card — never an optimistic success.
      * @param {Object} data The `lifecycleIntent` payload `{action, agentId, source}` — Neo stamps `source`.
      */
     onAgentLifecycleIntent(data) {
         const card = Neo.getComponent(data.source);
 
-        card && handleFleetLifecycleIntent(data, card.getStateProvider())
+        card && handleFleetLifecycleIntent(data, card.record)
     }
 }
 

--- a/apps/agentos/view/fleet/FleetGrid.mjs
+++ b/apps/agentos/view/fleet/FleetGrid.mjs
@@ -137,24 +137,54 @@ class FleetGrid extends Container {
      */
     onConstructed(...args) {
         super.onConstructed(...args);
-        this.refreshGrid()
+
+        let me = this;
+
+        // the health bar tallies from the SAME bound store (its own reactive record seam, no array copy)
+        me.getReference('fleet-health').store = me.store;
+        me.refreshGrid()
     }
 
     /**
      * Triggered after the store config changed — re-seats the reactive wire: the grid re-derives on
-     * the store's `load` and routes `recordChange` to a re-rank or an in-place card update.
+     * the store's `load` and routes `recordChange` to a re-rank or an in-place card update; the
+     * header's health bar is re-seated onto the same store (it tallies via its own record seam).
      * @param {Neo.data.Store|null} value
      * @param {Neo.data.Store|null} oldValue
      * @protected
      */
     afterSetStore(value, oldValue) {
         let me        = this,
-            listeners = {load: me.onStoreLoad, recordChange: me.onStoreRecordChange, scope: me};
+            listeners = me.getStoreListeners();
 
         oldValue?.un(listeners);
         value   ?.on(listeners);
 
-        me.isConstructed && me.refreshGrid()
+        if (me.isConstructed) {
+            me.getReference('fleet-health').store = value;
+            me.refreshGrid()
+        }
+    }
+
+    /**
+     * @summary The one listener set this grid seats on its bound store — kept in one place so
+     * `afterSetStore` re-seating and `destroy` teardown stay symmetric.
+     * @returns {Object}
+     * @protected
+     */
+    getStoreListeners() {
+        let me = this;
+
+        return {load: me.onStoreLoad, recordChange: me.onStoreRecordChange, scope: me}
+    }
+
+    /**
+     *
+     */
+    destroy() {
+        this.store?.un(this.getStoreListeners());
+
+        super.destroy()
     }
 
     /**
@@ -228,11 +258,10 @@ class FleetGrid extends Container {
               rank           = rankFleet(records, {foldThreshold: me.foldThreshold}),
               {adapterState} = me;
 
-        // header — updated in place; the health bar instance persists so counts animate, not flash
-        me.getReference('fleet-title').text    = `Fleet · ${rank.total} agents`;
-        me.getReference('fleet-stale').text    = adapterState === 'stale' ? 'stale — reconnecting' : adapterState === 'sample' ? 'sample roster' : '';
-        me.getReference('fleet-health').agents = records;
-        me.getReference('fleet-head').cls      = ['fm-fleet-head', `is-${adapterState}`];
+        // header — updated in place (the health bar is store-bound and tallies itself)
+        me.getReference('fleet-title').text = `Fleet · ${rank.total} agents`;
+        me.getReference('fleet-stale').text = adapterState === 'stale' ? 'stale — reconnecting' : adapterState === 'sample' ? 'sample roster' : '';
+        me.getReference('fleet-head').cls   = ['fm-fleet-head', `is-${adapterState}`];
 
         // card set — rebuilt (the visible cards change with the roster)
         const cards = [...rank.online.map(record => me.agentCardConfig(record))];

--- a/apps/agentos/view/fleet/FleetGrid.mjs
+++ b/apps/agentos/view/fleet/FleetGrid.mjs
@@ -22,7 +22,7 @@ const isOnline = state => state === 'ok' || state === 'limited' || state === 'we
  * it the grid shows every card (the 3-col view); at/above it the idle tier collapses to a count so a
  * 12–20-agent fleet never buries the online agents under a wall of idle cards. Pure + serializable;
  * the grid renders its result, so the ordering is unit-provable in isolation.
- * @param {Object[]} agents Roster entries carrying a `state` field.
+ * @param {Object[]} agents Roster entries carrying a `state` field — FleetAgent records or plain rows.
  * @param {Object} [options]
  * @param {Number} [options.foldThreshold=12] Registered-agent count at/above which the idle tier collapses.
  * @returns {{online: Object[], idle: Object[], benched: Object[], folded: Boolean, idleCount: Number, total: Number}}
@@ -42,17 +42,17 @@ export function rankFleet(agents, {foldThreshold = 12} = {}) {
 
 /**
  * @summary The fleet grid — the cockpit's default view (SSOT §01 fleet zone): a health-summary bar
- * over a ranked, density-aware grid of {@link AgentCard}s. Composes the built primitives (AgentCard ·
- * {@link HealthBar} → HealthSwatch/StateDot) and lays them out against the MEASURED fleet density
- * rather than the mock's six-agent assumption: below `foldThreshold` every card renders (the 3-col
- * view); at/above it the idle tier collapses to a count so the online agents stay in view at 12–20+
- * scale. The header (title + health bar) is a STABLE sub-tree updated in place — only the card set
- * rebuilds on a roster change, so the glance-instrument counts animate rather than flashing. On
- * adapter loss it degrades honestly — a stale banner over the last-known roster, never a blanked grid.
- *
- * The live-roster / runtime-status wire binding and the NL-verified mount at live scale are
- * sibling leaves; this leaf is the grid component + its ranking contract, unit-provable against
- * fixture rosters.
+ * over a ranked, density-aware grid of {@link AgentCard}s, rendered from ONE bound `data.Store`
+ * ({@link AgentOS.store.FleetRoster}) of {@link AgentOS.model.FleetAgent} records. The Store is the
+ * per-row reactive layer: a `load` re-derives the whole surface; a `recordChange` re-ranks when the
+ * session `state` moved a card between tiers, and otherwise updates the one affected card in place —
+ * no hand-rolled array diffing. Composes the built primitives (AgentCard · {@link HealthBar} →
+ * HealthSwatch/StateDot) and lays them out against the MEASURED fleet density rather than the mock's
+ * six-agent assumption: below `foldThreshold` every card renders (the 3-col view); at/above it the
+ * idle tier collapses to a count so the online agents stay in view at 12–20+ scale. The header
+ * (title + health bar) is a STABLE sub-tree updated in place — only the card set rebuilds on a
+ * roster change, so the glance-instrument counts animate rather than flashing. On adapter loss it
+ * degrades honestly — a stale banner over the last-known roster, never a blanked grid.
  *
  * @class AgentOS.view.fleet.FleetGrid
  * @extends Neo.container.Base
@@ -79,11 +79,13 @@ class FleetGrid extends Container {
          */
         layout: {ntype: 'vbox', align: 'stretch'},
         /**
-         * The roster to render — every card and the health counts derive from it.
-         * @member {Object[]} agents_=[]
+         * The bound roster Store — every card and the health counts derive from its records.
+         * Pass the shared {@link AgentOS.store.FleetRoster} singleton (or an isolated Store of
+         * {@link AgentOS.model.FleetAgent} records in tests).
+         * @member {Neo.data.Store|null} store_=null
          * @reactive
          */
-        agents_: [],
+        store_: null,
         /**
          * Registered-agent count at/above which the idle tier collapses to a count (density-derived).
          * Config-driven so the threshold is tunable, not hard-coded at the call site.
@@ -92,14 +94,15 @@ class FleetGrid extends Container {
          */
         foldThreshold_: 12,
         /**
-         * Feed liveness — `live` renders normally; `stale` renders the degrade banner over the
-         * last-known roster (never a blanked grid).
+         * Feed liveness — `live` renders normally; `sample` marks the honestly-labelled fixture seed
+         * (no roster source wired yet); `stale` renders the degrade banner over the last-known
+         * roster (never a blanked grid).
          * @member {String} adapterState_='live'
          * @reactive
          */
         adapterState_: 'live',
         /**
-         * A STABLE surface: the header (title · stale marker · flex spacer · live {@link HealthBar})
+         * A STABLE surface: the header (title · liveness marker · flex spacer · live {@link HealthBar})
          * and the card region. Only the card region's items rebuild on a roster change — the header
          * and its health bar are updated in place so the counts animate rather than flash.
          * @member {Object[]} items
@@ -129,7 +132,7 @@ class FleetGrid extends Container {
 
     /**
      * @summary Populate the roster-derived surface once constructed (the header sub-tree exists from
-     * static config; its content + the card set are data-derived).
+     * static config; its content + the card set are record-derived).
      * @param {...*} args
      */
     onConstructed(...args) {
@@ -138,12 +141,20 @@ class FleetGrid extends Container {
     }
 
     /**
-     * @param {Object[]} value
-     * @param {Object[]} oldValue
+     * Triggered after the store config changed — re-seats the reactive wire: the grid re-derives on
+     * the store's `load` and routes `recordChange` to a re-rank or an in-place card update.
+     * @param {Neo.data.Store|null} value
+     * @param {Neo.data.Store|null} oldValue
      * @protected
      */
-    afterSetAgents(value, oldValue) {
-        this.isConstructed && this.refreshGrid()
+    afterSetStore(value, oldValue) {
+        let me        = this,
+            listeners = {load: me.onStoreLoad, recordChange: me.onStoreRecordChange, scope: me};
+
+        oldValue?.un(listeners);
+        value   ?.on(listeners);
+
+        me.isConstructed && me.refreshGrid()
     }
 
     /**
@@ -165,61 +176,95 @@ class FleetGrid extends Container {
     }
 
     /**
-     * @summary Refresh the surface: update the stable header in place (title · stale marker · health
-     * bar counts) and rebuild only the ranked card set (online cards → collapsed-idle fold when over
-     * threshold, else idle cards → benched tail).
+     * @summary The store's `load` — the roster set changed (seed, live replace, clear): re-derive
+     * the whole surface.
+     * @param {Object} data The store load event `{items, ...}`.
+     * @protected
      */
-    refreshGrid() {
-        const rank  = rankFleet(this.agents, {foldThreshold: this.foldThreshold}),
-              stale = this.adapterState === 'stale';
+    onStoreLoad(data) {
+        this.isConstructed && this.refreshGrid()
+    }
 
-        // header — updated in place; the health bar instance persists so counts animate, not flash
-        this.getReference('fleet-title').text    = `Fleet · ${rank.total} agents`;
-        this.getReference('fleet-stale').text    = stale ? 'stale — reconnecting' : '';
-        this.getReference('fleet-health').agents = this.agents;
-        this.getReference('fleet-head').cls      = ['fm-fleet-head', stale ? 'is-stale' : 'is-live'];
+    /**
+     * @summary One record's fields changed. A session-`state` change moves the card between tiers
+     * (online / idle / benched), so it re-ranks; any other field set (display state, the B4/C2
+     * `pendingAction` / `controlReason` control seam) updates the one affected card in place — the
+     * Store is the per-row reactive layer, no array diffing.
+     * @param {Object} data The store recordChange event `{fields, record, index, model}`.
+     * @protected
+     */
+    onStoreRecordChange({fields, record}) {
+        let me = this;
 
-        // card set — rebuilt (the visible cards change with the roster)
-        const cards = [...rank.online.map(agent => this.agentCardConfig(agent))];
-
-        if (rank.folded) {
-            rank.idleCount > 0 && cards.push(this.foldConfig(rank.idleCount))
-        } else {
-            cards.push(...rank.idle.map(agent => this.agentCardConfig(agent)))
+        if (!me.isConstructed) {
+            return
         }
 
-        cards.push(...rank.benched.map(agent => this.agentCardConfig(agent)));
+        if (fields.some(field => field.name === 'state')) {
+            me.refreshGrid()
+        } else {
+            me.getReference('fleet-cards').items
+                .find(card => card.record === record)
+                ?.applyRecord()
+        }
+    }
 
-        const cardsContainer = this.getReference('fleet-cards');
+    /**
+     * @summary The bound store's records (empty when no store is bound).
+     * @returns {Object[]}
+     */
+    getRecords() {
+        return this.store?.items ?? []
+    }
+
+    /**
+     * @summary Refresh the surface: update the stable header in place (title · liveness marker ·
+     * health bar counts) and rebuild only the ranked card set (online cards → collapsed-idle fold
+     * when over threshold, else idle cards → benched tail).
+     */
+    refreshGrid() {
+        const me             = this,
+              records        = me.getRecords(),
+              rank           = rankFleet(records, {foldThreshold: me.foldThreshold}),
+              {adapterState} = me;
+
+        // header — updated in place; the health bar instance persists so counts animate, not flash
+        me.getReference('fleet-title').text    = `Fleet · ${rank.total} agents`;
+        me.getReference('fleet-stale').text    = adapterState === 'stale' ? 'stale — reconnecting' : adapterState === 'sample' ? 'sample roster' : '';
+        me.getReference('fleet-health').agents = records;
+        me.getReference('fleet-head').cls      = ['fm-fleet-head', `is-${adapterState}`];
+
+        // card set — rebuilt (the visible cards change with the roster)
+        const cards = [...rank.online.map(record => me.agentCardConfig(record))];
+
+        if (rank.folded) {
+            rank.idleCount > 0 && cards.push(me.foldConfig(rank.idleCount))
+        } else {
+            cards.push(...rank.idle.map(record => me.agentCardConfig(record)))
+        }
+
+        cards.push(...rank.benched.map(record => me.agentCardConfig(record)));
+
+        const cardsContainer = me.getReference('fleet-cards');
 
         cardsContainer.removeAll(true);
         cardsContainer.add(cards)
     }
 
     /**
-     * @summary One AgentCard config from a roster entry — maps the entry onto the card's per-card
-     * `stateProvider.data` binding surface (the card owns its own render; this just seeds it).
-     * @param {Object} agent
+     * @summary One AgentCard config from a roster record — the card renders from the record itself
+     * (the card owns its own render; this just seats the record).
+     * @param {Object} record An AgentOS.model.FleetAgent record.
      * @returns {Object}
      */
-    agentCardConfig(agent) {
+    agentCardConfig(record) {
         return {
-            module       : AgentCard,
+            module   : AgentCard,
             // The card's control cluster fires an intent-only `lifecycleIntent`; this listener resolves
             // UP the controller chain (card → grid [no controller] → cockpit) to
             // FleetCockpitController.onAgentLifecycleIntent — the C2 consumer that drives the round-trip.
-            listeners    : {lifecycleIntent: 'onAgentLifecycleIntent'},
-            stateProvider: {
-                data: {
-                    agentId    : agent?.agentId     ?? null,
-                    avatarUrl  : agent?.avatarUrl   ?? null,
-                    displayName: agent?.displayName ?? null,
-                    engineTag  : agent?.engineTag   ?? null,
-                    family     : agent?.family      ?? null,
-                    laneLine   : agent?.laneLine    ?? null,
-                    state      : agent?.state       ?? 'off'
-                }
-            }
+            listeners: {lifecycleIntent: 'onAgentLifecycleIntent'},
+            record
         }
     }
 

--- a/apps/agentos/view/fleet/HealthBar.mjs
+++ b/apps/agentos/view/fleet/HealthBar.mjs
@@ -16,7 +16,7 @@ const HEALTH_ORDER = ['ok', 'idle', 'wedged', 'limited', 'off'];
  * matching the grid's benched tier, rather than a literal key the five-swatch bar would never render.
  * Every agent therefore lands in a RENDERED bucket and the visible bar total can never undercount the
  * roster. Pure + serializable; the bar renders its result, so the tally is unit-provable in isolation.
- * @param {Object[]} agents Roster entries carrying a `state` field.
+ * @param {Object[]} agents Roster entries carrying a `state` field — FleetAgent records or plain rows.
  * @returns {Object} `{ok, idle, wedged, limited, off}` — exactly the five canonical keys (zero-filled); the counts sum to the roster length.
  */
 export function healthCounts(agents) {
@@ -37,13 +37,12 @@ export function healthCounts(agents) {
  * @summary The fleet health-summary bar — the scale-to-a-glance instrument:
  * the counts must read before any single card does. Composes one {@link HealthSwatch} per canonical
  * category (working · idle · wedged · rate-limited · benched) in legend order, each carrying its live
- * count. The swatch instances are STABLE across roster changes — `afterSetAgents` updates their
- * counts in place rather than rebuilding — so a count transition animates smoothly instead of
- * flashing, and the CSS pulse stays gated behind `prefers-reduced-motion` (the count value, not the
- * motion, carries the signal).
- *
- * The live-roster wire binding is the sibling leaf; this leaf renders whatever roster it is
- * handed, unit-provable against a fixture.
+ * count, tallied from the SAME bound roster Store the grid renders from ({@link AgentOS.store.FleetRoster}
+ * records — no re-materialized plain-array copy). The Store is the reactive layer: a `load` re-tallies,
+ * and a `recordChange` re-tallies when the session `state` moved a resident between buckets. The swatch
+ * instances are STABLE across roster changes — counts update in place rather than rebuilding — so a
+ * count transition animates smoothly instead of flashing, and the CSS pulse stays gated behind
+ * `prefers-reduced-motion` (the count value, not the motion, carries the signal).
  *
  * @class AgentOS.view.fleet.HealthBar
  * @extends Neo.container.Base
@@ -70,11 +69,13 @@ class HealthBar extends Container {
          */
         layout: {ntype: 'hbox', align: 'center'},
         /**
-         * The roster the counts derive from; the counts refresh whenever it changes.
-         * @member {Object[]} agents_=[]
+         * The bound roster Store the counts derive from — the same record seam the grid renders
+         * (never a hand-pushed plain-array copy). Counts refresh on `load` and on session-`state`
+         * record changes.
+         * @member {Neo.data.Store|null} store_=null
          * @reactive
          */
-        agents_: [],
+        store_: null,
         /**
          * Whether count transitions animate — carried onto the bar as a class the CSS reads (the
          * animation itself is additionally gated behind `prefers-reduced-motion`, so this is the
@@ -102,12 +103,20 @@ class HealthBar extends Container {
     }
 
     /**
-     * @param {Object[]} value
-     * @param {Object[]} oldValue
+     * Triggered after the store config changed — re-seats the reactive wire: the bar re-tallies on
+     * the store's `load` and on session-`state` record changes.
+     * @param {Neo.data.Store|null} value
+     * @param {Neo.data.Store|null} oldValue
      * @protected
      */
-    afterSetAgents(value, oldValue) {
-        this.isConstructed && this.applyCounts()
+    afterSetStore(value, oldValue) {
+        let me        = this,
+            listeners = me.getStoreListeners();
+
+        oldValue?.un(listeners);
+        value   ?.on(listeners);
+
+        me.isConstructed && me.applyCounts()
     }
 
     /**
@@ -117,6 +126,46 @@ class HealthBar extends Container {
      */
     afterSetAnimateCounts(value, oldValue) {
         this.isConstructed && this.updateAnimateCls()
+    }
+
+    /**
+     * @summary The one listener set this bar seats on its bound store — kept in one place so
+     * `afterSetStore` re-seating and `destroy` teardown stay symmetric.
+     * @returns {Object}
+     * @protected
+     */
+    getStoreListeners() {
+        let me = this;
+
+        return {load: me.onStoreLoad, recordChange: me.onStoreRecordChange, scope: me}
+    }
+
+    /**
+     * @summary The store's `load` — the roster set changed: re-tally.
+     * @param {Object} data The store load event `{items, ...}`.
+     * @protected
+     */
+    onStoreLoad(data) {
+        this.isConstructed && this.applyCounts()
+    }
+
+    /**
+     * @summary One record's fields changed — only a session-`state` change can move a resident
+     * between buckets, so anything else is a no-op for the tally.
+     * @param {Object} data The store recordChange event `{fields, record, index, model}`.
+     * @protected
+     */
+    onStoreRecordChange({fields}) {
+        this.isConstructed && fields.some(field => field.name === 'state') && this.applyCounts()
+    }
+
+    /**
+     *
+     */
+    destroy() {
+        this.store?.un(this.getStoreListeners());
+
+        super.destroy()
     }
 
     /**
@@ -136,7 +185,7 @@ class HealthBar extends Container {
      * the transition animates rather than the bar rebuilding.
      */
     applyCounts() {
-        const counts = healthCounts(this.agents);
+        const counts = healthCounts(this.store?.items ?? []);
 
         this.items.forEach(swatch => {
             swatch.count = counts[swatch.state] ?? 0

--- a/apps/agentos/view/fleet/HealthSwatch.mjs
+++ b/apps/agentos/view/fleet/HealthSwatch.mjs
@@ -1,5 +1,6 @@
 import Component    from '../../../../src/component/Base.mjs';
-import {stateToken} from './StateDot.mjs';
+import NeoArray     from '../../../../src/util/Array.mjs';
+import {stateClass} from './StateDot.mjs';
 
 /**
  * Canonical legend label per session-state category. Kept beside the state→token map so the fleet
@@ -29,10 +30,11 @@ export function stateLabel(state) {
 
 /**
  * A single entry in the fleet health-summary legend / bar: a swatch dot (colored from the same
- * `--fm-state-*` token as {@link StateDot} via the shared `stateToken` — one source of truth on the
- * agent-health axis), an optional count, and the category label. Composable BOTH ways: a plain
- * legend row (no count) and the count-carrying bar unit the health summary consumes (set `count`).
- * An unknown category renders off-toned with its literal text — never invisible.
+ * `--fm-state-*` token as {@link StateDot} via the shared `stateClass` — one source of truth on the
+ * agent-health axis, bound in the component SCSS), an optional count, and the category label.
+ * Composable BOTH ways: a plain legend row (no count) and the count-carrying bar unit the health
+ * summary consumes (set `count`). An unknown category renders off-toned with its literal text —
+ * never invisible.
  *
  * @class AgentOS.view.fleet.HealthSwatch
  * @extends Neo.component.Base
@@ -87,16 +89,23 @@ class HealthSwatch extends Component {
     }
 
     /**
-     * Triggered after the state config changed — rebinds the dot's `--fm-dot` token (shared with
-     * StateDot on the agent-health axis) and refreshes the label (when no override is set).
+     * Triggered after the state config changed — swaps the root state class (shared `stateClass`
+     * vocabulary with StateDot on the agent-health axis; the class binds the dot's `--fm-dot` token
+     * in the component SCSS — zero inline styles) and refreshes the label (when no override is set).
      * @param {String} value
      * @param {String} oldValue
      * @protected
      */
     afterSetState(value, oldValue) {
-        this.vdom.cn[0].style = {'--fm-dot': `var(${stateToken(value)})`};
-        this.applyLabel();
-        this.update()
+        let me  = this,
+            cls = me.cls;
+
+        oldValue !== undefined && NeoArray.remove(cls, stateClass(oldValue));
+        NeoArray.add(cls, stateClass(value));
+        me.cls = cls;
+
+        me.applyLabel();
+        me.update()
     }
 
     /**

--- a/apps/agentos/view/fleet/StateDot.mjs
+++ b/apps/agentos/view/fleet/StateDot.mjs
@@ -30,6 +30,18 @@ export function stateToken(state) {
 }
 
 /**
+ * Pure state → CSS-class mapping — the token name minus its `--` custom-property prefix (e.g.
+ * `fm-state-ok`). The class binds `--fm-dot` in the component SCSS, so color stays entirely in the
+ * token/skin layer: components swap a class, never write a style. Shares `stateToken`'s closed-set
+ * degrade (unknown → `fm-state-off`).
+ * @param {String} state
+ * @returns {String} the state class name (e.g. `fm-state-ok`)
+ */
+export function stateClass(state) {
+    return stateToken(state).slice(2)
+}
+
+/**
  * The atomic session-state indicator: a colored dot whose color is driven entirely by the
  * `--fm-state-*` token layer, with an optional live-pulse gated behind `prefers-reduced-motion`
  * in the component SCSS (`resources/scss/src/apps/agentos/fleet/StateDot.scss`). The color — not the
@@ -72,16 +84,20 @@ class StateDot extends Component {
     }
 
     /**
-     * Triggered after the state config changed — rebinds the `--fm-dot` color token from the
-     * closed-set resolver. State is session-state, never identity.
+     * Triggered after the state config changed — swaps the state class from the closed-set
+     * resolver; the class binds the `--fm-dot` color token in the component SCSS (zero inline
+     * styles — color lives only in the token/skin layer). State is session-state, never identity.
      * @param {String} value
      * @param {String} oldValue
      * @protected
      */
     afterSetState(value, oldValue) {
-        let style = this.style || {};
-        style['--fm-dot'] = `var(${stateToken(value)})`;
-        this.style = style
+        let cls = this.cls;
+
+        oldValue !== undefined && NeoArray.remove(cls, stateClass(oldValue));
+        NeoArray.add(cls, stateClass(value));
+
+        this.cls = cls
     }
 
     /**

--- a/apps/agentos/view/fleet/fleetCardFactory.mjs
+++ b/apps/agentos/view/fleet/fleetCardFactory.mjs
@@ -32,10 +32,11 @@ export function agentCardComponentRef(agentId) {
 
 /**
  * @summary Map one fleet-cockpit DTO row to its dock card descriptor: a stable componentRef, a
- * serializable creation blueprint (the card's `ntype` + the per-card provider data), agent-card policy
- * hints, and JSON identity metadata. Field mapping is null-safe and forward-compatible — `engineTag`,
- * `family`, and `laneLine` map through as `null` until the DTO enrichment + activity/runtime wires
- * land, with no change needed here.
+ * serializable creation blueprint (the card's `ntype` + its `record` field bag — the same
+ * {@link AgentOS.model.FleetAgent} field shape the store-backed cards render from, as a plain
+ * snapshot), agent-card policy hints, and JSON identity metadata. Field mapping is null-safe and
+ * forward-compatible — `engineTag`, `family`, and `laneLine` map through as `null` until the DTO
+ * enrichment + activity/runtime wires land, with no change needed here.
  * @param {Object} row=({}) A fleet-cockpit DTO row.
  * @returns {Object} `{componentRef, blueprint, policy, metadata}`
  */
@@ -45,17 +46,15 @@ export function toAgentCardDescriptor(row = {}) {
     return {
         componentRef: agentCardComponentRef(agentId),
         blueprint   : {
-            ntype        : AGENT_CARD_NTYPE,
-            stateProvider: {
-                data: {
-                    agentId,
-                    avatarUrl  : row.avatarUrl ?? null,
-                    displayName: row.displayName ?? null,
-                    engineTag  : row.engineTag ?? null,
-                    family     : row.family ?? null,
-                    laneLine   : row.laneLine ?? null,
-                    state      : row.lifecycle?.state ?? 'off'
-                }
+            ntype : AGENT_CARD_NTYPE,
+            record: {
+                agentId,
+                avatarUrl  : row.avatarUrl ?? null,
+                displayName: row.displayName ?? null,
+                engineTag  : row.engineTag ?? null,
+                family     : row.family ?? null,
+                laneLine   : row.laneLine ?? null,
+                state      : row.lifecycle?.state ?? 'off'
             }
         },
         policy  : {...AGENT_CARD_POLICY},

--- a/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.mjs
+++ b/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.mjs
@@ -1,12 +1,14 @@
 /**
  * @summary C2 adapter for Fleet cockpit lifecycle intents: consume a per-card
  * `lifecycleIntent`, call the existing registry bridge lifecycle verb, and write the honest
- * round-trip state back to the card's `state.Provider`.
+ * round-trip state onto the card's roster record.
  *
  * The B4 control surface owns intent emission + rendering. This helper owns the transport-adapter
  * half only: no Node-side imports, no bespoke bridge path, and no optimistic success state. The
- * provider contract is the two-field seam consumed by the B4 control renderer:
- * `pendingAction:String|null` and `controlReason:{action,kind,reason}|null`.
+ * record contract is the two-field seam consumed by the B4 control renderer
+ * ({@link AgentOS.model.FleetAgent} fields): `pendingAction:String|null` and
+ * `controlReason:{action,kind,reason}|null` — written via `record.set()`, so the store's
+ * `recordChange` re-renders the card.
  * @module apps/agentos/view/fleet/fleetLifecycleIntentAdapter
  */
 
@@ -32,7 +34,7 @@ export function getFleetRegistryBridge() {
 }
 
 /**
- * @summary Redact secret-shaped material before a bridge error becomes UI/provider state.
+ * @summary Redact secret-shaped material before a bridge error becomes UI/record state.
  * @param {*} value
  * @param {String} fallback
  * @returns {String}
@@ -48,7 +50,7 @@ export function sanitizeControlReason(value, fallback='Lifecycle request failed'
 }
 
 /**
- * @summary Build the terminal non-success provider payload.
+ * @summary Build the terminal non-success control-reason payload.
  * @param {String} action
  * @param {'rejected'|'unauthorized'|'timeout'} kind
  * @param {*} reason
@@ -63,22 +65,23 @@ export function createControlReason(action, kind, reason) {
 }
 
 /**
- * @summary Write one or more lifecycle-control fields onto a StateProvider-like object.
- * @param {Object} stateProvider A Neo.state.Provider or a test double exposing `setData()` / `data`.
+ * @summary Write one or more lifecycle-control fields onto a card's record.
+ * @param {Object} record An AgentOS.model.FleetAgent record (or any record-like exposing `set()`),
+ *     or a plain field bag (dock-blueprint snapshot / test double) mutated in place.
  * @param {Object} values
  */
-export function writeLifecycleControlState(stateProvider, values) {
-    if (typeof stateProvider?.setData === 'function') {
-        stateProvider.setData(values);
+export function writeLifecycleControlState(record, values) {
+    if (typeof record?.set === 'function') {
+        record.set(values);
         return
     }
 
-    if (stateProvider?.data && typeof stateProvider.data === 'object') {
-        Object.assign(stateProvider.data, values);
+    if (record && typeof record === 'object') {
+        Object.assign(record, values);
         return
     }
 
-    throw new Error('fleet lifecycle intent adapter requires a card stateProvider')
+    throw new Error('fleet lifecycle intent adapter requires a card record')
 }
 
 /**
@@ -119,17 +122,17 @@ function withTimeout(promise, action, {
 }
 
 /**
- * @summary Consume one per-card lifecycle intent and write honest provider state for B4 to render.
+ * @summary Consume one per-card lifecycle intent and write honest record state for B4 to render.
  * @param {Object} intent
  * @param {'start'|'stop'|'restart'} intent.action
  * @param {String} intent.agentId Durable fleet agent id.
- * @param {Object} stateProvider The target card's `state.Provider`.
+ * @param {Object} record The target card's roster record (see writeLifecycleControlState).
  * @param {Object} [options]
  * @param {Object|null} [options.bridge=getFleetRegistryBridge()] Test seam or injected registry bridge.
  * @param {Number} [options.timeoutMs=30000] Timeout for settle-or-reject honesty.
  * @returns {Promise<Object>} Result metadata for controller/tests.
  */
-export async function handleFleetLifecycleIntent(intent={}, stateProvider, options={}) {
+export async function handleFleetLifecycleIntent(intent={}, record, options={}) {
     options ||= {};
 
     const
@@ -140,7 +143,7 @@ export async function handleFleetLifecycleIntent(intent={}, stateProvider, optio
     if (!method) {
         const controlReason = createControlReason(action, 'rejected', `Unsupported lifecycle action '${action}'`);
 
-        writeLifecycleControlState(stateProvider, {pendingAction: null, controlReason});
+        writeLifecycleControlState(record, {pendingAction: null, controlReason});
 
         return {accepted: false, action, method: null, ok: false, status: 'rejected', controlReason}
     }
@@ -148,7 +151,7 @@ export async function handleFleetLifecycleIntent(intent={}, stateProvider, optio
     if (!agentId) {
         const controlReason = createControlReason(action, 'rejected', 'Lifecycle intent is missing agentId');
 
-        writeLifecycleControlState(stateProvider, {pendingAction: null, controlReason});
+        writeLifecycleControlState(record, {pendingAction: null, controlReason});
 
         return {accepted: false, action, method, ok: false, status: 'rejected', controlReason}
     }
@@ -156,12 +159,12 @@ export async function handleFleetLifecycleIntent(intent={}, stateProvider, optio
     if (typeof bridge?.[method] !== 'function') {
         const controlReason = createControlReason(action, 'unauthorized', 'Fleet Registry bridge unavailable');
 
-        writeLifecycleControlState(stateProvider, {pendingAction: null, controlReason});
+        writeLifecycleControlState(record, {pendingAction: null, controlReason});
 
         return {accepted: false, action, method, ok: false, status: 'unauthorized', controlReason}
     }
 
-    writeLifecycleControlState(stateProvider, {
+    writeLifecycleControlState(record, {
         controlReason: null,
         pendingAction: action
     });
@@ -173,7 +176,7 @@ export async function handleFleetLifecycleIntent(intent={}, stateProvider, optio
             options
         );
 
-        writeLifecycleControlState(stateProvider, {
+        writeLifecycleControlState(record, {
             controlReason: null,
             pendingAction: null
         });
@@ -184,7 +187,7 @@ export async function handleFleetLifecycleIntent(intent={}, stateProvider, optio
             kind          = error?.isFleetLifecycleTimeout ? 'timeout' : 'rejected',
             controlReason = createControlReason(action, kind, error?.message);
 
-        writeLifecycleControlState(stateProvider, {pendingAction: null, controlReason});
+        writeLifecycleControlState(record, {pendingAction: null, controlReason});
 
         return {accepted: true, action, method, ok: false, status: kind, controlReason}
     }

--- a/apps/agentos/view/fleet/kindRegistry.mjs
+++ b/apps/agentos/view/fleet/kindRegistry.mjs
@@ -63,6 +63,18 @@ export function kindToken(kind) {
 }
 
 /**
+ * Pure kind → CSS-class resolver — the kind token minus its `--` custom-property prefix (e.g.
+ * `fm-kind-pr`). The class binds `--fm-chip` in the chip SCSS, so color stays entirely in the
+ * token/skin layer: the chip swaps a class, never writes a style. Shares `kindToken`'s
+ * unknown → neutral degrade.
+ * @param {String} kind
+ * @returns {String} the kind class name (e.g. `fm-kind-pr`)
+ */
+export function kindClass(kind) {
+    return kindToken(kind).slice(2)
+}
+
+/**
  * Pure kind → short-label resolver. Unknown kinds fall back to the kind string itself, so a new
  * kind still renders a readable (if verbose) chip until it earns a short label here. Uses an
  * `Object.hasOwn` check (not `MAP[k] ||`) so a prototype-shaped key (`toString`, `constructor`,

--- a/resources/scss/src/apps/agentos/fleet/EventChip.scss
+++ b/resources/scss/src/apps/agentos/fleet/EventChip.scss
@@ -1,6 +1,7 @@
 /* Event-kind chip — a tinted-outline plate colored entirely by the kind token (--fm-chip): text,
    border, and faint fill are all color-mixed from that one custom property, so a growing kind set never
-   adds a hand-rolled color and an unknown kind reads as neutral. */
+   adds a hand-rolled color and an unknown kind reads as neutral. The token binds from the chip's
+   fm-kind-* class (kindRegistry's kindClass resolver — the chip swaps a class, never writes a style). */
 .fm-event-chip {
     display       : inline-block;
     padding       : 1px 6px;
@@ -13,4 +14,11 @@
     color         : var(--fm-chip, var(--fm-state-off));
     background    : color-mix(in srgb, var(--fm-chip, var(--fm-state-off)) 14%, transparent);
     border        : 1px solid color-mix(in srgb, var(--fm-chip, var(--fm-state-off)) 34%, transparent);
+
+    /* kind class → color token: the closed --fm-kind-* target set from kindRegistry */
+    &.fm-kind-pr      { --fm-chip: var(--fm-kind-pr); }
+    &.fm-kind-a2a     { --fm-chip: var(--fm-kind-a2a); }
+    &.fm-kind-review  { --fm-chip: var(--fm-kind-review); }
+    &.fm-kind-alert   { --fm-chip: var(--fm-kind-alert); }
+    &.fm-kind-neutral { --fm-chip: var(--fm-kind-neutral); }
 }

--- a/resources/scss/src/apps/agentos/fleet/FamilyRail.scss
+++ b/resources/scss/src/apps/agentos/fleet/FamilyRail.scss
@@ -1,10 +1,18 @@
-/* Model-family rail — a thin spine bound from the current-era family token; an unclassified/absent
-   family renders a hatched neutral rail, visibly distinct from any real family. */
+/* Model-family rail — a thin spine bound from the current-era family token via the rail's
+   fm-family-* class (FamilyRail's familyClass resolver — the component swaps a class, never writes a
+   style); an unclassified/absent family renders a hatched neutral rail, visibly distinct from any
+   real family. */
 .fm-family-rail {
     width        : 3px;
     align-self   : stretch;
     border-radius: 3px 0 0 3px;
     background   : var(--fm-rail, var(--fm-state-off));
+
+    /* family class → rail token: the closed FAMILY_TOKEN set */
+    &.fm-family-claude { --fm-rail: var(--fm-family-claude); }
+    &.fm-family-gpt    { --fm-rail: var(--fm-family-gpt); }
+    &.fm-family-gemini { --fm-rail: var(--fm-family-gemini); }
+    &.fm-family-human  { --fm-rail: var(--fm-family-human); }
 
     &.fm-family-unclassified {
         background: repeating-linear-gradient(

--- a/resources/scss/src/apps/agentos/fleet/HealthSwatch.scss
+++ b/resources/scss/src/apps/agentos/fleet/HealthSwatch.scss
@@ -1,5 +1,7 @@
 /* Health-summary swatch — a legend row (dot + label) or a count-bar unit (dot + count + label), all
-   scoped under the component root. The dot reuses the state token via --fm-dot. */
+   scoped under the component root. The dot reuses the state token via --fm-dot, bound from the root's
+   fm-state-* class (shared stateClass vocabulary with StateDot — the component swaps a class, never
+   writes a style). */
 .fm-health-swatch {
     display    : inline-flex;
     align-items: center;
@@ -7,6 +9,13 @@
     font-family: var(--fm-font-mono);
     font-size  : 11px;
     color      : var(--fm-ink-dim);
+
+    /* state class → color token, inherited by the .fm-sw-dot child */
+    &.fm-state-ok      { --fm-dot: var(--fm-state-ok); }
+    &.fm-state-idle    { --fm-dot: var(--fm-state-idle); }
+    &.fm-state-wedged  { --fm-dot: var(--fm-state-wedged); }
+    &.fm-state-limited { --fm-dot: var(--fm-state-limited); }
+    &.fm-state-off     { --fm-dot: var(--fm-state-off); }
 
     .fm-sw-dot {
         width        : 9px;

--- a/resources/scss/src/apps/agentos/fleet/StateDot.scss
+++ b/resources/scss/src/apps/agentos/fleet/StateDot.scss
@@ -1,5 +1,6 @@
 /* Session-state dot — geometry + the reduced-motion-gated pulse, scoped under the component root.
-   COLOR binds at the component via --fm-dot; the pulse is decoration, the color carries the signal. */
+   COLOR binds via the fm-state-* class → --fm-dot mapping below (the component swaps a class, never
+   writes a style); the pulse is decoration, the color carries the signal. */
 .fm-state-dot {
     width        : 8px;
     height       : 8px;
@@ -7,6 +8,13 @@
     border-radius: 50%;
     background   : var(--fm-dot, var(--fm-state-off));
     box-shadow   : 0 0 0 3px color-mix(in srgb, var(--fm-dot, var(--fm-state-off)) 22%, transparent);
+
+    /* state class → color token: the closed fm-state-* set from StateDot's stateClass() resolver */
+    &.fm-state-ok      { --fm-dot: var(--fm-state-ok); }
+    &.fm-state-idle    { --fm-dot: var(--fm-state-idle); }
+    &.fm-state-wedged  { --fm-dot: var(--fm-state-wedged); }
+    &.fm-state-limited { --fm-dot: var(--fm-state-limited); }
+    &.fm-state-off     { --fm-dot: var(--fm-state-off); }
 
     @media (prefers-reduced-motion: no-preference) {
         &.fm-live {

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -17,51 +17,83 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import Instance       from '../../../../../../../src/manager/Instance.mjs';
 
-test.describe('Fleet cockpit AgentCard — resident card composing the class primitives + avatar (#14755)', () => {
-    let AgentCard;
+test.describe('Fleet cockpit AgentCard — resident card rendering its roster record (#14755)', () => {
+    let AgentCard, FleetAgent, Store;
 
-    const readData = (card, key) => card.getStateProvider().getDataConfig(key).get();
+    const stores = [];
 
-    const createCard = data => Neo.create(AgentCard, {appName, stateProvider: {data}});
+    // a real store-backed record — the production shape (an AgentOS.store.FleetRoster row). The
+    // store mirrors FleetRoster's keyProperty (the collection default 'id' would shadow the model's).
+    const makeRecord = data => {
+        const store = Neo.create(Store, {keyProperty: 'agentId', model: FleetAgent, data: [data]});
+
+        stores.push(store);
+
+        return store.get(data.agentId)
+    };
+
+    const createCard = data => Neo.create(AgentCard, {appName, record: makeRecord(data)});
+
+    // in the cockpit composition the GRID routes the store's recordChange to the card; standalone
+    // card units drive the same seam directly: mutate the record, then apply it.
+    const applySet = (card, values) => {
+        card.record.set(values);
+        card.applyRecord()
+    };
 
     test.beforeAll(async () => {
-        const mod = await import('../../../../../../../apps/agentos/view/fleet/AgentCard.mjs');
-        AgentCard = mod.default
+        AgentCard  = (await import('../../../../../../../apps/agentos/view/fleet/AgentCard.mjs')).default;
+        FleetAgent = (await import('../../../../../../../apps/agentos/model/FleetAgent.mjs')).default;
+        Store      = (await import('../../../../../../../src/data/Store.mjs')).default
     });
 
-    test('is a data-driven card composing the class primitives + the avatar — one provider surface', () => {
+    test.afterAll(() => {
+        stores.forEach(store => store.destroy());
+        stores.length = 0
+    });
+
+    test('is a data-driven card composing the class primitives + the avatar — one record surface, zero providers', () => {
         const card = createCard({
             agentId: 'vega', avatarUrl: 'vega.png', displayName: 'Vega', family: 'claude', engineTag: 'opus-4.8', state: 'wedged'
         });
 
-        // the per-card provider is the single binding surface (data-driven, no per-field config threading)
-        expect(card.getStateProvider()).not.toBeNull();
-        expect(readData(card, 'state')).toBe('wedged');
-        expect(readData(card, 'family')).toBe('claude');
-        expect(readData(card, 'avatarUrl')).toBe('vega.png');
+        // the roster record is the single data surface (no per-card state.Provider)
+        expect(card.record.agentId).toBe('vega');
+        expect(card.stateProvider ?? null).toBeNull();
 
-        // composes the class primitives (FamilyRail + StateDot) and the avatar Image
-        expect(card.down({ntype: 'fm-family-rail'})).toBeTruthy();
-        expect(card.down({ntype: 'fm-state-dot'})).toBeTruthy();
-        expect(card.down({ntype: 'image'})).toBeTruthy();
+        // composes the class primitives (FamilyRail + StateDot) and the avatar Image, fed from the record
+        expect(card.down({ntype: 'fm-family-rail'}).family).toBe('claude');
+        expect(card.down({ntype: 'fm-state-dot'}).state).toBe('wedged');
+        expect(card.down({ntype: 'image'}).src).toBe('vega.png');
+        expect(card.down({reference: 'card-name'}).text).toBe('Vega');
+        expect(card.down({reference: 'card-engine'}).text).toBe('opus-4.8');
 
         card.destroy()
     });
 
-    test('ADR-0032: avatar/name/engine are display state over the durable id — setState re-renders in place, never a re-key', () => {
+    test('a plain field-bag record renders the same snapshot — the dock-blueprint restore shape', () => {
+        const card = Neo.create(AgentCard, {appName, record: {agentId: 'ghost', displayName: 'Ghost', state: 'ok'}});
+
+        expect(card.down({reference: 'card-name'}).text).toBe('Ghost');
+        expect(card.down({ntype: 'fm-state-dot'}).state).toBe('ok');
+
+        card.destroy()
+    });
+
+    test('ADR-0032: avatar/name/engine are display state over the durable id — a record write re-renders in place, never a re-key', () => {
         const card     = createCard({agentId: 'vega', displayName: 'Vega', avatarUrl: 'a.png', engineTag: 'opus-4.8', state: 'ok'});
         const beforeId = card.id;
 
-        card.setState({displayName: 'Vega (renamed)', avatarUrl: 'b.png', engineTag: 'fable-5'});
+        applySet(card, {displayName: 'Vega (renamed)', avatarUrl: 'b.png', engineTag: 'fable-5'});
 
         // the SAME instance — identity is the durable agentId, not the presentation
         expect(card.id).toBe(beforeId);
-        expect(readData(card, 'agentId')).toBe('vega');
-        expect(readData(card, 'displayName')).toBe('Vega (renamed)');
-        expect(readData(card, 'avatarUrl')).toBe('b.png');
-        expect(readData(card, 'engineTag')).toBe('fable-5');
+        expect(card.record.agentId).toBe('vega');
+        expect(card.down({reference: 'card-name'}).text).toBe('Vega (renamed)');
+        expect(card.down({ntype: 'image'}).src).toBe('b.png');
+        expect(card.down({reference: 'card-engine'}).text).toBe('fable-5');
         // a display-state change never disturbs the session-state axis
-        expect(readData(card, 'state')).toBe('ok');
+        expect(card.down({ntype: 'fm-state-dot'}).state).toBe('ok');
 
         card.destroy()
     });
@@ -70,10 +102,10 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
         const card     = createCard({agentId: 'vega', family: 'claude', state: 'ok'});
         const beforeId = card.id;
 
-        card.setState('family', 'gpt');
+        applySet(card, {family: 'gpt'});
 
         expect(card.id).toBe(beforeId);
-        expect(readData(card, 'family')).toBe('gpt')
+        expect(card.down({ntype: 'fm-family-rail'}).family).toBe('gpt');
 
         card.destroy()
     });
@@ -98,7 +130,7 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
 
         // running → the SAME toggle is now stop (■) and restart appears
         fired.length = 0;
-        card.setState('state', 'ok');
+        applySet(card, {state: 'ok'});
         expect(toggle.iconCls).toBe('fa-solid fa-stop');
         expect(restart.hidden).toBe(false);
         card.getController().onToggleLifecycle();
@@ -122,18 +154,18 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
         expect(status().hidden).toBe(true);
 
         // Lane-C set a verb in flight → controls disabled (no second intent mid-round-trip); pending rendered
-        card.setState('pendingAction', 'restart');
+        applySet(card, {pendingAction: 'restart'});
         expect(verbs().every(button => button.disabled)).toBe(true);
         expect(status().hidden).toBe(false);
         expect(status().text).toBe('restart…');
 
         // Lane-C rejected it → the honest reason renders; never an optimistic success
-        card.setState({controlReason: {action: 'restart', kind: 'rejected', reason: 'harness offline'}, pendingAction: null});
+        applySet(card, {controlReason: {action: 'restart', kind: 'rejected', reason: 'harness offline'}, pendingAction: null});
         expect(status().hidden).toBe(false);
         expect(status().text).toBe('⚠ rejected: harness offline');
 
         // a NEW attempt takes visual priority over a stale reason (the clear-on-new-intent nuance, render side)
-        card.setState('pendingAction', 'start');
+        applySet(card, {pendingAction: 'start'});
         expect(status().text).toBe('start…');
 
         card.destroy()
@@ -146,13 +178,13 @@ test.describe('Fleet cockpit AgentCard — resident card composing the class pri
 
         // unauthorized (Lane-C denied / bridge unavailable) → the cluster DISABLES with the reason, not a
         // live button beside a warning: you cannot retry into a closed door (the accepted B4/C2 contract)
-        card.setState({controlReason: {action: 'start', kind: 'unauthorized', reason: 'Fleet Registry bridge unavailable'}, pendingAction: null});
+        applySet(card, {controlReason: {action: 'start', kind: 'unauthorized', reason: 'Fleet Registry bridge unavailable'}, pendingAction: null});
         expect(verbs().every(button => button.disabled)).toBe(true);
         expect(status().text).toBe('⚠ unauthorized: Fleet Registry bridge unavailable');
 
         // timeout → the outcome is UNKNOWN (the verb may still be running, we lost the answer) → stale-pending:
         // an unfinished "…", NOT a resolved "⚠" failure, and retry stays OPEN (the cluster re-enables)
-        card.setState({controlReason: {action: 'restart', kind: 'timeout', reason: 'restart timed out after 30000ms'}, pendingAction: null});
+        applySet(card, {controlReason: {action: 'restart', kind: 'timeout', reason: 'restart timed out after 30000ms'}, pendingAction: null});
         expect(status().text).toBe('restart… stale — no response');
         expect(verbs()[0].disabled).toBe(false);
 

--- a/test/playwright/unit/apps/agentos/view/fleet/eventChip.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/eventChip.spec.mjs
@@ -24,19 +24,22 @@ test.describe('Fleet cockpit EventChip — renders a kind via the shared registr
         EventChip = (await import('../../../../../../../apps/agentos/view/fleet/EventChip.mjs')).default
     });
 
-    test('EventChip binds the kind token via --fm-chip and renders the label as a span', async () => {
+    test('EventChip binds the kind token via its fm-kind-* class (zero inline styles) and renders the label as a span', async () => {
         const chip = Neo.create(EventChip, {appName, kind: 'work-stall'});
         await chip.initVnode();
 
         expect(chip.vdom.tag).toBe('span');
         expect(chip.vdom.cls).toContain('fm-event-chip');
-        expect(chip.vdom.style['--fm-chip']).toBe('var(--fm-kind-alert)');
+        // the class carries the color binding (SCSS maps it onto --fm-chip); no inline style write
+        expect(chip.vdom.cls).toContain('fm-kind-alert');
+        expect(chip.vdom.style?.['--fm-chip']).toBeUndefined();
         expect(chip.vdom.text).toBe('stall');
 
-        // a kind swap re-renders the same instance
+        // a kind swap re-renders the same instance — old class out, new class in
         const before = chip.id;
         chip.kind = 'review';
-        expect(chip.vdom.style['--fm-chip']).toBe('var(--fm-kind-review)');
+        expect(chip.vdom.cls).toContain('fm-kind-review');
+        expect(chip.vdom.cls).not.toContain('fm-kind-alert');
         expect(chip.vdom.text).toBe('review');
         expect(chip.id).toBe(before);
 
@@ -47,7 +50,7 @@ test.describe('Fleet cockpit EventChip — renders a kind via the shared registr
         const chip = Neo.create(EventChip, {appName, kind: 'graduation-signal'});
         await chip.initVnode();
 
-        expect(chip.vdom.style['--fm-chip']).toBe('var(--fm-kind-neutral)');
+        expect(chip.vdom.cls).toContain('fm-kind-neutral');
         expect(chip.vdom.text).toBe('graduation-signal');
 
         chip.destroy()
@@ -57,7 +60,7 @@ test.describe('Fleet cockpit EventChip — renders a kind via the shared registr
         const chip = Neo.create(EventChip, {appName, kind: 'pr', label: 'merged'});
         await chip.initVnode();
 
-        expect(chip.vdom.style['--fm-chip']).toBe('var(--fm-kind-pr)');
+        expect(chip.vdom.cls).toContain('fm-kind-pr');
         expect(chip.vdom.text).toBe('merged');
 
         chip.destroy()

--- a/test/playwright/unit/apps/agentos/view/fleet/familyRail.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/familyRail.spec.mjs
@@ -18,12 +18,13 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 
 test.describe('Fleet cockpit FamilyRail — data-driven era attribute, unclassified-safe (#14635)', () => {
-    let FamilyRail, familyToken, isKnownFamily;
+    let FamilyRail, familyClass, familyToken, isKnownFamily;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../../apps/agentos/view/fleet/FamilyRail.mjs');
 
         FamilyRail    = mod.default;
+        familyClass   = mod.familyClass;
         familyToken   = mod.familyToken;
         isKnownFamily = mod.isKnownFamily
     });
@@ -43,6 +44,15 @@ test.describe('Fleet cockpit FamilyRail — data-driven era attribute, unclassif
         expect(familyToken('__proto__')).toBe('--fm-state-off')
     });
 
+    test('familyClass is the token minus the custom-property prefix for KNOWN families; unknown → null (the unclassified marker carries neutral)', () => {
+        expect(familyClass('claude')).toBe('fm-family-claude');
+        expect(familyClass('gpt')).toBe('fm-family-gpt');
+        expect(familyClass('human')).toBe('fm-family-human');
+        expect(familyClass('mystery')).toBeNull();
+        expect(familyClass(null)).toBeNull();
+        expect(familyClass('__proto__')).toBeNull()
+    });
+
     test('isKnownFamily gates the unclassified marker', () => {
         expect(isKnownFamily('claude')).toBe(true);
         expect(isKnownFamily('human')).toBe(true);
@@ -52,17 +62,19 @@ test.describe('Fleet cockpit FamilyRail — data-driven era attribute, unclassif
         expect(isKnownFamily('__proto__')).toBe(false)
     });
 
-    test('FamilyRail binds --fm-rail from the family and marks unknown/absent as unclassified', async () => {
+    test('FamilyRail binds --fm-rail from the family class and marks unknown/absent as unclassified', async () => {
         const rail = Neo.create(FamilyRail, {appName, family: 'claude'});
         await rail.initVnode();
 
         expect(rail.vdom.cls).toContain('fm-family-rail');
         expect(rail.vdom.cls).not.toContain('fm-family-unclassified');
-        expect(rail.vdom.style['--fm-rail']).toBe('var(--fm-family-claude)');
+        // the class carries the rail binding (SCSS maps it onto --fm-rail); no inline style write
+        expect(rail.vdom.cls).toContain('fm-family-claude');
+        expect(rail.vdom.style?.['--fm-rail']).toBeUndefined();
 
         // an unknown/absent family renders neutral + the unclassified marker — never a guessed family
         rail.family = 'mystery';
-        expect(rail.vdom.style['--fm-rail']).toBe('var(--fm-state-off)');
+        expect(rail.vdom.cls).not.toContain('fm-family-claude');
         expect(rail.vdom.cls).toContain('fm-family-unclassified');
 
         rail.destroy()
@@ -75,7 +87,8 @@ test.describe('Fleet cockpit FamilyRail — data-driven era attribute, unclassif
         const before = rail.id;
         // Opus→Fable is still Claude-family; a cross-family swap (Claude→GPT) is the harder case
         rail.family = 'gpt';
-        expect(rail.vdom.style['--fm-rail']).toBe('var(--fm-family-gpt)');
+        expect(rail.vdom.cls).toContain('fm-family-gpt');
+        expect(rail.vdom.cls).not.toContain('fm-family-claude');
         expect(rail.id).toBe(before);
         expect(rail.vdom.cls).not.toContain('fm-family-unclassified');
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
@@ -43,7 +43,7 @@ test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#1479
         expect(cards[0].componentRef).toBe(agentCardComponentRef('vega'))
     })
 
-    test('emits a fully JSON-serializable blueprint (ntype + provider data — no live objects)', () => {
+    test('emits a fully JSON-serializable blueprint (ntype + record field bag — no live objects)', () => {
         const snapshot = createFleetCockpitStatus({
             agents     : [{id: 'vega', githubUsername: 'neo-opus-vega', displayName: 'Vega'}],
             fleetStatus: []
@@ -52,10 +52,10 @@ test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#1479
         const [card] = createFleetCardDescriptors(snapshot)
 
         expect(card.blueprint.ntype).toBe('fm-agent-card')
-        expect(card.blueprint.stateProvider.data.agentId).toBe('vega')
-        expect(card.blueprint.stateProvider.data.displayName).toBe('Vega')
+        expect(card.blueprint.record.agentId).toBe('vega')
+        expect(card.blueprint.record.displayName).toBe('Vega')
         // the avatar auto-derived through the DTO (from the GitHub account) rides into the blueprint
-        expect(card.blueprint.stateProvider.data.avatarUrl).toBe('https://github.com/neo-opus-vega.png?size=80')
+        expect(card.blueprint.record.avatarUrl).toBe('https://github.com/neo-opus-vega.png?size=80')
 
         // serializable end-to-end — a captured perspective can restore a real card from the blueprint
         expect(() => JSON.stringify(card.blueprint)).not.toThrow()
@@ -69,8 +69,8 @@ test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#1479
     })
 
     test('null-safe + forward-compatible: a sparse row yields null display fields, never undefined', () => {
-        const card   = toAgentCardDescriptor({id: 'ghost'})
-        const {data} = card.blueprint.stateProvider
+        const card = toAgentCardDescriptor({id: 'ghost'})
+        const data = card.blueprint.record
 
         expect(card.componentRef).toBe('fm-agent-card-ghost')
         expect(data.agentId).toBe('ghost')
@@ -88,7 +88,7 @@ test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#1479
     test('maps the session state through from the DTO lifecycle axis', () => {
         const card = toAgentCardDescriptor({id: 'vega', lifecycle: {state: 'ok'}})
 
-        expect(card.blueprint.stateProvider.data.state).toBe('ok')
+        expect(card.blueprint.record.state).toBe('ok')
     })
 
     test('createFleetCardDescriptors tolerates a rowless / empty DTO', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -163,7 +163,20 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         expect(euclid.isRecord).toBe(true);
         expect(euclid.displayName).toBe('Euclid');
         expect(euclid.pendingAction).toBeNull();
-        expect(euclid.controlReason).toBeNull()
+        expect(euclid.controlReason).toBeNull();
+
+        // engine tags pinned to CURRENT identity truth (the registry designations at seed time) —
+        // this front-door surface must not silently reintroduce a stale model designation
+        const engineTags = Object.fromEntries(FleetRoster.items.map(record => [record.agentId, record.engineTag]));
+        expect(engineTags).toEqual({
+            'neo-fable'     : 'fable-5',
+            'neo-fable-clio': 'fable-5',
+            'neo-gemini-pro': '3.1-pro',
+            'neo-gpt'       : 'gpt-5.6-sol',
+            'neo-opus-ada'  : 'opus-4.8',
+            'neo-opus-grace': 'opus-4.8',
+            'neo-opus-vega' : 'opus-4.8'
+        })
     });
 
     test('no bridge / no verb / not-wired / thrown → keeps the last-known roster (fail-closed, no crash)', async () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -99,6 +99,132 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
     });
 });
 
+/**
+ * Covers the Store-backed roster data path: the shared `FleetRoster` singleton contract
+ * and the fail-closed routing matrix for `FleetCockpit.loadRoster()` — the app-side consumption of
+ * the read-observe `fleetRoster` bridge verb. Like `loadActivity`, the unit is the ROUTING decision;
+ * the grid + store are collaborators, mocked with spies that record what `loadRoster` does to them.
+ */
+test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
+    let FleetAgent, FleetCockpit, FleetRoster;
+
+    const clearBridge = () => { delete globalThis.AgentOS };
+
+    // a spy store + grid: `loadRoster` clears/adds on first wire, merges after, flips adapterState
+    const makeGrid = (known = {}) => {
+        const store = {
+            added  : [],
+            cleared: 0,
+            clear() { this.cleared++ },
+            add(rows) { this.added.push(...[].concat(rows)) },
+            get(id) { return known[id] ?? null }
+        };
+
+        return {adapterState: 'sample', store}
+    };
+
+    const makeCockpit = (grid, rosterWired = false) => ({
+        getReference: reference => reference === 'fleet-grid' ? grid : null,
+        mergeRoster : FleetCockpit.prototype.mergeRoster,
+        rosterWired
+    });
+
+    const routeLoadRoster = async (bridge, {known, rosterWired} = {}) => {
+        bridge ? (globalThis.AgentOS = {fleet: {registryBridge: bridge}}) : clearBridge();
+
+        const grid    = makeGrid(known),
+              cockpit = makeCockpit(grid, rosterWired);
+
+        await FleetCockpit.prototype.loadRoster.call(cockpit);
+
+        return {cockpit, grid}
+    };
+
+    test.beforeAll(async () => {
+        FleetAgent   = (await import('../../../../../../../apps/agentos/model/FleetAgent.mjs')).default;
+        FleetCockpit = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default;
+        FleetRoster  = (await import('../../../../../../../apps/agentos/store/FleetRoster.mjs')).default
+    });
+
+    test.afterEach(() => clearBridge());
+
+    test('FleetRoster is the shared Store of FleetAgent records — durable agentId keying, honest sample seed', () => {
+        // ONE Store singleton is the roster SSOT; its Model fields ARE the card contract
+        expect(FleetRoster.getKeyProperty()).toBe('agentId');
+        expect(FleetRoster.model.className).toBe('AgentOS.model.FleetAgent');
+
+        // the seed is the seven REAL maintainer identities — an honest sample, no invented agents
+        expect(FleetRoster.count).toBe(7);
+        const knownHandles = ['neo-fable', 'neo-fable-clio', 'neo-gemini-pro', 'neo-gpt', 'neo-opus-ada', 'neo-opus-grace', 'neo-opus-vega'];
+        expect(FleetRoster.items.map(record => record.agentId).sort()).toEqual(knownHandles);
+
+        // rows hydrate as records exposing the model fields — incl the B4/C2 control seam defaults
+        const euclid = FleetRoster.get('neo-gpt');
+        expect(euclid.isRecord).toBe(true);
+        expect(euclid.displayName).toBe('Euclid');
+        expect(euclid.pendingAction).toBeNull();
+        expect(euclid.controlReason).toBeNull()
+    });
+
+    test('no bridge / no verb / not-wired / thrown → keeps the last-known roster (fail-closed, no crash)', async () => {
+        for (const bridge of [
+            null,
+            {},
+            {fleetRoster: async () => ({capability: {state: 'not-wired'}, agents: [{agentId: 'x'}]})},
+            {fleetRoster: async () => { throw new Error('bridge boom') }}
+        ]) {
+            const {grid} = await routeLoadRoster(bridge);
+
+            expect(grid.adapterState).toBe('sample');
+            expect(grid.store.cleared).toBe(0);
+            expect(grid.store.added).toEqual([])
+        }
+    });
+
+    test('wired + EMPTY → keeps the last-known roster — an empty fleet from a wired source never blanks the cockpit', async () => {
+        const {grid} = await routeLoadRoster({fleetRoster: async () => ({capability: {state: 'wired'}, agents: []})});
+
+        expect(grid.adapterState).toBe('sample');
+        expect(grid.store.cleared).toBe(0)
+    });
+
+    test('degraded → the stale banner over the last-known roster', async () => {
+        const {grid} = await routeLoadRoster({fleetRoster: async () => ({capability: {state: 'degraded'}, agents: []})});
+
+        expect(grid.adapterState).toBe('stale');
+        expect(grid.store.cleared).toBe(0)
+    });
+
+    test('the FIRST wired payload populates the Store (replaces the sample seed) and goes live — rows without agentId are dropped', async () => {
+        const {cockpit, grid} = await routeLoadRoster({fleetRoster: async () => ({
+            capability: {state: 'wired'},
+            agents    : [{agentId: 'vega', state: 'ok'}, {noId: true}, {agentId: 'ada', state: 'idle'}]
+        })});
+
+        expect(grid.store.cleared).toBe(1);
+        expect(grid.store.added.map(row => row.agentId)).toEqual(['vega', 'ada']);
+        expect(grid.adapterState).toBe('live');
+        expect(cockpit.rosterWired).toBe(true)
+    });
+
+    test('later wired payloads MERGE onto records — record.set(row) per known agentId, add for a new resident', async () => {
+        const writes = [],
+              vega   = {set(row) { writes.push(row) }};
+
+        const {grid} = await routeLoadRoster({fleetRoster: async () => ({
+            capability: {state: 'wired'},
+            agents    : [{agentId: 'vega', state: 'wedged'}, {agentId: 'joiner', state: 'ok'}]
+        })}, {known: {vega}, rosterWired: true});
+
+        // known resident → runtime status merged onto ITS record (the store re-renders just that card)
+        expect(writes).toEqual([{agentId: 'vega', state: 'wedged'}]);
+        // new resident → joins the roster; the seed is never re-cleared on a merge
+        expect(grid.store.added.map(row => row.agentId)).toEqual(['joiner']);
+        expect(grid.store.cleared).toBe(0);
+        expect(grid.adapterState).toBe('live')
+    });
+});
+
 test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
     let FleetCockpitController;
 
@@ -109,19 +235,19 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
     test('onStartFleet fans out start to every resident card via the C2 adapter (fold skipped; no bridge → fail-closed per card, never optimistic)', () => {
         // The morning-start button drives the round-trip directly (the cockpit owns the wire): it
         // enumerates the rendered cards — the collapsed-idle fold is filtered by ntype — and dispatches a
-        // start intent + each card's provider to the adapter. No bridge → each card takes an honest
-        // `unauthorized` controlReason, never an optimistic fleet-wide success.
+        // start intent + each card's roster record to the adapter. No bridge → each card takes an honest
+        // `unauthorized` controlReason onto its record, never an optimistic fleet-wide success.
         delete globalThis.AgentOS;
 
         const mkCard = agentId => {
-            const writes   = [],
-                  provider = {setData(values) { writes.push(values) }, getData: key => key === 'agentId' ? agentId : null};
-            return {ntype: 'fm-agent-card', writes, getStateProvider: () => provider}
+            const writes = [],
+                  record = {agentId, writes, set(values) { writes.push(values) }};
+            return {ntype: 'fm-agent-card', record, writes}
         };
 
         const vega = mkCard('neo-opus-vega'),
               ada  = mkCard('neo-opus-ada'),
-              fold = {ntype: 'component'}; // the collapsed-idle fold — no provider, must be skipped
+              fold = {ntype: 'component'}; // the collapsed-idle fold — no record, must be skipped
 
         const controller = Object.create(FleetCockpitController.prototype);
 
@@ -133,16 +259,16 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
         expect(ada.writes.some(write => write.controlReason?.kind === 'unauthorized')).toBe(true)
     });
 
-    test('onAgentLifecycleIntent resolves the firing card + drives the C2 adapter — no bridge → fail-closed onto the card provider, never optimistic', () => {
+    test('onAgentLifecycleIntent resolves the firing card + drives the C2 adapter — no bridge → fail-closed onto the card record, never optimistic', () => {
         // A card fires intent-only; the cockpit resolves the firing card from the event `source` and
-        // hands it + the card's provider to the adapter. With no registry bridge the adapter fails
-        // closed — an `unauthorized` controlReason lands on the provider, never an optimistic success.
+        // hands it + the card's roster record to the adapter. With no registry bridge the adapter fails
+        // closed — an `unauthorized` controlReason lands on the record, never an optimistic success.
         delete globalThis.AgentOS;
 
-        const writes   = [],
-              provider = {setData(values) { writes.push(values) }},
-              card     = {getStateProvider: () => provider},
-              origGet  = Neo.getComponent;
+        const writes  = [],
+              record  = {agentId: 'vega', set(values) { writes.push(values) }},
+              card    = {record},
+              origGet = Neo.getComponent;
 
         Neo.getComponent = id => id === 'fm-card-x' ? card : null;
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
@@ -139,11 +139,20 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         const first = rankFleet(store.items).online[0];
         expect(lastId()).not.toBe(first.agentId);
 
+        // the grid seats its store onto the header health bar — counts derive from the same records
+        const bar = grid.getReference('fleet-health');
+        expect(bar.store).toBe(store);
+        expect(swatchOf(bar, 'ok').count).toBe(2);
+
         first.set({state: 'off'});
 
         expect(agentCards(grid).length).toBe(3);           // still every card — a tier move, not a drop
         expect(lastId()).toBe(first.agentId);              // now the benched tail
         expect(agentCards(grid).at(-1).down({ntype: 'fm-state-dot'}).state).toBe('off');
+
+        // ...and the store-bound health bar re-tallied through ITS OWN record seam (no array push)
+        expect(swatchOf(bar, 'ok').count).toBe(1);
+        expect(swatchOf(bar, 'off').count).toBe(1);
 
         grid.destroy()
     });
@@ -183,8 +192,9 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         grid.destroy()
     });
 
-    test('HealthBar renders the five swatches and updates counts IN PLACE across roster changes (no rebuild)', () => {
-        const bar = Neo.create(HealthBar, {appName, agents: roster(['ok', 'ok', 'idle', 'off'])});
+    test('HealthBar is Store-bound — counts tally from records and react through the store seam, swatches stable (no rebuild)', () => {
+        const store = makeStore(roster(['ok', 'ok', 'idle', 'off'])),
+              bar   = Neo.create(HealthBar, {appName, store});
 
         expect(bar.items.length).toBe(5);
         expect(swatchOf(bar, 'ok').count).toBe(2);
@@ -192,19 +202,22 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         expect(swatchOf(bar, 'off').count).toBe(1);
         expect(swatchOf(bar, 'wedged').count).toBe(0);   // zero still renders (confirms "none")
 
-        // stable instances: capture ids, change the roster, assert SAME swatch instances updated
+        // stable instances: capture ids, mutate a RECORD, assert SAME swatch instances re-tallied
         const idsBefore = bar.items.map(sw => sw.id);
-        bar.agents = roster(['ok', 'ok', 'ok', 'wedged', 'wedged']);
+        store.items[2].set({state: 'wedged'});                   // idle → wedged, via the record seam
         expect(bar.items.map(sw => sw.id)).toEqual(idsBefore);   // not recreated → the count transition can animate
-        expect(swatchOf(bar, 'ok').count).toBe(3);
-        expect(swatchOf(bar, 'wedged').count).toBe(2);
         expect(swatchOf(bar, 'idle').count).toBe(0);
+        expect(swatchOf(bar, 'wedged').count).toBe(1);
+
+        // a store load (roster growth) re-tallies too
+        store.add({agentId: 'agent-99', state: 'ok'});
+        expect(swatchOf(bar, 'ok').count).toBe(3);
 
         // guest/unknown folds into the VISIBLE off swatch — the five-swatch bar never undercounts a roster
-        bar.agents = roster(['ok', 'guest', 'mysterious']);
+        store.items[0].set({state: 'mysterious'});
         expect(bar.items.length).toBe(5);              // still no 6th swatch
-        expect(swatchOf(bar, 'off').count).toBe(2);    // guest + mysterious rendered as benched
-        expect(swatchOf(bar, 'ok').count).toBe(1);
+        expect(swatchOf(bar, 'off').count).toBe(2);    // off + mysterious rendered as benched
+        expect(swatchOf(bar, 'ok').count).toBe(2);
 
         bar.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
@@ -17,8 +17,10 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import Instance       from '../../../../../../../src/manager/Instance.mjs';
 
-test.describe('Fleet cockpit FleetGrid + HealthBar — density-ranked grid (#14599)', () => {
-    let FleetGrid, HealthBar, rankFleet, healthCounts;
+test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-ranked grid (#14599)', () => {
+    let FleetAgent, FleetGrid, HealthBar, Store, rankFleet, healthCounts;
+
+    const stores = [];
 
     // a roster from a list of states; agentIds are shuffled-stable so the sort is provable
     const roster = states => states.map((state, i) => ({
@@ -26,6 +28,16 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — density-ranked grid (#145
         displayName: `Agent ${i}`,
         state
     }));
+
+    // one Store of FleetAgent records per grid — the production data path (an isolated
+    // AgentOS.store.FleetRoster shape; keyProperty mirrored per the collection-default shadow)
+    const makeStore = rows => {
+        const store = Neo.create(Store, {keyProperty: 'agentId', model: FleetAgent, data: rows});
+
+        stores.push(store);
+
+        return store
+    };
 
     const cardsBox   = grid => grid.items.find(item => item.cls.includes('fm-fleet-cards'));
     const agentCards = grid => cardsBox(grid).items.filter(item => item.ntype === 'fm-agent-card');
@@ -40,7 +52,14 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — density-ranked grid (#145
         FleetGrid    = gridMod.default;
         rankFleet    = gridMod.rankFleet;
         HealthBar    = barMod.default;
-        healthCounts = barMod.healthCounts
+        healthCounts = barMod.healthCounts;
+        FleetAgent   = (await import('../../../../../../../apps/agentos/model/FleetAgent.mjs')).default;
+        Store        = (await import('../../../../../../../src/data/Store.mjs')).default
+    });
+
+    test.afterAll(() => {
+        stores.forEach(store => store.destroy());
+        stores.length = 0
     });
 
     test('healthCounts is the pure tally — five canonical categories; unknown/guest folds into off (no 6th key, no undercount)', () => {
@@ -81,29 +100,85 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — density-ranked grid (#145
         expect(rankFleet(roster(Array(20).fill('idle')), {foldThreshold: 12}).folded).toBe(true)
     });
 
-    test('below threshold the grid renders every card in ranked order — no fold', () => {
-        const grid = Neo.create(FleetGrid, {appName, foldThreshold: 12, agents: roster(['ok', 'idle', 'off', 'ok', 'idle', 'wedged'])});
+    test('below threshold the grid renders every record as a card in ranked order — no fold', () => {
+        const grid = Neo.create(FleetGrid, {appName, foldThreshold: 12, store: makeStore(roster(['ok', 'idle', 'off', 'ok', 'idle', 'wedged']))});
 
         expect(agentCards(grid).length).toBe(6);   // all six render
         expect(foldRow(grid)).toBeFalsy();          // nothing collapsed
         expect(head(grid).items.find(i => i.cls.includes('fm-fleet-title')).text).toBe('Fleet · 6 agents');
+        // each card renders from a live store record, not a mapped copy
+        expect(agentCards(grid).every(card => card.record.isRecord)).toBe(true);
 
         grid.destroy()
     });
 
     test('at/over threshold the idle tier collapses to an honest count — online + benched stay as cards', () => {
         // 4 online · 6 idle · 2 benched = 12 → folded
-        const grid = Neo.create(FleetGrid, {appName, foldThreshold: 12, agents: roster([
+        const grid = Neo.create(FleetGrid, {appName, foldThreshold: 12, store: makeStore(roster([
             'ok', 'ok', 'limited', 'wedged',
             'idle', 'idle', 'idle', 'idle', 'idle', 'idle',
             'off', 'off'
-        ])});
+        ]))});
 
         // online (4) + benched (2) render as cards; the six idle do NOT
         expect(agentCards(grid).length).toBe(6);
         // the fold surfaces the folded idle count — never a silent drop
         expect(foldRow(grid)).toBeTruthy();
         expect(foldRow(grid).text).toBe('6 idle');
+
+        grid.destroy()
+    });
+
+    test('a record `state` change re-ranks the grid — the store recordChange IS the reactive layer, no manual diffing', () => {
+        const store = makeStore(roster(['ok', 'ok', 'idle'])),
+              grid  = Neo.create(FleetGrid, {appName, foldThreshold: 12, store});
+
+        const lastId = () => agentCards(grid).at(-1).record.agentId;
+
+        // pick the first online record and bench it — the card must move to the benched tail
+        const first = rankFleet(store.items).online[0];
+        expect(lastId()).not.toBe(first.agentId);
+
+        first.set({state: 'off'});
+
+        expect(agentCards(grid).length).toBe(3);           // still every card — a tier move, not a drop
+        expect(lastId()).toBe(first.agentId);              // now the benched tail
+        expect(agentCards(grid).at(-1).down({ntype: 'fm-state-dot'}).state).toBe('off');
+
+        grid.destroy()
+    });
+
+    test('a non-state record write updates the ONE affected card in place — same card instances, no rebuild', () => {
+        const store = makeStore(roster(['ok', 'ok', 'idle'])),
+              grid  = Neo.create(FleetGrid, {appName, foldThreshold: 12, store});
+
+        const idsBefore = agentCards(grid).map(card => card.id),
+              record    = store.items[0];
+
+        record.set({laneLine: 'rebuilt on records', pendingAction: 'start'});
+
+        // the card set was NOT rebuilt — the same instances survived (the in-place seam)
+        expect(agentCards(grid).map(card => card.id)).toEqual(idsBefore);
+
+        // ...and the one affected card re-rendered its record: lane line + the B4 pending render
+        const card = agentCards(grid).find(c => c.record === record);
+        expect(card.down({reference: 'card-lane'}).text).toBe('rebuilt on records');
+        expect(card.down({reference: 'control-verbs'}).items.every(button => button.disabled)).toBe(true);
+        expect(card.down({reference: 'control-status'}).text).toBe('start…');
+
+        grid.destroy()
+    });
+
+    test('a store load re-derives the surface — adding a resident extends the grid and the title', () => {
+        const store = makeStore(roster(['ok', 'idle'])),
+              grid  = Neo.create(FleetGrid, {appName, store});
+
+        expect(agentCards(grid).length).toBe(2);
+
+        store.add({agentId: 'agent-99', displayName: 'Joiner', state: 'ok'});
+
+        expect(agentCards(grid).length).toBe(3);
+        expect(head(grid).items.find(i => i.cls.includes('fm-fleet-title')).text).toBe('Fleet · 3 agents');
 
         grid.destroy()
     });
@@ -135,12 +210,22 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — density-ranked grid (#145
     });
 
     test('degrades honestly on adapter loss — a stale header, never a blanked grid', () => {
-        const grid = Neo.create(FleetGrid, {appName, adapterState: 'stale', agents: roster(['ok', 'idle', 'off'])});
+        const grid = Neo.create(FleetGrid, {appName, adapterState: 'stale', store: makeStore(roster(['ok', 'idle', 'off']))});
 
         expect(head(grid).cls).toContain('is-stale');
         expect(head(grid).items.find(i => i.cls.includes('fm-fleet-stale')).text).toBe('stale — reconnecting');
         // the cards still render — degrade surfaces the state, it does not blank the grid
         expect(agentCards(grid).length).toBe(3);
+
+        grid.destroy()
+    });
+
+    test('labels the seeded roster honestly — a sample marker until the live source wires', () => {
+        const grid = Neo.create(FleetGrid, {appName, adapterState: 'sample', store: makeStore(roster(['ok']))});
+
+        expect(head(grid).cls).toContain('is-sample');
+        expect(head(grid).items.find(i => i.cls.includes('fm-fleet-stale')).text).toBe('sample roster');
+        expect(agentCards(grid).length).toBe(1);
 
         grid.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.spec.mjs
@@ -24,30 +24,34 @@ import {
     writeLifecycleControlState
 } from '../../../../../../../apps/agentos/view/fleet/fleetLifecycleIntentAdapter.mjs';
 
-const createProvider = (data = {}) => ({
-    data  : {pendingAction: null, controlReason: null, ...data},
+// a record double: bulk `set()` like a Neo.data record (the C2 write seam), fields readable as
+// plain properties — mirrors AgentOS.model.FleetAgent's pendingAction/controlReason contract.
+const createRecord = (data = {}) => ({
+    pendingAction: null,
+    controlReason: null,
+    ...data,
     writes: [],
 
-    setData(values) {
+    set(values) {
         this.writes.push({...values});
-        Object.assign(this.data, values)
+        Object.assign(this, values)
     }
 });
 
-test.describe('fleetLifecycleIntentAdapter — lifecycleIntent → registry bridge → provider state (#14889)', () => {
+test.describe('fleetLifecycleIntentAdapter — lifecycleIntent → registry bridge → record state (#14889)', () => {
     test('maps start/stop/restart intents to existing bridge verbs with agentId-only payloads', async () => {
         const
-            provider = createProvider({controlReason: {action: 'stop', kind: 'rejected', reason: 'old failure'}}),
-            calls    = [],
-            bridge   = {
+            record = createRecord({controlReason: {action: 'stop', kind: 'rejected', reason: 'old failure'}}),
+            calls  = [],
+            bridge = {
                 startAgent  : async id => { calls.push(['startAgent', id]); return {state: 'running'} },
                 stopAgent   : async id => { calls.push(['stopAgent', id]); return {state: 'stopped'} },
                 restartAgent: async id => { calls.push(['restartAgent', id]); return {state: 'running'} }
             };
 
-        await handleFleetLifecycleIntent({action: 'start', agentId: 'vega'}, provider, {bridge});
-        await handleFleetLifecycleIntent({action: 'stop', agentId: 'vega'}, provider, {bridge});
-        await handleFleetLifecycleIntent({action: 'restart', agentId: 'vega'}, provider, {bridge});
+        await handleFleetLifecycleIntent({action: 'start', agentId: 'vega'}, record, {bridge});
+        await handleFleetLifecycleIntent({action: 'stop', agentId: 'vega'}, record, {bridge});
+        await handleFleetLifecycleIntent({action: 'restart', agentId: 'vega'}, record, {bridge});
 
         expect(calls).toEqual([
             ['startAgent', 'vega'],
@@ -56,29 +60,29 @@ test.describe('fleetLifecycleIntentAdapter — lifecycleIntent → registry brid
         ]);
         // Secret boundary: bridge verbs receive the operation-specific id only, never an object carrying PATs.
         expect(calls.every(([, payload]) => typeof payload === 'string')).toBe(true);
-        expect(provider.data.pendingAction).toBeNull();
-        expect(provider.data.controlReason).toBeNull()
+        expect(record.pendingAction).toBeNull();
+        expect(record.controlReason).toBeNull()
     });
 
     test('sets pendingAction and clears stale controlReason when an accepted intent enters pending', async () => {
         const
-            provider     = createProvider({controlReason: {action: 'start', kind: 'rejected', reason: 'old'}}),
+            record       = createRecord({controlReason: {action: 'start', kind: 'rejected', reason: 'old'}}),
             bridge       = {startAgent: () => Promise.resolve({state: 'running'})},
-            settleResult = await handleFleetLifecycleIntent({action: 'start', agentId: 'vega'}, provider, {bridge});
+            settleResult = await handleFleetLifecycleIntent({action: 'start', agentId: 'vega'}, record, {bridge});
 
-        expect(provider.writes[0]).toEqual({controlReason: null, pendingAction: 'start'});
-        expect(provider.writes.at(-1)).toEqual({controlReason: null, pendingAction: null});
+        expect(record.writes[0]).toEqual({controlReason: null, pendingAction: 'start'});
+        expect(record.writes.at(-1)).toEqual({controlReason: null, pendingAction: null});
         expect(settleResult).toMatchObject({accepted: true, action: 'start', method: 'startAgent', ok: true, status: 'settled'})
     });
 
     test('bridge rejection clears pendingAction and writes a sanitized rejected reason', async () => {
         const
-            provider = createProvider(),
-            bridge   = {restartAgent: async () => { throw new Error('PAT: github_pat_secretvalue') }},
-            result   = await handleFleetLifecycleIntent({action: 'restart', agentId: 'vega'}, provider, {bridge});
+            record = createRecord(),
+            bridge = {restartAgent: async () => { throw new Error('PAT: github_pat_secretvalue') }},
+            result = await handleFleetLifecycleIntent({action: 'restart', agentId: 'vega'}, record, {bridge});
 
-        expect(provider.data.pendingAction).toBeNull();
-        expect(provider.data.controlReason).toEqual({
+        expect(record.pendingAction).toBeNull();
+        expect(record.controlReason).toEqual({
             action: 'restart',
             kind  : 'rejected',
             reason: '[redacted]'
@@ -88,10 +92,10 @@ test.describe('fleetLifecycleIntentAdapter — lifecycleIntent → registry brid
 
     test('missing bridge fails closed as unauthorized without accepting a pending action', async () => {
         const
-            provider = createProvider(),
-            result   = await handleFleetLifecycleIntent({action: 'stop', agentId: 'vega'}, provider, {bridge: null});
+            record = createRecord(),
+            result = await handleFleetLifecycleIntent({action: 'stop', agentId: 'vega'}, record, {bridge: null});
 
-        expect(provider.writes).toEqual([{
+        expect(record.writes).toEqual([{
             pendingAction: null,
             controlReason: {action: 'stop', kind: 'unauthorized', reason: 'Fleet Registry bridge unavailable'}
         }]);
@@ -100,12 +104,12 @@ test.describe('fleetLifecycleIntentAdapter — lifecycleIntent → registry brid
 
     test('unsupported action rejects before calling the bridge', async () => {
         const
-            provider = createProvider(),
-            bridge   = {startAgent: async () => { throw new Error('must not call') }},
-            result   = await handleFleetLifecycleIntent({action: 'remove', agentId: 'vega'}, provider, {bridge});
+            record = createRecord(),
+            bridge = {startAgent: async () => { throw new Error('must not call') }},
+            result = await handleFleetLifecycleIntent({action: 'remove', agentId: 'vega'}, record, {bridge});
 
-        expect(provider.data.pendingAction).toBeNull();
-        expect(provider.data.controlReason).toEqual({
+        expect(record.pendingAction).toBeNull();
+        expect(record.controlReason).toEqual({
             action: 'remove',
             kind  : 'rejected',
             reason: "Unsupported lifecycle action 'remove'"
@@ -115,14 +119,14 @@ test.describe('fleetLifecycleIntentAdapter — lifecycleIntent → registry brid
 
     test('timeout clears pendingAction and writes a timeout reason', async () => {
         const
-            provider     = createProvider(),
+            record       = createRecord(),
             bridge       = {startAgent: () => new Promise(() => {})},
             setTimeoutFn = fn => {
                 fn();
                 return 'timeout-id'
             },
             clearCalls   = [],
-            result       = await handleFleetLifecycleIntent({action: 'start', agentId: 'vega'}, provider, {
+            result       = await handleFleetLifecycleIntent({action: 'start', agentId: 'vega'}, record, {
                 bridge,
                 clearTimeoutFn: id => clearCalls.push(id),
                 setTimeoutFn,
@@ -130,8 +134,8 @@ test.describe('fleetLifecycleIntentAdapter — lifecycleIntent → registry brid
             });
 
         expect(clearCalls).toEqual(['timeout-id']);
-        expect(provider.data.pendingAction).toBeNull();
-        expect(provider.data.controlReason).toEqual({
+        expect(record.pendingAction).toBeNull();
+        expect(record.controlReason).toEqual({
             action: 'start',
             kind  : 'timeout',
             reason: 'start timed out after 1ms'
@@ -139,19 +143,20 @@ test.describe('fleetLifecycleIntentAdapter — lifecycleIntent → registry brid
         expect(result).toMatchObject({accepted: true, ok: false, status: 'timeout'})
     });
 
-    test('the provider writer supports StateProvider-style setData and plain data fallbacks', () => {
-        const provider = createProvider();
+    test('the record writer supports record-style set() and the plain field-bag fallback (dock snapshot)', () => {
+        const record = createRecord();
 
-        writeLifecycleControlState(provider, {
+        writeLifecycleControlState(record, {
             controlReason: createControlReason('start', 'rejected', 'no slot'),
             pendingAction: null
         });
 
-        expect(provider.data.controlReason).toEqual({action: 'start', kind: 'rejected', reason: 'no slot'});
+        expect(record.controlReason).toEqual({action: 'start', kind: 'rejected', reason: 'no slot'});
 
-        const fallback = {data: {pendingAction: 'stop'}};
-        writeLifecycleControlState(fallback, {pendingAction: null});
-        expect(fallback.data.pendingAction).toBeNull()
+        // a plain field bag (the dock-blueprint snapshot shape) is mutated in place
+        const bag = {pendingAction: 'stop', controlReason: null};
+        writeLifecycleControlState(bag, {pendingAction: null});
+        expect(bag.pendingAction).toBeNull()
     });
 
     test('reason sanitization redacts token-shaped strings', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/healthSwatch.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/healthSwatch.spec.mjs
@@ -47,7 +47,9 @@ test.describe('Fleet cockpit HealthSwatch — state-axis legend + count-bar unit
               label = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-label')),
               count = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-count'));
 
-        expect(dot.style['--fm-dot']).toBe('var(--fm-state-wedged)');
+        // the ROOT carries the state class; SCSS binds --fm-dot from it (inherited by the dot) — no inline style
+        expect(sw.vdom.cls).toContain('fm-state-wedged');
+        expect(dot.style?.['--fm-dot']).toBeUndefined();
         expect(label.text).toBe('wedged');
         // class-idiom: the count node stays in cn, removeDom-toggled (not omitted) — so a plain
         // legend row renders no count element in the DOM.
@@ -74,10 +76,9 @@ test.describe('Fleet cockpit HealthSwatch — state-axis legend + count-bar unit
         const sw = Neo.create(HealthSwatch, {appName, state: 'mystery'});
         await sw.initVnode();
 
-        const dot   = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-dot')),
-              label = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-label'));
+        const label = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-label'));
 
-        expect(dot.style['--fm-dot']).toBe('var(--fm-state-off)');
+        expect(sw.vdom.cls).toContain('fm-state-off');
         expect(label.text).toBe('mystery');
 
         sw.destroy()
@@ -87,11 +88,10 @@ test.describe('Fleet cockpit HealthSwatch — state-axis legend + count-bar unit
         const sw = Neo.create(HealthSwatch, {appName, state: 'toString'});
         await sw.initVnode();
 
-        const dot   = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-dot')),
-              label = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-label'));
+        const label = sw.vdom.cn.find(n => n.cls?.includes('fm-sw-label'));
 
-        // both the dot token (via stateToken) and the label (via stateLabel) must be closed-set-safe
-        expect(dot.style['--fm-dot']).toBe('var(--fm-state-off)');
+        // both the dot class (via stateClass) and the label (via stateLabel) must be closed-set-safe
+        expect(sw.vdom.cls).toContain('fm-state-off');
         expect(label.text).toBe('toString');
 
         sw.destroy()

--- a/test/playwright/unit/apps/agentos/view/fleet/statePrimitives.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/statePrimitives.spec.mjs
@@ -18,12 +18,13 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 
 test.describe('Fleet cockpit StateDot — session-state token mapping + reduced-motion (#14593)', () => {
-    let StateDot, stateToken;
+    let StateDot, stateClass, stateToken;
 
     test.beforeAll(async () => {
         const dot = await import('../../../../../../../apps/agentos/view/fleet/StateDot.mjs');
 
         StateDot   = dot.default;
+        stateClass = dot.stateClass;
         stateToken = dot.stateToken
     });
 
@@ -42,19 +43,35 @@ test.describe('Fleet cockpit StateDot — session-state token mapping + reduced-
         expect(stateToken('__proto__')).toBe('--fm-state-off')
     });
 
-    test('StateDot binds the token via --fm-dot and gates the pulse behind the live config', async () => {
+    test('stateClass is the token minus the custom-property prefix — the class the SCSS token binding keys on', () => {
+        expect(stateClass('ok')).toBe('fm-state-ok');
+        expect(stateClass('wedged')).toBe('fm-state-wedged');
+        // shares the closed-set degrade — unknown / prototype-shaped → the neutral off class
+        expect(stateClass('nonsense')).toBe('fm-state-off');
+        expect(stateClass(undefined)).toBe('fm-state-off');
+        expect(stateClass('__proto__')).toBe('fm-state-off')
+    });
+
+    test('StateDot binds the token via its state class (zero inline styles) and gates the pulse behind the live config', async () => {
         const dot = Neo.create(StateDot, {appName, state: 'wedged', live: true});
         await dot.initVnode();
 
-        expect(dot.vdom.style['--fm-dot']).toBe('var(--fm-state-wedged)');
+        // the class carries the color binding (SCSS maps it onto --fm-dot); no inline style write
+        expect(dot.vdom.cls).toContain('fm-state-wedged');
+        expect(dot.vdom.style?.['--fm-dot']).toBeUndefined();
         expect(dot.vdom.cls).toContain('fm-state-dot');
         expect(dot.vdom.cls).toContain('fm-live');
+
+        // a state transition swaps the class in place — old class out, new class in
+        dot.state = 'ok';
+        expect(dot.vdom.cls).toContain('fm-state-ok');
+        expect(dot.vdom.cls).not.toContain('fm-state-wedged');
 
         // reduced-motion config path: dropping live removes the pulse class; the color (signal) stays
         dot.live = false;
         expect(dot.vdom.cls).toContain('fm-state-dot');
         expect(dot.vdom.cls).not.toContain('fm-live');
-        expect(dot.vdom.style['--fm-dot']).toBe('var(--fm-state-wedged)');
+        expect(dot.vdom.cls).toContain('fm-state-ok');
 
         dot.destroy()
     });
@@ -63,7 +80,8 @@ test.describe('Fleet cockpit StateDot — session-state token mapping + reduced-
         const dot = Neo.create(StateDot, {appName, state: 'nonsense'});
         await dot.initVnode();
 
-        expect(dot.vdom.style['--fm-dot']).toBe('var(--fm-state-off)');
+        expect(dot.vdom.cls).toContain('fm-state-off');
+        expect(dot.vdom.style?.['--fm-dot']).toBeUndefined();
         expect(dot.vdom.cls).not.toContain('fm-live');
 
         dot.destroy()


### PR DESCRIPTION
Resolves #14899

Related: #13015 (parent epic) · #14611 (B4/C2 honest-state contract, preserved) · #14802 (registry↔identity producer, out of scope) · #14868 (`loadActivity` fail-closed sibling)

Rebuilds the FM cockpit fleet view **on** Neo's data primitives instead of against them: one `AgentOS.store.FleetRoster` Store (singleton) of `AgentOS.model.FleetAgent` records is now the roster SSOT — the plain-array `agents_` path, the hand-mapped fixture flow, and all seven-per-fleet per-card `state.Provider` instances are gone. Cards render from their record (`applyRecord`, in-place reference updates); the grid routes the store's reactivity (`load` re-derives, `recordChange` re-ranks on session-`state` change and updates the one affected card in place otherwise); the C2 lifecycle adapter writes `pendingAction`/`controlReason` via `record.set()`, so control state re-renders through the same store seam — never optimistic. CSS-in-JS is fully killed across the fleet primitives (StateDot, HealthSwatch, EventChip, FamilyRail) via class→token resolvers (`stateClass`/`kindClass`/`familyClass`) bound in the component SCSS, and `AGENTS.md` gains the operator-directed app-work required-context gate.

Evidence: L2 (live dev-server mount + computed-style/interaction probes + local unit runs; sandbox ceiling = local runtime) → L2 required (AC 8 mount-verified at live scale; all other ACs covered by unit/static L1). No residuals.

## Deltas from ticket

- **Anchor drift:** the ticket's `FleetCockpit.mjs:168/:194` `loadRoster` anchors described the abandoned `feat/fm-cockpit-live-roster` branch; dev reality was `FIXTURE_ROSTER`-only. `loadRoster()` is implemented fresh on the Store path mirroring `loadActivity`'s fail-closed routing: first wired payload populates the store (replacing the sample seed), later payloads merge onto records (`record.set(row)` per known `agentId`, `add` for a joiner), wired-but-EMPTY / not-wired / absent / thrown keep the last-known roster.
- **keyProperty shadow (framework observation):** `collection.Base` defaults `keyProperty: 'id'` (truthy), so `Store.getKeyProperty()`'s `this.keyProperty || this.model.keyProperty` fallback can never reach a model-level key. `FleetRoster` mirrors `keyProperty: 'agentId'` at store level with an explanatory comment. Left un-ticketed per this ticket's own "no new tickets" AC — surfacing here for the swarm to route.
- **CSS-in-JS audit widened** per the ticket's "full audit required" clause: beyond `StateDot.style['--fm-dot']`, the sweep found `HealthSwatch` (vdom node style), `EventChip` (`--fm-chip`) and `FamilyRail` (`--fm-rail`) — all four converted to the uniform class→token idiom with SCSS bindings per component.
- **Dock blueprint reshaped:** `fleetCardFactory` emits `record: {field bag}` instead of `stateProvider: {data}` (a restored card would otherwise re-mint a provider). AgentCard accepts a live record or a plain snapshot bag through the same `applyRecord` path; the factory is spec-only-consumed today.
- **Honest sample label:** `FleetGrid.adapterState` gains `'sample'` — the seeded fixture renders "sample roster" instead of passing as live.
- **AGENTS.md byte budget:** the file sat 9 bytes under the 24KB harness cap, so the gate addition is paired with semantics-preserving compressions (net result: 26 bytes below the pre-PR size, 35 below the cap) — see slot rationale.

## Substrate slot rationale (AGENTS.md)

- **Added:** the app-work context gate as an extension of the existing `§edge_case_triggers` "Authoring Discipline" row (no new row/section). 3-Axis: trigger-frequency = every `apps/**` writing/reviewing turn; failure-severity = high (the operator-verdict full-rejection class this ticket cleans up — the anti-pattern shipped twice past review); enforceability = discipline-only today, MACHINE-ENFORCEABLE-CANDIDATE. Retirement trigger stated in-row: retire once a mechanical `apps/**` data-path/style lint enforces it.
- **Modified (byte-budget enablers, semantics preserved, Atlas detail verified present before compressing):** critical gate 6 tightened; gate 7's Maintainer-Polish sentence compressed to its `pull-request-workflow.md §10` pointer (gate enumeration verified there); gate 8's release-mutation sentence tightened; `§pre_commit_gates` Gates 1–2 tightened; the Skill-Adherence pre-flight tail tightened; `§edge_case_triggers` Wake/Heartbeat + Ticket-Creation-Freshness rows tightened. File: 24,567 → 24,541 bytes (cap 24,576).

## Test Evidence

- **Local unit runs** (canonical unit config minus its Chroma webServer — which cannot start in this clone — `--workers=1` matching CI): **75 passed** across the 11 fleet spec files, plus `cockpitDockDocument.spec.mjs` 5 passed. The 3 remaining failures are a pre-existing cross-file worker-reuse transient: reproduced IDENTICALLY on `origin/dev` in a clean worktree under the same runner (`eventChip:27`, `fleetGrid` below-threshold, `healthSwatch:42` — dev: 57 passed/3 failed; this branch: 75 passed/3 failed, +13 net-new tests). CI's canonical runner passes these specs on dev.
- **Direct node import probes:** `FleetRoster` seeds 7 records keyed `agentId`; `record.set()` fires `recordChange` with exact field arrays; no-op sets suppressed by the deep-equal guard; `controlReason` object fields survive typed parsing; `store.add` returns records.
- **Live mount (AC 8):** dev-server `apps/agentos#/fleet` — zero console errors; header "FLEET · 7 AGENTS sample roster"; health legend 5 working / 1 idle / 0 wedged / 0 rate-limited / 1 benched matches the record seed; tiers ranked online (agentId-sorted) → idle → benched with the benched card showing only the state-reachable ▶.
- **Class→token colors (AC 3, live):** after `build-themes`, computed styles resolve `fm-state-ok` → `rgb(52,211,153)`, `fm-state-idle` → `rgb(245,181,68)`, chip `fm-kind-pr`/`fm-kind-a2a` and rails `fm-family-claude`/`fm-family-gpt` to distinct token colors; **zero inline `--fm-*` styles anywhere in the cockpit DOM** (`querySelectorAll('[style*="--fm"]')` → 0).
- **Live control round-trip (AC 5):** clicking card controls with the dev bridge's endpoint absent renders "⚠ rejected: Failed to fetch" per card — the full chain `button → controller (record reads) → lifecycleIntent → cockpit controller → C2 adapter → record.set → store recordChange → in-place applyRecord`, retry open, no optimistic success.
- **AC 3 grep evidence:** `rg -n "\.style\s*=|\.style\[|style:\s*\{" apps/agentos/view/fleet/*.mjs` → zero code hits (comment mentions only).
- `node --check` green on all touched `.mjs`; `check-block-alignment` green; `npm run agent-preflight -- --no-fix` green with this body.

## Post-Merge Validation

- [ ] Deployed/portal build renders the fleet cockpit from `FleetRoster` with class→token colors + the "sample roster" label after its theme build.
- [ ] First real `fleetRoster` bridge payload (the #14802 producer) populates the store and flips the grid `live` through `loadRoster`'s first-wire path.

## Commits

- 4018ca323 — the full rebuild: FleetAgent model + FleetRoster store, record-driven card/grid/cockpit, C2 adapter record seam, CSS-in-JS kill + SCSS class→token bindings, 9 spec rewrites (+13 net-new tests), AGENTS.md app-work gate with paired compressions.

Authored by Vega (Claude Fable 5, Claude Code). Session d2fbbdb4-404b-47e1-bbb3-1b9e0330894b.
