### PR TITLE
feat(agentos): render Fleet source health honestly (#14643)

### DIFF
--- a/apps/agentos/model/FleetAgent.mjs
+++ b/apps/agentos/model/FleetAgent.mjs
@@ -7,10 +7,10 @@ import Model from '../../../src/data/Model.mjs';
  * @summary The cockpit fleet-roster record contract: one row per resident, keyed by the durable
  * `agentId`. The `fields` array IS the card's data contract — display state (`displayName`,
  * `avatarUrl`, `engineTag`, `family`, `laneLine`), session `state` (what the resident is doing
- * now, never identity), and the B4/C2 lifecycle-control seam (`pendingAction`, `controlReason`)
- * all live on the record, so one Store of these records is the per-row reactive layer for the
- * whole fleet view. Sibling of {@link AgentOS.model.AgentDefinition} (the credential-side
- * definition shape); this model carries no credential field by design.
+ * now, never identity), per-source `sources` provenance, and the B4/C2 lifecycle-control seam
+ * (`pendingAction`, `controlReason`) all live on the record, so one Store of these records is the
+ * per-row reactive layer for the whole fleet view. Sibling of {@link AgentOS.model.AgentDefinition}
+ * (the credential-side definition shape); this model carries no credential field by design.
  */
 class FleetAgent extends Model {
     static config = {
@@ -64,6 +64,13 @@ class FleetAgent extends Model {
             name        : 'state',
             type        : 'String',
             defaultValue: 'off'
+        }, {
+            // normalized `fleetCockpitStatus.rows[*].sources`: roster / repoStatus / runtime
+            // provenance. Replaced as one Object on each snapshot so Store recordChange remains
+            // the single reactive path; no nested per-card state layer.
+            name        : 'sources',
+            type        : 'Object',
+            defaultValue: null
         }]
     }
 }

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -1,14 +1,16 @@
-import AgentCardController from './AgentCardController.mjs';
-import Button              from '../../../../src/button/Base.mjs';
-import Container           from '../../../../src/container/Base.mjs';
-import FamilyRail          from './FamilyRail.mjs';
-import Image               from '../../../../src/component/Image.mjs';
-import StateDot            from './StateDot.mjs';
+import AgentCardController     from './AgentCardController.mjs';
+import Button                  from '../../../../src/button/Base.mjs';
+import Container               from '../../../../src/container/Base.mjs';
+import FamilyRail              from './FamilyRail.mjs';
+import Image                   from '../../../../src/component/Image.mjs';
+import SourceHealthMarker      from './SourceHealthMarker.mjs';
+import StateDot                from './StateDot.mjs';
+import {normalizeFleetSources} from './sourceHealth.mjs';
 
 /**
  * The resident card: the cockpit's atom. Composes the class-based fleet primitives (FamilyRail +
- * StateDot) with a profile avatar, name, engine tag, and current-lane line into the SSOT card
- * anatomy.
+ * StateDot + SourceHealthMarker) with a profile avatar, name, engine tag, and current-lane line
+ * into the SSOT card anatomy.
  *
  * **Data-driven from its `record`** — one {@link AgentOS.model.FleetAgent} record (a row of the
  * shared {@link AgentOS.store.FleetRoster} Store) is the card's single data surface; there is no
@@ -57,17 +59,20 @@ class AgentCard extends Container {
         /**
          * The card's data surface: an {@link AgentOS.model.FleetAgent} record (store-backed, live)
          * or a plain field bag with the same keys (dock-blueprint snapshot). `agentId` is the
-         * DURABLE identity; every other field is display state over it. `pendingAction` +
-         * `controlReason` are the B4/C2 control seam the C2 adapter writes via `record.set()`.
+         * DURABLE identity; every other field is display state over it. `sources` carries the
+         * roster / repository / runtime provenance that gates honest session rendering;
+         * `pendingAction` + `controlReason` are the B4/C2 control seam the C2 adapter writes via
+         * `record.set()`.
          * @member {Object|null} record_=null
          * @reactive
          */
         record_: null,
         /**
          * The card anatomy — family rail · avatar · body (name-row [state dot + name + engine tag] +
-         * current-lane line) · controls slot (start/stop/restart → a single `lifecycleIntent` event
-         * for the Lane C round-trip). Each child is a referenced, in-place-updated surface fed from
-         * the record by {@link #applyRecord}; foot meta is a sibling leaf.
+         * current-lane line + per-source health markers) · controls slot (start/stop/restart → a
+         * single `lifecycleIntent` event for the Lane C round-trip). Each child is a referenced,
+         * in-place-updated surface fed from the record by {@link #applyRecord}; foot meta is a sibling
+         * leaf.
          * @member {Object[]} items
          */
         items: [{
@@ -109,6 +114,28 @@ class AgentCard extends Container {
                 ntype    : 'component',
                 cls      : ['fm-card-lane'],
                 reference: 'card-lane'
+            }, {
+                ntype    : 'container',
+                cls      : ['fm-card-source-health'],
+                reference: 'source-health',
+                role     : 'group',
+                vdom     : {'aria-label': 'Source health'},
+                layout   : {ntype: 'hbox', align: 'center'},
+                // Runtime comes first: at constrained card widths the action-owning source must
+                // remain the first visible / wrapped fact.
+                items    : [{
+                    module   : SourceHealthMarker,
+                    reference: 'source-runtime',
+                    sourceKey: 'runtime'
+                }, {
+                    module   : SourceHealthMarker,
+                    reference: 'source-roster',
+                    sourceKey: 'roster'
+                }, {
+                    module   : SourceHealthMarker,
+                    reference: 'source-repo-status',
+                    sourceKey: 'repoStatus'
+                }]
             }]
         }, {
             ntype : 'container',
@@ -174,9 +201,10 @@ class AgentCard extends Container {
      * @summary Render the record onto the card's referenced children, in place.
      *
      * The one read-side consumer of the record contract: display fields land on the rail / avatar /
-     * name-row / lane surfaces, and the B4/C2 control seam renders the honest round-trip matrix —
-     * the card RENDERS what Lane-C writes, never fakes success, and each terminal kind renders
-     * DISTINCTLY:
+     * name-row / lane surfaces. Source facts are normalized once, update the three reusable markers,
+     * and gate the state dot so missing runtime evidence cannot render as live. The B4/C2 control
+     * seam renders the honest round-trip matrix — the card RENDERS what Lane-C writes, never fakes
+     * success, and each terminal kind renders DISTINCTLY:
      *   unauthorized → the reason shows AND the control cluster stays disabled — you cannot retry
      *                  into a closed door;
      *   timeout      → stale-pending: the outcome is UNKNOWN (the verb may still be running, we
@@ -195,14 +223,29 @@ class AgentCard extends Container {
         const
             controlReason = record.controlReason ?? null,
             pendingAction = record.pendingAction ?? null,
-            state         = record.state ?? 'off',
-            disabled      = Boolean(pendingAction) || controlReason?.kind === 'unauthorized';
+            sources       = normalizeFleetSources(record.sources),
+            runtime       = sources.runtime,
+            sourceUsable  = runtime.state === 'wired',
+            recordState   = record.state ?? 'off',
+            displayState  = sourceUsable ? recordState : 'off',
+            sourceReason  = sourceUsable
+                ? null
+                : runtime.state === 'missing'
+                    ? 'MISSING'
+                    : 'NOT WIRED',
+            disabled      = Boolean(pendingAction) || Boolean(sourceReason) || controlReason?.kind === 'unauthorized';
 
         me.getReference('family-rail').family = record.family ?? null;
-        me.getReference('state-dot').state    = state;
-        me.getReference('card-name').text     = record.displayName ?? '';
-        me.getReference('card-engine').text   = record.engineTag ?? '';
-        me.getReference('card-lane').text     = record.laneLine ?? '';
+        me.getReference('state-dot').set({
+            live : displayState === 'ok' && runtime.confidence === 'observed',
+            state: displayState
+        });
+        me.getReference('card-name').text          = record.displayName ?? '';
+        me.getReference('card-engine').text        = record.engineTag ?? '';
+        me.getReference('card-lane').text          = record.laneLine ?? '';
+        me.getReference('source-roster').health    = sources.roster;
+        me.getReference('source-repo-status').health = sources.repoStatus;
+        me.getReference('source-runtime').health   = runtime;
 
         me.getReference('card-avatar').set({
             alt: record.displayName ?? '',
@@ -211,22 +254,22 @@ class AgentCard extends Container {
 
         me.getReference('control-toggle').set({
             disabled,
-            iconCls: state === 'off' ? 'fa-solid fa-play' : 'fa-solid fa-stop'
+            iconCls: recordState === 'off' ? 'fa-solid fa-play' : 'fa-solid fa-stop'
         });
 
         me.getReference('control-restart').set({
             disabled,
-            hidden: state === 'off'
+            hidden: recordState === 'off'
         });
 
         me.getReference('control-status').set({
-            hidden: !pendingAction && !controlReason,
+            hidden: !pendingAction && !controlReason && !sourceReason,
             // pending takes visual priority over a prior reason, so a new attempt never shows a
             // stale rejection (complements C2 clearing controlReason on a new accepted intent)
             text  : pendingAction
                 ? `${pendingAction}…`
                 : !controlReason
-                    ? ''
+                    ? sourceReason ?? ''
                     : controlReason.kind === 'timeout'
                         ? `${controlReason.action}… stale — no response`
                         : `⚠ ${controlReason.kind}: ${controlReason.reason}`

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1,10 +1,11 @@
-import ActivityStream         from './ActivityStream.mjs';
-import Button                 from '../../../../src/button/Base.mjs';
-import Container              from '../../../../src/container/Base.mjs';
-import FleetCockpitController from './FleetCockpitController.mjs';
-import FleetGrid              from './FleetGrid.mjs';
-import FleetRoster            from '../../store/FleetRoster.mjs';
-import StateProvider          from '../../../../src/state/Provider.mjs';
+import ActivityStream          from './ActivityStream.mjs';
+import Button                  from '../../../../src/button/Base.mjs';
+import Container               from '../../../../src/container/Base.mjs';
+import FleetCockpitController  from './FleetCockpitController.mjs';
+import FleetGrid               from './FleetGrid.mjs';
+import FleetRoster             from '../../store/FleetRoster.mjs';
+import StateProvider           from '../../../../src/state/Provider.mjs';
+import {mapFleetSessionHealth} from './sourceHealth.mjs';
 
 /**
  * Recent fleet activity for the fixture-fed stream — the live A2A / PR / lane adapters
@@ -281,21 +282,25 @@ class FleetCockpit extends Container {
      * @summary Map one assembler DTO row onto the FleetAgent record contract. The durable `id`
      * becomes `agentId`; identity display facts (`family` / `engineTag`) flow through (null =
      * unclassified / tagless, never guessed); the runtime `lifecycle.state` maps onto the cockpit's
-     * session-state vocabulary — `running` → `ok`, anything else (`stopped` / `not-wired` /
-     * unknown liveness) → `off`, honestly benched until the richer watchdog states land. `laneLine`
-     * is deliberately OMITTED (not nulled): the activity capability owns it, and a merge must never
-     * wipe what another producer wrote.
+     * session-state vocabulary only when `sources.runtime` is usable; missing / not-wired /
+     * malformed source truth forces `off`, so placeholder can never render as fact. The normalized
+     * three-source object remains on the record for the card markers. `laneLine` is deliberately
+     * OMITTED (not nulled): the activity capability owns it, and a merge must never wipe what another
+     * producer wrote.
      * @param {Object} row One cockpit DTO row (`fleetCockpitStatus` shape).
      * @returns {Object} FleetAgent record field values.
      */
     mapRosterRow(row) {
+        const sessionHealth = mapFleetSessionHealth(row.lifecycle, row.sources);
+
         return {
             agentId    : row.id,
             avatarUrl  : row.avatarUrl ?? null,
             displayName: row.displayName ?? null,
             engineTag  : row.engineTag ?? null,
             family     : row.family ?? null,
-            state      : row.lifecycle?.state === 'running' ? 'ok' : 'off'
+            sources    : sessionHealth.sources,
+            state      : sessionHealth.state
         }
     }
 

--- a/apps/agentos/view/fleet/SourceHealthMarker.mjs
+++ b/apps/agentos/view/fleet/SourceHealthMarker.mjs
@@ -108,7 +108,8 @@ class SourceHealthMarker extends Component {
     }
 
     /**
-     * @summary Swap the closed state/confidence classes and accessible label in place.
+     * @summary Atomically swap the closed state/confidence classes plus visible text, then update
+     * the accessible label in place.
      * @protected
      */
     applyHealth() {
@@ -120,8 +121,10 @@ class SourceHealthMarker extends Component {
         NeoArray.add(cls, view.stateClass);
         NeoArray.add(cls, view.confidenceClass);
 
-        this.cls  = cls;
-        this.text = view.text;
+        this.set({
+            cls,
+            text: view.text
+        });
         this.changeVdomRootKey('aria-label', view.ariaLabel)
     }
 }

--- a/apps/agentos/view/fleet/SourceHealthMarker.mjs
+++ b/apps/agentos/view/fleet/SourceHealthMarker.mjs
@@ -1,0 +1,129 @@
+import Component                  from '../../../../src/component/Base.mjs';
+import NeoArray                   from '../../../../src/util/Array.mjs';
+import {normalizeFleetSourceFact} from './sourceHealth.mjs';
+
+const SOURCE_LABELS = Object.freeze({
+    roster    : {long: 'Roster',     short: 'ROS'},
+    repoStatus: {long: 'Repository', short: 'REP'},
+    runtime   : {long: 'Runtime',    short: 'RUN'}
+});
+
+const
+    SOURCE_STATE_CLASSES      = Object.freeze(['fm-source-wired', 'fm-source-missing', 'fm-source-not-wired']),
+    SOURCE_CONFIDENCE_CLASSES = Object.freeze(['fm-confidence-observed', 'fm-confidence-inferred', 'fm-confidence-none']);
+
+/**
+ * @summary Resolve one source fact into its visible and accessible marker treatment. Both state and
+ * confidence remain explicit; normalization ensures no malformed combination can look healthy.
+ * @param {String} sourceKey `roster` · `repoStatus` · `runtime`
+ * @param {*} health Source-health input; malformed values fail closed.
+ * @returns {{state: String, confidence: String, stateClass: String, confidenceClass: String,
+ * text: String, ariaLabel: String}}
+ */
+export function sourceMarkerView(sourceKey, health) {
+    const
+        label      = Object.hasOwn(SOURCE_LABELS, sourceKey) ? SOURCE_LABELS[sourceKey] : {long: 'Unknown', short: 'SRC'},
+        normalized = normalizeFleetSourceFact(sourceKey, health),
+        treatment  = normalized.state === 'wired'
+            ? normalized.confidence.toUpperCase()
+            : normalized.state === 'missing'
+                ? 'MISSING'
+                : 'NOT WIRED';
+
+    return {
+        ...normalized,
+        stateClass     : `fm-source-${normalized.state}`,
+        confidenceClass: `fm-confidence-${normalized.confidence}`,
+        text           : `${label.short} ${treatment}`,
+        ariaLabel      : `${label.long} source: ${normalized.state.replace('-', ' ')}, confidence ${normalized.confidence}.`
+    }
+}
+
+/**
+ * @summary Reusable card-grain source-health marker. Visible text, geometry, and ARIA expose the
+ * source state plus confidence without color-only meaning; all color bindings remain token classes.
+ * @class AgentOS.view.fleet.SourceHealthMarker
+ * @extends Neo.component.Base
+ */
+class SourceHealthMarker extends Component {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.SourceHealthMarker'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.SourceHealthMarker',
+        /**
+         * @member {String} ntype='fm-source-health-marker'
+         * @protected
+         */
+        ntype: 'fm-source-health-marker',
+        /**
+         * @member {String[]} baseCls=['fm-source-health-marker']
+         */
+        baseCls: ['fm-source-health-marker'],
+        /**
+         * @member {String} role='img'
+         * @reactive
+         */
+        role: 'img',
+        /**
+         * @member {String} sourceKey_='runtime'
+         * @reactive
+         */
+        sourceKey_: 'runtime',
+        /**
+         * @member {Object|null} health_=null
+         * @reactive
+         */
+        health_: null
+    }
+
+    /**
+     * @summary Apply the initial marker once its VDOM exists.
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+        this.applyHealth()
+    }
+
+    /**
+     * @summary Re-render the marker when its source-health fact changes.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetHealth(value, oldValue) {
+        this.isConstructed && this.applyHealth()
+    }
+
+    /**
+     * @summary Re-render the marker when it is rebound to another Fleet source axis.
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetSourceKey(value, oldValue) {
+        this.isConstructed && this.applyHealth()
+    }
+
+    /**
+     * @summary Swap the closed state/confidence classes and accessible label in place.
+     * @protected
+     */
+    applyHealth() {
+        const
+            view = sourceMarkerView(this.sourceKey, this.health),
+            cls  = this.cls;
+
+        [...SOURCE_STATE_CLASSES, ...SOURCE_CONFIDENCE_CLASSES].forEach(name => NeoArray.remove(cls, name));
+        NeoArray.add(cls, view.stateClass);
+        NeoArray.add(cls, view.confidenceClass);
+
+        this.cls  = cls;
+        this.text = view.text;
+        this.changeVdomRootKey('aria-label', view.ariaLabel)
+    }
+}
+
+export default Neo.setupClass(SourceHealthMarker);

--- a/apps/agentos/view/fleet/fleetCardFactory.mjs
+++ b/apps/agentos/view/fleet/fleetCardFactory.mjs
@@ -1,3 +1,5 @@
+import {mapFleetSessionHealth} from './sourceHealth.mjs';
+
 /**
  * @summary Fleet card-factory — transforms the Body-side fleet-cockpit DTO into per-card descriptors
  * for the workspace dock. This is the UPSTREAM half of the card-wall seam: it registers a stable
@@ -36,12 +38,15 @@ export function agentCardComponentRef(agentId) {
  * {@link AgentOS.model.FleetAgent} field shape the store-backed cards render from, as a plain
  * snapshot), agent-card policy hints, and JSON identity metadata. Field mapping is null-safe and
  * forward-compatible — `engineTag`, `family`, and `laneLine` map through as `null` until the DTO
- * enrichment + activity/runtime wires land, with no change needed here.
+ * enrichment + activity/runtime wires land, with no change needed here. Source-health mapping is
+ * shared with the Store-backed cockpit path so dock restore cannot silently regain placeholder-as-fact.
  * @param {Object} row=({}) A fleet-cockpit DTO row.
  * @returns {Object} `{componentRef, blueprint, policy, metadata}`
  */
 export function toAgentCardDescriptor(row = {}) {
-    const agentId = row.id ?? null;
+    const
+        agentId       = row.id ?? null,
+        sessionHealth = mapFleetSessionHealth(row.lifecycle, row.sources);
 
     return {
         componentRef: agentCardComponentRef(agentId),
@@ -54,7 +59,8 @@ export function toAgentCardDescriptor(row = {}) {
                 engineTag  : row.engineTag ?? null,
                 family     : row.family ?? null,
                 laneLine   : row.laneLine ?? null,
-                state      : row.lifecycle?.state ?? 'off'
+                sources    : sessionHealth.sources,
+                state      : sessionHealth.state
             }
         },
         policy  : {...AGENT_CARD_POLICY},

--- a/apps/agentos/view/fleet/sourceHealth.mjs
+++ b/apps/agentos/view/fleet/sourceHealth.mjs
@@ -1,0 +1,164 @@
+import {FLEET_COCKPIT_SOURCES} from '../../../../src/ai/fleet/fleetCockpitStatus.mjs';
+
+/**
+ * @summary Closed source-health contract shared by the Fleet cockpit's store-backed cards and
+ * serializable dock blueprints. It preserves the DTO's roster / repo / runtime provenance while
+ * failing malformed or contradictory input to `not-wired` + `none` — never to healthy fact.
+ */
+
+export const FLEET_SOURCE_KEYS = Object.freeze(['roster', 'repoStatus', 'runtime']);
+
+const
+    CARD_STATES         = Object.freeze(['ok', 'idle', 'wedged', 'limited', 'off']),
+    FLEET_SOURCE_BY_KEY = Object.freeze({
+        roster    : FLEET_COCKPIT_SOURCES.roster,
+        repoStatus: FLEET_COCKPIT_SOURCES.repoStatus,
+        runtime   : FLEET_COCKPIT_SOURCES.runtime
+    });
+
+/**
+ * @summary Normalize one `fleetCockpitStatus` row-source fact onto the closed render vocabulary.
+ * `missing` and `not-wired` cannot carry confidence; `wired` is usable only with `observed` or
+ * `inferred`. When supplied, `expectedSource` closes the fact over its DTO-owned producer. Unknown,
+ * inherited, malformed, cross-axis, and contradictory values fail closed.
+ * @param {*} value Source-health input; malformed values fail closed.
+ * @param {String|null} expectedSource Canonical producer literal for this source axis.
+ * @returns {{source: String|null, state: String, confidence: String}}
+ */
+export function normalizeSourceFact(value, expectedSource = null) {
+    if (!isPlainObject(value)) {
+        return {source: null, state: 'not-wired', confidence: 'none'}
+    }
+
+    const
+        source     = Object.hasOwn(value, 'source') && typeof value.source === 'string' && value.source.trim()
+            ? value.source.trim()
+            : null,
+        state      = Object.hasOwn(value, 'state') ? value.state : null,
+        confidence = Object.hasOwn(value, 'confidence') ? value.confidence : null;
+
+    if (!source || expectedSource && source !== expectedSource) {
+        return {source, state: 'not-wired', confidence: 'none'}
+    }
+
+    if (state === 'missing') {
+        return {source, state: 'missing', confidence: 'none'}
+    }
+
+    if (state === 'wired' && (confidence === 'observed' || confidence === 'inferred')) {
+        return {source, state: 'wired', confidence}
+    }
+
+    return {source, state: 'not-wired', confidence: 'none'}
+}
+
+/**
+ * @summary Normalize one named Fleet source axis against its exact DTO producer. Unknown axes fail
+ * closed rather than inheriting the generic source-fact behavior.
+ * @param {String} sourceKey `roster` · `repoStatus` · `runtime`
+ * @param {*} value Source-health input; malformed values fail closed.
+ * @returns {{source: String|null, state: String, confidence: String}}
+ */
+export function normalizeFleetSourceFact(sourceKey, value) {
+    return Object.hasOwn(FLEET_SOURCE_BY_KEY, sourceKey)
+        ? normalizeSourceFact(value, FLEET_SOURCE_BY_KEY[sourceKey])
+        : normalizeSourceFact(null)
+}
+
+/**
+ * @summary Normalize the three per-row Fleet source facts. Extra future keys are ignored so this
+ * card-grain contract can evolve independently from broader cockpit DTO capabilities.
+ * @param {*} value Source collection; malformed values fail closed.
+ * @returns {{roster: Object, repoStatus: Object, runtime: Object}}
+ */
+export function normalizeFleetSources(value) {
+    const input = isPlainObject(value) ? value : {};
+
+    return Object.fromEntries(FLEET_SOURCE_KEYS.map(key => [
+        key,
+        normalizeFleetSourceFact(key, Object.hasOwn(input, key) ? input[key] : null)
+    ]))
+}
+
+/**
+ * @summary Normalize one DTO row's source facts and session state as one atomic honesty contract. A
+ * lifecycle/runtime mismatch downgrades runtime provenance to `not-wired` + `none`, so downstream
+ * cards cannot show `RUN OBSERVED` or enable controls while the lifecycle fact itself is unusable.
+ * A matching stopped lifecycle remains a wired, honestly off session.
+ * @param {*} lifecycle Lifecycle input; malformed values fail closed.
+ * @param {*} sources Source collection; malformed values fail closed.
+ * @returns {{sources: Object, state: String}}
+ */
+export function mapFleetSessionHealth(lifecycle, sources) {
+    const
+        normalizedSources = normalizeFleetSources(sources),
+        runtime           = normalizedSources.runtime,
+        downgradeRuntime  = () => ({
+            sources: {
+                ...normalizedSources,
+                runtime: {source: runtime.source, state: 'not-wired', confidence: 'none'}
+            },
+            state: 'off'
+        });
+
+    if (runtime.state !== 'wired') {
+        return {sources: normalizedSources, state: 'off'}
+    }
+
+    if (!isPlainObject(lifecycle)) {
+        return downgradeRuntime()
+    }
+
+    const
+        lifecycleSource = Object.hasOwn(lifecycle, 'source') && typeof lifecycle.source === 'string'
+            ? lifecycle.source.trim()
+            : null,
+        state               = Object.hasOwn(lifecycle, 'state') ? lifecycle.state : null,
+        lifecycleConfidence = Object.hasOwn(lifecycle, 'confidence') ? lifecycle.confidence : null;
+
+    if (!lifecycleSource || lifecycleSource !== runtime.source || lifecycleConfidence !== runtime.confidence) {
+        return downgradeRuntime()
+    }
+
+    if (state === 'running') {
+        return {sources: normalizedSources, state: 'ok'}
+    }
+
+    if (state === 'stopped') {
+        return {sources: normalizedSources, state: 'off'}
+    }
+
+    if (!CARD_STATES.includes(state)) {
+        return downgradeRuntime()
+    }
+
+    return {sources: normalizedSources, state}
+}
+
+/**
+ * @summary Return only the session-state field from {@link mapFleetSessionHealth} for consumers
+ * that do not persist the normalized source collection.
+ * @param {*} lifecycle Lifecycle input; malformed values fail closed.
+ * @param {*} sources Source collection; malformed values fail closed.
+ * @returns {String} `ok` · `idle` · `wedged` · `limited` · `off`
+ */
+export function mapFleetSessionState(lifecycle, sources) {
+    return mapFleetSessionHealth(lifecycle, sources).state
+}
+
+/**
+ * @summary Return true only for own-key JSON-style objects; reject arrays, class instances, and
+ * inherited/prototype-shaped input before it reaches the source-health contract.
+ * @param {*} value
+ * @returns {Boolean}
+ * @private
+ */
+function isPlainObject(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return false
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+
+    return prototype === Object.prototype || prototype === null
+}

--- a/resources/scss/src/apps/agentos/fleet/AgentCard.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentCard.scss
@@ -47,6 +47,14 @@
         text-overflow: ellipsis;
     }
 
+    .fm-card-source-health {
+        flex-wrap : wrap;
+        gap       : 4px 7px;
+        min-width : 0;
+        overflow  : visible;
+        padding-top: 2px;
+    }
+
     .fm-card-controls {
         flex: none;
         gap : 2px;

--- a/resources/scss/src/apps/agentos/fleet/SourceHealthMarker.scss
+++ b/resources/scss/src/apps/agentos/fleet/SourceHealthMarker.scss
@@ -1,0 +1,48 @@
+/* Per-source provenance marker. State + confidence remain visible in text and geometry; color is
+   supplemental and token-only. Source health is not session health, so wired never borrows the
+   green --fm-state-ok token. */
+.fm-source-health-marker {
+    --fm-source-mark: var(--fm-state-off);
+
+    display    : inline-flex;
+    align-items: center;
+    flex       : none;
+    min-width  : 0;
+    color      : var(--fm-ink-dim);
+    font-family: var(--fm-font-mono);
+    font-size  : 9px;
+    line-height: 1;
+    white-space: nowrap;
+
+    &::before {
+        content      : '';
+        width        : 6px;
+        height       : 6px;
+        margin-right : 2px;
+        flex         : none;
+        border       : 1px solid var(--fm-source-mark);
+        border-radius: 50%;
+        box-sizing   : border-box;
+    }
+
+    &.fm-source-wired {
+        --fm-source-mark: var(--fm-ink-dim);
+    }
+
+    &.fm-source-wired.fm-confidence-observed::before {
+        background: var(--fm-source-mark);
+    }
+
+    &.fm-source-wired.fm-confidence-inferred::before {
+        background: linear-gradient(90deg, var(--fm-source-mark) 50%, transparent 50%);
+    }
+
+    &.fm-source-missing::before {
+        border-style : dashed;
+        border-radius: 1px;
+    }
+
+    &.fm-source-not-wired::before {
+        background: linear-gradient(135deg, transparent 42%, var(--fm-source-mark) 43%, var(--fm-source-mark) 57%, transparent 58%);
+    }
+}

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -20,12 +20,19 @@ import Instance       from '../../../../../../../src/manager/Instance.mjs';
 test.describe('Fleet cockpit AgentCard — resident card rendering its roster record (#14755)', () => {
     let AgentCard, FleetAgent, Store;
 
-    const stores = [];
+    const
+        stores          = [],
+        observedSources = {
+            roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
+            repoStatus: {source: 'fleet:fleetStatus',   state: 'wired', confidence: 'observed'},
+            runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
+        };
 
     // a real store-backed record — the production shape (an AgentOS.store.FleetRoster row). The
     // store mirrors FleetRoster's keyProperty (the collection default 'id' would shadow the model's).
     const makeRecord = data => {
-        const store = Neo.create(Store, {keyProperty: 'agentId', model: FleetAgent, data: [data]});
+        const row   = {...data, sources: data.sources === undefined ? observedSources : data.sources},
+              store = Neo.create(Store, {keyProperty: 'agentId', model: FleetAgent, data: [row]});
 
         stores.push(store);
 
@@ -72,10 +79,52 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
     });
 
     test('a plain field-bag record renders the same snapshot — the dock-blueprint restore shape', () => {
-        const card = Neo.create(AgentCard, {appName, record: {agentId: 'ghost', displayName: 'Ghost', state: 'ok'}});
+        const card = Neo.create(AgentCard, {appName, record: {agentId: 'ghost', displayName: 'Ghost', sources: observedSources, state: 'ok'}});
 
         expect(card.down({reference: 'card-name'}).text).toBe('Ghost');
         expect(card.down({ntype: 'fm-state-dot'}).state).toBe('ok');
+
+        card.destroy()
+    });
+
+    test('source markers update in place; absent runtime fails the state dot closed and never pulses', () => {
+        const card     = createCard({agentId: 'vega', state: 'ok'}),
+              beforeId = card.id,
+              runtime  = card.down({reference: 'source-runtime'}),
+              markerId = runtime.id,
+              stateDot = card.down({ntype: 'fm-state-dot'});
+
+        expect(runtime.text).toBe('RUN OBSERVED');
+        expect(stateDot.state).toBe('ok');
+        expect(stateDot.live).toBe(true);
+
+        applySet(card, {sources: {
+            roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
+            repoStatus: {source: 'fleet:fleetStatus',   state: 'missing', confidence: 'none'},
+            runtime   : {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}
+        }});
+
+        expect(card.id).toBe(beforeId);
+        expect(card.down({reference: 'source-runtime'}).id).toBe(markerId);
+        expect(runtime.text).toBe('RUN NOT WIRED');
+        expect(card.down({reference: 'source-repo-status'}).text).toBe('REP MISSING');
+        expect(stateDot.state).toBe('off');
+        expect(stateDot.live).toBe(false);
+        expect(card.down({reference: 'control-toggle'}).iconCls).toBe('fa-solid fa-stop');
+        expect(card.down({reference: 'control-toggle'}).disabled).toBe(true);
+        expect(card.down({reference: 'control-restart'}).hidden).toBe(false);
+        expect(card.down({reference: 'control-restart'}).disabled).toBe(true);
+        expect(card.down({reference: 'control-status'}).text).toBe('NOT WIRED');
+
+        applySet(card, {sources: {
+            ...observedSources,
+            runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'inferred'}
+        }});
+        expect(runtime.text).toBe('RUN INFERRED');
+        expect(stateDot.state).toBe('ok');
+        expect(stateDot.live).toBe(false);
+        expect(card.down({reference: 'control-toggle'}).disabled).toBe(false);
+        expect(card.down({reference: 'control-status'}).hidden).toBe(true);
 
         card.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
@@ -56,6 +56,11 @@ test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#1479
         expect(card.blueprint.record.displayName).toBe('Vega')
         // the avatar auto-derived through the DTO (from the GitHub account) rides into the blueprint
         expect(card.blueprint.record.avatarUrl).toBe('https://github.com/neo-opus-vega.png?size=80')
+        expect(card.blueprint.record.sources.runtime).toEqual({
+            confidence: 'none',
+            source    : 'fleet:runtimeStatus',
+            state     : 'not-wired'
+        })
 
         // serializable end-to-end — a captured perspective can restore a real card from the blueprint
         expect(() => JSON.stringify(card.blueprint)).not.toThrow()
@@ -85,10 +90,22 @@ test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#1479
         expect(card.metadata.githubUsername).toBeNull()
     })
 
-    test('maps the session state through from the DTO lifecycle axis', () => {
-        const card = toAgentCardDescriptor({id: 'vega', lifecycle: {state: 'ok'}})
+    test('maps the session state through only when runtime source truth is usable', () => {
+        const sources   = {runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}}
+        const lifecycle = {source: 'fleet:runtimeStatus', state: 'running', confidence: 'observed'}
+        const card      = toAgentCardDescriptor({id: 'vega', lifecycle, sources})
 
         expect(card.blueprint.record.state).toBe('ok')
+        expect(card.blueprint.record.sources.runtime).toEqual({source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'})
+
+        const placeholder = toAgentCardDescriptor({id: 'vega', lifecycle: {state: 'running'}})
+        expect(placeholder.blueprint.record.state).toBe('off')
+
+        const contradictory = toAgentCardDescriptor({id: 'vega', sources})
+        expect(contradictory.blueprint.record).toMatchObject({
+            state  : 'off',
+            sources: {runtime: {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}}
+        })
     })
 
     test('createFleetCardDescriptors tolerates a rowless / empty DTO', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -116,6 +116,12 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
 test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
     let FleetAgent, FleetCockpit, FleetRoster;
 
+    const liveSources = (runtimeConfidence = 'observed') => ({
+        roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
+        repoStatus: {source: 'fleet:fleetStatus',   state: 'wired', confidence: 'observed'},
+        runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: runtimeConfidence}
+    });
+
     // scope the mock to the `fleet` subkey ONLY: `globalThis.AgentOS` is the app's Neo NAMESPACE
     // root — replacing or deleting it wipes every `AgentOS.*` class registration for all later
     // spec files in the shared worker (order-dependent cross-file bleed).
@@ -235,7 +241,8 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             avatarUrl  : 'https://github.com/neo-gpt.png?size=80',
             family     : 'gpt',
             engineTag  : 'GPT-5.6 Sol',
-            lifecycle  : {state: 'running', confidence: 'observed'}
+            lifecycle  : {source: 'fleet:runtimeStatus', state: 'running', confidence: 'observed'},
+            sources    : liveSources()
         });
 
         expect(mapped).toEqual({
@@ -244,6 +251,7 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             displayName: 'Neo GPT',
             engineTag  : 'GPT-5.6 Sol',
             family     : 'gpt',
+            sources    : liveSources(),
             state      : 'ok'
         });
 
@@ -251,13 +259,42 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         expect(Object.hasOwn(mapped, 'laneLine')).toBe(false)
     });
 
-    test('mapRosterRow state vocabulary — running → ok; stopped / not-wired / absent liveness → off (benched, never guessed)', () => {
-        const map = lifecycle => FleetCockpit.prototype.mapRosterRow({id: 'x', lifecycle}).state;
+    test('mapRosterRow state vocabulary — running is healthy only behind wired runtime provenance', () => {
+        const map = (state, sources = liveSources(), confidence = 'observed') => FleetCockpit.prototype.mapRosterRow({
+            id       : 'x',
+            lifecycle: {source: 'fleet:runtimeStatus', state, confidence},
+            sources
+        }).state;
 
-        expect(map({state: 'running'})).toBe('ok');
-        expect(map({state: 'stopped'})).toBe('off');
-        expect(map({state: 'not-wired'})).toBe('off');
+        expect(map('running')).toBe('ok');
+        expect(map('stopped')).toBe('off');
+        expect(map('not-wired')).toBe('off');
         expect(map(undefined)).toBe('off');
+        expect(map('running', {runtime: {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}})).toBe('off');
+        expect(map('running', {runtime: {source: 'fleet:runtimeStatus', state: 'missing', confidence: 'none'}})).toBe('off');
+        expect(map('running', {})).toBe('off');
+        expect(map('running', liveSources('inferred'), 'observed')).toBe('off');
+
+        const
+            contradictory = FleetCockpit.prototype.mapRosterRow({
+                id       : 'x',
+                lifecycle: {source: 'fleet:runtimeStatus', state: 'running', confidence: 'inferred'},
+                sources  : liveSources()
+            }),
+            stopped       = FleetCockpit.prototype.mapRosterRow({
+                id       : 'x',
+                lifecycle: {source: 'fleet:runtimeStatus', state: 'stopped', confidence: 'observed'},
+                sources  : liveSources()
+            });
+
+        expect(contradictory).toMatchObject({
+            state  : 'off',
+            sources: {runtime: {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}}
+        });
+        expect(stopped).toMatchObject({
+            state  : 'off',
+            sources: {runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}}
+        });
 
         // un-enriched identity facts flow as nulls (unclassified / tagless)
         const bare = FleetCockpit.prototype.mapRosterRow({id: 'x'});
@@ -267,7 +304,7 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
 
     test('the FIRST non-empty snapshot populates the Store (replaces the sample seed) and goes live — rows without a durable id are dropped', async () => {
         const {cockpit, grid} = await routeLoadRoster({fleetRoster: async () => ({rows: [
-            {id: 'vega', lifecycle: {state: 'running'}},
+            {id: 'vega', lifecycle: {source: 'fleet:runtimeStatus', state: 'running', confidence: 'observed'}, sources: liveSources()},
             {noId: true},
             {id: 'ada', lifecycle: {state: 'stopped'}}
         ]})});
@@ -285,7 +322,7 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
               ghost  = {agentId: 'removed-agent'};
 
         const {grid} = await routeLoadRoster({fleetRoster: async () => ({rows: [
-            {id: 'vega', family: 'claude', lifecycle: {state: 'running'}},
+            {id: 'vega', family: 'claude', lifecycle: {source: 'fleet:runtimeStatus', state: 'running', confidence: 'observed'}, sources: liveSources()},
             {id: 'joiner', lifecycle: {state: 'stopped'}}
         ]})}, {known: {vega}, items: [vega, ghost], rosterWired: true});
 
@@ -296,6 +333,7 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             displayName: null,
             engineTag  : null,
             family     : 'claude',
+            sources    : liveSources(),
             state      : 'ok'
         }]);
 

--- a/test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs
@@ -1,0 +1,191 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FleetSourceHealthMarkerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}                                                                            from '@playwright/test';
+import Neo                                                                                       from '../../../../../../../src/Neo.mjs';
+import * as core                                                                                 from '../../../../../../../src/core/_export.mjs';
+import SourceHealthMarker, {sourceMarkerView}                                                    from '../../../../../../../apps/agentos/view/fleet/SourceHealthMarker.mjs';
+import {mapFleetSessionHealth, mapFleetSessionState, normalizeFleetSources, normalizeSourceFact} from '../../../../../../../apps/agentos/view/fleet/sourceHealth.mjs';
+
+test.describe('Fleet source-health honesty (#14643)', () => {
+    test('renders every source-state × confidence combination without a placeholder-as-fact path', () => {
+        const
+            states      = ['wired', 'missing', 'not-wired'],
+            confidences = ['observed', 'inferred', 'none'];
+
+        for (const state of states) {
+            for (const confidence of confidences) {
+                const
+                    health        = {source: 'fleet:runtimeStatus', state, confidence},
+                    normalized    = normalizeSourceFact(health),
+                    expectedState = state === 'wired' && confidence !== 'none'
+                        ? 'wired'
+                        : state === 'missing'
+                            ? 'missing'
+                            : 'not-wired',
+                    expectedConfidence   = expectedState === 'wired' ? confidence : 'none',
+                    expectedTreatment    = expectedState === 'wired'
+                        ? expectedConfidence.toUpperCase()
+                        : expectedState === 'missing'
+                            ? 'MISSING'
+                            : 'NOT WIRED',
+                    view                 = sourceMarkerView('runtime', health),
+                    marker               = Neo.create(SourceHealthMarker, {appName, sourceKey: 'runtime', health});
+
+                expect(normalized).toEqual({source: 'fleet:runtimeStatus', state: expectedState, confidence: expectedConfidence});
+                expect(view).toMatchObject({
+                    stateClass     : `fm-source-${expectedState}`,
+                    confidenceClass: `fm-confidence-${expectedConfidence}`,
+                    text           : `RUN ${expectedTreatment}`,
+                    ariaLabel      : `Runtime source: ${expectedState.replace('-', ' ')}, confidence ${expectedConfidence}.`
+                });
+                expect(marker.cls).toContain(view.stateClass);
+                expect(marker.cls).toContain(view.confidenceClass);
+                expect(marker.text).toBe(view.text);
+                expect(marker.getVdomRoot()['aria-label']).toBe(view.ariaLabel);
+
+                marker.destroy()
+            }
+        }
+    });
+
+    test('malformed, unknown, inherited, and prototype-shaped inputs fail closed', () => {
+        for (const value of [null, undefined, [], 'wired', {}, {state: 'unknown', confidence: 'observed'}, Object.create({state: 'wired', confidence: 'observed'})]) {
+            expect(normalizeSourceFact(value)).toEqual({source: null, state: 'not-wired', confidence: 'none'})
+        }
+
+        const polluted = Object.create({runtime: {state: 'wired', confidence: 'observed'}});
+        expect(normalizeFleetSources(polluted).runtime).toEqual({source: null, state: 'not-wired', confidence: 'none'});
+
+        for (const source of [undefined, '', '   ', 42]) {
+            expect(normalizeSourceFact({source, state: 'wired', confidence: 'observed'}))
+                .toEqual({source: null, state: 'not-wired', confidence: 'none'})
+
+            expect(normalizeSourceFact({source, state: 'missing', confidence: 'none'}))
+                .toEqual({source: null, state: 'not-wired', confidence: 'none'})
+        }
+    });
+
+    test('running state is trusted only behind a wired runtime source', () => {
+        const observed = {
+            lifecycle: {source: 'fleet:runtimeStatus', state: 'running', confidence: 'observed'},
+            sources  : {runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}}
+        };
+
+        expect(mapFleetSessionState(observed.lifecycle, observed.sources)).toBe('ok');
+        expect(mapFleetSessionState(
+            {...observed.lifecycle, confidence: 'inferred'},
+            {runtime: {...observed.sources.runtime, confidence: 'inferred'}}
+        )).toBe('ok');
+        expect(mapFleetSessionState(observed.lifecycle, {runtime: {...observed.sources.runtime, state: 'not-wired', confidence: 'none'}})).toBe('off');
+        expect(mapFleetSessionState(observed.lifecycle, {runtime: {...observed.sources.runtime, state: 'missing', confidence: 'none'}})).toBe('off');
+        expect(mapFleetSessionState({...observed.lifecycle, source: ''}, observed.sources)).toBe('off');
+        expect(mapFleetSessionState({...observed.lifecycle, confidence: 'none'}, observed.sources)).toBe('off');
+        expect(mapFleetSessionState({...observed.lifecycle, confidence: 'inferred'}, observed.sources)).toBe('off');
+        expect(mapFleetSessionState(observed.lifecycle, {})).toBe('off')
+    });
+
+    test('source axes and lifecycle fields require canonical own-key facts', () => {
+        const
+            inheritedFact = new Proxy({source: 'fleet:runtimeStatus'}, {
+                get(target, key, receiver) {
+                    if (key === 'state') return 'wired'
+                    if (key === 'confidence') return 'observed'
+                    return Reflect.get(target, key, receiver)
+                }
+            }),
+            inheritedSources = new Proxy({}, {
+                get(target, key, receiver) {
+                    return key === 'runtime'
+                        ? {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
+                        : Reflect.get(target, key, receiver)
+                }
+            }),
+            inheritedLifecycle = new Proxy({source: 'fleet:runtimeStatus', state: 'running'}, {
+                get(target, key, receiver) {
+                    return key === 'confidence' ? 'observed' : Reflect.get(target, key, receiver)
+                }
+            }),
+            runtime = {runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}};
+
+        expect(normalizeSourceFact(inheritedFact)).toEqual({source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'});
+        expect(normalizeFleetSources(inheritedSources).runtime).toEqual({source: null, state: 'not-wired', confidence: 'none'});
+        expect(mapFleetSessionState(inheritedLifecycle, runtime)).toBe('off');
+        expect(mapFleetSessionHealth(
+            {source: 'fleet:listAgents', state: 'running', confidence: 'observed'},
+            {runtime: {source: 'fleet:listAgents', state: 'wired', confidence: 'observed'}}
+        )).toMatchObject({state: 'off', sources: {runtime: {state: 'not-wired', confidence: 'none'}}})
+    });
+
+    test('lifecycle/source contradictions downgrade runtime provenance atomically', () => {
+        const sources = {runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}};
+
+        expect(mapFleetSessionHealth(null, sources)).toEqual({
+            sources: {
+                roster    : {source: null, state: 'not-wired', confidence: 'none'},
+                repoStatus: {source: null, state: 'not-wired', confidence: 'none'},
+                runtime   : {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}
+            },
+            state: 'off'
+        });
+        expect(mapFleetSessionHealth(
+            {source: 'fleet:runtimeStatus', state: 'running', confidence: 'inferred'},
+            sources
+        )).toMatchObject({state: 'off', sources: {runtime: {state: 'not-wired', confidence: 'none'}}});
+        expect(mapFleetSessionHealth(
+            {source: 'fleet:runtimeStatus', state: 'stopped', confidence: 'observed'},
+            sources
+        )).toMatchObject({state: 'off', sources: {runtime: {state: 'wired', confidence: 'observed'}}})
+    });
+
+    test('presentation carries both axes in classes, visible text, and ARIA', () => {
+        const inferred = sourceMarkerView('runtime', {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'inferred'});
+        expect(inferred).toMatchObject({
+            stateClass     : 'fm-source-wired',
+            confidenceClass: 'fm-confidence-inferred',
+            text           : 'RUN INFERRED',
+            ariaLabel      : 'Runtime source: wired, confidence inferred.'
+        });
+
+        const absent = sourceMarkerView('repoStatus', null);
+        expect(absent).toMatchObject({
+            stateClass     : 'fm-source-not-wired',
+            confidenceClass: 'fm-confidence-none',
+            text           : 'REP NOT WIRED'
+        })
+    });
+
+    test('component swaps state + confidence treatments in place with zero inline token writes', () => {
+        const marker = Neo.create(SourceHealthMarker, {
+            appName,
+            sourceKey: 'runtime',
+            health   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
+        });
+
+        expect(marker.cls).toContain('fm-source-wired');
+        expect(marker.cls).toContain('fm-confidence-observed');
+        expect(marker.text).toBe('RUN OBSERVED');
+        expect(marker.getVdomRoot()['aria-label']).toBe('Runtime source: wired, confidence observed.');
+        expect(marker.style?.['--fm-source-mark']).toBeUndefined();
+
+        marker.health = {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'};
+        expect(marker.cls).toContain('fm-source-not-wired');
+        expect(marker.cls).toContain('fm-confidence-none');
+        expect(marker.cls).not.toContain('fm-source-wired');
+        expect(marker.text).toBe('RUN NOT WIRED');
+
+        marker.destroy()
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs
@@ -188,4 +188,28 @@ test.describe('Fleet source-health honesty (#14643)', () => {
 
         marker.destroy()
     })
+
+    test('publishes class and text changes as one coherent reactive batch', () => {
+        const
+            marker = Neo.create(SourceHealthMarker, {
+                appName,
+                sourceKey: 'runtime',
+                health   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
+            }),
+            observed = [];
+
+        const cleanup = marker.observeConfig(marker, 'cls', cls => {
+            observed.push({cls, text: marker.text})
+        });
+
+        marker.health = {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'};
+
+        expect(observed).toHaveLength(1);
+        expect(observed[0].cls).toContain('fm-source-not-wired');
+        expect(observed[0].cls).not.toContain('fm-source-wired');
+        expect(observed[0].text).toBe('RUN NOT WIRED');
+
+        cleanup();
+        marker.destroy()
+    })
 });


### PR DESCRIPTION
Resolves #14643

Ships the Fleet cockpit's source-honesty layer end to end. A closed `sourceHealth` contract now preserves the assembler DTO's roster, repository, and runtime provenance through the Store-backed record boundary; malformed, inherited, prototype-shaped, or lifecycle-contradictory facts fail closed. `SourceHealthMarker` renders each axis as visible text plus matching state/confidence classes and ARIA, and `AgentCard`, `FleetCockpit`, and the card factory all consume the same contract without leaf providers or CSS-in-JS.

Evidence: L3 (fresh branch app consumed a real Fleet HTTP DTO; Neural Link inspected the live Store/card/markers, highlighted the runtime marker, verified nonzero computed geometry + visible text/classes/ARIA, found zero console errors, and passed component consistency) → L3 required (AC3 live-data Neural Link verification). No residuals.

## Deltas from ticket

- The live DTO at verification time carried per-row `roster: wired/observed`, `repoStatus: wired/observed`, and `runtime: wired/inferred`; its fleet activity capability was the current `not-wired/none` surface. The implementation therefore does not hardcode the ticket's earlier current-state example: it renders the live facts and retains a closed fixture matrix for every source-state × confidence combination.
- Runtime lifecycle state is now mapped atomically with runtime provenance. A nominally running lifecycle behind absent, malformed, or non-wired runtime truth downgrades to `off` instead of presenting placeholder state as fact.
- The reusable pattern lives in `SourceHealthMarker` plus pure `sourceHealth` helpers so the future detail-pane consumer can reuse it without duplicating card logic.
- Author-side audit tightened `SourceHealthMarker`'s reactive boundary: visible classes and text now publish in one `set({...})` batch, with a regression proving observers cannot see a mixed old-text/new-class state.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs --workers=1` → **41/41 passed** at current head `4fd26cb331` after rebasing onto current `origin/dev`.
- `npm run agent-preflight -- --no-fix apps/agentos/view/fleet/SourceHealthMarker.mjs test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs` → ticket archaeology and staged check-only gates passed.
- `node --check` passed for both files in the author-audit delta; `git diff --check origin/dev..HEAD` passed before push.
- Live Neural Link proof at pre-rebase source commit `7907d6e3d6e47293ea376ccceb6ffd82eff67921`:
  - FleetRoster contained the real bridge row for the probe identity with all three DTO source facts.
  - Runtime marker VDOM: `RUN INFERRED`, `fm-source-wired`, `fm-confidence-inferred`, `aria-label="Runtime source: wired, confidence inferred."`.
  - Computed marker geometry: `73.03125 × 9` px; three markers occupied distinct nonzero rectangles.
  - `verify_component_consistency` reported `consistent: true`; Neural Link console error query returned none.

## Post-Merge Validation

- [ ] Detail-pane delivery under #14608 reuses the source-health pattern rather than cloning its vocabulary.

## Commits

- `1930e00bf3` — render Fleet source health honestly.
- `4fd26cb331` — batch source-marker presentation updates.

## Evolution

The implementation initially sat behind the Store de-singleton work. After PR #14920 merged, this branch rebased onto `dev` and retained the provider-hosted Store boundary. The final live probe used the actual bridge DTO rather than promoting the fixture matrix into runtime evidence. Before cross-family review, an adversarial author audit found the marker's separate reactive writes; the fix batched its visible state, added a coherence regression, and rebased the PR onto current `origin/dev`.

Related: #14560 #14598 #14608 #14920

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session de713f27-0e82-4960-b4c6-f281e0c36449.
