### PR TITLE
refactor(orchestrator): ADR-0019 batch-2 — dbPath/dataDir provider leaves replace module-level env derivation (#12456)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -430,6 +430,28 @@ class Config extends ConfigProvider {
              */
             orchestrator: {
                 /**
+                 * Directory owning ALL orchestrator-daemon runtime state: the daemon + child-task
+                 * PID files, `orchestrator.log`, `orchestrator-state.json`, and the heavy-maintenance
+                 * lease + tenant-repo-sync revision files stored beside them. Kept relative on
+                 * purpose — it resolves against the daemon's cwd (repo root under the standard
+                 * launch). Owning the default AND the `NEO_AI_ORCHESTRATOR_DIR` env binding here
+                 * (instead of a module-level `process.env` read at the consumer) keeps the
+                 * config-is-SSOT contract: no consumer re-derives from env, no consumer holds a
+                 * hidden default.
+                 * @type {String}
+                 */
+                dataDir: leaf('.neo-ai-data/orchestrator-daemon', 'NEO_AI_ORCHESTRATOR_DIR', 'string'),
+                /**
+                 * SQLite Memory Core graph database file the orchestrator opens for graph-backed
+                 * health checks and maintenance decisions. Kept relative on purpose — it resolves
+                 * against the daemon's cwd (repo root under the standard launch). Owning the
+                 * default AND the `NEO_AI_DB_PATH` env binding here (instead of a module-level
+                 * `process.env` read at the consumer) keeps the config-is-SSOT contract: no
+                 * consumer re-derives from env, no consumer holds a hidden default.
+                 * @type {String}
+                 */
+                dbPath: leaf('.neo-ai-data/sqlite/memory-core-graph.sqlite', 'NEO_AI_DB_PATH', 'string'),
+                /**
                  * Deployment profile for Agent OS maintenance ownership.
                  * `local` preserves maintainer-checkout behavior; `cloud` disables local-only
                  * maintenance lanes unless a narrower localOnly override opts them back in.

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -57,11 +57,7 @@ import {
     buildOrchestratorSchedulingOptions,
     runSchedulingPipeline
 } from './scheduling/pipeline.mjs';
-import {
-    DEFAULT_DB_PATH,
-    DEFAULT_DATA_DIR,
-    DEFAULT_SCRIPT_DIR
-} from './taskDefinitions.mjs';
+import {DEFAULT_SCRIPT_DIR} from './taskDefinitions.mjs';
 import {
     inspectHeavyMaintenanceLeaseSync
 } from './services/heavyMaintenanceLeasePrimitives.mjs';
@@ -198,12 +194,14 @@ export class Orchestrator extends Base {
         dataRecoveryActuatorService_    : null,
         dataIntegrityDiagnosisService_  : null,
         maintenanceBackpressureService_ : MaintenanceBackpressureService,
-        dataDir_                        : DEFAULT_DATA_DIR,
-        taskDefinitions_                : null,
-        taskStateService_               : TaskStateService,
-        healthService_                  : HealthService,
-        spawnFn_                        : spawn,
-        heavyMaintenanceLeasePath_      : null
+        // null = "resolve from the owning config leaf on read" (see beforeGetDataDir): a leaf
+        // value in this static block would freeze at module load, not at the use site.
+        dataDir_                  : null,
+        taskDefinitions_          : null,
+        taskStateService_         : TaskStateService,
+        healthService_            : HealthService,
+        spawnFn_                  : spawn,
+        heavyMaintenanceLeasePath_: null
     }
 
     primaryRepoSyncService   = PrimaryRepoSyncService
@@ -226,7 +224,9 @@ export class Orchestrator extends Base {
     isPolling                     = false
     pollHandle                    = null
     db                            = null
-    dbPath                        = DEFAULT_DB_PATH
+    // Construct-time use-site read: a class-field initializer evaluates per instance, never at
+    // module load, so the leaf stays the SSOT for the pre-start() default.
+    dbPath                        = AiConfig.orchestrator.dbPath
     logFile                       = null
     stateFile                     = null
     primaryDevSyncRootsConfig     = null
@@ -353,6 +353,16 @@ export class Orchestrator extends Base {
                 this.writeLog('ERROR', `[Orchestrator] REM consolidation stall-alarm wake pulse failed: ${e.message}`);
             }
         }
+    }
+
+    /**
+     * @summary Resolves the runtime-state directory from the owning config leaf when no explicit
+     * value was set — a per-read use-site resolution, never a module-load capture.
+     * @param {String|null} value
+     * @returns {String}
+     */
+    beforeGetDataDir(value) {
+        return value ?? AiConfig.orchestrator.dataDir
     }
 
     /**
@@ -811,7 +821,7 @@ export class Orchestrator extends Base {
         }
 
         const scriptDir = options.scriptDir || DEFAULT_SCRIPT_DIR;
-        const dataDir   = options.dataDir   || DEFAULT_DATA_DIR;
+        const dataDir   = options.dataDir   || AiConfig.orchestrator.dataDir;
 
         this.dataDir                   = dataDir;
         this.taskDefinitions   = options.taskDefinitions || this.buildConfiguredTaskDefinitions({
@@ -819,7 +829,7 @@ export class Orchestrator extends Base {
             nodeBin: options.nodeBin || process.argv[0]
         });
 
-        this.dbPath                    = options.dbPath   || DEFAULT_DB_PATH;
+        this.dbPath                    = options.dbPath   || AiConfig.orchestrator.dbPath;
         this.logFile                   = options.logFile  || path.join(dataDir, 'orchestrator.log');
         this.stateFile                 = options.stateFile || path.join(dataDir, 'orchestrator-state.json');
         this.heavyMaintenanceLeasePath = options.heavyMaintenanceLeasePath ?? this.heavyMaintenanceLeasePath;

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -196,12 +196,15 @@ export class Orchestrator extends Base {
         maintenanceBackpressureService_ : MaintenanceBackpressureService,
         // null = "resolve from the owning config leaf on read" (see beforeGetDataDir): a leaf
         // value in this static block would freeze at module load, not at the use site.
-        dataDir_                  : null,
-        taskDefinitions_          : null,
-        taskStateService_         : TaskStateService,
-        healthService_            : HealthService,
-        spawnFn_                  : spawn,
-        heavyMaintenanceLeasePath_: null
+        dataDir_                        : null,
+        // Same contract as dataDir_: the singleton is constructed during module import, so a
+        // class-field leaf read would still be a module-load capture.
+        dbPath_                         : null,
+        taskDefinitions_                : null,
+        taskStateService_               : TaskStateService,
+        healthService_                  : HealthService,
+        spawnFn_                        : spawn,
+        heavyMaintenanceLeasePath_      : null
     }
 
     primaryRepoSyncService   = PrimaryRepoSyncService
@@ -224,9 +227,6 @@ export class Orchestrator extends Base {
     isPolling                     = false
     pollHandle                    = null
     db                            = null
-    // Construct-time use-site read: a class-field initializer evaluates per instance, never at
-    // module load, so the leaf stays the SSOT for the pre-start() default.
-    dbPath                        = AiConfig.orchestrator.dbPath
     logFile                       = null
     stateFile                     = null
     primaryDevSyncRootsConfig     = null
@@ -363,6 +363,16 @@ export class Orchestrator extends Base {
      */
     beforeGetDataDir(value) {
         return value ?? AiConfig.orchestrator.dataDir
+    }
+
+    /**
+     * @summary Resolves the graph database path from the owning config leaf when no explicit value
+     * was set, preserving Provider refreshes before orchestrator start.
+     * @param {String|null} value
+     * @returns {String}
+     */
+    beforeGetDbPath(value) {
+        return value ?? AiConfig.orchestrator.dbPath
     }
 
     /**

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -34,11 +34,39 @@ import AiConfig                              from '../../config.mjs';
 import Orchestrator, {rotateLogFileIfNewDay} from './Orchestrator.mjs';
 import {assertConfigFresh}                   from '../../scripts/setup/initServerConfigs.mjs';
 
-const DAEMON_DATA_DIR               = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
-const PID_FILE                      = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
-const LOG_FILE                      = path.join(DAEMON_DATA_DIR, 'orchestrator.log');
 const ORCHESTRATOR_DAEMON_PATH_TAIL = 'ai/daemons/orchestrator/daemon.mjs';
 export const LOCAL_AI_CONFIG_FILE = fileURLToPath(new URL('../../config.mjs', import.meta.url));
+
+/**
+ * @summary Resolves the orchestrator daemon's runtime data directory from the config provider.
+ *
+ * The provider owns the default AND the `NEO_AI_ORCHESTRATOR_DIR` env binding, so this
+ * entrypoint reads the resolved leaf instead of re-deriving it from `process.env` with a
+ * shadow default. Resolved lazily at each use site (all of which run after the boot-time
+ * config-freshness guard) rather than via an eager module-level `path.join`: on a stale
+ * config overlay the leaf is missing, and an eager join would crash module evaluation
+ * before the guard can name the actionable `--migrate-config` fix.
+ * @returns {String}
+ */
+function daemonDataDir() {
+    return AiConfig.orchestrator.dataDir;
+}
+
+/**
+ * @summary Resolves the daemon singleton PID-file path under {@link daemonDataDir}.
+ * @returns {String}
+ */
+function pidFilePath() {
+    return path.join(daemonDataDir(), 'orchestrator-daemon.pid');
+}
+
+/**
+ * @summary Resolves the shared orchestrator log-file path under {@link daemonDataDir}.
+ * @returns {String}
+ */
+function logFilePath() {
+    return path.join(daemonDataDir(), 'orchestrator.log');
+}
 
 /**
  * @summary Checks whether a process command belongs to this daemon entry point.
@@ -51,16 +79,18 @@ export function isOrchestratorDaemonCommand(cmd) {
 }
 
 function writeLog(level, message) {
+    const logFile = logFilePath();
+
     // Both this wrapper writer AND Orchestrator.writeLog append to the same orchestrator.log, so
     // BOTH must rotate-before-append: an unguarded append here would advance the file's mtime past
     // the day boundary and defeat the mtime-based daily rotation.
-    rotateLogFileIfNewDay(LOG_FILE);
+    rotateLogFileIfNewDay(logFile);
 
     const timestamp = new Date().toISOString();
     const line      = `[${timestamp}] [PID:${process.pid}] [${level}] ${message}`;
 
     try {
-        fs.appendFileSync(LOG_FILE, line + '\n', 'utf8');
+        fs.appendFileSync(logFile, line + '\n', 'utf8');
     } catch (e) {}
 
     if (level === 'ERROR') {
@@ -90,17 +120,21 @@ async function waitForExit(pid, timeoutMs) {
 }
 
 function removePidFile() {
+    const pidFile = pidFilePath();
+
     try {
-        if (fs.existsSync(PID_FILE) && parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10) === process.pid) {
-            fs.unlinkSync(PID_FILE);
+        if (fs.existsSync(pidFile) && parseInt(fs.readFileSync(pidFile, 'utf8'), 10) === process.pid) {
+            fs.unlinkSync(pidFile);
         }
     } catch (e) {}
 }
 
 async function enforceSingleton() {
-    if (fs.existsSync(PID_FILE)) {
+    const pidFile = pidFilePath();
+
+    if (fs.existsSync(pidFile)) {
         try {
-            const oldPid = parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10);
+            const oldPid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
             if (!Number.isNaN(oldPid) && oldPid > 0 && oldPid !== process.pid) {
                 let isAlive = false;
 
@@ -128,7 +162,7 @@ async function enforceSingleton() {
         }
     }
 
-    fs.writeFileSync(PID_FILE, process.pid.toString(), 'utf8');
+    fs.writeFileSync(pidFile, process.pid.toString(), 'utf8');
 }
 
 function setupCleanupHandlers() {
@@ -183,13 +217,15 @@ export async function loadLocalAiConfig({
  * @returns {Promise<void>}
  */
 export async function startOrchestrator(options = {}) {
-    fs.ensureDirSync(DAEMON_DATA_DIR);
+    const dataDir = daemonDataDir();
+
+    fs.ensureDirSync(dataDir);
     await enforceSingleton();
     setupCleanupHandlers();
     await loadLocalAiConfig();
 
     return Orchestrator.start({
-        dataDir                  : DAEMON_DATA_DIR,
+        dataDir,
         primaryDevSyncRootsConfig: AiConfig.orchestrator.devSyncRoots,
         ...options
     });

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -6,7 +6,6 @@ import {
     acquireHeavyMaintenanceLeaseSync,
     releaseHeavyMaintenanceLeaseSync
 } from './HeavyMaintenanceLeaseService.mjs';
-import {DEFAULT_DATA_DIR} from '../taskDefinitions.mjs';
 
 /**
  * Canonical set of heavy-maintenance task names that participate in the cross-poll
@@ -177,7 +176,7 @@ export function getActiveGoldenPathDependencyTask({
  */
 export function resolveHeavyMaintenanceLeasePath({heavyMaintenanceLeasePath, dataDir}) {
     if (heavyMaintenanceLeasePath) return heavyMaintenanceLeasePath;
-    return path.join(dataDir || DEFAULT_DATA_DIR, 'heavy-maintenance-lease.json');
+    return path.join(dataDir || AiConfig.orchestrator.dataDir, 'heavy-maintenance-lease.json');
 }
 
 // ============================================================================
@@ -332,10 +331,12 @@ export class MaintenanceBackpressureService extends Base {
          */
         heavyMaintenanceLeasePath_: null,
         /**
-         * @member {String} dataDir_=DEFAULT_DATA_DIR
+         * `null` = "resolve from the owning config leaf on read" (see `beforeGetDataDir`): a
+         * leaf value in this static block would freeze at module load, not at the use site.
+         * @member {String|null} dataDir_=null
          * @reactive
          */
-        dataDir_: DEFAULT_DATA_DIR,
+        dataDir_: null,
         /**
          * @member {Object|null} taskStateService_=null
          * @reactive
@@ -380,6 +381,16 @@ export class MaintenanceBackpressureService extends Base {
      * @member {Number} shedUntil=0
      */
     shedUntil = 0
+
+    /**
+     * @summary Resolves the runtime-state directory from the owning config leaf when no explicit
+     * value was set — a per-read use-site resolution, never a module-load capture.
+     * @param {String|null} value
+     * @returns {String}
+     */
+    beforeGetDataDir(value) {
+        return value ?? AiConfig.orchestrator.dataDir
+    }
 
     /**
      * @summary Opens an auto-expiring shed-window: until `now + durationMs`, `acquireLeaseAndExecute` defers ALL

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -15,7 +15,6 @@ import {
     appendHealEvent,
     validateHealLedgerRetention
 } from '../../../services/memory-core/helpers/healEventLedgerStore.mjs';
-import {DEFAULT_DATA_DIR} from '../taskDefinitions.mjs';
 
 const DEFAULT_ACTIONS        = Object.freeze(['restart', 'redeploy', 'warm-provider']);
 const DEFAULT_DEPLOY_TARGETS = Object.freeze(['cloud-deploy']);
@@ -107,11 +106,13 @@ export class RecoveryActuatorService extends Base {
          */
         actuatorConfig_: null,
         /**
-         * @member {String} dataDir_='.neo-ai-data/orchestrator-daemon'
+         * `null` = "resolve from the owning config leaf on read" (see `beforeGetDataDir`): a
+         * leaf value in this static block would freeze at module load, not at the use site.
+         * @member {String|null} dataDir_=null
          * @protected
          * @reactive
          */
-        dataDir_: DEFAULT_DATA_DIR,
+        dataDir_: null,
         /**
          * @member {Object|null} healthService_=null
          * @protected
@@ -458,6 +459,16 @@ export class RecoveryActuatorService extends Base {
             taskStatus: 'failed',
             updatedAt
         });
+    }
+
+    /**
+     * @summary Resolves the runtime-state directory from the owning config leaf when no explicit
+     * value was set — a per-read use-site resolution, never a module-load capture.
+     * @param {String|null} value
+     * @returns {String}
+     */
+    beforeGetDataDir(value) {
+        return value ?? AiConfig.orchestrator.dataDir
     }
 
     /**

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -2,7 +2,6 @@ import fs                    from 'fs-extra';
 import path                  from 'node:path';
 import Base                  from '../../../../src/core/Base.mjs';
 import AiConfig              from '../../../config.mjs';
-import {DEFAULT_DATA_DIR}    from '../taskDefinitions.mjs';
 import GitMirror             from '../../../services/knowledge-base/helpers/gitMirror.mjs';
 import {buildIngestEnvelope} from '../../../services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 import {isRepoDue}           from '../scheduling/tenantRepoSync.mjs';
@@ -219,7 +218,7 @@ class TenantRepoSyncService extends Base {
      * @param {Object} [options.gitMirror=GitMirror] Injectable mirror primitive (test seam).
      * @param {Object} [options.knowledgeBaseIngestionService] KB ingestion service singleton (test seam). Resolved from `ai/services.mjs` if omitted.
      * @param {String[]} [options.onlyRepoSlugs] If provided, only sync repos whose `repoSlug` is in the list. Used by the manual CLI run path. Empty filter result against non-empty list surfaces `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED`.
-     * @param {String} [options.revisionsFilePath] Override the per-tenant-repo lastIngestedRev persistence file path (test seam). Defaults to `<DEFAULT_DATA_DIR>/tenant-repo-sync-revisions.json`.
+     * @param {String} [options.revisionsFilePath] Override the per-tenant-repo lastIngestedRev persistence file path (test seam). Defaults to `<orchestrator dataDir leaf>/tenant-repo-sync-revisions.json`.
      * @param {Function} [options.envelopeBuilder=buildIngestEnvelope] Injectable envelope-builder (test seam). Production callers omit; unit tests pass a fake that returns canned envelope shape.
      * @returns {Promise<Object>} `{status, details}` — status ∈ {`completed`, `failed`, `skipped`}.
      */
@@ -631,15 +630,16 @@ class TenantRepoSyncService extends Base {
 
     /**
      * Default per-tenant-repo lastIngestedRev persistence file path. Lives next to
-     * the orchestrator state file (`<DEFAULT_DATA_DIR>/orchestrator-state.json`)
+     * the orchestrator state file (`<orchestrator dataDir leaf>/orchestrator-state.json`)
      * so the two persistence surfaces share lifecycle (same data-dir = same recovery scope).
      * Separate file (not inlined into TaskStateService's state) prevents `markCompleted/markFailed`
-     * task-lifecycle writes from racing with revision-map writes.
+     * task-lifecycle writes from racing with revision-map writes. The dataDir resolves from the
+     * owning config leaf inline — a use-site read, never a module-load capture.
      *
      * @returns {String}
      */
     defaultRevisionsFilePath() {
-        return path.join(DEFAULT_DATA_DIR, PERSISTED_REVISIONS_FILE_NAME);
+        return path.join(AiConfig.orchestrator.dataDir, PERSISTED_REVISIONS_FILE_NAME);
     }
 
     /**

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -7,25 +7,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 /**
- * SQLite Memory Core graph database file the orchestrator opens for graph-backed health
- * checks. Leaf-fed: the config provider owns the default AND the `NEO_AI_DB_PATH` env
- * binding — this constant only re-exports the resolved leaf so the existing orchestrator
- * consumer surface stays stable.
- * @type {String}
- */
-export const DEFAULT_DB_PATH = AiConfig.orchestrator.dbPath;
-
-/**
- * Orchestrator-daemon runtime-state directory (PID files, log, state, lease + revision
- * files). Leaf-fed: the config provider owns the default AND the `NEO_AI_ORCHESTRATOR_DIR`
- * env binding — this constant only re-exports the resolved leaf so the existing
- * orchestrator consumer surface stays stable.
- * @type {String}
- */
-export const DEFAULT_DATA_DIR = AiConfig.orchestrator.dataDir;
-
-/**
  * Default maintenance-script directory, resolved relative to this module.
+ *
+ * The orchestrator's db path + runtime-state dir carry NO re-export here: consumers read the
+ * `AiConfig.orchestrator.dbPath` / `AiConfig.orchestrator.dataDir` leaves inline at each use
+ * site — exporting a resolved leaf freezes it at module load and hands consumers a
+ * config-shaped constant, both forbidden by the config-is-SSOT contract.
  * @type {String}
  */
 export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -1,12 +1,33 @@
 import path            from 'path';
 import net             from 'net';
 import {fileURLToPath} from 'url';
+import AiConfig        from '../../config.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
-export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
-export const DEFAULT_DATA_DIR   = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
+/**
+ * SQLite Memory Core graph database file the orchestrator opens for graph-backed health
+ * checks. Leaf-fed: the config provider owns the default AND the `NEO_AI_DB_PATH` env
+ * binding — this constant only re-exports the resolved leaf so the existing orchestrator
+ * consumer surface stays stable.
+ * @type {String}
+ */
+export const DEFAULT_DB_PATH = AiConfig.orchestrator.dbPath;
+
+/**
+ * Orchestrator-daemon runtime-state directory (PID files, log, state, lease + revision
+ * files). Leaf-fed: the config provider owns the default AND the `NEO_AI_ORCHESTRATOR_DIR`
+ * env binding — this constant only re-exports the resolved leaf so the existing
+ * orchestrator consumer surface stays stable.
+ * @type {String}
+ */
+export const DEFAULT_DATA_DIR = AiConfig.orchestrator.dataDir;
+
+/**
+ * Default maintenance-script directory, resolved relative to this module.
+ * @type {String}
+ */
 export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
 
 const DEFAULT_CHROMA_HEALTH_ENDPOINT   = '/api/v2/heartbeat';

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -1,7 +1,6 @@
 import path            from 'path';
 import net             from 'net';
 import {fileURLToPath} from 'url';
-import AiConfig        from '../../config.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -661,7 +661,7 @@ test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
         }
     });
 
-    test('Orchestrator.mjs has no `_`-suffix reactive config slot without a corresponding `beforeSet*` or `afterSet*` hook', async () => {
+    test('Orchestrator.mjs has no `_`-suffix reactive config slot without a corresponding config hook', async () => {
         const source    = await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8');
         const codeLines = stripCommentsAndStrings(source);
 
@@ -670,13 +670,14 @@ test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
         const slotNames   = slotMatches.map(m => m[1]).filter(name => name !== 'class' && name !== 'static');
 
         const missingHook = slotNames.filter(name => {
-            const cap      = name.charAt(0).toUpperCase() + name.slice(1);
-            const beforeRe = new RegExp(`\\bbeforeSet${cap}\\s*\\(`);
-            const afterRe  = new RegExp(`\\bafterSet${cap}\\s*\\(`);
-            return !beforeRe.test(codeLines) && !afterRe.test(codeLines);
+            const cap         = name.charAt(0).toUpperCase() + name.slice(1);
+            const beforeGetRe = new RegExp(`\\bbeforeGet${cap}\\s*\\(`);
+            const beforeSetRe = new RegExp(`\\bbeforeSet${cap}\\s*\\(`);
+            const afterSetRe  = new RegExp(`\\bafterSet${cap}\\s*\\(`);
+            return !beforeGetRe.test(codeLines) && !beforeSetRe.test(codeLines) && !afterSetRe.test(codeLines);
         });
 
-        expect(missingHook, `Reactive config slots with \`_\`-suffix MUST have a corresponding \`beforeSetX\` or \`afterSetX\` hook (Sub-1 anti-pattern: cargo-cult underscores without hooks). Offending slots: ${missingHook.join(', ')}.`).toEqual([]);
+        expect(missingHook, `Reactive config slots with \`_\`-suffix MUST have a corresponding \`beforeGetX\`, \`beforeSetX\`, or \`afterSetX\` hook (Sub-1 anti-pattern: cargo-cult underscores without hooks). Offending slots: ${missingHook.join(', ')}.`).toEqual([]);
     });
 });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1179,6 +1179,27 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(orchestrator.taskDefinitions.mlx).toBeUndefined();
     });
 
