### PR TITLE
feat(agentos): de-singleton the stores to provider-hosted + JSON-fetched seeds (#14909)

### DIFF
--- a/apps/agentos/resources/data/fleetRoster.json
+++ b/apps/agentos/resources/data/fleetRoster.json
@@ -1,0 +1,11 @@
+{
+    "data": [
+        {"agentId": "neo-opus-grace", "displayName": "Grace",     "engineTag": "opus-4.8",    "family": "claude", "state": "ok",   "avatarUrl": "https://github.com/neo-opus-grace.png?size=80", "laneLine": "design authority — cockpit SSOT conformance review"},
+        {"agentId": "neo-gpt",        "displayName": "Euclid",    "engineTag": "gpt-5.6-sol", "family": "gpt",    "state": "ok",   "avatarUrl": "https://github.com/neo-gpt.png?size=80",        "laneLine": "NL transaction archive + replay"},
+        {"agentId": "neo-opus-ada",   "displayName": "Ada",       "engineTag": "opus-4.8",    "family": "claude", "state": "ok",   "avatarUrl": "https://github.com/neo-opus-ada.png?size=80",   "laneLine": "control-plane restart actuator — the R3 seam"},
+        {"agentId": "neo-opus-vega",  "displayName": "Vega",      "engineTag": "opus-4.8",    "family": "claude", "state": "ok",   "avatarUrl": "https://github.com/neo-opus-vega.png?size=80",  "laneLine": "harness-UI shell + left-rail nav"},
+        {"agentId": "neo-fable",      "displayName": "Mnemosyne", "engineTag": "fable-5",     "family": "claude", "state": "ok",   "avatarUrl": "https://github.com/neo-fable.png?size=80",      "laneLine": "golden-path direction-velocity writer"},
+        {"agentId": "neo-fable-clio", "displayName": "Clio",      "engineTag": "fable-5",     "family": "claude", "state": "idle", "avatarUrl": "https://github.com/neo-fable-clio.png?size=80", "laneLine": "CrossWindowDragTarget docking — awaiting review"},
+        {"agentId": "neo-gemini-pro", "displayName": "Gemini",    "engineTag": "3.1-pro",     "family": "gemini", "state": "off",  "avatarUrl": "https://github.com/neo-gemini-pro.png?size=80", "laneLine": "operator-benched"}
+    ]
+}

--- a/apps/agentos/store/AgentDefinitions.mjs
+++ b/apps/agentos/store/AgentDefinitions.mjs
@@ -8,10 +8,12 @@ import Store                from '../../../src/data/Store.mjs';
  * @summary Redacted Fleet Manager agent definition list — the shared fleet roster. The seed row is a
  * local bridge-state placeholder, not persisted registry data, and carries no credential bytes.
  *
- * Exposed as a **singleton** so the keeper-views that compose the cockpit bind one shared instance:
- * `AgentOS.view.Accounts` writes redacted identities into it (after the Brain-side credential submit),
- * and `AgentOS.view.FleetSettingsPanel`'s roster grid reads from it reactively. No credential bytes
- * ever enter this Body-side store.
+ * **Not a singleton**: the sharing scope is the `state.Provider` that hosts it — the Viewport-level
+ * provider `stores` block, the shared ancestor of both consumers ("if used inside a state provider,
+ * we get it anyway"). `AgentOS.view.Accounts` writes redacted identities into it (after the
+ * Brain-side credential submit) via `getStateProvider().getStore('agentDefinitions')`, and
+ * `AgentOS.view.FleetSettingsPanel`'s roster grid binds it via
+ * `bind: {store: 'stores.agentDefinitions'}`. No credential bytes ever enter this Body-side store.
  */
 class AgentDefinitions extends Store {
     static config = {
@@ -20,10 +22,6 @@ class AgentDefinitions extends Store {
          * @protected
          */
         className: 'AgentOS.store.AgentDefinitions',
-        /**
-         * @member {Boolean} singleton=true
-         */
-        singleton: true,
         /**
          * @member {Object[]} data
          */

--- a/apps/agentos/store/FleetRoster.mjs
+++ b/apps/agentos/store/FleetRoster.mjs
@@ -7,13 +7,15 @@ import Store           from '../../../src/data/Store.mjs';
  *
  * @summary The cockpit fleet roster — ONE Store of {@link AgentOS.model.FleetAgent} records as the
  * single source of truth for every fleet surface (the ranked card grid, the health bar, the
- * lifecycle-control round-trip). Exposed as a **singleton** so the keeper-views share one instance.
+ * lifecycle-control round-trip). **Not a singleton**: the sharing scope is the `state.Provider`
+ * that hosts it (`FleetCockpit`'s provider `stores` block — "if used inside a state provider, we
+ * get it anyway"), so views bind the shared instance via `bind: {store: 'stores.fleetRoster'}`
+ * instead of importing module-global state (the `Portal.store.*` house pattern).
  *
- * Seeded with the seven real cross-family maintainer identities — the live-wire binding
- * (`FleetCockpit.loadRoster()` consuming the registry bridge) replaces this seed when the roster
- * source is wired. Identities + avatars are real (the `githubAvatarUrl` pattern, so identity reads
- * at a glance); session state + lane-line are an illustrative snapshot until the live source is
- * wired. NO invented agents.
+ * The sample seed lives in `apps/agentos/resources/data/fleetRoster.json`, fetched via the Store's
+ * native `url` pipeline (the provider declaration sets `autoLoad`) — the seven real cross-family
+ * maintainer identities; session state + lane-line are an illustrative snapshot until
+ * `FleetCockpit.loadRoster()` replaces it with the live registry roster. NO invented agents.
  */
 class FleetRoster extends Store {
     static config = {
@@ -23,10 +25,6 @@ class FleetRoster extends Store {
          */
         className: 'AgentOS.store.FleetRoster',
         /**
-         * @member {Boolean} singleton=true
-         */
-        singleton: true,
-        /**
          * The durable identity key. Declared on the store as well as the model: the collection
          * layer defaults `keyProperty` to `'id'`, which always wins the store-level
          * `this.keyProperty || this.model.keyProperty` fallback — so the model's `agentId` must be
@@ -35,22 +33,14 @@ class FleetRoster extends Store {
          */
         keyProperty: 'agentId',
         /**
-         * @member {Object[]} data
-         */
-        data: [
-            {agentId: 'neo-opus-grace', displayName: 'Grace',     engineTag: 'opus-4.8', family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-opus-grace.png?size=80', laneLine: 'design authority — cockpit SSOT conformance review'},
-            {agentId: 'neo-gpt',        displayName: 'Euclid',    engineTag: 'gpt-5.6-sol', family: 'gpt',   state: 'ok',   avatarUrl: 'https://github.com/neo-gpt.png?size=80',        laneLine: 'NL transaction archive + replay'},
-            {agentId: 'neo-opus-ada',   displayName: 'Ada',       engineTag: 'opus-4.8', family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-opus-ada.png?size=80',   laneLine: 'control-plane restart actuator — the R3 seam'},
-            {agentId: 'neo-opus-vega',  displayName: 'Vega',      engineTag: 'opus-4.8', family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-opus-vega.png?size=80',  laneLine: 'harness-UI shell + left-rail nav'},
-            {agentId: 'neo-fable',      displayName: 'Mnemosyne', engineTag: 'fable-5',  family: 'claude', state: 'ok',   avatarUrl: 'https://github.com/neo-fable.png?size=80',      laneLine: 'golden-path direction-velocity writer'},
-            {agentId: 'neo-fable-clio', displayName: 'Clio',      engineTag: 'fable-5',  family: 'claude', state: 'idle', avatarUrl: 'https://github.com/neo-fable-clio.png?size=80', laneLine: 'CrossWindowDragTarget docking — awaiting review'},
-            {agentId: 'neo-gemini-pro', displayName: 'Gemini',    engineTag: '3.1-pro',     family: 'gemini', state: 'off',  avatarUrl: 'https://github.com/neo-gemini-pro.png?size=80', laneLine: 'operator-benched'}
-        ],
-        /**
          * @member {Neo.data.Model} model=FleetAgentModel
          * @reactive
          */
-        model: FleetAgentModel
+        model: FleetAgentModel,
+        /**
+         * @member {String} url='../../apps/agentos/resources/data/fleetRoster.json'
+         */
+        url: '../../apps/agentos/resources/data/fleetRoster.json'
     }
 }
 

--- a/apps/agentos/view/Accounts.mjs
+++ b/apps/agentos/view/Accounts.mjs
@@ -1,11 +1,10 @@
-import AgentDefinitions from '../store/AgentDefinitions.mjs';
-import Button           from '../../../src/button/Base.mjs';
-import DashboardPanel   from '../../../src/dashboard/Panel.mjs';
-import FormContainer    from '../../../src/form/Container.mjs';
-import PasswordField    from '../../../src/form/field/Password.mjs';
-import Radio            from '../../../src/form/field/Radio.mjs';
-import TextField        from '../../../src/form/field/Text.mjs';
-import Toolbar          from '../../../src/toolbar/Base.mjs';
+import Button         from '../../../src/button/Base.mjs';
+import DashboardPanel from '../../../src/dashboard/Panel.mjs';
+import FormContainer  from '../../../src/form/Container.mjs';
+import PasswordField  from '../../../src/form/field/Password.mjs';
+import Radio          from '../../../src/form/field/Radio.mjs';
+import TextField      from '../../../src/form/field/Text.mjs';
+import Toolbar        from '../../../src/toolbar/Base.mjs';
 
 /**
  * @class AgentOS.view.Accounts
@@ -30,6 +29,18 @@ class Accounts extends DashboardPanel {
          * @protected
          */
         className: 'AgentOS.view.Accounts',
+        /**
+         * The shared roster store, bound from the Viewport provider's `stores.agentDefinitions`
+         * (see the `bind` config) — resolved to the INSTANCE at construct, so a pop-out reparent
+         * keeps the reference. Never a module-global singleton.
+         * @member {Neo.data.Store|null} agentDefinitionsStore_=null
+         * @reactive
+         */
+        agentDefinitionsStore_: null,
+        /**
+         * @member {Object} bind={agentDefinitionsStore:'stores.agentDefinitions'}
+         */
+        bind: {agentDefinitionsStore: 'stores.agentDefinitions'},
         /**
          * @member {String[]} cls=['agent-panel-accounts']
          * @reactive
@@ -207,9 +218,9 @@ class Accounts extends DashboardPanel {
         }
 
         const payload = {
-            credential    : values.credential,
+            credential : values.credential,
             githubUsername,
-            harnessType   : values.harnessType
+            harnessType: values.harnessType
         };
 
         try {
@@ -286,14 +297,17 @@ class Accounts extends DashboardPanel {
     }
 
     /**
-     * @summary Write the redacted projection into the shared `AgentDefinitions` roster singleton,
-     * replacing any prior row for the same agent. The Fleet view's grid (bound to the same singleton)
-     * re-renders reactively — no cross-view reference is needed.
+     * @summary Write the redacted projection into the shared roster store (the Viewport-provider-
+     * hosted `AgentDefinitions` instance this view binds), replacing any prior row for the same
+     * agent. The Fleet view's grid (bound to the same provider store) re-renders reactively — no
+     * cross-view reference is needed.
      * @param {Object} definition
      */
     upsertPublicAgentDefinition(definition) {
-        AgentDefinitions.remove(definition.id);
-        AgentDefinitions.add(definition)
+        const store = this.agentDefinitionsStore;
+
+        store.remove(definition.id);
+        store.add(definition)
     }
 
     /**

--- a/apps/agentos/view/Accounts.mjs
+++ b/apps/agentos/view/Accounts.mjs
@@ -31,8 +31,10 @@ class Accounts extends DashboardPanel {
         className: 'AgentOS.view.Accounts',
         /**
          * The shared roster store, bound from the Viewport provider's `stores.agentDefinitions`
-         * (see the `bind` config) — resolved to the INSTANCE at construct, so a pop-out reparent
-         * keeps the reference. Never a module-global singleton.
+         * (see the `bind` config) — declarative and resolved once at construct. Pop-outs swap the
+         * render target only, never the owning component/provider tree (components stay one live
+         * object in the shared App-Worker heap), so the bound instance naturally stays valid.
+         * Never a module-global singleton.
          * @member {Neo.data.Store|null} agentDefinitionsStore_=null
          * @reactive
          */

--- a/apps/agentos/view/FleetSettingsPanel.mjs
+++ b/apps/agentos/view/FleetSettingsPanel.mjs
@@ -1,16 +1,15 @@
-import AgentDefinitions from '../store/AgentDefinitions.mjs';
-import Button           from '../../../src/button/Base.mjs';
-import DashboardPanel   from '../../../src/dashboard/Panel.mjs';
-import GridContainer    from '../../../src/grid/Container.mjs';
-import Toolbar          from '../../../src/toolbar/Base.mjs';
+import Button         from '../../../src/button/Base.mjs';
+import DashboardPanel from '../../../src/dashboard/Panel.mjs';
+import GridContainer  from '../../../src/grid/Container.mjs';
+import Toolbar        from '../../../src/toolbar/Base.mjs';
 
 /**
  * @class AgentOS.view.FleetSettingsPanel
  * @extends Neo.dashboard.Panel
  *
  * @summary The **Fleet view** — run the fleet: the live, redacted roster (grid) + the lifecycle
- * controls (Start / Stop / Restart). Reads the shared `AgentDefinitions` roster singleton that
- * `AgentOS.view.Accounts` writes into; identity *setup* + all credential handling live in `Accounts`
+ * controls (Start / Stop / Restart). Its grid binds the shared `AgentDefinitions` roster instance
+ * from the Viewport provider (`stores.agentDefinitions`) that `AgentOS.view.Accounts` writes into; identity *setup* + all credential handling live in `Accounts`
  * (the cockpit keeper-view split). This view holds no credential logic — it is read + lifecycle only:
  * the lifecycle controls call the injected fleet registry bridge (`globalThis.AgentOS.fleet.registryBridge`,
  * the same Node↔Body transport `Accounts` defines through) and fail closed when it is absent, exactly
@@ -58,7 +57,7 @@ class FleetSettingsPanel extends DashboardPanel {
             cls      : ['agent-definition-grid'],
             flex     : 1,
             reference: 'agent-grid',
-            store    : AgentDefinitions,
+            bind     : {store: 'stores.agentDefinitions'},
 
             columns: [{
                 dataField: 'githubUsername',
@@ -121,7 +120,8 @@ class FleetSettingsPanel extends DashboardPanel {
      * @returns {Object|null} an `AgentDefinitions` record, or `null` when no real agent is defined yet.
      */
     getTargetAgentRecord() {
-        return AgentDefinitions.getRange().find(record => record.id !== 'bridge-pending') || null
+        // the grid holds the provider-resolved store instance (bound at construct — pop-out safe)
+        return this.getReference('agent-grid').store.getRange().find(record => record.id !== 'bridge-pending') || null
     }
 
     /**

--- a/apps/agentos/view/Viewport.mjs
+++ b/apps/agentos/view/Viewport.mjs
@@ -1,8 +1,10 @@
 import Accounts           from './Accounts.mjs';
+import AgentDefinitions   from '../store/AgentDefinitions.mjs';
 import BaseViewport       from '../../../src/container/Viewport.mjs';
 import Dashboard          from '../../../src/dashboard/Container.mjs';
 import FleetCockpit       from './fleet/FleetCockpit.mjs';
 import FleetSettingsPanel from './FleetSettingsPanel.mjs';
+import StateProvider      from '../../../src/state/Provider.mjs';
 import TabContainer       from '../../../src/tab/Container.mjs';
 import ViewportController from './ViewportController.mjs';
 
@@ -39,6 +41,21 @@ class Viewport extends BaseViewport {
          * @reactive
          */
         layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * The shell-level shared-store host — the one sharing scope both keeper-view consumers
+         * resolve (Accounts writes into it, FleetSettingsPanel's grid reads it; each binds the
+         * instance at construct, so a pop-out reparent keeps the reference). Store classes are NOT
+         * singletons — the provider IS the sharing mechanism.
+         * @member {Object} stateProvider
+         */
+        stateProvider: {
+            module: StateProvider,
+            stores: {
+                agentDefinitions: {
+                    module: AgentDefinitions
+                }
+            }
+        },
         /**
          * Top chrome (logo · title · theme switch) over the left-rail keeper-view nav.
          * @member {Object[]} items

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -4,6 +4,7 @@ import Container              from '../../../../src/container/Base.mjs';
 import FleetCockpitController from './FleetCockpitController.mjs';
 import FleetGrid              from './FleetGrid.mjs';
 import FleetRoster            from '../../store/FleetRoster.mjs';
+import StateProvider          from '../../../../src/state/Provider.mjs';
 
 /**
  * Recent fleet activity for the fixture-fed stream — the live A2A / PR / lane adapters
@@ -26,10 +27,12 @@ const FIXTURE_ACTIVITY = [
  * activity stream, in the SSOT's ~1.55fr / 1fr split. This is the "run the fleet" keeper-view the harness-UI
  * definition specifies, reached from the harness shell's left-rail nav — the cards, NOT a data-grid table.
  *
- * The roster data layer is the shared {@link AgentOS.store.FleetRoster} Store of
- * {@link AgentOS.model.FleetAgent} records — seeded with the honestly-labelled sample roster, bound
- * to the {@link FleetGrid}, and re-pointed at the running fleet by {@link #loadRoster} when the
- * registry bridge wires up. The activity zone composes {@link ActivityStream} → EventChip against a
+ * The roster data layer is ONE {@link AgentOS.store.FleetRoster} Store of
+ * {@link AgentOS.model.FleetAgent} records, hosted by THIS view's `state.Provider` (`stores`
+ * block — the provider is the sharing scope; store classes are never singletons). The provider
+ * `autoLoad`s the honestly-labelled JSON sample seed, the {@link FleetGrid} binds the instance via
+ * `bind: {store: 'stores.fleetRoster'}`, and {@link #loadRoster} re-points it at the running fleet
+ * when the registry bridge wires up. The activity zone composes {@link ActivityStream} → EventChip against a
  * representative snapshot the same way ({@link #loadActivity}).
  *
  * @class AgentOS.view.fleet.FleetCockpit
@@ -59,6 +62,21 @@ class FleetCockpit extends Container {
          */
         controller: FleetCockpitController,
         /**
+         * The cockpit-level roster host — ONE provider-owned {@link AgentOS.store.FleetRoster}
+         * instance (autoLoaded from the JSON sample seed) that the grid + health bar bind; the
+         * provider is the sharing scope, never a store singleton.
+         * @member {Object} stateProvider
+         */
+        stateProvider: {
+            module: StateProvider,
+            stores: {
+                fleetRoster: {
+                    autoLoad: true,
+                    module  : FleetRoster
+                }
+            }
+        },
+        /**
          * Vertical stack: the control bar over the full-width fleet grid over the full-width activity
          * feed. The fleet zone gets the full width for its ranked card grid; the live feed is the
          * bottom strip, not a right-hand column.
@@ -85,7 +103,7 @@ class FleetCockpit extends Container {
             flex        : 1.55,
             reference   : 'fleet-grid',
             adapterState: 'sample', // the seeded roster is a representative sample until the live source is wired
-            store       : FleetRoster
+            bind        : {store: 'stores.fleetRoster'}
         }, {
             module      : ActivityStream,
             flex        : 1,

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -114,6 +114,14 @@ class FleetCockpit extends Container {
     }
 
     /**
+     * The last authoritative (bridge-sourced) roster snapshot, kept so a slower store load — the
+     * JSON sample seed racing {@link #loadRoster} — can never overwrite live truth
+     * (see {@link #onRosterStoreLoad}).
+     * @member {Object[]|null} lastLiveRows=null
+     * @protected
+     */
+    lastLiveRows = null
+    /**
      * Set once {@link #loadRoster} has replaced the sample seed with a wired roster payload —
      * subsequent wired payloads MERGE onto the existing records (runtime status refresh) instead of
      * re-seeding the store.
@@ -123,13 +131,46 @@ class FleetCockpit extends Container {
     rosterWired = false
 
     /**
-     * @summary On construct, bind the fleet surfaces to their live feeds.
+     * @summary On construct, bind the fleet surfaces to their live feeds, and guard the roster
+     * store's async seed load against clobbering a faster live source.
      * @param {...*} args
      */
     onConstructed(...args) {
         super.onConstructed(...args);
-        this.loadActivity();
-        this.loadRoster()
+
+        let me = this;
+
+        me.getReference('fleet-grid')?.store?.on({load: me.onRosterStoreLoad, scope: me});
+
+        me.loadActivity();
+        me.loadRoster()
+    }
+
+    /**
+     * @summary Source-precedence guard: the provider-hosted roster store `autoLoad`s the JSON
+     * sample seed while {@link #loadRoster} races the bridge. When the bridge wins, the sample's
+     * later `load` would silently replace live rows (the grid still claiming `live`). Any store
+     * load landing AFTER live truth re-applies the last authoritative snapshot — idempotent,
+     * fail-closed toward live. A load before live truth is the normal seed path and passes through.
+     * @protected
+     */
+    onRosterStoreLoad() {
+        let me = this;
+
+        if (me.rosterWired && me.lastLiveRows) {
+            me.reconcileRoster(me.getReference('fleet-grid').store, me.lastLiveRows)
+        }
+    }
+
+    /**
+     * @summary Detach the roster-store load guard; the provider tears the owned store itself down.
+     * @param {...*} args
+     */
+    destroy(...args) {
+        let me = this;
+
+        me.getReference('fleet-grid')?.store?.un({load: me.onRosterStoreLoad, scope: me});
+        super.destroy(...args)
     }
 
     /**
@@ -202,6 +243,8 @@ class FleetCockpit extends Container {
             }
 
             const mapped = rows.filter(row => row?.id).map(row => me.mapRosterRow(row));
+
+            me.lastLiveRows = mapped;
 
             if (me.rosterWired) {
                 me.reconcileRoster(grid.store, mapped)

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -122,6 +122,15 @@ class FleetCockpit extends Container {
      */
     lastLiveRows = null
     /**
+     * Re-entrancy latch for {@link #onRosterStoreLoad}: the store fires `load` for its own
+     * mutations (mutate → onCollectionMutate → load), so the guard's reconciliation adds/removals
+     * re-trigger the very listener that issued them — unlatched, that recursion is a real stack
+     * overflow (~524 frames on a 5k-row snapshot).
+     * @member {Boolean} reconcilingRoster=false
+     * @protected
+     */
+    reconcilingRoster = false
+    /**
      * Set once {@link #loadRoster} has replaced the sample seed with a wired roster payload —
      * subsequent wired payloads MERGE onto the existing records (runtime status refresh) instead of
      * re-seeding the store.
@@ -152,13 +161,21 @@ class FleetCockpit extends Container {
      * later `load` would silently replace live rows (the grid still claiming `live`). Any store
      * load landing AFTER live truth re-applies the last authoritative snapshot — idempotent,
      * fail-closed toward live. A load before live truth is the normal seed path and passes through.
+     * Latched via {@link #reconcilingRoster}: the reconciliation's own mutations fire `load` back
+     * into this listener.
      * @protected
      */
     onRosterStoreLoad() {
         let me = this;
 
-        if (me.rosterWired && me.lastLiveRows) {
-            me.reconcileRoster(me.getReference('fleet-grid').store, me.lastLiveRows)
+        if (!me.reconcilingRoster && me.rosterWired && me.lastLiveRows) {
+            me.reconcilingRoster = true;
+
+            try {
+                me.reconcileRoster(me.getReference('fleet-grid').store, me.lastLiveRows)
+            } finally {
+                me.reconcilingRoster = false
+            }
         }
     }
 
@@ -294,13 +311,18 @@ class FleetCockpit extends Container {
      * @protected
      */
     reconcileRoster(store, rows) {
-        const snapshotIds = new Set(rows.map(row => row.agentId));
+        const
+            snapshotIds = new Set(rows.map(row => row.agentId)),
+            joiners     = [];
 
         rows.forEach(row => {
             const record = store.get(row.agentId);
 
-            record ? record.set(row) : store.add(row)
+            record ? record.set(row) : joiners.push(row)
         });
+
+        // one batched add — every store mutation fires `load`, so per-row adds would fan out
+        joiners.length > 0 && store.add(joiners);
 
         store.items
             .filter(record => !snapshotIds.has(record.agentId))

--- a/apps/agentos/view/fleet/FleetGrid.mjs
+++ b/apps/agentos/view/fleet/FleetGrid.mjs
@@ -80,8 +80,8 @@ class FleetGrid extends Container {
         layout: {ntype: 'vbox', align: 'stretch'},
         /**
          * The bound roster Store — every card and the health counts derive from its records.
-         * Pass the shared {@link AgentOS.store.FleetRoster} singleton (or an isolated Store of
-         * {@link AgentOS.model.FleetAgent} records in tests).
+         * Pass the provider-hosted {@link AgentOS.store.FleetRoster} instance (or an isolated
+         * Store of {@link AgentOS.model.FleetAgent} records in tests).
          * @member {Neo.data.Store|null} store_=null
          * @reactive
          */

--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -75,7 +75,7 @@ class Component extends Abstract {
         align_: {
             [isDescriptor]: true,
             merge         : 'deep',
-            value: {
+            value         : {
                 edgeAlign  : 't-b',
                 constrainTo: 'document.body'
             }
@@ -1189,6 +1189,8 @@ class Component extends Abstract {
         me.controller = null; // triggers destroy()
 
         me.reference && me.getController()?.removeReference(me); // remove own reference from parent controllers
+
+        me.stateProvider = null; // triggers destroy(), incl. provider-owned stores
 
         me.plugins?.forEach(plugin => {
             plugin.destroy()

--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -1190,8 +1190,6 @@ class Component extends Abstract {
 
         me.reference && me.getController()?.removeReference(me); // remove own reference from parent controllers
 
-        me.stateProvider = null; // triggers destroy(), incl. provider-owned stores
-
         me.plugins?.forEach(plugin => {
             plugin.destroy()
         });

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -273,7 +273,7 @@ class GridContainer extends BaseContainer {
     construct(config) {
         super.construct(config);
 
-        let me = this,
+        let me                                    = this,
             {appName, rowHeight, store, windowId} = me;
 
         me.items = me.items || [];
@@ -545,10 +545,12 @@ class GridContainer extends BaseContainer {
         value   ?.on(listeners);
         oldValue?.un(listeners);
 
-        // in case we dynamically change the store, grid.Body needs to get the new reference
-        if (me.body)      me.body.store = value;
-        if (me.bodyStart) me.bodyStart.store = value;
-        if (me.bodyEnd)   me.bodyEnd.store = value
+        // in case we dynamically change the store (incl. a state.Provider store binding resolving
+        // after construction), grid.Body + the scrollbar need to get the new reference
+        if (me.body)              me.body.store = value;
+        if (me.bodyStart)         me.bodyStart.store = value;
+        if (me.bodyEnd)           me.bodyEnd.store = value
+        if (me.verticalScrollbar) me.verticalScrollbar.store = value
 
         if (me.footerToolbar && me.footerToolbar.store !== value) {
             me.footerToolbar.store = value
@@ -836,14 +838,14 @@ class GridContainer extends BaseContainer {
                 me.bodyStart = Neo.create(GridBody, {
                     ...me.body.initialConfig,
                     selectionModel: null, // grid.View owns the single model; locked bodies must not clone it
-                    flex         : 'none',
-                    gridContainer: me,
-                    parentId     : me.view.id,
-                    rowHeight    : me.rowHeight,
-                    store        : me.store,
-                    theme        : me.theme,
-                    useInternalId: me.useInternalId,
-                    windowId     : me.windowId
+                    flex          : 'none',
+                    gridContainer : me,
+                    parentId      : me.view.id,
+                    rowHeight     : me.rowHeight,
+                    store         : me.store,
+                    theme         : me.theme,
+                    useInternalId : me.useInternalId,
+                    windowId      : me.windowId
                 })
             }
         } else if (me.bodyStart) {
@@ -861,14 +863,14 @@ class GridContainer extends BaseContainer {
                 me.bodyEnd = Neo.create(GridBody, {
                     ...me.body.initialConfig,
                     selectionModel: null, // grid.View owns the single model; locked bodies must not clone it
-                    flex         : 'none',
-                    gridContainer: me,
-                    parentId     : me.view.id,
-                    rowHeight    : me.rowHeight,
-                    store        : me.store,
-                    theme        : me.theme,
-                    useInternalId: me.useInternalId,
-                    windowId     : me.windowId
+                    flex          : 'none',
+                    gridContainer : me,
+                    parentId      : me.view.id,
+                    rowHeight     : me.rowHeight,
+                    store         : me.store,
+                    theme         : me.theme,
+                    useInternalId : me.useInternalId,
+                    windowId      : me.windowId
                 })
             }
         } else if (me.bodyEnd) {
@@ -1256,9 +1258,9 @@ class GridContainer extends BaseContainer {
      * @returns {Promise<void>}
      */
     async passSizeToBody(silent=false) {
-        let me            = this,
+        let me                             = this,
             {footerToolbar, headerToolbar} = me,
-            domRects      = [me.id, headerToolbar.id],
+            domRects                       = [me.id, headerToolbar.id],
             containerRect, footerRect, headerRect;
 
         if (footerToolbar) {
@@ -1323,11 +1325,11 @@ class GridContainer extends BaseContainer {
      * @param {Number} step
      */
     scrollByColumns(index, step) {
-        let me           = this,
-            {body}       = me,
+        let me                                                                = this,
+            {body}                                                            = me,
             {columnPositions, containerWidth, mountedColumns, visibleColumns} = body,
-            countColumns = columnPositions.getCount(),
-            newIndex     = index + step,
+            countColumns                                                      = columnPositions.getCount(),
+            newIndex                                                          = index + step,
             column, mounted, scrollLeft, visible;
 
         if (newIndex >= countColumns) {
@@ -1386,12 +1388,12 @@ class GridContainer extends BaseContainer {
 
         return {
             ...super.toJSON(),
-            body             : me.body?.toJSON(),
-            cellEditing      : me.cellEditing,
-            columns          : me.columns?.items.map(item => item.toJSON()),
-            footerToolbar    : me.footerToolbar?.toJSON(),
-            headerToolbar    : me.headerToolbar?.toJSON(),
-            rowHeight        : me.rowHeight,
+            body         : me.body?.toJSON(),
+            cellEditing  : me.cellEditing,
+            columns      : me.columns?.items.map(item => item.toJSON()),
+            footerToolbar: me.footerToolbar?.toJSON(),
+            headerToolbar: me.headerToolbar?.toJSON(),
+            rowHeight    : me.rowHeight,
 
             scrollManager     : me.scrollManager?.toJSON(),
             showHeaderFilters : me.showHeaderFilters,

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -542,8 +542,10 @@ class GridContainer extends BaseContainer {
 
         me.isTreeGrid = value?.isTreeStore === true;
 
-        value   ?.on(listeners);
-        oldValue?.un(listeners);
+        // on() and un() both consume (delete) keys like `scope` from the passed object,
+        // so each call needs its own copy — a shared object breaks the second call silently.
+        value   ?.on({...listeners});
+        oldValue?.un({...listeners});
 
         // in case we dynamically change the store (incl. a state.Provider store binding resolving
         // after construction), grid.Body + the scrollbar need to get the new reference

--- a/src/grid/VerticalScrollbar.mjs
+++ b/src/grid/VerticalScrollbar.mjs
@@ -123,15 +123,17 @@ class VerticalScrollbar extends Component {
      * @protected
      */
     afterSetStore(value, oldValue) {
-        if (value) {
-            let me = this;
-
-            value.on({
+        let me        = this,
+            listeners = {
                 filter: me.updateScrollHeight,
                 load  : me.updateScrollHeight,
                 scope : me
-            })
-        }
+            };
+
+        // on() and un() both consume (delete) keys like `scope` from the passed object,
+        // so each call needs its own copy — a shared object breaks the second call silently.
+        value   ?.on({...listeners});
+        oldValue?.un({...listeners})
     }
 
     /**

--- a/src/grid/VerticalScrollbar.mjs
+++ b/src/grid/VerticalScrollbar.mjs
@@ -2,37 +2,37 @@ import Component from '../component/Base.mjs';
 
 /**
  * # The "Dual-Pipeline" Scrolling Architecture
- * 
+ *
  * We do not use native vertical scrollbars on the `neo-grid-view` itself for several absolutely
  * critical architectural reasons required to maintain 60 FPS performance in the Multi-Body Grid.
- * 
+ *
  * 1. The Optical Overlay (Z-Order): If we relied strictly on native container scrollbars, the scrollbar
  *    would appear inside the right-most column segment. By utilizing an absolutely positioned dummy scrollbar
  *    at the container level, we ensure the scrollbar consistently overlays all locked and scrolling body segments,
- *    giving mobile and desktop users guaranteed thumb grab access seamlessly on the far right edge without 
+ *    giving mobile and desktop users guaranteed thumb grab access seamlessly on the far right edge without
  *    column boundary conflicts.
- * 
- * 2. Asynchronous Wheel/Trackpad Gliding: The `neo-grid-view` strictly utilizes `overflow-y: scroll`. This 
- *    is intentional. It allows wheel and trackpad scroll events to be fully hardware-accelerated by the browser's 
- *    GPU compositor, producing zero-lag buttery smooth scrolling. The ScrollManager simply records the delta and 
+ *
+ * 2. Asynchronous Wheel/Trackpad Gliding: The `neo-grid-view` strictly utilizes `overflow-y: scroll`. This
+ *    is intentional. It allows wheel and trackpad scroll events to be fully hardware-accelerated by the browser's
+ *    GPU compositor, producing zero-lag buttery smooth scrolling. The ScrollManager simply records the delta and
  *    syncs the dummy scrollbar passively.
- * 
+ *
  * 3. The Thread-Blocking Thumb-Drag Paradox: When a user grabs a native scrollbar thumb and drags it at
  *    high velocity, the DOM immediately scrolls the container *before* the App Worker can calculate, serialize,
  *    and ship new VDOM rows. This results in horrific "blank body" artifacting where the DOM outpaces the JS engine.
- * 
+ *
  * To solve #3, this `VerticalScrollbar` component acts as a physical proxy. When a user drags THIS scrollbar's target,
- * the `GridRowScrollPinning` main-thread add-on intercepts the interaction. Instead of the browser natively scrolling 
+ * the `GridRowScrollPinning` main-thread add-on intercepts the interaction. Instead of the browser natively scrolling
  * the grid view, the add-on applies Main-Thread synchronous `translate3d` transforms (hardware-accelerated GPU pinning)
  * to forcefully lock the grid bodies into optical alignment with the delayed VDOM deltas.
- * 
+ *
  * This effectively prevents the chromium scrolling compositor from dropping row nodes due to VDOM backpressure,
  * completely eliminating rendering jitter during brutal manual thumb interactions.
- * 
- * CRITICAL DIRECTIVE: This component is fundamental to the framework's baseline physics engine. 
- * DO NOT ATTEMPT to merge this scrollbar back into localized native `overflow-y` styling, or you will categorically 
+ *
+ * CRITICAL DIRECTIVE: This component is fundamental to the framework's baseline physics engine.
+ * DO NOT ATTEMPT to merge this scrollbar back into localized native `overflow-y` styling, or you will categorically
  * resurrect high-velocity JS-driven scroll tearing.
- * 
+ *
  * @class Neo.grid.VerticalScrollbar
  * @extends Neo.component.Base
  */
@@ -142,7 +142,7 @@ class VerticalScrollbar extends Component {
      */
     updateScrollHeight(data) {
         let me           = this,
-            countRecords = data?.total ? data.total : me.store.count,
+            countRecords = data?.total ? data.total : (me.store?.count ?? 0),
             {rowHeight}  = me;
 
         if (countRecords > 0 && rowHeight > 0) {

--- a/src/state/Provider.mjs
+++ b/src/state/Provider.mjs
@@ -184,6 +184,14 @@ class Provider extends Base {
      */
     #formulaEffects = new Map()
     /**
+     * Tracks store instances THIS provider created from `stores` descriptors (class / config
+     * shapes). Passed-in instances are never added: the provider shares those, it does not own
+     * them. Owned instances get destroyed with the provider.
+     * @member {Set} #ownedStores=new Set()
+     * @private
+     */
+    #ownedStores = new Set()
+    /**
      * Tracks provider-owned Record field bindings by StateProvider data path.
      * @member {Map} #recordDataBindings=new Map()
      * @private
@@ -290,6 +298,8 @@ class Provider extends Base {
             });
 
             Object.entries(value).forEach(([key, storeValue]) => {
+                const providerCreates = Neo.typeOf(storeValue) !== 'NeoInstance';
+
                 storeValue = me.normalizeProviderStoreConfig(key, storeValue, storeIds);
 
                 // support mapping string based listeners into the stateProvider instance
@@ -297,7 +307,9 @@ class Provider extends Base {
                     me.bindCallback(listener, listenerKey, me, storeValue.listeners)
                 })
 
-                value[key] = ClassSystemUtil.beforeSetInstance(storeValue)
+                value[key] = ClassSystemUtil.beforeSetInstance(storeValue);
+
+                providerCreates && me.#ownedStores.add(value[key])
             })
         }
 
@@ -452,7 +464,9 @@ class Provider extends Base {
     }
 
     /**
-     * Destroys the state provider and cleans up all associated effects.
+     * Destroys the state provider and cleans up all associated effects, plus every store instance
+     * the provider itself created from a `stores` descriptor (passed-in instances stay alive —
+     * shared, not owned).
      */
     destroy() {
         const me = this;
@@ -464,6 +478,9 @@ class Provider extends Base {
 
         me.#bindingEffects.forEach(effect => effect.destroy());
         me.#bindingEffects.clear();
+
+        me.#ownedStores.forEach(store => store.destroy());
+        me.#ownedStores.clear();
 
         super.destroy()
     }

--- a/src/state/Provider.mjs
+++ b/src/state/Provider.mjs
@@ -192,6 +192,15 @@ class Provider extends Base {
      */
     #ownedStores = new Set()
     /**
+     * Bumped on every reactive `stores` replacement and suffixed into the predictable provider-store
+     * ids. Reusing the exact id of a just-destroyed owned store would make the replacement look like
+     * a no-op to the config system's equality check (instances compare by their serialized id), so
+     * the new value would never get stored — a fresh generation keeps replacement ids unique.
+     * @member {Number} #storesGeneration=0
+     * @private
+     */
+    #storesGeneration = 0
+    /**
      * Tracks provider-owned Record field bindings by StateProvider data path.
      * @member {Map} #recordDataBindings=new Map()
      * @private
@@ -286,6 +295,26 @@ class Provider extends Base {
     beforeSetStores(value, oldValue) {
         const me = this;
 
+        // reactive replacement (or null-removal): an owned instance the provider no longer hosts
+        // gets destroyed NOW — deferring it to provider destroy would leak a live, registered
+        // store nothing can resolve anymore. Passed-in instances stay externally owned.
+        // ORDER MATTERS: this runs BEFORE the new value instantiates, and the generation bump
+        // gives same-key replacements a fresh predictable id (see #storesGeneration).
+        if (oldValue) {
+            const reusedInstances = new Set(
+                Object.values(value || {}).filter(storeValue => Neo.typeOf(storeValue) === 'NeoInstance')
+            );
+
+            me.#storesGeneration++;
+
+            Object.values(oldValue).forEach(store => {
+                if (me.#ownedStores.has(store) && !reusedInstances.has(store)) {
+                    me.#ownedStores.delete(store);
+                    store.destroy()
+                }
+            })
+        }
+
         if (value) {
             const storeIds = {};
 
@@ -313,20 +342,6 @@ class Provider extends Base {
             })
         }
 
-        // reactive replacement (or null-removal): an owned instance the provider no longer hosts
-        // gets destroyed NOW — deferring it to provider destroy would leak a live, registered
-        // store nothing can resolve anymore. Passed-in instances stay externally owned.
-        if (oldValue) {
-            const keptInstances = new Set(Object.values(value || {}));
-
-            Object.values(oldValue).forEach(store => {
-                if (me.#ownedStores.has(store) && !keptInstances.has(store)) {
-                    me.#ownedStores.delete(store);
-                    store.destroy()
-                }
-            })
-        }
-
         return value
     }
 
@@ -340,18 +355,21 @@ class Provider extends Base {
      * @protected
      */
     getProviderStoreId(key, storeValue) {
-        const type = Neo.typeOf(storeValue);
+        const
+            type       = Neo.typeOf(storeValue),
+            generation = this.#storesGeneration,
+            baseId     = generation > 0 ? `${this.id}__${key}__${generation}` : `${this.id}__${key}`;
 
         if (type === 'NeoInstance') {
             return storeValue.id
         }
 
         if (type === 'Object') {
-            return storeValue.id || `${this.id}__${key}`
+            return storeValue.id || baseId
         }
 
         if (type === 'NeoClass') {
-            return `${this.id}__${key}`
+            return baseId
         }
 
         return null

--- a/src/state/Provider.mjs
+++ b/src/state/Provider.mjs
@@ -284,10 +284,10 @@ class Provider extends Base {
      * @protected
      */
     beforeSetStores(value, oldValue) {
+        const me = this;
+
         if (value) {
-            const
-                me       = this,
-                storeIds = {};
+            const storeIds = {};
 
             Object.entries(value).forEach(([key, storeValue]) => {
                 const storeId = me.getProviderStoreId(key, storeValue);
@@ -310,6 +310,20 @@ class Provider extends Base {
                 value[key] = ClassSystemUtil.beforeSetInstance(storeValue);
 
                 providerCreates && me.#ownedStores.add(value[key])
+            })
+        }
+
+        // reactive replacement (or null-removal): an owned instance the provider no longer hosts
+        // gets destroyed NOW — deferring it to provider destroy would leak a live, registered
+        // store nothing can resolve anymore. Passed-in instances stay externally owned.
+        if (oldValue) {
+            const keptInstances = new Set(Object.values(value || {}));
+
+            Object.values(oldValue).forEach(store => {
+                if (me.#ownedStores.has(store) && !keptInstances.has(store)) {
+                    me.#ownedStores.delete(store);
+                    store.destroy()
+                }
             })
         }
 

--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -50,11 +50,13 @@ test.describe('AgentOS.view.Accounts credential boundary', () => {
     test('identity setup writes only the redacted projection to the shared roster', () => {
         const source = fs.readFileSync(viewPath, 'utf8');
 
-        // upsert goes through the AgentDefinitions singleton with the redacted projection,
-        // never the raw form values / credential.
-        expect(source).toContain('AgentDefinitions.add');
+        // upsert goes through the provider-bound roster store with the redacted projection,
+        // never the raw form values / credential — and never a module-global singleton import.
+        expect(source).toContain("bind: {agentDefinitionsStore: 'stores.agentDefinitions'}");
+        expect(source).toContain('store.add(definition)');
         expect(source).toContain('createPublicAgentDefinition');
-        expect(source).not.toMatch(/AgentDefinitions\.add\(\s*values/)
+        expect(source).not.toContain("from '../store/AgentDefinitions.mjs'");
+        expect(source).not.toMatch(/store\.add\(\s*values/)
     });
 
     test('visible setup actions use product language instead of bridge/protocol labels', () => {
@@ -121,7 +123,7 @@ test.describe('AgentOS.view.Accounts NL-MCP connect entry (#13548)', () => {
         const calls = [];
         const stub  = {
             connectExternalHarnessBridge: async () => { throw new Error('Neural Link connection bridge unavailable') },
-            updateBridgeStatus: (stateCls, message) => calls.push({stateCls, message})
+            updateBridgeStatus          : (stateCls, message) => calls.push({stateCls, message})
         };
 
         await Accounts.prototype.onConnectExternalHarnessClick.call(stub);

--- a/test/playwright/unit/apps/agentos/FleetSettingsPanel.spec.mjs
+++ b/test/playwright/unit/apps/agentos/FleetSettingsPanel.spec.mjs
@@ -23,15 +23,28 @@ const
     panelPath  = path.join(repoRoot, 'apps/agentos/view/FleetSettingsPanel.mjs');
 
 test.describe('AgentOS.view.FleetSettingsPanel fleet roster', () => {
-    test('shared agent-definition roster (singleton) exposes only redacted public fields', () => {
-        // AgentDefinitions is a singleton: Accounts writes, this view's grid reads the same instance.
-        const [record] = AgentDefinitions.getRange();
+    test('shared agent-definition roster exposes only redacted public fields — provider-hosted, never a singleton', () => {
+        // AgentDefinitions is a CLASS (no singleton): the Viewport provider hosts the one shared
+        // instance ('stores.agentDefinitions'); Accounts writes, this view's grid binds the same one.
+        const store    = Neo.create(AgentDefinitions, {}),
+              [record] = store.getRange();
 
+        expect(AgentDefinitions.isClass).toBe(true);
+        expect(store.singleton).toBeFalsy();
         expect(record.credentialState).toBe('redacted');
         expect(record.statusText).toContain('PAT values are never loaded');
         expect(record.credential).toBeUndefined();
         expect(record.pat).toBeUndefined();
-        expect(record.token).toBeUndefined()
+        expect(record.token).toBeUndefined();
+
+        store.destroy()
+    });
+
+    test('the grid binds the provider store — no module-global store import survives in the view', () => {
+        const source = fs.readFileSync(panelPath, 'utf8');
+
+        expect(source).toContain("bind     : {store: 'stores.agentDefinitions'}");
+        expect(source).not.toContain("from '../store/AgentDefinitions.mjs'")
     });
 
     test('fleet view is read + lifecycle only — no credential logic (that lives in Accounts)', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -12,10 +12,15 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../../src/core/_export.mjs';
-import Instance       from '../../../../../../../src/manager/Instance.mjs';
+import {test, expect}  from '@playwright/test';
+import {readFileSync}  from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+import Instance        from '../../../../../../../src/manager/Instance.mjs';
+
+const seedPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../../../apps/agentos/resources/data/fleetRoster.json');
 
 /**
  * Covers the fail-closed matrix for `FleetCockpit.loadActivity()` — the app-side consumption of the
@@ -153,26 +158,22 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
 
     test.afterEach(() => clearBridge());
 
-    test('FleetRoster is the shared Store of FleetAgent records — durable agentId keying, honest sample seed', () => {
-        // ONE Store singleton is the roster SSOT; its Model fields ARE the card contract
-        expect(FleetRoster.getKeyProperty()).toBe('agentId');
-        expect(FleetRoster.model.className).toBe('AgentOS.model.FleetAgent');
+    test('FleetRoster is a provider-hosted Store CLASS — JSON-fetched seed, durable agentId keying, honest sample', () => {
+        // no singleton: the cockpit provider hosts + autoLoads the ONE shared instance; the class
+        // carries the url seed (the Portal.store.* house pattern)
+        expect(FleetRoster.isClass).toBe(true);
+        expect(FleetRoster.config.singleton).toBeFalsy();
+        expect(FleetRoster.config.url).toBe('../../apps/agentos/resources/data/fleetRoster.json');
 
-        // the seed is the seven REAL maintainer identities — an honest sample, no invented agents
-        expect(FleetRoster.count).toBe(7);
+        // the JSON sample seed: the seven REAL maintainer identities — no invented agents
+        const seed = JSON.parse(readFileSync(seedPath, 'utf8')).data;
+        expect(seed).toHaveLength(7);
         const knownHandles = ['neo-fable', 'neo-fable-clio', 'neo-gemini-pro', 'neo-gpt', 'neo-opus-ada', 'neo-opus-grace', 'neo-opus-vega'];
-        expect(FleetRoster.items.map(record => record.agentId).sort()).toEqual(knownHandles);
+        expect(seed.map(row => row.agentId).sort()).toEqual(knownHandles);
 
-        // rows hydrate as records exposing the model fields — incl the B4/C2 control seam defaults
-        const euclid = FleetRoster.get('neo-gpt');
-        expect(euclid.isRecord).toBe(true);
-        expect(euclid.displayName).toBe('Euclid');
-        expect(euclid.pendingAction).toBeNull();
-        expect(euclid.controlReason).toBeNull();
-
-        // engine tags pinned to CURRENT identity truth (the registry designations at seed time) —
-        // this front-door surface must not silently reintroduce a stale model designation
-        const engineTags = Object.fromEntries(FleetRoster.items.map(record => [record.agentId, record.engineTag]));
+        // engine tags pinned to the registry designations at seed time — this front-door surface
+        // must not silently reintroduce a stale model designation
+        const engineTags = Object.fromEntries(seed.map(row => [row.agentId, row.engineTag]));
         expect(engineTags).toEqual({
             'neo-fable'     : 'fable-5',
             'neo-fable-clio': 'fable-5',
@@ -181,7 +182,20 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             'neo-opus-ada'  : 'opus-4.8',
             'neo-opus-grace': 'opus-4.8',
             'neo-opus-vega' : 'opus-4.8'
-        })
+        });
+
+        // seed rows hydrate as records exposing the model fields — incl the B4/C2 control seam defaults
+        const store = Neo.create(FleetRoster, {data: seed});
+        expect(store.getKeyProperty()).toBe('agentId');
+        expect(store.model.className).toBe('AgentOS.model.FleetAgent');
+
+        const euclid = store.get('neo-gpt');
+        expect(euclid.isRecord).toBe(true);
+        expect(euclid.displayName).toBe('Euclid');
+        expect(euclid.pendingAction).toBeNull();
+        expect(euclid.controlReason).toBeNull();
+
+        store.destroy()
     });
 
     test('no bridge / no verb / malformed rows / thrown → keeps the last-known roster (fail-closed, no crash)', async () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -302,25 +302,33 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
     });
 
     // Source precedence: the provider-hosted store autoLoads the JSON sample while loadRoster races
-    // the bridge. These run against a REAL isolated FleetRoster instance so the reconciliation is
-    // exercised end-to-end, with onRosterStoreLoad standing in for the store's late `load` event.
-    const makeLiveCockpit = store => {
+    // the bridge. These run against a REAL isolated FleetRoster instance with the REAL load
+    // listener attached (the store fires `load` for its own mutations, so the guard's recursion
+    // behavior is only observable through the live listener path — a manual handler call is a
+    // mock-hole).
+    const makeLiveCockpit = (store, index) => {
         const grid = {adapterState: 'sample', store};
 
-        return {
+        const cockpit = {
             getReference     : reference => reference === 'fleet-grid' ? grid : null,
             grid,
+            id               : `fake-fleet-cockpit-${index}`,
             lastLiveRows     : null,
             mapRosterRow     : FleetCockpit.prototype.mapRosterRow,
             onRosterStoreLoad: FleetCockpit.prototype.onRosterStoreLoad,
             reconcileRoster  : FleetCockpit.prototype.reconcileRoster,
+            reconcilingRoster: false,
             rosterWired      : false
-        }
+        };
+
+        store.on({load: cockpit.onRosterStoreLoad, scope: cockpit});
+
+        return cockpit
     };
 
     test('a sample seed landing AFTER live truth cannot overwrite the roster (fail-closed toward live)', async () => {
         const store   = Neo.create(FleetRoster, {data: []}),
-              cockpit = makeLiveCockpit(store);
+              cockpit = makeLiveCockpit(store, 1);
 
         globalThis.AgentOS = {fleet: {registryBridge: {fleetRoster: async () => ({rows: [
             {id: 'ada',  family: 'claude', lifecycle: {state: 'running'}},
@@ -334,10 +342,10 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         expect(cockpit.lastLiveRows.map(row => row.agentId)).toEqual(['ada', 'vega']);
         expect(store.getCount()).toBe(2);
 
-        // now the slower JSON seed lands: the url pipeline replaces the items and fires `load`
+        // now the slower JSON seed lands: replace the items — the store fires `load` itself,
+        // reaching the guard through the REAL listener
         store.clear();
         store.add([{agentId: 'sample-1'}, {agentId: 'sample-2'}, {agentId: 'sample-3'}]);
-        cockpit.onRosterStoreLoad();
 
         // live truth is re-asserted: sample rows evicted, live residents restored
         expect(store.getCount()).toBe(2);
@@ -350,14 +358,42 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
 
     test('a seed load BEFORE live truth passes through untouched (the normal boot path)', () => {
         const store   = Neo.create(FleetRoster, {data: []}),
-              cockpit = makeLiveCockpit(store);
+              cockpit = makeLiveCockpit(store, 2);
 
-        // the seed lands while nothing live exists yet
+        // the seed lands while nothing live exists yet — the store's own load fires the guard
         store.add([{agentId: 'sample-1'}, {agentId: 'sample-2'}]);
-        cockpit.onRosterStoreLoad();
 
         expect(store.getCount()).toBe(2);
         expect(store.get('sample-1')).toBeTruthy();
+
+        store.destroy()
+    });
+
+    test('guard re-entry is latched: reconciling a large snapshot through the live listener cannot overflow the stack', async () => {
+        const store   = Neo.create(FleetRoster, {data: []}),
+              cockpit = makeLiveCockpit(store, 3);
+
+        // 1,000 authoritative rows — the unlatched recursion overflowed at ~524 nested frames
+        const rows = Array.from({length: 1000}, (item, index) => ({
+            id: `agent-${index}`, lifecycle: {state: 'running'}
+        }));
+
+        globalThis.AgentOS = {fleet: {registryBridge: {fleetRoster: async () => ({rows})}}};
+
+        await FleetCockpit.prototype.loadRoster.call(cockpit);
+
+        expect(cockpit.rosterWired).toBe(true);
+        expect(store.getCount()).toBe(1000);
+
+        // a late seed load now triggers reconciliation of all 1,000 rows THROUGH the listener:
+        // every joiner add fires `load` back at the guard — the latch must hold
+        store.clear();
+        store.add([{agentId: 'sample-1'}]);
+
+        expect(store.getCount()).toBe(1000);
+        expect(store.get('agent-0')).toBeTruthy();
+        expect(store.get('agent-999')).toBeTruthy();
+        expect(store.get('sample-1')).toBeFalsy();
 
         store.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -300,6 +300,67 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         expect(grid.store.cleared).toBe(0);
         expect(grid.adapterState).toBe('live')
     });
+
+    // Source precedence: the provider-hosted store autoLoads the JSON sample while loadRoster races
+    // the bridge. These run against a REAL isolated FleetRoster instance so the reconciliation is
+    // exercised end-to-end, with onRosterStoreLoad standing in for the store's late `load` event.
+    const makeLiveCockpit = store => {
+        const grid = {adapterState: 'sample', store};
+
+        return {
+            getReference     : reference => reference === 'fleet-grid' ? grid : null,
+            grid,
+            lastLiveRows     : null,
+            mapRosterRow     : FleetCockpit.prototype.mapRosterRow,
+            onRosterStoreLoad: FleetCockpit.prototype.onRosterStoreLoad,
+            reconcileRoster  : FleetCockpit.prototype.reconcileRoster,
+            rosterWired      : false
+        }
+    };
+
+    test('a sample seed landing AFTER live truth cannot overwrite the roster (fail-closed toward live)', async () => {
+        const store   = Neo.create(FleetRoster, {data: []}),
+              cockpit = makeLiveCockpit(store);
+
+        globalThis.AgentOS = {fleet: {registryBridge: {fleetRoster: async () => ({rows: [
+            {id: 'ada',  family: 'claude', lifecycle: {state: 'running'}},
+            {id: 'vega', family: 'claude', lifecycle: {state: 'stopped'}}
+        ]})}}};
+
+        // the bridge wins the race: live truth lands first
+        await FleetCockpit.prototype.loadRoster.call(cockpit);
+
+        expect(cockpit.rosterWired).toBe(true);
+        expect(cockpit.lastLiveRows.map(row => row.agentId)).toEqual(['ada', 'vega']);
+        expect(store.getCount()).toBe(2);
+
+        // now the slower JSON seed lands: the url pipeline replaces the items and fires `load`
+        store.clear();
+        store.add([{agentId: 'sample-1'}, {agentId: 'sample-2'}, {agentId: 'sample-3'}]);
+        cockpit.onRosterStoreLoad();
+
+        // live truth is re-asserted: sample rows evicted, live residents restored
+        expect(store.getCount()).toBe(2);
+        expect(store.get('ada')).toBeTruthy();
+        expect(store.get('vega')).toBeTruthy();
+        expect(store.get('sample-1')).toBeFalsy();
+
+        store.destroy()
+    });
+
+    test('a seed load BEFORE live truth passes through untouched (the normal boot path)', () => {
+        const store   = Neo.create(FleetRoster, {data: []}),
+              cockpit = makeLiveCockpit(store);
+
+        // the seed lands while nothing live exists yet
+        store.add([{agentId: 'sample-1'}, {agentId: 'sample-2'}]);
+        cockpit.onRosterStoreLoad();
+
+        expect(store.getCount()).toBe(2);
+        expect(store.get('sample-1')).toBeTruthy();
+
+        store.destroy()
+    });
 });
 
 test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {

--- a/test/playwright/unit/grid/VerticalScrollbarStoreSwap.spec.mjs
+++ b/test/playwright/unit/grid/VerticalScrollbarStoreSwap.spec.mjs
@@ -1,0 +1,84 @@
+/**
+ * @file test/playwright/unit/grid/VerticalScrollbarStoreSwap.spec.mjs
+ * @summary Regression: replacing a grid store must fully detach the scrollbar from the OLD store.
+ *
+ * `VerticalScrollbar.afterSetStore` historically only subscribed to the incoming store — it never
+ * unsubscribed from the replaced one, so after a store swap (reachable since provider-bound stores
+ * resolve post-construct and `grid.Container.afterSetStore` propagates them) the OLD store's
+ * `load`/`filter` events kept driving the CURRENT scrollbar's height. The listener contract is now
+ * symmetric (`value?.on` / `oldValue?.un`, the `grid.Container` idiom).
+ *
+ * @see Neo.grid.VerticalScrollbar
+ * @see Neo.grid.Container
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'GridVerticalScrollbarSwapTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../src/Neo.mjs';
+import * as core         from '../../../../src/core/_export.mjs';
+import Store             from '../../../../src/data/Store.mjs';
+import VerticalScrollbar from '../../../../src/grid/VerticalScrollbar.mjs';
+
+const makeStore = rowCount => Neo.create(Store, {
+    data       : Array.from({length: rowCount}, (item, index) => ({id: index + 1})),
+    keyProperty: 'id'
+});
+
+test.describe('Neo.grid.VerticalScrollbar store replacement', () => {
+
+    test('a replaced store stops driving the scrollbar; the new one takes over', () => {
+        const
+            storeA    = makeStore(1),
+            storeB    = makeStore(100),
+            scrollbar = Neo.create(VerticalScrollbar, {rowHeight: 32, store: storeA});
+
+        // the current store's load drives the height: (1 + 1) * 32
+        storeA.fire('load', {items: storeA.items});
+        expect(scrollbar.vdom.cn[0].height).toBe('64px');
+
+        scrollbar.store = storeB;
+
+        // the OLD store firing must be inert now — pre-fix this flipped 64px to 3232px
+        storeA.fire('load', {total: 100});
+        expect(scrollbar.vdom.cn[0].height).toBe('64px');
+
+        // the NEW store drives it: (100 + 1) * 32
+        storeB.fire('load', {items: storeB.items});
+        expect(scrollbar.vdom.cn[0].height).toBe('3232px');
+
+        scrollbar.destroy();
+        storeA.destroy();
+        storeB.destroy();
+    });
+
+    test('detaching the store entirely (null) leaves the last height untouched and stays inert', () => {
+        const
+            storeA    = makeStore(2),
+            scrollbar = Neo.create(VerticalScrollbar, {rowHeight: 32, store: storeA});
+
+        storeA.fire('load', {items: storeA.items});
+        expect(scrollbar.vdom.cn[0].height).toBe('96px');
+
+        scrollbar.store = null;
+
+        storeA.fire('load', {total: 50});
+        expect(scrollbar.vdom.cn[0].height).toBe('96px');
+
+        scrollbar.destroy();
+        storeA.destroy();
+    });
+});

--- a/test/playwright/unit/state/Provider.spec.mjs
+++ b/test/playwright/unit/state/Provider.spec.mjs
@@ -17,6 +17,7 @@ import Neo             from '../../../../src/Neo.mjs';
 import * as core       from '../../../../src/core/_export.mjs';
 import Component       from '../../../../src/component/Base.mjs';
 import InstanceManager from '../../../../src/manager/Instance.mjs';
+import Plugin          from '../../../../src/plugin/Base.mjs';
 import StateProvider   from '../../../../src/state/Provider.mjs';
 import Store           from '../../../../src/data/Store.mjs';
 import StoreManager    from '../../../../src/manager/Store.mjs';
@@ -687,5 +688,83 @@ test.describe('Neo.state.Provider hosted-store lifecycle', () => {
         expect(provider.isDestroyed).toBe(true);
         expect(store.isDestroyed).toBe(true);
         expect(StoreManager.get(storeId)).toBeFalsy();
+    });
+
+    test('reactive stores replacement destroys the removed OWNED store immediately; a passed-in one survives', () => {
+        const external = Neo.create(Store, {keyProperty: 'id'});
+        const provider = Neo.create(StateProvider, {
+            stores: {
+                owned : {module: Store, keyProperty: 'id'},
+                shared: external
+            }
+        });
+
+        const owned   = provider.getStore('owned');
+        const ownedId = owned.id;
+
+        expect(StoreManager.get(ownedId)).toBe(owned);
+
+        // reactive replacement: neither previous entry is hosted anymore
+        provider.stores = {second: {module: Store, keyProperty: 'id'}};
+
+        // the removed provider-created instance is destroyed + deregistered NOW, not at provider death
+        expect(owned.isDestroyed).toBe(true);
+        expect(StoreManager.get(ownedId)).toBeFalsy();
+        expect(provider.stores.owned).toBeFalsy();
+
+        // the removed passed-in instance stays alive — shared, not owned
+        expect(external.isDestroyed).toBeFalsy();
+
+        const second = provider.getStore('second');
+
+        provider.destroy();
+
+        expect(second.isDestroyed).toBe(true);
+
+        external.destroy();
+    });
+
+    test('setting stores to null destroys every provider-owned instance', () => {
+        const provider = Neo.create(StateProvider, {
+            stores: {roster: {module: Store, keyProperty: 'id'}}
+        });
+
+        const store = provider.getStore('roster');
+
+        provider.stores = null;
+
+        expect(store.isDestroyed).toBe(true);
+
+        provider.destroy();
+    });
+
+    test('plugin teardown still observes a LIVE provider (release stays at the inherited post-plugin point)', () => {
+        const observed = {providerAtPluginDestroy: undefined};
+
+        class ProbePlugin extends Plugin {
+            static config = {
+                className: 'Probe.Plugin'
+            }
+
+            destroy(...args) {
+                observed.providerAtPluginDestroy = this.owner?.stateProvider ?? null;
+                super.destroy(...args)
+            }
+        }
+        const ProbePluginClass = Neo.setupClass(ProbePlugin);
+
+        const component = Neo.create(MockComponent, {
+            plugins      : [{module: ProbePluginClass}],
+            stateProvider: {module: StateProvider, data: {x: 1}}
+        });
+
+        const provider = component.getStateProvider();
+
+        component.destroy();
+
+        // the provider must be released AFTER plugin teardown (component.Abstract's established
+        // point) — a plugin's destroy() sees it alive; afterwards it is destroyed
+        expect(observed.providerAtPluginDestroy).toBe(provider);
+        expect(provider.isDestroyed).toBe(true);
     });
 });

--- a/test/playwright/unit/state/Provider.spec.mjs
+++ b/test/playwright/unit/state/Provider.spec.mjs
@@ -19,6 +19,7 @@ import Component       from '../../../../src/component/Base.mjs';
 import InstanceManager from '../../../../src/manager/Instance.mjs';
 import StateProvider   from '../../../../src/state/Provider.mjs';
 import Store           from '../../../../src/data/Store.mjs';
+import StoreManager    from '../../../../src/manager/Store.mjs';
 
 // Mock Component for testing purposes
 class MockComponent extends Component {
@@ -55,7 +56,7 @@ test.describe('Neo.state.Provider (Node.js)', () => {
 
     test('Provider should update data and trigger config changes', () => {
         const component = Neo.create(MockComponent, {stateProvider: {data: {counter: 0}}});
-        const provider = component.getStateProvider();
+        const provider  = component.getStateProvider();
 
         let effectRunCount = 0;
         provider.createBinding(component.id, 'testConfig', data => {
@@ -82,7 +83,7 @@ test.describe('Neo.state.Provider (Node.js)', () => {
             stateProvider: {data: {appTitle: 'My App', user: {firstName: 'Parent'}}}
         });
         const childComponent = Neo.create(MockComponent, {
-            stateProvider: {data: {user: {lastName: 'Child'}}},
+            stateProvider  : {data: {user: {lastName: 'Child'}}},
             parentComponent: parentComponent
         });
 
@@ -113,10 +114,10 @@ test.describe('Neo.state.Provider (Node.js)', () => {
 
     test('Provider should remove bindings on component destroy', () => {
         const component = Neo.create(MockComponent, {stateProvider: {data: {test: 1}}});
-        const provider = component.getStateProvider();
+        const provider  = component.getStateProvider();
 
-        let effectRunCount = 0;
-        const bindingEffect = provider.createBinding(component.id, 'testConfig', data => {
+        let   effectRunCount = 0;
+        const bindingEffect  = provider.createBinding(component.id, 'testConfig', data => {
             effectRunCount++;
             return data.test;
         });
@@ -133,10 +134,10 @@ test.describe('Neo.state.Provider (Node.js)', () => {
 
     test('Provider should remove bindings on provider destroy', () => {
         const component = Neo.create(MockComponent, {stateProvider: {data: {test: 1}}});
-        const provider = component.getStateProvider();
+        const provider  = component.getStateProvider();
 
-        let effectRunCount = 0;
-        const bindingEffect = provider.createBinding(component.id, 'testConfig', data => {
+        let   effectRunCount = 0;
+        const bindingEffect  = provider.createBinding(component.id, 'testConfig', data => {
             effectRunCount++;
             return data.test;
         });
@@ -155,7 +156,7 @@ test.describe('Neo.state.Provider (Node.js)', () => {
 
     test('setData should create new data properties if they do not exist', () => {
         const component = Neo.create(MockComponent, {stateProvider: {data: {}}});
-        const provider = component.getStateProvider();
+        const provider  = component.getStateProvider();
 
         let effectRunCount = 0;
         provider.createBinding(component.id, 'testConfig', data => {
@@ -388,7 +389,7 @@ test.describe('Neo.state.Provider (Node.js)', () => {
     test('Inline provider stores should get predictable ids and resolve sibling sourceId keys', () => {
         const component = Neo.create(MockComponent, {
             stateProvider: {
-                id: 'state-provider-sourceid-test',
+                id    : 'state-provider-sourceid-test',
                 stores: {
                     users: {
                         module: Store,
@@ -436,7 +437,7 @@ test.describe('Neo.state.Provider (Node.js)', () => {
 
         const component = Neo.create(MockComponent, {
             stateProvider: {
-                id: 'state-provider-explicit-sourceid-test',
+                id    : 'state-provider-explicit-sourceid-test',
                 stores: {
                     explicitUsers: {
                         id    : 'provider-sourceid-explicit-users',
@@ -483,9 +484,9 @@ test.describe('Neo.state.Provider (Node.js)', () => {
         class ClassLevelProvider extends StateProvider {
             static config = {
                 className: 'ClassLevelProvider',
-                data:  {
-                    a: 1,
-                    b: { c: 2, d: 3 },
+                data     : {
+                    a  : 1,
+                    b  : { c: 2, d: 3 },
                     arr: [1, 2]
                 }
             }
@@ -513,7 +514,7 @@ test.describe('Neo.state.Provider (Node.js)', () => {
         class GrandparentProvider extends StateProvider {
             static config = {
                 className: 'GrandparentProvider',
-                data: { app: { name: 'My App', version: '1.0.0' }, user: { role: 'guest', settings: { theme: 'dark' } } }
+                data     : { app: { name: 'My App', version: '1.0.0' }, user: { role: 'guest', settings: { theme: 'dark' } } }
             }
         }
         GrandparentProvider = Neo.setupClass(GrandparentProvider);
@@ -521,7 +522,7 @@ test.describe('Neo.state.Provider (Node.js)', () => {
         class ParentProvider extends GrandparentProvider {
             static config = {
                 className: 'ParentProvider',
-                data: { app: { version: '1.1.0', author: 'Neo' }, user: { id: 123, settings: { notifications: true } }, newParentProp: 'parentValue' }
+                data     : { app: { version: '1.1.0', author: 'Neo' }, user: { id: 123, settings: { notifications: true } }, newParentProp: 'parentValue' }
             }
         }
         ParentProvider = Neo.setupClass(ParentProvider);
@@ -529,33 +530,33 @@ test.describe('Neo.state.Provider (Node.js)', () => {
         class ChildProvider extends ParentProvider {
             static config = {
                 className: 'ChildProvider',
-                data: { user: { role: 'admin', preferences: { language: 'en' } }, newChildProp: 'childValue' }
+                data     : { user: { role: 'admin', preferences: { language: 'en' } }, newChildProp: 'childValue' }
             }
         }
         ChildProvider = Neo.setupClass(ChildProvider);
 
         const provider1 = Neo.create(ChildProvider);
         expect(proxyToObject(provider1.data)).toEqual({
-            app: { name: 'My App', version: '1.1.0', author: 'Neo' },
-            user: { role: 'admin', id: 123, settings: { theme: 'dark', notifications: true }, preferences: { language: 'en' } },
+            app          : { name: 'My App', version: '1.1.0', author: 'Neo' },
+            user         : { role: 'admin', id: 123, settings: { theme: 'dark', notifications: true }, preferences: { language: 'en' } },
             newParentProp: 'parentValue',
-            newChildProp: 'childValue'
+            newChildProp : 'childValue'
         });
         provider1.destroy();
 
         const provider2 = Neo.create(ChildProvider, {
             data: {
-                app: { version: '2.0.0', status: 'beta' },
-                user: { id: 456, settings: { theme: 'light', notifications: false } },
-                newChildProp: 'overriddenChildValue',
+                app             : { version: '2.0.0', status: 'beta' },
+                user            : { id: 456, settings: { theme: 'light', notifications: false } },
+                newChildProp    : 'overriddenChildValue',
                 instanceOnlyProp: 'instanceValue'
             }
         });
         expect(proxyToObject(provider2.data)).toEqual({
-            app: { name: 'My App', version: '2.0.0', author: 'Neo', status: 'beta' },
-            user: { role: 'admin', id: 456, settings: { theme: 'light', notifications: false }, preferences: { language: 'en' } },
-            newParentProp: 'parentValue',
-            newChildProp: 'overriddenChildValue',
+            app             : { name: 'My App', version: '2.0.0', author: 'Neo', status: 'beta' },
+            user            : { role: 'admin', id: 456, settings: { theme: 'light', notifications: false }, preferences: { language: 'en' } },
+            newParentProp   : 'parentValue',
+            newChildProp    : 'overriddenChildValue',
             instanceOnlyProp: 'instanceValue'
         });
         provider2.destroy();
@@ -571,7 +572,7 @@ test.describe('Neo.state.Provider (Node.js)', () => {
             parentComponent,
 
             stateProvider: {
-                data: { itemQuantity: 2 },
+                data    : { itemQuantity: 2 },
                 formulas: {
                     totalCost: (data) => (data.basePrice * data.itemQuantity) * (1 + data.taxRate)
                 }
@@ -599,11 +600,11 @@ test.describe('Neo.state.Provider (Node.js)', () => {
     test('Component bind_ config should deep merge class and instance level bindings', () => {
         class BoundComponent extends Component {
             static config = {
-                className: 'BoundComponent',
+                className   : 'BoundComponent',
                 appName,
                 testConfig1_: null,
                 testConfig2_: null,
-                bind: {
+                bind        : {
                     testConfig1: data => data.val1
                 }
             }
@@ -625,5 +626,66 @@ test.describe('Neo.state.Provider (Node.js)', () => {
         expect(component.testConfig2).toBe('B');
 
         component.destroy();
+    });
+});
+
+// Provider-owned lifetime: a store the provider CREATES from a `stores` descriptor dies with the
+// provider (and with the owning component); an externally created instance passed into `stores`
+// is shared, not owned — it must survive.
+test.describe('Neo.state.Provider hosted-store lifecycle', () => {
+
+    test('a descriptor-created store is destroyed with its provider and deregistered', () => {
+        const provider = Neo.create(StateProvider, {
+            stores: {roster: {module: Store, keyProperty: 'id'}}
+        });
+
+        const store = provider.getStore('roster');
+
+        expect(store.isDestroyed).toBeFalsy();
+        expect(StoreManager.get(store.id)).toBe(store);
+
+        const storeId = store.id;
+
+        provider.destroy();
+
+        expect(store.isDestroyed).toBe(true);
+        expect(StoreManager.get(storeId)).toBeFalsy();
+    });
+
+    test('a passed-in store instance survives provider destroy (shared, not owned)', () => {
+        const external = Neo.create(Store, {keyProperty: 'id'});
+        const provider = Neo.create(StateProvider, {
+            stores: {shared: external}
+        });
+
+        expect(provider.getStore('shared')).toBe(external);
+
+        provider.destroy();
+
+        expect(external.isDestroyed).toBeFalsy();
+        expect(StoreManager.get(external.id)).toBe(external);
+
+        external.destroy();
+    });
+
+    test('component destroy tears down its provider AND the provider-owned stores (the full chain)', () => {
+        const component = Neo.create(MockComponent, {
+            stateProvider: {
+                module: StateProvider,
+                stores: {roster: {module: Store, keyProperty: 'id'}}
+            }
+        });
+
+        const provider = component.getStateProvider();
+        const store    = provider.getStore('roster');
+        const storeId  = store.id;
+
+        expect(store.isDestroyed).toBeFalsy();
+
+        component.destroy();
+
+        expect(provider.isDestroyed).toBe(true);
+        expect(store.isDestroyed).toBe(true);
+        expect(StoreManager.get(storeId)).toBeFalsy();
     });
 });

--- a/test/playwright/unit/state/Provider.spec.mjs
+++ b/test/playwright/unit/state/Provider.spec.mjs
@@ -767,4 +767,34 @@ test.describe('Neo.state.Provider hosted-store lifecycle', () => {
         expect(observed.providerAtPluginDestroy).toBe(provider);
         expect(provider.isDestroyed).toBe(true);
     });
+
+    test('SAME-key descriptor replacement yields a live, registered fresh store (no id-collision no-op)', () => {
+        const provider = Neo.create(StateProvider, {
+            stores: {roster: {module: Store, keyProperty: 'id'}}
+        });
+
+        const first   = provider.getStore('roster');
+        const firstId = first.id;
+
+        provider.stores = {roster: {module: Store, keyProperty: 'id'}};
+
+        const second = provider.getStore('roster');
+
+        // the old owned instance died; the replacement is a LIVE, distinct instance the provider
+        // actually resolves — reusing the exact old id would make the whole replacement look like
+        // a no-op to the config system's equality check (instances compare by serialized id), so
+        // replacement generations get fresh predictable ids. The key-based contract is what
+        // consumers bind (`stores.roster`); the id is internal.
+        expect(first.isDestroyed).toBe(true);
+        expect(second.isDestroyed).toBeFalsy();
+        expect(second).not.toBe(first);
+        expect(second.id).not.toBe(firstId);
+        expect(StoreManager.get(second.id)).toBe(second);
+        expect(StoreManager.get(firstId)).toBeFalsy();
+
+        provider.destroy();
+
+        expect(second.isDestroyed).toBe(true);
+        expect(StoreManager.get(second.id)).toBeFalsy();
+    });
 });


### PR DESCRIPTION
> **Merge disposition (2026-07-10):** Exact head `d66f04a1a8e9424758a0dd7b816c8f2414c43db0` is merge-ready. The explicit-ID same-key replacement edge moved to #14939, assigned to `@neo-gpt`; it is no longer an author action on this PR. This note supersedes the earlier “no residuals” / “flagged for direction” wording below.

Resolves #14909

Related: #13015 (parent epic) · PR #14905 / PR #14910 (the Store-backed cockpit this completes) · #14807 (account/config arc, consumer of this topology)

Implements the operator's two post-#14905 directives as the established house pattern (`Portal.store.*`): **no store is a singleton — the `state.Provider` is the sharing scope** ("if used inside a state provider, we get it anyway"), and **seed data is a fetched JSON file**, not inline rows. `FleetRoster` and `AgentDefinitions` become plain Store classes; `FleetCockpit` hosts `stores.fleetRoster` (autoLoaded from `apps/agentos/resources/data/fleetRoster.json` via the Store's native `url` pipeline) with the grid binding `bind: {store: 'stores.fleetRoster'}`; the Viewport hosts `stores.agentDefinitions` for its two consumers — `FleetSettingsPanel`'s grid binds it, `Accounts` binds it onto an `agentDefinitionsStore_` config (declarative, resolved once at construct; pop-outs swap render targets only, never the owning component/provider tree — ADR 0029). Consumer migration is atomic: zero `singleton: true` under `apps/agentos/store/**`, zero store-class imports under `view/**` outside the two provider hosts.

**Cycle-2 (RC discharge, head `402127635`)** — the review's three exact-head probes each convicted a real lifecycle gap; all three are fixed WITH the missing chain link the fixes exposed:

1. **Provider-owned lifetime (probe 1):** `state.Provider` now tracks instances it creates from `stores` descriptors (`#ownedStores`; passed-in instances are shared, never owned) and destroys them in `destroy()`. **Correction from cycle-2's claim (reviewer-caught):** the component chain never lacked an outer release — `component.Abstract.destroy()` already releases the provider at the established post-plugin point; the missing behavior was ONLY the provider-owned store teardown. A duplicated release briefly added to `component.Base.destroy()` in cycle 2 (which silently reordered provider release AHEAD of plugin teardown) is removed in cycle 4, with a plugin-order regression pinning the inherited release point.
2. **Source precedence (probe 2):** `FleetCockpit` now remembers `lastLiveRows` and guards the roster store's `load` event (`onRosterStoreLoad`, attached at construct, detached in `destroy`): a sample seed landing AFTER live truth re-applies the last authoritative snapshot — idempotent, fail-closed toward live; a seed before live truth passes through (the normal boot path).
3. **Destroy-symmetric listeners (probe 3):** `VerticalScrollbar.afterSetStore` now unbinds the old store. The fix surfaced a deeper latent defect: **`Observable.addListener` AND `removeListener` both mutate the passed listeners object** (`delete name.scope`), so the shared-object `value?.on(listeners); oldValue?.un(listeners)` idiom — including `grid.Container.afterSetStore`'s pre-existing use — silently never unbinds (`on` consumes `scope`, `un` then can't match). Both call sites now pass per-call copies with an explanatory comment; the Observable API wart itself is flagged below as follow-up material.
4. **Stale terminology (rhetorical-drift findings):** `FleetGrid`'s "singleton" JSDoc → "provider-hosted instance"; the `Accounts` "child-window tree after reparenting" rationale corrected to the ADR 0029 model (render targets swap, ownership trees don't).

Evidence: L2 (fresh-browser e2e incl. Neural-Link lifecycle whitebox + local unit runs; sandbox ceiling = local runtime) → L2 required (boot/mount + cross-view sharing are app behavior; contract ACs covered at L1). No residuals.

## Deltas from ticket

- **Two-line framework enabler (`src/grid`):** provider-bound stores resolve AFTER construction, and `grid.Container` could not boot storeless — `VerticalScrollbar.updateScrollHeight` read `me.store.count` during construct (via `afterSetRowHeight`, boot crash), and `grid.Container.afterSetStore`'s dynamic-store propagation covered body/bodies/footer but missed the scrollbar. Fixed: a null-guard (`me.store?.count ?? 0` — a storeless scrollbar has zero rows) and the missing `verticalScrollbar.store = value` line, completing the contract the method's own comment already claims ("in case we dynamically change the store…"). This is what makes `bind: {store: 'stores.*'}` viable on `grid.Container` at all — the full grid unit tree passes.
- **`module: StateProvider` is load-bearing in component-level provider configs:** a `stateProvider: {stores: {...}}` object without it constructs a broken provider ("Class created with object configuration missing className or module") whose stores never exist and whose binds silently never resolve — the app boots to nothing with no surfaced error. Both hosts declare it explicitly (the AgentCard precedent had it; the portal uses a Provider subclass, which is why its declarations don't show the field).
- **`Accounts` write-path shape:** the ticket sketched `getStateProvider().getStore(...)` at call time; implemented as a construct-time bound config instead because both consumer panels are pop-out capable (`popupUrl` dashboards) — a call-time tree walk would re-resolve against the child-window tree after reparenting, while a bound instance reference survives it.
- **`AgentDefinitions`' bridge-pending placeholder row stays inline** (the ticket left it to the implementer): it is a bridge-state indicator, not sample data.
- **Verification-environment incident (not a code issue, documented for the next agent):** mid-verification the in-app preview browser stopped booting ANY version of the app — including clean `dev` (stash-baseline test) — with silent worker-side mount death (`Neo.main.DomAccess.applyBodyCls is not a function` signature: a stale-cached main-thread framework build mismatching fresh worker code after the night's dev pulls). Falsified as environmental via the stash test + the e2e suite's fresh Chrome, which boots and passes everything. The preview pane needs a profile/cache reset.

- **Follow-up candidate surfaced (not fixed here, scope discipline):** the `Observable` on/un caller-object mutation (`delete name.delay/once/order/scope`) makes the natural shared-object idiom a silent trap framework-wide. A non-mutating rewrite (or an internal copy at the API boundary) is one small PR; flagged for the reviewer/operator to direct.

## Test Evidence

- **Fresh-browser e2e (the mount authority): 3/3 passed** — `Cockpit.spec.mjs` ("boots to the Fleet cockpit default; Control + Accounts reachable via the rail") + both `FleetCockpitLifecycleNL.spec.mjs` Neural-Link whitebox tests (UI-driven Start with App-Worker state + minimal bridge payload verification; rejected bridge call renders an error without credentials) — all against this head's provider-hosted topology, JSON seed fetch, and grid binds, in the e2e config's own clean Chrome.
- **Local unit runs** (no-Chroma canonical shape, `--workers=1`): `grid/` + `apps/agentos/` trees together: **186 passed**; only the 3 known dev-reproduced boundary transients (eventChip:27 / fleetGrid:103 / healthSwatch:42) remain, unchanged. Changed specs: the roster contract now pins the CLASS shape + `url` + the JSON seed content (read from the file, engineTag truth map intact) + record hydration via an isolated instance; FleetSettingsPanel/Accounts specs assert the provider-bound topology and the absence of singleton imports; boot-shape probes (provider-hosted settings grid + cockpit) were used during development and removed.
- **Construct-time probes:** provider-hosted `AgentDefinitions` + bound settings grid constructs and resolves (`grid.store.className === 'AgentOS.store.AgentDefinitions'`); cockpit provider + bound fleet grid resolves `AgentOS.store.FleetRoster`.
- `node --check` green on all touched files; `check-block-alignment` green (incl. pre-existing drift in `src/grid/Container.mjs` + trailing-whitespace in `VerticalScrollbar.mjs` surfaced by the whole-file gates); `check-ticket-archaeology` 11 files / 0 violations; grep-proof: `rg 'singleton: true' apps/agentos/store/` → zero; store-class imports under `apps/agentos/view/**` → only the two provider hosts.

## Post-Merge Validation

- [ ] Fresh-profile browser session: the cockpit renders the seven-agent JSON sample with the `sample roster` label; the Control grid renders the bridge-pending row from the Viewport provider store; Accounts "Use sample" upserts into the same grid reactively.
- [ ] Pop-out regression: detach the Control panel to a child window — the grid keeps rendering its bound store (construct-time instance reference).

**Cycles 3+4 (heads `a7f4add9a` → `cca7ba774`)** — the cycle-2 review's residual edges + the evidence addendum, all discharged:

- **Listener re-entry (addendum):** `Store` fires `load` for its own mutations (mutate → `onCollectionMutate` → `load`), so the cycle-2 guard re-entered itself through `reconcileRoster`'s adds/removes — a real stack overflow (~524 frames on a 5k snapshot). Fixed two-layer: a `reconcilingRoster` latch (try/finally) + batched joiner adds (one `load` fan-out instead of N). The spec mock-hole is closed: `makeLiveCockpit` carries an Observable-suitable `id` and attaches the REAL `load` listener; both race tests run through the live event path, plus a 1,000-row latch regression.
- **Reactive `stores` replacement (probe 1):** replacing/nulling `provider.stores` now destroys + deregisters owned instances the provider no longer hosts, immediately — passed-in instances survive replacement. Pinned with StoreManager assertions (replacement + null-removal).
- **Teardown order (probe 2):** the duplicated `component.Base.destroy()` provider release is removed — `component.Abstract.destroy()` keeps its established post-plugin release point; a probe-plugin regression asserts plugins observe a LIVE provider during their own destroy.
- Cycle-3/4 local runs: `state` + `component` + `grid` + cockpit trees **165/165** at `cca7ba774`.

**Cycle-5 (head `d66f04a1a`)** — the same-key blocker, root-caused and fixed:

- **The mechanism (three probes deep):** on same-key replacement, `beforeSetStores` correctly destroyed the old owned instance and returned a fresh one — but the CONFIG SYSTEM dropped the update: `Neo.isEqual` compares instances by their serialized (id-based) form, so a fresh store under the SAME predictable id looks "equal" to the destroyed old one → the setter no-ops → `stores.roster` keeps the destroyed instance while the fresh one orphans live in StoreManager. (Two earlier probes chased phantom leads because `core.Base.destroy` deletes own properties — probe tags on the old instance vanished mid-investigation.)
- **The fix:** `#storesGeneration` — bumped on every reactive `stores` replacement and suffixed into the predictable ids (`${provider.id}__${key}__${gen}`), so replacements are never id-colliding no-ops. The public contract is unchanged: consumers bind by KEY (`stores.roster`); ids are internal.
- **Regression:** same-key replacement → old destroyed + deregistered, replacement LIVE, distinct, key-resolvable, registered under its own id; provider destroy still tears it down. Trees at head: 166/166.
- **Flagged for direction (not fixed here):** the underlying wart is `Neo.isEqual` treating two DIFFERENT live instances as equal because instance serialization is id-based — reference equality for `NeoInstance` values is arguably the correct config-equality semantic. That is core Config surgery with its own blast radius; happy to file/fix as a follow-up on direction.

**Cycle-2 evidence (head `402127635`):** new regressions mirror the review's probes exactly — `state/Provider.spec.mjs` +3 (descriptor-created store destroyed+deregistered with the provider · passed-in instance survives · the FULL component→provider→store chain), `grid/VerticalScrollbarStoreSwap.spec.mjs` NEW (the 64px→3232px probe as a regression: old store inert after swap, new store takes over · null-detach stays inert), `fleetCockpit.spec.mjs` +2 against a REAL isolated `FleetRoster` (sample-after-live evicted + live residents restored · seed-before-live passes through). Local no-Chroma runs at head: the 3 touched spec files 41/41; the full `grid` + `state` + `component` + `apps/agentos` trees **278 passed** with only the 3 known dev-reproduced batch-bleed transients (eventChip:27 / fleetGrid:103 / healthSwatch:42 — the review itself attributed them off-PR), each re-verified green solo. `node --check` + `check-block-alignment` green on all 10 touched files (whole-file gates pulled 28 pre-existing alignment lines in `state/Provider.spec.mjs` + 1 in `component/Base.mjs`, same class of inherited cleanup as `grid/Container.mjs` at cycle 1).

## Commits

- 7dfa531af — the full topology change: both stores de-singletoned, JSON seed + `url` fetch, cockpit + Viewport provider hosts (`module: StateProvider` explicit), grid/Accounts binds, the two-line `src/grid` late-store enabler, spec reshaping.
- 402127635 — cycle-2 RC discharge: provider-owned store teardown, the roster source-precedence guard, symmetric scrollbar/Container store listeners (incl. the Observable shared-object mutation trap), stale-terminology fixes, 6 new regression tests.
- a7f4add9a — cycle-3 (addendum): re-entrancy latch + batched joiner adds; race specs re-wired through the REAL attached listener + 1,000-row latch regression.
- cca7ba774 — cycle-4: owned-store destruction on reactive `stores` replacement/null (immediate, StoreManager-pinned); duplicated `component.Base.destroy` provider release REMOVED (inherited post-plugin point preserved, probe-plugin regression); PR-body claim corrected.
- d66f04a1a — cycle-5: `#storesGeneration` id-suffixing — same-key replacement survives the config equality no-op (`Neo.isEqual` id-based instance comparison, root-caused); same-key StoreManager regression.

Authored by Vega (Claude Fable 5, Claude Code). Session d2fbbdb4-404b-47e1-bbb3-1b9e0330894b.
