### PR TITLE
test(dashboard): motion e2e — the signal brackets real motion + the three integration defects it exposed (#14973)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -44,11 +44,16 @@
     &-bottom { animation-name: neo-dock-reveal-from-bottom }
 }
 
+// The slide SETTLES TOWARD the owning edge (workspace-side origin): an edge-ward origin
+// would overlap the rail strip mid-entry and intercept clicks meant for it — geometry the
+// tour's step-gated fast clicks and Playwright actionability both convict. Inward-origin
+// motion never touches the rail, needs no pointer guard, and still reads as the panel
+// seating itself into its edge.
 @keyframes neo-dock-reveal-fade        { from { opacity: 0.4 } }
-@keyframes neo-dock-reveal-from-left   { from { opacity: 0.4; transform: translateX(-10px) } }
-@keyframes neo-dock-reveal-from-right  { from { opacity: 0.4; transform: translateX(10px) } }
-@keyframes neo-dock-reveal-from-top    { from { opacity: 0.4; transform: translateY(-10px) } }
-@keyframes neo-dock-reveal-from-bottom { from { opacity: 0.4; transform: translateY(10px) } }
+@keyframes neo-dock-reveal-from-left   { from { opacity: 0.4; transform: translateX(8px) } }
+@keyframes neo-dock-reveal-from-right  { from { opacity: 0.4; transform: translateX(-8px) } }
+@keyframes neo-dock-reveal-from-top    { from { opacity: 0.4; transform: translateY(8px) } }
+@keyframes neo-dock-reveal-from-bottom { from { opacity: 0.4; transform: translateY(-8px) } }
 
 // Arrival settle: a brief outline pulse on the pane that just landed from another window
 // (§2.3 cross-window arrival) — the workspace toggles the class; the animation completes

