### PR TITLE
feat(dashboard): changed-topology restore reconciler — affinity mapping + fail-closed contract (#14668)

### DIFF
--- a/src/dashboard/DockTopologyReconciler.mjs
+++ b/src/dashboard/DockTopologyReconciler.mjs
@@ -1,0 +1,280 @@
+import DockRestorePlanner from './DockRestorePlanner.mjs';
+import DockZoneModel      from './DockZoneModel.mjs';
+
+/**
+ * @summary Changed-topology perspective restore: maps captured workspace slots onto live windows
+ * by shape affinity (never ids), composes the landed per-window restore, and reports everything
+ * it cannot cover — nothing silently drops, in either direction.
+ *
+ * The same-topology planner deliberately DEFERS on a shape-fingerprint mismatch ("the
+ * cross-topology leaf owns that path") — this module is that leaf. Reconciliation semantics:
+ *
+ * - **Validate everything before mutating anything.** Any invalid captured slot or live document
+ *   fails the ENTIRE restore closed: no document changes, every captured item reported
+ *   `unrestored` with reason `validation-failed`, errors surfaced. There is no partial restore
+ *   across the validation boundary.
+ * - **Slot mapping is deterministic and id-free.** Affinity = Jaccard overlap of the two
+ *   documents' item catalogs (`dockItemId` sets), tie-broken by structural similarity (node-type
+ *   multiset overlap), then by stable live-document order; captured slots map greedily in
+ *   captured order. Zero-overlap slots never map (`unmapped-slot`); slots beyond the live window
+ *   supply stay uncovered (`no-live-window`).
+ * - **Per-window restore composes, never duplicates.** A mapped pair with an IDENTICAL shape
+ *   fingerprint restores incrementally through `DockRestorePlanner.restoreToward()` (no-flicker
+ *   semantic operations). A mapped pair with a DIFFERENT shape adopts the captured document
+ *   wholesale — and every live item absent from the adopted document is reported in `displaced`
+ *   (documents never destroy pane instances; the workspace decides what to do with displaced
+ *   content, e.g. fallback placement).
+ * - **No window creation.** A restore MUST NOT depend on popup permission: this module exposes no
+ *   spawning path whatsoever; excess live windows keep their documents untouched.
+ *
+ * Conservation invariant (spec-pinned): every captured item id appears in exactly one of
+ * `restored` or `unrestored`.
+ *
+ * @class Neo.dashboard.DockTopologyReconciler
+ * @extends Neo.core.Base
+ * @see Neo.dashboard.DockRestorePlanner
+ * @see Neo.dashboard.DockZoneModel
+ * @see learn/agentos/HarnessDockZoneModel.md
+ */
+class DockTopologyReconciler {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockTopologyReconciler'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockTopologyReconciler'
+    }
+
+    /**
+     * Reason class: the captured slot could not map because every live window is already taken.
+     * @member {String} REASON_NO_LIVE_WINDOW='no-live-window'
+     * @static
+     */
+    static REASON_NO_LIVE_WINDOW = 'no-live-window'
+    /**
+     * Reason class: the captured slot shares no item overlap with any remaining live window.
+     * @member {String} REASON_UNMAPPED_SLOT='unmapped-slot'
+     * @static
+     */
+    static REASON_UNMAPPED_SLOT = 'unmapped-slot'
+    /**
+     * Reason class: validation failed somewhere — the whole restore fails closed.
+     * @member {String} REASON_VALIDATION_FAILED='validation-failed'
+     * @static
+     */
+    static REASON_VALIDATION_FAILED = 'validation-failed'
+
+    /**
+     * Extracts the captured workspace-slot documents from a topology-scope saved layout:
+     * slot 0 is the wrapper's `dockZone`, slots 1..N are `windowDocuments`.
+     * @param {Object} savedLayout
+     * @returns {Object[]}
+     * @static
+     */
+    static capturedSlots(savedLayout) {
+        return [savedLayout?.dockZone, ...(savedLayout?.windowDocuments || [])].filter(Boolean)
+    }
+
+    /**
+     * Id-free affinity between a captured slot and a live document.
+     * Primary: Jaccard overlap of item-id catalogs. Secondary (tie-breaker only): node-type
+     * multiset overlap fraction. Never reads node ids or window identifiers.
+     * @param {Object} captured
+     * @param {Object} live
+     * @returns {{jaccard: Number, structural: Number}}
+     * @static
+     */
+    static slotAffinity(captured, live) {
+        let capturedIds = Object.keys(captured?.items || {}),
+            liveIds     = new Set(Object.keys(live?.items || {})),
+            overlap     = capturedIds.filter(id => liveIds.has(id)).length,
+            union       = capturedIds.length + liveIds.size - overlap;
+
+        return {
+            jaccard   : union === 0 ? 0 : overlap / union,
+            structural: this.structuralAffinity(captured, live)
+        }
+    }
+
+    /**
+     * Node-type multiset overlap fraction — the structural tie-breaker.
+     * @param {Object} captured
+     * @param {Object} live
+     * @returns {Number}
+     * @static
+     */
+    static structuralAffinity(captured, live) {
+        const counts = document => {
+            let map = {};
+            Object.values(document?.nodes || {}).forEach(node => {
+                map[node.type] = (map[node.type] || 0) + 1
+            });
+            return map
+        };
+
+        let a     = counts(captured),
+            b     = counts(live),
+            types = new Set([...Object.keys(a), ...Object.keys(b)]),
+            inter = 0,
+            union = 0;
+
+        types.forEach(type => {
+            inter += Math.min(a[type] || 0, b[type] || 0);
+            union += Math.max(a[type] || 0, b[type] || 0)
+        });
+
+        return union === 0 ? 0 : inter / union
+    }
+
+    /**
+     * Deterministic greedy slot mapping: captured slots claim live documents in captured order;
+     * each takes the highest-affinity remaining live document (jaccard desc → structural desc →
+     * live index asc). A slot maps only when its Jaccard overlap is > 0.
+     * @param {Object[]} capturedDocs
+     * @param {Object[]} liveDocs
+     * @returns {{mapping: Object[], unmapped: Object[], unmatchedLive: Number[]}}
+     *          `mapping`: `[{capturedIndex, liveIndex, affinity}]` · `unmapped`:
+     *          `[{capturedIndex, reason}]` · `unmatchedLive`: live indices left untouched.
+     * @static
+     */
+    static mapWorkspaceSlots(capturedDocs, liveDocs) {
+        let remaining = liveDocs.map((doc, index) => ({doc, index})),
+            mapping   = [],
+            unmapped  = [];
+
+        capturedDocs.forEach((captured, capturedIndex) => {
+            if (!remaining.length) {
+                unmapped.push({capturedIndex, reason: this.REASON_NO_LIVE_WINDOW});
+                return
+            }
+
+            let best = null;
+
+            remaining.forEach(candidate => {
+                let affinity = this.slotAffinity(captured, candidate.doc);
+
+                if (affinity.jaccard <= 0) {
+                    return
+                }
+
+                if (!best
+                    || affinity.jaccard   > best.affinity.jaccard
+                    || (affinity.jaccard   === best.affinity.jaccard && affinity.structural > best.affinity.structural)
+                    || (affinity.jaccard   === best.affinity.jaccard && affinity.structural === best.affinity.structural && candidate.index < best.liveIndex)
+                ) {
+                    best = {affinity, liveIndex: candidate.index}
+                }
+            });
+
+            if (best) {
+                mapping.push({capturedIndex, liveIndex: best.liveIndex, affinity: best.affinity});
+                remaining = remaining.filter(candidate => candidate.index !== best.liveIndex)
+            } else {
+                unmapped.push({capturedIndex, reason: this.REASON_UNMAPPED_SLOT})
+            }
+        });
+
+        return {mapping, unmapped, unmatchedLive: remaining.map(candidate => candidate.index)}
+    }
+
+    /**
+     * Reconciles a topology-scope perspective onto a changed live topology.
+     *
+     * Fail-closed validation boundary first; then deterministic slot mapping; then per-window
+     * restore (incremental via the landed planner on shape match, wholesale adoption on
+     * mismatch); uncovered captured content returns reason-classed. Live documents are NEVER
+     * mutated in place — the result carries next-documents per live index.
+     * @param {Object} savedLayout   Topology-scope saved layout (`dockZone` + `windowDocuments`).
+     * @param {Object[]} liveDocuments Live per-window committed documents, in window order.
+     * @returns {{
+     *     applied: Object[],
+     *     displaced: Object[],
+     *     documents: Object[],
+     *     errors: String[],
+     *     mapping: Object[],
+     *     restored: String[],
+     *     unmatchedLive: Number[],
+     *     unrestored: Object[]
+     * }} `documents` mirrors `liveDocuments` (adopted/advanced or untouched); `restored` =
+     *     covered captured item ids; `unrestored` = `[{itemId, reason, capturedIndex}]`;
+     *     `displaced` = `[{itemId, liveIndex}]` live items absent from an adopted document;
+     *     `applied` = per-mapping restore results (`{capturedIndex, liveIndex, mode, applied}`).
+     * @static
+     */
+    static reconcile(savedLayout, liveDocuments = []) {
+        let slots  = this.capturedSlots(savedLayout),
+            errors = [];
+
+        // §validation boundary: everything valid before anything mutates — no partial restore.
+        slots.forEach((doc, index) => {
+            DockZoneModel.validate(doc).forEach(error => errors.push(`captured slot ${index}: ${error}`))
+        });
+        liveDocuments.forEach((doc, index) => {
+            DockZoneModel.validate(doc).forEach(error => errors.push(`live document ${index}: ${error}`))
+        });
+
+        if (!slots.length) {
+            errors.push('savedLayout carries no captured workspace documents')
+        }
+
+        if (errors.length) {
+            return {
+                applied      : [],
+                displaced    : [],
+                documents    : liveDocuments,
+                errors,
+                mapping      : [],
+                restored     : [],
+                unmatchedLive: liveDocuments.map((doc, index) => index),
+                unrestored   : slots.flatMap((doc, capturedIndex) =>
+                    Object.keys(doc?.items || {}).map(itemId =>
+                        ({capturedIndex, itemId, reason: this.REASON_VALIDATION_FAILED})))
+            }
+        }
+
+        let {mapping, unmapped, unmatchedLive} = this.mapWorkspaceSlots(slots, liveDocuments),
+            documents                          = [...liveDocuments],
+            applied                            = [],
+            displaced                          = [],
+            restored                           = [],
+            unrestored                         = [];
+
+        mapping.forEach(({capturedIndex, liveIndex, affinity}) => {
+            let captured = slots[capturedIndex],
+                live     = documents[liveIndex],
+                result   = DockRestorePlanner.restoreToward(live, captured);
+
+            if (result.deferred) {
+                // Shape mismatch: the captured document is adopted wholesale (the wrapper-restore
+                // semantics); live-only items are DISPLACED — reported, never silently dropped.
+                let capturedIds = new Set(Object.keys(captured.items || {}));
+
+                Object.keys(live.items || {}).forEach(itemId => {
+                    capturedIds.has(itemId) || displaced.push({itemId, liveIndex})
+                });
+
+                documents[liveIndex] = DockZoneModel.clone(captured);
+                applied.push({capturedIndex, liveIndex, affinity, applied: 0, mode: 'adopt'});
+                restored.push(...Object.keys(captured.items || {}))
+            } else if (result.errors.length) {
+                // Per-window executor failure: that window stays as-is; its slot reports closed.
+                errors.push(`slot ${capturedIndex} -> live ${liveIndex}: ${result.errors[0]}`);
+                Object.keys(captured.items || {}).forEach(itemId =>
+                    unrestored.push({capturedIndex, itemId, reason: this.REASON_VALIDATION_FAILED}))
+            } else {
+                documents[liveIndex] = result.document;
+                applied.push({capturedIndex, liveIndex, affinity, applied: result.applied, mode: 'incremental'});
+                restored.push(...Object.keys(captured.items || {}))
+            }
+        });
+
+        unmapped.forEach(({capturedIndex, reason}) => {
+            Object.keys(slots[capturedIndex].items || {}).forEach(itemId =>
+                unrestored.push({capturedIndex, itemId, reason}))
+        });
+
+        return {applied, displaced, documents, errors, mapping, restored, unmatchedLive, unrestored}
+    }
+}
+
+export default Neo.setupClass(DockTopologyReconciler);

