### PR TITLE
feat(fleet): two-phase peer-onboarding conductor over owned contracts (#14937)

### DIFF
--- a/ai/scripts/fleet/onboardPeer.mjs
+++ b/ai/scripts/fleet/onboardPeer.mjs
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+/**
+ * @module ai/scripts/fleet/onboardPeer
+ * @summary The peer-onboarding conductor: one dry-run-first command that walks an operator from
+ * "I want a new resident" to "a supervised harness is running in its own home, awaiting exactly
+ * one login" — as a THIN two-phase composition over owned contracts. It re-implements NOTHING:
+ * every write goes through the owning registry/manager surface, and the identity + wake substrate
+ * come from the roster ceremony, never from this script.
+ *
+ * **Phase A — before the roster merge (addressability intent):**
+ *   1. `define`  — the Fleet registry agent definition (curated intent: githubUsername +
+ *      harnessType + id; the raw-launch stop-line stays untouched).
+ *   2. `repo`    — `metadata.repo` coordinates on the definition (`setRepo`), so the launch
+ *      provisions the agent's own checkout.
+ *   3. `roster`  — PRINT the roster-generator invocation. The roster PR + its cross-family
+ *      review IS the membership ceremony; this script never writes committed files.
+ *
+ * **The operator gate (printed, never automated):** merge the roster PR, pull, and restart the
+ * Memory Core server — boot seeding materializes the resident's `AgentIdentity` node (with its
+ * `subscriptionTemplate`) from the committed roster; the peer's FIRST boot then materializes the
+ * wake route itself via the wake-subscription `bootstrap` action from the real boot envelope.
+ *
+ * **Phase B — after the gate (launch):**
+ *   4. `preflight` — verify the roster entry exists in THIS checkout AND the graph node is
+ *      seeded (read-only probe). Refuse with the exact missing operator step named.
+ *   5. `launch`    — `FleetManager.startAgent(id)` (provision-then-start, supervised child in
+ *      its isolated instance home via the curated per-family template).
+ *   6. `auth`      — read `status(id)`, print the per-home login line. Secrets never touch
+ *      this script: authentication is the operator-owned step by design.
+ *
+ * Idempotent per segment because every underlying contract already is (define/setRepo upsert,
+ * repo ensure-or-reuse, start short-circuits when running, boot seeding + wake bootstrap are
+ * idempotent at their owners). Dry-run renders the true per-segment delta AND which phase the
+ * onboarding is currently in; `--commit` executes exactly that delta.
+ *
+ * **Usage**:
+ *   node ai/scripts/fleet/onboardPeer.mjs --resident-id <s> --github-username <s>
+ *       --harness-type <codex|claude-code> [--clone-url <s> --repo-slug <s>]   # dry-run
+ *   node ai/scripts/fleet/onboardPeer.mjs ... --commit                          # execute phase delta
+ *   node ai/scripts/fleet/onboardPeer.mjs --help
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+
+/**
+ * @summary The curated harness families the conductor accepts — must stay a subset of the
+ * registry's own `harnessTypes` vocabulary (the registry re-validates on define; this list only
+ * gives the CLI an early, named refusal).
+ * @type {ReadonlyArray<String>}
+ */
+export const CURATED_HARNESS_TYPES = Object.freeze(['claude-code', 'codex']);
+
+/**
+ * @summary Normalizes a lowercase token input; fail-closed on empty or malformed values.
+ * @param {String} value Raw input
+ * @param {String} label Flag name for the refusal message
+ * @returns {{valid: Boolean, reason: String|null, token: String|null}}
+ */
+export function normalizeToken(value, label) {
+    if (typeof value !== 'string' || value.trim() === '') {
+        return {valid: false, reason: `${label} requires a non-empty string`, token: null};
+    }
+
+    const token = value.trim().replace(/^@/, '');
+
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(token)) {
+        return {valid: false, reason: `${label} must be a lowercase token ([a-z0-9-]) — received '${value}'`, token: null};
+    }
+
+    return {valid: true, reason: null, token}
+}
+
+/**
+ * @summary Builds the frozen onboarding intent (the PURE input half): validated identifiers plus
+ * optional repo coordinates. Engine/model and social-name inputs have NO surface here at all —
+ * engine truth is observation-owned and names are the post-boot peer ritual; both arrive via the
+ * roster ceremony and later layers, never via onboarding flags.
+ * @param {Object} options
+ * @param {String} options.residentId Durable resident handle (also the Fleet agent id)
+ * @param {String} options.githubUsername GitHub login the agent operates as
+ * @param {String} options.harnessType One of {@link CURATED_HARNESS_TYPES}
+ * @param {String} [options.cloneUrl] Working-repo clone URL (with repoSlug ⇒ the repo segment)
+ * @param {String} [options.repoSlug] Working-repo slug (e.g. 'neomjs/neo')
+ * @returns {{valid: Boolean, reason: String|null, intent: Object|null}}
+ */
+export function buildOnboardingIntent(options = {}) {
+    const resident = normalizeToken(options.residentId, '--resident-id');
+    if (!resident.valid) return {valid: false, reason: resident.reason, intent: null};
+
+    const github = normalizeToken(options.githubUsername, '--github-username');
+    if (!github.valid) return {valid: false, reason: github.reason, intent: null};
+
+    if (!CURATED_HARNESS_TYPES.includes(options.harnessType)) {
+        return {valid: false, reason: `--harness-type must be one of: ${CURATED_HARNESS_TYPES.join(', ')} — received '${String(options.harnessType)}'`, intent: null};
+    }
+
+    const hasCloneUrl = typeof options.cloneUrl === 'string' && options.cloneUrl.trim() !== '',
+          hasRepoSlug = typeof options.repoSlug === 'string' && options.repoSlug.trim() !== '';
+
+    if (hasCloneUrl !== hasRepoSlug) {
+        return {valid: false, reason: '--clone-url and --repo-slug come together or not at all (one without the other cannot provision a checkout)', intent: null};
+    }
+
+    return {
+        valid : true,
+        reason: null,
+        intent: Object.freeze({
+            residentId    : resident.token,
+            agentId       : resident.token,
+            githubUsername: github.token,
+            harnessType   : options.harnessType,
+            repo          : hasCloneUrl
+                ? Object.freeze({cloneUrl: options.cloneUrl.trim(), repoSlug: options.repoSlug.trim()})
+                : null
+        })
+    }
+}
+
+/**
+ * @summary The pure two-phase decision: given the intent and the OBSERVED facts, decide the
+ * current phase and the exact per-segment delta. Facts arrive observed (the CLI gathers them;
+ * tests inject them) so the planner stays side-effect-free:
+ * `agentDefined` / `repoConfigured` (registry reads), `rosterHasResident` (this checkout's
+ * committed roster), `graphNodeSeeded` (read-only graph probe; `null` = no graph reachable),
+ * `running` / `authRequired` (lifecycle status).
+ * @param {Object} options
+ * @param {Object} options.intent A valid intent from {@link buildOnboardingIntent}
+ * @param {Object} options.facts Observed facts as described above
+ * @returns {{phase: String, segments: Object[], gateMessage: String|null}}
+ */
+export function planOnboarding({intent, facts = {}} = {}) {
+    const
+        segments = [],
+        push     = (key, action, detail) => segments.push({key, action, detail});
+
+    // --- Phase A segments (always evaluated: re-runs report EXISTS honestly) -----------------
+    push('define', facts.agentDefined ? 'EXISTS' : 'CREATE',
+        `fleet agent '${intent.agentId}' (githubUsername '${intent.githubUsername}', harnessType '${intent.harnessType}')`);
+
+    if (intent.repo) {
+        push('repo', facts.repoConfigured ? 'EXISTS' : 'CREATE',
+            `metadata.repo → ${intent.repo.repoSlug} (${intent.repo.cloneUrl})`);
+    } else {
+        push('repo', 'SKIP', 'no --clone-url/--repo-slug given — the harness will start in the inherited cwd');
+    }
+
+    // --- The gate: the roster ceremony decides which phase we are in --------------------------
+    if (!facts.rosterHasResident) {
+        push('roster', 'PRINT',
+            `node ai/scripts/setup/generateRosterOnboarding.mjs --resident-id ${intent.residentId} --github-username ${intent.githubUsername} --family <family>`);
+
+        return {
+            phase      : 'A',
+            segments,
+            gateMessage: `'${intent.residentId}' is not in this checkout's committed roster. Next: run the roster generator above on a feature branch, open the PR (the cross-family-reviewed membership ceremony), merge it, pull, restart the Memory Core server (boot seeding creates the identity node + wake template), then re-run this command.`
+        }
+    }
+
+    // --- Phase B segments ----------------------------------------------------------------------
+    if (facts.graphNodeSeeded === false) {
+        push('preflight', 'REFUSE',
+            `roster entry present but the graph carries no '${intent.residentId}' AgentIdentity node — restart the Memory Core server so boot seeding materializes it, then re-run`);
+
+        return {phase: 'B', segments, gateMessage: null}
+    }
+
+    push('preflight', facts.graphNodeSeeded === null ? 'WARN' : 'OK',
+        facts.graphNodeSeeded === null
+            ? 'no live graph reachable read-only — cannot verify seeding; the launch will still be attempted on --commit'
+            : `roster entry + seeded '${intent.residentId}' AgentIdentity node verified`);
+
+    push('launch', facts.running ? 'EXISTS' : 'CREATE',
+        facts.running
+            ? `'${intent.agentId}' is already running — start short-circuits to status`
+            : `FleetManager.startAgent('${intent.agentId}') — provision-then-start via the curated '${intent.harnessType}' template`);
+
+    push('auth', 'PRINT',
+        facts.authRequired === false
+            ? 'per-home credentials already present — no login step required'
+            : `per-home login required once (surfaced via status().authRequired after launch)`);
+
+    return {phase: 'B', segments, gateMessage: null}
+}
+
+/**
+ * @summary Renders a plan as printable lines — dry-run output and `--commit` behavior derive
+ * from the SAME plan, so they cannot drift.
+ * @param {Object} intent A valid intent
+ * @param {Object} plan A plan from {@link planOnboarding}
+ * @returns {String[]}
+ */
+export function renderPlan(intent, plan) {
+    const lines = [`[onboardPeer] resident: ${intent.residentId} (phase ${plan.phase})`, ''];
+
+    for (const segment of plan.segments) {
+        lines.push(`  [${segment.action}] ${segment.key}: ${segment.detail}`);
+    }
+
+    if (plan.gateMessage) {
+        lines.push('', `  OPERATOR GATE — ${plan.gateMessage}`);
+    }
+
+    lines.push('');
+    return lines;
+}
+
+/**
+ * @summary Parses the CLI argv (pure; unknown flags refuse instead of being silently ignored).
+ * @param {String[]} argv Arguments after the script path (`process.argv.slice(2)`)
+ * @returns {{valid: Boolean, reason: String|null, options: Object|null}}
+ */
+export function parseOnboardArgs(argv = []) {
+    const valueFlags = {
+        '--clone-url'      : 'cloneUrl',
+        '--github-username': 'githubUsername',
+        '--harness-type'   : 'harnessType',
+        '--repo-slug'      : 'repoSlug',
+        '--resident-id'    : 'residentId'
+    };
+
+    const booleanFlags = {
+        '--commit': 'commit',
+        '--help'  : 'help'
+    };
+
+    const options = {commit: false, help: false};
+
+    for (let i = 0; i < argv.length; i++) {
+        const flag = argv[i];
+
+        if (booleanFlags[flag]) {
+            options[booleanFlags[flag]] = true;
+            continue;
+        }
+
+        if (valueFlags[flag]) {
+            const value = argv[i + 1];
+
+            if (value === undefined || value.startsWith('--')) {
+                return {valid: false, reason: `${flag} requires a value`, options: null};
+            }
+
+            options[valueFlags[flag]] = value;
+            i++;
+            continue;
+        }
+
+        return {valid: false, reason: `unknown option '${flag}' — onboarding accepts only: ${[...Object.keys(valueFlags), ...Object.keys(booleanFlags)].join(', ')}`, options: null};
+    }
+
+    return {valid: true, reason: null, options}
+}
+
+/**
+ * @summary Prints the CLI usage block.
+ * @returns {void}
+ */
+function printUsage() {
+    console.log('Usage: node ai/scripts/fleet/onboardPeer.mjs --resident-id <s> --github-username <s>');
+    console.log('           --harness-type <codex|claude-code> [--clone-url <s> --repo-slug <s>] [--commit]');
+    console.log('');
+    console.log('  (no flags)  Dry-run — print the two-phase segment delta without touching anything.');
+    console.log('  --commit    Execute the CURRENT phase\'s delta through the owning fleet services.');
+    console.log('');
+    console.log('  There is deliberately NO --model flag (engine truth is observation-owned) and NO');
+    console.log('  name flag (Social Names are the post-boot peer ritual). Identity + wake substrate');
+    console.log('  arrive via the roster ceremony: generator → PR → merge → Memory Core restart.');
+}
+
+async function main() {
+    const parsed = parseOnboardArgs(process.argv.slice(2));
+
+    if (!parsed.valid) {
+        console.error(`[onboardPeer] FATAL: ${parsed.reason}`);
+        printUsage();
+        process.exit(1);
+    }
+
+    if (parsed.options.help) {
+        printUsage();
+        return;
+    }
+
+    const built = buildOnboardingIntent(parsed.options);
+
+    if (!built.valid) {
+        console.error(`[onboardPeer] FATAL: ${built.reason}`);
+        printUsage();
+        process.exit(1);
+    }
+
+    const {intent} = built;
+
+    // Fact gathering (the side-effect half; every read is an owned surface). The Neo bootstrap +
+    // service imports are LAZY and sequenced so `--help` and the module import stay runnable in a
+    // bare fresh process.
+    await import('../../../src/Neo.mjs');
+    await import('../../../src/core/_export.mjs');
+
+    const
+        {default: FleetRegistryService}  = await import('../../services/fleet/FleetRegistryService.mjs'),
+        {default: FleetLifecycleService} = await import('../../services/fleet/FleetLifecycleService.mjs'),
+        {default: FleetManager}          = await import('../../services/fleet/FleetManager.mjs'),
+        {IDENTITIES}                     = await import('../../graph/identityRoots.mjs'),
+        // the graph db path is OWNED by the memory-core server config (its useTestDatabase-derived
+        // formula), not the root config — same layering the Day-0 lineage established
+        {default: memoryCoreConfig}      = await import('../../mcp/server/memory-core/config.mjs'),
+        {existsSync}                     = await import('node:fs');
+
+    const agent = FleetRegistryService.getAgent(intent.agentId);
+
+    // Read-only graph probe: absent file / absent node are DISTINCT facts (null = unverifiable).
+    let   graphNodeSeeded = null;
+    const graphPath       = memoryCoreConfig.storagePaths.graph;
+
+    if (typeof graphPath === 'string' && graphPath !== ':memory:' && existsSync(graphPath)) {
+        const {default: Database} = await import('better-sqlite3');
+        const sqlite              = new Database(graphPath, {readonly: true});
+
+        try {
+            graphNodeSeeded = Boolean(sqlite.prepare('SELECT id FROM Nodes WHERE id = ? LIMIT 1').get(`@${intent.residentId}`));
+        } finally {
+            sqlite.close();
+        }
+    }
+
+    const facts = {
+        agentDefined     : Boolean(agent),
+        repoConfigured   : Boolean(agent?.metadata?.repo),
+        rosterHasResident: IDENTITIES.some(identity => identity.id === `@${intent.residentId}`),
+        graphNodeSeeded,
+        running          : FleetLifecycleService.isRunning(intent.agentId),
+        authRequired     : null
+    };
+
+    const plan = planOnboarding({intent, facts});
+
+    console.log(renderPlan(intent, plan).join('\n'));
+
+    if (!parsed.options.commit) {
+        console.log('[onboardPeer] DRY-RUN complete. No changes applied. Re-run with --commit to execute this phase.');
+        return;
+    }
+
+    // --commit: execute exactly the rendered delta, refusing where the plan refuses.
+    if (plan.segments.some(segment => segment.action === 'REFUSE')) {
+        console.error('[onboardPeer] FATAL: the plan contains a REFUSE segment — resolve the named operator step first.');
+        process.exit(1);
+    }
+
+    for (const segment of plan.segments) {
+        if (segment.action !== 'CREATE') continue;
+
+        if (segment.key === 'define') {
+            FleetRegistryService.defineAgent({
+                id            : intent.agentId,
+                githubUsername: intent.githubUsername,
+                harnessType   : intent.harnessType
+            });
+            console.log(`  [DONE] define — '${intent.agentId}'`);
+        }
+
+        if (segment.key === 'repo') {
+            FleetManager.setRepo({id: intent.agentId, cloneUrl: intent.repo.cloneUrl, repoSlug: intent.repo.repoSlug});
+            console.log(`  [DONE] repo — ${intent.repo.repoSlug}`);
+        }
+
+        if (segment.key === 'launch') {
+            const status = await FleetManager.startAgent(intent.agentId);
+            console.log(`  [DONE] launch — state '${status.state}' (pid ${status.pid ?? 'n/a'})`);
+
+            if (status.authRequired) {
+                const home = status.instanceHome ?? '<instance home>';
+                console.log('');
+                console.log('  LOGIN REQUIRED (operator-owned, exactly once for this home):');
+                console.log(intent.harnessType === 'codex'
+                    ? `    CODEX_HOME=${home} codex login`
+                    : `    CLAUDE_CONFIG_DIR=${home} claude  # then /login inside the session`);
+            }
+        }
+    }
+
+    console.log('');
+    console.log(`[onboardPeer] COMMIT complete for phase ${plan.phase}.`);
+
+    if (plan.gateMessage) {
+        console.log('');
+        console.log(`OPERATOR GATE — ${plan.gateMessage}`);
+    }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    main().catch(err => {
+        console.error('[onboardPeer] FATAL:', err);
+        process.exit(1);
+    });
+}

