### PR TITLE
refactor(mcp): ADR-0019 batch-3 — server-shared env reads onto owning config leaves + census (#12456)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -75,6 +75,14 @@ class Config extends ConfigProvider {
              */
             allowedHosts: leaf(null, 'NEO_MCP_ALLOWED_HOSTS', 'string'),
             /**
+             * Hostname (or full `protocol://host` URL) the SSE / HTTP transport advertises when
+             * `publicUrl` is unset. Bare hostnames infer their protocol by convention (http for
+             * localhost/127.0.0.1, https otherwise); values containing '://' are parsed verbatim.
+             * Bound to the platform-standard `HOST` env var. Consumed by TransportService.setup.
+             * @type {string}
+             */
+            mcpHttpHost: leaf('localhost', 'HOST', 'string'),
+            /**
              * Port the MCP server's HTTP/SSE transport listens on.
              * Sub-servers will typically override this with their own defaultPort.
              * @type {number}

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -1,4 +1,4 @@
-import Base from '../../../../../src/core/Base.mjs';
+import Base                  from '../../../../../src/core/Base.mjs';
 import RequestContextService from './RequestContextService.mjs';
 
 /**
@@ -58,9 +58,9 @@ class TransportService extends Base {
             const proxyUserId = req.headers['x-preferred-username'] || req.headers['x-auth-request-preferred-username'];
             if (proxyUserId) {
                 baseAuth = {
-                    userId: proxyUserId,
+                    userId  : proxyUserId,
                     username: proxyUserId,
-                    source: 'proxy-header'
+                    source  : 'proxy-header'
                 };
             } else {
                 req.app?.locals?.logger?.warn('Unauthorized: trustProxyIdentity is enabled but X-PREFERRED-USERNAME header is missing');
@@ -132,10 +132,10 @@ class TransportService extends Base {
     async setup(options) {
         const { server, aiConfig, logger, resourceName } = options;
 
-        const { createMcpExpressApp } = await import('@modelcontextprotocol/sdk/server/express.js');
+        const { createMcpExpressApp }           = await import('@modelcontextprotocol/sdk/server/express.js');
         const { StreamableHTTPServerTransport } = await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
-        const crypto = await import('crypto');
-        const cors = await import('cors');
+        const crypto                            = await import('crypto');
+        const cors                              = await import('cors');
         // Host-allowlist for the SDK's DNS-rebinding protection. Always includes localhost (the
         // container healthcheck hits 127.0.0.1) plus the publicUrl hostname + NEO_MCP_ALLOWED_HOSTS,
         // so a cloud deployment behind a reverse proxy on a public hostname is not rejected with
@@ -145,7 +145,7 @@ class TransportService extends Base {
         this.app = app;
 
         app.use(cors.default({
-            origin: '*',
+            origin        : '*',
             exposedHeaders: ['Mcp-Session-Id'],
         }));
 
@@ -157,7 +157,10 @@ class TransportService extends Base {
             return new URL(`${protocol}://${host}:${port}`);
         };
 
-        const mcpServerUrl = aiConfig.publicUrl ? new URL(aiConfig.publicUrl) : getFullUrl(process.env.HOST || 'localhost', aiConfig.mcpHttpPort);
+        // The config owns the advertised transport host (default + the platform-standard `HOST`
+        // env binding on the `mcpHttpHost` leaf) — consumed at the use site, never re-derived
+        // from env here.
+        const mcpServerUrl = aiConfig.publicUrl ? new URL(aiConfig.publicUrl) : getFullUrl(aiConfig.mcpHttpHost, aiConfig.mcpHttpPort);
         this.mcpServerUrl = mcpServerUrl;
 
         // Optional Authorization: OIDC/OAuth (host / issuerUrl) OR the GitLab-PAT bearer mode.
@@ -189,7 +192,7 @@ class TransportService extends Base {
                 }
             } else {
                 transport = new StreamableHTTPServerTransport({
-                    sessionIdGenerator: () => crypto.randomUUID(),
+                    sessionIdGenerator  : () => crypto.randomUUID(),
                     onsessioninitialized: (id) => {
                         this.transports.set(id, transport);
                         if (mcpServerInstance) {
@@ -244,9 +247,9 @@ class TransportService extends Base {
                 requestContext = await server.buildRequestContext(baseAuth);
             } else {
                 requestContext = {
-                    userId: baseAuth?.userId,
+                    userId  : baseAuth?.userId,
                     username: baseAuth?.username,
-                    source: baseAuth?.source
+                    source  : baseAuth?.source
                 };
             }
 

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -55,6 +55,16 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(fresh.getDataConfig('mcpHttpPort').get()).toBe(initialPort);
     });
 
+    test('mcpHttpHost transport-host leaf owns the HOST env binding', () => {
+        // Consumers (TransportService) read the resolved leaf; the env-override-with-default
+        // behavior lives here on the leaf, so prove the binding resolves through it.
+        expect(Config.mcpHttpHost).toBe(process.env.HOST || 'localhost');
+
+        const fresh = Neo.create(ConfigProvider, {data: Config._data});
+        fresh.setEnvOverride('HOST', 'internal-host');
+        expect(fresh.getDataConfig('mcpHttpHost').get()).toBe('internal-host');
+    });
+
     test('ships a machine-neutral orchestrator dev-sync root default', async () => {
         expect(Config.orchestrator.devSyncRoots).toEqual([]);
     });

--- a/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
@@ -14,9 +14,9 @@ setup({
 });
 
 import { test, expect } from '@playwright/test';
-import http from 'http';
-import Neo from '../../../../../../../../src/Neo.mjs';
-import * as core from '../../../../../../../../src/core/_export.mjs';
+import http             from 'http';
+import Neo              from '../../../../../../../../src/Neo.mjs';
+import * as core        from '../../../../../../../../src/core/_export.mjs';
 
 test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
 
@@ -29,40 +29,40 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
         const closedPromise = new Promise(resolve => resolveClosed = resolve);
 
         const mockServer = {
-            mcpServer: { connect: async () => {} },
+            mcpServer      : { connect: async () => {} },
             onSessionClosed: (id) => {
                 closedSessionId = id;
                 resolveClosed();
             }
         };
 
-        const testPort = 3125;
-        const mockAiConfig = { mcpHttpPort: testPort, auth: {} };
-        const mockLogger = { info: () => {} };
+        const testPort     = 3125;
+        const mockAiConfig = { mcpHttpHost: 'localhost', mcpHttpPort: testPort, auth: {} };
+        const mockLogger   = { info: () => {} };
 
         // Setup the real transport service which starts the Express app
         await TransportService.setup({
-            server: mockServer,
-            aiConfig: mockAiConfig,
-            logger: mockLogger,
+            server      : mockServer,
+            aiConfig    : mockAiConfig,
+            logger      : mockLogger,
             resourceName: 'TestResource'
         });
 
         // 1. Initialize the session via POST
         const initResponse = await fetch(`http://localhost:${testPort}/mcp`, {
-            method: 'POST',
+            method : 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'Accept': 'application/json, text/event-stream'
+                'Accept'      : 'application/json, text/event-stream'
             },
             body: JSON.stringify({
                 jsonrpc: "2.0",
-                id: 1,
-                method: "initialize",
-                params: {
+                id     : 1,
+                method : "initialize",
+                params : {
                     protocolVersion: "2024-11-05",
-                    capabilities: {},
-                    clientInfo: { name: "test", version: "1.0.0" }
+                    capabilities   : {},
+                    clientInfo     : { name: "test", version: "1.0.0" }
                 }
             })
         });
@@ -72,9 +72,9 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
         // 2. Terminate the session via DELETE
         // This triggers handleDeleteRequest -> onsessionclosed
         await fetch(`http://localhost:${testPort}/mcp`, {
-            method: 'DELETE',
+            method : 'DELETE',
             headers: {
-                'mcp-session-id': sessionId,
+                'mcp-session-id'      : sessionId,
                 'mcp-protocol-version': '2024-11-05'
             }
         });
@@ -103,18 +103,18 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
         // must not surface a connection-refused error.
         const TransportService = (await import('../../../../../../../../ai/mcp/server/shared/services/TransportService.mjs')).default;
 
-        const probePort = 3126; // distinct from the prior test's 3125 to avoid intra-spec collision
+        const probePort  = 3126; // distinct from the prior test's 3125 to avoid intra-spec collision
         const mockServer = {
             mcpServer      : { connect: async () => {} },
             onSessionClosed: () => {}
         };
-        const mockAiConfig = { mcpHttpPort: probePort, auth: {} };
+        const mockAiConfig = { mcpHttpHost: 'localhost', mcpHttpPort: probePort, auth: {} };
         const mockLogger   = { info: () => {} };
 
         await TransportService.setup({
-            server: mockServer,
-            aiConfig: mockAiConfig,
-            logger: mockLogger,
+            server      : mockServer,
+            aiConfig    : mockAiConfig,
+            logger      : mockLogger,
             resourceName: 'BindRaceProbeResource'
         });
 
@@ -150,7 +150,7 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
 
         test('OIDC precedence: native req.auth overrides proxy headers', () => {
             const req = {
-                auth: { userId: 'oidc-user', username: 'oidc-user', source: 'jwt' },
+                auth   : { userId: 'oidc-user', username: 'oidc-user', source: 'jwt' },
                 headers: { 'x-preferred-username': 'spoofed-user' }
             };
             const aiConfig = { auth: { trustProxyIdentity: true } };
@@ -159,15 +159,15 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
 
             expect(result.error).toBeUndefined();
             expect(result.auth).toEqual({
-                userId: 'oidc-user',
+                userId  : 'oidc-user',
                 username: 'oidc-user',
-                source: 'jwt'
+                source  : 'jwt'
             });
         });
 
         test('Active proxy identity injection (canonical header)', () => {
             const req = {
-                auth: undefined,
+                auth   : undefined,
                 headers: { 'x-preferred-username': 'proxy-user' }
             };
             const aiConfig = { auth: { trustProxyIdentity: true } };
@@ -176,15 +176,15 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
 
             expect(result.error).toBeUndefined();
             expect(result.auth).toEqual({
-                userId: 'proxy-user',
+                userId  : 'proxy-user',
                 username: 'proxy-user',
-                source: 'proxy-header'
+                source  : 'proxy-header'
             });
         });
 
         test('OAuth2-proxy variant header fallback', () => {
             const req = {
-                auth: undefined,
+                auth   : undefined,
                 headers: { 'x-auth-request-preferred-username': 'oauth2-user' }
             };
             const aiConfig = { auth: { trustProxyIdentity: true } };
@@ -193,15 +193,15 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
 
             expect(result.error).toBeUndefined();
             expect(result.auth).toEqual({
-                userId: 'oauth2-user',
+                userId  : 'oauth2-user',
                 username: 'oauth2-user',
-                source: 'proxy-header'
+                source  : 'proxy-header'
             });
         });
 
         test('Gate-disabled behavior: ignores headers when trustProxyIdentity is false', () => {
             const req = {
-                auth: undefined,
+                auth   : undefined,
                 headers: { 'x-preferred-username': 'ignored-user' }
             };
             const aiConfig = { auth: { trustProxyIdentity: false } };
@@ -214,9 +214,9 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
 
         test('Both headers provided: prioritizes canonical over oauth2-proxy', () => {
             const req = {
-                auth: undefined,
+                auth   : undefined,
                 headers: {
-                    'x-preferred-username': 'primary-user',
+                    'x-preferred-username'             : 'primary-user',
                     'x-auth-request-preferred-username': 'secondary-user'
                 }
             };
@@ -226,15 +226,15 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
 
             expect(result.error).toBeUndefined();
             expect(result.auth).toEqual({
-                userId: 'primary-user',
+                userId  : 'primary-user',
                 username: 'primary-user',
-                source: 'proxy-header'
+                source  : 'proxy-header'
             });
         });
 
         test('Header-spoof resistance / required identity: returns 401 when enabled but headers are missing', () => {
             const req = {
-                auth: undefined,
+                auth   : undefined,
                 headers: {}
             };
             const aiConfig = { auth: { trustProxyIdentity: true } };
@@ -260,49 +260,40 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
             }
         });
 
-        test('uses aiConfig.publicUrl when set', async () => {
-            const originalHost = process.env.HOST;
-            process.env.HOST = 'internal-host';
-
+        // The `HOST` env binding lives on the `mcpHttpHost` config leaf (covered by the root
+        // config.template spec); TransportService only ever sees the resolved config value, so
+        // these mocks model the resolved contract instead of mutating process.env.
+        test('uses aiConfig.publicUrl when set (wins over mcpHttpHost)', async () => {
             await TransportService.setup({
-                server: { mcpServer: { connect: async () => {} } },
-                aiConfig: { publicUrl: 'https://public.example.com', mcpHttpPort: 3000, auth: {} },
-                logger: { info: () => {} },
+                server      : { mcpServer: { connect: async () => {} } },
+                aiConfig    : { publicUrl: 'https://public.example.com', mcpHttpHost: 'internal-host', mcpHttpPort: 3000, auth: {} },
+                logger      : { info: () => {} },
                 resourceName: 'Test'
             });
 
             expect(TransportService.mcpServerUrl.href).toBe('https://public.example.com/');
-            process.env.HOST = originalHost;
         });
 
-        test('falls back to HOST and port when publicUrl is unset', async () => {
-            const originalHost = process.env.HOST;
-            process.env.HOST = 'internal-host';
-
+        test('falls back to mcpHttpHost and port when publicUrl is unset', async () => {
             await TransportService.setup({
-                server: { mcpServer: { connect: async () => {} } },
-                aiConfig: { mcpHttpPort: 3000, auth: {} },
-                logger: { info: () => {} },
+                server      : { mcpServer: { connect: async () => {} } },
+                aiConfig    : { mcpHttpHost: 'internal-host', mcpHttpPort: 3000, auth: {} },
+                logger      : { info: () => {} },
                 resourceName: 'Test'
             });
 
             expect(TransportService.mcpServerUrl.href).toBe('https://internal-host:3000/');
-            process.env.HOST = originalHost;
         });
 
-        test('falls back to HOST and port when publicUrl is empty string', async () => {
-            const originalHost = process.env.HOST;
-            process.env.HOST = 'internal-host';
-
+        test('falls back to mcpHttpHost and port when publicUrl is empty string', async () => {
             await TransportService.setup({
-                server: { mcpServer: { connect: async () => {} } },
-                aiConfig: { publicUrl: '', mcpHttpPort: 3000, auth: {} },
-                logger: { info: () => {} },
+                server      : { mcpServer: { connect: async () => {} } },
+                aiConfig    : { publicUrl: '', mcpHttpHost: 'internal-host', mcpHttpPort: 3000, auth: {} },
+                logger      : { info: () => {} },
                 resourceName: 'Test'
             });
 
             expect(TransportService.mcpServerUrl.href).toBe('https://internal-host:3000/');
-            process.env.HOST = originalHost;
         });
     });
 


### PR DESCRIPTION
Resolves #14956

Related: #12456 (batch 3 — MCP server-shared layer env-read census + the clear config-owned fix).

## Context

Batch 3 of the ADR-0019 cleanup sweeps the MCP server-shared layer for raw `process.env` reads: `BaseServer.mjs`, `shared/services/TransportService.mjs`, `shared/services/DestructiveOperationGuard.mjs`, `gitlab-workflow/Server.mjs`, `knowledge-base/Server.mjs` + `toolService.mjs` (remaining reads), and `neural-link/Bridge.mjs`. Every surveyed read is classified in the census table below; the single CLEAR config-owned violation is fixed on the owning config.

**The fix (A1 — module/inline env re-derivation with a hidden default):** `TransportService.setup()` derived the advertised SSE/HTTP transport host as `process.env.HOST || 'localhost'` at the use site — a raw env read with a shadow default, sitting right next to config-owned `aiConfig.publicUrl` / `aiConfig.mcpHttpPort` reads. The deployment host is config, so it now lives as a `mcpHttpHost: leaf('localhost', 'HOST', 'string')` on the **root** `ai/config.template.mjs` transport cluster (between `allowedHosts` and `mcpHttpPort`), and TransportService consumes `aiConfig.mcpHttpHost` at the use site. The existing `HOST` env binding stays bound through the leaf — no operator-visible env-var rename. Placement on the root (not duplicated per-server) is the sanctioned realm-chain shape: per-server configs resolve `mcpHttpHost` override-else-inherit via `getParent()`.

**Exact-semantics preservation:** `Neo.util.Env.parseString` returns `undefined` for absent *and empty-string* env values (`Neo.isEmpty` guard), so the leaf reproduces the `||` fallback exactly, including the `HOST=''` edge. Env re-resolution is bounded (construct / `setEnvOverride` / `load` / `refreshEnv`) per the documented ConfigProvider contract — for a server that reads the value once at boot, behavior is identical.

**Spec-shape shift:** the three `mcpServerUrl` resolution tests in `TransportService.spec.mjs` previously mutated `process.env.HOST`; they now model the resolved config contract (`mcpHttpHost` in the mock `aiConfig`), and the env binding itself is covered by a new root `config.template.spec.mjs` test (`setEnvOverride('HOST', ...)` resolving through the leaf on a fresh provider instance). Net: zero `process.env` mutation left in the transport spec.

Gitignored overlays (`ai/config.mjs`) were re-synced to the updated template in both the worktree and the operator checkout, so live servers pick up the leaf on next restart.

Evidence: runtime-verified — realm-chain resolution probed on live configs (root/kb/memory-core all resolve `mcpHttpHost`, and `HOST=internal-host` resolves through the root leaf from a child config read), plus 402-spec unit run (see Test Evidence).

## Deltas from ticket

- The batch prompt listed `knowledge-base/toolService.mjs:23` (`NEO_AI_MCP_KB_OPENAPI_PATH`) among census targets; it is already converted by open batch-1 PR #14935, so it is census-rowed here but deliberately untouched to avoid a cross-batch conflict.
- The `npm_package_version` duplicates in `gitlab-workflow/Server.mjs` / `knowledge-base/Server.mjs` are census-deferred rather than fixed: the identical shape exists in three sibling servers outside this batch's file list (`github-workflow`, `file-system`, `memory-core`), and removing only the in-scope two would create sibling drift. See census rows 3–4 for the recommended one-shot fold-out.
- `DestructiveOperationGuard`'s `UNIT_TEST_MODE` read is NOT mapped onto the `useTestDatabase` leaf pattern — deliberate skip with rationale (census row 10): the guard is fail-closed defense-in-depth against config-resolution mistakes; routing its bypass through config would reintroduce the exact trust-the-config dependency it exists to defend against.

## Census — every surveyed env read in the batch-3 file set

| # | File:Line | Env var(s) | Classification | Disposition |
|---|---|---|---|---|
| 1 | `ai/mcp/server/shared/services/TransportService.mjs:160` | `HOST` | **CONFIG-OWNED (A1)** — deployment host re-derived inline with hidden `'localhost'` default | **FIXED** — `mcpHttpHost` leaf on root `ai/config.template.mjs`; consumed at use site |
| 2 | `ai/mcp/server/BaseServer.mjs:301` | `npm_package_version` | Runtime process metadata — npm-injected package version, not a deployment value | Keep — the single canonical fallback site (`metadata.version \|\| env \|\| '1.0.0'`) |
| 3 | `ai/mcp/server/gitlab-workflow/Server.mjs:37` | `npm_package_version` | Redundant duplicate — the expression is always truthy, so BaseServer:301's identical fallback never fires for this server | **DEFERRED** — fold out all five per-server duplicates in one pass (also `github-workflow/Server.mjs:38`, `file-system/Server.mjs:46`, `memory-core/Server.mjs:84`); partial removal here would create sibling drift |
| 4 | `ai/mcp/server/knowledge-base/Server.mjs:40` | `npm_package_version` | Redundant duplicate (same as row 3) | **DEFERRED** — same fold-out |
| 5 | `ai/mcp/server/knowledge-base/Server.mjs:106` | `NEO_AGENT_ID`, `USER` | Runtime-identity contract — per-process identity injected by the spawner | Never config — untouched |
| 6 | `ai/mcp/server/knowledge-base/Server.mjs:110` | `NEO_SESSION_ID` | Runtime-identity contract | Never config — untouched |
| 7 | `ai/mcp/server/knowledge-base/toolService.mjs:23` | `NEO_AI_MCP_KB_OPENAPI_PATH` | Config-owned (file path + test-isolation seam) | **FIXED IN BATCH-1** (open PR #14935 — `openApiPath` leaf on the kb server config); untouched here to avoid cross-batch conflict |
| 8 | `ai/mcp/server/knowledge-base/toolService.mjs:94` | `NEO_AGENT_ID`, `USER` | Runtime-identity contract | Never config — untouched |
| 9 | `ai/mcp/server/knowledge-base/toolService.mjs:95` | `NEO_SESSION_ID` | Runtime-identity contract | Never config — untouched |
| 10 | `ai/mcp/server/shared/services/DestructiveOperationGuard.mjs:113` | `UNIT_TEST_MODE` | Deliberate ambient safety check — the canonical-collection delete guard is fail-closed defense-in-depth against config-resolution mistakes (its own contract hardcodes canonical names for exactly this reason); a config leaf would reintroduce the trust-the-config dependency the guard defends against | Skip — intentional; not the `useTestDatabase` storage-selection case |
| 11 | `ai/mcp/server/shared/services/DestructiveOperationGuard.mjs:236` | `env = process.env` DI default (gates `NEO_ALLOW_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE` in `#isProductionConfirmed`) | Operator-confirmation contract — dual-gate (env + explicit token) for deliberate production maintenance, injectable-for-tests by design | Skip — intentional (lines 78/199/225 are doc-comment mentions of the same contract, not code reads) |
| 12 | `ai/mcp/server/neural-link/Bridge.mjs:141` | `NEO_FLEET_BRIDGE_PUBLIC_KEY` | Credential injection — per-process key material injected by the fleet spawner | Never config — untouched |

Totals: 12 code-level env-read sites surveyed → 1 fixed here · 1 fixed in batch-1 · 5 runtime-identity/credential · 1 runtime process metadata (canonical) · 2 deferred (duplicate fold-out) · 2 deliberate safety-guard contracts.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/ test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs --workers=1` → **400 passed / 402** on the merged `origin/dev` base (4d4b20dca), reproducible across two runs.
  - Control run of the **identical suite on detached clean `origin/dev`** (no batch-3 diff): **399 passed / 401 with the exact same 2 failures** — both are pre-existing in this environment, independent of this diff (the +1 test on the branch is the new `mcpHttpHost` leaf-binding test, green).
  - `BootEnvelopeResolver.spec.mjs:51` ("empty-string env vars are treated as absent (default instance)") — pre-existing, environment-specific (also fails on a clean stashed tree in isolation).
  - `memory-core/Server.spec.mjs:383` (#14388 separate-graph-process identity) — order-dependent in the full run; passes 17/17 when the spec file runs in isolation; outside this diff's surface.
- Touched-surface subset (shared services + root config template + SSOT lint + kb/memory-core config templates): 179/180, same single pre-existing BootEnvelopeResolver failure.
- SSOT lint (`lint-config-template-ssot`) green: the new leaf default is a literal (no inline env), and no baseline row referenced `TransportService`/`HOST`, so no baseline churn.
- Runtime probe (Neo-bootstrapped node): root `mcpHttpHost === 'localhost'`; kb + memory-core configs resolve `'localhost'` via the realm chain; `HOST=internal-host` resolves `'internal-host'` from a child-config read.
- `node --check` green on all four touched files; whitespace / shorthand / jsdoc-types / ticket-archaeology / block-alignment / aiconfig-test-mutation gates green (lint-staged at commit).

## Post-Merge Validation

- Restart any SSE-mode MCP server (`NEO_TRANSPORT=sse`) and confirm the advertised `mcpServerUrl` is unchanged for the deployment (`HOST` env still wins over the `localhost` default; `publicUrl` still wins over both).
- Operators with a customized `ai/config.mjs` overlay: re-sync the overlay from the template (or add the `mcpHttpHost` leaf) — the shipped worktree/checkout overlays were already re-synced; a missing leaf on a stale overlay resolves to `undefined` and fails loud at SSE boot, per the no-defensive-fallback contract.
- Batches 4+ can consume census rows 3–4 (npm version duplicate fold-out, five siblings in one pass).

## Commits

- 38fcee8d0 `refactor(mcp): ADR-0019 batch-3 — server-shared env reads onto owning config leaves + census (#12456)`

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b956ba53-01ed-4ea6-a1e5-62969f887bc3.