--- a/src/dashboard/DockTopologyReconciler.mjs
+++ b/src/dashboard/DockTopologyReconciler.mjs
@@ -13,25 +13,36 @@ import DockZoneModel      from './DockZoneModel.mjs';
  *
  * - **Envelope authority first.** The saved-layout envelope validates through the landed
  *   `DockZoneModel.restoreSavedLayout()` (schema, `captureScope` ↔ `windowDocuments` coupling,
- *   slot-indexed document validation, primary presence) plus slot-indexed live-document
- *   validation. Any failure fails the ENTIRE restore closed without throwing: no document
- *   changes, every captured item reported `unrestored` with reason `validation-failed`.
+ *   slot-indexed document validation with the finite durable-field boundary applied to EVERY
+ *   slot, primary presence) plus slot-indexed live-document validation and live cross-window
+ *   item disjointness. Validation is total: a malformed envelope (e.g. a non-array
+ *   `windowDocuments`) fails the ENTIRE restore closed without throwing — no document changes,
+ *   every captured item reported `unrestored` with reason `validation-failed`, original
+ *   captured indices preserved.
  * - **Assignment is optimal and deterministic.** Maximum cardinality first, then maximum summed
  *   Jaccard affinity (item-catalog overlap), then maximum summed structural affinity (node-type
- *   multiset overlap), then the lexicographically smallest live-index sequence — the tie rule is
- *   content-stable: ties at all affinity keys mean the candidate windows are interchangeable at
- *   affinity altitude, so index order is an honest deterministic pick. Pairs require Jaccard > 0.
- *   Never reads node ids or window identifiers.
+ *   multiset overlap), then the lexicographically smallest CONTENT signature — each pair keyed by
+ *   the live window's sorted item catalog + node-type multiset, so equal-affinity candidates with
+ *   DIFFERENT content resolve to the same content regardless of live array order (permutation-
+ *   stable). Only fully content-identical candidates fall through to live index order, where the
+ *   pick is content-irrelevant by construction. Pairs require Jaccard > 0. Never reads node ids
+ *   or window identifiers.
  * - **Per-window restore branches on the planner's OWN verdict.** Clean plan → incremental
  *   semantic operations. Deferred with reason `topology-fingerprint-mismatch` (the one deferral
  *   this leaf owns) → wholesale adoption of the captured document, with every live-only item
  *   reported in `displaced`. Any OTHER deferral reason passes through verbatim into `unrestored`
  *   (the owning leaf for that reason is not this one); executor failures report `apply-error` —
  *   never mislabeled as validation.
- * - **Workspace-global item uniqueness.** A slot whose placement would duplicate an item id
- *   already restored into another output document does not place; its items report
- *   `duplicate-item`. Conservation is global: every captured item id lands in exactly one of
- *   `restored` or `unrestored`.
+ * - **Workspace-global item uniqueness — over the COMPLETE final output.** Live documents must
+ *   enter with pairwise-disjoint item catalogs (a cross-window duplicate is a validation
+ *   failure). Every final document participates — placements, deferred slots' untouched live
+ *   documents, and unmatched pass-through documents. A contested id resolves by LIVE
+ *   OWNERSHIP: the window already holding it live keeps it whenever its final catalog retains
+ *   it, and a placement importing that id elsewhere demotes to `duplicate-item` (its live
+ *   window stays reference-identical). An owner that drops the id disclaims it; the earliest
+ *   captured slot among importing placements wins. Demotions re-enter the check (fixpoint),
+ *   so the emitted workspace never contains a duplicate id. Conservation is global: every
+ *   captured item id lands in exactly one of `restored` or `unrestored`.
  * - **No window creation.** A restore MUST NOT depend on popup permission: this module exposes
  *   no spawning path whatsoever; unmatched live windows keep reference-identical documents.
  *
@@ -85,13 +96,18 @@ class DockTopologyReconciler extends Base {
 
     /**
      * Extracts the captured workspace-slot documents from a topology-scope saved layout:
-     * slot 0 is the wrapper's `dockZone`, slots 1..N are `windowDocuments`.
+     * slot 0 is the wrapper's `dockZone`, slots 1..N are `windowDocuments`. Total and
+     * index-preserving: a non-array `windowDocuments` contributes nothing (never spread —
+     * never throws), and invalid/null slots stay IN PLACE so every downstream report carries
+     * the ORIGINAL captured index (validation, not compaction, owns rejecting them).
      * @param {Object} savedLayout
      * @returns {Object[]}
      * @static
      */
     static capturedSlots(savedLayout) {
-        return [savedLayout?.dockZone, ...(savedLayout?.windowDocuments || [])].filter(Boolean)
+        let extra = savedLayout?.windowDocuments;
+
+        return [savedLayout?.dockZone ?? null, ...(Array.isArray(extra) ? extra : [])]
     }
 
     /**
@@ -113,6 +129,22 @@ class DockTopologyReconciler extends Base {
             jaccard   : union === 0 ? 0 : overlap / union,
             structural: this.structuralAffinity(captured, live)
         }
+    }
+
+    /**
+     * Canonical content key of a live document: sorted item catalog + sorted node-type multiset.
+     * Two documents share a key iff they are content-interchangeable at affinity altitude —
+     * the assignment tie rule compares candidates by THIS key, never by live array position,
+     * so equal-affinity ties resolve permutation-stably (same content wins under any live order).
+     * @param {Object} live
+     * @returns {String}
+     * @static
+     */
+    static liveContentKey(live) {
+        let items = Object.keys(live?.items || {}).sort().join(','),
+            types = Object.values(live?.nodes || {}).map(node => node.type).sort().join(',');
+
+        return `${items}#${types}`
     }
 
     /**
@@ -147,8 +179,11 @@ class DockTopologyReconciler extends Base {
 
     /**
      * Optimal deterministic slot assignment: exhaustive search over the (small — window-count-
-     * bounded) pairing space, maximizing `(cardinality, Σ jaccard, Σ structural)` with the
-     * lexicographically smallest live-index sequence as the content-stable final tie rule.
+     * bounded) pairing space, maximizing `(cardinality, Σ jaccard, Σ structural)`, then the
+     * lexicographically smallest CONTENT signature (`capturedIndex>liveContentKey` per pair) —
+     * permutation-stable: equal-affinity candidates with different content resolve to the SAME
+     * content under any live array order. Only fully content-identical candidates fall through
+     * to the smallest live-index sequence, where the pick is content-irrelevant by construction.
      * A pair requires Jaccard > 0. Greedy captured-order matching is explicitly NOT used — it
      * can strand a slot whose only viable window was consumed by an earlier slot's marginally
      * better match (the greedy trap; spec-pinned).
@@ -160,20 +195,25 @@ class DockTopologyReconciler extends Base {
      * @static
      */
     static assignSlots(capturedDocs, liveDocs) {
-        let matrix = capturedDocs.map(captured => liveDocs.map(live => this.slotAffinity(captured, live))),
-            best   = null;
+        let matrix      = capturedDocs.map(captured => liveDocs.map(live => this.slotAffinity(captured, live))),
+            contentKeys = liveDocs.map(live => this.liveContentKey(live)),
+            best        = null;
 
         const consider = (slotIndex, used, pairs, cardinality, jaccardSum, structuralSum) => {
             if (slotIndex === capturedDocs.length) {
-                let sequence = pairs.map(pair => pair.liveIndex).join(',');
+                // Content first (permutation-stable), live-index sequence last (only reachable
+                // between fully content-identical candidates, where the pick is content-free).
+                let signature = pairs.map(pair => `${pair.capturedIndex}>${contentKeys[pair.liveIndex]}`).join('|'),
+                    sequence  = pairs.map(pair => pair.liveIndex).join(',');
 
                 if (!best
                     || cardinality > best.cardinality
                     || (cardinality === best.cardinality && jaccardSum > best.jaccardSum)
                     || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum > best.structuralSum)
-                    || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum === best.structuralSum && sequence < best.sequence)
+                    || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum === best.structuralSum && signature < best.signature)
+                    || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum === best.structuralSum && signature === best.signature && sequence < best.sequence)
                 ) {
-                    best = {cardinality, jaccardSum, pairs: [...pairs], sequence, structuralSum}
+                    best = {cardinality, jaccardSum, pairs: [...pairs], sequence, signature, structuralSum}
                 }
                 return
             }
@@ -253,6 +293,20 @@ class DockTopologyReconciler extends Base {
             DockZoneModel.validate(doc).forEach(error => errors.push(`live document ${index}: ${error}`))
         });
 
