### PR TITLE
feat(dashboard): auto-hide reveal/dismiss interaction — state machine, overlay host, pin escape (#14660)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -45,6 +45,41 @@
     cursor    : pointer;
     font-size : 11px;
     padding   : 4px 1px;
+}
+
+.neo-dashboard-dock-reveal-overlay {
+    --neo-dock-reveal-ms : 200ms;
+    --neo-dock-dismiss-ms: 160ms;
+
+    display : flex;
+    flex-direction: column;
+    position: absolute;
+    z-index : 20;
+
+    &-hidden {
+        display: none;
+    }
+
+    &-left   { inset: 0 auto 0 14px; }
+    &-right  { inset: 0 14px 0 auto; }
+    &-top    { inset: 14px 0 auto 0; }
+    &-bottom { inset: auto 0 14px 0; }
+}
+
+.neo-dashboard-dock-reveal-header {
+    align-items    : center;
+    display        : flex;
+    flex           : none;
+    gap            : 4px;
+    justify-content: space-between;
+}
+
+.neo-dashboard-dock-reveal-pane-slot {
+    flex: 1;
+}
+
+.neo-dashboard-dock-reveal-pin {
+    cursor: pointer;
 
     &-disabled {
         cursor : not-allowed;

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -209,6 +209,7 @@ class DockLayoutAdapter extends Base {
 
         return this.projectNode(model.root, {
             applyDockZoneOperation  : options.applyDockZoneOperation,
+            autoHideRevealOnHover   : options.autoHideRevealOnHover === true,
             dockZoneDocument        : options.dockZoneDocument || model,
             items                   : model.items || {},
             nodes                   : model.nodes,
@@ -302,6 +303,7 @@ class DockLayoutAdapter extends Base {
     static createEdgeRail(itemIds, edge, context) {
         return {
             applyDockZoneOperation  : context.applyDockZoneOperation,
+            autoHideRevealOnHover   : context.autoHideRevealOnHover === true,
             dockEdge                : edge,
             dockNodeType            : 'edge-rail',
             dockZoneDocument        : context.dockZoneDocument,
@@ -311,6 +313,61 @@ class DockLayoutAdapter extends Base {
             onDockZoneDocumentChange: context.onDockZoneDocumentChange,
             railItems               : itemIds.map(itemId => this.createRailTab(itemId, edge, context))
         }
+    }
+
+    /**
+     * Resolves the reveal overlay's free-dimension extent for an item: the share its owning
+     * subtree holds at the nearest ancestor split, per that split's committed `sizes` — the
+     * "last committed extent, still in the document" rule. Returns `null` when no ancestor split
+     * carries usable sizes (e.g. a tabs node sitting directly in an edge-zone slot); the overlay
+     * then falls back to its workspace-configurable default fraction. Never reads DOM geometry.
+     * @param {Object} model Committed dock-zone document.
+     * @param {String} itemId
+     * @returns {Number|null} Fraction in `(0, 1]`, or `null`.
+     * @static
+     */
+    static resolveRevealExtent(model, itemId) {
+        let nodes   = model?.nodes || {},
+            childId = Object.keys(nodes).find(nodeId =>
+                nodes[nodeId].type === 'tabs' && (nodes[nodeId].items || []).includes(itemId)),
+            parent;
+
+        const findParent = id => {
+            for (const [nodeId, node] of Object.entries(nodes)) {
+                if (node.type === 'split' && (node.children || []).includes(id)) {
+                    return {index: node.children.indexOf(id), nodeId, split: true}
+                }
+                if (node.type === 'edge-zone' && Object.values(node.zones || {}).includes(id)) {
+                    return {nodeId, split: false}
+                }
+            }
+            return null
+        };
+
+        while (childId) {
+            parent = findParent(childId);
+
+            if (!parent) {
+                return null
+            }
+
+            if (parent.split) {
+                let sizes = nodes[parent.nodeId].sizes;
+
+                if (Array.isArray(sizes) && sizes.length) {
+                    let total = sizes.reduce((sum, value) => sum + (Number(value) || 0), 0),
+                        share = Number(sizes[parent.index]);
+
+                    return total > 0 && Number.isFinite(share) && share > 0 ? share / total : null
+                }
+
+                return null
+            }
+
+            childId = parent.nodeId
+        }
+
+        return null
     }
 
     /**

--- a/src/dashboard/DockRail.mjs
+++ b/src/dashboard/DockRail.mjs
@@ -1,6 +1,7 @@
-import Component     from '../component/Base.mjs';
-import DockZoneModel from './DockZoneModel.mjs';
-import NeoArray      from '../util/Array.mjs';
+import Component              from '../component/Base.mjs';
+import DockRevealStateMachine from './DockRevealStateMachine.mjs';
+import DockZoneModel          from './DockZoneModel.mjs';
+import NeoArray               from '../util/Array.mjs';
 
 /**
  * @summary Runtime edge-rail affordance rendering committed auto-hidden items as labeled rail tabs,
@@ -12,14 +13,20 @@ import NeoArray      from '../util/Array.mjs';
  * than from the pane components themselves, so the pane never learns it is railed (pane-blindness) and
  * a destroyed or unresolvable pane cannot break its recall affordance.
  *
- * Interaction contract (current slice): click = restore, committed through the owning reducer callback
+ * Interaction contract: a tab click opens a TRANSIENT reveal (focus moves into the overlay); re-click,
+ * `Escape`, outside-click, or focus/pointer leaving dismiss it — reveal state is runtime-only and no
+ * operation descriptor exists for dismissal. Hover-reveal is a workspace opt-in (`autoHideRevealOnHover`;
+ * dwell-gated, never steals focus — hover reveals are an accessibility hazard by default). The PERSIST
+ * path is the overlay's pin control: `setItemPinned(true)` committed through the owning reducer callback
  * (`applyDockZoneOperation`) or a local `DockZoneModel.applyOperation()` — never a parallel mutation
- * path. The follow-up reveal/dismiss slice upgrades click to a transient reveal overlay and moves the
- * persist to the overlay's pin control; this component is the mount point for that state machine.
+ * path; the model clears `autoHidden` itself.
  *
- * Policy honesty: the model rejects `setItemAutoHidden(false)` for `pinnable: false` items, which is
- * reachable when an item's policy flips after it railed. Such a tab renders disabled and rejects locally
- * instead of emitting a doomed operation — the affordance mirrors what the executor would answer.
+ * Reveal is policy-free: even a `pinnable: false` item (whose PIN the model would reject) must stay
+ * reachable through reveal — anything else is item loss. The policy projection (`restorable`) therefore
+ * gates the overlay's pin control, not the tab.
+ *
+ * The reveal/dismiss timing brain lives in {@link DockRevealStateMachine} (documented state table);
+ * this component owns DOM wiring, overlay binding and the executor commit path.
  *
  * @class Neo.dashboard.DockRail
  * @extends Neo.component.Base
@@ -51,6 +58,14 @@ class DockRail extends Component {
          */
         applyDockZoneOperation: null,
         /**
+         * Workspace-level opt-in for hover-born reveals (dwell-gated, never steals focus).
+         * Default off — hover reveals are an accessibility hazard; click-reveal is the contract
+         * default. Not persisted per item: this is per-workspace interaction preference.
+         * @member {Boolean} autoHideRevealOnHover_=false
+         * @reactive
+         */
+        autoHideRevealOnHover_: false,
+        /**
          * Current committed dock-zone document. Used when no reducer callback is supplied.
          * @member {Object|null} dockZoneDocument_=null
          * @reactive
@@ -69,6 +84,18 @@ class DockRail extends Component {
          */
         onDockZoneDocumentChange: null,
         /**
+         * Dismiss-grace override in ms; `null` keeps the machine's named design constant.
+         * @member {Number|null} revealDismissGraceMs_=null
+         * @reactive
+         */
+        revealDismissGraceMs_: null,
+        /**
+         * Hover-dwell override in ms; `null` keeps the machine's named design constant.
+         * @member {Number|null} revealDwellMs_=null
+         * @reactive
+         */
+        revealDwellMs_: null,
+        /**
          * Rail tab metadata, in document order: `[{dockEdge, dockItemId, restorable, title}]`.
          * Projection input from `DockLayoutAdapter.createRailTab()` — model-derived, never persisted.
          * @member {Object[]|null} railItems_=null
@@ -77,6 +104,18 @@ class DockRail extends Component {
         railItems_: null
     }
 
+    /**
+     * The reveal/dismiss timing brain. Runtime-only; created per instance, torn down in `destroy()`.
+     * @member {DockRevealStateMachine|null} revealMachine=null
+     * @protected
+     */
+    revealMachine = null
+    /**
+     * The overlay bound via {@link Neo.dashboard.DockRail#bindRevealOverlay}, when one exists.
+     * @member {Neo.dashboard.DockRevealOverlay|null} revealOverlay=null
+     * @protected
+     */
+    revealOverlay = null
     /**
      * Maps projected tab node ids to dock item ids for delegate-click resolution.
      * Runtime-only lookup state, rebuilt on every `railItems` pass — id-based resolution avoids
@@ -95,8 +134,51 @@ class DockRail extends Component {
         let me = this;
 
         me.addDomListeners([
-            {click: me.onRailClick, delegate: '.neo-dashboard-dock-rail-tab', scope: me}
-        ])
+            {click     : me.onRailClick,   delegate: '.neo-dashboard-dock-rail-tab', scope: me},
+            {mouseenter: me.onTabHoverIn,  delegate: '.neo-dashboard-dock-rail-tab', scope: me},
+            {mouseleave: me.onTabHoverOut, delegate: '.neo-dashboard-dock-rail-tab', scope: me}
+        ]);
+
+        me.revealMachine = new DockRevealStateMachine({
+            dwellMs      : Number.isFinite(me.revealDwellMs)        ? me.revealDwellMs        : undefined,
+            graceMs      : Number.isFinite(me.revealDismissGraceMs) ? me.revealDismissGraceMs : undefined,
+            onChange     : me.onRevealStateChange.bind(me),
+            revealOnHover: me.autoHideRevealOnHover
+        })
+    }
+
+    /**
+     * Live-updates the machine when the workspace flips the hover opt-in.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetAutoHideRevealOnHover(value, oldValue) {
+        if (this.revealMachine) {
+            this.revealMachine.revealOnHover = value === true
+        }
+    }
+
+    /**
+     * @param {Number|null} value
+     * @param {Number|null} oldValue
+     * @protected
+     */
+    afterSetRevealDismissGraceMs(value, oldValue) {
+        if (this.revealMachine && Number.isFinite(value)) {
+            this.revealMachine.graceMs = value
+        }
+    }
+
+    /**
+     * @param {Number|null} value
+     * @param {Number|null} oldValue
+     * @protected
+     */
+    afterSetRevealDwellMs(value, oldValue) {
+        if (this.revealMachine && Number.isFinite(value)) {
+            this.revealMachine.dwellMs = value
+        }
     }
 
     /**
@@ -126,6 +208,10 @@ class DockRail extends Component {
     /**
      * Rebuilds the tab vdom in place — the component instance and its root node stay stable across
      * model flips (object permanence at the affordance level); only the tab children re-render.
+     *
+     * Tabs are never disabled: reveal is policy-free (a `pinnable: false` item must stay reachable),
+     * so the `restorable` projection gates the overlay's pin control instead. Items that left the
+     * rail fail-close any reveal of them (`itemCleared`).
      * @param {Object[]|null} value
      * @param {Object[]|null} oldValue
      * @protected
@@ -138,38 +224,67 @@ class DockRail extends Component {
         me.tabIdToItemId = {};
 
         vdom.cn = (value || []).map((railItem, index) => {
-            let tabId      = `${me.id}__tab-${index}`,
-                restorable = railItem.restorable !== false,
-                cls        = ['neo-dashboard-dock-rail-tab'];
-
-            if (!restorable) {
-                cls.push('neo-dashboard-dock-rail-tab-disabled')
-            }
+            let tabId = `${me.id}__tab-${index}`;
 
             me.tabIdToItemId[tabId] = railItem.dockItemId;
 
             return {
-                tag     : 'button',
-                cls,
-                data    : {dockEdge: railItem.dockEdge || edge, dockItemId: railItem.dockItemId, dockRailTab: true},
-                disabled: restorable ? null : true,
-                id      : tabId,
-                text    : railItem.title || railItem.dockItemId
+                tag : 'button',
+                cls : ['neo-dashboard-dock-rail-tab'],
+                data: {dockEdge: railItem.dockEdge || edge, dockItemId: railItem.dockItemId, dockRailTab: true},
+                id  : tabId,
+                text: railItem.title || railItem.dockItemId
             }
         });
 
-        me.update()
+        (oldValue || []).forEach(railItem => {
+            if (!(value || []).some(item => item.dockItemId === railItem.dockItemId)) {
+                me.revealMachine?.itemCleared(railItem.dockItemId)
+            }
+        });
+
+        me.update();
+        me.syncRevealOverlay()
     }
 
     /**
-     * Commits a restore descriptor through the owning reducer callback, falling back to a local
-     * `DockZoneModel.applyOperation()` — identical commit contract to `DockSplitter.commitResizeSplit()`
-     * so dashboard reducers handle both affordances with one code path.
+     * Binds a reveal overlay to this rail: overlay intents (pointer, focus, escape, pin) feed the
+     * state machine, and machine state pushes back into the overlay — the full focus-hold loop
+     * becomes testable without a live workspace.
+     * @param {Neo.dashboard.DockRevealOverlay} overlay
+     * @returns {Neo.dashboard.DockRevealOverlay}
+     */
+    bindRevealOverlay(overlay) {
+        let me = this;
+
+        me.revealOverlay = overlay;
+
+        overlay.on({
+            revealEscape      : me.onOverlayEscape,
+            revealFocusEnter  : me.onOverlayFocusEnter,
+            revealFocusLeave  : me.onOverlayFocusLeave,
+            revealPinRequested: me.onRevealPinRequested,
+            revealPointerEnter: me.onOverlayPointerEnter,
+            revealPointerLeave: me.onOverlayPointerLeave,
+            scope             : me
+        });
+
+        me.syncRevealOverlay();
+
+        return overlay
+    }
+
+    /**
+     * Commits a dock-zone operation descriptor through the owning reducer callback, falling back to
+     * a local `DockZoneModel.applyOperation()` — identical commit contract to
+     * `DockSplitter.commitResizeSplit()` so dashboard reducers handle every affordance with one
+     * code path. The rail commits `setItemPinned` (the overlay pin escape); reveal/dismiss never
+     * commit anything.
      * @param {Object} descriptor
      * @returns {{document:(Object|null), errors:String[]}}
      * @protected
      */
-    commitRestore(descriptor) {
+    commitOperation(descriptor) {
         let me     = this,
             result = null;
 
@@ -182,7 +297,7 @@ class DockRail extends Component {
         if (!result) {
             result = {
                 document: me.dockZoneDocument,
-                errors  : ['DockRail requires `dockZoneDocument` or `applyDockZoneOperation` to commit setItemAutoHidden.']
+                errors  : ['DockRail requires `dockZoneDocument` or `applyDockZoneOperation` to commit dock-zone operations.']
             }
         }
 
@@ -198,6 +313,21 @@ class DockRail extends Component {
     }
 
     /**
+     * Tears down the reveal machinery before component destruction — pending dwell/grace timers
+     * must never outlive the rail.
+     * @param {...*} args
+     */
+    destroy(...args) {
+        let me = this;
+
+        me.revealMachine?.destroy();
+        me.revealMachine = null;
+        me.revealOverlay = null;
+
+        super.destroy(...args)
+    }
+
+    /**
      * @param {String} edge
      * @returns {String}
      * @protected
@@ -207,15 +337,73 @@ class DockRail extends Component {
     }
 
     /**
-     * Delegate click handler for rail tabs: resolves the clicked tab to its dock item, honours the
-     * restore policy, and commits `setItemAutoHidden(false)` through the reducer path.
-     * Fires `dockRailRestore` on commit, `dockRailRestoreRejected` on policy block or executor error.
+     * @protected
+     */
+    onOverlayEscape() {
+        this.revealMachine?.escape()
+    }
+
+    /**
+     * @protected
+     */
+    onOverlayFocusEnter() {
+        this.revealMachine?.overlayFocusEnter()
+    }
+
+    /**
+     * @protected
+     */
+    onOverlayFocusLeave() {
+        this.revealMachine?.overlayFocusLeave()
+    }
+
+    /**
+     * @protected
+     */
+    onOverlayPointerEnter() {
+        this.revealMachine?.overlayPointerEnter()
+    }
+
+    /**
+     * @protected
+     */
+    onOverlayPointerLeave() {
+        this.revealMachine?.overlayPointerLeave()
+    }
+
+    /**
+     * Delegate click handler for rail tabs: resolves the clicked tab to its dock item and feeds the
+     * reveal machine — click opens a focused transient reveal, re-click dismisses. No operation is
+     * committed here; the persist path is the overlay pin
+     * ({@link Neo.dashboard.DockRail#onRevealPinRequested}).
      * @param {Object} data
-     * @returns {{document:(Object|null), errors:String[]}|null}
+     * @returns {{revealedItemId:(String|null), state:String}|null} Machine snapshot after the input.
      */
     onRailClick(data={}) {
         let me     = this,
-            itemId = me.tabIdToItemId[data.currentTarget],
+            itemId = me.tabIdToItemId[data.currentTarget];
+
+        if (!itemId) {
+            return null
+        }
+
+        me.revealMachine.tabClick(itemId);
+
+        return {revealedItemId: me.revealMachine.revealedItemId, state: me.revealMachine.state}
+    }
+
+    /**
+     * The pin escape: honours the pin policy, commits `setItemPinned(true)` through the reducer
+     * path — the model clears `autoHidden` itself (landed guard) — and fail-closes the reveal.
+     * Fires `dockRailOperation` on commit, `dockRailOperationRejected` on policy block or executor
+     * error.
+     * @param {Object} data
+     * @param {String} [data.itemId] Defaults to the currently revealed item.
+     * @returns {{document:(Object|null), errors:String[]}|null}
+     */
+    onRevealPinRequested(data={}) {
+        let me     = this,
+            itemId = data.itemId || me.revealMachine?.revealedItemId,
             descriptor, railItem, result;
 
         if (!itemId) {
@@ -227,18 +415,22 @@ class DockRail extends Component {
         if (railItem?.restorable === false) {
             result = {
                 document: me.dockZoneDocument,
-                errors  : [`item "${itemId}" restore blocked by policy (pinnable: false)`]
+                errors  : [`item "${itemId}" pin blocked by policy (pinnable: false)`]
             };
 
-            me.fire('dockRailRestoreRejected', {descriptor: null, itemId, rail: me, result});
+            me.fire('dockRailOperationRejected', {descriptor: null, itemId, rail: me, result});
 
             return result
         }
 
-        descriptor = {autoHidden: false, itemId, operation: 'setItemAutoHidden'};
-        result     = me.commitRestore(descriptor);
+        descriptor = {itemId, operation: 'setItemPinned', pinned: true};
+        result     = me.commitOperation(descriptor);
 
-        me.fire(result.errors?.length ? 'dockRailRestoreRejected' : 'dockRailRestore', {
+        if (!result.errors?.length) {
+            me.revealMachine?.itemCleared(itemId)
+        }
+
+        me.fire(result.errors?.length ? 'dockRailOperationRejected' : 'dockRailOperation', {
             descriptor,
             itemId,
             rail: me,
@@ -246,6 +438,84 @@ class DockRail extends Component {
         });
 
         return result
+    }
+
+    /**
+     * Machine change hook: fires `dockRailRevealChange` and pushes the snapshot into a bound
+     * overlay. Reveal state is runtime-only — nothing here touches a document.
+     * @param {Object} next {revealedItemId, state}
+     * @param {Object} previous {revealedItemId, state}
+     * @protected
+     */
+    onRevealStateChange(next, previous) {
+        let me = this;
+
+        me.fire('dockRailRevealChange', {
+            next,
+            previous,
+            rail    : me,
+            railItem: (me.railItems || []).find(item => item.dockItemId === next.revealedItemId) || null
+        });
+
+        me.syncRevealOverlay()
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onTabHoverIn(data={}) {
+        let itemId = this.tabIdToItemId[data.currentTarget];
+
+        if (itemId) {
+            this.revealMachine.tabHoverIn(itemId)
+        }
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onTabHoverOut(data={}) {
+        this.revealMachine.tabHoverOut()
+    }
+
+    /**
+     * Resolves the overlay's free-dimension extent for an item: the share its owning split last
+     * committed (still in the document), else `null` — the overlay then falls back to its
+     * workspace-configurable default fraction.
+     * @param {String} itemId
+     * @returns {Number|null}
+     * @protected
+     */
+    resolveRevealExtent(itemId) {
+        let document = this.dockZoneDocument;
+
+        return document ? Neo.dashboard.DockLayoutAdapter.resolveRevealExtent(document, itemId) : null
+    }
+
+    /**
+     * Pushes the current reveal snapshot into the bound overlay, when one exists.
+     * @protected
+     */
+    syncRevealOverlay() {
+        let me      = this,
+            overlay = me.revealOverlay,
+            machine = me.revealMachine,
+            railItem;
+
+        if (!overlay || !machine) {
+            return
+        }
+
+        railItem = (me.railItems || []).find(item => item.dockItemId === machine.revealedItemId) || null;
+
+        overlay.set({
+            edge        : me.getValidatedEdge(me.edge),
+            revealExtent: railItem ? me.resolveRevealExtent(railItem.dockItemId) : null,
+            revealState : machine.state,
+            revealedItem: railItem
+        })
     }
 }
 

--- a/src/dashboard/DockRevealOverlay.mjs
+++ b/src/dashboard/DockRevealOverlay.mjs
@@ -1,0 +1,271 @@
+import Component from '../component/Base.mjs';
+import NeoArray  from '../util/Array.mjs';
+
+/**
+ * @summary Presentation host for the transient reveal of an auto-hidden dock item — an
+ * edge-anchored overlay that renders OVER the committed projection, never re-layouts it.
+ *
+ * The overlay is pure per-window runtime state: it renders whatever reveal snapshot its owning
+ * rail pushes (via `DockRail.bindRevealOverlay()`) and translates DOM reality back into semantic
+ * INTENTS the rail's state machine consumes — `revealPointerEnter/Leave`, `revealFocusEnter/Leave`,
+ * `revealEscape`, `revealPinRequested`. It decides nothing itself: timing, focus-hold and policy
+ * all live upstream. It has no write path to any document.
+ *
+ * Sizing follows the auto-hide contract: the free dimension (width for left/right rails, height
+ * for top/bottom) uses the extent the item's owning split last committed when one exists
+ * (`revealExtent`, resolved by the rail), else the workspace-configurable `defaultRevealFraction`.
+ * Left/right reveals span full height; top/bottom span full width. The overlay stays visible
+ * through the dismiss grace window (`dismiss-pending`) — pointer wobble must not flicker it.
+ *
+ * Pane hosting contract: the consuming workspace mounts the revealed pane into the slot node
+ * (`<overlay id>__pane-slot`) and clears it on dismissal — pane resolution stays the workspace's
+ * concern (same seam as the adapter's `resolveComponentRef`), keeping this overlay pane-blind.
+ *
+ * The pin control persists the reveal: it requests `setItemPinned(true)` from the rail (executor
+ * path — no parallel mutation grammar) and renders disabled when the item's policy forbids
+ * pinning (`restorable: false`) — the one honest non-pinnable affordance state.
+ *
+ * @class Neo.dashboard.DockRevealOverlay
+ * @extends Neo.component.Base
+ * @see Neo.dashboard.DockRail
+ * @see Neo.dashboard.DockRevealStateMachine
+ * @see learn/agentos/HarnessDockZoneModel.md
+ */
+class DockRevealOverlay extends Component {
+    /**
+     * Reveal states in which the overlay renders visibly — `dismiss-pending` included: the grace
+     * window is part of the shown lifecycle.
+     * @member {Set<String>} VISIBLE_STATES
+     * @static
+     */
+    static VISIBLE_STATES = new Set(['dismiss-pending', 'revealed', 'revealed-focused'])
+
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockRevealOverlay'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockRevealOverlay',
+        /**
+         * @member {String} ntype='dashboard-dock-reveal-overlay'
+         * @protected
+         */
+        ntype: 'dashboard-dock-reveal-overlay',
+        /**
+         * @member {String[]} baseCls=['neo-dashboard-dock-reveal-overlay']
+         */
+        baseCls: ['neo-dashboard-dock-reveal-overlay'],
+        /**
+         * Workspace-configurable fallback for the free dimension when the document carries no
+         * committed extent for the item (fraction of the workspace extent).
+         * @member {Number} defaultRevealFraction_=0.25
+         * @reactive
+         */
+        defaultRevealFraction_: 0.25,
+        /**
+         * Owning workspace edge (`top`, `right`, `bottom`, `left`).
+         * @member {String} edge_='left'
+         * @reactive
+         */
+        edge_: 'left',
+        /**
+         * Committed extent fraction for the free dimension, or `null` for the default fraction.
+         * Resolved by the rail from the live document — never computed from DOM geometry.
+         * @member {Number|null} revealExtent_=null
+         * @reactive
+         */
+        revealExtent_: null,
+        /**
+         * Current machine state snapshot (`idle`, `dwell-pending`, `revealed`, `revealed-focused`,
+         * `dismiss-pending`).
+         * @member {String} revealState_='idle'
+         * @reactive
+         */
+        revealState_: 'idle',
+        /**
+         * Rail-item metadata of the revealed item (`{dockEdge, dockItemId, restorable, title}`),
+         * or `null` when nothing reveals.
+         * @member {Object|null} revealedItem_=null
+         * @reactive
+         */
+        revealedItem_: null
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        me.addDomListeners([
+            {click     : me.onPinClick, delegate: '.neo-dashboard-dock-reveal-pin', scope: me},
+            {focusin   : me.onFocusIn,                                              scope: me},
+            {focusout  : me.onFocusOut,                                             scope: me},
+            {keydown   : me.onKeyDown,                                              scope: me},
+            {mouseenter: me.onPointerEnter,                                         scope: me},
+            {mouseleave: me.onPointerLeave,                                         scope: me}
+        ])
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetEdge(value, oldValue) {
+        let me  = this,
+            cls = me.cls || [];
+
+        if (oldValue) {
+            NeoArray.remove(cls, `neo-dashboard-dock-reveal-overlay-${oldValue}`)
+        }
+
+        NeoArray.add(cls, `neo-dashboard-dock-reveal-overlay-${value}`);
+
+        me.cls = cls;
+        me.syncVdom()
+    }
+
+    /**
+     * @param {Number|null} value
+     * @param {Number|null} oldValue
+     * @protected
+     */
+    afterSetRevealExtent(value, oldValue) {
+        this.syncVdom()
+    }
+
+    /**
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetRevealState(value, oldValue) {
+        this.syncVdom()
+    }
+
+    /**
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetRevealedItem(value, oldValue) {
+        this.syncVdom()
+    }
+
+    /**
+     * Whether the current snapshot renders visibly.
+     * @returns {Boolean}
+     */
+    get visible() {
+        return DockRevealOverlay.VISIBLE_STATES.has(this.revealState) && !!this.revealedItem
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onFocusIn(data) {
+        this.fire('revealFocusEnter', {overlay: this})
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onFocusOut(data) {
+        this.fire('revealFocusLeave', {overlay: this})
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onKeyDown(data={}) {
+        if (data.key === 'Escape') {
+            this.fire('revealEscape', {overlay: this})
+        }
+    }
+
+    /**
+     * Requests the pin escape from the owning rail. Policy is honoured upstream; the disabled
+     * rendering here is the honest affordance mirror, not the enforcement point.
+     * @param {Object} data
+     * @protected
+     */
+    onPinClick(data) {
+        let item = this.revealedItem;
+
+        if (item) {
+            this.fire('revealPinRequested', {itemId: item.dockItemId, overlay: this})
+        }
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onPointerEnter(data) {
+        this.fire('revealPointerEnter', {overlay: this})
+    }
+
+    /**
+     * @param {Object} data
+     * @protected
+     */
+    onPointerLeave(data) {
+        this.fire('revealPointerLeave', {overlay: this})
+    }
+
+    /**
+     * Rebuilds the overlay vdom from the current snapshot: visibility cls, free-dimension style,
+     * header (title + pin) and the pane slot the consuming workspace mounts into.
+     * @protected
+     */
+    syncVdom() {
+        let me         = this,
+            edge       = me.edge,
+            isVertical = edge === 'left' || edge === 'right',
+            item       = me.revealedItem,
+            fraction   = Number.isFinite(me.revealExtent) ? me.revealExtent : me.defaultRevealFraction,
+            pct        = `${Math.round(fraction * 10000) / 100}%`,
+            pinnable   = item?.restorable !== false,
+            vdom       = me.vdom,
+            cls        = me.cls || [];
+
+        NeoArray[me.visible ? 'remove' : 'add'](cls, 'neo-dashboard-dock-reveal-overlay-hidden');
+        me.cls = cls;
+
+        me.style = {
+            ...(me.style || {}),
+            height: isVertical ? null : pct,
+            width : isVertical ? pct  : null
+        };
+
+        vdom.cn = !item ? [] : [
+            {
+                cls: ['neo-dashboard-dock-reveal-header'],
+                cn : [
+                    {tag: 'span', cls: ['neo-dashboard-dock-reveal-title'], text: item.title || item.dockItemId},
+                    {
+                        tag     : 'button',
+                        cls     : ['neo-dashboard-dock-reveal-pin', !pinnable && 'neo-dashboard-dock-reveal-pin-disabled'].filter(Boolean),
+                        data    : {dockItemId: item.dockItemId},
+                        disabled: pinnable ? null : true,
+                        text    : 'Pin'
+                    }
+                ]
+            },
+            {
+                cls: ['neo-dashboard-dock-reveal-pane-slot'],
+                id : `${me.id}__pane-slot`
+            }
+        ];
+
+        me.update()
+    }
+}
+
+export default Neo.setupClass(DockRevealOverlay);

--- a/src/dashboard/DockRevealStateMachine.mjs
+++ b/src/dashboard/DockRevealStateMachine.mjs
@@ -1,0 +1,260 @@
+/**
+ * @summary Pure reveal/dismiss state machine for auto-hidden dock items — runtime-only by
+ * construction, timer-injectable for deterministic specs.
+ *
+ * This module is deliberately NOT a Neo class: it holds per-window runtime interaction state
+ * (which item is transiently revealed, and why) that must never touch the persisted dock-zone
+ * document. It has no write path to any document — its only outputs are `onChange`
+ * notifications the owning affordance (`Neo.dashboard.DockRail`) maps to overlay updates and,
+ * for the pin escape, to an executor-routed operation OUTSIDE this machine.
+ *
+ * ## States
+ *
+ * | State | Meaning |
+ * |---|---|
+ * | `idle` | No reveal. The rail renders tabs only. |
+ * | `dwell-pending` | Hover intent detected (opt-in mode); reveal fires when the dwell timer elapses. |
+ * | `revealed` | Overlay open WITHOUT focus (hover-born reveal — hover never steals focus). |
+ * | `revealed-focused` | Overlay open and holding focus. A focused reveal never auto-dismisses. |
+ * | `dismiss-pending` | Pointer left an unfocused overlay; dismissal fires when the grace timer elapses. |
+ *
+ * ## Transitions
+ *
+ * | From | Input | To | Notes |
+ * |---|---|---|---|
+ * | `idle` | `tabClick(item)` | `revealed-focused` | Click-reveal is the DEFAULT interaction; focus moves into the pane. |
+ * | `idle` | `tabHoverIn(item)` | `dwell-pending` | Only when `revealOnHover` (workspace opt-in — hover reveals are an a11y hazard by default). |
+ * | `dwell-pending` | dwell elapsed | `revealed` | Hover reveal never steals focus. |
+ * | `dwell-pending` | `tabHoverOut()` | `idle` | Pass-through hovers never flicker an overlay. |
+ * | `dwell-pending` | `tabClick(item)` | `revealed-focused` | Click overrides the dwell wait. |
+ * | `revealed*` | `tabClick(same item)` | `idle` | Re-clicking the tab dismisses. |
+ * | `revealed*` | `tabClick(other item)` | `revealed-focused(other)` | Retarget: the reveal follows intent. |
+ * | `revealed` / `dismiss-pending` | `tabHoverIn(other item)` | `dwell-pending(other)` | Hover retarget re-dwells; the current reveal survives until the new one commits. |
+ * | `revealed` | `overlayPointerLeave()` | `dismiss-pending` | Grace timer starts — pointer wobble must not kill the overlay. |
+ * | `dismiss-pending` | `overlayPointerEnter()` | `revealed` | Grace return. |
+ * | `dismiss-pending` | grace elapsed | `idle` | Dismissed; no operation is emitted. |
+ * | `revealed` / `dismiss-pending` | `overlayFocusEnter()` | `revealed-focused` | Focus rescues and holds. |
+ * | `revealed-focused` | `overlayPointerLeave()` | `revealed-focused` | FOCUS-HOLD: a focused reveal never auto-dismisses. |
+ * | `revealed-focused` | `overlayFocusLeave()` | `idle` | Focus leaving the overlay dismisses. |
+ * | `revealed*` / `dismiss-pending` | `escape()` / `outsideClick()` | `idle` | Explicit dismissal. |
+ * | any | `itemCleared(item)` | `idle` | Fail-closed sync: the item left auto-hidden state (pin, restore, transfer, policy) — a reveal of it cannot survive. |
+ *
+ * Dismissal in every form discards runtime state only; no operation descriptor exists for it.
+ *
+ * ## Design constants
+ *
+ * Sourced from the S3 storyboard notes (`apps/agentos/design/dock-choreography-demo.html`):
+ * dwell + grace are INTERACTION timings owned here; the 200ms/160ms reveal/dismiss slide
+ * durations are ANIMATION timings and live in CSS, not in this machine.
+ */
+class DockRevealStateMachine {
+    /**
+     * Hover intent dwell before a reveal fires (opt-in hover mode only).
+     * @member {Number} DWELL_MS=150
+     * @static
+     */
+    static DWELL_MS = 150
+    /**
+     * Grace period after the pointer leaves an unfocused overlay before it dismisses.
+     * @member {Number} DISMISS_GRACE_MS=300
+     * @static
+     */
+    static DISMISS_GRACE_MS = 300
+
+    /**
+     * @param {Object} config
+     * @param {Function} [config.clearTimeoutFn=globalThis.clearTimeout] Injectable for fake-timer specs.
+     * @param {Number} [config.dwellMs=DockRevealStateMachine.DWELL_MS]
+     * @param {Number} [config.graceMs=DockRevealStateMachine.DISMISS_GRACE_MS]
+     * @param {Function|null} [config.onChange=null] Receives `(next, previous)` snapshots `{revealedItemId, state}`.
+     * @param {Boolean} [config.revealOnHover=false] Workspace-level opt-in; hover inputs are ignored without it.
+     * @param {Function} [config.setTimeoutFn=globalThis.setTimeout] Injectable for fake-timer specs.
+     */
+    constructor({clearTimeoutFn, dwellMs, graceMs, onChange, revealOnHover, setTimeoutFn} = {}) {
+        this.clearTimeoutFn = clearTimeoutFn || globalThis.clearTimeout.bind(globalThis);
+        this.dwellMs        = Number.isFinite(dwellMs) ? dwellMs : DockRevealStateMachine.DWELL_MS;
+        this.graceMs        = Number.isFinite(graceMs) ? graceMs : DockRevealStateMachine.DISMISS_GRACE_MS;
+        this.onChange       = typeof onChange === 'function' ? onChange : null;
+        this.pendingItemId  = null;
+        this.revealOnHover  = revealOnHover === true;
+        this.revealedItemId = null;
+        this.setTimeoutFn   = setTimeoutFn || globalThis.setTimeout.bind(globalThis);
+        this.state          = 'idle';
+        this.timerId        = null
+    }
+
+    /**
+     * Clears any pending dwell/grace timer. Idempotent.
+     * @protected
+     */
+    clearTimer() {
+        if (this.timerId !== null) {
+            this.clearTimeoutFn(this.timerId);
+            this.timerId = null
+        }
+    }
+
+    /**
+     * Tears the machine down: clears timers and detaches the change listener.
+     */
+    destroy() {
+        this.clearTimer();
+        this.onChange = null
+    }
+
+    /**
+     * `Escape` inside a revealed overlay dismisses it — runtime state only, no operation.
+     */
+    escape() {
+        if (this.state !== 'idle') {
+            this.transition('idle', null)
+        }
+    }
+
+    /**
+     * Fail-closed sync input: the item left committed auto-hidden state (pin escape, restore,
+     * transfer, policy flip). Any reveal of it — pending or open — cannot survive.
+     * @param {String} itemId
+     */
+    itemCleared(itemId) {
+        if (this.revealedItemId === itemId || this.pendingItemId === itemId) {
+            this.transition('idle', null)
+        }
+    }
+
+    /**
+     * A click outside the overlay and rail dismisses the reveal.
+     */
+    outsideClick() {
+        this.escape()
+    }
+
+    /**
+     * Focus entered the overlay: engage focus-hold — a focused reveal never auto-dismisses.
+     */
+    overlayFocusEnter() {
+        if (this.state === 'revealed' || this.state === 'dismiss-pending') {
+            this.transition('revealed-focused', this.revealedItemId)
+        }
+    }
+
+    /**
+     * Focus left the overlay: the reveal dismisses (the pointer-grace path only serves
+     * unfocused reveals).
+     */
+    overlayFocusLeave() {
+        if (this.state === 'revealed-focused') {
+            this.transition('idle', null)
+        }
+    }
+
+    /**
+     * Pointer returned to the overlay during the dismiss grace window.
+     */
+    overlayPointerEnter() {
+        if (this.state === 'dismiss-pending') {
+            this.transition('revealed', this.revealedItemId)
+        }
+    }
+
+    /**
+     * Pointer left the overlay. Unfocused reveals enter the grace window; focused reveals
+     * hold (focus-hold rule).
+     */
+    overlayPointerLeave() {
+        let me = this;
+
+        if (me.state === 'revealed') {
+            me.transition('dismiss-pending', me.revealedItemId);
+
+            me.timerId = me.setTimeoutFn(() => {
+                me.timerId = null;
+
+                if (me.state === 'dismiss-pending') {
+                    me.transition('idle', null)
+                }
+            }, me.graceMs)
+        }
+    }
+
+    /**
+     * Tab click — the DEFAULT reveal interaction. Toggles: clicking the revealed item's tab
+     * dismisses; clicking another tab retargets. Click-born reveals hold focus immediately.
+     * @param {String} itemId
+     */
+    tabClick(itemId) {
+        let me = this;
+
+        if (me.revealedItemId === itemId && me.state !== 'dwell-pending') {
+            me.transition('idle', null);
+            return
+        }
+
+        me.transition('revealed-focused', itemId)
+    }
+
+    /**
+     * Hover entered a rail tab. Ignored unless the workspace opted in via `revealOnHover`.
+     * Starts (or retargets) the dwell window; hover-born reveals never steal focus.
+     * @param {String} itemId
+     */
+    tabHoverIn(itemId) {
+        let me = this;
+
+        if (!me.revealOnHover || me.state === 'revealed-focused' || me.revealedItemId === itemId && me.state === 'revealed') {
+            return
+        }
+
+        me.clearTimer();
+        me.pendingItemId = itemId;
+
+        if (me.state !== 'dwell-pending') {
+            me.transition('dwell-pending', me.revealedItemId, itemId)
+        }
+
+        me.timerId = me.setTimeoutFn(() => {
+            me.timerId = null;
+
+            if (me.state === 'dwell-pending' && me.pendingItemId === itemId) {
+                me.transition('revealed', itemId)
+            }
+        }, me.dwellMs)
+    }
+
+    /**
+     * Hover left the rail tab before the dwell elapsed — a pass-through must never flicker
+     * an overlay open.
+     */
+    tabHoverOut() {
+        let me = this;
+
+        if (me.state === 'dwell-pending') {
+            me.transition(me.revealedItemId ? 'revealed' : 'idle', me.revealedItemId)
+        }
+    }
+
+    /**
+     * Central transition executor: clears timers, applies the snapshot, notifies `onChange`
+     * exactly once per effective change.
+     * @param {String} state
+     * @param {String|null} revealedItemId
+     * @param {String|null} [pendingItemId=null]
+     * @protected
+     */
+    transition(state, revealedItemId, pendingItemId=null) {
+        let me       = this,
+            previous = {revealedItemId: me.revealedItemId, state: me.state};
+
+        me.clearTimer();
+
+        me.pendingItemId  = pendingItemId;
+        me.revealedItemId = revealedItemId;
+        me.state          = state;
+
+        if ((previous.state !== state || previous.revealedItemId !== revealedItemId) && me.onChange) {
+            me.onChange({revealedItemId, state}, previous)
+        }
+    }
+}
+
+export default DockRevealStateMachine;

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -405,15 +405,36 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
 
         let result = DockLayoutAdapter.project(model, {
                 applyDockZoneOperation,
+                autoHideRevealOnHover: true,
                 onDockZoneDocumentChange,
-                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+                resolveComponentRef  : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
             }),
             rail = result.items[0].items.find(item => item.dockNodeType === 'edge-rail');
 
-        // Restore commits must ride the workspace's single operation path — same threading as splitters.
+        // Commits must ride the workspace's single operation path — same threading as splitters.
         expect(rail.applyDockZoneOperation).toBe(applyDockZoneOperation);
         expect(rail.onDockZoneDocumentChange).toBe(onDockZoneDocumentChange);
         expect(rail.dockZoneDocument).toBe(model);
+        // The workspace-level hover opt-in threads through; it defaults to false when absent.
+        expect(rail.autoHideRevealOnHover).toBe(true);
+        expect(DockLayoutAdapter.project(model, {
+            resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+        }).items[0].items.find(item => item.dockNodeType === 'edge-rail').autoHideRevealOnHover).toBe(false);
+    });
+
+    test('resolveRevealExtent returns the committed split share, else null', () => {
+        let model = createEdgeZoneModel();
+
+        // terminal-tabs is side-split child 0: sizes [0.55, 0.45] → 0.55 share.
+        expect(DockLayoutAdapter.resolveRevealExtent(model, 'terminal')).toBeCloseTo(0.55);
+        expect(DockLayoutAdapter.resolveRevealExtent(model, 'inspector')).toBeCloseTo(0.45);
+
+        // strategy's tabs node sits directly in an edge-zone slot — no ancestor split, no extent.
+        expect(DockLayoutAdapter.resolveRevealExtent(model, 'strategy')).toBeNull();
+
+        // Unknown items and absent models fail null-safe.
+        expect(DockLayoutAdapter.resolveRevealExtent(model, 'ghost')).toBeNull();
+        expect(DockLayoutAdapter.resolveRevealExtent(null, 'terminal')).toBeNull();
     });
 
     test('projects one rail per edge with correct membership (multi-edge grouping)', () => {

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -32,6 +32,20 @@ const createRailItems = () => ([
     {dockEdge: 'right', dockItemId: 'terminal', restorable: true, title: 'Terminal'}
 ]);
 
+const createStubOverlay = () => ({
+    calls    : [],
+    listeners: {},
+    fire(name, data) {
+        this.listeners[name]?.call(this.listeners.scope, data)
+    },
+    on(map) {
+        Object.assign(this.listeners, map)
+    },
+    set(config) {
+        this.calls.push(config)
+    }
+});
+
 test.describe('Neo.dashboard.DockRail', () => {
     let rail;
 
@@ -52,7 +66,6 @@ test.describe('Neo.dashboard.DockRail', () => {
         expect(rail.vdom.cn[0].tag).toBe('button');
         expect(rail.vdom.cn[0].text).toBe('Terminal');
         expect(rail.vdom.cn[0].data).toEqual({dockEdge: 'right', dockItemId: 'terminal', dockRailTab: true});
-        expect(rail.vdom.cn[0].disabled).toBeNull();
 
         // Model flip: a second item rails — same instance, tab children re-render in place.
         rail.railItems = [
@@ -70,63 +83,85 @@ test.describe('Neo.dashboard.DockRail', () => {
         expect(rail.vdom.cn).toHaveLength(0);
     });
 
-    test('restore rides the reducer callback: click commits setItemAutoHidden(false)', () => {
-        let descriptors = [],
-            events      = [],
-            nextDoc     = createDocument();
-
-        nextDoc.items.terminal.autoHidden = false;
+    test('click opens a focused transient reveal WITHOUT emitting any operation; re-click dismisses', () => {
+        let committed = [],
+            reveals   = [];
 
         rail = Neo.create(DockRail, {
-            applyDockZoneOperation: (descriptor, railInstance) => {
-                descriptors.push({descriptor, railInstance});
-                return {document: nextDoc, errors: []}
+            applyDockZoneOperation: descriptor => {
+                committed.push(descriptor);
+                return {document: null, errors: []}
             },
             edge     : 'right',
-            id       : 'dock-rail-callback',
+            id       : 'dock-rail-click-reveal',
             railItems: createRailItems()
         });
 
-        rail.on('dockRailRestore', data => events.push(data));
+        rail.on('dockRailRevealChange', data => reveals.push(data));
 
-        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        let snapshot = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
 
-        expect(descriptors).toHaveLength(1);
-        expect(descriptors[0].descriptor).toEqual({autoHidden: false, itemId: 'terminal', operation: 'setItemAutoHidden'});
-        expect(descriptors[0].railInstance).toBe(rail);
-        expect(result.errors).toEqual([]);
-        // The config system clones object configs on set — value equality IS the contract here.
-        expect(rail.dockZoneDocument).toEqual(nextDoc);
-        expect(events).toHaveLength(1);
-        expect(events[0].itemId).toBe('terminal');
-        expect(events[0].descriptor.operation).toBe('setItemAutoHidden');
+        expect(snapshot).toEqual({revealedItemId: 'terminal', state: 'revealed-focused'});
+        expect(committed).toHaveLength(0);
+        expect(reveals).toHaveLength(1);
+        expect(reveals[0].railItem.dockItemId).toBe('terminal');
+
+        snapshot = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+
+        expect(snapshot).toEqual({revealedItemId: null, state: 'idle'});
+        expect(committed).toHaveLength(0);
+        expect(reveals).toHaveLength(2);
     });
 
-    test('falls back to a local DockZoneModel commit and notifies the document listener', () => {
+    test('reveal state never persists: a full reveal/dismiss cycle leaves the document untouched', () => {
         let changes  = [],
-            document = createDocument();
+            document = createDocument(),
+            snapshot = JSON.stringify(document);
 
         rail = Neo.create(DockRail, {
             dockZoneDocument        : document,
             edge                    : 'right',
-            id                      : 'dock-rail-local',
-            onDockZoneDocumentChange: (doc, descriptor, railInstance) => changes.push({descriptor, doc, railInstance}),
+            id                      : 'dock-rail-no-persist',
+            onDockZoneDocumentChange: () => changes.push(1),
             railItems               : createRailItems()
         });
 
-        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        rail.revealMachine.escape();
 
-        expect(result.errors).toEqual([]);
-        expect(result.document.items.terminal.autoHidden).toBe(false);
-        // The input document stays untouched — reducer immutability holds at the affordance level.
-        expect(document.items.terminal.autoHidden).toBe(true);
-        expect(rail.dockZoneDocument).toEqual(result.document);
-        expect(changes).toHaveLength(1);
-        expect(changes[0].doc).toBe(result.document);
-        expect(changes[0].railInstance).toBe(rail);
+        expect(JSON.stringify(document)).toBe(snapshot);
+        expect(JSON.parse(JSON.stringify(rail.dockZoneDocument))).toEqual(JSON.parse(snapshot));
+        expect(changes).toHaveLength(0);
     });
 
-    test('policy: a non-restorable tab renders disabled and rejects locally without emitting an operation', () => {
+    test('pin escape rides the executor: setItemPinned(true) commits, model clears autoHidden, reveal closes', () => {
+        let changes    = [],
+            document   = createDocument(),
+            operations = [];
+
+        rail = Neo.create(DockRail, {
+            dockZoneDocument        : document,
+            edge                    : 'right',
+            id                      : 'dock-rail-pin',
+            onDockZoneDocumentChange: (doc, descriptor) => changes.push({descriptor, doc}),
+            railItems               : createRailItems()
+        });
+
+        rail.on('dockRailOperation', data => operations.push(data));
+        rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+
+        let result = rail.onRevealPinRequested({itemId: 'terminal'});
+
+        expect(result.errors).toEqual([]);
+        expect(result.document.items.terminal.pinned).toBe(true);
+        expect(result.document.items.terminal.autoHidden).toBe(false);
+        expect(rail.revealMachine.state).toBe('idle');
+        expect(changes).toHaveLength(1);
+        expect(operations).toHaveLength(1);
+        expect(operations[0].descriptor).toEqual({itemId: 'terminal', operation: 'setItemPinned', pinned: true});
+    });
+
+    test('pin policy: tab stays clickable, pin request rejects locally without emitting an operation', () => {
         let committed = [],
             rejected  = [];
 
@@ -136,27 +171,27 @@ test.describe('Neo.dashboard.DockRail', () => {
                 return {document: null, errors: []}
             },
             edge     : 'right',
-            id       : 'dock-rail-policy',
+            id       : 'dock-rail-pin-policy',
             railItems: [{dockEdge: 'right', dockItemId: 'terminal', restorable: false, title: 'Terminal'}]
         });
 
-        rail.on('dockRailRestoreRejected', data => rejected.push(data));
+        rail.on('dockRailOperationRejected', data => rejected.push(data));
 
-        expect(rail.vdom.cn[0].disabled).toBe(true);
-        expect(rail.vdom.cn[0].cls).toContain('neo-dashboard-dock-rail-tab-disabled');
+        // Reveal is policy-free: the tab renders enabled — item content must stay reachable.
+        expect(rail.vdom.cn[0].disabled).toBeUndefined();
 
-        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        let snapshot = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        expect(snapshot.state).toBe('revealed-focused');
+
+        let result = rail.onRevealPinRequested({itemId: 'terminal'});
 
         expect(committed).toHaveLength(0);
         expect(result.errors.join(' ')).toContain('blocked by policy');
         expect(rejected).toHaveLength(1);
         expect(rejected[0].descriptor).toBeNull();
-        expect(rejected[0].itemId).toBe('terminal');
     });
 
-    test('an executor rejection surfaces as dockRailRestoreRejected with the document unchanged', () => {
-        // Belt-and-braces: the projection says restorable, but the live document's policy flipped
-        // between projection and click — the model guard answers, the rail relays honestly.
+    test('a stale-projection pin surfaces the executor rejection with the document unchanged', () => {
         let document = createDocument(),
             rejected = [];
 
@@ -165,17 +200,88 @@ test.describe('Neo.dashboard.DockRail', () => {
         rail = Neo.create(DockRail, {
             dockZoneDocument: document,
             edge            : 'right',
-            id              : 'dock-rail-executor-reject',
+            id              : 'dock-rail-pin-executor-reject',
             railItems       : createRailItems()
         });
 
-        rail.on('dockRailRestoreRejected', data => rejected.push(data));
+        rail.on('dockRailOperationRejected', data => rejected.push(data));
 
-        let result = rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        let result = rail.onRevealPinRequested({itemId: 'terminal'});
 
         expect(result.errors.join(' ')).toContain('not pinnable');
         expect(rail.dockZoneDocument.items.terminal.autoHidden).toBe(true);
         expect(rejected).toHaveLength(1);
+    });
+
+    test('hover input is inert without the workspace opt-in, live with it', () => {
+        rail = Neo.create(DockRail, {
+            edge     : 'right',
+            id       : 'dock-rail-hover-optin',
+            railItems: createRailItems()
+        });
+
+        rail.onTabHoverIn({currentTarget: `${rail.id}__tab-0`});
+        expect(rail.revealMachine.state).toBe('idle');
+
+        rail.autoHideRevealOnHover = true;
+
+        rail.onTabHoverIn({currentTarget: `${rail.id}__tab-0`});
+        expect(rail.revealMachine.state).toBe('dwell-pending');
+
+        rail.onTabHoverOut({});
+        expect(rail.revealMachine.state).toBe('idle');
+    });
+
+    test('bindRevealOverlay: state pushes into the overlay; overlay intents feed back; focus-hold holds', () => {
+        let overlay = createStubOverlay();
+
+        rail = Neo.create(DockRail, {
+            edge     : 'right',
+            id       : 'dock-rail-overlay-binding',
+            railItems: createRailItems()
+        });
+
+        rail.bindRevealOverlay(overlay);
+
+        // Initial sync pushes the idle snapshot.
+        expect(overlay.calls.at(-1)).toMatchObject({revealState: 'idle', revealedItem: null});
+
+        rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+
+        expect(overlay.calls.at(-1)).toMatchObject({
+            edge       : 'right',
+            revealState: 'revealed-focused'
+        });
+        expect(overlay.calls.at(-1).revealedItem.dockItemId).toBe('terminal');
+
+        // FOCUS-HOLD: pointer leaving a focused reveal must not dismiss it.
+        overlay.fire('revealPointerLeave', {});
+        expect(rail.revealMachine.state).toBe('revealed-focused');
+
+        // Focus leaving dismisses; the overlay receives the idle snapshot.
+        overlay.fire('revealFocusLeave', {});
+        expect(rail.revealMachine.state).toBe('idle');
+        expect(overlay.calls.at(-1)).toMatchObject({revealState: 'idle', revealedItem: null});
+
+        // Escape intent routes through as well.
+        rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        overlay.fire('revealEscape', {});
+        expect(rail.revealMachine.state).toBe('idle');
+    });
+
+    test('an item leaving the rail fail-closes its reveal', () => {
+        rail = Neo.create(DockRail, {
+            edge     : 'right',
+            id       : 'dock-rail-fail-close',
+            railItems: createRailItems()
+        });
+
+        rail.onRailClick({currentTarget: `${rail.id}__tab-0`});
+        expect(rail.revealMachine.state).toBe('revealed-focused');
+
+        rail.railItems = [];
+
+        expect(rail.revealMachine.state).toBe('idle');
     });
 
     test('ignores clicks that do not resolve to a known tab', () => {

--- a/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs
@@ -1,0 +1,138 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockRevealOverlayTest'
+    }
+});
+
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../src/Neo.mjs';
+import * as core         from '../../../../src/core/_export.mjs';
+import DockRevealOverlay from '../../../../src/dashboard/DockRevealOverlay.mjs';
+
+const createItem = (config={}) => ({
+    dockEdge  : 'right',
+    dockItemId: 'terminal',
+    restorable: true,
+    title     : 'Terminal',
+    ...config
+});
+
+test.describe('Neo.dashboard.DockRevealOverlay', () => {
+    let overlay;
+
+    test.afterEach(() => {
+        overlay?.destroy();
+        overlay = null
+    });
+
+    test('stays hidden while idle, renders header + pane slot when revealed', () => {
+        overlay = Neo.create(DockRevealOverlay, {
+            edge: 'right',
+            id  : 'dock-reveal-render'
+        });
+
+        expect(overlay.visible).toBe(false);
+        expect(overlay.cls).toContain('neo-dashboard-dock-reveal-overlay-hidden');
+        expect(overlay.cls).toContain('neo-dashboard-dock-reveal-overlay-right');
+
+        overlay.set({revealState: 'revealed', revealedItem: createItem()});
+
+        expect(overlay.visible).toBe(true);
+        expect(overlay.cls).not.toContain('neo-dashboard-dock-reveal-overlay-hidden');
+
+        let [header, paneSlot] = overlay.vdom.cn;
+
+        expect(header.cn[0].text).toBe('Terminal');
+        expect(header.cn[1].cls).toContain('neo-dashboard-dock-reveal-pin');
+        expect(header.cn[1].disabled).toBeNull();
+        expect(paneSlot.id).toBe('dock-reveal-render__pane-slot');
+        expect(paneSlot.cls).toContain('neo-dashboard-dock-reveal-pane-slot');
+    });
+
+    test('remains visible through the dismiss grace window', () => {
+        overlay = Neo.create(DockRevealOverlay, {
+            edge        : 'left',
+            id          : 'dock-reveal-grace',
+            revealState : 'dismiss-pending',
+            revealedItem: createItem()
+        });
+
+        expect(overlay.visible).toBe(true);
+    });
+
+    test('sizes the free dimension from the committed extent, else the default fraction', () => {
+        overlay = Neo.create(DockRevealOverlay, {
+            edge        : 'left',
+            id          : 'dock-reveal-sizing',
+            revealExtent: 0.3,
+            revealState : 'revealed',
+            revealedItem: createItem({dockEdge: 'left'})
+        });
+
+        expect(overlay.style.width).toBe('30%');
+        expect(overlay.style.height).toBeNull();
+
+        overlay.revealExtent = null;
+        expect(overlay.style.width).toBe('25%');
+
+        overlay.set({defaultRevealFraction: 0.4, edge: 'top'});
+        expect(overlay.style.height).toBe('40%');
+        expect(overlay.style.width).toBeNull();
+    });
+
+    test('renders a disabled pin for a non-pinnable item; intent still routes upstream', () => {
+        let pins = [];
+
+        overlay = Neo.create(DockRevealOverlay, {
+            edge        : 'right',
+            id          : 'dock-reveal-pin-policy',
+            revealState : 'revealed',
+            revealedItem: createItem({restorable: false})
+        });
+
+        overlay.on('revealPinRequested', data => pins.push(data));
+
+        let pin = overlay.vdom.cn[0].cn[1];
+
+        expect(pin.disabled).toBe(true);
+        expect(pin.cls).toContain('neo-dashboard-dock-reveal-pin-disabled');
+
+        // Enforcement lives in the rail/model; the overlay only mirrors the affordance.
+        overlay.onPinClick({});
+        expect(pins).toHaveLength(1);
+        expect(pins[0].itemId).toBe('terminal');
+    });
+
+    test('translates DOM reality into semantic intents (pointer, focus, escape, pin)', () => {
+        let fired = [];
+
+        overlay = Neo.create(DockRevealOverlay, {
+            edge        : 'right',
+            id          : 'dock-reveal-intents',
+            revealState : 'revealed',
+            revealedItem: createItem()
+        });
+
+        ['revealEscape', 'revealFocusEnter', 'revealFocusLeave', 'revealPinRequested', 'revealPointerEnter', 'revealPointerLeave']
+            .forEach(name => overlay.on(name, () => fired.push(name)));
+
+        overlay.onPointerEnter({});
+        overlay.onPointerLeave({});
+        overlay.onFocusIn({});
+        overlay.onFocusOut({});
+        overlay.onKeyDown({key: 'Escape'});
+        overlay.onKeyDown({key: 'Enter'});
+        overlay.onPinClick({});
+
+        expect(fired).toEqual([
+            'revealPointerEnter',
+            'revealPointerLeave',
+            'revealFocusEnter',
+            'revealFocusLeave',
+            'revealEscape',
+            'revealPinRequested'
+        ]);
+    });
+});

--- a/test/playwright/unit/dashboard/DockRevealStateMachine.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRevealStateMachine.spec.mjs
@@ -1,0 +1,231 @@
+import {test, expect}         from '@playwright/test';
+import DockRevealStateMachine from '../../../../src/dashboard/DockRevealStateMachine.mjs';
+
+const createFakeTimers = () => {
+    let nextId = 1,
+        now    = 0,
+        queue  = new Map();
+
+    return {
+        advance(ms) {
+            now += ms;
+
+            [...queue.entries()]
+                .sort((a, b) => a[1].at - b[1].at)
+                .forEach(([id, timer]) => {
+                    if (timer.at <= now && queue.has(id)) {
+                        queue.delete(id);
+                        timer.fn()
+                    }
+                })
+        },
+        clearTimeoutFn(id) {
+            queue.delete(id)
+        },
+        pendingCount() {
+            return queue.size
+        },
+        setTimeoutFn(fn, ms) {
+            let id = nextId++;
+            queue.set(id, {at: now + ms, fn});
+            return id
+        }
+    }
+};
+
+const createMachine = (config={}) => {
+    let changes = [],
+        timers  = createFakeTimers(),
+        machine = new DockRevealStateMachine({
+            clearTimeoutFn: timers.clearTimeoutFn.bind(timers),
+            onChange      : (next, previous) => changes.push({next, previous}),
+            setTimeoutFn  : timers.setTimeoutFn.bind(timers),
+            ...config
+        });
+
+    return {changes, machine, timers}
+};
+
+test.describe('DockRevealStateMachine', () => {
+    test('click-reveal is the default: click focuses, re-click dismisses', () => {
+        let {changes, machine} = createMachine();
+
+        machine.tabClick('terminal');
+
+        expect(machine.state).toBe('revealed-focused');
+        expect(machine.revealedItemId).toBe('terminal');
+
+        machine.tabClick('terminal');
+
+        expect(machine.state).toBe('idle');
+        expect(machine.revealedItemId).toBeNull();
+        expect(changes.map(change => change.next.state)).toEqual(['revealed-focused', 'idle']);
+    });
+
+    test('hover input is ignored without the workspace opt-in (a11y default)', () => {
+        let {machine, timers} = createMachine();
+
+        machine.tabHoverIn('terminal');
+
+        expect(machine.state).toBe('idle');
+        expect(timers.pendingCount()).toBe(0);
+    });
+
+    test('opt-in hover reveals after the dwell, without stealing focus', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+
+        expect(machine.state).toBe('dwell-pending');
+
+        timers.advance(DockRevealStateMachine.DWELL_MS - 1);
+        expect(machine.state).toBe('dwell-pending');
+
+        timers.advance(1);
+        expect(machine.state).toBe('revealed');
+        expect(machine.revealedItemId).toBe('terminal');
+    });
+
+    test('a pass-through hover never flickers an overlay open', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        machine.tabHoverOut();
+
+        expect(machine.state).toBe('idle');
+
+        timers.advance(DockRevealStateMachine.DWELL_MS * 2);
+        expect(machine.state).toBe('idle');
+    });
+
+    test('pointer-away dismisses an unfocused reveal only after the grace period', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        machine.overlayPointerLeave();
+
+        expect(machine.state).toBe('dismiss-pending');
+
+        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS - 1);
+        expect(machine.state).toBe('dismiss-pending');
+
+        timers.advance(1);
+        expect(machine.state).toBe('idle');
+    });
+
+    test('a grace-window pointer return keeps the overlay open', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        machine.overlayPointerLeave();
+        machine.overlayPointerEnter();
+
+        expect(machine.state).toBe('revealed');
+
+        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 2);
+        expect(machine.state).toBe('revealed');
+    });
+
+    test('focus-hold: a focused reveal never auto-dismisses; focus leave dismisses', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        machine.overlayFocusEnter();
+
+        expect(machine.state).toBe('revealed-focused');
+
+        machine.overlayPointerLeave();
+        expect(machine.state).toBe('revealed-focused');
+
+        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 10);
+        expect(machine.state).toBe('revealed-focused');
+
+        machine.overlayFocusLeave();
+        expect(machine.state).toBe('idle');
+    });
+
+    test('focus entering during the grace window rescues the reveal into focus-hold', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        machine.overlayPointerLeave();
+        machine.overlayFocusEnter();
+
+        expect(machine.state).toBe('revealed-focused');
+
+        timers.advance(DockRevealStateMachine.DISMISS_GRACE_MS * 2);
+        expect(machine.state).toBe('revealed-focused');
+    });
+
+    test('escape and outside-click dismiss from every revealed state', () => {
+        let {machine} = createMachine();
+
+        machine.tabClick('terminal');
+        machine.escape();
+        expect(machine.state).toBe('idle');
+
+        machine.tabClick('terminal');
+        machine.outsideClick();
+        expect(machine.state).toBe('idle');
+    });
+
+    test('click retargets an open reveal to the other item', () => {
+        let {machine} = createMachine();
+
+        machine.tabClick('terminal');
+        machine.tabClick('inspector');
+
+        expect(machine.state).toBe('revealed-focused');
+        expect(machine.revealedItemId).toBe('inspector');
+    });
+
+    test('hover retarget re-dwells while the current reveal survives until commit', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        expect(machine.revealedItemId).toBe('terminal');
+
+        machine.tabHoverIn('inspector');
+        expect(machine.state).toBe('dwell-pending');
+        expect(machine.revealedItemId).toBe('terminal');
+
+        timers.advance(DockRevealStateMachine.DWELL_MS);
+        expect(machine.state).toBe('revealed');
+        expect(machine.revealedItemId).toBe('inspector');
+    });
+
+    test('itemCleared fail-closes any reveal or pending dwell of that item', () => {
+        let {machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabClick('terminal');
+        machine.itemCleared('inspector');
+        expect(machine.state).toBe('revealed-focused');
+
+        machine.itemCleared('terminal');
+        expect(machine.state).toBe('idle');
+
+        machine.tabHoverIn('inspector');
+        machine.itemCleared('inspector');
+        expect(machine.state).toBe('idle');
+
+        timers.advance(DockRevealStateMachine.DWELL_MS * 2);
+        expect(machine.state).toBe('idle');
+    });
+
+    test('destroy clears pending timers and detaches the change listener', () => {
+        let {changes, machine, timers} = createMachine({revealOnHover: true});
+
+        machine.tabHoverIn('terminal');
+        machine.destroy();
+
+        timers.advance(DockRevealStateMachine.DWELL_MS * 2);
+
+        expect(timers.pendingCount()).toBe(0);
+        expect(changes.map(change => change.next.state)).toEqual(['dwell-pending']);
+    });
+});


### PR DESCRIPTION
Resolves #14660

Ships line D2 — the reveal/dismiss interaction contract — on top of the D1 rail (stacked on `agent/14654-autohide-rail-affordance`, PR #14906; rebase onto `dev` + retarget follows its merge). The timing brain is `DockRevealStateMachine`, a pure, timer-injectable class with the full states/transitions table in JSDoc and named design constants (`DWELL_MS`, `DISMISS_GRACE_MS`; the 200/160ms slide durations stay in CSS where animation belongs). `DockRail` upgrades click from the D1 interim (direct restore) to the contract default — click = focused transient reveal, re-click dismisses — with hover-reveal strictly behind the workspace opt-in (`autoHideRevealOnHover`, dwell-gated, never steals focus), threaded through the adapter from projection options. `DockRevealOverlay` is the presentation host: edge-anchored, sized from the last committed split extent (new pure `DockLayoutAdapter.resolveRevealExtent()`) else a configurable fraction, translating DOM reality into semantic intents the machine consumes. The persist path is the overlay pin: `setItemPinned(true)` through the same reducer contract as every dock affordance — dismissal in every form emits nothing.

Evidence: L2 (unit contract specs — 190/190 dashboard suite green, incl. 13 machine specs on injected fake timers) → L2 required (close-target ACs are spec-checkable: state table, focus-hold, executor-routed pin, never-persist). Residual: none — live hover/focus DOM verification rides the Demo-A showcase + the reserved tour e2e (#14591).

## AC map

- **State machine documented; grace constants named** → `DockRevealStateMachine` JSDoc carries the states table and the transitions table; `DWELL_MS` / `DISMISS_GRACE_MS` are named statics, workspace-overridable via rail configs (`revealDwellMs`, `revealDismissGraceMs`).
- **Focused pane never auto-dismisses** → focus-hold specs at BOTH altitudes: machine (`focus-hold: a focused reveal never auto-dismisses`) and rail↔overlay binding (`bindRevealOverlay … focus-hold holds`).
- **Pin escape = executor op, no parallel path** → `onRevealPinRequested` → `commitOperation({operation: 'setItemPinned', pinned: true})` → callback / `DockZoneModel.applyOperation()`; the model clears `autoHidden` itself (landed guard). Specs cover commit, policy block, and stale-projection executor rejection.
- **Reveal state never persists** → dedicated spec: a full reveal/dismiss cycle leaves the document byte-identical and fires zero document-change notifications.
- **Cross-family review** → requested after the stack rebases onto `dev` (per stacked-PR review semantics).

## Deltas from ticket

- **ADR precedence applied to the ticket's hover framing**: the ticket headlines "hover-reveal", but its own cited authority (the docking design record's interaction table) mandates click-reveal as DEFAULT with hover as an a11y-gated workspace opt-in. Both paths shipped; the default is click. The Demo-A S3 hover choreography runs on the opt-in config (flagged to the screenplay owner via A2A at intake).
- **D1's disabled-tab treatment migrates to the overlay pin control**: composing D1+D2 revealed that a `pinnable: false` item with a disabled tab would become unreachable content — item loss. Reveal is policy-free; only PIN is policy-gated. The D1 tab-disable code and specs are superseded in this stack.
- **Pointer-away grace applies to unfocused reveals only** — focused reveals dismiss on focus-leave/Escape/outside-click per the contract; this is the focus-hold rule, made explicit in the state table.
- **The pane-side collapse control** (tuck a visible pane to its rail) is out of scope here — it lives with the pin-controls line (D4), not the rail's interaction layer.
- **Pane hosting is a documented slot contract** (`<overlay id>__pane-slot`): the consuming workspace mounts/clears the revealed pane, same seam as `resolveComponentRef` — keeps the overlay pane-blind at this altitude.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/dashboard/
190 passed (30.9s)
```

New: `DockRevealStateMachine.spec.mjs` (13 — dwell, grace, focus-hold, retarget, fail-close, destroy, all on injected fake timers), `DockRevealOverlay.spec.mjs` (5 — visibility incl. grace window, sizing, pin policy mirror, intent translation). Rewritten: `DockRail.spec.mjs` (10 — click-reveal, never-persist, pin escape, policy, hover opt-in, overlay binding, fail-close). Extended: `DockLayoutAdapter.spec.mjs` (`resolveRevealExtent` cases + hover opt-in threading).

## Post-Merge Validation

- [ ] Rebase onto `dev` + retarget after PR #14906 merges; full CI on the merge candidate before cross-family approval.
- [ ] Demo-A scene-3 choreography drives reveal/dismiss live (screenplay sets `autoHideRevealOnHover` for the S3 hover beat).
- [ ] Tour e2e asserts reveal motion + focus-hold via `observe_motion` (#14591, reserved lane).

## Commits

- dc64c419c — state machine + overlay host + rail upgrade + adapter extent resolver + specs

Process note: authored during an operator-granted temporary Fable 5 model window (2026-07-10).

Authored by Grace (Claude Fable 5, Claude Code). Session ef6b9a4a-54ec-4afb-8438-f89a3ee46ad2.
