### PR TITLE
feat(fleet): claude-desktop + antigravity launch coverage — the argv-isolation launch axis (#14972)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -66,10 +66,24 @@ class Config extends ConfigProvider {
                 instanceRoot   : leaf(path.resolve(neoRootDir, '.neo-ai-data/fleet/instances'), 'NEO_FLEET_INSTANCE_ROOT', 'string'),
                 harnessBinaries: {
                     /**
+                     * The antigravity harness binary — the app-bundle MAIN binary (a directly
+                     * spawnable, supervisable child), never an `open -n` launcher. macOS default;
+                     * other hosts pin this leaf.
+                     * @type {string}
+                     */
+                    antigravity: leaf('/Applications/Antigravity.app/Contents/MacOS/Antigravity', 'NEO_FLEET_ANTIGRAVITY_BIN', 'string'),
+                    /**
                      * The claude-code harness binary — PATH-resolved by default.
                      * @type {string}
                      */
                     claudeCode: leaf('claude', 'NEO_FLEET_CLAUDE_CODE_BIN', 'string'),
+                    /**
+                     * The claude-desktop harness binary — the app-bundle MAIN binary (a directly
+                     * spawnable, supervisable child), never an `open -n` launcher. macOS default;
+                     * other hosts pin this leaf.
+                     * @type {string}
+                     */
+                    claudeDesktop: leaf('/Applications/Claude.app/Contents/MacOS/Claude', 'NEO_FLEET_CLAUDE_DESKTOP_BIN', 'string'),
                     /**
                      * The codex harness binary. The default is the ChatGPT-app-bundled CLI — an
                      * alpha channel that self-updates with its app; production fleets pin this

--- a/ai/scripts/fleet/onboardPeer.mjs
+++ b/ai/scripts/fleet/onboardPeer.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-import * as acorn                   from 'acorn';
+import * as acorn                  from 'acorn';
 import {execFileSync}              from 'node:child_process';
 import path                        from 'node:path';
 import {fileURLToPath}             from 'node:url';
 import {createFleetRegistryBridge} from '../../../src/ai/fleet/createFleetRegistryBridge.mjs';
+import {LAUNCHABLE_HARNESS_TYPES}  from '../../services/fleet/deriveHarnessLaunchSpec.mjs';
 
 /**
  * @module ai/scripts/fleet/onboardPeer
@@ -43,8 +44,8 @@ import {createFleetRegistryBridge} from '../../../src/ai/fleet/createFleetRegist
  *
  * **Usage**:
  *   node ai/scripts/fleet/onboardPeer.mjs --resident-id <s> --github-username <s>
- *       --harness-type <codex|claude-code> [--clone-url <s> --repo-slug <s>]   # dry-run;
- *                                                      # pair required unless repo already exists
+ *       --harness-type <antigravity|claude-code|claude-desktop|codex>          # dry-run;
+ *           [--clone-url <s> --repo-slug <s>]          # pair required unless repo already exists
  *   node ai/scripts/fleet/onboardPeer.mjs ... --commit                          # execute phase delta
  *   node ai/scripts/fleet/onboardPeer.mjs --help
  */
@@ -53,17 +54,20 @@ const
     __filename       = fileURLToPath(import.meta.url),
     REPO_ROOT        = path.resolve(path.dirname(__filename), '../../..'),
     HARNESS_FAMILIES = Object.freeze({
-        'claude-code': 'claude',
-        codex        : 'gpt'
+        'antigravity'   : 'gemini',
+        'claude-code'   : 'claude',
+        'claude-desktop': 'claude',
+        codex           : 'gpt'
     });
 
 /**
- * @summary The curated harness families the conductor accepts — must stay a subset of the
- * registry's own `harnessTypes` vocabulary (the registry re-validates on define; this list only
- * gives the CLI an early, named refusal).
+ * @summary The curated harness families the conductor accepts — the launch-templated subset of the
+ * shared registry vocabulary, consumed from the launch seam itself (ONE derived truth: a family
+ * becomes onboardable exactly when its launch template lands; the registry re-validates on define,
+ * this list only gives the CLI an early, named refusal).
  * @type {ReadonlyArray<String>}
  */
-export const CURATED_HARNESS_TYPES = Object.freeze(['claude-code', 'codex']);
+export const CURATED_HARNESS_TYPES = LAUNCHABLE_HARNESS_TYPES;
 
 const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
 
@@ -424,9 +428,17 @@ export function buildLoginCommand({harnessType, instanceHome, launchCommand} = {
         quotedHome    = quote(instanceHome),
         quotedCommand = quote(launchCommand);
 
-    return harnessType === 'codex'
-        ? `CODEX_HOME=${quotedHome} ${quotedCommand} login`
-        : `CLAUDE_CONFIG_DIR=${quotedHome} ${quotedCommand}  # then /login inside the session`;
+    // Per-family operator-owned auth step: CLI families have a login command / in-session login;
+    // the app-bundle GUI families sign in INSIDE the launched window (no CLI login exists) — the
+    // printed line relaunches the same isolated instance if the operator closed it.
+    switch (harnessType) {
+        case 'codex':
+            return `CODEX_HOME=${quotedHome} ${quotedCommand} login`;
+        case 'claude-code':
+            return `CLAUDE_CONFIG_DIR=${quotedHome} ${quotedCommand}  # then /login inside the session`;
+        default:
+            return `${quotedCommand} --user-data-dir=${quotedHome}  # sign in inside the app window (relaunch if closed)`;
+    }
 }
 
 /**
@@ -482,7 +494,7 @@ export function parseOnboardArgs(argv = []) {
  */
 function printUsage() {
     console.log('Usage: node ai/scripts/fleet/onboardPeer.mjs --resident-id <s> --github-username <s>');
-    console.log('           --harness-type <codex|claude-code> [--clone-url <s> --repo-slug <s>] [--commit]');
+    console.log(`           --harness-type <${CURATED_HARNESS_TYPES.join('|')}> [--clone-url <s> --repo-slug <s>] [--commit]`);
     console.log('');
     console.log('  (no flags)  Dry-run — print the two-phase segment delta without touching anything.');
     console.log('  --commit    Execute the CURRENT phase\'s delta through the owning fleet services.');

--- a/ai/scripts/fleet/onboardPeer.mjs
+++ b/ai/scripts/fleet/onboardPeer.mjs
@@ -4,7 +4,8 @@ import {execFileSync}              from 'node:child_process';
 import path                        from 'node:path';
 import {fileURLToPath}             from 'node:url';
 import {createFleetRegistryBridge} from '../../../src/ai/fleet/createFleetRegistryBridge.mjs';
-import {LAUNCHABLE_HARNESS_TYPES}  from '../../services/fleet/deriveHarnessLaunchSpec.mjs';
+
+import {LAUNCHABLE_HARNESS_TYPES, getHarnessAuthMode} from '../../services/fleet/deriveHarnessLaunchSpec.mjs';
 
 /**
  * @module ai/scripts/fleet/onboardPeer
@@ -370,12 +371,18 @@ export function planOnboarding({intent, facts = {}} = {}) {
             ? `'${intent.agentId}' is already running — start short-circuits to status`
             : `FleetManager.startAgent('${intent.agentId}') — provision-then-start via the curated '${intent.harnessType}' template`);
 
+    // The auth segment names the FAMILY's auth mode, not just the marker heuristic: in-app
+    // families carry a permanently-null `authRequired` (no marker exists), so their handoff is the
+    // in-window sign-in — rendered from the launch contract's authMode, mirroring the exact
+    // decision `deriveAuthHandoff` makes post-launch (dry-run and --commit cannot drift).
     push('auth', 'PRINT',
-        facts.authRequired === false
-            ? 'per-home credentials already present — no login step required'
-            : facts.authRequired === true
-                ? 'per-home login required once (surfaced via status().authRequired after launch)'
-                : 'auth state UNKNOWN until the long-lived owner returns live launch status');
+        getHarnessAuthMode(intent.harnessType) === 'in-app'
+            ? 'in-app sign-in inside the launched window (operator-owned; the isolated relaunch line prints after launch)'
+            : facts.authRequired === false
+                ? 'per-home credentials already present — no login step required'
+                : facts.authRequired === true
+                    ? 'per-home login required once (surfaced via status().authRequired after launch)'
+                    : 'auth state UNKNOWN until the long-lived owner returns live launch status');
 
     return {phase: 'B', segments, gateMessage: null}
 }
@@ -439,6 +446,49 @@ export function buildLoginCommand({harnessType, instanceHome, launchCommand} = {
         default:
             return `${quotedCommand} --user-data-dir=${quotedHome}  # sign in inside the app window (relaunch if closed)`;
     }
+}
+
+/**
+ * @summary The post-launch auth handoff DECISION — the one branch `--commit` executes after
+ * `startAgent` returns, extracted pure so tests enter where the real conductor does. Mode-first:
+ * an `'in-app'` family (permanently-null `authRequired` — no marker exists) ALWAYS hands off the
+ * in-window sign-in instruction; a `'marker'` family branches on the live heuristic (`true` →
+ * the login command, `false` → done, `null` → an honest WARN, never a guessed command).
+ * @param {Object} options
+ * @param {String} options.harnessType Curated harness family.
+ * @param {Object} options.status The long-lived owner's `startAgent`/`status` projection —
+ *                                `{authRequired, instanceHome, launchCommand}` consumed here.
+ * @returns {{kind: 'sign-in-app'|'login-required'|'done'|'unknown', lines: String[]}} printable
+ * lines in conductor voice; `kind` is the decision itself, assertable without string-matching.
+ */
+export function deriveAuthHandoff({harnessType, status} = {}) {
+    if (getHarnessAuthMode(harnessType) === 'in-app') {
+        return {
+            kind : 'sign-in-app',
+            lines: [
+                '',
+                '  SIGN-IN REQUIRED (operator-owned, inside the launched app window):',
+                `    ${buildLoginCommand({harnessType, instanceHome: status.instanceHome, launchCommand: status.launchCommand})}`
+            ]
+        };
+    }
+
+    if (status.authRequired === true) {
+        return {
+            kind : 'login-required',
+            lines: [
+                '',
+                '  LOGIN REQUIRED (operator-owned, exactly once for this home):',
+                `    ${buildLoginCommand({harnessType, instanceHome: status.instanceHome, launchCommand: status.launchCommand})}`
+            ]
+        };
+    }
+
+    if (status.authRequired === false) {
+        return {kind: 'done', lines: ['  [DONE] auth — per-home credentials already present']};
+    }
+
+    return {kind: 'unknown', lines: ['  [WARN] auth — the owner returned no curated auth state; no login command was guessed']};
 }
 
 /**
@@ -610,20 +660,10 @@ async function main() {
 
         console.log(`  [DONE] launch — state '${status.state}' (pid ${status.pid ?? 'n/a'})`);
 
-        if (status.authRequired === true) {
-            const loginCommand = buildLoginCommand({
-                harnessType  : intent.harnessType,
-                instanceHome : status.instanceHome,
-                launchCommand: status.launchCommand
-            });
-
-            console.log('');
-            console.log('  LOGIN REQUIRED (operator-owned, exactly once for this home):');
-            console.log(`    ${loginCommand}`);
-        } else if (status.authRequired === false) {
-            console.log('  [DONE] auth — per-home credentials already present');
-        } else {
-            console.log('  [WARN] auth — the owner returned no curated auth state; no login command was guessed');
+        // The auth handoff is the tested decision (`deriveAuthHandoff`): mode-first, so in-app
+        // families reach their sign-in instruction despite a permanently-null authRequired.
+        for (const line of deriveAuthHandoff({harnessType: intent.harnessType, status}).lines) {
+            console.log(line);
         }
     }
 

--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -23,8 +23,10 @@ const AGENT_IDENTITY_ENV_VAR = 'NEO_AGENT_IDENTITY';
 // The AiConfig `fleet.harnessBinaries` leaf key per harness family. An unknown family has no
 // entry — `resolveLaunch` fails loud instead of guessing a command for it.
 const HARNESS_BINARY_LEAF_KEYS = {
-    'claude-code': 'claudeCode',
-    'codex'      : 'codex'
+    'antigravity'   : 'antigravity',
+    'claude-code'   : 'claudeCode',
+    'claude-desktop': 'claudeDesktop',
+    'codex'         : 'codex'
 };
 
 // The ONLY ambient parent-env vars that cross into a spawned harness. The FM's own environment
@@ -44,7 +46,10 @@ const PROTO_ENV_KEYS = Object.freeze(['__proto__', 'constructor', 'prototype']);
 // Per-family auth-marker files inside an instance home: present ⇒ the home has completed its
 // operator-owned per-home login; absent ⇒ `authRequired` surfaces `true` so the cockpit shows the
 // onboarding step honestly. A HEURISTIC on documented CLI state layouts, not a credential read —
-// the marker's presence is checked, never its content.
+// the marker's presence is checked, never its content. The app-bundle GUI families
+// (claude-desktop / antigravity) have NO documented marker — auth is the in-app sign-in inside a
+// Chromium profile — so they carry no entry and `authRequiredForHome` answers `null` (honest
+// unknown), never a guessed boolean.
 const HARNESS_AUTH_MARKERS = {
     'claude-code': '.credentials.json',
     'codex'      : 'auth.json'
@@ -76,12 +81,15 @@ const HARNESS_AUTH_MARKERS = {
  *   registry-internal `setLaunchOverride` — a method that exists on no bridge and no wire allowlist.
  *   Wire callers send curated `harnessType` intent, nothing more.
  *
- * **Supervision transport (the topology that keeps a CLI harness alive):** children spawn with
- * `stdio: ['pipe', 'ignore', 'pipe']` — stdin is a HELD-OPEN pipe, because both supported harness
- * CLIs exit immediately on an EOF'd/ignored stdin (probed on the exact binaries: codex `app-server`
- * and claude-code stream-json both stay alive on a held pipe and exit without it). The launch
- * templates pin the per-family long-lived mode args; stdout is discarded until a protocol consumer
- * lands; stderr is drained byte-counted as below.
+ * **Supervision transport (the topology that keeps a harness alive):** children spawn with
+ * `stdio: ['pipe', 'ignore', 'pipe']` — stdin is a HELD-OPEN pipe, because the CLI families exit
+ * immediately on an EOF'd/ignored stdin (probed on the exact binaries: codex `app-server` and
+ * claude-code stream-json both stay alive on a held pipe and exit without it); the app-bundle GUI
+ * families (claude-desktop / antigravity) are stdin-indifferent — the held pipe is harmless there,
+ * and pid/SIGTERM is the supervision handle (probed per family: dual-instance coexistence on
+ * distinct `--user-data-dir` homes, SIGTERM-clean exit 0). The launch templates pin the
+ * per-family long-lived mode args; stdout is discarded until a protocol consumer lands; stderr is
+ * drained byte-counted as below.
  *
  * **Child env (minimal by construction):** the child receives ONLY the `AMBIENT_ENV_ALLOWLIST`
  * process-runtime vars — never a full parent-env copy, so ambient operator secrets cannot leak into
@@ -346,17 +354,26 @@ class FleetLifecycleService extends Base {
         this.processes.set(id, record);
 
         // Best-effort version surface (the pin/verify half of the executable preflight): capture
-        // `<binary> --version` async onto the record — the status read surfaces what actually runs,
-        // so an app-bundle alpha channel that self-updated is VISIBLE, not silently different.
-        // Failure is non-fatal (version stays null); the probe never blocks the spawn path.
-        // The probe runs under the SAME minimal env as the supervised child: every subprocess this
-        // service creates shares one secret boundary — an auxiliary execFile inheriting the full
-        // parent env would hand ambient provider secrets to the probed binary.
-        try {
-            this.getExecFileFn()(command, ['--version'], {timeout: 3000, env}, (error, stdout) => {
-                if (!error && stdout) record.binaryVersion = String(stdout).trim().split('\n')[0].slice(0, 80);
-            });
-        } catch (ignored) {}
+        // the template-owned version-probe argv async onto the record — the status read surfaces
+        // what actually runs, so an app-bundle alpha channel that self-updated is VISIBLE, not
+        // silently different. The argv is per-family template data: arg-isolated families carry
+        // their `--user-data-dir` flag so the probe subprocess can never land inside another
+        // profile's single-instance scope, and a family whose binary cannot answer a version ask
+        // without booting the whole app derives `null` — the probe is SKIPPED and `binaryVersion`
+        // stays honestly null (see deriveHarnessLaunchSpec). Raw launches keep the legacy bare
+        // `--version`. Failure is non-fatal (version stays null); the probe never blocks the spawn
+        // path. The probe runs under the SAME minimal env as the supervised child: every subprocess
+        // this service creates shares one secret boundary — an auxiliary execFile inheriting the
+        // full parent env would hand ambient provider secrets to the probed binary.
+        const versionProbeArgs = launch.versionProbeArgs === undefined ? ['--version'] : launch.versionProbeArgs;
+
+        if (versionProbeArgs) {
+            try {
+                this.getExecFileFn()(command, versionProbeArgs, {timeout: 3000, env}, (error, stdout) => {
+                    if (!error && stdout) record.binaryVersion = String(stdout).trim().split('\n')[0].slice(0, 80);
+                });
+            } catch (ignored) {}
+        }
 
         // Drain stderr so a noisy harness can't block on a full pipe buffer. Retain only a byte
         // COUNT, never the content: the child's stderr is untrusted and may echo the injected PAT,
@@ -583,10 +600,12 @@ class FleetLifecycleService extends Base {
      * @summary Resolve the harness binary path for one harness family: the `harnessBinaryPaths`
      * field entry when explicitly injected (the test/tenant override seam), else the family's
      * AiConfig `fleet.harnessBinaries.*` leaf — the SSOT owning the default and its env binding
-     * (`NEO_FLEET_CODEX_BIN` / `NEO_FLEET_CLAUDE_CODE_BIN`). The codex leaf default is the
-     * ChatGPT-app-bundled CLI — an alpha channel that self-updates with its app, so production
-     * fleets pin the leaf; `status().binaryVersion` surfaces what actually ran. An untemplated
-     * family resolves `null` — {@link resolveLaunch} fails loud rather than guessing.
+     * (`NEO_FLEET_CODEX_BIN` / `NEO_FLEET_CLAUDE_CODE_BIN` / `NEO_FLEET_CLAUDE_DESKTOP_BIN` /
+     * `NEO_FLEET_ANTIGRAVITY_BIN`). The codex leaf default is the ChatGPT-app-bundled CLI — an
+     * alpha channel that self-updates with its app, so production fleets pin the leaf;
+     * `status().binaryVersion` surfaces what actually ran. The app-bundle families default to
+     * their macOS bundle MAIN binaries (directly spawnable — never an `open -n` launcher). An
+     * untemplated family resolves `null` — {@link resolveLaunch} fails loud rather than guessing.
      * @param {String} harnessType
      * @returns {String|null}
      */

--- a/ai/services/fleet/deriveHarnessLaunchSpec.mjs
+++ b/ai/services/fleet/deriveHarnessLaunchSpec.mjs
@@ -27,23 +27,32 @@ import {HARNESS_TYPES} from '../../../src/ai/fleet/harnessTypes.mjs';
 //   probe and `binaryVersion` stays honestly `null`. For `homeArgFlag` families the derivation
 //   prepends the isolation flag, so even the probe subprocess can never cross into another
 //   instance's (or the operator's own) single-instance scope.
+// - `authMode` — how the operator-owned per-home auth step happens for the family:
+//   `'marker'` = a documented marker file inside the home flips the lifecycle `authRequired`
+//   heuristic (CLI families; the login is a command). `'in-app'` = auth is the sign-in INSIDE the
+//   launched window — no marker exists, `authRequired` stays honestly `null`, and the handoff
+//   instruction must render from THIS mode, never from the (permanently null) heuristic.
 const HARNESS_LAUNCH_CONTRACTS = {
     'antigravity': {
+        authMode        : 'in-app',
         homeArgFlag     : '--user-data-dir',
         modeArgs        : [],
         versionProbeArgs: null
     },
     'claude-code': {
+        authMode        : 'marker',
         homeEnvVar      : 'CLAUDE_CONFIG_DIR',
         modeArgs        : ['--input-format', 'stream-json', '--output-format', 'stream-json', '--print', '--verbose'],
         versionProbeArgs: ['--version']
     },
     'claude-desktop': {
+        authMode        : 'in-app',
         homeArgFlag     : '--user-data-dir',
         modeArgs        : [],
         versionProbeArgs: ['--version']
     },
     'codex': {
+        authMode        : 'marker',
         homeEnvVar      : 'CODEX_HOME',
         modeArgs        : ['app-server'],
         versionProbeArgs: ['--version']
@@ -73,6 +82,19 @@ const HARNESS_LAUNCH_CONTRACTS = {
  * @type {ReadonlyArray<String>}
  */
 export const LAUNCHABLE_HARNESS_TYPES = Object.freeze(Object.keys(HARNESS_LAUNCH_CONTRACTS).sort());
+
+/**
+ * @summary The family's operator-owned auth mode — `'marker'` (a documented marker file inside the
+ * home drives the lifecycle `authRequired` heuristic; the login is a command) or `'in-app'` (auth
+ * is the sign-in inside the launched window; no marker exists and `authRequired` stays honestly
+ * `null`, so ANY auth handoff for these families must branch on THIS mode, never on the
+ * permanently-null heuristic). `null` for unlaunchable/unknown families — consumers fail closed.
+ * @param {String} harnessType
+ * @returns {'marker'|'in-app'|null}
+ */
+export function getHarnessAuthMode(harnessType) {
+    return HARNESS_LAUNCH_CONTRACTS[harnessType]?.authMode ?? null;
+}
 
 /**
  * @summary Derive the per-family harness launch template for a Fleet Manager agent: the

--- a/ai/services/fleet/deriveHarnessLaunchSpec.mjs
+++ b/ai/services/fleet/deriveHarnessLaunchSpec.mjs
@@ -1,32 +1,83 @@
-// Per-family harness-home env contract: the ONE env var each supported harness CLI honors as its
-// config/state home — the isolation mechanism that lets many agents share one machine without
-// sharing auth or session state. These are CROSS-PROCESS CONTRACTS (each CLI reads its exact name),
-// so fixed module data, not configurable fields — an override would set a var the harness never
-// reads, silently collapsing the isolation (fail-OPEN). Empirical grounding per family in the
-// function JSDoc below.
-const HARNESS_HOME_ENV_VARS = {
-    'claude-code': 'CLAUDE_CONFIG_DIR',
-    'codex'      : 'CODEX_HOME'
+import {HARNESS_TYPES} from '../../../src/ai/fleet/harnessTypes.mjs';
+
+// Per-family launch contracts — ONE entry per LAUNCHABLE family, keyed by the durable harness-type
+// from the shared registry authority (src/ai/fleet/harnessTypes.mjs). Every entry carries the three
+// template halves; all of them are CROSS-PROCESS CONTRACTS (each harness reads its exact env var /
+// command-line switch), so fixed module data, not configurable fields — an override would set a
+// name the harness never reads, silently collapsing the isolation (fail-OPEN):
+//
+// - isolation — exactly ONE of:
+//   `homeEnvVar`  (CLI families): the env var the harness honors as its config/state home.
+//   `homeArgFlag` (Electron/Chromium app-bundle families): the switch that relocates the profile
+//   AND the per-profile single-instance lock — which is precisely what lets many supervised
+//   instances of one GUI app coexist on a single machine (probed per family; see the fn JSDoc).
+// - `modeArgs` — the LONG-LIVED mode half for CLI families (both CLIs exit immediately on a
+//   non-TTY/EOF'd stdin, so a supervisable template pins a protocol mode AND the supervisor holds
+//   stdin open as a pipe — the lifecycle service's stdio contract):
+//   - codex `app-server`: the CLI's own long-lived JSON-RPC-over-stdio protocol mode — probed alive
+//     at 4s on a held pipe (codex-cli 0.144.0-alpha.4), clean SIGTERM stop.
+//   - claude-code stream-json print mode: the CLI's long-lived stream-JSON session over stdio —
+//     probed alive at 4s on a held pipe (claude CLI 2.1.156), clean SIGTERM stop. `--verbose` is
+//     required by the CLI when combining `--print` with `--output-format stream-json`.
+//   GUI app-bundle families are inherently long-lived (an app run IS the session) and indifferent
+//   to stdin — the held pipe is harmless there; pid/SIGTERM is the supervision handle. Empty.
+// - `versionProbeArgs` — the argv for the supervisor's best-effort `binaryVersion` capture, or
+//   `null` when the family cannot answer a version ask without booting the whole app (probed:
+//   antigravity boots and emits wizard log lines instead of a version) — the supervisor SKIPS the
+//   probe and `binaryVersion` stays honestly `null`. For `homeArgFlag` families the derivation
+//   prepends the isolation flag, so even the probe subprocess can never cross into another
+//   instance's (or the operator's own) single-instance scope.
+const HARNESS_LAUNCH_CONTRACTS = {
+    'antigravity': {
+        homeArgFlag     : '--user-data-dir',
+        modeArgs        : [],
+        versionProbeArgs: null
+    },
+    'claude-code': {
+        homeEnvVar      : 'CLAUDE_CONFIG_DIR',
+        modeArgs        : ['--input-format', 'stream-json', '--output-format', 'stream-json', '--print', '--verbose'],
+        versionProbeArgs: ['--version']
+    },
+    'claude-desktop': {
+        homeArgFlag     : '--user-data-dir',
+        modeArgs        : [],
+        versionProbeArgs: ['--version']
+    },
+    'codex': {
+        homeEnvVar      : 'CODEX_HOME',
+        modeArgs        : ['app-server'],
+        versionProbeArgs: ['--version']
+    }
 };
 
-// Per-family LONG-LIVED mode args — the half of the launch tuple that keeps the process alive
-// under supervision. Both CLIs exit immediately when launched bare with a non-TTY/EOF'd stdin
-// (probed on the exact binaries), so a supervisable template MUST pin a protocol mode AND the
-// supervisor MUST hold stdin open as a pipe (the lifecycle service's stdio contract):
-// - codex `app-server`: the CLI's own long-lived JSON-RPC-over-stdio protocol mode — probed alive
-//   at 4s on a held pipe (codex-cli 0.144.0-alpha.4), clean SIGTERM stop.
-// - claude-code stream-json print mode: the CLI's long-lived stream-JSON session over stdio —
-//   probed alive at 4s on a held pipe (claude CLI 2.1.156), clean SIGTERM stop. `--verbose` is
-//   required by the CLI when combining `--print` with `--output-format stream-json`.
-const HARNESS_MODE_ARGS = {
-    'claude-code': ['--input-format', 'stream-json', '--output-format', 'stream-json', '--print', '--verbose'],
-    'codex'      : ['app-server']
-};
+// Lockstep guard (fail-loud at import): the launch vocabulary is a strict SUBSET of the shared
+// registry authority — a contract for an unregistered type means the two lists were edited out of
+// order (register the harness type first; the Body's pickers/cards derive from that same entry).
+{
+    const registered = new Set(HARNESS_TYPES.map(entry => entry.type));
+
+    for (const type of Object.keys(HARNESS_LAUNCH_CONTRACTS)) {
+        if (!registered.has(type)) {
+            throw new Error(`deriveHarnessLaunchSpec: launch contract '${type}' is not a registered harness type (src/ai/fleet/harnessTypes.mjs). Register the type there first — the launch vocabulary must stay a subset of the shared authority.`);
+        }
+    }
+}
+
+/**
+ * @summary The launch-TEMPLATED subset of the shared harness-type registry, alphabetical — the ONE
+ * derived truth for "can the Fleet Manager launch this family?". Consumers (the onboarding
+ * conductor's curated intent, cockpit launchability rendering) read this instead of keeping a
+ * second list. `native-neo` is deliberately registered-but-unlaunchable: it names the Body-native
+ * agent runtime, not an external harness process — it joins this set only when that runtime exists
+ * to be spawned.
+ * @type {ReadonlyArray<String>}
+ */
+export const LAUNCHABLE_HARNESS_TYPES = Object.freeze(Object.keys(HARNESS_LAUNCH_CONTRACTS).sort());
 
 /**
  * @summary Derive the per-family harness launch template for a Fleet Manager agent: the
- * `{command, args, env}` spec that starts one ISOLATED harness instance bound to its own
- * config/state home.
+ * `{command, args, env, versionProbeArgs}` spec that starts one ISOLATED harness instance bound to
+ * its own config/state home.
  *
  * The pure half of Fleet Manager harness-launch templating: given a harness family, the agent's
  * derived instance home (see {@link Neo.ai.services.fleet.deriveAgentInstanceHome}) and the
@@ -36,10 +87,9 @@ const HARNESS_MODE_ARGS = {
  * never carries a command), keeping the correctness-and-security-critical mapping fully
  * unit-testable.
  *
- * Per-family contracts — isolation (the home env var each CLI honors) AND liveness (the
- * long-lived protocol mode each CLI stays resident in; see the mode-args map above — a bare
- * launch exits immediately without a TTY, so the mode args are part of the template, never a
- * caller afterthought):
+ * Per-family contracts — isolation AND liveness (see the contract map above for the mechanism
+ * split: env-var homes for CLI families, `--user-data-dir` profile relocation for app-bundle
+ * families):
  *
  * - **`'codex'`** → `{command: binaryPath, args: ['app-server'], env: {CODEX_HOME: instanceHome}}`.
  *   Isolation empirically proven: the codex CLI honors `CODEX_HOME` — `codex doctor` against a
@@ -60,23 +110,47 @@ const HARNESS_MODE_ARGS = {
  *   on a held-open piped stdin stays resident and stops cleanly on SIGTERM. Per-home `/login` is
  *   the operator-owned auth step.
  *
- * GUI launches (`open -n -a …`) are **excluded by design**: `open` detaches — the spawned process
- * is the launcher, not the harness — so the Fleet Manager could never supervise (signal, reap, or
- * observe) the actual harness. Only directly-spawnable CLI binaries are templated.
+ * - **`'claude-desktop'`** → `{command: binaryPath, args: ['--user-data-dir=<home>'], env: {}}`.
+ *   The app-bundle MAIN binary (`Claude.app/Contents/MacOS/Claude`, a universal Mach-O) spawned
+ *   DIRECTLY — a real supervisable child, not an `open -n` launcher. Probed on the exact binary
+ *   (Claude 1.20186.0, macOS): two instances with distinct `--user-data-dir` homes coexist
+ *   (the Electron single-instance lock keys on the profile dir), each home materializes its own
+ *   Chromium profile tree, both stop SIGTERM-clean (exit 0), and
+ *   `--user-data-dir=<home> --version` answers `1.20186.0` in ~330ms without booting the app.
+ *   Auth is the in-app sign-in inside the launched window — no CLI login; no documented auth
+ *   marker, so the lifecycle `authRequired` heuristic stays `null` (honest unknown) for this
+ *   family.
+ *
+ * - **`'antigravity'`** → `{command: binaryPath, args: ['--user-data-dir=<home>'], env: {}}`.
+ *   Same direct-spawn contract on the VSCode-fork main binary
+ *   (`Antigravity.app/Contents/MacOS/Antigravity`). Probed (macOS): dual-instance
+ *   coexistence on distinct homes, per-home profile trees, SIGTERM-clean exit 0. Its binary does
+ *   NOT answer `--version` without booting the app (wizard log lines instead of a version), so
+ *   `versionProbeArgs` is `null` — the supervisor skips the probe and `binaryVersion` stays
+ *   honestly `null`. Auth is the in-app sign-in; `authRequired` stays `null` as above.
+ *
+ * `open -n -a …` launches remain **excluded by design**: `open` detaches — the spawned process is
+ * the launcher, not the harness — so the Fleet Manager could never supervise (signal, reap, or
+ * observe) the actual harness. The app-bundle families above are templated precisely because their
+ * MAIN binaries spawn directly; the exclusion still bars any template built on a detaching
+ * launcher.
  *
  * An unknown / absent `harnessType` **throws**, naming the supported set — mirroring the lifecycle
  * service's "classification, not a launcher" stance: this module maps known families; it never
  * guesses a brittle command for an unknown one.
  *
  * @param {Object} options
- * @param {String} options.harnessType  The harness family — one of `'codex'`, `'claude-code'`.
+ * @param {String} options.harnessType  The harness family — one of {@link LAUNCHABLE_HARNESS_TYPES}.
  * @param {String} options.instanceHome The agent's isolated harness home (see
  *                                      {@link Neo.ai.services.fleet.deriveAgentInstanceHome}).
  * @param {String} options.binaryPath   The harness binary to spawn (config-resolved by the caller;
  *                                      never guessed here).
- * @returns {{command: String, args: String[], env: Object}} a fresh spec per call — `args` / `env`
- * are caller-mutable without cross-call bleed.
- * @throws {Error} If any argument is not a non-empty string, or `harnessType` is not a supported
+ * @returns {{command: String, args: String[], env: Object, versionProbeArgs: String[]|null}} a
+ * fresh spec per call — `args` / `env` / `versionProbeArgs` are caller-mutable without cross-call
+ * bleed. `versionProbeArgs` is the argv for the supervisor's best-effort version capture
+ * (isolation-flag-prefixed for `homeArgFlag` families) or `null` when the family cannot answer one
+ * without booting the app — the supervisor skips the probe.
+ * @throws {Error} If any argument is not a non-empty string, or `harnessType` is not a launchable
  * family.
  */
 export function deriveHarnessLaunchSpec({harnessType, instanceHome, binaryPath} = {}) {
@@ -84,14 +158,32 @@ export function deriveHarnessLaunchSpec({harnessType, instanceHome, binaryPath} 
     assertNonEmptyString(instanceHome, 'instanceHome');
     assertNonEmptyString(binaryPath,   'binaryPath');
 
-    const homeEnvVar = HARNESS_HOME_ENV_VARS[harnessType];
+    const contract = HARNESS_LAUNCH_CONTRACTS[harnessType];
 
-    if (!homeEnvVar) {
-        const supported = Object.keys(HARNESS_HOME_ENV_VARS).map(type => `'${type}'`).join(', ');
+    if (!contract) {
+        const supported = LAUNCHABLE_HARNESS_TYPES.map(type => `'${type}'`).join(', ');
         throw new Error(`deriveHarnessLaunchSpec: unsupported harnessType '${harnessType}'. Supported: ${supported}.`);
     }
 
-    return {command: binaryPath, args: [...HARNESS_MODE_ARGS[harnessType]], env: {[homeEnvVar]: instanceHome}};
+    if (contract.homeEnvVar) {
+        return {
+            command         : binaryPath,
+            args            : [...contract.modeArgs],
+            env             : {[contract.homeEnvVar]: instanceHome},
+            versionProbeArgs: contract.versionProbeArgs && [...contract.versionProbeArgs]
+        };
+    }
+
+    // homeArgFlag family: the isolation rides argv — on the launch AND on the version probe, so no
+    // subprocess of this instance can ever land inside another profile's single-instance scope.
+    const homeArg = `${contract.homeArgFlag}=${instanceHome}`;
+
+    return {
+        command         : binaryPath,
+        args            : [homeArg, ...contract.modeArgs],
+        env             : {},
+        versionProbeArgs: contract.versionProbeArgs && [homeArg, ...contract.versionProbeArgs]
+    };
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
@@ -124,12 +124,16 @@ test.describe('onboardPeer — intent construction (pure half)', () => {
     });
 
     test('only curated harness families are accepted, with a named refusal', () => {
-        expect(CURATED_HARNESS_TYPES).toEqual(['claude-code', 'codex']);
+        // The curated set IS the launch-templated subset — one derived truth, widened in lockstep
+        // with deriveHarnessLaunchSpec. `native-neo` stays registered-but-unlaunchable.
+        expect(CURATED_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex']);
+        expect(CURATED_HARNESS_TYPES).not.toContain('native-neo');
 
         const built = buildOnboardingIntent({...BASE_OPTIONS, harnessType: 'gemini-cli'});
 
         expect(built.valid).toBe(false);
         expect(built.reason).toContain('claude-code');
+        expect(built.reason).toContain('antigravity');
     });
 
     test('malformed identifiers fail loud, and the @-prefix normalizes off', () => {
@@ -268,6 +272,15 @@ test.describe('onboardPeer — auth handoff', () => {
             .toContain("CLAUDE_CONFIG_DIR='/tmp/claude-home'");
         expect(() => buildLoginCommand({harnessType: 'codex', instanceHome: '<instance home>', launchCommand: '/opt/codex'})).toThrow(/absolute instanceHome/);
         expect(() => buildLoginCommand({harnessType: 'codex', instanceHome: '/tmp/x\nFAKE', launchCommand: '/opt/codex'})).toThrow(/control-character-free/);
+    });
+
+    test('GUI app-bundle families print the isolated relaunch line — auth is the in-app sign-in, no CLI login exists', () => {
+        expect(buildLoginCommand({harnessType: 'claude-desktop', instanceHome: '/srv/homes/a', launchCommand: '/Applications/Claude.app/Contents/MacOS/Claude'}))
+            .toBe("'/Applications/Claude.app/Contents/MacOS/Claude' --user-data-dir='/srv/homes/a'  # sign in inside the app window (relaunch if closed)");
+        expect(buildLoginCommand({harnessType: 'antigravity', instanceHome: '/srv/homes/b', launchCommand: '/Applications/Antigravity.app/Contents/MacOS/Antigravity'}))
+            .toContain("--user-data-dir='/srv/homes/b'");
+        // The curated guard still fronts the family switch — an unlaunchable family never renders a line.
+        expect(() => buildLoginCommand({harnessType: 'native-neo', instanceHome: '/srv/homes/c', launchCommand: '/bin/x'})).toThrow(/unsupported harnessType/);
     });
 
     test('the rendered login line executes through /bin/sh without command injection', async () => {

--- a/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
@@ -18,6 +18,7 @@ import {
     buildLoginCommand,
     buildOnboardingIntent,
     createOnboardingFleetBridge,
+    deriveAuthHandoff,
     normalizeToken,
     originDevRosterHasResident,
     parseOnboardArgs,
@@ -281,6 +282,52 @@ test.describe('onboardPeer — auth handoff', () => {
             .toContain("--user-data-dir='/srv/homes/b'");
         // The curated guard still fronts the family switch — an unlaunchable family never renders a line.
         expect(() => buildLoginCommand({harnessType: 'native-neo', instanceHome: '/srv/homes/c', launchCommand: '/bin/x'})).toThrow(/unsupported harnessType/);
+    });
+
+    test('the REAL post-launch decision: an in-app family reaches its sign-in handoff despite authRequired null — the exact branch --commit executes', () => {
+        // This enters where main() enters: null previously fell through to the generic WARN, so the
+        // GUI instruction was unreachable in a real run. Mode-first fixes the decision itself.
+        const desktop = deriveAuthHandoff({
+            harnessType: 'claude-desktop',
+            status     : {authRequired: null, instanceHome: '/srv/homes/a', launchCommand: '/Applications/Claude.app/Contents/MacOS/Claude'}
+        });
+
+        expect(desktop.kind).toBe('sign-in-app');
+        expect(desktop.lines.join('\n')).toContain('SIGN-IN REQUIRED');
+        expect(desktop.lines.join('\n')).toContain("--user-data-dir='/srv/homes/a'");
+
+        expect(deriveAuthHandoff({
+            harnessType: 'antigravity',
+            status     : {authRequired: null, instanceHome: '/srv/homes/b', launchCommand: '/Applications/Antigravity.app/Contents/MacOS/Antigravity'}
+        }).kind).toBe('sign-in-app');
+    });
+
+    test('marker families keep the heuristic-driven branches unchanged: true → login command, false → done, null → honest WARN with no guessed command', () => {
+        const required = deriveAuthHandoff({harnessType: 'codex', status: {authRequired: true, instanceHome: '/srv/homes/c', launchCommand: '/opt/codex'}});
+
+        expect(required.kind).toBe('login-required');
+        expect(required.lines.join('\n')).toContain("CODEX_HOME='/srv/homes/c' '/opt/codex' login");
+
+        expect(deriveAuthHandoff({harnessType: 'codex', status: {authRequired: false, instanceHome: '/srv/homes/c', launchCommand: '/opt/codex'}}).kind).toBe('done');
+
+        const unknown = deriveAuthHandoff({harnessType: 'codex', status: {authRequired: null, instanceHome: '/srv/homes/c', launchCommand: '/opt/codex'}});
+
+        expect(unknown.kind).toBe('unknown');
+        expect(unknown.lines.join('\n')).not.toContain('codex login');
+    });
+
+    test('the dry-run planner names the in-app mode for GUI families — plan and post-launch decision cannot drift', () => {
+        const intent = buildIntent({harnessType: 'claude-desktop'}),
+              plan   = planOnboarding({intent, facts: {agent: buildAgent({harnessType: 'claude-desktop'}), rosterHasResident: true, graphNodeSeeded: true, running: false, authRequired: null}}),
+              auth   = plan.segments.find(segment => segment.key === 'auth');
+
+        expect(auth.detail).toContain('in-app sign-in');
+        expect(auth.detail).not.toContain('UNKNOWN');
+
+        // marker families keep the heuristic wording
+        const codexPlan = planOnboarding({intent: buildIntent(), facts: {agent: buildAgent(), rosterHasResident: true, graphNodeSeeded: true, running: false, authRequired: null}});
+
+        expect(codexPlan.segments.find(segment => segment.key === 'auth').detail).toContain('UNKNOWN');
     });
 
     test('the rendered login line executes through /bin/sh without command injection', async () => {

--- a/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
@@ -1,5 +1,6 @@
-import {test, expect}            from '@playwright/test';
-import {deriveHarnessLaunchSpec} from '../../../../../../ai/services/fleet/deriveHarnessLaunchSpec.mjs';
+import {test, expect}                                      from '@playwright/test';
+import {HARNESS_TYPES}                                     from '../../../../../../src/ai/fleet/harnessTypes.mjs';
+import {LAUNCHABLE_HARNESS_TYPES, deriveHarnessLaunchSpec} from '../../../../../../ai/services/fleet/deriveHarnessLaunchSpec.mjs';
 
 // Pure function — imported directly (no fs / spawn / env / Neo runtime), so the suite has no
 // host-runtime side effects and each case is fully isolated. Mirrors deriveAgentRepoPath.spec.
@@ -11,16 +12,48 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         // `app-server` is the LIVENESS half of the tuple: a bare codex launch exits immediately on a
         // non-TTY stdin (probed on the exact binary), so the mode arg is template-owned, never a
         // caller afterthought.
-        expect(spec).toEqual({command: '/opt/codex', args: ['app-server'], env: {CODEX_HOME: '/srv/instances/a/codex'}});
+        expect(spec).toEqual({
+            command         : '/opt/codex',
+            args            : ['app-server'],
+            env             : {CODEX_HOME: '/srv/instances/a/codex'},
+            versionProbeArgs: ['--version']
+        });
     });
 
     test('claude-code: the binary + the stream-json long-lived print mode + CLAUDE_CONFIG_DIR pinned to the instance home', () => {
         const spec = deriveHarnessLaunchSpec({harnessType: 'claude-code', instanceHome: '/srv/instances/a/claude', binaryPath: '/usr/local/bin/claude'});
 
         expect(spec).toEqual({
-            command: '/usr/local/bin/claude',
-            args   : ['--input-format', 'stream-json', '--output-format', 'stream-json', '--print', '--verbose'],
-            env    : {CLAUDE_CONFIG_DIR: '/srv/instances/a/claude'}
+            command         : '/usr/local/bin/claude',
+            args            : ['--input-format', 'stream-json', '--output-format', 'stream-json', '--print', '--verbose'],
+            env             : {CLAUDE_CONFIG_DIR: '/srv/instances/a/claude'},
+            versionProbeArgs: ['--version']
+        });
+    });
+
+    test('claude-desktop: the app-bundle main binary with --user-data-dir isolation riding ARGV — env stays empty', () => {
+        const spec = deriveHarnessLaunchSpec({harnessType: 'claude-desktop', instanceHome: '/srv/instances/a/claude-desktop', binaryPath: '/Applications/Claude.app/Contents/MacOS/Claude'});
+
+        // The profile switch is BOTH halves at once for an Electron app: it relocates the config
+        // home AND the single-instance lock (probed: two instances on distinct homes coexist,
+        // SIGTERM-clean). The version probe carries the SAME flag so the probe subprocess
+        // can never land inside another profile's single-instance scope.
+        expect(spec).toEqual({
+            command         : '/Applications/Claude.app/Contents/MacOS/Claude',
+            args            : ['--user-data-dir=/srv/instances/a/claude-desktop'],
+            env             : {},
+            versionProbeArgs: ['--user-data-dir=/srv/instances/a/claude-desktop', '--version']
+        });
+    });
+
+    test('antigravity: same argv isolation contract; the version probe derives NULL (the binary boots the app instead of answering)', () => {
+        const spec = deriveHarnessLaunchSpec({harnessType: 'antigravity', instanceHome: '/srv/instances/a/antigravity', binaryPath: '/Applications/Antigravity.app/Contents/MacOS/Antigravity'});
+
+        expect(spec).toEqual({
+            command         : '/Applications/Antigravity.app/Contents/MacOS/Antigravity',
+            args            : ['--user-data-dir=/srv/instances/a/antigravity'],
+            env             : {},
+            versionProbeArgs: null   // skip-the-probe marker: binaryVersion stays honestly null
         });
     });
 
@@ -30,15 +63,32 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         expect(Object.keys(spec.env)).toEqual(['CODEX_HOME']);
     });
 
-    test('returns a FRESH spec per call — a caller mutating args/env never bleeds into the template or later calls', () => {
+    test('returns a FRESH spec per call — a caller mutating args/env/probe-args never bleeds into the template or later calls', () => {
         const
             a = deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '/h', binaryPath: '/b'}),
             b = deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '/h', binaryPath: '/b'});
 
         a.args.push('--extra');
+        a.versionProbeArgs.push('--extra');
 
-        expect(b.args).toEqual(['app-server']);   // the template stayed pristine
+        expect(b.args).toEqual(['app-server']);            // the template stayed pristine
+        expect(b.versionProbeArgs).toEqual(['--version']);
         expect(a.env).not.toBe(b.env);
+    });
+
+    test('LAUNCHABLE_HARNESS_TYPES is the frozen alphabetical template subset AND every entry is a registered harness type', () => {
+        expect(LAUNCHABLE_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex']);
+        expect(Object.isFrozen(LAUNCHABLE_HARNESS_TYPES)).toBe(true);
+
+        // The lockstep invariant the module also guards at import: launch vocabulary ⊆ the shared
+        // registry authority. `native-neo` stays registered-but-unlaunchable by design.
+        const registered = new Set(HARNESS_TYPES.map(entry => entry.type));
+
+        for (const type of LAUNCHABLE_HARNESS_TYPES) {
+            expect(registered.has(type), `'${type}' must be registered in src/ai/fleet/harnessTypes.mjs`).toBe(true);
+        }
+        expect(registered.has('native-neo')).toBe(true);
+        expect(LAUNCHABLE_HARNESS_TYPES).not.toContain('native-neo');
     });
 
     test('throws on an unknown harnessType, naming the supported set (classification, not a launcher)', () => {
@@ -47,6 +97,8 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         expect(call).toThrow(/unsupported harnessType 'gemini-cli'/);
         expect(call).toThrow(/'claude-code'/);
         expect(call).toThrow(/'codex'/);
+        expect(call).toThrow(/'claude-desktop'/);
+        expect(call).toThrow(/'antigravity'/);
     });
 
     test('fails loud on contract violations (no silent default spec)', () => {

--- a/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
@@ -1,6 +1,6 @@
 import {test, expect}                                      from '@playwright/test';
 import {HARNESS_TYPES}                                     from '../../../../../../src/ai/fleet/harnessTypes.mjs';
-import {LAUNCHABLE_HARNESS_TYPES, deriveHarnessLaunchSpec} from '../../../../../../ai/services/fleet/deriveHarnessLaunchSpec.mjs';
+import {LAUNCHABLE_HARNESS_TYPES, deriveHarnessLaunchSpec, getHarnessAuthMode} from '../../../../../../ai/services/fleet/deriveHarnessLaunchSpec.mjs';
 
 // Pure function — imported directly (no fs / spawn / env / Neo runtime), so the suite has no
 // host-runtime side effects and each case is fully isolated. Mirrors deriveAgentRepoPath.spec.
@@ -89,6 +89,15 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         }
         expect(registered.has('native-neo')).toBe(true);
         expect(LAUNCHABLE_HARNESS_TYPES).not.toContain('native-neo');
+    });
+
+    test('getHarnessAuthMode: marker for the CLI families, in-app for the app bundles, null fail-closed for everything else', () => {
+        expect(getHarnessAuthMode('codex')).toBe('marker');
+        expect(getHarnessAuthMode('claude-code')).toBe('marker');
+        expect(getHarnessAuthMode('claude-desktop')).toBe('in-app');
+        expect(getHarnessAuthMode('antigravity')).toBe('in-app');
+        expect(getHarnessAuthMode('native-neo')).toBeNull();
+        expect(getHarnessAuthMode(undefined)).toBeNull();
     });
 
     test('throws on an unknown harnessType, naming the supported set (classification, not a launcher)', () => {


### PR DESCRIPTION
Resolves #14972

The Fleet launch seam covered 2 of the shared registry's 5 harness families while the cockpit picker offers all 5 — the gap the operator flagged post-#14965. This PR closes it for the two probe-verified app-bundle families and makes the remaining gap HONEST: launch templates for **claude-desktop** and **antigravity** via a new **argv-isolation axis**, one derived launchability truth (`LAUNCHABLE_HARNESS_TYPES`), and `native-neo` explicitly registered-but-unlaunchable.

- **Unified per-family launch contracts** (`HARNESS_LAUNCH_CONTRACTS` in `deriveHarnessLaunchSpec`): isolation = `homeEnvVar` (CLI families) XOR `homeArgFlag` (Electron/Chromium app bundles — `--user-data-dir` relocates the profile AND the per-profile single-instance lock, which is exactly what lets many supervised instances of one GUI app coexist). Import-time lockstep guard: launch vocabulary ⊆ `src/ai/fleet/harnessTypes.mjs` (edit-out-of-order fails loud, naming the register-first rule).
- **Direct spawn, not `open -n`**: both app-bundle MAIN binaries are real supervisable children — probed on the exact binaries under the lifecycle service's exact stdio topology (`['pipe','ignore','pipe']`, held stdin): dual-instance coexistence on distinct homes, per-home Chromium profile trees materialize, SIGTERM-clean exit 0 for both families. The `open -n` detachment exclusion is sidestepped, not revised — the JSDoc still bars any template built on a detaching launcher.
- **Per-family version probe** (`versionProbeArgs` on the spec): claude-desktop answers `--user-data-dir=<home> --version` with `1.20186.0` in ~330ms — the probe rides INSIDE the isolation boundary, so the probe subprocess can never land in another profile's (or the operator's own) single-instance scope; antigravity boots the app instead of answering, so it derives `null` — the supervisor SKIPS the probe and `binaryVersion` stays honestly null. Raw launches keep the legacy bare `--version`.
- **Honest auth, reachable in the REAL flow** (review cycle-1 P1): the GUI families have no documented auth marker (auth is the in-app sign-in) → no `HARNESS_AUTH_MARKERS` entry → `authRequired` stays `null` (honest unknown, never a guessed boolean). Because that null previously fell into the generic WARN, the handoff is now MODE-FIRST: the launch contracts carry `authMode: 'marker' | 'in-app'` (exported as `getHarnessAuthMode`), and the conductor's post-`startAgent` branch is extracted into the pure, exported `deriveAuthHandoff` — `main()` prints exactly its lines, tests enter exactly where `--commit` does, and an in-app family reaches its isolated sign-in instruction despite the permanently-null heuristic. The dry-run planner's auth segment names the same mode (plan and post-launch decision cannot drift); marker families keep every existing branch byte-identical.
- **Conductor widened in lockstep**: `CURATED_HARNESS_TYPES = LAUNCHABLE_HARNESS_TYPES` (one derived truth — a family becomes onboardable exactly when its launch template lands), `HARNESS_FAMILIES` maps the new families for the roster PRINT (claude-desktop→claude, antigravity→gemini), usage text derives from the list.
- **AiConfig leaves** (ADR-0019 sanctioned pattern 2 — declarative `leaf()`): `fleet.harnessBinaries.claudeDesktop` / `.antigravity` defaulting to the macOS bundle MAIN binaries, env bindings `NEO_FLEET_CLAUDE_DESKTOP_BIN` / `NEO_FLEET_ANTIGRAVITY_BIN`; `getHarnessBinaryPath` stays generic over the leaf-key map.

Evidence: live spawn receipts on the ticket (issue comment) re-anchored at this head's contract shape — claude-desktop version-answer `1.20186.0` @ 332ms, dual-instance coexistence + SIGTERM-clean exit 0 for BOTH families under the exact supervision stdio topology; live conductor dry-run at this head renders claude-desktop Phase A (CREATE / CREATE / PRINT `--family claude` + the operator gate) against a worktree-local fleet owner; `native-neo` refuses early naming the widened set.

## Deltas from ticket

- The ticket's "detached-GUI lifecycle class as the named fallback" is NOT built: the probe falsified its premise (both bundles expose directly-spawnable main binaries), so the existing lifecycle service supervises them unchanged — no new class, no new daemon.
- Cockpit honest-launchability rendering ships as the Brain-side primitive only (`LAUNCHABLE_HARNESS_TYPES` + `getHarnessAuthMode` + conductor consumption). **Close-target reconciliation (review cycle-1 P1): #14972 is rescoped to this fully-delivered Brain leaf; the projection/cockpit remainder is the named successor #14987** (projection launchability enrichment — self-assigned, seam ruling by @neo-opus-vega: runtime truth rides the projection; consumer: the #13015 start-control leaf).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs --workers=1` → **34 passed** (4-family template matrix incl. argv isolation + probe-args derivation, lockstep subset guard incl. `native-neo` exclusion, per-call freshness incl. probe args, widened curated set + named refusal, `getHarnessAuthMode` surface, **the real Phase-B decision path**: in-app family reaches `sign-in-app` on `authRequired: null` / marker branches byte-stable / planner-parity, fresh-process `--help`, sh-injection e2e).
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/ test/playwright/unit/ai/scripts/fleet/ --workers=1` → **133 passed** (full fleet blast radius).
- `node ai/scripts/lint/lint-config-template-ssot.mjs` → OK, all baselined (0 new violations).
- `node --check` green on all six files; pre-commit gates green (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation

- [ ] Operator overlay: a pinned local `ai/config.mjs` that redefines `fleet.harnessBinaries` needs the two new leaves added (a thin-delta overlay inherits them from the template automatically)
- [ ] The real thing: define a claude-desktop agent and start it from the cockpit — the launched window is the FM-supervised isolated instance (converges with the #13015 start-control leaf)
- [ ] `native-neo` renders honest-unlaunchable in the cockpit once #14987 (projection enrichment) + the #13015 start-control leaf land

## Commits

- 10aac39be — the argv-isolation launch axis: unified contracts + two app-bundle templates + per-family probe policy + conductor widening + config leaves + the widened test matrix.
- b570f719f — review cycle-1 discharge: `authMode` on the launch contracts (`getHarnessAuthMode`), the pure `deriveAuthHandoff` post-launch decision consumed verbatim by `--commit`, planner auth-segment parity, +4 tests entering at the real decision path.

Related: parent #13015 · consumed authority: `src/ai/fleet/harnessTypes.mjs` (#14960, merged) · consumer: the onboarding conductor (#14965, merged) · successor: #14987 (projection launchability) · deferral: `native-neo` stays registered-but-unlaunchable by design · v13.2 cornerstone-1 (#14560 / #13448).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 9cf9cce9-23bf-4211-ab0d-bab51d5e1d14.