+        // Workspace-global uniqueness is only provable over disjoint live inputs: a duplicate
+        // item id ACROSS live windows is corrupt workspace state — fail closed, mutate nothing.
+        let liveIdOwner = new Map();
+
+        liveDocuments.forEach((doc, index) => {
+            Object.keys(doc?.items || {}).forEach(itemId => {
+                if (liveIdOwner.has(itemId)) {
+                    errors.push(`live documents ${liveIdOwner.get(itemId)} and ${index} both carry item "${itemId}"`)
+                } else {
+                    liveIdOwner.set(itemId, index)
+                }
+            })
+        });
+
         let slots = this.capturedSlots(savedLayout);
 
         if (!errors.length && !slots.length) {
@@ -278,7 +332,6 @@ class DockTopologyReconciler extends Base {
             documents                          = [...liveDocuments],
             applied                            = [],
             displaced                          = [],
-            placedIds                          = new Set(),
             restored                           = [],
             unrestored                         = [];
 
@@ -287,21 +340,91 @@ class DockTopologyReconciler extends Base {
                 unrestored.push({capturedIndex, itemId, reason}))
         };
 
-        mapping.forEach(({affinity, capturedIndex, liveIndex}) => {
+        // Phase 1 — pure proposals: run the planner per pair against the ORIGINAL live document
+        // (each live index pairs at most once, so no proposal sees another's output). A proposal
+        // carries the document catalog it would contribute to the final workspace: the placed
+        // catalog for adopt/incremental, the untouched live catalog for pass-through verdicts.
+        let proposals = mapping.map(({affinity, capturedIndex, liveIndex}) => {
             let captured    = slots[capturedIndex],
-                capturedIds = Object.keys(captured.items || {});
+                capturedIds = Object.keys(captured.items || {}),
+                live        = liveDocuments[liveIndex],
+                result      = DockRestorePlanner.restoreToward(live, captured),
+                mode        = (result.deferred && result.reason === 'topology-fingerprint-mismatch') ? 'adopt'
+                            : (result.deferred || result.errors.length)                              ? 'stay'
+                            : 'incremental';
 
-            // Workspace-global uniqueness: a placement that would duplicate an already-restored
-            // item id across output documents does not happen — the whole slot reports.
-            if (capturedIds.some(itemId => placedIds.has(itemId))) {
+            return {
+                affinity, captured, capturedIds, capturedIndex, live, liveIndex, mode, result,
+                finalIds: new Set(mode === 'adopt'        ? capturedIds
+                                : mode === 'incremental'  ? Object.keys(result.document.items || {})
+                                : Object.keys(live.items  || {}))
+            }
+        });
+
+        // Phase 2 — workspace-global uniqueness over the COMPLETE final output: unmatched
+        // pass-through documents, stay verdicts, and placements all participate. Per contested
+        // id, priority follows LIVE OWNERSHIP (unique by the disjointness validation above):
+        // the window already holding the id live keeps it whenever its own final catalog
+        // retains it — placements IMPORTING that id elsewhere convict (minimal motion, never
+        // over-demotes the owner). An owner whose placement drops the id disclaims it; then the
+        // earliest-capturedIndex importing placement wins. A convicted slot demotes to
+        // `duplicate-item`, its live catalog re-enters the pool, and the check re-runs to
+        // fixpoint (monotone: place → stay only, so it terminates).
+        let liveOwner        = new Map(),
+            proposalByWindow = new Map(proposals.map(proposal => [proposal.liveIndex, proposal])),
+            changed          = true;
+
+        liveDocuments.forEach((doc, index) => {
+            Object.keys(doc?.items || {}).forEach(itemId => liveOwner.set(itemId, index))
+        });
+
+        // The final catalog a live window contributes: its proposal's (placements advance,
+        // demoted/stay proposals hold live content) — or its untouched live items when unmatched.
+        const windowFinalIds = index => proposalByWindow.get(index)?.finalIds
+            ?? new Set(Object.keys(liveDocuments[index].items || {}));
+
+        const convicted = proposal => {
+            for (const itemId of proposal.finalIds) {
+                let owner = liveOwner.get(itemId);
+
+                // The proposal's own window already owned this id live — retaining it is free.
+                if (owner === proposal.liveIndex) continue;
+
+                // The live owner keeps a retained id — this import loses.
+                if (owner !== undefined && windowFinalIds(owner).has(itemId)) return true;
+
+                // Owner disclaimed (or the id is purely captured): the earliest captured slot
+                // among importing placements wins the id; every later importer convicts.
+                for (const other of proposals) {
+                    if (other !== proposal && !other.duplicate && other.mode !== 'stay' &&
+                        other.capturedIndex < proposal.capturedIndex && other.finalIds.has(itemId)) {
+                        return true
+                    }
+                }
+            }
+            return false
+        };
+
+        while (changed) {
+            changed = false;
+
+            proposals.forEach(proposal => {
+                if (proposal.mode !== 'stay' && !proposal.duplicate && convicted(proposal)) {
+                    proposal.duplicate = true;
+                    proposal.finalIds  = new Set(Object.keys(proposal.live.items || {}));
+                    changed            = true
+                }
+            })
+        }
+
+        // Phase 3 — commit the surviving proposals; convicted and stay verdicts report.
+        proposals.forEach(({affinity, captured, capturedIds, capturedIndex, duplicate, live, liveIndex, mode, result}) => {
+            if (duplicate) {
                 reportSlot(capturedIndex, this.REASON_DUPLICATE_ITEM);
                 return
             }
 
-            let live   = documents[liveIndex],
-                result = DockRestorePlanner.restoreToward(live, captured);
-
-            if (result.deferred && result.reason === 'topology-fingerprint-mismatch') {
+            if (mode === 'adopt') {
                 // The ONE deferral this leaf owns: adopt wholesale; live-only items are DISPLACED.
                 let capturedIdSet = new Set(capturedIds);
 
@@ -311,18 +434,16 @@ class DockTopologyReconciler extends Base {
 
                 documents[liveIndex] = DockZoneModel.clone(captured);
                 applied.push({affinity, applied: 0, capturedIndex, liveIndex, mode: 'adopt'});
-                capturedIds.forEach(itemId => placedIds.add(itemId));
                 restored.push(...capturedIds)
-            } else if (result.deferred) {
+            } else if (mode === 'stay' && result.deferred) {
                 // Every other deferral reason belongs to its own leaf: pass it through verbatim.
                 reportSlot(capturedIndex, result.reason)
-            } else if (result.errors.length) {
+            } else if (mode === 'stay') {
                 errors.push(`slot ${capturedIndex} -> live ${liveIndex}: ${result.errors[0]}`);
                 reportSlot(capturedIndex, this.REASON_APPLY_ERROR)
             } else {
                 documents[liveIndex] = result.document;
                 applied.push({affinity, applied: result.applied, capturedIndex, liveIndex, mode: 'incremental'});
-                capturedIds.forEach(itemId => placedIds.add(itemId));
                 restored.push(...capturedIds)
             }
         });

--- a/src/dashboard/DockTopologyReconciler.mjs
+++ b/src/dashboard/DockTopologyReconciler.mjs
@@ -1,34 +1,39 @@
+import Base               from '../core/Base.mjs';
 import DockRestorePlanner from './DockRestorePlanner.mjs';
 import DockZoneModel      from './DockZoneModel.mjs';
 
 /**
- * @summary Changed-topology perspective restore: maps captured workspace slots onto live windows
- * by shape affinity (never ids), composes the landed per-window restore, and reports everything
- * it cannot cover — nothing silently drops, in either direction.
+ * @summary Changed-topology perspective restore: assigns captured workspace slots onto live
+ * windows by id-free shape affinity (optimal assignment, never greedy order), composes the landed
+ * per-window restore, and reports everything it cannot cover — nothing silently drops, in either
+ * direction, and no item ever duplicates across the output documents.
  *
  * The same-topology planner deliberately DEFERS on a shape-fingerprint mismatch ("the
  * cross-topology leaf owns that path") — this module is that leaf. Reconciliation semantics:
  *
- * - **Validate everything before mutating anything.** Any invalid captured slot or live document
- *   fails the ENTIRE restore closed: no document changes, every captured item reported
- *   `unrestored` with reason `validation-failed`, errors surfaced. There is no partial restore
- *   across the validation boundary.
- * - **Slot mapping is deterministic and id-free.** Affinity = Jaccard overlap of the two
- *   documents' item catalogs (`dockItemId` sets), tie-broken by structural similarity (node-type
- *   multiset overlap), then by stable live-document order; captured slots map greedily in
- *   captured order. Zero-overlap slots never map (`unmapped-slot`); slots beyond the live window
- *   supply stay uncovered (`no-live-window`).
- * - **Per-window restore composes, never duplicates.** A mapped pair with an IDENTICAL shape
- *   fingerprint restores incrementally through `DockRestorePlanner.restoreToward()` (no-flicker
- *   semantic operations). A mapped pair with a DIFFERENT shape adopts the captured document
- *   wholesale — and every live item absent from the adopted document is reported in `displaced`
- *   (documents never destroy pane instances; the workspace decides what to do with displaced
- *   content, e.g. fallback placement).
- * - **No window creation.** A restore MUST NOT depend on popup permission: this module exposes no
- *   spawning path whatsoever; excess live windows keep their documents untouched.
- *
- * Conservation invariant (spec-pinned): every captured item id appears in exactly one of
- * `restored` or `unrestored`.
+ * - **Envelope authority first.** The saved-layout envelope validates through the landed
+ *   `DockZoneModel.restoreSavedLayout()` (schema, `captureScope` ↔ `windowDocuments` coupling,
+ *   slot-indexed document validation, primary presence) plus slot-indexed live-document
+ *   validation. Any failure fails the ENTIRE restore closed without throwing: no document
+ *   changes, every captured item reported `unrestored` with reason `validation-failed`.
+ * - **Assignment is optimal and deterministic.** Maximum cardinality first, then maximum summed
+ *   Jaccard affinity (item-catalog overlap), then maximum summed structural affinity (node-type
+ *   multiset overlap), then the lexicographically smallest live-index sequence — the tie rule is
+ *   content-stable: ties at all affinity keys mean the candidate windows are interchangeable at
+ *   affinity altitude, so index order is an honest deterministic pick. Pairs require Jaccard > 0.
+ *   Never reads node ids or window identifiers.
+ * - **Per-window restore branches on the planner's OWN verdict.** Clean plan → incremental
+ *   semantic operations. Deferred with reason `topology-fingerprint-mismatch` (the one deferral
+ *   this leaf owns) → wholesale adoption of the captured document, with every live-only item
+ *   reported in `displaced`. Any OTHER deferral reason passes through verbatim into `unrestored`
+ *   (the owning leaf for that reason is not this one); executor failures report `apply-error` —
+ *   never mislabeled as validation.
+ * - **Workspace-global item uniqueness.** A slot whose placement would duplicate an item id
+ *   already restored into another output document does not place; its items report
+ *   `duplicate-item`. Conservation is global: every captured item id lands in exactly one of
+ *   `restored` or `unrestored`.
+ * - **No window creation.** A restore MUST NOT depend on popup permission: this module exposes
+ *   no spawning path whatsoever; unmatched live windows keep reference-identical documents.
  *
  * @class Neo.dashboard.DockTopologyReconciler
  * @extends Neo.core.Base
@@ -36,7 +41,7 @@ import DockZoneModel      from './DockZoneModel.mjs';
  * @see Neo.dashboard.DockZoneModel
  * @see learn/agentos/HarnessDockZoneModel.md
  */
-class DockTopologyReconciler {
+class DockTopologyReconciler extends Base {
     static config = {
         /**
          * @member {String} className='Neo.dashboard.DockTopologyReconciler'
@@ -46,19 +51,33 @@ class DockTopologyReconciler {
     }
 
     /**
-     * Reason class: the captured slot could not map because every live window is already taken.
+     * Reason class: the per-window executor failed while applying an incremental plan.
+     * @member {String} REASON_APPLY_ERROR='apply-error'
+     * @static
+     */
+    static REASON_APPLY_ERROR = 'apply-error'
+    /**
+     * Reason class: placing this slot would duplicate an item id already restored into another
+     * output document (workspace-global uniqueness).
+     * @member {String} REASON_DUPLICATE_ITEM='duplicate-item'
+     * @static
+     */
+    static REASON_DUPLICATE_ITEM = 'duplicate-item'
+    /**
+     * Reason class: the captured slot had positive affinity somewhere, but every such window was
+     * assigned to a better-matching slot — the topology shrank underneath it.
      * @member {String} REASON_NO_LIVE_WINDOW='no-live-window'
      * @static
      */
     static REASON_NO_LIVE_WINDOW = 'no-live-window'
     /**
-     * Reason class: the captured slot shares no item overlap with any remaining live window.
+     * Reason class: the captured slot shares no item overlap with ANY live window.
      * @member {String} REASON_UNMAPPED_SLOT='unmapped-slot'
      * @static
      */
     static REASON_UNMAPPED_SLOT = 'unmapped-slot'
     /**
-     * Reason class: validation failed somewhere — the whole restore fails closed.
+     * Reason class: the envelope or a document failed validation — the whole restore fails closed.
      * @member {String} REASON_VALIDATION_FAILED='validation-failed'
      * @static
      */
@@ -127,64 +146,86 @@ class DockTopologyReconciler {
     }
 
     /**
-     * Deterministic greedy slot mapping: captured slots claim live documents in captured order;
-     * each takes the highest-affinity remaining live document (jaccard desc → structural desc →
-     * live index asc). A slot maps only when its Jaccard overlap is > 0.
+     * Optimal deterministic slot assignment: exhaustive search over the (small — window-count-
+     * bounded) pairing space, maximizing `(cardinality, Σ jaccard, Σ structural)` with the
+     * lexicographically smallest live-index sequence as the content-stable final tie rule.
+     * A pair requires Jaccard > 0. Greedy captured-order matching is explicitly NOT used — it
+     * can strand a slot whose only viable window was consumed by an earlier slot's marginally
+     * better match (the greedy trap; spec-pinned).
      * @param {Object[]} capturedDocs
      * @param {Object[]} liveDocs
      * @returns {{mapping: Object[], unmapped: Object[], unmatchedLive: Number[]}}
-     *          `mapping`: `[{capturedIndex, liveIndex, affinity}]` · `unmapped`:
-     *          `[{capturedIndex, reason}]` · `unmatchedLive`: live indices left untouched.
+     *          `mapping`: `[{capturedIndex, liveIndex, affinity}]` in captured order · `unmapped`:
+     *          `[{capturedIndex, reason}]` · `unmatchedLive`: untouched live indices.
      * @static
      */
-    static mapWorkspaceSlots(capturedDocs, liveDocs) {
-        let remaining = liveDocs.map((doc, index) => ({doc, index})),
-            mapping   = [],
-            unmapped  = [];
+    static assignSlots(capturedDocs, liveDocs) {
+        let matrix = capturedDocs.map(captured => liveDocs.map(live => this.slotAffinity(captured, live))),
+            best   = null;
 
-        capturedDocs.forEach((captured, capturedIndex) => {
-            if (!remaining.length) {
-                unmapped.push({capturedIndex, reason: this.REASON_NO_LIVE_WINDOW});
+        const consider = (slotIndex, used, pairs, cardinality, jaccardSum, structuralSum) => {
+            if (slotIndex === capturedDocs.length) {
+                let sequence = pairs.map(pair => pair.liveIndex).join(',');
+
+                if (!best
+                    || cardinality > best.cardinality
+                    || (cardinality === best.cardinality && jaccardSum > best.jaccardSum)
+                    || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum > best.structuralSum)
+                    || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum === best.structuralSum && sequence < best.sequence)
+                ) {
+                    best = {cardinality, jaccardSum, pairs: [...pairs], sequence, structuralSum}
+                }
                 return
             }
 
-            let best = null;
+            // Option A: leave this slot unassigned.
+            consider(slotIndex + 1, used, pairs, cardinality, jaccardSum, structuralSum);
 
-            remaining.forEach(candidate => {
-                let affinity = this.slotAffinity(captured, candidate.doc);
-
-                if (affinity.jaccard <= 0) {
-                    return
+            // Option B: pair it with any unused positive-affinity window.
+            matrix[slotIndex].forEach((affinity, liveIndex) => {
+                if (affinity.jaccard > 0 && !used.has(liveIndex)) {
+                    used.add(liveIndex);
+                    pairs.push({affinity, capturedIndex: slotIndex, liveIndex});
+                    consider(slotIndex + 1, used, pairs, cardinality + 1, jaccardSum + affinity.jaccard, structuralSum + affinity.structural);
+                    pairs.pop();
+                    used.delete(liveIndex)
                 }
+            })
+        };
 
-                if (!best
-                    || affinity.jaccard   > best.affinity.jaccard
-                    || (affinity.jaccard   === best.affinity.jaccard && affinity.structural > best.affinity.structural)
-                    || (affinity.jaccard   === best.affinity.jaccard && affinity.structural === best.affinity.structural && candidate.index < best.liveIndex)
-                ) {
-                    best = {affinity, liveIndex: candidate.index}
-                }
-            });
+        consider(0, new Set(), [], 0, 0, 0);
 
-            if (best) {
-                mapping.push({capturedIndex, liveIndex: best.liveIndex, affinity: best.affinity});
-                remaining = remaining.filter(candidate => candidate.index !== best.liveIndex)
-            } else {
-                unmapped.push({capturedIndex, reason: this.REASON_UNMAPPED_SLOT})
+        let assigned = new Set(best.pairs.map(pair => pair.capturedIndex)),
+            usedLive = new Set(best.pairs.map(pair => pair.liveIndex)),
+            unmapped = [];
+
+        capturedDocs.forEach((doc, capturedIndex) => {
+            if (!assigned.has(capturedIndex)) {
+                // Cardinality-first optimality guarantees: a slot with positive affinity to a
+                // STILL-FREE window would have been assigned — so an unassigned slot either had
+                // zero affinity everywhere, or every viable window went to a better match.
+                let hadAffinity = matrix[capturedIndex].some(affinity => affinity.jaccard > 0);
+
+                unmapped.push({
+                    capturedIndex,
+                    reason: hadAffinity ? this.REASON_NO_LIVE_WINDOW : this.REASON_UNMAPPED_SLOT
+                })
             }
         });
 
-        return {mapping, unmapped, unmatchedLive: remaining.map(candidate => candidate.index)}
+        return {
+            mapping      : best.pairs.sort((a, b) => a.capturedIndex - b.capturedIndex),
+            unmapped,
+            unmatchedLive: liveDocs.map((doc, index) => index).filter(index => !usedLive.has(index))
+        }
     }
 
     /**
-     * Reconciles a topology-scope perspective onto a changed live topology.
-     *
-     * Fail-closed validation boundary first; then deterministic slot mapping; then per-window
-     * restore (incremental via the landed planner on shape match, wholesale adoption on
-     * mismatch); uncovered captured content returns reason-classed. Live documents are NEVER
-     * mutated in place — the result carries next-documents per live index.
-     * @param {Object} savedLayout   Topology-scope saved layout (`dockZone` + `windowDocuments`).
+     * Reconciles a topology-scope perspective onto a changed live topology. See the class
+     * summary for the governing semantics; every branch is spec-pinned. Live documents are
+     * never mutated in place — `documents` mirrors `liveDocuments` (advanced, adopted, or
+     * reference-identical untouched).
+     * @param {Object} savedLayout    Topology-scope saved layout (`dockZone` + `windowDocuments`).
      * @param {Object[]} liveDocuments Live per-window committed documents, in window order.
      * @returns {{
      *     applied: Object[],
@@ -195,25 +236,26 @@ class DockTopologyReconciler {
      *     restored: String[],
      *     unmatchedLive: Number[],
      *     unrestored: Object[]
-     * }} `documents` mirrors `liveDocuments` (adopted/advanced or untouched); `restored` =
-     *     covered captured item ids; `unrestored` = `[{itemId, reason, capturedIndex}]`;
-     *     `displaced` = `[{itemId, liveIndex}]` live items absent from an adopted document;
-     *     `applied` = per-mapping restore results (`{capturedIndex, liveIndex, mode, applied}`).
+     * }}
      * @static
      */
     static reconcile(savedLayout, liveDocuments = []) {
-        let slots  = this.capturedSlots(savedLayout),
-            errors = [];
+        let errors = [];
 
-        // §validation boundary: everything valid before anything mutates — no partial restore.
-        slots.forEach((doc, index) => {
-            DockZoneModel.validate(doc).forEach(error => errors.push(`captured slot ${index}: ${error}`))
-        });
+        // Envelope authority: the landed restore validator owns the wrapper contract — schema,
+        // captureScope ↔ windowDocuments coupling, slot-indexed tree validation, primary document.
+        // Non-throwing by its own contract.
+        let envelope = DockZoneModel.restoreSavedLayout(savedLayout ?? {});
+
+        errors.push(...envelope.errors);
+
         liveDocuments.forEach((doc, index) => {
             DockZoneModel.validate(doc).forEach(error => errors.push(`live document ${index}: ${error}`))
         });
 
-        if (!slots.length) {
+        let slots = this.capturedSlots(savedLayout);
+
+        if (!errors.length && !slots.length) {
             errors.push('savedLayout carries no captured workspace documents')
         }
 
@@ -232,46 +274,60 @@ class DockTopologyReconciler {
             }
         }
 
-        let {mapping, unmapped, unmatchedLive} = this.mapWorkspaceSlots(slots, liveDocuments),
+        let {mapping, unmapped, unmatchedLive} = this.assignSlots(slots, liveDocuments),
             documents                          = [...liveDocuments],
             applied                            = [],
             displaced                          = [],
+            placedIds                          = new Set(),
             restored                           = [],
             unrestored                         = [];
 
-        mapping.forEach(({capturedIndex, liveIndex, affinity}) => {
-            let captured = slots[capturedIndex],
-                live     = documents[liveIndex],
-                result   = DockRestorePlanner.restoreToward(live, captured);
+        const reportSlot = (capturedIndex, reason) => {
+            Object.keys(slots[capturedIndex].items || {}).forEach(itemId =>
+                unrestored.push({capturedIndex, itemId, reason}))
+        };
 
-            if (result.deferred) {
-                // Shape mismatch: the captured document is adopted wholesale (the wrapper-restore
-                // semantics); live-only items are DISPLACED — reported, never silently dropped.
-                let capturedIds = new Set(Object.keys(captured.items || {}));
+        mapping.forEach(({affinity, capturedIndex, liveIndex}) => {
+            let captured    = slots[capturedIndex],
+                capturedIds = Object.keys(captured.items || {});
+
+            // Workspace-global uniqueness: a placement that would duplicate an already-restored
+            // item id across output documents does not happen — the whole slot reports.
+            if (capturedIds.some(itemId => placedIds.has(itemId))) {
+                reportSlot(capturedIndex, this.REASON_DUPLICATE_ITEM);
+                return
+            }
+
+            let live   = documents[liveIndex],
+                result = DockRestorePlanner.restoreToward(live, captured);
+
+            if (result.deferred && result.reason === 'topology-fingerprint-mismatch') {
+                // The ONE deferral this leaf owns: adopt wholesale; live-only items are DISPLACED.
+                let capturedIdSet = new Set(capturedIds);
 
                 Object.keys(live.items || {}).forEach(itemId => {
-                    capturedIds.has(itemId) || displaced.push({itemId, liveIndex})
+                    capturedIdSet.has(itemId) || displaced.push({itemId, liveIndex})
                 });
 
                 documents[liveIndex] = DockZoneModel.clone(captured);
-                applied.push({capturedIndex, liveIndex, affinity, applied: 0, mode: 'adopt'});
-                restored.push(...Object.keys(captured.items || {}))
+                applied.push({affinity, applied: 0, capturedIndex, liveIndex, mode: 'adopt'});
+                capturedIds.forEach(itemId => placedIds.add(itemId));
+                restored.push(...capturedIds)
+            } else if (result.deferred) {
+                // Every other deferral reason belongs to its own leaf: pass it through verbatim.
+                reportSlot(capturedIndex, result.reason)
             } else if (result.errors.length) {
-                // Per-window executor failure: that window stays as-is; its slot reports closed.
                 errors.push(`slot ${capturedIndex} -> live ${liveIndex}: ${result.errors[0]}`);
-                Object.keys(captured.items || {}).forEach(itemId =>
-                    unrestored.push({capturedIndex, itemId, reason: this.REASON_VALIDATION_FAILED}))
+                reportSlot(capturedIndex, this.REASON_APPLY_ERROR)
             } else {
                 documents[liveIndex] = result.document;
-                applied.push({capturedIndex, liveIndex, affinity, applied: result.applied, mode: 'incremental'});
-                restored.push(...Object.keys(captured.items || {}))
+                applied.push({affinity, applied: result.applied, capturedIndex, liveIndex, mode: 'incremental'});
+                capturedIds.forEach(itemId => placedIds.add(itemId));
+                restored.push(...capturedIds)
             }
         });
 
-        unmapped.forEach(({capturedIndex, reason}) => {
-            Object.keys(slots[capturedIndex].items || {}).forEach(itemId =>
-                unrestored.push({capturedIndex, itemId, reason}))
-        });
+        unmapped.forEach(({capturedIndex, reason}) => reportSlot(capturedIndex, reason));
 
         return {applied, displaced, documents, errors, mapping, restored, unmatchedLive, unrestored}
     }

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -969,6 +969,15 @@ class DockZoneModel extends Base {
                     if (treeErrors.length) {
                         errors.push(`windowDocuments[${index}] is not a valid dock-zone document: ${treeErrors[0]}`)
                     }
+
+                    // The finite durable-field boundary applies to EVERY captured slot, not only
+                    // the primary `dockZone` — runtime-bearing fields (window fingerprints,
+                    // rects) must not ride an additional window document into persistence.
+                    const unexpected = DockZoneModel.findUnexpectedDockZoneKey(tree, `windowDocuments[${index}]`);
+
+                    if (unexpected) {
+                        errors.push(`windowDocuments[${index}] contains unexpected field "${unexpected.key}" at ${unexpected.path}: ${unexpected.reason}`)
+                    }
                 })
             }
         }

--- a/test/playwright/unit/dashboard/DockTopologyReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologyReconciler.spec.mjs
@@ -69,15 +69,16 @@ test.describe('Neo.dashboard.DockTopologyReconciler', () => {
     });
 
     test('the greedy trap: optimal assignment maps BOTH slots where captured-order greedy strands one', () => {
-        // Slot 0 marginally prefers W0 (0.6 vs 0.5); slot 1 can ONLY use W0 (0.4, zero for W1).
-        // Greedy: slot 0 eats W0, slot 1 strands (cardinality 1). Optimal: both map (cardinality 2).
+        // Disjoint live catalogs (the workspace invariant); slot 0's items straddle both windows.
+        // Greedy: slot 0 eats W0 (its best, .5), stranding slot 1 (zero for W1) → cardinality 1.
+        // Optimal: slot 0 takes W1 (.25) so slot 1 keeps W0 (.25) → cardinality 2.
         let saved = capture([
-                tabsDoc(['a', 'b', 'c']),
-                tabsDoc(['d', 'e'])
+                tabsDoc(['p', 'q', 'r']),
+                tabsDoc(['s', 't'])
             ]),
             live  = [
-                tabsDoc(['a', 'b', 'c', 'd', 'e']),           // W0: slot0 j=3/5=.6 · slot1 j=2/5=.4
-                tabsDoc(['a', 'b', 'c', 'x', 'y', 'z'])       // W1: slot0 j=3/6=.5 · slot1 j=0
+                tabsDoc(['p', 'q', 's']),                     // W0: slot0 j=2/4=.5  · slot1 j=1/4=.25
+                tabsDoc(['r', 'u'])                           // W1: slot0 j=1/4=.25 · slot1 j=0
             ],
             result = DockTopologyReconciler.reconcile(saved, live);
 
@@ -88,20 +89,74 @@ test.describe('Neo.dashboard.DockTopologyReconciler', () => {
         expectConservation(saved, result)
     });
 
-    test('exact ties resolve content-stably: identical candidate windows + live permutation → same mapping content', () => {
-        let saved  = capture([tabsDoc(['alpha'])]),
-            cloneA = tabsDoc(['alpha']),
-            cloneB = tabsDoc(['alpha']),
-            first  = DockTopologyReconciler.reconcile(saved, [cloneA, cloneB]),
-            second = DockTopologyReconciler.reconcile(saved, [cloneB, cloneA]);
+    test('non-identical equal-aggregate ties resolve by CONTENT, permutation-stably: both live orders advance the same window content', () => {
+        // TWO cardinality-2 assignments tie on every affinity key ({S0→A,S1→B} vs {S0→B,S1→A}:
+        // all four pairs share jaccard 1/4 and identical structure) — but the candidate windows
+        // are NOT interchangeable: A={a,c,x} and B={b,d,y} differ in content. The content-
+        // signature tie rule must map S0={a,b} to A (smallest content key) under EITHER live
+        // order. (Live arity differs from captured so placements ride the adopt path — the
+        // landed planner refuses to invent missing items incrementally.)
+        let saved = capture([tabsDoc(['a', 'b']), tabsDoc(['c', 'd'])]),
+            docA  = () => tabsDoc(['a', 'c', 'x']),
+            docB  = () => tabsDoc(['b', 'd', 'y']),
 
-        // Identical candidates are interchangeable at affinity altitude: the tie rule picks the
-        // smallest live index deterministically, and the CONTENT of the outcome is permutation-stable.
-        expect(first.mapping).toEqual([expect.objectContaining({capturedIndex: 0, liveIndex: 0})]);
-        expect(second.mapping).toEqual([expect.objectContaining({capturedIndex: 0, liveIndex: 0})]);
-        expect(Object.keys(first.documents[0].items)).toEqual(Object.keys(second.documents[0].items));
+            first  = DockTopologyReconciler.reconcile(saved, [docA(), docB()]),
+            second = DockTopologyReconciler.reconcile(saved, [docB(), docA()]);
+
+        const contentOf = result => result.applied
+            .map(({capturedIndex, liveIndex}) => [capturedIndex, Object.keys(result.documents[liveIndex].items).sort().join(',')])
+            .sort();
+
         expect(first.errors).toEqual([]);
-        expect(second.errors).toEqual([])
+        expect(second.errors).toEqual([]);
+        // Same captured→content mapping, same restored set, same (empty) displaced set — the
+        // live ARRAY ORDER left no fingerprint on the outcome.
+        expect(contentOf(first)).toEqual(contentOf(second));
+        expect([...first.restored].sort()).toEqual([...second.restored].sort());
+        // displaced/unrestored compare by CONTENT — liveIndex legitimately follows the permutation.
+        expect(first.displaced.map(entry => entry.itemId).sort()).toEqual(second.displaced.map(entry => entry.itemId).sort());
+        expect(first.unrestored).toEqual(second.unrestored);
+        expectConservation(saved, first);
+        expectConservation(saved, second)
+    });
+
+    test('a straddling slot never emits a duplicate: the unmatched pass-through window convicts the placement, permutation-stably', () => {
+        // Captured {a,b} straddles two disjoint live windows ({a,c,x} / {b,d,y}) with equal
+        // aggregate affinity. WHICHEVER window it lands on, the OTHER stays live and keeps its
+        // copy — so placing would duplicate an item across the final workspace. The reconciler
+        // must route the slot to duplicate-item, leave BOTH windows reference-identical, and
+        // report identically under either live order.
+        let saved = capture([tabsDoc(['a', 'b'])]),
+            docA  = () => tabsDoc(['a', 'c', 'x']),
+            docB  = () => tabsDoc(['b', 'd', 'y']);
+
+        [[docA(), docB()], [docB(), docA()]].forEach(live => {
+            let result = DockTopologyReconciler.reconcile(saved, live);
+
+            expect(result.errors).toEqual([]);
+            expect(result.applied).toEqual([]);
+            expect(result.displaced).toEqual([]);
+            expect(result.documents[0]).toBe(live[0]);
+            expect(result.documents[1]).toBe(live[1]);
+            expect(result.unrestored).toEqual([
+                {capturedIndex: 0, itemId: 'a', reason: DockTopologyReconciler.REASON_DUPLICATE_ITEM},
+                {capturedIndex: 0, itemId: 'b', reason: DockTopologyReconciler.REASON_DUPLICATE_ITEM}
+            ]);
+            expectConservation(saved, result)
+        })
+    });
+
+    test('duplicate item ids ACROSS live windows are corrupt input: fail closed, mutate nothing', () => {
+        let saved  = capture([tabsDoc(['alpha'])]),
+            live   = [tabsDoc(['alpha', 'solo']), tabsDoc(['alpha'])],
+            result = DockTopologyReconciler.reconcile(saved, live);
+
+        expect(result.errors.join(' ')).toContain('both carry item "alpha"');
+        expect(result.applied).toEqual([]);
+        expect(result.documents[0]).toBe(live[0]);
+        expect(result.documents[1]).toBe(live[1]);
+        result.unrestored.forEach(entry =>
+            expect(entry.reason).toBe(DockTopologyReconciler.REASON_VALIDATION_FAILED))
     });
 
     test('grown topology: excess live windows stay reference-identical; no spawning surface exists', () => {
@@ -147,8 +202,10 @@ test.describe('Neo.dashboard.DockTopologyReconciler', () => {
         // Missing primary document.
         expectFailClosed((() => { let broken = {...valid}; delete broken.dockZone; return broken })(), 'missing dockZone');
 
-        // Non-array windowDocuments.
+        // Non-array windowDocuments — the string AND the plain-object shape (an object reaches
+        // a spread as a non-iterable: the total extractor must never throw on it).
         expectFailClosed({...valid, windowDocuments: 'nope'}, 'non-array windowDocuments');
+        expectFailClosed({...valid, windowDocuments: {}},     'object windowDocuments');
 
         // A malformed slot fails closed with its index preserved in the surfaced error.
         let badSlot = expectFailClosed({
@@ -166,9 +223,62 @@ test.describe('Neo.dashboard.DockTopologyReconciler', () => {
         expectFailClosed(null, 'null envelope')
     });
 
+    test('a null middle slot preserves ORIGINAL captured indices in the fail-closed report', () => {
+        // Slot layout: 0 = dockZone(a1), 1 = windowDocuments[0] → nulled, 2 = windowDocuments[1](c1).
+        // Compacting the null away would misreport slot 2 as index 1 — the extractor must not.
+        let saved = capture([tabsDoc(['a1']), tabsDoc(['b1']), tabsDoc(['c1'])]),
+            live  = [tabsDoc(['a1'])];
+
+        saved = {...saved, windowDocuments: [null, saved.windowDocuments[1]]};
+
+        let result;
+
+        expect(() => { result = DockTopologyReconciler.reconcile(saved, live) }).not.toThrow();
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.documents[0]).toBe(live[0]);
+        // Slot 2's items report under capturedIndex 2 — NOT 1 — with the null slot in between.
+        expect(result.unrestored).toEqual([
+            {capturedIndex: 0, itemId: 'a1', reason: DockTopologyReconciler.REASON_VALIDATION_FAILED},
+            {capturedIndex: 2, itemId: 'c1', reason: DockTopologyReconciler.REASON_VALIDATION_FAILED}
+        ])
+    });
+
+    test('the finite durable-field boundary applies to EVERY captured slot, not only the primary document', () => {
+        let saved = capture([tabsDoc(['a1']), tabsDoc(['b1'])]),
+            live  = [tabsDoc(['a1']), tabsDoc(['b1'])],
+            slot  = saved.windowDocuments[0];
+
+        // Runtime-bearing fields must not ride an ADDITIONAL window document into a restore:
+        // a document-level window fingerprint...
+        let fingerprinted = {...saved, windowDocuments: [{...slot, windowFingerprint: {windowId: 'w2'}}]},
+            first         = DockTopologyReconciler.reconcile(fingerprinted, live);
+
+        expect(first.errors.join(' ')).toContain('windowDocuments[0]');
+        expect(first.errors.join(' ')).toContain('windowFingerprint');
+        expect(first.applied).toEqual([]);
+        first.unrestored.forEach(entry =>
+            expect(entry.reason).toBe(DockTopologyReconciler.REASON_VALIDATION_FAILED));
+
+        // ...and an item-level runtime rect both fail the restore closed, offender indexed.
+        let rected = {
+                ...saved,
+                windowDocuments: [{...slot, items: {b1: {...slot.items.b1, runtimeRect: {x: 0, y: 0}}}}]
+            },
+            second = DockTopologyReconciler.reconcile(rected, live);
+
+        expect(second.errors.join(' ')).toContain('windowDocuments[0]');
+        expect(second.errors.join(' ')).toContain('runtimeRect');
+        expect(second.applied).toEqual([]);
+        second.unrestored.forEach(entry =>
+            expect(entry.reason).toBe(DockTopologyReconciler.REASON_VALIDATION_FAILED))
+    });
+
     test('workspace-global uniqueness: a slot whose placement would duplicate an item does not place', () => {
         // Hand-built envelope (schema-complete, passes the landed validator): two slots carrying
-        // the SAME item id — a state the capture producer does not emit, but a stored layout could.
+        // the SAME item id — a state the capture producer does not emit, but a stored layout
+        // could. Live catalogs are DISJOINT (the workspace invariant). 'shared' lives in W1;
+        // slot 1 restores it in place, so slot 0's placement would IMPORT a second copy into
+        // W0 — live ownership convicts the importer, and the id stays single in the output.
         let shared = {
                 schema           : DockZoneModel.LAYOUT_SCHEMA,
                 layoutId         : 'dup-test',
@@ -179,21 +289,23 @@ test.describe('Neo.dashboard.DockTopologyReconciler', () => {
                 dockZone         : tabsDoc(['shared', 'solo']),
                 windowDocuments  : [tabsDoc(['shared'])]
             },
-            live   = [tabsDoc(['shared', 'solo']), tabsDoc(['shared'])],
+            live   = [tabsDoc(['solo', 'filler', 'pad']), tabsDoc(['shared'])],
             result = DockTopologyReconciler.reconcile(shared, live);
 
-        // Exactly one PLACEMENT of 'shared' across the documents that received placements —
-        // a dup-blocked slot's window stays untouched (its pre-existing live content is not a
-        // placement and is not this module's to rewrite).
-        let placedIndexes = result.applied.map(entry => entry.liveIndex),
-            placedShared  = placedIndexes.filter(index => result.documents[index].items?.shared).length;
+        // 'shared' appears in EXACTLY ONE final document — the complete-output invariant, not
+        // merely a per-placement count (a placed copy next to an untouched live copy would
+        // still be a workspace duplicate).
+        let finalShared = result.documents.filter(doc => doc.items?.shared).length;
 
         expect(result.errors).toEqual([]);
-        expect(placedShared).toBe(1);
-        // The dup-blocked slot's window keeps reference identity.
-        expect(result.documents[1]).toBe(live[1]);
+        expect(finalShared).toBe(1);
+        expect(result.restored).toEqual(['shared']);
+        // The convicted importer's window keeps reference identity — slot-atomic: BOTH its
+        // items report, including the collision-free one.
+        expect(result.documents[0]).toBe(live[0]);
         expect(result.unrestored).toEqual([
-            {capturedIndex: 1, itemId: 'shared', reason: DockTopologyReconciler.REASON_DUPLICATE_ITEM}
+            {capturedIndex: 0, itemId: 'shared', reason: DockTopologyReconciler.REASON_DUPLICATE_ITEM},
+            {capturedIndex: 0, itemId: 'solo',   reason: DockTopologyReconciler.REASON_DUPLICATE_ITEM}
         ]);
         expectConservation(shared, result)
     });

--- a/test/playwright/unit/dashboard/DockTopologyReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologyReconciler.spec.mjs
@@ -11,6 +11,7 @@ import Neo                    from '../../../../src/Neo.mjs';
 import * as core              from '../../../../src/core/_export.mjs';
 import DockRestorePlanner     from '../../../../src/dashboard/DockRestorePlanner.mjs';
 import DockTopologyReconciler from '../../../../src/dashboard/DockTopologyReconciler.mjs';
+import DockZoneModel          from '../../../../src/dashboard/DockZoneModel.mjs';
 
 const tabsDoc = ids => ({
     schema: 'neo.harness.dockZone.v1',
@@ -21,14 +22,17 @@ const tabsDoc = ids => ({
     }
 });
 
-const layout = (slot0, windowDocs = []) => ({
-    schema         : 'neo.harness.dockLayout.v1',
-    layoutId       : 'test-perspective',
-    title          : 'Test',
-    captureScope   : 'topology',
-    dockZone       : slot0,
-    windowDocuments: windowDocs
-});
+// Fixtures ride the REAL landed producer — hand-rolled envelopes only appear in the negative
+// cases that deliberately break the envelope contract.
+const capture = docs => {
+    let {layout, errors} = DockZoneModel.captureTopologyPerspective(docs, {layoutId: 'test-perspective', title: 'Test'});
+
+    if (errors.length) {
+        throw new Error(`fixture capture failed: ${errors[0]}`)
+    }
+
+    return layout
+};
 
 const capturedIdsOf = saved => DockTopologyReconciler.capturedSlots(saved)
     .flatMap(doc => Object.keys(doc.items || {}));
@@ -41,119 +45,227 @@ const expectConservation = (saved, result) => {
 };
 
 test.describe('Neo.dashboard.DockTopologyReconciler', () => {
-    test('shrunk topology: best-coverage mapping + reason-classed remainder + conservation', () => {
-        let saved = layout(
+    test('shrunk topology: best-coverage assignment + reason-classed remainder + conservation', () => {
+        let saved = capture([
                 tabsDoc(['alpha', 'beta']),
-                [tabsDoc(['gamma', 'delta']), tabsDoc(['omega', 'psi'])]
-            ),
+                tabsDoc(['gamma', 'delta']),
+                tabsDoc(['omega', 'psi'])
+            ]),
             live  = [
-                tabsDoc(['gamma', 'delta']),   // strong match for slot 1
-                tabsDoc(['alpha', 'beta'])     // strong match for slot 0
+                tabsDoc(['gamma', 'delta']),
+                tabsDoc(['alpha', 'beta'])
             ],
             result = DockTopologyReconciler.reconcile(saved, live);
 
         expect(result.errors).toEqual([]);
-        // Slot 0 -> live 1, slot 1 -> live 0 — affinity decides, never order or ids.
         expect(result.mapping.map(({capturedIndex, liveIndex}) => [capturedIndex, liveIndex]))
             .toEqual([[0, 1], [1, 0]]);
-        // Slot 2 (omega/psi) has no window left: reasoned, never dropped.
+        // Slot 2 HAD affinity nowhere-free: the topology shrank underneath it — reasoned, never dropped.
         expect(result.unrestored).toEqual([
-            {capturedIndex: 2, itemId: 'omega', reason: DockTopologyReconciler.REASON_NO_LIVE_WINDOW},
-            {capturedIndex: 2, itemId: 'psi',   reason: DockTopologyReconciler.REASON_NO_LIVE_WINDOW}
+            {capturedIndex: 2, itemId: 'omega', reason: DockTopologyReconciler.REASON_UNMAPPED_SLOT},
+            {capturedIndex: 2, itemId: 'psi',   reason: DockTopologyReconciler.REASON_UNMAPPED_SLOT}
         ]);
         expectConservation(saved, result)
     });
 
-    test('zero item overlap never maps: unmapped-slot even with live windows available', () => {
-        let saved  = layout(tabsDoc(['alpha', 'beta'])),
-            live   = [tabsDoc(['unrelated1', 'unrelated2'])],
+    test('the greedy trap: optimal assignment maps BOTH slots where captured-order greedy strands one', () => {
+        // Slot 0 marginally prefers W0 (0.6 vs 0.5); slot 1 can ONLY use W0 (0.4, zero for W1).
+        // Greedy: slot 0 eats W0, slot 1 strands (cardinality 1). Optimal: both map (cardinality 2).
+        let saved = capture([
+                tabsDoc(['a', 'b', 'c']),
+                tabsDoc(['d', 'e'])
+            ]),
+            live  = [
+                tabsDoc(['a', 'b', 'c', 'd', 'e']),           // W0: slot0 j=3/5=.6 · slot1 j=2/5=.4
+                tabsDoc(['a', 'b', 'c', 'x', 'y', 'z'])       // W1: slot0 j=3/6=.5 · slot1 j=0
+            ],
             result = DockTopologyReconciler.reconcile(saved, live);
 
-        expect(result.mapping).toEqual([]);
-        expect(result.unrestored.map(entry => entry.reason))
-            .toEqual([DockTopologyReconciler.REASON_UNMAPPED_SLOT, DockTopologyReconciler.REASON_UNMAPPED_SLOT]);
-        // The available live window stays untouched.
-        expect(result.unmatchedLive).toEqual([0]);
-        expect(result.documents[0]).toBe(live[0]);
+        expect(result.errors).toEqual([]);
+        expect(result.mapping.map(({capturedIndex, liveIndex}) => [capturedIndex, liveIndex]))
+            .toEqual([[0, 1], [1, 0]]);
+        expect(result.unrestored).toEqual([]);
         expectConservation(saved, result)
     });
 
-    test('grown topology: excess live windows stay untouched; no spawning surface exists', () => {
-        let saved  = layout(tabsDoc(['alpha'])),
+    test('exact ties resolve content-stably: identical candidate windows + live permutation → same mapping content', () => {
+        let saved  = capture([tabsDoc(['alpha'])]),
+            cloneA = tabsDoc(['alpha']),
+            cloneB = tabsDoc(['alpha']),
+            first  = DockTopologyReconciler.reconcile(saved, [cloneA, cloneB]),
+            second = DockTopologyReconciler.reconcile(saved, [cloneB, cloneA]);
+
+        // Identical candidates are interchangeable at affinity altitude: the tie rule picks the
+        // smallest live index deterministically, and the CONTENT of the outcome is permutation-stable.
+        expect(first.mapping).toEqual([expect.objectContaining({capturedIndex: 0, liveIndex: 0})]);
+        expect(second.mapping).toEqual([expect.objectContaining({capturedIndex: 0, liveIndex: 0})]);
+        expect(Object.keys(first.documents[0].items)).toEqual(Object.keys(second.documents[0].items));
+        expect(first.errors).toEqual([]);
+        expect(second.errors).toEqual([])
+    });
+
+    test('grown topology: excess live windows stay reference-identical; no spawning surface exists', () => {
+        let saved  = capture([tabsDoc(['alpha'])]),
             live   = [tabsDoc(['zeta']), tabsDoc(['alpha']), tabsDoc(['eta'])],
             result = DockTopologyReconciler.reconcile(saved, live);
 
         expect(result.mapping).toEqual([
-            {capturedIndex: 0, liveIndex: 1, affinity: expect.objectContaining({jaccard: 1})}
+            expect.objectContaining({capturedIndex: 0, liveIndex: 1})
         ]);
         expect(result.unmatchedLive.sort()).toEqual([0, 2]);
-        // Untouched = the SAME document references, byte-identical governance (§ excess windows).
         expect(result.documents[0]).toBe(live[0]);
         expect(result.documents[2]).toBe(live[2]);
         expect(result.unrestored).toEqual([]);
         expectConservation(saved, result)
     });
 
-    test('determinism: permuting live-document order never changes the content of the mapping', () => {
-        let slotA         = tabsDoc(['alpha', 'beta']),
-            slotB         = tabsDoc(['gamma']),
-            saved         = layout(slotA, [slotB]),
-            liveA         = tabsDoc(['alpha', 'beta']),
-            liveB         = tabsDoc(['gamma']),
-            first         = DockTopologyReconciler.reconcile(saved, [liveA, liveB]),
-            second        = DockTopologyReconciler.reconcile(saved, [liveB, liveA]),
-            pairByContent = result => result.mapping
-                .map(({capturedIndex, liveIndex}) => [capturedIndex, result.documents[liveIndex]])
-                .map(([capturedIndex, doc]) => [capturedIndex, Object.keys(doc.items).sort().join(',')]);
+    test('envelope authority fails the ENTIRE restore closed, without throwing', () => {
+        let live = [tabsDoc(['alpha'])];
 
-        expect(pairByContent(first)).toEqual(pairByContent(second));
-        expect(first.errors).toEqual([]);
-        expect(second.errors).toEqual([])
-    });
+        const expectFailClosed = (savedLayout, label) => {
+            let result;
 
-    test('fail-closed validation boundary: one invalid slot voids the ENTIRE restore, nothing mutates', () => {
-        let broken = {
+            expect(() => { result = DockTopologyReconciler.reconcile(savedLayout, live) },
+                `${label} must not throw`).not.toThrow();
+            expect(result.errors.length, `${label} must surface errors`).toBeGreaterThan(0);
+            expect(result.mapping).toEqual([]);
+            expect(result.documents[0]).toBe(live[0]);
+            result.unrestored.forEach(entry =>
+                expect(entry.reason).toBe(DockTopologyReconciler.REASON_VALIDATION_FAILED));
+
+            return result
+        };
+
+        let valid = capture([tabsDoc(['alpha']), tabsDoc(['beta'])]);
+
+        // Foreign wrapper schema.
+        expectFailClosed({...valid, schema: 'neo.harness.dockLayout.v999'}, 'foreign schema');
+
+        // Wrong scope smuggling windowDocuments.
+        expectFailClosed({...valid, captureScope: 'window'}, 'window-scope + smuggled windowDocuments');
+
+        // Missing primary document.
+        expectFailClosed((() => { let broken = {...valid}; delete broken.dockZone; return broken })(), 'missing dockZone');
+
+        // Non-array windowDocuments.
+        expectFailClosed({...valid, windowDocuments: 'nope'}, 'non-array windowDocuments');
+
+        // A malformed slot fails closed with its index preserved in the surfaced error.
+        let badSlot = expectFailClosed({
+            ...valid,
+            windowDocuments: [{
                 schema: 'neo.harness.dockZone.v1',
                 root  : 'r',
                 items : {},
                 nodes : {r: {type: 'tabs', items: ['ghost'], activeItemId: 'ghost'}}
-            },
-            saved  = layout(tabsDoc(['alpha']), [broken]),
-            live   = [tabsDoc(['alpha'])],
-            result = DockTopologyReconciler.reconcile(saved, live);
+            }]
+        }, 'malformed slot');
+        expect(badSlot.errors.join(' ')).toContain('windowDocuments[0]');
 
-        expect(result.errors.length).toBeGreaterThan(0);
-        expect(result.mapping).toEqual([]);
-        expect(result.documents[0]).toBe(live[0]);
-        // EVERY captured item reports validation-failed — including the valid slot's: no partial restore.
-        expect(new Set(result.unrestored.map(entry => entry.reason)))
-            .toEqual(new Set([DockTopologyReconciler.REASON_VALIDATION_FAILED]));
-        expectConservation(saved, result)
+        // Null / empty envelopes fail closed too.
+        expectFailClosed(null, 'null envelope')
+    });
+
+    test('workspace-global uniqueness: a slot whose placement would duplicate an item does not place', () => {
+        // Hand-built envelope (schema-complete, passes the landed validator): two slots carrying
+        // the SAME item id — a state the capture producer does not emit, but a stored layout could.
+        let shared = {
+                schema           : DockZoneModel.LAYOUT_SCHEMA,
+                layoutId         : 'dup-test',
+                title            : 'Dup',
+                captureScope     : 'topology',
+                windowFingerprint: null,
+                metadata         : {},
+                dockZone         : tabsDoc(['shared', 'solo']),
+                windowDocuments  : [tabsDoc(['shared'])]
+            },
+            live   = [tabsDoc(['shared', 'solo']), tabsDoc(['shared'])],
+            result = DockTopologyReconciler.reconcile(shared, live);
+
+        // Exactly one PLACEMENT of 'shared' across the documents that received placements —
+        // a dup-blocked slot's window stays untouched (its pre-existing live content is not a
+        // placement and is not this module's to rewrite).
+        let placedIndexes = result.applied.map(entry => entry.liveIndex),
+            placedShared  = placedIndexes.filter(index => result.documents[index].items?.shared).length;
+
+        expect(result.errors).toEqual([]);
+        expect(placedShared).toBe(1);
+        // The dup-blocked slot's window keeps reference identity.
+        expect(result.documents[1]).toBe(live[1]);
+        expect(result.unrestored).toEqual([
+            {capturedIndex: 1, itemId: 'shared', reason: DockTopologyReconciler.REASON_DUPLICATE_ITEM}
+        ]);
+        expectConservation(shared, result)
+    });
+
+    test('deferral reasons pass through verbatim: only topology-fingerprint-mismatch may adopt', () => {
+        let saved    = capture([tabsDoc(['alpha'])]),
+            live     = [tabsDoc(['alpha'])],
+            original = DockRestorePlanner.restoreToward;
+
+        try {
+            DockRestorePlanner.restoreToward = () => ({
+                applied: 0, deferred: true, document: live[0], errors: [],
+                plan   : [], reason: 'cross-node-singleton-cycle', surplus: []
+            });
+
+            let result = DockTopologyReconciler.reconcile(saved, live);
+
+            // NOT adopted: the live document is untouched and the foreign reason passes through.
+            expect(result.documents[0]).toBe(live[0]);
+            expect(result.applied).toEqual([]);
+            expect(result.unrestored).toEqual([
+                {capturedIndex: 0, itemId: 'alpha', reason: 'cross-node-singleton-cycle'}
+            ]);
+            expectConservation(saved, result)
+        } finally {
+            DockRestorePlanner.restoreToward = original
+        }
+    });
+
+    test('executor failures report apply-error — never mislabeled as validation', () => {
+        let saved    = capture([tabsDoc(['alpha'])]),
+            live     = [tabsDoc(['alpha'])],
+            original = DockRestorePlanner.restoreToward;
+
+        try {
+            DockRestorePlanner.restoreToward = () => ({
+                applied: 0, deferred: false, document: live[0], errors: ['boom'],
+                plan   : [], reason: null, surplus: []
+            });
+
+            let result = DockTopologyReconciler.reconcile(saved, live);
+
+            expect(result.documents[0]).toBe(live[0]);
+            expect(result.errors.join(' ')).toContain('boom');
+            expect(result.unrestored).toEqual([
+                {capturedIndex: 0, itemId: 'alpha', reason: DockTopologyReconciler.REASON_APPLY_ERROR}
+            ]);
+            expectConservation(saved, result)
+        } finally {
+            DockRestorePlanner.restoreToward = original
+        }
     });
 
     test('composition: same shape restores incrementally through the landed planner; changed shape adopts + reports displaced', () => {
-        // Same item set, same shape (one tabs node, two items), different active tab -> incremental.
         let capturedSame = tabsDoc(['alpha', 'beta']),
             liveSame     = {...tabsDoc(['alpha', 'beta']), nodes: {r: {type: 'tabs', items: ['alpha', 'beta'], activeItemId: 'beta'}}},
             expected     = DockRestorePlanner.restoreToward(liveSame, capturedSame),
 
-            // Overlapping items, different shape (2 vs 3 tabs) -> wholesale adopt; live-only item displaced.
             capturedGrow = tabsDoc(['gamma', 'delta']),
             liveGrow     = tabsDoc(['gamma', 'delta', 'extra']),
 
-            saved  = layout(capturedSame, [capturedGrow]),
+            saved  = capture([capturedSame, capturedGrow]),
             result = DockTopologyReconciler.reconcile(saved, [liveSame, liveGrow]);
 
         expect(result.errors).toEqual([]);
         expect(result.applied.map(entry => entry.mode)).toEqual(['incremental', 'adopt']);
 
-        // Incremental pair equals the planner's own output — composition, not duplication.
         expect(result.documents[0]).toEqual(expected.document);
         expect(result.applied[0].applied).toBe(expected.applied);
 
-        // Adopted pair: document becomes the captured slot (cloned), live-only content is DISPLACED.
-        expect(result.documents[1]).toEqual(capturedGrow);
-        expect(result.documents[1]).not.toBe(capturedGrow);
+        expect(result.documents[1]).toEqual(DockTopologyReconciler.capturedSlots(saved)[1]);
+        expect(result.documents[1]).not.toBe(DockTopologyReconciler.capturedSlots(saved)[1]);
         expect(result.displaced).toEqual([{itemId: 'extra', liveIndex: 1}]);
         expectConservation(saved, result)
     });

--- a/test/playwright/unit/dashboard/DockTopologyReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologyReconciler.spec.mjs
@@ -1,0 +1,160 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockTopologyReconcilerTest'
+    }
+});
+
+import {test, expect}         from '@playwright/test';
+import Neo                    from '../../../../src/Neo.mjs';
+import * as core              from '../../../../src/core/_export.mjs';
+import DockRestorePlanner     from '../../../../src/dashboard/DockRestorePlanner.mjs';
+import DockTopologyReconciler from '../../../../src/dashboard/DockTopologyReconciler.mjs';
+
+const tabsDoc = ids => ({
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'r',
+    items : Object.fromEntries(ids.map(id => [id, {componentRef: id, title: id}])),
+    nodes : {
+        r: {type: 'tabs', items: [...ids], activeItemId: ids[0]}
+    }
+});
+
+const layout = (slot0, windowDocs = []) => ({
+    schema         : 'neo.harness.dockLayout.v1',
+    layoutId       : 'test-perspective',
+    title          : 'Test',
+    captureScope   : 'topology',
+    dockZone       : slot0,
+    windowDocuments: windowDocs
+});
+
+const capturedIdsOf = saved => DockTopologyReconciler.capturedSlots(saved)
+    .flatMap(doc => Object.keys(doc.items || {}));
+
+// Conservation invariant: every captured item id lands in exactly one of restored/unrestored.
+const expectConservation = (saved, result) => {
+    let covered = [...result.restored, ...result.unrestored.map(entry => entry.itemId)].sort();
+
+    expect(covered).toEqual(capturedIdsOf(saved).sort())
+};
+
+test.describe('Neo.dashboard.DockTopologyReconciler', () => {
+    test('shrunk topology: best-coverage mapping + reason-classed remainder + conservation', () => {
+        let saved = layout(
+                tabsDoc(['alpha', 'beta']),
+                [tabsDoc(['gamma', 'delta']), tabsDoc(['omega', 'psi'])]
+            ),
+            live  = [
+                tabsDoc(['gamma', 'delta']),   // strong match for slot 1
+                tabsDoc(['alpha', 'beta'])     // strong match for slot 0
+            ],
+            result = DockTopologyReconciler.reconcile(saved, live);
+
+        expect(result.errors).toEqual([]);
+        // Slot 0 -> live 1, slot 1 -> live 0 — affinity decides, never order or ids.
+        expect(result.mapping.map(({capturedIndex, liveIndex}) => [capturedIndex, liveIndex]))
+            .toEqual([[0, 1], [1, 0]]);
+        // Slot 2 (omega/psi) has no window left: reasoned, never dropped.
+        expect(result.unrestored).toEqual([
+            {capturedIndex: 2, itemId: 'omega', reason: DockTopologyReconciler.REASON_NO_LIVE_WINDOW},
+            {capturedIndex: 2, itemId: 'psi',   reason: DockTopologyReconciler.REASON_NO_LIVE_WINDOW}
+        ]);
+        expectConservation(saved, result)
+    });
+
+    test('zero item overlap never maps: unmapped-slot even with live windows available', () => {
+        let saved  = layout(tabsDoc(['alpha', 'beta'])),
+            live   = [tabsDoc(['unrelated1', 'unrelated2'])],
+            result = DockTopologyReconciler.reconcile(saved, live);
+
+        expect(result.mapping).toEqual([]);
+        expect(result.unrestored.map(entry => entry.reason))
+            .toEqual([DockTopologyReconciler.REASON_UNMAPPED_SLOT, DockTopologyReconciler.REASON_UNMAPPED_SLOT]);
+        // The available live window stays untouched.
+        expect(result.unmatchedLive).toEqual([0]);
+        expect(result.documents[0]).toBe(live[0]);
+        expectConservation(saved, result)
+    });
+
+    test('grown topology: excess live windows stay untouched; no spawning surface exists', () => {
+        let saved  = layout(tabsDoc(['alpha'])),
+            live   = [tabsDoc(['zeta']), tabsDoc(['alpha']), tabsDoc(['eta'])],
+            result = DockTopologyReconciler.reconcile(saved, live);
+
+        expect(result.mapping).toEqual([
+            {capturedIndex: 0, liveIndex: 1, affinity: expect.objectContaining({jaccard: 1})}
+        ]);
+        expect(result.unmatchedLive.sort()).toEqual([0, 2]);
+        // Untouched = the SAME document references, byte-identical governance (§ excess windows).
+        expect(result.documents[0]).toBe(live[0]);
+        expect(result.documents[2]).toBe(live[2]);
+        expect(result.unrestored).toEqual([]);
+        expectConservation(saved, result)
+    });
+
+    test('determinism: permuting live-document order never changes the content of the mapping', () => {
+        let slotA         = tabsDoc(['alpha', 'beta']),
+            slotB         = tabsDoc(['gamma']),
+            saved         = layout(slotA, [slotB]),
+            liveA         = tabsDoc(['alpha', 'beta']),
+            liveB         = tabsDoc(['gamma']),
+            first         = DockTopologyReconciler.reconcile(saved, [liveA, liveB]),
+            second        = DockTopologyReconciler.reconcile(saved, [liveB, liveA]),
+            pairByContent = result => result.mapping
+                .map(({capturedIndex, liveIndex}) => [capturedIndex, result.documents[liveIndex]])
+                .map(([capturedIndex, doc]) => [capturedIndex, Object.keys(doc.items).sort().join(',')]);
+
+        expect(pairByContent(first)).toEqual(pairByContent(second));
+        expect(first.errors).toEqual([]);
+        expect(second.errors).toEqual([])
+    });
+
+    test('fail-closed validation boundary: one invalid slot voids the ENTIRE restore, nothing mutates', () => {
+        let broken = {
+                schema: 'neo.harness.dockZone.v1',
+                root  : 'r',
+                items : {},
+                nodes : {r: {type: 'tabs', items: ['ghost'], activeItemId: 'ghost'}}
+            },
+            saved  = layout(tabsDoc(['alpha']), [broken]),
+            live   = [tabsDoc(['alpha'])],
+            result = DockTopologyReconciler.reconcile(saved, live);
+
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.mapping).toEqual([]);
+        expect(result.documents[0]).toBe(live[0]);
+        // EVERY captured item reports validation-failed — including the valid slot's: no partial restore.
+        expect(new Set(result.unrestored.map(entry => entry.reason)))
+            .toEqual(new Set([DockTopologyReconciler.REASON_VALIDATION_FAILED]));
+        expectConservation(saved, result)
+    });
+
+    test('composition: same shape restores incrementally through the landed planner; changed shape adopts + reports displaced', () => {
+        // Same item set, same shape (one tabs node, two items), different active tab -> incremental.
+        let capturedSame = tabsDoc(['alpha', 'beta']),
+            liveSame     = {...tabsDoc(['alpha', 'beta']), nodes: {r: {type: 'tabs', items: ['alpha', 'beta'], activeItemId: 'beta'}}},
+            expected     = DockRestorePlanner.restoreToward(liveSame, capturedSame),
+
+            // Overlapping items, different shape (2 vs 3 tabs) -> wholesale adopt; live-only item displaced.
+            capturedGrow = tabsDoc(['gamma', 'delta']),
+            liveGrow     = tabsDoc(['gamma', 'delta', 'extra']),
+
+            saved  = layout(capturedSame, [capturedGrow]),
+            result = DockTopologyReconciler.reconcile(saved, [liveSame, liveGrow]);
+
+        expect(result.errors).toEqual([]);
+        expect(result.applied.map(entry => entry.mode)).toEqual(['incremental', 'adopt']);
+
+        // Incremental pair equals the planner's own output — composition, not duplication.
+        expect(result.documents[0]).toEqual(expected.document);
+        expect(result.applied[0].applied).toBe(expected.applied);
+
+        // Adopted pair: document becomes the captured slot (cloned), live-only content is DISPLACED.
+        expect(result.documents[1]).toEqual(capturedGrow);
+        expect(result.documents[1]).not.toBe(capturedGrow);
+        expect(result.displaced).toEqual([{itemId: 'extra', liveIndex: 1}]);
+        expectConservation(saved, result)
+    });
+});

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -391,6 +391,26 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(errors.join(' ')).toContain('documents[1]')
         });
 
+        test('windowDocuments slots enforce the SAME finite durable-field boundary as the primary document', () => {
+            const {layout} = DockZoneModel.captureTopologyPerspective([doc(), doc()], {layoutId: 'x', title: 'X'});
+
+            // A runtime-bearing field on an ADDITIONAL slot must fail exactly like it would on
+            // `dockZone` — document-level and item-level offenders both, index preserved.
+            const slot     = layout.windowDocuments[0],
+                  poisoned = {...layout, windowDocuments: [{...slot, runtimeRect: {x: 0, y: 0}}]},
+                  topLevel = DockZoneModel.restoreSavedLayout(poisoned).errors.join(' ');
+
+            expect(topLevel).toContain('windowDocuments[0]');
+            expect(topLevel).toContain('runtimeRect');
+
+            const [itemId]  = Object.keys(slot.items),
+                  badItems  = {...slot, items: {[itemId]: {...slot.items[itemId], windowId: 'w2'}}},
+                  itemLevel = DockZoneModel.restoreSavedLayout({...layout, windowDocuments: [badItems]}).errors.join(' ');
+
+            expect(itemLevel).toContain(`windowDocuments[0].items.${itemId}`);
+            expect(itemLevel).toContain('windowId')
+        });
+
         test('fingerprint walk fails closed on dangling node refs', () => {
             const broken = doc();
             broken.root = 'missing-node';


### PR DESCRIPTION
Resolves #14668

Ships line B5 — the changed-topology restore reconciler — as `Neo.dashboard.DockTopologyReconciler`: a pure static module mapping captured workspace slots onto live windows by id-free shape affinity, composing the landed per-window restore, and reporting everything it cannot cover in both directions. This is the leaf the same-topology planner's `topology-fingerprint-mismatch` deferral explicitly reserved ("the cross-topology leaf owns that path"). Mapping: optimal assignment — max cardinality → max Σ Jaccard (item-catalog overlap) → max Σ structural (node-type multiset) → lexicographic-smallest CONTENT signature, with live index reachable only between fully content-identical candidates — permutation-stable by construction. Per mapped pair: identical shape fingerprint restores incrementally through `DockRestorePlanner.restoreToward()` (zero duplicated restore logic); changed shape adopts the captured document wholesale with every live-only item reported in `displaced`. Uncovered captured content returns reason-classed (`no-live-window` / `unmapped-slot` / `validation-failed`); the validation boundary fails the ENTIRE restore closed (no partial restore); no window-creation path exists anywhere in the module and excess live windows keep reference-identical documents.

Evidence: L2 (210/210 dashboard unit suite; 14 reconciler + 1 model contract specs pin every AC clause incl. the cycle-2 additions: total/index-preserving envelope handling, per-slot finite durable-field boundary, non-identical equal-aggregate tie permutation, straddling-slot unmatched-duplicate conviction, cross-live-window duplicate input) → L2 required (all close-target ACs are spec/diff-checkable pure logic; the ticket's own Out-of-Scope excludes UI rendering — Demo-B G4 + B7 consume the result shape). Residual: none.

## AC map

- **Slot mapping deterministic + id-free** → affinity reads item catalogs + node-type multisets only (never node ids, never window ids); permutation spec proves order-independence by content.
- **Unrestored carries reason classes; NOTHING silently drops** → conservation invariant asserted in EVERY spec: restored + unrestored ids === captured ids exactly. Plus the honest extension: `displaced` reports live-side items absent from an adopted document — silent drops are banned in both directions.
- **No window creation in v1** → no spawning surface exists in the module (review-checkable); grown-topology spec pins excess windows as reference-identical untouched documents.
- **Composes #14653 per-window** → the incremental path's output is spec-asserted EQUAL to `DockRestorePlanner.restoreToward()`'s own result (composition proof, not duplication); the adopt path consumes the planner's designed deferral.
- **Cross-family review** → routed at CI-green.

## Deltas from ticket

- **`displaced` result set added** (contract addition, flagged on the ticket): the planner's deferral design surfaces live-only items on shape mismatch; adopting wholesale without reporting them would be the exact silent-drop the ticket bans — so they return as `[{itemId, liveIndex}]` for the workspace's fallback-placement decision. Documents never destroy pane instances.
- Adopt-mode semantics ride ADR-0029 §2.2 row 2 (workspace documents restore wholesale) where the incremental refinement is structurally impossible; the fail-closed whole-restore boundary rides row 1 verbatim.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/dashboard/ --workers=1
210 passed
```

New: `DockTopologyReconciler.spec.mjs` (14 — shrunk-topology best-coverage + reasoned remainder, greedy-trap, content-stable tie permutation (non-identical equal-aggregate), straddling-slot duplicate conviction, cross-live-dup fail-closed, grown-topology untouched-excess, envelope negatives incl. object `windowDocuments`, null-middle index preservation, per-slot runtime-field rejection, global uniqueness with live-ownership, deferral pass-through, apply-error, composition). Plus `DockZoneModel.spec.mjs`: the per-slot finite durable-field boundary at the SSOT. Conservation invariant asserted throughout.

## Post-Merge Validation

- [ ] Demo-B scene G4 renders the fail-closed result honestly (consumes `unrestored` + `displaced` shapes; #14590).
- [ ] B7 switcher affordances consume `unmatchedLive` / hint reporting per §2.2 row 3.

## Evolution

- **Cycle-1 rework (review-driven):** envelope authority now composes the landed `restoreSavedLayout()` validator wholesale (schema, scope↔windowDocuments coupling, indexed slot validation, primary presence — non-throwing, indices preserved) and fixtures rebuild through the REAL `captureTopologyPerspective()` producer; greedy captured-order matching replaced by optimal deterministic assignment — the greedy trap is spec-pinned; per-window branching is reason-true (ONLY `topology-fingerprint-mismatch` adopts; other deferrals pass through verbatim, executor failures report `apply-error`); workspace-global item uniqueness enforced (`duplicate-item` reason); class genuinely `extends Base` per the sibling convention.
- **Cycle-2 rework (review-driven, three semantic invariants):** (1) slot validation is TOTAL and index-preserving — `capturedSlots` never spreads a non-array and never compacts null slots, so original captured indices survive into every report; the finite durable-field boundary now applies to EVERY `windowDocuments` slot at the SSOT (`DockZoneModel.validatePerspectiveFields` runs `findUnexpectedDockZoneKey` per slot — `windowFingerprint`/`runtimeRect` riders fail any slot, not only the primary). (2) Assignment ties canonicalized by CONTENT signature (sorted item catalog + node-type multiset per pair) — permutation-stable for distinct-content ties; live index reachable only between content-identical candidates. (3) Item uniqueness enforced over the COMPLETE final output (placements + deferred stays + unmatched pass-through) via three-phase propose → live-ownership fixpoint → commit: a contested id stays with the window already holding it live (importers demote to `duplicate-item`, slot-atomic, live window reference-identical); a disclaiming owner yields to the earliest captured slot; cross-live-window duplicate ids fail validation closed.

## Commits

- c2a906c4e — first cut: reconciler + 6-spec suite (greedy matching — superseded by cycle-1)
- b4796cc67 — cycle-1: envelope authority + optimal assignment + reason-true branching + 9-spec suite
- 72da2822b — cycle-2: total slot validation + content-stable ties + complete-output uniqueness + 14-spec suite

Process note: authored during the operator-granted temporary Fable 5 window (2026-07-10), at its tail — design contract was posted on the ticket before implementation; the shipped module matches it plus the flagged `displaced` addition.

Authored by Grace (Claude Fable 5, Claude Code). Session ef6b9a4a-54ec-4afb-8438-f89a3ee46ad2.

