### PR TITLE
fix(dashboard): mount the dock token scope on every projection + load its theme file per surface (#14969)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoAWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoAWorkspace.mjs
@@ -51,10 +51,14 @@ class DemoAWorkspace extends Container {
         /**
          * The `--fm-*` design tokens this skin consumes are defined in the main app
          * Viewport's theme layer; per-class CSS loading would never fetch it from a
-         * childapp, so it is declared as an additional theme dependency here.
-         * @member {String[]} additionalThemeFiles=['AgentOS.view.Viewport']
+         * childapp, so it is declared as an additional theme dependency here. The
+         * `Neo.dashboard.Container` entry carries the dock motion/token contract
+         * (`--dock-transition-*`, reveal keyframes) — the projected dock tree is plain
+         * containers, so nothing loads it per-class; the projection root carries the
+         * matching `.neo-dashboard` scope class.
+         * @member {String[]} additionalThemeFiles=['AgentOS.view.Viewport','Neo.dashboard.Container']
          */
-        additionalThemeFiles: ['AgentOS.view.Viewport'],
+        additionalThemeFiles: ['AgentOS.view.Viewport', 'Neo.dashboard.Container'],
         /**
          * @member {String[]} cls=['agentos-dockdemo-workspace']
          */

--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -109,6 +109,14 @@ class MainContainer extends Viewport {
          */
         className: 'Neo.examples.dashboard.dock.MainContainer',
         /**
+         * The dock motion/token contract (`--dock-transition-*`, reveal keyframes, splitter
+         * cursors) lives in the `Neo.dashboard.Container` theme file — the projected dock tree
+         * is plain containers, so per-class loading never fetches it; the workspace declares
+         * the dependency (the projection root carries the matching `.neo-dashboard` scope).
+         * @member {String[]} additionalThemeFiles=['Neo.dashboard.Container']
+         */
+        additionalThemeFiles: ['Neo.dashboard.Container'],
+        /**
          * @member {Object} layout={ntype:'vbox', align:'stretch'}
          */
         layout: {ntype: 'vbox', align: 'stretch'}

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -24,12 +24,17 @@
 .neo-dashboard-dock-splitter {
     flex-shrink: 0;
     touch-action: none;
+}
 
-    &-horizontal {
+// Scoped to 0,3,0 on purpose: the generic sort affordance (`.neo-container .neo-draggable`,
+// 0,2,0 in SortZone.css) otherwise wins the cascade and paints the resize handles with a
+// `pointer` cursor — load-order ties are not a contract.
+.neo-dashboard .neo-dashboard-dock-splitter {
+    &.neo-dashboard-dock-splitter-horizontal {
         cursor: ew-resize;
     }
 
-    &-vertical {
+    &.neo-dashboard-dock-splitter-vertical {
         cursor: ns-resize;
     }
 }

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -190,6 +190,17 @@ class DockLayoutAdapter extends Base {
 
     /**
      * Projects the model root into a Neo-compatible config tree.
+     *
+     * The returned ROOT config carries the dock token SCOPE with it: the `--dock-transition-*`
+     * tokens, reveal keyframes and splitter cursors all live in the `Neo.dashboard.Container`
+     * theme file, scoped to `.neo-dashboard` — but a projected dock tree is plain containers,
+     * so no element ever carried the scope and the motion contract was invisible on every
+     * dock-zone surface. The projection root stamps the scope class itself, so it rides every
+     * re-projection by construction. The CSS-LOADING half cannot ride the projection — the
+     * worker reads `additionalThemeFiles` from the class prototype, never from instance
+     * configs — so each consuming workspace declares
+     * `additionalThemeFiles: ['Neo.dashboard.Container']` in its own static config (one line;
+     * the `DemoAWorkspace` token-bridge precedent).
      * @param {Object} model
      * @param {Object} [options={}]
      * @param {Function} [options.resolveComponentRef]
@@ -207,7 +218,7 @@ class DockLayoutAdapter extends Base {
             throw new Error('DockLayoutAdapter requires a model with `root` and `nodes`.')
         }
 
-        return this.projectNode(model.root, {
+        let config = this.projectNode(model.root, {
             applyDockZoneOperation  : options.applyDockZoneOperation,
             autoHideRevealOnHover   : options.autoHideRevealOnHover === true,
             defaultRevealFraction   : Number.isFinite(options.defaultRevealFraction) ? options.defaultRevealFraction : null,
@@ -217,7 +228,11 @@ class DockLayoutAdapter extends Base {
             onDockCrossZoneDrop     : options.onDockCrossZoneDrop,
             onDockZoneDocumentChange: options.onDockZoneDocumentChange,
             resolveComponentRef     : options.resolveComponentRef || (() => null)
-        })
+        });
+
+        config.cls = [...new Set([...(config.cls || []), 'neo-dashboard'])];
+
+        return config
     }
 
     /**


### PR DESCRIPTION
Resolves #14969

## What

The entire dock motion contract — the `--dock-transition-*` token set, reveal keyframes, arrival settle class, and splitter cursors — lives in the `Neo.dashboard.Container` theme file, scoped to `.neo-dashboard`. Neither dock-zone surface instantiated that class, so the CSS never loaded and no element carried the scope: tokens computed unset on `examples/dashboard/dock` and the dockdemo childapp, leaving DockFlip and the #14966 choreography classes on their fail-safe instant path. The FM cockpit was unaffected because its Viewport mounts a real `dashboard.Container`.

Three pieces restore the owning contract:

1. `DockLayoutAdapter.project()` stamps `.neo-dashboard` on the projection root, so the scope survives every re-projection by construction.
2. Both consuming surfaces declare `additionalThemeFiles: ['Neo.dashboard.Container']` in their static configs. CSS loading stays on class prototypes, matching the existing `DemoAWorkspace` token-bridge precedent.
3. `Container.scss` raises splitter cursor selector specificity above the generic sort affordance without relying on stylesheet load order.

Evidence: L3 achieved (live computed styles + stylesheet inventory + Neural-Link committed-operation timing on both dock surfaces, plus native Playwright reduced-motion emulation) → L3 required (visible motion/scope restoration). Residual: none for #14969.

## Deltas from ticket

- Chose the ticket's minimal Shape A for the July window: existing workspaces opt into the owning theme file, while the adapter stamps the durable projection scope.
- Kept `additionalThemeFiles` out of projected instance configs after runtime inspection proved `worker/App.mjs` reads it from the consuming class prototype.
- Added the cursor-specificity correction discovered only after the stylesheet became live; load-order ties are not treated as a contract.
- Shape B (a new thin dashboard host class and theme migration) remains deferred until a third consumer justifies the abstraction.

## Test Evidence

- Both live surfaces compute `--dock-transition-duration: 260ms` and `cubic-bezier(0, 0, 0.2, 1)` on the projection root, with `dashboard/Container.css` present in `document.styleSheets`.
- Edge-band width renders 280px from the loaded stylesheet; splitter cursors compute `ew-resize` / `ns-resize` by orientation.
- A committed Neural-Link `splitNode` operation traversed `captureFirst` → `play()` and resolved `true` after 379ms, proving the animated FLIP envelope rather than the instant fallback.
- On the native exact-head surface with no style/DOM injection, the same `.neo-dashboard` root computed `260ms` with no preference and `0ms` after Playwright enabled `prefers-reduced-motion: reduce`; `Container.css` remained the loaded authority.
- The dashboard unit directory passed 222/222.
- Hosted exact-head code, unit, integration, JSDoc, CodeQL, and archaeology checks are green; the initial PR-body lint failure was metadata-only and is corrected by this body.

## Post-Merge Validation

- [x] Native exact-head Playwright emulation confirms the scoped duration computes `0ms` under `prefers-reduced-motion: reduce` (and `260ms` with no preference), with no style/DOM injection.
- [ ] Re-run the Demo A committed-operation tour without injection and retain the animated `play() === true` receipt.
- [ ] Track the independently reproduced overlay cls-delta delivery defect in #14970; no worker/choreography correction belongs in this PR.

## Boundaries

- #14970 is an engine-tier investigation: worker state, overlay cls truth, and motion counters are correct while the DOM can remain stale.
- Shape B remains a follow-up decision if a third consumer appears.
- This PR changes no motion token values or choreography classes; it mounts their existing owning stylesheet/scope.

Related: #14944 · #14947 · #14959 · #14966 · #14970 · parent #13158

Authored by Clio (Claude Fable 5, Claude Code). Session 183ac080-2f24-4837-8f63-69bfc536af0d.