--- a/ai/scripts/fleet/onboardPeer.mjs
+++ b/ai/scripts/fleet/onboardPeer.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
-import path            from 'node:path';
-import {fileURLToPath} from 'node:url';
+import * as acorn                   from 'acorn';
+import {execFileSync}              from 'node:child_process';
+import path                        from 'node:path';
+import {fileURLToPath}             from 'node:url';
+import {createFleetRegistryBridge} from '../../../src/ai/fleet/createFleetRegistryBridge.mjs';
 
 /**
  * @module ai/scripts/fleet/onboardPeer
@@ -24,26 +27,35 @@ import {fileURLToPath} from 'node:url';
  * wake route itself via the wake-subscription `bootstrap` action from the real boot envelope.
  *
  * **Phase B — after the gate (launch):**
- *   4. `preflight` — verify the roster entry exists in THIS checkout AND the graph node is
+ *   4. `preflight` — verify the roster entry exists on merged `origin/dev` AND the graph node is
  *      seeded (read-only probe). Refuse with the exact missing operator step named.
  *   5. `launch`    — `FleetManager.startAgent(id)` (provision-then-start, supervised child in
  *      its isolated instance home via the curated per-family template).
- *   6. `auth`      — read `status(id)`, print the per-home login line. Secrets never touch
- *      this script: authentication is the operator-owned step by design.
+ *   6. `auth`      — take `instanceHome` + `authRequired` from the long-lived lifecycle owner's
+ *      `startAgent` status and print the exact per-home login line. Secrets never touch this script:
+ *      authentication is the operator-owned step by design.
  *
- * Idempotent per segment because every underlying contract already is (define/setRepo upsert,
- * repo ensure-or-reuse, start short-circuits when running, boot seeding + wake bootstrap are
- * idempotent at their owners). Dry-run renders the true per-segment delta AND which phase the
- * onboarding is currently in; `--commit` executes exactly that delta.
+ * Idempotent per segment because every underlying contract already is (definition conflicts refuse,
+ * repo drift reconciles through `setRepo`, repo ensure-or-reuse, start short-circuits when running,
+ * boot seeding + wake bootstrap are idempotent at their owners). Dry-run renders the true
+ * per-segment delta AND which phase the onboarding is currently in; `--commit` executes exactly
+ * that delta.
  *
  * **Usage**:
  *   node ai/scripts/fleet/onboardPeer.mjs --resident-id <s> --github-username <s>
- *       --harness-type <codex|claude-code> [--clone-url <s> --repo-slug <s>]   # dry-run
+ *       --harness-type <codex|claude-code> [--clone-url <s> --repo-slug <s>]   # dry-run;
+ *                                                      # pair required unless repo already exists
  *   node ai/scripts/fleet/onboardPeer.mjs ... --commit                          # execute phase delta
  *   node ai/scripts/fleet/onboardPeer.mjs --help
  */
 
