### PR TITLE
docs(agentos): ADR 0034 — Electron shell architecture (#14786)

### DIFF
--- a/learn/agentos/decisions/0031-target-architecture-composition.md
+++ b/learn/agentos/decisions/0031-target-architecture-composition.md
@@ -68,6 +68,7 @@ decision owns; *Parent* = the composition record that already aggregates it, whe
 | 0031 | Organism | **This record**: composition seams + trajectory invariants + the staleness guard | — |
 | 0032 | Body ↔ Brain seam | Institution-Cockpit render-model (object-permanent selves + COP; identity anti-lock-in contract) | extends 0020 |
 | 0033 | Brain / graph | Direction contract: deterministic evolution-direction keys + per-direction `{v,s,r}` velocity + the fail-open additive boundary | amends 0024/0028 |
+| 0034 | Body ↔ Brain seam | Electron shell architecture (process model, SharedWorker window topology, security posture, distribution) | extends 0020 |
 
 ## §3 Trajectory Invariants
 

--- a/learn/agentos/decisions/0034-electron-shell-architecture.md
+++ b/learn/agentos/decisions/0034-electron-shell-architecture.md
@@ -1,0 +1,250 @@
+# ADR 0034: Electron Shell Architecture — Process Model, Window Topology, Security Posture, Distribution
+
+> Architectural Decision Record settling the six load-bearing questions every Electron-shell leaf
+> inherits (epic #13377): how the main process hosts the Brain, under which constraints Chromium
+> shares Neo's one SharedWorker heap across OS windows (verified empirically, not asserted), the
+> renderer security stance, the dock/OS-window fusion mapping, the distribution channel, and
+> dev/prod parity. Everything here is **additive on ADR 0020 §3** (the shell decision itself —
+> Electron, decided) and consumes the landed window-manager substrate as boundaries — it reopens
+> nothing.
+
+| Attribute | Value |
+|---|---|
+| **Status** | Proposed — 2026-07-10 (#14786; pending human merge gate per ADR-0005 lifecycle). |
+| **Author** | @neo-opus-vega (Vega, Claude Fable 5, Claude Code) — #13377 epic steward. |
+| **Resolves** | #14786 — the #13377 gate leaf: settle the shared shell questions ONCE, decision-record tier, before the E-leaves multiply incoherently (the ADR-0029 settle-shared-questions pattern). |
+| **Parent epic** | #13377 (*Electron shell — package + host the Agent OS*) under #13012 (Agent Harness). |
+| **Depends on** | **ADR 0020** (the embodiment vessel — extended, never superseded; §3 fixes the shell decision, the in-process target + child-process fallback, source-tree discipline, and PATs-Brain-side); **ADR 0029** (docking design — its §2.1 state-class table and window-manager boundaries are consumed, not reopened). |
+| **Connects to** | #13033 (build-root spike leaf, owner @neo-opus-ada — carries the *hosting-topology* spike; §2.1 frames it, never pre-empts it) · #13025 / #13028 (landed window-manager leaves, consumed as boundaries) · #13446 (NL window ops — gains an Electron backend per §2.4) · #14230 (fork-path onboarding — stays the contributor door per §2.5) · Discussion #10119 (Neural Link thesis). |
+| **Empirical anchor** | Spike branch `spike/14786-electron-sharedworker` @ `8bf8a915d` — the §2.2 SharedWorker constraint matrix (Electron v43.1.0, macOS, 2026-07-10). Reproduce: `cd spikes/14786-electron-sharedworker && npm install && npm start`. |
+| **Implemented by** | the §5 decomposition — one Contract-Ledgered leaf per row, mapped on the #13377 epic; each cites its section here as upstream contract. |
+| **Anti-anchor for** | **file:// harness loading** (falsified: kills the shared heap, §2.2); **a second window manager** (Electron materializes, `Neo.manager.Window` owns choreography); **serialize-and-recreate across BrowserWindows** (components exist once in the SharedWorker heap — ADR 0029); **a Brain-daemon fork** (one lifecycle owner, §2.1); **per-window session partitions** (§2.2); **credentials in the renderer** (PATs never transit the browser — ADR 0020 §3). |
+
+---
+
+## 1. Context
+
+ADR 0020 §3 decided the shell (operator, 2026-06-12): **Electron — always Chromium + always
+Node.js**, Tauri retired, Agent OS **in-process in the Electron main as target** with
+**child-process supervision as the sanctioned fallback**, and web-served mode staying the dev
+convenience. The #13377 epic added the decisive boundary (operator correction, 2026-06-15):
+**Electron is the shell only — it does not own the additional windows.** Multi-window remains
+Chromium popups managed by `Neo.manager.Window` (browser-native → Electron-agnostic → the web
+version stays alive).
+
+What no record settles is everything a *packaged* shell adds on top of those two anchors: the exact
+constraints under which Chromium shares one SharedWorker across OS windows (Neo's whole
+architecture rides this — asserted often, verified never), the renderer security flags, how
+`window.open` popups materialize, what artifact a stranger downloads, and how the packaged boot
+path stays identical to `npm run dev`. Six questions, named by #14786; made implicitly per-leaf,
+they diverge — the access-ban lesson (disconnected surfaces, no coherent shell) repeats at the OS
+level. This record settles them once.
+
+## 2. Decision
+
+### §2.1 Process model — the Brain rides in the shell, one lifecycle owner (Q1)
+
+**Settled frame (carrying ADR 0020 §3, not re-deciding it):** the packaged app boots the whole
+organism — the Electron main process *hosts* the Agent OS (orchestrator + MCP servers) in-process
+as the target topology, or *supervises it as a child process* as the sanctioned fallback. Which arm
+wins is **#13033's spike outcome and stays that leaf's property**; this ADR binds what is true in
+EITHER arm:
+
+1. **One lifecycle owner.** The main process is the single authority for Brain start/stop/restart —
+   whether that means in-process module lifecycles or child-process supervision. No second
+   supervisor, no daemon fork: a packaged install and an externally-run daemon topology never
+   manage the same Brain state concurrently. Attach-to-external stays a **dev-mode** capability
+   (§2.6), never a packaged-app default.
+2. **Restart affordances settle-or-reject.** Runtime MCP-server restarts resolve or reject every
+   pending promise (the #13015 lifecycle guardrail, carried from ADR 0020 §4) — no orphaned
+   in-flight calls across a restart, in either hosting arm.
+3. **Data-root resolution moves to the app tier.** The Memory Core owns SQLite/Chroma paths under
+   `.neo-ai-data/`; a packaged app resolves that root against the OS user-data directory
+   (`app.getPath('userData')`), a repo checkout resolves it repo-relative. The resolution seam is
+   ONE injectable path — Brain services never hardcode either root.
+4. **Port discipline.** Brain-side listeners (NL WebSocket, MCP HTTP, the fleet dev transport) bind
+   loopback-only in the packaged app (§2.3) with ports chosen/managed by the lifecycle owner, so
+   two installs (or install + dev repo) fail loudly at boot instead of silently cross-talking.
+
+**Falsifier:** if #13033's spike shows in-process hosting cannot satisfy settle-or-reject restarts
+(e.g. MCP server state cannot be torn down cleanly in-process), the child-process arm becomes the
+recorded topology — this section's four bindings survive unchanged; only the arm flips.
+
+### §2.2 Window topology — the SharedWorker constraint set, verified (Q2)
+
+The one-heap multi-window architecture survives inside Electron **only under specific, now-named
+constraints** — established empirically (spike branch `spike/14786-electron-sharedworker`
+@ `8bf8a915d`, Electron v43.1.0; method + raw matrix in its README):
+
+| Constraint | Empirical basis |
+|---|---|
+| **C1 — Real origin required.** The harness MUST be served from a standard-scheme origin: a custom privileged scheme (`app://` via `protocol.registerSchemesAsPrivileged([{scheme, privileges: {standard: true, secure: true}}])` + `protocol.handle`) or localhost HTTP. **`file://` loading silently isolates every window's SharedWorker** — the app renders, boots, and has no shared heap. | `file2win`/`filepopup` = ISOLATED; `app2win`/`http2win` = SHARED |
+| **C2 — One session partition.** SharedWorker scope is partition-bound; every harness window lives in the default (or one named) partition. Per-window partitions sever the heap. | `partition` control = no cross-partition join |
+| **C3 — The popup path is preserved.** `window.open()` from a renderer — the `Neo.manager.Window` pattern — joins the same heap when the shell allows it via `setWindowOpenHandler({action: 'allow', overrideBrowserWindowOptions})`. The popup materializes as an Electron-managed `BrowserWindow`; the same-origin `window.opener` relationship survives. | `apppopup`/`httppopup` = SHARED |
+| **C4 — Secure defaults cost nothing.** All of the above holds under `contextIsolation: true`, sandbox on, `nodeIntegration: false` — worker topology and the §2.3 security posture are decoupled. | entire matrix ran on default secure flags |
+| **C5 — Worker identity is `(origin, URL)`.** The packaged origin must be *stable* across windows and app restarts (one canonical `app://` host + path scheme), or windows resolve different worker identities. | phase-scoped worker URLs isolate by construction |
+
+**The seam, restated under the shell-only boundary:** `Neo.manager.Window` keeps the God-View —
+placement intent, `getWindowAt(x, y)`, drag choreography, popup lifecycles (`#8164`→`#9498`
+lineage). Electron's contribution is exactly two enhancement classes: **materialization** (the
+`setWindowOpenHandler` path turning `window.open` into a real `BrowserWindow` without the browser
+popup-blocker ceremony) and **OS chrome control** (exact spawn-at-position, move events, frame
+options — the enhancement points #13025/#13028/#13030 named and #13446's NL window ops consume).
+The shell never grows placement policy, z-order arbitration, or window state of its own.
+
+**Decision within C1:** the packaged app serves the built harness over a **custom privileged
+scheme** (working name `app://`), not a localhost HTTP server — no port to collide, no firewall
+prompt, no other-local-process access to the harness origin, and offline-clean. Localhost HTTP
+remains the dev-mode origin (§2.6); the spike proves both share identically, so the choice is
+operational, not architectural.
+
+**Falsifier:** a future Electron major changing SharedWorker scoping (e.g. site-isolation changes
+re-keying workers) — the spike is the regression harness; §5 binds re-running it on every Electron
+major bump.
+
+### §2.3 Security posture — isolated renderers, loopback Brain, credentials never cross (Q3)
+
+1. **Renderer flags:** `contextIsolation: true`, sandbox **on**, `nodeIntegration: false` for every
+   window — including popups (enforced centrally in the `setWindowOpenHandler` override). §2.2 C4
+   proves this costs the architecture nothing; there is no worker-topology excuse for weakening it.
+2. **Preload surface:** one minimal `contextBridge` API, capability-shaped and allowlisted —
+   the renderer gets named shell affordances (window placement enhancement, lifecycle intents),
+   never `ipcRenderer` raw, never Node. The existing Brain-side pattern is the model: the
+   `FleetControlBridge` allowlist choke-point (`FLEET_WIRE_METHODS`) already demonstrates
+   capability-allowlist discipline for exactly this class of boundary.
+3. **Brain endpoints bind loopback TCP** (`127.0.0.1`), never `0.0.0.0`, never unix sockets —
+   renderer `WebSocket`/`fetch` cannot reach unix sockets, and the NL/MCP endpoints must stay
+   reachable from the harness renderer and local tooling alike. When the Brain rides in-app
+   (§2.1), endpoints additionally carry a **per-boot bearer token** injected into the harness via
+   the preload (never persisted to renderer-readable storage): loopback alone does not
+   authenticate against other local processes.
+4. **Credentials (PATs) stay Brain-side** (ADR 0020 §3, re-bound here): they never transit the
+   renderer, never appear in preload-exposed state, never echo through bridge responses. The
+   Add-Peer curated-intent boundary (Body submits `{harnessType, id, repo/account facts}` only —
+   never command/args/env) is the shipped precedent this posture generalizes.
+
+**Falsifier:** any leaf needing a renderer capability the preload cannot express through a named,
+allowlisted intent amends THIS section first (ADR-0005 lifecycle) — it never flips a window to
+`nodeIntegration: true` as a leaf-local decision.
+
+### §2.4 Dock/OS-window fusion — same semantics, richer vessel (Q4)
+
+`detachItem` → OS window today spawns a browser popup; **inside the shell it stays exactly that
+call** — `window.open` through `Neo.manager.Window` — materialized by Electron per §2.2 C3 as a
+real `BrowserWindow`. The mapping, named:
+
+| Layer | Owner | In the shell |
+|---|---|---|
+| Detach semantics (`detachItem`, catalog membership, placement hints) | `dockZone.v1` + ADR 0029 §2.1 | unchanged — worker-owned shared truth |
+| Popup lifecycle + God-View | `Neo.manager.Window` | unchanged — same API, same events |
+| Materialization | browser popup ceremony | `setWindowOpenHandler` → `BrowserWindow` (no popup blocker, no chrome-strip ceremony) |
+| OS affordances | unavailable | exact spawn-at-position, native move/resize events, frame control — consumed via the #13446 NL window-op backend and `main.addon.WindowPosition` enhancement points |
+
+The **embodiment vessel contract (ADR 0020) is extended, never superseded**: a docked pane
+detaches into a real OS window and returns as the same live heap object (ADR 0029's
+no-serialize-and-recreate anti-anchor re-bound here). What changes in the shell is vessel
+*quality* — frameless windows, precise placement, native drag events — never vessel *semantics*.
+
+**Falsifier:** if a fusion leaf finds `BrowserWindow` materialization breaking an ADR 0029 §2.1
+state-class boundary (e.g. render-projection state needing main-process persistence), that leaf
+amends ADR 0029 and this section together, before implementation.
+
+### §2.5 Distribution — signed installers for strangers, the repo for contributors (Q5)
+
+1. **Artifact:** platform-native installers — macOS `dmg` (signed + notarized), Windows `exe`
+   (signed), Linux `AppImage` — built by an electron-builder-class pipeline from the packaging
+   root (own `package.json`, wraps BUILT Body + Brain; ADR 0020 §3 source-tree discipline). "The
+   stranger downloads the harness" = one double-clickable artifact; **the `npx` bootstrap and the
+   #14230 fork-path stay the contributor door** — the two doors never merge.
+2. **Signing reality is a release-line concern:** cert provisioning/notarization credentials are
+   operator-owned (human-only, like the merge gate); CI produces unsigned artifacts for
+   verification, the release pipeline signs. No leaf embeds signing material in repo tooling.
+3. **Two-speed updates, decoupled by design:** the SHELL updates rarely (Electron/Chromium security
+   cadence — autoUpdater-class mechanism, its own channel); the ORGANISM (harness app + Brain)
+   ships with the shell version it was packaged with and updates by shipping a new package. No
+   self-mutating installed app in v1: partial in-place organism updates (pulling new Brain/Body
+   into an installed shell) are explicitly deferred — they reintroduce the drift matrix
+   (shell×organism version pairs) that packaged-together avoids, and nothing in H1 needs them.
+4. **Update cadence ≠ repo release cadence:** packaged releases cut from the release line
+   (`main`), on their own schedule, versioned independently of npm releases.
+
+**Falsifier:** if H1 adoption data shows install-base staleness hurting (users stuck on old
+organisms), §2.5.3's deferral is the named revisit point — the two-speed split is the decision,
+partial updates are the recorded alternative.
+
+### §2.6 Dev/prod parity — one harness root, two origins, identical topology (Q6)
+
+1. **One boot path:** `npm run dev` (webpack-serve, localhost HTTP) and the packaged app
+   (`app://`, §2.2) load the **same built harness app root** — #13033's build-root is the
+   substrate; this section binds it. No packaged-only entry file, no dev-only worker wiring:
+   `neo-config` + worker URLs resolve identically relative to either origin.
+2. **Parity is achievable BECAUSE of C1:** both origins are standard-scheme; the worker topology
+   (App/VDom/Data/Canvas on one SharedWorker heap) is byte-identical dev↔packaged. The spike's
+   http/app rows agreeing is the empirical parity floor.
+3. **Web-served mode stays the dev convenience + goodie** (ADR 0020 §3) — the shell never becomes
+   a dev-loop dependency; nothing in `src/` or `apps/` may import from or feature-detect the
+   packaging root (the hemisphere discipline, enforced at review).
+4. **Brain parity:** dev attaches to externally-run daemons (today's topology); packaged hosts per
+   §2.1. The seam that makes both true is §2.1.3's injectable data-root + §2.1.4's managed ports —
+   the SAME Brain code, two lifecycle owners, never both at once.
+
+**Falsifier:** any leaf introducing a `process.versions.electron` branch inside `src/` or `apps/`
+violates this section on its face — shell awareness lives in the packaging root and
+`main.addon.*` enhancement points only.
+
+## 3. Consequences
+
+- Every #13377 E-leaf cites its §2 section as upstream contract; changing a §2 decision amends
+  this ADR first (ADR-0005 lifecycle), never lands leaf-local.
+- #13033 implements against §2.1/§2.6 and records the hosting-arm outcome; its spike scope is
+  unchanged by this record.
+- The `app://` scheme handler, the `setWindowOpenHandler` materialization path, and the preload
+  contract each become one leaf (§5).
+- The spike branch is a permanent regression harness: **every Electron major bump re-runs it**
+  before adoption (§2.2 falsifier).
+- Web portability is structurally guaranteed: because the shell only materializes and decorates,
+  removing it leaves a working web app — the boundary that keeps the future web version alive.
+
+## 4. Prior art & rejected shapes
+
+- **Tauri / WebKitGTK** — retired at ADR 0020 (worker-topology determinism + Node-in-process beat
+  binary-size aesthetics).
+- **Electron owning the windows** — rejected (operator, 2026-06-15); would fork window management
+  into a web arm and a shell arm and kill web portability.
+- **`file://` + `loadFile()` packaging** — the naive Electron default, **empirically falsified**
+  (§2.2 C1): boots, renders, silently loses the shared heap.
+- **Localhost HTTP as the packaged origin** — works (spike), rejected operationally: port
+  collisions, firewall prompts, and any local process gaining harness-origin access for free.
+- **Unix sockets for Brain endpoints** — unreachable from renderer WebSocket/fetch; loopback TCP
+  + per-boot token instead (§2.3.3).
+- **Serialize-and-recreate popout state** — rejected at ADR 0029; re-bound here because Electron
+  makes it *tempting* (BrowserWindows feel ownable from main).
+
+## 5. Decomposition — the E-leaf gate (map lives on the #13377 epic)
+
+| Leaf | Scope | Upstream contract |
+|---|---|---|
+| E1 — build root (#13033, exists) | packaging root, main entry, hosting-arm spike, boot | §2.1, §2.6 |
+| E2 — origin + scheme server | `app://` privileged scheme, `protocol.handle` over the built root, stable origin | §2.2 C1/C5, §2.6 |
+| E3 — window materialization bridge | `setWindowOpenHandler` path, secure-flag enforcement on popups, OS-chrome enhancement points, #13446 NL backend | §2.2 C3, §2.3.1, §2.4 |
+| E4 — Brain lifecycle service | start/stop/restart with settle-or-reject, port management, data-root injection | §2.1 |
+| E5 — preload capability contract | the one `contextBridge` surface + allowlist | §2.3.2 |
+| E6 — packaging + signing pipeline | electron-builder config, per-platform artifacts, unsigned-CI/signed-release split | §2.5 |
+| E7 — update channel | shell autoUpdater wiring, two-speed policy | §2.5.3 |
+
+Leaves E2–E7 are filed on demand under #13377 (epic bodies never enumerate subs — ADR 0020 §6);
+each carries its own Contract Ledger and cites this table row.
+
+## 6. Verification
+
+- **Empirical:** spike branch `spike/14786-electron-sharedworker` @ `8bf8a915d` — 7-phase
+  SharedWorker matrix (two-window + popup paths × file/app/http origins + partition control),
+  Electron v43.1.0, default secure flags, results in its README. Re-run on Electron major bumps.
+- **Authority chain:** ADR 0020 §3 (shell decision, hosting arms, source discipline, PATs) ·
+  #13377 epic body (shell-only boundary, operator 2026-06-15) · ADR 0029 §2.1 (state classes,
+  window-manager boundaries) — all consumed, none reopened.
+- **AC mapping (#14786):** six questions → §2.1–§2.6, each with named constraints + falsifiers;
+  anti-anchor section = the attribute-table row (all three ticket-named minimums present:
+  no serialize-and-recreate, no second window manager, no Brain-daemon fork);
+  SharedWorker constraint set verified in the spike branch, not asserted; epic body update to cite
+  this ADR follows on the resolving PR.

--- a/learn/agentos/decisions/0034-electron-shell-architecture.md
+++ b/learn/agentos/decisions/0034-electron-shell-architecture.md
@@ -1,12 +1,12 @@
 # ADR 0034: Electron Shell Architecture — Process Model, Window Topology, Security Posture, Distribution
 
 > Architectural Decision Record settling the six load-bearing questions every Electron-shell leaf
-> inherits (epic #13377): how the main process hosts the Brain, under which constraints Chromium
-> shares Neo's one SharedWorker heap across OS windows (verified empirically, not asserted), the
-> renderer security stance, the dock/OS-window fusion mapping, the distribution channel, and
-> dev/prod parity. Everything here is **additive on ADR 0020 §3** (the shell decision itself —
-> Electron, decided) and consumes the landed window-manager substrate as boundaries — it reopens
-> nothing.
+> inherits (epic #13377): how the main process hosts the Brain and what its window/app lifecycle
+> means for the organism, under which constraints Chromium shares Neo's SharedWorkers across OS
+> windows (verified empirically, not asserted), the fail-closed renderer security contract, the
+> dock/OS-window fusion mapping, the distribution channel, and dev/prod parity. Everything here is
+> **additive on ADR 0020 §3** (the shell decision itself — Electron, decided) and consumes the
+> landed window-manager substrate as boundaries — it reopens nothing.
 
 | Attribute | Value |
 |---|---|
@@ -14,11 +14,11 @@
 | **Author** | @neo-opus-vega (Vega, Claude Fable 5, Claude Code) — #13377 epic steward. |
 | **Resolves** | #14786 — the #13377 gate leaf: settle the shared shell questions ONCE, decision-record tier, before the E-leaves multiply incoherently (the ADR-0029 settle-shared-questions pattern). |
 | **Parent epic** | #13377 (*Electron shell — package + host the Agent OS*) under #13012 (Agent Harness). |
-| **Depends on** | **ADR 0020** (the embodiment vessel — extended, never superseded; §3 fixes the shell decision, the in-process target + child-process fallback, source-tree discipline, and PATs-Brain-side); **ADR 0029** (docking design — its §2.1 state-class table and window-manager boundaries are consumed, not reopened). |
-| **Connects to** | #13033 (build-root spike leaf, owner @neo-opus-ada — carries the *hosting-topology* spike; §2.1 frames it, never pre-empts it) · #13025 / #13028 (landed window-manager leaves, consumed as boundaries) · #13446 (NL window ops — gains an Electron backend per §2.4) · #14230 (fork-path onboarding — stays the contributor door per §2.5) · Discussion #10119 (Neural Link thesis). |
-| **Empirical anchor** | Spike branch `spike/14786-electron-sharedworker` @ `8bf8a915d` — the §2.2 SharedWorker constraint matrix (Electron v43.1.0, macOS, 2026-07-10). Reproduce: `cd spikes/14786-electron-sharedworker && npm install && npm start`. |
+| **Depends on** | **ADR 0020** (the embodiment vessel — extended, never superseded; §3 fixes the shell decision, the in-process target + child-process fallback, source-tree discipline, and PATs-Brain-side); **ADR 0029** (docking design — its §2.1 state-class table, window-manager boundaries, and semantic-restore rules are consumed, not reopened). |
+| **Connects to** | #13033 (build-root leaf, owner @neo-opus-ada — its live Contract Ledger is consumed AS-IS; §5 maps the refinement leaves that follow it) · #13025 / #13028 (landed window-manager leaves, consumed as boundaries) · #13446 (NL window ops — gains an Electron backend per §2.4) · #14793 (native-shell UX spec — consumes §2.1's lifecycle decisions) · #14230 (fork-path onboarding — stays the contributor door per §2.5). |
+| **Empirical anchor** | In-tree spike `spikes/14786-electron-sharedworker/` (merged with this record): pinned Electron 43.1.0 · Chromium 150.0.7871.47 · Node 24.18.0 · darwin 25.5.0; raw committed run: `spike-results.json`. Reproduce: `npm install && npm start`. Re-run trigger: every Electron major bump BEFORE adoption; owner: the §5 E2 leaf owner. (The pre-review branch `spike/14786-electron-sharedworker` is superseded by the in-tree copy.) |
 | **Implemented by** | the §5 decomposition — one Contract-Ledgered leaf per row, mapped on the #13377 epic; each cites its section here as upstream contract. |
-| **Anti-anchor for** | **file:// harness loading** (falsified: kills the shared heap, §2.2); **a second window manager** (Electron materializes, `Neo.manager.Window` owns choreography); **serialize-and-recreate across BrowserWindows** (components exist once in the SharedWorker heap — ADR 0029); **a Brain-daemon fork** (one lifecycle owner, §2.1); **per-window session partitions** (§2.2); **credentials in the renderer** (PATs never transit the browser — ADR 0020 §3). |
+| **Anti-anchor for** | **file:// harness loading** (falsified: kills worker sharing, §2.2); **a second window manager** (Electron materializes, the Neo window substrate owns semantics); **serialize-and-recreate across BrowserWindows** (components exist once in the shared App-Worker heap — ADR 0029); **a Brain-daemon fork** (one lifecycle owner, §2.1); **per-window session partitions** (§2.2); **credential or token bytes in renderer-readable state** (§2.3); **auto-spawning OS windows on perspective restore** (ADR 0029's rule, re-bound §2.4). |
 
 ---
 
@@ -29,16 +29,16 @@ Node.js**, Tauri retired, Agent OS **in-process in the Electron main as target**
 **child-process supervision as the sanctioned fallback**, and web-served mode staying the dev
 convenience. The #13377 epic added the decisive boundary (operator correction, 2026-06-15):
 **Electron is the shell only — it does not own the additional windows.** Multi-window remains
-Chromium popups managed by `Neo.manager.Window` (browser-native → Electron-agnostic → the web
+Chromium popups on Neo's own window substrate (browser-native → Electron-agnostic → the web
 version stays alive).
 
 What no record settles is everything a *packaged* shell adds on top of those two anchors: the exact
-constraints under which Chromium shares one SharedWorker across OS windows (Neo's whole
-architecture rides this — asserted often, verified never), the renderer security flags, how
-`window.open` popups materialize, what artifact a stranger downloads, and how the packaged boot
-path stays identical to `npm run dev`. Six questions, named by #14786; made implicitly per-leaf,
-they diverge — the access-ban lesson (disconnected surfaces, no coherent shell) repeats at the OS
-level. This record settles them once.
+constraints under which Chromium shares Neo's SharedWorkers across OS windows (the whole
+architecture rides this — asserted often, verified never), what last-window-close means when the
+shell hosts the Brain, the renderer security contract, how `window.open` popups materialize, what
+artifact a stranger downloads, and how the packaged boot path stays identical to `npm run dev`.
+Six questions, named by #14786; made implicitly per-leaf, they diverge — the access-ban lesson
+(disconnected surfaces, no coherent shell) repeats at the OS level. This record settles them once.
 
 ## 2. Decision
 
@@ -65,85 +65,117 @@ EITHER arm:
 4. **Port discipline.** Brain-side listeners (NL WebSocket, MCP HTTP, the fleet dev transport) bind
    loopback-only in the packaged app (§2.3) with ports chosen/managed by the lifecycle owner, so
    two installs (or install + dev repo) fail loudly at boot instead of silently cross-talking.
+5. **App lifecycle: the organism outlives its windows.** The shell suppresses Electron's default
+   quit-on-`window-all-closed` (the spike documents that default silently emptying a multi-window
+   app). Closing the last window leaves the Brain running with the tray as its handle; **Brain
+   teardown happens ONLY on explicit quit** (tray/app-menu). The cockpit window itself is hidden
+   on close, never destroyed while the app runs: SharedWorker lifetime is client-scoped, so
+   destroying the last window would kill the App-Worker heap (stores, undo state, live UI) while
+   the tray still claims the institution is running. The UX surface of these semantics (tray
+   triad, first-run, window defaults) is #14793's spec; the SEMANTICS are bound here.
 
 **Falsifier:** if #13033's spike shows in-process hosting cannot satisfy settle-or-reject restarts
 (e.g. MCP server state cannot be torn down cleanly in-process), the child-process arm becomes the
-recorded topology — this section's four bindings survive unchanged; only the arm flips.
+recorded topology — this section's five bindings survive unchanged; only the arm flips.
 
 ### §2.2 Window topology — the SharedWorker constraint set, verified (Q2)
 
-The one-heap multi-window architecture survives inside Electron **only under specific, now-named
-constraints** — established empirically (spike branch `spike/14786-electron-sharedworker`
-@ `8bf8a915d`, Electron v43.1.0; method + raw matrix in its README):
+Neo boots **separate SharedWorker identities per role** — App, VDom, Data, Canvas (as configured)
+— and same-origin windows share EACH of those identities. That per-worker sharing is what the
+multi-window architecture rides, and inside Electron it survives **only under specific, now-named
+constraints** — established empirically (in-tree spike `spikes/14786-electron-sharedworker/`,
+raw run committed as `spike-results.json`; method + full matrix in its README):
 
 | Constraint | Empirical basis |
 |---|---|
-| **C1 — Real origin required.** The harness MUST be served from a standard-scheme origin: a custom privileged scheme (`app://` via `protocol.registerSchemesAsPrivileged([{scheme, privileges: {standard: true, secure: true}}])` + `protocol.handle`) or localhost HTTP. **`file://` loading silently isolates every window's SharedWorker** — the app renders, boots, and has no shared heap. | `file2win`/`filepopup` = ISOLATED; `app2win`/`http2win` = SHARED |
-| **C2 — One session partition.** SharedWorker scope is partition-bound; every harness window lives in the default (or one named) partition. Per-window partitions sever the heap. | `partition` control = no cross-partition join |
-| **C3 — The popup path is preserved.** `window.open()` from a renderer — the `Neo.manager.Window` pattern — joins the same heap when the shell allows it via `setWindowOpenHandler({action: 'allow', overrideBrowserWindowOptions})`. The popup materializes as an Electron-managed `BrowserWindow`; the same-origin `window.opener` relationship survives. | `apppopup`/`httppopup` = SHARED |
+| **C1 — Real origin required, with the full privilege set.** The harness MUST be served from a standard-scheme origin: a custom privileged scheme (`app://` via `protocol.registerSchemesAsPrivileged([{scheme, privileges: {standard: true, secure: true, supportFetchAPI: true}}])` + `protocol.handle`) or localhost HTTP. **`supportFetchAPI: true` is normative** — `data.Store` `url` seeds and every fetch-consuming surface depend on it (the spike's working privilege set includes it; the fetch smoke consumes it). **`file://` loading silently isolates every window's workers** — the app renders, boots, and shares nothing. | `file2win`/`filepopup` = ISOLATED; `app2win`/`http2win` = SHARED; `fetchsmoke` = `fetchOk: true` |
+| **C2 — One session partition, positively verified.** SharedWorker scope is partition-bound: with origin, page URL, and preload held constant and ONLY the partition varied, the second window reports a FRESH worker (count 1) — on both sharing origins. Every harness window lives in the default (or one named) partition. | `partitionapp` + `partitionhttp` = both windows report (1, 1) |
+| **C3 — The popup path is preserved.** `window.open()` — issued on the main thread by `Neo.Main.windowOpen()` — joins the same workers when the shell allows it via `setWindowOpenHandler({action: 'allow', overrideBrowserWindowOptions})`. The popup materializes as an Electron-managed `BrowserWindow`; the same-origin `window.opener` relationship survives. | `apppopup`/`httppopup` = SHARED |
 | **C4 — Secure defaults cost nothing.** All of the above holds under `contextIsolation: true`, sandbox on, `nodeIntegration: false` — worker topology and the §2.3 security posture are decoupled. | entire matrix ran on default secure flags |
-| **C5 — Worker identity is `(origin, URL)`.** The packaged origin must be *stable* across windows and app restarts (one canonical `app://` host + path scheme), or windows resolve different worker identities. | phase-scoped worker URLs isolate by construction |
+| **C5 — Worker identity is `(origin, URL)` per worker.** The packaged origin must be *stable* across windows and app restarts (one canonical `app://` host + path scheme), or windows resolve different identities for the SAME worker role. | phase-scoped worker URLs isolate by construction |
+| **C6 — Protocol handlers are session-specific.** `protocol.handle` on the default session does not serve other partitions; a window in a `persist:` partition cannot even LOAD `app://` without its own registration. Operationally this reinforces C2: one partition, one registration. | the `partitionapp` control required `session.fromPartition(...).protocol.handle` before window B loaded at all |
 
-**The seam, restated under the shell-only boundary:** `Neo.manager.Window` keeps the God-View —
-placement intent, `getWindowAt(x, y)`, drag choreography, popup lifecycles (`#8164`→`#9498`
-lineage). Electron's contribution is exactly two enhancement classes: **materialization** (the
-`setWindowOpenHandler` path turning `window.open` into a real `BrowserWindow` without the browser
-popup-blocker ceremony) and **OS chrome control** (exact spawn-at-position, move events, frame
-options — the enhancement points #13025/#13028/#13030 named and #13446's NL window ops consume).
-The shell never grows placement policy, z-order arbitration, or window state of its own.
+**The seam, restated under the shell-only boundary — who owns what:**
 
-**Decision within C1:** the packaged app serves the built harness over a **custom privileged
-scheme** (working name `app://`), not a localhost HTTP server — no port to collide, no firewall
-prompt, no other-local-process access to the harness origin, and offline-clean. Localhost HTTP
-remains the dev-mode origin (§2.6); the spike proves both share identically, so the choice is
-operational, not architectural.
+| Concern | Owner (current source) | In the shell |
+|---|---|---|
+| Popup creation | `Neo.Main.windowOpen()` (main thread) owns the actual `window.open(url, name, features)` call; App-Worker code (e.g. `dashboard.Container.openWidgetInPopup()`) reaches it as a remote method | unchanged — the same call, materialized per C3 |
+| Window observation + choreography | `Neo.manager.Window` (App Worker) — connected-window registry, geometry, `getWindowAt(x, y)`, with `main.addon.WindowPosition` | unchanged — gains precision via the §2.4 enhancement points |
+| Detach semantics | `DockZoneModel.detachItem()` — catalog/tree state only | unchanged |
 
-**Falsifier:** a future Electron major changing SharedWorker scoping (e.g. site-isolation changes
-re-keying workers) — the spike is the regression harness; §5 binds re-running it on every Electron
-major bump.
+The shell's contribution is exactly two enhancement classes: **materialization** (the
+`setWindowOpenHandler` path turning the main-thread `window.open` into a real `BrowserWindow`
+without browser popup ceremony) and **OS chrome control** (exact spawn-at-position, native
+move/resize events, frame options — the enhancement points #13025/#13028/#13030 named and
+#13446's NL window ops consume). The shell never grows placement policy, z-order arbitration, or
+window state of its own.
 
-### §2.3 Security posture — isolated renderers, loopback Brain, credentials never cross (Q3)
+**Falsifier:** a future Electron major changing SharedWorker scoping or protocol/session semantics
+— the in-tree spike is the re-run gate (§6); the E2 leaf owner runs it on every major bump before
+adoption.
+
+### §2.3 Security posture — fail-closed everywhere, credentials never renderer-readable (Q3)
 
 1. **Renderer flags:** `contextIsolation: true`, sandbox **on**, `nodeIntegration: false` for every
    window — including popups (enforced centrally in the `setWindowOpenHandler` override). §2.2 C4
    proves this costs the architecture nothing; there is no worker-topology excuse for weakening it.
-2. **Preload surface:** one minimal `contextBridge` API, capability-shaped and allowlisted —
-   the renderer gets named shell affordances (window placement enhancement, lifecycle intents),
-   never `ipcRenderer` raw, never Node. The existing Brain-side pattern is the model: the
-   `FleetControlBridge` allowlist choke-point (`FLEET_WIRE_METHODS`) already demonstrates
-   capability-allowlist discipline for exactly this class of boundary.
-3. **Brain endpoints bind loopback TCP** (`127.0.0.1`), never `0.0.0.0`, never unix sockets —
+2. **Fail-closed window policy:** `setWindowOpenHandler` ALLOWS only same-origin harness URLs (an
+   explicit origin/path allowlist) and DENIES everything else; `will-navigate` denies any
+   off-origin navigation in every window. The allow path IS the C3 popup contract; everything else
+   fails closed.
+3. **Permissions and content:** a `setPermissionRequestHandler` that denies by default with a
+   named, minimal allowlist (empty until a leaf needs one — additions amend this section); a
+   restrictive CSP served by the `app://` handler for every document; no remote content inside
+   harness windows.
+4. **IPC discipline:** one minimal `contextBridge` preload exposing named, capability-shaped
+   affordances — never `ipcRenderer` raw, never Node. Main-process handlers validate
+   `event.senderFrame` origin against the packaged origin before acting. The Brain-side
+   `FleetControlBridge` allowlist choke-point (`FLEET_WIRE_METHODS`) is the in-repo model for this
+   capability-allowlist discipline.
+5. **Brain endpoints bind loopback TCP** (`127.0.0.1`), never `0.0.0.0`, never unix sockets —
    renderer `WebSocket`/`fetch` cannot reach unix sockets, and the NL/MCP endpoints must stay
-   reachable from the harness renderer and local tooling alike. When the Brain rides in-app
-   (§2.1), endpoints additionally carry a **per-boot bearer token** injected into the harness via
-   the preload (never persisted to renderer-readable storage): loopback alone does not
-   authenticate against other local processes.
-4. **Credentials (PATs) stay Brain-side** (ADR 0020 §3, re-bound here): they never transit the
-   renderer, never appear in preload-exposed state, never echo through bridge responses. The
-   Add-Peer curated-intent boundary (Body submits `{harnessType, id, repo/account facts}` only —
-   never command/args/env) is the shipped precedent this posture generalizes.
+   reachable from the harness renderer and local tooling alike. When the Brain rides in-app,
+   endpoint auth uses a **per-boot token whose bytes never enter renderer-readable state**: the
+   preload/main capability attaches it to outbound requests internally; the renderer invokes named
+   capabilities and never sees the secret. Loopback alone does not authenticate against other
+   local processes.
+6. **Credential custody (ADR 0020 §3, re-bound and made honest):** PATs live Brain-side. The
+   TARGET ingress is a shell-owned surface where credential bytes flow preload/main → Brain and
+   never enter App-Worker state. The CURRENT `Accounts` add-agent path — a PAT collected in an
+   App-Worker form field and submitted once through the registry bridge (ephemeral, fail-closed,
+   never stored Body-side) — is **transitional drift against this posture**, acceptable only in
+   the dev-server topology; the packaged shell migrates credential entry to the shell-owned
+   surface as part of the §5 E5 leaf. The Add-Peer **curated-intent boundary** (Body submits
+   `{harnessType, id, repo/account facts}` — never command/args/env) is the design contract that
+   surface implements.
 
 **Falsifier:** any leaf needing a renderer capability the preload cannot express through a named,
 allowlisted intent amends THIS section first (ADR-0005 lifecycle) — it never flips a window to
-`nodeIntegration: true` as a leaf-local decision.
+`nodeIntegration: true`, widens the window allowlist, or moves secret bytes into renderer state
+as a leaf-local decision.
 
 ### §2.4 Dock/OS-window fusion — same semantics, richer vessel (Q4)
 
 `detachItem` → OS window today spawns a browser popup; **inside the shell it stays exactly that
-call** — `window.open` through `Neo.manager.Window` — materialized by Electron per §2.2 C3 as a
-real `BrowserWindow`. The mapping, named:
+call chain** — App-Worker intent → `Neo.Main.windowOpen()` → `window.open` — materialized by
+Electron per §2.2 C3 as a real `BrowserWindow`. The mapping, named:
 
 | Layer | Owner | In the shell |
 |---|---|---|
 | Detach semantics (`detachItem`, catalog membership, placement hints) | `dockZone.v1` + ADR 0029 §2.1 | unchanged — worker-owned shared truth |
-| Popup lifecycle + God-View | `Neo.manager.Window` | unchanged — same API, same events |
-| Materialization | browser popup ceremony | `setWindowOpenHandler` → `BrowserWindow` (no popup blocker, no chrome-strip ceremony) |
-| OS affordances | unavailable | exact spawn-at-position, native move/resize events, frame control — consumed via the #13446 NL window-op backend and `main.addon.WindowPosition` enhancement points |
+| Popup issuing | `Neo.Main.windowOpen()` (main thread), reached as a remote method | unchanged — same API, same events |
+| Window observation / God-View | `Neo.manager.Window` + `main.addon.WindowPosition` | unchanged |
+| Materialization | browser popup ceremony | `setWindowOpenHandler` → `BrowserWindow` (no popup blocker, no chrome-strip ceremony), under the §2.3.2 allowlist |
+| OS affordances | unavailable | exact spawn-at-position, native move/resize events, frame control — consumed via the #13446 NL window-op backend and the #13025/#13028/#13030 enhancement points |
 
 The **embodiment vessel contract (ADR 0020) is extended, never superseded**: a docked pane
 detaches into a real OS window and returns as the same live heap object (ADR 0029's
-no-serialize-and-recreate anti-anchor re-bound here). What changes in the shell is vessel
-*quality* — frameless windows, precise placement, native drag events — never vessel *semantics*.
+no-serialize-and-recreate anti-anchor re-bound here). **ADR 0029's semantic-restore rule carries
+over explicitly:** perspective restore re-enters items at their semantic `fallbackTarget` and
+NEVER auto-spawns OS windows — the shell's removal of popup ceremony makes auto-spawn *possible*,
+which is exactly why the prohibition is restated here rather than left implicit. What changes in
+the shell is vessel *quality* — frameless windows, precise placement, native drag events — never
+vessel *semantics*.
 
 **Falsifier:** if a fusion leaf finds `BrowserWindow` materialization breaking an ADR 0029 §2.1
 state-class boundary (e.g. render-projection state needing main-process persistence), that leaf
@@ -178,9 +210,10 @@ partial updates are the recorded alternative.
    (`app://`, §2.2) load the **same built harness app root** — #13033's build-root is the
    substrate; this section binds it. No packaged-only entry file, no dev-only worker wiring:
    `neo-config` + worker URLs resolve identically relative to either origin.
-2. **Parity is achievable BECAUSE of C1:** both origins are standard-scheme; the worker topology
-   (App/VDom/Data/Canvas on one SharedWorker heap) is byte-identical dev↔packaged. The spike's
-   http/app rows agreeing is the empirical parity floor.
+2. **Parity is achievable BECAUSE of C1:** both origins are standard-scheme with fetch support
+   (`supportFetchAPI` normative — JSON seeds via `data.Store` `url` behave identically), so every
+   SharedWorker identity the app boots (App/VDom/Data/Canvas) shares the same way dev↔packaged.
+   The spike's http/app rows agreeing — including the fetch smoke — is the empirical parity floor.
 3. **Web-served mode stays the dev convenience + goodie** (ADR 0020 §3) — the shell never becomes
    a dev-loop dependency; nothing in `src/` or `apps/` may import from or feature-detect the
    packaging root (the hemisphere discipline, enforced at review).
@@ -196,12 +229,12 @@ violates this section on its face — shell awareness lives in the packaging roo
 
 - Every #13377 E-leaf cites its §2 section as upstream contract; changing a §2 decision amends
   this ADR first (ADR-0005 lifecycle), never lands leaf-local.
-- #13033 implements against §2.1/§2.6 and records the hosting-arm outcome; its spike scope is
-  unchanged by this record.
-- The `app://` scheme handler, the `setWindowOpenHandler` materialization path, and the preload
-  contract each become one leaf (§5).
-- The spike branch is a permanent regression harness: **every Electron major bump re-runs it**
-  before adoption (§2.2 falsifier).
+- #13033 implements against §2.1/§2.6 **as its live Contract Ledger stands** and records the
+  hosting-arm outcome; §5 maps the refinement leaves that follow it.
+- The `app://` scheme handler (with C1's full privilege set + §2.3.3 CSP), the materialization +
+  window-policy bridge, and the preload capability contract each become one leaf (§5).
+- The in-tree spike is the regression gate: **the E2 leaf owner re-runs it on every Electron major
+  bump** before adoption (§2.2 falsifier; committed raw run + pinned versions make drift visible).
 - Web portability is structurally guaranteed: because the shell only materializes and decorates,
   removing it leaves a working web app — the boundary that keeps the future web version alive.
 
@@ -212,39 +245,47 @@ violates this section on its face — shell awareness lives in the packaging roo
 - **Electron owning the windows** — rejected (operator, 2026-06-15); would fork window management
   into a web arm and a shell arm and kill web portability.
 - **`file://` + `loadFile()` packaging** — the naive Electron default, **empirically falsified**
-  (§2.2 C1): boots, renders, silently loses the shared heap.
+  (§2.2 C1): boots, renders, silently loses worker sharing.
 - **Localhost HTTP as the packaged origin** — works (spike), rejected operationally: port
   collisions, firewall prompts, and any local process gaining harness-origin access for free.
 - **Unix sockets for Brain endpoints** — unreachable from renderer WebSocket/fetch; loopback TCP
-  + per-boot token instead (§2.3.3).
+  + non-renderer-readable per-boot token instead (§2.3.5).
 - **Serialize-and-recreate popout state** — rejected at ADR 0029; re-bound here because Electron
   makes it *tempting* (BrowserWindows feel ownable from main).
+- **Renderer-readable bearer tokens** — rejected during review of this record: a token the
+  renderer can read still crosses the boundary; capability-internal attachment replaced it.
 
 ## 5. Decomposition — the E-leaf gate (map lives on the #13377 epic)
 
 | Leaf | Scope | Upstream contract |
 |---|---|---|
-| E1 — build root (#13033, exists) | packaging root, main entry, hosting-arm spike, boot | §2.1, §2.6 |
-| E2 — origin + scheme server | `app://` privileged scheme, `protocol.handle` over the built root, stable origin | §2.2 C1/C5, §2.6 |
-| E3 — window materialization bridge | `setWindowOpenHandler` path, secure-flag enforcement on popups, OS-chrome enhancement points, #13446 NL backend | §2.2 C3, §2.3.1, §2.4 |
-| E4 — Brain lifecycle service | start/stop/restart with settle-or-reject, port management, data-root injection | §2.1 |
-| E5 — preload capability contract | the one `contextBridge` surface + allowlist | §2.3.2 |
+| E1 — build root (#13033, exists, owner @neo-opus-ada) | **as its live Contract Ledger stands:** packaging root + main entry, hosting-arm spike, Agent-OS boot, first harness window, popup windows joining the shared workers, and the window-management bridge enhancement points | §2.1, §2.6 (frame only — the leaf's ledger is consumed unchanged) |
+| E2 — origin + scheme hardening (post-E1) | `app://` privileged scheme with C1's FULL privilege set (`supportFetchAPI` normative), stable origin, CSP delivery, the fetch/JSON smoke, spike re-run ownership | §2.2 C1/C5/C6, §2.3.3, §2.6 |
+| E3 — window policy + materialization hardening (post-E1) | fail-closed `setWindowOpenHandler` allowlist, `will-navigate` denial, secure-flag enforcement on popups, OS-chrome enhancement points, #13446 NL backend | §2.2 C3, §2.3.1–.4, §2.4 |
+| E4 — Brain lifecycle service | start/stop/restart with settle-or-reject, port management, data-root injection | §2.1.1–.4 |
+| E5 — preload capability contract + credential ingress | the one `contextBridge` surface + allowlist, sender validation, token custody, the shell-owned credential surface retiring the transitional Accounts path | §2.3.4–.6 |
 | E6 — packaging + signing pipeline | electron-builder config, per-platform artifacts, unsigned-CI/signed-release split | §2.5 |
 | E7 — update channel | shell autoUpdater wiring, two-speed policy | §2.5.3 |
+| E8 — app lifecycle + tray | `window-all-closed` suppression, explicit-quit-only teardown, hide-not-destroy cockpit close, tray handle — the #14793 UX spec implements against it | §2.1.5 |
 
-Leaves E2–E7 are filed on demand under #13377 (epic bodies never enumerate subs — ADR 0020 §6);
-each carries its own Contract Ledger and cites this table row.
+E2–E8 are filed on demand under #13377 (epic bodies never enumerate subs — ADR 0020 §6); each
+carries its own Contract Ledger and cites this table row. E2/E3 refine what E1 lands — they never
+reopen its ledger.
 
 ## 6. Verification
 
-- **Empirical:** spike branch `spike/14786-electron-sharedworker` @ `8bf8a915d` — 7-phase
-  SharedWorker matrix (two-window + popup paths × file/app/http origins + partition control),
-  Electron v43.1.0, default secure flags, results in its README. Re-run on Electron major bumps.
+- **Empirical:** in-tree spike `spikes/14786-electron-sharedworker/` — 9-phase matrix (two-window
+  + popup paths × file/app/http origins, TWO one-variable partition controls on sharing origins
+  with both windows reporting, the `app://` fetch smoke), pinned Electron 43.1.0 / Chromium
+  150.0.7871.47 / Node 24.18.0 / darwin 25.5.0, raw run committed (`spike-results.json`).
+  Re-run owner + trigger: the E2 leaf owner, every Electron major bump before adoption.
 - **Authority chain:** ADR 0020 §3 (shell decision, hosting arms, source discipline, PATs) ·
-  #13377 epic body (shell-only boundary, operator 2026-06-15) · ADR 0029 §2.1 (state classes,
-  window-manager boundaries) — all consumed, none reopened.
+  #13377 epic body (shell-only boundary, operator 2026-06-15; cites this record as design
+  authority) · ADR 0029 §2.1 (state classes, window-manager boundaries, semantic restore) ·
+  `Neo.Main.windowOpen` / `Neo.manager.Window` / `DockZoneModel.detachItem` ownership verified
+  at source during review cycle 2.
 - **AC mapping (#14786):** six questions → §2.1–§2.6, each with named constraints + falsifiers;
-  anti-anchor section = the attribute-table row (all three ticket-named minimums present:
-  no serialize-and-recreate, no second window manager, no Brain-daemon fork);
-  SharedWorker constraint set verified in the spike branch, not asserted; epic body update to cite
-  this ADR follows on the resolving PR.
+  anti-anchor row carries the three ticket-named minimums (no serialize-and-recreate, no second
+  window manager, no Brain-daemon fork) plus the review-added ones; the SharedWorker constraint
+  set verified in the committed spike, not asserted; #13377 cites this ADR (updated with the
+  resolving PR, status-honest as Proposed until merge).

--- a/spikes/14786-electron-sharedworker/README.md
+++ b/spikes/14786-electron-sharedworker/README.md
@@ -1,0 +1,75 @@
+# Spike: SharedWorker constraints inside Electron (#14786 / ADR 0034)
+
+Empirical verification for the Electron shell architecture ADR (ADR 0034; #14786 under epic
+#13377): under which origin classes, window-creation paths, and session partitions do two
+Electron-hosted pages reach **one** SharedWorker instance — the load-bearing prerequisite for
+Neo's shared-worker multi-window architecture (ADR 0020 §3).
+
+Run: `npm install && npm start` (Electron is **pinned exactly**; all windows are `show: false` —
+nothing appears on screen; results print to stdout as a `SPIKE_RESULTS_JSON` block).
+**Raw committed evidence:** [spike-results.json](./spike-results.json) — the verbatim result
+object of the recorded run, including exact runtime versions.
+
+**Re-run trigger:** every Electron major bump, BEFORE adoption — owner: the E2 (origin + scheme
+server) leaf owner under epic #13377; binding lives in ADR 0034 §6.
+
+## Method
+
+`worker.js` counts `onconnect` events per instance and echoes the count to each connecting page.
+Two pages reporting `{1, 2}` reached the SAME instance (**SHARED**); both reporting `{1, 1}` means
+each got its own (**ISOLATED**) — every verdict requires BOTH windows to report; silence is never
+evidence. Pages report via a `contextBridge` preload; `window.open()` popups (which carry no
+preload) relay through their same-origin opener. SharedWorker identity is `(origin, URL)`, so each
+phase uses a phase-scoped worker URL — no cross-phase bleed. All windows use Electron's default
+secure flags: `contextIsolation: true`, sandbox on, `nodeIntegration: false`.
+
+The partition controls are **one-variable**: a SHARING origin, the same page URL, the same preload
+— only window B's `partition` differs. The `app://` control additionally requires registering the
+protocol handler on the control partition's session (see findings). A `mode=fetch` smoke phase
+proves the packaged origin serves JSON via `fetch()` — the `data.Store` `url` seed path.
+
+## Results — Electron 43.1.0 · Chromium 150.0.7871.47 · Node 24.18.0 · darwin 25.5.0 (2026-07-10)
+
+| Phase | Origin | Variable under test | Verdict |
+|---|---|---|---|
+| `file2win` | `file://` | two `BrowserWindow`s | **ISOLATED** (1, 1) |
+| `filepopup` | `file://` | `window.open()` popup | **ISOLATED** (1, 1) |
+| `app2win` | `app://` (privileged standard scheme) | two `BrowserWindow`s | **SHARED** (1, 2) |
+| `apppopup` | `app://` | `window.open()` popup | **SHARED** (1, 2) |
+| `http2win` | `http://127.0.0.1` | two `BrowserWindow`s | **SHARED** (1, 2) |
+| `httppopup` | `http://127.0.0.1` | `window.open()` popup | **SHARED** (1, 2) |
+| `partitionapp` | `app://` (sharing origin) | window B on `persist:other` — ONLY partition varies | **ISOLATED** (1, 1) — both windows report |
+| `partitionhttp` | `http://127.0.0.1` (sharing origin) | window B on `persist:other` | **ISOLATED** (1, 1) — both windows report |
+| `fetchsmoke` | `app://` | `fetch('data.json')` | **fetchOk: true** |
+
+## The findings ADR 0034 binds
+
+1. **`file://` loading breaks worker sharing.** File pages are opaque origins in Chromium: every
+   window gets a private SharedWorker instance — silently. A naively packaged Electron app that
+   `loadFile()`s the harness would boot, render, and have NO shared worker state.
+2. **A real origin restores sharing.** Both a custom privileged standard scheme
+   (`protocol.registerSchemesAsPrivileged([{scheme, privileges: {standard: true, secure: true,
+   supportFetchAPI: true}}])` + `protocol.handle`) and localhost HTTP share correctly.
+   **`supportFetchAPI: true` is part of the working privilege set** — the fetch smoke consumes it.
+3. **The Neo popup pattern works under real origins.** `window.open()` — issued main-thread by
+   `Neo.Main.windowOpen()` — joins the same worker when allowed via
+   `setWindowOpenHandler({action: 'allow'})`, with the popup materialized as an Electron-managed
+   `BrowserWindow`. The same-origin `window.opener` relationship survives.
+4. **Default secure flags cost nothing.** Sharing works with `contextIsolation: true` + sandbox on.
+5. **Sharing is partition-scoped — positively observed.** With origin, URL, and preload held
+   constant, a window in a different session partition reports a FRESH worker (count 1, both
+   partition controls, both sharing origins). All harness windows must live in ONE partition.
+6. **Protocol handlers are session-specific.** `protocol.handle('app', …)` on the default session
+   does NOT serve a `persist:` partition — its windows cannot load `app://` at all until the
+   handler is registered on that session too (`session.fromPartition(...).protocol.handle`).
+   Reinforces finding 5 operationally: one partition, one registration.
+
+## Electron-runner gotchas (recorded for the next spike author)
+
+- Electron's default `window-all-closed` behavior quits the app the first time a multi-phase
+  harness destroys its windows — subscribe `app.on('window-all-closed', () => {})` or every phase
+  after the first silently never runs (exit code 0, no output).
+- When merging `BrowserWindow` options, strip `webPreferences` from the extra object BEFORE
+  spreading the rest — a plain `...extra` after the `webPreferences` block replaces the whole
+  object and silently drops the preload (v0.0.1 of this spike lost its partition-control report
+  channel exactly this way).

--- a/spikes/14786-electron-sharedworker/data.json
+++ b/spikes/14786-electron-sharedworker/data.json
@@ -1,0 +1,1 @@
+{"ok": true, "purpose": "fetch smoke for the app:// packaged origin — stands in for a data.Store url seed"}

--- a/spikes/14786-electron-sharedworker/main.mjs
+++ b/spikes/14786-electron-sharedworker/main.mjs
@@ -1,0 +1,177 @@
+// Electron SharedWorker constraint-set spike for the Electron shell ADR (ticket 14786).
+// Empirically answers: under which origin classes, window-creation paths, and session
+// partitions do two Electron-hosted pages share ONE SharedWorker instance?
+//
+// Phases (all windows show:false — fully invisible):
+//   file2win   — two BrowserWindows, file:// origin, default secure flags
+//   filepopup  — one BrowserWindow + window.open() popup, file://
+//   app2win    — two BrowserWindows, custom privileged app:// scheme
+//   apppopup   — one BrowserWindow + window.open() popup, app://
+//   http2win   — two BrowserWindows, http://127.0.0.1 (in-process node server)
+//   httppopup  — one BrowserWindow + window.open() popup, http://127.0.0.1
+//   partition  — two BrowserWindows, same URL, DIFFERENT session partitions (negative control)
+//
+// Verdict per phase: reported `connections` values {1,2} = SHARED (same worker instance);
+// {1,1} = ISOLATED (one instance each); error/timeout recorded verbatim.
+
+import {app, BrowserWindow, ipcMain, protocol, session} from 'electron';
+import http                                             from 'node:http';
+import {createReadStream}                               from 'node:fs';
+import os                                               from 'node:os';
+import {fileURLToPath}                                  from 'node:url';
+import path                                             from 'node:path';
+
+const dir     = path.dirname(fileURLToPath(import.meta.url));
+const results = {};
+let   reports = [];
+
+protocol.registerSchemesAsPrivileged([
+    {scheme: 'app', privileges: {standard: true, secure: true, supportFetchAPI: true}}
+]);
+
+ipcMain.on('spike-report', (event, payload) => {
+    reports.push(payload);
+});
+
+function winOpts(extra = {}) {
+    // strip webPreferences BEFORE spreading the rest — a plain `...extra` after the
+    // webPreferences block would REPLACE the whole object and silently drop the preload
+    const {webPreferences = {}, ...extraRest} = extra;
+
+    return {
+        show          : false,
+        webPreferences: {
+            preload: path.join(dir, 'preload.cjs'),
+            ...webPreferences
+        },
+        ...extraRest
+    };
+}
+
+function makeWindow(url, extra = {}) {
+    const win = new BrowserWindow(winOpts(extra));
+
+    // Allow window.open() popups; keep them invisible and preload-free (relay via opener).
+    win.webContents.setWindowOpenHandler(() => ({
+        action                      : 'allow',
+        overrideBrowserWindowOptions: {show: false}
+    }));
+
+    win.loadURL(url);
+    return win;
+}
+
+function collect(phase, expected, timeoutMs = 6000) {
+    return new Promise(resolve => {
+        const t0    = Date.now();
+        const timer = setInterval(() => {
+            if (reports.length >= expected || Date.now() - t0 > timeoutMs) {
+                clearInterval(timer);
+                results[phase] = reports.slice();
+                reports        = [];
+                console.log(`PHASE ${phase}: ${JSON.stringify(results[phase])}`);
+                resolve();
+            }
+        }, 100);
+    });
+}
+
+async function closeAll() {
+    for (const w of BrowserWindow.getAllWindows()) w.destroy();
+    await new Promise(r => setTimeout(r, 300)); // let workers wind down
+}
+
+async function twoWindowPhase(phase, baseUrl, win2Extra = {}) {
+    makeWindow(`${baseUrl}?label=${phase}-A`);
+    await new Promise(r => setTimeout(r, 600)); // deterministic connect order
+    makeWindow(`${baseUrl}?label=${phase}-B`, win2Extra);
+    await collect(phase, 2);
+    await closeAll();
+}
+
+async function popupPhase(phase, baseUrl) {
+    makeWindow(`${baseUrl}?label=${phase}-A&open=1`);
+    await collect(phase, 2, 8000);
+    await closeAll();
+}
+
+// The spike opens/destroys windows per phase — without this, Electron's default
+// window-all-closed behavior quits the app after the FIRST phase's teardown.
+app.on('window-all-closed', () => {});
+
+process.on('unhandledRejection', err => {
+    console.log('UNHANDLED_REJECTION: ' + (err?.stack || err));
+    app.exit(2);
+});
+process.on('uncaughtException', err => {
+    console.log('UNCAUGHT: ' + (err?.stack || err));
+    app.exit(3);
+});
+
+app.whenReady().then(async () => {
+    console.log('READY_PHASE_START');
+
+    const appHandler = req => {
+        const {pathname} = new URL(req.url);
+        const file       = path.join(dir, pathname === '/' ? 'page.html' : pathname);
+        const type       = file.endsWith('.js')   ? 'text/javascript'
+                         : file.endsWith('.json') ? 'application/json'
+                         : 'text/html';
+        return new Response(createReadStream(file), {headers: {'content-type': type}});
+    };
+
+    // protocol handlers are SESSION-specific (a load-bearing constraint in its own right):
+    // the default session serves the main matrix; the control partition needs its OWN
+    // registration or its windows cannot load app:// at all.
+    protocol.handle('app', appHandler);
+    session.fromPartition('persist:other').protocol.handle('app', appHandler);
+
+    // http://127.0.0.1 serves the spike dir
+    const server = http.createServer((req, res) => {
+        const {pathname} = new URL(req.url, 'http://x');
+        const file       = path.join(dir, pathname === '/' ? 'page.html' : pathname);
+        res.setHeader('content-type', file.endsWith('.js') ? 'text/javascript' : 'text/html');
+        createReadStream(file).pipe(res);
+    });
+    await new Promise(r => server.listen(0, '127.0.0.1', r));
+    const httpBase = `http://127.0.0.1:${server.address().port}/page.html`;
+
+    const fileBase = `file://${path.join(dir, 'page.html')}`;
+    const appBase  = 'app://spike/page.html';
+
+    await twoWindowPhase('file2win',  fileBase);
+    await popupPhase   ('filepopup', fileBase);
+    await twoWindowPhase('app2win',   appBase);
+    await popupPhase   ('apppopup',  appBase);
+    await twoWindowPhase('http2win',  httpBase);
+    await popupPhase   ('httppopup', httpBase);
+
+    // ONE-VARIABLE partition controls on SHARING origins: same URL, same preload — only
+    // window B's session partition differs. Both windows must REPORT their own counts;
+    // isolation shows as B seeing a FRESH worker (count 1), never as silence.
+    await twoWindowPhase('partitionapp',  appBase,  {webPreferences: {partition: 'persist:other'}});
+    await twoWindowPhase('partitionhttp', httpBase, {webPreferences: {partition: 'persist:other'}});
+
+    // fetch smoke: the packaged origin must serve JSON via fetch() — the Store `url` seed path
+    await (async () => {
+        makeWindow(`${appBase}?label=fetchsmoke-A&mode=fetch`);
+        await collect('fetchsmoke', 1);
+        await closeAll();
+    })();
+
+    results.versions = {
+        chrome  : process.versions.chrome,
+        electron: process.versions.electron,
+        node    : process.versions.node,
+        platform: `${process.platform} ${os.release()}`
+    };
+
+    console.log('SPIKE_RESULTS_JSON=' + JSON.stringify(results, null, 2));
+    app.exit(0);
+});
+
+// Hard safety net
+setTimeout(() => {
+    console.log('SPIKE_TIMEOUT — partial: ' + JSON.stringify(results));
+    app.exit(1);
+}, 90000);

--- a/spikes/14786-electron-sharedworker/package.json
+++ b/spikes/14786-electron-sharedworker/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "spike-14786-electron-sharedworker",
+    "private": true,
+    "version": "0.0.2",
+    "description": "Empirical SharedWorker constraint-set spike for the Electron shell ADR (ticket 14786). Re-run on every Electron major bump (owner: the E2 leaf owner; ADR 0034 §6).",
+    "main": "main.mjs",
+    "scripts": {
+        "start": "electron main.mjs"
+    },
+    "devDependencies": {
+        "electron": "43.1.0"
+    }
+}

--- a/spikes/14786-electron-sharedworker/page.html
+++ b/spikes/14786-electron-sharedworker/page.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>spike</title></head>
+<body>
+<script>
+    const params = new URLSearchParams(location.search);
+    const label  = params.get('label') || 'unlabeled';
+    const phase  = label.split('-')[0];
+    const doOpen = params.get('open') === '1';
+
+    function report(payload) {
+        // Popups opened via window.open() have no preload; relay through the opener.
+        if (window.spike) {
+            window.spike.report(payload);
+        } else if (window.opener?.spike) {
+            window.opener.spike.report(payload);
+        }
+    }
+
+    if (params.get('mode') === 'fetch') {
+        // the packaged origin must serve JSON via fetch() — the data.Store `url` seed path
+        fetch('data.json')
+            .then(response => response.json())
+            .then(json => report({label, origin: location.origin, fetchOk: json.ok === true}))
+            .catch(err => report({label, origin: location.origin, fetchOk: false, error: err.message}));
+    } else try {
+        // SharedWorker identity = (origin, URL, name) — phase-scoped URL isolates phases from each other.
+        const worker = new SharedWorker('worker.js?p=' + encodeURIComponent(phase));
+        worker.port.onmessage = e => {
+            report({label, origin: location.origin, protocol: location.protocol, connections: e.data.connections});
+
+            if (doOpen) {
+                // The Neo pattern: a renderer-initiated popup joining the heap.
+                window.open(location.pathname + '?label=' + encodeURIComponent(phase + '-popup'), '_blank', 'width=200,height=200');
+            }
+        };
+        worker.port.start();
+    } catch (err) {
+        report({label, origin: location.origin, protocol: location.protocol, error: err.message});
+    }
+</script>
+</body>
+</html>

--- a/spikes/14786-electron-sharedworker/preload.cjs
+++ b/spikes/14786-electron-sharedworker/preload.cjs
@@ -1,0 +1,5 @@
+const {contextBridge, ipcRenderer} = require('electron');
+
+contextBridge.exposeInMainWorld('spike', {
+    report: payload => ipcRenderer.send('spike-report', payload)
+});

--- a/spikes/14786-electron-sharedworker/spike-results.json
+++ b/spikes/14786-electron-sharedworker/spike-results.json
@@ -1,0 +1,127 @@
+{
+  "file2win": [
+    {
+      "label": "file2win-A",
+      "origin": "file://",
+      "protocol": "file:",
+      "connections": 1
+    },
+    {
+      "label": "file2win-B",
+      "origin": "file://",
+      "protocol": "file:",
+      "connections": 1
+    }
+  ],
+  "filepopup": [
+    {
+      "label": "filepopup-A",
+      "origin": "file://",
+      "protocol": "file:",
+      "connections": 1
+    },
+    {
+      "label": "filepopup-popup",
+      "origin": "file://",
+      "protocol": "file:",
+      "connections": 1
+    }
+  ],
+  "app2win": [
+    {
+      "label": "app2win-A",
+      "origin": "app://spike",
+      "protocol": "app:",
+      "connections": 1
+    },
+    {
+      "label": "app2win-B",
+      "origin": "app://spike",
+      "protocol": "app:",
+      "connections": 2
+    }
+  ],
+  "apppopup": [
+    {
+      "label": "apppopup-A",
+      "origin": "app://spike",
+      "protocol": "app:",
+      "connections": 1
+    },
+    {
+      "label": "apppopup-popup",
+      "origin": "app://spike",
+      "protocol": "app:",
+      "connections": 2
+    }
+  ],
+  "http2win": [
+    {
+      "label": "http2win-A",
+      "origin": "http://127.0.0.1:51815",
+      "protocol": "http:",
+      "connections": 1
+    },
+    {
+      "label": "http2win-B",
+      "origin": "http://127.0.0.1:51815",
+      "protocol": "http:",
+      "connections": 2
+    }
+  ],
+  "httppopup": [
+    {
+      "label": "httppopup-A",
+      "origin": "http://127.0.0.1:51815",
+      "protocol": "http:",
+      "connections": 1
+    },
+    {
+      "label": "httppopup-popup",
+      "origin": "http://127.0.0.1:51815",
+      "protocol": "http:",
+      "connections": 2
+    }
+  ],
+  "partitionapp": [
+    {
+      "label": "partitionapp-A",
+      "origin": "app://spike",
+      "protocol": "app:",
+      "connections": 1
+    },
+    {
+      "label": "partitionapp-B",
+      "origin": "app://spike",
+      "protocol": "app:",
+      "connections": 1
+    }
+  ],
+  "partitionhttp": [
+    {
+      "label": "partitionhttp-A",
+      "origin": "http://127.0.0.1:51815",
+      "protocol": "http:",
+      "connections": 1
+    },
+    {
+      "label": "partitionhttp-B",
+      "origin": "http://127.0.0.1:51815",
+      "protocol": "http:",
+      "connections": 1
+    }
+  ],
+  "fetchsmoke": [
+    {
+      "label": "fetchsmoke-A",
+      "origin": "app://spike",
+      "fetchOk": true
+    }
+  ],
+  "versions": {
+    "chrome": "150.0.7871.47",
+    "electron": "43.1.0",
+    "node": "24.18.0",
+    "platform": "darwin 25.5.0"
+  }
+}

--- a/spikes/14786-electron-sharedworker/worker.js
+++ b/spikes/14786-electron-sharedworker/worker.js
@@ -1,0 +1,10 @@
+// SharedWorker under test: counts distinct port connections.
+// If two pages report counts 1 and 2, they reached the SAME worker instance.
+// If both report 1, each page got its own instance (no sharing).
+let connections = 0;
+
+onconnect = e => {
+    connections++;
+    const port = e.ports[0];
+    port.postMessage({connections});
+};


### PR DESCRIPTION
Resolves #14786

Related: #13377 (parent epic — body update citing this ADR follows merge) · ADR 0020 (extended, never superseded) · ADR 0029 (window-manager boundaries consumed) · #13033 (build-root leaf — its hosting-arm spike is framed, not pre-empted) · spike branch `spike/14786-electron-sharedworker` @ `8bf8a915d` (the empirical anchor)

One new decision record — `learn/agentos/decisions/0034-electron-shell-architecture.md` — plus its mandatory one-line seam-table row in ADR 0031, plus (cycle 2) the **in-tree spike** `spikes/14786-electron-sharedworker/` making the empirical evidence durable: pinned Electron 43.1.0, committed raw run (`spike-results.json`) with exact Chromium/Node/OS versions, and a named re-run owner + trigger (E2 leaf owner, every Electron major). The ADR settles the six shell questions the ticket names, ADR-0029-pattern (per-section falsifiers, anti-anchor row, §5 decomposition table gating the E-leaves). The decisions carried: **§2.1** one Brain lifecycle owner + settle-or-reject restarts + injectable data-root + managed loopback ports (frames #13033's spike without stealing its outcome); **§2.2** the empirically-verified SharedWorker constraint set — the headline finding is that **`file://` packaging silently destroys Neo's one-heap multi-window architecture** (every window gets a private "shared" worker; the app boots and renders normally) — so the packaged origin is a custom privileged `app://` scheme, with the `window.open` popup path preserved via `setWindowOpenHandler` under default secure flags; **§2.3** contextIsolation/sandbox/no-nodeIntegration everywhere, one capability-allowlisted preload (FleetControlBridge discipline generalized), loopback-TCP-plus-per-boot-token Brain endpoints, PATs never cross; **§2.4** dock/OS-window fusion = same `Neo.manager.Window` semantics, Electron only materializes + decorates (shell-only boundary, operator 2026-06-15, honored against the ticket's "become real BrowserWindows" framing); **§2.5** signed installers for strangers / repo for contributors, two-speed updates with partial organism updates explicitly deferred; **§2.6** one built harness root behind two standard-scheme origins = byte-identical worker topology dev↔packaged.

Evidence: L1+L2 (empirical spike on a never-merging branch + authority-chain V-B-A; sandbox ceiling = local Electron runtime) → the AC's own bar ("verified empirically in a spike branch, not asserted") is met by the spike matrix. No residuals.

**Cycle-2 (RC discharge, head `a8c6e49a3`)** — all six Required Actions executed:

1. **C2 made causal:** the partition control had TWO confounds (a `winOpts` spread bug silently dropping the control window's preload — its report channel — and a `file://` base that was isolated regardless). Re-designed as two one-variable controls on SHARING origins (`app://` + `http://127.0.0.1`; same URL, same preload, only `partition` varies): **both windows now REPORT**, B seeing a fresh worker (1,1) on both origins. The fix surfaced constraint **C6**: `protocol.handle` is session-specific — the control partition could not even load `app://` until the handler was registered on its session.
2. **`supportFetchAPI: true` normative** in C1/E2/§2.6 + a committed `fetchsmoke` phase (`fetchOk: true` on `app://` — the `data.Store` `url` seed path).
3. **Ownership/topology corrected at source:** `Neo.Main.windowOpen()` (main thread) owns `window.open`; `Neo.manager.Window` observes/choreographs; `DockZoneModel.detachItem` is catalog/tree state — now a three-row ownership table in §2.2/§2.4. Worker model corrected throughout: App/VDom/Data/Canvas are SEPARATE SharedWorker identities, each shared per-origin — no "one combined heap" phrasing survives.
4. **Security contract completed (§2.3):** fail-closed `setWindowOpenHandler` origin/path allowlist, `will-navigate` denial, deny-by-default permission handler, restrictive CSP via the `app://` handler, IPC `senderFrame` validation, capability-shaped preload — and token custody hardened per the review's [ARCHITECTURAL_RISK]: per-boot token bytes never enter renderer-readable state (capability-internal attachment). The CURRENT Accounts PAT path is classified honestly as **transitional drift** (ephemeral browser-transit, dev-server only) with its migration bound to the E5 leaf; the curated-intent boundary is cited as the design contract, no longer as "shipped precedent".
5. **Lifecycle decided (§2.1.5 + E8):** `window-all-closed` suppressed; Brain teardown ONLY on explicit quit; cockpit close = hide-never-destroy (SharedWorker lifetime is client-scoped — destroying the last window kills the App-Worker heap while the tray claims the institution runs); tray = the handle; #14793 consumes the semantics. ADR 0029's no-auto-spawn-on-perspective-restore rule carried explicitly in §2.4.
6. **AC4 + parent map:** live #13377 now carries a "Design authority" section citing ADR 0034 (status-honest as Proposed) + the E-map disposition; §5's E1 row consumes #13033's live Contract Ledger UNCHANGED (build root incl. first window, popup-join proof, window-bridge enhancement points), with E2/E3 re-scoped as post-E1 hardening leaves that never reopen its ledger.

## Deltas from ticket

- **Q4 framing reconciled, not adopted:** the ticket sketches detach popups "becom[ing] real BrowserWindows"; the epic's recorded operator boundary (2026-06-15) says Electron never owns windows. §2.4 resolves both: the `window.open`/`Neo.manager.Window` call chain is unchanged and Electron's `setWindowOpenHandler` merely materializes it — richer vessel, identical semantics.
- **Q1 scope discipline:** ADR 0020 §3 already fixed target-arm (in-process) and fallback (child-process supervision), and #13033 owns that spike. §2.1 binds only what is true in either arm (lifecycle owner, settle-or-reject, data-root, ports) — no double-decision, no leaf pre-emption.
- **A seventh constraint surfaced beyond the ticket's list:** SharedWorker sharing is session-partition-scoped (spike negative control) — banned per-window partitions joined the anti-anchor row.

## Test Evidence

**Cycle-2 (head `a8c6e49a3`):** in-tree spike re-run — 9 phases, all reporting: file ISOLATED (1,1 both paths) · app + http SHARED (1,2 all four) · `partitionapp`/`partitionhttp` one-variable controls ISOLATED with BOTH windows reporting (1,1) · `fetchsmoke` `fetchOk: true` · versions block committed (Electron 43.1.0 / Chromium 150.0.7871.47 / Node 24.18.0 / darwin 25.5.0). Raw run committed as `spike-results.json`. `node --check` + `check-block-alignment` + `check-ticket-archaeology` green on the spike; `lint-adr-seam-table` green (row unchanged).

- **Spike branch `spike/14786-electron-sharedworker` @ `8bf8a915d`** (never merges; reproducer: `npm install && npm start`): 7-phase matrix — {two BrowserWindows, `window.open` popup} × {`file://`, privileged `app://`, `http://127.0.0.1`} + a cross-partition negative control, Electron v43.1.0, macOS, all windows `show:false`, default secure flags. Results: file = ISOLATED (1,1 both paths); app + http = SHARED (1,2 all four phases); partition control = no cross-partition join. Raw JSON in the spike README + `SPIKE_RESULTS_JSON` stdout block.
- ADR consistency: authority citations verified against the live sources this session (ADR 0020 §3 text, #13377 epic body, ADR 0029 §2.1 state-class table, #13033 ticket body); next-free ADR number (0034) verified against the decisions tree; ADR-0033's landing commit confirmed no index/tree.json registration is required for a new decision record.
- `lint-adr-seam-table` locally green at head (the first push failed it — the by-construction guard working exactly as designed; the row landed as its own commit).
- `check-block-alignment` green (markdown-only diff); no `.mjs` touched on this branch.

## Post-Merge Validation

- [ ] #13377 epic body updated to cite ADR 0034 as design authority for the E-leaves (AC 4 — executes right after merge, epic-body edit).
- [ ] #13033 (Ada) intake picks up §2.1/§2.6 as upstream contract without needing its scope reshaped — if it does need reshaping, that's an ADR amendment conversation, not a leaf-local decision.

## Commits

- 928dbf31f — the ADR (one new file, 250 lines).
- bfcbd0b76 — the ADR 0031 seam-table row (one line; the lint-mandated same-diff registration).
- a8c6e49a3 — cycle-2 RC discharge: causal partition controls + C6 + fetch smoke (in-tree spike w/ pinned Electron + committed raw run), ownership/topology corrections, full §2.3 security contract, §2.1.5 lifecycle + E8, honest credential classification, #13033 ledger reconciliation. Epic #13377 body updated in the same cycle (Design authority section).

Authored by Vega (Claude Fable 5, Claude Code). Session d2fbbdb4-404b-47e1-bbb3-1b9e0330894b.
