### PR TITLE
fix(tests): cross-file spec bleed - restore neoConfig overrides + scope AgentOS mock (#14917)

### DIFF
--- a/test/playwright/setup.mjs
+++ b/test/playwright/setup.mjs
@@ -29,6 +29,14 @@ globalThis.DOMRect = class DOMRect {
 // VDOM unit tests without a browser or jsdom.
 
 /**
+ * The pre-override values of the LAST `setup()` call's `neoConfig` keys — restored on the next
+ * call so one spec file's overrides never leak into a later file in the same worker process.
+ * `undefined` records a key that did not exist (restored via delete).
+ * @type {Object|null}
+ */
+let priorNeoConfigOverrides = null;
+
+/**
  * Configures the single-threaded Playwright unit-test runtime with the minimal
  * Neo globals required by App Worker and VDom Worker classes.
  * @param {Object} options={}
@@ -50,6 +58,26 @@ export function setup(options = {}) {
         unitTestMode: true,
         windowId    : 1
     };
+
+    // Cross-file isolation in the single shared worker: restore whatever the PREVIOUS spec file's
+    // `neoConfig` overrides replaced BEFORE applying this file's. Without this, a non-default key
+    // (e.g. `useDomApiRenderer: true`) set by one file leaks into every later file in the process —
+    // order-dependent bleed the victims cannot defend against, since `Object.assign` below only
+    // re-asserts the three default keys.
+    if (priorNeoConfigOverrides) {
+        Object.entries(priorNeoConfigOverrides).forEach(([key, value]) => {
+            if (value === undefined) {
+                delete Neo.config[key]
+            } else {
+                Neo.config[key] = value
+            }
+        })
+    }
+
+    priorNeoConfigOverrides = {};
+    Object.keys(neoConfig).forEach(key => {
+        priorNeoConfigOverrides[key] = Neo.config[key]
+    });
 
     Object.assign(Neo.config, defaultNeoConfig);
     Object.assign(Neo.config, neoConfig);

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -30,7 +30,10 @@ import Instance       from '../../../../../../../src/manager/Instance.mjs';
 test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', () => {
     let FleetCockpit;
 
-    const clearBridge = () => { delete globalThis.AgentOS };
+    // scope the mock to the `fleet` subkey ONLY: `globalThis.AgentOS` is the app's Neo NAMESPACE
+    // root — replacing or deleting it wipes every `AgentOS.*` class registration for all later
+    // spec files in the shared worker (order-dependent cross-file bleed).
+    const clearBridge = () => { delete globalThis.AgentOS?.fleet };
 
     // a spy stream: `loadActivity` either assigns `adapterState` directly (stale) or calls `set({...})`
     // (live); both land on the same object so the resulting state is assertable.
@@ -41,7 +44,7 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
      * @returns {Promise<Object>} the spy stream after loadActivity routed to it.
      */
     const routeLoadActivity = async bridge => {
-        bridge ? (globalThis.AgentOS = {fleet: {registryBridge: bridge}}) : clearBridge();
+        bridge ? ((globalThis.AgentOS ??= {}).fleet = {registryBridge: bridge}) : clearBridge();
 
         const stream  = makeStream(),
               cockpit = {getReference: reference => reference === 'activity-stream' ? stream : null};
@@ -108,7 +111,10 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
 test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
     let FleetAgent, FleetCockpit, FleetRoster;
 
-    const clearBridge = () => { delete globalThis.AgentOS };
+    // scope the mock to the `fleet` subkey ONLY: `globalThis.AgentOS` is the app's Neo NAMESPACE
+    // root — replacing or deleting it wipes every `AgentOS.*` class registration for all later
+    // spec files in the shared worker (order-dependent cross-file bleed).
+    const clearBridge = () => { delete globalThis.AgentOS?.fleet };
 
     // a spy store + grid: `loadRoster` clears/adds on the first snapshot, reconciles after (upsert +
     // remove-absent), flips adapterState. `items` feeds the reconciliation's absence sweep.
@@ -135,7 +141,7 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
     });
 
     const routeLoadRoster = async (bridge, {known, items, rosterWired} = {}) => {
-        bridge ? (globalThis.AgentOS = {fleet: {registryBridge: bridge}}) : clearBridge();
+        bridge ? ((globalThis.AgentOS ??= {}).fleet = {registryBridge: bridge}) : clearBridge();
 
         const grid    = makeGrid(known, items),
               cockpit = makeCockpit(grid, rosterWired);
@@ -300,7 +306,7 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
         // enumerates the rendered cards — the collapsed-idle fold is filtered by ntype — and dispatches a
         // start intent + each card's roster record to the adapter. No bridge → each card takes an honest
         // `unauthorized` controlReason onto its record, never an optimistic fleet-wide success.
-        delete globalThis.AgentOS;
+        delete globalThis.AgentOS?.fleet;
 
         const mkCard = agentId => {
             const writes = [],
@@ -326,7 +332,7 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
         // A card fires intent-only; the cockpit resolves the firing card from the event `source` and
         // hands it + the card's roster record to the adapter. With no registry bridge the adapter fails
         // closed — an `unauthorized` controlReason lands on the record, never an optimistic success.
-        delete globalThis.AgentOS;
+        delete globalThis.AgentOS?.fleet;
 
         const writes  = [],
               record  = {agentId: 'vega', set(values) { writes.push(values) }},


### PR DESCRIPTION
Resolves #14917

Two distinct cross-file leak sources root-caused by pair-bisection and fixed at their mechanisms — no reordering, no `.serial`, no retries, no loosened assertions:

1. **`test/playwright/setup.mjs` merged but never restored `neoConfig` overrides.** `setup()` re-asserted only its three default keys, so a non-default key set by one spec file (`fleetGrid.spec`'s `useDomApiRenderer: true` + `allowVdomUpdatesInTests: true`) persisted in the shared worker's `Neo.config` for every later file — `healthSwatch.spec`'s vdom-shape assertions died under a renderer it never asked for. Fix: `setup()` now records the pre-override values of each call's `neoConfig` keys and restores them on the next call — every file starts from the baseline, order-independent by construction.
2. **`fleetCockpit.spec` replaced/deleted the `AgentOS` namespace ROOT to mock its bridge.** `globalThis.AgentOS = {fleet: …}` / `delete globalThis.AgentOS` wiped every `Neo.setupClass` registration under `AgentOS.*` — and since ES module cache never re-executes imports, `fleetGrid.spec`'s `AgentOS.view.fleet.HealthBar` className resolution failed for the rest of the process (`Class … does not exist` at `Neo.mjs:312`). Fix: the mock now touches ONLY the `fleet` subkey (`(globalThis.AgentOS ??= {}).fleet = …` / `delete globalThis.AgentOS?.fleet`), preserving class registrations.

Poisoning interactions, named per the AC: `fleetGrid.spec` → `healthSwatch.spec:42` (leaked renderer config), `fleetCockpit.spec` → `fleetGrid.spec:103` (wiped namespace). The eventChip/fleetGrid failures observed in larger batches were the same two mechanisms at different orderings.

Evidence: L1 (deterministic unit-run matrix below; the leak class is fully reproducible and fully covered in-process) → L1 required (test-reliability ACs). Residual: none.

## Deltas from ticket

- The ticket allowed a generic `setup.mjs`-level fix "if the root cause is generic" — it was (leak source #1), and the minimal general mechanism (restore-previous-overrides) shipped instead of per-file pinning, healing current AND future spec files.
- A second, independent leak source (#2, the namespace wipe) surfaced during bisection and is fixed in the same PR — same defect class, same acceptance matrix, splitting it would leave the dir red.

## Test Evidence

- Minimal reproducers before the fix: `fleetGrid + healthSwatch` → 1 failed; `fleetCockpit + fleetGrid` → 1 failed (`Class AgentOS.view.fleet.HealthBar does not exist`).
- After: original failing trio → **19 passed**; full `test/playwright/unit/apps/agentos/view/fleet` dir `--workers=1` → **74 passed × 3 consecutive runs**; the 3-dir batch (`ai/services/fleet` + `ai/graph` + the fleet app dir) → **263 passed, 0 failed** (this exact batch failed 3 specs on dev before the fix).
- Ops note surfaced while running the matrix: rapid consecutive runs can hit the known port-18180 stale-webServer race (pre-existing, out of scope, worked around with a port clear between runs).

## Post-Merge Validation

- [ ] CI unit shards stay green across the next several PRs (the bleed was order-dependent; shard-boundary shifts were the latent risk)

## Commits

- bcb477c53 — both leak-source fixes: `setup.mjs` override restore + `fleetCockpit.spec` namespace-scoped mock.

Related: #14637 / #14594 / #14599 (the victim specs' origin tickets) · PR #14910 review thread (where the two datums were empirically attributed on dev).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b956ba53-01ed-4ea6-a1e5-62969f887bc3.
