### PR TITLE
refactor(kb): ADR-0019 batch-1 — openApiPath config leaf + chroma endpoint SSOT consumption (#12456)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -48,6 +48,17 @@ class Config extends ConfigProvider {
              */
             transport: leaf('stdio', 'NEO_TRANSPORT', 'string'),
             /**
+             * Absolute path to this server's OpenAPI tool-contract file. The env binding is the
+             * test-isolation seam: a parallel test run points its server instance at a scratch
+             * copy so tool-contract mutations never corrupt the canonical file — extensible per
+             * server via the `NEO_AI_MCP_<SERVER>_OPENAPI_PATH` naming convention. Owning the
+             * default AND the env binding here (instead of a module-level `process.env` read at
+             * the consumer) keeps the config-is-SSOT contract: no consumer re-derives from env,
+             * no consumer holds a hidden default.
+             * @type {string}
+             */
+            openApiPath: leaf(path.join(__dirname, 'openapi.yaml'), 'NEO_AI_MCP_KB_OPENAPI_PATH', 'string'),
+            /**
              * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
              *
              * Operator env var: `MCP_HTTP_PORT`.

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -1,5 +1,3 @@
-import path                          from 'path';
-import {fileURLToPath}               from 'url';
 import DatabaseService               from '../../../services/knowledge-base/DatabaseService.mjs';
 import DocumentService               from '../../../services/knowledge-base/DocumentService.mjs';
 import HealthService                 from '../../../services/knowledge-base/HealthService.mjs';
@@ -9,6 +7,7 @@ import QueryService                  from '../../../services/knowledge-base/Quer
 import SearchService                 from '../../../services/knowledge-base/SearchService.mjs';
 import ToolService                   from '../../ToolService.mjs';
 import AiConfig                      from '../../../config.mjs';
+import kbConfig                      from './config.mjs';
 import {readDeploymentStateSnapshot} from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
 import {
     assertToolTransportAllowed,
@@ -16,11 +15,6 @@ import {
     ingestToolName,
     isIngestSourceFilesToolVisible
 } from './ingestSourceFilesTool.mjs';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname  = path.dirname(__filename);
-/** @anchor test-isolation - ENV override to prevent parallel test mutations from corrupting the canonical file. Easily extensible to other servers via NEO_AI_MCP_<SERVER>_OPENAPI_PATH. */
-const openApiFilePath = process.env.NEO_AI_MCP_KB_OPENAPI_PATH || path.join(__dirname, 'openapi.yaml');
 
 const readDeploymentInspection = args => readDeploymentStateSnapshot({
     filePath    : AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
@@ -81,7 +75,9 @@ const serviceMapping = {
 
 const toolService = Neo.create(ToolService, {
     compactToolDescriptions     : true,
-    openApiFilePath,
+    // The server config owns the OpenAPI-contract path (default + the test-isolation env
+    // binding) — consumed at the use site, never re-derived from env here.
+    openApiFilePath             : kbConfig.openApiPath,
     serviceMapping,
     toolListDescriptionMaxLength: 120
 });

--- a/ai/scripts/migrations/backfillChromaSharedUserId.mjs
+++ b/ai/scripts/migrations/backfillChromaSharedUserId.mjs
@@ -40,8 +40,9 @@
  * @see ai/services/memory-core/SummaryService.mjs
  */
 
-import path from 'node:path';
+import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
+import kbConfig        from '../../mcp/server/knowledge-base/config.mjs';
 import {
     createDynamicTextEmbeddingFunction,
     registerNeoChromaEmbeddingFunctions
@@ -77,13 +78,15 @@ registerNeoChromaEmbeddingFunctions();
 
 function parseArgs(argv) {
     const args = {
-        apply       : false,
-        help        : false,
-        host        : process.env.NEO_CHROMA_HOST || process.env.NEO_KB_CHROMA_HOST || 'localhost',
-        port        : Number(process.env.NEO_CHROMA_PORT || process.env.NEO_KB_CHROMA_PORT || 8000),
-        memoryOnly  : false,
-        sessionOnly : false,
-        debugHidden : false
+        apply: false,
+        help : false,
+        // The KB server config OWNS the chroma endpoint (default + the NEO_CHROMA_* env
+        // bindings) — consumed at the use site, never re-derived from env with a shadow default.
+        host       : kbConfig.host,
+        port       : kbConfig.port,
+        memoryOnly : false,
+        sessionOnly: false,
+        debugHidden: false
     };
     for (let i = 2; i < argv.length; i++) {
         const a = argv[i];
@@ -176,12 +179,12 @@ function hasCoreSwarmParticipant(participatingAgents) {
  */
 async function findRecordsToTag(collection, {promoteCoreSwarmSummaries = false, debugHidden = false} = {}) {
     const tagRecords           = [];
-    let totalScanned           = 0;
-    let alreadyTagged          = 0;
-    let untagged               = 0;
-    let alreadyShared          = 0;
-    let coreSwarmParticipant   = 0;
-    let batchOffset            = 0;
+    let   totalScanned         = 0;
+    let   alreadyTagged        = 0;
+    let   untagged             = 0;
+    let   alreadyShared        = 0;
+    let   coreSwarmParticipant = 0;
+    let   batchOffset          = 0;
 
     while (true) {
         const batch = await collection.get({
@@ -198,10 +201,10 @@ async function findRecordsToTag(collection, {promoteCoreSwarmSummaries = false, 
 
             // Treat both missing key AND empty-string as untagged. Mirrors the
             // COALESCE(...) IS NULL OR = '' pattern in HealthService graph-side checker.
-            const userId = metadata && metadata.userId;
+            const userId           = metadata && metadata.userId;
             const normalizedUserId = normalizeUserId(userId);
-            const missingUserId = userId === undefined || userId === null || userId === '';
-            const hasCorePeer = promoteCoreSwarmSummaries && hasCoreSwarmParticipant(metadata?.participatingAgents);
+            const missingUserId    = userId === undefined || userId === null || userId === '';
+            const hasCorePeer      = promoteCoreSwarmSummaries && hasCoreSwarmParticipant(metadata?.participatingAgents);
 
             if (missingUserId) {
                 untagged++;
@@ -278,7 +281,7 @@ async function processCollection(client, collectionName, args) {
     const total = await collection.count();
     console.log(`  total records: ${total}`);
 
-    const promoteCoreSwarmSummaries = collectionName === COLLECTION_SESSION;
+    const promoteCoreSwarmSummaries                                                                              = collectionName === COLLECTION_SESSION;
     const {tagRecords: recordsToTag, totalScanned, alreadyTagged, untagged, alreadyShared, coreSwarmParticipant} = await findRecordsToTag(collection, {
         promoteCoreSwarmSummaries,
         debugHidden: args.debugHidden
@@ -323,7 +326,7 @@ async function main() {
     console.log(`[backfillChromaSharedUserId] collections: ${[targetMemory && COLLECTION_MEMORY, targetSession && COLLECTION_SESSION].filter(Boolean).join(', ')}`);
 
     const {ChromaClient} = await import('chromadb');
-    const client = new ChromaClient({host: args.host, port: args.port, ssl: false});
+    const client         = new ChromaClient({host: args.host, port: args.port, ssl: false});
 
     // Quick reachability check
     try {

--- a/ai/scripts/migrations/backfillChromaSharedUserId.mjs
+++ b/ai/scripts/migrations/backfillChromaSharedUserId.mjs
@@ -42,7 +42,6 @@
 
 import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
-import kbConfig        from '../../mcp/server/knowledge-base/config.mjs';
 import {
     createDynamicTextEmbeddingFunction,
     registerNeoChromaEmbeddingFunctions
@@ -53,10 +52,12 @@ const __dirname  = path.dirname(__filename);
 
 // MUST match `SHARED_USER_ID` exported from `ai/mcp/server/shared/services/RequestContextService.mjs`.
 // Hardcoded (vs imported) because that module transitively pulls in the Neo class system, which
-// requires a bootstrap this standalone script intentionally avoids — keeping the migration runner
-// dependency-light and fast to invoke. The sync invariant (script literal == service export) is
-// asserted by the `SHARED_USER_ID is in sync with the migration runner script's hardcoded copy`
-// test in `test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs`,
+// needs the runtime global before any class module evaluates — and THIS module's import scope
+// (plus the `--help` path) must stay runnable in a bare fresh process. A real migration run
+// bootstraps Neo lazily inside main() for config resolution only; module scope stays
+// bootstrap-free. The sync invariant (script literal == service export) is asserted by the
+// `SHARED_USER_ID is in sync with the migration runner script's hardcoded copy` test in
+// `test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs`,
 // which reads this script as text + regex-extracts the constant + compares against the import.
 const SHARED_USER_ID = 'shared';
 
@@ -80,10 +81,11 @@ function parseArgs(argv) {
     const args = {
         apply: false,
         help : false,
-        // The KB server config OWNS the chroma endpoint (default + the NEO_CHROMA_* env
-        // bindings) — consumed at the use site, never re-derived from env with a shadow default.
-        host       : kbConfig.host,
-        port       : kbConfig.port,
+        // null = "resolve from the KB server config at run time": the config transitively pulls
+        // the Neo class system, so its import is LAZY inside main() behind the bootstrap — flag
+        // parsing (and `--help`) must stay runnable in a bare fresh process.
+        host       : null,
+        port       : null,
         memoryOnly : false,
         sessionOnly: false,
         debugHidden: false
@@ -115,8 +117,8 @@ userId key, restoring tenant-aware read access to legacy data.
 Options:
   (no flags)         Dry-run mode — print the migration plan without committing
   --apply            Commit the migration (calls collection.update on all matched ids)
-  --host <host>      Override ChromaDB host (default: NEO_CHROMA_HOST, fallback localhost)
-  --port <port>      Override ChromaDB port (default: NEO_CHROMA_PORT, fallback 8000)
+  --host <host>      Override ChromaDB host (default: the KB server config's chroma endpoint; NEO_CHROMA_HOST binds through its leaf)
+  --port <port>      Override ChromaDB port (default: the KB server config's chroma endpoint; NEO_CHROMA_PORT binds through its leaf)
   --memory-only      Tag only the neo-agent-memory collection
   --session-only     Tag only the neo-agent-sessions collection
   --debug-hidden     Diagnostic dump of records to investigate parser shapes
@@ -315,6 +317,18 @@ async function main() {
     if (args.help) {
         printUsage();
         process.exit(0);
+    }
+
+    // The KB server config OWNS the chroma endpoint (default + the NEO_CHROMA_* env bindings) —
+    // consumed at the use site. Its import chain evaluates Neo class modules, which need the
+    // runtime global first, so the bootstrap + config import are LAZY and sequenced here: the
+    // module import and the `--help` path above stay runnable in a bare fresh process.
+    if (args.host == null || args.port == null) {
+        await import('../../../src/Neo.mjs');
+        await import('../../../src/core/_export.mjs');
+        const {default: kbConfig} = await import('../../mcp/server/knowledge-base/config.mjs');
+        args.host ??= kbConfig.host;
+        args.port ??= kbConfig.port;
     }
 
     const targetMemory  = !args.sessionOnly;

--- a/ai/scripts/migrations/renameAgentIdentities.mjs
+++ b/ai/scripts/migrations/renameAgentIdentities.mjs
@@ -31,8 +31,9 @@
  * preserved on the canonical node.
  */
 
-import path from 'node:path';
+import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
+import kbConfig        from '../../mcp/server/knowledge-base/config.mjs';
 import {
     createDynamicTextEmbeddingFunction,
     registerNeoChromaEmbeddingFunctions
@@ -112,14 +113,16 @@ registerNeoChromaEmbeddingFunctions();
  */
 export function parseArgs(argv) {
     const args = {
-        apply      : false,
-        chromaOnly : false,
-        db         : null,
-        graphOnly  : false,
-        help       : false,
-        host       : process.env.NEO_CHROMA_HOST || process.env.NEO_KB_CHROMA_HOST || 'localhost',
+        apply     : false,
+        chromaOnly: false,
+        db        : null,
+        graphOnly : false,
+        help      : false,
+        // The KB server config OWNS the chroma endpoint (default + the NEO_CHROMA_* env
+        // bindings) — consumed at the use site, never re-derived from env with a shadow default.
+        host       : kbConfig.host,
         memoryOnly : false,
-        port       : Number(process.env.NEO_CHROMA_PORT || process.env.NEO_KB_CHROMA_PORT || 8000),
+        port       : kbConfig.port,
         sessionOnly: false
     };
 
@@ -318,7 +321,7 @@ function ensureTargetIdentityNode(db, rename, apply, stats) {
         return;
     }
 
-    const oldData = parseGraphData(oldRow.data);
+    const oldData  = parseGraphData(oldRow.data);
     const nextData = targetRow
         ? mergeIdentityNodeData(oldData, parseGraphData(targetRow.data))
         : rewriteIdentityFields({...oldData, id: rename.toNodeId});
@@ -353,7 +356,7 @@ function rewriteIdentityEdges(db, rename, apply, stats) {
     for (const edge of edges) {
         const nextSource = edge.source === rename.fromNodeId ? rename.toNodeId : edge.source;
         const nextTarget = edge.target === rename.fromNodeId ? rename.toNodeId : edge.target;
-        const duplicate = db.prepare(
+        const duplicate  = db.prepare(
             'SELECT id FROM Edges WHERE source = ? AND target = ? AND type = ? AND id != ?'
         ).get(nextSource, nextTarget, edge.type, edge.id);
 
@@ -440,15 +443,15 @@ function deleteOldIdentityNode(db, rename, apply, stats) {
 export function runGraphMigration(db, apply) {
     const stats = {
         graph: {
-            duplicateCollisions   : 0,
+            duplicateCollisions    : 0,
             edgeMetadataRowsUpdated: 0,
-            edgesDropped          : 0,
-            edgesRewritten        : 0,
+            edgesDropped           : 0,
+            edgesRewritten         : 0,
             nodeMetadataRowsUpdated: 0,
-            nodesDeleted          : 0,
-            nodesInserted         : 0,
-            nodesMerged           : 0,
-            skipped               : []
+            nodesDeleted           : 0,
+            nodesInserted          : 0,
+            nodesMerged            : 0,
+            skipped                : []
         }
     };
 
@@ -477,8 +480,8 @@ export function runGraphMigration(db, apply) {
  */
 export async function findChromaMetadataUpdates(collection) {
     const updates = [];
-    let scanned   = 0;
-    let offset    = 0;
+    let   scanned = 0;
+    let   offset  = 0;
 
     while (true) {
         const batch = await collection.get({
@@ -537,12 +540,12 @@ async function applyChromaMetadataUpdates(collection, updates) {
 async function processChromaCollection(client, collectionName, apply) {
     console.log(`\n[${collectionName}]`);
     const embeddingFunction = createDynamicTextEmbeddingFunction();
-    const collection = await client.getOrCreateCollection({
+    const collection        = await client.getOrCreateCollection({
         name: collectionName,
         embeddingFunction
     });
 
-    const total = await collection.count();
+    const total              = await collection.count();
     const {scanned, updates} = await findChromaMetadataUpdates(collection);
 
     console.log(`  total records: ${total}`);
@@ -571,7 +574,7 @@ async function processChromaCollection(client, collectionName, apply) {
  */
 async function runChromaMigration(args) {
     const {ChromaClient} = await import('chromadb');
-    const client = new ChromaClient({host: args.host, port: args.port, ssl: false});
+    const client         = new ChromaClient({host: args.host, port: args.port, ssl: false});
 
     try {
         await client.heartbeat();
@@ -581,7 +584,7 @@ async function runChromaMigration(args) {
 
     const targetMemory  = !args.sessionOnly;
     const targetSession = !args.memoryOnly;
-    const summary = {memory: null, session: null};
+    const summary       = {memory: null, session: null};
 
     if (targetMemory) {
         summary.memory = await processChromaCollection(client, COLLECTION_MEMORY, args.apply);
@@ -612,7 +615,7 @@ async function main() {
 
     if (!args.chromaOnly) {
         const Database = (await import('better-sqlite3')).default;
-        const db = new Database(dbPath, {verbose: null});
+        const db       = new Database(dbPath, {verbose: null});
         try {
             const graphStats = runGraphMigration(db, args.apply);
             console.log('\n[SQLite graph]');

--- a/ai/scripts/migrations/renameAgentIdentities.mjs
+++ b/ai/scripts/migrations/renameAgentIdentities.mjs
@@ -33,7 +33,6 @@
 
 import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
-import kbConfig        from '../../mcp/server/knowledge-base/config.mjs';
 import {
     createDynamicTextEmbeddingFunction,
     registerNeoChromaEmbeddingFunctions
@@ -118,11 +117,12 @@ export function parseArgs(argv) {
         db        : null,
         graphOnly : false,
         help      : false,
-        // The KB server config OWNS the chroma endpoint (default + the NEO_CHROMA_* env
-        // bindings) — consumed at the use site, never re-derived from env with a shadow default.
-        host       : kbConfig.host,
+        // null = "resolve from the KB server config at run time": the config transitively pulls
+        // the Neo class system, so its import is LAZY inside main() behind the bootstrap — flag
+        // parsing (and `--help`) must stay runnable in a bare fresh process.
+        host       : null,
         memoryOnly : false,
-        port       : kbConfig.port,
+        port       : null,
         sessionOnly: false
     };
 
@@ -166,8 +166,8 @@ Options:
   (no flags)         Dry-run mode — print the migration plan without committing
   --apply            Commit the migration
   --db <path>        Override SQLite graph path (default: .neo-ai-data/sqlite/memory-core-graph.sqlite)
-  --host <host>      Override ChromaDB host (default: NEO_CHROMA_HOST, fallback localhost)
-  --port <port>      Override ChromaDB port (default: NEO_CHROMA_PORT, fallback 8000)
+  --host <host>      Override ChromaDB host (default: the KB server config's chroma endpoint; NEO_CHROMA_HOST binds through its leaf)
+  --port <port>      Override ChromaDB port (default: the KB server config's chroma endpoint; NEO_CHROMA_PORT binds through its leaf)
   --graph-only       Update only the SQLite Native Edge Graph
   --chroma-only      Update only ChromaDB metadata
   --memory-only      Update only neo-agent-memory Chroma metadata
@@ -605,6 +605,18 @@ async function main() {
     if (args.help) {
         printUsage();
         process.exit(0);
+    }
+
+    // The KB server config OWNS the chroma endpoint (default + the NEO_CHROMA_* env bindings) —
+    // consumed at the use site. Its import chain evaluates Neo class modules, which need the
+    // runtime global first, so the bootstrap + config import are LAZY and sequenced here: the
+    // module import and the `--help` path above stay runnable in a bare fresh process.
+    if (args.host == null || args.port == null) {
+        await import('../../../src/Neo.mjs');
+        await import('../../../src/core/_export.mjs');
+        const {default: kbConfig} = await import('../../mcp/server/knowledge-base/config.mjs');
+        args.host ??= kbConfig.host;
+        args.port ??= kbConfig.port;
     }
 
     const dbPath = args.db || path.resolve(neoRoot, '.neo-ai-data/sqlite/memory-core-graph.sqlite');

--- a/test/playwright/unit/ai/scripts/migrations/renameAgentIdentities.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/renameAgentIdentities.spec.mjs
@@ -13,12 +13,13 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Database       from 'better-sqlite3';
+import {test, expect}                         from '@playwright/test';
+import Database                               from 'better-sqlite3';
+import {spawnSync}                            from 'node:child_process';
 import {lstatSync, readdirSync, readFileSync} from 'node:fs';
-import path           from 'node:path';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import path                                   from 'node:path';
+import Neo                                    from '../../../../../../src/Neo.mjs';
+import * as core                              from '../../../../../../src/core/_export.mjs';
 import {
     findChromaMetadataUpdates,
     rewriteIdentityFields,
@@ -132,10 +133,26 @@ function findFilesContaining(repoRoot, entries, pattern) {
     return matches;
 }
 
+test.describe('migration CLIs — fresh-process bootstrap contract', () => {
+    test('both --help commands exit 0 with usage output in a BARE process — no Neo bootstrap, no Chroma/SQLite access', () => {
+        // The load-bearing regression: Playwright preloads Neo/core before importing these
+        // modules, so an in-process import can pass while the real CLI dies on the missing
+        // runtime global. Only a spawned fresh process proves the standalone entrypoint contract.
+        const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../../../../..');
+
+        for (const script of ['ai/scripts/migrations/renameAgentIdentities.mjs', 'ai/scripts/migrations/backfillChromaSharedUserId.mjs']) {
+            const result = spawnSync(process.execPath, [script, '--help'], {cwd: repoRoot, encoding: 'utf-8', timeout: 30_000});
+
+            expect(result.status, `${script} --help must exit 0 (stderr: ${result.stderr})`).toBe(0);
+            expect(result.stdout).toContain('Usage:');
+        }
+    });
+});
+
 test.describe('ai/scripts/migrations/renameAgentIdentities', () => {
     test('stale versioned handles are confined to the migration runner and its fixtures', () => {
         const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../../../../..');
-        const output = findFilesContaining(repoRoot, [
+        const output   = findFilesContaining(repoRoot, [
             'ai',
             '.github',
             'README.md',
@@ -162,13 +179,13 @@ test.describe('ai/scripts/migrations/renameAgentIdentities', () => {
             id        : '@neo-opus-4-7',
             label     : 'MESSAGE',
             properties: {
-                agentIdentity       : '@neo-opus-4-7',
-                bodyText            : 'historical body mentions @neo-opus-4-7',
-                participatingAgents : '@neo-opus-4-7, @neo-gemini-3-1-pro',
-                requiredGithubLogin : '@neo-gemini-3-1-pro',
+                agentIdentity        : '@neo-opus-4-7',
+                bodyText             : 'historical body mentions @neo-opus-4-7',
+                participatingAgents  : '@neo-opus-4-7, @neo-gemini-3-1-pro',
+                requiredGithubLogin  : '@neo-gemini-3-1-pro',
                 sourceAgentIdentities: ['@neo-opus-4-7', '@neo-gpt'],
-                subject             : 'historical subject mentions @neo-gemini-3-1-pro',
-                userId              : 'neo-opus-4-7'
+                subject              : 'historical subject mentions @neo-gemini-3-1-pro',
+                userId               : 'neo-opus-4-7'
             }
         };
 


### PR DESCRIPTION
Resolves #14953

Contributes to #12456 (batch 1 — the KB-domain violation class; the cornerstone grind epic stays open)

First violations batch of the AiConfig-cleanup cornerstone: the knowledge-base domain's config-SSOT violations, all of the module-level-env-re-derivation + hidden-default class the config-is-SSOT decision record catalogs.

- **`ai/mcp/server/knowledge-base/config.template.mjs`** gains the `openApiPath` leaf (`NEO_AI_MCP_KB_OPENAPI_PATH`, default `<serverDir>/openapi.yaml`). The env binding was previously a module-level `process.env` read in `toolService.mjs` with the default hidden at the consumer — the leaf now owns both, and the documented test-isolation seam (parallel runs pointing a server instance at a scratch copy) is preserved through the SSOT instead of around it. The gitignored local overlay carries the same leaf.
- **`toolService.mjs`** consumes `kbConfig.openApiPath` at the use site; the module-level `__dirname`/env derivation and its now-dead `path`/`fileURLToPath` imports are removed.
- **`ai/scripts/migrations/renameAgentIdentities.mjs` + `backfillChromaSharedUserId.mjs`** consumed the chroma endpoint via `process.env.NEO_CHROMA_HOST || process.env.NEO_KB_CHROMA_HOST || 'localhost'` (+ port twin) — a shadow re-derivation with its own hidden defaults for values the KB config already owns (`host`/`port` leaves bind `NEO_CHROMA_*` and default from the engine SSOT). Both now consume `kbConfig.host`/`kbConfig.port`; the `--host`/`--port` CLI overrides are untouched.

**Named behavior change:** the undocumented `NEO_KB_CHROMA_HOST`/`NEO_KB_CHROMA_PORT` fallback aliases existed ONLY inside these two scripts (repo-wide grep: no other definition, no docs) and are dropped by SSOT consumption — the canonical `NEO_CHROMA_*` bindings keep working through the leaves.

**Surveyed and classified NOT-violations (census notes for the epic):** `NEO_AGENT_IDENTITY` / `NEO_AGENT_ID` / `NEO_SESSION_ID` reads (per-process runtime identity injection, a cross-process contract — deliberately not config), `NEO_FLEET_BRIDGE_PUBLIC_KEY` (per-process credential material), `NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN` (parent→child lease inheritance). The orchestrator's `DEFAULT_DB_PATH`/`DEFAULT_DATA_DIR` module exports (`taskDefinitions.mjs` + the `daemon.mjs` duplicate) ARE the next real violation class — deferred to batch 2 deliberately: they feed 5+ files of live daemon infra and deserve their own review cycle, not a rushed rider here.

**The standalone-bootstrap contract (cycle-1 correction):** the original leaf-consumption import broke both migration CLIs in a bare process — the KB config chain evaluates Neo class modules, which need the runtime global first, so `node <script> --help` died on `ReferenceError: Neo is not defined` while the in-process specs stayed green (Playwright preloads Neo/core). The repair: module scope and the `--help` path are bootstrap-free again (parseArgs defaults host/port to `null`); a real run bootstraps lazily in `main()` — `import Neo.mjs` → `import core/_export.mjs` → `import kbConfig` in sequence — then fills the endpoint from the leaf. CLI `--host`/`--port` overrides skip the bootstrap entirely. The backfill script's hardcoded-sentinel rationale block is reconciled with this reality.

Evidence: L3 achieved for the CLI contract — fresh-process receipts at this head: `node ai/scripts/migrations/renameAgentIdentities.mjs --help` → exit 0 + usage; `node ai/scripts/migrations/backfillChromaSharedUserId.mjs --help` → exit 0 + usage (both bare, no Chroma/SQLite access); pinned permanently by a spawned-fresh-process regression in the migrations spec. L1 for the leaf/consumer shape (covering suites below).

## Deltas from ticket

- #12456's checklist is epic-scale; this PR carves the narrowest coherent domain slice (KB) rather than a repo-wide sweep — the census table above feeds the epic's remaining batches.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/migrations test/playwright/unit/ai/mcp/server/knowledge-base test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs --workers=1` → **108 passed** at this head (incl. the new fresh-process `--help` regression spawning both CLIs bare).
- Fresh-process L3 receipts (bare `node`, no runner): both `--help` commands exit 0 with usage output.
- `node --check` green on all sources; pre-commit gates green (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation (active-clone rollout)

- [ ] `npm run prepare -- --migrate-config` on the active clone (folds the new `openApiPath` leaf into the live gitignored overlay)
- [ ] KB harness/server restart so the running MCP instance serves through the leaf
- [ ] Normal-priority peer notification of the live-config behavior change
- [ ] One dry-run of `renameAgentIdentities.mjs` against the live chroma endpoint resolves host/port from config (no `--host` flag needed)

## Commits

- f9ee82613 — the batch: leaf + consumer + both migration scripts.
- eeda35f0a — cycle-1 correction: lazy Neo bootstrap for the CLIs' config reads; bare-process `--help` restored + fresh-process regression; usage/comment truth.

Related: #12456 (cornerstone-5 epic, stays open) · the config-SSOT decision record (gate-read discharged before authoring) · #14500 (Grace's mechanical-lint sub — this batch removes violations; her lint prevents new ones; no overlap).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b956ba53-01ed-4ea6-a1e5-62969f887bc3.
