### PR TITLE
fix(dashboard): restore dock reveal visibility and focus (#14970)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -123,7 +123,9 @@
     position: absolute;
     z-index : 20;
 
-    &-hidden {
+    // The overlay is also a flex container. Keep the semantic visibility state above the generic
+    // `.neo-flex-container {display:flex}` rule without depending on stylesheet load order.
+    &.neo-dashboard-dock-reveal-overlay-hidden {
         display: none;
     }
 

--- a/src/dashboard/DockRevealOverlay.mjs
+++ b/src/dashboard/DockRevealOverlay.mjs
@@ -233,10 +233,17 @@ class DockRevealOverlay extends Container {
     /**
      * Moves REAL browser focus into the overlay (first focusable descendant — the pin control at
      * minimum, the hosted pane's focusables once mounted). The owning rail calls this when a
-     * click-born reveal opens: focus-hold must be embodied, not a state label.
+     * click-born reveal opens: focus-hold must be embodied, not a state label. Awaiting the
+     * component update is required because a genuinely hidden overlay cannot accept focus until
+     * the main thread has applied the visibility-class removal.
+     * @returns {Promise<void>}
      */
-    focusReveal() {
-        this.focus(this.id, true)
+    async focusReveal() {
+        await this.promiseUpdate();
+
+        if (this.visible && !this.isDestroyed) {
+            this.focus(this.id, true)
+        }
     }
 
     /**

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -68,13 +68,32 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
         const hidden = await readModel();
         expect(hidden?.items?.inspector?.autoHidden, 'worker truth must carry autoHidden: true').toBe(true);
 
+        await page.evaluate(() => {
+            window.__neoDockRevealAnimationStarts = 0;
+
+            document.addEventListener('animationstart', event => {
+                if (event.animationName.startsWith('neo-dock-reveal-')) {
+                    window.__neoDockRevealAnimationStarts++
+                }
+            })
+        });
+
         // Native gesture: CLICK the rail tab -> transient reveal overlay.
         await railTab.click();
         await page.waitForTimeout(600);
 
-        const overlay = page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)');
+        // Keep the locator bound to the stable overlay node. A selector that excludes the hidden
+        // class disappears from the result set as soon as worker truth adds that class, which can
+        // make `toBeHidden()` pass even when a later equal-specificity layout rule keeps the real
+        // element painted as `display:flex`.
+        const overlay = page.locator('.neo-dashboard-dock-reveal-overlay').first();
         await expect(overlay, 'the reveal overlay must open on rail-tab click').toBeVisible({ timeout: 10000 });
         await expect(overlay.locator('.neo-dashboard-dock-reveal-title'), 'the overlay must title the revealed item').toHaveText('Inspector');
+        await expect.poll(() => page.evaluate(() => window.__neoDockRevealAnimationStarts), {
+            message: 'the token-scoped reveal animation must start on the first reveal'
+        }).toBeGreaterThan(0);
+
+        const firstRevealAnimationStarts = await page.evaluate(() => window.__neoDockRevealAnimationStarts);
 
         // Product truth #2: reveal is runtime-only — worker truth is byte-stable across the reveal.
         const revealed = await readModel();
@@ -95,6 +114,9 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
         await railTab.click();
         await page.waitForTimeout(400);
         await expect(overlay).toBeVisible();
+        await expect.poll(() => page.evaluate(() => window.__neoDockRevealAnimationStarts), {
+            message: 'the token-scoped reveal animation must restart on re-reveal'
+        }).toBeGreaterThan(firstRevealAnimationStarts);
         await page.locator('.neo-tab-header-button', { hasText: 'Strategy' }).first().click();
         await page.waitForTimeout(400);
         await expect(overlay, 'an outside click must dismiss the focused reveal').toBeHidden();
@@ -156,7 +178,7 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
         await railTab.click();
         await page.waitForTimeout(600);
 
-        const overlay = page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)');
+        const overlay = page.locator('.neo-dashboard-dock-reveal-overlay').first();
         await expect(overlay).toBeVisible({ timeout: 10000 });
         await overlay.locator('.neo-dashboard-dock-reveal-pin').first().click();
         await page.waitForTimeout(1500);


### PR DESCRIPTION
Resolves #14970

Restores the dock reveal overlay's physical hidden state and embodied focus ordering. The fix raises the semantic hidden selector above the generic flex layout rule, waits for the hidden-to-visible paint before moving browser focus, and hardens the existing Neural Link journey so it observes the stable DOM node plus token-scoped animation restarts.

Evidence: L3 (browser-rendered Chromium + Neural Link journey, repeated five times) → L3 required (physical dismissal, real focus, and animation restart on the live dock surface). No residuals.

Related: #14966
Related: #14969
Related: #14971

## Deltas from ticket

The investigation falsified the ticket's original missing-delta hypothesis: worker config, VDOM classes, and real DOM classes transition correctly. The owning defect is an equal-specificity CSS cascade conflict; fixing it exposed a focus-before-paint race that the formerly always-painted overlay had masked. The ticket title/body now carry this corrected root-cause truth.

## Test Evidence

- `npm run build-themes -- -e dev -n` — passed; compiled CSS contains the higher-specificity hidden selector.
- `npm run test-unit -- test/playwright/unit/dashboard/DockRevealOverlay.spec.mjs --workers=1` — 7 passed.
- `NEO_E2E_PORT=8097 npx playwright test test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1 --grep "rail click reveals" --repeat-each=5` — 5 passed; each run proves physical hide, real focus, and animation restart.
- `node --check src/dashboard/DockRevealOverlay.mjs` — passed.
- `git diff --check` — passed.

The initial sandboxed whitebox attempt could not start its web server (`uv_uptime EPERM`); the same focused command passed outside that sandbox ceiling.

## Post-Merge Validation

- [ ] Re-run the dock demo pixel gate on merged `dev` to confirm the composed choreography remains visually clean.

## Evolution

Live falsification prevented a delta-pipeline refactor: 10/10 expected class mutations landed across five manual cycles. Binding the spec to the stable overlay node then turned the prior vacuous hidden assertion into a deterministic failure and exposed the smaller CSS/focus-order fix.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session 019f484c-662f-7f31-969a-cbde373efd4a.
