### PR TITLE
feat(dashboard): motion-contract substrate — transition tokens + the dock-animating signal (#14779)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -4,8 +4,14 @@
     // FLIP commit layer all read THESE (a call-site duration/easing literal is a contract
     // violation). Motion lifecycle is observable via the `neo-dashboard-dock-animating` class
     // (present during motion, removed on settle — see Neo.dashboard.DockMotionSignal).
-    --dock-transition-duration: 260ms;
-    --dock-transition-easing  : cubic-bezier(0, 0, 0.2, 1);
+    //
+    // Layering: these are the DOCK-DOMAIN aliases of the product motion vocabulary (the
+    // motion-standards tier owns the semantic set — panel-move duration, settle easing). Dock
+    // call sites read the dock tokens; the vocabulary governs the VALUE through the var()
+    // indirection, so the standards tier landing snaps every dock motion to it in one place.
+    // The fallbacks keep the contract live until that tier ships.
+    --dock-transition-duration: var(--motion-panel, 260ms);
+    --dock-transition-easing  : var(--ease-out-soft, cubic-bezier(0, 0, 0.2, 1));
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -1,5 +1,18 @@
 .neo-dashboard {
+    // The dock motion-contract token set: the ONLY sanctioned duration/easing source for dock
+    // transitions — splitter ease, tab insert/remove morphing, auto-hide rail slide, and the
+    // FLIP commit layer all read THESE (a call-site duration/easing literal is a contract
+    // violation). Motion lifecycle is observable via the `neo-dashboard-dock-animating` class
+    // (present during motion, removed on settle — see Neo.dashboard.DockMotionSignal).
+    --dock-transition-duration: 260ms;
+    --dock-transition-easing  : cubic-bezier(0, 0, 0.2, 1);
+}
 
+@media (prefers-reduced-motion: reduce) {
+    .neo-dashboard {
+        // Token-layer collapse: every dock motion goes instant HERE — never per call site.
+        --dock-transition-duration: 0ms;
+    }
 }
 
 .neo-dashboard-dock-splitter {

--- a/src/dashboard/DockMotionSignal.mjs
+++ b/src/dashboard/DockMotionSignal.mjs
@@ -16,13 +16,19 @@ import Base from '../core/Base.mjs';
  * - **Counted, not boolean.** Concurrent motions nest: the class appears on the 0→1 transition
  *   and leaves on the 1→0 transition only — a tab morph finishing must not strip the signal
  *   while a splitter ease is still playing.
+ * - **Ownership binds to the INSTANCE, never the id.** Bookkeeping is keyed by component
+ *   reference: a replacement component reusing a destroyed predecessor's id can never have its
+ *   entry decremented, deleted, or fail-safe-cleared by the STALE instance's leftovers, and a
+ *   runtime id change neither strands nor duplicates an entry. Id-based reads (`isAnimating`)
+ *   resolve against live instances at query time.
  * - **Fail-safe, never wedged.** Every `enter` (re)arms a fail-safe timer; if producers lose a
  *   `leave` (an interrupted transition, a thrown handler), the timer force-clears the signal and
- *   the counter. Animation errors must never wedge layout — a stale signal would stall every
- *   consumer waiting on settle.
- * - **Destroy-safe.** A destroyed component is a no-op in both directions, and the fail-safe
- *   re-checks destruction before touching the instance (mid-transition teardown is a landed
- *   defect class — the DOM-corpse family).
+ *   the counter — and it can only clear ITS OWN instance's entry, by construction. Animation
+ *   errors must never wedge layout — a stale signal would stall every consumer waiting on
+ *   settle.
+ * - **Destroy-safe.** A destroyed OR destroying component is a no-op in both directions, and
+ *   the fail-safe re-checks destruction before touching the instance (mid-transition teardown
+ *   is a landed defect class — the DOM-corpse family).
  * - **Presentation-only.** Nothing here reads or writes dock documents; the signal is pure
  *   projection-tier state, per the JSON-first guardrail.
  *
@@ -57,12 +63,25 @@ class DockMotionSignal extends Base {
      */
     static SIGNAL_CLS = 'neo-dashboard-dock-animating'
     /**
-     * In-flight motion bookkeeping: componentId → {count, timer}.
+     * In-flight motion bookkeeping, keyed by component INSTANCE (never id — see the ownership
+     * contract in the class summary): component → {count, timer}.
      * @member {Map} activeMotions
      * @protected
      * @static
      */
     static activeMotions = new Map()
+
+    /**
+     * Whether the component may be touched at all — destroyed and destroying instances are
+     * outside the signal's writable world in every path, including the fail-safe.
+     * @param {Neo.component.Base} component
+     * @returns {Boolean}
+     * @protected
+     * @static
+     */
+    static isLive(component) {
+        return !!component && !component.isDestroyed && !component.isDestroying
+    }
 
     /**
      * Registers one motion start on a workspace component. Adds the signal class on the 0→1
@@ -73,49 +92,55 @@ class DockMotionSignal extends Base {
      * @static
      */
     static enter(component, setTimeoutFn = globalThis.setTimeout.bind(globalThis), clearTimeoutFn = globalThis.clearTimeout.bind(globalThis)) {
-        if (!component || component.isDestroyed) return;
+        if (!this.isLive(component)) return;
 
-        let entry = this.activeMotions.get(component.id);
+        let entry = this.activeMotions.get(component);
 
         if (!entry) {
             entry = {count: 0, timer: null};
-            this.activeMotions.set(component.id, entry);
+            this.activeMotions.set(component, entry);
             component.addCls(this.SIGNAL_CLS)
         }
 
         entry.count++;
 
-        // every new motion pushes the wedge horizon out — the backstop covers the LAST starter
+        // every new motion pushes the wedge horizon out — the backstop covers the LAST starter,
+        // and the closure holds the INSTANCE: it can only ever clear its own entry
         entry.timer && clearTimeoutFn(entry.timer);
         entry.timer = setTimeoutFn(() => {
-            this.activeMotions.delete(component.id);
-            component.isDestroyed || component.removeCls(this.SIGNAL_CLS)
+            this.activeMotions.delete(component);
+            this.isLive(component) && component.removeCls(this.SIGNAL_CLS)
         }, this.FAIL_SAFE_MS)
     }
 
     /**
-     * Whether a component currently carries an in-flight motion signal. Read-only helper for
-     * producers that gate work on settle.
+     * Whether a component currently carries an in-flight motion signal, resolved by CURRENT id
+     * against live instances at query time (an id reused by a replacement instance reads the
+     * replacement's state, never a stale predecessor's).
      * @param {String} componentId
      * @returns {Boolean}
      * @static
      */
     static isAnimating(componentId) {
-        return this.activeMotions.has(componentId)
+        for (const component of this.activeMotions.keys()) {
+            if (component.id === componentId) return true
+        }
+
+        return false
     }
 
     /**
-     * Registers one motion settle. Removes the signal class on the 1→0 transition. Unbalanced
-     * calls (a leave without an enter, a leave after the fail-safe already cleared) are safe
-     * no-ops — producers in teardown paths must be able to call this unconditionally.
+     * Registers one motion settle. Removes the signal class on the 1→0 transition. Unbalanced or
+     * STALE calls (a leave without an enter, a leave after the fail-safe cleared, a destroyed
+     * predecessor leaving after its id was reused) are safe no-ops — producers in teardown paths
+     * must be able to call this unconditionally, and only the entry-owning instance can
+     * decrement its own bookkeeping.
      * @param {Neo.component.Base} component
      * @param {Function} [clearTimeoutFn=globalThis.clearTimeout]
      * @static
      */
     static leave(component, clearTimeoutFn = globalThis.clearTimeout.bind(globalThis)) {
-        if (!component) return;
-
-        const entry = this.activeMotions.get(component.id);
+        const entry = component && this.activeMotions.get(component);
 
         if (!entry) return;
 
@@ -123,8 +148,8 @@ class DockMotionSignal extends Base {
 
         if (entry.count <= 0) {
             entry.timer && clearTimeoutFn(entry.timer);
-            this.activeMotions.delete(component.id);
-            component.isDestroyed || component.removeCls(this.SIGNAL_CLS)
+            this.activeMotions.delete(component);
+            this.isLive(component) && component.removeCls(this.SIGNAL_CLS)
         }
     }
 }

--- a/src/dashboard/DockMotionSignal.mjs
+++ b/src/dashboard/DockMotionSignal.mjs
@@ -123,7 +123,7 @@ class DockMotionSignal extends Base {
      */
     static isAnimating(componentId) {
         for (const component of this.activeMotions.keys()) {
-            if (component.id === componentId) return true
+            if (this.isLive(component) && component.id === componentId) return true
         }
 
         return false

--- a/src/dashboard/DockMotionSignal.mjs
+++ b/src/dashboard/DockMotionSignal.mjs
@@ -1,0 +1,132 @@
+import Base from '../core/Base.mjs';
+
+/**
+ * @summary The dock motion-observability signal: `neo-dashboard-dock-animating` lifecycle owner.
+ *
+ * One half of the motion contract (the other half is the `--dock-transition-*` token set in the
+ * dashboard theme layer): while ANY dock motion is in flight on a workspace component, the
+ * component carries the `neo-dashboard-dock-animating` class; when the last motion settles, the
+ * class leaves. Assertion surfaces (`observe_motion` e2e specs, tour-runner step gating) key off
+ * exactly this signal, and every motion producer — the choreography transitions AND the FLIP
+ * commit layer — routes through it rather than toggling classes ad hoc, so there is ONE lifecycle
+ * to observe no matter how many mechanisms animate.
+ *
+ * Semantics (binding):
+ *
+ * - **Counted, not boolean.** Concurrent motions nest: the class appears on the 0→1 transition
+ *   and leaves on the 1→0 transition only — a tab morph finishing must not strip the signal
+ *   while a splitter ease is still playing.
+ * - **Fail-safe, never wedged.** Every `enter` (re)arms a fail-safe timer; if producers lose a
+ *   `leave` (an interrupted transition, a thrown handler), the timer force-clears the signal and
+ *   the counter. Animation errors must never wedge layout — a stale signal would stall every
+ *   consumer waiting on settle.
+ * - **Destroy-safe.** A destroyed component is a no-op in both directions, and the fail-safe
+ *   re-checks destruction before touching the instance (mid-transition teardown is a landed
+ *   defect class — the DOM-corpse family).
+ * - **Presentation-only.** Nothing here reads or writes dock documents; the signal is pure
+ *   projection-tier state, per the JSON-first guardrail.
+ *
+ * Timer functions are injectable for deterministic unit specs (the DockRevealStateMachine
+ * precedent); production callers never pass them.
+ *
+ * @class Neo.dashboard.DockMotionSignal
+ * @extends Neo.core.Base
+ */
+class DockMotionSignal extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockMotionSignal'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockMotionSignal'
+    }
+
+    /**
+     * Fail-safe horizon: the longest a signal may outlive its producers. Sized to the token
+     * default (260ms) plus a generous settle grace — NOT a tuning knob for motion itself (the
+     * CSS tokens own durations); only the wedge backstop.
+     * @member {Number} FAIL_SAFE_MS=2000
+     * @static
+     */
+    static FAIL_SAFE_MS = 2000
+    /**
+     * The observable motion-lifecycle class. Consumers assert against THIS name; producers never
+     * hand-roll it.
+     * @member {String} SIGNAL_CLS='neo-dashboard-dock-animating'
+     * @static
+     */
+    static SIGNAL_CLS = 'neo-dashboard-dock-animating'
+    /**
+     * In-flight motion bookkeeping: componentId → {count, timer}.
+     * @member {Map} activeMotions
+     * @protected
+     * @static
+     */
+    static activeMotions = new Map()
+
+    /**
+     * Registers one motion start on a workspace component. Adds the signal class on the 0→1
+     * transition and (re)arms the fail-safe.
+     * @param {Neo.component.Base} component The dock workspace (or any motion-hosting) component.
+     * @param {Function} [setTimeoutFn=globalThis.setTimeout] Injectable for unit determinism.
+     * @param {Function} [clearTimeoutFn=globalThis.clearTimeout]
+     * @static
+     */
+    static enter(component, setTimeoutFn = globalThis.setTimeout.bind(globalThis), clearTimeoutFn = globalThis.clearTimeout.bind(globalThis)) {
+        if (!component || component.isDestroyed) return;
+
+        let entry = this.activeMotions.get(component.id);
+
+        if (!entry) {
+            entry = {count: 0, timer: null};
+            this.activeMotions.set(component.id, entry);
+            component.addCls(this.SIGNAL_CLS)
+        }
+
+        entry.count++;
+
+        // every new motion pushes the wedge horizon out — the backstop covers the LAST starter
+        entry.timer && clearTimeoutFn(entry.timer);
+        entry.timer = setTimeoutFn(() => {
+            this.activeMotions.delete(component.id);
+            component.isDestroyed || component.removeCls(this.SIGNAL_CLS)
+        }, this.FAIL_SAFE_MS)
+    }
+
+    /**
+     * Whether a component currently carries an in-flight motion signal. Read-only helper for
+     * producers that gate work on settle.
+     * @param {String} componentId
+     * @returns {Boolean}
+     * @static
+     */
+    static isAnimating(componentId) {
+        return this.activeMotions.has(componentId)
+    }
+
+    /**
+     * Registers one motion settle. Removes the signal class on the 1→0 transition. Unbalanced
+     * calls (a leave without an enter, a leave after the fail-safe already cleared) are safe
+     * no-ops — producers in teardown paths must be able to call this unconditionally.
+     * @param {Neo.component.Base} component
+     * @param {Function} [clearTimeoutFn=globalThis.clearTimeout]
+     * @static
+     */
+    static leave(component, clearTimeoutFn = globalThis.clearTimeout.bind(globalThis)) {
+        if (!component) return;
+
+        const entry = this.activeMotions.get(component.id);
+
+        if (!entry) return;
+
+        entry.count--;
+
+        if (entry.count <= 0) {
+            entry.timer && clearTimeoutFn(entry.timer);
+            this.activeMotions.delete(component.id);
+            component.isDestroyed || component.removeCls(this.SIGNAL_CLS)
+        }
+    }
+}
+
+export default Neo.setupClass(DockMotionSignal);

--- a/test/playwright/unit/dashboard/DockMotionSignal.spec.mjs
+++ b/test/playwright/unit/dashboard/DockMotionSignal.spec.mjs
@@ -143,25 +143,32 @@ test.describe('Neo.dashboard.DockMotionSignal (the motion-contract observability
     });
 
     test('ownership binds to the INSTANCE: a same-id replacement is untouchable by the stale predecessor', () => {
-        const t   = makeTimers(),
-              old = makeComponent('ws-8');
+        const oldTimers  = makeTimers(),
+              nextTimers = makeTimers(),
+              old        = makeComponent('ws-8');
 
         // the predecessor enters, then tears down mid-motion WITHOUT a leave — its fail-safe stays pending
-        DockMotionSignal.enter(old, t.setTimeoutFn, t.clearTimeoutFn);
+        DockMotionSignal.enter(old, oldTimers.setTimeoutFn, oldTimers.clearTimeoutFn);
         old.isDestroyed = true;
 
-        // a replacement instance reuses the SAME id and starts its own motion
+        // An idle replacement reusing the SAME id must not inherit the destroyed predecessor's
+        // observation state; only live entries participate in id-level reads.
         const next = makeComponent('ws-8');
-        DockMotionSignal.enter(next, t.setTimeoutFn, t.clearTimeoutFn);
+        expect(DockMotionSignal.isAnimating('ws-8')).toBe(false);
+
+        DockMotionSignal.enter(next, nextTimers.setTimeoutFn, nextTimers.clearTimeoutFn);
         expect(DockMotionSignal.isAnimating('ws-8')).toBe(true);
 
-        // the stale predecessor's leave() must not decrement the replacement's entry...
-        DockMotionSignal.leave(old, t.clearTimeoutFn);
+        // The predecessor's still-pending fail-safe ACTUALLY fires while the replacement is active;
+        // it clears only the corpse entry and cannot change the live replacement observation.
+        oldTimers.fire();
         expect(DockMotionSignal.isAnimating('ws-8')).toBe(true);
 
-        // ...and BOTH pending fail-safes fire: the old one clears only its own (corpse) entry —
-        // the replacement's entry goes ONLY via its own timer, removing cls on the live instance
-        t.fire();
+        // A late stale leave remains a no-op, and the replacement settles only through its own timer.
+        DockMotionSignal.leave(old, oldTimers.clearTimeoutFn);
+        expect(DockMotionSignal.isAnimating('ws-8')).toBe(true);
+
+        nextTimers.fire();
         expect(DockMotionSignal.isAnimating('ws-8')).toBe(false);
         expect(old.calls).toEqual([['add', 'neo-dashboard-dock-animating']]);           // corpse never touched again
         expect(next.calls).toEqual([

--- a/test/playwright/unit/dashboard/DockMotionSignal.spec.mjs
+++ b/test/playwright/unit/dashboard/DockMotionSignal.spec.mjs
@@ -1,0 +1,143 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockMotionSignalTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+test.describe('Neo.dashboard.DockMotionSignal (the motion-contract observability signal)', () => {
+    let DockMotionSignal;
+
+    // Deterministic timer doubles (the DockRevealStateMachine precedent): capture the fail-safe
+    // callback instead of scheduling it, fire it by hand.
+    const makeTimers = () => {
+        const pending = new Map();
+        let   nextId  = 1;
+
+        return {
+            pending,
+            setTimeoutFn  : fn => { const id = nextId++; pending.set(id, fn); return id },
+            clearTimeoutFn: id => pending.delete(id),
+            fire          : () => { const fns = [...pending.values()]; pending.clear(); fns.forEach(fn => fn()) }
+        };
+    };
+
+    const makeComponent = id => {
+        const calls = [];
+
+        return {
+            id,
+            isDestroyed: false,
+            calls,
+            addCls     : cls => calls.push(['add', cls]),
+            removeCls  : cls => calls.push(['remove', cls])
+        };
+    };
+
+    test.beforeAll(async () => {
+        DockMotionSignal = (await import('../../../../src/dashboard/DockMotionSignal.mjs')).default
+    });
+
+    test.afterEach(() => {
+        DockMotionSignal.activeMotions.clear()
+    });
+
+    test('the class appears on 0→1 and leaves on 1→0 only — concurrent motions nest', () => {
+        const t = makeTimers(),
+              c = makeComponent('ws-1');
+
+        DockMotionSignal.enter(c, t.setTimeoutFn, t.clearTimeoutFn);
+        DockMotionSignal.enter(c, t.setTimeoutFn, t.clearTimeoutFn);
+
+        expect(c.calls).toEqual([['add', 'neo-dashboard-dock-animating']]); // added ONCE
+        expect(DockMotionSignal.isAnimating('ws-1')).toBe(true);
+
+        DockMotionSignal.leave(c, t.clearTimeoutFn);
+        expect(c.calls.length).toBe(1);                                     // still animating: no remove
+        expect(DockMotionSignal.isAnimating('ws-1')).toBe(true);
+
+        DockMotionSignal.leave(c, t.clearTimeoutFn);
+        expect(c.calls[1]).toEqual(['remove', 'neo-dashboard-dock-animating']);
+        expect(DockMotionSignal.isAnimating('ws-1')).toBe(false)
+    });
+
+    test('the fail-safe force-clears a wedged motion — a lost leave never wedges the signal', () => {
+        const t = makeTimers(),
+              c = makeComponent('ws-2');
+
+        DockMotionSignal.enter(c, t.setTimeoutFn, t.clearTimeoutFn);
+        expect(DockMotionSignal.isAnimating('ws-2')).toBe(true);
+
+        t.fire(); // the producer lost its leave — the backstop fires
+
+        expect(DockMotionSignal.isAnimating('ws-2')).toBe(false);
+        expect(c.calls[1]).toEqual(['remove', 'neo-dashboard-dock-animating']);
+
+        // the signal is REUSABLE after a force-clear: state fully cleaned
+        DockMotionSignal.enter(c, t.setTimeoutFn, t.clearTimeoutFn);
+        expect(DockMotionSignal.isAnimating('ws-2')).toBe(true);
+        expect(c.calls[2]).toEqual(['add', 'neo-dashboard-dock-animating'])
+    });
+
+    test('every new enter re-arms the fail-safe — the backstop covers the LAST starter', () => {
+        const t = makeTimers(),
+              c = makeComponent('ws-3');
+
+        DockMotionSignal.enter(c, t.setTimeoutFn, t.clearTimeoutFn);
+        DockMotionSignal.enter(c, t.setTimeoutFn, t.clearTimeoutFn);
+
+        // the first timer was cleared by the second enter: exactly ONE pending backstop
+        expect(t.pending.size).toBe(1)
+    });
+
+    test('destroyed components are no-ops in both directions, including inside the fail-safe', () => {
+        const t = makeTimers(),
+              c = makeComponent('ws-4');
+
+        c.isDestroyed = true;
+        DockMotionSignal.enter(c, t.setTimeoutFn, t.clearTimeoutFn);
+        expect(c.calls).toEqual([]);
+        expect(DockMotionSignal.isAnimating('ws-4')).toBe(false);
+
+        // live enter, THEN mid-flight destroy, then the backstop fires: bookkeeping clears,
+        // but the destroyed instance is never touched (the DOM-corpse defect family)
+        const d = makeComponent('ws-5');
+        DockMotionSignal.enter(d, t.setTimeoutFn, t.clearTimeoutFn);
+        d.isDestroyed = true;
+        t.fire();
+
+        expect(DockMotionSignal.isAnimating('ws-5')).toBe(false);
+        expect(d.calls).toEqual([['add', 'neo-dashboard-dock-animating']]) // no remove on a corpse
+    });
+
+    test('unbalanced leaves are safe no-ops — teardown paths may call unconditionally', () => {
+        const t = makeTimers(),
+              c = makeComponent('ws-6');
+
+        DockMotionSignal.leave(c, t.clearTimeoutFn);          // never entered
+        expect(c.calls).toEqual([]);
+
+        DockMotionSignal.enter(c, t.setTimeoutFn, t.clearTimeoutFn);
+        t.fire();                                             // fail-safe already cleared
+        DockMotionSignal.leave(c, t.clearTimeoutFn);          // late leave after force-clear
+
+        expect(c.calls.filter(([kind]) => kind === 'remove').length).toBe(1) // exactly one remove
+    });
+
+    test('mid-flight destroy plus a producer leave stays corpse-safe', () => {
+        const t = makeTimers(),
+              c = makeComponent('ws-7');
+
+        DockMotionSignal.enter(c, t.setTimeoutFn, t.clearTimeoutFn);
+        c.isDestroyed = true;
+        DockMotionSignal.leave(c, t.clearTimeoutFn);
+
+        expect(DockMotionSignal.isAnimating('ws-7')).toBe(false);
+        expect(c.calls).toEqual([['add', 'neo-dashboard-dock-animating']]) // bookkeeping cleared, corpse untouched
+    });
+});

--- a/test/playwright/unit/dashboard/DockMotionSignal.spec.mjs
+++ b/test/playwright/unit/dashboard/DockMotionSignal.spec.mjs
@@ -32,10 +32,11 @@ test.describe('Neo.dashboard.DockMotionSignal (the motion-contract observability
 
         return {
             id,
-            isDestroyed: false,
+            isDestroyed : false,
+            isDestroying: false,
             calls,
-            addCls     : cls => calls.push(['add', cls]),
-            removeCls  : cls => calls.push(['remove', cls])
+            addCls      : cls => calls.push(['add', cls]),
+            removeCls   : cls => calls.push(['remove', cls])
         };
     };
 
@@ -139,5 +140,71 @@ test.describe('Neo.dashboard.DockMotionSignal (the motion-contract observability
 
         expect(DockMotionSignal.isAnimating('ws-7')).toBe(false);
         expect(c.calls).toEqual([['add', 'neo-dashboard-dock-animating']]) // bookkeeping cleared, corpse untouched
+    });
+
+    test('ownership binds to the INSTANCE: a same-id replacement is untouchable by the stale predecessor', () => {
+        const t   = makeTimers(),
+              old = makeComponent('ws-8');
+
+        // the predecessor enters, then tears down mid-motion WITHOUT a leave — its fail-safe stays pending
+        DockMotionSignal.enter(old, t.setTimeoutFn, t.clearTimeoutFn);
+        old.isDestroyed = true;
+
+        // a replacement instance reuses the SAME id and starts its own motion
+        const next = makeComponent('ws-8');
+        DockMotionSignal.enter(next, t.setTimeoutFn, t.clearTimeoutFn);
+        expect(DockMotionSignal.isAnimating('ws-8')).toBe(true);
+
+        // the stale predecessor's leave() must not decrement the replacement's entry...
+        DockMotionSignal.leave(old, t.clearTimeoutFn);
+        expect(DockMotionSignal.isAnimating('ws-8')).toBe(true);
+
+        // ...and BOTH pending fail-safes fire: the old one clears only its own (corpse) entry —
+        // the replacement's entry goes ONLY via its own timer, removing cls on the live instance
+        t.fire();
+        expect(DockMotionSignal.isAnimating('ws-8')).toBe(false);
+        expect(old.calls).toEqual([['add', 'neo-dashboard-dock-animating']]);           // corpse never touched again
+        expect(next.calls).toEqual([
+            ['add', 'neo-dashboard-dock-animating'],
+            ['remove', 'neo-dashboard-dock-animating']
+        ])
+    });
+
+    test('a runtime id change neither strands nor duplicates the entry — instance keying, id-resolved reads', () => {
+        const t = makeTimers(),
+              c = makeComponent('ws-9');
+
+        DockMotionSignal.enter(c, t.setTimeoutFn, t.clearTimeoutFn);
+        c.id = 'ws-9-renamed';
+
+        // reads resolve the CURRENT id; the old id reads idle
+        expect(DockMotionSignal.isAnimating('ws-9')).toBe(false);
+        expect(DockMotionSignal.isAnimating('ws-9-renamed')).toBe(true);
+
+        // the leave still finds its instance-keyed entry and cleans up fully
+        DockMotionSignal.leave(c, t.clearTimeoutFn);
+        expect(DockMotionSignal.isAnimating('ws-9-renamed')).toBe(false);
+        expect(c.calls[1]).toEqual(['remove', 'neo-dashboard-dock-animating']);
+        expect(t.pending.size).toBe(0)
+    });
+
+    test('isDestroying gates exactly like isDestroyed: no entry, no instance touch, bookkeeping still clears', () => {
+        const t = makeTimers(),
+              c = makeComponent('ws-10');
+
+        c.isDestroying = true;
+        DockMotionSignal.enter(c, t.setTimeoutFn, t.clearTimeoutFn);
+        expect(c.calls).toEqual([]);
+        expect(DockMotionSignal.isAnimating('ws-10')).toBe(false);
+
+        // live enter, then teardown BEGINS (isDestroying) before the leave: the entry clears,
+        // the in-teardown instance is not touched
+        const d = makeComponent('ws-11');
+        DockMotionSignal.enter(d, t.setTimeoutFn, t.clearTimeoutFn);
+        d.isDestroying = true;
+        DockMotionSignal.leave(d, t.clearTimeoutFn);
+
+        expect(DockMotionSignal.isAnimating('ws-11')).toBe(false);
+        expect(d.calls).toEqual([['add', 'neo-dashboard-dock-animating']])
     });
 });


### PR DESCRIPTION
Resolves #14779

Ships the motion-contract SUBSTRATE under the signed disposition on the ticket (the #14929-owner ratification): #14779 owns the contract — this PR lands its load-bearing half, the piece every motion mechanism and every assertion surface consumes. The choreography transitions themselves (rail slide, splitter ease, tab morph, arrival settle) become CONSUMERS of this substrate — per the disposition they ride follow-up leaves/ranges, and the FLIP addon amends to consumer on its own branch (the #14929 owner's recorded ledger).

Evidence: L2 (nine deterministic lifecycle specs at exact head + review-checkable token SCSS + hosted unit/integration gates) → L2 required (the substrate is pure projection-tier contract — class-toggle bookkeeping + theme tokens; live-motion evidence belongs to consumer leaves). Residual: none for the substrate; consumer wiring evidence lands with each consumer.

## AC map (against the ticket's disposition-scoped contract)

- **`--dock-transition-*` tokens as the ONLY duration/easing source** → `--dock-transition-duration: 260ms` (the Demo-A design language's standard-decelerate midpoint as the token VALUE, never a call-site literal) + `--dock-transition-easing`, scoped on `.neo-dashboard` (the dashboard Container baseCls — reaches every dock surface).
- **Token-layer `prefers-reduced-motion` collapse** → the media query zeroes the duration token in ONE place; no per-call-site checks anywhere, by construction.
- **`dock-animating` observability** → `Neo.dashboard.DockMotionSignal` owns the `neo-dashboard-dock-animating` lifecycle: counted not boolean; ownership binds to component INSTANCE rather than mutable/reusable id; ID-level reads include only live instances; stale leaves/fail-safes cannot mutate or report a replacement generation; dynamic id changes remain observable; destroy/destroying paths are corpse-safe; lost leaves force-clear without wedging consumers. `observe_motion` e2e assertions and tour step-gating consume exactly this class.
- **Zero motion state in documents/previews/persistence** → nothing here touches a dock document; pure projection tier (review-checkable).
- **Cross-family review** → requested.

## Deltas

- `resources/scss/src/dashboard/Container.scss` — the token set + reduced-motion collapse on `.neo-dashboard`
- `src/dashboard/DockMotionSignal.mjs` (new) — the signal lifecycle owner (core.Base sibling convention, static surface, injectable timers per the DockRevealStateMachine precedent)
- `test/playwright/unit/dashboard/DockMotionSignal.spec.mjs` (new) — nine specs: nesting, fail-safe force-clear + reuse, backstop re-arm, destroyed/destroying corpse safety, unbalanced leaves, same-id replacement isolation with independently fired timers, stale leave safety, and dynamic-id cleanup

## Test Evidence

```
NEO_CHROMA_PORT_TEST=34987 npm run test-unit -- test/playwright/unit/dashboard/DockMotionSignal.spec.mjs --workers=1
9 passed (exact head 3b001f748)

npm run test-unit -- test/playwright/unit/dashboard/ --workers=1
205 passed (ca9580916 lifecycle delta; the final one-predicate/test correction is covered above and by current hosted CI)
```

## Post-Merge Validation

- [ ] The #14929 FLIP addon's consumer amendments read durations from the tokens and route through `DockMotionSignal` (the owner's recorded ledger).
- [ ] The #14591 animation-assertion successor authors `observe_motion` specs against `neo-dashboard-dock-animating`.
- [ ] Choreography ranges (rail slide, splitter ease, arrival settle) consume the substrate as they land.

Process note: authored during the operator-granted temporary Fable 5 window.

Authored by Grace (Claude Fable 5, Claude Code). Session ef6b9a4a-54ec-4afb-8438-f89a3ee46ad2
Maintainer polish by Euclid (GPT-5.6 Sol, Codex). Session de713f27-0e82-4960-b4c6-f281e0c36449.

