### PR TITLE
feat(agentos): day-0 resident-identity provisioning — three-key contract successor (#14915)

### DIFF
--- a/ai/scripts/setup/provisionAgentIdentity.mjs
+++ b/ai/scripts/setup/provisionAgentIdentity.mjs
@@ -292,14 +292,17 @@ export function buildProvisionPlan(options = {}) {
 
     const writeSpecs = Object.freeze({
         // The durable resident node (the addressable A2A / wake / permission surface). Layer-1
-        // operational fields ONLY: name is the handle-derived display form, NOT a Social Name;
-        // engine facts are absent by design (observation-owned); modelFamily stays flat because
-        // the CURRENT operational surface reads it flat. fleetInstanceIds is ADDITIVE linkage —
-        // an operational pointer list, never a key.
+        // operational fields ONLY. The top-level `name` is ALWAYS handle-derived — it is the
+        // Social Name surface, and caller input must never reach it (naming sovereignty: names
+        // are granted post-boot by the peer ritual, never seeded); the `--display-name` override
+        // lands ONLY on the operational `properties.displayName`. Engine facts are absent by
+        // design (observation-owned); modelFamily stays flat because the CURRENT operational
+        // surface reads it flat. fleetInstanceIds is ADDITIVE linkage — an operational pointer
+        // list, never a key.
         identity: Object.freeze({
             id         : residentId,
             type       : 'AgentIdentity',
-            name       : displayForm,
+            name       : deriveDisplayForm(residentId),
             description: `Day-0 provisioned ${options.family}-family maintainer identity.`,
             properties : Object.freeze({
                 githubLogin     : github.handle,
@@ -406,7 +409,7 @@ export function parseNodeRow(row) {
  * connection.
  * @param {Object} sqlite Open better-sqlite3 connection (the graph storage's `db`)
  * @param {Object} plan A valid plan from {@link buildProvisionPlan}
- * @returns {{identityRow: Object|null, wakeRows: Object[], subscribesToEdges: Object[]}}
+ * @returns {{identityRow: Object|null, wakeRows: Object[], subscribesToEdges: Object[], plannedWakeIdRow: Object|null, foreignInstanceOwners: String[]}}
  */
 export function readExistingState(sqlite, plan) {
     const identityRow = parseNodeRow(sqlite.prepare('SELECT id, data FROM Nodes WHERE id = ? LIMIT 1').get(plan.residentId));
@@ -422,7 +425,28 @@ export function readExistingState(sqlite, plan) {
         WHERE source = ? AND type = 'SUBSCRIBES_TO'
     `).all(plan.residentId);
 
-    return {identityRow, wakeRows, subscribesToEdges}
+    // The exact planned deterministic wake id, read UNCONDITIONALLY: the owner-scoped wakeRows
+    // query above cannot see a squatter — a node under this id with a different type or a
+    // different owner — and scheduling upsertNode against an unseen squatter would destructively
+    // relabel it. The decision refuses on any incompatible occupant.
+    const plannedWakeIdRow = parseNodeRow(sqlite.prepare('SELECT id, data FROM Nodes WHERE id = ? LIMIT 1').get(plan.writeSpecs.wakeSubscription.id));
+
+    // Single-owner Fleet-instance linkage: any OTHER resident already carrying the requested
+    // instance token makes the linkage ambiguous — the decision refuses instead of silently
+    // creating a second owner.
+    const foreignInstanceOwners = plan.fleetInstanceId
+        ? sqlite.prepare(`
+            SELECT id FROM Nodes
+            WHERE json_extract(data, '$.label') = 'AgentIdentity'
+              AND id != ?
+              AND EXISTS (
+                  SELECT 1 FROM json_each(json_extract(data, '$.properties.fleetInstanceIds'))
+                  WHERE json_each.value = ?
+              )
+        `).all(plan.residentId, plan.fleetInstanceId).map(row => row.id)
+        : [];
+
+    return {identityRow, wakeRows, subscribesToEdges, plannedWakeIdRow, foreignInstanceOwners}
 }
 
 /**
@@ -464,14 +488,16 @@ export function decideProvision({plan, existing = {}, rosterIds = IDENTITIES.map
         return refuse('decideProvision requires a valid plan from buildProvisionPlan');
     }
 
-    const identityRow       = existing.identityRow || null,
-          wakeRows          = existing.wakeRows || [],
-          subscribesToEdges = existing.subscribesToEdges || [],
-          divergences       = [],
-          notes             = [],
-          writes            = [];
+    const identityRow           = existing.identityRow || null,
+          wakeRows              = existing.wakeRows || [],
+          subscribesToEdges     = existing.subscribesToEdges || [],
+          plannedWakeIdRow      = existing.plannedWakeIdRow || null,
+          foreignInstanceOwners = existing.foreignInstanceOwners || [],
+          divergences           = [],
+          notes                 = [],
+          writes                = [];
 
-    for (const row of [identityRow, ...wakeRows]) {
+    for (const row of [identityRow, plannedWakeIdRow, ...wakeRows]) {
         if (row && row.parseError) {
             return refuse(`existing graph row '${row.id}' is unparseable (${row.parseError}) — refusing to decide against corrupt state`);
         }
@@ -481,6 +507,26 @@ export function decideProvision({plan, existing = {}, rosterIds = IDENTITIES.map
     // seeding path and the committed roots file — Day-0 provisioning targets NEW residents only.
     if (rosterIds.includes(plan.residentId)) {
         return refuse(`${plan.residentId} is a committed-roster resident (ai/graph/identityRoots.mjs) — its identity substrate is owned by the committed seeding path; Day-0 provisioning targets new residents only`);
+    }
+
+    // Wake-id squatter refusal: the planned deterministic wake id may only be occupied by a
+    // compatible node — this resident's own WAKE_SUBSCRIPTION. Any other occupant (wrong type,
+    // or a wake node owned by ANOTHER resident) would be destructively relabeled by upsertNode,
+    // so the whole run refuses instead.
+    if (plannedWakeIdRow) {
+        if (plannedWakeIdRow.label !== 'WAKE_SUBSCRIPTION') {
+            return refuse(`node '${plannedWakeIdRow.id}' (the planned deterministic wake id) exists with type '${plannedWakeIdRow.label}', not WAKE_SUBSCRIPTION — refusing to overwrite a wrong-type occupant`);
+        }
+        if (plannedWakeIdRow.properties.agentIdentity !== plan.residentId) {
+            return refuse(`node '${plannedWakeIdRow.id}' (the planned deterministic wake id) is owned by '${plannedWakeIdRow.properties.agentIdentity}', not '${plan.residentId}' — refusing to reassign another resident's wake subscription`);
+        }
+    }
+
+    // Single-owner Fleet-instance refusal: an instance token already linked to a DIFFERENT
+    // resident makes ownership ambiguous — one Fleet instance embodies one resident at a time.
+    // Same-resident re-runs stay zero-op and one resident may still accrue MANY instances.
+    if (foreignInstanceOwners.length > 0) {
+        return refuse(`fleet instance '${plan.fleetInstanceId}' is already linked to ${foreignInstanceOwners.join(', ')} — refusing to create a second owner; unlink it from the current resident first`);
     }
 
     // --- identity surface -------------------------------------------------------------------

--- a/ai/scripts/setup/provisionAgentIdentity.mjs
+++ b/ai/scripts/setup/provisionAgentIdentity.mjs
@@ -1,0 +1,942 @@
+#!/usr/bin/env node
+import path                      from 'node:path';
+import {fileURLToPath}           from 'node:url';
+import {IDENTITIES, TRUST_TIERS} from '../../graph/identityRoots.mjs';
+
+/**
+ * @module ai/scripts/setup/provisionAgentIdentity
+ * @summary Day-0 resident-identity provisioning (R3a of the peer-onboarding rail): builds and —
+ * under `--commit` — persists the Memory Core resident `AgentIdentity` node and the Day-0 wake
+ * route (`WAKE_SUBSCRIPTION` node AND its `SUBSCRIBES_TO` edge) for ONE new resident. Dry-run by
+ * default; the dry-run reads the live graph read-only and renders the TRUE desired-vs-current
+ * delta — on a fully provisioned resident, dry-run and commit both honestly report zero writes.
+ *
+ * **Three identity layers, kept separate by construction (the successor contract):**
+ * 1. **Durable resident identity** — the anchor this script provisions. It survives model swaps,
+ *    family placement, and instance topology: the same resident may run different engines across
+ *    months and remain the same peer. The resident handle is the `AgentIdentity` id, the mailbox
+ *    owner, and the wake owner.
+ * 2. **Fleet instance id** — an operational key, never an identity. One resident can own multiple
+ *    Fleet instances, so the optional `--fleet-instance-id` records ADDITIVE linkage on the
+ *    resident (`properties.fleetInstanceIds`, union-merged on re-entry) and is never substituted
+ *    for the resident key anywhere durable.
+ * 3. **Runtime-observed engine episode** — deliberately ABSENT here. There is NO `--model` input:
+ *    engine embodiment opens when the runtime observes the engine (handshake evidence), never
+ *    from an operator prediction at provisioning time. Engine-class flags are rejected loudly.
+ *
+ * **Why the input surface has NO socialName-class parameter (load-bearing):** Social Names are
+ * the post-boot peer-naming ritual — peer-sketched, bearer-assented, peer-vetoable,
+ * operator-confirmed. They are NEVER seed data: a name provisioned before the bearer can assent
+ * would fabricate the assent. Day-0 residents get the handle-derived display form only, and any
+ * socialName-class input (flag or option key) is rejected loudly instead of ignored.
+ *
+ * **Idempotency = full read/compare/repair.** Re-entry reads EVERY required node and edge
+ * (including the `SUBSCRIBES_TO` edge — a wake node without its edge is NOT provisioned),
+ * compares every declared identity-contract field, repairs missing pieces (edge, instance
+ * linkage), and refuses loudly on contract divergence or wrong-type rows. Display-form fields
+ * (`name` / `displayName`) are compared as non-blocking notes: the naming ritual legitimately
+ * evolves them post-boot, so a granted name never bricks re-entry.
+ *
+ * **Post-verify:** after `--commit`, the write set is re-read and re-decided; success is only
+ * reported when the re-decision is zero-op. A crash-interrupted commit therefore completes on
+ * re-run, and a "successful" run that failed to persist is caught, not assumed.
+ *
+ * **Write path (side-effect half, `--commit` only):** the sibling seed script's real path —
+ * `Memory_GraphService` from `ai/services.mjs` (`initAsync` → `upsertGlobalNode` for the
+ * identity substrate + `upsertNode` / `linkNodes` for the wake route, matching
+ * `WakeSubscriptionService.subscribe`'s durable shape). Services are imported lazily inside the
+ * commit branch. Dry-run opens a READ-ONLY SQLite connection at the owning config leaf
+ * (`AiConfig.storagePaths.graph`) and writes nothing; an absent graph file is reported as empty
+ * state (the delta is then the full desired set, which is the truth).
+ *
+ * **Why the Day-0 wake route is `mcp-notifications` (Shape A):** richer routes require
+ * boot-environment facts (appName, per-instance address) that do not exist at provisioning
+ * time — fabricating them is exactly the hardcoded-route rot the wake-subscription migration
+ * exists to clean up. Shape A is the only metadata-free channel, so the resident has a live wake
+ * surface from minute zero; the runtime `manage_wake_subscription {action: 'bootstrap'}`
+ * self-registration upgrades the route from the real boot envelope. Any ACTIVE same-trigger
+ * route owned by the resident counts as wake-provisioned — Day-0 never duplicates fanout beside
+ * a richer self-registered route.
+ *
+ * Everything decision-shaped here is pure and fail-closed: builders/validators return
+ * `{valid, reason, ...}` and never throw; an invalid plan, a divergent existing state, or a
+ * wrong-type row refuses loudly and writes NOTHING. This script never writes committed files —
+ * the committed-file surfaces are the follow-up PR ({@link R3B_FOLLOW_UP_CHECKLIST}), printed on
+ * every successful run.
+ *
+ * **Usage**:
+ *   node ai/scripts/setup/provisionAgentIdentity.mjs --resident-id <s> --family <s>
+ *       [--display-name <s>] [--github-username <s>] [--mailbox <s>]
+ *       [--fleet-instance-id <s>]                                # dry-run (default, read-only)
+ *   node ai/scripts/setup/provisionAgentIdentity.mjs ... --commit    # execute + post-verify
+ *   node ai/scripts/setup/provisionAgentIdentity.mjs --help          # print usage
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+
+/**
+ * @summary The socialName-class option keys the provisioning input surface REJECTS. Social
+ * Names are the post-boot peer-naming ritual (bearer-assented), never seed data — rejecting
+ * instead of ignoring keeps the guard visible to callers.
+ * @type {ReadonlyArray<String>}
+ */
+export const SOCIAL_NAME_CLASS_KEYS = Object.freeze([
+    'disclosablePrior', 'name', 'salute', 'socialLayer', 'socialName'
+]);
+
+/**
+ * @summary The socialName-class CLI flags rejected with the ritual pointer (the flag-shaped
+ * mirror of {@link SOCIAL_NAME_CLASS_KEYS}).
+ * @type {ReadonlyArray<String>}
+ */
+export const SOCIAL_NAME_CLASS_FLAGS = Object.freeze([
+    '--disclosable-prior', '--name', '--salute', '--social-layer', '--social-name'
+]);
+
+/**
+ * @summary The engine-class option keys the provisioning input surface REJECTS. Engine
+ * embodiment is observation-owned: an episode opens when the runtime observes the engine, never
+ * from an operator prediction at Day-0 — a `--model` here would be fabricated observation.
+ * @type {ReadonlyArray<String>}
+ */
+export const ENGINE_CLASS_KEYS = Object.freeze([
+    'capabilities', 'engine', 'engineTag', 'model'
+]);
+
+/**
+ * @summary The engine-class CLI flags rejected with the observation pointer (the flag-shaped
+ * mirror of {@link ENGINE_CLASS_KEYS}).
+ * @type {ReadonlyArray<String>}
+ */
+export const ENGINE_CLASS_FLAGS = Object.freeze([
+    '--capabilities', '--engine', '--engine-tag', '--model'
+]);
+
+/**
+ * @summary The Day-0 wake route defaults: `SENT_TO_ME` on the metadata-free `mcp-notifications`
+ * channel, high-priority filtered — mirroring the roster templates' trigger/filter idiom
+ * without fabricating harness facts (see module JSDoc).
+ * @type {Object}
+ */
+export const WAKE_SUBSCRIPTION_DEFAULTS = Object.freeze({
+    trigger      : 'SENT_TO_ME',
+    filters      : Object.freeze({priority: 'high'}),
+    harnessTarget: 'mcp-notifications'
+});
+
+/**
+ * @summary The identity-contract fields compared verbatim on re-entry — divergence on ANY of
+ * these refuses the whole run (loud diff, nothing written). Dotted paths reach into
+ * `identityContract`. Display-form fields (`name` / `displayName`) are deliberately NOT here:
+ * the naming ritual evolves them post-boot, so they surface as non-blocking notes instead.
+ * @type {ReadonlyArray<String>}
+ */
+export const IDENTITY_CONTRACT_FIELDS = Object.freeze([
+    'accountType',
+    'githubLogin',
+    'identityContract.canonicalIdentityId',
+    'identityContract.requiredA2aMailboxAddress',
+    'identityContract.requiredGithubLogin',
+    'modelFamily',
+    'participationStatus',
+    'trustTier'
+]);
+
+/**
+ * @summary The follow-up checklist: the committed-file surfaces a roots-onboarding PR must touch
+ * AFTER Day-0 provisioning. This script NEVER writes committed files itself.
+ * @type {ReadonlyArray<String>}
+ */
+export const R3B_FOLLOW_UP_CHECKLIST = Object.freeze([
+    'ai/graph/identityRoots.mjs — add the resident\'s IDENTITIES roster entry (Layer-1 operational fields; social layer stays empty until the naming ritual)',
+    'README.md — add the maintainer roster row (Name / Maintainer / Role / Identity table)',
+    'learn/agentos/ModelStats.md — add the resident\'s capability section (source-cited; capability facts live HERE, never guessed at provisioning)',
+    'ai/graph/identityRootsMigration.mjs — check REGISTRY_MODEL_DESIGNATIONS + the MIGRATION_EPOCH note (post-epoch onboarding must NOT retro-seed; the engine era opens at first OBSERVED embodiment, never at provisioning)',
+    'test/playwright/unit/ai/graph/identityRoots.spec.mjs — pin the new roster entry'
+]);
+
+/**
+ * @summary Normalizes a handle-shaped input to its canonical `@`-prefixed form; fail-closed on
+ * empty or malformed values.
+ * @param {String} value Raw handle input (with or without the `@` prefix)
+ * @param {String} label Field name for the refusal message
+ * @returns {{valid: Boolean, reason: String|null, handle: String|null}}
+ */
+export function normalizeHandle(value, label) {
+    if (typeof value !== 'string' || value.trim() === '') {
+        return {valid: false, reason: `${label} requires a non-empty string`, handle: null};
+    }
+
+    const body = value.trim().replace(/^@/, '');
+
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(body)) {
+        return {valid: false, reason: `${label} must be a lowercase handle ([a-z0-9-], e.g. '@neo-fable-clio') — received '${value}'`, handle: null};
+    }
+
+    return {valid: true, reason: null, handle: `@${body}`}
+}
+
+/**
+ * @summary Normalizes a Fleet instance id to its plain lowercase-token form — deliberately NOT
+ * `@`-prefixed: the instance id is an operational Fleet-registry key, not an addressable
+ * identity handle, and keeping the forms visually distinct guards the layer boundary.
+ * @param {String} value Raw Fleet instance id
+ * @returns {{valid: Boolean, reason: String|null, token: String|null}}
+ */
+export function normalizeInstanceToken(value) {
+    if (typeof value !== 'string' || value.trim() === '') {
+        return {valid: false, reason: '--fleet-instance-id, when given, requires a non-empty string', token: null};
+    }
+
+    const token = value.trim();
+
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(token)) {
+        return {valid: false, reason: `--fleet-instance-id must be a lowercase token ([a-z0-9-], no '@' — it is a Fleet-registry key, not an identity handle) — received '${value}'`, token: null};
+    }
+
+    return {valid: true, reason: null, token}
+}
+
+/**
+ * @summary Derives the handle-derived DISPLAY form from a resident id — the operational default
+ * a resident keeps until (and unless) the naming ritual grants a Social Name.
+ * E.g. '@neo-fable-clio' → 'Neo Fable Clio'.
+ * @param {String} residentId The `@`-prefixed resident id
+ * @returns {String}
+ */
+export function deriveDisplayForm(residentId) {
+    return residentId
+        .replace(/^@/, '')
+        .split('-')
+        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+}
+
+/**
+ * @summary Builds the frozen Day-0 provisioning plan (the PURE half): the resident
+ * `AgentIdentity` write spec (Layer-1 fields only, keyed by the durable resident handle), the
+ * Day-0 wake route (node + `SUBSCRIBES_TO` edge), and the optional Fleet instance linkage. The
+ * input surface has NO socialName-class and NO engine-class parameter (module JSDoc); both
+ * classes are rejected loudly.
+ * @param {Object} options
+ * @param {String} options.residentId The durable resident identity handle — the anchor key
+ * @param {String} options.family Model family (e.g. 'claude' | 'gpt' | 'gemini') — the flat operational field the current surface reads
+ * @param {String} [options.displayName] Handle-derived display form override — operational display, NOT a Social Name
+ * @param {String} [options.githubUsername] GitHub login (defaults to the resident id)
+ * @param {String} [options.mailbox] A2A mailbox address (defaults to the resident id)
+ * @param {String} [options.fleetInstanceId] Optional Fleet instance id — ADDITIVE linkage on the resident, never a durable key
+ * @param {Date|String} [options.now] Clock override for deterministic tests; defaults to the real now
+ * @returns {{valid: Boolean, reason: String|null, plan: Object|null}}
+ */
+export function buildProvisionPlan(options = {}) {
+    const leakedSocial = SOCIAL_NAME_CLASS_KEYS.filter(key => key in options);
+
+    if (leakedSocial.length > 0) {
+        return {valid: false, reason: `socialName-class inputs are rejected by design: ${leakedSocial.join(', ')} — Social Names are the post-boot peer-naming ritual (bearer-assented), never seed data`, plan: null};
+    }
+
+    const leakedEngine = ENGINE_CLASS_KEYS.filter(key => key in options);
+
+    if (leakedEngine.length > 0) {
+        return {valid: false, reason: `engine-class inputs are rejected by design: ${leakedEngine.join(', ')} — engine embodiment opens at first OBSERVED runtime evidence, never from an operator prediction at Day-0`, plan: null};
+    }
+
+    const resident = normalizeHandle(options.residentId, '--resident-id');
+
+    if (!resident.valid) {
+        return {valid: false, reason: resident.reason, plan: null};
+    }
+
+    if (typeof options.family !== 'string' || !/^[a-z][a-z0-9-]*$/.test(options.family)) {
+        return {valid: false, reason: `--family must be a lowercase family token (e.g. 'claude') — received '${String(options.family)}'`, plan: null};
+    }
+
+    if (options.displayName !== undefined && (typeof options.displayName !== 'string' || options.displayName.trim() === '')) {
+        return {valid: false, reason: '--display-name, when given, requires a non-empty string', plan: null};
+    }
+
+    const github = normalizeHandle(options.githubUsername === undefined ? resident.handle : options.githubUsername, '--github-username');
+
+    if (!github.valid) {
+        return {valid: false, reason: github.reason, plan: null};
+    }
+
+    const mailbox = normalizeHandle(options.mailbox === undefined ? resident.handle : options.mailbox, '--mailbox');
+
+    if (!mailbox.valid) {
+        return {valid: false, reason: mailbox.reason, plan: null};
+    }
+
+    let fleetInstanceId = null;
+
+    if (options.fleetInstanceId !== undefined) {
+        const instance = normalizeInstanceToken(options.fleetInstanceId);
+
+        if (!instance.valid) {
+            return {valid: false, reason: instance.reason, plan: null};
+        }
+
+        fleetInstanceId = instance.token;
+    }
+
+    const nowMs = Date.parse(options.now === undefined ? new Date().toISOString() : options.now);
+
+    if (!Number.isFinite(nowMs)) {
+        return {valid: false, reason: `the provisioning timestamp must be parseable — received '${String(options.now)}' (records carry the ACTUAL provisioning time; no backfill)`, plan: null};
+    }
+
+    const residentId  = resident.handle,
+          since       = new Date(nowMs).toISOString(),
+          displayForm = options.displayName === undefined ? deriveDisplayForm(residentId) : options.displayName.trim(),
+          handleBody  = residentId.slice(1);
+
+    const writeSpecs = Object.freeze({
+        // The durable resident node (the addressable A2A / wake / permission surface). Layer-1
+        // operational fields ONLY: name is the handle-derived display form, NOT a Social Name;
+        // engine facts are absent by design (observation-owned); modelFamily stays flat because
+        // the CURRENT operational surface reads it flat. fleetInstanceIds is ADDITIVE linkage —
+        // an operational pointer list, never a key.
+        identity: Object.freeze({
+            id         : residentId,
+            type       : 'AgentIdentity',
+            name       : displayForm,
+            description: `Day-0 provisioned ${options.family}-family maintainer identity.`,
+            properties : Object.freeze({
+                githubLogin     : github.handle,
+                displayName     : displayForm,
+                modelFamily     : options.family,
+                accountType     : 'agent',
+                trustTier       : TRUST_TIERS.PEER_TRUSTED,
+                identityContract: Object.freeze({
+                    canonicalIdentityId      : residentId,
+                    requiredGithubLogin      : github.handle,
+                    requiredA2aMailboxAddress: mailbox.handle
+                }),
+                fleetInstanceIds   : Object.freeze(fleetInstanceId ? [fleetInstanceId] : []),
+                participationStatus: 'active',
+                statusReason       : null,
+                authority          : null,
+                since              : null,
+                reactivationTrigger: null,
+                createdAt          : since
+            })
+        }),
+        // The durable wake route — the exact node + edge shape WakeSubscriptionService.subscribe
+        // persists, on the only channel that requires no fabricated harness metadata.
+        wakeSubscription: Object.freeze({
+            id        : `WAKE_SUB:day0-${handleBody}`,
+            type      : 'WAKE_SUBSCRIPTION',
+            properties: Object.freeze({
+                agentIdentity        : residentId,
+                trigger              : WAKE_SUBSCRIPTION_DEFAULTS.trigger,
+                filters              : WAKE_SUBSCRIPTION_DEFAULTS.filters,
+                harnessTarget        : WAKE_SUBSCRIPTION_DEFAULTS.harnessTarget,
+                harnessTargetMetadata: Object.freeze({}),
+                createdAt            : since,
+                updatedAt            : since,
+                userId               : handleBody,
+                sharedEntity         : false,
+                status               : 'active'
+            })
+        }),
+        wakeEdge: Object.freeze({
+            source      : residentId,
+            target      : `WAKE_SUB:day0-${handleBody}`,
+            relationship: 'SUBSCRIBES_TO',
+            weight      : 1.0
+        })
+    });
+
+    return {
+        valid : true,
+        reason: null,
+        plan  : Object.freeze({
+            residentId,
+            family        : options.family,
+            displayForm,
+            githubUsername: github.handle,
+            mailbox       : mailbox.handle,
+            fleetInstanceId,
+            since,
+            writeSpecs
+        })
+    }
+}
+
+/**
+ * @summary The complete ordered DESIRED write set for a plan — what a from-scratch provision
+ * executes. The actual write set is the delta {@link decideProvision} computes against live
+ * state (repairs included), so callers rendering "what will happen" must render the DECISION's
+ * writes, never this raw set.
+ * @param {Object} plan A valid plan from {@link buildProvisionPlan}
+ * @returns {Object[]} Ordered ops `{surface, op, spec|edge}`
+ */
+export function planWrites(plan) {
+    return [
+        {surface: 'identity', op: 'upsertGlobalNode', spec: plan.writeSpecs.identity},
+        {surface: 'wake',     op: 'upsertNode',       spec: plan.writeSpecs.wakeSubscription},
+        {surface: 'wakeEdge', op: 'linkNodes',        edge: plan.writeSpecs.wakeEdge}
+    ];
+}
+
+/**
+ * @summary Parses a graph `Nodes` row's JSON payload; fail-closed on unparseable data. Surfaces
+ * `name`/`description` alongside `label`/`properties` so repair ops can rebuild a full
+ * non-clobbering upsert spec from the persisted row.
+ * @param {Object|undefined} row `{id, data}` from SQLite, or undefined when absent
+ * @returns {Object|null} `{id, label, name, description, properties}`, `{id, parseError}`, or null when absent
+ */
+export function parseNodeRow(row) {
+    if (!row) return null;
+
+    try {
+        const node = JSON.parse(row.data);
+
+        return {id: row.id, label: node.label, name: node.name, description: node.description, properties: node.properties || {}}
+    } catch (error) {
+        return {id: row.id, parseError: error.message}
+    }
+}
+
+/**
+ * @summary Reads the existing graph state a provisioning decision needs — nodes AND the
+ * `SUBSCRIBES_TO` edges (a wake node without its edge is not provisioned; the edge is part of
+ * the read-set by contract). Kept raw-SQLite (the durable-row idiom the wake substrate peeks
+ * through) so it is testable against an in-memory database and usable on a READ-ONLY dry-run
+ * connection.
+ * @param {Object} sqlite Open better-sqlite3 connection (the graph storage's `db`)
+ * @param {Object} plan A valid plan from {@link buildProvisionPlan}
+ * @returns {{identityRow: Object|null, wakeRows: Object[], subscribesToEdges: Object[]}}
+ */
+export function readExistingState(sqlite, plan) {
+    const identityRow = parseNodeRow(sqlite.prepare('SELECT id, data FROM Nodes WHERE id = ? LIMIT 1').get(plan.residentId));
+
+    const wakeRows = sqlite.prepare(`
+        SELECT id, data FROM Nodes
+        WHERE json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'
+          AND json_extract(data, '$.properties.agentIdentity') = ?
+    `).all(plan.residentId).map(parseNodeRow);
+
+    const subscribesToEdges = sqlite.prepare(`
+        SELECT id, source, target, type FROM Edges
+        WHERE source = ? AND type = 'SUBSCRIBES_TO'
+    `).all(plan.residentId);
+
+    return {identityRow, wakeRows, subscribesToEdges}
+}
+
+/**
+ * @summary Reads a dotted-path value from an identity row's properties (one level of nesting —
+ * the `identityContract.*` paths).
+ * @param {Object} properties The parsed row's properties
+ * @param {String} fieldPath Flat key or `parent.child` path
+ * @returns {*}
+ */
+function readContractField(properties, fieldPath) {
+    const parts = fieldPath.split('.');
+
+    return parts.length === 1 ? properties[parts[0]] : (properties[parts[0]] || {})[parts[1]];
+}
+
+/**
+ * @summary The pure idempotence decision — full read/compare/repair. Per surface:
+ * `create` (absent) / `exists` (present + contract-equivalent) / `repair` (present but missing a
+ * required piece: the `SUBSCRIBES_TO` edge, or a not-yet-linked Fleet instance id). Contract
+ * divergence or a wrong-type row refuses the WHOLE run (loud diff, nothing written); display-form
+ * drift (`name`/`displayName`) is reported as non-blocking notes because the naming ritual
+ * legitimately evolves those post-boot. The returned `writes` are the TRUE delta — a fully
+ * provisioned resident decides zero ops, which is exactly what dry-run renders and what
+ * post-verify asserts.
+ *
+ * Repair ops never clobber: the instance-linkage repair rebuilds the upsert spec FROM the
+ * persisted row (union-merging `fleetInstanceIds` only), and the edge repair targets the
+ * EXISTING accepted wake node, not the Day-0 template id.
+ * @param {Object} options
+ * @param {Object} options.plan A valid plan from {@link buildProvisionPlan}
+ * @param {Object} options.existing State from {@link readExistingState}
+ * @param {String[]} [options.rosterIds] Committed-roster ids (test seam; defaults to `identityRoots.IDENTITIES`)
+ * @returns {{valid: Boolean, reason: String|null, alreadyProvisioned: Boolean, surfaces: Object, divergences: Object[], notes: Object[], writes: Object[]}}
+ */
+export function decideProvision({plan, existing = {}, rosterIds = IDENTITIES.map(identity => identity.id)} = {}) {
+    const refuse = reason => ({valid: false, reason, alreadyProvisioned: false, surfaces: {}, divergences: [], notes: [], writes: []});
+
+    if (!plan || !plan.writeSpecs) {
+        return refuse('decideProvision requires a valid plan from buildProvisionPlan');
+    }
+
+    const identityRow       = existing.identityRow || null,
+          wakeRows          = existing.wakeRows || [],
+          subscribesToEdges = existing.subscribesToEdges || [],
+          divergences       = [],
+          notes             = [],
+          writes            = [];
+
+    for (const row of [identityRow, ...wakeRows]) {
+        if (row && row.parseError) {
+            return refuse(`existing graph row '${row.id}' is unparseable (${row.parseError}) — refusing to decide against corrupt state`);
+        }
+    }
+
+    // Committed-roster residents already own identity substrate via the boot-time roster
+    // seeding path and the committed roots file — Day-0 provisioning targets NEW residents only.
+    if (rosterIds.includes(plan.residentId)) {
+        return refuse(`${plan.residentId} is a committed-roster resident (ai/graph/identityRoots.mjs) — its identity substrate is owned by the committed seeding path; Day-0 provisioning targets new residents only`);
+    }
+
+    // --- identity surface -------------------------------------------------------------------
+    let identityAction = 'create';
+
+    if (identityRow) {
+        // Wrong-type refusal: a row squatting on the resident key that is not an AgentIdentity
+        // must never receive identity writes.
+        if (identityRow.label !== 'AgentIdentity') {
+            return refuse(`node '${plan.residentId}' exists with type '${identityRow.label}', not AgentIdentity — refusing to write identity substrate onto a wrong-type row`);
+        }
+
+        identityAction = 'exists';
+
+        const props = identityRow.properties;
+
+        for (const fieldPath of IDENTITY_CONTRACT_FIELDS) {
+            const existingValue = readContractField(props, fieldPath),
+                  plannedValue  = readContractField(plan.writeSpecs.identity.properties, fieldPath);
+
+            if (existingValue !== plannedValue) {
+                divergences.push({surface: 'identity', field: fieldPath, existing: existingValue, planned: plannedValue});
+            }
+        }
+
+        // Display-form drift is a note, never a refusal: the naming ritual evolves these.
+        if (props.displayName !== plan.displayForm) {
+            notes.push({surface: 'identity', field: 'displayName', existing: props.displayName, planned: plan.displayForm,
+                note: 'display forms may legitimately evolve post-boot (naming ritual) — not treated as divergence'});
+        }
+
+        // Fleet instance linkage is ADDITIVE: a new instance id on a known resident is a repair
+        // (union-merge), never divergence — one resident legitimately accrues instances.
+        if (plan.fleetInstanceId) {
+            const linked = Array.isArray(props.fleetInstanceIds) ? props.fleetInstanceIds : [];
+
+            if (!linked.includes(plan.fleetInstanceId)) {
+                identityAction = 'repair';
+
+                const mergedSpec = {
+                    id  : identityRow.id,
+                    type: identityRow.label,
+                    ...(identityRow.name !== undefined && {name: identityRow.name}),
+                    ...(identityRow.description !== undefined && {description: identityRow.description}),
+                    properties: {...props, fleetInstanceIds: [...linked, plan.fleetInstanceId]}
+                };
+
+                writes.push({surface: 'identity', op: 'upsertGlobalNode', spec: mergedSpec, repair: 'fleet-instance-link'});
+            }
+        }
+    }
+
+    // --- wake surface -------------------------------------------------------------------------
+    // Any ACTIVE same-trigger route owned by the resident counts as the provisioned wake node —
+    // including a richer self-registered runtime route; Day-0 never duplicates fanout beside it.
+    const activeWakeRows = wakeRows.filter(row =>
+        (row.properties.status || 'active') === 'active' &&
+        row.properties.trigger === WAKE_SUBSCRIPTION_DEFAULTS.trigger
+    );
+
+    let wakeAction     = 'create',
+        wakeEdgeAction = 'create',
+        edgeTargetId   = plan.writeSpecs.wakeSubscription.id;
+
+    if (activeWakeRows.length > 0) {
+        wakeAction = 'exists';
+
+        // The edge is part of the provisioned contract: an accepted wake node without its
+        // SUBSCRIBES_TO edge is a crash-window remnant — repair the edge, targeting the row
+        // that actually exists.
+        const edgeTargets = new Set(subscribesToEdges.map(edge => edge.target)),
+              linkedRow   = activeWakeRows.find(row => edgeTargets.has(row.id));
+
+        if (linkedRow) {
+            wakeEdgeAction = 'exists';
+        } else {
+            wakeEdgeAction = 'repair';
+            edgeTargetId   = activeWakeRows[0].id;
+        }
+    }
+
+    const surfaces = {identity: identityAction, wake: wakeAction, wakeEdge: wakeEdgeAction};
+
+    if (divergences.length > 0) {
+        return {
+            valid             : false,
+            reason            : `existing state diverges from the identity contract on ${divergences.length} field(s) — nothing will be written`,
+            alreadyProvisioned: false,
+            surfaces,
+            divergences,
+            notes,
+            writes            : []
+        };
+    }
+
+    if (identityAction === 'create') {
+        writes.unshift({surface: 'identity', op: 'upsertGlobalNode', spec: plan.writeSpecs.identity});
+    }
+
+    if (wakeAction === 'create') {
+        writes.push({surface: 'wake', op: 'upsertNode', spec: plan.writeSpecs.wakeSubscription});
+    }
+
+    if (wakeEdgeAction !== 'exists') {
+        writes.push({surface: 'wakeEdge', op: 'linkNodes', edge: {
+            source      : plan.residentId,
+            target      : edgeTargetId,
+            relationship: 'SUBSCRIBES_TO',
+            weight      : 1.0
+        }});
+    }
+
+    return {
+        valid             : true,
+        reason            : null,
+        alreadyProvisioned: writes.length === 0,
+        surfaces,
+        divergences       : [],
+        notes,
+        writes
+    };
+}
+
+/**
+ * @summary Renders a decision's TRUE write delta as printable lines — dry-run output and commit
+ * behavior derive from the SAME decision, so what dry-run prints and what `--commit` writes
+ * cannot drift; a fully provisioned resident renders zero operations, honestly.
+ * @param {Object} plan A valid plan from {@link buildProvisionPlan}
+ * @param {Object} decision A decision from {@link decideProvision}
+ * @returns {String[]}
+ */
+export function renderDecision(plan, decision) {
+    const lines = [`[provisionAgentIdentity] decision for ${plan.residentId} (resident anchor; since: ${plan.since})`, ''];
+
+    for (const [surface, action] of Object.entries(decision.surfaces)) {
+        lines.push(`  [${action.toUpperCase()}] ${surface}`);
+    }
+    lines.push('');
+
+    for (const note of decision.notes) {
+        lines.push(`  [NOTE] ${note.surface}.${note.field}: existing '${note.existing}' vs planned '${note.planned}' — ${note.note}`);
+    }
+
+    if (decision.notes.length > 0) {
+        lines.push('');
+    }
+
+    if (decision.writes.length === 0) {
+        lines.push('  (zero operations — the resident is fully provisioned; commit would write nothing)');
+        lines.push('');
+        return lines;
+    }
+
+    for (const write of decision.writes) {
+        if (write.op === 'linkNodes') {
+            lines.push(`  [${write.surface}] linkNodes ${write.edge.source} -[${write.edge.relationship}]-> ${write.edge.target} (weight ${write.edge.weight})`);
+        } else {
+            lines.push(`  [${write.surface}] ${write.op} ${write.spec.id}${write.repair ? ` (repair: ${write.repair})` : ''}`);
+            lines.push(...JSON.stringify(write.spec, null, 4).split('\n').map(line => `      ${line}`));
+        }
+        lines.push('');
+    }
+
+    return lines;
+}
+
+/**
+ * @summary Executes a valid decision's write set against an injected graph adapter — the
+ * documented write seam. The CLI wires `Memory_GraphService` (the sibling seed script's real
+ * path); tests wire a recording fake. Fail-closed: an invalid decision executes NOTHING.
+ * @param {Object} options
+ * @param {Object} options.decision A decision from {@link decideProvision}
+ * @param {Object} options.graph Adapter exposing `upsertGlobalNode(spec)`, `upsertNode(spec)`, `linkNodes(source, target, relationship, weight)`
+ * @returns {{valid: Boolean, reason: String|null, executed: Object[]}}
+ */
+export function executeProvision({decision, graph} = {}) {
+    if (!decision || decision.valid !== true) {
+        return {valid: false, reason: 'refusing to execute: the decision is missing or invalid', executed: []};
+    }
+
+    if (!graph || typeof graph.upsertGlobalNode !== 'function' || typeof graph.upsertNode !== 'function' || typeof graph.linkNodes !== 'function') {
+        return {valid: false, reason: 'refusing to execute: the graph adapter must expose upsertGlobalNode, upsertNode and linkNodes', executed: []};
+    }
+
+    const executed = [];
+
+    for (const write of decision.writes) {
+        if (write.op === 'linkNodes') {
+            graph.linkNodes(write.edge.source, write.edge.target, write.edge.relationship, write.edge.weight);
+            executed.push({op: write.op, id: `${write.edge.source} -[${write.edge.relationship}]-> ${write.edge.target}`});
+        } else {
+            graph[write.op](write.spec);
+            executed.push({op: write.op, id: write.spec.id});
+        }
+    }
+
+    return {valid: true, reason: null, executed}
+}
+
+/**
+ * @summary Post-verify: re-reads persisted state and re-decides — provisioning only counts as
+ * successful when the re-decision is zero-op (everything present, contract-clean, edge linked).
+ * A commit whose writes did not actually persist is caught here rather than reported as success.
+ * @param {Object} options
+ * @param {Object} options.sqlite Open better-sqlite3 connection (the graph storage's `db`)
+ * @param {Object} options.plan A valid plan from {@link buildProvisionPlan}
+ * @param {String[]} [options.rosterIds] Committed-roster ids (test seam)
+ * @returns {{valid: Boolean, reason: String|null, remaining: Object[]}}
+ */
+export function verifyProvisioned({sqlite, plan, rosterIds} = {}) {
+    const existing = readExistingState(sqlite, plan),
+          decision = decideProvision(rosterIds ? {plan, existing, rosterIds} : {plan, existing});
+
+    if (!decision.valid) {
+        return {valid: false, reason: `post-verify re-decision refused: ${decision.reason}`, remaining: []};
+    }
+
+    if (!decision.alreadyProvisioned) {
+        const remaining = decision.writes.map(write => write.op === 'linkNodes'
+            ? `${write.op} ${write.edge.source} -[${write.edge.relationship}]-> ${write.edge.target}`
+            : `${write.op} ${write.spec.id}`);
+
+        return {valid: false, reason: `post-verify found ${remaining.length} write(s) still missing — the commit did not fully persist`, remaining};
+    }
+
+    return {valid: true, reason: null, remaining: []}
+}
+
+/**
+ * @summary Parses the CLI argv (pure, hand-rolled by design: unknown flags refuse instead of
+ * being silently ignored; the socialName-class flags refuse with the ritual pointer and the
+ * engine-class flags refuse with the observation pointer — all part of the tested input
+ * contract). Required-field enforcement lives in {@link buildProvisionPlan}; this layer owns
+ * flag SYNTAX only.
+ * @param {String[]} argv Arguments after the script path (`process.argv.slice(2)`)
+ * @returns {{valid: Boolean, reason: String|null, options: Object|null}}
+ */
+export function parseProvisionArgs(argv = []) {
+    const valueFlags = {
+        '--display-name'     : 'displayName',
+        '--family'           : 'family',
+        '--fleet-instance-id': 'fleetInstanceId',
+        '--github-username'  : 'githubUsername',
+        '--mailbox'          : 'mailbox',
+        '--resident-id'      : 'residentId'
+    };
+
+    const booleanFlags = {
+        '--commit': 'commit',
+        '--help'  : 'help'
+    };
+
+    const options = {commit: false, help: false};
+
+    for (let i = 0; i < argv.length; i++) {
+        const flag = argv[i];
+
+        if (SOCIAL_NAME_CLASS_FLAGS.includes(flag)) {
+            return {valid: false, reason: `${flag} is rejected by design — Social Names are the post-boot peer-naming ritual (bearer-assented), never seed data`, options: null};
+        }
+
+        if (ENGINE_CLASS_FLAGS.includes(flag)) {
+            return {valid: false, reason: `${flag} is rejected by design — engine embodiment opens at first OBSERVED runtime evidence (the era layer's follow-up), never from an operator prediction at Day-0`, options: null};
+        }
+
+        if (booleanFlags[flag]) {
+            options[booleanFlags[flag]] = true;
+            continue;
+        }
+
+        if (valueFlags[flag]) {
+            const value = argv[i + 1];
+
+            if (value === undefined || value.startsWith('--')) {
+                return {valid: false, reason: `${flag} requires a value`, options: null};
+            }
+
+            options[valueFlags[flag]] = value;
+            i++;
+            continue;
+        }
+
+        return {valid: false, reason: `unknown option '${flag}' — provisioning accepts only: ${[...Object.keys(valueFlags), ...Object.keys(booleanFlags)].join(', ')}`, options: null};
+    }
+
+    return {valid: true, reason: null, options}
+}
+
+/**
+ * @summary Prints the CLI usage block.
+ * @returns {void}
+ */
+function printUsage() {
+    console.log('Usage: node ai/scripts/setup/provisionAgentIdentity.mjs --resident-id <s> --family <s>');
+    console.log('           [--display-name <s>] [--github-username <s>] [--mailbox <s>]');
+    console.log('           [--fleet-instance-id <s>] [--commit]');
+    console.log('');
+    console.log('  (no flags)  Dry-run — read the live graph READ-ONLY and print the true desired-vs-current delta.');
+    console.log('  --commit    Execute the delta via Memory_GraphService, then post-verify by re-read.');
+    console.log('');
+    console.log('  There is deliberately NO --social-name style flag (Social Names are the post-boot');
+    console.log('  naming ritual, never seed data) and NO --model flag (engine embodiment opens at');
+    console.log('  first OBSERVED runtime evidence, never from a Day-0 prediction).');
+}
+
+/**
+ * @summary Prints the follow-up checklist — the committed-file surfaces this script never
+ * writes itself.
+ * @returns {void}
+ */
+function printFollowUpChecklist() {
+    console.log('[provisionAgentIdentity] R3b follow-up — the roots-onboarding PR must touch:');
+
+    for (const item of R3B_FOLLOW_UP_CHECKLIST) {
+        console.log(`  [ ] ${item}`);
+    }
+}
+
+async function main() {
+    const parsed = parseProvisionArgs(process.argv.slice(2));
+
+    if (!parsed.valid) {
+        console.error(`[provisionAgentIdentity] FATAL: ${parsed.reason}`);
+        printUsage();
+        process.exit(1);
+    }
+
+    if (parsed.options.help) {
+        printUsage();
+        return;
+    }
+
+    const built = buildProvisionPlan(parsed.options);
+
+    if (!built.valid) {
+        console.error(`[provisionAgentIdentity] FATAL: ${built.reason}`);
+        printUsage();
+        process.exit(1);
+    }
+
+    const {plan} = built;
+
+    console.log(`[provisionAgentIdentity] resident: ${plan.residentId} (family: ${plan.family}${plan.fleetInstanceId ? `, fleet instance: ${plan.fleetInstanceId}` : ''})`);
+    console.log(`[provisionAgentIdentity] mode:     ${parsed.options.commit ? 'COMMIT' : 'DRY-RUN (read-only)'}`);
+    console.log('');
+
+    if (!parsed.options.commit) {
+        // Dry-run reads the live graph READ-ONLY through the owning config leaf and writes
+        // NOTHING — the rendered delta is the same decision --commit would execute.
+        const {default: AiConfig} = await import('../../config.mjs');
+        const {existsSync}        = await import('node:fs');
+        const dbPath              = AiConfig.storagePaths.graph;
+
+        let existing = {identityRow: null, wakeRows: [], subscribesToEdges: []};
+
+        if (existsSync(dbPath)) {
+            const {default: Database} = await import('better-sqlite3');
+            const sqlite              = new Database(dbPath, {readonly: true});
+
+            try {
+                existing = readExistingState(sqlite, plan);
+            } finally {
+                sqlite.close();
+            }
+        } else {
+            console.log(`[provisionAgentIdentity] no live graph at ${dbPath} — nothing exists yet; the delta below is the full desired set.`);
+            console.log('');
+        }
+
+        const decision = decideProvision({plan, existing});
+
+        if (!decision.valid) {
+            console.error(`[provisionAgentIdentity] FATAL: ${decision.reason}`);
+
+            for (const divergence of decision.divergences) {
+                console.error(`  [DIVERGENT] ${divergence.surface}.${divergence.field}: existing '${divergence.existing}' vs planned '${divergence.planned}'`);
+            }
+
+            process.exit(1);
+        }
+
+        console.log(renderDecision(plan, decision).join('\n'));
+        printFollowUpChecklist();
+        console.log('');
+        console.log('[provisionAgentIdentity] DRY-RUN complete. No changes applied. Re-run with --commit to execute.');
+        return;
+    }
+
+    // Side-effect half — the sibling seed script's write path, imported lazily so only
+    // --commit ever boots services.
+    const {Memory_GraphService} = await import('../../services.mjs');
+
+    console.log('[provisionAgentIdentity] Bootstrapping Memory Graph Service...');
+    await Memory_GraphService.initAsync();
+
+    const sqlite = Memory_GraphService.db && Memory_GraphService.db.storage && Memory_GraphService.db.storage.db;
+
+    if (!sqlite) {
+        console.error('[provisionAgentIdentity] FATAL: graph SQLite storage is not mounted — refusing to write.');
+        process.exit(1);
+    }
+
+    const existing = readExistingState(sqlite, plan);
+    const decision = decideProvision({plan, existing});
+
+    if (!decision.valid) {
+        console.error(`[provisionAgentIdentity] FATAL: ${decision.reason}`);
+
+        for (const divergence of decision.divergences) {
+            console.error(`  [DIVERGENT] ${divergence.surface}.${divergence.field}: existing '${divergence.existing}' vs planned '${divergence.planned}'`);
+        }
+
+        process.exit(1);
+    }
+
+    console.log(renderDecision(plan, decision).join('\n'));
+
+    if (decision.alreadyProvisioned) {
+        console.log(`[provisionAgentIdentity] ${plan.residentId} is already provisioned — no changes applied.`);
+        printFollowUpChecklist();
+        process.exit(0);
+    }
+
+    const execution = executeProvision({decision, graph: Memory_GraphService});
+
+    if (!execution.valid) {
+        console.error(`[provisionAgentIdentity] FATAL: ${execution.reason}`);
+        process.exit(1);
+    }
+
+    for (const write of execution.executed) {
+        console.log(`  [WROTE] ${write.op} ${write.id}`);
+    }
+
+    // Post-verify: success is only reported when a re-read re-decision is zero-op.
+    const verification = verifyProvisioned({sqlite, plan});
+
+    if (!verification.valid) {
+        console.error(`[provisionAgentIdentity] FATAL: ${verification.reason}`);
+
+        for (const remaining of verification.remaining) {
+            console.error(`  [MISSING] ${remaining}`);
+        }
+
+        process.exit(1);
+    }
+
+    console.log('');
+    console.log(`[provisionAgentIdentity] COMMIT complete + post-verified: ${execution.executed.length} write(s) for ${plan.residentId}.`);
+    printFollowUpChecklist();
+    process.exit(0);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    main().catch(err => {
+        console.error('[provisionAgentIdentity] FATAL:', err);
+        process.exit(1);
+    });
+}

--- a/test/playwright/unit/ai/scripts/setup/provisionAgentIdentity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/provisionAgentIdentity.spec.mjs
@@ -1,0 +1,531 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'ProvisionAgentIdentityTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Database       from 'better-sqlite3';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    ENGINE_CLASS_KEYS,
+    IDENTITY_CONTRACT_FIELDS,
+    R3B_FOLLOW_UP_CHECKLIST,
+    SOCIAL_NAME_CLASS_KEYS,
+    WAKE_SUBSCRIPTION_DEFAULTS,
+    buildProvisionPlan,
+    decideProvision,
+    deriveDisplayForm,
+    executeProvision,
+    normalizeInstanceToken,
+    parseProvisionArgs,
+    planWrites,
+    readExistingState,
+    renderDecision,
+    verifyProvisioned
+} from '../../../../../../ai/scripts/setup/provisionAgentIdentity.mjs';
+
+const FIXED_NOW    = '2026-07-10T12:00:00.000Z';
+const BASE_OPTIONS = Object.freeze({
+    residentId: '@neo-test-agent',
+    family    : 'claude',
+    now       : FIXED_NOW
+});
+
+/**
+ * @summary Builds a valid plan from the shared fixture options.
+ * @param {Object} [overrides] Option overrides.
+ * @returns {Object} The frozen plan.
+ */
+function buildPlan(overrides = {}) {
+    const built = buildProvisionPlan({...BASE_OPTIONS, ...overrides});
+
+    expect(built.valid).toBe(true);
+
+    return built.plan;
+}
+
+/**
+ * @summary Simulates the parsed graph rows a prior successful `--commit` of the SAME plan
+ * persisted — the fully-provisioned re-entry fixture (node rows AND the SUBSCRIBES_TO edge).
+ * @param {Object} plan A valid plan.
+ * @returns {Object} An `existing` shape for decideProvision.
+ */
+function existingFromPlan(plan) {
+    const asRow = spec => ({id: spec.id, label: spec.type, name: spec.name, description: spec.description, properties: spec.properties});
+
+    return {
+        identityRow      : asRow(plan.writeSpecs.identity),
+        wakeRows         : [asRow(plan.writeSpecs.wakeSubscription)],
+        subscribesToEdges: [{id: 'e1', source: plan.residentId, target: plan.writeSpecs.wakeSubscription.id, type: 'SUBSCRIBES_TO'}]
+    };
+}
+
+/**
+ * @summary Opens an in-memory graph database with the durable Nodes/Edges shape the read-set
+ * queries against, plus insert helpers mirroring how the graph storage persists rows.
+ * @returns {Object} `{sqlite, insertNode, insertEdge}`
+ */
+function memoryGraph() {
+    const sqlite = new Database(':memory:');
+
+    sqlite.exec(`
+        CREATE TABLE Nodes (id TEXT PRIMARY KEY, data TEXT NOT NULL);
+        CREATE TABLE Edges (id TEXT PRIMARY KEY, source TEXT NOT NULL, target TEXT NOT NULL, type TEXT NOT NULL, data TEXT NOT NULL);
+    `);
+
+    const insertNode = spec => sqlite.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(
+        spec.id, JSON.stringify({label: spec.type, name: spec.name, description: spec.description, properties: spec.properties})
+    );
+
+    const insertEdge = edge => sqlite.prepare('INSERT OR REPLACE INTO Edges (id, source, target, type, data) VALUES (?, ?, ?, ?, ?)').run(
+        edge.id || `${edge.source}->${edge.target}`, edge.source, edge.target, edge.relationship || edge.type, JSON.stringify({})
+    );
+
+    return {sqlite, insertNode, insertEdge}
+}
+
+test.describe('provisionAgentIdentity — Day-0 plan construction (pure half)', () => {
+
+    test('the resident handle is the anchor key everywhere durable — identity id, mailbox owner, wake owner', () => {
+        const plan = buildPlan();
+
+        expect(plan.residentId).toBe('@neo-test-agent');
+        expect(plan.writeSpecs.identity.id).toBe('@neo-test-agent');
+        expect(plan.writeSpecs.identity.properties.identityContract.canonicalIdentityId).toBe('@neo-test-agent');
+        expect(plan.writeSpecs.wakeSubscription.properties.agentIdentity).toBe('@neo-test-agent');
+        expect(plan.writeSpecs.wakeEdge.source).toBe('@neo-test-agent');
+        expect(plan.since).toBe(FIXED_NOW);
+    });
+
+    test('NO engine surface exists at Day-0 — the write set carries no episode, no era anchor, no model field anywhere', () => {
+        const plan = buildPlan();
+
+        // exactly the three Day-0 ops: resident node, wake node, wake edge
+        const writes = planWrites(plan);
+        expect(writes.map(write => write.surface)).toEqual(['identity', 'wake', 'wakeEdge']);
+
+        // and no engine fact leaks onto the resident node
+        const serialized = JSON.stringify(plan.writeSpecs);
+        expect(plan.writeSpecs.identity.properties.model).toBeUndefined();
+        expect(serialized).not.toContain('EmbodiedEpisode');
+        expect(serialized).not.toContain('IdentityState');
+    });
+
+    test('engine-class inputs are rejected loudly — an operator-predicted model is fabricated observation', () => {
+        for (const key of ENGINE_CLASS_KEYS) {
+            const built = buildProvisionPlan({...BASE_OPTIONS, [key]: 'claude-test-1'});
+
+            expect(built.valid).toBe(false);
+            expect(built.reason).toContain('engine-class inputs are rejected by design');
+            expect(built.reason).toContain('OBSERVED');
+        }
+    });
+
+    test('socialName-class inputs are rejected loudly with the ritual pointer', () => {
+        for (const key of SOCIAL_NAME_CLASS_KEYS) {
+            const built = buildProvisionPlan({...BASE_OPTIONS, [key]: 'Minerva'});
+
+            expect(built.valid).toBe(false);
+            expect(built.reason).toContain('socialName-class inputs are rejected by design');
+        }
+    });
+
+    test('github/mailbox default to the resident handle; explicit values are normalized', () => {
+        const plan = buildPlan({githubUsername: 'neo-shared-account', mailbox: '@neo-test-agent-mail'});
+
+        expect(plan.githubUsername).toBe('@neo-shared-account');
+        expect(plan.mailbox).toBe('@neo-test-agent-mail');
+        expect(plan.writeSpecs.identity.properties.identityContract.requiredA2aMailboxAddress).toBe('@neo-test-agent-mail');
+
+        const defaulted = buildPlan();
+        expect(defaulted.githubUsername).toBe('@neo-test-agent');
+        expect(defaulted.mailbox).toBe('@neo-test-agent');
+    });
+
+    test('the fleet instance id is a plain token (never @-prefixed) and lands as ADDITIVE linkage, not a key', () => {
+        expect(normalizeInstanceToken('@euclid-2').valid).toBe(false);
+        expect(normalizeInstanceToken('euclid-2')).toEqual({valid: true, reason: null, token: 'euclid-2'});
+
+        const plan = buildPlan({fleetInstanceId: 'euclid-2'});
+
+        expect(plan.fleetInstanceId).toBe('euclid-2');
+        expect(plan.writeSpecs.identity.properties.fleetInstanceIds).toEqual(['euclid-2']);
+        // the linkage never replaces the resident key
+        expect(plan.writeSpecs.identity.id).toBe('@neo-test-agent');
+
+        const without = buildPlan();
+        expect(without.writeSpecs.identity.properties.fleetInstanceIds).toEqual([]);
+    });
+
+    test('the wake route is the metadata-free Day-0 shape — no fabricated harness facts', () => {
+        const plan = buildPlan();
+        const wake = plan.writeSpecs.wakeSubscription;
+
+        expect(wake.properties.trigger).toBe(WAKE_SUBSCRIPTION_DEFAULTS.trigger);
+        expect(wake.properties.harnessTarget).toBe('mcp-notifications');
+        expect(wake.properties.harnessTargetMetadata).toEqual({});
+        expect(plan.writeSpecs.wakeEdge.relationship).toBe('SUBSCRIBES_TO');
+        expect(plan.writeSpecs.wakeEdge.target).toBe(wake.id);
+    });
+
+    test('display form derives from the resident handle; the social layer has no input surface at all', () => {
+        expect(deriveDisplayForm('@neo-fable-clio')).toBe('Neo Fable Clio');
+
+        const plan = buildPlan();
+        expect(plan.displayForm).toBe('Neo Test Agent');
+        // no social-layer write spec exists — unreachable is structural, not filtered
+        expect(JSON.stringify(planWrites(plan))).not.toContain('socialLayer');
+    });
+
+    test('fails loud on contract violations (no silent default plan)', () => {
+        expect(buildProvisionPlan({}).valid).toBe(false);
+        expect(buildProvisionPlan({...BASE_OPTIONS, residentId: 'Bad Handle'}).valid).toBe(false);
+        expect(buildProvisionPlan({...BASE_OPTIONS, family: 'Claude'}).valid).toBe(false);
+        expect(buildProvisionPlan({...BASE_OPTIONS, displayName: '   '}).valid).toBe(false);
+        expect(buildProvisionPlan({...BASE_OPTIONS, now: 'not-a-date'}).valid).toBe(false);
+        expect(buildProvisionPlan({...BASE_OPTIONS, fleetInstanceId: '  '}).valid).toBe(false);
+    });
+});
+
+test.describe('provisionAgentIdentity — decideProvision (full read/compare/repair)', () => {
+
+    test('fresh state → exactly the three creates, in dependency order', () => {
+        const plan     = buildPlan(),
+              decision = decideProvision({plan, existing: {}, rosterIds: []});
+
+        expect(decision.valid).toBe(true);
+        expect(decision.alreadyProvisioned).toBe(false);
+        expect(decision.surfaces).toEqual({identity: 'create', wake: 'create', wakeEdge: 'create'});
+        expect(decision.writes.map(write => write.op)).toEqual(['upsertGlobalNode', 'upsertNode', 'linkNodes']);
+    });
+
+    test('fully provisioned re-entry → ZERO operations (the honest idempotent no-op)', () => {
+        const plan     = buildPlan(),
+              decision = decideProvision({plan, existing: existingFromPlan(plan), rosterIds: []});
+
+        expect(decision.valid).toBe(true);
+        expect(decision.alreadyProvisioned).toBe(true);
+        expect(decision.writes).toEqual([]);
+        expect(decision.surfaces).toEqual({identity: 'exists', wake: 'exists', wakeEdge: 'exists'});
+    });
+
+    test('CRASH-WINDOW REPAIR: a wake node WITHOUT its SUBSCRIBES_TO edge is NOT provisioned — the edge is repaired, targeting the EXISTING node', () => {
+        const plan     = buildPlan(),
+              existing = existingFromPlan(plan);
+
+        // simulate the crash window: node persisted, edge write never landed
+        existing.subscribesToEdges = [];
+        // and the existing node id differs from the Day-0 template id (a runtime self-registered route)
+        existing.wakeRows[0].id = 'WAKE_SUB:runtime-abc123';
+
+        const decision = decideProvision({plan, existing, rosterIds: []});
+
+        expect(decision.valid).toBe(true);
+        expect(decision.alreadyProvisioned).toBe(false);
+        expect(decision.surfaces.wake).toBe('exists');
+        expect(decision.surfaces.wakeEdge).toBe('repair');
+        expect(decision.writes).toHaveLength(1);
+        expect(decision.writes[0].op).toBe('linkNodes');
+        expect(decision.writes[0].edge.target).toBe('WAKE_SUB:runtime-abc123');   // the row that EXISTS, not the template id
+    });
+
+    test('a changed mailbox is LOUD divergence, never silently accepted', () => {
+        const plan     = buildPlan(),
+              existing = existingFromPlan(plan);
+
+        existing.identityRow = {
+            ...existing.identityRow,
+            properties: {
+                ...existing.identityRow.properties,
+                identityContract: {...existing.identityRow.properties.identityContract, requiredA2aMailboxAddress: '@somewhere-else'}
+            }
+        };
+
+        const decision = decideProvision({plan, existing, rosterIds: []});
+
+        expect(decision.valid).toBe(false);
+        expect(decision.writes).toEqual([]);
+        expect(decision.divergences).toEqual([expect.objectContaining({
+            surface : 'identity',
+            field   : 'identityContract.requiredA2aMailboxAddress',
+            existing: '@somewhere-else',
+            planned : '@neo-test-agent'
+        })]);
+    });
+
+    test('EVERY declared identity-contract field is compared — each one alone triggers loud refusal', () => {
+        const plan = buildPlan();
+
+        for (const fieldPath of IDENTITY_CONTRACT_FIELDS) {
+            const existing        = existingFromPlan(plan),
+                  [parent, child] = fieldPath.split('.'),
+                  properties      = {...existing.identityRow.properties};
+
+            if (child) {
+                properties[parent] = {...properties[parent], [child]: 'tampered-value'};
+            } else {
+                properties[parent] = 'tampered-value';
+            }
+
+            existing.identityRow = {...existing.identityRow, properties};
+
+            const decision = decideProvision({plan, existing, rosterIds: []});
+
+            expect(decision.valid, `field '${fieldPath}' must be compared`).toBe(false);
+            expect(decision.divergences.map(divergence => divergence.field)).toContain(fieldPath);
+        }
+    });
+
+    test('a wrong-type row on the resident key REFUSES outright — no identity write onto a squatter', () => {
+        const plan     = buildPlan(),
+              existing = existingFromPlan(plan);
+
+        existing.identityRow = {...existing.identityRow, label: 'Concept'};
+
+        const decision = decideProvision({plan, existing, rosterIds: []});
+
+        expect(decision.valid).toBe(false);
+        expect(decision.reason).toContain("type 'Concept', not AgentIdentity");
+        expect(decision.writes).toEqual([]);
+    });
+
+    test('display-form drift is a non-blocking NOTE — a ritual-granted name never bricks re-entry', () => {
+        const plan     = buildPlan(),
+              existing = existingFromPlan(plan);
+
+        existing.identityRow = {
+            ...existing.identityRow,
+            properties: {...existing.identityRow.properties, displayName: 'Minerva'}
+        };
+
+        const decision = decideProvision({plan, existing, rosterIds: []});
+
+        expect(decision.valid).toBe(true);
+        expect(decision.alreadyProvisioned).toBe(true);
+        expect(decision.notes).toEqual([expect.objectContaining({field: 'displayName', existing: 'Minerva'})]);
+    });
+
+    test('a NEW fleet instance on an existing resident is an ADDITIVE repair-merge — union, non-clobbering', () => {
+        const plan     = buildPlan({fleetInstanceId: 'euclid-2'}),
+              existing = existingFromPlan(buildPlan());   // persisted WITHOUT the new instance
+
+        // the persisted resident evolved: a granted name + a previously linked instance
+        existing.identityRow = {
+            ...existing.identityRow,
+            name      : 'Minerva',
+            properties: {...existing.identityRow.properties, displayName: 'Minerva', fleetInstanceIds: ['euclid-1']}
+        };
+
+        const decision = decideProvision({plan, existing, rosterIds: []});
+
+        expect(decision.valid).toBe(true);
+        expect(decision.surfaces.identity).toBe('repair');
+
+        const repair = decision.writes.find(write => write.repair === 'fleet-instance-link');
+
+        expect(repair.op).toBe('upsertGlobalNode');
+        expect(repair.spec.properties.fleetInstanceIds).toEqual(['euclid-1', 'euclid-2']);   // union, order-preserving
+        expect(repair.spec.name).toBe('Minerva');                                            // the evolved name survives — no clobber
+        expect(repair.spec.properties.displayName).toBe('Minerva');
+    });
+
+    test('an already-linked fleet instance decides zero-op', () => {
+        const plan     = buildPlan({fleetInstanceId: 'euclid-1'}),
+              existing = existingFromPlan(plan);
+
+        const decision = decideProvision({plan, existing, rosterIds: []});
+
+        expect(decision.valid).toBe(true);
+        expect(decision.alreadyProvisioned).toBe(true);
+    });
+
+    test('committed-roster residents are refused — their substrate is owned by the seeding path', () => {
+        const plan     = buildPlan(),
+              decision = decideProvision({plan, existing: {}, rosterIds: ['@neo-test-agent']});
+
+        expect(decision.valid).toBe(false);
+        expect(decision.reason).toContain('committed-roster resident');
+    });
+
+    test('an unparseable existing row refuses outright — never decide against corrupt state', () => {
+        const plan     = buildPlan(),
+              decision = decideProvision({plan, existing: {identityRow: {id: '@neo-test-agent', parseError: 'bad json'}}, rosterIds: []});
+
+        expect(decision.valid).toBe(false);
+        expect(decision.reason).toContain('unparseable');
+    });
+
+    test('renderDecision on a fully provisioned resident says zero operations, honestly', () => {
+        const plan     = buildPlan(),
+              decision = decideProvision({plan, existing: existingFromPlan(plan), rosterIds: []}),
+              rendered = renderDecision(plan, decision).join('\n');
+
+        expect(rendered).toContain('zero operations');
+        expect(rendered).not.toContain('upsertGlobalNode');
+    });
+});
+
+test.describe('provisionAgentIdentity — read-set + post-verify against a real database', () => {
+
+    test('readExistingState reads nodes AND the SUBSCRIBES_TO edges — the full contract read-set', () => {
+        const plan                             = buildPlan(),
+              {sqlite, insertNode, insertEdge} = memoryGraph();
+
+        insertNode(plan.writeSpecs.identity);
+        insertNode(plan.writeSpecs.wakeSubscription);
+        insertEdge(plan.writeSpecs.wakeEdge);
+
+        const existing = readExistingState(sqlite, plan);
+
+        expect(existing.identityRow.id).toBe('@neo-test-agent');
+        expect(existing.identityRow.label).toBe('AgentIdentity');
+        expect(existing.identityRow.name).toBe('Neo Test Agent');   // surfaced for non-clobbering repair
+        expect(existing.wakeRows).toHaveLength(1);
+        expect(existing.subscribesToEdges).toEqual([expect.objectContaining({source: '@neo-test-agent', type: 'SUBSCRIBES_TO'})]);
+
+        sqlite.close();
+    });
+
+    test('verifyProvisioned FAILS on a partial persist (edge missing) and PASSES once the edge lands', () => {
+        const plan                             = buildPlan(),
+              {sqlite, insertNode, insertEdge} = memoryGraph();
+
+        insertNode(plan.writeSpecs.identity);
+        insertNode(plan.writeSpecs.wakeSubscription);
+        // edge NOT written — the crash window
+
+        const partial = verifyProvisioned({sqlite, plan, rosterIds: []});
+
+        expect(partial.valid).toBe(false);
+        expect(partial.reason).toContain('did not fully persist');
+        expect(partial.remaining).toEqual([expect.stringContaining('SUBSCRIBES_TO')]);
+
+        insertEdge(plan.writeSpecs.wakeEdge);
+
+        expect(verifyProvisioned({sqlite, plan, rosterIds: []})).toEqual({valid: true, reason: null, remaining: []});
+
+        sqlite.close();
+    });
+
+    test('the crash-interrupted commit completes on re-run: decide → execute-into-db → verify green', () => {
+        const plan                             = buildPlan(),
+              {sqlite, insertNode, insertEdge} = memoryGraph();
+
+        // crash window: only the identity landed
+        insertNode(plan.writeSpecs.identity);
+
+        const existing = readExistingState(sqlite, plan),
+              decision = decideProvision({plan, existing, rosterIds: []});
+
+        expect(decision.valid).toBe(true);
+        expect(decision.surfaces.identity).toBe('exists');
+        expect(decision.writes.map(write => write.op)).toEqual(['upsertNode', 'linkNodes']);   // exactly the missing rest
+
+        // a graph adapter that persists into the same in-memory database
+        const graph = {
+            upsertGlobalNode: spec => insertNode(spec),
+            upsertNode      : spec => insertNode(spec),
+            linkNodes       : (source, target, relationship, weight) => insertEdge({source, target, relationship, weight})
+        };
+
+        const execution = executeProvision({decision, graph});
+
+        expect(execution.valid).toBe(true);
+        expect(verifyProvisioned({sqlite, plan, rosterIds: []}).valid).toBe(true);
+
+        sqlite.close();
+    });
+});
+
+test.describe('provisionAgentIdentity — executeProvision (write seam)', () => {
+
+    test('executes the decision delta in order against the injected adapter', () => {
+        const plan     = buildPlan(),
+              decision = decideProvision({plan, existing: {}, rosterIds: []}),
+              calls    = [];
+
+        const graph = {
+            upsertGlobalNode: spec => calls.push(['upsertGlobalNode', spec.id]),
+            upsertNode      : spec => calls.push(['upsertNode', spec.id]),
+            linkNodes       : (source, target, relationship) => calls.push(['linkNodes', `${source}->${target}:${relationship}`])
+        };
+
+        const execution = executeProvision({decision, graph});
+
+        expect(execution.valid).toBe(true);
+        expect(calls).toEqual([
+            ['upsertGlobalNode', '@neo-test-agent'],
+            ['upsertNode', 'WAKE_SUB:day0-neo-test-agent'],
+            ['linkNodes', '@neo-test-agent->WAKE_SUB:day0-neo-test-agent:SUBSCRIBES_TO']
+        ]);
+    });
+
+    test('refuses an invalid decision and an incomplete adapter — nothing executes', () => {
+        const plan     = buildPlan(),
+              decision = decideProvision({plan, existing: {}, rosterIds: []});
+
+        expect(executeProvision({decision: {valid: false}, graph: {}}).valid).toBe(false);
+        expect(executeProvision({decision, graph: {upsertGlobalNode: () => {}}}).valid).toBe(false);
+    });
+});
+
+test.describe('provisionAgentIdentity — CLI argument contract', () => {
+
+    test('parses the full happy path', () => {
+        const parsed = parseProvisionArgs([
+            '--resident-id', '@neo-test-agent', '--family', 'gpt',
+            '--github-username', 'shared-login', '--mailbox', '@neo-test-agent',
+            '--fleet-instance-id', 'euclid-2', '--commit'
+        ]);
+
+        expect(parsed.valid).toBe(true);
+        expect(parsed.options).toEqual({
+            commit         : true,
+            help           : false,
+            residentId     : '@neo-test-agent',
+            family         : 'gpt',
+            githubUsername : 'shared-login',
+            mailbox        : '@neo-test-agent',
+            fleetInstanceId: 'euclid-2'
+        });
+    });
+
+    test('--model is rejected by design with the observation pointer — Day-0 has no engine input', () => {
+        const parsed = parseProvisionArgs(['--resident-id', '@x', '--family', 'gpt', '--model', 'gpt-5.6-sol']);
+
+        expect(parsed.valid).toBe(false);
+        expect(parsed.reason).toContain('--model is rejected by design');
+        expect(parsed.reason).toContain('OBSERVED');
+    });
+
+    test('social-name flags are rejected by design with the ritual pointer', () => {
+        const parsed = parseProvisionArgs(['--social-name', 'Minerva']);
+
+        expect(parsed.valid).toBe(false);
+        expect(parsed.reason).toContain('rejected by design');
+        expect(parsed.reason).toContain('ritual');
+    });
+
+    test('unknown flags and missing values refuse instead of being silently ignored', () => {
+        expect(parseProvisionArgs(['--instance-id', '@x']).valid).toBe(false);   // the SUPERSEDED key form is not silently accepted
+        expect(parseProvisionArgs(['--resident-id']).valid).toBe(false);
+        expect(parseProvisionArgs(['--resident-id', '--commit']).valid).toBe(false);
+    });
+
+    test('the follow-up checklist names the committed surfaces and never claims a Day-0 era opened', () => {
+        expect(R3B_FOLLOW_UP_CHECKLIST).toHaveLength(5);
+        expect(R3B_FOLLOW_UP_CHECKLIST.join('\n')).toContain('identityRoots.mjs');
+        expect(R3B_FOLLOW_UP_CHECKLIST.join('\n')).toContain('OBSERVED embodiment');
+    });
+});

--- a/test/playwright/unit/ai/scripts/setup/provisionAgentIdentity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/provisionAgentIdentity.spec.mjs
@@ -358,6 +358,55 @@ test.describe('provisionAgentIdentity — decideProvision (full read/compare/rep
         expect(decision.reason).toContain('committed-roster resident');
     });
 
+    test('WAKE-ID SQUATTER (wrong type): a non-WAKE_SUBSCRIPTION node under the planned deterministic id refuses the whole run', () => {
+        const plan     = buildPlan(),
+              decision = decideProvision({plan, existing: {
+                  plannedWakeIdRow: {id: plan.writeSpecs.wakeSubscription.id, label: 'Concept', properties: {}}
+              }, rosterIds: []});
+
+        expect(decision.valid).toBe(false);
+        expect(decision.reason).toContain('not WAKE_SUBSCRIPTION');
+        expect(decision.writes).toEqual([]);   // never a destructive relabel
+    });
+
+    test('WAKE-ID SQUATTER (foreign owner): another resident\'s wake node under the planned id refuses — never reassigned', () => {
+        const plan     = buildPlan(),
+              decision = decideProvision({plan, existing: {
+                  plannedWakeIdRow: {
+                      id        : plan.writeSpecs.wakeSubscription.id,
+                      label     : 'WAKE_SUBSCRIPTION',
+                      properties: {agentIdentity: '@someone-else', trigger: 'SENT_TO_ME', status: 'active'}
+                  }
+              }, rosterIds: []});
+
+        expect(decision.valid).toBe(false);
+        expect(decision.reason).toContain("owned by '@someone-else'");
+        expect(decision.writes).toEqual([]);
+    });
+
+    test('CROSS-RESIDENT INSTANCE CONFLICT: a fleet token already linked to another resident refuses — single owner, ever', () => {
+        const plan     = buildPlan({fleetInstanceId: 'euclid-2'}),
+              decision = decideProvision({plan, existing: {foreignInstanceOwners: ['@other-resident']}, rosterIds: []});
+
+        expect(decision.valid).toBe(false);
+        expect(decision.reason).toContain("already linked to @other-resident");
+        expect(decision.writes).toEqual([]);
+
+        // while same-resident additive multi-instance stays intact (no foreign owners → normal create)
+        const clean = decideProvision({plan, existing: {}, rosterIds: []});
+        expect(clean.valid).toBe(true);
+    });
+
+    test('NAMING SOVEREIGNTY: caller-controlled --display-name never reaches the top-level Social Name surface', () => {
+        const plan = buildPlan({displayName: 'Minerva The Chosen'});
+
+        // the override lands ONLY on the operational display property...
+        expect(plan.writeSpecs.identity.properties.displayName).toBe('Minerva The Chosen');
+        // ...while the top-level name (the Social Name surface) stays handle-derived, always
+        expect(plan.writeSpecs.identity.name).toBe('Neo Test Agent');
+        expect(plan.displayForm).toBe('Minerva The Chosen');
+    });
+
     test('an unparseable existing row refuses outright — never decide against corrupt state', () => {
         const plan     = buildPlan(),
               decision = decideProvision({plan, existing: {identityRow: {id: '@neo-test-agent', parseError: 'bad json'}}, rosterIds: []});
@@ -393,6 +442,38 @@ test.describe('provisionAgentIdentity — read-set + post-verify against a real 
         expect(existing.identityRow.name).toBe('Neo Test Agent');   // surfaced for non-clobbering repair
         expect(existing.wakeRows).toHaveLength(1);
         expect(existing.subscribesToEdges).toEqual([expect.objectContaining({source: '@neo-test-agent', type: 'SUBSCRIBES_TO'})]);
+        expect(existing.plannedWakeIdRow.id).toBe(plan.writeSpecs.wakeSubscription.id);   // the compatible own row
+        expect(existing.foreignInstanceOwners).toEqual([]);
+
+        sqlite.close();
+    });
+
+    test('the read-set SURFACES a wake-id squatter and a foreign instance owner from the real database', () => {
+        const plan                 = buildPlan({fleetInstanceId: 'euclid-2'}),
+              {sqlite, insertNode} = memoryGraph();
+
+        // a foreign-owner squatter under the planned deterministic wake id — invisible to the
+        // owner-scoped wakeRows query, visible ONLY through the planned-id read
+        insertNode({
+            id        : plan.writeSpecs.wakeSubscription.id,
+            type      : 'WAKE_SUBSCRIPTION',
+            properties: {agentIdentity: '@someone-else', trigger: 'SENT_TO_ME', status: 'active'}
+        });
+        // and another resident already carrying the requested instance token
+        insertNode({
+            id        : '@other-resident',
+            type      : 'AgentIdentity',
+            properties: {accountType: 'agent', fleetInstanceIds: ['euclid-2']}
+        });
+
+        const existing = readExistingState(sqlite, plan);
+
+        expect(existing.wakeRows).toHaveLength(0);                                        // the owner-scoped query cannot see it
+        expect(existing.plannedWakeIdRow.properties.agentIdentity).toBe('@someone-else'); // the planned-id read can
+        expect(existing.foreignInstanceOwners).toEqual(['@other-resident']);
+
+        const decision = decideProvision({plan, existing, rosterIds: []});
+        expect(decision.valid).toBe(false);   // and the decision refuses on the surfaced facts
 
         sqlite.close();
     });


### PR DESCRIPTION
Resolves #14915

This is the successor implementation of Day-0 resident-identity provisioning, built on the corrected three-layer contract: (1) the **durable resident identity** is the anchor — the `AgentIdentity` id, mailbox owner, and wake owner, surviving model swaps, family placement, and instance topology; (2) the **Fleet instance id** is an operational key recorded as ADDITIVE linkage on the resident (`properties.fleetInstanceIds`, union-merged on re-entry), never substituted for the resident key anywhere durable; (3) the **runtime-observed engine episode** is deliberately absent at Day-0 — there is no `--model` input, and engine-class flags/keys are rejected loudly, because engine embodiment opens at first OBSERVED runtime evidence, never from an operator prediction at provisioning time. This PR supersedes the closed PR #14919 per its cycle-1 Drop+Supersede review, which identified the key-grain collapse (instance-keyed identity) and the incomplete idempotency read-set; the successor ships full read/compare/repair idempotency (every required node AND the `SUBSCRIBES_TO` edge read on re-entry, every declared identity-contract field compared, missing pieces repaired, divergence loud, wrong-type rows refused), a read-only dry-run that renders the TRUE desired-vs-current delta, and a post-verify that only reports success when a re-read re-decision is zero-op.

Evidence: L1 unit evidence — 31 Playwright unit tests covering the pure planner (input-surface rejections, three-key separation, wake-route shape), the full read/compare/repair decision matrix (zero-op re-entry, crash-window edge repair, divergence refusal per contract field, wrong-type refusal, additive fleet-instance union-merge), and the in-memory-SQLite read-set/post-verify tests (readExistingState reads nodes AND `SUBSCRIBES_TO` edges against a real database; verifyProvisioned fails on partial persist and passes once the edge lands; a crash-interrupted commit completes on re-run).

## Deltas from ticket

- The ticket's arg sketch listed a `wakeRoute` caller input. The implementation makes the Day-0 wake route template-owned instead: Shape A `mcp-notifications` (`SENT_TO_ME`, high-priority filter, empty `harnessTargetMetadata`), not a caller input. Richer routes require boot-envelope facts (appName, per-instance address) that do not exist at Day-0 — accepting them as operator input would fabricate exactly the hardcoded-route rot the wake-subscription migration cleans up. The runtime `manage_wake_subscription {action: 'bootstrap'}` self-registration upgrades the route from the real boot envelope, and any ACTIVE same-trigger route owned by the resident counts as wake-provisioned on re-entry (Day-0 never duplicates fanout beside a richer self-registered route).
- Engine-class rejection is broader than "no `--model`": the whole engine-class key/flag family (`model`, `engine`, `engineTag`, `capabilities`) refuses loudly with the observation pointer, mirroring the socialName-class rejection idiom, so the guard is visible to callers rather than silently ignored.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/scripts/setup/provisionAgentIdentity.spec.mjs --workers=1
```

Result: **31 passed** (0 failed, 0 skipped). Also `node --check ai/scripts/setup/provisionAgentIdentity.mjs` clean.

## Post-Merge Validation

- [ ] Operator-assisted: provision the first real gpt-family sibling resident via dry-run → review the rendered delta → `--commit`
- [ ] Verify wake delivery reaches the new resident over the Day-0 `mcp-notifications` route
- [ ] Verify `assertExpectedIdentity` passes against the resident anchor (Memory Core written under the resident key, not a Fleet instance key)
- [ ] Re-run the script post-provisioning and confirm the honest zero-op report (dry-run AND commit paths)

## Commits

- 78a0870282f62c67edf002ef4f1d015354aa7e7f feat(agentos): day-0 resident-identity provisioning — three-key contract successor (#14915)

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b956ba53-01ed-4ea6-a1e5-62969f887bc3.