+    test('keeps the pre-start dbPath leaf reactive while an explicit override remains stable', () => {
+        const orchestrator = Neo.create(Orchestrator);
+        const originalPath = AiConfig.orchestrator.dbPath;
+
+        try {
+            orchestrator.dbPath = null;
+            AiConfig.setEnvOverride('NEO_AI_DB_PATH', '/tmp/orchestrator-provider-first.sqlite');
+            expect(orchestrator.dbPath).toBe('/tmp/orchestrator-provider-first.sqlite');
+
+            AiConfig.setEnvOverride('NEO_AI_DB_PATH', '/tmp/orchestrator-provider-refreshed.sqlite');
+            expect(orchestrator.dbPath).toBe('/tmp/orchestrator-provider-refreshed.sqlite');
+
+            orchestrator.dbPath = '/tmp/orchestrator-explicit.sqlite';
+            AiConfig.setEnvOverride('NEO_AI_DB_PATH', '/tmp/orchestrator-provider-third.sqlite');
+            expect(orchestrator.dbPath).toBe('/tmp/orchestrator-explicit.sqlite');
+        } finally {
+            orchestrator.dbPath = null;
+            AiConfig.setEnvOverride('NEO_AI_DB_PATH', originalPath);
+        }
+    });
+
     test('passes local mlx launch model config into task definitions', () => {
         const savedMlx = {...AiConfig.orchestrator.mlx};
 


### PR DESCRIPTION
Resolves #14957

Related: #12456 (ADR-0019 cornerstone parent; this is the orchestrator dbPath/dataDir leaf).

## Context

`ai/daemons/orchestrator/taskDefinitions.mjs` exported two module-level environment re-derivations with hidden defaults, while `daemon.mjs` carried an independent `NEO_AI_ORCHESTRATOR_DIR` drift twin. The initial compatibility rewrite replaced the env reads with module-scope Provider captures; exact CI correctly rejected those exports as the same config-value-freezing class in a different costume.

The delivered shape removes the re-export boundary entirely:

1. **`ai/config.template.mjs` owns the values.** `orchestrator.dataDir` and `orchestrator.dbPath` carry the previous defaults plus their existing env bindings.
2. **Consumers read at use sites.** `Orchestrator` resolves instance/start defaults; `MaintenanceBackpressureService`, `RecoveryActuatorService`, and `TenantRepoSyncService` resolve their own persistence paths from the leaf when no explicit test/runtime override exists.
3. **`daemon.mjs` stays fail-loud and freshness-safe.** Lazy `daemonDataDir()`, `pidFilePath()`, and `logFilePath()` reads occur after the boot-time config-freshness guard rather than crashing module evaluation on a stale overlay.
4. **`taskDefinitions.mjs` remains config-free and bootstrap-free.** It exports only `DEFAULT_SCRIPT_DIR`; the obsolete config import was removed in `25fc820ef`.
5. **Reactive defaults stay reactive before `start()`.** `Orchestrator` keeps both `dataDir_` and `dbPath_` null and resolves them through substantive `beforeGet*` hooks, so Provider/env refreshes are visible until an explicit instance override is set.

Evidence: L3 (the real child-process workspace-safety run boots `daemon.mjs` with both env overrides and reaches `[Orchestrator] Started`, backed by focused ADR-0019/config tests) → L3 required by #14957's real-daemon boot AC. Residual: canonical deployment restart remains operational post-merge validation; no code residual is deferred.

## Deltas from ticket

- The ticket anticipated deleting the two config-shaped exports and migrating consumers. The first commit temporarily preserved them for compatibility; CI and reviewer probes falsified that shape, so commit `b5e9c72cd` completed the intended use-site migration in the same PR.
- Class config defaults use `null` plus `beforeGetDataDir()` rather than freezing a Provider value in the static block. Explicit caller overrides continue to win.
- `Orchestrator` resolves `dataDir` and `dbPath` through per-read hooks before start; `start()` re-reads both defaults at the operational boundary. Explicit instance/options overrides continue to win.
- The active gitignored `ai/config.mjs` overlay was migrated during author validation; tracked source remains `ai/config.template.mjs`.

## Test Evidence

- `lint-config-template-ssot` → **OK**, zero new violations.
- `lintConfigTemplateSsot.spec.mjs` plus the complete `test/playwright/unit/ai/daemons/orchestrator/` surface → **845 passed**.
- `AgentOrchestrator.spec.mjs` → **9 passed**.
- `workspaceSafety.spec.mjs` boots the real daemon child with `NEO_AI_ORCHESTRATOR_DIR` / `NEO_AI_DB_PATH` overrides and reaches `[Orchestrator] Started`.
- Maintainer-polish probe at `25fc820ef`: `node --check ai/daemons/orchestrator/taskDefinitions.mjs`, `git diff --check`, and a bootstrap-free dynamic import all pass; `DEFAULT_SCRIPT_DIR` still resolves to `ai/scripts`.
- Reactive db-path correction at `cb66d8241`: `Orchestrator.spec.mjs` **61/61**, Orchestrator + invariants **87/87**, broader daemon/services **127 passed**, and workspace-safety integration **3/3**; SSOT lint green.
- Exact-head hosted CI is the merge gate.

## Post-Merge Validation

- [ ] Restart the canonical orchestrator daemon after config migration.
- [ ] Confirm PID/log/state files remain under `.neo-ai-data/orchestrator-daemon` (or the configured override).
- [ ] Confirm the graph DB opens at `.neo-ai-data/sqlite/memory-core-graph.sqlite` (or the configured override).

## Commits

- `dd6211c453` — initial leaf ownership and daemon lazy reads.
- `b5e9c72cdf` — remove config-shaped exports and migrate consumers to use-site reads.
- `25fc820ef4` — maintainer polish: remove the now-unused config import and restore bootstrap-free task-definition loading.
- `cb66d82414` — preserve reactive pre-start `dbPath` reads with `beforeGetDbPath` and focused refresh/override coverage.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b956ba53-01ed-4ea6-a1e5-62969f887bc3.
Maintainer polish by Euclid (GPT-5.6 Sol, Codex). Session de713f27-0e82-4960-b4c6-f281e0c36449.



