### PR TITLE
fix(state): preserve explicit-ID Store replacement (#14939)

### DIFF
--- a/src/state/Provider.mjs
+++ b/src/state/Provider.mjs
@@ -161,7 +161,31 @@ class Provider extends Base {
          *     }
          * @reactive
          */
-        stores_: null,
+        stores_: {
+            [isDescriptor]: true,
+            /**
+             * Compares provider store maps by key and instance identity.
+             * @summary Allows same-id replacement instances to commit while suppressing identical mappings.
+             * @param {Object|null} value
+             * @param {Object|null} oldValue
+             * @returns {Boolean}
+             */
+            isEqual(value, oldValue) {
+                if (value === oldValue) {
+                    return true
+                }
+
+                if (!value || !oldValue) {
+                    return false
+                }
+
+                const keys = Object.keys(value);
+
+                return keys.length === Object.keys(oldValue).length
+                    && keys.every(key => value[key] === oldValue[key])
+            },
+            value: null
+        },
         /**
          * @member {String|null} windowId=null
          */
@@ -192,10 +216,9 @@ class Provider extends Base {
      */
     #ownedStores = new Set()
     /**
-     * Bumped on every reactive `stores` replacement and suffixed into the predictable provider-store
-     * ids. Reusing the exact id of a just-destroyed owned store would make the replacement look like
-     * a no-op to the config system's equality check (instances compare by their serialized id), so
-     * the new value would never get stored — a fresh generation keeps replacement ids unique.
+     * Bumped on every reactive `stores` replacement and suffixed into generated provider-store ids.
+     * A fresh generation keeps implicit ids unique; explicit caller-provided ids remain unchanged
+     * and replacement identity is detected by the `stores` config's reference comparator.
      * @member {Number} #storesGeneration=0
      * @private
      */
@@ -298,8 +321,8 @@ class Provider extends Base {
         // reactive replacement (or null-removal): an owned instance the provider no longer hosts
         // gets destroyed NOW — deferring it to provider destroy would leak a live, registered
         // store nothing can resolve anymore. Passed-in instances stay externally owned.
-        // ORDER MATTERS: this runs BEFORE the new value instantiates, and the generation bump
-        // gives same-key replacements a fresh predictable id (see #storesGeneration).
+        // ORDER MATTERS: this runs BEFORE the new value instantiates, freeing explicit ids for safe
+        // reuse while the generation bump gives implicit same-key replacements a fresh predictable id.
         if (oldValue) {
             const reusedInstances = new Set(
                 Object.values(value || {}).filter(storeValue => Neo.typeOf(storeValue) === 'NeoInstance')

--- a/test/playwright/unit/state/Provider.spec.mjs
+++ b/test/playwright/unit/state/Provider.spec.mjs
@@ -797,4 +797,38 @@ test.describe('Neo.state.Provider hosted-store lifecycle', () => {
         expect(second.isDestroyed).toBe(true);
         expect(StoreManager.get(second.id)).toBeFalsy();
     });
+
+    test('SAME-key explicit-id replacement preserves identity and ownership across generations', () => {
+        const storeId  = 'provider-explicit-id-replacement-store';
+        const provider = Neo.create(StateProvider, {
+            stores: {roster: {module: Store, id: storeId, keyProperty: 'id'}}
+        });
+
+        const first = provider.getStore('roster');
+
+        provider.stores = {roster: {module: Store, id: storeId, keyProperty: 'id'}};
+
+        const second = provider.getStore('roster');
+
+        expect(first.isDestroyed).toBe(true);
+        expect(second.isDestroyed).toBeFalsy();
+        expect(second).not.toBe(first);
+        expect(second.id).toBe(storeId);
+        expect(StoreManager.get(storeId)).toBe(second);
+
+        provider.stores = {roster: {module: Store, id: storeId, keyProperty: 'id'}};
+
+        const third = provider.getStore('roster');
+
+        expect(second.isDestroyed).toBe(true);
+        expect(third.isDestroyed).toBeFalsy();
+        expect(third).not.toBe(second);
+        expect(third.id).toBe(storeId);
+        expect(StoreManager.get(storeId)).toBe(third);
+
+        provider.destroy();
+
+        expect(third.isDestroyed).toBe(true);
+        expect(StoreManager.get(storeId)).toBeFalsy();
+    });
 });


### PR DESCRIPTION
Resolves #14939

Provider-local `stores` equality now compares each key's actual Store instance reference, so a replacement that intentionally preserves a caller-supplied explicit ID still commits as the Provider's live binding. The existing collision-safe teardown order remains intact: the old provider-owned Store is destroyed and deregistered before the replacement is created, while generated IDs and externally owned Store instances retain their existing behavior.

Related: #14920

Evidence: L2 (focused `state.Provider` runtime-contract coverage in the unit harness) → L2 required (all close-target acceptance criteria). No residuals.

## Deltas from ticket

None substantive. The fix stays inside `Neo.state.Provider` through a descriptor-local equality comparator; it does not broaden into framework-wide `Neo.isEqual` semantics or rewrite caller-provided IDs.

## Test Evidence

- `node --check src/state/Provider.mjs`
- `node --check test/playwright/unit/state/Provider.spec.mjs`
- `NEO_CHROMA_PORT_TEST=18239 npm run test-unit -- test/playwright/unit/state/Provider.spec.mjs --workers=1` — 26 passed
- `npm run agent-preflight -- src/state/Provider.mjs test/playwright/unit/state/Provider.spec.mjs` — passed
- `git diff --check` — passed

The focused regression performs two consecutive same-key replacements using the same explicit Store ID and proves reference replacement, old-instance destruction, StoreManager convergence, ID preservation, and final teardown.

## Post-Merge Validation

- [ ] Confirm the merge-candidate CI Provider unit shard remains green.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session e2f886a3-3100-458e-a9b3-635e7d09c183.
