### PR TITLE
feat(dashboard): auto-hide rail + reveal/dismiss + pin — the atomic interaction arc (#14654)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -8,33 +8,39 @@ import '../../../src/tab/Container.mjs'; // registers the `tab-container` ntype 
 import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype used by the perspective toolbar
 
 /**
- * A representative dock-zone document (`neo.harness.dockZone.v1`): a horizontal split of a two-tab main zone and a
- * vertical side-split of two single-tab zones, over four items. The shape `Neo.dashboard.DockLayoutAdapter.project`
- * consumes — see its spec for the full contract. Used as the example's INITIAL committed document; the live document
- * advances on each splitter resize (see `MainContainer#dockModel`).
+ * A representative dock-zone document (`neo.harness.dockZone.v1`): an edge-zone root whose center is a
+ * horizontal split of a two-tab main zone and a vertical side-split of two single-tab zones, plus a
+ * right edge band holding a single-tab inspector zone — the auto-hide surface (committing
+ * `setItemAutoHidden` on an edge-band item collapses it to a `Neo.dashboard.DockRail` edge tab).
+ * The shape `Neo.dashboard.DockLayoutAdapter.project` consumes — see its spec for the full contract.
+ * Used as the example's INITIAL committed document; the live document advances on each commit
+ * (see `MainContainer#dockModel`).
  * @type {Object}
  */
 const initialDockModel = {
     schema: 'neo.harness.dockZone.v1',
     root  : 'root',
     items : {
-        strategy: {componentRef: 'Strategy', title: 'Strategy', kind: 'panel'},
-        swarm   : {componentRef: 'Swarm',    title: 'Swarm',    kind: 'panel'},
-        terminal: {componentRef: 'Terminal', title: 'Terminal', kind: 'terminal'},
-        logs    : {componentRef: 'Logs',     title: 'Logs',     kind: 'panel'}
+        strategy : {componentRef: 'Strategy',  title: 'Strategy',  kind: 'panel'},
+        swarm    : {componentRef: 'Swarm',     title: 'Swarm',     kind: 'panel'},
+        terminal : {componentRef: 'Terminal',  title: 'Terminal',  kind: 'terminal'},
+        logs     : {componentRef: 'Logs',      title: 'Logs',      kind: 'panel'},
+        inspector: {componentRef: 'Inspector', title: 'Inspector', kind: 'panel'}
     },
     nodes: {
-        root           : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-split'], sizes: [0.65, 0.35]},
-        'main-tabs'    : {type: 'tabs',  items: ['strategy', 'swarm'], activeItemId: 'strategy'},
-        'side-split'   : {type: 'split', orientation: 'vertical', children: ['terminal-tabs', 'logs-tabs'], sizes: [0.6, 0.4]},
-        'terminal-tabs': {type: 'tabs',  items: ['terminal'], activeItemId: 'terminal'},
-        'logs-tabs'    : {type: 'tabs',  items: ['logs'],     activeItemId: 'logs'}
+        root            : {type: 'edge-zone', zones: {center: 'root-split', right: 'inspector-tabs'}},
+        'root-split'    : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-split'], sizes: [0.65, 0.35]},
+        'main-tabs'     : {type: 'tabs',  items: ['strategy', 'swarm'], activeItemId: 'strategy'},
+        'side-split'    : {type: 'split', orientation: 'vertical', children: ['terminal-tabs', 'logs-tabs'], sizes: [0.6, 0.4]},
+        'terminal-tabs' : {type: 'tabs',  items: ['terminal'],  activeItemId: 'terminal'},
+        'logs-tabs'     : {type: 'tabs',  items: ['logs'],      activeItemId: 'logs'},
+        'inspector-tabs': {type: 'tabs',  items: ['inspector'], activeItemId: 'inspector'}
     }
 };
 
 const reviewDockModel = DockZoneModel.clone(initialDockModel);
 
-reviewDockModel.nodes.root.sizes = [0.48, 0.52];
+reviewDockModel.nodes['root-split'].sizes = [0.48, 0.52];
 reviewDockModel.nodes['main-tabs'].activeItemId = 'swarm';
 reviewDockModel.nodes['side-split'].sizes = [0.42, 0.58];
 

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -15,16 +15,16 @@
     }
 }
 
-// Demo-consumable minimal hooks only — the real visual language lands with the F-tranche (#14638).
+// Demo-consumable minimal hooks only — the real visual language lands with the F-tranche.
+// Flow direction comes from the rail's layout (vbox/vertical, hbox/horizontal edges); the
+// buttons bring their own base theming — these hooks only shape the strip.
 .neo-dashboard-dock-edge-rail {
-    display    : flex;
     flex-shrink: 0;
     gap        : 2px;
 
     &-left,
     &-right {
-        flex-direction: column;
-        width         : 14px;
+        width: 14px;
 
         .neo-dashboard-dock-rail-tab {
             writing-mode: vertical-rl;
@@ -33,21 +33,11 @@
 
     &-top,
     &-bottom {
-        flex-direction: row;
-        height        : 14px;
+        height: 14px;
     }
 }
 
 .neo-dashboard-dock-rail-tab {
-    background: none;
-    border    : none;
-    color     : inherit;
-    cursor    : pointer;
-    font-size : 11px;
-    padding   : 4px 1px;
-
-    &-disabled {
-        cursor : not-allowed;
-        opacity: 0.4;
-    }
+    font-size: 11px;
+    padding  : 4px 1px;
 }

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -14,3 +14,40 @@
         cursor: ns-resize;
     }
 }
+
+// Demo-consumable minimal hooks only — the real visual language lands with the F-tranche (#14638).
+.neo-dashboard-dock-edge-rail {
+    display    : flex;
+    flex-shrink: 0;
+    gap        : 2px;
+
+    &-left,
+    &-right {
+        flex-direction: column;
+        width         : 14px;
+
+        .neo-dashboard-dock-rail-tab {
+            writing-mode: vertical-rl;
+        }
+    }
+
+    &-top,
+    &-bottom {
+        flex-direction: row;
+        height        : 14px;
+    }
+}
+
+.neo-dashboard-dock-rail-tab {
+    background: none;
+    border    : none;
+    color     : inherit;
+    cursor    : pointer;
+    font-size : 11px;
+    padding   : 4px 1px;
+
+    &-disabled {
+        cursor : not-allowed;
+        opacity: 0.4;
+    }
+}

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -41,3 +41,36 @@
     font-size: 11px;
     padding  : 4px 1px;
 }
