### PR TITLE
feat(harness): the Brain rides supervised — Arm B orchestrator child, isolated env, settle-or-reject teardown (#14967)

### DIFF
--- a/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
+++ b/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
@@ -34,6 +34,7 @@ export function buildConfiguredTaskDefinitions({
     const tasks = buildTaskDefinitions({
         scriptDir,
         nodeBin,
+        chromaDataDir             : AiConfig.engines.chroma.dataDir,
         chromaHost                : AiConfig.engines.chroma.host,
         chromaPort                : AiConfig.engines.chroma.port,
         devServerPort             : AiConfig.orchestrator.devServer.port,

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -230,6 +230,7 @@ export function buildOllamaServeEnv({host, keepAlive, contextLength, requirePara
  * @param {String} [options.scriptDir] Script directory.
  * @param {String} [options.nodeBin] Node executable.
  * @param {String|Number} [options.chromaPort] Chroma daemon port — used for the `--port` arg and as the chroma task's `singletonPort` (the port the orchestrator reaps duplicate listeners on).
+ * @param {String} [options.chromaDataDir] Chroma persist dir for the `--path` arg — the configured builder passes the resolved `engines.chroma.dataDir` leaf so env-shifted profiles (`UNIT_TEST_MODE` isolation) move the DATA with the port; the literal default keeps direct callers launch-resilient.
  * @param {String} [options.chromaHost='localhost'] Chroma daemon host for HTTP service-health probes.
  * @param {Number} [options.chromaHealthProbeTimeoutMs=1000] Chroma HTTP health probe timeout.
  * @param {Function} [options.chromaHealthFetchFn] Optional fetch implementation seam for tests.
@@ -242,7 +243,8 @@ export function buildOllamaServeEnv({host, keepAlive, contextLength, requirePara
 export function buildTaskDefinitions({
     scriptDir  = DEFAULT_SCRIPT_DIR,
     nodeBin    = process.argv[0],
-    chromaHost = 'localhost',
+    chromaDataDir = '.neo-ai-data/chroma/unified',
+    chromaHost    = 'localhost',
     chromaPort,
     chromaHealthProbeTimeoutMs = DEFAULT_CHROMA_HEALTH_TIMEOUT_MS,
     chromaHealthFetchFn,
@@ -258,12 +260,12 @@ export function buildTaskDefinitions({
         chroma: {
             label  : 'chroma daemon',
             command: 'chroma',
-            // The --path persist dir resolves to the same dir as AiConfig.engines.chroma.dataDir
-            // — the SSOT that KB/MC configs + defragChromaDB read — under the standard
-            // cwd==repoRoot. Kept as a relative literal here (not SSOT-sourced) for daemon-launch
-            // resilience: a stale config.mjs lacking the SSOT key would otherwise launch the daemon
-            // with `--path undefined`. Keep this value in sync with engines.chroma.dataDir.
-            args           : ['run', '--path', '.neo-ai-data/chroma/unified', '--port', String(chromaPort)],
+            // The --path persist dir is the resolved engines.chroma.dataDir leaf when built through
+            // the configured builder (the SSOT that KB/MC configs + defragChromaDB read) — an
+            // env-shifted profile MUST move the data with the port, or a test-port launch serves the
+            // production persist dir (empirically observed: a second server on the live store). The
+            // parameter default keeps direct callers launch-resilient against a stale config.mjs.
+            args           : ['run', '--path', chromaDataDir, '--port', String(chromaPort)],
             pidFileName    : 'chroma.pid',
             expectedCommand: 'chroma',
             singletonPort  : chromaPort,

--- a/harness/.gitignore
+++ b/harness/.gitignore
@@ -1,0 +1,3 @@
+.brain/
+smoke-timeout.png
+node_modules/

--- a/harness/README.md
+++ b/harness/README.md
@@ -68,8 +68,9 @@ exercised listener to a runtime-allocated port, and gates every other lane OFF v
 env switch (dev server, Neural Link, embed/message daemons, mlx/ollama/lms, swarm heartbeat, the
 sync + enrichment lanes, deployment-state bridge). The matrix is EXECUTABLE, not documentation:
 `resolveBrainPaths` re-resolves the leaves through `ai/config.mjs` itself under the profile env,
-and the smoke fails on any leaf escaping the isolation root — asserting what the tree actually
-consumes, not what the profile intended.
+and the smoke fails on any leaf escaping the isolation root — by FILESYSTEM IDENTITY (ancestor
+symlinks resolved on both sides), asserting what the tree actually consumes, not what the profile
+intended.
 
 **Readiness is service readiness, never PID existence.** The daemon writes its PID file before
 config load and `Orchestrator.start()`, so the up-gates are: the orchestrator's own
@@ -84,8 +85,11 @@ exit additionally requires the unforced path plus released listeners. SIGINT (no
 graceful rung by measurement: the chromadb npm wrapper ignores group-SIGTERM indefinitely but
 exits on SIGINT in milliseconds, and both supervised entries register the two identically. Every
 smoke exit path (will-quit, verdict, timeout net, unhandled-rejection net) runs the teardown; a
-crashed run's process groups are recorded in `.brain/smoke/run-state.json` and swept on the next
-smoke boot.
+crashed run's process groups are recorded in `.brain/smoke/run-state.json` WITH an ownership
+token (the leader's entry script), cleared on clean stop, and swept on the next smoke boot only
+after the recorded identity re-verifies — a bare PGID is an observation, not ownership. The same
+rule governs attach: `fleetServing` requires the `listAgents` wire envelope, and a foreign
+listener squatting the fleet port fails the product boot closed instead of reading as a Brain.
 
 ## Why the window loads DEV MODE (operator decision, 2026-07-10)
 

--- a/harness/README.md
+++ b/harness/README.md
@@ -28,9 +28,32 @@ cd /path/to/neo      # repo root
 npm install         # source-mode runtime + canonical theme builder dependencies
 cd harness
 npm install
-npm start          # prepares missing dev assets, then boots the harness window
-npm run smoke      # boot + popup + shared-worker + clean-runtime evidence, JSON verdict
+npm start            # prepares missing dev assets, then boots the harness window (UI only)
+npm run start:brain  # the window + the SUPERVISED Agent OS (Arm B — see below)
+npm run smoke        # boot + popup + shared-worker + clean-runtime evidence, JSON verdict
+npm run smoke:brain  # the full verdict incl. the Brain leg (up + clean teardown + no orphan)
 ```
+
+Prerequisite for the Brain legs: a fresh per-clone `ai/config.mjs` — if the orchestrator child
+crashes at import with `ERR_INVALID_ARG_TYPE` on a config path, run
+`npm run prepare -- --migrate-config` from the repo root (the instance config drifted behind the
+template; the daemon's own freshness assert fires too late to catch this because the Orchestrator
+singleton constructs at module import).
+
+## The Brain rides supervised (Arm B — the hosting-spike verdict)
+
+The Electron main supervises ONE system-Node child — the orchestrator daemon — which supervises
+the rest of the Agent OS through its own `ProcessSupervisorService` (Chroma, wake/embed/message
+daemons, scheduled maintenance). Arm A (in-process) is falsified in this repo by the native-ABI
+split: `better-sqlite3` builds for one ABI, and the shared `node_modules` must keep serving the
+system-Node dev loop (the verdict + reproduction probe live on the hosting-spike ticket).
+
+**Dev-machine safety (load-bearing):** the orchestrator performs single-instance TAKEOVER — on
+boot it SIGTERMs any PID in its PID file. `brain.mjs` therefore always boots the child with an
+ISOLATED env (`harness/.brain/` data-root + the config's own `UNIT_TEST_MODE` Chroma test
+coordinates + a shifted dev-server port) so a harness Brain can never target a canonical Brain
+running on the same machine. Teardown is settle-or-reject: SIGTERM → bounded grace → SIGKILL
+escalation, and the smoke's exit code requires the UNforced path plus a no-orphan check.
 
 ## Why the window loads DEV MODE (operator decision, 2026-07-10)
 

--- a/harness/README.md
+++ b/harness/README.md
@@ -42,18 +42,50 @@ singleton constructs at module import).
 
 ## The Brain rides supervised (Arm B — the hosting-spike verdict)
 
-The Electron main supervises ONE system-Node child — the orchestrator daemon — which supervises
-the rest of the Agent OS through its own `ProcessSupervisorService` (Chroma, wake/embed/message
-daemons, scheduled maintenance). Arm A (in-process) is falsified in this repo by the native-ABI
-split: `better-sqlite3` builds for one ABI, and the shared `node_modules` must keep serving the
-system-Node dev loop (the verdict + reproduction probe live on the hosting-spike ticket).
+The Electron main supervises system-Node children: the orchestrator daemon (which supervises the
+rest of the Agent OS through its own `ProcessSupervisorService`) and the fleet HTTP transport the
+Fleet Manager window consumes (`devFleetServer.mjs`, `POST /fleet`). Arm A (in-process) is
+falsified in this repo by the native-ABI split: `better-sqlite3` builds for one ABI, and the
+shared `node_modules` must keep serving the system-Node dev loop (the verdict + reproduction
+probe live on the hosting-spike ticket).
 
-**Dev-machine safety (load-bearing):** the orchestrator performs single-instance TAKEOVER — on
-boot it SIGTERMs any PID in its PID file. `brain.mjs` therefore always boots the child with an
-ISOLATED env (`harness/.brain/` data-root + the config's own `UNIT_TEST_MODE` Chroma test
-coordinates + a shifted dev-server port) so a harness Brain can never target a canonical Brain
-running on the same machine. Teardown is settle-or-reject: SIGTERM → bounded grace → SIGKILL
-escalation, and the smoke's exit code requires the UNforced path plus a no-orphan check.
+**`start:brain` is ATTACH-OR-OWN (the dev-machine safety contract).** The orchestrator performs
+single-instance TAKEOVER (on boot it SIGTERMs any PID in its PID file) and its supervisor REAPS
+foreign listeners on supervised singleton ports — a second organism beside a live canonical Brain
+is never safe, and never useful (the Fleet Manager should manage the REAL fleet). So the product
+boot resolves the live state through the config SSOT and:
+
+- **attach** — a live orchestrator is detected (PID file + command check): the harness starts
+  only what is missing (the fleet transport, when `:8083` is not already listening) and on quit
+  stops exactly what IT started. The canonical Brain is never touched.
+- **own** — nothing is up (the fresh-machine / packaged-app shape): the harness starts the whole
+  organism on the default canonical-layout paths, and quitting tears the full tree down.
+
+**The smoke runs a fully ISOLATED organism instead.** `brain.mjs#buildBrainProfile` binds every
+mutable path the spawned tree consumes under `harness/.brain/smoke/` (orchestrator data dir, the
+graph sqlite, Chroma persist dir, fleet instance root, backup target, REM run-state), moves every
+exercised listener to a runtime-allocated port, and gates every other lane OFF via its config
+env switch (dev server, Neural Link, embed/message daemons, mlx/ollama/lms, swarm heartbeat, the
+sync + enrichment lanes, deployment-state bridge). The matrix is EXECUTABLE, not documentation:
+`resolveBrainPaths` re-resolves the leaves through `ai/config.mjs` itself under the profile env,
+and the smoke fails on any leaf escaping the isolation root — asserting what the tree actually
+consumes, not what the profile intended.
+
+**Readiness is service readiness, never PID existence.** The daemon writes its PID file before
+config load and `Orchestrator.start()`, so the up-gates are: the orchestrator's own
+`[Orchestrator] Started.` poll-loop marker, the isolated Chroma actually serving on its allocated
+port, a real `{method: 'listAgents'}` wire round-trip against the fleet transport — and the smoke
+re-runs that same verb FROM THE RENDERER (the AC's "window reaches the fleet transport"). Boot
+promises reject deterministically on spawn error or early exit.
+
+**Teardown owns the whole process TREE.** Children spawn `detached` into their own process group;
+stop is group-SIGINT → bounded grace → group-SIGKILL, settled on group-empty, and the smoke's
+exit additionally requires the unforced path plus released listeners. SIGINT (not SIGTERM) is the
+graceful rung by measurement: the chromadb npm wrapper ignores group-SIGTERM indefinitely but
+exits on SIGINT in milliseconds, and both supervised entries register the two identically. Every
+smoke exit path (will-quit, verdict, timeout net, unhandled-rejection net) runs the teardown; a
+crashed run's process groups are recorded in `.brain/smoke/run-state.json` and swept on the next
+smoke boot.
 
 ## Why the window loads DEV MODE (operator decision, 2026-07-10)
 
@@ -90,3 +122,14 @@ allowlist), so required `dist/development/css/*` stays reachable. Recorded in AD
    matches `protocol` + `host`.
 5. **`window-all-closed` default quits Electron.** The skeleton keeps quit-on-close deliberately
    (no tray yet); E8 lands ADR 0034 §2.1.5's suppress + tray + hide-never-destroy semantics.
+6. **Bare tool commands in the supervised tree resolve via PATH — guarantee it.** The
+   orchestrator's `chroma` task works under `npm run` by accident of npm's `.bin` prepending; a
+   packaged shell has no npm in the chain. `startBrainChild` prepends the repo's
+   `node_modules/.bin` explicitly.
+7. **Loopback bind family matters.** Chroma binds `localhost` → `::1` on macOS while the fleet
+   transport binds `127.0.0.1`; probing the wrong family reads a listening server as dead. Port
+   probes take an explicit `host`.
+8. **The chromadb npm wrapper ignores SIGTERM** (measured: 40s+ alive after group-SIGTERM) but
+   exits on SIGINT within milliseconds. Group-SIGINT is the graceful teardown rung; a cold Chroma
+   start on a fresh persist dir takes ~a minute, so the smoke settles on chroma-listening before
+   quitting and the Brain smoke's safety net allows 240s.

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -1,143 +1,580 @@
 // The Arm-B Brain supervision module (the recorded topology of the hosting spike — see the
-// falsifier-1 verdict on its ticket): the Electron main supervises ONE system-Node child — the
-// orchestrator daemon — which supervises the rest of the Agent OS through its own
-// ProcessSupervisorService (Chroma, wake/embed/message daemons, scheduled maintenance). Arm A
-// (in-process) is falsified in this repo by the native-ABI split: better-sqlite3 builds for ONE
-// ABI, and the shared node_modules must keep serving the system-Node dev loop.
+// falsifier-1 verdict on its ticket): the Electron main supervises system-Node children — the
+// orchestrator daemon (which supervises the rest of the Agent OS through its own
+// ProcessSupervisorService) and the fleet HTTP transport the Fleet Manager window consumes.
 //
 // Shell-ADR bindings implemented here:
-//   §2.1.1  one lifecycle owner — the main process starts/stops the Brain; no daemon fork
-//   §2.1.3  injectable data-root — every path below arrives via env leaves, nothing hardcoded
-//   §2.1.4  port discipline — the isolated env shifts every port-bearing task off the defaults
-//   §2.1.5  teardown on quit — SIGTERM, bounded grace, SIGKILL escalation; settle-or-reject
+//   §2.1.1  one lifecycle owner — the harness stops exactly the processes IT started
+//   §2.1.3  injectable data-root — every mutable path arrives via env leaves, nothing hardcoded
+//   §2.1.4  port discipline — smoke ports are runtime-allocated by this lifecycle owner
+//   §2.1.5  teardown on quit — process-GROUP SIGINT, bounded grace, group SIGKILL; settle-or-reject
 //
-// DEV-MACHINE SAFETY (load-bearing): the orchestrator daemon performs single-instance TAKEOVER —
-// on boot it SIGTERMs any PID found in its PID file. A child launched with default env on a
-// machine running the canonical Brain would kill it. `buildIsolatedBrainEnv` is therefore not
-// politeness; it is the precondition for booting a Brain here at all. The isolation rides the
-// config's own by-construction test contract (UNIT_TEST_MODE flips Chroma to the env-bindable
-// test coordinates — "a database-name swap alone is not isolation", per the config template).
+// ATTACH-OR-OWN (the dev-machine safety contract): the orchestrator daemon performs
+// single-instance TAKEOVER — on boot it SIGTERMs any PID in its PID file — and its supervised
+// children hold singleton ports it reaps foreign listeners from. A second organism beside a live
+// canonical Brain is therefore never safe OR useful (the Fleet Manager should manage the REAL
+// fleet). So the product boot ATTACHES when a Brain is already alive (supervising only the missing
+// fleet transport) and OWNS the full organism only when nothing is up (a fresh machine — the
+// packaged-app shape). Full isolation exists for the SMOKE profile only, where every mutable
+// path/listener the spawned tree consumes is bound under one throwaway root and asserted through
+// the config SSOT itself (resolveBrainPaths) before anything spawns.
+//
+// Teardown is process-GROUP-based: children spawn `detached` into their own group, so
+// SIGINT/SIGKILL on `-pid` reaches every descendant — including grandchildren the orchestrator's
+// supervisor tracks (Chroma, daemons) AND anything untracked. The orchestrator itself deliberately
+// orphans its children on SIGTERM (its supervisor re-adopts them by PID file / singleton port on
+// the next canonical restart — see ProcessSupervisorService.reconcileSingletonPort), which is
+// exactly why parent-only teardown leaks: the group is the only boundary that owns the whole tree.
 
-import {spawn} from 'node:child_process';
-import fs      from 'node:fs';
-import path    from 'node:path';
+import {execFile, spawn} from 'node:child_process';
+import fs                from 'node:fs';
+import net               from 'node:net';
+import path              from 'node:path';
 
-const ORCHESTRATOR_ENTRY = 'ai/daemons/orchestrator/daemon.mjs';
+export const ORCHESTRATOR_ENTRY = 'ai/daemons/orchestrator/daemon.mjs';
+export const FLEET_SERVER_ENTRY = 'ai/services/fleet/devFleetServer.mjs';
 
-/**
- * @summary Builds the isolated environment for a harness-supervised Brain on a dev machine:
- * own orchestrator data-root (PID files, db, logs — makes the daemon's single-instance takeover
- * target ITSELF, never the canonical), Chroma on the test coordinates (own persist dir + port,
- * the config's by-construction isolation), and the dev-server task shifted off :8080 (which the
- * canonical orchestrator owns on shared machines; the harness serves via app:// anyway).
- * @param {Object} options
- * @param {String} options.isolationRoot Directory that will own every mutable path.
- * @returns {Object} env fragment to merge over process.env
- */
-export function buildIsolatedBrainEnv({isolationRoot}) {
-    return {
-        NEO_AI_ORCHESTRATOR_DIR         : path.join(isolationRoot, 'orchestrator'),
-        NEO_CHROMA_DATA_DIR_TEST        : path.join(isolationRoot, 'chroma'),
-        NEO_CHROMA_PORT_TEST            : '18201',
-        NEO_ORCHESTRATOR_DEV_SERVER_PORT: '8093',
-        UNIT_TEST_MODE                  : '1'
-    }
+// The daemon logs this exact line when its poll loop is live (Orchestrator.start's last act) —
+// the earliest honest "the supervisor supervises" observable. The PID file is NOT it: the daemon
+// writes that before config load and before start(), so it only proves the process exists.
+const ORCHESTRATOR_READY_MARKER = '[Orchestrator] Started.';
+
+function nodeBin() {
+    return process.env.NEO_HARNESS_NODE_BIN || 'node'
 }
 
 /**
- * @summary Spawns the orchestrator daemon as a supervised system-Node child. The system Node is
- * deliberate (the Arm-B core): the repo's native modules are built for the system ABI, and
- * `ELECTRON_RUN_AS_NODE` children would carry Electron's ABI back into the same conflict. The
- * packaged-app arm (bundled per-target node_modules) is the packaging leaf's problem, recorded
- * on the ticket so it inherits correctly.
- * @param {Object} options
- * @param {String}   options.repoRoot Repo root (cwd for the child; the daemon resolves the rest).
- * @param {Object}   options.env      Env fragment merged over process.env (see {@link buildIsolatedBrainEnv}).
- * @param {Function} [options.onLog]  Receives trimmed child stdout/stderr lines.
- * @returns {import('node:child_process').ChildProcess}
+ * @summary Allocates a free loopback TCP port via a zero-port listen. The classic race (another
+ * process binding between close and child bind) is accepted: the child's own bind failure exits
+ * it early, which the readiness contract converts into a deterministic boot rejection.
+ * @returns {Promise<Number>}
  */
-export function startBrain({repoRoot, env, onLog}) {
-    const child = spawn(process.env.NEO_HARNESS_NODE_BIN || 'node', [ORCHESTRATOR_ENTRY], {
-        cwd  : repoRoot,
-        env  : {...process.env, ...env},
-        stdio: ['ignore', 'pipe', 'pipe']
-    });
+export function allocatePort() {
+    return new Promise((resolve, reject) => {
+        const server = net.createServer();
 
-    if (onLog) {
-        const forward = chunk => String(chunk).split('\n').filter(Boolean).forEach(line => onLog(line));
-
-        child.stdout.on('data', forward);
-        child.stderr.on('data', forward)
-    }
-
-    return child
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            const {port} = server.address();
+            server.close(() => resolve(port))
+        })
+    })
 }
 
 /**
- * @summary Awaits the Brain's up-observable: the daemon writes `<dataDir>/orchestrator-daemon.pid`
- * containing ITS OWN pid once ownership is established — pid-file-matches-child is therefore the
- * honest "the supervisor owns its root" signal (a foreign pid would mean we probed someone else's
- * Brain, which the isolated env exists to prevent).
+ * @summary Resolves true when a loopback TCP port currently accepts a connection. `host` matters:
+ * Chroma binds `localhost` (::1 on macOS) while the fleet transport binds `127.0.0.1` — probing
+ * the wrong family reads a listening server as dead.
  * @param {Object} options
- * @param {import('node:child_process').ChildProcess} options.child
- * @param {String} options.dataDir The child's `NEO_AI_ORCHESTRATOR_DIR`.
- * @param {Number} [options.timeoutMs=20000]
- * @returns {Promise<{up: Boolean, pidFileSeen: Boolean, exitedEarly: Boolean}>}
+ * @param {Number|String} options.port
+ * @param {String} [options.host='127.0.0.1']
+ * @param {Number} [options.timeoutMs=1500]
+ * @returns {Promise<Boolean>}
  */
-export function awaitBrainUp({child, dataDir, timeoutMs = 20000}) {
-    const pidFile = path.join(dataDir, 'orchestrator-daemon.pid');
-
+export function probePort({port, host = '127.0.0.1', timeoutMs = 1500}) {
     return new Promise(resolve => {
-        const t0 = Date.now();
+        const
+            socket = net.connect({host, port: Number(port)}),
+            finish = result => { socket.destroy(); resolve(result) };
 
-        const timer = setInterval(() => {
-            if (child.exitCode !== null) {
-                clearInterval(timer);
-                resolve({up: false, pidFileSeen: fs.existsSync(pidFile), exitedEarly: true});
+        socket.setTimeout(timeoutMs);
+        socket.once('connect', () => finish(true));
+        socket.once('timeout', () => finish(false));
+        socket.once('error',   () => finish(false))
+    })
+}
+
+/**
+ * @summary Resolves the Brain's mutable-path/port leaves THROUGH the config SSOT itself: a
+ * one-shot system-Node child imports `ai/config.mjs` under the given env and prints the resolved
+ * leaves. This is the executable isolation matrix — the smoke asserts what the spawned tree will
+ * ACTUALLY consume (the config provider owns env resolution as the single source of truth;
+ * re-deriving the mapping here would assert our guess, not the truth). A stale instance config
+ * fails this probe with the
+ * daemon's own `--migrate-config` guidance on stderr, before anything spawns.
+ * @param {Object} options
+ * @param {String} options.repoRoot
+ * @param {Object} [options.env] Env fragment merged over process.env for the resolver child.
+ * @param {Function} [options.execFileFn=execFile] Injection seam for tests.
+ * @returns {Promise<Object>} `{chromaDataDir, chromaPort, dbPath, fleetInstanceRoot, orchestratorDataDir}`
+ */
+export function resolveBrainPaths({repoRoot, env = {}, execFileFn = execFile}) {
+    const script = [
+        // The daemon entrypoints' own bootstrap order: Neo namespace before any setupClass consumer.
+        "import Neo from './src/Neo.mjs';",
+        "import * as core from './src/core/_export.mjs';",
+        "import InstanceManager from './src/manager/Instance.mjs';",
+        "import AiConfig from './ai/config.mjs';",
+        "process.stdout.write(JSON.stringify({",
+        "    backupPath         : AiConfig.data.backupPath,",
+        "    chromaDataDir      : AiConfig.engines.chroma.dataDir,",
+        "    chromaPort         : AiConfig.engines.chroma.port,",
+        "    dbPath             : AiConfig.orchestrator.dbPath,",
+        "    fleetInstanceRoot  : AiConfig.fleet.instanceRoot,",
+        "    orchestratorDataDir: AiConfig.orchestrator.dataDir",
+        "}));"
+    ].join('\n');
+
+    return new Promise((resolve, reject) => {
+        execFileFn(nodeBin(), ['--input-type=module', '-e', script], {
+            cwd: repoRoot,
+            env: {...process.env, ...env}
+        }, (error, stdout, stderr) => {
+            if (error) {
+                reject(new Error(`config resolver failed: ${String(stderr || error.message).slice(0, 800)}`));
                 return
             }
 
             try {
-                if (parseInt(fs.readFileSync(pidFile, 'utf8'), 10) === child.pid) {
-                    clearInterval(timer);
-                    resolve({up: true, pidFileSeen: true, exitedEarly: false});
-                    return
-                }
-            } catch (error) {
-                // pid file not written yet — keep polling
+                resolve(JSON.parse(stdout))
+            } catch (parseError) {
+                reject(new Error(`config resolver returned non-JSON: ${String(stdout).slice(0, 200)}`))
             }
-
-            if (Date.now() - t0 > timeoutMs) {
-                clearInterval(timer);
-                resolve({up: false, pidFileSeen: fs.existsSync(pidFile), exitedEarly: false})
-            }
-        }, 250)
+        })
     })
 }
 
 /**
- * @summary Settle-or-reject teardown: SIGTERM (the daemon's cleanup path tears down ITS children),
- * a bounded grace wait, SIGKILL escalation — and the promise always settles with what actually
- * happened, so a caller can gate an exit code on `forced === false`.
- * @param {import('node:child_process').ChildProcess} child
- * @param {Object} [options]
- * @param {Number} [options.graceMs=10000]
- * @returns {Promise<{exited: Boolean, forced: Boolean, code: Number|null, signal: String|null}>}
+ * @summary Builds the SMOKE isolation profile: every mutable path the spawned tree consumes bound
+ * under one throwaway root, every listener either gated OFF or moved to a runtime-allocated port.
+ * The gates matter as much as the paths — supervised tasks reap foreign listeners on their
+ * singleton ports (ProcessSupervisorService.reconcileSingletonPort), so an unshifted, ungated
+ * port-bearing task aimed at a live machine is a kill vector, not just cross-talk. The WAL needs
+ * no leaf here: `UNIT_TEST_MODE` derives a per-process tmp test WAL by construction.
+ * @param {Object} options
+ * @param {String} options.isolationRoot Directory that will own every mutable path.
+ * @param {Number|String} options.chromaPort Runtime-allocated Chroma port.
+ * @param {Number|String} options.fleetPort Runtime-allocated fleet transport port.
+ * @returns {Object} env fragment to merge over process.env
  */
-export function stopBrain(child, {graceMs = 10000} = {}) {
-    return new Promise(resolve => {
+export function buildBrainProfile({isolationRoot, chromaPort, fleetPort}) {
+    return {
+        // Mutable paths → instance-scoped leaves. NEO_BACKUP_PATH matters even with the sync lanes
+        // gated: the SCHEDULED task family (backup et al) is interval-driven with no enable gates,
+        // and a fresh state file makes it due immediately — the write target must be ours.
+        NEO_AI_DB_PATH          : path.join(isolationRoot, 'sqlite', 'memory-core-graph.sqlite'),
+        NEO_AI_ORCHESTRATOR_DIR : path.join(isolationRoot, 'orchestrator'),
+        NEO_BACKUP_PATH         : path.join(isolationRoot, 'backups'),
+        NEO_CHROMA_DATA_DIR_TEST: path.join(isolationRoot, 'chroma'),
+        NEO_FLEET_INSTANCE_ROOT : path.join(isolationRoot, 'fleet', 'instances'),
+        NEO_REM_RUN_STATE_DIR   : path.join(isolationRoot, 'rem-runs'),
+        UNIT_TEST_MODE          : '1',
+
+        // Listeners the smoke exercises → runtime-allocated ports
+        NEO_CHROMA_PORT_TEST: String(chromaPort),
+        NEO_FLEET_PORT      : String(fleetPort),
+
+        // Every other port-bearing or shared-state lane → OFF. The smoke proves the harness can
+        // OWN the organism's lifecycle; it must not double-run swarm lanes or reap live listeners.
+        NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED                 : '0',
+        NEO_ORCHESTRATOR_DEV_SERVER_ENABLED                 : '0',
+        NEO_ORCHESTRATOR_EMBED_DAEMON_ENABLED               : '0',
+        NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_ENABLED       : '0',
+        NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED: '0',
+        NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_ENABLED        : '0',
+        NEO_ORCHESTRATOR_KB_SYNC_ENABLED                    : '0',
+        NEO_ORCHESTRATOR_LMS_ENABLED                        : '0',
+        NEO_ORCHESTRATOR_MESSAGE_DAEMON_ENABLED             : '0',
+        NEO_ORCHESTRATOR_MLX_ENABLED                        : '0',
+        NEO_ORCHESTRATOR_NL_BRIDGE_ENABLED                  : '0',
+        NEO_ORCHESTRATOR_OLLAMA_ENABLED                     : '0',
+        NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED           : '0',
+        NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED            : '0'
+    }
+}
+
+/**
+ * @summary Verifies the RESOLVED leaves against the isolation contract: every mutable path under
+ * the isolation root, every probed port the allocated one. Run against `resolveBrainPaths` output
+ * so the assertion covers what the tree actually consumes, not what the profile intended.
+ * @param {Object} options
+ * @param {Object} options.resolved Output of {@link resolveBrainPaths} under the profile env.
+ * @param {String} options.isolationRoot
+ * @param {Number|String} options.chromaPort
+ * @returns {String[]} Human-readable violations; empty = isolated.
+ */
+export function assertIsolatedProfile({resolved, isolationRoot, chromaPort}) {
+    const
+        violations = [],
+        root       = path.resolve(isolationRoot) + path.sep,
+        pathLeaves = ['backupPath', 'chromaDataDir', 'dbPath', 'fleetInstanceRoot', 'orchestratorDataDir'];
+
+    for (const leafName of pathLeaves) {
+        const value = resolved[leafName];
+
+        if (typeof value !== 'string' || !path.resolve(value).startsWith(root)) {
+            violations.push(`${leafName}=${value} escapes isolation root ${isolationRoot}`)
+        }
+    }
+
+    if (Number(resolved.chromaPort) !== Number(chromaPort)) {
+        violations.push(`chromaPort=${resolved.chromaPort} is not the allocated ${chromaPort}`)
+    }
+
+    return violations
+}
+
+/**
+ * @summary Detects a live Brain on this machine WITHOUT spawning one: the orchestrator's own
+ * PID-file + command-line liveness idiom (read from the RESOLVED dataDir leaf, so an env-shifted
+ * setup is honored) plus a fleet-transport port probe. Drives the attach-or-own decision.
+ * @param {Object} options
+ * @param {String} options.orchestratorDataDir Resolved `AiConfig.orchestrator.dataDir`.
+ * @param {Number|String} options.fleetPort Fleet transport port to probe.
+ * @param {Function} [options.killFn=process.kill] Injection seam for tests.
+ * @param {Function} [options.commandFn] pid → command line. Injection seam for tests.
+ * @param {Function} [options.probePortFn=probePort] Injection seam for tests.
+ * @returns {Promise<{orchestratorAlive: Boolean, orchestratorPid: Number|null, fleetListening: Boolean}>}
+ */
+export async function detectLiveBrain({
+    orchestratorDataDir,
+    fleetPort,
+    killFn      = process.kill,
+    commandFn   = null,
+    probePortFn = probePort
+}) {
+    const
+        pidFile = path.join(orchestratorDataDir, 'orchestrator-daemon.pid'),
+        result  = {fleetListening: await probePortFn({port: fleetPort}), orchestratorAlive: false, orchestratorPid: null};
+
+    try {
+        const pid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
+
+        if (Number.isInteger(pid) && pid > 0) {
+            killFn(pid, 0);
+
+            // Mirrors the daemon's own isOrchestratorDaemonCommand guard (not imported: that module
+            // pulls the full Neo bootstrap into the Electron main, which the ABI verdict forbids).
+            const command = commandFn
+                ? commandFn(pid)
+                : (await new Promise(resolve => {
+                    execFile('ps', ['-p', String(pid), '-o', 'command='], (error, stdout) => resolve(error ? '' : stdout))
+                })).trim();
+
+            if (command.includes(ORCHESTRATOR_ENTRY)) {
+                result.orchestratorAlive = true;
+                result.orchestratorPid   = pid
+            }
+        }
+    } catch (error) {
+        // No PID file / stale pid — no live orchestrator; fall through to the probe result.
+    }
+
+    return result
+}
+
+function forwardLines(child, onLog) {
+    if (!onLog) {
+        return
+    }
+
+    const forward = chunk => String(chunk).split('\n').filter(Boolean).forEach(line => onLog(line));
+
+    child.stdout.on('data', forward);
+    child.stderr.on('data', forward)
+}
+
+/**
+ * @summary Spawns one supervised system-Node child DETACHED into its own process group — the
+ * teardown boundary that owns every descendant. System Node is deliberate (the Arm-B core): the
+ * repo's native modules are built for the system ABI, and `ELECTRON_RUN_AS_NODE` children would
+ * carry Electron's ABI back into the same conflict.
+ * @param {Object} options
+ * @param {String}   options.repoRoot Repo root (cwd for the child).
+ * @param {String}   options.entry Entry script, repo-relative.
+ * @param {Object}   [options.env] Env fragment merged over process.env.
+ * @param {Function} [options.onLog] Receives trimmed child stdout/stderr lines.
+ * @param {Function} [options.spawnFn=spawn] Injection seam for tests.
+ * @returns {import('node:child_process').ChildProcess}
+ */
+export function startBrainChild({repoRoot, entry, env = {}, onLog, spawnFn = spawn}) {
+    // The supervised tree resolves bare tool commands (the orchestrator's `chroma` task) via PATH.
+    // npm-run contexts prepend the repo's node_modules/.bin by accident of cwd; a packaged shell
+    // has no npm in the chain at all — so the lifecycle owner guarantees the resolution explicitly.
+    const binPath = path.join(repoRoot, 'node_modules', '.bin');
+
+    const child = spawnFn(nodeBin(), [entry], {
+        cwd     : repoRoot,
+        detached: true,
+        env     : {...process.env, ...env, PATH: `${binPath}${path.delimiter}${process.env.PATH ?? ''}`},
+        stdio   : ['ignore', 'pipe', 'pipe']
+    });
+
+    forwardLines(child, onLog);
+    return child
+}
+
+/**
+ * @summary The boot-promise contract: resolves when the child's stdout carries the given readiness
+ * marker; REJECTS deterministically on spawn error, early exit, or timeout — a PID's existence is
+ * never presented as readiness.
+ * @param {Object} options
+ * @param {import('node:child_process').ChildProcess} options.child
+ * @param {String} options.marker Stdout substring that constitutes readiness.
+ * @param {String} options.label For error messages.
+ * @param {Number} [options.timeoutMs=30000]
+ * @returns {Promise<void>}
+ */
+export function awaitReadyMarker({child, marker, label, timeoutMs = 30000}) {
+    return new Promise((resolve, reject) => {
+        let buffered = '';
+
+        const finish = (error) => {
+            clearTimeout(timer);
+            child.stdout.off('data', onData);
+            child.off('exit', onExit);
+            child.off('error', onError);
+            error ? reject(error) : resolve()
+        };
+
+        const onData = chunk => {
+            buffered = (buffered + String(chunk)).slice(-4096);
+
+            if (buffered.includes(marker)) {
+                finish()
+            }
+        };
+
+        const onExit  = (code, signal) => finish(new Error(`${label} exited before ready (code=${code} signal=${signal})`));
+        const onError = error => finish(new Error(`${label} failed to spawn: ${error.message}`));
+        const timer   = setTimeout(() => finish(new Error(`${label} not ready within ${timeoutMs}ms`)), timeoutMs);
+
         if (child.exitCode !== null) {
-            resolve({exited: true, forced: false, code: child.exitCode, signal: child.signalCode});
+            finish(new Error(`${label} exited before ready (code=${child.exitCode})`));
             return
         }
 
-        const killTimer = setTimeout(() => child.kill('SIGKILL'), graceMs);
-
-        child.once('exit', (code, signal) => {
-            clearTimeout(killTimer);
-            resolve({exited: true, forced: signal === 'SIGKILL', code, signal})
-        });
-
-        child.kill('SIGTERM')
+        child.stdout.on('data', onData);
+        child.once('exit', onExit);
+        child.once('error', onError)
     })
+}
+
+/**
+ * @summary Awaits the orchestrator's genuine readiness: its own "poll loop live" log marker.
+ * @param {Object} options
+ * @param {import('node:child_process').ChildProcess} options.child
+ * @param {Number} [options.timeoutMs=30000]
+ * @returns {Promise<void>}
+ */
+export function awaitOrchestratorReady({child, timeoutMs = 30000}) {
+    return awaitReadyMarker({child, label: 'orchestrator', marker: ORCHESTRATOR_READY_MARKER, timeoutMs})
+}
+
+/**
+ * @summary Awaits the fleet transport's genuine readiness: a REAL wire verb round-trip
+ * (`POST /fleet {method:'listAgents'}`) answering `{ok:true}` — the same surface the Fleet
+ * Manager window consumes. Rejects on child exit/spawn error or timeout.
+ * @param {Object} options
+ * @param {import('node:child_process').ChildProcess} options.child
+ * @param {Number|String} options.port
+ * @param {Number} [options.timeoutMs=15000]
+ * @param {Function} [options.fetchFn=fetch] Injection seam for tests.
+ * @returns {Promise<void>}
+ */
+export function awaitFleetReady({child, port, timeoutMs = 15000, fetchFn = fetch}) {
+    return new Promise((resolve, reject) => {
+        let settled = false;
+
+        const finish = error => {
+            if (settled) {
+                return
+            }
+
+            settled = true;
+            clearTimeout(timer);
+            clearInterval(poller);
+            child.off('exit', onExit);
+            child.off('error', onExit);
+            error ? reject(error) : resolve()
+        };
+
+        const onExit = (codeOrError, signal) => finish(new Error(
+            `fleet transport exited before ready (${codeOrError instanceof Error ? codeOrError.message : `code=${codeOrError} signal=${signal}`})`
+        ));
+
+        const probe = async () => {
+            try {
+                const response = await fetchFn(`http://127.0.0.1:${port}/fleet`, {
+                    body   : JSON.stringify({method: 'listAgents', params: {}}),
+                    headers: {'content-type': 'application/json'},
+                    method : 'POST'
+                });
+
+                const body = await response.json();
+
+                if (body?.ok === true) {
+                    finish()
+                }
+            } catch (error) {
+                // Not listening yet — keep polling until the deadline.
+            }
+        };
+
+        const timer  = setTimeout(() => finish(new Error(`fleet transport not ready within ${timeoutMs}ms`)), timeoutMs);
+        const poller = setInterval(probe, 300);
+
+        child.once('exit', onExit);
+        child.once('error', onExit);
+        probe()
+    })
+}
+
+/**
+ * @summary Polls a loopback port until it accepts a connection or the deadline passes. The smoke
+ * uses it to let the supervised organism SETTLE (the isolated Chroma actually serving on the
+ * allocated port — live evidence the data moved with the port) before quitting: group-SIGTERM
+ * into a mid-startup child is the one path that legitimately needs force-escalation, and a
+ * graceful-teardown gate must not measure that race.
+ * @param {Object} options
+ * @param {Number|String} options.port
+ * @param {String} [options.host='127.0.0.1'] See {@link probePort} — bind-family matters.
+ * @param {Number} [options.timeoutMs=30000]
+ * @param {Number} [options.pollMs=300]
+ * @param {Function} [options.probePortFn=probePort] Injection seam for tests.
+ * @returns {Promise<Boolean>} true when the port started listening within the deadline.
+ */
+export async function awaitPortListening({port, host = '127.0.0.1', timeoutMs = 30000, pollMs = 300, probePortFn = probePort}) {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        if (await probePortFn({host, port})) {
+            return true
+        }
+
+        await new Promise(resolve => setTimeout(resolve, pollMs))
+    }
+
+    return false
+}
+
+function groupAlive(pgid, killFn) {
+    try {
+        killFn(-pgid, 0);
+        return true
+    } catch (error) {
+        return false
+    }
+}
+
+/**
+ * @summary Settle-or-reject FULL-TREE teardown of one detached child: SIGINT to the process
+ * GROUP (every descendant gets it — the orchestrator's own children included), a bounded grace
+ * poll for group-empty, SIGKILL escalation to the group, and a final group-empty verdict. The
+ * promise always settles with what actually happened so a caller can gate an exit code on
+ * `forced === false && groupEmpty === true`.
+ *
+ * SIGINT, not SIGTERM, is the graceful rung — measured, not assumed: the chromadb npm wrapper
+ * ignores group-SIGTERM indefinitely (40s+) but exits cleanly on SIGINT within milliseconds
+ * (terminal Ctrl-C semantics), and every supervised entry (orchestrator daemon, fleet server)
+ * registers SIGINT and SIGTERM identically.
+ * @param {import('node:child_process').ChildProcess|{pid: Number}} child
+ * @param {Object} [options]
+ * @param {Number} [options.graceMs=10000]
+ * @param {Number} [options.pollMs=200]
+ * @param {Function} [options.killFn=process.kill] Injection seam for tests.
+ * @returns {Promise<{exited: Boolean, forced: Boolean, groupEmpty: Boolean}>}
+ */
+export async function stopBrainChild(child, {graceMs = 10000, pollMs = 200, killFn = process.kill} = {}) {
+    const pgid = child.pid;
+
+    if (!groupAlive(pgid, killFn)) {
+        return {exited: true, forced: false, groupEmpty: true}
+    }
+
+    try {
+        killFn(-pgid, 'SIGINT')
+    } catch (error) {
+        // Group vanished between the probe and the signal.
+    }
+
+    const deadline = Date.now() + graceMs;
+
+    while (Date.now() < deadline) {
+        if (!groupAlive(pgid, killFn)) {
+            return {exited: true, forced: false, groupEmpty: true}
+        }
+
+        await new Promise(resolve => setTimeout(resolve, pollMs))
+    }
+
+    try {
+        killFn(-pgid, 'SIGKILL')
+    } catch (error) {}
+
+    // SIGKILL is not interceptable; give the kernel a bounded beat to reap the group.
+    const killDeadline = Date.now() + 2000;
+
+    while (Date.now() < killDeadline && groupAlive(pgid, killFn)) {
+        await new Promise(resolve => setTimeout(resolve, pollMs))
+    }
+
+    return {exited: true, forced: true, groupEmpty: !groupAlive(pgid, killFn)}
+}
+
+/**
+ * @summary Tears down every supervised child (fleet first — it consumes the orchestrator's
+ * organism, so reverse-dependency order) and reports per-child.
+ * @param {Object[]} children `{label, child}` entries.
+ * @param {Object} [options] Passed through to {@link stopBrainChild}.
+ * @returns {Promise<Object>} label → stop report
+ */
+export async function stopBrainTree(children, options = {}) {
+    const report = {};
+
+    for (const {label, child} of [...children].reverse()) {
+        report[label] = await stopBrainChild(child, options)
+    }
+
+    return report
+}
+
+/**
+ * @summary Persists the process-group ids of a SMOKE run so a crashed harness's next run can
+ * sweep its own leftovers (the crash path bypasses will-quit). Product own-mode leftovers are
+ * deliberately NOT swept: a still-live default-paths Brain is simply attached to next boot.
+ * @param {Object} options
+ * @param {String} options.isolationRoot
+ * @param {Number[]} options.pgids
+ */
+export function writeRunState({isolationRoot, pgids}) {
+    fs.mkdirSync(isolationRoot, {recursive: true});
+    fs.writeFileSync(path.join(isolationRoot, 'run-state.json'), JSON.stringify({pgids}), 'utf8')
+}
+
+/**
+ * @summary Sweeps a prior crashed smoke run's process groups (ownership: they were spawned under
+ * OUR isolation root) and clears the run-state file. No-op when no state exists.
+ * @param {Object} options
+ * @param {String} options.isolationRoot
+ * @param {Function} [options.killFn=process.kill] Injection seam for tests.
+ * @returns {Number[]} pgids that were still alive and got killed.
+ */
+export function sweepStaleRunState({isolationRoot, killFn = process.kill}) {
+    const
+        runStateFile = path.join(isolationRoot, 'run-state.json'),
+        swept        = [];
+
+    let pgids = [];
+
+    try {
+        pgids = JSON.parse(fs.readFileSync(runStateFile, 'utf8')).pgids ?? []
+    } catch (error) {
+        return swept
+    }
+
+    for (const pgid of pgids) {
+        if (Number.isInteger(pgid) && pgid > 1 && groupAlive(pgid, killFn)) {
+            try {
+                killFn(-pgid, 'SIGKILL');
+                swept.push(pgid)
+            } catch (error) {}
+        }
+    }
+
+    try {
+        fs.unlinkSync(runStateFile)
+    } catch (error) {}
+
+    return swept
 }

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -26,10 +26,10 @@
 // the next canonical restart — see ProcessSupervisorService.reconcileSingletonPort), which is
 // exactly why parent-only teardown leaks: the group is the only boundary that owns the whole tree.
 
-import {execFile, spawn} from 'node:child_process';
-import fs                from 'node:fs';
-import net               from 'node:net';
-import path              from 'node:path';
+import {execFile, execFileSync, spawn} from 'node:child_process';
+import fs                              from 'node:fs';
+import net                             from 'node:net';
+import path                            from 'node:path';
 
 export const ORCHESTRATOR_ENTRY = 'ai/daemons/orchestrator/daemon.mjs';
 export const FLEET_SERVER_ENTRY = 'ai/services/fleet/devFleetServer.mjs';
@@ -184,9 +184,44 @@ export function buildBrainProfile({isolationRoot, chromaPort, fleetPort}) {
 }
 
 /**
+ * @summary Resolves a path by FILESYSTEM IDENTITY: realpath of its deepest existing ancestor with
+ * the not-yet-created tail re-appended. A lexical `startsWith` is an observation about strings; a
+ * symlinked ancestor inside the root (e.g. `sqlite/` → an outside directory) satisfies it while
+ * the data lands elsewhere. Isolation is an identity contract, so containment must resolve links.
+ * @param {String} value
+ * @returns {String}
+ */
+export function resolveRealPath(value) {
+    let
+        current = path.resolve(value),
+        tail    = [];
+
+    while (!fs.existsSync(current)) {
+        const parent = path.dirname(current);
+
+        tail.unshift(path.basename(current));
+
+        if (parent === current) {
+            break
+        }
+
+        current = parent
+    }
+
+    try {
+        current = fs.realpathSync(current)
+    } catch (error) {
+        // Keep the lexical resolution when even the existing ancestor cannot be resolved.
+    }
+
+    return path.join(current, ...tail)
+}
+
+/**
  * @summary Verifies the RESOLVED leaves against the isolation contract: every mutable path under
- * the isolation root, every probed port the allocated one. Run against `resolveBrainPaths` output
- * so the assertion covers what the tree actually consumes, not what the profile intended.
+ * the isolation root BY FILESYSTEM IDENTITY (ancestor symlinks resolved on both sides), every
+ * probed port the allocated one. Run against `resolveBrainPaths` output so the assertion covers
+ * what the tree actually consumes, not what the profile intended.
  * @param {Object} options
  * @param {Object} options.resolved Output of {@link resolveBrainPaths} under the profile env.
  * @param {String} options.isolationRoot
@@ -196,14 +231,14 @@ export function buildBrainProfile({isolationRoot, chromaPort, fleetPort}) {
 export function assertIsolatedProfile({resolved, isolationRoot, chromaPort}) {
     const
         violations = [],
-        root       = path.resolve(isolationRoot) + path.sep,
+        root       = resolveRealPath(isolationRoot) + path.sep,
         pathLeaves = ['backupPath', 'chromaDataDir', 'dbPath', 'fleetInstanceRoot', 'orchestratorDataDir'];
 
     for (const leafName of pathLeaves) {
         const value = resolved[leafName];
 
-        if (typeof value !== 'string' || !path.resolve(value).startsWith(root)) {
-            violations.push(`${leafName}=${value} escapes isolation root ${isolationRoot}`)
+        if (typeof value !== 'string' || !resolveRealPath(value).startsWith(root)) {
+            violations.push(`${leafName}=${value} escapes isolation root ${isolationRoot} (real path: ${typeof value === 'string' ? resolveRealPath(value) : value})`)
         }
     }
 
@@ -215,27 +250,63 @@ export function assertIsolatedProfile({resolved, isolationRoot, chromaPort}) {
 }
 
 /**
+ * @summary Probes FLEET PROTOCOL IDENTITY on a port: one `POST /fleet {method:'listAgents'}`
+ * round-trip answering `{ok:true}`. A listening socket is an observation about occupancy; only
+ * the wire envelope proves the listener IS the fleet transport — a foreign server squatting the
+ * port must read as "held but not serving", never as attach-ready.
+ * @param {Object} options
+ * @param {Number|String} options.port
+ * @param {Number} [options.timeoutMs=2500]
+ * @param {Function} [options.fetchFn=fetch] Injection seam for tests.
+ * @returns {Promise<Boolean>}
+ */
+export async function probeFleetServing({port, timeoutMs = 2500, fetchFn = fetch}) {
+    try {
+        const response = await fetchFn(`http://127.0.0.1:${port}/fleet`, {
+            body   : JSON.stringify({method: 'listAgents', params: {}}),
+            headers: {'content-type': 'application/json'},
+            method : 'POST',
+            signal : AbortSignal.timeout(timeoutMs)
+        });
+
+        return (await response.json())?.ok === true
+    } catch (error) {
+        return false
+    }
+}
+
+/**
  * @summary Detects a live Brain on this machine WITHOUT spawning one: the orchestrator's own
  * PID-file + command-line liveness idiom (read from the RESOLVED dataDir leaf, so an env-shifted
- * setup is honored) plus a fleet-transport port probe. Drives the attach-or-own decision.
+ * setup is honored) plus fleet-transport PROTOCOL identity — `fleetServing` requires a real wire
+ * envelope, while `fleetPortHeld` reports raw occupancy so a foreign listener fails the boot
+ * closed instead of masquerading as an attach target. Drives the attach-or-own decision.
  * @param {Object} options
  * @param {String} options.orchestratorDataDir Resolved `AiConfig.orchestrator.dataDir`.
  * @param {Number|String} options.fleetPort Fleet transport port to probe.
  * @param {Function} [options.killFn=process.kill] Injection seam for tests.
  * @param {Function} [options.commandFn] pid → command line. Injection seam for tests.
  * @param {Function} [options.probePortFn=probePort] Injection seam for tests.
- * @returns {Promise<{orchestratorAlive: Boolean, orchestratorPid: Number|null, fleetListening: Boolean}>}
+ * @param {Function} [options.probeFleetFn=probeFleetServing] Injection seam for tests.
+ * @returns {Promise<{orchestratorAlive: Boolean, orchestratorPid: Number|null, fleetServing: Boolean, fleetPortHeld: Boolean}>}
  */
 export async function detectLiveBrain({
     orchestratorDataDir,
     fleetPort,
-    killFn      = process.kill,
-    commandFn   = null,
-    probePortFn = probePort
+    killFn       = process.kill,
+    commandFn    = null,
+    probePortFn  = probePort,
+    probeFleetFn = probeFleetServing
 }) {
     const
-        pidFile = path.join(orchestratorDataDir, 'orchestrator-daemon.pid'),
-        result  = {fleetListening: await probePortFn({port: fleetPort}), orchestratorAlive: false, orchestratorPid: null};
+        pidFile      = path.join(orchestratorDataDir, 'orchestrator-daemon.pid'),
+        fleetServing = await probeFleetFn({port: fleetPort}),
+        result       = {
+            fleetPortHeld    : fleetServing || await probePortFn({port: fleetPort}),
+            fleetServing,
+            orchestratorAlive: false,
+            orchestratorPid  : null
+        };
 
     try {
         const pid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
@@ -530,51 +601,86 @@ export async function stopBrainTree(children, options = {}) {
 }
 
 /**
- * @summary Persists the process-group ids of a SMOKE run so a crashed harness's next run can
- * sweep its own leftovers (the crash path bypasses will-quit). Product own-mode leftovers are
- * deliberately NOT swept: a still-live default-paths Brain is simply attached to next boot.
+ * @summary Persists the process groups of a SMOKE run — WITH an ownership token per group (the
+ * group leader's entry script) — so a crashed harness's next run can sweep its own leftovers
+ * (the crash path bypasses will-quit). A bare PGID is not ownership evidence: the OS reuses ids,
+ * so the sweep re-verifies the recorded identity before signaling. Product own-mode leftovers
+ * are deliberately NOT recorded: a still-live default-paths Brain is attached to next boot.
  * @param {Object} options
  * @param {String} options.isolationRoot
- * @param {Number[]} options.pgids
+ * @param {Object[]} options.children `{pgid, entry}` per supervised group leader.
  */
-export function writeRunState({isolationRoot, pgids}) {
+export function writeRunState({isolationRoot, children}) {
     fs.mkdirSync(isolationRoot, {recursive: true});
-    fs.writeFileSync(path.join(isolationRoot, 'run-state.json'), JSON.stringify({pgids}), 'utf8')
+    fs.writeFileSync(path.join(isolationRoot, 'run-state.json'), JSON.stringify({children}), 'utf8')
 }
 
 /**
- * @summary Sweeps a prior crashed smoke run's process groups (ownership: they were spawned under
- * OUR isolation root) and clears the run-state file. No-op when no state exists.
+ * @summary Clears the persisted run-state after a CLEAN teardown. Without this, the record
+ * outlives the run and a later sweep would signal whatever now owns the recycled ids.
+ * @param {Object} options
+ * @param {String} options.isolationRoot
+ */
+export function clearRunState({isolationRoot}) {
+    try {
+        fs.unlinkSync(path.join(isolationRoot, 'run-state.json'))
+    } catch (error) {
+        // Nothing persisted — already clean.
+    }
+}
+
+/**
+ * @summary Sweeps a prior CRASHED smoke run's process groups — but only after re-proving
+ * ownership: the group leader's current command line must still carry the recorded entry script.
+ * An identity mismatch (recycled pid) drops the record without signaling. The state file is
+ * cleared either way. No-op when no state exists.
  * @param {Object} options
  * @param {String} options.isolationRoot
  * @param {Function} [options.killFn=process.kill] Injection seam for tests.
- * @returns {Number[]} pgids that were still alive and got killed.
+ * @param {Function} [options.commandFn] pid → current command line ('' when gone). Injection seam for tests.
+ * @returns {Number[]} pgids that were alive, identity-verified, and killed.
  */
-export function sweepStaleRunState({isolationRoot, killFn = process.kill}) {
+export function sweepStaleRunState({isolationRoot, killFn = process.kill, commandFn = null}) {
     const
         runStateFile = path.join(isolationRoot, 'run-state.json'),
-        swept        = [];
+        readCommand  = commandFn ?? (pid => {
+            try {
+                return execFileSyncCommand(pid)
+            } catch (error) {
+                return ''
+            }
+        }),
+        swept          = [];
 
-    let pgids = [];
+    let children = [];
 
     try {
-        pgids = JSON.parse(fs.readFileSync(runStateFile, 'utf8')).pgids ?? []
+        children = JSON.parse(fs.readFileSync(runStateFile, 'utf8')).children ?? []
     } catch (error) {
         return swept
     }
 
-    for (const pgid of pgids) {
-        if (Number.isInteger(pgid) && pgid > 1 && groupAlive(pgid, killFn)) {
-            try {
-                killFn(-pgid, 'SIGKILL');
-                swept.push(pgid)
-            } catch (error) {}
+    for (const {pgid, entry} of children) {
+        if (!Number.isInteger(pgid) || pgid <= 1 || typeof entry !== 'string' || !groupAlive(pgid, killFn)) {
+            continue
         }
+
+        // Ownership re-proof: the recorded leader must still run OUR entry script. Mirrors the
+        // daemon's own isOrchestratorDaemonCommand guard against recycled pids.
+        if (!readCommand(pgid).includes(entry)) {
+            continue
+        }
+
+        try {
+            killFn(-pgid, 'SIGKILL');
+            swept.push(pgid)
+        } catch (error) {}
     }
 
-    try {
-        fs.unlinkSync(runStateFile)
-    } catch (error) {}
-
+    clearRunState({isolationRoot});
     return swept
+}
+
+function execFileSyncCommand(pid) {
+    return execFileSync('ps', ['-p', String(pid), '-o', 'command=']).toString().trim()
 }

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -1,0 +1,143 @@
+// The Arm-B Brain supervision module (the recorded topology of the hosting spike — see the
+// falsifier-1 verdict on its ticket): the Electron main supervises ONE system-Node child — the
+// orchestrator daemon — which supervises the rest of the Agent OS through its own
+// ProcessSupervisorService (Chroma, wake/embed/message daemons, scheduled maintenance). Arm A
+// (in-process) is falsified in this repo by the native-ABI split: better-sqlite3 builds for ONE
+// ABI, and the shared node_modules must keep serving the system-Node dev loop.
+//
+// Shell-ADR bindings implemented here:
+//   §2.1.1  one lifecycle owner — the main process starts/stops the Brain; no daemon fork
+//   §2.1.3  injectable data-root — every path below arrives via env leaves, nothing hardcoded
+//   §2.1.4  port discipline — the isolated env shifts every port-bearing task off the defaults
+//   §2.1.5  teardown on quit — SIGTERM, bounded grace, SIGKILL escalation; settle-or-reject
+//
+// DEV-MACHINE SAFETY (load-bearing): the orchestrator daemon performs single-instance TAKEOVER —
+// on boot it SIGTERMs any PID found in its PID file. A child launched with default env on a
+// machine running the canonical Brain would kill it. `buildIsolatedBrainEnv` is therefore not
+// politeness; it is the precondition for booting a Brain here at all. The isolation rides the
+// config's own by-construction test contract (UNIT_TEST_MODE flips Chroma to the env-bindable
+// test coordinates — "a database-name swap alone is not isolation", per the config template).
+
+import {spawn} from 'node:child_process';
+import fs      from 'node:fs';
+import path    from 'node:path';
+
+const ORCHESTRATOR_ENTRY = 'ai/daemons/orchestrator/daemon.mjs';
+
+/**
+ * @summary Builds the isolated environment for a harness-supervised Brain on a dev machine:
+ * own orchestrator data-root (PID files, db, logs — makes the daemon's single-instance takeover
+ * target ITSELF, never the canonical), Chroma on the test coordinates (own persist dir + port,
+ * the config's by-construction isolation), and the dev-server task shifted off :8080 (which the
+ * canonical orchestrator owns on shared machines; the harness serves via app:// anyway).
+ * @param {Object} options
+ * @param {String} options.isolationRoot Directory that will own every mutable path.
+ * @returns {Object} env fragment to merge over process.env
+ */
+export function buildIsolatedBrainEnv({isolationRoot}) {
+    return {
+        NEO_AI_ORCHESTRATOR_DIR         : path.join(isolationRoot, 'orchestrator'),
+        NEO_CHROMA_DATA_DIR_TEST        : path.join(isolationRoot, 'chroma'),
+        NEO_CHROMA_PORT_TEST            : '18201',
+        NEO_ORCHESTRATOR_DEV_SERVER_PORT: '8093',
+        UNIT_TEST_MODE                  : '1'
+    }
+}
+
+/**
+ * @summary Spawns the orchestrator daemon as a supervised system-Node child. The system Node is
+ * deliberate (the Arm-B core): the repo's native modules are built for the system ABI, and
+ * `ELECTRON_RUN_AS_NODE` children would carry Electron's ABI back into the same conflict. The
+ * packaged-app arm (bundled per-target node_modules) is the packaging leaf's problem, recorded
+ * on the ticket so it inherits correctly.
+ * @param {Object} options
+ * @param {String}   options.repoRoot Repo root (cwd for the child; the daemon resolves the rest).
+ * @param {Object}   options.env      Env fragment merged over process.env (see {@link buildIsolatedBrainEnv}).
+ * @param {Function} [options.onLog]  Receives trimmed child stdout/stderr lines.
+ * @returns {import('node:child_process').ChildProcess}
+ */
+export function startBrain({repoRoot, env, onLog}) {
+    const child = spawn(process.env.NEO_HARNESS_NODE_BIN || 'node', [ORCHESTRATOR_ENTRY], {
+        cwd  : repoRoot,
+        env  : {...process.env, ...env},
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    if (onLog) {
+        const forward = chunk => String(chunk).split('\n').filter(Boolean).forEach(line => onLog(line));
+
+        child.stdout.on('data', forward);
+        child.stderr.on('data', forward)
+    }
+
+    return child
+}
+
+/**
+ * @summary Awaits the Brain's up-observable: the daemon writes `<dataDir>/orchestrator-daemon.pid`
+ * containing ITS OWN pid once ownership is established — pid-file-matches-child is therefore the
+ * honest "the supervisor owns its root" signal (a foreign pid would mean we probed someone else's
+ * Brain, which the isolated env exists to prevent).
+ * @param {Object} options
+ * @param {import('node:child_process').ChildProcess} options.child
+ * @param {String} options.dataDir The child's `NEO_AI_ORCHESTRATOR_DIR`.
+ * @param {Number} [options.timeoutMs=20000]
+ * @returns {Promise<{up: Boolean, pidFileSeen: Boolean, exitedEarly: Boolean}>}
+ */
+export function awaitBrainUp({child, dataDir, timeoutMs = 20000}) {
+    const pidFile = path.join(dataDir, 'orchestrator-daemon.pid');
+
+    return new Promise(resolve => {
+        const t0 = Date.now();
+
+        const timer = setInterval(() => {
+            if (child.exitCode !== null) {
+                clearInterval(timer);
+                resolve({up: false, pidFileSeen: fs.existsSync(pidFile), exitedEarly: true});
+                return
+            }
+
+            try {
+                if (parseInt(fs.readFileSync(pidFile, 'utf8'), 10) === child.pid) {
+                    clearInterval(timer);
+                    resolve({up: true, pidFileSeen: true, exitedEarly: false});
+                    return
+                }
+            } catch (error) {
+                // pid file not written yet — keep polling
+            }
+
+            if (Date.now() - t0 > timeoutMs) {
+                clearInterval(timer);
+                resolve({up: false, pidFileSeen: fs.existsSync(pidFile), exitedEarly: false})
+            }
+        }, 250)
+    })
+}
+
+/**
+ * @summary Settle-or-reject teardown: SIGTERM (the daemon's cleanup path tears down ITS children),
+ * a bounded grace wait, SIGKILL escalation — and the promise always settles with what actually
+ * happened, so a caller can gate an exit code on `forced === false`.
+ * @param {import('node:child_process').ChildProcess} child
+ * @param {Object} [options]
+ * @param {Number} [options.graceMs=10000]
+ * @returns {Promise<{exited: Boolean, forced: Boolean, code: Number|null, signal: String|null}>}
+ */
+export function stopBrain(child, {graceMs = 10000} = {}) {
+    return new Promise(resolve => {
+        if (child.exitCode !== null) {
+            resolve({exited: true, forced: false, code: child.exitCode, signal: child.signalCode});
+            return
+        }
+
+        const killTimer = setTimeout(() => child.kill('SIGKILL'), graceMs);
+
+        child.once('exit', (code, signal) => {
+            clearTimeout(killTimer);
+            resolve({exited: true, forced: signal === 'SIGKILL', code, signal})
+        });
+
+        child.kill('SIGTERM')
+    })
+}

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -1,6 +1,7 @@
-// The Electron harness main: boots the Agent OS app on the packaged origin ADR 0034 specifies.
-// Scope: harness skeleton + multi-window join; NO Agent OS hosting yet (the topology spike is the
-// next slice; isolating shell risk is the point).
+// The Electron harness main: boots the Agent OS app on the packaged origin the Electron-shell ADR
+// specifies (ADR 0034 — ticket-ref-ok: this file IS that contract's implementation; every §-ref
+// below resolves against it). Scope: harness skeleton + multi-window join + the supervised Brain
+// (the hosting-spike verdict: Arm B — see brain.mjs).
 //
 // ADR bindings implemented here:
 //   §2.2 C1  privileged app:// scheme (standard + secure + supportFetchAPI), one stable origin
@@ -28,6 +29,7 @@ import {
     isAllowedHarnessAssetPath,
     isHarnessDocumentUrl
 } from './contentPolicy.mjs';
+import {awaitBrainUp, buildIsolatedBrainEnv, startBrain, stopBrain} from './brain.mjs';
 
 const
     harnessDir = path.dirname(fileURLToPath(import.meta.url)),
@@ -36,6 +38,10 @@ const
     // zero-build SOURCE app — Neural Link possession needs real ESM, which minification destroys.
     APP_URL    = `app://${APP_HOST}/apps/agentos/index.html`,
     smokeMode  = process.env.NEO_HARNESS_SMOKE === '1',
+    // The Arm-B Brain leg (opt-in): the main supervises the orchestrator daemon as a system-Node
+    // child. Isolated env by default — on a dev machine the daemon's single-instance takeover
+    // would otherwise SIGTERM the canonical Brain (see brain.mjs).
+    brainMode  = process.env.NEO_HARNESS_BRAIN === '1',
     smokeState = {
         assetFailures : new Set(),
         assetsSeen    : new Set(),
@@ -351,12 +357,46 @@ process.on('unhandledRejection', error => {
     smokeMode && app.exit(2)
 });
 
+let brainChild = null;
+
+/**
+ * @summary Boots the supervised Brain (Arm B) with the isolated env and registers the
+ * settle-or-reject teardown on quit — §2.1.1 one lifecycle owner, §2.1.5 teardown-with-the-shell.
+ * @returns {Promise<{child: import('node:child_process').ChildProcess, dataDir: String, upReport: Object}>}
+ */
+async function bootSupervisedBrain() {
+    const
+        isolationRoot = process.env.NEO_HARNESS_BRAIN_ROOT || path.join(harnessDir, '.brain'),
+        env           = buildIsolatedBrainEnv({isolationRoot}),
+        child         = startBrain({
+            repoRoot,
+            env,
+            onLog: smokeMode ? line => console.log('HARNESS_BRAIN ' + line.slice(0, 300)) : undefined
+        });
+
+    brainChild = child;
+
+    const upReport = await awaitBrainUp({child, dataDir: env.NEO_AI_ORCHESTRATOR_DIR});
+
+    return {child, dataDir: env.NEO_AI_ORCHESTRATOR_DIR, upReport}
+}
+
+app.on('will-quit', async event => {
+    if (brainChild && brainChild.exitCode === null) {
+        event.preventDefault();
+        const stop = await stopBrain(brainChild);
+        brainChild = null;
+        smokeMode && console.log('HARNESS_BRAIN_STOP ' + JSON.stringify(stop));
+        app.quit()
+    }
+});
+
 app.whenReady().then(async () => {
     resolveHarnessAsset = await createHarnessAssetResolver(repoRoot);
     await protocol.handle('app', serveHarnessContent);
 
     // §2.3.3 deny-by-default; Electron requires BOTH handlers for complete permission coverage.
-    // Allowlist additions amend ADR 0034 §2.3 first.
+    // Allowlist additions amend the shell ADR §2.3 first.
     session.defaultSession.setPermissionCheckHandler(() => false);
     session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => callback(false));
 
@@ -366,6 +406,10 @@ app.whenReady().then(async () => {
         ipcMain.on('shell-boot-report', onBootReport);
         ipcMain.on('shell-runtime-error', onRuntimeError)
     }
+
+    // The Brain boots in parallel with the window — the UI never blocks on the supervisor, and
+    // fail-closed surfaces render honestly until the transport is reachable.
+    const brainBoot = brainMode ? bootSupervisedBrain() : null;
 
     const win1 = createHarnessWindow(APP_URL);
 
@@ -398,6 +442,28 @@ app.whenReady().then(async () => {
 
     await awaitRequiredAssets();
 
+    // The Brain leg (Arm B): supervisor up under the ISOLATED root, then settle-or-reject
+    // teardown with an orphan check — falsifier 3's live observables (ports/PID across the
+    // child's lifecycle are the orchestrator's own job; ours is owning ITS lifecycle cleanly).
+    let brain = {mode: false};
+
+    if (brainBoot) {
+        const {child, dataDir, upReport} = await brainBoot;
+        const stop                       = await stopBrain(child);
+
+        let orphaned = false;
+
+        try {
+            process.kill(child.pid, 0);
+            orphaned = true
+        } catch (error) {
+            // ESRCH — the process is gone, which is the pass condition
+        }
+
+        brainChild = null;
+        brain      = {mode: true, dataDir, ...upReport, stop, orphaned}
+    }
+
     const
         assetFailures       = [...smokeState.assetFailures],
         rendererErrors      = [...smokeState.rendererErrors],
@@ -412,22 +478,25 @@ app.whenReady().then(async () => {
             assetFailures,
             boot1,
             boot2,
+            brain,
             popupMaterialized: Boolean(win2),
             rendererErrors,
             requiredAssetsReady,
             sharedHeapEvidence,
-            versions: {
+            versions         : {
                 chrome  : process.versions.chrome,
                 electron: process.versions.electron,
                 node    : process.versions.node
             }
         },
+        brainPassed = !brain.mode || (brain.up && brain.stop.exited && !brain.stop.forced && !brain.orphaned),
         passed = boot1.mounted > 10 &&
             boot2.mounted > 10 &&
             results.popupMaterialized &&
             requiredAssetsReady &&
             sharedHeapEvidence &&
-            rendererErrors.length === 0;
+            rendererErrors.length === 0 &&
+            brainPassed;
 
     console.log('HARNESS_SMOKE_RESULTS=' + JSON.stringify(results, null, 2));
     app.exit(passed ? 0 : 1)

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -36,6 +36,7 @@ import {
     awaitOrchestratorReady,
     awaitPortListening,
     buildBrainProfile,
+    clearRunState,
     detectLiveBrain,
     FLEET_SERVER_ENTRY,
     ORCHESTRATOR_ENTRY,
@@ -378,7 +379,7 @@ process.on('unhandledRejection', async error => {
     }
 });
 
-const brainState = {children: []};
+const brainState = {children: [], isolationRoot: null};
 
 function brainLog(line) {
     console.log('HARNESS_BRAIN ' + line.slice(0, 300))
@@ -386,7 +387,9 @@ function brainLog(line) {
 
 /**
  * @summary Full-tree teardown of every child the harness started (and only those — §2.1.1 one
- * lifecycle owner). Callable from every exit path: will-quit, smoke completion, the smoke nets.
+ * lifecycle owner), then clears the smoke run-state: a record surviving a CLEAN stop would make
+ * a later sweep signal whatever now owns the recycled process-group ids. Callable from every
+ * exit path: will-quit, smoke completion, the smoke nets.
  * @returns {Promise<Object|null>} per-child stop report, or null when nothing was supervised
  */
 async function teardownBrain() {
@@ -397,7 +400,15 @@ async function teardownBrain() {
     const children = brainState.children;
 
     brainState.children = [];
-    return stopBrainTree(children)
+
+    const report = await stopBrainTree(children);
+
+    if (brainState.isolationRoot) {
+        clearRunState({isolationRoot: brainState.isolationRoot});
+        brainState.isolationRoot = null
+    }
+
+    return report
 }
 
 /**
@@ -423,7 +434,14 @@ async function bootProductBrain() {
         await awaitOrchestratorReady({child: orchestrator})
     }
 
-    if (!live.fleetListening) {
+    if (!live.fleetServing) {
+        // Protocol identity, fail closed: a listener that does NOT answer the fleet wire verb is
+        // a foreign server squatting the port — spawning into it would EADDRINUSE, and skipping
+        // the spawn would report a Brain that the window cannot actually reach.
+        if (live.fleetPortHeld) {
+            throw new Error(`fleet port ${fleetPort} is held by a foreign listener (no listAgents envelope) — free the port or set NEO_FLEET_PORT`)
+        }
+
         const fleet = startBrainChild({
             entry: FLEET_SERVER_ENTRY,
             env  : {NEO_FLEET_PORT: String(fleetPort)},
@@ -464,8 +482,12 @@ async function bootSmokeBrain() {
         orchestrator = startBrainChild({entry: ORCHESTRATOR_ENTRY, env: profile, onLog: brainLog, repoRoot}),
         fleet        = startBrainChild({entry: FLEET_SERVER_ENTRY, env: profile, onLog: brainLog, repoRoot});
 
-    brainState.children.push({child: orchestrator, label: 'orchestrator'}, {child: fleet, label: 'fleet'});
-    writeRunState({isolationRoot, pgids: brainState.children.map(entry => entry.child.pid)});
+    brainState.children.push(
+        {child: orchestrator, entry: ORCHESTRATOR_ENTRY, label: 'orchestrator'},
+        {child: fleet,        entry: FLEET_SERVER_ENTRY, label: 'fleet'}
+    );
+    brainState.isolationRoot = isolationRoot;
+    writeRunState({isolationRoot, children: brainState.children.map(entry => ({entry: entry.entry, pgid: entry.child.pid}))});
 
     await Promise.all([
         awaitOrchestratorReady({child: orchestrator}),

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -29,7 +29,23 @@ import {
     isAllowedHarnessAssetPath,
     isHarnessDocumentUrl
 } from './contentPolicy.mjs';
-import {awaitBrainUp, buildIsolatedBrainEnv, startBrain, stopBrain} from './brain.mjs';
+import {
+    allocatePort,
+    assertIsolatedProfile,
+    awaitFleetReady,
+    awaitOrchestratorReady,
+    awaitPortListening,
+    buildBrainProfile,
+    detectLiveBrain,
+    FLEET_SERVER_ENTRY,
+    ORCHESTRATOR_ENTRY,
+    probePort,
+    resolveBrainPaths,
+    startBrainChild,
+    stopBrainTree,
+    sweepStaleRunState,
+    writeRunState
+} from './brain.mjs';
 
 const
     harnessDir = path.dirname(fileURLToPath(import.meta.url)),
@@ -351,41 +367,118 @@ async function awaitRequiredAssets(timeoutMs = 3000) {
 
 app.on('web-contents-created', (event, contents) => configureWebContents(contents));
 
-process.on('unhandledRejection', error => {
+process.on('unhandledRejection', async error => {
     recordSmokeFailure('main-unhandled-rejection', error);
     console.log('HARNESS_UNHANDLED ' + (error?.stack || error));
-    smokeMode && app.exit(2)
+
+    if (smokeMode) {
+        // app.exit bypasses will-quit, so the failure net owns the Brain teardown explicitly.
+        await teardownBrain();
+        app.exit(2)
+    }
 });
 
-let brainChild = null;
+const brainState = {children: []};
+
+function brainLog(line) {
+    console.log('HARNESS_BRAIN ' + line.slice(0, 300))
+}
 
 /**
- * @summary Boots the supervised Brain (Arm B) with the isolated env and registers the
- * settle-or-reject teardown on quit — §2.1.1 one lifecycle owner, §2.1.5 teardown-with-the-shell.
- * @returns {Promise<{child: import('node:child_process').ChildProcess, dataDir: String, upReport: Object}>}
+ * @summary Full-tree teardown of every child the harness started (and only those — §2.1.1 one
+ * lifecycle owner). Callable from every exit path: will-quit, smoke completion, the smoke nets.
+ * @returns {Promise<Object|null>} per-child stop report, or null when nothing was supervised
  */
-async function bootSupervisedBrain() {
+async function teardownBrain() {
+    if (!brainState.children.length) {
+        return null
+    }
+
+    const children = brainState.children;
+
+    brainState.children = [];
+    return stopBrainTree(children)
+}
+
+/**
+ * The product Brain boot — ATTACH-OR-OWN (see brain.mjs): on a machine with a live Brain the
+ * harness supervises only the missing fleet transport against the REAL organism; on a fresh
+ * machine it owns the whole organism on the default (canonical-layout) paths. It never boots a
+ * second organism beside a live one — the daemon's single-instance takeover and the supervisor's
+ * singleton-port reaping make that unsafe by construction.
+ * @summary Boots or attaches the Brain for `start:brain`, supervising only what is missing.
+ * @returns {Promise<Object>}
+ */
+async function bootProductBrain() {
     const
-        isolationRoot = process.env.NEO_HARNESS_BRAIN_ROOT || path.join(harnessDir, '.brain'),
-        env           = buildIsolatedBrainEnv({isolationRoot}),
-        child         = startBrain({
-            repoRoot,
-            env,
-            onLog: smokeMode ? line => console.log('HARNESS_BRAIN ' + line.slice(0, 300)) : undefined
+        fleetPort = Number(process.env.NEO_FLEET_PORT) || 8083,
+        paths     = await resolveBrainPaths({repoRoot}),
+        live      = await detectLiveBrain({fleetPort, orchestratorDataDir: paths.orchestratorDataDir}),
+        mode      = live.orchestratorAlive ? 'attach' : 'own';
+
+    if (mode === 'own') {
+        const orchestrator = startBrainChild({entry: ORCHESTRATOR_ENTRY, onLog: brainLog, repoRoot});
+
+        brainState.children.push({child: orchestrator, label: 'orchestrator'});
+        await awaitOrchestratorReady({child: orchestrator})
+    }
+
+    if (!live.fleetListening) {
+        const fleet = startBrainChild({
+            entry: FLEET_SERVER_ENTRY,
+            env  : {NEO_FLEET_PORT: String(fleetPort)},
+            onLog: brainLog,
+            repoRoot
         });
 
-    brainChild = child;
+        brainState.children.push({child: fleet, label: 'fleet'});
+        await awaitFleetReady({child: fleet, port: fleetPort})
+    }
 
-    const upReport = await awaitBrainUp({child, dataDir: env.NEO_AI_ORCHESTRATOR_DIR});
+    console.log(`HARNESS_BRAIN_MODE ${mode} fleetPort=${fleetPort} started=[${brainState.children.map(entry => entry.label).join(',') || 'none'}]`);
+    return {fleetPort, mode, up: true}
+}
 
-    return {child, dataDir: env.NEO_AI_ORCHESTRATOR_DIR, upReport}
+/**
+ * The smoke Brain boot — the fully ISOLATED profile: allocate ports, bind every mutable path
+ * under a throwaway root, then assert the isolation matrix THROUGH the config SSOT before
+ * anything spawns. Readiness is genuine service readiness (orchestrator poll-loop marker + a
+ * real fleet wire-verb round-trip), never PID existence.
+ * @summary Boots the isolated smoke organism, returning every observable the verdict gates on.
+ * @returns {Promise<Object>}
+ */
+async function bootSmokeBrain() {
+    const
+        isolationRoot           = process.env.NEO_HARNESS_BRAIN_ROOT || path.join(harnessDir, '.brain', 'smoke'),
+        sweptPgids              = sweepStaleRunState({isolationRoot}),
+        [chromaPort, fleetPort] = await Promise.all([allocatePort(), allocatePort()]),
+        profile                 = buildBrainProfile({chromaPort, fleetPort, isolationRoot}),
+        resolved                = await resolveBrainPaths({env: profile, repoRoot}),
+        matrixViolations        = assertIsolatedProfile({chromaPort, isolationRoot, resolved});
+
+    if (matrixViolations.length > 0) {
+        return {chromaPort, fleetPort, isolationRoot, matrixViolations, sweptPgids, up: false}
+    }
+
+    const
+        orchestrator = startBrainChild({entry: ORCHESTRATOR_ENTRY, env: profile, onLog: brainLog, repoRoot}),
+        fleet        = startBrainChild({entry: FLEET_SERVER_ENTRY, env: profile, onLog: brainLog, repoRoot});
+
+    brainState.children.push({child: orchestrator, label: 'orchestrator'}, {child: fleet, label: 'fleet'});
+    writeRunState({isolationRoot, pgids: brainState.children.map(entry => entry.child.pid)});
+
+    await Promise.all([
+        awaitOrchestratorReady({child: orchestrator}),
+        awaitFleetReady({child: fleet, port: fleetPort})
+    ]);
+
+    return {chromaPort, fleetPort, isolationRoot, matrixViolations, sweptPgids, up: true}
 }
 
 app.on('will-quit', async event => {
-    if (brainChild && brainChild.exitCode === null) {
+    if (brainState.children.length) {
         event.preventDefault();
-        const stop = await stopBrain(brainChild);
-        brainChild = null;
+        const stop = await teardownBrain();
         smokeMode && console.log('HARNESS_BRAIN_STOP ' + JSON.stringify(stop));
         app.quit()
     }
@@ -408,8 +501,15 @@ app.whenReady().then(async () => {
     }
 
     // The Brain boots in parallel with the window — the UI never blocks on the supervisor, and
-    // fail-closed surfaces render honestly until the transport is reachable.
-    const brainBoot = brainMode ? bootSupervisedBrain() : null;
+    // fail-closed surfaces render honestly until the transport is reachable. Boot rejection is
+    // deterministic (readiness contract) and lands as up:false, never as a hung promise.
+    const brainBoot = brainMode
+        ? (smokeMode ? bootSmokeBrain() : bootProductBrain())
+            .catch(error => {
+                console.log('HARNESS_BRAIN_BOOT_FAILED ' + error.message);
+                return {error: error.message, up: false}
+            })
+        : null;
 
     const win1 = createHarnessWindow(APP_URL);
 
@@ -442,26 +542,46 @@ app.whenReady().then(async () => {
 
     await awaitRequiredAssets();
 
-    // The Brain leg (Arm B): supervisor up under the ISOLATED root, then settle-or-reject
-    // teardown with an orphan check — falsifier 3's live observables (ports/PID across the
-    // child's lifecycle are the orchestrator's own job; ours is owning ITS lifecycle cleanly).
+    // The Brain leg (Arm B): the isolated organism proven through its OWN consumable surfaces —
+    // the resolved-leaf isolation matrix, genuine orchestrator + fleet readiness, a REAL wire
+    // verb from the renderer (the AC's "window reaches the fleet transport"), then full-tree
+    // group teardown gated on group-empty AND released listeners.
     let brain = {mode: false};
 
     if (brainBoot) {
-        const {child, dataDir, upReport} = await brainBoot;
-        const stop                       = await stopBrain(child);
+        const boot = await brainBoot;
 
-        let orphaned = false;
+        let chromaListening = null,
+            fleetFromWindow = null;
 
-        try {
-            process.kill(child.pid, 0);
-            orphaned = true
-        } catch (error) {
-            // ESRCH — the process is gone, which is the pass condition
+        if (boot.up) {
+            // Let the organism SETTLE before quitting: the isolated Chroma serving on the
+            // allocated port is live isolation evidence AND removes the mid-startup-child race
+            // from the graceful-teardown measurement. Chroma binds `localhost` (::1 on macOS),
+            // and a cold start on a fresh persist dir takes ~a minute.
+            chromaListening = await awaitPortListening({host: 'localhost', port: boot.chromaPort, timeoutMs: 120000});
+
+            fleetFromWindow = await Promise.race([
+                win1.webContents.executeJavaScript(
+                    `fetch('http://127.0.0.1:${boot.fleetPort}/fleet', {` +
+                    `method: 'POST', headers: {'content-type': 'application/json'},` +
+                    `body: '{"method":"listAgents","params":{}}'` +
+                    `}).then(r => r.json()).then(j => ({ok: j.ok === true}))` +
+                    `.catch(e => ({ok: false, error: String(e).slice(0, 200)}))`, true
+                ),
+                new Promise(resolve => setTimeout(() => resolve({error: 'renderer-probe-wedged', ok: false}), 8000))
+            ])
         }
 
-        brainChild = null;
-        brain      = {mode: true, dataDir, ...upReport, stop, orphaned}
+        const
+            stop          = await teardownBrain(),
+            stopReports   = Object.values(stop ?? {}),
+            groupsEmpty   = stopReports.every(report => report.groupEmpty),
+            portsReleased = boot.up
+                ? !(await probePort({host: 'localhost', port: boot.chromaPort})) && !(await probePort({port: boot.fleetPort}))
+                : null;
+
+        brain = {mode: true, ...boot, chromaListening, fleetFromWindow, groupsEmpty, portsReleased, stop}
     }
 
     const
@@ -489,7 +609,15 @@ app.whenReady().then(async () => {
                 node    : process.versions.node
             }
         },
-        brainPassed = !brain.mode || (brain.up && brain.stop.exited && !brain.stop.forced && !brain.orphaned),
+        brainPassed = !brain.mode || (
+            brain.up === true &&
+            (brain.matrixViolations ?? ['unresolved']).length === 0 &&
+            brain.chromaListening === true &&
+            brain.fleetFromWindow?.ok === true &&
+            brain.groupsEmpty === true &&
+            brain.portsReleased === true &&
+            Object.values(brain.stop ?? {}).every(report => report.exited && !report.forced)
+        ),
         passed = boot1.mounted > 10 &&
             boot2.mounted > 10 &&
             results.popupMaterialized &&
@@ -524,5 +652,8 @@ smokeMode && setTimeout(async () => {
         console.log('HARNESS_TIMEOUT_CAPTURE_FAIL ' + error.message)
     }
 
+    // app.exit bypasses will-quit, so the timeout net owns the Brain teardown explicitly.
+    await teardownBrain();
     app.exit(1)
-}, 60000);
+    // The Brain leg legitimately spends ~2min on a cold Chroma start; the UI-only smoke stays tight.
+}, brainMode ? 240000 : 60000);

--- a/harness/package.json
+++ b/harness/package.json
@@ -2,13 +2,15 @@
     "name": "neo-harness",
     "private": true,
     "version": "0.0.1",
-    "description": "The Agent Harness's native vessel (ticket 14962 under 13033/13377): boots the dev-mode harness app on the privileged app:// origin per the Electron-shell ADR. Wraps what the repo serves — never a source hemisphere.",
+    "description": "The Agent Harness's native vessel (ticket 14962 under 13033/13377): boots the dev-mode harness app on the privileged app:// origin per the Electron-shell ADR. Wraps what the repo serves \u2014 never a source hemisphere.",
     "main": "main.mjs",
     "scripts": {
         "prestart": "node prepareAssets.mjs",
         "presmoke": "node prepareAssets.mjs",
         "start": "electron main.mjs",
-        "smoke": "cross-env NEO_HARNESS_SMOKE=1 electron main.mjs"
+        "smoke": "cross-env NEO_HARNESS_SMOKE=1 electron main.mjs",
+        "smoke:brain": "cross-env NEO_HARNESS_SMOKE=1 NEO_HARNESS_BRAIN=1 electron main.mjs",
+        "start:brain": "cross-env NEO_HARNESS_BRAIN=1 electron main.mjs"
     },
     "devDependencies": {
         "cross-env": "^10.1.0",

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -2150,3 +2150,18 @@ test.describe('Neo.ai.daemons.Orchestrator — chroma max-runtime recycle (#1213
         expect(orchestrator._chromaDefragPending).toBe(true);
     });
 });
+
+test.describe('taskDefinitions — chroma persist dir rides the resolved leaf (#14967)', () => {
+    test('an explicit chromaDataDir lands in the --path arg beside the port', () => {
+        const tasks = buildTaskDefinitions({chromaDataDir: '/isolated/chroma', chromaPort: 18500});
+
+        expect(tasks.chroma.args).toEqual(['run', '--path', '/isolated/chroma', '--port', '18500']);
+        expect(tasks.chroma.singletonPort).toBe(18500);
+    });
+
+    test('direct callers keep the launch-resilient literal default', () => {
+        const tasks = buildTaskDefinitions({chromaPort: 8000});
+
+        expect(tasks.chroma.args).toEqual(['run', '--path', '.neo-ai-data/chroma/unified', '--port', '8000']);
+    });
+});

--- a/test/playwright/unit/harness/brain.spec.mjs
+++ b/test/playwright/unit/harness/brain.spec.mjs
@@ -1,0 +1,348 @@
+import {expect, test}                                       from '@playwright/test';
+import {EventEmitter}                                       from 'node:events';
+import {mkdtemp, rm}                                        from 'node:fs/promises';
+import {readFileSync, writeFileSync, mkdirSync, existsSync} from 'node:fs';
+import net                                                  from 'node:net';
+import {tmpdir}                                             from 'node:os';
+import path                                                 from 'node:path';
+import {
+    allocatePort,
+    assertIsolatedProfile,
+    awaitFleetReady,
+    awaitOrchestratorReady,
+    awaitReadyMarker,
+    buildBrainProfile,
+    detectLiveBrain,
+    ORCHESTRATOR_ENTRY,
+    probePort,
+    stopBrainChild,
+    stopBrainTree,
+    sweepStaleRunState,
+    writeRunState
+} from '../../../../harness/brain.mjs';
+
+/**
+ * A stub supervised child: EventEmitter shape matching the ChildProcess surface the lifecycle
+ * contract consumes (stdout stream, exit/error events, pid, exitCode).
+ */
+function createFakeChild({pid = 4242} = {}) {
+    const child = new EventEmitter();
+
+    child.pid      = pid;
+    child.exitCode = null;
+    child.stdout   = new EventEmitter();
+    child.stderr   = new EventEmitter();
+
+    child.emitLine = line => child.stdout.emit('data', Buffer.from(line + '\n'));
+    child.exit     = (code = 0, signal = null) => {
+        child.exitCode = code;
+        child.emit('exit', code, signal)
+    };
+
+    return child
+}
+
+/**
+ * A stub process-group registry backing an injected killFn: signal 0 probes liveness (throws
+ * ESRCH when the group is gone), SIGINT/SIGKILL transition it per the scenario. Signals must
+ * arrive group-addressed (negative pid) — that IS the descendant-ownership contract.
+ */
+function createFakeGroup({pid, diesOn}) {
+    const state = {alive: true, signals: []};
+
+    state.killFn = (target, signal) => {
+        if (target !== -pid && signal !== 0) {
+            throw new Error(`expected group-addressed signal, got target=${target}`)
+        }
+
+        if (!state.alive) {
+            const error = new Error('ESRCH');
+            error.code  = 'ESRCH';
+            throw error
+        }
+
+        if (signal !== 0) {
+            state.signals.push(signal);
+
+            if (diesOn.includes(signal)) {
+                state.alive = false
+            }
+        }
+
+        return true
+    };
+
+    return state
+}
+
+test.describe('harness brain lifecycle', () => {
+    let workDir;
+
+    test.beforeEach(async () => {
+        workDir = await mkdtemp(path.join(tmpdir(), 'neo-harness-brain-'))
+    });
+
+    test.afterEach(async () => {
+        await rm(workDir, {force: true, recursive: true})
+    });
+
+    test('buildBrainProfile binds every mutable path under the isolation root and gates every side lane off', () => {
+        const profile = buildBrainProfile({chromaPort: 18500, fleetPort: 18501, isolationRoot: workDir});
+
+        for (const leafName of ['NEO_AI_DB_PATH', 'NEO_AI_ORCHESTRATOR_DIR', 'NEO_BACKUP_PATH', 'NEO_CHROMA_DATA_DIR_TEST', 'NEO_FLEET_INSTANCE_ROOT', 'NEO_REM_RUN_STATE_DIR']) {
+            expect(profile[leafName].startsWith(workDir + path.sep)).toBe(true)
+        }
+
+        expect(profile.UNIT_TEST_MODE).toBe('1');
+        expect(profile.NEO_CHROMA_PORT_TEST).toBe('18500');
+        expect(profile.NEO_FLEET_PORT).toBe('18501');
+
+        // Every gate leaf is OFF — an ungated port-bearing task can reap live listeners
+        // (ProcessSupervisorService.reconcileSingletonPort), so this list is a safety contract.
+        const gates = Object.entries(profile).filter(([name]) => name.endsWith('_ENABLED'));
+
+        expect(gates.length).toBeGreaterThanOrEqual(14);
+        gates.forEach(([, value]) => expect(value).toBe('0'))
+    });
+
+    test('assertIsolatedProfile passes an isolated resolution and names every escape', () => {
+        const isolated = {
+            backupPath         : path.join(workDir, 'backups'),
+            chromaDataDir      : path.join(workDir, 'chroma'),
+            chromaPort         : 18500,
+            dbPath             : path.join(workDir, 'sqlite', 'memory-core-graph.sqlite'),
+            fleetInstanceRoot  : path.join(workDir, 'fleet', 'instances'),
+            orchestratorDataDir: path.join(workDir, 'orchestrator')
+        };
+
+        expect(assertIsolatedProfile({chromaPort: 18500, isolationRoot: workDir, resolved: isolated})).toEqual([]);
+
+        const leaky = assertIsolatedProfile({
+            chromaPort   : 18500,
+            isolationRoot: workDir,
+            resolved     : {...isolated, chromaPort: 8000, dbPath: '.neo-ai-data/sqlite/memory-core-graph.sqlite'}
+        });
+
+        expect(leaky.some(violation => violation.includes('dbPath'))).toBe(true);
+        expect(leaky.some(violation => violation.includes('chromaPort'))).toBe(true);
+        expect(leaky).toHaveLength(2)
+    });
+
+    test('awaitReadyMarker resolves on the marker and never on PID existence alone', async () => {
+        const
+            child = createFakeChild(),
+            ready = awaitReadyMarker({child, label: 'orchestrator', marker: '[Orchestrator] Started.', timeoutMs: 2000});
+
+        let settled = false;
+
+        ready.then(() => { settled = true });
+
+        // PID-file-era false readiness: lines flow, process exists — not ready yet.
+        child.emitLine('[2026-07-10T20:00:00.000Z] [PID:4242] [INFO] [Orchestrator] Found existing instance');
+        await new Promise(resolve => setTimeout(resolve, 30));
+        expect(settled).toBe(false);
+
+        child.emitLine('[2026-07-10T20:00:01.000Z] [PID:4242] [INFO] [Orchestrator] Started. summaryInterval=1000ms');
+        await expect(ready).resolves.toBeUndefined()
+    });
+
+    test('awaitOrchestratorReady rejects deterministically on early exit', async () => {
+        const
+            child = createFakeChild(),
+            ready = awaitOrchestratorReady({child, timeoutMs: 2000});
+
+        child.exit(1);
+        await expect(ready).rejects.toThrow(/exited before ready \(code=1/)
+    });
+
+    test('awaitReadyMarker rejects on spawn error and on an already-exited child', async () => {
+        const errored = createFakeChild();
+        const ready   = awaitReadyMarker({child: errored, label: 'orchestrator', marker: 'never', timeoutMs: 2000});
+
+        errored.emit('error', new Error('ENOENT'));
+        await expect(ready).rejects.toThrow(/failed to spawn: ENOENT/);
+
+        const dead = createFakeChild();
+
+        dead.exitCode = 127;
+        await expect(awaitReadyMarker({child: dead, label: 'fleet', marker: 'never', timeoutMs: 2000}))
+            .rejects.toThrow(/exited before ready \(code=127/)
+    });
+
+    test('awaitReadyMarker rejects on timeout', async () => {
+        const child = createFakeChild();
+
+        await expect(awaitReadyMarker({child, label: 'orchestrator', marker: 'never-emitted', timeoutMs: 120}))
+            .rejects.toThrow(/not ready within 120ms/)
+    });
+
+    test('awaitFleetReady polls through failures and requires a real ok:true wire envelope', async () => {
+        const child = createFakeChild();
+
+        let calls = 0;
+
+        const fetchFn = async (url, init) => {
+            calls++;
+            expect(url).toContain('/fleet');
+            expect(JSON.parse(init.body).method).toBe('listAgents');
+
+            if (calls < 3) {
+                throw new Error('ECONNREFUSED')
+            }
+
+            return {json: async () => ({ok: true, result: []})}
+        };
+
+        await expect(awaitFleetReady({child, fetchFn, port: 18501, timeoutMs: 5000})).resolves.toBeUndefined();
+        expect(calls).toBeGreaterThanOrEqual(3)
+    });
+
+    test('awaitFleetReady rejects when the transport child dies first', async () => {
+        const
+            child = createFakeChild(),
+            ready = awaitFleetReady({child, fetchFn: async () => { throw new Error('ECONNREFUSED') }, port: 18501, timeoutMs: 5000});
+
+        child.exit(1);
+        await expect(ready).rejects.toThrow(/fleet transport exited before ready/)
+    });
+
+    // SIGINT is the graceful rung by measurement: the chromadb npm wrapper ignores group-SIGTERM
+    // indefinitely but exits on SIGINT in milliseconds; every supervised entry handles both.
+    test('stopBrainChild settles the graceful group path: SIGINT only, group empty, never forced', async () => {
+        const
+            child = createFakeChild({pid: 5001}),
+            group = createFakeGroup({diesOn: ['SIGINT'], pid: 5001}),
+            stop  = await stopBrainChild(child, {graceMs: 500, killFn: group.killFn, pollMs: 20});
+
+        expect(stop).toEqual({exited: true, forced: false, groupEmpty: true});
+        expect(group.signals).toEqual(['SIGINT'])
+    });
+
+    test('stopBrainChild escalates a SIGINT-ignoring group to SIGKILL and reports forced', async () => {
+        const
+            child = createFakeChild({pid: 5002}),
+            group = createFakeGroup({diesOn: ['SIGKILL'], pid: 5002}),
+            stop  = await stopBrainChild(child, {graceMs: 100, killFn: group.killFn, pollMs: 20});
+
+        expect(stop).toEqual({exited: true, forced: true, groupEmpty: true});
+        expect(group.signals).toEqual(['SIGINT', 'SIGKILL'])
+    });
+
+    test('stopBrainChild is idempotent: a second stop of a dead group settles immediately', async () => {
+        const
+            child = createFakeChild({pid: 5003}),
+            group = createFakeGroup({diesOn: ['SIGINT'], pid: 5003});
+
+        await stopBrainChild(child, {graceMs: 500, killFn: group.killFn, pollMs: 20});
+
+        const again = await stopBrainChild(child, {graceMs: 500, killFn: group.killFn, pollMs: 20});
+
+        expect(again).toEqual({exited: true, forced: false, groupEmpty: true});
+        expect(group.signals).toEqual(['SIGINT'])
+    });
+
+    test('stopBrainTree stops the consumer (fleet) before the organism (orchestrator)', async () => {
+        const
+            order        = [],
+            orchestrator = createFakeChild({pid: 6001}),
+            fleet        = createFakeChild({pid: 6002}),
+            groups       = {
+                6001: createFakeGroup({diesOn: ['SIGINT'], pid: 6001}),
+                6002: createFakeGroup({diesOn: ['SIGINT'], pid: 6002})
+            },
+            killFn = (target, signal) => {
+                const pid = Math.abs(target);
+
+                signal === 'SIGINT' && order.push(pid);
+                return groups[pid].killFn(target, signal)
+            },
+            report = await stopBrainTree([
+                {child: orchestrator, label: 'orchestrator'},
+                {child: fleet,        label: 'fleet'}
+            ], {graceMs: 500, killFn, pollMs: 20});
+
+        expect(order).toEqual([6002, 6001]);
+        expect(report.fleet.groupEmpty).toBe(true);
+        expect(report.orchestrator.groupEmpty).toBe(true)
+    });
+
+    test('run-state round-trip: a crashed run\'s live groups are swept, dead ones skipped, state cleared', () => {
+        const group = createFakeGroup({diesOn: ['SIGKILL'], pid: 7001});
+
+        writeRunState({isolationRoot: workDir, pgids: [7001, 999999]});
+
+        const killFn = (target, signal) => {
+            if (Math.abs(target) === 999999) {
+                const error = new Error('ESRCH');
+                error.code  = 'ESRCH';
+                throw error
+            }
+
+            return group.killFn(target, signal)
+        };
+
+        expect(sweepStaleRunState({isolationRoot: workDir, killFn})).toEqual([7001]);
+        expect(group.signals).toEqual(['SIGKILL']);
+        expect(existsSync(path.join(workDir, 'run-state.json'))).toBe(false);
+
+        // No state file → no-op.
+        expect(sweepStaleRunState({isolationRoot: workDir, killFn})).toEqual([])
+    });
+
+    test('detectLiveBrain: live pid + orchestrator command + fleet probe drive the attach decision', async () => {
+        const dataDir = path.join(workDir, 'orchestrator');
+
+        mkdirSync(dataDir, {recursive: true});
+        writeFileSync(path.join(dataDir, 'orchestrator-daemon.pid'), '8123', 'utf8');
+
+        const live = await detectLiveBrain({
+            commandFn          : () => `node ${ORCHESTRATOR_ENTRY}`,
+            fleetPort          : 18501,
+            killFn             : () => true,
+            orchestratorDataDir: dataDir,
+            probePortFn        : async () => true
+        });
+
+        expect(live).toEqual({fleetListening: true, orchestratorAlive: true, orchestratorPid: 8123});
+
+        // A recycled pid running something else must NOT read as a live Brain.
+        const foreign = await detectLiveBrain({
+            commandFn          : () => '/usr/bin/some-other-tool',
+            fleetPort          : 18501,
+            killFn             : () => true,
+            orchestratorDataDir: dataDir,
+            probePortFn        : async () => false
+        });
+
+        expect(foreign.orchestratorAlive).toBe(false);
+        expect(foreign.fleetListening).toBe(false);
+
+        // No PID file at all.
+        const missing = await detectLiveBrain({
+            fleetPort          : 18501,
+            orchestratorDataDir: path.join(workDir, 'nowhere'),
+            probePortFn        : async () => false
+        });
+
+        expect(missing.orchestratorAlive).toBe(false)
+    });
+
+    test('allocatePort returns a free loopback port and probePort tracks its occupancy', async () => {
+        const port = await allocatePort();
+
+        expect(await probePort({port, timeoutMs: 500})).toBe(false);
+
+        const server = net.createServer();
+
+        await new Promise(resolve => server.listen(port, '127.0.0.1', resolve));
+        expect(await probePort({port, timeoutMs: 500})).toBe(true);
+        await new Promise(resolve => server.close(resolve));
+        expect(await probePort({port, timeoutMs: 500})).toBe(false)
+    });
+
+    test('run-state file content stays a minimal pgid list', () => {
+        writeRunState({isolationRoot: workDir, pgids: [111, 222]});
+
+        expect(JSON.parse(readFileSync(path.join(workDir, 'run-state.json'), 'utf8'))).toEqual({pgids: [111, 222]})
+    })
+});

--- a/test/playwright/unit/harness/brain.spec.mjs
+++ b/test/playwright/unit/harness/brain.spec.mjs
@@ -1,6 +1,6 @@
 import {expect, test}                                       from '@playwright/test';
 import {EventEmitter}                                       from 'node:events';
-import {mkdtemp, rm}                                        from 'node:fs/promises';
+import {mkdtemp, rm, symlink}                               from 'node:fs/promises';
 import {readFileSync, writeFileSync, mkdirSync, existsSync} from 'node:fs';
 import net                                                  from 'node:net';
 import {tmpdir}                                             from 'node:os';
@@ -12,9 +12,13 @@ import {
     awaitOrchestratorReady,
     awaitReadyMarker,
     buildBrainProfile,
+    clearRunState,
     detectLiveBrain,
+    FLEET_SERVER_ENTRY,
     ORCHESTRATOR_ENTRY,
+    probeFleetServing,
     probePort,
+    resolveRealPath,
     stopBrainChild,
     stopBrainTree,
     sweepStaleRunState,
@@ -126,6 +130,42 @@ test.describe('harness brain lifecycle', () => {
         expect(leaky.some(violation => violation.includes('dbPath'))).toBe(true);
         expect(leaky.some(violation => violation.includes('chromaPort'))).toBe(true);
         expect(leaky).toHaveLength(2)
+    });
+
+    // Isolation is a filesystem-IDENTITY contract: a symlinked ancestor inside the root satisfies
+    // a lexical prefix check while the data lands outside. The containment must resolve links.
+    test('assertIsolatedProfile flags a symlinked ancestor escaping the root by identity', async () => {
+        const outside = await mkdtemp(path.join(tmpdir(), 'neo-harness-outside-'));
+
+        try {
+            const isolated = {
+                backupPath         : path.join(workDir, 'backups'),
+                chromaDataDir      : path.join(workDir, 'chroma'),
+                chromaPort         : 18500,
+                dbPath             : path.join(workDir, 'sqlite', 'memory-core-graph.sqlite'),
+                fleetInstanceRoot  : path.join(workDir, 'fleet', 'instances'),
+                orchestratorDataDir: path.join(workDir, 'orchestrator')
+            };
+
+            // The lexical form is identical before and after; only the identity changes.
+            expect(assertIsolatedProfile({chromaPort: 18500, isolationRoot: workDir, resolved: isolated})).toEqual([]);
+
+            await symlink(outside, path.join(workDir, 'sqlite'));
+
+            const violations = assertIsolatedProfile({chromaPort: 18500, isolationRoot: workDir, resolved: isolated});
+
+            expect(violations.some(violation => violation.includes('dbPath'))).toBe(true);
+            // realpath both sides: os.tmpdir() itself sits behind a symlink on macOS (/var → /private/var).
+            expect(resolveRealPath(isolated.dbPath).startsWith(resolveRealPath(outside))).toBe(true)
+        } finally {
+            await rm(outside, {force: true, recursive: true})
+        }
+    });
+
+    test('probeFleetServing requires the wire envelope — occupancy alone is not fleet identity', async () => {
+        expect(await probeFleetServing({fetchFn: async () => ({json: async () => ({ok: true, result: []})}), port: 1})).toBe(true);
+        expect(await probeFleetServing({fetchFn: async () => ({json: async () => 'not the fleet protocol'}), port: 1})).toBe(false);
+        expect(await probeFleetServing({fetchFn: async () => { throw new Error('ECONNREFUSED') }, port: 1})).toBe(false)
     });
 
     test('awaitReadyMarker resolves on the marker and never on PID existence alone', async () => {
@@ -266,13 +306,27 @@ test.describe('harness brain lifecycle', () => {
         expect(report.orchestrator.groupEmpty).toBe(true)
     });
 
-    test('run-state round-trip: a crashed run\'s live groups are swept, dead ones skipped, state cleared', () => {
+    // A bare PGID is not ownership: the OS recycles ids, so the sweep must re-prove the recorded
+    // identity (the leader still runs OUR entry script) before signaling, and a CLEAN stop must
+    // clear the record so it can never outlive the run.
+    test('run-state sweep kills only identity-verified groups, skips recycled pids, clears state', () => {
         const group = createFakeGroup({diesOn: ['SIGKILL'], pid: 7001});
 
-        writeRunState({isolationRoot: workDir, pgids: [7001, 999999]});
+        writeRunState({
+            children     : [
+                {entry: ORCHESTRATOR_ENTRY, pgid: 7001},
+                {entry: FLEET_SERVER_ENTRY, pgid: 7002},
+                {entry: ORCHESTRATOR_ENTRY, pgid: 999999}
+            ],
+            isolationRoot: workDir
+        });
 
         const killFn = (target, signal) => {
-            if (Math.abs(target) === 999999) {
+            if ([7002, 999999].includes(Math.abs(target))) {
+                if (Math.abs(target) === 7002 && signal === 0) {
+                    return true // alive — but identity will mismatch below
+                }
+
                 const error = new Error('ESRCH');
                 error.code  = 'ESRCH';
                 throw error
@@ -281,15 +335,30 @@ test.describe('harness brain lifecycle', () => {
             return group.killFn(target, signal)
         };
 
-        expect(sweepStaleRunState({isolationRoot: workDir, killFn})).toEqual([7001]);
+        const commandFn = pgid => pgid === 7001
+            ? `node ${ORCHESTRATOR_ENTRY}`
+            : '/usr/bin/unrelated-tool-that-recycled-the-pid';
+
+        // 7001: alive + identity match → killed. 7002: alive but recycled → SKIPPED. 999999: dead.
+        expect(sweepStaleRunState({commandFn, isolationRoot: workDir, killFn})).toEqual([7001]);
         expect(group.signals).toEqual(['SIGKILL']);
         expect(existsSync(path.join(workDir, 'run-state.json'))).toBe(false);
 
         // No state file → no-op.
-        expect(sweepStaleRunState({isolationRoot: workDir, killFn})).toEqual([])
+        expect(sweepStaleRunState({commandFn, isolationRoot: workDir, killFn})).toEqual([])
     });
 
-    test('detectLiveBrain: live pid + orchestrator command + fleet probe drive the attach decision', async () => {
+    test('clearRunState removes the record after a clean stop and tolerates absence', () => {
+        writeRunState({children: [{entry: ORCHESTRATOR_ENTRY, pgid: 7100}], isolationRoot: workDir});
+        expect(existsSync(path.join(workDir, 'run-state.json'))).toBe(true);
+
+        clearRunState({isolationRoot: workDir});
+        expect(existsSync(path.join(workDir, 'run-state.json'))).toBe(false);
+
+        clearRunState({isolationRoot: workDir}) // idempotent
+    });
+
+    test('detectLiveBrain: protocol identity drives attach; a foreign listener reads held-not-serving', async () => {
         const dataDir = path.join(workDir, 'orchestrator');
 
         mkdirSync(dataDir, {recursive: true});
@@ -300,10 +369,25 @@ test.describe('harness brain lifecycle', () => {
             fleetPort          : 18501,
             killFn             : () => true,
             orchestratorDataDir: dataDir,
+            probeFleetFn       : async () => true,
             probePortFn        : async () => true
         });
 
-        expect(live).toEqual({fleetListening: true, orchestratorAlive: true, orchestratorPid: 8123});
+        expect(live).toEqual({fleetPortHeld: true, fleetServing: true, orchestratorAlive: true, orchestratorPid: 8123});
+
+        // A foreign HTTP server on the fleet port: occupied, but NOT the fleet protocol —
+        // attach must not treat it as a reachable Brain surface.
+        const squatted = await detectLiveBrain({
+            commandFn          : () => `node ${ORCHESTRATOR_ENTRY}`,
+            fleetPort          : 18501,
+            killFn             : () => true,
+            orchestratorDataDir: dataDir,
+            probeFleetFn       : async () => false,
+            probePortFn        : async () => true
+        });
+
+        expect(squatted.fleetServing).toBe(false);
+        expect(squatted.fleetPortHeld).toBe(true);
 
         // A recycled pid running something else must NOT read as a live Brain.
         const foreign = await detectLiveBrain({
@@ -311,16 +395,19 @@ test.describe('harness brain lifecycle', () => {
             fleetPort          : 18501,
             killFn             : () => true,
             orchestratorDataDir: dataDir,
+            probeFleetFn       : async () => false,
             probePortFn        : async () => false
         });
 
         expect(foreign.orchestratorAlive).toBe(false);
-        expect(foreign.fleetListening).toBe(false);
+        expect(foreign.fleetServing).toBe(false);
+        expect(foreign.fleetPortHeld).toBe(false);
 
         // No PID file at all.
         const missing = await detectLiveBrain({
             fleetPort          : 18501,
             orchestratorDataDir: path.join(workDir, 'nowhere'),
+            probeFleetFn       : async () => false,
             probePortFn        : async () => false
         });
 
@@ -340,9 +427,10 @@ test.describe('harness brain lifecycle', () => {
         expect(await probePort({port, timeoutMs: 500})).toBe(false)
     });
 
-    test('run-state file content stays a minimal pgid list', () => {
-        writeRunState({isolationRoot: workDir, pgids: [111, 222]});
+    test('run-state file content carries the ownership token per group', () => {
+        writeRunState({children: [{entry: ORCHESTRATOR_ENTRY, pgid: 111}], isolationRoot: workDir});
 
-        expect(JSON.parse(readFileSync(path.join(workDir, 'run-state.json'), 'utf8'))).toEqual({pgids: [111, 222]})
+        expect(JSON.parse(readFileSync(path.join(workDir, 'run-state.json'), 'utf8')))
+            .toEqual({children: [{entry: ORCHESTRATOR_ENTRY, pgid: 111}]})
     })
 });


### PR DESCRIPTION
Resolves #14967

Related: #13033 (parent — slice 3 of its intake plan; the falsifier verdict is recorded on #14967 with @neo-opus-ada's countersign requested, and the ledger reconciliation onto #13033 follows merge) · epic #13377 · ADR 0034 §2.1 (upstream contract) · PR #14963 (the packaging root this builds on) · #13015 (the PoC bar this un-gates)

**The Brain rides inside the harness — supervised (Arm B), as one supervision contract: isolate → become reachable → tear down the whole tree.** The falsifier gate ran first and the verdict is on the ticket: `better-sqlite3` under Electron 43's main = `ERR_DLOPEN_FAILED` (ABI 141 vs 148 — falsifier 1), and the standard rebuild fails the gate's fights-the-stack condition structurally (one shared `node_modules` must keep serving the system-Node dev loop). Per ADR 0034 §2.1's falsifier clause the arm flips and the five §2.1 bindings survive unchanged.

**Cycle-3 convergence (@neo-gpt's identity falsifiers — isolation, ownership, and attach are IDENTITY contracts, not observations):** `assertIsolatedProfile` resolves ancestor symlinks on both sides (`resolveRealPath` — realpath of the deepest existing ancestor + the uncreated tail), so a symlinked `sqlite/` under the smoke root fails containment by filesystem identity; run-state carries an ownership token per group (the leader's entry script), is CLEARED on clean stop, and the crash sweep re-proves the leader's command line before signaling (a recycled pgid is skipped); `detectLiveBrain.fleetServing` requires a real `listAgents` envelope (`probeFleetServing`), raw occupancy reports separately as `fleetPortHeld`, and `bootProductBrain` fails CLOSED on a foreign listener squatting the fleet port. +5 unit pins.

**Cycle-2 convergence (@neo-gpt's exact-head audit — all three required actions, plus the Brain-side root cause his probe uncovered):**

1. **[P0] The isolation profile is complete and EXECUTABLE.** `buildBrainProfile` binds every mutable path the spawned tree consumes under one throwaway root — orchestrator data dir, **the graph sqlite (`NEO_AI_DB_PATH` — previously open on the canonical store through the clone's symlink)**, Chroma persist dir, fleet instance root, **backup target (the interval-driven scheduled family has no enable gates and fires immediately on a fresh state file)**, REM run-state — and gates every other lane OFF via its config env switch (14 gates: dev server, Neural Link, embed/message daemons, mlx/ollama/lms, swarm heartbeat, sync + enrichment lanes, deployment-state bridge). The gates are safety-critical, not hygiene: `ProcessSupervisorService.reconcileSingletonPort` REAPS foreign listeners on supervised singleton ports, so an ungated port-bearing task aimed at a live machine is a kill vector. The matrix is asserted through the SSOT itself: `resolveBrainPaths` re-resolves the leaves via a one-shot `ai/config.mjs` import under the profile env, and the smoke fails on any leaf escaping the root — what the tree ACTUALLY consumes, never our guess. Exercised ports are runtime-allocated by the lifecycle owner.
2. **Brain-side root cause fixed at the seam the audit named:** the chroma task's `--path` was a relative literal while `--port` read the resolved leaf — so a `UNIT_TEST_MODE` profile launched a **test-port server on the PRODUCTION persist dir** (empirically observed on this machine: an orphaned `--port 18201 --path .neo-ai-data/chroma/unified` server beside the canonical one, on a `chroma/` symlink to the canonical clone). `ConfiguredTaskDefinitionsService` now passes the resolved `engines.chroma.dataDir`; the pure layer keeps the literal as a default for direct callers (launch-resilience rationale preserved). Two exact-args pins added.
3. **[P1] Readiness is a reachable Brain/Fleet surface.** The PID-file up-gate is deleted (confirmed written before config load and `Orchestrator.start()` — it proved existence, not readiness). The gates now: the daemon's own `[Orchestrator] Started.` poll-loop marker → the isolated Chroma actually serving its allocated port → a real `POST /fleet {method:'listAgents'}` wire round-trip — **re-run FROM THE RENDERER** (`fleetFromWindow.ok: true` — the AC's "window reaches the fleet transport", against the same transport surface the merged conductor consumes). Boot promises reject deterministically on spawn error and early exit.
4. **[P1] Teardown owns the whole process tree through every exit path.** Children spawn `detached` into their own process groups; stop is group-SIGINT → bounded grace → group-SIGKILL, settled on group-empty, and the smoke exit additionally requires unforced + released listeners. SIGINT is the graceful rung **by measurement, not assumption**: the chromadb npm wrapper ignores group-SIGTERM indefinitely (measured 40s+) but exits on SIGINT in milliseconds; both supervised entries register SIGINT/SIGTERM identically. All four exit paths (will-quit, smoke verdict, timeout net, unhandled-rejection net) run the teardown — `app.exit` no longer bypasses it. Crashed smoke runs persist their pgids in run-state and are swept on the next boot.
5. **`start:brain` is ATTACH-OR-OWN (the product contract the audit's safety bar implies).** A second organism beside a live canonical Brain is never safe (takeover + port-reaping) and never useful (the FM should manage the REAL fleet). The product boot detects a live Brain through the SSOT-resolved PID file + command-line check and then supervises ONLY what is missing (the fleet transport on `:8083`); a fresh machine — the packaged-app shape — owns the full organism on default paths. On quit the harness stops exactly what it started (§2.1.1 one lifecycle owner).

Evidence: L2 (the runnable smoke drives the REAL isolated organism in the real Electron runtime; readiness/teardown observables are the services' own surfaces) + L1 (16-test lifecycle unit suite over the injectable seams: spawn error, false readiness, timeout, escalation, idempotent stop, reverse-order tree stop, run-state sweep, live-Brain detection; 2 exact-args pins for the chroma seam) → L2 required (process lifecycle is runtime behavior). Sandbox ceiling: Electron needs a local display, no hosted-CI lane (the recorded E6-adjacent follow-up).

## Deltas from ticket

- **The fleet transport joined the supervised set in THIS slice** (as a harness-supervised sibling child of the orchestrator, not an orchestrator task): the review correctly held my earlier "next leaf" scope-delta against the ticket's own AC ("window reaches the fleet transport"), so the deferral is retracted and the AC is met in-PR. Orchestrator-task-ification (for headless/cloud parity) remains open under the #13377 map.
- **A Brain-side diff exists (scoped):** `taskDefinitions.mjs` + `ConfiguredTaskDefinitionsService.mjs` — the chroma persist-dir seam (item 2). No other `src/`/`apps/`/`ai/` behavior change; the dev loop still cannot have gained a Brain/shell coupling.
- **The boot-order defect stands, unfixed here, flagged for its own leaf:** the daemon crashes at import on a stale per-clone `ai/config.mjs` because the Orchestrator singleton constructs before `assertConfigFresh` fires; `resolveBrainPaths` surfaces the daemon's own `--migrate-config` guidance pre-spawn. Homes under the #14230 arc.
- **Scheduled-task family has no enable gates** (interval-driven; due-immediately on fresh state). Contained here by binding the write target (`NEO_BACKUP_PATH`); a profile-level gate is a recorded Brain-side follow-up.

## Test Evidence

- **`cd harness && npm run smoke:brain` — exit 0 at head `83ae579c3`** (re-run post-cycle-3; run-state verified CLEARED after the clean stop), full verdict: UI legs unchanged-green (boot 252ms/251ms, 116 nodes ×2, popup materialized, `sharedHeapEvidence: true`, `rendererErrors: []`, assets ready) plus the Brain leg: `matrixViolations: []` (every leaf SSOT-resolved under `harness/.brain/smoke/`), `up: true` (Started marker + fleet wire verb), `chromaListening: true` (the isolated Chroma serving the ALLOCATED port from the ISOLATED dir — live proof of the task-args fix), `fleetFromWindow: {ok: true}` (renderer-issued `listAgents`), teardown `fleet {exited, !forced, groupEmpty}` and `orchestrator {exited, !forced, groupEmpty}`, `portsReleased: true`.
- **`npm run smoke` (UI-only) — exit 0** at the same head: the non-Brain path is unchanged.
- **Unit: 88 passed** (`unit/harness` 25 incl. the 21 lifecycle/identity tests; `Orchestrator.spec.mjs` 63 incl. the 2 chroma-args pins). One pre-existing local `DreamServiceGoldenPath` failure reproduces identically on the clean tree (stash-bisected) — local-runner env, not this diff; CI is the gate.
- Teardown-latency measurement (the SIGINT verdict): group-SIGTERM left the chromadb wrapper alive 40s+; direct probe exits on SIGINT in 5ms. Recorded as harness field note 8.
- `node --check` on all touched files; `check-block-alignment`, `check-ticket-archaeology`, `check-whitespace`, `check-jsdoc-types`, `check-shorthand`, `check-aiconfig-test-mutation` green (husky pre-commit run).

## Post-Merge Validation

- [ ] Operator: `cd harness && npm install && npm run start:brain` — with the canonical Brain running this now logs `HARNESS_BRAIN_MODE attach` and starts ONLY the fleet transport; the FM opens as a native window against the real fleet, and quitting stops only the fleet child. (On a machine with no Brain: `HARNESS_BRAIN_MODE own` + full-organism teardown on quit.)
- [ ] Operator cleanup (pre-fix leftovers, one-time): the 2026-07-10 19:46 run left three orphans — `kill -INT 53498; kill 53512 53513` (the chroma wrapper needs INT; my session's kill call was permission-denied).
- [ ] #13033 Contract-Ledger reconciliation: the Arm-B outcome + falsifier record land on the parent (with @neo-opus-ada's countersign per the co-ownership agreement); #13033 then closes or names its remainder explicitly.

## Commits

- ab67f5229 — the cycle-1 slice (superseded supervision internals; falsifier verdict + Arm-B topology + scripts stand).
- 83ae579c3 — the identity contracts: realpath containment, ownership-verified sweep + clean-stop clearing, fleet protocol probe + fail-closed foreign-listener rejection (+5 pins).
- abd299d88 — the supervision contract: executable isolation matrix + gates, chroma persist-dir seam fix (+pins), service readiness incl. the renderer fleet verb, group-based full-tree teardown on every exit path, attach-or-own product boot, the 16-test lifecycle suite, README (attach-or-own + matrix + field notes 6–8).

Authored by Vega (Claude Fable 5, Claude Code). Session d2fbbdb4-404b-47e1-bbb3-1b9e0330894b.
