### PR TITLE
feat(agentos): roster-onboarding artifact generator — four-surface R3b payload (#14916)

### DIFF
--- a/ai/scripts/setup/generateRosterOnboarding.mjs
+++ b/ai/scripts/setup/generateRosterOnboarding.mjs
@@ -1,0 +1,826 @@
+#!/usr/bin/env node
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {execFileSync}  from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+
+/**
+ * @module ai/scripts/setup/generateRosterOnboarding
+ * @summary Roster-onboarding artifact generator (R3b of the peer-onboarding rail): derives the
+ * FOUR committed-file surfaces a new resident's onboarding PR must touch, as a reviewable
+ * payload — the sibling of the Day-0 provisioning script, which owns the Memory Core half and
+ * never writes committed files.
+ *
+ * The four surfaces (derived from the live files, never from memory):
+ *
+ * 1. `ai/graph/identityRoots.mjs` — the resident's `IDENTITIES` roster entry (Layer-1
+ *    operational fields only; pending-first-boot lifecycle state)
+ * 2. `README.md` — the maintainer roster row (Name / Maintainer / Role / Identity table)
+ * 3. `learn/agentos/ModelStats.md` — the capability section skeleton under the pending
+ *    identities heading, with source-citation placeholders
+ * 4. `test/playwright/unit/ai/graph/identityRoots.spec.mjs` — the roster pin
+ *
+ * **Why the input surface has NO model/engine parameter (load-bearing):** engine facts
+ * (designation, context window, pricing, thought budget, release date, tier) are
+ * OBSERVATION-OWNED — they are recorded from the live harness at first boot and land through
+ * the source-cited ModelStats.md discipline. An operator prediction at onboarding time would
+ * fabricate them; the roster deliberately carries no current-engine field, so every
+ * engine-class input (flag or option key) is rejected loudly instead of ignored.
+ *
+ * **Why there is NO socialName-class parameter either (mirrors the Day-0 sibling):** Social
+ * Names are the post-boot peer-naming ritual — peer-sketched, bearer-assented, peer-vetoable,
+ * operator-confirmed — never seed data. The resident gets the handle-derived display form
+ * only; socialName-class inputs are rejected loudly.
+ *
+ * **Dry-run by default; `--write` is branch-guarded:** the default run PRINTS the four
+ * proposed modifications (proposed snippet + insertion anchor per surface) and applies
+ * nothing. `--write` applies them via normal file APIs ONLY on a non-`dev`/non-`main` git
+ * branch — the payload always travels as a reviewable branch + PR, never as a live edit to an
+ * integration branch. The generator never pushes and never opens the PR itself.
+ *
+ * **Idempotency:** a resident already present in a surface reports EXISTS and emits no
+ * duplicate; `--write` skips EXISTS surfaces, so a partially-applied payload completes on
+ * re-run and a second run changes nothing.
+ *
+ * Everything decision-shaped is pure and fail-closed: planners return
+ * `{valid, reason, ...}` / per-surface `{status, reason, ...}` and never throw; a missing
+ * insertion anchor refuses loudly and writes nothing.
+ *
+ * **Usage**:
+ *   node ai/scripts/setup/generateRosterOnboarding.mjs --handle <s> --family <s>
+ *       [--github-username <s>] [--mailbox <s>]        # dry-run (default): print the payload
+ *   node ai/scripts/setup/generateRosterOnboarding.mjs ... --write   # apply on a work branch
+ *   node ai/scripts/setup/generateRosterOnboarding.mjs --help        # print usage
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+
+/**
+ * @summary The socialName-class option keys the input surface REJECTS. Social Names are the
+ * post-boot peer-naming ritual (bearer-assented), never seed data — rejecting instead of
+ * ignoring keeps the guard visible to callers.
+ * @type {ReadonlyArray<String>}
+ */
+export const SOCIAL_NAME_CLASS_KEYS = Object.freeze([
+    'disclosablePrior', 'name', 'salute', 'socialLayer', 'socialName'
+]);
+
+/**
+ * @summary The socialName-class CLI flags rejected with the ritual pointer (the flag-shaped
+ * mirror of {@link SOCIAL_NAME_CLASS_KEYS}).
+ * @type {ReadonlyArray<String>}
+ */
+export const SOCIAL_NAME_CLASS_FLAGS = Object.freeze([
+    '--disclosable-prior', '--name', '--salute', '--social-layer', '--social-name'
+]);
+
+/**
+ * @summary The engine-class option keys the input surface REJECTS. Engine facts are
+ * observation-owned: they are recorded from the live harness at first boot and land through
+ * the source-cited ModelStats.md discipline — an onboarding-time prediction would fabricate
+ * them.
+ * @type {ReadonlyArray<String>}
+ */
+export const ENGINE_CLASS_KEYS = Object.freeze([
+    'contextWindowInput', 'designation', 'engine', 'model', 'modelDesignation',
+    'pricingInput', 'pricingOutput', 'releaseDate', 'thoughtBudget', 'tier'
+]);
+
+/**
+ * @summary The engine-class CLI flags rejected with the observation pointer (the flag-shaped
+ * mirror of {@link ENGINE_CLASS_KEYS}).
+ * @type {ReadonlyArray<String>}
+ */
+export const ENGINE_CLASS_FLAGS = Object.freeze([
+    '--context-window', '--designation', '--engine', '--model', '--model-designation',
+    '--pricing-input', '--pricing-output', '--release-date', '--thought-budget', '--tier'
+]);
+
+/**
+ * @summary Vendor + display token per known model family, for README/ModelStats prose.
+ * Unknown families render with the bare family token — never a guessed vendor.
+ * @type {Object}
+ */
+export const FAMILY_DISPLAY = Object.freeze({
+    claude: Object.freeze({vendor: 'Anthropic',           display: 'Claude'}),
+    gemini: Object.freeze({vendor: 'Google DeepMind',     display: 'Gemini'}),
+    gemma : Object.freeze({vendor: 'Google open-weights', display: 'Gemma'}),
+    gpt   : Object.freeze({vendor: 'OpenAI',              display: 'GPT'})
+});
+
+/**
+ * @summary Repo-root-relative paths of the four onboarding surfaces.
+ * @type {Object}
+ */
+export const SURFACE_PATHS = Object.freeze({
+    identityRoots: 'ai/graph/identityRoots.mjs',
+    modelStats   : 'learn/agentos/ModelStats.md',
+    readme       : 'README.md',
+    spec         : 'test/playwright/unit/ai/graph/identityRoots.spec.mjs'
+});
+
+/**
+ * @summary Escapes a literal value for safe embedding inside a RegExp source.
+ * @param {String} value The literal to escape
+ * @returns {String}
+ */
+export function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * @summary Normalizes a handle-shaped input to its canonical `@`-prefixed form; fail-closed on
+ * empty or malformed values.
+ * @param {String} value Raw handle input (with or without the `@` prefix)
+ * @param {String} label Field name for the refusal message
+ * @returns {{valid: Boolean, reason: String|null, handle: String|null}}
+ */
+export function normalizeHandle(value, label) {
+    if (typeof value !== 'string' || value.trim() === '') {
+        return {valid: false, reason: `${label} requires a non-empty string`, handle: null};
+    }
+
+    const body = value.trim().replace(/^@/, '');
+
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(body)) {
+        return {valid: false, reason: `${label} must be a lowercase handle ([a-z0-9-], e.g. '@neo-fable-clio') — received '${value}'`, handle: null};
+    }
+
+    return {valid: true, reason: null, handle: `@${body}`}
+}
+
+/**
+ * @summary Derives the handle-derived DISPLAY form from a resident handle — the operational
+ * default a resident keeps until (and unless) the naming ritual grants a Social Name.
+ * E.g. '@neo-fable-clio' → 'Neo Fable Clio'.
+ * @param {String} handle The `@`-prefixed resident handle
+ * @returns {String}
+ */
+export function deriveDisplayForm(handle) {
+    return handle
+        .replace(/^@/, '')
+        .split('-')
+        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+}
+
+/**
+ * @summary Derives the ModelStats section anchor from a resident handle.
+ * E.g. '@neo-fable-clio' → 'neo_fable_clio' (rendered as `§neo_fable_clio`).
+ * @param {String} handle The `@`-prefixed resident handle
+ * @returns {String}
+ */
+export function deriveSectionAnchor(handle) {
+    return handle.replace(/^@/, '').replace(/-/g, '_');
+}
+
+/**
+ * @summary Builds the frozen onboarding plan (the PURE input half): normalized handles, the
+ * handle-derived display form, the ModelStats section anchor, and the generation timestamp.
+ * The input surface has NO engine-class and NO socialName-class parameter (module JSDoc);
+ * both classes are rejected loudly.
+ * @param {Object} options
+ * @param {String} options.handle The resident handle — the roster id and A2A address
+ * @param {String} options.family Model family (e.g. 'claude' | 'gpt' | 'gemini')
+ * @param {String} [options.githubUsername] GitHub login (defaults to the handle)
+ * @param {String} [options.mailbox] A2A mailbox address (defaults to the handle)
+ * @param {Date|String} [options.now] Clock override for deterministic tests; defaults to the real now
+ * @returns {{valid: Boolean, reason: String|null, plan: Object|null}}
+ */
+export function buildOnboardingPlan(options = {}) {
+    const socialLeaks = SOCIAL_NAME_CLASS_KEYS.filter(key => key in options);
+
+    if (socialLeaks.length > 0) {
+        return {valid: false, reason: `socialName-class inputs are rejected by design: ${socialLeaks.join(', ')} — Social Names are the post-boot peer-naming ritual (bearer-assented), never seed data`, plan: null};
+    }
+
+    const engineLeaks = ENGINE_CLASS_KEYS.filter(key => key in options);
+
+    if (engineLeaks.length > 0) {
+        return {valid: false, reason: `engine-class inputs are rejected by design: ${engineLeaks.join(', ')} — engine facts are observation-owned and land through the source-cited ModelStats.md discipline at first boot, never as onboarding predictions`, plan: null};
+    }
+
+    const resident = normalizeHandle(options.handle, '--handle');
+
+    if (!resident.valid) {
+        return {valid: false, reason: resident.reason, plan: null};
+    }
+
+    if (typeof options.family !== 'string' || !/^[a-z][a-z0-9-]*$/.test(options.family)) {
+        return {valid: false, reason: `--family must be a lowercase family token (e.g. 'claude') — received '${String(options.family)}'`, plan: null};
+    }
+
+    const github = normalizeHandle(options.githubUsername === undefined ? resident.handle : options.githubUsername, '--github-username');
+
+    if (!github.valid) {
+        return {valid: false, reason: github.reason, plan: null};
+    }
+
+    const mailbox = normalizeHandle(options.mailbox === undefined ? resident.handle : options.mailbox, '--mailbox');
+
+    if (!mailbox.valid) {
+        return {valid: false, reason: mailbox.reason, plan: null};
+    }
+
+    const nowMs = Date.parse(options.now === undefined ? new Date().toISOString() : options.now);
+
+    if (!Number.isFinite(nowMs)) {
+        return {valid: false, reason: `the generation timestamp must be parseable — received '${String(options.now)}' (the pending-state 'since' records the ACTUAL onboarding time; no backfill)`, plan: null};
+    }
+
+    const handle = resident.handle,
+          family = FAMILY_DISPLAY[options.family] || null;
+
+    return {
+        valid : true,
+        reason: null,
+        plan  : Object.freeze({
+            handle,
+            handleBody    : handle.slice(1),
+            family        : options.family,
+            familyVendor  : family && family.vendor,
+            familyDisplay : family ? family.display : options.family,
+            githubUsername: github.handle,
+            githubBody    : github.handle.slice(1),
+            mailbox       : mailbox.handle,
+            displayForm   : deriveDisplayForm(handle),
+            sectionAnchor : deriveSectionAnchor(handle),
+            since         : new Date(nowMs).toISOString()
+        })
+    }
+}
+
+/**
+ * @summary Renders the resident's `IDENTITIES` roster entry for `ai/graph/identityRoots.mjs`:
+ * Layer-1 operational fields only, pending-first-boot lifecycle state, and deliberately NO
+ * capability fields (engine facts are observation-owned) and NO static subscriptionTemplate
+ * (committing harness metadata at onboarding would fabricate boot facts).
+ * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @returns {String} The entry block, indented for the `IDENTITIES` array, ending with `},`
+ */
+export function renderRosterEntry(plan) {
+    return `    {
+        id         : '${plan.handle}',
+        type       : 'AgentIdentity',
+        name       : '${plan.displayForm}', // Handle-derived display form — the Social Name is the post-boot peer-naming ritual (bearer-assented), never onboarding seed data
+        description: 'Onboarding ${plan.family}-family maintainer identity with version-free handle; engine designation pending first-boot observation.',
+        properties : {
+            githubLogin     : '${plan.githubUsername}',
+            displayName     : '${plan.displayForm}',
+            modelFamily     : '${plan.family}',
+            accountType     : 'agent',
+            trustTier       : TRUST_TIERS.PEER_TRUSTED,
+            identityContract: {
+                canonicalIdentityId      : '${plan.handle}',
+                requiredGithubLogin      : '${plan.githubUsername}',
+                requiredA2aMailboxAddress: '${plan.mailbox}',
+                handlePolicy             : 'version-free-github-handle',
+                modelVersionSource       : 'learn/agentos/ModelStats.md §${plan.sectionAnchor}',
+                activationPrerequisites  : [
+                    'Operator stands up the isolated harness instance (own user-data-dir, own repo checkout, identity env binding).',
+                    'First-boot wake self-registration verified from the real boot envelope.',
+                    'Naming-round outcome recorded (Social Name assent, or the handle-derived display form stays).'
+                ]
+            },
+            // No static subscriptionTemplate — the Day-0 wake route lives in the Memory Core
+            // (provisioned at onboarding, upgraded by runtime self-registration from the real
+            // boot envelope); committing harness metadata here would fabricate boot facts.
+            // No capability fields — engine facts are observation-owned and land through the
+            // source-cited ModelStats.md discipline once the first boot is observed.
+            family: '${plan.family}',
+            // Pending first boot: excluded from active routing, quorum, and review-approval
+            // semantics until the first-boot ritual completes and this flips to 'active'.
+            participationStatus: 'temporarily_unreachable',
+            statusReason       : 'Provisioned ahead of first boot — onboarding in progress',
+            authority          : '@tobiu',
+            since              : '${plan.since}',
+            reactivationTrigger: 'First-boot ritual completes: identity bind, runtime wake self-registration, and the naming-round outcome recorded',
+            createdAt          : new Date().toISOString()
+        }
+    },`;
+}
+
+/**
+ * @summary Renders the resident's README maintainer roster row. The Name cell stays `-` (no
+ * Social Name at onboarding); the Role cell carries the family only — the engine designation
+ * is observation-owned and lands post-boot.
+ * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @returns {String} The single table row
+ */
+export function renderReadmeRow(plan) {
+    const familyPhrase = plan.familyVendor ? `${plan.familyVendor} ${plan.familyDisplay}` : plan.familyDisplay;
+
+    return `| - | [@${plan.githubBody}](https://github.com/${plan.githubBody}) | AI maintainer (${familyPhrase} family — engine designation pending first boot) | Machine Account |`;
+}
+
+/**
+ * @summary Renders the resident's ModelStats.md capability section skeleton: every
+ * observation-owned value is an explicit source-citation placeholder — never an invented
+ * capability fact. Lands under the pending identities heading; the activation flip moves the
+ * section and fills the values source-cited.
+ * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @returns {String} The markdown section (no trailing newline)
+ */
+export function renderModelStatsSection(plan) {
+    const familyCell = plan.familyVendor ? '`' + plan.family + '` (' + plan.familyVendor + ')' : '`' + plan.family + '`';
+
+    return [
+        '### §' + plan.sectionAnchor,
+        '',
+        '| Field | Value |',
+        '|---|---|',
+        '| `id` / `githubLogin` | `' + plan.handle + '` |',
+        '| `name` | (engine designation: V-B-A pending — observation-owned; recorded from the live harness at first boot) |',
+        '| `family` | ' + familyCell + ' |',
+        '| `participationStatus` | `temporarily_unreachable` (provisioned ahead of first boot — onboarding in progress; flips to `active` when the first-boot ritual completes) |',
+        '| `hosting` | (V-B-A pending — recorded at first boot) |',
+        '| `tier` | (V-B-A pending — recorded at first boot) |',
+        '| `contextWindowInput` | (V-B-A pending — model card / official docs cite needed) |',
+        '| `parallelToolCalls` | (V-B-A pending — model card / official docs cite needed) |',
+        '| `thoughtBudget` | (V-B-A pending — record the harness setting in use at first boot) |',
+        '| `releaseDate` | (V-B-A pending — model card cite needed) |',
+        '| `pricingInput` | (V-B-A pending — model card cite needed) |',
+        '| `pricingOutput` | (V-B-A pending — model card cite needed) |',
+        '| `sunsetTriggers` | (V-B-A pending — defined against the observed engine at the activation flip) |',
+        '| `swarmRole` | Onboarding in progress — recorded at the activation flip |',
+        '',
+        '**Sources** (primary first):',
+        '- **Primary**: (pending — cite the model card / release notes / official docs for the observed engine at first boot; capability values are never guessed at onboarding)',
+        '- **Primary**: GitHub account `' + plan.githubBody + '` (verify profile name + AI-disclosure bio at account creation)'
+    ].join('\n');
+}
+
+/**
+ * @summary Renders the resident's roster pin for `identityRoots.spec.mjs`: Layer-1 identity
+ * invariants only. Lifecycle state stays unpinned (status flips are their own PRs); the
+ * engine-fact absence assertions hold until the activation flip lands source-cited capability
+ * fields and updates the pin alongside the roster entry.
+ * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @returns {String} The spec block (no trailing newline)
+ */
+export function renderSpecPin(plan) {
+    return `/**
+ * @summary Roster pin for the onboarded resident ${plan.handle}: Layer-1 identity invariants only.
+ *
+ * Lifecycle state (participationStatus) is deliberately unpinned — status flips are their own
+ * PRs. The engine-fact absence assertions hold until the activation flip lands source-cited
+ * capability fields; that PR updates this pin alongside the roster entry.
+ */
+test.describe('ai/graph/identityRoots — ${plan.handle} roster pin', () => {
+    const findIdentity = id => IDENTITIES.find(node => node.type === 'AgentIdentity' && node.id === id);
+
+    test('${plan.handle} is a registered AgentIdentity root with Layer-1 operational fields', () => {
+        const entry = findIdentity('${plan.handle}');
+
+        expect(entry, '${plan.handle} must be a registered AgentIdentity root').toBeTruthy();
+        expect(entry).toMatchObject({
+            id        : '${plan.handle}',
+            type      : 'AgentIdentity',
+            properties: {
+                githubLogin: '${plan.githubUsername}',
+                displayName: '${plan.displayForm}',
+                modelFamily: '${plan.family}',
+                accountType: 'agent',
+                trustTier  : 'peer-trusted'
+            }
+        });
+    });
+
+    test('${plan.handle} commits no static wake template and no engine facts (observation-owned)', () => {
+        const entry = findIdentity('${plan.handle}');
+
+        expect(entry.properties).not.toHaveProperty('subscriptionTemplate');
+        expect(entry.properties).not.toHaveProperty('modelAssignment');
+        expect(entry.properties).not.toHaveProperty('contextWindowInput');
+        expect(entry.properties).not.toHaveProperty('pricingInput');
+        expect(entry.properties).not.toHaveProperty('pricingOutput');
+    });
+});`;
+}
+
+/**
+ * @summary Plans the `identityRoots.mjs` surface: EXISTS when the roster already carries the
+ * resident's id; otherwise inserts the entry immediately before the `AGENT:*`
+ * BroadcastSentinel entry (the roster's stable tail). Fail-closed when the anchor is missing.
+ * @param {String} source Current file content
+ * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @returns {{surface: String, path: String, status: String, reason: String|null, anchor: String, snippet: String, updated: String|null}}
+ */
+export function planRosterSurface(source, plan) {
+    const base = {surface: 'identityRoots', path: SURFACE_PATHS.identityRoots, anchor: `immediately before the 'AGENT:*' BroadcastSentinel entry`, snippet: renderRosterEntry(plan)};
+
+    if (typeof source !== 'string' || source === '') {
+        return {...base, status: 'invalid', reason: 'identityRoots source must be a non-empty string', updated: null};
+    }
+
+    if (new RegExp(`id\\s*:\\s*'${escapeRegExp(plan.handle)}'`).test(source)) {
+        return {...base, status: 'exists', reason: `${plan.handle} already has an IDENTITIES roster entry`, updated: null};
+    }
+
+    const sentinel = source.match(/\n    \{\n\s+id\s*:\s*'AGENT:\*'/);
+
+    if (!sentinel) {
+        return {...base, status: 'invalid', reason: `insertion anchor not found: the 'AGENT:*' BroadcastSentinel entry is missing from ${SURFACE_PATHS.identityRoots}`, updated: null};
+    }
+
+    const insertAt = sentinel.index + 1;
+
+    return {
+        ...base,
+        status : 'insert',
+        reason : null,
+        updated: source.slice(0, insertAt) + base.snippet + '\n' + source.slice(insertAt)
+    };
+}
+
+/**
+ * @summary Plans the README surface: EXISTS when the roster table already links the resident's
+ * GitHub account; otherwise appends the row after the last row of the maintainer roster table.
+ * Fail-closed when the table header is missing.
+ * @param {String} source Current file content
+ * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @returns {{surface: String, path: String, status: String, reason: String|null, anchor: String, snippet: String, updated: String|null}}
+ */
+export function planReadmeSurface(source, plan) {
+    const base = {surface: 'readme', path: SURFACE_PATHS.readme, anchor: 'appended after the last row of the maintainer roster table', snippet: renderReadmeRow(plan)};
+
+    if (typeof source !== 'string' || source === '') {
+        return {...base, status: 'invalid', reason: 'README source must be a non-empty string', updated: null};
+    }
+
+    if (source.includes(`](https://github.com/${plan.githubBody})`)) {
+        return {...base, status: 'exists', reason: `@${plan.githubBody} already has a maintainer roster row`, updated: null};
+    }
+
+    const lines     = source.split('\n'),
+          headerIdx = lines.indexOf('| Name | Maintainer | Role | Identity |');
+
+    if (headerIdx === -1) {
+        return {...base, status: 'invalid', reason: `insertion anchor not found: the '| Name | Maintainer | Role | Identity |' table header is missing from ${SURFACE_PATHS.readme}`, updated: null};
+    }
+
+    let end = headerIdx + 1;
+
+    while (end < lines.length && lines[end].startsWith('|')) {
+        end++;
+    }
+
+    lines.splice(end, 0, base.snippet);
+
+    return {...base, status: 'insert', reason: null, updated: lines.join('\n')};
+}
+
+/**
+ * @summary Plans the ModelStats.md surface: EXISTS when the section anchor or the resident's
+ * id/githubLogin cell is already present; otherwise inserts the skeleton inside the pending
+ * identities section, before the divider that closes it. Fail-closed when the heading or
+ * divider is missing.
+ * @param {String} source Current file content
+ * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @returns {{surface: String, path: String, status: String, reason: String|null, anchor: String, snippet: String, updated: String|null}}
+ */
+export function planModelStatsSurface(source, plan) {
+    const base = {surface: 'modelStats', path: SURFACE_PATHS.modelStats, anchor: 'inside §pending_swarm_identities, before the closing divider', snippet: renderModelStatsSection(plan)};
+
+    if (typeof source !== 'string' || source === '') {
+        return {...base, status: 'invalid', reason: 'ModelStats source must be a non-empty string', updated: null};
+    }
+
+    if (source.includes(`### §${plan.sectionAnchor}\n`) || source.includes('| `id` / `githubLogin` | `' + plan.handle + '` |')) {
+        return {...base, status: 'exists', reason: `${plan.handle} already has a ModelStats section`, updated: null};
+    }
+
+    const headingIdx = source.indexOf('\n## §pending_swarm_identities');
+
+    if (headingIdx === -1) {
+        return {...base, status: 'invalid', reason: `insertion anchor not found: the '## §pending_swarm_identities' heading is missing from ${SURFACE_PATHS.modelStats}`, updated: null};
+    }
+
+    const dividerIdx = source.indexOf('\n---\n', headingIdx);
+
+    if (dividerIdx === -1) {
+        return {...base, status: 'invalid', reason: `insertion anchor not found: no '---' divider closes §pending_swarm_identities in ${SURFACE_PATHS.modelStats}`, updated: null};
+    }
+
+    return {
+        ...base,
+        status : 'insert',
+        reason : null,
+        updated: source.slice(0, dividerIdx) + '\n' + base.snippet + '\n' + source.slice(dividerIdx)
+    };
+}
+
+/**
+ * @summary Plans the roster-pin spec surface: EXISTS when the spec already references the
+ * resident's handle as a quoted literal (any existing reference means a pin or invariant
+ * already covers the identity — emitting another block would duplicate coverage); otherwise
+ * appends the pin block at the end of the spec.
+ * @param {String} source Current file content
+ * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @returns {{surface: String, path: String, status: String, reason: String|null, anchor: String, snippet: String, updated: String|null}}
+ */
+export function planSpecSurface(source, plan) {
+    const base = {surface: 'spec', path: SURFACE_PATHS.spec, anchor: 'appended at the end of the spec file', snippet: renderSpecPin(plan)};
+
+    if (typeof source !== 'string' || source === '') {
+        return {...base, status: 'invalid', reason: 'spec source must be a non-empty string', updated: null};
+    }
+
+    if (source.includes(`'${plan.handle}'`)) {
+        return {...base, status: 'exists', reason: `${plan.handle} is already referenced by the roster spec`, updated: null};
+    }
+
+    return {
+        ...base,
+        status : 'insert',
+        reason : null,
+        updated: source.replace(/\s*$/, '\n') + '\n' + base.snippet + '\n'
+    };
+}
+
+/**
+ * @summary Plans all four onboarding surfaces from live file contents — the single source both
+ * the dry-run rendering and the `--write` path consume, so "what dry-run prints" and "what
+ * `--write` applies" cannot drift. Fail-closed: any invalid surface invalidates the whole
+ * payload and nothing is applicable.
+ * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @param {Object} files Current file contents keyed `{identityRoots, readme, modelStats, spec}`
+ * @returns {{valid: Boolean, reason: String|null, surfaces: Object[]}}
+ */
+export function planOnboardingSurfaces(plan, files = {}) {
+    if (!plan || typeof plan.handle !== 'string') {
+        return {valid: false, reason: 'planOnboardingSurfaces requires a valid plan from buildOnboardingPlan', surfaces: []};
+    }
+
+    for (const key of ['identityRoots', 'modelStats', 'readme', 'spec']) {
+        if (typeof files[key] !== 'string') {
+            return {valid: false, reason: `missing file content for surface '${key}'`, surfaces: []};
+        }
+    }
+
+    const surfaces = [
+        planRosterSurface(files.identityRoots, plan),
+        planReadmeSurface(files.readme, plan),
+        planModelStatsSurface(files.modelStats, plan),
+        planSpecSurface(files.spec, plan)
+    ];
+
+    const invalid = surfaces.find(surface => surface.status === 'invalid');
+
+    return {
+        valid : !invalid,
+        reason: invalid ? invalid.reason : null,
+        surfaces
+    };
+}
+
+/**
+ * @summary Advisory notes printed with every payload — adjacent concerns the generator
+ * deliberately does NOT write (they are either untouchable by rule or editorial).
+ * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @returns {String[]}
+ */
+export function renderAdvisoryNotes(plan) {
+    return [
+        '[generateRosterOnboarding] advisory (printed, never written):',
+        `  - Migration epoch note: post-epoch onboarding must NOT retro-seed the migration map — ${plan.handle}'s era opens at onboarding time via the Day-0 provisioning script; the seed epoch stays untouched.`,
+        '  - ModelStats §update_history: add a row citing the onboarding PR number once the PR exists.',
+        '  - README credits: the co-developed-by sentence near the end of the README lists maintainer handles; extending it is an editorial call at review time.',
+        '  - Activation flip: participationStatus \'active\', source-cited capability facts, and the swarmRole land in the post-first-boot flip PR — never here.'
+    ];
+}
+
+/**
+ * @summary Renders the payload report: per-surface status, target path, insertion anchor, and
+ * the exact proposed snippet — the dry-run output IS the write set.
+ * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @param {Object} planned The result of {@link planOnboardingSurfaces}
+ * @returns {String[]}
+ */
+export function renderOnboardingReport(plan, planned) {
+    const lines = [
+        `[generateRosterOnboarding] four-surface onboarding payload for ${plan.handle} (family: ${plan.family})`,
+        ''
+    ];
+
+    for (const surface of planned.surfaces) {
+        lines.push(`  [${surface.status.toUpperCase()}] ${surface.path}`);
+
+        if (surface.status === 'insert') {
+            lines.push(`      anchor: ${surface.anchor}`);
+            lines.push(...surface.snippet.split('\n').map(line => `      ${line}`.replace(/\s+$/, '')));
+        } else {
+            lines.push(`      ${surface.reason}`);
+        }
+
+        lines.push('');
+    }
+
+    lines.push(...renderAdvisoryNotes(plan));
+
+    return lines;
+}
+
+/**
+ * @summary The pure `--write` branch guard: committed-file application is allowed ONLY on a
+ * resolvable git work branch that is neither `dev` nor `main` — the payload always travels as
+ * a reviewable branch + PR, never as a live edit to an integration branch.
+ * @param {Object} options
+ * @param {String|null} options.branch Current branch name from `git rev-parse --abbrev-ref HEAD`, or null when unresolvable
+ * @returns {{valid: Boolean, reason: String|null}}
+ */
+export function checkWriteGuard({branch} = {}) {
+    if (typeof branch !== 'string' || branch.trim() === '') {
+        return {valid: false, reason: '--write requires a git work tree with a resolvable branch — refusing to apply'};
+    }
+
+    const name = branch.trim();
+
+    if (name === 'HEAD') {
+        return {valid: false, reason: '--write refuses a detached HEAD — check out a work branch first'};
+    }
+
+    if (name === 'dev' || name === 'main') {
+        return {valid: false, reason: `--write refuses to apply on '${name}' — onboarding payloads travel as a reviewable branch + PR, never as a live edit to an integration branch`};
+    }
+
+    return {valid: true, reason: null}
+}
+
+/**
+ * @summary Parses the CLI argv (pure, hand-rolled by design: unknown flags refuse instead of
+ * being silently ignored; socialName-class flags refuse with the ritual pointer and
+ * engine-class flags with the observation pointer — all three are part of the tested input
+ * contract). Required-field enforcement lives in {@link buildOnboardingPlan}; this layer owns
+ * flag SYNTAX only.
+ * @param {String[]} argv Arguments after the script path (`process.argv.slice(2)`)
+ * @returns {{valid: Boolean, reason: String|null, options: Object|null}}
+ */
+export function parseGenerateArgs(argv = []) {
+    const valueFlags = {
+        '--family'         : 'family',
+        '--github-username': 'githubUsername',
+        '--handle'         : 'handle',
+        '--mailbox'        : 'mailbox'
+    };
+
+    const booleanFlags = {
+        '--help' : 'help',
+        '--write': 'write'
+    };
+
+    const options = {help: false, write: false};
+
+    for (let i = 0; i < argv.length; i++) {
+        const flag = argv[i];
+
+        if (SOCIAL_NAME_CLASS_FLAGS.includes(flag)) {
+            return {valid: false, reason: `${flag} is rejected by design — Social Names are the post-boot peer-naming ritual (bearer-assented), never seed data`, options: null};
+        }
+
+        if (ENGINE_CLASS_FLAGS.includes(flag)) {
+            return {valid: false, reason: `${flag} is rejected by design — engine facts are observation-owned and land through the source-cited ModelStats.md discipline at first boot, never as onboarding predictions`, options: null};
+        }
+
+        if (booleanFlags[flag]) {
+            options[booleanFlags[flag]] = true;
+            continue;
+        }
+
+        if (valueFlags[flag]) {
+            const value = argv[i + 1];
+
+            if (value === undefined || value.startsWith('--')) {
+                return {valid: false, reason: `${flag} requires a value`, options: null};
+            }
+
+            options[valueFlags[flag]] = value;
+            i++;
+            continue;
+        }
+
+        return {valid: false, reason: `unknown option '${flag}' — the generator accepts only: ${[...Object.keys(valueFlags), ...Object.keys(booleanFlags)].join(', ')}`, options: null};
+    }
+
+    return {valid: true, reason: null, options}
+}
+
+/**
+ * @summary Reads the four surface files from the repo root — the side-effect half's only read
+ * surface.
+ * @param {String} repoRoot Absolute repo root path
+ * @returns {Object} File contents keyed `{identityRoots, modelStats, readme, spec}`
+ */
+export function readSurfaceFiles(repoRoot) {
+    const contents = {};
+
+    for (const [key, relative] of Object.entries(SURFACE_PATHS)) {
+        contents[key] = fs.readFileSync(path.join(repoRoot, relative), 'utf8');
+    }
+
+    return contents;
+}
+
+/**
+ * @summary Resolves the current git branch name, or null when unresolvable — feeds the pure
+ * {@link checkWriteGuard}.
+ * @param {String} repoRoot Absolute repo root path
+ * @returns {String|null}
+ */
+export function currentGitBranch(repoRoot) {
+    try {
+        return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {cwd: repoRoot, encoding: 'utf8'}).trim();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * @summary Prints the CLI usage block.
+ * @returns {void}
+ */
+function printUsage() {
+    console.log('Usage: node ai/scripts/setup/generateRosterOnboarding.mjs --handle <s> --family <s>');
+    console.log('           [--github-username <s>] [--mailbox <s>] [--write]');
+    console.log('');
+    console.log('  (no flags)  Dry-run — print the four proposed file modifications without applying them.');
+    console.log('  --write     Apply the insertions (branch-guarded: refuses on dev/main; EXISTS surfaces skipped).');
+    console.log('');
+    console.log('  There is deliberately NO model/engine flag (engine facts are observation-owned; they land');
+    console.log('  source-cited in ModelStats.md at first boot) and NO social-name flag (Social Names are the');
+    console.log('  post-boot peer-naming ritual, never seed data).');
+}
+
+/**
+ * @summary CLI entry: parse → plan → print; `--write` applies the insertions behind the branch
+ * guard. Dry-run touches nothing.
+ * @returns {Promise<void>}
+ */
+async function main() {
+    const parsed = parseGenerateArgs(process.argv.slice(2));
+
+    if (!parsed.valid) {
+        console.error(`[generateRosterOnboarding] FATAL: ${parsed.reason}`);
+        printUsage();
+        process.exit(1);
+    }
+
+    if (parsed.options.help) {
+        printUsage();
+        return;
+    }
+
+    const built = buildOnboardingPlan(parsed.options);
+
+    if (!built.valid) {
+        console.error(`[generateRosterOnboarding] FATAL: ${built.reason}`);
+        printUsage();
+        process.exit(1);
+    }
+
+    const {plan}   = built,
+          repoRoot = path.resolve(path.dirname(__filename), '../../..'),
+          planned  = planOnboardingSurfaces(plan, readSurfaceFiles(repoRoot));
+
+    console.log(renderOnboardingReport(plan, planned).join('\n'));
+    console.log('');
+
+    if (!planned.valid) {
+        console.error(`[generateRosterOnboarding] FATAL: ${planned.reason}`);
+        process.exit(1);
+    }
+
+    if (!parsed.options.write) {
+        console.log('[generateRosterOnboarding] DRY-RUN complete. No files touched. Re-run with --write on a work branch to apply.');
+        return;
+    }
+
+    const guard = checkWriteGuard({branch: currentGitBranch(repoRoot)});
+
+    if (!guard.valid) {
+        console.error(`[generateRosterOnboarding] FATAL: ${guard.reason}`);
+        process.exit(1);
+    }
+
+    let written = 0;
+
+    for (const surface of planned.surfaces) {
+        if (surface.status === 'insert') {
+            fs.writeFileSync(path.join(repoRoot, surface.path), surface.updated);
+            console.log(`  [WROTE] ${surface.path}`);
+            written++;
+        } else {
+            console.log(`  [SKIPPED] ${surface.path} — ${surface.reason}`);
+        }
+    }
+
+    console.log('');
+    console.log(`[generateRosterOnboarding] applied ${written} of 4 surfaces for ${plan.handle}. Review the diff, commit on this branch, and open the PR through the normal pull-request protocol.`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    main().catch(err => {
+        console.error('[generateRosterOnboarding] FATAL:', err);
+        process.exit(1);
+    });
+}

--- a/test/playwright/unit/ai/scripts/setup/generateRosterOnboarding.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/generateRosterOnboarding.spec.mjs
@@ -1,0 +1,489 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'GenerateRosterOnboardingTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import {
+    ENGINE_CLASS_KEYS,
+    SOCIAL_NAME_CLASS_KEYS,
+    SURFACE_PATHS,
+    buildOnboardingPlan,
+    checkWriteGuard,
+    deriveDisplayForm,
+    deriveSectionAnchor,
+    parseGenerateArgs,
+    planModelStatsSurface,
+    planOnboardingSurfaces,
+    planReadmeSurface,
+    planRosterSurface,
+    planSpecSurface,
+    renderModelStatsSection,
+    renderOnboardingReport,
+    renderReadmeRow,
+    renderRosterEntry,
+    renderSpecPin
+} from '../../../../../../ai/scripts/setup/generateRosterOnboarding.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
+
+const FIXED_NOW    = '2026-07-10T12:00:00.000Z';
+const BASE_OPTIONS = Object.freeze({
+    handle: '@neo-unit-probe',
+    family: 'claude',
+    now   : FIXED_NOW
+});
+
+/**
+ * @summary Builds a valid plan from the shared fixture options.
+ * @param {Object} [overrides] Option overrides.
+ * @returns {Object} The frozen plan.
+ */
+function buildPlan(overrides = {}) {
+    const built = buildOnboardingPlan({...BASE_OPTIONS, ...overrides});
+
+    expect(built.valid).toBe(true);
+
+    return built.plan;
+}
+
+/**
+ * @summary Reads the four REAL surface files from the repo root, so anchor assumptions are
+ * verified against the live shapes rather than fixtures alone.
+ * @returns {Object} File contents keyed `{identityRoots, modelStats, readme, spec}`
+ */
+function readRealFiles() {
+    const files = {};
+
+    for (const [key, relative] of Object.entries(SURFACE_PATHS)) {
+        files[key] = fs.readFileSync(path.join(REPO_ROOT, relative), 'utf8');
+    }
+
+    return files;
+}
+
+const ROSTER_FIXTURE = `export const TRUST_TIERS = Object.freeze({PEER_TRUSTED: 'peer-trusted', UNCLASSIFIED: 'unclassified'});
+
+export const IDENTITIES = [
+    {
+        id         : '@neo-existing',
+        type       : 'AgentIdentity',
+        properties : {}
+    },
+    {
+        id         : 'AGENT:*',
+        type       : 'BroadcastSentinel',
+        properties : {}
+    }
+];
+`;
+
+const README_FIXTURE = `# Fixture
+
+| Name | Maintainer | Role | Identity |
+|---|---|---|---|
+| Tobias | [@tobiu](https://github.com/tobiu) | Gardener | Human |
+| Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer | Machine Account |
+
+Trailing prose.
+`;
+
+const MODEL_STATS_FIXTURE = `# Model Stats Registry
+
+## §active_swarm_identities
+
+### §neo_gpt
+
+| Field | Value |
+|---|---|
+| \`id\` / \`githubLogin\` | \`@neo-gpt\` |
+
+---
+
+## §pending_swarm_identities
+
+Pending identities paragraph.
+
+---
+
+## §mlx_local_operational
+`;
+
+const SPEC_FIXTURE = `import {test, expect} from '@playwright/test';
+import {IDENTITIES}   from '../../../../../ai/graph/identityRoots.mjs';
+
+test.describe('existing', () => {
+    test('pins @neo-existing', () => {
+        expect(IDENTITIES.find(node => node.id === '@neo-existing')).toBeTruthy();
+    });
+});
+`;
+
+const FIXTURE_FILES = Object.freeze({
+    identityRoots: ROSTER_FIXTURE,
+    modelStats   : MODEL_STATS_FIXTURE,
+    readme       : README_FIXTURE,
+    spec         : SPEC_FIXTURE
+});
+
+test.describe('generateRosterOnboarding — plan construction (pure half)', () => {
+
+    test('builds the Layer-1 plan: handle-derived display form, defaults, section anchor, since = generation time', () => {
+        const plan = buildPlan();
+
+        expect(plan.handle).toBe('@neo-unit-probe');
+        expect(plan.handleBody).toBe('neo-unit-probe');
+        expect(plan.family).toBe('claude');
+        expect(plan.familyVendor).toBe('Anthropic');
+        expect(plan.familyDisplay).toBe('Claude');
+        expect(plan.displayForm).toBe('Neo Unit Probe');
+        expect(plan.sectionAnchor).toBe('neo_unit_probe');
+        expect(plan.since).toBe(FIXED_NOW);
+
+        // github + mailbox default to the resident handle
+        expect(plan.githubUsername).toBe('@neo-unit-probe');
+        expect(plan.mailbox).toBe('@neo-unit-probe');
+
+        // helper derivations hold for multi-part handles
+        expect(deriveDisplayForm('@neo-fable-clio')).toBe('Neo Fable Clio');
+        expect(deriveSectionAnchor('@neo-fable-clio')).toBe('neo_fable_clio');
+
+        // unknown families render with the bare token — never a guessed vendor
+        const exotic = buildPlan({family: 'newfamily'});
+        expect(exotic.familyVendor).toBeNull();
+        expect(exotic.familyDisplay).toBe('newfamily');
+    });
+
+    test('every socialName-class key is rejected loudly — Social Names are never seed data', () => {
+        for (const key of SOCIAL_NAME_CLASS_KEYS) {
+            const built = buildOnboardingPlan({...BASE_OPTIONS, [key]: 'Muse'});
+
+            expect(built.valid).toBe(false);
+            expect(built.plan).toBeNull();
+            expect(built.reason).toContain('naming ritual');
+        }
+    });
+
+    test('every engine-class key is rejected loudly — engine facts are observation-owned', () => {
+        for (const key of ENGINE_CLASS_KEYS) {
+            const built = buildOnboardingPlan({...BASE_OPTIONS, [key]: 'some-engine-5'});
+
+            expect(built.valid).toBe(false);
+            expect(built.plan).toBeNull();
+            expect(built.reason).toContain('observation-owned');
+        }
+    });
+
+    test('malformed inputs refuse: handle, family, github username, mailbox, timestamp', () => {
+        expect(buildOnboardingPlan({...BASE_OPTIONS, handle: ''}).valid).toBe(false);
+        expect(buildOnboardingPlan({...BASE_OPTIONS, handle: '@Neo-Upper'}).valid).toBe(false);
+        expect(buildOnboardingPlan({...BASE_OPTIONS, family: 'Claude'}).valid).toBe(false);
+        expect(buildOnboardingPlan({...BASE_OPTIONS, family: undefined}).valid).toBe(false);
+        expect(buildOnboardingPlan({...BASE_OPTIONS, githubUsername: 'not a handle!'}).valid).toBe(false);
+        expect(buildOnboardingPlan({...BASE_OPTIONS, mailbox: '@@double'}).valid).toBe(false);
+        expect(buildOnboardingPlan({...BASE_OPTIONS, now: 'not-a-date'}).valid).toBe(false);
+    });
+});
+
+test.describe('generateRosterOnboarding — surface emitters (pure half)', () => {
+
+    test('the roster entry is Layer-1 only: pending lifecycle state, no engine facts, no wake template, no social name', () => {
+        const entry = renderRosterEntry(buildPlan());
+
+        // Layer-1 operational fields
+        expect(entry).toContain(`id         : '@neo-unit-probe',`);
+        expect(entry).toContain(`githubLogin     : '@neo-unit-probe',`);
+        expect(entry).toContain(`displayName     : 'Neo Unit Probe',`);
+        expect(entry).toContain(`modelFamily     : 'claude',`);
+        expect(entry).toContain('trustTier       : TRUST_TIERS.PEER_TRUSTED,');
+        expect(entry).toContain(`requiredA2aMailboxAddress: '@neo-unit-probe',`);
+        expect(entry).toContain(`modelVersionSource       : 'learn/agentos/ModelStats.md §neo_unit_probe',`);
+
+        // pending-first-boot lifecycle state with the ACTUAL generation timestamp (no backfill)
+        expect(entry).toContain(`participationStatus: 'temporarily_unreachable',`);
+        expect(entry).toContain(`since              : '${FIXED_NOW}',`);
+        expect(entry).toContain(`authority          : '@tobiu',`);
+
+        // engine facts, wake templates, and social-name material are absent BY CONSTRUCTION —
+        // asserted at property-KEY position (the explanatory comments may name the absences)
+        for (const forbidden of ['contextWindowInput', 'pricingInput', 'pricingOutput', 'thoughtBudget', 'releaseDate', 'sunsetTriggers', 'swarmRole', 'subscriptionTemplate', 'modelAssignment', 'socialName']) {
+            expect(entry, `roster entry must not carry a '${forbidden}' property`).not.toMatch(new RegExp(`^\\s*${forbidden}\\s*:`, 'm'));
+        }
+    });
+
+    test('the README row keeps the Name cell bare and the Role cell family-only (engine designation pending)', () => {
+        expect(renderReadmeRow(buildPlan())).toBe(
+            '| - | [@neo-unit-probe](https://github.com/neo-unit-probe) | AI maintainer (Anthropic Claude family — engine designation pending first boot) | Machine Account |'
+        );
+
+        // unknown family: bare token, no invented vendor
+        expect(renderReadmeRow(buildPlan({family: 'newfamily'}))).toContain('AI maintainer (newfamily family — engine designation pending first boot)');
+    });
+
+    test('the ModelStats skeleton carries source-citation placeholders, never invented capability facts', () => {
+        const section = renderModelStatsSection(buildPlan());
+
+        expect(section.startsWith('### §neo_unit_probe\n')).toBe(true);
+        expect(section).toContain('| `id` / `githubLogin` | `@neo-unit-probe` |');
+        expect(section).toContain('| `family` | `claude` (Anthropic) |');
+        expect(section).toContain('`temporarily_unreachable`');
+        expect(section).toContain('**Sources** (primary first):');
+
+        // every observation-owned value is an explicit placeholder
+        for (const field of ['name', 'hosting', 'tier', 'contextWindowInput', 'parallelToolCalls', 'thoughtBudget', 'releaseDate', 'pricingInput', 'pricingOutput', 'sunsetTriggers']) {
+            const row = section.split('\n').find(line => line.startsWith('| `' + field + '` |'));
+
+            expect(row, `ModelStats row for '${field}' must exist`).toBeTruthy();
+            expect(row, `ModelStats row for '${field}' must be a V-B-A placeholder`).toContain('V-B-A pending');
+        }
+
+        // no invented numeric capability values anywhere (token counts, prices, dates)
+        expect(section).not.toMatch(/\| `(contextWindowInput|pricingInput|pricingOutput|releaseDate)` \| [^(]/);
+    });
+
+    test('the spec pin asserts Layer-1 invariants and engine-fact absence', () => {
+        const pin = renderSpecPin(buildPlan());
+
+        expect(pin).toContain(`test.describe('ai/graph/identityRoots — @neo-unit-probe roster pin', () => {`);
+        expect(pin).toContain(`githubLogin: '@neo-unit-probe',`);
+        expect(pin).toContain(`displayName: 'Neo Unit Probe',`);
+        expect(pin).toContain(`trustTier  : 'peer-trusted'`);
+        expect(pin).toContain(`not.toHaveProperty('subscriptionTemplate')`);
+        expect(pin).toContain(`not.toHaveProperty('contextWindowInput')`);
+    });
+});
+
+test.describe('generateRosterOnboarding — surface planning (anchors + idempotency)', () => {
+
+    test('roster surface: inserts immediately before the broadcast sentinel; a second run reports EXISTS', () => {
+        const plan  = buildPlan();
+        const first = planRosterSurface(ROSTER_FIXTURE, plan);
+
+        expect(first.status).toBe('insert');
+        expect(first.updated).toContain(`id         : '@neo-unit-probe',`);
+        expect(first.updated.indexOf(`'@neo-unit-probe'`)).toBeGreaterThan(first.updated.indexOf(`'@neo-existing'`));
+        expect(first.updated.indexOf(`'@neo-unit-probe'`)).toBeLessThan(first.updated.indexOf(`'AGENT:*'`));
+
+        const second = planRosterSurface(first.updated, plan);
+
+        expect(second.status).toBe('exists');
+        expect(second.updated).toBeNull();
+    });
+
+    test('README surface: appends after the last roster-table row; a second run reports EXISTS', () => {
+        const plan  = buildPlan();
+        const first = planReadmeSurface(README_FIXTURE, plan);
+
+        expect(first.status).toBe('insert');
+
+        const lines  = first.updated.split('\n'),
+              rowIdx = lines.indexOf(renderReadmeRow(plan));
+
+        expect(rowIdx).toBeGreaterThan(-1);
+        expect(lines[rowIdx - 1].startsWith('| Euclid |')).toBe(true);
+        expect(lines[rowIdx + 1]).toBe('');
+
+        const second = planReadmeSurface(first.updated, plan);
+
+        expect(second.status).toBe('exists');
+        expect(second.updated).toBeNull();
+    });
+
+    test('ModelStats surface: inserts inside the pending section before its divider; a second run reports EXISTS', () => {
+        const plan  = buildPlan();
+        const first = planModelStatsSurface(MODEL_STATS_FIXTURE, plan);
+
+        expect(first.status).toBe('insert');
+
+        const sectionIdx = first.updated.indexOf('### §neo_unit_probe');
+
+        expect(sectionIdx).toBeGreaterThan(first.updated.indexOf('## §pending_swarm_identities'));
+        expect(sectionIdx).toBeLessThan(first.updated.indexOf('## §mlx_local_operational'));
+
+        const second = planModelStatsSurface(first.updated, plan);
+
+        expect(second.status).toBe('exists');
+        expect(second.updated).toBeNull();
+    });
+
+    test('spec surface: appends the pin at the end; a second run reports EXISTS', () => {
+        const plan  = buildPlan();
+        const first = planSpecSurface(SPEC_FIXTURE, plan);
+
+        expect(first.status).toBe('insert');
+        expect(first.updated.trimEnd().endsWith('});')).toBe(true);
+        expect(first.updated.indexOf('@neo-unit-probe roster pin')).toBeGreaterThan(first.updated.indexOf(`node.id === '@neo-existing'`));
+
+        const second = planSpecSurface(first.updated, plan);
+
+        expect(second.status).toBe('exists');
+        expect(second.updated).toBeNull();
+    });
+
+    test('a ModelStats anchor prefix-collision does not false-report EXISTS (§neo_x vs §neo_x_sibling)', () => {
+        const sibling = MODEL_STATS_FIXTURE.replace('### §neo_gpt', '### §neo_unit_probe_sibling');
+        const result  = planModelStatsSurface(sibling, buildPlan());
+
+        expect(result.status).toBe('insert');
+    });
+
+    test('missing insertion anchors refuse loudly instead of guessing', () => {
+        const plan = buildPlan();
+
+        expect(planRosterSurface('export const IDENTITIES = [];\n', plan).status).toBe('invalid');
+        expect(planReadmeSurface('# No table here\n', plan).status).toBe('invalid');
+        expect(planModelStatsSurface('# No pending heading\n', plan).status).toBe('invalid');
+        expect(planSpecSurface('', plan).status).toBe('invalid');
+    });
+
+    test('planOnboardingSurfaces is fail-closed: missing file content or an invalid surface invalidates the payload', () => {
+        const plan = buildPlan();
+
+        const missing = planOnboardingSurfaces(plan, {identityRoots: ROSTER_FIXTURE});
+
+        expect(missing.valid).toBe(false);
+        expect(missing.surfaces).toEqual([]);
+
+        const broken = planOnboardingSurfaces(plan, {...FIXTURE_FILES, readme: '# No table here\n'});
+
+        expect(broken.valid).toBe(false);
+        expect(broken.reason).toContain('insertion anchor not found');
+
+        const healthy = planOnboardingSurfaces(plan, FIXTURE_FILES);
+
+        expect(healthy.valid).toBe(true);
+        expect(healthy.surfaces.map(surface => surface.status)).toEqual(['insert', 'insert', 'insert', 'insert']);
+    });
+
+    test('the dry-run report prints status, anchor, and the exact snippet per surface, plus the advisory notes', () => {
+        const plan    = buildPlan();
+        const planned = planOnboardingSurfaces(plan, FIXTURE_FILES);
+        const report  = renderOnboardingReport(plan, planned).join('\n');
+
+        expect(report).toContain('[INSERT] ai/graph/identityRoots.mjs');
+        expect(report).toContain('[INSERT] README.md');
+        expect(report).toContain('[INSERT] learn/agentos/ModelStats.md');
+        expect(report).toContain('[INSERT] test/playwright/unit/ai/graph/identityRoots.spec.mjs');
+        expect(report).toContain('anchor: immediately before the');
+        expect(report).toContain('advisory (printed, never written)');
+        expect(report).toContain('must NOT retro-seed the migration map');
+
+        // EXISTS surfaces report the reason instead of a duplicate snippet
+        const applied  = planOnboardingSurfaces(plan, {...FIXTURE_FILES, readme: planned.surfaces[1].updated});
+        const rerender = renderOnboardingReport(plan, applied).join('\n');
+
+        expect(rerender).toContain('[EXISTS] README.md');
+    });
+});
+
+test.describe('generateRosterOnboarding — live-file anchoring (the anchors must match the real shapes)', () => {
+
+    test('a fresh resident plans INSERT on all four REAL surfaces', () => {
+        const planned = planOnboardingSurfaces(buildPlan(), readRealFiles());
+
+        expect(planned.valid).toBe(true);
+        expect(planned.surfaces.map(surface => surface.status)).toEqual(['insert', 'insert', 'insert', 'insert']);
+    });
+
+    test('an existing resident (@neo-fable) reports EXISTS on all four REAL surfaces — no duplicates possible', () => {
+        const planned = planOnboardingSurfaces(buildPlan({handle: '@neo-fable'}), readRealFiles());
+
+        expect(planned.valid).toBe(true);
+        expect(planned.surfaces.map(surface => surface.status)).toEqual(['exists', 'exists', 'exists', 'exists']);
+    });
+
+    test('the applied REAL roster output is valid JavaScript and lands the Layer-1 entry (data-URL import)', async () => {
+        const plan   = buildPlan();
+        const result = planRosterSurface(readRealFiles().identityRoots, plan);
+
+        expect(result.status).toBe('insert');
+
+        const module_ = await import('data:text/javascript;base64,' + Buffer.from(result.updated, 'utf8').toString('base64'));
+        const entry   = module_.IDENTITIES.find(node => node.id === '@neo-unit-probe');
+
+        expect(entry).toBeTruthy();
+        expect(entry.type).toBe('AgentIdentity');
+        expect(entry.name).toBe('Neo Unit Probe');
+        expect(entry.properties.githubLogin).toBe('@neo-unit-probe');
+        expect(entry.properties.trustTier).toBe('peer-trusted');
+        expect(entry.properties.participationStatus).toBe('temporarily_unreachable');
+        expect(entry.properties.since).toBe(FIXED_NOW);
+
+        // the emitted entry carries NO engine facts and NO wake template
+        for (const forbidden of ['contextWindowInput', 'pricingInput', 'pricingOutput', 'thoughtBudget', 'releaseDate', 'subscriptionTemplate', 'modelAssignment']) {
+            expect(entry.properties, `applied entry must not carry '${forbidden}'`).not.toHaveProperty(forbidden);
+        }
+
+        // the sentinel stays the roster tail; the resident sits directly before it
+        const ids = module_.IDENTITIES.map(node => node.id);
+
+        expect(ids.indexOf('@neo-unit-probe')).toBe(ids.indexOf('AGENT:*') - 1);
+    });
+});
+
+test.describe('generateRosterOnboarding — CLI contract + write guard', () => {
+
+    test('the write guard refuses integration branches, detached HEAD, and unresolvable branches', () => {
+        expect(checkWriteGuard({branch: 'dev'}).valid).toBe(false);
+        expect(checkWriteGuard({branch: 'main'}).valid).toBe(false);
+        expect(checkWriteGuard({branch: 'HEAD'}).valid).toBe(false);
+        expect(checkWriteGuard({branch: null}).valid).toBe(false);
+        expect(checkWriteGuard({branch: ''}).valid).toBe(false);
+        expect(checkWriteGuard({}).valid).toBe(false);
+
+        const allowed = checkWriteGuard({branch: 'agent/14916-roster-onboarding-generator'});
+
+        expect(allowed).toEqual({valid: true, reason: null});
+    });
+
+    test('engine-class and socialName-class flags refuse loudly; unknown flags refuse; the valid surface parses', () => {
+        const engine = parseGenerateArgs(['--handle', '@neo-x', '--family', 'claude', '--model', 'some-engine-5']);
+
+        expect(engine.valid).toBe(false);
+        expect(engine.reason).toContain('observation-owned');
+
+        const designation = parseGenerateArgs(['--designation', 'some-engine-5']);
+
+        expect(designation.valid).toBe(false);
+
+        const social = parseGenerateArgs(['--handle', '@neo-x', '--family', 'claude', '--social-name', 'Muse']);
+
+        expect(social.valid).toBe(false);
+        expect(social.reason).toContain('naming ritual');
+
+        const unknown = parseGenerateArgs(['--frobnicate', 'x']);
+
+        expect(unknown.valid).toBe(false);
+
+        const missingValue = parseGenerateArgs(['--handle']);
+
+        expect(missingValue.valid).toBe(false);
+
+        const parsed = parseGenerateArgs(['--handle', '@neo-x', '--family', 'claude', '--github-username', '@neo-x-gh', '--mailbox', '@neo-x-mail', '--write']);
+
+        expect(parsed.valid).toBe(true);
+        expect(parsed.options).toEqual({
+            family        : 'claude',
+            githubUsername: '@neo-x-gh',
+            handle        : '@neo-x',
+            help          : false,
+            mailbox       : '@neo-x-mail',
+            write         : true
+        });
+    });
+});


### PR DESCRIPTION
Resolves #14916

The R3b leaf of the peer-onboarding rail: a generator that derives the FOUR committed-file surfaces a new resident's onboarding PR must touch, as a reviewable payload — from the LIVE files, never from memory or a template frozen in prose:

1. `ai/graph/identityRoots.mjs` — the IDENTITIES roster entry, mirroring the file's CURRENT field shape exactly (the entry carries NO engine/designation field: engine truth is observation-owned and lives in the era layer, not the roster — the generator's input surface rejects the whole engine-class key family loudly, same idiom as the Day-0 sibling).
2. `README.md` — the maintainer roster table row.
3. `learn/agentos/ModelStats.md` — a capability-section SKELETON with source-citation placeholders; capability FACTS are never invented at generation time.
4. `test/playwright/unit/ai/graph/identityRoots.spec.mjs` — the roster pin.

**Dry-run by default; `--write` is branch-guarded**: the default run prints the four proposed modifications with insertion anchors and touches nothing; `--write` applies them only on a non-`dev`/non-`main` branch (refuses otherwise — committed-file writes ride branch+PR, never a default line). **Idempotent per surface**: an already-present resident reports EXISTS and emits no duplicate, so a partially-applied payload completes on re-run. Social-name-class inputs are rejected with the post-boot ritual pointer (seed data must never pre-assign names).

Evidence: L1 (pure planner + per-surface emitter matrix; 21 tests incl. engine-class and social-class rejection, EXISTS idempotency per surface, branch-guard refusal, live-shape derivation) → L1 required (generator emits proposals; the applying PR is where the artifacts get reviewed).

## Deltas from ticket

- The ticket's original surface list predated the removal of the roster's designation field from dev; the generator is built against the live four-surface reality (peer-confirmed on-ticket by @neo-opus-vega: rotation surface sets re-derived from the merged diff).
- Salvage provenance: authored by a background build that was terminated pre-commit; salvaged, premise-verified (live-file derivation, four surfaces, engine-class rejection), tested green, and shipped unchanged except mechanical block-alignment.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/setup/generateRosterOnboarding.spec.mjs --workers=1` → **21 passed** at this head.
- `node --check` green on both files; pre-commit gates green (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation

- [ ] Dry-run against the live checkout renders all four proposals for a hypothetical resident with zero writes
- [ ] The first real sibling onboarding (the rail's own thesis) applies a generated payload on a feature branch and the roster spec pin passes

## Commits

- f978bdbb9 — the full leaf: generator + spec.

Related: parent #13015 · Day-0 sibling #14915 (PR #14931) · launch sibling #14914 (PR #14918) · capstone runbook #14937 (prints this generator's invocation).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b956ba53-01ed-4ea6-a1e5-62969f887bc3.