-const __filename = fileURLToPath(import.meta.url);
+const
+    __filename       = fileURLToPath(import.meta.url),
+    REPO_ROOT        = path.resolve(path.dirname(__filename), '../../..'),
+    HARNESS_FAMILIES = Object.freeze({
+        'claude-code': 'claude',
+        codex        : 'gpt'
+    });
 
 /**
  * @summary The curated harness families the conductor accepts — must stay a subset of the
@@ -52,6 +64,135 @@ const __filename = fileURLToPath(import.meta.url);
  * @type {ReadonlyArray<String>}
  */
 export const CURATED_HARNESS_TYPES = Object.freeze(['claude-code', 'codex']);
+
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
+
+/**
+ * @summary Parse the merged roster source without executing it and return only literal ids from
+ * the canonical exported `IDENTITIES` array. AST parsing makes comments and unrelated strings
+ * inert; a missing/non-literal authority shape fails closed rather than guessing membership.
+ * @param {String} source The `origin/dev:ai/graph/identityRoots.mjs` source text.
+ * @returns {Set<String>} Literal identity ids declared by the exported roster array.
+ */
+function parseIdentityRootIds(source) {
+    const ast = acorn.parse(String(source), {ecmaVersion: 'latest', sourceType: 'module'});
+
+    let identities;
+
+    for (const statement of ast.body) {
+        if (statement.type !== 'ExportNamedDeclaration' || statement.declaration?.type !== 'VariableDeclaration') continue;
+
+        const declarator = statement.declaration.declarations.find(item => item.id?.type === 'Identifier' && item.id.name === 'IDENTITIES');
+
+        if (declarator) {
+            identities = declarator.init;
+            break
+        }
+    }
+
+    if (identities?.type !== 'ArrayExpression') {
+        throw new Error('merged roster must export IDENTITIES as a literal array');
+    }
+
+    const ids = new Set();
+
+    for (const element of identities.elements) {
+        if (element?.type !== 'ObjectExpression') continue;
+
+        const idProperty = element.properties.find(property => property.type === 'Property'
+            && !property.computed
+            && (property.key?.name === 'id' || property.key?.value === 'id'));
+
+        if (idProperty?.value?.type === 'Literal' && typeof idProperty.value.value === 'string') {
+            ids.add(idProperty.value.value);
+        }
+    }
+
+    return ids
+}
+
+/**
+ * @summary Verify membership against the merged roster authority (`origin/dev`), never the
+ * conductor's current feature-branch worktree. This keeps Phase B locked until the ceremony PR
+ * actually merged and the operator refreshed the remote-tracking ref. Git is invoked shell-free;
+ * failures refuse instead of silently treating stale or unavailable authority as membership.
+ * @param {Object} options
+ * @param {String} options.residentId Normalized resident handle.
+ * @param {String} [options.repoRoot] Repository working directory.
+ * @param {Function} [options.execFileImpl] Injectable `execFileSync` seam.
+ * @returns {Boolean} Whether the merged roster contains the exact resident id.
+ */
+export function originDevRosterHasResident({residentId, repoRoot = REPO_ROOT, execFileImpl = execFileSync} = {}) {
+    const normalized = normalizeToken(residentId, 'residentId');
+
+    if (!normalized.valid) {
+        throw new Error(`originDevRosterHasResident: ${normalized.reason}`);
+    }
+
+    let source;
+
+    try {
+        source = execFileImpl('git', ['show', 'origin/dev:ai/graph/identityRoots.mjs'], {
+            cwd     : repoRoot,
+            encoding: 'utf8'
+        });
+    } catch (error) {
+        throw new Error("onboardPeer: cannot verify the merged roster at origin/dev; run 'git fetch origin dev' and re-run", {cause: error});
+    }
+
+    let ids;
+
+    try {
+        ids = parseIdentityRootIds(source)
+    } catch (error) {
+        throw new Error('onboardPeer: cannot parse the merged identity roster at origin/dev; refresh the ref and re-run', {cause: error});
+    }
+
+    return ids.has(`@${normalized.token}`)
+}
+
+/**
+ * @summary Build the CLI's client for the ONE long-lived Fleet lifecycle owner. Every independently
+ * invoked conductor process talks to this HTTP seam rather than constructing a private in-process
+ * `FleetLifecycleService`, so process state and idempotency survive across shells. The request seam
+ * is injectable for exact ephemeral-server tests; transport/envelope unwrapping stays on the shared
+ * {@link createFleetRegistryBridge} contract consumed by the cockpit.
+ * @param {Object} [options]
+ * @param {String} [options.url='http://127.0.0.1:8083/fleet'] Fleet owner endpoint.
+ * @param {Function} [options.fetchImpl=globalThis.fetch] Injectable Fetch implementation.
+ * @returns {Object} Async Fleet wire methods.
+ */
+export function createOnboardingFleetBridge({url = 'http://127.0.0.1:8083/fleet', fetchImpl = globalThis.fetch} = {}) {
+    if (typeof fetchImpl !== 'function') {
+        throw new Error('createOnboardingFleetBridge: fetchImpl must be a function.');
+    }
+
+    const send = async request => {
+        let response;
+
+        try {
+            response = await fetchImpl(url, {
+                method : 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body   : JSON.stringify(request)
+            });
+        } catch (error) {
+            throw new Error(`onboardPeer: long-lived Fleet owner is unreachable at ${url}; start it with 'npm run ai:fleet-server' and re-run`, {cause: error});
+        }
+
+        if (!response?.ok) {
+            throw new Error(`onboardPeer: Fleet owner at ${url} returned HTTP ${response?.status ?? 'unknown'}`);
+        }
+
+        try {
+            return await response.json()
+        } catch (error) {
+            throw new Error(`onboardPeer: Fleet owner at ${url} returned a non-JSON response`, {cause: error});
+        }
+    };
+
+    return createFleetRegistryBridge(send)
+}
 
 /**
  * @summary Normalizes a lowercase token input; fail-closed on empty or malformed values.
@@ -104,6 +245,31 @@ export function buildOnboardingIntent(options = {}) {
         return {valid: false, reason: '--clone-url and --repo-slug come together or not at all (one without the other cannot provision a checkout)', intent: null};
     }
 
+    if (hasCloneUrl) {
+        const
+            cloneUrl = options.cloneUrl.trim(),
+            repoSlug = options.repoSlug.trim();
+
+        if (CONTROL_CHARACTERS.test(cloneUrl) || CONTROL_CHARACTERS.test(repoSlug)) {
+            return {valid: false, reason: '--clone-url and --repo-slug may not contain control characters', intent: null};
+        }
+
+        try {
+            const parsedUrl = new URL(cloneUrl);
+
+            if (parsedUrl.password || (['http:', 'https:'].includes(parsedUrl.protocol) && parsedUrl.username)) {
+                return {valid: false, reason: '--clone-url must not embed credentials; Fleet registry metadata is non-secret', intent: null};
+            }
+            if (['http:', 'https:'].includes(parsedUrl.protocol) && (parsedUrl.search || parsedUrl.hash)) {
+                return {valid: false, reason: '--clone-url HTTP(S) URLs may not contain a query string or fragment; Fleet registry metadata is non-secret', intent: null};
+            }
+        } catch {
+            // SCP-like Git URLs (`git@host:owner/repo.git`) are valid clone inputs but not WHATWG
+            // URLs. The downstream provisioner uses `execFile('git', ['clone', '--', ...])`, so they
+            // remain shell-free; only control characters are rejected above.
+        }
+    }
+
     return {
         valid : true,
         reason: null,
@@ -122,10 +288,10 @@ export function buildOnboardingIntent(options = {}) {
 /**
  * @summary The pure two-phase decision: given the intent and the OBSERVED facts, decide the
  * current phase and the exact per-segment delta. Facts arrive observed (the CLI gathers them;
- * tests inject them) so the planner stays side-effect-free:
- * `agentDefined` / `repoConfigured` (registry reads), `rosterHasResident` (this checkout's
- * committed roster), `graphNodeSeeded` (read-only graph probe; `null` = no graph reachable),
- * `running` / `authRequired` (lifecycle status).
+ * tests inject them) so the planner stays side-effect-free: `agent` (the registry's public
+ * definition, or null), `rosterHasResident` (the merged `origin/dev` roster),
+ * `graphNodeSeeded` (read-only graph probe; `null` = no graph reachable), and `running` /
+ * `authRequired` (lifecycle status).
  * @param {Object} options
  * @param {Object} options.intent A valid intent from {@link buildOnboardingIntent}
  * @param {Object} options.facts Observed facts as described above
@@ -134,43 +300,66 @@ export function buildOnboardingIntent(options = {}) {
 export function planOnboarding({intent, facts = {}} = {}) {
     const
         segments = [],
-        push     = (key, action, detail) => segments.push({key, action, detail});
+        push     = (key, action, detail) => segments.push({key, action, detail}),
+        agent    = facts.agent ?? null;
 
     // --- Phase A segments (always evaluated: re-runs report EXISTS honestly) -----------------
-    push('define', facts.agentDefined ? 'EXISTS' : 'CREATE',
-        `fleet agent '${intent.agentId}' (githubUsername '${intent.githubUsername}', harnessType '${intent.harnessType}')`);
+    if (!agent) {
+        push('define', 'CREATE',
+            `fleet agent '${intent.agentId}' (githubUsername '${intent.githubUsername}', harnessType '${intent.harnessType}')`);
+    } else if (agent.githubUsername === intent.githubUsername && agent.harnessType === intent.harnessType) {
+        push('define', 'EXISTS',
+            `fleet agent '${intent.agentId}' matches githubUsername '${intent.githubUsername}' + harnessType '${intent.harnessType}'`);
+    } else {
+        push('define', 'REFUSE',
+            `fleet agent '${intent.agentId}' exists with a different githubUsername or harnessType — reconcile the occupied definition through the Fleet registry owner before onboarding`);
+    }
+
+    const existingRepo = agent?.metadata?.repo ?? null;
 
     if (intent.repo) {
-        push('repo', facts.repoConfigured ? 'EXISTS' : 'CREATE',
-            `metadata.repo → ${intent.repo.repoSlug} (${intent.repo.cloneUrl})`);
+        if (!existingRepo) {
+            push('repo', 'CREATE',
+                `metadata.repo → ${intent.repo.repoSlug} (clone source configured; credentials forbidden)`);
+        } else if (existingRepo.cloneUrl === intent.repo.cloneUrl && existingRepo.repoSlug === intent.repo.repoSlug) {
+            push('repo', 'EXISTS', `metadata.repo → ${intent.repo.repoSlug}`);
+        } else {
+            push('repo', 'UPDATE',
+                `existing metadata.repo differs — replace it through FleetManager.setRepo with ${intent.repo.repoSlug}`);
+        }
+    } else if (existingRepo) {
+        push('repo', 'EXISTS', 'existing metadata.repo coordinates retained');
     } else {
-        push('repo', 'SKIP', 'no --clone-url/--repo-slug given — the harness will start in the inherited cwd');
+        push('repo', 'REFUSE', 'no existing metadata.repo and no --clone-url/--repo-slug given — peer onboarding never launches in the Fleet process cwd');
     }
 
     // --- The gate: the roster ceremony decides which phase we are in --------------------------
     if (!facts.rosterHasResident) {
         push('roster', 'PRINT',
-            `node ai/scripts/setup/generateRosterOnboarding.mjs --resident-id ${intent.residentId} --github-username ${intent.githubUsername} --family <family>`);
+            `node ai/scripts/setup/generateRosterOnboarding.mjs --handle ${intent.residentId} --github-username ${intent.githubUsername} --family ${HARNESS_FAMILIES[intent.harnessType]}`);
 
         return {
             phase      : 'A',
             segments,
-            gateMessage: `'${intent.residentId}' is not in this checkout's committed roster. Next: run the roster generator above on a feature branch, open the PR (the cross-family-reviewed membership ceremony), merge it, pull, restart the Memory Core server (boot seeding creates the identity node + wake template), then re-run this command.`
+            gateMessage: `'${intent.residentId}' is not in the merged origin/dev roster. Next: run the roster generator above on a feature branch, open the PR (the cross-family-reviewed membership ceremony), merge it, pull/fetch origin/dev, restart the Memory Core server (boot seeding creates the identity node + wake template), then re-run this command.`
         }
     }
 
     // --- Phase B segments ----------------------------------------------------------------------
-    if (facts.graphNodeSeeded === false) {
+    if (segments.some(segment => segment.action === 'REFUSE')) {
+        return {phase: 'B', segments, gateMessage: null}
+    }
+
+    if (facts.graphNodeSeeded !== true) {
         push('preflight', 'REFUSE',
-            `roster entry present but the graph carries no '${intent.residentId}' AgentIdentity node — restart the Memory Core server so boot seeding materializes it, then re-run`);
+            facts.graphNodeSeeded === false
+                ? `roster entry present but the graph carries no '${intent.residentId}' AgentIdentity node — restart the Memory Core server so boot seeding materializes it, then re-run`
+                : 'the configured Memory Core graph is not reachable read-only — start or reconnect the owning Memory Core server and re-run; unverifiable identity state never reaches launch');
 
         return {phase: 'B', segments, gateMessage: null}
     }
 
-    push('preflight', facts.graphNodeSeeded === null ? 'WARN' : 'OK',
-        facts.graphNodeSeeded === null
-            ? 'no live graph reachable read-only — cannot verify seeding; the launch will still be attempted on --commit'
-            : `roster entry + seeded '${intent.residentId}' AgentIdentity node verified`);
+    push('preflight', 'OK', `roster entry + seeded '${intent.residentId}' AgentIdentity node verified`);
 
     push('launch', facts.running ? 'EXISTS' : 'CREATE',
         facts.running
@@ -180,7 +369,9 @@ export function planOnboarding({intent, facts = {}} = {}) {
     push('auth', 'PRINT',
         facts.authRequired === false
             ? 'per-home credentials already present — no login step required'
-            : `per-home login required once (surfaced via status().authRequired after launch)`);
+            : facts.authRequired === true
+                ? 'per-home login required once (surfaced via status().authRequired after launch)'
+                : 'auth state UNKNOWN until the long-lived owner returns live launch status');
 
     return {phase: 'B', segments, gateMessage: null}
 }
@@ -205,6 +396,37 @@ export function renderPlan(intent, plan) {
 
     lines.push('');
     return lines;
+}
+
+/**
+ * @summary Build the exact operator-owned login command from the instance home resolved by the
+ * lifecycle service. The home and executable are owned launch-contract outputs — never guessed
+ * from the resident id or PATH — and are single-quoted so shell metacharacters remain data.
+ * @param {Object} options
+ * @param {String} options.harnessType Curated harness family.
+ * @param {String} options.instanceHome Absolute instance home from lifecycle status.
+ * @param {String} options.launchCommand Absolute executable path from lifecycle status.
+ * @returns {String}
+ */
+export function buildLoginCommand({harnessType, instanceHome, launchCommand} = {}) {
+    if (!CURATED_HARNESS_TYPES.includes(harnessType)) {
+        throw new Error(`buildLoginCommand: unsupported harnessType '${String(harnessType)}'.`);
+    }
+    if (typeof instanceHome !== 'string' || !path.isAbsolute(instanceHome) || CONTROL_CHARACTERS.test(instanceHome)) {
+        throw new Error('buildLoginCommand: lifecycle status must provide a control-character-free absolute instanceHome.');
+    }
+    if (typeof launchCommand !== 'string' || !path.isAbsolute(launchCommand) || CONTROL_CHARACTERS.test(launchCommand)) {
+        throw new Error('buildLoginCommand: lifecycle status must provide a control-character-free absolute launchCommand.');
+    }
+
+    const
+        quote         = value => `'${value.replaceAll("'", "'\\''")}'`,
+        quotedHome    = quote(instanceHome),
+        quotedCommand = quote(launchCommand);
+
+    return harnessType === 'codex'
+        ? `CODEX_HOME=${quotedHome} ${quotedCommand} login`
+        : `CLAUDE_CONFIG_DIR=${quotedHome} ${quotedCommand}  # then /login inside the session`;
 }
 
 /**
@@ -264,6 +486,7 @@ function printUsage() {
     console.log('');
     console.log('  (no flags)  Dry-run — print the two-phase segment delta without touching anything.');
     console.log('  --commit    Execute the CURRENT phase\'s delta through the owning fleet services.');
+    console.log('  repo pair   Required for a new resident; omission reuses an existing metadata.repo only.');
     console.log('');
     console.log('  There is deliberately NO --model flag (engine truth is observation-owned) and NO');
     console.log('  name flag (Social Names are the post-boot peer ritual). Identity + wake substrate');
@@ -294,23 +517,23 @@ async function main() {
 
     const {intent} = built;
 
-    // Fact gathering (the side-effect half; every read is an owned surface). The Neo bootstrap +
-    // service imports are LAZY and sequenced so `--help` and the module import stay runnable in a
-    // bare fresh process.
+    // Fact gathering (the side-effect half; every Fleet read hits the ONE long-lived HTTP owner).
+    // The Neo bootstrap + graph/config imports stay LAZY so `--help` and the module import remain
+    // runnable in a bare fresh process.
     await import('../../../src/Neo.mjs');
     await import('../../../src/core/_export.mjs');
 
     const
-        {default: FleetRegistryService}  = await import('../../services/fleet/FleetRegistryService.mjs'),
-        {default: FleetLifecycleService} = await import('../../services/fleet/FleetLifecycleService.mjs'),
-        {default: FleetManager}          = await import('../../services/fleet/FleetManager.mjs'),
-        {IDENTITIES}                     = await import('../../graph/identityRoots.mjs'),
         // the graph db path is OWNED by the memory-core server config (its useTestDatabase-derived
         // formula), not the root config — same layering the Day-0 lineage established
-        {default: memoryCoreConfig}      = await import('../../mcp/server/memory-core/config.mjs'),
-        {existsSync}                     = await import('node:fs');
+        {default: memoryCoreConfig} = await import('../../mcp/server/memory-core/config.mjs'),
+        {existsSync}                = await import('node:fs'),
+        fleet                       = createOnboardingFleetBridge();
 
-    const agent = FleetRegistryService.getAgent(intent.agentId);
+    const [agent, runtimeRows] = await Promise.all([
+        fleet.getAgent(intent.agentId),
+        fleet.fleetRuntimeStatus()
+    ]);
 
     // Read-only graph probe: absent file / absent node are DISTINCT facts (null = unverifiable).
     let   graphNodeSeeded = null;
@@ -328,11 +551,10 @@ async function main() {
     }
 
     const facts = {
-        agentDefined     : Boolean(agent),
-        repoConfigured   : Boolean(agent?.metadata?.repo),
-        rosterHasResident: IDENTITIES.some(identity => identity.id === `@${intent.residentId}`),
+        agent,
+        rosterHasResident: originDevRosterHasResident({residentId: intent.residentId}),
         graphNodeSeeded,
-        running          : FleetLifecycleService.isRunning(intent.agentId),
+        running          : Boolean(runtimeRows.find(row => row.agentId === intent.agentId)?.running),
         authRequired     : null
     };
 
@@ -352,10 +574,10 @@ async function main() {
     }
 
     for (const segment of plan.segments) {
-        if (segment.action !== 'CREATE') continue;
+        if (!['CREATE', 'UPDATE'].includes(segment.action)) continue;
 
-        if (segment.key === 'define') {
-            FleetRegistryService.defineAgent({
+        if (segment.key === 'define' && segment.action === 'CREATE') {
+            await fleet.defineAgent({
                 id            : intent.agentId,
                 githubUsername: intent.githubUsername,
                 harnessType   : intent.harnessType
@@ -364,22 +586,32 @@ async function main() {
         }
 
         if (segment.key === 'repo') {
-            FleetManager.setRepo({id: intent.agentId, cloneUrl: intent.repo.cloneUrl, repoSlug: intent.repo.repoSlug});
+            await fleet.setRepo({id: intent.agentId, cloneUrl: intent.repo.cloneUrl, repoSlug: intent.repo.repoSlug});
             console.log(`  [DONE] repo — ${intent.repo.repoSlug}`);
         }
+    }
 
-        if (segment.key === 'launch') {
-            const status = await FleetManager.startAgent(intent.agentId);
-            console.log(`  [DONE] launch — state '${status.state}' (pid ${status.pid ?? 'n/a'})`);
+    // `startAgent` is idempotent at the long-lived owner: call it for CREATE *or* EXISTS so a
+    // cross-shell re-run returns the authoritative auth/home status without spawning a duplicate.
+    if (plan.segments.some(segment => segment.key === 'launch')) {
+        const status = await fleet.startAgent(intent.agentId);
 
-            if (status.authRequired) {
-                const home = status.instanceHome ?? '<instance home>';
-                console.log('');
-                console.log('  LOGIN REQUIRED (operator-owned, exactly once for this home):');
-                console.log(intent.harnessType === 'codex'
-                    ? `    CODEX_HOME=${home} codex login`
-                    : `    CLAUDE_CONFIG_DIR=${home} claude  # then /login inside the session`);
-            }
+        console.log(`  [DONE] launch — state '${status.state}' (pid ${status.pid ?? 'n/a'})`);
+
+        if (status.authRequired === true) {
+            const loginCommand = buildLoginCommand({
+                harnessType  : intent.harnessType,
+                instanceHome : status.instanceHome,
+                launchCommand: status.launchCommand
+            });
+
+            console.log('');
+            console.log('  LOGIN REQUIRED (operator-owned, exactly once for this home):');
+            console.log(`    ${loginCommand}`);
+        } else if (status.authRequired === false) {
+            console.log('  [DONE] auth — per-home credentials already present');
+        } else {
+            console.log('  [WARN] auth — the owner returned no curated auth state; no login command was guessed');
         }
     }
 

--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -278,7 +278,9 @@ class FleetLifecycleService extends Base {
         // required (existence alone lets a mode-0644 candidate publish a running status, then flip
         // to failed on the child's asynchronous permission error — a transient false-running state
         // no supervisor may emit).
-        if (!this.resolveExecutable(command, env.PATH, opts.cwd)) {
+        const resolvedCommand = this.resolveExecutable(command, env.PATH, opts.cwd);
+
+        if (!resolvedCommand) {
             throw new Error(`FleetLifecycleService.start: harness binary '${command}' not found or not executable for agent '${id}' (path-shaped commands resolve against the child cwd; bare commands against the child's PATH; executable permission required). Pin the AiConfig fleet.harnessBinaries leaf or the harnessBinaryPaths field to a real executable.`);
         }
 
@@ -338,6 +340,7 @@ class FleetLifecycleService extends Base {
             // per-home `authRequired` heuristic; null for raw-launch agents (unknown layout).
             harnessType  : launch.instanceHome ? agent.harnessType : null,
             instanceHome : launch.instanceHome ?? null,
+            launchCommand: launch.instanceHome ? resolvedCommand : null,
             binaryVersion: null
         };
         this.processes.set(id, record);
@@ -437,15 +440,20 @@ class FleetLifecycleService extends Base {
      * `authRequired` checks a marker file's PRESENCE, never its content).
      * @param {String} id
      * @returns {Object} `{id, state, running, pid, startedAt, uptimeMs, exitCode, exitedAt,
-     *     stderrBytes, authRequired, binaryVersion}` — `authRequired` is the LIVE per-home
+     *     stderrBytes, authRequired, instanceHome, launchCommand, binaryVersion}` — `authRequired`
+     *     is the LIVE per-home
      *     auth-marker heuristic for curated launches (`true` = the operator-owned per-home login has
      *     not happened yet; recomputed each read so a completed login flips it without a restart);
-     *     `null` for raw-launch / untracked agents. `binaryVersion` is the best-effort
+     *     `null` for raw-launch / untracked agents. `instanceHome` is the non-secret, absolute
+     *     lifecycle-owned home needed for the operator login handoff; `launchCommand` is the
+     *     non-secret executable path resolved from AiConfig/the lifecycle owner (`null` for
+     *     raw/untracked agents). Both are intentionally safe for the dev-only unauthenticated
+     *     loopback Fleet bridge: they expose no auth contents. `binaryVersion` is the best-effort
      *     `--version` capture of what actually ran (`null` until/unless the probe answered).
      */
     status(id) {
         const record = this.processes.get(id);
-        if (!record) return {id, state: 'stopped', running: false, pid: null, startedAt: null, uptimeMs: null, exitCode: null, exitedAt: null, stderrBytes: 0, authRequired: null, binaryVersion: null};
+        if (!record) return {id, state: 'stopped', running: false, pid: null, startedAt: null, uptimeMs: null, exitCode: null, exitedAt: null, stderrBytes: 0, authRequired: null, instanceHome: null, launchCommand: null, binaryVersion: null};
 
         return {
             id,
@@ -458,6 +466,8 @@ class FleetLifecycleService extends Base {
             exitedAt     : record.exitedAt,
             stderrBytes  : record.stderrBytes ?? 0,
             authRequired : this.authRequiredForHome(record.harnessType, record.instanceHome),
+            instanceHome : record.instanceHome ?? null,
+            launchCommand: record.launchCommand ?? null,
             binaryVersion: record.binaryVersion ?? null
         };
     }

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -396,9 +396,14 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — curated launch + 
 
         FleetLifecycleService.start('peer2');
 
-        expect(FleetLifecycleService.status('peer2').authRequired).toBe(true);  // fresh home: login pending
+        const
+            home   = spawn.calls[0].opts.env.CODEX_HOME,
+            status = FleetLifecycleService.status('peer2');
 
-        const home = spawn.calls[0].opts.env.CODEX_HOME;
+        expect(status.authRequired).toBe(true);  // fresh home: login pending
+        expect(status.instanceHome).toBe(home); // exact non-secret owner path for the login handoff
+        expect(status.launchCommand).toBe(process.execPath); // actual AiConfig/lifecycle binary, not PATH
+
         fs.mkdirSync(home, {recursive: true});
         fs.writeFileSync(path.join(home, 'auth.json'), '{}');
 

--- a/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
@@ -1,20 +1,42 @@
-import {test, expect} from '@playwright/test';
-import {spawnSync}    from 'node:child_process';
-import path           from 'node:path';
+import {test, expect}           from '@playwright/test';
+import {execFile, spawnSync}    from 'node:child_process';
+import {EventEmitter}           from 'node:events';
+import fs                       from 'node:fs';
+import os                       from 'node:os';
+import path                     from 'node:path';
+import {promisify}              from 'node:util';
+import Neo                      from '../../../../../../src/Neo.mjs';
+import * as core                from '../../../../../../src/core/_export.mjs';
+import FleetControlBridge       from '../../../../../../ai/services/fleet/FleetControlBridge.mjs';
+import FleetLifecycleService    from '../../../../../../ai/services/fleet/FleetLifecycleService.mjs';
+import FleetManager             from '../../../../../../ai/services/fleet/FleetManager.mjs';
+import FleetRegistryService     from '../../../../../../ai/services/fleet/FleetRegistryService.mjs';
+import {deriveAgentRepoPath}    from '../../../../../../ai/services/fleet/deriveAgentRepoPath.mjs';
+import {startFleetBridgeServer} from '../../../../../../ai/services/fleet/fleetBridgeServer.mjs';
 import {
     CURATED_HARNESS_TYPES,
+    buildLoginCommand,
     buildOnboardingIntent,
+    createOnboardingFleetBridge,
     normalizeToken,
+    originDevRosterHasResident,
     parseOnboardArgs,
     planOnboarding,
     renderPlan
 } from '../../../../../../ai/scripts/fleet/onboardPeer.mjs';
+import {parseGenerateArgs} from '../../../../../../ai/scripts/setup/generateRosterOnboarding.mjs';
 
-const BASE_OPTIONS = Object.freeze({
-    residentId    : 'neo-gpt-2',
-    githubUsername: 'neo-gpt-2',
-    harnessType   : 'codex'
-});
+const
+    execFileAsync = promisify(execFile),
+    BASE_OPTIONS  = Object.freeze({
+        residentId    : 'neo-gpt-2',
+        githubUsername: 'neo-gpt-2',
+        harnessType   : 'codex'
+    }),
+    REPO_OPTIONS = Object.freeze({
+        cloneUrl: 'https://github.com/x/y.git',
+        repoSlug: 'x/y'
+    });
 
 /**
  * @summary Builds a valid intent from the shared fixture options.
@@ -29,16 +51,76 @@ function buildIntent(overrides = {}) {
     return built.intent;
 }
 
+/**
+ * @summary Builds the registry's public agent projection for planner facts.
+ * @param {Object} [overrides] Agent-field overrides.
+ * @returns {Object}
+ */
+function buildAgent(overrides = {}) {
+    return {
+        id            : 'neo-gpt-2',
+        githubUsername: 'neo-gpt-2',
+        harnessType   : 'codex',
+        metadata      : {repo: {...REPO_OPTIONS}},
+        ...overrides
+    }
+}
+
+/**
+ * @summary Close an ephemeral Fleet HTTP server and await its listening-socket release.
+ * @param {Object} server Node HTTP server.
+ * @returns {Promise<void>}
+ */
+function closeServer(server) {
+    return new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+}
+
 test.describe('onboardPeer — intent construction (pure half)', () => {
 
     test('the resident handle is the Fleet agent id; repo coordinates come as a pair or not at all', () => {
-        const intent = buildIntent({cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'});
+        const intent = buildIntent(REPO_OPTIONS);
 
         expect(intent.agentId).toBe('neo-gpt-2');
         expect(intent.repo).toEqual({cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'});
 
         expect(buildOnboardingIntent({...BASE_OPTIONS, cloneUrl: 'https://github.com/x/y.git'}).valid).toBe(false);
         expect(buildOnboardingIntent({...BASE_OPTIONS, repoSlug: 'x/y'}).valid).toBe(false);
+    });
+
+    test('credential-bearing clone URLs and terminal-control payloads refuse before registry persistence or rendering', () => {
+        expect(buildOnboardingIntent({...BASE_OPTIONS, ...REPO_OPTIONS, cloneUrl: 'https://ghp_SUPERSECRET@github.com/x/y.git'})).toMatchObject({valid: false});
+        expect(buildOnboardingIntent({...BASE_OPTIONS, ...REPO_OPTIONS, cloneUrl: 'https://github.com/x/y.git?access_token=SUPERSECRET'})).toMatchObject({valid: false});
+        expect(buildOnboardingIntent({...BASE_OPTIONS, ...REPO_OPTIONS, cloneUrl: 'https://github.com/x/y.git#SUPERSECRET'})).toMatchObject({valid: false});
+        expect(buildOnboardingIntent({...BASE_OPTIONS, ...REPO_OPTIONS, repoSlug: 'x/y\n[FAKE]'})).toMatchObject({valid: false});
+
+        const
+            secret = 'https://ghp_SUPERSECRET@github.com/x/y.git',
+            intent = buildIntent(REPO_OPTIONS),
+            report = renderPlan(intent, planOnboarding({intent, facts: {agent: null, rosterHasResident: false}})).join('\n');
+
+        expect(report).not.toContain(intent.repo.cloneUrl);
+        expect(report).not.toContain(secret);
+    });
+
+    test('merged-roster verification reads the exact origin/dev authority, not the current worktree', () => {
+        let invocation;
+        const present = originDevRosterHasResident({
+            residentId  : 'neo-gpt-2',
+            repoRoot    : '/repo',
+            execFileImpl: (...args) => {
+                invocation = args;
+                return "export const IDENTITIES = [{id: '@neo-gpt-2'}];";
+            }
+        });
+
+        expect(present).toBe(true);
+        expect(invocation).toEqual(['git', ['show', 'origin/dev:ai/graph/identityRoots.mjs'], {cwd: '/repo', encoding: 'utf8'}]);
+        expect(originDevRosterHasResident({
+            residentId  : 'neo-gpt-2',
+            execFileImpl: () => "// retired: {id: '@neo-gpt-2'}\nexport const IDENTITIES = [{id: '@neo-gpt-20'}];"
+        })).toBe(false);
+        expect(() => originDevRosterHasResident({residentId: 'neo-gpt-2', execFileImpl: () => 'not valid module source'}))
+            .toThrow(/cannot parse the merged identity roster/);
     });
 
     test('only curated harness families are accepted, with a named refusal', () => {
@@ -66,8 +148,8 @@ test.describe('onboardPeer — intent construction (pure half)', () => {
 test.describe('onboardPeer — the two-phase planner', () => {
 
     test('PHASE A: an un-rostered resident ends at the roster ceremony PRINT + the operator gate', () => {
-        const intent = buildIntent({cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'}),
-              plan   = planOnboarding({intent, facts: {agentDefined: false, repoConfigured: false, rosterHasResident: false}});
+        const intent = buildIntent(REPO_OPTIONS),
+              plan   = planOnboarding({intent, facts: {agent: null, rosterHasResident: false}});
 
         expect(plan.phase).toBe('A');
         expect(plan.segments.map(segment => [segment.key, segment.action])).toEqual([
@@ -75,7 +157,13 @@ test.describe('onboardPeer — the two-phase planner', () => {
             ['repo',   'CREATE'],
             ['roster', 'PRINT']
         ]);
-        expect(plan.segments[2].detail).toContain('generateRosterOnboarding.mjs');
+        const generator = plan.segments[2].detail;
+
+        expect(generator).toContain('generateRosterOnboarding.mjs --handle neo-gpt-2');
+        expect(generator).not.toContain('--resident-id');
+        expect(generator).toContain('--family gpt');
+        expect(generator).not.toContain('<family>');
+        expect(parseGenerateArgs(['--handle', 'neo-gpt-2', '--github-username', 'neo-gpt-2', '--family', 'gpt']).valid).toBe(true);
         expect(plan.gateMessage).toContain('membership ceremony');
         expect(plan.gateMessage).toContain('restart the Memory Core');
         // Phase A NEVER contains a launch segment — launching an un-rostered resident is refused by omission
@@ -83,15 +171,49 @@ test.describe('onboardPeer — the two-phase planner', () => {
     });
 
     test('PHASE A re-run: existing definition + repo report EXISTS honestly', () => {
-        const intent = buildIntent({cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'}),
-              plan   = planOnboarding({intent, facts: {agentDefined: true, repoConfigured: true, rosterHasResident: false}});
+        const intent = buildIntent(REPO_OPTIONS),
+              plan   = planOnboarding({intent, facts: {agent: buildAgent(), rosterHasResident: false}});
 
         expect(plan.segments.map(segment => segment.action)).toEqual(['EXISTS', 'EXISTS', 'PRINT']);
     });
 
+    test('occupied-definition drift REFUSES; repo-coordinate drift UPDATEs only through the owner', () => {
+        const intent = buildIntent(REPO_OPTIONS);
+
+        const wrongIdentity = planOnboarding({
+            intent,
+            facts: {agent: buildAgent({githubUsername: 'someone-else'}), rosterHasResident: true, graphNodeSeeded: true}
+        });
+
+        expect(wrongIdentity.segments.find(segment => segment.key === 'define').action).toBe('REFUSE');
+        expect(wrongIdentity.segments.some(segment => segment.key === 'launch')).toBe(false);
+
+        const repoDrift = planOnboarding({
+            intent,
+            facts: {agent: buildAgent({metadata: {repo: {cloneUrl: 'https://github.com/old/repo.git', repoSlug: 'old/repo'}}}), rosterHasResident: true, graphNodeSeeded: true}
+        });
+
+        expect(repoDrift.segments.find(segment => segment.key === 'repo')).toMatchObject({action: 'UPDATE'});
+        expect(repoDrift.segments.find(segment => segment.key === 'repo').detail).toContain('FleetManager.setRepo');
+    });
+
+    test('a missing repo intent REFUSES for a new resident, but may reuse exact existing coordinates', () => {
+        const intent = buildIntent();
+
+        const missing = planOnboarding({intent, facts: {agent: null, rosterHasResident: true, graphNodeSeeded: true}});
+
+        expect(missing.segments.find(segment => segment.key === 'repo')).toMatchObject({action: 'REFUSE'});
+        expect(missing.segments.some(segment => segment.key === 'launch')).toBe(false);
+
+        const existing = planOnboarding({intent, facts: {agent: buildAgent(), rosterHasResident: true, graphNodeSeeded: true, running: false}});
+
+        expect(existing.segments.find(segment => segment.key === 'repo')).toMatchObject({action: 'EXISTS'});
+        expect(existing.segments.find(segment => segment.key === 'launch')).toMatchObject({action: 'CREATE'});
+    });
+
     test('PHASE B REFUSE: roster merged but the graph node is NOT seeded — the exact operator step is named', () => {
-        const intent = buildIntent(),
-              plan   = planOnboarding({intent, facts: {agentDefined: true, rosterHasResident: true, graphNodeSeeded: false}});
+        const intent = buildIntent(REPO_OPTIONS),
+              plan   = planOnboarding({intent, facts: {agent: buildAgent(), rosterHasResident: true, graphNodeSeeded: false}});
 
         expect(plan.phase).toBe('B');
 
@@ -102,35 +224,195 @@ test.describe('onboardPeer — the two-phase planner', () => {
         expect(plan.segments.some(segment => segment.key === 'launch')).toBe(false);
     });
 
-    test('PHASE B happy path: seeded node → launch CREATE + auth PRINT; unverifiable graph degrades to WARN, never a false OK', () => {
-        const intent = buildIntent(),
-              seeded = planOnboarding({intent, facts: {agentDefined: true, rosterHasResident: true, graphNodeSeeded: true, running: false}});
+    test('PHASE B REFUSE: an unreachable graph cannot be promoted from unverifiable to launchable', () => {
+        const intent = buildIntent(REPO_OPTIONS),
+              plan   = planOnboarding({intent, facts: {agent: buildAgent(), rosterHasResident: true, graphNodeSeeded: null, running: false}});
+
+        expect(plan.segments.find(segment => segment.key === 'preflight')).toMatchObject({action: 'REFUSE'});
+        expect(plan.segments.some(segment => segment.key === 'launch')).toBe(false);
+    });
+
+    test('PHASE B happy path: seeded node → launch CREATE + auth PRINT', () => {
+        const intent = buildIntent(REPO_OPTIONS),
+              seeded = planOnboarding({intent, facts: {agent: buildAgent(), rosterHasResident: true, graphNodeSeeded: true, running: false}});
 
         expect(seeded.phase).toBe('B');
         expect(seeded.segments.find(segment => segment.key === 'preflight').action).toBe('OK');
         expect(seeded.segments.find(segment => segment.key === 'launch').action).toBe('CREATE');
         expect(seeded.segments.find(segment => segment.key === 'auth').action).toBe('PRINT');
-
-        const unverifiable = planOnboarding({intent, facts: {agentDefined: true, rosterHasResident: true, graphNodeSeeded: null, running: false}});
-
-        expect(unverifiable.segments.find(segment => segment.key === 'preflight').action).toBe('WARN');
     });
 
     test('PHASE B re-run on a running agent reports launch EXISTS (start short-circuits at the owner)', () => {
-        const intent = buildIntent(),
-              plan   = planOnboarding({intent, facts: {agentDefined: true, rosterHasResident: true, graphNodeSeeded: true, running: true}});
+        const intent = buildIntent(REPO_OPTIONS),
+              plan   = planOnboarding({intent, facts: {agent: buildAgent(), rosterHasResident: true, graphNodeSeeded: true, running: true}});
 
         expect(plan.segments.find(segment => segment.key === 'launch').action).toBe('EXISTS');
     });
 
     test('renderPlan derives from the same plan the commit path executes — phase + gate rendered verbatim', () => {
-        const intent   = buildIntent(),
-              plan     = planOnboarding({intent, facts: {rosterHasResident: false}}),
+        const intent   = buildIntent(REPO_OPTIONS),
+              plan     = planOnboarding({intent, facts: {agent: null, rosterHasResident: false}}),
               rendered = renderPlan(intent, plan).join('\n');
 
         expect(rendered).toContain('phase A');
         expect(rendered).toContain('OPERATOR GATE');
         expect(rendered).toContain('[PRINT] roster');
+    });
+});
+
+test.describe('onboardPeer — auth handoff', () => {
+    test('the lifecycle-resolved absolute home is shell-quoted; placeholders and relative homes refuse', () => {
+        expect(buildLoginCommand({harnessType: 'codex', instanceHome: "/tmp/neo homes/o'neil", launchCommand: '/Applications/ChatGPT.app/Contents/Resources/codex'}))
+            .toBe("CODEX_HOME='/tmp/neo homes/o'\\''neil' '/Applications/ChatGPT.app/Contents/Resources/codex' login");
+        expect(buildLoginCommand({harnessType: 'claude-code', instanceHome: '/tmp/claude-home', launchCommand: '/opt/claude'}))
+            .toContain("CLAUDE_CONFIG_DIR='/tmp/claude-home'");
+        expect(() => buildLoginCommand({harnessType: 'codex', instanceHome: '<instance home>', launchCommand: '/opt/codex'})).toThrow(/absolute instanceHome/);
+        expect(() => buildLoginCommand({harnessType: 'codex', instanceHome: '/tmp/x\nFAKE', launchCommand: '/opt/codex'})).toThrow(/control-character-free/);
+    });
+
+    test('the rendered login line executes through /bin/sh without command injection', async () => {
+        const root          = fs.mkdtempSync(path.join(os.tmpdir(), 'onboard-peer-login-')),
+              capturePath   = path.join(root, 'capture.json'),
+              sentinelPath  = path.join(root, 'PWNED'),
+              launchCommand = path.join(root, 'fake;touch PWNED'),
+              instanceHome  = path.join(root, "home with ' quote"),
+              command       = buildLoginCommand({harnessType: 'codex', instanceHome, launchCommand});
+
+        try {
+            fs.writeFileSync(launchCommand, `#!/usr/bin/env node\nimport fs from 'node:fs';\nfs.writeFileSync(process.env.CAPTURE, JSON.stringify({home: process.env.CODEX_HOME, argv: process.argv.slice(2)}));\n`);
+            fs.chmodSync(launchCommand, 0o755);
+
+            await execFileAsync('/bin/sh', ['-c', command], {
+                cwd: root,
+                env: {...process.env, CAPTURE: capturePath}
+            });
+
+            expect(JSON.parse(fs.readFileSync(capturePath, 'utf8'))).toEqual({home: instanceHome, argv: ['login']});
+            expect(fs.existsSync(sentinelPath)).toBe(false);
+        } finally {
+            fs.rmSync(root, {recursive: true, force: true});
+        }
+    });
+});
+
+test.describe('onboardPeer — long-lived Fleet owner transport', () => {
+    test('two independent Node CLI processes observe one owner process and an idempotent second start', async () => {
+        let spawnCount = 0,
+              capturedSpawn;
+        const root         = fs.mkdtempSync(path.join(os.tmpdir(), 'onboard-peer-owner-')),
+              managedRoot  = path.join(root, 'repos'),
+              instanceRoot = path.join(root, 'instance homes'),
+              repoPath     = deriveAgentRepoPath({managedRoot, agentId: 'neo-gpt-2', repoSlug: 'x/y'}),
+              original     = {
+                  bridgeManager        : FleetControlBridge.manager,
+                  bridgeRegistry       : FleetControlBridge.registry,
+                  lifecycleBinaries    : FleetLifecycleService.harnessBinaryPaths,
+                  lifecycleExecFile    : FleetLifecycleService.execFileFn,
+                  lifecycleInstanceRoot: FleetLifecycleService.instanceRoot,
+                  lifecycleRegistry    : FleetLifecycleService.registry,
+                  lifecycleSpawn       : FleetLifecycleService.spawnFn,
+                  managerLifecycle     : FleetManager.lifecycleService,
+                  managerManagedRoot   : FleetManager.managedRoot,
+                  managerProvision     : FleetManager.provisionAndStartFn,
+                  registryDataDir      : FleetRegistryService.dataDir
+              };
+
+        fs.mkdirSync(path.join(repoPath, '.git'), {recursive: true});
+
+        FleetRegistryService.dataDir  = path.join(root, 'registry');
+        FleetRegistryService.loadedDir = null;
+        FleetRegistryService.agents.clear();
+
+        FleetLifecycleService.processes.clear();
+        FleetLifecycleService.registry           = FleetRegistryService;
+        FleetLifecycleService.instanceRoot       = instanceRoot;
+        FleetLifecycleService.harnessBinaryPaths = {codex: process.execPath};
+        FleetLifecycleService.execFileFn         = () => {};
+        FleetLifecycleService.spawnFn            = (command, args, options) => {
+            spawnCount++;
+            capturedSpawn = {command, args, options};
+
+            const child = new EventEmitter();
+            child.pid    = 4242;
+            child.stderr = new EventEmitter();
+            child.kill   = () => true;
+            return child
+        };
+
+        FleetManager.lifecycleService    = FleetLifecycleService;
+        FleetManager.managedRoot         = managedRoot;
+        FleetManager.provisionAndStartFn = null;
+        FleetControlBridge.registry      = FleetRegistryService;
+        FleetControlBridge.manager       = FleetManager;
+
+        const server    = await startFleetBridgeServer({port: 0}),
+              url       = `http://127.0.0.1:${server.address().port}/fleet`,
+              moduleUrl = new URL('../../../../../../ai/scripts/fleet/onboardPeer.mjs', import.meta.url).href;
+
+        try {
+            const firstCode = `
+                const {createOnboardingFleetBridge} = await import(${JSON.stringify(moduleUrl)});
+                const bridge = createOnboardingFleetBridge({url: ${JSON.stringify(url)}});
+                await bridge.defineAgent({id:'neo-gpt-2', githubUsername:'neo-gpt-2', harnessType:'codex'});
+                await bridge.setRepo({id:'neo-gpt-2', cloneUrl:'https://github.com/x/y.git', repoSlug:'x/y'});
+                console.log(JSON.stringify(await bridge.startAgent('neo-gpt-2')));
+            `;
+            const firstRun   = await execFileAsync(process.execPath, ['--input-type=module', '-e', firstCode], {encoding: 'utf8', timeout: 30_000}),
+                  firstStart = JSON.parse(firstRun.stdout);
+
+            const relativeHome = path.relative(instanceRoot, firstStart.instanceHome);
+
+            expect(firstStart.instanceHome).toBe(capturedSpawn.options.env.CODEX_HOME);
+            expect(firstStart.launchCommand).toBe(process.execPath);
+            expect(capturedSpawn.command).toBe(process.execPath);
+            expect(relativeHome).not.toBe('');
+            expect(relativeHome.startsWith('..')).toBe(false);
+            expect(path.isAbsolute(relativeHome)).toBe(false);
+
+            const secondCode = `
+                const {createOnboardingFleetBridge} = await import(${JSON.stringify(moduleUrl)});
+                const bridge = createOnboardingFleetBridge({url: ${JSON.stringify(url)}});
+                console.log(JSON.stringify({
+                    agent: await bridge.getAgent('neo-gpt-2'),
+                    runtime: await bridge.fleetRuntimeStatus(),
+                    start: await bridge.startAgent('neo-gpt-2')
+                }));
+            `;
+            const secondRun  = await execFileAsync(process.execPath, ['--input-type=module', '-e', secondCode], {encoding: 'utf8', timeout: 30_000}),
+                  secondView = JSON.parse(secondRun.stdout);
+
+            expect(secondView.agent).toMatchObject({metadata: {repo: REPO_OPTIONS}});
+            expect(secondView.runtime).toEqual([
+                expect.objectContaining({agentId: 'neo-gpt-2', running: true, state: 'running'})
+            ]);
+            expect(secondView.start.pid).toBe(4242);
+            expect(spawnCount).toBe(1);
+        } finally {
+            await closeServer(server);
+            FleetLifecycleService.processes.clear();
+            FleetControlBridge.manager                 = original.bridgeManager;
+            FleetControlBridge.registry                = original.bridgeRegistry;
+            FleetLifecycleService.harnessBinaryPaths   = original.lifecycleBinaries;
+            FleetLifecycleService.execFileFn           = original.lifecycleExecFile;
+            FleetLifecycleService.instanceRoot         = original.lifecycleInstanceRoot;
+            FleetLifecycleService.registry             = original.lifecycleRegistry;
+            FleetLifecycleService.spawnFn              = original.lifecycleSpawn;
+            FleetManager.lifecycleService              = original.managerLifecycle;
+            FleetManager.managedRoot                   = original.managerManagedRoot;
+            FleetManager.provisionAndStartFn           = original.managerProvision;
+            FleetRegistryService.dataDir               = original.registryDataDir;
+            FleetRegistryService.loadedDir             = null;
+            FleetRegistryService.agents.clear();
+            fs.rmSync(root, {recursive: true, force: true});
+        }
+    });
+
+    test('an unreachable long-lived owner fails closed with the operator recovery command', async () => {
+        const bridge = createOnboardingFleetBridge({
+            fetchImpl: async () => { throw new Error('ECONNREFUSED') }
+        });
+
+        await expect(bridge.getAgent('neo-gpt-2')).rejects.toThrow(/npm run ai:fleet-server/);
     });
 });
 

--- a/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
@@ -1,0 +1,146 @@
+import {test, expect} from '@playwright/test';
+import {spawnSync}    from 'node:child_process';
+import path           from 'node:path';
+import {
+    CURATED_HARNESS_TYPES,
+    buildOnboardingIntent,
+    normalizeToken,
+    parseOnboardArgs,
+    planOnboarding,
+    renderPlan
+} from '../../../../../../ai/scripts/fleet/onboardPeer.mjs';
+
+const BASE_OPTIONS = Object.freeze({
+    residentId    : 'neo-gpt-2',
+    githubUsername: 'neo-gpt-2',
+    harnessType   : 'codex'
+});
+
+/**
+ * @summary Builds a valid intent from the shared fixture options.
+ * @param {Object} [overrides] Option overrides.
+ * @returns {Object} The frozen intent.
+ */
+function buildIntent(overrides = {}) {
+    const built = buildOnboardingIntent({...BASE_OPTIONS, ...overrides});
+
+    expect(built.valid).toBe(true);
+
+    return built.intent;
+}
+
+test.describe('onboardPeer — intent construction (pure half)', () => {
+
+    test('the resident handle is the Fleet agent id; repo coordinates come as a pair or not at all', () => {
+        const intent = buildIntent({cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'});
+
+        expect(intent.agentId).toBe('neo-gpt-2');
+        expect(intent.repo).toEqual({cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'});
+
+        expect(buildOnboardingIntent({...BASE_OPTIONS, cloneUrl: 'https://github.com/x/y.git'}).valid).toBe(false);
+        expect(buildOnboardingIntent({...BASE_OPTIONS, repoSlug: 'x/y'}).valid).toBe(false);
+    });
+
+    test('only curated harness families are accepted, with a named refusal', () => {
+        expect(CURATED_HARNESS_TYPES).toEqual(['claude-code', 'codex']);
+
+        const built = buildOnboardingIntent({...BASE_OPTIONS, harnessType: 'gemini-cli'});
+
+        expect(built.valid).toBe(false);
+        expect(built.reason).toContain('claude-code');
+    });
+
+    test('malformed identifiers fail loud, and the @-prefix normalizes off', () => {
+        expect(normalizeToken('@neo-gpt-2', '--resident-id')).toEqual({valid: true, reason: null, token: 'neo-gpt-2'});
+        expect(normalizeToken('Bad Handle', '--resident-id').valid).toBe(false);
+        expect(buildOnboardingIntent({}).valid).toBe(false);
+    });
+
+    test('there is NO engine and NO name input surface — the flags do not exist', () => {
+        expect(parseOnboardArgs(['--model', 'gpt-6']).valid).toBe(false);
+        expect(parseOnboardArgs(['--social-name', 'Minerva']).valid).toBe(false);
+        expect(parseOnboardArgs(['--resident-id']).valid).toBe(false);   // missing value refuses too
+    });
+});
+
+test.describe('onboardPeer — the two-phase planner', () => {
+
+    test('PHASE A: an un-rostered resident ends at the roster ceremony PRINT + the operator gate', () => {
+        const intent = buildIntent({cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'}),
+              plan   = planOnboarding({intent, facts: {agentDefined: false, repoConfigured: false, rosterHasResident: false}});
+
+        expect(plan.phase).toBe('A');
+        expect(plan.segments.map(segment => [segment.key, segment.action])).toEqual([
+            ['define', 'CREATE'],
+            ['repo',   'CREATE'],
+            ['roster', 'PRINT']
+        ]);
+        expect(plan.segments[2].detail).toContain('generateRosterOnboarding.mjs');
+        expect(plan.gateMessage).toContain('membership ceremony');
+        expect(plan.gateMessage).toContain('restart the Memory Core');
+        // Phase A NEVER contains a launch segment — launching an un-rostered resident is refused by omission
+        expect(plan.segments.some(segment => segment.key === 'launch')).toBe(false);
+    });
+
+    test('PHASE A re-run: existing definition + repo report EXISTS honestly', () => {
+        const intent = buildIntent({cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'}),
+              plan   = planOnboarding({intent, facts: {agentDefined: true, repoConfigured: true, rosterHasResident: false}});
+
+        expect(plan.segments.map(segment => segment.action)).toEqual(['EXISTS', 'EXISTS', 'PRINT']);
+    });
+
+    test('PHASE B REFUSE: roster merged but the graph node is NOT seeded — the exact operator step is named', () => {
+        const intent = buildIntent(),
+              plan   = planOnboarding({intent, facts: {agentDefined: true, rosterHasResident: true, graphNodeSeeded: false}});
+
+        expect(plan.phase).toBe('B');
+
+        const preflight = plan.segments.find(segment => segment.key === 'preflight');
+
+        expect(preflight.action).toBe('REFUSE');
+        expect(preflight.detail).toContain('restart the Memory Core server');
+        expect(plan.segments.some(segment => segment.key === 'launch')).toBe(false);
+    });
+
+    test('PHASE B happy path: seeded node → launch CREATE + auth PRINT; unverifiable graph degrades to WARN, never a false OK', () => {
+        const intent = buildIntent(),
+              seeded = planOnboarding({intent, facts: {agentDefined: true, rosterHasResident: true, graphNodeSeeded: true, running: false}});
+
+        expect(seeded.phase).toBe('B');
+        expect(seeded.segments.find(segment => segment.key === 'preflight').action).toBe('OK');
+        expect(seeded.segments.find(segment => segment.key === 'launch').action).toBe('CREATE');
+        expect(seeded.segments.find(segment => segment.key === 'auth').action).toBe('PRINT');
+
+        const unverifiable = planOnboarding({intent, facts: {agentDefined: true, rosterHasResident: true, graphNodeSeeded: null, running: false}});
+
+        expect(unverifiable.segments.find(segment => segment.key === 'preflight').action).toBe('WARN');
+    });
+
+    test('PHASE B re-run on a running agent reports launch EXISTS (start short-circuits at the owner)', () => {
+        const intent = buildIntent(),
+              plan   = planOnboarding({intent, facts: {agentDefined: true, rosterHasResident: true, graphNodeSeeded: true, running: true}});
+
+        expect(plan.segments.find(segment => segment.key === 'launch').action).toBe('EXISTS');
+    });
+
+    test('renderPlan derives from the same plan the commit path executes — phase + gate rendered verbatim', () => {
+        const intent   = buildIntent(),
+              plan     = planOnboarding({intent, facts: {rosterHasResident: false}}),
+              rendered = renderPlan(intent, plan).join('\n');
+
+        expect(rendered).toContain('phase A');
+        expect(rendered).toContain('OPERATOR GATE');
+        expect(rendered).toContain('[PRINT] roster');
+    });
+});
+
+test.describe('onboardPeer — fresh-process bootstrap contract', () => {
+    test('--help exits 0 with usage output in a BARE process — no Neo bootstrap, no services touched', () => {
+        const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../../../../..'),
+              result   = spawnSync(process.execPath, ['ai/scripts/fleet/onboardPeer.mjs', '--help'], {cwd: repoRoot, encoding: 'utf-8', timeout: 30_000});
+
+        expect(result.status, `--help must exit 0 (stderr: ${result.stderr})`).toBe(0);
+        expect(result.stdout).toContain('Usage:');
+        expect(result.stdout).toContain('roster ceremony');
+    });
+});


### PR DESCRIPTION
Resolves #14937

The peer-onboarding rail's capstone: `ai/scripts/fleet/onboardPeer.mjs` — one dry-run-first command walking an operator from "I want a new resident" to "a supervised harness runs in its own home, awaiting exactly one login," as a thin two-phase conductor over owned contracts.

- **Phase A** (`define` → `repo` → `roster`): reads and writes the Fleet registry through the one long-lived HTTP owner, refuses occupied-definition drift, creates or reconciles exact `metadata.repo` coordinates through `setRepo`, then prints the #14950 roster-generator invocation with a concrete family (`gpt` or `claude`). Clone credentials, HTTP(S) query/fragment payloads, and terminal-control characters are rejected before persistence, and dry-run output never prints the clone URL.
- **The operator gate**: merge the roster PR, refresh `origin/dev`, and restart the Memory Core server. The conductor Acorn-parses the active exported `IDENTITIES` array from `git show origin/dev:ai/graph/identityRoots.mjs`, not its current feature branch or source-text comments, so an unmerged/retired entry cannot unlock Phase B.
- **Phase B** (`preflight` → `launch` → `auth`): both the merged roster entry and seeded graph node must be verifiable. Missing or unreachable graph state is `REFUSE`, never WARN-and-launch. Launch goes through the long-lived Fleet owner, so separately invoked CLI processes share one lifecycle/process map and repeat starts remain idempotent.
- **Auth handoff**: lifecycle status returns the non-secret resolved `instanceHome` and actual executable path. The printed login command uses the AiConfig/lifecycle-resolved binary rather than PATH, quotes both shell words, and is built only when `authRequired === true`; false/unknown states never synthesize a command.

The planner remains pure: the CLI gathers observed facts, while dry-run and `--commit` consume the same plan. Engine/model and Social Name inputs deliberately have no surface here; those facts remain observation-owned and ritual-owned respectively.

Evidence: L2 achieved (real default Fleet HTTP dispatch with two independent Node clients + authority/security falsifiers) → L3 required (operator-managed end-to-end second-peer onboarding after merge). Residual: live Phase A → roster merge/restart → Phase B/login/first-boot validation [#14937].

## Deltas from ticket

- The conductor now requires the dev-only loopback Fleet server (`npm run ai:fleet-server`) instead of constructing process-local service singletons. This is required for cross-shell lifecycle truth.
- Phase-B roster membership is proven by parsing the active exported literal roster from the merged `origin/dev` artifact rather than regex-matching the current worktree/source text.
- Unreachable graph state fails closed. The original WARN path contradicted the ticket's “refuses until verifiable” acceptance criterion and was removed.
- A new resident must supply repo coordinates; an existing exact repo may be reused. Launch never falls back to the Fleet owner's cwd.
- Lifecycle status exposes only two additional non-secret operator-handoff fields (`instanceHome`, `launchCommand`) over the already dev-only unauthenticated loopback bridge; no auth contents cross it.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs test/playwright/unit/ai/FleetLifecycleService.spec.mjs test/playwright/unit/ai/services/fleet/deriveAgentRepoPath.spec.mjs --workers=1` → **57 passed**, twice on the final staged delta.
- The 57-test matrix includes the real ephemeral Fleet HTTP chain with two external Node clients, exact active `origin/dev` roster parsing (including commented/malformed-authority refusal), fail-closed graph/repo/definition cases, HTTPS query/fragment secret refusal, clone-secret/output controls, actual `/bin/sh` login-line execution, lifecycle auth/home/binary status, and repo-path containment.
- `node --check` passed for all four modified modules/specs.
- `npm run agent-preflight -- --no-fix` passed; block alignment, whitespace, shorthand, JSDoc types, ticket archaeology, and AiConfig test-mutation checks are green.

## Post-Merge Validation

- [ ] Start the canonical loopback owner with `npm run ai:fleet-server`, then onboard the second GPT-family peer end-to-end: Phase A `--commit`, roster PR via #14950, merge + refresh `origin/dev` + Memory Core restart, Phase B `--commit`, one login using the printed resolved-binary command, then first boot self-registers its wake route.
- [ ] Confirm the canonical live graph produces preflight `OK`, and that stopping the graph produces a named `REFUSE` without a spawn.

## Commits

- `2800be120` — initial conductor + pure planner coverage.
- `e335a2574` — exact-head convergence: long-lived owner, fail-closed Acorn roster authority, URL-secret refusal, authoritative auth paths, and integration/security falsifiers.

Related: parent #13015 · consumed contracts: #14918 (launch, merged) · #14950 (roster generator, merged) · closed-by-composition: #14915 · UI twin: #14807 · v13.2 cornerstone-1 (#14560 / #13448).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b956ba53-01ed-4ea6-a1e5-62969f887bc3. Exact-head convergence by Euclid (GPT-5.6 Sol, Codex).