--- a/test/playwright/e2e/dashboard/DemoATourNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DemoATourNL.spec.mjs
@@ -57,7 +57,10 @@ test.describe('Demo-A dock-choreography tour journey (Neural Link)', () => {
 
                 rails > window.__e2e.maxRailTabs && (window.__e2e.maxRailTabs = rails);
 
-                document.querySelector('[class*="reveal"]')?.offsetParent && (window.__e2e.revealSeen = true);
+                // any-match: the first '[class*="reveal"]' node can be a legitimately HIDDEN
+                // overlay instance (display:none → offsetParent null) while a different one
+                // is genuinely revealed — a single-match read here passes/fails vacuously
+                [...document.querySelectorAll('[class*="dock-reveal-overlay"]')].some(el => el.offsetParent) && (window.__e2e.revealSeen = true);
 
                 window.__e2e.done || requestAnimationFrame(tick)
             };

--- a/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
@@ -1,0 +1,189 @@
+import { test, expect } from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e for the dock motion pipeline — the "e2e-tested" half of "animated": committed dock
+ * operations on the REAL app move real pixels, and the `neo-dashboard-dock-animating` signal
+ * (`DockMotionSignal`) brackets each motion — appears when motion starts, clears when it settles.
+ * That bracket is the exact lifecycle tour step-gating and the recording pipeline consume, so these
+ * specs pin the integrated truth of the three-producer pipeline (the token contract, the
+ * choreography classes, and the FLIP commit layer) rather than any single producer's unit view.
+ *
+ * Waits are event/state-driven only (`expect.poll` on DOM class presence, `observe_motion` rect
+ * samples over a window) — no timing sleeps, per the house e2e rule.
+ *
+ * Run: NEO_E2E_PORT=8093 npx playwright test dashboard/DockMotionNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+
+const SIGNAL = '.neo-dashboard-dock-animating';
+
+const connect = async (page, neuralLink) => {
+    await page.goto('/examples/dashboard/dock/');
+    page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+    await page.waitForTimeout(2500); // settle worker boot + first render (the one sanctioned boot wait)
+
+    const app      = await neuralLink.connectToApp('Neo.examples.dashboard.dock');
+    const holders  = await app.findInstances({ className: 'Neo.examples.dashboard.dock.MainContainer' }, ['id']);
+    const holderId = Array.isArray(holders) ? holders[0]?.id : holders?.id;
+    expect(holderId, 'the dock MainContainer must exist in the App Worker').toBeTruthy();
+
+    // Motion-contract readiness: the dock tokens arrive via the per-surface theme-file loading
+    // — a state-driven wait, not a sleep. If this times out, the LOADER is the defect
+    // (tokens absent → every motion collapses to instant): see the token-delivery bug ticket.
+    await expect.poll(async () => page.evaluate(() => {
+        const scope = document.querySelector('.neo-dashboard') || document.body;
+        return getComputedStyle(scope).getPropertyValue('--dock-transition-duration').trim();
+    }), { message: 'the dock motion tokens must be resolvable on the surface (theme-file delivery)', timeout: 15000, intervals: [250] }).not.toBe('');
+
+    return { app, holderId };
+};
+
+// The signal class must APPEAR (motion started) — polled fast enough to catch a token-length
+// (260ms) window — and then CLEAR (motion settled). Producer-side leaves are event-driven
+// (transitionend / animationend / FLIP play resolution); the clear bound includes the signal's
+// own fail-safe horizon so a lost end event fails the spec only if the BACKSTOP also fails.
+const expectSignalBracket = async (page, {appearMs = 1500, clearMs = 3500} = {}) => {
+    await expect.poll(
+        () => page.locator(SIGNAL).count(),
+        { message: 'the dock-animating signal must APPEAR when motion starts', timeout: appearMs, intervals: [25] }
+    ).toBeGreaterThan(0);
+
+    await expect.poll(
+        () => page.locator(SIGNAL).count(),
+        { message: 'the dock-animating signal must CLEAR when motion settles', timeout: clearMs, intervals: [50] }
+    ).toBe(0);
+};
+
+test.describe('Dock motion pipeline (Neural Link) — the signal brackets real motion', () => {
+    test.setTimeout(90000);
+    test.use({ viewport: { width: 1600, height: 900 } });
+
+    test('a committed resizeSplit GLIDES: real geometry motion over time, signal-bracketed', async ({ page, neuralLink }) => {
+        const { app, holderId } = await connect(page, neuralLink);
+
+        // sample DOM rects by the FLIP MARKER class, not by instance id: the re-projection
+        // rebuilds the pane instances (removeAll + add), so any instance-bound observation dies
+        // mid-window — the marker class is exactly the survives-recreation correlation key the
+        // FLIP addon itself uses
+        await page.evaluate(() => {
+            window.__glide = [];
+            const tick = () => {
+                const el = document.querySelector('[class*="dock-flip-item-"]');
+                el && window.__glide.push(Math.round(el.getBoundingClientRect().width));
+                if (window.__glide.length < 120) requestAnimationFrame(tick);
+            };
+            requestAnimationFrame(tick);
+        });
+
+        // state-relative: the app heap is SHARED across the sweep (SharedWorker), so derive a
+        // guaranteed-delta target from the CURRENT committed sizes rather than assuming seeds
+        const topo0  = await app.getDockTopology(holderId);
+        const doc0   = topo0?.document ?? topo0;
+        const cur    = doc0.nodes['root-split'].sizes;
+        const target = cur[0] < 0.5 ? [0.65, 0.35] : [0.3, 0.7];
+
+        const result = await app.executeDockOperation(holderId, {
+            operation: 'resizeSplit', splitNodeId: 'root-split', sizes: target
+        });
+        expect(result.errors).toEqual([]);
+        expect(result.applied).toBe(true);
+        await expectSignalBracket(page);
+
+        // real movement: the pane traveled THROUGH intermediate widths (a hard cut shows at
+        // most the before/after pair; a glide shows a progression)
+        const widths = [...new Set(await page.evaluate(() => window.__glide))].filter(w => w > 0);
+        expect(widths.length, `the pane must move THROUGH intermediate widths (saw ${widths.length} distinct)`).toBeGreaterThan(2);
+    });
+
+    test('a committed moveItem is FLIP-bracketed: the signal appears and clears around the structural commit', async ({ page, neuralLink }) => {
+        const { app, holderId } = await connect(page, neuralLink);
+
+        // state-relative (shared heap): pick a REAL cross-zone move from the current doc —
+        // an item out of main-tabs if it has one, else one back INTO it
+        const topo0     = await app.getDockTopology(holderId);
+        const doc0      = topo0?.document ?? topo0;
+        const mainItems = doc0.nodes['main-tabs']?.items || [];
+        const move      = mainItems.length
+            ? { itemId: mainItems[0], targetNodeId: 'terminal-tabs' }
+            : { itemId: (doc0.nodes['terminal-tabs']?.items || [])[0], targetNodeId: 'main-tabs' };
+        expect(move.itemId, 'a movable item must exist in the shared-heap doc').toBeTruthy();
+
+        const [result] = await Promise.all([
+            app.executeDockOperation(holderId, {
+                operation: 'moveItem', itemId: move.itemId, targetNodeId: move.targetNodeId, index: 0
+            }),
+            expectSignalBracket(page)
+        ]);
+
+        expect(result.errors).toEqual([]);
+        expect(result.applied).toBe(true);
+        // document truth stays pinned by the structural suite; here the claim is the BRACKET —
+        // but assert the move landed so a silent no-op cannot green this spec
+        const topo = await app.getDockTopology(holderId);
+        const doc  = topo?.document ?? topo;
+        expect(doc.nodes[move.targetNodeId].items).toContain(move.itemId);
+    });
+
+    test('a rail-click reveal SLIDES: the overlay motion is signal-bracketed through the counted window', async ({ page, neuralLink }) => {
+        const { app, holderId } = await connect(page, neuralLink);
+
+        // the seeded workspace shows the inspector VISIBLE — auto-hide it first (the landed
+        // reveal journey's own setup op), which projects its rail tab
+        // idempotent under the shared heap: a prior spec may already have hidden or pinned it
+        const topo0 = await app.getDockTopology(holderId);
+        const doc0  = topo0?.document ?? topo0;
+
+        if (doc0.items?.inspector?.autoHidden !== true) {
+            const setup = await app.executeDockOperation(holderId, {
+                operation: 'setItemAutoHidden', itemId: 'inspector', autoHidden: true
+            });
+            expect(setup.errors).toEqual([]);
+        }
+
+        const railTab = page.locator('.neo-dashboard-dock-rail-tab', { hasText: 'Inspector' }).first();
+        await expect(railTab, 'the inspector rail tab must render after auto-hiding').toBeVisible({ timeout: 10000 });
+
+
+        await Promise.all([
+            railTab.click(),
+            expectSignalBracket(page)
+        ]);
+
+        // the reveal actually opened (the signal wasn't a stray)
+        await expect(page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)'))
+            .toHaveCount(1);
+    });
+});
+
+test.describe('Dock motion pipeline — reduced-motion collapses through the token layer', () => {
+    test.setTimeout(90000);
+    test.use({ viewport: { width: 1600, height: 900 }, reducedMotion: 'reduce' });
+
+    test('a committed resizeSplit lands INSTANTLY: correct document, no sustained motion, signal clears within the fail-safe', async ({ page, neuralLink }) => {
+        const { app, holderId } = await connect(page, neuralLink);
+
+        const tabs   = await app.findInstances({ ntype: 'tab-container' }, ['id']);
+        const paneId = (Array.isArray(tabs) ? tabs : [tabs]).map(t => t?.id).filter(Boolean)[0];
+
+        const [motion, result] = await Promise.all([
+            app.observeMotion([paneId], 1200, 50),
+            app.executeDockOperation(holderId, {
+                operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.3, 0.7]
+            })
+        ]);
+
+        expect(result.errors).toEqual([]);
+        expect(result.applied).toBe(true);
+
+        // instant settle: at most the before/after widths — never a progression of intermediates
+        const widths = [...new Set((motion?.samples || []).map(s => Math.round(s.rects?.[0]?.width ?? -1)).filter(w => w >= 0))];
+        expect(widths.length, `reduced motion must NOT glide (saw widths: ${widths.join(',')})`).toBeLessThanOrEqual(2);
+
+        // the HONEST signal bound under 0ms durations: a zero-duration transition fires no
+        // transitionend, so the producer's leave may ride the fail-safe backstop (2s) — the
+        // contract claim is "clears within the horizon", not a false instant-clear
+        await expect.poll(
+            () => page.locator(SIGNAL).count(),
+            { message: 'the signal must clear within the fail-safe horizon', timeout: 3500, intervals: [100] }
+        ).toBe(0);
+    });
+});

