### PR TITLE
feat(design): drag-affordance authority + DockPreview FM polish (#14930)

### DIFF
--- a/apps/agentos/design/dock-choreography-demo.html
+++ b/apps/agentos/design/dock-choreography-demo.html
@@ -276,4 +276,62 @@
       <b>Real today (shipped dockZone.v1 + landed #14625 tools):</b> every S1–S3 operation class — split, resizeSplit, moveItem→tab, setItemAutoHidden — executes semantically with animated transitions, agent-drivable end-to-end. <b>Designed here, building in the tree:</b> the edge-rail affordance (#14654) and reveal/dismiss timing (#14660) for S3's beats 1–3; the tour runner (#14640) and this screenplay as its script (#14661). <b>Deliberately absent:</b> perspectives and multi-window pop-out — that is Demo B (#14590, spec-gated), and blending the two would blur both stories. No performance numbers appear anywhere in the demo (#13032 guardrail; the motion must simply LOOK effortless — a claim the viewer verifies with their own eyes).
     </div>
   </section>
+
+  <!-- 06 · DRAG AFFORDANCES (#14930) — the felt Qt-parity floor: parallel-visible drop options -->
+  <section class="sec">
+    <div class="sec-head"><span class="sec-num">06</span><h2>Drag affordances — show the menu, never make them guess</h2>
+      <p class="muted" style="margin:0 0 0 auto;font-size:13px">authority section for #14930; Qt-ADS is the floor, not the blueprint</p>
+    </div>
+
+    <p class="lede" style="font-size:16px">The disposition, decided here: <b style="color:var(--ink)">the indicator-overlay model is the primary drag affordance; pointer-zone inference demotes to fallback.</b> Rationale: discoverability is the felt difference — the floor system shows every valid drop option <i>simultaneously</i> while dragging (a 5-position cross on the hovered area, edge chips on the container); ours makes the user divine invisible zones from pointer position. Functional is not felt. The user picks from a visible menu; the menu is the affordance.</p>
+
+    <div class="scene" style="margin-top:18px">
+      <div class="scene-head"><span class="scene-id">DRAG</span><h3>Mid-drag: the option menu, lit</h3><span class="scene-dur">proxy + cross + edge chips + target preview</span></div>
+      <div class="scene-body">
+        <div class="board"><div class="board-label">Dragging TERMINAL over the editor area</div>
+          <div class="stage" style="grid-template:1fr / 2fr 1fr;position:relative">
+            <div class="pane" style="background:var(--pane-a)">EDITOR ⟳
+              <span style="position:absolute;inset:0;display:grid;place-items:center;pointer-events:none">
+                <span style="display:grid;grid-template:14px 14px 14px / 14px 14px 14px;gap:2px">
+                  <span></span><span style="background:var(--panel-2);border:1px solid var(--line);border-radius:3px"></span><span></span>
+                  <span style="background:var(--panel-2);border:1px solid var(--line);border-radius:3px"></span><span style="background:var(--signal);border-radius:3px"></span><span style="background:var(--panel-2);border:1px solid var(--line);border-radius:3px"></span>
+                  <span></span><span style="background:var(--panel-2);border:1px solid var(--line);border-radius:3px"></span><span></span>
+                </span>
+              </span>
+            </div>
+            <div class="pane" style="background:var(--pane-b);opacity:.55">PREVIEW</div>
+            <div class="pane" style="position:absolute;left:34%;top:58%;width:120px;height:34px;background:var(--pane-c);box-shadow:var(--shadow);border:1px solid var(--signal);font-size:9.5px">TERMINAL (proxy)</div>
+          </div>
+        </div>
+        <div class="board"><div class="board-label">Hovering the ◀ indicator: the target region previews</div>
+          <div class="stage" style="grid-template:1fr / 2fr 1fr">
+            <div class="pane" style="background:var(--pane-a);display:grid;grid-template:1fr / 1fr 1fr;gap:3px;place-items:stretch">
+              <span style="background:var(--signal);opacity:.28;border:2px solid var(--signal);border-radius:5px"></span>
+              <span style="display:grid;place-items:center">EDITOR ⟳</span>
+            </div>
+            <div class="pane" style="background:var(--pane-b);opacity:.55">PREVIEW</div>
+          </div>
+        </div>
+      </div>
+      <div class="scene-notes">
+        <div class="note"><h4>The affordance grammar</h4>
+          <ol>
+            <li><b>Drag proxy</b> — the tab travels with the pointer (content pixmap tier later; label chip now)</li>
+            <li><b>Indicator cross</b> on the hovered area: center = tab-merge · N/S/E/W = directional splits; <b>edge chips</b> on the container borders</li>
+            <li><b>Target preview</b> — hovering an indicator fills the exact post-drop region (accept: signal-tinted; reject: <span style="color:var(--hot)">hot</span> dashed, policy-honest)</li>
+            <li><b>Drop commits</b> through <span class="op">previewToOperation</span> unchanged; <b>Escape cancels</b> mid-flight (absorbs tree line C5, single-window)</li>
+          </ol>
+        </div>
+        <div class="note"><h4>Bindings &amp; boundaries</h4>
+          <ul>
+            <li>Tokens: chips on <span class="op">--fm-panel-2/--fm-line</span>, active option <span class="op">--fm-signal</span>, reject <span class="op">--fm-hot</span>; motion via the <span class="op">--dock-transition-*</span> contract — zero local duration policy</li>
+            <li>Producer extends one-affordance-from-pointer → <b>full candidate set for the hovered area</b>; presentation-tier only, reducer contract untouched</li>
+            <li>Edge-band inference stays as the <b>fallback</b> tier (touch, and mid-drag before any indicator is hovered)</li>
+            <li>Grouped-drag proxy (E-tranche) and cross-window drag scenes (#14772) stay out of scope here</li>
+            <li><b>The camera beat:</b> Demo A's cold open — ~15s of hand-drag with this menu lit, then "now watch an agent do it"</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
 </div>

--- a/apps/agentos/design/dock-choreography-demo.html
+++ b/apps/agentos/design/dock-choreography-demo.html
@@ -324,7 +324,7 @@
         </div>
         <div class="note"><h4>Bindings &amp; boundaries</h4>
           <ul>
-            <li>Tokens: chips on <span class="op">--fm-panel-2/--fm-line</span>, active option <span class="op">--fm-signal</span>, reject <span class="op">--fm-hot</span>; motion via the <span class="op">--dock-transition-*</span> contract — zero local duration policy</li>
+            <li>Tokens: chips on <span class="op">--fm-panel-2/--fm-line</span>; active and reject previews consume the component-domain <span class="op">--agent-dock-preview-accept/reject</span> aliases, whose theme values map to this artifact's signal/hot columns while #14681 owns the future global light-native FM vocabulary; motion via the <span class="op">--dock-transition-*</span> contract — zero local duration policy</li>
             <li>Producer extends one-affordance-from-pointer → <b>full candidate set for the hovered area</b>; presentation-tier only, reducer contract untouched</li>
             <li>Edge-band inference stays as the <b>fallback</b> tier (touch, and mid-drag before any indicator is hovered)</li>
             <li>Grouped-drag proxy (E-tranche) and cross-window drag scenes (#14772) stay out of scope here</li>

--- a/resources/scss/src/apps/agentos/DockPreview.scss
+++ b/resources/scss/src/apps/agentos/DockPreview.scss
@@ -7,11 +7,11 @@
         opacity        : 0.85;
         pointer-events : none;
         position       : absolute;
-        // motion rides the dock transition contract (fast tier); fallbacks hold today's
-        // behavior until the token substrate lands — zero local duration policy by design
-        transition     : opacity var(--dock-transition-duration-fast, 0.12s) var(--dock-transition-easing, ease),
-                         background-color var(--dock-transition-duration-fast, 0.12s) var(--dock-transition-easing, ease),
-                         border-color var(--dock-transition-duration-fast, 0.12s) var(--dock-transition-easing, ease);
+        // Motion rides the one dock transition contract. Reduced-motion collapses the duration
+        // at that authority, never at this call site.
+        transition     : opacity var(--dock-transition-duration) var(--dock-transition-easing),
+                         background-color var(--dock-transition-duration) var(--dock-transition-easing),
+                         border-color var(--dock-transition-duration) var(--dock-transition-easing);
     }
 
     // Zone highlights — edge bands and whole-node tab targets — read as a translucent filled region.

--- a/resources/scss/src/apps/agentos/DockPreview.scss
+++ b/resources/scss/src/apps/agentos/DockPreview.scss
@@ -7,7 +7,11 @@
         opacity        : 0.85;
         pointer-events : none;
         position       : absolute;
-        transition     : opacity 0.12s ease, background-color 0.12s ease, border-color 0.12s ease;
+        // motion rides the dock transition contract (fast tier); fallbacks hold today's
+        // behavior until the token substrate lands — zero local duration policy by design
+        transition     : opacity var(--dock-transition-duration-fast, 0.12s) var(--dock-transition-easing, ease),
+                         background-color var(--dock-transition-duration-fast, 0.12s) var(--dock-transition-easing, ease),
+                         border-color var(--dock-transition-duration-fast, 0.12s) var(--dock-transition-easing, ease);
     }
 
     // Zone highlights — edge bands and whole-node tab targets — read as a translucent filled region.

--- a/resources/scss/theme-neo-dark/apps/agentos/DockPreview.scss
+++ b/resources/scss/theme-neo-dark/apps/agentos/DockPreview.scss
@@ -1,6 +1,9 @@
+// §06 authority (dock-choreography design artifact): drag affordances speak the FM family —
+// accept = signal, reject = hot; the fills are those hues at translucent strength. The FM
+// vocabulary stays value authority; this layer only re-points the dock-preview aliases.
 :root .neo-theme-neo-dark {
-    --agent-dock-preview-accept      : var(--agent-state-focus, #58a6ff);
-    --agent-dock-preview-accept-fill : rgba(88, 166, 255, 0.22);
-    --agent-dock-preview-reject      : var(--agent-accent-intervention, #cf222e);
-    --agent-dock-preview-reject-fill : rgba(207, 34, 46, 0.16);
+    --agent-dock-preview-accept      : var(--fm-signal, #5eead4);
+    --agent-dock-preview-accept-fill : rgba(94, 234, 212, 0.20);
+    --agent-dock-preview-reject      : var(--fm-hot, #f4718b);
+    --agent-dock-preview-reject-fill : rgba(244, 113, 139, 0.16);
 }

--- a/resources/scss/theme-neo-dark/apps/agentos/DockPreview.scss
+++ b/resources/scss/theme-neo-dark/apps/agentos/DockPreview.scss
@@ -1,9 +1,9 @@
-// §06 authority (dock-choreography design artifact): drag affordances speak the FM family —
-// accept = signal, reject = hot; the fills are those hues at translucent strength. The FM
-// vocabulary stays value authority; this layer only re-points the dock-preview aliases.
+// §06 authority (dock-choreography design artifact): these component-domain aliases map accept
+// and reject to the artifact's dark signal/hot column. Global FM light-native tokens remain
+// #14681's authority; this layer does not mint a parallel --fm-* vocabulary.
 :root .neo-theme-neo-dark {
-    --agent-dock-preview-accept      : var(--fm-signal, #5eead4);
+    --agent-dock-preview-accept      : #5eead4;
     --agent-dock-preview-accept-fill : rgba(94, 234, 212, 0.20);
-    --agent-dock-preview-reject      : var(--fm-hot, #f4718b);
+    --agent-dock-preview-reject      : #f4718b;
     --agent-dock-preview-reject-fill : rgba(244, 113, 139, 0.16);
 }

--- a/resources/scss/theme-neo-light/apps/agentos/DockPreview.scss
+++ b/resources/scss/theme-neo-light/apps/agentos/DockPreview.scss
@@ -1,6 +1,8 @@
+// §06 authority (dock-choreography design artifact): drag affordances speak the FM family —
+// accept = signal, reject = hot; light-mode hues per the artifact's light token column.
 :root .neo-theme-neo-light {
-    --agent-dock-preview-accept      : var(--agent-state-focus, #0969da);
-    --agent-dock-preview-accept-fill : rgba(9, 105, 218, 0.16);
-    --agent-dock-preview-reject      : var(--agent-accent-intervention, #cf222e);
-    --agent-dock-preview-reject-fill : rgba(207, 34, 46, 0.12);
+    --agent-dock-preview-accept      : var(--fm-signal, #0d9488);
+    --agent-dock-preview-accept-fill : rgba(13, 148, 136, 0.14);
+    --agent-dock-preview-reject      : var(--fm-hot, #be123c);
+    --agent-dock-preview-reject-fill : rgba(190, 18, 60, 0.12);
 }

--- a/resources/scss/theme-neo-light/apps/agentos/DockPreview.scss
+++ b/resources/scss/theme-neo-light/apps/agentos/DockPreview.scss
@@ -1,8 +1,9 @@
-// §06 authority (dock-choreography design artifact): drag affordances speak the FM family —
-// accept = signal, reject = hot; light-mode hues per the artifact's light token column.
+// §06 authority (dock-choreography design artifact): these component-domain aliases map accept
+// and reject to the artifact's light signal/hot column without pre-empting #14681's global FM
+// light-native token system.
 :root .neo-theme-neo-light {
-    --agent-dock-preview-accept      : var(--fm-signal, #0d9488);
+    --agent-dock-preview-accept      : #0d9488;
     --agent-dock-preview-accept-fill : rgba(13, 148, 136, 0.14);
-    --agent-dock-preview-reject      : var(--fm-hot, #be123c);
+    --agent-dock-preview-reject      : #be123c;
     --agent-dock-preview-reject-fill : rgba(190, 18, 60, 0.12);
 }

--- a/test/playwright/unit/apps/agentos/DockPreview.spec.mjs
+++ b/test/playwright/unit/apps/agentos/DockPreview.spec.mjs
@@ -69,6 +69,29 @@ test.describe('AgentOS.view.DockPreview', () => {
             expect(light).toContain('--agent-dock-preview-accept');
             expect(light).toContain('--agent-dock-preview-reject')
         })
+
+        test('domain-token consumers stay on the declared DockPreview contract', () => {
+            const structural = fs.readFileSync(path.join(repoRoot, 'resources/scss/src/apps/agentos/DockPreview.scss'), 'utf8'),
+                  dark       = fs.readFileSync(path.join(repoRoot, 'resources/scss/theme-neo-dark/apps/agentos/DockPreview.scss'), 'utf8'),
+                  light      = fs.readFileSync(path.join(repoRoot, 'resources/scss/theme-neo-light/apps/agentos/DockPreview.scss'), 'utf8'),
+                  consumers  = [...new Set(
+                      [structural, dark, light].flatMap(source =>
+                          [...source.matchAll(/var\((--(?:fm|dock-transition)-[\w-]+)/g)].map(match => match[1])
+                      )
+                  )].sort();
+
+            // This explicit census fails if a call site invents a pseudo-token such as
+            // --dock-transition-duration-fast or an undeclared --fm-* semantic alias.
+            expect(consumers).toEqual([
+                '--dock-transition-duration',
+                '--dock-transition-easing'
+            ]);
+
+            expect(dark).toMatch(/--agent-dock-preview-accept\s*:\s*#5eead4;/);
+            expect(dark).toMatch(/--agent-dock-preview-reject\s*:\s*#f4718b;/);
+            expect(light).toMatch(/--agent-dock-preview-accept\s*:\s*#0d9488;/);
+            expect(light).toMatch(/--agent-dock-preview-reject\s*:\s*#be123c;/)
+        })
     });
 
     test.describe('isValidPreview (fail-closed)', () => {


### PR DESCRIPTION
Resolves #14930

Refs #14959

Related: #14947 · #14681

Delivers the narrowed design tier of the drag-affordance lane. **Slice 1, the authority:** §06 lands in the dock-choreography design artifact and makes the indicator-overlay menu the primary drag affordance (5-position cross on the hovered area + container-edge chips, every valid option visible while dragging; per-option target preview; drag proxy; Escape-cancel), with pointer-zone edge-band inference explicitly retained as the fallback tier. **Slice 2, the polish:** `DockPreview`'s component-domain accept/reject aliases now map exactly to the artifact's dark and light signal/hot columns without inventing a global FM token or pre-empting the light-native FM system. All transitions consume the merged `--dock-transition-duration` / `--dock-transition-easing` authority, including its reduced-motion collapse; a focused token-consumer census prevents undeclared `--fm-*` or `--dock-transition-*` aliases from returning.

Evidence: L2 (authority section render-verified; both themes compile; the exact stylesheet contract and token census pass in the focused unit suite) → L3 post-merge validation for the live mid-drag rendering because previews only exist during a real gesture. Residual: none on this narrowed close target — the producer extension, indicator component, and camera beat live in #14959.

## Deltas from ticket

- **Indicator idiom decided as authority, not deferred:** the ticket's original compass-vs-edge-band hedge was upgraded by the on-ticket AC amendment. §06 records the discoverability decision and the unchanged preview-to-operation boundary.
- **Implementation tier split by replacement:** the producer candidate-set extension, `DockDropIndicators`, Escape wiring, and cold-open camera beat moved to #14959; this PR closes only the authority + current `DockPreview` polish tier.
- **Token authority corrected during review:** the final patch uses the existing component-domain aliases for dual-theme accept/reject values, keeps global FM light-native work under #14681, and consumes the single dock-motion contract merged by #14947.

## Test Evidence

```text
npm run test-unit -- test/playwright/unit/apps/agentos/DockPreview.spec.mjs
  37 passed

npm run build-themes -- --noquestions --themes neo-dark,neo-light --env dev
  passed; compiled DockPreview.css consumes only --dock-transition-duration/easing

node --check test/playwright/unit/apps/agentos/DockPreview.spec.mjs
  passed

git diff --check
  passed
```

The new stylesheet-contract census pins the only permitted domain consumers to `--dock-transition-duration` and `--dock-transition-easing`, rejects invented `--fm-*` / dock-motion aliases, and pins both artifact palette columns at the theme-token layer.

## Post-Merge Validation

- [ ] During a live drag, accept/reject affordances render the artifact's dark and light palette values.
- [ ] With `prefers-reduced-motion: reduce`, the merged dock-motion token collapses preview transitions to `0ms`.

## Commits

- 7665a8dee — §06 drag-affordance authority section
- 4ce58224f — DockPreview theme + motion polish
- 367da3fecd — bind the real dock-motion contract and component-domain theme aliases; add token census

Authored by Clio (Claude Fable 5, Claude Code). Session 54156254-a1a8-40b3-ba22-86e7d2a1bf81.
