### PR TITLE
feat(dashboard): dock motion-contract tokens — single duration source (#14779)

### DIFF
--- a/resources/scss/src/dashboard/dockTransitions.scss
+++ b/resources/scss/src/dashboard/dockTransitions.scss
@@ -1,0 +1,28 @@
+// Dock motion contract — token substrate (#14779)
+//
+// This token set is the ONLY sanctioned duration/easing source for dock motion.
+// Consumers include the DockFlip addon (src/main/addon/DockFlip.mjs) and the
+// class-toggle transition layer; no dock motion mechanism may hardcode its own
+// duration or easing — it reads these tokens.
+//
+// Observability: the `dock-animating` host class is the motion signal — any dock
+// motion mechanism toggles it on the animating host for the duration of play
+// (DockFlip already emits it), and e2e observe_motion assertions read it to know
+// when motion is in flight.
+//
+// Reduced motion: the tokens themselves collapse to 0ms under
+// `prefers-reduced-motion: reduce`, so every consumer inherits the collapse
+// with no per-consumer handling.
+
+:root {
+    --dock-transition-duration     : 280ms;
+    --dock-transition-duration-fast: 160ms;
+    --dock-transition-easing       : cubic-bezier(0, 0, 0.2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    :root {
+        --dock-transition-duration     : 0ms;
+        --dock-transition-duration-fast: 0ms;
+    }
+}


### PR DESCRIPTION
Refs #14779

This PR delivers the first slice of the dock motion contract: the token substrate. A `--dock-transition-*` CSS custom-property set (`resources/scss/src/dashboard/dockTransitions.scss`) becomes the single sanctioned duration/easing source for all dock motion — `--dock-transition-duration: 280ms`, `--dock-transition-duration-fast: 160ms`, `--dock-transition-easing: cubic-bezier(0, 0, 0.2, 1)`. Reduced-motion handling collapses both durations to `0ms` at the token layer under `prefers-reduced-motion: reduce`, so every consumer inherits the collapse with no per-consumer handling. The `dock-animating` observability class is documented in the file header: any dock motion mechanism emits it on the animating host during play (the DockFlip addon already does), and e2e `observe_motion` assertions consume it. The remaining #14779 scope — class-toggle transition wiring — follows in the next slice.

Evidence: L1 (static token substrate; no runtime behavior yet) → L1 sufficient for this slice. Residual: transition wiring + consumer amendments ride the ticket.

## Deltas from ticket

None substantive — first slice as disposed on the ticket thread.

## Test Evidence

Static SCSS addition; token consumption verified by the follow-up slices.

## Post-Merge Validation

- [ ] DockFlip addon amends to consume the duration tokens
- [ ] class-toggle transition layer consumes the token set

Authored by a swarm task agent under Clio's #14779 disposition (Claude Fable 5, Claude Code). Session 54156254-a1a8-40b3-ba22-86e7d2a1bf81.
