### PR TITLE
fix(neural-link): make property-read truncation machine-visible + point at tree-read paths (#14927)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -214,6 +214,13 @@ paths:
 
         **When to Use:**
         To inspect the current state of any Neo instance (e.g., Component, Store, Controller, Manager).
+
+        **Serialization contract (deep objects):** a property whose value is itself a Neo instance
+        (e.g. `vnode`, a hosted store) arrives as a compact identity SNAPSHOT via `toJSON()`, marked
+        `__truncated: 'neo-instance-snapshot'` — never as the full object graph. Treat a marked
+        payload as "structure not included", not as evidence about the structure's size or content.
+        For tree-shaped reads use `query_vdom`, `get_component_tree`, or
+        `inspect_component_render_tree` instead.
       tags: [Instance]
       requestBody:
         required: true

--- a/src/ai/client/Service.mjs
+++ b/src/ai/client/Service.mjs
@@ -20,6 +20,14 @@ class Service extends Base {
     }
 
     /**
+     * @summary Serializes a property value for the wire. Plain objects and arrays serialize in
+     * full; a Neo INSTANCE collapses to its `toJSON()` identity snapshot — which is a truncation
+     * of the instance's object graph, so the snapshot carries a `__truncated` marker making the
+     * collapse machine-distinguishable from a genuinely small value. Without the marker, a deep
+     * structure read (a `vnode` tree, a hosted store) looks like confident evidence of a tiny
+     * object — a silent false negative in exactly the whitebox-debugging situations this wire
+     * exists for. Structure-shaped reads belong to the tree tools (`query_vdom`,
+     * `get_component_tree`, `inspect_component_render_tree`).
      * @param {*} value
      * @returns {*}
      */
@@ -27,7 +35,7 @@ class Service extends Base {
         const type = Neo.typeOf(value);
 
         if (type === 'NeoInstance') {
-            return value.toJSON()
+            return {...value.toJSON(), __truncated: 'neo-instance-snapshot'}
         }
 
         if (type === 'Object') {

--- a/test/playwright/unit/ai/client/InstanceService.spec.mjs
+++ b/test/playwright/unit/ai/client/InstanceService.spec.mjs
@@ -1,0 +1,76 @@
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../src/Neo.mjs';
+import * as core       from '../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../src/manager/Instance.mjs';
+import InstanceService from '../../../../../src/ai/client/InstanceService.mjs';
+
+/**
+ * @summary The property-read serialization contract: a Neo-instance-valued property collapses to
+ * its identity snapshot, and that collapse must be MACHINE-DISTINGUISHABLE from a genuinely small
+ * value — a silently-truncated deep read produces confident false negatives in exactly the
+ * whitebox probes the wire exists for.
+ */
+test.describe.serial('Neo.ai.client.Service.safeSerialize — truncation visibility', () => {
+    let service;
+
+    test.beforeAll(() => {
+        // client services are per-Client instances (Neo.create'd by Neo.ai.Client), never singletons
+        service = Neo.create(InstanceService, {});
+    });
+
+    test.afterAll(() => {
+        service.destroy();
+    });
+
+    test('a Neo instance collapses to its toJSON snapshot WITH the truncation marker', () => {
+        const instance   = Neo.create(core.Base, {});
+        const serialized = service.safeSerialize(instance);
+
+        expect(serialized.__truncated).toBe('neo-instance-snapshot');
+        // the snapshot's own identity fields survive alongside the marker
+        expect(serialized.className).toBe('Neo.core.Base');
+        expect(serialized.id).toBe(instance.id);
+
+        instance.destroy();
+    });
+
+    test('a genuinely small plain object serializes in full and carries NO marker', () => {
+        const serialized = service.safeSerialize({state: 'OPEN', count: 3, nested: {deep: true}});
+
+        expect(serialized).toEqual({state: 'OPEN', count: 3, nested: {deep: true}});
+        expect(serialized.__truncated).toBeUndefined();
+    });
+
+    test('instances NESTED inside objects and arrays are marked at each collapse point', () => {
+        const instance   = Neo.create(core.Base, {});
+        const serialized = service.safeSerialize({
+            plain: 1,
+            ref  : instance,
+            list : [instance, {ok: true}]
+        });
+
+        expect(serialized.plain).toBe(1);
+        expect(serialized.ref.__truncated).toBe('neo-instance-snapshot');
+        expect(serialized.list[0].__truncated).toBe('neo-instance-snapshot');
+        expect(serialized.list[1]).toEqual({ok: true});
+        expect(serialized.list[1].__truncated).toBeUndefined();
+
+        instance.destroy();
+    });
+
+    test('getInstanceProperties surfaces the marker end-to-end for an instance-valued property', () => {
+        const holder = Neo.create(core.Base, {});
+        const child  = Neo.create(core.Base, {});
+
+        // an instance-valued property on a registered instance — the vnode-read shape
+        holder.probeTarget = child;
+
+        const {properties} = service.getInstanceProperties({id: holder.id, properties: ['probeTarget']});
+
+        expect(properties.probeTarget.__truncated).toBe('neo-instance-snapshot');
+        expect(properties.probeTarget.id).toBe(child.id);
+
+        child.destroy();
+        holder.destroy();
+    });
+});


### PR DESCRIPTION
Resolves #14927

**Root cause (found, not assumed):** the Neural Link property-read path has no depth cap at all — `safeSerialize` recurses plain objects and arrays in full. The truncation lives in one specific branch: a property whose value is a **Neo instance** collapses to `value.toJSON()`, an identity snapshot (className/id-grade fields). That is exactly the 334-byte `vnode` "tree" from the empirical anchor: the payload was not a capped tree, it was a snapshot of the VNode instance — machine-indistinguishable from a genuinely small value, which turned "id absent from vnode" into confident false evidence during a live root-cause hunt.

**The fix:**
- **`src/ai/client/Service.mjs`** — the NeoInstance branch of `safeSerialize` now returns `{...value.toJSON(), __truncated: 'neo-instance-snapshot'}`: a single additive, truthy, self-explaining marker at every collapse point (top-level property values AND instances nested inside objects/arrays). Snapshot identity fields survive alongside it, so existing consumers reading `.id`/`.className` keep working.
- **`ai/mcp/server/neural-link/openapi.yaml`** — `get_instance_properties`'s description now names the serialization contract plainly (instance-valued properties arrive as marked snapshots, never object graphs) and points at the tree-shaped read paths: `query_vdom`, `get_component_tree`, `inspect_component_render_tree`.
- **Regression spec** (`test/playwright/unit/ai/client/InstanceService.spec.mjs`): marker present on a serialized instance with identity fields intact; a genuinely small plain object carries NO marker and round-trips exactly; nested instances marked at each collapse point inside objects and arrays; and the end-to-end `getInstanceProperties` read of an instance-valued property surfaces the marker.

**Deliberately not done:** the ticket's optional `depth` opt-in (scope discipline — the marker + tool-description pointer discharge the ACs; a bounded deep-read mode is additive later), and no marker on `findInstances`'s top-level snapshot list (returning snapshots is that tool's advertised contract, not a surprise — the marker targets property VALUES where a caller asked for the real thing).

Evidence: L1 (65 passed on the client suite incl. the four new regressions; 43 passed on the MCP OpenAPI validation suite covering the YAML edit) → L1 required (serialization-contract class; the empirical anchor's probe shape is reproduced as the end-to-end test).

## Deltas from ticket

- The ticket prescribed marking "when the serializer caps depth/size" — the census showed there IS no depth/size cap; the one truncation class is instance-collapse, so the marker lands exactly there and the tool description documents the real contract rather than a hypothetical cap.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/client --workers=1` → **65 passed** (61 pre-existing + 4 new).
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation --workers=1` → **43 passed** (the OpenAPI contract remains valid after the description change).
- `node --check` green; pre-commit gates green (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation

- [ ] A live NL probe of a component's `vnode` property returns the marker (`__truncated: 'neo-instance-snapshot'`), and the same component's tree via `query_vdom` returns actual structure
- [ ] The playwright NL fixture's `getComponent(id, ['vnode'])` consumers (the #14911-class investigations) treat marked payloads as structure-not-included

## Commits

- 7a1de582c — marker + tool-description contract + 4-test regression spec.

Related: the empirical anchor investigation (the 334-byte vnode stub flagged INCONCLUSIVE) · filed by @neo-opus-grace's investigation trail, disposed to me.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b956ba53-01ed-4ea6-a1e5-62969f887bc3.