--- a/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
@@ -8,8 +8,8 @@ import { test, expect } from '../../fixtures.mjs';
  * specs pin the integrated truth of the three-producer pipeline (the token contract, the
  * choreography classes, and the FLIP commit layer) rather than any single producer's unit view.
  *
- * Waits are event/state-driven only (`expect.poll` on DOM class presence, `observe_motion` rect
- * samples over a window) — no timing sleeps, per the house e2e rule.
+ * Waits are event/state-driven only (`expect.poll` on DOM class presence, rAF rect samples over a
+ * window) — no timing sleeps, per the house e2e rule.
  *
  * Run: NEO_E2E_PORT=8093 npx playwright test dashboard/DockMotionNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -53,26 +53,64 @@ const expectSignalBracket = async (page, {appearMs = 1500, clearMs = 3500} = {})
     ).toBe(0);
 };
 
+// The stable-marker motion witness: rAF-records {x, y, w, o} tuples for the first element
+// matching the selector. Sampling by MARKER CLASS, never by instance, is what lets observation
+// live THROUGH a removeAll+rebuild re-projection — the marker is exactly the
+// survives-recreation correlation key the FLIP addon itself uses. Fail-closed semantics:
+// frames without a match count as gaps (no fabricated zeros), zero-size reads ARE recorded so
+// a consumer can convict them, and every consumer asserts a minimum sample floor before
+// reading shape — an oracle that observed nothing must fail, never default-pass.
+const startMotionSampler = (page, selector) => page.evaluate(sel => {
+    window.__motion = { gaps: 0, samples: [], stop: false };
+
+    const tick = () => {
+        const el = document.querySelector(sel);
+
+        if (el) {
+            const r = el.getBoundingClientRect();
+
+            window.__motion.samples.push({
+                o: Math.round(parseFloat(getComputedStyle(el).opacity) * 100),
+                w: Math.round(r.width),
+                x: Math.round(r.x),
+                y: Math.round(r.y)
+            })
+        } else {
+            window.__motion.gaps++
+        }
+
+        window.__motion.stop || window.__motion.samples.length + window.__motion.gaps > 600 || requestAnimationFrame(tick)
+    };
+
+    requestAnimationFrame(tick)
+}, selector);
+
+const readMotionSamples = page => page.evaluate(() => {
+    window.__motion.stop = true;
+    return window.__motion
+});
+
+// The explicit witness precondition: the target must be laid out (present + non-zero width)
+// BEFORE the operation fires, so "no motion observed" can never be confused with "nothing
+// existed to observe".
+const expectMarkerLaidOut = (page, selector) => expect.poll(
+    () => page.evaluate(sel => {
+        const el = document.querySelector(sel);
+        return el ? Math.round(el.getBoundingClientRect().width) : 0
+    }, selector),
+    { message: `the motion witness target must be laid out before the operation (${selector})`, timeout: 10000, intervals: [100] }
+).toBeGreaterThan(0);
+
 test.describe('Dock motion pipeline (Neural Link) — the signal brackets real motion', () => {
     test.setTimeout(90000);
     test.use({ viewport: { width: 1600, height: 900 } });
 
     test('a committed resizeSplit GLIDES: real geometry motion over time, signal-bracketed', async ({ page, neuralLink }) => {
         const { app, holderId } = await connect(page, neuralLink);
+        const MARKER            = '[class*="dock-flip-item-"]';
 
-        // sample DOM rects by the FLIP MARKER class, not by instance id: the re-projection
-        // rebuilds the pane instances (removeAll + add), so any instance-bound observation dies
-        // mid-window — the marker class is exactly the survives-recreation correlation key the
-        // FLIP addon itself uses
-        await page.evaluate(() => {
-            window.__glide = [];
-            const tick = () => {
-                const el = document.querySelector('[class*="dock-flip-item-"]');
-                el && window.__glide.push(Math.round(el.getBoundingClientRect().width));
-                if (window.__glide.length < 120) requestAnimationFrame(tick);
-            };
-            requestAnimationFrame(tick);
-        });
+        await expectMarkerLaidOut(page, MARKER);
+        await startMotionSampler(page, MARKER);
 
         // state-relative: the app heap is SHARED across the sweep (SharedWorker), so derive a
         // guaranteed-delta target from the CURRENT committed sizes rather than assuming seeds
@@ -81,20 +119,30 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
         const cur    = doc0.nodes['root-split'].sizes;
         const target = cur[0] < 0.5 ? [0.65, 0.35] : [0.3, 0.7];
 
-        const result = await app.executeDockOperation(holderId, {
-            operation: 'resizeSplit', splitNodeId: 'root-split', sizes: target
-        });
+        // the bracket is armed CONCURRENTLY with the operation: the appear-poll races the op's
+        // delivery into the browser, so the witness cannot miss a motion window that opens
+        // before the RPC settles
+        const [result] = await Promise.all([
+            app.executeDockOperation(holderId, {
+                operation: 'resizeSplit', splitNodeId: 'root-split', sizes: target
+            }),
+            expectSignalBracket(page)
+        ]);
+
         expect(result.errors).toEqual([]);
         expect(result.applied).toBe(true);
-        await expectSignalBracket(page);
 
         // real movement: the pane traveled THROUGH intermediate widths (a hard cut shows at
-        // most the before/after pair; a glide shows a progression)
-        const widths = [...new Set(await page.evaluate(() => window.__glide))].filter(w => w > 0);
+        // most the before/after pair; a glide shows a progression) — on valid reads only
+        const { samples } = await readMotionSamples(page);
+        expect(samples.length, 'the glide witness must have observed real frames').toBeGreaterThan(5);
+        expect(samples.every(s => s.w > 0), 'a zero-width sample means the witness watched a dead node').toBe(true);
+
+        const widths = [...new Set(samples.map(s => s.w))];
         expect(widths.length, `the pane must move THROUGH intermediate widths (saw ${widths.length} distinct)`).toBeGreaterThan(2);
     });
 
-    test('a committed moveItem is FLIP-bracketed: the signal appears and clears around the structural commit', async ({ page, neuralLink }) => {
+    test('a committed moveItem is FLIP-bracketed: the pane travels between real positions around the structural commit', async ({ page, neuralLink }) => {
         const { app, holderId } = await connect(page, neuralLink);
 
         // state-relative (shared heap): pick a REAL cross-zone move from the current doc —
@@ -107,6 +155,18 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
             : { itemId: (doc0.nodes['terminal-tabs']?.items || [])[0], targetNodeId: 'main-tabs' };
         expect(move.itemId, 'a movable item must exist in the shared-heap doc').toBeTruthy();
 
+        // the moved pane's OWN marker (the per-item correlation key the projection stamps) —
+        // geometry is asserted on the item that moves, not on whichever pane matches first
+        const itemMarker = `[class*="dock-flip-item-${encodeURIComponent(move.itemId)}"]`;
+        await expectMarkerLaidOut(page, itemMarker);
+
+        const before = await page.evaluate(sel => {
+            const r = document.querySelector(sel).getBoundingClientRect();
+            return { x: Math.round(r.x), y: Math.round(r.y) }
+        }, itemMarker);
+
+        await startMotionSampler(page, itemMarker);
+
         const [result] = await Promise.all([
             app.executeDockOperation(holderId, {
                 operation: 'moveItem', itemId: move.itemId, targetNodeId: move.targetNodeId, index: 0
@@ -116,14 +176,29 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
 
         expect(result.errors).toEqual([]);
         expect(result.applied).toBe(true);
-        // document truth stays pinned by the structural suite; here the claim is the BRACKET —
-        // but assert the move landed so a silent no-op cannot green this spec
+
+        // document truth stays pinned by the structural suite; the landed-move guard keeps a
+        // silent no-op from greening the bracket
         const topo = await app.getDockTopology(holderId);
         const doc  = topo?.document ?? topo;
         expect(doc.nodes[move.targetNodeId].items).toContain(move.itemId);
+
+        // positive geometry: the pane physically LANDED somewhere else, and the FLIP carried
+        // it THROUGH intermediate positions (a hard cut yields at most the two endpoints)
+        const { samples } = await readMotionSamples(page);
+        expect(samples.length, 'the FLIP witness must have observed real frames').toBeGreaterThan(5);
+
+        const last = samples[samples.length - 1];
+        expect(
+            Math.abs(last.x - before.x) + Math.abs(last.y - before.y),
+            `the moved pane must land at a different position (from ${before.x},${before.y} to ${last.x},${last.y})`
+        ).toBeGreaterThan(20);
+
+        const positions = [...new Set(samples.map(s => `${s.x},${s.y}`))];
+        expect(positions.length, `the FLIP must travel THROUGH intermediate positions (saw ${positions.length})`).toBeGreaterThan(2);
     });
 
-    test('a rail-click reveal SLIDES: the overlay motion is signal-bracketed through the counted window', async ({ page, neuralLink }) => {
+    test('a rail-click reveal SLIDES: the overlay travels through intermediate render states, signal-bracketed', async ({ page, neuralLink }) => {
         const { app, holderId } = await connect(page, neuralLink);
 
         // the seeded workspace shows the inspector VISIBLE — auto-hide it first (the landed
@@ -142,15 +217,28 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
         const railTab = page.locator('.neo-dashboard-dock-rail-tab', { hasText: 'Inspector' }).first();
         await expect(railTab, 'the inspector rail tab must render after auto-hiding').toBeVisible({ timeout: 10000 });
 
+        // the witness watches the VISIBLE overlay only — pre-entry frames (hidden overlay or
+        // none) count as gaps, so every recorded sample is a real revealed-state paint
+        const OVERLAY = '.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)';
+        await startMotionSampler(page, OVERLAY);
 
         await Promise.all([
             railTab.click(),
             expectSignalBracket(page)
         ]);
 
+        // positive geometry: the entry GLIDES — the slide translates and the fade progresses,
+        // so the revealed overlay paints through intermediate {position, opacity} states (a
+        // hard cut yields at most the entry and settled states)
+        const { samples } = await readMotionSamples(page);
+        expect(samples.length, 'the entry witness must have observed the revealed overlay').toBeGreaterThan(5);
+        expect(samples.every(s => s.w > 0), 'a zero-width sample means the witness watched a dead node').toBe(true);
+
+        const states = [...new Set(samples.map(s => `${s.x},${s.y},${s.o}`))];
+        expect(states.length, `the reveal entry must travel through intermediate states (saw ${states.length})`).toBeGreaterThan(2);
+
         // the reveal actually opened (the signal wasn't a stray)
-        await expect(page.locator('.neo-dashboard-dock-reveal-overlay:not(.neo-dashboard-dock-reveal-overlay-hidden)'))
-            .toHaveCount(1);
+        await expect(page.locator(OVERLAY)).toHaveCount(1);
     });
 });
 
@@ -160,22 +248,59 @@ test.describe('Dock motion pipeline — reduced-motion collapses through the tok
 
     test('a committed resizeSplit lands INSTANTLY: correct document, no sustained motion, signal clears within the fail-safe', async ({ page, neuralLink }) => {
         const { app, holderId } = await connect(page, neuralLink);
+        const MARKER            = '[class*="dock-flip-item-"]';
 
-        const tabs   = await app.findInstances({ ntype: 'tab-container' }, ['id']);
-        const paneId = (Array.isArray(tabs) ? tabs : [tabs]).map(t => t?.id).filter(Boolean)[0];
+        await expectMarkerLaidOut(page, MARKER);
 
-        const [motion, result] = await Promise.all([
-            app.observeMotion([paneId], 1200, 50),
-            app.executeDockOperation(holderId, {
-                operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.3, 0.7]
-            })
-        ]);
+        // state-relative target (shared heap): derive a guaranteed-delta ratio from the
+        // CURRENT committed sizes — a hardcoded target the document already holds would make
+        // the whole spec a no-op that "lands instantly" without any resize happening
+        const topo0  = await app.getDockTopology(holderId);
+        const doc0   = topo0?.document ?? topo0;
+        const cur    = doc0.nodes['root-split'].sizes;
+        const target = cur[0] < 0.5 ? [0.65, 0.35] : [0.3, 0.7];
+
+        const beforeW = await page.evaluate(
+            sel => Math.round(document.querySelector(sel).getBoundingClientRect().width), MARKER
+        );
+
+        await startMotionSampler(page, MARKER);
+
+        // no bracket arming here: with 0ms durations an instant settle may never paint the
+        // signal class at all — the signal claim under reduced motion is the fail-safe clear
+        const result = await app.executeDockOperation(holderId, {
+            operation: 'resizeSplit', splitNodeId: 'root-split', sizes: target
+        });
 
         expect(result.errors).toEqual([]);
         expect(result.applied).toBe(true);
 
-        // instant settle: at most the before/after widths — never a progression of intermediates
-        const widths = [...new Set((motion?.samples || []).map(s => Math.round(s.rects?.[0]?.width ?? -1)).filter(w => w >= 0))];
+        // document truth: the committed topology holds the requested geometry
+        const topo1 = await app.getDockTopology(holderId);
+        const doc1  = topo1?.document ?? topo1;
+        expect(doc1.nodes['root-split'].sizes).toEqual(target);
+
+        // DOM truth through the STABLE marker: the replacement pane settles at the NEW
+        // geometry — a real resize happened. A dead/absent read yields delta 0 (keeps
+        // polling → fails the bound), so a destroyed node can never satisfy this.
+        await expect.poll(
+            async () => {
+                const w = await page.evaluate(sel => {
+                    const el = document.querySelector(sel);
+                    return el ? Math.round(el.getBoundingClientRect().width) : 0
+                }, MARKER);
+                return w > 0 ? Math.abs(w - beforeW) : 0
+            },
+            { message: 'the replacement pane must land at the NEW geometry (real resize, no dead-node read)', timeout: 5000, intervals: [100] }
+        ).toBeGreaterThan(50);
+
+        // instant settle: among the frames that observed a laid-out marker, at most the
+        // before/after widths — and a zero read is an oracle failure, never a pass
+        const { samples } = await readMotionSamples(page);
+        expect(samples.length, 'the reduced-motion witness must have observed real frames').toBeGreaterThan(5);
+        expect(samples.every(s => s.w > 0), 'a zero-width sample means the witness watched a dead node').toBe(true);
+
+        const widths = [...new Set(samples.map(s => s.w))];
         expect(widths.length, `reduced motion must NOT glide (saw widths: ${widths.join(',')})`).toBeLessThanOrEqual(2);
 
         // the HONEST signal bound under 0ms durations: a zero-duration transition fires no


### PR DESCRIPTION
Resolves #14973

The motion pipeline's "e2e-tested" half: committed dock operations on the REAL app move real pixels, with the `neo-dashboard-dock-animating` signal bracketing each motion — the exact lifecycle tour step-gating and the recording pipeline consume. Four specs (resize glide with intermediate-width proof, FLIP-bracketed structural commit, signal-routed reveal slide, reduced-motion token collapse at its honest contract bound), all state-relative under the SharedWorker heap and event-driven-wait only.

Building these assertions falsified three shipped integration defects — the leaf earned its premise before it merged. Two of the three have since landed on `dev` via PR #14975 (#14970): Euclid independently converged on byte-identical mechanics for the specificity pin and the focus-ordering fix from his own #14966 pixel-gate trail, and his `focusReveal()` shape is strictly better (post-await `visible && !isDestroyed` guard closes the destroy/hide-during-flush window mine left open). This PR was rebased to drop those two hunks in favor of his merged versions — the convergence record lives in my review on PR #14975. What this PR still carries:

1. **The reveal entry slide overlapped its own rail** (`Container.scss`): edge-ward keyframe origins pushed the overlay INTO the rail strip mid-entry, intercepting the very clicks that open reveals (convicted by both Playwright actionability and the tour's step-gated fast clicks; invisible to paced journeys, which is why it survived #14975). The slide now settles TOWARD the edge from a workspace-side origin — never touches the rail, needs no pointer guard.
2. **The four motion specs, fail-closed after the review cycle** — the falsifier harness itself, hardened per Euclid's REQUEST_CHANGES: a shared stable-marker witness (rAF `{x, y, w, opacity}` tuples; absent frames count as gaps, never fabricated zeros; every consumer asserts a sample floor + no-zero-width before reading shape), the resize bracket armed CONCURRENTLY with the operation (no delivery-ordering dependence), positive before/target/after geometry for FLIP (the moved item's OWN marker: landed-position delta + intermediate positions) and reveal (intermediate `{position, opacity}` states), and the reduced-motion oracle rebuilt: explicit laid-out precondition, state-relative target (the old hardcoded `[0.3, 0.7]` was a shared-heap no-op risk), final document + replacement-pane geometry asserts, and a destroyed-instance zero now FAILS instead of sliding under `<= 2`.
3. **The tour's vacuous reveal detector** (`DemoATourNL.spec.mjs`) — the first-match `querySelector('[class*="reveal"]')?.offsetParent` read passed against the pre-fix ghost overlay and failed against a legitimately hidden instance once hiding became real; now any-match (`querySelectorAll` + `.some(el => el.offsetParent)`) on the tighter `dock-reveal-overlay` token. Fixed here per the review's smallest-honest-boundary call (this PR's CSS correction is what exposed it).

For the record, the two convergence-retired defects this leaf originally exposed: the `-hidden` class at (0,1,0) tying the flex-utility sheet (ghost overlay intercepting rail clicks, load-order-dependent), and `focusReveal()` dispatching focus ahead of the batched `-hidden` removal (focus landing in a `display:none` subtree). Both now guarded on `dev`; the specs here assert the behaviors they broke.

Evidence: L3 (the FULL named dashboard suite — 16/16 — driven live at an isolated port on a fresh-built theme, at the current head) → L3 required (integrated live motion truth is the entire premise). Residual: none.

## AC map

- **Each live motion class asserted (geometry + signal bracket, event-driven)** → resize glide (rAF marker-rect sampler proves intermediate widths; instance-bound observation documented as dying with re-projection), FLIP commit (bracket + landed-move guard against silent no-ops), reveal slide (idempotent auto-hide setup, bracket through the counted window).
- **Reduced motion** → `reducedMotion: 'reduce'` context: documents correct, geometry settles with ≤2 distinct widths, signal clears within the fail-safe horizon (the honest bound: 0ms transitions fire no `transitionend`; any tighter claim belongs to a producer-seam decision).
- **Named config, no CI-hardcoded skips** → the e2e config + `NEO_E2E_PORT` isolation.
- **Cross-family review** → requested.

## Deltas

- `test/playwright/e2e/dashboard/DockMotionNL.spec.mjs` (new) — the four motion assertions, fail-closed (stable-marker witness, concurrent bracket arming, per-class geometry proofs, state-relative reduced-motion target) + the motion-contract readiness wait
- `test/playwright/e2e/dashboard/DemoATourNL.spec.mjs` — the reveal detector goes any-match (the vacuous first-match read this PR's CSS correction exposed)
- `resources/scss/src/dashboard/Container.scss` — workspace-side slide origins (the rail-overlap fix)
- ~~`src/dashboard/DockRevealOverlay.mjs`~~ — dropped in the rebase; the focus-ordering fix merged via PR #14975 with a stronger guard (zero diff vs `dev` now)

## Test Evidence

At the current head (`a1696becc`, on top of `dev` including #14975 + #14974), themes rebuilt first:

```
node ./buildScripts/build/themes.mjs -f -n -e dev
NEO_E2E_PORT=8117 npx playwright test dashboard -c test/playwright/playwright.config.e2e.mjs --workers=1
16 passed (2.3m)   → the FULL named dashboard suite, including DemoATourNL (the prior standing red) and Euclid's hardened reveal journey, unmodified
```

Theme-rebuild note stands: the merged motion SCSS is invisible in stale built artifacts — unit-green + stale-artifact e2e are both blind to every defect class above.

## Post-Merge Validation

- [ ] Peers rebuild themes (`build-themes`) before running dock e2e — stale artifacts silently mask motion behavior.
- [ ] The port-isolation convention needs a collision guard (two agents on NEO_E2E_PORT=8093 cross-served each other's trees this session; candidate: per-clone derived default port). Related environment footgun found this rebase: a refreshed `@playwright/test` (1.61.1 → chromium r1228) with a stale browser cache fails ALL specs with an install banner — `npx playwright install chromium` is the fix.

Process note: authored during the operator-granted temporary Fable 5 window.

Authored by Grace (Claude Fable 5, Claude Code). Session ef6b9a4a-54ec-4afb-8438-f89a3ee46ad2
