### PR TITLE
fix(core): Observable on/un parse a copy — stop mutating the caller's listeners object (#14928)

### DIFF
--- a/src/core/Observable.mjs
+++ b/src/core/Observable.mjs
@@ -183,9 +183,9 @@ class Observable extends Base {
      * @protected
      */
     afterSetListeners(value, oldValue) {
-        let me           = this,
-            oldConfig    = oldValue || {},
-            newConfig    = value    || {},
+        let me        = this,
+            oldConfig = oldValue || {},
+            newConfig = value    || {},
             // delay/once/order/scope sit at the config top level and apply to EVERY event entry, so
             // they must travel with each per-event slice — and a change to any of them changes every
             // event's effective registration (→ full re-bind).

--- a/src/core/Observable.mjs
+++ b/src/core/Observable.mjs
@@ -90,6 +90,10 @@ class Observable extends Base {
         }
 
         if (nameObject) {
+            // parse a COPY: mutating the caller's object would silently break shared-object
+            // usage like `subject.on(listeners)` followed by `otherSubject.un(listeners)`
+            name = {...name};
+
             if (name.hasOwnProperty('delay')) {
                 delay = name.delay;
                 delete name.delay
@@ -336,6 +340,10 @@ class Observable extends Base {
         }
 
         if (Neo.isObject(name)) {
+            // parse a COPY: mutating the caller's object would silently break shared-object
+            // usage like `subject.on(listeners)` followed by `otherSubject.un(listeners)`
+            name = {...name};
+
             if (name.scope) {
                 scope = name.scope;
                 delete name.scope;

--- a/test/playwright/unit/core/ObservableListenerObjects.spec.mjs
+++ b/test/playwright/unit/core/ObservableListenerObjects.spec.mjs
@@ -1,0 +1,99 @@
+import {setup} from '../../setup.mjs';
+
+setup();
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * @summary Verifies that Observable's object-form on()/un() parse a COPY of the caller's object.
+ *
+ * Historically both `addListener` and `removeListener` deleted the reserved keys (`scope`, `once`,
+ * `delay`, `order`) off the object they received. That silently broke the natural shared-object
+ * idiom `newSubject.on(listeners); oldSubject.un(listeners)` — the first call consumed `scope`, so
+ * the second matched nothing and the old subject kept firing its stale handler (the grid
+ * store-replacement leak). Observable itself carried an internal workaround
+ * (`updateConfiguredListeners` passes fresh per-event slices) — these tests pin the API boundary
+ * so external callers never need one.
+ */
+class ObservableSubject extends core.Base {
+    static config = {
+        className: 'Test.Unit.Core.ObservableSubject',
+        mixins   : [core.Observable]
+    }
+}
+const Subject = Neo.setupClass(ObservableSubject);
+
+test.describe('Observable object-form listeners stay caller-owned', () => {
+
+    test('on() does not mutate the passed listeners object', () => {
+        const
+            subject = Neo.create(Subject, {}),
+            scope   = {id: 'probe-scope'},
+            handler = () => {},
+            input   = {change: handler, load: handler, delay: 5, once: true, order: 'before', scope};
+
+        subject.on(input);
+
+        expect(input).toEqual({change: handler, load: handler, delay: 5, once: true, order: 'before', scope});
+
+        subject.destroy();
+    });
+
+    test('un() does not mutate the passed listeners object', () => {
+        const
+            subject = Neo.create(Subject, {}),
+            scope   = {id: 'probe-scope'},
+            handler = () => {},
+            input   = {change: handler, scope};
+
+        subject.on({change: handler, scope});
+        subject.un(input);
+
+        expect(input).toEqual({change: handler, scope});
+
+        subject.destroy();
+    });
+
+    test('the shared-object swap idiom works: new.on(listeners) then old.un(listeners) actually unbinds old', () => {
+        const
+            oldSubject = Neo.create(Subject, {}),
+            newSubject = Neo.create(Subject, {}),
+            calls      = [],
+            scope      = {id: 'consumer'},
+            listeners  = {change: function(data) { calls.push(data.from) }, scope};
+
+        // the consumer bound the OLD subject earlier
+        oldSubject.on({...listeners});
+
+        // the swap — exactly the afterSetStore shape: one shared object, on() before un()
+        newSubject.on(listeners);
+        oldSubject.un(listeners);
+
+        oldSubject.fire('change', {from: 'old'});
+        newSubject.fire('change', {from: 'new'});
+
+        // pre-fix: on() consumed `scope`, un() matched nothing, and 'old' leaked through
+        expect(calls).toEqual(['new']);
+
+        oldSubject.destroy();
+        newSubject.destroy();
+    });
+
+    test('a same-subject on/un round-trip over one shared object unbinds', () => {
+        const
+            subject   = Neo.create(Subject, {}),
+            calls     = [],
+            scope     = {id: 'consumer'},
+            listeners = {change: () => calls.push(1), scope};
+
+        subject.on(listeners);
+        subject.un(listeners);
+        subject.fire('change', {});
+
+        expect(calls).toEqual([]);
+
+        subject.destroy();
+    });
+});


### PR DESCRIPTION
Resolves #14928

Related: PR #14920 (the discovery + shipped call-site workarounds) · #14909 (the lane that surfaced it)

`core.Observable`'s object-form `addListener` AND `removeListener` deleted the reserved keys (`scope`, plus `once`/`delay`/`order` in add) off the CALLER's object while parsing. The natural symmetric idiom — one `listeners` object through `newSubject.on(listeners); oldSubject.un(listeners)` — therefore silently never unbound: `on()` consumed `scope`, `un()` matched nothing, and the old subject kept driving its consumer. This bit two framework call sites this week (`grid.Container.afterSetStore` latently since introduction; `grid.VerticalScrollbar` the moment store replacement became reachable), and Observable ITSELF already carried an internal workaround: `updateConfiguredListeners` passes "FRESH per-event slices" with a comment naming exactly this corruption. The fix moves that discipline to the API boundary — both object-form branches parse a shallow COPY (`name = {...name}`) — so no caller ever needs to know.

Behavior is otherwise identical: same parse, same stored listener shapes, same matching. The caller-object mutation was never a documented contract, and no caller reads back the consumed keys (the internal workaround exists precisely because mutation was a hazard, not a feature). The per-call copies PR #14920 shipped at the two grid sites stay — harmless, and their comments document the historical trap for archaeology.

Evidence: L1 (unit — the defect and fix are single-class semantics; the full core/component/grid/state trees are the behavior-preservation guard). No residuals.

## Deltas from ticket

- Ticket's implementation-time check ("other Observable surfaces sharing the destructive parse") ran: `grep 'delete '` over the class shows exactly the two fixed branches plus the `afterSetListeners` internal workaround — no third site.
- One pre-existing 3-line alignment drift in `afterSetListeners` fixed as its own commit (whole-file CI gate; the fixer's diff is exactly those 3 lines).

## Test Evidence

- **New spec `test/playwright/unit/core/ObservableListenerObjects.spec.mjs` (4 tests):** `on()` non-mutation (all reserved keys survive) · `un()` non-mutation · the shared-object SWAP idiom (`new.on(listeners); old.un(listeners)` → old actually unbinds, only 'new' fires) · the same-subject on/un round-trip over one shared object.
- **Teeth-check (stash-run-unstash at this head):** all except the on()-mutation case FAIL without the fix — including the same-subject round-trip (even `subject.on(L); subject.un(L)` never unbound pre-fix).
- **Behavior-preservation guard:** full `core` + `component` + `grid` + `state` unit trees, no-Chroma config `--workers=1`: **186 passed / 0 failed** at the fix head.
- `node --check` + `check-block-alignment` + `check-ticket-archaeology` green on both touched files.

## Post-Merge Validation

- [ ] PR #14920's call-site copies (`{...listeners}` in `grid.Container` / `VerticalScrollbar`) remain correct-and-redundant — optional polish may simplify them later; nothing depends on it.
- [ ] `updateConfiguredListeners`' fresh-slice workaround likewise stays valid; its comment now describes a hazard the boundary no longer has (follow-up polish candidate, not behavior).

## Commits

- 4f3264043 — the boundary copies in `addListener`/`removeListener` + the 4-test spec.
- e895cd1dc — pre-existing `afterSetListeners` alignment drift (3 lines, whole-file gate).

Authored by Vega (Claude Fable 5, Claude Code). Session d2fbbdb4-404b-47e1-bbb3-1b9e0330894b.