+
+.neo-dashboard-dock-edge-band {
+    &-left,
+    &-right {
+        width: 280px;
+    }
+
+    &-top,
+    &-bottom {
+        height: 200px;
+    }
+}
+
+.neo-dashboard-dock-reveal-overlay {
+    --neo-dock-reveal-ms : 200ms;
+    --neo-dock-dismiss-ms: 160ms;
+
+    position: absolute;
+    z-index : 20;
+
+    &-hidden {
+        display: none;
+    }
+
+    &-left   { inset: 0 auto 0 14px; }
+    &-right  { inset: 0 14px 0 auto; }
+    &-top    { inset: 14px 0 auto 0; }
+    &-bottom { inset: auto 0 14px 0; }
+}
+
+.neo-dashboard-dock-reveal-header {
+    gap: 4px;
+}

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -210,6 +210,7 @@ class DockLayoutAdapter extends Base {
         return this.projectNode(model.root, {
             applyDockZoneOperation  : options.applyDockZoneOperation,
             autoHideRevealOnHover   : options.autoHideRevealOnHover === true,
+            defaultRevealFraction   : Number.isFinite(options.defaultRevealFraction) ? options.defaultRevealFraction : null,
             dockZoneDocument        : options.dockZoneDocument || model,
             items                   : model.items || {},
             nodes                   : model.nodes,
@@ -304,6 +305,7 @@ class DockLayoutAdapter extends Base {
         return {
             applyDockZoneOperation  : context.applyDockZoneOperation,
             autoHideRevealOnHover   : context.autoHideRevealOnHover === true,
+            defaultRevealFraction   : context.defaultRevealFraction ?? null,
             dockEdge                : edge,
             dockNodeType            : 'edge-rail',
             dockZoneDocument        : context.dockZoneDocument,

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -209,6 +209,7 @@ class DockLayoutAdapter extends Base {
 
         return this.projectNode(model.root, {
             applyDockZoneOperation  : options.applyDockZoneOperation,
+            autoHideRevealOnHover   : options.autoHideRevealOnHover === true,
             dockZoneDocument        : options.dockZoneDocument || model,
             items                   : model.items || {},
             nodes                   : model.nodes,
@@ -302,6 +303,7 @@ class DockLayoutAdapter extends Base {
     static createEdgeRail(itemIds, edge, context) {
         return {
             applyDockZoneOperation  : context.applyDockZoneOperation,
+            autoHideRevealOnHover   : context.autoHideRevealOnHover === true,
             dockEdge                : edge,
             dockNodeType            : 'edge-rail',
             dockZoneDocument        : context.dockZoneDocument,
@@ -309,8 +311,64 @@ class DockLayoutAdapter extends Base {
             module                  : DockRail,
             ntype                   : 'dashboard-dock-rail',
             onDockZoneDocumentChange: context.onDockZoneDocumentChange,
-            railItems               : itemIds.map(itemId => this.createRailTab(itemId, edge, context))
+            railItems               : itemIds.map(itemId => this.createRailTab(itemId, edge, context)),
+            resolveComponentRef     : context.resolveComponentRef
         }
+    }
+
+    /**
+     * Resolves the reveal overlay's free-dimension extent for an item: the share its owning
+     * subtree holds at the nearest ancestor split, per that split's committed `sizes` — the
+     * "last committed extent, still in the document" rule. Returns `null` when no ancestor split
+     * carries usable sizes (e.g. a tabs node sitting directly in an edge-zone slot); the overlay
+     * then falls back to its workspace-configurable default fraction. Never reads DOM geometry.
+     * @param {Object} model Committed dock-zone document.
+     * @param {String} itemId
+     * @returns {Number|null} Fraction in `(0, 1]`, or `null`.
+     * @static
+     */
+    static resolveRevealExtent(model, itemId) {
+        let nodes   = model?.nodes || {},
+            childId = Object.keys(nodes).find(nodeId =>
+                nodes[nodeId].type === 'tabs' && (nodes[nodeId].items || []).includes(itemId)),
+            parent;
+
+        const findParent = id => {
+            for (const [nodeId, node] of Object.entries(nodes)) {
+                if (node.type === 'split' && (node.children || []).includes(id)) {
+                    return {index: node.children.indexOf(id), nodeId, split: true}
+                }
+                if (node.type === 'edge-zone' && Object.values(node.zones || {}).includes(id)) {
+                    return {nodeId, split: false}
+                }
+            }
+            return null
+        };
+
+        while (childId) {
+            parent = findParent(childId);
+
+            if (!parent) {
+                return null
+            }
+
+            if (parent.split) {
+                let sizes = nodes[parent.nodeId].sizes;
+
+                if (Array.isArray(sizes) && sizes.length) {
+                    let total = sizes.reduce((sum, value) => sum + (Number(value) || 0), 0),
+                        share = Number(sizes[parent.index]);
+
+                    return total > 0 && Number.isFinite(share) && share > 0 ? share / total : null
+                }
+
+                return null
+            }
+
+            childId = parent.nodeId
+        }
+
+        return null
     }
 
     /**
@@ -347,12 +405,19 @@ class DockLayoutAdapter extends Base {
         // Pass the railed set down so projectTabsNode drops those items from the tab flow.
         let childContext = railedItemIds.size ? {...context, railedItemIds} : context,
             middleItems  = [],
-            rows         = [];
+            rows         = [],
+            centerConfig;
 
         if (railsByEdge.left)  middleItems.push(this.createEdgeRail(railsByEdge.left, 'left', context));
-        if (zones.left)        middleItems.push(this.projectNode(zones.left, childContext));
-        if (zones.center)      middleItems.push(this.projectNode(zones.center, childContext));
-        if (zones.right)       middleItems.push(this.projectNode(zones.right, childContext));
+        if (zones.left)        middleItems.push(this.projectEdgeBand(zones.left, 'left', childContext));
+
+        if (zones.center) {
+            centerConfig      = this.projectNode(zones.center, childContext);
+            centerConfig.flex = 1;
+            middleItems.push(centerConfig)
+        }
+
+        if (zones.right)       middleItems.push(this.projectEdgeBand(zones.right, 'right', childContext));
         if (railsByEdge.right) middleItems.push(this.createEdgeRail(railsByEdge.right, 'right', context));
 
         if (railsByEdge.top) {
@@ -360,7 +425,7 @@ class DockLayoutAdapter extends Base {
         }
 
         if (zones.top) {
-            rows.push(this.projectNode(zones.top, childContext))
+            rows.push(this.projectEdgeBand(zones.top, 'top', childContext))
         }
 
         if (middleItems.length === 1) {
@@ -376,7 +441,7 @@ class DockLayoutAdapter extends Base {
         }
 
         if (zones.bottom) {
-            rows.push(this.projectNode(zones.bottom, childContext))
+            rows.push(this.projectEdgeBand(zones.bottom, 'bottom', childContext))
         }
 
         if (railsByEdge.bottom) {
@@ -391,6 +456,26 @@ class DockLayoutAdapter extends Base {
             layout      : {ntype: 'vbox', align: 'stretch'},
             ntype       : 'container'
         }
+    }
+
+    /**
+     * Marks an edge-band zone projection: bands keep a fixed cross-extent (the
+     * `neo-dashboard-dock-edge-band(-edge)` CSS hooks) instead of flexing against the center —
+     * an unsized band silently eats workspace geometry the center owns.
+     * @param {String} zoneId
+     * @param {String} edge One of `top`, `right`, `bottom`, `left`.
+     * @param {Object} context
+     * @returns {Object}
+     * @protected
+     * @static
+     */
+    static projectEdgeBand(zoneId, edge, context) {
+        let config = this.projectNode(zoneId, context);
+
+        config.cls  = [...(config.cls || []), 'neo-dashboard-dock-edge-band', `neo-dashboard-dock-edge-band-${edge}`];
+        config.flex = 'none';
+
+        return config
     }
 
     /**

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -1,4 +1,5 @@
 import Base            from '../core/Base.mjs';
+import DockRail        from './DockRail.mjs';
 import DockSplitter    from './DockSplitter.mjs';
 import DockTabSortZone from './DockTabSortZone.mjs';
 import DockZoneModel   from './DockZoneModel.mjs';
@@ -257,10 +258,12 @@ class DockLayoutAdapter extends Base {
     }
 
     /**
-     * Projects one auto-hidden item id into a collapsed rail-tab affordance.
+     * Projects one auto-hidden item id into the rail-tab metadata `DockRail` renders.
      *
-     * The rail tab carries stable `dockItemId` + `dockEdge` metadata so a later reveal/pin slice
-     * can convert a click into a transient reveal or a `setItemPinned` operation.
+     * The metadata carries stable `dockItemId` + `dockEdge` so the rail's click (and the follow-up
+     * reveal/pin slice) can address the item semantically, plus the `restorable` policy projection
+     * (`pinnable !== false`) — a tab whose restore the model would reject renders disabled instead
+     * of lying about the affordance.
      * No DOMRect, hover, or open geometry is emitted — reveal/open state stays runtime-only per the
      * JSON-first guardrail (HarnessDockZoneModel.md §Serializable vs Runtime).
      * @param {String} itemId
@@ -274,18 +277,21 @@ class DockLayoutAdapter extends Base {
         let item = context.items[itemId] || {};
 
         return {
-            cls         : ['neo-dashboard-dock-rail-tab'],
-            data        : {dockEdge: edge, dockItemId: itemId, dockRailTab: true},
-            dockEdge    : edge,
-            dockItemId  : itemId,
-            dockNodeType: 'edge-rail-tab',
-            ntype       : 'button',
-            text        : item.title || itemId
+            dockEdge  : edge,
+            dockItemId: itemId,
+            restorable: item.pinnable !== false,
+            title     : item.title || itemId
         }
     }
 
     /**
-     * Projects a set of auto-hidden item ids into a thin edge-rail strip for the owning edge.
+     * Projects a set of auto-hidden item ids into a `Neo.dashboard.DockRail` affordance for the
+     * owning edge.
+     *
+     * Mirrors `createSplitterAffordance()`: the reducer callbacks thread from projection context into
+     * the component so restore commits ride the workspace's single operation path — no parallel
+     * mutation grammar. Rail extent and tab writing-mode are CSS concerns keyed off the per-edge cls
+     * hook (JSON-first: no pixel geometry in the projection).
      * @param {String[]} itemIds
      * @param {String} edge One of `top`, `right`, `bottom`, `left`.
      * @param {Object} context
@@ -294,15 +300,16 @@ class DockLayoutAdapter extends Base {
      * @static
      */
     static createEdgeRail(itemIds, edge, context) {
-        let isVertical = edge === 'left' || edge === 'right';
-
         return {
-            cls         : ['neo-dashboard-dock-edge-rail', `neo-dashboard-dock-edge-rail-${edge}`],
-            dockEdge    : edge,
-            dockNodeType: 'edge-rail',
-            items       : itemIds.map(itemId => this.createRailTab(itemId, edge, context)),
-            layout      : {ntype: isVertical ? 'vbox' : 'hbox', align: 'start'},
-            ntype       : 'container'
+            applyDockZoneOperation  : context.applyDockZoneOperation,
+            dockEdge                : edge,
+            dockNodeType            : 'edge-rail',
+            dockZoneDocument        : context.dockZoneDocument,
+            edge,
+            module                  : DockRail,
+            ntype                   : 'dashboard-dock-rail',
+            onDockZoneDocumentChange: context.onDockZoneDocumentChange,
+            railItems               : itemIds.map(itemId => this.createRailTab(itemId, edge, context))
         }
     }
 

--- a/src/dashboard/DockRail.mjs
+++ b/src/dashboard/DockRail.mjs
@@ -641,16 +641,18 @@ class DockRail extends Container {
      * Live-instance contract: a resolver-returned Neo INSTANCE is added as-is and PARKED on
      * dismissal (removed without destroy — moved/re-parented, never destroyed), so its identity
      * and transient state survive reveal/dismiss cycles and the pin transition back into the
-     * flow. A blueprint-created pane (config resolution — the no-live-instance fallback) is
-     * cached per item and parked the same way: mounted children are never destroyed mid-session
-     * (`revealPaneCache` tears down with the rail).
+     * flow. The resolution CASCADE mirrors the adapter's in-flow `projectItem()` exactly:
+     * live resolution → `item.blueprint` instantiation → recoverable placeholder (never a silent
+     * empty overlay). Blueprint- and placeholder-created panes are cached per item and parked
+     * the same way: mounted children are never destroyed mid-session (`revealPaneCache` tears
+     * down with the rail).
      * @param {Object|null} railItem
      * @protected
      */
     syncRevealPane(railItem) {
         let me   = this,
             slot = me.revealOverlay?.paneSlot,
-            child, componentRef, currentId, nextId, resolved;
+            child, currentId, item, nextId, resolved;
 
         // Stub/external overlays without a pane slot render header-only — valid by contract.
         if (!slot?.add) {
@@ -674,15 +676,24 @@ class DockRail extends Container {
             if (me.revealPaneCache[nextId] && !me.revealPaneCache[nextId].isDestroyed) {
                 slot.add(me.revealPaneCache[nextId])
             } else {
-                componentRef = me.dockZoneDocument?.items?.[nextId]?.componentRef;
-                resolved     = componentRef != null ? me.resolveComponentRef(componentRef) : null;
+                item     = me.dockZoneDocument?.items?.[nextId];
+                resolved = item?.componentRef != null ? me.resolveComponentRef(item.componentRef, item, nextId) : null;
 
-                if (resolved) {
-                    if (Neo.typeOf(resolved) === 'NeoInstance') {
-                        slot.add(resolved)
-                    } else {
-                        me.revealPaneCache[nextId] = slot.add({...resolved})
-                    }
+                if (!resolved && item?.blueprint) {
+                    resolved = Neo.clone(item.blueprint, true)
+                }
+
+                if (Neo.typeOf(resolved) === 'NeoInstance') {
+                    slot.add(resolved)
+                } else if (resolved) {
+                    me.revealPaneCache[nextId] = slot.add({...resolved})
+                } else if (item) {
+                    // Neither live instance nor blueprint resolves: recoverable placeholder,
+                    // never a silently empty overlay — the adapter's own policy.
+                    me.revealPaneCache[nextId] = slot.add(
+                        Neo.dashboard?.DockLayoutAdapter?.createPlaceholder?.(nextId, item) ??
+                        {cls: ['neo-dashboard-dock-placeholder'], dockItemId: nextId, ntype: 'component'}
+                    )
                 }
             }
         }

--- a/src/dashboard/DockRail.mjs
+++ b/src/dashboard/DockRail.mjs
@@ -1,0 +1,252 @@
+import Component     from '../component/Base.mjs';
+import DockZoneModel from './DockZoneModel.mjs';
+import NeoArray      from '../util/Array.mjs';
+
+/**
+ * @summary Runtime edge-rail affordance rendering committed auto-hidden items as labeled rail tabs,
+ * converting a tab click into a `setItemAutoHidden(false)` operation through the dock-zone reducer.
+ *
+ * The rail is pure render projection (per-window, derived, never persisted): WHICH items rail — and on
+ * which edge — is committed `dockZone.v1` truth the adapter derives
+ * (`DockLayoutAdapter.collectAutoHiddenItems()`). Tabs render from plain `railItems` metadata rather
+ * than from the pane components themselves, so the pane never learns it is railed (pane-blindness) and
+ * a destroyed or unresolvable pane cannot break its recall affordance.
+ *
+ * Interaction contract (current slice): click = restore, committed through the owning reducer callback
+ * (`applyDockZoneOperation`) or a local `DockZoneModel.applyOperation()` — never a parallel mutation
+ * path. The follow-up reveal/dismiss slice upgrades click to a transient reveal overlay and moves the
+ * persist to the overlay's pin control; this component is the mount point for that state machine.
+ *
+ * Policy honesty: the model rejects `setItemAutoHidden(false)` for `pinnable: false` items, which is
+ * reachable when an item's policy flips after it railed. Such a tab renders disabled and rejects locally
+ * instead of emitting a doomed operation — the affordance mirrors what the executor would answer.
+ *
+ * @class Neo.dashboard.DockRail
+ * @extends Neo.component.Base
+ * @see Neo.dashboard.DockLayoutAdapter
+ * @see Neo.dashboard.DockSplitter
+ * @see Neo.dashboard.DockZoneModel
+ * @see learn/agentos/HarnessDockZoneModel.md
+ */
+class DockRail extends Component {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockRail'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockRail',
+        /**
+         * @member {String} ntype='dashboard-dock-rail'
+         * @protected
+         */
+        ntype: 'dashboard-dock-rail',
+        /**
+         * @member {String[]} baseCls=['neo-dashboard-dock-edge-rail']
+         */
+        baseCls: ['neo-dashboard-dock-edge-rail'],
+        /**
+         * Callback for an owning Harness/dashboard reducer. Receives `(descriptor, rail)`.
+         * When absent, the component falls back to committing against its own `dockZoneDocument`.
+         * @member {Function|null} applyDockZoneOperation=null
+         */
+        applyDockZoneOperation: null,
+        /**
+         * Current committed dock-zone document. Used when no reducer callback is supplied.
+         * @member {Object|null} dockZoneDocument_=null
+         * @reactive
+         */
+        dockZoneDocument_: null,
+        /**
+         * Owning workspace edge (`top`, `right`, `bottom`, `left`). Drives the per-edge cls hook;
+         * tab flow direction and writing-mode are CSS concerns keyed off that hook.
+         * @member {String} edge_='left'
+         * @reactive
+         */
+        edge_: 'left',
+        /**
+         * Notified after a successful local document commit.
+         * @member {Function|null} onDockZoneDocumentChange=null
+         */
+        onDockZoneDocumentChange: null,
+        /**
+         * Rail tab metadata, in document order: `[{dockEdge, dockItemId, restorable, title}]`.
+         * Projection input from `DockLayoutAdapter.createRailTab()` — model-derived, never persisted.
+         * @member {Object[]|null} railItems_=null
+         * @reactive
+         */
+        railItems_: null
+    }
+
+    /**
+     * Maps projected tab node ids to dock item ids for delegate-click resolution.
+     * Runtime-only lookup state, rebuilt on every `railItems` pass — id-based resolution avoids
+     * parsing dataset payloads out of serialized event paths.
+     * @member {Object} tabIdToItemId={}
+     * @protected
+     */
+    tabIdToItemId = {}
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        me.addDomListeners([
+            {click: me.onRailClick, delegate: '.neo-dashboard-dock-rail-tab', scope: me}
+        ])
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetEdge(value, oldValue) {
+        let me   = this,
+            edge = me.getValidatedEdge(value),
+            cls  = me.cls || [];
+
+        if (oldValue) {
+            NeoArray.remove(cls, `neo-dashboard-dock-edge-rail-${me.getValidatedEdge(oldValue)}`)
+        }
+
+        NeoArray.add(cls, `neo-dashboard-dock-edge-rail-${edge}`);
+
+        me.cls = cls;
+
+        me.data = {
+            ...(me.data || {}),
+            dockEdge: edge
+        }
+    }
+
+    /**
+     * Rebuilds the tab vdom in place — the component instance and its root node stay stable across
+     * model flips (object permanence at the affordance level); only the tab children re-render.
+     * @param {Object[]|null} value
+     * @param {Object[]|null} oldValue
+     * @protected
+     */
+    afterSetRailItems(value, oldValue) {
+        let me   = this,
+            edge = me.getValidatedEdge(me.edge),
+            vdom = me.vdom;
+
+        me.tabIdToItemId = {};
+
+        vdom.cn = (value || []).map((railItem, index) => {
+            let tabId      = `${me.id}__tab-${index}`,
+                restorable = railItem.restorable !== false,
+                cls        = ['neo-dashboard-dock-rail-tab'];
+
+            if (!restorable) {
+                cls.push('neo-dashboard-dock-rail-tab-disabled')
+            }
+
+            me.tabIdToItemId[tabId] = railItem.dockItemId;
+
+            return {
+                tag     : 'button',
+                cls,
+                data    : {dockEdge: railItem.dockEdge || edge, dockItemId: railItem.dockItemId, dockRailTab: true},
+                disabled: restorable ? null : true,
+                id      : tabId,
+                text    : railItem.title || railItem.dockItemId
+            }
+        });
+
+        me.update()
+    }
+
+    /**
+     * Commits a restore descriptor through the owning reducer callback, falling back to a local
+     * `DockZoneModel.applyOperation()` — identical commit contract to `DockSplitter.commitResizeSplit()`
+     * so dashboard reducers handle both affordances with one code path.
+     * @param {Object} descriptor
+     * @returns {{document:(Object|null), errors:String[]}}
+     * @protected
+     */
+    commitRestore(descriptor) {
+        let me     = this,
+            result = null;
+
+        if (typeof me.applyDockZoneOperation === 'function') {
+            result = me.applyDockZoneOperation(descriptor, me) || null
+        } else if (me.dockZoneDocument) {
+            result = DockZoneModel.applyOperation(me.dockZoneDocument, descriptor)
+        }
+
+        if (!result) {
+            result = {
+                document: me.dockZoneDocument,
+                errors  : ['DockRail requires `dockZoneDocument` or `applyDockZoneOperation` to commit setItemAutoHidden.']
+            }
+        }
+
+        if (!result.errors?.length && result.document) {
+            me.dockZoneDocument = result.document;
+
+            if (typeof me.onDockZoneDocumentChange === 'function') {
+                me.onDockZoneDocumentChange(result.document, descriptor, me)
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * @param {String} edge
+     * @returns {String}
+     * @protected
+     */
+    getValidatedEdge(edge) {
+        return ['top', 'right', 'bottom', 'left'].includes(edge) ? edge : 'left'
+    }
+
+    /**
+     * Delegate click handler for rail tabs: resolves the clicked tab to its dock item, honours the
+     * restore policy, and commits `setItemAutoHidden(false)` through the reducer path.
+     * Fires `dockRailRestore` on commit, `dockRailRestoreRejected` on policy block or executor error.
+     * @param {Object} data
+     * @returns {{document:(Object|null), errors:String[]}|null}
+     */
+    onRailClick(data={}) {
+        let me     = this,
+            itemId = me.tabIdToItemId[data.currentTarget],
+            descriptor, railItem, result;
+
+        if (!itemId) {
+            return null
+        }
+
+        railItem = (me.railItems || []).find(item => item.dockItemId === itemId);
+
+        if (railItem?.restorable === false) {
+            result = {
+                document: me.dockZoneDocument,
+                errors  : [`item "${itemId}" restore blocked by policy (pinnable: false)`]
+            };
+
+            me.fire('dockRailRestoreRejected', {descriptor: null, itemId, rail: me, result});
+
+            return result
+        }
+
+        descriptor = {autoHidden: false, itemId, operation: 'setItemAutoHidden'};
+        result     = me.commitRestore(descriptor);
+
+        me.fire(result.errors?.length ? 'dockRailRestoreRejected' : 'dockRailRestore', {
+            descriptor,
+            itemId,
+            rail: me,
+            result
+        });
+
+        return result
+    }
+}
+
+export default Neo.setupClass(DockRail);

--- a/src/dashboard/DockRail.mjs
+++ b/src/dashboard/DockRail.mjs
@@ -1,34 +1,44 @@
-import Component     from '../component/Base.mjs';
+import Button        from '../button/Base.mjs';
+import Container     from '../container/Base.mjs';
 import DockZoneModel from './DockZoneModel.mjs';
 import NeoArray      from '../util/Array.mjs';
 
 /**
- * @summary Runtime edge-rail affordance rendering committed auto-hidden items as labeled rail tabs,
- * converting a tab click into a `setItemAutoHidden(false)` operation through the dock-zone reducer.
+ * @summary Runtime edge-rail affordance rendering committed auto-hidden items as real button
+ * children, converting a tab click into a `setItemAutoHidden(false)` operation through the
+ * dock-zone reducer.
  *
- * The rail is pure render projection (per-window, derived, never persisted): WHICH items rail — and on
- * which edge — is committed `dockZone.v1` truth the adapter derives
- * (`DockLayoutAdapter.collectAutoHiddenItems()`). Tabs render from plain `railItems` metadata rather
- * than from the pane components themselves, so the pane never learns it is railed (pane-blindness) and
- * a destroyed or unresolvable pane cannot break its recall affordance.
+ * The rail is pure render projection (per-window, derived, never persisted): WHICH items rail — and
+ * on which edge — is committed `dockZone.v1` truth the adapter derives
+ * (`DockLayoutAdapter.collectAutoHiddenItems()`). Tabs are `Neo.button.Base` child components built
+ * from plain `railItems` metadata rather than from the pane components themselves, so the pane never
+ * learns it is railed (pane-blindness) and a destroyed or unresolvable pane cannot break its recall
+ * affordance. Composition over synthesis: clicks ride the button `handler` contract and each button
+ * carries its `dockItemId` — no hand-rolled DOM listeners, no tab-id bookkeeping.
  *
- * Interaction contract (current slice): click = restore, committed through the owning reducer callback
- * (`applyDockZoneOperation`) or a local `DockZoneModel.applyOperation()` — never a parallel mutation
- * path. The follow-up reveal/dismiss slice upgrades click to a transient reveal overlay and moves the
- * persist to the overlay's pin control; this component is the mount point for that state machine.
+ * Model flips reconcile the button set IN PLACE (`reconcileTabs()`): surviving items keep their live
+ * component instance — object permanence at the affordance level — while leavers and newcomers
+ * remove/insert at their document-order position.
+ *
+ * Interaction contract (current slice): click = restore, committed through the owning reducer
+ * callback (`applyDockZoneOperation`) or a local `DockZoneModel.applyOperation()` — never a parallel
+ * mutation path. The follow-up reveal/dismiss slice upgrades click to a transient reveal overlay and
+ * moves the persist to the overlay's pin control; this component is the mount point for that state
+ * machine.
  *
  * Policy honesty: the model rejects `setItemAutoHidden(false)` for `pinnable: false` items, which is
- * reachable when an item's policy flips after it railed. Such a tab renders disabled and rejects locally
- * instead of emitting a doomed operation — the affordance mirrors what the executor would answer.
+ * reachable when an item's policy flips after it railed. Such a tab renders disabled and rejects
+ * locally instead of emitting a doomed operation — the affordance mirrors what the executor would
+ * answer.
  *
  * @class Neo.dashboard.DockRail
- * @extends Neo.component.Base
+ * @extends Neo.container.Base
  * @see Neo.dashboard.DockLayoutAdapter
  * @see Neo.dashboard.DockSplitter
  * @see Neo.dashboard.DockZoneModel
  * @see learn/agentos/HarnessDockZoneModel.md
  */
-class DockRail extends Component {
+class DockRail extends Container {
     static config = {
         /**
          * @member {String} className='Neo.dashboard.DockRail'
@@ -57,8 +67,9 @@ class DockRail extends Component {
          */
         dockZoneDocument_: null,
         /**
-         * Owning workspace edge (`top`, `right`, `bottom`, `left`). Drives the per-edge cls hook;
-         * tab flow direction and writing-mode are CSS concerns keyed off that hook.
+         * Owning workspace edge (`top`, `right`, `bottom`, `left`). Drives the per-edge cls hook
+         * and the tab-flow layout direction; the tab writing-mode is a CSS concern keyed off the
+         * cls hook.
          * @member {String} edge_='left'
          * @reactive
          */
@@ -78,25 +89,16 @@ class DockRail extends Component {
     }
 
     /**
-     * Maps projected tab node ids to dock item ids for delegate-click resolution.
-     * Runtime-only lookup state, rebuilt on every `railItems` pass — id-based resolution avoids
-     * parsing dataset payloads out of serialized event paths.
-     * @member {Object} tabIdToItemId={}
-     * @protected
-     */
-    tabIdToItemId = {}
-
-    /**
+     * Seeds the initial button set from `railItems` before the container creates its items —
+     * later flips go through `reconcileTabs()` instead.
      * @param {Object} config
      */
-    construct(config) {
-        super.construct(config);
+    construct(config={}) {
+        if (config.railItems?.length && !config.items) {
+            config.items = config.railItems.map(railItem => this.createTabConfig(railItem, config.edge))
+        }
 
-        let me = this;
-
-        me.addDomListeners([
-            {click: me.onRailClick, delegate: '.neo-dashboard-dock-rail-tab', scope: me}
-        ])
+        super.construct(config)
     }
 
     /**
@@ -105,9 +107,10 @@ class DockRail extends Component {
      * @protected
      */
     afterSetEdge(value, oldValue) {
-        let me   = this,
-            edge = me.getValidatedEdge(value),
-            cls  = me.cls || [];
+        let me         = this,
+            edge       = me.getValidatedEdge(value),
+            isVertical = edge === 'left' || edge === 'right',
+            cls        = me.cls || [];
 
         if (oldValue) {
             NeoArray.remove(cls, `neo-dashboard-dock-edge-rail-${me.getValidatedEdge(oldValue)}`)
@@ -115,56 +118,30 @@ class DockRail extends Component {
 
         NeoArray.add(cls, `neo-dashboard-dock-edge-rail-${edge}`);
 
-        me.cls = cls;
-
-        me.data = {
-            ...(me.data || {}),
-            dockEdge: edge
-        }
+        me.set({
+            cls,
+            layout: {ntype: isVertical ? 'vbox' : 'hbox', align: 'stretch'}
+        })
     }
 
     /**
-     * Rebuilds the tab vdom in place — the component instance and its root node stay stable across
-     * model flips (object permanence at the affordance level); only the tab children re-render.
+     * Construction seeds the button set directly (see `construct()`); only live model flips
+     * reconcile — the initial pass would race the container's own item creation.
      * @param {Object[]|null} value
      * @param {Object[]|null} oldValue
      * @protected
      */
     afterSetRailItems(value, oldValue) {
-        let me   = this,
-            edge = me.getValidatedEdge(me.edge),
-            vdom = me.vdom;
-
-        me.tabIdToItemId = {};
-
-        vdom.cn = (value || []).map((railItem, index) => {
-            let tabId      = `${me.id}__tab-${index}`,
-                restorable = railItem.restorable !== false,
-                cls        = ['neo-dashboard-dock-rail-tab'];
-
-            if (!restorable) {
-                cls.push('neo-dashboard-dock-rail-tab-disabled')
-            }
-
-            me.tabIdToItemId[tabId] = railItem.dockItemId;
-
-            return {
-                tag     : 'button',
-                cls,
-                data    : {dockEdge: railItem.dockEdge || edge, dockItemId: railItem.dockItemId, dockRailTab: true},
-                disabled: restorable ? null : true,
-                id      : tabId,
-                text    : railItem.title || railItem.dockItemId
-            }
-        });
-
-        me.update()
+        if (oldValue !== undefined) {
+            this.reconcileTabs(value || [])
+        }
     }
 
     /**
      * Commits a restore descriptor through the owning reducer callback, falling back to a local
-     * `DockZoneModel.applyOperation()` — identical commit contract to `DockSplitter.commitResizeSplit()`
-     * so dashboard reducers handle both affordances with one code path.
+     * `DockZoneModel.applyOperation()` — identical commit contract to
+     * `DockSplitter.commitResizeSplit()` so dashboard reducers handle both affordances with one
+     * code path.
      * @param {Object} descriptor
      * @returns {{document:(Object|null), errors:String[]}}
      * @protected
@@ -198,6 +175,29 @@ class DockRail extends Component {
     }
 
     /**
+     * Builds one rail-tab button config from rail-item metadata. The button carries its
+     * `dockItemId`, so click resolution is instance-based — no id bookkeeping.
+     * @param {Object} railItem {dockEdge, dockItemId, restorable, title}
+     * @param {String} edge
+     * @returns {Object}
+     * @protected
+     */
+    createTabConfig(railItem, edge) {
+        let me = this;
+
+        return {
+            module         : Button,
+            cls            : ['neo-dashboard-dock-rail-tab'],
+            disabled       : railItem.restorable === false,
+            dockItemId     : railItem.dockItemId,
+            handler        : me.onTabClick,
+            handlerScope   : me,
+            text           : railItem.title || railItem.dockItemId,
+            useRippleEffect: false
+        }
+    }
+
+    /**
      * @param {String} edge
      * @returns {String}
      * @protected
@@ -207,15 +207,16 @@ class DockRail extends Component {
     }
 
     /**
-     * Delegate click handler for rail tabs: resolves the clicked tab to its dock item, honours the
+     * Button handler for rail tabs: resolves the clicked button to its dock item, honours the
      * restore policy, and commits `setItemAutoHidden(false)` through the reducer path.
-     * Fires `dockRailRestore` on commit, `dockRailRestoreRejected` on policy block or executor error.
-     * @param {Object} data
+     * Fires `dockRailRestore` on commit, `dockRailRestoreRejected` on policy block or executor
+     * error.
+     * @param {Object} data The button click event data; `data.component` is the tab button.
      * @returns {{document:(Object|null), errors:String[]}|null}
      */
-    onRailClick(data={}) {
+    onTabClick(data={}) {
         let me     = this,
-            itemId = me.tabIdToItemId[data.currentTarget],
+            itemId = data.component?.dockItemId,
             descriptor, railItem, result;
 
         if (!itemId) {
@@ -246,6 +247,44 @@ class DockRail extends Component {
         });
 
         return result
+    }
+
+    /**
+     * Reconciles the live button set against fresh rail-item metadata: surviving items keep their
+     * component instance and receive in-place `set()` updates (object permanence at the affordance
+     * level), leavers are removed, newcomers insert at their document-order position.
+     * @param {Object[]} target Fresh rail-item metadata.
+     * @protected
+     */
+    reconcileTabs(target) {
+        let me       = this,
+            existing = [...(me.items || [])],
+            index;
+
+        for (index = existing.length - 1; index >= 0; index--) {
+            if (!target.some(railItem => railItem.dockItemId === existing[index].dockItemId)) {
+                me.removeAt(index)
+            }
+        }
+
+        target.forEach((railItem, targetIndex) => {
+            let button       = (me.items || []).find(item => item.dockItemId === railItem.dockItemId),
+                currentIndex = button ? me.items.indexOf(button) : -1;
+
+            if (button) {
+                button.set({
+                    disabled: railItem.restorable === false,
+                    text    : railItem.title || railItem.dockItemId
+                });
+
+                if (currentIndex !== targetIndex) {
+                    me.remove(button, false, true);
+                    me.insert(targetIndex, button)
+                }
+            } else {
+                me.insert(targetIndex, me.createTabConfig(railItem, me.edge))
+            }
+        })
     }
 }
 

--- a/src/dashboard/DockRail.mjs
+++ b/src/dashboard/DockRail.mjs
@@ -1,39 +1,47 @@
-import Button        from '../button/Base.mjs';
-import Container     from '../container/Base.mjs';
-import DockZoneModel from './DockZoneModel.mjs';
-import NeoArray      from '../util/Array.mjs';
+import Button                 from '../button/Base.mjs';
+import Container              from '../container/Base.mjs';
+import DockRevealOverlay      from './DockRevealOverlay.mjs';
+import DockRevealStateMachine from './DockRevealStateMachine.mjs';
+import DockZoneModel          from './DockZoneModel.mjs';
+import NeoArray               from '../util/Array.mjs';
 
 /**
  * @summary Runtime edge-rail affordance rendering committed auto-hidden items as real button
- * children, converting a tab click into a `setItemAutoHidden(false)` operation through the
- * dock-zone reducer.
+ * children, with the full reveal/dismiss/pin interaction contract riding the dock-zone reducer.
  *
  * The rail is pure render projection (per-window, derived, never persisted): WHICH items rail — and
  * on which edge — is committed `dockZone.v1` truth the adapter derives
  * (`DockLayoutAdapter.collectAutoHiddenItems()`). Tabs are `Neo.button.Base` child components built
  * from plain `railItems` metadata rather than from the pane components themselves, so the pane never
  * learns it is railed (pane-blindness) and a destroyed or unresolvable pane cannot break its recall
- * affordance. Composition over synthesis: clicks ride the button `handler` contract and each button
- * carries its `dockItemId` — no hand-rolled DOM listeners, no tab-id bookkeeping.
+ * affordance. Composition over synthesis: clicks ride the button `handler` contract, hover intents
+ * ride per-button `domListeners`, and each button carries its `dockItemId` — no hand-rolled DOM
+ * synthesis, no tab-id bookkeeping.
  *
  * Model flips reconcile the button set IN PLACE (`reconcileTabs()`): surviving items keep their live
- * component instance — object permanence at the affordance level — while leavers and newcomers
- * remove/insert at their document-order position.
+ * component instance — object permanence at the affordance level — while leavers fail-close any
+ * reveal of them and remove; newcomers insert at their document-order position.
  *
- * Interaction contract (current slice): click = restore, committed through the owning reducer
- * callback (`applyDockZoneOperation`) or a local `DockZoneModel.applyOperation()` — never a parallel
- * mutation path. The follow-up reveal/dismiss slice upgrades click to a transient reveal overlay and
- * moves the persist to the overlay's pin control; this component is the mount point for that state
- * machine.
+ * Interaction contract: a tab click opens a TRANSIENT reveal (focus moves into the overlay);
+ * re-click, `Escape`, outside-click, or focus/pointer leaving dismiss it — reveal state is
+ * runtime-only and no operation descriptor exists for dismissal. Hover-reveal is a workspace opt-in
+ * (`autoHideRevealOnHover`; dwell-gated, never steals focus — hover reveals are an accessibility
+ * hazard by default). The PERSIST path is the overlay's pin control: `setItemPinned(true)` committed
+ * through the owning reducer callback (`applyDockZoneOperation`) or a local
+ * `DockZoneModel.applyOperation()` — never a parallel mutation path; the model clears `autoHidden`
+ * itself.
  *
- * Policy honesty: the model rejects `setItemAutoHidden(false)` for `pinnable: false` items, which is
- * reachable when an item's policy flips after it railed. Such a tab renders disabled and rejects
- * locally instead of emitting a doomed operation — the affordance mirrors what the executor would
- * answer.
+ * Reveal is policy-free: even a `pinnable: false` item (whose PIN the model would reject) must stay
+ * reachable through reveal — anything else is item loss. The policy projection (`restorable`)
+ * therefore gates the overlay's pin control, never the tab.
+ *
+ * The reveal/dismiss timing brain lives in {@link DockRevealStateMachine} (documented state table);
+ * this component owns composition, overlay binding and the executor commit path.
  *
  * @class Neo.dashboard.DockRail
  * @extends Neo.container.Base
  * @see Neo.dashboard.DockLayoutAdapter
+ * @see Neo.dashboard.DockRevealOverlay
  * @see Neo.dashboard.DockSplitter
  * @see Neo.dashboard.DockZoneModel
  * @see learn/agentos/HarnessDockZoneModel.md
@@ -61,6 +69,14 @@ class DockRail extends Container {
          */
         applyDockZoneOperation: null,
         /**
+         * Workspace-level opt-in for hover-born reveals (dwell-gated, never steals focus).
+         * Default off — hover reveals are an accessibility hazard; click-reveal is the contract
+         * default. Not persisted per item: this is per-workspace interaction preference.
+         * @member {Boolean} autoHideRevealOnHover_=false
+         * @reactive
+         */
+        autoHideRevealOnHover_: false,
+        /**
          * Current committed dock-zone document. Used when no reducer callback is supplied.
          * @member {Object|null} dockZoneDocument_=null
          * @reactive
@@ -85,20 +101,82 @@ class DockRail extends Container {
          * @member {Object[]|null} railItems_=null
          * @reactive
          */
-        railItems_: null
+        railItems_: null,
+        /**
+         * Resolves a model `componentRef` to the component config the reveal overlay's pane slot
+         * materializes — the same resolution seam the adapter uses for in-flow panes, threaded from
+         * projection context. Without it, reveals render header-only.
+         * @member {Function|null} resolveComponentRef=null
+         */
+        resolveComponentRef: null,
+        /**
+         * Dismiss-grace override in ms; `null` keeps the machine's named design constant.
+         * @member {Number|null} revealDismissGraceMs_=null
+         * @reactive
+         */
+        revealDismissGraceMs_: null,
+        /**
+         * Hover-dwell override in ms; `null` keeps the machine's named design constant.
+         * @member {Number|null} revealDwellMs_=null
+         * @reactive
+         */
+        revealDwellMs_: null
     }
 
     /**
+     * The reveal/dismiss timing brain. Runtime-only; created per instance, torn down in `destroy()`.
+     * @member {DockRevealStateMachine|null} revealMachine=null
+     * @protected
+     */
+    revealMachine = null
+    /**
+     * The overlay bound via {@link Neo.dashboard.DockRail#bindRevealOverlay}, when one exists.
+     * @member {Neo.dashboard.DockRevealOverlay|null} revealOverlay=null
+     * @protected
+     */
+    revealOverlay = null
+
+    /**
      * Seeds the initial button set from `railItems` before the container creates its items —
-     * later flips go through `reconcileTabs()` instead.
+     * later flips go through `reconcileTabs()` instead — and boots the reveal machine.
      * @param {Object} config
      */
     construct(config={}) {
-        if (config.railItems?.length && !config.items) {
-            config.items = config.railItems.map(railItem => this.createTabConfig(railItem, config.edge))
+        if (!config.items) {
+            // The overlay is part of the INITIAL composition (hidden while idle): the rail's
+            // subtree never changes shape post-mount for the reveal path — structural self-
+            // mutation after mount is what a wholesale workspace re-render cannot reconcile.
+            config.items = [
+                ...(config.railItems || []).map(railItem => this.createTabConfig(railItem, config.edge)),
+                {
+                    module: DockRevealOverlay,
+                    edge  : this.getValidatedEdge(config.edge)
+                }
+            ]
         }
 
-        super.construct(config)
+        super.construct(config);
+
+        let me = this;
+
+        me.revealMachine = new DockRevealStateMachine({
+            dwellMs      : Number.isFinite(me.revealDwellMs)        ? me.revealDwellMs        : undefined,
+            graceMs      : Number.isFinite(me.revealDismissGraceMs) ? me.revealDismissGraceMs : undefined,
+            onChange     : me.onRevealStateChange.bind(me),
+            revealOnHover: me.autoHideRevealOnHover
+        })
+    }
+
+    /**
+     * Live-updates the machine when the workspace flips the hover opt-in.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetAutoHideRevealOnHover(value, oldValue) {
+        if (this.revealMachine) {
+            this.revealMachine.revealOnHover = value === true
+        }
     }
 
     /**
@@ -132,21 +210,74 @@ class DockRail extends Container {
      * @protected
      */
     afterSetRailItems(value, oldValue) {
+        let me = this;
+
         if (oldValue !== undefined) {
-            this.reconcileTabs(value || [])
+            me.reconcileTabs(value || []);
+            me.syncRevealOverlay()
         }
     }
 
     /**
-     * Commits a restore descriptor through the owning reducer callback, falling back to a local
-     * `DockZoneModel.applyOperation()` — identical commit contract to
-     * `DockSplitter.commitResizeSplit()` so dashboard reducers handle both affordances with one
-     * code path.
+     * @param {Number|null} value
+     * @param {Number|null} oldValue
+     * @protected
+     */
+    afterSetRevealDismissGraceMs(value, oldValue) {
+        if (this.revealMachine && Number.isFinite(value)) {
+            this.revealMachine.graceMs = value
+        }
+    }
+
+    /**
+     * @param {Number|null} value
+     * @param {Number|null} oldValue
+     * @protected
+     */
+    afterSetRevealDwellMs(value, oldValue) {
+        if (this.revealMachine && Number.isFinite(value)) {
+            this.revealMachine.dwellMs = value
+        }
+    }
+
+    /**
+     * Binds a reveal overlay to this rail: overlay intents (pointer, focus, escape, pin) feed the
+     * state machine, and machine state pushes back into the overlay — the full focus-hold loop
+     * becomes testable without a live workspace.
+     * @param {Neo.dashboard.DockRevealOverlay} overlay
+     * @returns {Neo.dashboard.DockRevealOverlay}
+     */
+    bindRevealOverlay(overlay) {
+        let me = this;
+
+        me.revealOverlay = overlay;
+
+        overlay.on({
+            revealEscape      : me.onOverlayEscape,
+            revealFocusEnter  : me.onOverlayFocusEnter,
+            revealFocusLeave  : me.onOverlayFocusLeave,
+            revealPinRequested: me.onRevealPinRequested,
+            revealPointerEnter: me.onOverlayPointerEnter,
+            revealPointerLeave: me.onOverlayPointerLeave,
+            scope             : me
+        });
+
+        me.syncRevealOverlay();
+
+        return overlay
+    }
+
+    /**
+     * Commits a dock-zone operation descriptor through the owning reducer callback, falling back to
+     * a local `DockZoneModel.applyOperation()` — identical commit contract to
+     * `DockSplitter.commitResizeSplit()` so dashboard reducers handle every affordance with one
+     * code path. The rail commits `setItemPinned` (the overlay pin escape); reveal/dismiss never
+     * commit anything.
      * @param {Object} descriptor
      * @returns {{document:(Object|null), errors:String[]}}
      * @protected
      */
-    commitRestore(descriptor) {
+    commitOperation(descriptor) {
         let me     = this,
             result = null;
 
@@ -159,7 +290,7 @@ class DockRail extends Container {
         if (!result) {
             result = {
                 document: me.dockZoneDocument,
-                errors  : ['DockRail requires `dockZoneDocument` or `applyDockZoneOperation` to commit setItemAutoHidden.']
+                errors  : ['DockRail requires `dockZoneDocument` or `applyDockZoneOperation` to commit dock-zone operations.']
             }
         }
 
@@ -176,7 +307,8 @@ class DockRail extends Container {
 
     /**
      * Builds one rail-tab button config from rail-item metadata. The button carries its
-     * `dockItemId`, so click resolution is instance-based — no id bookkeeping.
+     * `dockItemId` (instance-based click/hover resolution — no id bookkeeping) and stays enabled
+     * regardless of policy: reveal is policy-free, the overlay pin is the gated affordance.
      * @param {Object} railItem {dockEdge, dockItemId, restorable, title}
      * @param {String} edge
      * @returns {Object}
@@ -186,15 +318,34 @@ class DockRail extends Container {
         let me = this;
 
         return {
-            module         : Button,
-            cls            : ['neo-dashboard-dock-rail-tab'],
-            disabled       : railItem.restorable === false,
-            dockItemId     : railItem.dockItemId,
-            handler        : me.onTabClick,
-            handlerScope   : me,
+            module      : Button,
+            cls         : ['neo-dashboard-dock-rail-tab'],
+            dockItemId  : railItem.dockItemId,
+            domListeners: [
+                {mouseenter: me.onTabHoverIn,  scope: me},
+                {mouseleave: me.onTabHoverOut, scope: me}
+            ],
+            // Explicitly bound: the button invokes function-type handlers as plain calls — the
+            // rail, not the button, must be `this` inside the handler.
+            handler        : me.onTabClick.bind(me),
             text           : railItem.title || railItem.dockItemId,
             useRippleEffect: false
         }
+    }
+
+    /**
+     * Tears down the reveal machinery before container destruction — pending dwell/grace timers
+     * must never outlive the rail.
+     * @param {...*} args
+     */
+    destroy(...args) {
+        let me = this;
+
+        me.revealMachine?.destroy();
+        me.revealMachine = null;
+        me.revealOverlay = null;
+
+        super.destroy(...args)
     }
 
     /**
@@ -207,16 +358,52 @@ class DockRail extends Container {
     }
 
     /**
-     * Button handler for rail tabs: resolves the clicked button to its dock item, honours the
-     * restore policy, and commits `setItemAutoHidden(false)` through the reducer path.
-     * Fires `dockRailRestore` on commit, `dockRailRestoreRejected` on policy block or executor
+     * @protected
+     */
+    onOverlayEscape() {
+        this.revealMachine?.escape()
+    }
+
+    /**
+     * @protected
+     */
+    onOverlayFocusEnter() {
+        this.revealMachine?.overlayFocusEnter()
+    }
+
+    /**
+     * @protected
+     */
+    onOverlayFocusLeave() {
+        this.revealMachine?.overlayFocusLeave()
+    }
+
+    /**
+     * @protected
+     */
+    onOverlayPointerEnter() {
+        this.revealMachine?.overlayPointerEnter()
+    }
+
+    /**
+     * @protected
+     */
+    onOverlayPointerLeave() {
+        this.revealMachine?.overlayPointerLeave()
+    }
+
+    /**
+     * The pin escape: honours the pin policy, commits `setItemPinned(true)` through the reducer
+     * path — the model clears `autoHidden` itself (landed guard) — and fail-closes the reveal.
+     * Fires `dockRailOperation` on commit, `dockRailOperationRejected` on policy block or executor
      * error.
-     * @param {Object} data The button click event data; `data.component` is the tab button.
+     * @param {Object} data
+     * @param {String} [data.itemId] Defaults to the currently revealed item.
      * @returns {{document:(Object|null), errors:String[]}|null}
      */
-    onTabClick(data={}) {
+    onRevealPinRequested(data={}) {
         let me     = this,
-            itemId = data.component?.dockItemId,
+            itemId = data.itemId || me.revealMachine?.revealedItemId,
             descriptor, railItem, result;
 
         if (!itemId) {
@@ -228,18 +415,22 @@ class DockRail extends Container {
         if (railItem?.restorable === false) {
             result = {
                 document: me.dockZoneDocument,
-                errors  : [`item "${itemId}" restore blocked by policy (pinnable: false)`]
+                errors  : [`item "${itemId}" pin blocked by policy (pinnable: false)`]
             };
 
-            me.fire('dockRailRestoreRejected', {descriptor: null, itemId, rail: me, result});
+            me.fire('dockRailOperationRejected', {descriptor: null, itemId, rail: me, result});
 
             return result
         }
 
-        descriptor = {autoHidden: false, itemId, operation: 'setItemAutoHidden'};
-        result     = me.commitRestore(descriptor);
+        descriptor = {itemId, operation: 'setItemPinned', pinned: true};
+        result     = me.commitOperation(descriptor);
 
-        me.fire(result.errors?.length ? 'dockRailRestoreRejected' : 'dockRailRestore', {
+        if (!result.errors?.length) {
+            me.revealMachine?.itemCleared(itemId)
+        }
+
+        me.fire(result.errors?.length ? 'dockRailOperationRejected' : 'dockRailOperation', {
             descriptor,
             itemId,
             rail: me,
@@ -250,9 +441,87 @@ class DockRail extends Container {
     }
 
     /**
+     * Binds the composed overlay child once the container created its items — an externally
+     * bound overlay (`bindRevealOverlay()`) simply replaces the binding; the composed child then
+     * stays idle-hidden.
+     */
+    onConstructed() {
+        super.onConstructed();
+
+        let me = this;
+
+        if (!me.revealOverlay) {
+            let overlay = (me.items || []).find(item => item.ntype === 'dashboard-dock-reveal-overlay');
+
+            overlay && me.bindRevealOverlay(overlay)
+        }
+    }
+
+    /**
+     * Machine change hook: fires `dockRailRevealChange` and pushes the snapshot into the bound
+     * overlay. Reveal state is runtime-only — nothing here touches a document.
+     * @param {Object} next {revealedItemId, state}
+     * @param {Object} previous {revealedItemId, state}
+     * @protected
+     */
+    onRevealStateChange(next, previous) {
+        let me = this;
+
+        me.fire('dockRailRevealChange', {
+            next,
+            previous,
+            rail    : me,
+            railItem: (me.railItems || []).find(item => item.dockItemId === next.revealedItemId) || null
+        });
+
+        me.syncRevealOverlay()
+    }
+
+    /**
+     * Button handler for rail tabs: feeds the reveal machine — click opens a focused transient
+     * reveal, re-click dismisses. No operation is committed here; the persist path is the overlay
+     * pin ({@link Neo.dashboard.DockRail#onRevealPinRequested}).
+     * @param {Object} data The button click event data; `data.component` is the tab button.
+     * @returns {{revealedItemId:(String|null), state:String}|null} Machine snapshot after the input.
+     */
+    onTabClick(data={}) {
+        let me     = this,
+            itemId = data.component?.dockItemId;
+
+        if (!itemId) {
+            return null
+        }
+
+        me.revealMachine.tabClick(itemId);
+
+        return {revealedItemId: me.revealMachine.revealedItemId, state: me.revealMachine.state}
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onTabHoverIn(data={}) {
+        let itemId = data.component?.dockItemId;
+
+        if (itemId) {
+            this.revealMachine.tabHoverIn(itemId)
+        }
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onTabHoverOut(data={}) {
+        this.revealMachine.tabHoverOut()
+    }
+
+    /**
      * Reconciles the live button set against fresh rail-item metadata: surviving items keep their
      * component instance and receive in-place `set()` updates (object permanence at the affordance
-     * level), leavers are removed, newcomers insert at their document-order position.
+     * level), leavers fail-close any reveal of them and are removed, newcomers insert at their
+     * document-order position.
      * @param {Object[]} target Fresh rail-item metadata.
      * @protected
      */
@@ -262,7 +531,13 @@ class DockRail extends Container {
             index;
 
         for (index = existing.length - 1; index >= 0; index--) {
+            // Only rail-tab buttons carry a dockItemId — the self-hosted overlay child is not a tab.
+            if (existing[index].dockItemId == null) {
+                continue
+            }
+
             if (!target.some(railItem => railItem.dockItemId === existing[index].dockItemId)) {
+                me.revealMachine?.itemCleared(existing[index].dockItemId);
                 me.removeAt(index)
             }
         }
@@ -273,8 +548,7 @@ class DockRail extends Container {
 
             if (button) {
                 button.set({
-                    disabled: railItem.restorable === false,
-                    text    : railItem.title || railItem.dockItemId
+                    text: railItem.title || railItem.dockItemId
                 });
 
                 if (currentIndex !== targetIndex) {
@@ -285,6 +559,87 @@ class DockRail extends Container {
                 me.insert(targetIndex, me.createTabConfig(railItem, me.edge))
             }
         })
+    }
+
+    /**
+     * Resolves the overlay's free-dimension extent for an item: the share its owning split last
+     * committed (still in the document), else `null` — the overlay then falls back to its
+     * workspace-configurable default fraction.
+     * @param {String} itemId
+     * @returns {Number|null}
+     * @protected
+     */
+    resolveRevealExtent(itemId) {
+        let document = this.dockZoneDocument;
+
+        // Runtime namespace lookup avoids an import cycle (the adapter imports this class);
+        // fail-soft to null — the overlay then uses its default fraction.
+        return document ? (Neo.dashboard?.DockLayoutAdapter?.resolveRevealExtent(document, itemId) ?? null) : null
+    }
+
+    /**
+     * Pushes the current reveal snapshot into the bound overlay, when one exists, and keeps the
+     * overlay's pane slot in sync.
+     * @protected
+     */
+    syncRevealOverlay() {
+        let me      = this,
+            machine = me.revealMachine,
+            overlay = me.revealOverlay,
+            railItem;
+
+        if (!overlay || !machine) {
+            return
+        }
+
+        railItem = (me.railItems || []).find(item => item.dockItemId === machine.revealedItemId) || null;
+
+        overlay.set({
+            edge        : me.getValidatedEdge(me.edge),
+            revealExtent: railItem ? me.resolveRevealExtent(railItem.dockItemId) : null,
+            revealState : machine.state,
+            revealedItem: railItem
+        });
+
+        me.syncRevealPane(railItem)
+    }
+
+    /**
+     * Materializes the revealed item's pane into the overlay's slot — resolved through the SAME
+     * `resolveComponentRef` seam the adapter uses for in-flow panes, with the `componentRef` read
+     * from the committed document (the rail's copy re-projects on every change). An auto-hidden
+     * item has no live pane instance, so the overlay creates a transient one and destroys it on
+     * dismissal — transient by design, like every other piece of reveal state.
+     * @param {Object|null} railItem
+     * @protected
+     */
+    syncRevealPane(railItem) {
+        let me   = this,
+            slot = me.revealOverlay?.paneSlot,
+            currentId, nextId, componentRef, paneConfig;
+
+        // Stub/external overlays without a pane slot render header-only — valid by contract.
+        if (!slot?.add) {
+            return
+        }
+
+        currentId = me.revealOverlay.revealPaneItemId ?? null;
+        nextId    = railItem?.dockItemId ?? null;
+
+        if (currentId === nextId) {
+            return
+        }
+
+        slot.removeAll();
+
+        if (nextId && typeof me.resolveComponentRef === 'function') {
+            componentRef = me.dockZoneDocument?.items?.[nextId]?.componentRef;
+            paneConfig   = componentRef != null ? me.resolveComponentRef(componentRef) : null;
+
+            paneConfig && slot.add({...paneConfig})
+        }
+
+        me.revealOverlay.revealPaneItemId = nextId
     }
 }
 

--- a/src/dashboard/DockRail.mjs
+++ b/src/dashboard/DockRail.mjs
@@ -77,6 +77,14 @@ class DockRail extends Container {
          */
         autoHideRevealOnHover_: false,
         /**
+         * Workspace-level default for the overlay's free-dimension fraction when the document
+         * carries no committed extent (`null` keeps the overlay's own default). Threaded from
+         * projection options exactly like the hover opt-in.
+         * @member {Number|null} defaultRevealFraction_=null
+         * @reactive
+         */
+        defaultRevealFraction_: null,
+        /**
          * Current committed dock-zone document. Used when no reducer callback is supplied.
          * @member {Object|null} dockZoneDocument_=null
          * @reactive
@@ -123,6 +131,14 @@ class DockRail extends Container {
         revealDwellMs_: null
     }
 
+    /**
+     * Blueprint-created reveal panes, cached per dock item id. Parked (removed without destroy)
+     * on dismissal and re-parented on the next reveal — mounted children are never destroyed
+     * mid-session; the cache tears down with the rail.
+     * @member {Object} revealPaneCache={}
+     * @protected
+     */
+    revealPaneCache = {}
     /**
      * The reveal/dismiss timing brain. Runtime-only; created per instance, torn down in `destroy()`.
      * @member {DockRevealStateMachine|null} revealMachine=null
@@ -345,6 +361,11 @@ class DockRail extends Container {
         me.revealMachine = null;
         me.revealOverlay = null;
 
+        Object.values(me.revealPaneCache).forEach(pane => {
+            pane?.isDestroyed || pane?.destroy?.()
+        });
+        me.revealPaneCache = {};
+
         super.destroy(...args)
     }
 
@@ -474,7 +495,14 @@ class DockRail extends Container {
             railItem: (me.railItems || []).find(item => item.dockItemId === next.revealedItemId) || null
         });
 
-        me.syncRevealOverlay()
+        me.syncRevealOverlay();
+
+        // Embodied focus-hold: a click-born reveal moves REAL browser focus into the overlay.
+        // Focus-rescue transitions (revealed / dismiss-pending -> focused) already hold focus
+        // inside the subtree by definition — re-focusing would fight the user's caret.
+        if (next.state === 'revealed-focused' && previous.state !== 'revealed' && previous.state !== 'dismiss-pending') {
+            me.revealOverlay?.focusReveal?.()
+        }
     }
 
     /**
@@ -598,7 +626,8 @@ class DockRail extends Container {
             edge        : me.getValidatedEdge(me.edge),
             revealExtent: railItem ? me.resolveRevealExtent(railItem.dockItemId) : null,
             revealState : machine.state,
-            revealedItem: railItem
+            revealedItem: railItem,
+            ...(Number.isFinite(me.defaultRevealFraction) ? {defaultRevealFraction: me.defaultRevealFraction} : {})
         });
 
         me.syncRevealPane(railItem)
@@ -607,16 +636,21 @@ class DockRail extends Container {
     /**
      * Materializes the revealed item's pane into the overlay's slot — resolved through the SAME
      * `resolveComponentRef` seam the adapter uses for in-flow panes, with the `componentRef` read
-     * from the committed document (the rail's copy re-projects on every change). An auto-hidden
-     * item has no live pane instance, so the overlay creates a transient one and destroys it on
-     * dismissal — transient by design, like every other piece of reveal state.
+     * from the committed document (the rail's copy re-projects on every change).
+     *
+     * Live-instance contract: a resolver-returned Neo INSTANCE is added as-is and PARKED on
+     * dismissal (removed without destroy — moved/re-parented, never destroyed), so its identity
+     * and transient state survive reveal/dismiss cycles and the pin transition back into the
+     * flow. A blueprint-created pane (config resolution — the no-live-instance fallback) is
+     * cached per item and parked the same way: mounted children are never destroyed mid-session
+     * (`revealPaneCache` tears down with the rail).
      * @param {Object|null} railItem
      * @protected
      */
     syncRevealPane(railItem) {
         let me   = this,
             slot = me.revealOverlay?.paneSlot,
-            currentId, nextId, componentRef, paneConfig;
+            child, componentRef, currentId, nextId, resolved;
 
         // Stub/external overlays without a pane slot render header-only — valid by contract.
         if (!slot?.add) {
@@ -630,13 +664,27 @@ class DockRail extends Container {
             return
         }
 
-        slot.removeAll();
+        child = slot.items?.[0];
+
+        if (child) {
+            slot.remove(child, false)
+        }
 
         if (nextId && typeof me.resolveComponentRef === 'function') {
-            componentRef = me.dockZoneDocument?.items?.[nextId]?.componentRef;
-            paneConfig   = componentRef != null ? me.resolveComponentRef(componentRef) : null;
+            if (me.revealPaneCache[nextId] && !me.revealPaneCache[nextId].isDestroyed) {
+                slot.add(me.revealPaneCache[nextId])
+            } else {
+                componentRef = me.dockZoneDocument?.items?.[nextId]?.componentRef;
+                resolved     = componentRef != null ? me.resolveComponentRef(componentRef) : null;
 
-            paneConfig && slot.add({...paneConfig})
+                if (resolved) {
+                    if (Neo.typeOf(resolved) === 'NeoInstance') {
+                        slot.add(resolved)
+                    } else {
+                        me.revealPaneCache[nextId] = slot.add({...resolved})
+                    }
+                }
+            }
         }
 
         me.revealOverlay.revealPaneItemId = nextId

--- a/src/dashboard/DockRevealOverlay.mjs
+++ b/src/dashboard/DockRevealOverlay.mjs
@@ -146,12 +146,19 @@ class DockRevealOverlay extends Container {
         super.construct(config);
 
         me.addDomListeners([
-            {focusin   : me.onFocusIn,      scope: me},
-            {focusout  : me.onFocusOut,     scope: me},
             {keydown   : me.onKeyDown,      scope: me},
             {mouseenter: me.onPointerEnter, scope: me},
             {mouseleave: me.onPointerLeave, scope: me}
         ])
+    }
+
+    /**
+     * Moves REAL browser focus into the overlay (first focusable descendant — the pin control at
+     * minimum, the hosted pane's focusables once mounted). The owning rail calls this when a
+     * click-born reveal opens: focus-hold must be embodied, not a state label.
+     */
+    focusReveal() {
+        this.focus(this.id, true)
     }
 
     /**
@@ -240,18 +247,27 @@ class DockRevealOverlay extends Container {
     }
 
     /**
+     * `manager.Focus` containment hook: fires only when focus genuinely ENTERS this component's
+     * subtree — internal focus movement never re-triggers it, which is exactly the containment
+     * guard the dismiss contract needs.
      * @param {Object} data
      * @protected
      */
-    onFocusIn(data) {
+    onFocusEnter(data) {
+        super.onFocusEnter(data);
         this.fire('revealFocusEnter', {overlay: this})
     }
 
     /**
+     * `manager.Focus` containment hook: fires only when focus genuinely LEAVES the subtree —
+     * moving focus between the pin control and the hosted pane stays silent. Clicking anywhere
+     * outside a focused overlay moves focus out, so outside-click dismissal of a focused reveal
+     * is embodied here.
      * @param {Object} data
      * @protected
      */
-    onFocusOut(data) {
+    onFocusLeave(data) {
+        super.onFocusLeave(data);
         this.fire('revealFocusLeave', {overlay: this})
     }
 

--- a/src/dashboard/DockRevealOverlay.mjs
+++ b/src/dashboard/DockRevealOverlay.mjs
@@ -1,0 +1,332 @@
+import Button    from '../button/Base.mjs';
+import Container from '../container/Base.mjs';
+import Label     from '../component/Label.mjs';
+import NeoArray  from '../util/Array.mjs';
+
+/**
+ * @summary Presentation host for the transient reveal of an auto-hidden dock item — an
+ * edge-anchored overlay that renders OVER the committed projection, never re-layouts it.
+ *
+ * The overlay is pure per-window runtime state: it renders whatever reveal snapshot its owning
+ * rail pushes (via `DockRail.bindRevealOverlay()`) and translates DOM reality back into semantic
+ * INTENTS the rail's state machine consumes — `revealPointerEnter/Leave`, `revealFocusEnter/Leave`,
+ * `revealEscape`, `revealPinRequested`. It decides nothing itself: timing, focus-hold and policy
+ * all live upstream. It has no write path to any document.
+ *
+ * Composition: a header row (`Neo.component.Label` title + `Neo.button.Base` pin control) above a
+ * pane-slot `Neo.container.Base`. The consuming workspace mounts the revealed pane INTO the slot
+ * container (`overlay.paneSlot.add(...)` / `removeAll()`) — pane resolution stays the workspace's
+ * concern (same seam as the adapter's `resolveComponentRef`), keeping this overlay pane-blind.
+ * Root-level `domListeners` (focus, key, pointer) are the container-level interaction surface;
+ * every interactive CHILD is a real component.
+ *
+ * Sizing follows the auto-hide contract: the free dimension (width for left/right rails, height
+ * for top/bottom) uses the extent the item's owning split last committed when one exists
+ * (`revealExtent`, resolved by the rail), else the workspace-configurable `defaultRevealFraction`.
+ * Left/right reveals span full height; top/bottom span full width. The overlay stays visible
+ * through the dismiss grace window (`dismiss-pending`) — pointer wobble must not flicker it.
+ *
+ * The pin control persists the reveal: it requests `setItemPinned(true)` from the rail (executor
+ * path — no parallel mutation grammar) and renders disabled when the item's policy forbids pinning
+ * (`restorable: false`) — the one honest non-pinnable affordance state, while reveal itself stays
+ * policy-free.
+ *
+ * @class Neo.dashboard.DockRevealOverlay
+ * @extends Neo.container.Base
+ * @see Neo.dashboard.DockRail
+ * @see Neo.dashboard.DockRevealStateMachine
+ * @see learn/agentos/HarnessDockZoneModel.md
+ */
+class DockRevealOverlay extends Container {
+    /**
+     * Reveal states in which the overlay renders visibly — `dismiss-pending` included: the grace
+     * window is part of the shown lifecycle.
+     * @member {Set<String>} VISIBLE_STATES
+     * @static
+     */
+    static VISIBLE_STATES = new Set(['dismiss-pending', 'revealed', 'revealed-focused'])
+
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockRevealOverlay'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockRevealOverlay',
+        /**
+         * @member {String} ntype='dashboard-dock-reveal-overlay'
+         * @protected
+         */
+        ntype: 'dashboard-dock-reveal-overlay',
+        /**
+         * @member {String[]} baseCls=['neo-dashboard-dock-reveal-overlay']
+         */
+        baseCls: ['neo-dashboard-dock-reveal-overlay'],
+        /**
+         * Workspace-configurable fallback for the free dimension when the document carries no
+         * committed extent for the item (fraction of the workspace extent).
+         * @member {Number} defaultRevealFraction_=0.25
+         * @reactive
+         */
+        defaultRevealFraction_: 0.25,
+        /**
+         * Owning workspace edge (`top`, `right`, `bottom`, `left`).
+         * @member {String} edge_='left'
+         * @reactive
+         */
+        edge_: 'left',
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * Committed extent fraction for the free dimension, or `null` for the default fraction.
+         * Resolved by the rail from the live document — never computed from DOM geometry.
+         * @member {Number|null} revealExtent_=null
+         * @reactive
+         */
+        revealExtent_: null,
+        /**
+         * Current machine state snapshot (`idle`, `dwell-pending`, `revealed`, `revealed-focused`,
+         * `dismiss-pending`).
+         * @member {String} revealState_='idle'
+         * @reactive
+         */
+        revealState_: 'idle',
+        /**
+         * Rail-item metadata of the revealed item (`{dockEdge, dockItemId, restorable, title}`),
+         * or `null` when nothing reveals.
+         * @member {Object|null} revealedItem_=null
+         * @reactive
+         */
+        revealedItem_: null
+    }
+
+    /**
+     * The dock item id whose pane currently occupies the slot — maintained by the owning rail's
+     * pane sync. Runtime-only bookkeeping, never persisted.
+     * @member {String|null} revealPaneItemId=null
+     * @protected
+     */
+    revealPaneItemId = null
+
+    /**
+     * Assembles the fixed child skeleton (header: title label + pin button; pane slot) with
+     * instance-bound handlers, wires the container-level interaction listeners, then applies the
+     * initial snapshot.
+     * @param {Object} config
+     */
+    construct(config={}) {
+        let me = this;
+
+        config.items = [{
+            module: Container,
+            cls   : ['neo-dashboard-dock-reveal-header'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                module: Label,
+                cls   : ['neo-dashboard-dock-reveal-title'],
+                flex  : 1,
+                text  : ''
+            }, {
+                module: Button,
+                cls   : ['neo-dashboard-dock-reveal-pin'],
+                // Explicitly bound: function-type button handlers run as plain calls.
+                handler        : me.onPinClick.bind(me),
+                text           : 'Pin',
+                useRippleEffect: false
+            }]
+        }, {
+            module: Container,
+            cls   : ['neo-dashboard-dock-reveal-pane-slot'],
+            flex  : 1,
+            items : []
+        }];
+
+        super.construct(config);
+
+        me.addDomListeners([
+            {focusin   : me.onFocusIn,      scope: me},
+            {focusout  : me.onFocusOut,     scope: me},
+            {keydown   : me.onKeyDown,      scope: me},
+            {mouseenter: me.onPointerEnter, scope: me},
+            {mouseleave: me.onPointerLeave, scope: me}
+        ])
+    }
+
+    /**
+     * Child instances exist only after the container created its items — the initial snapshot
+     * application waits for that.
+     */
+    onConstructed() {
+        super.onConstructed();
+        this.syncSnapshot()
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetEdge(value, oldValue) {
+        let me  = this,
+            cls = me.cls || [];
+
+        if (oldValue) {
+            NeoArray.remove(cls, `neo-dashboard-dock-reveal-overlay-${oldValue}`)
+        }
+
+        NeoArray.add(cls, `neo-dashboard-dock-reveal-overlay-${value}`);
+
+        me.cls = cls;
+        me.isConstructed && me.syncSnapshot()
+    }
+
+    /**
+     * @param {Number|null} value
+     * @param {Number|null} oldValue
+     * @protected
+     */
+    afterSetRevealExtent(value, oldValue) {
+        this.isConstructed && this.syncSnapshot()
+    }
+
+    /**
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetRevealState(value, oldValue) {
+        this.isConstructed && this.syncSnapshot()
+    }
+
+    /**
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetRevealedItem(value, oldValue) {
+        this.isConstructed && this.syncSnapshot()
+    }
+
+    /**
+     * The pane-slot container the consuming workspace mounts the revealed pane into.
+     * @returns {Neo.container.Base}
+     */
+    get paneSlot() {
+        return this.items[1]
+    }
+
+    /**
+     * @returns {Neo.button.Base}
+     */
+    get pinButton() {
+        return this.items[0].items[1]
+    }
+
+    /**
+     * @returns {Neo.component.Label}
+     */
+    get titleLabel() {
+        return this.items[0].items[0]
+    }
+
+    /**
+     * Whether the current snapshot renders visibly.
+     * @returns {Boolean}
+     */
+    get visible() {
+        return DockRevealOverlay.VISIBLE_STATES.has(this.revealState) && !!this.revealedItem
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onFocusIn(data) {
+        this.fire('revealFocusEnter', {overlay: this})
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onFocusOut(data) {
+        this.fire('revealFocusLeave', {overlay: this})
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onKeyDown(data={}) {
+        if (data.key === 'Escape') {
+            this.fire('revealEscape', {overlay: this})
+        }
+    }
+
+    /**
+     * Requests the pin escape from the owning rail. Policy is honoured upstream; the disabled
+     * rendering here is the honest affordance mirror, not the enforcement point.
+     * @param {Object} data The pin button click event data.
+     * @protected
+     */
+    onPinClick(data) {
+        let item = this.revealedItem;
+
+        if (item) {
+            this.fire('revealPinRequested', {itemId: item.dockItemId, overlay: this})
+        }
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onPointerEnter(data) {
+        this.fire('revealPointerEnter', {overlay: this})
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onPointerLeave(data) {
+        this.fire('revealPointerLeave', {overlay: this})
+    }
+
+    /**
+     * Applies the current snapshot to the composed children in place: visibility cls,
+     * free-dimension style, title text and pin policy — the child instances persist across
+     * snapshots (object permanence at the overlay level too).
+     * @protected
+     */
+    syncSnapshot() {
+        let me         = this,
+            edge       = me.edge,
+            isVertical = edge === 'left' || edge === 'right',
+            fraction   = Number.isFinite(me.revealExtent) ? me.revealExtent : me.defaultRevealFraction,
+            item       = me.revealedItem,
+            pct        = `${Math.round(fraction * 10000) / 100}%`,
+            cls        = me.cls || [];
+
+        NeoArray[me.visible ? 'remove' : 'add'](cls, 'neo-dashboard-dock-reveal-overlay-hidden');
+
+        me.set({
+            cls,
+            style: {
+                ...(me.style || {}),
+                height: isVertical ? null : pct,
+                width : isVertical ? pct  : null
+            }
+        });
+
+        me.titleLabel.text = item ? (item.title || item.dockItemId) : '';
+
+        me.pinButton.set({
+            disabled: item ? item.restorable === false : true
+        })
+    }
+}
+
+export default Neo.setupClass(DockRevealOverlay);

--- a/src/dashboard/DockRevealStateMachine.mjs
+++ b/src/dashboard/DockRevealStateMachine.mjs
@@ -26,6 +26,7 @@
  * | `idle` | `tabHoverIn(item)` | `dwell-pending` | Only when `revealOnHover` (workspace opt-in — hover reveals are an a11y hazard by default). |
  * | `dwell-pending` | dwell elapsed | `revealed` | Hover reveal never steals focus. |
  * | `dwell-pending` | `tabHoverOut()` | `idle` | Pass-through hovers never flicker an overlay. |
+ * | `revealed` | `tabHoverOut()` | `dismiss-pending` | Hover-born reveal whose pointer leaves the TAB without ever entering the overlay dismisses through the same grace window. |
  * | `dwell-pending` | `tabClick(item)` | `revealed-focused` | Click overrides the dwell wait. |
  * | `revealed*` | `tabClick(same item)` | `idle` | Re-clicking the tab dismisses. |
  * | `revealed*` | `tabClick(other item)` | `revealed-focused(other)` | Retarget: the reveal follows intent. |
@@ -222,14 +223,18 @@ class DockRevealStateMachine {
     }
 
     /**
-     * Hover left the rail tab before the dwell elapsed — a pass-through must never flicker
-     * an overlay open.
+     * Hover left the rail tab. Before the dwell elapsed, a pass-through must never flicker an
+     * overlay open; after a hover-born reveal opened, leaving the tab WITHOUT entering the
+     * overlay starts the same dismiss grace the overlay's own pointer-leave uses (a pointer
+     * that reaches the overlay cancels it via `overlayPointerEnter()`).
      */
     tabHoverOut() {
         let me = this;
 
         if (me.state === 'dwell-pending') {
             me.transition(me.revealedItemId ? 'revealed' : 'idle', me.revealedItemId)
+        } else if (me.state === 'revealed') {
+            me.overlayPointerLeave()
         }
     }
 

--- a/src/dashboard/DockRevealStateMachine.mjs
+++ b/src/dashboard/DockRevealStateMachine.mjs
@@ -1,0 +1,260 @@
+/**
+ * @summary Pure reveal/dismiss state machine for auto-hidden dock items — runtime-only by
+ * construction, timer-injectable for deterministic specs.
+ *
+ * This module is deliberately NOT a Neo class: it holds per-window runtime interaction state
+ * (which item is transiently revealed, and why) that must never touch the persisted dock-zone
+ * document. It has no write path to any document — its only outputs are `onChange`
+ * notifications the owning affordance (`Neo.dashboard.DockRail`) maps to overlay updates and,
+ * for the pin escape, to an executor-routed operation OUTSIDE this machine.
+ *
+ * ## States
+ *
+ * | State | Meaning |
+ * |---|---|
+ * | `idle` | No reveal. The rail renders tabs only. |
+ * | `dwell-pending` | Hover intent detected (opt-in mode); reveal fires when the dwell timer elapses. |
+ * | `revealed` | Overlay open WITHOUT focus (hover-born reveal — hover never steals focus). |
+ * | `revealed-focused` | Overlay open and holding focus. A focused reveal never auto-dismisses. |
+ * | `dismiss-pending` | Pointer left an unfocused overlay; dismissal fires when the grace timer elapses. |
+ *
+ * ## Transitions
+ *
+ * | From | Input | To | Notes |
+ * |---|---|---|---|
+ * | `idle` | `tabClick(item)` | `revealed-focused` | Click-reveal is the DEFAULT interaction; focus moves into the pane. |
+ * | `idle` | `tabHoverIn(item)` | `dwell-pending` | Only when `revealOnHover` (workspace opt-in — hover reveals are an a11y hazard by default). |
+ * | `dwell-pending` | dwell elapsed | `revealed` | Hover reveal never steals focus. |
+ * | `dwell-pending` | `tabHoverOut()` | `idle` | Pass-through hovers never flicker an overlay. |
+ * | `dwell-pending` | `tabClick(item)` | `revealed-focused` | Click overrides the dwell wait. |
+ * | `revealed*` | `tabClick(same item)` | `idle` | Re-clicking the tab dismisses. |
+ * | `revealed*` | `tabClick(other item)` | `revealed-focused(other)` | Retarget: the reveal follows intent. |
+ * | `revealed` / `dismiss-pending` | `tabHoverIn(other item)` | `dwell-pending(other)` | Hover retarget re-dwells; the current reveal survives until the new one commits. |
+ * | `revealed` | `overlayPointerLeave()` | `dismiss-pending` | Grace timer starts — pointer wobble must not kill the overlay. |
+ * | `dismiss-pending` | `overlayPointerEnter()` | `revealed` | Grace return. |
+ * | `dismiss-pending` | grace elapsed | `idle` | Dismissed; no operation is emitted. |
+ * | `revealed` / `dismiss-pending` | `overlayFocusEnter()` | `revealed-focused` | Focus rescues and holds. |
+ * | `revealed-focused` | `overlayPointerLeave()` | `revealed-focused` | FOCUS-HOLD: a focused reveal never auto-dismisses. |
+ * | `revealed-focused` | `overlayFocusLeave()` | `idle` | Focus leaving the overlay dismisses. |
+ * | `revealed*` / `dismiss-pending` | `escape()` / `outsideClick()` | `idle` | Explicit dismissal. |
+ * | any | `itemCleared(item)` | `idle` | Fail-closed sync: the item left auto-hidden state (pin, restore, transfer, policy) — a reveal of it cannot survive. |
+ *
+ * Dismissal in every form discards runtime state only; no operation descriptor exists for it.
+ *
+ * ## Design constants
+ *
+ * Sourced from the S3 storyboard notes (`apps/agentos/design/dock-choreography-demo.html`):
+ * dwell + grace are INTERACTION timings owned here; the 200ms/160ms reveal/dismiss slide
+ * durations are ANIMATION timings and live in CSS, not in this machine.
+ */
+class DockRevealStateMachine {
+    /**
+     * Hover intent dwell before a reveal fires (opt-in hover mode only).
+     * @member {Number} DWELL_MS=150
+     * @static
+     */
+    static DWELL_MS = 150
+    /**
+     * Grace period after the pointer leaves an unfocused overlay before it dismisses.
+     * @member {Number} DISMISS_GRACE_MS=300
+     * @static
+     */
+    static DISMISS_GRACE_MS = 300
+
+    /**
+     * @param {Object} config
+     * @param {Function} [config.clearTimeoutFn=globalThis.clearTimeout] Injectable for fake-timer specs.
+     * @param {Number} [config.dwellMs=DockRevealStateMachine.DWELL_MS]
+     * @param {Number} [config.graceMs=DockRevealStateMachine.DISMISS_GRACE_MS]
+     * @param {Function|null} [config.onChange=null] Receives `(next, previous)` snapshots `{revealedItemId, state}`.
+     * @param {Boolean} [config.revealOnHover=false] Workspace-level opt-in; hover inputs are ignored without it.
+     * @param {Function} [config.setTimeoutFn=globalThis.setTimeout] Injectable for fake-timer specs.
+     */
+    constructor({clearTimeoutFn, dwellMs, graceMs, onChange, revealOnHover, setTimeoutFn} = {}) {
+        this.clearTimeoutFn = clearTimeoutFn || globalThis.clearTimeout.bind(globalThis);
+        this.dwellMs        = Number.isFinite(dwellMs) ? dwellMs : DockRevealStateMachine.DWELL_MS;
+        this.graceMs        = Number.isFinite(graceMs) ? graceMs : DockRevealStateMachine.DISMISS_GRACE_MS;
+        this.onChange       = typeof onChange === 'function' ? onChange : null;
+        this.pendingItemId  = null;
+        this.revealOnHover  = revealOnHover === true;
+        this.revealedItemId = null;
+        this.setTimeoutFn   = setTimeoutFn || globalThis.setTimeout.bind(globalThis);
+        this.state          = 'idle';
+        this.timerId        = null
+    }
+
+    /**
+     * Clears any pending dwell/grace timer. Idempotent.
+     * @protected
+     */
+    clearTimer() {
+        if (this.timerId !== null) {
+            this.clearTimeoutFn(this.timerId);
+            this.timerId = null
+        }
+    }
+
+    /**
+     * Tears the machine down: clears timers and detaches the change listener.
+     */
+    destroy() {
+        this.clearTimer();
+        this.onChange = null
+    }
+
+    /**
+     * `Escape` inside a revealed overlay dismisses it — runtime state only, no operation.
+     */
+    escape() {
+        if (this.state !== 'idle') {
+            this.transition('idle', null)
+        }
+    }
+
+    /**
+     * Fail-closed sync input: the item left committed auto-hidden state (pin escape, restore,
+     * transfer, policy flip). Any reveal of it — pending or open — cannot survive.
+     * @param {String} itemId
+     */
+    itemCleared(itemId) {
+        if (this.revealedItemId === itemId || this.pendingItemId === itemId) {
+            this.transition('idle', null)
+        }
+    }
+
+    /**
+     * A click outside the overlay and rail dismisses the reveal.
+     */
+    outsideClick() {
+        this.escape()
+    }
+
+    /**
+     * Focus entered the overlay: engage focus-hold — a focused reveal never auto-dismisses.
+     */
+    overlayFocusEnter() {
+        if (this.state === 'revealed' || this.state === 'dismiss-pending') {
+            this.transition('revealed-focused', this.revealedItemId)
+        }
+    }
+
+    /**
+     * Focus left the overlay: the reveal dismisses (the pointer-grace path only serves
+     * unfocused reveals).
+     */
+    overlayFocusLeave() {
+        if (this.state === 'revealed-focused') {
+            this.transition('idle', null)
+        }
+    }
+
+    /**
+     * Pointer returned to the overlay during the dismiss grace window.
+     */
+    overlayPointerEnter() {
+        if (this.state === 'dismiss-pending') {
+            this.transition('revealed', this.revealedItemId)
+        }
+    }
+
+    /**
+     * Pointer left the overlay. Unfocused reveals enter the grace window; focused reveals
+     * hold (focus-hold rule).
+     */
+    overlayPointerLeave() {
+        let me = this;
+
+        if (me.state === 'revealed') {
+            me.transition('dismiss-pending', me.revealedItemId);
+
+            me.timerId = me.setTimeoutFn(() => {
+                me.timerId = null;
+
+                if (me.state === 'dismiss-pending') {
+                    me.transition('idle', null)
+                }
+            }, me.graceMs)
+        }
+    }
+
+    /**
+     * Tab click — the DEFAULT reveal interaction. Toggles: clicking the revealed item's tab
+     * dismisses; clicking another tab retargets. Click-born reveals hold focus immediately.
+     * @param {String} itemId
+     */
+    tabClick(itemId) {
+        let me = this;
+
+        if (me.revealedItemId === itemId && me.state !== 'dwell-pending') {
+            me.transition('idle', null);
+            return
+        }
+
+        me.transition('revealed-focused', itemId)
+    }
+
+    /**
+     * Hover entered a rail tab. Ignored unless the workspace opted in via `revealOnHover`.
+     * Starts (or retargets) the dwell window; hover-born reveals never steal focus.
+     * @param {String} itemId
+     */
+    tabHoverIn(itemId) {
+        let me = this;
+
+        if (!me.revealOnHover || me.state === 'revealed-focused' || me.revealedItemId === itemId && me.state === 'revealed') {
+            return
+        }
+
+        me.clearTimer();
+        me.pendingItemId = itemId;
+
+        if (me.state !== 'dwell-pending') {
+            me.transition('dwell-pending', me.revealedItemId, itemId)
+        }
+
+        me.timerId = me.setTimeoutFn(() => {
+            me.timerId = null;
+
+            if (me.state === 'dwell-pending' && me.pendingItemId === itemId) {
+                me.transition('revealed', itemId)
+            }
+        }, me.dwellMs)
+    }
+
+    /**
+     * Hover left the rail tab before the dwell elapsed — a pass-through must never flicker
+     * an overlay open.
+     */
+    tabHoverOut() {
+        let me = this;
+
+        if (me.state === 'dwell-pending') {
+            me.transition(me.revealedItemId ? 'revealed' : 'idle', me.revealedItemId)
+        }
+    }
+
+    /**
+     * Central transition executor: clears timers, applies the snapshot, notifies `onChange`
+     * exactly once per effective change.
+     * @param {String} state
+     * @param {String|null} revealedItemId
+     * @param {String|null} [pendingItemId=null]
+     * @protected
+     */
+    transition(state, revealedItemId, pendingItemId=null) {
+        let me       = this,
+            previous = {revealedItemId: me.revealedItemId, state: me.state};
+
+        me.clearTimer();
+
+        me.pendingItemId  = pendingItemId;
+        me.revealedItemId = revealedItemId;
+        me.state          = state;
+
+        if ((previous.state !== state || previous.revealedItemId !== revealedItemId) && me.onChange) {
+            me.onChange({revealedItemId, state}, previous)
+        }
+    }
+}
+
+export default DockRevealStateMachine;

--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -341,7 +341,7 @@ class VdomLifecycle extends Base {
                 // Distribute results back to ALL components in the batch
                 for (const id in response.vnodes) {
                     if (Object.hasOwn(response.vnodes, id)) {
-                        const vnode = response.vnodes[id];
+                        const vnode     = response.vnodes[id];
                         const component = Neo.getComponent(id);
 
                         if (component && !component.isDestroyed) {
@@ -437,10 +437,10 @@ class VdomLifecycle extends Base {
      * @returns {Object} opts
      */
     getVdomUpdatePayload(mergedChildIds, depth) {
-        let me = this,
-            updateDepth = depth ?? me.updateDepth,
+        let me            = this,
+            updateDepth   = depth ?? me.updateDepth,
             {vdom, vnode} = me,
-            opts = {
+            opts          = {
                 vdom : TreeBuilder.getVdomTree(vdom,   updateDepth, mergedChildIds),
                 vnode: TreeBuilder.getVnodeTree(vnode, updateDepth, mergedChildIds)
             };
@@ -540,9 +540,9 @@ class VdomLifecycle extends Base {
      * @returns {Promise<any>} If getting there, we return the data from vdom.Helper: create(), containing the vnode.
      */
     async initVnode(mount) {
-        let me        = this,
-            autoMount = mount || me.autoMount,
-            {app}     = me,
+        let me                                                     = this,
+            autoMount                                              = mount || me.autoMount,
+            {app}                                                  = me,
             {allowVdomUpdatesInTests, unitTestMode, useVdomWorker} = Neo.config;
 
         if (unitTestMode && !allowVdomUpdatesInTests) return;
@@ -946,7 +946,11 @@ class VdomLifecycle extends Base {
             {config}                   = Neo;
 
         if (config.unitTestMode && !config.allowVdomUpdatesInTests) {
-            reject?.();
+            // Unit-test mode deliberately skips vdom updates — a skipped update is a SUCCESSFUL
+            // no-op, not a failure. Rejecting here turned every naked promiseUpdate().then() chain
+            // (container insert/remove and friends) into an unhandled `undefined` rejection the
+            // moment a spec structurally mutated an unmounted container.
+            resolve?.();
             return
         }
 

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -80,6 +80,50 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
         const revealed = await readModel();
         expect(JSON.stringify(revealed), 'the committed document must NOT change on reveal').toBe(JSON.stringify(hidden));
 
+        // Embodied focus: real browser focus moved INSIDE the overlay on click-reveal.
+        expect(await page.evaluate(() =>
+            document.activeElement?.closest('.neo-dashboard-dock-reveal-overlay') !== null
+        ), 'click-reveal must move real focus into the overlay').toBe(true);
+
+        // Escape dismisses — runtime-only, document byte-stable.
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(400);
+        await expect(overlay, 'Escape must dismiss the reveal').toBeHidden();
+        expect(JSON.stringify(await readModel()), 'Escape dismissal must not touch the document').toBe(JSON.stringify(hidden));
+
+        // Outside-click dismissal (focused reveal): clicking outside moves focus out -> focus-leave dismisses.
+        await railTab.click();
+        await page.waitForTimeout(400);
+        await expect(overlay).toBeVisible();
+        await page.locator('.neo-tab-header-button', { hasText: 'Strategy' }).first().click();
+        await page.waitForTimeout(400);
+        await expect(overlay, 'an outside click must dismiss the focused reveal').toBeHidden();
+        expect(JSON.stringify(await readModel()), 'outside-click dismissal must not touch the document').toBe(JSON.stringify(hidden));
+
+        // Hover mode (workspace opt-in, live-configured): dwell opens; leaving the tab without
+        // ever entering the overlay dismisses through the grace window.
+        const railInstances = await app.findInstances({ ntype: 'dashboard-dock-rail' }, ['id']);
+        const railId        = Array.isArray(railInstances) ? railInstances[0]?.id : railInstances?.id;
+        await app.setProperties(railId, { autoHideRevealOnHover: true, revealDismissGraceMs: 400, revealDwellMs: 100 });
+
+        const railBox = await railTab.boundingBox();
+        await page.mouse.move(railBox.x + railBox.width / 2, railBox.y + railBox.height / 2);
+        await page.waitForTimeout(350); // > dwell
+        await expect(overlay, 'opt-in hover must reveal after the dwell').toBeVisible();
+
+        await page.mouse.move(100, 100); // jump far outside — never crosses the overlay
+        await page.waitForTimeout(150);  // < grace: still shown
+        await expect(overlay, 'the grace window must hold the overlay briefly').toBeVisible();
+        await page.waitForTimeout(600);  // > grace
+        await expect(overlay, 'hover-away without entering the overlay must dismiss through grace').toBeHidden();
+
+        await app.setProperties(railId, { autoHideRevealOnHover: false });
+
+        // Re-open for the pin tail.
+        await railTab.click();
+        await page.waitForTimeout(600);
+        await expect(overlay).toBeVisible();
+
         // Native gesture: PIN -> the one committed operation of the interaction.
         await overlay.locator('.neo-dashboard-dock-reveal-pin').first().click();
         await page.waitForTimeout(1500);

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -1,0 +1,125 @@
+import { test, expect } from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: the end-to-end gesture proof for the auto-hide interaction contract — a committed
+ * auto-hidden item collapses to a real edge-rail BUTTON, a native CLICK on that button opens a
+ * transient reveal overlay WITHOUT touching worker truth, and the overlay's PIN button commits
+ * `setItemPinned(true)` through the reducer.
+ *
+ * This is the epic's gesture-proof guardrail ridden in the same PR as the affordance: the product
+ * truths a unit spec cannot certify are (1) the rail projects real, clickable buttons in the DOM,
+ * (2) the reveal is genuinely runtime-only — the committed dockZone.v1 document in the App Worker
+ * is byte-stable across reveal open/close, (3) the pin gesture mutates worker truth exactly once,
+ * through the semantic operation path, and the affordance instances retire from the worker.
+ *
+ * Paradigm (whitebox-e2e protocol): Playwright drives native mouse gestures; the Neural Link
+ * fixture reads the holder's committed document (dockModel) at every stage and performs the ONE
+ * programmatic setup commit (auto-hiding the inspector) through the example's own reducer seam.
+ *
+ * Run: NEO_E2E_PORT=8091 npx playwright test DockAutoHideRevealNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ * (the port override isolates from any foreign dev-server squatting on 8080)
+ */
+
+const bootDockExample = async ({ page, neuralLink }) => {
+    await page.goto('/examples/dashboard/dock/');
+    page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+    await page.waitForTimeout(2500); // settle worker boot + first render
+
+    const app      = await neuralLink.connectToApp('Neo.examples.dashboard.dock');
+    const holders  = await app.findInstances({ className: 'Neo.examples.dashboard.dock.MainContainer' }, ['id']);
+    const holderId = Array.isArray(holders) ? holders[0]?.id : holders?.id;
+
+    expect(holderId, 'the dock MainContainer must exist in the App Worker').toBeTruthy();
+
+    const readModel = async () => (await app.getComponent(holderId, ['dockModel'])).dockModel;
+
+    return { app, holderId, readModel }
+};
+
+const tuckInspector = async ({ app, holderId, page }) => {
+    const commitResult = await app.callMethod(holderId, 'applyDockZoneOperation', [
+        { autoHidden: true, itemId: 'inspector', operation: 'setItemAutoHidden' }
+    ]);
+    expect(commitResult?.errors, 'the auto-hide commit must pass the model guards').toEqual([]);
+    await app.callMethod(holderId, 'onDockZoneDocumentChange', [commitResult.document]);
+    await page.waitForTimeout(1000)
+};
+
+test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
+    test.setTimeout(90000);
+    test.use({ viewport: { width: 1600, height: 900 } });
+
+    test('rail click reveals without persisting; the pin gesture commits setItemPinned through the reducer', async ({ page, neuralLink }) => {
+        const { app, holderId, readModel } = await bootDockExample({ page, neuralLink });
+
+        // Setup truth: inspector sits visible in the right edge band; nothing rails yet.
+        const before = await readModel();
+        expect(before?.nodes?.['inspector-tabs']?.items, 'the example must seed the inspector in the right edge band').toEqual(['inspector']);
+        expect(before?.items?.inspector?.autoHidden, 'the inspector must start visible').not.toBe(true);
+        await expect(page.locator('.neo-dashboard-dock-edge-rail .neo-dashboard-dock-rail-tab')).toHaveCount(0);
+
+        await tuckInspector({ app, holderId, page });
+
+        // Product truth #1: the committed auto-hidden item projects as a REAL rail button.
+        const railTab = page.locator('.neo-dashboard-dock-rail-tab', { hasText: 'Inspector' }).first();
+        await expect(railTab, 'the inspector must collapse to a labeled edge-rail tab').toBeVisible({ timeout: 10000 });
+
+        const hidden = await readModel();
+        expect(hidden?.items?.inspector?.autoHidden, 'worker truth must carry autoHidden: true').toBe(true);
+
+        // Native gesture: CLICK the rail tab -> transient reveal overlay.
+        await railTab.click();
+        await page.waitForTimeout(600);
+
+        const overlay = page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)');
+        await expect(overlay, 'the reveal overlay must open on rail-tab click').toBeVisible({ timeout: 10000 });
+        await expect(overlay.locator('.neo-dashboard-dock-reveal-title'), 'the overlay must title the revealed item').toHaveText('Inspector');
+
+        // Product truth #2: reveal is runtime-only — worker truth is byte-stable across the reveal.
+        const revealed = await readModel();
+        expect(JSON.stringify(revealed), 'the committed document must NOT change on reveal').toBe(JSON.stringify(hidden));
+
+        // Native gesture: PIN -> the one committed operation of the interaction.
+        await overlay.locator('.neo-dashboard-dock-reveal-pin').first().click();
+        await page.waitForTimeout(1500);
+
+        // Product truth #3: the pin gesture mutated worker truth through the semantic path.
+        const pinned = await readModel();
+        console.log('[auto-hide] inspector:', JSON.stringify(hidden?.items?.inspector), '->', JSON.stringify(pinned?.items?.inspector));
+        expect(pinned?.items?.inspector?.pinned,     'the pin gesture must commit setItemPinned(true)').toBe(true);
+        expect(pinned?.items?.inspector?.autoHidden, 'the model must clear autoHidden on pin (landed guard)').toBe(false);
+
+        // ...and the affordance retires from WORKER truth: the re-projected tree rails nothing.
+        expect(await app.findInstances({ ntype: 'dashboard-dock-rail' }, ['id']),
+            'no rail instance may survive the post-pin re-projection').toEqual([]);
+        expect(await app.findInstances({ ntype: 'dashboard-dock-reveal-overlay' }, ['id']),
+            'no overlay instance may survive the post-pin re-projection').toEqual([]);
+    });
+
+    // Pinned by #14911 (ticket-ref-ok: expected-fail pins must cite their tracking bug): the
+    // wholesale workspace refresh (removeAll + add) destroys the rail instances (asserted green
+    // above) but leaves their DOM in the main thread — a vdom reconciliation defect independent
+    // of the affordance components. Flips to green with #14911 (ticket-ref-ok: same pin).
+    test('post-pin DOM reconciliation removes the retired rail affordance (#14911)', async ({ page, neuralLink }) => {
+        test.fail(true, 'DOM cleanup of the destroyed rail lags worker truth — tracked in #14911');
+
+        const { app, holderId } = await bootDockExample({ page, neuralLink });
+
+        await tuckInspector({ app, holderId, page });
+
+        const railTab = page.locator('.neo-dashboard-dock-rail-tab', { hasText: 'Inspector' }).first();
+        await expect(railTab).toBeVisible({ timeout: 10000 });
+        await railTab.click();
+        await page.waitForTimeout(600);
+
+        const overlay = page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)');
+        await expect(overlay).toBeVisible({ timeout: 10000 });
+        await overlay.locator('.neo-dashboard-dock-reveal-pin').first().click();
+        await page.waitForTimeout(1500);
+
+        await expect(page.locator('.neo-dashboard-dock-rail-tab'), 'the retired rail tab must leave the DOM').toHaveCount(0);
+        await expect(page.locator('.neo-tab-header-button', { hasText: 'Inspector' }).first(),
+            'the pinned inspector must re-enter the rendered tab flow').toBeVisible({ timeout: 10000 });
+    });
+});

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -1,5 +1,9 @@
 import {defineConfig, devices} from '@playwright/test';
 
+// Overridable so agent/dev runs can isolate from a foreign dev-server already squatting on 8080
+// (a server started from ANOTHER checkout silently serves the wrong tree to every spec).
+const PORT = process.env.NEO_E2E_PORT || 8080;
+
 export default defineConfig({
     testDir      : './e2e',
     outputDir    : './test-results/e2e/artifacts',
@@ -15,20 +19,20 @@ export default defineConfig({
     ],
 
     use: {
-        baseURL: 'http://localhost:8080',
+        baseURL: `http://localhost:${PORT}`,
         trace  : 'on'
     },
 
     webServer: {
-        command            : 'npm run server-start',
-        url                : 'http://localhost:8080',
+        command            : `npm run server-start -- --port ${PORT} --no-open`,
+        url                : `http://localhost:${PORT}`,
         reuseExistingServer: !process.env.CI
     },
 
     projects: [{
         name: 'chromium',
         use : {
-            channel: 'chrome', // Use local Google Chrome instead of Playwright's Chromium binary
+            channel      : 'chrome', // Use local Google Chrome instead of Playwright's Chromium binary
             launchOptions: {
                 args: [
                     '--use-gl=desktop',

--- a/test/playwright/unit/core/VdomUnitModeUpdate.spec.mjs
+++ b/test/playwright/unit/core/VdomUnitModeUpdate.spec.mjs
@@ -1,0 +1,50 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'CoreVdomUnitModeUpdateTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import Container      from '../../../../src/container/Base.mjs';
+
+/**
+ * Direct contract pin for the unit-mode vdom-update semantics: when `unitTestMode` disables vdom
+ * updates (`allowVdomUpdatesInTests: false`), a skipped update is a SUCCESSFUL no-op — the promise
+ * RESOLVES. It must never reject: every naked `promiseUpdate().then()` chain in the framework
+ * (container insert/remove and friends) would otherwise surface an unhandled `undefined` rejection
+ * the moment a spec structurally mutates an unmounted container.
+ *
+ * The destroy-path contract (a pending update promise REJECTS when its component is destroyed)
+ * is pinned separately in `test/playwright/unit/core/AsyncDestruction.spec.mjs` and is unchanged.
+ */
+test.describe('VdomLifecycle unit-mode update contract', () => {
+    test('promiseUpdate() resolves as a successful no-op while unit mode disables vdom updates', async () => {
+        const component = Neo.create(Component, {id: 'vdom-unitmode-resolve'});
+
+        await expect(component.promiseUpdate()).resolves.toBeUndefined();
+
+        component.destroy()
+    });
+
+    test('a structural container op on an unmounted container settles cleanly — insert event fires, nothing rejects', async () => {
+        const container = Neo.create(Container, {id: 'vdom-unitmode-container', items: []});
+        const inserted  = [];
+
+        container.on('insert', data => inserted.push(data));
+        container.insert(0, {module: Component, id: 'vdom-unitmode-child'});
+
+        // insert()'s own promiseUpdate().then(fire) chain settles on the microtask queue.
+        await container.promiseUpdate();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(container.items).toHaveLength(1);
+        expect(inserted).toHaveLength(1);
+
+        container.destroy()
+    });
+});

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -411,6 +411,7 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         let result = DockLayoutAdapter.project(model, {
                 applyDockZoneOperation,
                 autoHideRevealOnHover: true,
+                defaultRevealFraction: 0.4,
                 onDockZoneDocumentChange,
                 resolveComponentRef  : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
             }),
@@ -420,8 +421,9 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(rail.applyDockZoneOperation).toBe(applyDockZoneOperation);
         expect(rail.onDockZoneDocumentChange).toBe(onDockZoneDocumentChange);
         expect(rail.dockZoneDocument).toBe(model);
-        // The workspace-level hover opt-in threads through; it defaults to false when absent.
+        // Workspace-level interaction options thread through; they default when absent.
         expect(rail.autoHideRevealOnHover).toBe(true);
+        expect(rail.defaultRevealFraction).toBe(0.4);
         expect(DockLayoutAdapter.project(model, {
             resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
         }).items[0].items.find(item => item.dockNodeType === 'edge-rail').autoHideRevealOnHover).toBe(false);

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -365,6 +365,11 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(terminalTabs.dockNodeId).toBe('terminal-tabs');
         expect(terminalTabs.items).toEqual([]);
         expect(terminalTabs.activeIndex).toBeNull();
+
+        // Geometry discipline: edge bands keep a fixed cross-extent, the center flexes.
+        expect(side.flex).toBe('none');
+        expect(side.cls).toEqual(expect.arrayContaining(['neo-dashboard-dock-edge-band', 'neo-dashboard-dock-edge-band-right']));
+        expect(row.items[0].flex).toBe(1);
     });
 
     test('does not rail an item that is pinned but not autoHidden', () => {
@@ -405,15 +410,36 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
 
         let result = DockLayoutAdapter.project(model, {
                 applyDockZoneOperation,
+                autoHideRevealOnHover: true,
                 onDockZoneDocumentChange,
-                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+                resolveComponentRef  : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
             }),
             rail = result.items[0].items.find(item => item.dockNodeType === 'edge-rail');
 
-        // Restore commits must ride the workspace's single operation path — same threading as splitters.
+        // Commits must ride the workspace's single operation path — same threading as splitters.
         expect(rail.applyDockZoneOperation).toBe(applyDockZoneOperation);
         expect(rail.onDockZoneDocumentChange).toBe(onDockZoneDocumentChange);
         expect(rail.dockZoneDocument).toBe(model);
+        // The workspace-level hover opt-in threads through; it defaults to false when absent.
+        expect(rail.autoHideRevealOnHover).toBe(true);
+        expect(DockLayoutAdapter.project(model, {
+            resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+        }).items[0].items.find(item => item.dockNodeType === 'edge-rail').autoHideRevealOnHover).toBe(false);
+    });
+
+    test('resolveRevealExtent returns the committed split share, else null', () => {
+        let model = createEdgeZoneModel();
+
+        // terminal-tabs is side-split child 0: sizes [0.55, 0.45] → 0.55 share.
+        expect(DockLayoutAdapter.resolveRevealExtent(model, 'terminal')).toBeCloseTo(0.55);
+        expect(DockLayoutAdapter.resolveRevealExtent(model, 'inspector')).toBeCloseTo(0.45);
+
+        // strategy's tabs node sits directly in an edge-zone slot — no ancestor split, no extent.
+        expect(DockLayoutAdapter.resolveRevealExtent(model, 'strategy')).toBeNull();
+
+        // Unknown items and absent models fail null-safe.
+        expect(DockLayoutAdapter.resolveRevealExtent(model, 'ghost')).toBeNull();
+        expect(DockLayoutAdapter.resolveRevealExtent(null, 'terminal')).toBeNull();
     });
 
     test('projects one rail per edge with correct membership (multi-edge grouping)', () => {

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -10,6 +10,7 @@ import {test, expect}    from '@playwright/test';
 import Neo               from '../../../../src/Neo.mjs';
 import * as core         from '../../../../src/core/_export.mjs';
 import DockLayoutAdapter from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockRail          from '../../../../src/dashboard/DockRail.mjs';
 import DockSplitter      from '../../../../src/dashboard/DockSplitter.mjs';
 import DockZoneModel     from '../../../../src/dashboard/DockZoneModel.mjs';
 
@@ -350,14 +351,15 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             side         = row.items.find(item => item.dockNodeId === 'side-split'),
             terminalTabs = getProjectedChildren(side)[0];
 
-        // The auto-hidden item surfaces as a right-edge rail tab.
+        // The auto-hidden item surfaces as a right-edge DockRail affordance.
         expect(rail).toBeTruthy();
         expect(rail.dockEdge).toBe('right');
-        expect(rail.layout).toEqual({ntype: 'vbox', align: 'start'});
-        expect(rail.items.map(item => item.dockItemId)).toEqual(['terminal']);
-        expect(rail.items[0].dockNodeType).toBe('edge-rail-tab');
-        expect(rail.items[0].text).toBe('Terminal');
-        expect(rail.items[0].data).toEqual({dockEdge: 'right', dockItemId: 'terminal', dockRailTab: true});
+        expect(rail.edge).toBe('right');
+        expect(rail.module).toBe(DockRail);
+        expect(rail.ntype).toBe('dashboard-dock-rail');
+        expect(rail.railItems).toEqual([
+            {dockEdge: 'right', dockItemId: 'terminal', restorable: true, title: 'Terminal'}
+        ]);
 
         // ...and is gone from its tab flow (the now-empty terminal-tabs).
         expect(terminalTabs.dockNodeId).toBe('terminal-tabs');
@@ -392,5 +394,81 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         // Center never auto-hides to a rail; the item stays visible rather than vanishing.
         expect(row.items.find(item => item.dockNodeType === 'edge-rail')).toBeUndefined();
         expect(center.items.map(item => item.data.dockItemId)).toEqual(['strategy', 'swarm']);
+    });
+
+    test('threads reducer callbacks from projection context into the rail affordance', () => {
+        let applyDockZoneOperation   = () => null,
+            model                    = createEdgeZoneModel(),
+            onDockZoneDocumentChange = () => null;
+
+        model.items.terminal.autoHidden = true;
+
+        let result = DockLayoutAdapter.project(model, {
+                applyDockZoneOperation,
+                onDockZoneDocumentChange,
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            }),
+            rail = result.items[0].items.find(item => item.dockNodeType === 'edge-rail');
+
+        // Restore commits must ride the workspace's single operation path — same threading as splitters.
+        expect(rail.applyDockZoneOperation).toBe(applyDockZoneOperation);
+        expect(rail.onDockZoneDocumentChange).toBe(onDockZoneDocumentChange);
+        expect(rail.dockZoneDocument).toBe(model);
+    });
+
+    test('projects one rail per edge with correct membership (multi-edge grouping)', () => {
+        let model = createEdgeZoneModel();
+
+        model.items.navigator    = {componentRef: 'navigator', title: 'Navigator', kind: 'panel'};
+        model.nodes['left-tabs'] = {type: 'tabs', items: ['navigator'], activeItemId: 'navigator'};
+        model.nodes.root.zones.left = 'left-tabs';
+
+        model.items.navigator.autoHidden = true;
+        model.items.terminal.autoHidden  = true;
+
+        let result = DockLayoutAdapter.project(model, {
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            }),
+            rails = result.items[0].items.filter(item => item.dockNodeType === 'edge-rail');
+
+        expect(rails.map(rail => rail.dockEdge)).toEqual(['left', 'right']);
+        expect(rails[0].railItems.map(item => item.dockItemId)).toEqual(['navigator']);
+        expect(rails[1].railItems.map(item => item.dockItemId)).toEqual(['terminal']);
+    });
+
+    test('re-projects consistently across rapid autoHidden toggles through the executor', () => {
+        let model    = createEdgeZoneModel(),
+            options  = {resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})},
+            findRail = result => result.items[0].items.find(item => item.dockNodeType === 'edge-rail');
+
+        let hidden = DockZoneModel.applyOperation(model, {autoHidden: true, itemId: 'terminal', operation: 'setItemAutoHidden'});
+        expect(hidden.errors).toEqual([]);
+
+        let railed = findRail(DockLayoutAdapter.project(hidden.document, options));
+        expect(railed.railItems.map(item => item.dockItemId)).toEqual(['terminal']);
+
+        let restored = DockZoneModel.applyOperation(hidden.document, {autoHidden: false, itemId: 'terminal', operation: 'setItemAutoHidden'});
+        expect(findRail(DockLayoutAdapter.project(restored.document, options))).toBeUndefined();
+
+        let rehidden = DockZoneModel.applyOperation(restored.document, {autoHidden: true, itemId: 'terminal', operation: 'setItemAutoHidden'});
+        expect(findRail(DockLayoutAdapter.project(rehidden.document, options)).railItems).toEqual(railed.railItems);
+    });
+
+    test('projects restorable: false for a railed item whose pinnable policy flipped off', () => {
+        let model = createEdgeZoneModel();
+
+        // Reachable state: the item railed first, then its policy flipped — the model would now
+        // reject setItemAutoHidden(false), so the tab must not lie about the affordance.
+        model.items.terminal.autoHidden = true;
+        model.items.terminal.pinnable   = false;
+
+        let result = DockLayoutAdapter.project(model, {
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            }),
+            rail = result.items[0].items.find(item => item.dockNodeType === 'edge-rail');
+
+        expect(rail.railItems).toEqual([
+            {dockEdge: 'right', dockItemId: 'terminal', restorable: false, title: 'Terminal'}
+        ]);
     });
 });

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -9,6 +9,7 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../src/Neo.mjs';
 import * as core      from '../../../../src/core/_export.mjs';
+import Button         from '../../../../src/button/Base.mjs';
 import DockRail       from '../../../../src/dashboard/DockRail.mjs';
 
 const createDocument = () => ({
@@ -40,7 +41,7 @@ test.describe('Neo.dashboard.DockRail', () => {
         rail = null
     });
 
-    test('renders labeled tabs from railItems and updates in place on model flips (no remount)', () => {
+    test('renders railItems as real button children and reconciles in place (object permanence)', () => {
         rail = Neo.create(DockRail, {
             edge     : 'right',
             id       : 'dock-rail-reactive',
@@ -48,29 +49,39 @@ test.describe('Neo.dashboard.DockRail', () => {
         });
 
         expect(rail.cls).toContain('neo-dashboard-dock-edge-rail-right');
-        expect(rail.vdom.cn).toHaveLength(1);
-        expect(rail.vdom.cn[0].tag).toBe('button');
-        expect(rail.vdom.cn[0].text).toBe('Terminal');
-        expect(rail.vdom.cn[0].data).toEqual({dockEdge: 'right', dockItemId: 'terminal', dockRailTab: true});
-        expect(rail.vdom.cn[0].disabled).toBeNull();
+        expect(rail.layout.ntype).toContain('vbox');
+        expect(rail.items).toHaveLength(1);
+        expect(rail.items[0] instanceof Button.constructor || rail.items[0].ntype).toBeTruthy();
+        expect(rail.items[0].text).toBe('Terminal');
+        expect(rail.items[0].dockItemId).toBe('terminal');
+        expect(rail.items[0].disabled).toBe(false);
 
-        // Model flip: a second item rails — same instance, tab children re-render in place.
+        let terminalButton = rail.items[0];
+
+        // Model flip: a second item rails — the surviving tab keeps its LIVE component instance.
         rail.railItems = [
             ...createRailItems(),
             {dockEdge: 'right', dockItemId: 'inspector', restorable: true, title: 'Inspector'}
         ];
 
-        expect(rail.id).toBe('dock-rail-reactive');
-        expect(rail.vdom.cn).toHaveLength(2);
-        expect(rail.vdom.cn[1].text).toBe('Inspector');
+        expect(rail.items).toHaveLength(2);
+        expect(rail.items[0]).toBe(terminalButton);
+        expect(rail.items[1].text).toBe('Inspector');
 
-        // ...and clears the same way (the empty rail renders no tabs).
+        // Title flips update the surviving instance in place; leavers are removed.
+        rail.railItems = [{dockEdge: 'right', dockItemId: 'terminal', restorable: true, title: 'Console'}];
+
+        expect(rail.items).toHaveLength(1);
+        expect(rail.items[0]).toBe(terminalButton);
+        expect(rail.items[0].text).toBe('Console');
+
+        // ...and the empty rail renders no tabs.
         rail.railItems = [];
 
-        expect(rail.vdom.cn).toHaveLength(0);
+        expect(rail.items).toHaveLength(0);
     });
 
-    test('restore rides the reducer callback: click commits setItemAutoHidden(false)', () => {
+    test('restore rides the reducer callback: tab click commits setItemAutoHidden(false)', () => {
         let descriptors = [],
             events      = [],
             nextDoc     = createDocument();
@@ -89,7 +100,9 @@ test.describe('Neo.dashboard.DockRail', () => {
 
         rail.on('dockRailRestore', data => events.push(data));
 
-        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        // The click path is button.Base's own handler contract; we invoke the handler the way
+        // the button does: with the click data carrying the button component.
+        let result = rail.onTabClick({component: rail.items[0]});
 
         expect(descriptors).toHaveLength(1);
         expect(descriptors[0].descriptor).toEqual({autoHidden: false, itemId: 'terminal', operation: 'setItemAutoHidden'});
@@ -114,7 +127,7 @@ test.describe('Neo.dashboard.DockRail', () => {
             railItems               : createRailItems()
         });
 
-        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        let result = rail.onTabClick({component: rail.items[0]});
 
         expect(result.errors).toEqual([]);
         expect(result.document.items.terminal.autoHidden).toBe(false);
@@ -126,7 +139,7 @@ test.describe('Neo.dashboard.DockRail', () => {
         expect(changes[0].railInstance).toBe(rail);
     });
 
-    test('policy: a non-restorable tab renders disabled and rejects locally without emitting an operation', () => {
+    test('policy: a non-restorable tab renders as a disabled button and rejects locally without emitting an operation', () => {
         let committed = [],
             rejected  = [];
 
@@ -142,16 +155,23 @@ test.describe('Neo.dashboard.DockRail', () => {
 
         rail.on('dockRailRestoreRejected', data => rejected.push(data));
 
-        expect(rail.vdom.cn[0].disabled).toBe(true);
-        expect(rail.vdom.cn[0].cls).toContain('neo-dashboard-dock-rail-tab-disabled');
+        expect(rail.items[0].disabled).toBe(true);
 
-        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        let result = rail.onTabClick({component: rail.items[0]});
 
         expect(committed).toHaveLength(0);
         expect(result.errors.join(' ')).toContain('blocked by policy');
         expect(rejected).toHaveLength(1);
         expect(rejected[0].descriptor).toBeNull();
         expect(rejected[0].itemId).toBe('terminal');
+
+        // A live policy flip re-enables the surviving button instance in place.
+        let button = rail.items[0];
+
+        rail.railItems = [{dockEdge: 'right', dockItemId: 'terminal', restorable: true, title: 'Terminal'}];
+
+        expect(rail.items[0]).toBe(button);
+        expect(button.disabled).toBe(false);
     });
 
     test('an executor rejection surfaces as dockRailRestoreRejected with the document unchanged', () => {
@@ -171,20 +191,20 @@ test.describe('Neo.dashboard.DockRail', () => {
 
         rail.on('dockRailRestoreRejected', data => rejected.push(data));
 
-        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        let result = rail.onTabClick({component: rail.items[0]});
 
         expect(result.errors.join(' ')).toContain('not pinnable');
         expect(rail.dockZoneDocument.items.terminal.autoHidden).toBe(true);
         expect(rejected).toHaveLength(1);
     });
 
-    test('ignores clicks that do not resolve to a known tab', () => {
+    test('ignores clicks that do not resolve to a rail-tab button', () => {
         rail = Neo.create(DockRail, {
             id       : 'dock-rail-unknown',
             railItems: createRailItems()
         });
 
-        expect(rail.onRailClick({currentTarget: 'not-a-tab'})).toBeNull();
-        expect(rail.onRailClick({})).toBeNull();
+        expect(rail.onTabClick({component: {}})).toBeNull();
+        expect(rail.onTabClick({})).toBeNull();
     });
 });

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -6,11 +6,11 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../src/Neo.mjs';
-import * as core      from '../../../../src/core/_export.mjs';
-import Button         from '../../../../src/button/Base.mjs';
-import DockRail       from '../../../../src/dashboard/DockRail.mjs';
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../src/Neo.mjs';
+import * as core         from '../../../../src/core/_export.mjs';
+import DockLayoutAdapter from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockRail          from '../../../../src/dashboard/DockRail.mjs';
 
 const createDocument = () => ({
     schema: 'neo.harness.dockZone.v1',
@@ -33,6 +33,23 @@ const createRailItems = () => ([
     {dockEdge: 'right', dockItemId: 'terminal', restorable: true, title: 'Terminal'}
 ]);
 
+// Rail children = tab buttons + the composed reveal overlay; tabs carry a dockItemId.
+const tabsOf = rail => (rail.items || []).filter(item => item.dockItemId != null);
+
+const createStubOverlay = () => ({
+    calls    : [],
+    listeners: {},
+    fire(name, data) {
+        this.listeners[name]?.call(this.listeners.scope, data)
+    },
+    on(map) {
+        Object.assign(this.listeners, map)
+    },
+    set(config) {
+        this.calls.push(config)
+    }
+});
+
 test.describe('Neo.dashboard.DockRail', () => {
     let rail;
 
@@ -50,13 +67,11 @@ test.describe('Neo.dashboard.DockRail', () => {
 
         expect(rail.cls).toContain('neo-dashboard-dock-edge-rail-right');
         expect(rail.layout.ntype).toContain('vbox');
-        expect(rail.items).toHaveLength(1);
-        expect(rail.items[0] instanceof Button.constructor || rail.items[0].ntype).toBeTruthy();
-        expect(rail.items[0].text).toBe('Terminal');
-        expect(rail.items[0].dockItemId).toBe('terminal');
-        expect(rail.items[0].disabled).toBe(false);
+        expect(tabsOf(rail)).toHaveLength(1);
+        expect(tabsOf(rail)[0].text).toBe('Terminal');
+        expect(tabsOf(rail)[0].dockItemId).toBe('terminal');
 
-        let terminalButton = rail.items[0];
+        let terminalButton = tabsOf(rail)[0];
 
         // Model flip: a second item rails — the surviving tab keeps its LIVE component instance.
         rail.railItems = [
@@ -64,82 +79,104 @@ test.describe('Neo.dashboard.DockRail', () => {
             {dockEdge: 'right', dockItemId: 'inspector', restorable: true, title: 'Inspector'}
         ];
 
-        expect(rail.items).toHaveLength(2);
-        expect(rail.items[0]).toBe(terminalButton);
-        expect(rail.items[1].text).toBe('Inspector');
+        expect(tabsOf(rail)).toHaveLength(2);
+        expect(tabsOf(rail)[0]).toBe(terminalButton);
+        expect(tabsOf(rail)[1].text).toBe('Inspector');
 
         // Title flips update the surviving instance in place; leavers are removed.
         rail.railItems = [{dockEdge: 'right', dockItemId: 'terminal', restorable: true, title: 'Console'}];
 
-        expect(rail.items).toHaveLength(1);
-        expect(rail.items[0]).toBe(terminalButton);
-        expect(rail.items[0].text).toBe('Console');
+        expect(tabsOf(rail)).toHaveLength(1);
+        expect(tabsOf(rail)[0]).toBe(terminalButton);
+        expect(tabsOf(rail)[0].text).toBe('Console');
 
-        // ...and the empty rail renders no tabs.
+        // ...and the empty rail renders no tabs (the composed overlay child remains).
         rail.railItems = [];
 
-        expect(rail.items).toHaveLength(0);
+        expect(tabsOf(rail)).toHaveLength(0);
     });
 
-    test('restore rides the reducer callback: tab click commits setItemAutoHidden(false)', () => {
-        let descriptors = [],
-            events      = [],
-            nextDoc     = createDocument();
-
-        nextDoc.items.terminal.autoHidden = false;
+    test('click opens a focused transient reveal WITHOUT emitting any operation; re-click dismisses', () => {
+        let committed = [],
+            reveals   = [];
 
         rail = Neo.create(DockRail, {
-            applyDockZoneOperation: (descriptor, railInstance) => {
-                descriptors.push({descriptor, railInstance});
-                return {document: nextDoc, errors: []}
+            applyDockZoneOperation: descriptor => {
+                committed.push(descriptor);
+                return {document: null, errors: []}
             },
             edge     : 'right',
-            id       : 'dock-rail-callback',
+            id       : 'dock-rail-click-reveal',
             railItems: createRailItems()
         });
 
-        rail.on('dockRailRestore', data => events.push(data));
+        rail.on('dockRailRevealChange', data => reveals.push(data));
 
         // The click path is button.Base's own handler contract; we invoke the handler the way
         // the button does: with the click data carrying the button component.
-        let result = rail.onTabClick({component: rail.items[0]});
+        let snapshot = rail.onTabClick({component: rail.items[0]});
 
-        expect(descriptors).toHaveLength(1);
-        expect(descriptors[0].descriptor).toEqual({autoHidden: false, itemId: 'terminal', operation: 'setItemAutoHidden'});
-        expect(descriptors[0].railInstance).toBe(rail);
-        expect(result.errors).toEqual([]);
-        // The config system clones object configs on set — value equality IS the contract here.
-        expect(rail.dockZoneDocument).toEqual(nextDoc);
-        expect(events).toHaveLength(1);
-        expect(events[0].itemId).toBe('terminal');
-        expect(events[0].descriptor.operation).toBe('setItemAutoHidden');
+        expect(snapshot).toEqual({revealedItemId: 'terminal', state: 'revealed-focused'});
+        expect(committed).toHaveLength(0);
+        expect(reveals).toHaveLength(1);
+        expect(reveals[0].railItem.dockItemId).toBe('terminal');
+
+        snapshot = rail.onTabClick({component: rail.items[0]});
+
+        expect(snapshot).toEqual({revealedItemId: null, state: 'idle'});
+        expect(committed).toHaveLength(0);
+        expect(reveals).toHaveLength(2);
     });
 
-    test('falls back to a local DockZoneModel commit and notifies the document listener', () => {
+    test('reveal state never persists: a full reveal/dismiss cycle leaves the document untouched', () => {
         let changes  = [],
-            document = createDocument();
+            document = createDocument(),
+            snapshot = JSON.stringify(document);
 
         rail = Neo.create(DockRail, {
             dockZoneDocument        : document,
             edge                    : 'right',
-            id                      : 'dock-rail-local',
-            onDockZoneDocumentChange: (doc, descriptor, railInstance) => changes.push({descriptor, doc, railInstance}),
+            id                      : 'dock-rail-no-persist',
+            onDockZoneDocumentChange: () => changes.push(1),
             railItems               : createRailItems()
         });
 
-        let result = rail.onTabClick({component: rail.items[0]});
+        rail.onTabClick({component: rail.items[0]});
+        rail.revealMachine.escape();
 
-        expect(result.errors).toEqual([]);
-        expect(result.document.items.terminal.autoHidden).toBe(false);
-        // The input document stays untouched — reducer immutability holds at the affordance level.
-        expect(document.items.terminal.autoHidden).toBe(true);
-        expect(rail.dockZoneDocument).toEqual(result.document);
-        expect(changes).toHaveLength(1);
-        expect(changes[0].doc).toBe(result.document);
-        expect(changes[0].railInstance).toBe(rail);
+        expect(JSON.stringify(document)).toBe(snapshot);
+        expect(JSON.parse(JSON.stringify(rail.dockZoneDocument))).toEqual(JSON.parse(snapshot));
+        expect(changes).toHaveLength(0);
     });
 
-    test('policy: a non-restorable tab renders as a disabled button and rejects locally without emitting an operation', () => {
+    test('pin escape rides the executor: setItemPinned(true) commits, model clears autoHidden, reveal closes', () => {
+        let changes    = [],
+            document   = createDocument(),
+            operations = [];
+
+        rail = Neo.create(DockRail, {
+            dockZoneDocument        : document,
+            edge                    : 'right',
+            id                      : 'dock-rail-pin',
+            onDockZoneDocumentChange: (doc, descriptor) => changes.push({descriptor, doc}),
+            railItems               : createRailItems()
+        });
+
+        rail.on('dockRailOperation', data => operations.push(data));
+        rail.onTabClick({component: rail.items[0]});
+
+        let result = rail.onRevealPinRequested({itemId: 'terminal'});
+
+        expect(result.errors).toEqual([]);
+        expect(result.document.items.terminal.pinned).toBe(true);
+        expect(result.document.items.terminal.autoHidden).toBe(false);
+        expect(rail.revealMachine.state).toBe('idle');
+        expect(changes).toHaveLength(1);
+        expect(operations).toHaveLength(1);
+        expect(operations[0].descriptor).toEqual({itemId: 'terminal', operation: 'setItemPinned', pinned: true});
+    });
+
+    test('pin policy: the tab stays a live enabled button (reveal is policy-free); pin rejects locally', () => {
         let committed = [],
             rejected  = [];
 
@@ -149,34 +186,28 @@ test.describe('Neo.dashboard.DockRail', () => {
                 return {document: null, errors: []}
             },
             edge     : 'right',
-            id       : 'dock-rail-policy',
+            id       : 'dock-rail-pin-policy',
             railItems: [{dockEdge: 'right', dockItemId: 'terminal', restorable: false, title: 'Terminal'}]
         });
 
-        rail.on('dockRailRestoreRejected', data => rejected.push(data));
+        rail.on('dockRailOperationRejected', data => rejected.push(data));
 
-        expect(rail.items[0].disabled).toBe(true);
+        // Reveal is policy-free: a disabled tab would make the item's content unreachable.
+        expect(rail.items[0].disabled).toBe(false);
 
-        let result = rail.onTabClick({component: rail.items[0]});
+        let snapshot = rail.onTabClick({component: rail.items[0]});
+        expect(snapshot.state).toBe('revealed-focused');
+
+        let result = rail.onRevealPinRequested({itemId: 'terminal'});
 
         expect(committed).toHaveLength(0);
         expect(result.errors.join(' ')).toContain('blocked by policy');
         expect(rejected).toHaveLength(1);
         expect(rejected[0].descriptor).toBeNull();
         expect(rejected[0].itemId).toBe('terminal');
-
-        // A live policy flip re-enables the surviving button instance in place.
-        let button = rail.items[0];
-
-        rail.railItems = [{dockEdge: 'right', dockItemId: 'terminal', restorable: true, title: 'Terminal'}];
-
-        expect(rail.items[0]).toBe(button);
-        expect(button.disabled).toBe(false);
     });
 
-    test('an executor rejection surfaces as dockRailRestoreRejected with the document unchanged', () => {
-        // Belt-and-braces: the projection says restorable, but the live document's policy flipped
-        // between projection and click — the model guard answers, the rail relays honestly.
+    test('a stale-projection pin surfaces the executor rejection with the document unchanged', () => {
         let document = createDocument(),
             rejected = [];
 
@@ -185,17 +216,126 @@ test.describe('Neo.dashboard.DockRail', () => {
         rail = Neo.create(DockRail, {
             dockZoneDocument: document,
             edge            : 'right',
-            id              : 'dock-rail-executor-reject',
+            id              : 'dock-rail-pin-executor-reject',
             railItems       : createRailItems()
         });
 
-        rail.on('dockRailRestoreRejected', data => rejected.push(data));
+        rail.on('dockRailOperationRejected', data => rejected.push(data));
 
-        let result = rail.onTabClick({component: rail.items[0]});
+        let result = rail.onRevealPinRequested({itemId: 'terminal'});
 
         expect(result.errors.join(' ')).toContain('not pinnable');
         expect(rail.dockZoneDocument.items.terminal.autoHidden).toBe(true);
         expect(rejected).toHaveLength(1);
+    });
+
+    test('hover input is inert without the workspace opt-in, live with it', () => {
+        rail = Neo.create(DockRail, {
+            edge     : 'right',
+            id       : 'dock-rail-hover-optin',
+            railItems: createRailItems()
+        });
+
+        rail.onTabHoverIn({component: rail.items[0]});
+        expect(rail.revealMachine.state).toBe('idle');
+
+        rail.autoHideRevealOnHover = true;
+
+        rail.onTabHoverIn({component: rail.items[0]});
+        expect(rail.revealMachine.state).toBe('dwell-pending');
+
+        rail.onTabHoverOut({});
+        expect(rail.revealMachine.state).toBe('idle');
+    });
+
+    test('bindRevealOverlay: state pushes into the overlay; overlay intents feed back; focus-hold holds', () => {
+        let overlay = createStubOverlay();
+
+        rail = Neo.create(DockRail, {
+            edge     : 'right',
+            id       : 'dock-rail-overlay-binding',
+            railItems: createRailItems()
+        });
+
+        rail.bindRevealOverlay(overlay);
+
+        // Initial sync pushes the idle snapshot.
+        expect(overlay.calls.at(-1)).toMatchObject({revealState: 'idle', revealedItem: null});
+
+        rail.onTabClick({component: rail.items[0]});
+
+        expect(overlay.calls.at(-1)).toMatchObject({
+            edge       : 'right',
+            revealState: 'revealed-focused'
+        });
+        expect(overlay.calls.at(-1).revealedItem.dockItemId).toBe('terminal');
+
+        // FOCUS-HOLD: pointer leaving a focused reveal must not dismiss it.
+        overlay.fire('revealPointerLeave', {});
+        expect(rail.revealMachine.state).toBe('revealed-focused');
+
+        // Focus leaving dismisses; the overlay receives the idle snapshot.
+        overlay.fire('revealFocusLeave', {});
+        expect(rail.revealMachine.state).toBe('idle');
+        expect(overlay.calls.at(-1)).toMatchObject({revealState: 'idle', revealedItem: null});
+
+        // Escape intent routes through as well.
+        rail.onTabClick({component: rail.items[0]});
+        overlay.fire('revealEscape', {});
+        expect(rail.revealMachine.state).toBe('idle');
+    });
+
+    test('self-hosts a composed reveal overlay child and materializes the pane through resolveComponentRef', () => {
+        rail = Neo.create(DockRail, {
+            dockZoneDocument   : createDocument(),
+            edge               : 'right',
+            id                 : 'dock-rail-composed-overlay',
+            railItems          : createRailItems(),
+            resolveComponentRef: componentRef => ({ntype: 'component', html: componentRef})
+        });
+
+        // Composed from construct: the overlay child exists idle-hidden before any reveal —
+        // the rail's subtree never changes shape post-mount for the reveal path.
+        expect(rail.revealOverlay?.ntype).toBe('dashboard-dock-reveal-overlay');
+        expect(rail.revealOverlay.visible).toBe(false);
+
+        rail.onTabClick({component: rail.items[0]});
+
+        let overlay = rail.revealOverlay;
+
+        expect(overlay?.ntype).toBe('dashboard-dock-reveal-overlay');
+        expect(rail.items).toContain(overlay);
+        expect(overlay.revealState).toBe('revealed-focused');
+        expect(overlay.titleLabel.text).toBe('Terminal');
+        expect(overlay.paneSlot.items).toHaveLength(1);
+        expect(overlay.paneSlot.items[0].html).toBe('terminal');
+
+        // Dismissal destroys the transient pane — reveal artifacts never outlive the reveal.
+        rail.revealMachine.escape();
+
+        expect(overlay.revealState).toBe('idle');
+        expect(overlay.visible).toBe(false);
+        expect(overlay.paneSlot.items).toHaveLength(0);
+
+        // The reconcile sweep must never mistake the overlay child for a leaving tab.
+        rail.railItems = [];
+
+        expect(rail.items).toContain(overlay);
+    });
+
+    test('an item leaving the rail fail-closes its reveal', () => {
+        rail = Neo.create(DockRail, {
+            edge     : 'right',
+            id       : 'dock-rail-fail-close',
+            railItems: createRailItems()
+        });
+
+        rail.onTabClick({component: rail.items[0]});
+        expect(rail.revealMachine.state).toBe('revealed-focused');
+
+        rail.railItems = [];
+
+        expect(rail.revealMachine.state).toBe('idle');
     });
 
     test('ignores clicks that do not resolve to a rail-tab button', () => {

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -1,0 +1,190 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockRailTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import DockRail       from '../../../../src/dashboard/DockRail.mjs';
+
+const createDocument = () => ({
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'root',
+    items : {
+        editor  : {componentRef: 'editor', title: 'Editor'},
+        terminal: {autoHidden: true, componentRef: 'terminal', title: 'Terminal'}
+    },
+    nodes: {
+        root: {
+            type : 'edge-zone',
+            zones: {center: 'main-tabs', right: 'side-tabs'}
+        },
+        'main-tabs': {type: 'tabs', items: ['editor'],   activeItemId: 'editor'},
+        'side-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
+    }
+});
+
+const createRailItems = () => ([
+    {dockEdge: 'right', dockItemId: 'terminal', restorable: true, title: 'Terminal'}
+]);
+
+test.describe('Neo.dashboard.DockRail', () => {
+    let rail;
+
+    test.afterEach(() => {
+        rail?.destroy();
+        rail = null
+    });
+
+    test('renders labeled tabs from railItems and updates in place on model flips (no remount)', () => {
+        rail = Neo.create(DockRail, {
+            edge     : 'right',
+            id       : 'dock-rail-reactive',
+            railItems: createRailItems()
+        });
+
+        expect(rail.cls).toContain('neo-dashboard-dock-edge-rail-right');
+        expect(rail.vdom.cn).toHaveLength(1);
+        expect(rail.vdom.cn[0].tag).toBe('button');
+        expect(rail.vdom.cn[0].text).toBe('Terminal');
+        expect(rail.vdom.cn[0].data).toEqual({dockEdge: 'right', dockItemId: 'terminal', dockRailTab: true});
+        expect(rail.vdom.cn[0].disabled).toBeNull();
+
+        // Model flip: a second item rails — same instance, tab children re-render in place.
+        rail.railItems = [
+            ...createRailItems(),
+            {dockEdge: 'right', dockItemId: 'inspector', restorable: true, title: 'Inspector'}
+        ];
+
+        expect(rail.id).toBe('dock-rail-reactive');
+        expect(rail.vdom.cn).toHaveLength(2);
+        expect(rail.vdom.cn[1].text).toBe('Inspector');
+
+        // ...and clears the same way (the empty rail renders no tabs).
+        rail.railItems = [];
+
+        expect(rail.vdom.cn).toHaveLength(0);
+    });
+
+    test('restore rides the reducer callback: click commits setItemAutoHidden(false)', () => {
+        let descriptors = [],
+            events      = [],
+            nextDoc     = createDocument();
+
+        nextDoc.items.terminal.autoHidden = false;
+
+        rail = Neo.create(DockRail, {
+            applyDockZoneOperation: (descriptor, railInstance) => {
+                descriptors.push({descriptor, railInstance});
+                return {document: nextDoc, errors: []}
+            },
+            edge     : 'right',
+            id       : 'dock-rail-callback',
+            railItems: createRailItems()
+        });
+
+        rail.on('dockRailRestore', data => events.push(data));
+
+        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+
+        expect(descriptors).toHaveLength(1);
+        expect(descriptors[0].descriptor).toEqual({autoHidden: false, itemId: 'terminal', operation: 'setItemAutoHidden'});
+        expect(descriptors[0].railInstance).toBe(rail);
+        expect(result.errors).toEqual([]);
+        // The config system clones object configs on set — value equality IS the contract here.
+        expect(rail.dockZoneDocument).toEqual(nextDoc);
+        expect(events).toHaveLength(1);
+        expect(events[0].itemId).toBe('terminal');
+        expect(events[0].descriptor.operation).toBe('setItemAutoHidden');
+    });
+
+    test('falls back to a local DockZoneModel commit and notifies the document listener', () => {
+        let changes  = [],
+            document = createDocument();
+
+        rail = Neo.create(DockRail, {
+            dockZoneDocument        : document,
+            edge                    : 'right',
+            id                      : 'dock-rail-local',
+            onDockZoneDocumentChange: (doc, descriptor, railInstance) => changes.push({descriptor, doc, railInstance}),
+            railItems               : createRailItems()
+        });
+
+        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+
+        expect(result.errors).toEqual([]);
+        expect(result.document.items.terminal.autoHidden).toBe(false);
+        // The input document stays untouched — reducer immutability holds at the affordance level.
+        expect(document.items.terminal.autoHidden).toBe(true);
+        expect(rail.dockZoneDocument).toEqual(result.document);
+        expect(changes).toHaveLength(1);
+        expect(changes[0].doc).toBe(result.document);
+        expect(changes[0].railInstance).toBe(rail);
+    });
+
+    test('policy: a non-restorable tab renders disabled and rejects locally without emitting an operation', () => {
+        let committed = [],
+            rejected  = [];
+
+        rail = Neo.create(DockRail, {
+            applyDockZoneOperation: descriptor => {
+                committed.push(descriptor);
+                return {document: null, errors: []}
+            },
+            edge     : 'right',
+            id       : 'dock-rail-policy',
+            railItems: [{dockEdge: 'right', dockItemId: 'terminal', restorable: false, title: 'Terminal'}]
+        });
+
+        rail.on('dockRailRestoreRejected', data => rejected.push(data));
+
+        expect(rail.vdom.cn[0].disabled).toBe(true);
+        expect(rail.vdom.cn[0].cls).toContain('neo-dashboard-dock-rail-tab-disabled');
+
+        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+
+        expect(committed).toHaveLength(0);
+        expect(result.errors.join(' ')).toContain('blocked by policy');
+        expect(rejected).toHaveLength(1);
+        expect(rejected[0].descriptor).toBeNull();
+        expect(rejected[0].itemId).toBe('terminal');
+    });
+
+    test('an executor rejection surfaces as dockRailRestoreRejected with the document unchanged', () => {
+        // Belt-and-braces: the projection says restorable, but the live document's policy flipped
+        // between projection and click — the model guard answers, the rail relays honestly.
+        let document = createDocument(),
+            rejected = [];
+
+        document.items.terminal.pinnable = false;
+
+        rail = Neo.create(DockRail, {
+            dockZoneDocument: document,
+            edge            : 'right',
+            id              : 'dock-rail-executor-reject',
+            railItems       : createRailItems()
+        });
+
+        rail.on('dockRailRestoreRejected', data => rejected.push(data));
+
+        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+
+        expect(result.errors.join(' ')).toContain('not pinnable');
+        expect(rail.dockZoneDocument.items.terminal.autoHidden).toBe(true);
+        expect(rejected).toHaveLength(1);
+    });
+
+    test('ignores clicks that do not resolve to a known tab', () => {
+        rail = Neo.create(DockRail, {
+            id       : 'dock-rail-unknown',
+            railItems: createRailItems()
+        });
+
+        expect(rail.onRailClick({currentTarget: 'not-a-tab'})).toBeNull();
+        expect(rail.onRailClick({})).toBeNull();
+    });
+});

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -12,6 +12,7 @@ import * as core         from '../../../../src/core/_export.mjs';
 import Button            from '../../../../src/button/Base.mjs';
 import DockLayoutAdapter from '../../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockRail          from '../../../../src/dashboard/DockRail.mjs';
+import Panel             from '../../../../src/dashboard/Panel.mjs';
 
 const createDocument = () => ({
     schema: 'neo.harness.dockZone.v1',
@@ -355,6 +356,55 @@ test.describe('Neo.dashboard.DockRail', () => {
 
         expect(slot.items[0]).toBe(livePane);
         expect(slot.items[0].id).toBe('dock-rail-live-pane');
+    });
+
+    test('blueprint fallback: a resolver miss materializes item.blueprint; identity survives re-reveal', () => {
+        let document = createDocument();
+
+        document.items.terminal.blueprint = {html: 'blueprint-pane', ntype: 'component'};
+
+        rail = Neo.create(DockRail, {
+            dockZoneDocument   : document,
+            edge               : 'right',
+            id                 : 'dock-rail-blueprint',
+            railItems          : createRailItems(),
+            resolveComponentRef: () => null
+        });
+
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        let slot = rail.revealOverlay.paneSlot,
+            pane = slot.items[0];
+
+        expect(pane?.html).toBe('blueprint-pane');
+
+        // Parked on dismissal, re-parented on re-reveal — same cache discipline as live instances.
+        rail.revealMachine.escape();
+
+        expect(slot.items).toHaveLength(0);
+        expect(pane.isDestroyed).not.toBe(true);
+
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        expect(slot.items[0]).toBe(pane);
+    });
+
+    test('recoverable placeholder when neither a live instance nor a blueprint resolves', () => {
+        rail = Neo.create(DockRail, {
+            dockZoneDocument   : createDocument(),
+            edge               : 'right',
+            id                 : 'dock-rail-placeholder',
+            railItems          : createRailItems(),
+            resolveComponentRef: () => null
+        });
+
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        let pane = rail.revealOverlay.paneSlot.items[0];
+
+        expect(pane).toBeTruthy();
+        expect(pane.cls).toContain('neo-dashboard-dock-placeholder');
+        expect(pane.dockItemId).toBe('terminal');
     });
 
     test('threads the workspace default reveal fraction into the bound overlay', () => {

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -9,6 +9,7 @@ setup({
 import {test, expect}    from '@playwright/test';
 import Neo               from '../../../../src/Neo.mjs';
 import * as core         from '../../../../src/core/_export.mjs';
+import Button            from '../../../../src/button/Base.mjs';
 import DockLayoutAdapter from '../../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockRail          from '../../../../src/dashboard/DockRail.mjs';
 
@@ -321,6 +322,55 @@ test.describe('Neo.dashboard.DockRail', () => {
         rail.railItems = [];
 
         expect(rail.items).toContain(overlay);
+    });
+
+    test('a resolver-returned live instance is parked on dismissal and re-parented on re-reveal (never destroyed)', () => {
+        let livePane = Neo.create(Button, {id: 'dock-rail-live-pane', text: 'Live'});
+
+        livePane.transientState = 'survives';
+
+        rail = Neo.create(DockRail, {
+            dockZoneDocument   : createDocument(),
+            edge               : 'right',
+            id                 : 'dock-rail-live-instance',
+            railItems          : createRailItems(),
+            resolveComponentRef: () => livePane
+        });
+
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        let slot = rail.revealOverlay.paneSlot;
+
+        expect(slot.items[0]).toBe(livePane);
+
+        // Dismissal PARKS the live instance — identity and transient state survive.
+        rail.revealMachine.escape();
+
+        expect(slot.items).toHaveLength(0);
+        expect(livePane.isDestroyed).not.toBe(true);
+        expect(livePane.transientState).toBe('survives');
+
+        // Re-reveal re-parents the SAME instance.
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        expect(slot.items[0]).toBe(livePane);
+        expect(slot.items[0].id).toBe('dock-rail-live-pane');
+    });
+
+    test('threads the workspace default reveal fraction into the bound overlay', () => {
+        let overlay = createStubOverlay();
+
+        rail = Neo.create(DockRail, {
+            defaultRevealFraction: 0.4,
+            edge                 : 'right',
+            id                   : 'dock-rail-fraction',
+            railItems            : createRailItems()
+        });
+
+        rail.bindRevealOverlay(overlay);
+        rail.onTabClick({component: tabsOf(rail)[0]});
+
+        expect(overlay.calls.at(-1).defaultRevealFraction).toBe(0.4);
     });
 
     test('an item leaving the rail fail-closes its reveal', () => {

--- a/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
@@ -124,8 +124,8 @@ test.describe('Neo.dashboard.DockRevealOverlay', () => {
 
         overlay.onPointerEnter({});
         overlay.onPointerLeave({});
-        overlay.onFocusIn({});
-        overlay.onFocusOut({});
+        overlay.onFocusEnter({});
+        overlay.onFocusLeave({});
         overlay.onKeyDown({key: 'Escape'});
         overlay.onKeyDown({key: 'Enter'});
         overlay.onPinClick({});

--- a/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
@@ -1,0 +1,142 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockRevealOverlayTest'
+    }
+});
+
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../src/Neo.mjs';
+import * as core         from '../../../../src/core/_export.mjs';
+import DockRevealOverlay from '../../../../src/dashboard/DockRevealOverlay.mjs';
+
+const createItem = (config={}) => ({
+    dockEdge  : 'right',
+    dockItemId: 'terminal',
+    restorable: true,
+    title     : 'Terminal',
+    ...config
+});
+
+test.describe('Neo.dashboard.DockRevealOverlay', () => {
+    let overlay;
+
+    test.afterEach(() => {
+        overlay?.destroy();
+        overlay = null
+    });
+
+    test('stays hidden while idle, composes header (label + pin) and pane slot as real children', () => {
+        overlay = Neo.create(DockRevealOverlay, {
+            edge: 'right',
+            id  : 'dock-reveal-render'
+        });
+
+        expect(overlay.visible).toBe(false);
+        expect(overlay.cls).toContain('neo-dashboard-dock-reveal-overlay-hidden');
+        expect(overlay.cls).toContain('neo-dashboard-dock-reveal-overlay-right');
+
+        overlay.set({revealState: 'revealed', revealedItem: createItem()});
+
+        expect(overlay.visible).toBe(true);
+        expect(overlay.cls).not.toContain('neo-dashboard-dock-reveal-overlay-hidden');
+
+        // Real composed children, not synthesized vdom.
+        expect(overlay.titleLabel.text).toBe('Terminal');
+        expect(overlay.pinButton.disabled).toBe(false);
+        expect(overlay.pinButton.cls).toContain('neo-dashboard-dock-reveal-pin');
+        expect(overlay.paneSlot.cls).toContain('neo-dashboard-dock-reveal-pane-slot');
+        expect(overlay.paneSlot.items).toHaveLength(0);
+    });
+
+    test('remains visible through the dismiss grace window', () => {
+        overlay = Neo.create(DockRevealOverlay, {
+            edge        : 'left',
+            id          : 'dock-reveal-grace',
+            revealState : 'dismiss-pending',
+            revealedItem: createItem()
+        });
+
+        expect(overlay.visible).toBe(true);
+    });
+
+    test('sizes the free dimension from the committed extent, else the default fraction', () => {
+        overlay = Neo.create(DockRevealOverlay, {
+            edge        : 'left',
+            id          : 'dock-reveal-sizing',
+            revealExtent: 0.3,
+            revealState : 'revealed',
+            revealedItem: createItem({dockEdge: 'left'})
+        });
+
+        expect(overlay.style.width).toBe('30%');
+        expect(overlay.style.height).toBeNull();
+
+        overlay.revealExtent = null;
+        expect(overlay.style.width).toBe('25%');
+
+        overlay.set({defaultRevealFraction: 0.4, edge: 'top'});
+        expect(overlay.style.height).toBe('40%');
+        expect(overlay.style.width).toBeNull();
+    });
+
+    test('the pin button mirrors policy: disabled for a non-pinnable item, intent still routes upstream', () => {
+        let pins = [];
+
+        overlay = Neo.create(DockRevealOverlay, {
+            edge        : 'right',
+            id          : 'dock-reveal-pin-policy',
+            revealState : 'revealed',
+            revealedItem: createItem({restorable: false})
+        });
+
+        overlay.on('revealPinRequested', data => pins.push(data));
+
+        expect(overlay.pinButton.disabled).toBe(true);
+
+        // Enforcement lives in the rail/model; the overlay only mirrors the affordance.
+        overlay.onPinClick({});
+        expect(pins).toHaveLength(1);
+        expect(pins[0].itemId).toBe('terminal');
+
+        // A live policy flip re-enables the SAME pin button instance.
+        let pinButton = overlay.pinButton;
+
+        overlay.revealedItem = createItem({restorable: true});
+
+        expect(overlay.pinButton).toBe(pinButton);
+        expect(pinButton.disabled).toBe(false);
+    });
+
+    test('translates DOM reality into semantic intents (pointer, focus, escape, pin)', () => {
+        let fired = [];
+
+        overlay = Neo.create(DockRevealOverlay, {
+            edge        : 'right',
+            id          : 'dock-reveal-intents',
+            revealState : 'revealed',
+            revealedItem: createItem()
+        });
+
+        ['revealEscape', 'revealFocusEnter', 'revealFocusLeave', 'revealPinRequested', 'revealPointerEnter', 'revealPointerLeave']
+            .forEach(name => overlay.on(name, () => fired.push(name)));
+
+        overlay.onPointerEnter({});
+        overlay.onPointerLeave({});
+        overlay.onFocusIn({});
+        overlay.onFocusOut({});
+        overlay.onKeyDown({key: 'Escape'});
+        overlay.onKeyDown({key: 'Enter'});
+        overlay.onPinClick({});
+
+        expect(fired).toEqual([
+            'revealPointerEnter',
+            'revealPointerLeave',
+            'revealFocusEnter',
+            'revealFocusLeave',
+            'revealEscape',
+            'revealPinRequested'
+        ]);
+    });
+});

--- a/test/playwright/unit/dashboard/DockRevealStateMachine.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealStateMachine.spec.mjs
@@ -1,0 +1,231 @@
+import {test, expect}         from '@playwright/test';
+import DockRevealStateMachine from '../../../../src/dashboard/DockRevealStateMachine.mjs';
+
+const createFakeTimers = () => {
+    let nextId = 1,
+        now    = 0,
+        queue  = new Map();
+
+    return {
+        advance(ms) {
+            now += ms;
+
+            [...queue.entries()]
+                .sort((a, b) => a[1].at - b[1].at)
+                .forEach(([id, timer]) => {
+                    if (timer.at <= now && queue.has(id)) {
+                        queue.delete(id);
+                        timer.fn()
+                    }
+                })
+        },
+        clearTimeoutFn(id) {
+            queue.delete(id)
+        },
+        pendingCount() {
+            return queue.size
+        },
+        setTimeoutFn(fn, ms) {
+            let id = nextId++;
+            queue.set(id, {at: now + ms, fn});
+            return id
+        }
+    }
+};
+
+const createMachine = (config={}) => {
+    let changes = [],
+        timers  = createFakeTimers(),
+        machine = new DockRevealStateMachine({
+            clearTimeoutFn: timers.clearTimeoutFn.bind(timers),
+            onChange      : (next, previous) => changes.push({next, previous}),
+            setTimeoutFn  : timers.setTimeoutFn.bind(timers),
+            ...config
+        });
+
+    return {changes, machine, timers}
+};
+
+test.describe('DockRevealStateMachine', () => {
+    test('click-reveal is the default: click focuses, re-click dismisses', () => {
+        let {changes, machine} = createMachine();
+
+        machine.tabClick('terminal');
+
+        expect(machine.state).toBe('revealed-focused');
+        expect(machine.revealedItemId).toBe('terminal');
+
+        machine.tabClick('terminal');
+
+        expect(machine.state).toBe('idle');
+        expect(machine.revealedItemId).toBeNull();
+        expect(changes.map(change => change.next.state)).toEqual(['revealed-focused', 'idle']);
+    });
+
+    test('hover input is ignored without the workspace opt-in (a11y default)', () => {
+        let {machine, timers} = createMachine();
+
+        machine.tabHoverIn('terminal');
+
+        expect(machine.state).toBe('idle');
+        expect(timers.pendingCount()).toBe(0);
+    });
+
+    test('opt-in hover reveals after the dwell, without stealing focus', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+
+        expect(machine.state).toBe('dwell-pending');
+
+        timers.advance(DockRevealStateMachine.DWELL_MS - 1);
+        expect(machine.state).toBe('dwell-pending');
+
+        timers.advance(1);
+        expect(machine.state).toBe('revealed');
+        expect(machine.revealedItemId).toBe('terminal');
+    });
+
+    test('a pass-through hover never flickers an overlay open', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        machine.tabHoverOut();
+
+        expect(machine.state).toBe('idle');
+
+        timers.advance(DockRevealStateMachine.DWELL_MS * 2);
+        expect(machine.state).toBe('idle');
+    });
+
+    test('pointer-away dismisses an unfocused reveal only after the grace period', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        machine.overlayPointerLeave();
+
+        expect(machine.state).toBe('dismiss-pending');
+
+        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS - 1);
+        expect(machine.state).toBe('dismiss-pending');
+
+        timers.advance(1);
+        expect(machine.state).toBe('idle');
+    });
+
+    test('a grace-window pointer return keeps the overlay open', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        machine.overlayPointerLeave();
+        machine.overlayPointerEnter();
+
+        expect(machine.state).toBe('revealed');
+
+        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 2);
+        expect(machine.state).toBe('revealed');
+    });
+
+    test('focus-hold: a focused reveal never auto-dismisses; focus leave dismisses', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        machine.overlayFocusEnter();
+
+        expect(machine.state).toBe('revealed-focused');
+
+        machine.overlayPointerLeave();
+        expect(machine.state).toBe('revealed-focused');
+
+        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 10);
+        expect(machine.state).toBe('revealed-focused');
+
+        machine.overlayFocusLeave();
+        expect(machine.state).toBe('idle');
+    });
+
+    test('focus entering during the grace window rescues the reveal into focus-hold', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        machine.overlayPointerLeave();
+        machine.overlayFocusEnter();
+
+        expect(machine.state).toBe('revealed-focused');
+
+        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 2);
+        expect(machine.state).toBe('revealed-focused');
+    });
+
+    test('escape and outside-click dismiss from every revealed state', () => {
+        let {machine} = createMachine();
+
+        machine.tabClick('terminal');
+        machine.escape();
+        expect(machine.state).toBe('idle');
+
+        machine.tabClick('terminal');
+        machine.outsideClick();
+        expect(machine.state).toBe('idle');
+    });
+
+    test('click retargets an open reveal to the other item', () => {
+        let {machine} = createMachine();
+
+        machine.tabClick('terminal');
+        machine.tabClick('inspector');
+
+        expect(machine.state).toBe('revealed-focused');
+        expect(machine.revealedItemId).toBe('inspector');
+    });
+
+    test('hover retarget re-dwells while the current reveal survives until commit', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        expect(machine.revealedItemId).toBe('terminal');
+
+        machine.tabHoverIn('inspector');
+        expect(machine.state).toBe('dwell-pending');
+        expect(machine.revealedItemId).toBe('terminal');
+
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        expect(machine.state).toBe('revealed');
+        expect(machine.revealedItemId).toBe('inspector');
+    });
+
+    test('itemCleared fail-closes any reveal or pending dwell of that item', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabClick('terminal');
+        machine.itemCleared('inspector');
+        expect(machine.state).toBe('revealed-focused');
+
+        machine.itemCleared('terminal');
+        expect(machine.state).toBe('idle');
+
+        machine.tabHoverIn('inspector');
+        machine.itemCleared('inspector');
+        expect(machine.state).toBe('idle');
+
+        timers.advance(DockRevealStateMachine.DWELL_MS * 2);
+        expect(machine.state).toBe('idle');
+    });
+
+    test('destroy clears pending timers and detaches the change listener', () => {
+        let {changes, machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        machine.destroy();
+
+        timers.advance(DockRevealStateMachine.DWELL_MS * 2);
+
+        expect(timers.pendingCount()).toBe(0);
+        expect(changes.map(change => change.next.state)).toEqual(['dwell-pending']);
+    });
+});

--- a/test/playwright/unit/dashboard/DockRevealStateMachine.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealStateMachine.spec.mjs
@@ -199,6 +199,26 @@ test.describe('DockRevealStateMachine', () => {
         expect(machine.revealedItemId).toBe('inspector');
     });
 
+    test('a hover-born reveal dismisses through grace when the pointer leaves the tab without entering the overlay', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        expect(machine.state).toBe('revealed');
+
+        machine.tabHoverOut();
+        expect(machine.state).toBe('dismiss-pending');
+
+        // Reaching the overlay during grace rescues the reveal...
+        machine.overlayPointerEnter();
+        expect(machine.state).toBe('revealed');
+
+        // ...while never reaching it lets the grace dismiss.
+        machine.tabHoverOut();
+        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS);
+        expect(machine.state).toBe('idle');
+    });
+
     test('itemCleared fail-closes any reveal or pending dwell of that item', () => {
         let {machine, timers} = createMachine({revealOnHover: true});
 

--- a/test/playwright/unit/dashboard/DockSplitter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitter.spec.mjs
@@ -164,8 +164,8 @@ test.describe('Neo.dashboard.DockSplitter', () => {
                 reducerCalls.push({descriptor, instance});
                 return {document: committedDoc, errors: []}
             },
-            boundaryIndex  : 0,
-            id             : 'dock-splitter-reducer',
+            boundaryIndex: 0,
+            id           : 'dock-splitter-reducer',
             onDockZoneDocumentChange(document, descriptor, instance) {
                 notifyCalls.push({document, descriptor, instance})
             },
@@ -213,9 +213,9 @@ test.describe('Neo.dashboard.DockSplitter', () => {
             onDockZoneDocumentChange() {
                 notified = true
             },
-            orientation     : 'horizontal',
-            parentComponent : parent,
-            splitNodeId     : 'root'
+            orientation    : 'horizontal',
+            parentComponent: parent,
+            splitNodeId    : 'root'
         });
 
         splitter.dragZone = {

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -929,7 +929,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             const resized = DockZoneModel.applyOperation(example.dockModel, {
                 operation  : 'resizeSplit',
                 sizes      : [0.4, 0.6],
-                splitNodeId: 'root'
+                splitNodeId: 'root-split'
             });
 
             expect(resized.errors).toEqual([]);
@@ -940,13 +940,13 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(saved.errors).toEqual([]);
             expect(saved.layout.layoutId).toBe('saved-perspective-1');
             expect(example.layoutCollection.activeLayoutId).toBe('saved-perspective-1');
-            expect(example.layoutCollection.layouts['saved-perspective-1'].dockZone.nodes.root.sizes).toEqual([0.4, 0.6]);
+            expect(example.layoutCollection.layouts['saved-perspective-1'].dockZone.nodes['root-split'].sizes).toEqual([0.4, 0.6]);
 
             const restored = example.restorePerspective('review-focus');
 
             expect(restored.errors).toEqual([]);
             expect(example.layoutCollection.activeLayoutId).toBe('review-focus');
-            expect(example.dockModel.nodes.root.sizes).toEqual([0.48, 0.52]);
+            expect(example.dockModel.nodes['root-split'].sizes).toEqual([0.48, 0.52]);
             expect(example.dockModel.nodes['main-tabs'].activeItemId).toBe('swarm');
 
             const deleted = example.removeActivePerspective();


### PR DESCRIPTION
Resolves #14654

Resolves #14660

Ships the auto-hide interaction arc ATOMICALLY — the review's structural objection resolved by delivery, not by drop: click is the transient reveal from the first merged commit; no interim click-restore ever reaches `dev`. `Neo.dashboard.DockRail` (a `container.Base` composing real `button.Base` tabs plus a composed-from-construct `DockRevealOverlay` child) renders committed auto-hidden items as labeled edge tabs; a tab click feeds `DockRevealStateMachine` (pure, timer-injectable, full states/transitions table in JSDoc, named `DWELL_MS`/`DISMISS_GRACE_MS` constants) which opens a focused transient reveal; hover-reveal sits strictly behind the workspace opt-in (`autoHideRevealOnHover`, threaded through projection options); the overlay materializes the pane through the adapter's own `resolveComponentRef` seam and its PIN control commits `setItemPinned(true)` through the reducer — the model clears `autoHidden` itself. Reveal is policy-free (a policy-blocked item must stay reachable — anything else is item loss); the `restorable` projection gates the pin, never the tab.

Evidence: L2 (237/237 unit — dashboard + core incl. the new direct `VdomUnitModeUpdate` contract pin, single-worker, zero out-of-test errors) + L3 (whitebox e2e journey GREEN against the live example: real rail button → native click → overlay opens with REAL browser focus inside it → Escape, outside-click, and hover-away-grace dismissals each leave the committed document byte-stable → native pin click → `pinned: true` / `autoHidden: false` in worker truth → affordance instances retired) → L3 required (parent epic's same-PR gesture-proof guardrail names reveal explicitly). Residual: post-pin DOM removal of the retired rail lags worker truth — a vdom reconciliation defect INDEPENDENT of these components, pinned as an expected-fail companion spec citing #14911.

## AC map

**#14654** — rail renders from model state only (adapter projects from committed `autoHidden` truth; specs) · restore-path rides the executor with policy honesty (composed contract: reveal→pin; stale-projection executor rejection spec) · reactive without remount (`reconcileTabs()` preserves live button INSTANCES — reference-identity specs) · multi-edge + rapid-toggle specs (adapter suite) · cross-family review (re-requested on CI-green head).

**#14660** — state machine documented + grace constants named (`DockRevealStateMachine` JSDoc tables; workspace-overridable rail configs) · focused pane never auto-dismisses (machine spec + rail↔overlay binding spec + the ADR's focus-hold row) · pin escape = executor op, no parallel path (unit specs + the LIVE e2e gesture) · reveal state never persists (unit: byte-identical document through a full cycle + zero change notifications; e2e: worker document byte-stable across a real reveal) · cross-family review.

## Deltas from ticket

- **Atomic delivery of both leaves in one PR** — the review's Depth-Floor challenge ("a later slice cannot retroactively make a merged interim source-correct") is accepted in substance: the D1-interim click-restore is GONE from history's mergeable state. The two tickets remain the planning decomposition; delivery honors the design record's one-interaction-contract invariant.
- **ADR precedence over the ticket's hover framing**: click-reveal is the DEFAULT; hover is the a11y-gated workspace opt-in with dwell. The Demo-A S3 hover beat runs on the opt-in config (screenplay owner flagged and confirmed).
- **`VdomLifecycle` unit-mode fix (root cause of the review's [TOOLING_GAP])**: unit-test mode REJECTED skipped vdom updates with no reason, turning every naked `promiseUpdate().then()` chain (container `insert`/`remove`) into an unhandled `undefined` rejection the moment a spec structurally mutated an unmounted container. A deliberately skipped update is a successful no-op — it now resolves. Unit-mode-scoped; zero runtime delta; the destroy-path rejection spec is untouched.
- **Edge-band geometry discipline (adapter)**: edge-zone band projections now carry `flex: 'none'` + `neo-dashboard-dock-edge-band(-edge)` CSS hooks — an unsized band silently ate ~half the workspace, corrupting drag-target geometry.
- **Example seed extended** to an edge-zone root with a right-band inspector zone — the canonical dock example gains the auto-hide surface the e2e drives; existing journeys (`DockDragDropNL` green) and perspective specs updated to the `root-split` node.
- **`NEO_E2E_PORT` override in the e2e config**: a dev-server from a DIFFERENT checkout squatting on 8080 silently serves the wrong tree to every spec (`reuseExistingServer`) — burned two full diagnosis rounds here.
- **Two pre-existing dev defects discovered and filed**: #14911 (wholesale container refresh leaves destroyed child DOM — reproducer + expected-fail pin in this PR's e2e) and #14913 (`DockCrossZoneDragNL` red on PURE dev at this branch's base: producer split-vs-tab drift + SortZone `moveTo` TypeError — verified via stash-clean runs; not this PR's blast radius).
- **Contract Ledger — challenge withdrawn, backfilled at T4**: cycle-2 cited ADR-0029 §5's verbatim "one Contract-Ledgered leaf per capability" — named authority beats my dock-line precedent argument. A consolidated matrix covering the atomic delivery (10 rows, every row Surface-Anchor-verified against head and test-backed) lives on #14654 with a crosslink from #14660.
- **Cycle-2 embodiment fixes**: click-born reveals move REAL browser focus into the overlay (`focusReveal()` → first focusable descendant); focus enter/leave now ride `manager.Focus` containment hooks (internal focus movement stays silent; clicking outside a focused overlay embodies outside-click dismissal); a hover-born reveal whose pointer leaves the tab without ever entering the overlay dismisses through the same grace window; `defaultRevealFraction` threads adapter→rail→overlay as the ADR's workspace-configurable fallback.
- **Live-pane continuity (§2.6)**: resolver-returned instances park on dismissal and re-parent on re-reveal — identity and transient state survive (unit-pinned by reference equality); blueprint panes cache per item and park identically, so NO mounted child is ever destroyed mid-session (the mid-session-destroy path is the same disease family as #14911 and is avoided by design; the cache tears down with the rail).

## Evolution

- **Composition pivot (operator review)**: raw `tag:'button'` vdom + manual DOM delegation inside `component.Base` → real `button.Base` children in `container.Base`; the tab-id bookkeeping map deleted (instances carry `dockItemId` — also the better Neural-Link whitebox seam); DOM `data-*` hooks dropped (a vdom-node feature, not a component config).
- **Fold (cross-family review)**: stacked D2 PR closed; reveal/dismiss/pin delivered here so the interaction contract merges atomically.
- **Live-gesture discovery (the guardrail earning its keep)**: `handlerScope` does not rebind function-type button handlers on the REAL click path — `this` was the button; unit specs invoking the handler directly could never catch it. Handlers are now explicitly bound. This single find justifies the same-PR e2e rule.
- **Corpse investigation**: three DockRail lifecycle shapes (silent+batched, lazy overlay insert, fully static composition) all reproduce the post-refresh DOM residue → component-independent, filed as #14911 with the evidence trail.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/dashboard/ test/playwright/unit/core/ --workers=1
237 passed — zero "error was not a part of any test"

NEO_E2E_PORT=8091 npx playwright test DockAutoHideRevealNL DockDragDropNL -c test/playwright/playwright.config.e2e.mjs --workers=1
3 passed — journey beats: rail renders → click-reveal + REAL focus containment → byte-stable Escape /
outside-click / hover-away-grace dismissals → pin commit → worker-instance retirement;
#14911 companion counts as expected-failure; DockDragDropNL regression-guard green
```

New: `DockRevealStateMachine.spec.mjs` (13, injected fake timers), `DockRevealOverlay.spec.mjs` (5, composed children), `DockAutoHideRevealNL.spec.mjs` (e2e journey + pinned companion). Rewritten: `DockRail.spec.mjs` (11 — composition, reveal semantics, never-persist, pin policy, overlay binding/focus-hold, fail-close). Extended: `DockLayoutAdapter.spec.mjs` (extent resolver, hover threading, band geometry). Updated: `DockZoneModel.spec.mjs` example-harness node refs.

## Post-Merge Validation

- [ ] #14911 fix flips the pinned companion spec green (un-pin it there).
- [ ] Demo-A scene-3 choreography drives reveal/dismiss live (screenplay sets `autoHideRevealOnHover`; note: the S3 rollback beat will exhibit #14911's stale-rail residue until that lands).
- [ ] Tour e2e asserts reveal motion + focus-hold via `observe_motion` (#14591, reserved lane).

## Commits

- a8e404521 — first cut: component.Base + raw vdom tabs (superseded by the composition pivot)
- ab1c6489e — rebuild on container.Base + button.Base composition, instance-preserving reconcile
- fa87421e6 — fold: reveal/dismiss state machine + overlay host + pin escape + gesture e2e + VdomLifecycle unit-mode fix + band geometry + example seed
- 0ecdcce2c — cycle-2: embodied focus (manager.Focus containment), all dismiss paths live-proven, §2.6 pane parking/caching, fraction threading, direct VdomLifecycle contract spec

Process note: authored during an operator-granted temporary Fable 5 model window (2026-07-10); composition pivot driven by direct operator review; atomic-fold shape driven by the cross-family review.

Authored by Grace (Claude Fable 5, Claude Code). Session ef6b9a4a-54ec-4afb-8438-f89a3ee46ad2.
